### PR TITLE
feat(ci): Claude auto-heal for workflow failures and deep evidence-driven PR review

### DIFF
--- a/.github/workflows/claude-autoheal-merge.yml
+++ b/.github/workflows/claude-autoheal-merge.yml
@@ -1,0 +1,46 @@
+# Merges ci-autoheal pull requests once the Develop PR Gate — the same
+# aggregate every human PR must clear — reports success, and never over a human
+# CHANGES_REQUESTED review. This is a polling watcher because auto-merge is
+# disabled repo-wide; the readiness rules live in the tested
+# evaluateMergeReadiness() (packages/scripts/ci-autoheal-merge.mjs), not here.
+name: Claude Autoheal Merge
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Evaluate readiness without merging
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: claude-autoheal-merge
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  merge:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+    steps:
+      - name: Check out merge watcher
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: develop
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Merge green autoheal pull requests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MERGE_DRY_RUN: ${{ inputs.dry_run == true && '1' || '0' }}
+        run: node packages/scripts/ci-autoheal-merge.mjs

--- a/.github/workflows/claude-ci-autoheal.yml
+++ b/.github/workflows/claude-ci-autoheal.yml
@@ -1,0 +1,129 @@
+# Auto-heals CI failures on develop. When a monitored workflow completes red,
+# a briefing of the failed jobs' decisive log regions is assembled
+# (packages/scripts/ci-autoheal-context.mjs), and a Claude agent is asked to
+# find the ROOT CAUSE, fix it, prove the fix locally, and open a pull request.
+# The companion watcher (claude-autoheal-merge.yml) merges that PR only after
+# the same Develop PR Gate every human PR must clear reports green.
+#
+# Safety model:
+#   - Heals ONLY failures on `develop` and on its own claude/autoheal/* branches
+#     (fix-the-fix); every other branch is refused in code, not in YAML.
+#   - One open heal PR per workflow; a hard 3-attempt ceiling, after which the
+#     failure is a human's problem. Both guards live in the tested decide().
+#   - The heal branch is pushed with GH_PAT, not the workflow token — pull
+#     requests opened by the default GITHUB_TOKEN never trigger CI, which would
+#     leave the gate silent and the PR unmergeable forever.
+#   - `workflow_run` executes THIS definition from the default branch, so a
+#     branch cannot rewrite the heal policy that runs against it.
+name: Claude CI Autoheal
+
+on:
+  workflow_run:
+    workflows:
+      - Develop PR
+      - ci
+      - Develop Exhaustive Lane
+      - Quality (Extended)
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Failed workflow run id to heal
+        required: true
+        type: number
+
+concurrency:
+  group: claude-ci-autoheal-${{ github.event.workflow_run.name || inputs.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  autoheal:
+    # Branch/attempt/dedupe guards live in ci-autoheal-context.mjs (tested);
+    # this expression only filters the obvious non-failures early.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'failure' &&
+       (github.event.workflow_run.head_branch == 'develop' ||
+        startsWith(github.event.workflow_run.head_branch, 'claude/autoheal/')))
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+      issues: write
+      id-token: write
+    steps:
+      - name: Check out develop
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: develop
+          fetch-depth: 50
+          # The agent pushes its heal branch with GH_PAT so the resulting pull
+          # request triggers CI (default-token pushes do not).
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Build failure briefing and decide whether to heal
+        id: context
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
+        run: node packages/scripts/ci-autoheal-context.mjs
+
+      - name: Report skip
+        if: steps.context.outputs.proceed != 'true'
+        run: 'echo "autoheal skipped: ${{ steps.context.outputs.skip_reason }}"'
+
+      - name: Heal the failure
+        if: steps.context.outputs.proceed == 'true'
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GH_PAT }}
+          prompt: |
+            You are the CI auto-heal agent for ${{ github.repository }}. The workflow
+            "${{ steps.context.outputs.workflow_name }}" failed on branch
+            `${{ steps.context.outputs.head_branch }}` at ${{ steps.context.outputs.head_sha }}.
+            Run: ${{ steps.context.outputs.run_url }}
+            This is heal attempt ${{ steps.context.outputs.attempt }} of ${{ steps.context.outputs.max_attempts }}.
+
+            Read the failure briefing at `${{ steps.context.outputs.briefing_path }}` first.
+            It contains the extracted error regions of every failed job log.
+
+            Non-negotiable standard — the deepest fix, never a bandaid:
+            1. Reproduce or fully explain the failure from the logs and code before
+               changing anything. State the root cause in one falsifiable sentence.
+            2. Distinguish the three failure classes and act accordingly:
+               - product bug → fix the product code;
+               - broken/flaky test or wrong assertion → fix the test to assert the
+                 truth, never to pass;
+               - infrastructure/workflow defect → fix the workflow or script.
+            3. FORBIDDEN, and treated as failure: skipping/x-ing/only-ing tests,
+               deleting assertions, adding `continue-on-error`, `|| true`,
+               `--passWithNoTests`, retry/timeout inflation, `as any` /
+               `@ts-ignore` / `@ts-nocheck`, empty catch, or `?? <literal>`
+               defaults that hide missing data. If the correct fix genuinely
+               exceeds what you can verify here, STOP and open an issue titled
+               "ci-autoheal escalation: <workflow>" describing the root cause and
+               evidence instead of shipping a shallow patch.
+            4. Verify before shipping: run the exact failing commands locally
+               (`bun install` first; scope with `--cwd` where possible) and paste
+               their passing output into the PR body. An unverified fix does not ship.
+            5. Deliver on branch `${{ steps.context.outputs.branch }}` (create or
+               force-update it from origin/develop), then open (or update) the pull
+               request to `develop` with `gh pr create` / `gh pr edit`:
+               - title: `fix(ci): autoheal ${{ steps.context.outputs.workflow_slug }} — <root cause>`
+               - label: `ci-autoheal` (add with `gh pr edit --add-label`)
+               - body MUST keep every `<!-- evidence-row:... -->` marker from
+                 `.github/pull_request_template.md`, filling each row either with a
+                 link to real evidence or `N/A - <concrete reason>`; put the failing-run
+                 link, root-cause analysis, and verification output under Testing.
+            6. If prior heal attempts exist (see briefing), read them with
+               `gh pr view` and do NOT repeat a diagnosis that already failed review.
+          claude_args: |
+            --model claude-opus-4-7
+            --allowedTools "Bash,Read,Edit,Write,Glob,Grep"
+            --system-prompt "Use bun only (no npm/pnpm/yarn). Follow CLAUDE.md. Structured logger only, never console, in server code. Prefer the smallest change that removes the root cause; never mask a failure to make CI green."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,27 +1,128 @@
+# Deep advisory review of every non-draft pull request. A dossier is built
+# first (packages/scripts/pr-deep-review-context.mjs): the evidence-row audit
+# through the repository's own gate parser, live check results for the head
+# commit, changed-source-vs-test pairing, mechanical surface-fix signals, and
+# the prior review conversation. The reviewer is then required to judge the
+# EVIDENCE and the DEPTH of the fix, not just the diff.
+#
+# The `claude-review` job name is load-bearing: repository rules referenced it
+# historically, so it stays stable and always concludes success — the review is
+# advisory (one sticky comment), never a merge blocker. Fork pull requests get
+# no agent run: repository secrets must not meet untrusted head code.
 name: Claude Code Review
 
-# Bootstrap stub for the retired automatic Anthropic review. Keep this workflow
-# and job name stable until repository rules no longer require `claude-review`.
-# PR #16634 contains the agent-review replacement; enabling it is a separate,
-# manually reviewed policy change.
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize, reopened]
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review
+        required: true
+        type: number
 
 concurrency:
-  group: claude-code-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: claude-code-review-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   claude-review:
     name: claude-review
     runs-on: ubuntu-24.04
-    timeout-minutes: 1
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      checks: read
+      actions: read
+      id-token: write
     steps:
-      - name: Report advisory review disabled
+      - name: Classify pull request
+        id: classify
+        env:
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
         run: |
-          echo "Automatic Anthropic review is disabled."
-          echo "PR #16634 proposes a replacement; activation is separate."
+          if [ "$IS_FORK" = "true" ]; then
+            echo "run_review=false" >> "$GITHUB_OUTPUT"
+            echo "Fork pull request: secrets do not meet untrusted code; no agent review."
+          elif [ "$IS_DRAFT" = "true" ]; then
+            echo "run_review=false" >> "$GITHUB_OUTPUT"
+            echo "Draft pull request: review runs when it is ready."
+          else
+            echo "run_review=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out base branch tooling
+        if: steps.classify.outputs.run_review == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          # The dossier builder and evidence parser run from the BASE ref: a
+          # pull request must not be able to edit the audit that judges it.
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Build review dossier
+        if: steps.classify.outputs.run_review == 'true'
+        id: dossier
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: node packages/scripts/pr-deep-review-context.mjs
+
+      - name: Deep review
+        if: steps.classify.outputs.run_review == 'true'
+        # Advisory: an unreachable model must not redden the pull request.
+        continue-on-error: true
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_sticky_comment: "true"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+
+            You are the deep reviewer for this repository. Read the dossier at
+            `${{ steps.dossier.outputs.dossier_path }}` in full before reading the
+            diff (`gh pr diff`), then review to this standard:
+
+            1. **Correct fix, not a bandaid.** Identify the problem the PR claims
+               to solve (linked issues, description). Trace the change to that
+               problem's ROOT CAUSE. If the change silences a symptom — see the
+               dossier's surface-fix signals, each of which you must explicitly
+               confirm as a real problem or clear as legitimate — say precisely
+               what the deeper fix is and where it belongs. Check the fix is in
+               the right layer and the right file, not the nearest place the
+               error was observable.
+            2. **Evidence.** The dossier audits the evidence rows mechanically;
+               your job is the part a parser cannot do: judge whether the linked
+               logs, screenshots, trajectories, and domain artifacts actually
+               demonstrate the claimed behavior, come from a real run (live model,
+               real device — not the proxy, not a mock), and are current for this
+               head commit. Name every claim that ships unproven.
+            3. **Verification & tests.** Confirm CI is green for the head commit
+               (dossier lists it — a review over red CI must say so first). For
+               each behavior change, point to the test that would catch its
+               regression; where the dossier's coverage section shows a gap,
+               either locate the covering test yourself or require one. Flag any
+               test changed in ways that weaken what it proves.
+            4. **Correctness & safety.** Real bugs, error handling that swallows
+               failures (CLAUDE.md's fail-fast policy), security issues, schema or
+               contract drift, and scope creep beyond the stated intent.
+
+            Output, in order: a verdict line (**APPROVE** / **REQUEST_CHANGES** /
+            **COMMENT** with one-sentence justification); numbered findings, each
+            with file:line, severity, why it matters, and the concrete fix;
+            an "Evidence assessment" section; a "Depth check" section stating in
+            plain words whether this is the deepest fix and why. No praise filler,
+            no style nits, no repeating prior review comments (the dossier lists
+            them — reference and update instead). Post the review as your sticky
+            comment; use `gh pr comment` only if the sticky mechanism fails.
+          claude_args: |
+            --model claude-opus-4-7
+            --allowedTools "Bash(gh pr:*),Bash(gh api:*),Bash(gh run:*),Bash(gh issue view:*),Read,Glob,Grep"
+            --system-prompt "You are reviewing, not fixing: never push commits or edit files. Be exact and terse; every finding must be actionable. Follow CLAUDE.md review standards."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -72,10 +72,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-        run: node packages/scripts/pr-deep-review-context.mjs
+        run: |
+          # The builder is read from the BASE ref by design; a base that predates
+          # it (the PR introducing this workflow, or a very stale base) has no
+          # audit tooling to run, which is a graceful skip, not a red check.
+          if [ ! -f packages/scripts/pr-deep-review-context.mjs ]; then
+            echo "dossier tooling absent on the base ref; skipping review"
+            echo "dossier_path=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          node packages/scripts/pr-deep-review-context.mjs
 
       - name: Deep review
-        if: steps.classify.outputs.run_review == 'true'
+        if: steps.classify.outputs.run_review == 'true' && steps.dossier.outputs.dossier_path != ''
         # Advisory: an unreachable model must not redden the pull request.
         continue-on-error: true
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,7 +43,11 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # ANTHROPIC_API_KEY is the credential that actually exists in this
+          # repository's secrets. The OAuth-token secret this workflow used to
+          # reference was never configured, which left every @claude mention
+          # silently dead behind continue-on-error.
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Allow cursor bot to trigger reviews
           allowed_bots: "cursor"

--- a/packages/scripts/__tests__/ci-autoheal.test.ts
+++ b/packages/scripts/__tests__/ci-autoheal.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Exercises the pure decision and briefing logic of the CI auto-heal pipeline
+ * (ci-autoheal-context.mjs, ci-autoheal-merge.mjs). These functions gate an
+ * agent that opens and merges pull requests without a human, so every refusal
+ * path is asserted here against a deterministic in-memory harness — no network,
+ * no mocks of the module under test.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  AUTOHEAL_BRANCH_PREFIX,
+  DEFAULT_MAX_ATTEMPTS,
+  decide,
+  excerptFailureLog,
+  healBranchFor,
+  renderBriefing,
+  slugifyWorkflow,
+  stripLogTimestamps,
+} from "../ci-autoheal-context.mjs";
+import {
+  evaluateMergeReadiness,
+  MERGE_BLOCKED,
+  MERGE_READY,
+  MERGE_WAIT,
+  REQUIRED_GATE_CHECK,
+} from "../ci-autoheal-merge.mjs";
+
+function failedRun(overrides: Record<string, unknown> = {}) {
+  return {
+    status: "completed",
+    conclusion: "failure",
+    head_branch: "develop",
+    head_sha: "abc123",
+    name: "Develop PR",
+    event: "push",
+    html_url: "https://github.com/elizaOS/eliza/actions/runs/1",
+    ...overrides,
+  };
+}
+
+describe("slugifyWorkflow / healBranchFor", () => {
+  test("produces branch-safe, collision-resistant slugs", () => {
+    expect(slugifyWorkflow("Develop PR Gate")).toBe("develop-pr-gate");
+    expect(slugifyWorkflow("ci")).toBe("ci");
+    expect(slugifyWorkflow("Quality (Extended)")).toBe("quality-extended");
+    expect(slugifyWorkflow("Develop PR")).not.toBe(
+      slugifyWorkflow("Develop PR Gate"),
+    );
+    expect(healBranchFor("Develop PR")).toBe(
+      `${AUTOHEAL_BRANCH_PREFIX}develop-pr`,
+    );
+  });
+
+  test("rejects names that slug to nothing", () => {
+    expect(() => slugifyWorkflow("™®")).toThrow(/empty slug/);
+  });
+});
+
+describe("decide", () => {
+  test("heals a completed failure on develop", () => {
+    const verdict = decide({ run: failedRun(), openHealPr: null, attempt: 1 });
+    expect(verdict.proceed).toBe(true);
+  });
+
+  test("refuses success, cancelled, and in-progress runs", () => {
+    expect(
+      decide({
+        run: failedRun({ conclusion: "success" }),
+        openHealPr: null,
+        attempt: 1,
+      }).proceed,
+    ).toBe(false);
+    expect(
+      decide({
+        run: failedRun({ conclusion: "cancelled" }),
+        openHealPr: null,
+        attempt: 1,
+      }).proceed,
+    ).toBe(false);
+    expect(
+      decide({
+        run: failedRun({ status: "in_progress", conclusion: null }),
+        openHealPr: null,
+        attempt: 1,
+      }).proceed,
+    ).toBe(false);
+  });
+
+  test("refuses branches auto-heal does not own", () => {
+    for (const branch of ["main", "feat/foo", "release/1.2", null]) {
+      const verdict = decide({
+        run: failedRun({ head_branch: branch }),
+        openHealPr: null,
+        attempt: 1,
+      });
+      expect(verdict.proceed).toBe(false);
+      expect(verdict.reason).toContain("not healable");
+    }
+  });
+
+  test("allows re-heal of its own heal branch (fix-the-fix)", () => {
+    const verdict = decide({
+      run: failedRun({ head_branch: `${AUTOHEAL_BRANCH_PREFIX}develop-pr` }),
+      openHealPr: { number: 9 },
+      attempt: 2,
+    });
+    expect(verdict.proceed).toBe(true);
+  });
+
+  test("enforces the attempt ceiling", () => {
+    const verdict = decide({
+      run: failedRun(),
+      openHealPr: null,
+      attempt: DEFAULT_MAX_ATTEMPTS + 1,
+    });
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.reason).toContain("human");
+  });
+
+  test("refuses a second concurrent heal of the same workflow", () => {
+    const verdict = decide({
+      run: failedRun(),
+      openHealPr: { number: 17 },
+      attempt: 1,
+    });
+    expect(verdict.proceed).toBe(false);
+    expect(verdict.reason).toContain("#17");
+  });
+});
+
+describe("excerptFailureLog", () => {
+  test("strips timestamps and keeps error regions with context", () => {
+    const noise = Array.from(
+      { length: 200 },
+      (_, i) => `2026-07-30T10:00:00.0000000Z setup line ${i}`,
+    );
+    const log = [
+      ...noise,
+      "2026-07-30T10:00:01.0000000Z src/foo.ts:12:5 - error TS2345: bad argument",
+      ...Array.from(
+        { length: 100 },
+        (_, i) => `2026-07-30T10:00:02.0000000Z more output ${i}`,
+      ),
+    ].join("\n");
+    const result = excerptFailureLog(log);
+    expect(result.excerpt).toContain("error TS2345");
+    expect(result.excerpt).not.toContain("2026-07-30T10:00:01");
+    // context precedes the hit
+    expect(result.excerpt).toContain("setup line 199");
+    // far-away noise is dropped
+    expect(result.excerpt).not.toContain("setup line 10\t");
+    expect(result.matchedErrors).toBe(1);
+    expect(result.totalLines).toBe(301);
+  });
+
+  test("always keeps the tail even without error matches", () => {
+    const log = Array.from({ length: 500 }, (_, i) => `plain line ${i}`).join(
+      "\n",
+    );
+    const result = excerptFailureLog(log);
+    expect(result.excerpt).toContain("plain line 499");
+    expect(result.excerpt).not.toContain("plain line 100\t");
+  });
+
+  test("honors the character budget and reports truncation", () => {
+    const log = Array.from(
+      { length: 3000 },
+      (_, i) =>
+        `##[error] failure number ${i} with a reasonably long explanatory suffix`,
+    ).join("\n");
+    const result = excerptFailureLog(log, 5_000);
+    expect(result.truncated).toBe(true);
+    expect(result.excerpt.length).toBeLessThanOrEqual(5_000 + 40);
+    expect(result.excerpt).toContain("[excerpt truncated]");
+  });
+
+  test("recognizes the toolchain's failure shapes", () => {
+    const shapes = [
+      "##[error]Process completed with exit code 1.",
+      "error TS2322: Type 'string' is not assignable",
+      " FAIL  packages/core/src/foo.test.ts",
+      "AssertionError: expected 1 to be 2",
+      "npm ERR! code ELIFECYCLE",
+      "Segmentation fault (core dumped)",
+    ];
+    for (const shape of shapes) {
+      expect(excerptFailureLog(shape).matchedErrors).toBeGreaterThan(0);
+    }
+  });
+
+  test("stripLogTimestamps only strips leading ISO stamps", () => {
+    expect(stripLogTimestamps("2026-07-30T10:00:00.123Z hello")).toBe("hello");
+    expect(stripLogTimestamps("keep 2026-07-30T10:00:00.123Z inline")).toBe(
+      "keep 2026-07-30T10:00:00.123Z inline",
+    );
+  });
+});
+
+describe("renderBriefing", () => {
+  test("carries run identity, attempt budget, prior attempt, and logs", () => {
+    const briefing = renderBriefing({
+      run: failedRun({
+        path: ".github/workflows/develop-pr.yml",
+        run_attempt: 2,
+      }),
+      failures: [
+        {
+          jobName: "typecheck",
+          jobUrl: "https://github.com/x/y/runs/5",
+          failedSteps: ["Run typecheck"],
+          log: {
+            excerpt: "42\terror TS2345: boom",
+            truncated: false,
+            keptLines: 1,
+            totalLines: 900,
+            matchedErrors: 1,
+          },
+        },
+        {
+          jobName: "lint",
+          jobUrl: "https://github.com/x/y/runs/6",
+          failedSteps: [],
+          log: null,
+          logError: "GitHub API 410",
+        },
+      ],
+      attempt: 2,
+      maxAttempts: 3,
+      priorPr: { number: 101, state: "closed" },
+    });
+    expect(briefing).toContain("attempt 2");
+    expect(briefing).toContain("Heal attempt: 2 of 3");
+    expect(briefing).toContain("#101");
+    expect(briefing).toContain("error TS2345: boom");
+    expect(briefing).toContain("Log unavailable: GitHub API 410");
+    expect(briefing).toContain("1 of 900 lines kept");
+  });
+});
+
+describe("evaluateMergeReadiness", () => {
+  function openPr(overrides: Record<string, unknown> = {}) {
+    return {
+      number: 7,
+      state: "open",
+      draft: false,
+      mergeable: true,
+      mergeable_state: "clean",
+      ...overrides,
+    };
+  }
+  const passingGate = {
+    name: REQUIRED_GATE_CHECK,
+    status: "completed",
+    conclusion: "success",
+    html_url: "https://github.com/x/y/runs/9",
+  };
+
+  test("merges only when the develop gate passed", () => {
+    const verdict = evaluateMergeReadiness({
+      pr: openPr(),
+      checkRuns: [passingGate],
+    });
+    expect(verdict.action).toBe(MERGE_READY);
+  });
+
+  test("waits while the gate is absent or running", () => {
+    expect(evaluateMergeReadiness({ pr: openPr(), checkRuns: [] }).action).toBe(
+      MERGE_WAIT,
+    );
+    expect(
+      evaluateMergeReadiness({
+        pr: openPr(),
+        checkRuns: [
+          { ...passingGate, status: "in_progress", conclusion: null },
+        ],
+      }).action,
+    ).toBe(MERGE_WAIT);
+  });
+
+  test("blocks on a failed gate and reports the run", () => {
+    const verdict = evaluateMergeReadiness({
+      pr: openPr(),
+      checkRuns: [{ ...passingGate, conclusion: "failure" }],
+    });
+    expect(verdict.action).toBe(MERGE_BLOCKED);
+    expect(verdict.gateUrl).toContain("/runs/9");
+  });
+
+  test("a lookalike check name does not satisfy the gate", () => {
+    const verdict = evaluateMergeReadiness({
+      pr: openPr(),
+      checkRuns: [{ ...passingGate, name: "Develop PR Gate (fork)" }],
+    });
+    expect(verdict.action).toBe(MERGE_WAIT);
+  });
+
+  test("human CHANGES_REQUESTED always blocks, even over a green gate", () => {
+    const verdict = evaluateMergeReadiness({
+      pr: openPr(),
+      checkRuns: [passingGate],
+      reviews: [{ state: "CHANGES_REQUESTED" }, { state: "APPROVED" }],
+    });
+    expect(verdict.action).toBe(MERGE_BLOCKED);
+    expect(verdict.reason).toContain("reviewer");
+  });
+
+  test("drafts wait; closed PRs block; conflicts block; unknown mergeability waits", () => {
+    expect(
+      evaluateMergeReadiness({
+        pr: openPr({ draft: true }),
+        checkRuns: [passingGate],
+      }).action,
+    ).toBe(MERGE_WAIT);
+    expect(
+      evaluateMergeReadiness({
+        pr: openPr({ state: "closed" }),
+        checkRuns: [passingGate],
+      }).action,
+    ).toBe(MERGE_BLOCKED);
+    expect(
+      evaluateMergeReadiness({
+        pr: openPr({ mergeable: false, mergeable_state: "dirty" }),
+        checkRuns: [passingGate],
+      }).action,
+    ).toBe(MERGE_BLOCKED);
+    expect(
+      evaluateMergeReadiness({
+        pr: openPr({ mergeable: null, mergeable_state: "unknown" }),
+        checkRuns: [passingGate],
+      }).action,
+    ).toBe(MERGE_WAIT);
+    expect(
+      evaluateMergeReadiness({
+        pr: openPr({ mergeable_state: "behind" }),
+        checkRuns: [passingGate],
+      }).action,
+    ).toBe(MERGE_WAIT);
+  });
+});

--- a/packages/scripts/__tests__/claude-autoheal-workflow-contract.test.ts
+++ b/packages/scripts/__tests__/claude-autoheal-workflow-contract.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Guards the wiring between the Claude autoheal/review workflows and the
+ * scripts they execute: the credential that exists, the PAT that makes heal
+ * PRs trigger CI, the branch guards, and the fork/draft safety gates. These
+ * are the properties whose silent loss would leave the automation dead or
+ * unsafe without any test going red.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  AUTOHEAL_LABEL,
+  HEALABLE_BASE_BRANCH,
+} from "../ci-autoheal-context.mjs";
+import { REQUIRED_GATE_CHECK } from "../ci-autoheal-merge.mjs";
+
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const read = (path: string) => readFileSync(`${ROOT}/${path}`, "utf8");
+
+const autoheal = read(".github/workflows/claude-ci-autoheal.yml");
+const merge = read(".github/workflows/claude-autoheal-merge.yml");
+const review = read(".github/workflows/claude-code-review.yml");
+const mention = read(".github/workflows/claude.yml");
+
+describe("credentials", () => {
+  test("every Claude workflow authenticates with ANTHROPIC_API_KEY, the secret that exists", () => {
+    for (const [name, body] of [
+      ["claude-ci-autoheal", autoheal],
+      ["claude-code-review", review],
+      ["claude", mention],
+    ] as const) {
+      expect(body, `${name} must use ANTHROPIC_API_KEY`).toContain(
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: asserting literal Actions expression syntax
+        "anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}",
+      );
+      expect(
+        body,
+        `${name} must not reference the never-configured OAuth token`,
+      ).not.toContain("CLAUDE_CODE_OAUTH_TOKEN");
+    }
+  });
+
+  test("the heal branch is pushed with GH_PAT so the resulting PR triggers CI", () => {
+    // Default-token pushes never fire pull_request workflows; the gate would
+    // stay silent and the heal PR could never merge.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: asserting literal Actions expression syntax
+    expect(autoheal).toContain("token: ${{ secrets.GH_PAT }}");
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: asserting literal Actions expression syntax
+    expect(autoheal).toContain("github_token: ${{ secrets.GH_PAT }}");
+  });
+});
+
+describe("autoheal workflow", () => {
+  test("executes the tested context builder and honors its verdict", () => {
+    expect(autoheal).toContain("node packages/scripts/ci-autoheal-context.mjs");
+    expect(autoheal).toContain("steps.context.outputs.proceed == 'true'");
+    expect(existsSync(`${ROOT}/packages/scripts/ci-autoheal-context.mjs`)).toBe(
+      true,
+    );
+  });
+
+  test("YAML pre-filter matches the script's branch policy", () => {
+    expect(autoheal).toContain(`head_branch == '${HEALABLE_BASE_BRANCH}'`);
+    expect(autoheal).toContain(
+      "startsWith(github.event.workflow_run.head_branch, 'claude/autoheal/')",
+    );
+  });
+
+  test("monitors the develop CI lanes by their exact display names", () => {
+    for (const workflowName of [
+      "Develop PR",
+      "ci",
+      "Develop Exhaustive Lane",
+      "Quality (Extended)",
+    ]) {
+      expect(autoheal).toContain(`- ${workflowName}`);
+    }
+    // Display-name drift silently detaches workflow_run triggers.
+    expect(read(".github/workflows/develop-pr.yml")).toContain(
+      "name: Develop PR",
+    );
+    expect(read(".github/workflows/ci.yaml")).toContain("name: ci");
+    expect(read(".github/workflows/develop-exhaustive.yml")).toContain(
+      "name: Develop Exhaustive Lane",
+    );
+    expect(read(".github/workflows/quality.yml")).toContain(
+      "name: Quality (Extended)",
+    );
+  });
+
+  test("instructs the agent to label the PR so the merge watcher can find it", () => {
+    expect(autoheal).toContain(AUTOHEAL_LABEL);
+  });
+
+  test("never masks its own failures with continue-on-error", () => {
+    // The bare phrase appears in the agent prompt's forbidden list; the YAML
+    // key form is what would mask a real failure.
+    expect(autoheal).not.toContain("continue-on-error:");
+  });
+});
+
+describe("merge watcher", () => {
+  test("runs the tested merge evaluator on a schedule", () => {
+    expect(merge).toContain("node packages/scripts/ci-autoheal-merge.mjs");
+    expect(merge).toMatch(/cron: "\*\/15 \* \* \* \*"/);
+    expect(existsSync(`${ROOT}/packages/scripts/ci-autoheal-merge.mjs`)).toBe(
+      true,
+    );
+  });
+
+  test("merge gate is the develop aggregate, defined once in the script", () => {
+    expect(REQUIRED_GATE_CHECK).toBe("Develop PR Gate");
+    // The watcher yml must not pass its own gate definition into the script —
+    // prose mentions are fine, a second machine-read copy is not.
+    expect(merge).not.toMatch(/GATE[_A-Z]*:|check_name/i);
+  });
+});
+
+describe("deep review workflow", () => {
+  test("keeps the rule-referenced claude-review job name", () => {
+    expect(review).toContain("claude-review:");
+    expect(review).toContain("name: claude-review");
+  });
+
+  test("builds the dossier from the BASE ref before the agent runs", () => {
+    expect(review).toContain(
+      "node packages/scripts/pr-deep-review-context.mjs",
+    );
+    expect(review.indexOf("pull_request.base.sha")).toBeLessThan(
+      review.indexOf("run: node packages/scripts/pr-deep-review-context.mjs"),
+    );
+    expect(
+      existsSync(`${ROOT}/packages/scripts/pr-deep-review-context.mjs`),
+    ).toBe(true);
+  });
+
+  test("fork pull requests never reach the agent step", () => {
+    expect(review).toContain("head.repo.full_name != github.repository");
+    expect(review).toContain("run_review=false");
+    expect(review).toContain("steps.classify.outputs.run_review == 'true'");
+  });
+
+  test("review agent is read-only: no Edit/Write tools, no PAT", () => {
+    expect(review).not.toContain('"Bash,');
+    expect(review).not.toMatch(/allowedTools[^\n]*(Edit|Write)/);
+    expect(review).not.toContain("GH_PAT");
+  });
+
+  test("stays advisory: model failure cannot redden the check", () => {
+    expect(review).toContain("continue-on-error: true");
+  });
+});

--- a/packages/scripts/__tests__/claude-autoheal-workflow-contract.test.ts
+++ b/packages/scripts/__tests__/claude-autoheal-workflow-contract.test.ts
@@ -129,7 +129,7 @@ describe("deep review workflow", () => {
       "node packages/scripts/pr-deep-review-context.mjs",
     );
     expect(review.indexOf("pull_request.base.sha")).toBeLessThan(
-      review.indexOf("run: node packages/scripts/pr-deep-review-context.mjs"),
+      review.indexOf("node packages/scripts/pr-deep-review-context.mjs"),
     );
     expect(
       existsSync(`${ROOT}/packages/scripts/pr-deep-review-context.mjs`),

--- a/packages/scripts/__tests__/pr-deep-review-context.test.ts
+++ b/packages/scripts/__tests__/pr-deep-review-context.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Exercises the pure analysis behind the deep PR review dossier
+ * (pr-deep-review-context.mjs): bandaid-signal detection with diff line
+ * mapping, changed-source-vs-test coverage pairing, linked-issue extraction,
+ * and the rendered dossier's load-bearing claims.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  detectBandaidSignals,
+  extractLinkedIssues,
+  renderDossier,
+  summarizeTestCoverage,
+} from "../pr-deep-review-context.mjs";
+
+function file(
+  filename: string,
+  patch?: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    filename,
+    patch,
+    status: "modified",
+    additions: 1,
+    deletions: 1,
+    ...overrides,
+  };
+}
+
+describe("detectBandaidSignals", () => {
+  test("flags skipped tests, deleted assertions, and swallowed errors with locations", () => {
+    const patch = [
+      "@@ -10,4 +10,5 @@",
+      " context line",
+      "+it.skip('was failing', () => {",
+      "-  expect(result).toBe(4);",
+      "+  try { run(); } catch (err) {}",
+      " tail",
+    ].join("\n");
+    const signals = detectBandaidSignals([
+      file("packages/core/src/foo.test.ts", patch),
+    ]);
+    const ids = signals.map((signal) => signal.id);
+    expect(ids).toContain("disabled-test");
+    expect(ids).toContain("removed-assertion");
+    expect(ids).toContain("swallowed-error");
+
+    const skip = signals.find((signal) => signal.id === "disabled-test");
+    expect(skip?.file).toBe("packages/core/src/foo.test.ts");
+    // hunk starts at +10; context is 10, the added skip is 11
+    expect(skip?.line).toBe(11);
+    const removed = signals.find((signal) => signal.id === "removed-assertion");
+    expect(removed?.line).toBeNull();
+  });
+
+  test("flags fabricated defaults, weakened types, and CI failure masks", () => {
+    const patch = [
+      "@@ -1,2 +1,5 @@",
+      "+const total = payload.total ?? 0;",
+      "+const data = response as unknown as Report;",
+      "+        continue-on-error: true",
+      "+  run: bun test || true",
+    ].join("\n");
+    const ids = detectBandaidSignals([
+      file("packages/core/src/report.ts", patch),
+    ]).map((signal) => signal.id);
+    expect(ids).toContain("fabricated-default");
+    expect(ids).toContain("weakened-type");
+    expect(ids).toContain("ci-failure-mask");
+  });
+
+  test("flags enlarged timeouts and focused tests", () => {
+    const patch = [
+      "@@ -1,1 +1,3 @@",
+      "+await waitFor(() => ready, { timeout: 30000 });",
+      "+test.only('just this one', () => {});",
+    ].join("\n");
+    const ids = detectBandaidSignals([
+      file("packages/app/src/e2e/x.test.ts", patch),
+    ]).map((signal) => signal.id);
+    expect(ids).toContain("loosened-timing");
+    expect(ids).toContain("focused-test");
+  });
+
+  test("stays quiet on an ordinary fix", () => {
+    const patch = [
+      "@@ -5,3 +5,4 @@",
+      " function add(a: number, b: number) {",
+      "-  return a - b;",
+      "+  return a + b;",
+      " }",
+    ].join("\n");
+    expect(
+      detectBandaidSignals([file("packages/core/src/math.ts", patch)]),
+    ).toEqual([]);
+  });
+
+  test("ignores files with no patch payload (binary, huge)", () => {
+    expect(detectBandaidSignals([file("assets/logo.png", undefined)])).toEqual(
+      [],
+    );
+  });
+});
+
+describe("summarizeTestCoverage", () => {
+  test("pairs sources with same-stem tests across directory layouts", () => {
+    const coverage = summarizeTestCoverage([
+      file("packages/core/src/runtime.ts"),
+      file("packages/core/src/__tests__/runtime.test.ts"),
+      file("packages/agent/src/loader.ts"),
+    ]);
+    expect(coverage.changedSourceCount).toBe(2);
+    expect(coverage.testFileCount).toBe(1);
+    expect(coverage.uncovered).toEqual(["packages/agent/src/loader.ts"]);
+  });
+
+  test("non-behavioral files need no coverage", () => {
+    const coverage = summarizeTestCoverage([
+      file("README.md"),
+      file(".github/workflows/ci.yaml"),
+      file("packages/core/package.json"),
+      file("docs/guide.mdx"),
+    ]);
+    expect(coverage.changedSourceCount).toBe(0);
+    expect(coverage.uncovered).toEqual([]);
+  });
+
+  test("colocated foo.test.ts counts as covering foo.ts", () => {
+    const coverage = summarizeTestCoverage([
+      file("packages/scripts/ci-autoheal-context.mjs"),
+      file("packages/scripts/ci-autoheal-context.test.mjs"),
+    ]);
+    expect(coverage.uncovered).toEqual([]);
+  });
+});
+
+describe("extractLinkedIssues", () => {
+  test("finds #refs and full URLs, deduped and sorted", () => {
+    const body = [
+      "Fixes #1234 and relates to #999.",
+      "See https://github.com/elizaOS/eliza/issues/1234 and",
+      "https://github.com/elizaOS/eliza/pull/17338.",
+    ].join("\n");
+    expect(extractLinkedIssues(body)).toEqual([999, 1234, 17338]);
+  });
+
+  test("ignores short numbers and empty bodies", () => {
+    expect(extractLinkedIssues("bullet #1 and #22")).toEqual([]);
+    expect(extractLinkedIssues(null)).toEqual([]);
+  });
+});
+
+describe("renderDossier", () => {
+  const basePr = {
+    number: 42,
+    title: "fix(core): stop dropping messages",
+    user: { login: "dev" },
+    base: { ref: "develop" },
+    head: { sha: "deadbeef" },
+    additions: 10,
+    deletions: 2,
+    changed_files: 2,
+    commits: 1,
+    draft: false,
+    mergeable_state: "clean",
+    body: "Fixes #1234",
+  };
+
+  test("surfaces failing evidence rows, red checks, gaps, and prior comments", () => {
+    const dossier = renderDossier({
+      pr: basePr,
+      files: [file("packages/core/src/bus.ts")],
+      evidence: {
+        ok: false,
+        findings: [
+          { id: "backend-logs", label: "Backend logs", status: "blank" },
+          { id: "after-screenshots", label: "After screenshots", status: "ok" },
+        ],
+      },
+      checks: [
+        {
+          name: "typecheck",
+          status: "completed",
+          conclusion: "failure",
+          html_url: "https://github.com/x/y/runs/3",
+        },
+        {
+          name: "lint",
+          status: "completed",
+          conclusion: "success",
+          html_url: "",
+        },
+      ],
+      coverage: {
+        changedSourceCount: 1,
+        testFileCount: 0,
+        uncovered: ["packages/core/src/bus.ts"],
+      },
+      signals: [
+        {
+          id: "swallowed-error",
+          severity: "high",
+          explain: "an error is caught and discarded",
+          file: "packages/core/src/bus.ts",
+          line: 12,
+          text: "+  } catch (err) {}",
+        },
+      ],
+      linkedIssues: [1234],
+      priorComments: [
+        {
+          author: "reviewer",
+          body: "this looks like a bandaid",
+          path: undefined,
+        },
+      ],
+    });
+    expect(dossier).toContain("**Backend logs** (`backend-logs`): blank");
+    expect(dossier).toContain("a passing review over red CI is not a review");
+    expect(dossier).toContain("typecheck: failure");
+    expect(dossier).toContain("no same-name test");
+    expect(dossier).toContain("swallowed-error");
+    expect(dossier).toContain("#1234");
+    expect(dossier).toContain("this looks like a bandaid");
+    expect(dossier).toContain("Do not repeat a point already made");
+  });
+
+  test("clean inputs render a clean dossier without inventing problems", () => {
+    const dossier = renderDossier({
+      pr: { ...basePr, body: "" },
+      files: [],
+      evidence: { ok: true, findings: [] },
+      checks: [],
+      coverage: { changedSourceCount: 0, testFileCount: 0, uncovered: [] },
+      signals: [],
+      linkedIssues: [],
+      priorComments: [],
+    });
+    expect(dossier).toContain("Every required evidence row is satisfied");
+    expect(dossier).toContain("No check runs reported");
+    expect(dossier).toContain("No surface-fix patterns matched");
+    expect(dossier).toContain("No prior review comments");
+    expect(dossier).toContain("(empty pull request description)");
+  });
+});

--- a/packages/scripts/ci-autoheal-context.mjs
+++ b/packages/scripts/ci-autoheal-context.mjs
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+/**
+ * Builds the root-cause briefing that the CI auto-heal agent reads before it
+ * touches a single line of code, and decides whether healing should run at all.
+ *
+ * The agent is only as good as what it is shown: a raw job log is megabytes of
+ * setup noise around a few decisive lines, and a model handed the tail alone
+ * will "fix" whatever error happened to be printed last. So this module
+ * extracts every error-bearing region of every failed step, keeps them in file
+ * order with their surrounding context, and states explicitly what it dropped.
+ *
+ * It is also the safety interlock. Auto-heal opens pull requests without a
+ * human in the loop, so the guards here — heal only branches we own, one open
+ * heal per workflow, a hard attempt ceiling — are what stop a wrong diagnosis
+ * from becoming an unbounded loop of pull requests. `decide()` is pure and
+ * exhaustively unit-tested for that reason; the network layer around it is a
+ * thin shell.
+ *
+ * Consumed by .github/workflows/claude-ci-autoheal.yml.
+ */
+
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+/** Branches auto-heal is allowed to act on. */
+export const HEALABLE_BASE_BRANCH = "develop";
+export const AUTOHEAL_BRANCH_PREFIX = "claude/autoheal/";
+export const AUTOHEAL_LABEL = "ci-autoheal";
+
+/** Default ceiling on consecutive heal attempts for one workflow. */
+export const DEFAULT_MAX_ATTEMPTS = 3;
+
+/** Character budget for the log excerpts embedded in the briefing. */
+export const DEFAULT_LOG_BUDGET = 120_000;
+
+/**
+ * Lines that mark the decisive region of a failed step. GitHub's own
+ * `##[error]` annotation is the strongest signal; the rest catch the common
+ * shapes this repo's toolchain emits (vitest, tsc, biome, bun, node).
+ *
+ * Deliberately case-sensitive: an insensitive `FAIL` also matches
+ * `fail-on-cache-miss: false` in every actions/cache setup dump, which floods
+ * the excerpt budget with healthy-run noise (observed live on run 30607730414).
+ */
+const ERROR_LINE_RE =
+  /(##\[error\]|^\s*(error|Error|ERROR|fatal|FATAL|panic)\b|\berror TS\d+\b|\bFAIL\b|\bAssertionError\b|^\s*✗|^\s*×|Traceback \(most recent call last\)|\b[Ee]xit(?:ed)? with (?:code|status) [1-9]|\bnpm ERR!|\bELIFECYCLE\b|\bSegmentation fault\b|^\s*at .*\(.*:\d+:\d+\)\s*$)/;
+
+/**
+ * ANSI color/style escapes survive into the raw job log and would otherwise be
+ * shipped verbatim to the healing agent; vitest failure blocks are heavy with
+ * them.
+ */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: the ESC byte is the anchor of every ANSI sequence
+const ANSI_ESCAPE_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
+
+/** Lines of context kept before and after each error hit. */
+const CONTEXT_BEFORE = 12;
+const CONTEXT_AFTER = 8;
+
+/** Trailing lines always kept, because failures often surface only at the end. */
+const TAIL_LINES = 60;
+
+/**
+ * Turns a workflow display name into a branch-safe slug. Distinct names must
+ * not collide, because the slug is the dedupe key for "is this workflow already
+ * being healed".
+ */
+export function slugifyWorkflow(name) {
+  const slug = String(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+  if (!slug) throw new Error(`workflow name produced an empty slug: ${name}`);
+  return slug;
+}
+
+/** The deterministic heal branch for a workflow. One branch, one open PR. */
+export function healBranchFor(workflowName) {
+  return `${AUTOHEAL_BRANCH_PREFIX}${slugifyWorkflow(workflowName)}`;
+}
+
+/**
+ * Strips the ISO-8601 timestamp GitHub prefixes onto every raw log line. The
+ * timestamps are pure noise to a reader and consume roughly a fifth of the
+ * character budget.
+ */
+export function stripLogTimestamps(text) {
+  return text
+    .replace(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s?/gm, "")
+    .replace(ANSI_ESCAPE_RE, "");
+}
+
+/**
+ * Selects the decisive regions of a job log: a window around every error-ish
+ * line plus the tail, merged in file order and truncated to `budget`.
+ *
+ * Returns the excerpt along with what was dropped, so the briefing can say
+ * "there is more" instead of letting the agent assume it saw everything.
+ */
+export function excerptFailureLog(rawLog, budget = DEFAULT_LOG_BUDGET) {
+  const lines = stripLogTimestamps(rawLog).split("\n");
+  const keep = new Set();
+
+  for (const [index, line] of lines.entries()) {
+    if (!ERROR_LINE_RE.test(line)) continue;
+    const start = Math.max(0, index - CONTEXT_BEFORE);
+    const end = Math.min(lines.length - 1, index + CONTEXT_AFTER);
+    for (let i = start; i <= end; i += 1) keep.add(i);
+  }
+  for (
+    let i = Math.max(0, lines.length - TAIL_LINES);
+    i < lines.length;
+    i += 1
+  ) {
+    keep.add(i);
+  }
+
+  const ordered = [...keep].sort((a, b) => a - b);
+  const segments = [];
+  let previous = -2;
+  for (const index of ordered) {
+    if (index !== previous + 1) segments.push([]);
+    segments.at(-1).push(`${index + 1}\t${lines[index]}`);
+    previous = index;
+  }
+
+  const rendered = segments.map((segment) => segment.join("\n")).join("\n…\n");
+  const truncated = rendered.length > budget;
+  return {
+    excerpt: truncated
+      ? `${rendered.slice(0, budget)}\n…[excerpt truncated]`
+      : rendered,
+    truncated,
+    keptLines: ordered.length,
+    totalLines: lines.length,
+    matchedErrors: lines.filter((line) => ERROR_LINE_RE.test(line)).length,
+  };
+}
+
+/**
+ * The guard decision. Pure so every refusal path is unit-testable: auto-heal
+ * that misfires costs real pull requests and real review attention.
+ */
+export function decide({
+  run,
+  openHealPr,
+  attempt,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+}) {
+  if (run.status !== "completed") {
+    return { proceed: false, reason: `run is ${run.status}, not completed` };
+  }
+  if (run.conclusion !== "failure") {
+    return {
+      proceed: false,
+      reason: `run concluded ${run.conclusion}, only failure is healed`,
+    };
+  }
+  const onBase = run.head_branch === HEALABLE_BASE_BRANCH;
+  const onHealBranch = String(run.head_branch ?? "").startsWith(
+    AUTOHEAL_BRANCH_PREFIX,
+  );
+  if (!onBase && !onHealBranch) {
+    return {
+      proceed: false,
+      reason: `branch ${run.head_branch} is not healable (only ${HEALABLE_BASE_BRANCH} and ${AUTOHEAL_BRANCH_PREFIX}*)`,
+    };
+  }
+  if (attempt > maxAttempts) {
+    return {
+      proceed: false,
+      reason: `attempt ${attempt} exceeds the ceiling of ${maxAttempts}; a human must look at this failure`,
+    };
+  }
+  // A heal PR already open for this workflow means the previous diagnosis is
+  // still under review. Opening a second one would race it and split context.
+  if (openHealPr && !onHealBranch) {
+    return {
+      proceed: false,
+      reason: `pull request #${openHealPr.number} is already healing this workflow`,
+    };
+  }
+  return { proceed: true, reason: "" };
+}
+
+/** Renders the briefing the agent reads. */
+export function renderBriefing({
+  run,
+  failures,
+  attempt,
+  maxAttempts,
+  priorPr,
+}) {
+  const lines = [
+    `# CI failure briefing: ${run.name}`,
+    "",
+    `- Workflow: **${run.name}** (\`${run.path ?? "unknown"}\`)`,
+    `- Run: ${run.html_url} (attempt ${run.run_attempt ?? 1})`,
+    `- Branch: \`${run.head_branch}\` at \`${run.head_sha}\``,
+    `- Trigger event: \`${run.event}\``,
+    `- Heal attempt: ${attempt} of ${maxAttempts}`,
+  ];
+  if (priorPr) {
+    lines.push(
+      `- Prior heal attempt: #${priorPr.number} (${priorPr.state}) — read it before repeating a failed diagnosis.`,
+    );
+  }
+  lines.push("", `## Failed jobs (${failures.length})`, "");
+
+  for (const failure of failures) {
+    lines.push(
+      `### ${failure.jobName}`,
+      "",
+      `- Job: ${failure.jobUrl}`,
+      `- Failed steps: ${failure.failedSteps.length ? failure.failedSteps.join(", ") : "none reported by the API"}`,
+    );
+    if (failure.log) {
+      lines.push(
+        `- Log: ${failure.log.keptLines} of ${failure.log.totalLines} lines kept, ${failure.log.matchedErrors} error-matching lines${failure.log.truncated ? ", excerpt truncated" : ""}`,
+        "",
+        "```text",
+        failure.log.excerpt,
+        "```",
+      );
+    } else {
+      lines.push("", `- Log unavailable: ${failure.logError}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Network shell
+// ---------------------------------------------------------------------------
+
+function requireEnv(env, name) {
+  const value = env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function createClient(token) {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  return {
+    async json(path) {
+      const response = await fetch(`https://api.github.com${path}`, {
+        headers,
+      });
+      if (!response.ok) {
+        throw new Error(
+          `GitHub API ${response.status} for ${path}: ${await response.text()}`,
+        );
+      }
+      return response.json();
+    },
+    async text(path) {
+      const response = await fetch(`https://api.github.com${path}`, {
+        headers,
+      });
+      if (!response.ok)
+        throw new Error(`GitHub API ${response.status} for ${path}`);
+      return response.text();
+    },
+  };
+}
+
+async function collectFailures(client, repo, runId, budget) {
+  const failures = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const payload = await client.json(
+      `/repos/${repo}/actions/runs/${runId}/jobs?per_page=100&page=${page}&filter=latest`,
+    );
+    const jobs = payload.jobs ?? [];
+    for (const job of jobs) {
+      if (job.conclusion !== "failure") continue;
+      const failedSteps = (job.steps ?? [])
+        .filter((step) => step.conclusion === "failure")
+        .map((step) => step.name);
+      let log = null;
+      let logError = "";
+      try {
+        const raw = await client.text(
+          `/repos/${repo}/actions/jobs/${job.id}/logs`,
+        );
+        log = excerptFailureLog(raw, budget);
+      } catch (error) {
+        // error-policy:J4 a log this agent cannot read is reported as missing in
+        // the briefing rather than aborting the heal; the other failed jobs may
+        // still carry the decisive evidence.
+        logError = error instanceof Error ? error.message : String(error);
+      }
+      failures.push({
+        jobName: job.name,
+        jobUrl: job.html_url,
+        failedSteps,
+        log,
+        logError,
+      });
+    }
+    if (jobs.length < 100) break;
+  }
+  return failures;
+}
+
+async function findOpenHealPr(client, repo, branch) {
+  const owner = repo.split("/")[0];
+  const prs = await client.json(
+    `/repos/${repo}/pulls?state=open&head=${owner}:${branch}&per_page=1`,
+  );
+  return prs[0] ?? null;
+}
+
+/**
+ * Consecutive heal attempts for this workflow: how many heal pull requests
+ * (open or closed) already exist for the branch. A merged heal resets nothing
+ * on its own — the ceiling exists to stop repeated failed diagnoses, so closed
+ * unmerged attempts are what count.
+ */
+async function countPriorAttempts(client, repo, branch) {
+  const owner = repo.split("/")[0];
+  const prs = await client.json(
+    `/repos/${repo}/pulls?state=all&head=${owner}:${branch}&per_page=100&sort=created&direction=desc`,
+  );
+  const unmergedFailures = prs.filter(
+    (pr) => pr.state === "closed" && !pr.merged_at,
+  );
+  return { attempts: unmergedFailures.length, latest: prs[0] ?? null };
+}
+
+function writeOutputs(outputPath, outputs) {
+  if (!outputPath) return;
+  const body = Object.entries(outputs)
+    .map(([key, value]) => `${key}=${String(value).replace(/\n/g, " ")}`)
+    .join("\n");
+  appendFileSync(outputPath, `${body}\n`);
+}
+
+export async function main(env = process.env) {
+  const repo = requireEnv(env, "GITHUB_REPOSITORY");
+  const token = requireEnv(env, "GITHUB_TOKEN");
+  const runId = requireEnv(env, "RUN_ID");
+  const maxAttempts = Number(env.AUTOHEAL_MAX_ATTEMPTS ?? DEFAULT_MAX_ATTEMPTS);
+  const budget = Number(env.AUTOHEAL_LOG_BUDGET ?? DEFAULT_LOG_BUDGET);
+  const outDir = env.AUTOHEAL_OUT_DIR ?? ".autoheal";
+
+  const client = createClient(token);
+  const run = await client.json(`/repos/${repo}/actions/runs/${runId}`);
+  const branch = healBranchFor(run.name);
+  const openHealPr = await findOpenHealPr(client, repo, branch);
+  const { attempts, latest } = await countPriorAttempts(client, repo, branch);
+  const attempt = attempts + 1;
+
+  const decision = decide({ run, openHealPr, attempt, maxAttempts });
+  if (!decision.proceed) {
+    console.log(`auto-heal skipped: ${decision.reason}`);
+    writeOutputs(env.GITHUB_OUTPUT, {
+      proceed: "false",
+      skip_reason: decision.reason,
+      workflow_name: run.name,
+      branch,
+    });
+    return { proceed: false, reason: decision.reason };
+  }
+
+  const failures = await collectFailures(client, repo, runId, budget);
+  if (failures.length === 0) {
+    // A failed run with no failed job means the failure is in the workflow
+    // definition or infrastructure, not in a step an agent can read.
+    const reason = "run failed but no job reported a failure conclusion";
+    console.log(`auto-heal skipped: ${reason}`);
+    writeOutputs(env.GITHUB_OUTPUT, {
+      proceed: "false",
+      skip_reason: reason,
+      workflow_name: run.name,
+      branch,
+    });
+    return { proceed: false, reason };
+  }
+
+  const briefing = renderBriefing({
+    run,
+    failures,
+    attempt,
+    maxAttempts,
+    priorPr: latest,
+  });
+  mkdirSync(outDir, { recursive: true });
+  const briefingPath = `${outDir}/briefing.md`;
+  writeFileSync(briefingPath, briefing);
+
+  writeOutputs(env.GITHUB_OUTPUT, {
+    proceed: "true",
+    skip_reason: "",
+    workflow_name: run.name,
+    workflow_slug: slugifyWorkflow(run.name),
+    branch,
+    head_sha: run.head_sha,
+    head_branch: run.head_branch,
+    run_url: run.html_url,
+    attempt: String(attempt),
+    max_attempts: String(maxAttempts),
+    briefing_path: briefingPath,
+    failed_job_count: String(failures.length),
+  });
+  console.log(
+    `auto-heal briefing written to ${briefingPath} (${failures.length} failed jobs)`,
+  );
+  return { proceed: true, briefingPath, failures, briefing };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main();
+}

--- a/packages/scripts/ci-autoheal-merge.mjs
+++ b/packages/scripts/ci-autoheal-merge.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Merges auto-heal pull requests once CI proves the fix, and reports the ones
+ * CI rejects.
+ *
+ * This exists as a polling watcher rather than GitHub's own auto-merge because
+ * `allow_auto_merge` is disabled on this repository, so nothing merges a green
+ * pull request unless something asks for it. The merge condition is deliberately
+ * the same aggregate gate a human PR must clear — `Develop PR Gate`, which
+ * itself waits on lint, typecheck, build, gitleaks, and the PR metadata checks
+ * (packages/scripts/develop-pr-aggregate.mjs). Auto-heal gets no shortcut and no
+ * second, weaker definition of "green".
+ *
+ * `evaluateMergeReadiness()` is pure: this process merges to `develop` without a
+ * human, so every reason to hold must be enumerable in a test.
+ *
+ * Consumed by .github/workflows/claude-autoheal-merge.yml.
+ */
+
+import { pathToFileURL } from "node:url";
+
+import { AUTOHEAL_LABEL } from "./ci-autoheal-context.mjs";
+
+/** The aggregate check that gates every merge into develop. */
+export const REQUIRED_GATE_CHECK = "Develop PR Gate";
+
+/** Merge strategy: develop's history is one squashed commit per pull request. */
+export const MERGE_METHOD = "squash";
+
+export const MERGE_READY = "merge";
+export const MERGE_WAIT = "wait";
+export const MERGE_BLOCKED = "blocked";
+
+/**
+ * Decides what to do with one heal pull request.
+ *
+ * `checkRuns` are the check runs for the head SHA; `reviews` the submitted
+ * reviews. A human "request changes" always wins — auto-heal must never merge
+ * over a person who looked at the diff and said no.
+ */
+export function evaluateMergeReadiness({ pr, checkRuns, reviews = [] }) {
+  if (pr.draft)
+    return { action: MERGE_WAIT, reason: "pull request is a draft" };
+  if (pr.state !== "open")
+    return { action: MERGE_BLOCKED, reason: `pull request is ${pr.state}` };
+
+  const changesRequested = reviews.some(
+    (review) => review.state === "CHANGES_REQUESTED",
+  );
+  if (changesRequested) {
+    return { action: MERGE_BLOCKED, reason: "a reviewer requested changes" };
+  }
+
+  const gate = checkRuns.find((check) => check.name === REQUIRED_GATE_CHECK);
+  if (!gate) {
+    return {
+      action: MERGE_WAIT,
+      reason: `${REQUIRED_GATE_CHECK} has not reported yet`,
+    };
+  }
+  if (gate.status !== "completed") {
+    return {
+      action: MERGE_WAIT,
+      reason: `${REQUIRED_GATE_CHECK} is ${gate.status}`,
+    };
+  }
+  if (gate.conclusion !== "success") {
+    return {
+      action: MERGE_BLOCKED,
+      reason: `${REQUIRED_GATE_CHECK} concluded ${gate.conclusion}`,
+      gateUrl: gate.html_url,
+    };
+  }
+
+  // `mergeable_state` is computed asynchronously by GitHub; "unknown" means the
+  // answer is not ready, which is a wait, not a refusal.
+  if (pr.mergeable === null || pr.mergeable_state === "unknown") {
+    return {
+      action: MERGE_WAIT,
+      reason: "GitHub has not finished computing mergeability",
+    };
+  }
+  if (pr.mergeable === false) {
+    return {
+      action: MERGE_BLOCKED,
+      reason: `pull request has conflicts (${pr.mergeable_state})`,
+    };
+  }
+  if (pr.mergeable_state === "behind") {
+    return {
+      action: MERGE_WAIT,
+      reason: "branch is behind its base and must be updated",
+    };
+  }
+
+  return { action: MERGE_READY, reason: `${REQUIRED_GATE_CHECK} passed` };
+}
+
+function requireEnv(env, name) {
+  const value = env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function createClient(token) {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  return async function request(path, options = {}) {
+    const response = await fetch(`https://api.github.com${path}`, {
+      ...options,
+      headers: { ...headers, ...options.headers },
+    });
+    if (!response.ok) {
+      throw new Error(
+        `GitHub API ${response.status} for ${path}: ${await response.text()}`,
+      );
+    }
+    return response.status === 204 ? null : response.json();
+  };
+}
+
+export async function main(env = process.env) {
+  const repo = requireEnv(env, "GITHUB_REPOSITORY");
+  const token = requireEnv(env, "GITHUB_TOKEN");
+  const dryRun = env.MERGE_DRY_RUN === "1";
+  const request = createClient(token);
+
+  const search = await request(
+    `/search/issues?q=${encodeURIComponent(`repo:${repo} is:pr is:open label:${AUTOHEAL_LABEL}`)}&per_page=50`,
+  );
+  const candidates = search.items ?? [];
+  console.log(
+    `found ${candidates.length} open ${AUTOHEAL_LABEL} pull requests`,
+  );
+
+  const outcomes = [];
+  for (const item of candidates) {
+    const pr = await request(`/repos/${repo}/pulls/${item.number}`);
+    const [checks, reviews] = await Promise.all([
+      request(`/repos/${repo}/commits/${pr.head.sha}/check-runs?per_page=100`),
+      request(`/repos/${repo}/pulls/${pr.number}/reviews?per_page=100`),
+    ]);
+    const verdict = evaluateMergeReadiness({
+      pr,
+      checkRuns: checks.check_runs ?? [],
+      reviews,
+    });
+    console.log(`#${pr.number}: ${verdict.action} — ${verdict.reason}`);
+    outcomes.push({ number: pr.number, ...verdict });
+
+    if (verdict.action !== MERGE_READY || dryRun) continue;
+
+    await request(`/repos/${repo}/pulls/${pr.number}/merge`, {
+      method: "PUT",
+      body: JSON.stringify({
+        merge_method: MERGE_METHOD,
+        commit_title: `${pr.title} (#${pr.number})`,
+        commit_message: `Auto-healed CI failure. ${REQUIRED_GATE_CHECK} passed before merge.`,
+      }),
+    });
+    console.log(`#${pr.number}: merged`);
+  }
+  return outcomes;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main();
+}

--- a/packages/scripts/pr-deep-review-context.mjs
+++ b/packages/scripts/pr-deep-review-context.mjs
@@ -1,0 +1,446 @@
+#!/usr/bin/env node
+/**
+ * Assembles the dossier the deep PR reviewer reads before it forms an opinion.
+ *
+ * A reviewing agent handed only a diff writes a plausible review of the diff.
+ * That is the failure this module exists to prevent: the questions that decide
+ * whether a change should merge here — is the evidence real, did CI actually
+ * pass, does the fix address the cause or the symptom, was a test weakened to
+ * make red go green — are answerable only from context that lives outside the
+ * patch. So the dossier carries the pull request's evidence-row audit (through
+ * the repository's own gate parser, never a second implementation of it), the
+ * live check results for the head commit, the review conversation so far, and a
+ * mechanical scan for the specific edits that make a symptom disappear without
+ * curing it.
+ *
+ * `detectBandaidSignals()` and `summarizeTestCoverage()` are pure and tested.
+ * They do not decide anything: they hand the agent leads it must confirm or
+ * dismiss by reading the code, which is why every signal names a file and line.
+ *
+ * Consumed by .github/workflows/claude-code-review.yml.
+ */
+
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+import {
+  evaluatePrEvidence,
+  REQUIRED_EVIDENCE_ROWS,
+} from "../../scripts/check-pr-evidence.mjs";
+
+/** Files whose changes are tests rather than shipped behavior. */
+const TEST_PATH_RE =
+  /(\.(test|spec|bench)\.[cm]?[jt]sx?$|(^|\/)(__tests__|__e2e__|e2e|tests?)\/)/i;
+
+/** Files that ship no behavior, so they neither need nor provide test cover. */
+const NON_BEHAVIORAL_RE =
+  /(\.(md|mdx|txt|json|ya?ml|lock|snap|svg|png|jpe?g|gif|webp|ico)$|(^|\/)(docs|\.github)\/)/i;
+
+const SOURCE_EXT_RE = /\.[cm]?[jt]sx?$|\.(rs|py|go|swift|kt|java)$/i;
+
+/**
+ * Edits that make a failure stop being visible without establishing that it
+ * stopped happening. Each entry is a lead for the reviewer, not a verdict —
+ * every one of these is legitimate somewhere, which is exactly why a human-
+ * grade review has to look at them individually instead of trusting green CI.
+ */
+const BANDAID_PATTERNS = [
+  {
+    id: "disabled-test",
+    severity: "high",
+    test: /^\+.*\b(it|test|describe)\.(skip|todo)\b|^\+.*\bx(it|describe)\(|^\+\s*\/\/\s*@ts-nocheck/,
+    explain: "a test was skipped or type-checking was switched off",
+  },
+  {
+    id: "focused-test",
+    severity: "high",
+    test: /^\+.*\b(it|test|describe)\.only\b/,
+    explain:
+      "a focused test silently stops every other test in the file from running",
+  },
+  {
+    id: "removed-assertion",
+    severity: "high",
+    test: /^-\s*(expect|assert|should)\b/,
+    explain:
+      "an assertion was deleted — confirm the behavior it guarded is still guarded",
+  },
+  {
+    id: "swallowed-error",
+    severity: "high",
+    test: /^\+.*(catch\s*\([^)]*\)\s*\{\s*\}|\.catch\(\s*\(\s*\)\s*=>\s*\{?\s*\}?\s*\)|except\s*:\s*pass)/,
+    explain:
+      "an error is caught and discarded, which hides the failure instead of handling it",
+  },
+  {
+    id: "fabricated-default",
+    severity: "high",
+    test: /^\+.*\?\?\s*(0|\[\]|""|''|\{\}|false)\s*[;,)\]]/,
+    explain:
+      "a literal default stands in for possibly-missing data, conflating 'not loaded' with 'empty'",
+  },
+  {
+    id: "weakened-type",
+    severity: "medium",
+    test: /^\+.*(:\s*any\b|as\s+any\b|as\s+unknown\s+as\b|@ts-(ignore|expect-error))/,
+    explain: "a type was weakened or an error suppressed rather than resolved",
+  },
+  {
+    id: "loosened-timing",
+    severity: "medium",
+    test: /^\+.*\b(setTimeout|sleep|waitFor|retries|retry|timeout)\b.*\b\d{4,}\b/,
+    explain:
+      "a timeout or retry was enlarged, which usually postpones a race rather than removing it",
+  },
+  {
+    id: "ci-failure-mask",
+    severity: "high",
+    test: /^\+.*(continue-on-error:\s*true|\|\|\s*true\b|--passWithNoTests|--no-verify)/,
+    explain: "a CI step was made unable to fail",
+  },
+  {
+    id: "snapshot-rewrite",
+    severity: "medium",
+    test: /^\+.*(-u\b|--update-snapshots?|toMatchSnapshot\(\))/,
+    explain:
+      "snapshots were regenerated — confirm the new snapshot is correct, not merely current",
+  },
+];
+
+/** Parses a unified diff hunk header into the new-file starting line. */
+function hunkStartLine(header) {
+  const match = /^@@ -\d+(?:,\d+)? \+(\d+)/.exec(header);
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * Scans patches for surface-fix tells, reporting the file and new-file line of
+ * every hit so the reviewer can go read it.
+ */
+export function detectBandaidSignals(files) {
+  const signals = [];
+  for (const file of files) {
+    if (!file.patch) continue;
+    let lineNumber = 0;
+    for (const line of file.patch.split("\n")) {
+      if (line.startsWith("@@")) {
+        const start = hunkStartLine(line);
+        if (start !== null) lineNumber = start - 1;
+        continue;
+      }
+      if (!line.startsWith("-")) lineNumber += 1;
+      for (const pattern of BANDAID_PATTERNS) {
+        if (!pattern.test.test(line)) continue;
+        signals.push({
+          id: pattern.id,
+          severity: pattern.severity,
+          explain: pattern.explain,
+          file: file.filename,
+          line: line.startsWith("-") ? null : lineNumber,
+          text: line.slice(0, 200),
+        });
+      }
+    }
+  }
+  return signals;
+}
+
+/**
+ * Which changed source files gained no test coverage in the same pull request.
+ * Matching is by basename because this repository colocates
+ * `foo.ts` with `__tests__/foo.test.ts` and `foo.test.ts` alike.
+ */
+export function summarizeTestCoverage(files) {
+  const testedStems = new Set();
+  const changedSources = [];
+  for (const file of files) {
+    const name = file.filename;
+    if (TEST_PATH_RE.test(name)) {
+      testedStems.add(basenameStem(name).replace(/\.(test|spec|bench)$/i, ""));
+      continue;
+    }
+    if (NON_BEHAVIORAL_RE.test(name) || !SOURCE_EXT_RE.test(name)) continue;
+    changedSources.push(name);
+  }
+  const uncovered = changedSources.filter(
+    (name) => !testedStems.has(basenameStem(name)),
+  );
+  return {
+    changedSourceCount: changedSources.length,
+    testFileCount: files.filter((file) => TEST_PATH_RE.test(file.filename))
+      .length,
+    uncovered,
+  };
+}
+
+function basenameStem(path) {
+  const base = path.split("/").pop() ?? path;
+  return base
+    .replace(/\.[cm]?[jt]sx?$/i, "")
+    .replace(/\.(rs|py|go|swift|kt|java)$/i, "");
+}
+
+/** Issue references in the pull request body, so the reviewer can check intent. */
+export function extractLinkedIssues(body) {
+  const found = new Set();
+  for (const match of String(body ?? "").matchAll(/(?:^|\s)#(\d{3,6})\b/g)) {
+    found.add(Number(match[1]));
+  }
+  for (const match of String(body ?? "").matchAll(
+    /github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\/(\d+)/g,
+  )) {
+    found.add(Number(match[1]));
+  }
+  return [...found].sort((a, b) => a - b);
+}
+
+/** Renders the dossier. */
+export function renderDossier({
+  pr,
+  files,
+  evidence,
+  checks,
+  coverage,
+  signals,
+  linkedIssues,
+  priorComments,
+}) {
+  const out = [
+    `# Review dossier: #${pr.number} — ${pr.title}`,
+    "",
+    `- Author: ${pr.user?.login} · Base: \`${pr.base?.ref}\` · Head: \`${pr.head?.sha}\``,
+    `- Churn: +${pr.additions}/-${pr.deletions} across ${pr.changed_files} files, ${pr.commits} commits`,
+    `- Draft: ${pr.draft ? "yes" : "no"} · Mergeable state: ${pr.mergeable_state ?? "unknown"}`,
+    `- Linked issues: ${linkedIssues.length ? linkedIssues.map((n) => `#${n}`).join(", ") : "none referenced"}`,
+    "",
+    "## Stated intent (the claim this change must be measured against)",
+    "",
+    "```markdown",
+    (pr.body ?? "").slice(0, 12_000) || "(empty pull request description)",
+    "```",
+    "",
+    "## Evidence gate audit",
+    "",
+  ];
+
+  const failing = evidence.findings.filter(
+    (finding) => finding.status !== "ok",
+  );
+  out.push(
+    evidence.ok
+      ? "Every required evidence row is satisfied by the repository's own gate parser."
+      : `${failing.length} evidence row(s) are NOT satisfied:`,
+  );
+  for (const finding of failing) {
+    out.push(`- **${finding.label}** (\`${finding.id}\`): ${finding.status}`);
+  }
+  out.push(
+    "",
+    "Row status meanings: `missing` = the marker was removed from the body; `blank` = no",
+    "artifact link and no `N/A - <reason>`; `artifact-required` = a rendered-UI file changed,",
+    "so real media is mandatory and N/A is refused; `ocr-required` = a UI diff without an OCR",
+    "text review. A satisfied row means a link is PRESENT — not that anyone opened it. Judging",
+    "whether the linked artifact actually shows the claimed behavior is your job, not the gate's.",
+    "",
+    "## CI state for the head commit",
+    "",
+  );
+
+  if (checks.length === 0) {
+    out.push("No check runs reported for this commit yet.");
+  } else {
+    const grouped = new Map();
+    for (const check of checks) {
+      const key =
+        check.status === "completed"
+          ? (check.conclusion ?? "unknown")
+          : check.status;
+      grouped.set(key, [...(grouped.get(key) ?? []), check.name]);
+    }
+    for (const [state, names] of [...grouped].sort()) {
+      out.push(
+        `- **${state}** (${names.length}): ${names.slice(0, 25).join(", ")}`,
+      );
+    }
+    const failed = checks.filter(
+      (check) =>
+        check.status === "completed" &&
+        !["success", "skipped", "neutral"].includes(check.conclusion),
+    );
+    if (failed.length) {
+      out.push(
+        "",
+        "Failing checks — a passing review over red CI is not a review:",
+      );
+      for (const check of failed)
+        out.push(`- ${check.name}: ${check.conclusion} — ${check.html_url}`);
+    }
+  }
+
+  out.push("", "## Test coverage of changed behavior", "");
+  out.push(
+    `- Changed source files: ${coverage.changedSourceCount}`,
+    `- Changed test files: ${coverage.testFileCount}`,
+  );
+  if (coverage.uncovered.length) {
+    out.push(
+      `- Source files with no same-name test touched in this pull request (${coverage.uncovered.length}):`,
+      ...coverage.uncovered.slice(0, 40).map((name) => `  - ${name}`),
+      "",
+      "Name matching is a heuristic. Confirm against the real suite before claiming a gap:",
+      "coverage may live in an integration or e2e test with an unrelated filename.",
+    );
+  } else {
+    out.push(
+      "- Every changed source file has a same-named test touched in this pull request.",
+    );
+  }
+
+  out.push("", "## Mechanical surface-fix signals", "");
+  if (signals.length === 0) {
+    out.push(
+      "No surface-fix patterns matched. Depth of the fix still has to be judged by reading it.",
+    );
+  } else {
+    out.push(
+      `${signals.length} pattern hit(s). Each is a LEAD to verify, never a finding on its own —`,
+      "confirm by reading the code, and say so explicitly if it is legitimate here.",
+      "",
+    );
+    for (const signal of signals.slice(0, 60)) {
+      const where = signal.line === null ? "(removed line)" : `:${signal.line}`;
+      out.push(
+        `- [${signal.severity}] \`${signal.id}\` ${signal.file}${where} — ${signal.explain}`,
+      );
+      out.push(`  \`${signal.text.replace(/`/g, "'")}\``);
+    }
+  }
+
+  out.push("", "## Changed files", "");
+  for (const file of files.slice(0, 200)) {
+    out.push(
+      `- ${file.status} \`${file.filename}\` (+${file.additions}/-${file.deletions})`,
+    );
+  }
+  if (files.length > 200) out.push(`- …and ${files.length - 200} more`);
+
+  out.push("", "## Review conversation so far", "");
+  if (priorComments.length === 0) {
+    out.push("No prior review comments.");
+  } else {
+    out.push(
+      "Do not repeat a point already made here; say whether it was addressed.",
+      "",
+    );
+    for (const comment of priorComments.slice(-40)) {
+      out.push(
+        `- **${comment.author}** on ${comment.path ?? "the pull request"}: ${comment.body.slice(0, 600).replace(/\n+/g, " ")}`,
+      );
+    }
+  }
+
+  return out.join("\n");
+}
+
+function requireEnv(env, name) {
+  const value = env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function createClient(token) {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  return async function request(path) {
+    const response = await fetch(`https://api.github.com${path}`, { headers });
+    if (!response.ok) {
+      throw new Error(
+        `GitHub API ${response.status} for ${path}: ${await response.text()}`,
+      );
+    }
+    return response.json();
+  };
+}
+
+async function paginate(request, path, limit = 5) {
+  const all = [];
+  for (let page = 1; page <= limit; page += 1) {
+    const separator = path.includes("?") ? "&" : "?";
+    const chunk = await request(`${path}${separator}per_page=100&page=${page}`);
+    all.push(...chunk);
+    if (chunk.length < 100) break;
+  }
+  return all;
+}
+
+export async function main(env = process.env) {
+  const repo = requireEnv(env, "GITHUB_REPOSITORY");
+  const token = requireEnv(env, "GITHUB_TOKEN");
+  const prNumber = Number(requireEnv(env, "PR_NUMBER"));
+  const outDir = env.REVIEW_OUT_DIR ?? ".review";
+  const request = createClient(token);
+
+  const pr = await request(`/repos/${repo}/pulls/${prNumber}`);
+  const files = await paginate(
+    request,
+    `/repos/${repo}/pulls/${prNumber}/files`,
+  );
+  const changedFiles = files.map((file) => file.filename).join("\n");
+  const addedFiles = files
+    .filter((file) => file.status === "added")
+    .map((file) => file.filename)
+    .join("\n");
+
+  const evidence = evaluatePrEvidence(pr.body ?? "", REQUIRED_EVIDENCE_ROWS, {
+    labels: (pr.labels ?? []).map((label) => label.name).join(","),
+    changedFiles,
+    addedFiles,
+  });
+
+  const checkPayload = await request(
+    `/repos/${repo}/commits/${pr.head.sha}/check-runs?per_page=100`,
+  );
+  const [issueComments, reviewComments] = await Promise.all([
+    paginate(request, `/repos/${repo}/issues/${prNumber}/comments`, 3),
+    paginate(request, `/repos/${repo}/pulls/${prNumber}/comments`, 3),
+  ]);
+  const priorComments = [...issueComments, ...reviewComments]
+    .filter((comment) => comment.body)
+    .map((comment) => ({
+      author: comment.user?.login ?? "unknown",
+      body: comment.body,
+      path: comment.path,
+    }));
+
+  const dossier = renderDossier({
+    pr,
+    files,
+    evidence,
+    checks: checkPayload.check_runs ?? [],
+    coverage: summarizeTestCoverage(files),
+    signals: detectBandaidSignals(files),
+    linkedIssues: extractLinkedIssues(pr.body),
+    priorComments,
+  });
+
+  mkdirSync(outDir, { recursive: true });
+  const dossierPath = `${outDir}/dossier.md`;
+  writeFileSync(dossierPath, dossier);
+  if (env.GITHUB_OUTPUT) {
+    appendFileSync(
+      env.GITHUB_OUTPUT,
+      `dossier_path=${dossierPath}\nhead_sha=${pr.head.sha}\nchanged_files=${files.length}\n`,
+    );
+  }
+  console.log(
+    `review dossier written to ${dossierPath} (${files.length} files)`,
+  );
+  return { dossierPath, dossier };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main();
+}


### PR DESCRIPTION
# Relates to

Sets up repository-native Claude automation: auto-healing CI failures on `develop` and deep, evidence-driven PR review. Also repairs the `@claude` mention workflow, which referenced a never-configured secret (`CLAUDE_CODE_OAUTH_TOKEN`) and has been silently dead behind `continue-on-error`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is built directly on the latest `origin/develop` (parent `d3d3bf29ea0`) with zero conflicts.
- [x] `bun install` and targeted verification were run; results below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Commit is parented on the exact current `origin/develop`; zero conflicts.
- [x] `bun x biome check` clean on all 6 new/changed script+test files; `actionlint` clean on all 4 workflows; 46/46 unit tests pass (output below).

# Risks

Medium. Two workflows can act without a human in the loop (open a PR; merge a PR). Mitigations, all unit-tested in pure functions rather than YAML:

- Auto-heal acts ONLY on `develop` and its own `claude/autoheal/*` branches; every other branch is refused in `decide()`.
- One open heal PR per workflow (deterministic branch name = dedupe key); hard 3-attempt ceiling, after which it stops and a human must look.
- The merge watcher merges ONLY when the **Develop PR Gate** — the same aggregate every human PR must clear — reports success, and never over a human `CHANGES_REQUESTED` review. Auto-merge stays disabled repo-wide; there is no second, weaker definition of "green".
- The review workflow is advisory (sticky comment, never a failing check), read-only (no Edit/Write tools, no PAT), and never runs on fork PRs (secrets must not meet untrusted code).
- The heal branch is pushed with `GH_PAT` so heal PRs actually trigger CI — default-token PRs run no workflows, which would leave the gate silent and the PR unmergeable.

# Background

## What does this PR do?

**1. CI auto-heal** (`claude-ci-autoheal.yml` + `packages/scripts/ci-autoheal-context.mjs`): on failure of the develop CI lanes (`Develop PR`, `ci`, `Develop Exhaustive Lane`, `Quality (Extended)`), builds a root-cause briefing — the decisive error regions of every failed job log (tested extractor; ANSI + timestamps stripped; explicit about truncation) plus prior heal attempts — and runs a Claude agent instructed to reproduce, state the root cause in one falsifiable sentence, fix the cause (product bug vs broken test vs infra defect), verify by running the exact failing commands, and open an evidence-complete PR labeled `ci-autoheal`. Bandaid moves (skipping tests, deleting assertions, `continue-on-error`, `|| true`, retry inflation, `as any`, empty catch, `?? <literal>`) are explicitly forbidden; if the correct fix can't be verified in-run, it must escalate via issue instead of shipping a shallow patch.

**2. Autoheal merge watcher** (`claude-autoheal-merge.yml` + `packages/scripts/ci-autoheal-merge.mjs`): every 15 min, evaluates open `ci-autoheal` PRs with tested `evaluateMergeReadiness()` and squash-merges only those where the Develop PR Gate passed, mergeability is clean, and no human requested changes.

**3. Deep PR review** (`claude-code-review.yml` + `packages/scripts/pr-deep-review-context.mjs`): replaces the disabled stub (job name `claude-review` kept stable). Before the agent runs, a dossier is built **from the base ref** (a PR cannot edit the audit that judges it): evidence-row audit through the repo's own `scripts/check-pr-evidence.mjs` parser, live check state for the head SHA, changed-source-vs-test pairing, a mechanical bandaid-signal scan with file:line locations, linked issues, and the prior review conversation. The reviewer must trace the change to the root cause of the stated problem, judge whether linked evidence actually demonstrates the claim, confirm CI state, and end with an explicit "Depth check" verdict on whether this is the deepest fix.

**4. `@claude` mention repair** (`claude.yml`): switches auth to the `ANTHROPIC_API_KEY` secret that actually exists.

A contract test (`claude-autoheal-workflow-contract.test.ts`) pins the wiring: credentials, GH_PAT usage, branch guards, monitored workflow display names (drift silently detaches `workflow_run` triggers), fork/draft gates, and the review agent's read-only tool set.

## What kind of change is this?

Features (CI/automation only; no runtime, UI, or agent behavior changes).

# Documentation changes needed?

Workflow headers carry the full safety model inline; no separate docs change.

# Testing

## Where should a reviewer start?

1. `packages/scripts/ci-autoheal-context.mjs` — `decide()` (the safety interlock) and `excerptFailureLog()`.
2. `packages/scripts/ci-autoheal-merge.mjs` — `evaluateMergeReadiness()`.
3. `packages/scripts/pr-deep-review-context.mjs` — `detectBandaidSignals()` and the dossier renderer.
4. The three workflows, whose YAML is deliberately thin over these tested scripts.

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/ci-autoheal.test.ts \
         packages/scripts/__tests__/pr-deep-review-context.test.ts \
         packages/scripts/__tests__/claude-autoheal-workflow-contract.test.ts
# 46 pass, 0 fail, 136 expect() calls

actionlint .github/workflows/claude-ci-autoheal.yml .github/workflows/claude-autoheal-merge.yml \
           .github/workflows/claude-code-review.yml .github/workflows/claude.yml
# clean

bun x biome check <all 6 script/test files>
# Checked 6 files. No fixes applied.
```

Live validation against the real GitHub API (read-only / dry-run), artifacts reviewed by hand:

- `ci-autoheal-context.mjs` against real failed develop run [30607730414](https://github.com/elizaOS/eliza/actions/runs/30607730414) ("Tests", 6 failed jobs) → briefing captured the real `AssertionError`s, the 20s test timeout, and exit codes; after tuning, zero `fail-on-cache-miss`/ANSI noise lines. Excerpt in Evidence Details below.
- `pr-deep-review-context.mjs` against real PR #17384 → dossier correctly reports test-only change, evidence rows satisfied, `cancelled` head-SHA checks, zero bandaid signals. Excerpt below.
- `ci-autoheal-merge.mjs` with `MERGE_DRY_RUN=1` → `found 0 open ci-autoheal pull requests` (correct: none exist yet).

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - CI workflow + script change only; nothing renders in any UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - CI workflow + script change only; nothing renders in any UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing flow; the observable behavior is workflow runs and PR comments, evidenced by logs below.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: live script runs against the real GitHub API pasted in Evidence Details below — briefing built from real failed run https://github.com/elizaOS/eliza/actions/runs/30607730414, dossier from https://github.com/elizaOS/eliza/pull/17384, merge dry-run.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code path exists in this change.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model runtime change; the Claude workflow agents cannot run until this PR's workflows land on the default branch (workflow_run/schedule execute the default-branch definition). First real runs will be linked from the follow-up validation on develop.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: generated briefing.md and dossier.md excerpts pasted inline below, produced from live API data (source run https://github.com/elizaOS/eliza/actions/runs/30607730414, source PR https://github.com/elizaOS/eliza/pull/17384) and reviewed line by line.

# Evidence Details

## Real LLM-call trajectory

N/A - see evidence row: workflow_run and schedule triggers execute the workflow definition from the default branch, so the healing/review agents are structurally unable to produce a trajectory before merge. The scripts they consume were validated live (below).

## Backend + frontend logs

<details>
<summary>Live run: auto-heal briefing on real failed run 30607730414 (Tests, develop)</summary>

```
auto-heal briefing written to …/autoheal2/briefing.md (6 failed jobs)
```

briefing.md excerpts (hand-reviewed):

```
# CI failure briefing: Tests
- Workflow: **Tests** (`.github/workflows/test.yml`)
- Run: https://github.com/elizaOS/eliza/actions/runs/30607730414 (attempt 1)
- Branch: `develop` at `23df24cf4533308900e2ad483d214139f0014053`
- Heal attempt: 1 of 3
## Failed jobs (6)
…
3609  [eliza-test] FAIL @elizaos/plugin-signal (plugins/plugin-signal)#test (23071ms)
3621   FAIL  src/setup-routes.test.ts > Signal setup routes > rejects hostile account ids before touching auth state
3641  ##[error]Error: Test timed out in 20000ms.
…
4295  ##[error]AssertionError: APP: real modes [create, launch, list, load_from_directory, relaunch, stop] != manifest [create, launch, list, load_from_directory, relaunch]
…
4694  ##[error]AssertionError: user-facing builtin views without matcher nouns: cloud-apps
```

16 `AssertionError`/`##[error]` lines captured; 0 noise matches (`fail-on-cache-miss`, ANSI codes) after extractor tuning.
</details>

<details>
<summary>Live run: review dossier on real PR #17384 + merge watcher dry-run</summary>

```
review dossier written to …/review/dossier.md (3 files)
```

dossier.md excerpts (hand-reviewed, all claims verified against the PR):

```
# Review dossier: #17384 — test(scenario-runner): cover APP stop mode
- Draft: yes · Mergeable state: unstable
- Linked issues: #17382
## Evidence gate audit
Every required evidence row is satisfied by the repository's own gate parser.
## CI state for the head commit
- **cancelled** (2): check-pr-evidence, Develop PR Gate
## Test coverage of changed behavior
- Changed source files: 0
- Changed test files: 3
## Mechanical surface-fix signals
No surface-fix patterns matched.
```

```
$ MERGE_DRY_RUN=1 node packages/scripts/ci-autoheal-merge.mjs
found 0 open ci-autoheal pull requests
```
</details>

<details>
<summary>Unit tests + linters</summary>

```
bun test … 46 pass, 0 fail, 136 expect() calls, 3 files
actionlint: clean on all 4 workflows
biome check: Checked 6 files. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

N/A - CI-only change; no rendered surface.

### Before

N/A - see above.

### After

N/A - see above.

### Walkthrough video

N/A - see above.

## Audio / voice walkthrough

N/A - no voice/audio surface touched.

## Known gaps / failures

- The healing and review **agents** cannot be exercised end-to-end before merge: `workflow_run` and `schedule` execute the default-branch workflow definition. Post-merge validation plan: (1) `workflow_dispatch` `Claude CI Autoheal` with a real failed run id and review the PR it opens; (2) `workflow_dispatch` `Claude Code Review` on an open PR and review the sticky comment; (3) `workflow_dispatch` `Claude Autoheal Merge` with `dry_run=true`.
- `Claude Autoheal Merge` and `Claude CI Autoheal` require the existing `GH_PAT` and `ANTHROPIC_API_KEY` secrets; both are present in the repository (verified via `gh secret list`).
- The `ci-autoheal` label must exist for the watcher's search to find heal PRs; created as part of rollout if missing.
