### PR TITLE
fix(ci): preflight Claude workflow credentials and surface real provider errors

### DIFF
--- a/.github/workflows/claude-ci-autoheal.yml
+++ b/.github/workflows/claude-ci-autoheal.yml
@@ -57,6 +57,34 @@ jobs:
       issues: write
       id-token: write
     steps:
+      # Validated live 2026-07-31: both credentials were dead (ANTHROPIC_API_KEY
+      # rejected instantly, GH_PAT from 2024 expired) and every failure was
+      # near-silent. This preflight makes a broken credential the FIRST, loudest
+      # failure, with the provider's own error text — never the key — in the log.
+      - name: Preflight credentials
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          HEAL_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          fail=0
+          status=$(curl -sS -o /tmp/anthropic.json -w "%{http_code}" https://api.anthropic.com/v1/messages \
+            -H "x-api-key: ${ANTHROPIC_API_KEY}" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+            -d '{"model":"claude-opus-4-7","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}')
+          if [ "$status" != "200" ]; then
+            echo "::error::ANTHROPIC_API_KEY preflight failed (HTTP $status): $(cat /tmp/anthropic.json)"
+            fail=1
+          else
+            echo "ANTHROPIC_API_KEY ok (model reachable)"
+          fi
+          status=$(curl -sS -o /tmp/gh.json -w "%{http_code}" -H "Authorization: Bearer ${HEAL_PAT}" https://api.github.com/user)
+          if [ "$status" != "200" ]; then
+            echo "::error::GH_PAT preflight failed (HTTP $status) — heal branches cannot be pushed and heal PRs would not trigger CI. Rotate the GH_PAT repository secret."
+            fail=1
+          else
+            echo "GH_PAT ok (authenticated as $(jq -r .login /tmp/gh.json))"
+          fi
+          exit "$fail"
+
       - name: Check out develop
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,8 +83,28 @@ jobs:
           fi
           node packages/scripts/pr-deep-review-context.mjs
 
-      - name: Deep review
+      # The review is advisory, so a dead credential must not redden the check —
+      # but it must be LOUD in the log. Validated live 2026-07-31: the previous
+      # key failed every call in ~400ms and the only visible symptom was a
+      # cryptic is_error:true.
+      - name: Preflight Anthropic credential
+        id: preflight
         if: steps.classify.outputs.run_review == 'true' && steps.dossier.outputs.dossier_path != ''
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          status=$(curl -sS -o /tmp/anthropic.json -w "%{http_code}" https://api.anthropic.com/v1/messages \
+            -H "x-api-key: ${ANTHROPIC_API_KEY}" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+            -d '{"model":"claude-opus-4-7","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}')
+          if [ "$status" != "200" ]; then
+            echo "::warning::deep review skipped — ANTHROPIC_API_KEY preflight failed (HTTP $status): $(cat /tmp/anthropic.json)"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deep review
+        if: steps.preflight.outputs.ok == 'true'
         # Advisory: an unreachable model must not redden the pull request.
         continue-on-error: true
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,22 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Diagnostic only (never fails the job): when the credential is broken,
+      # the action's own failure is a cryptic is_error:true, so print the
+      # provider's actual error here. Never prints the key.
+      - name: Preflight Anthropic credential
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          status=$(curl -sS -o /tmp/anthropic.json -w "%{http_code}" https://api.anthropic.com/v1/messages \
+            -H "x-api-key: ${ANTHROPIC_API_KEY}" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+            -d '{"model":"claude-opus-4-7","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}')
+          if [ "$status" != "200" ]; then
+            echo "::warning::ANTHROPIC_API_KEY preflight failed (HTTP $status): $(cat /tmp/anthropic.json)"
+          else
+            echo "ANTHROPIC_API_KEY ok"
+          fi
+
       - name: Run Claude Code
         id: claude
         # Don't fail the workflow when the Anthropic API is unavailable

--- a/packages/scripts/__tests__/claude-autoheal-workflow-contract.test.ts
+++ b/packages/scripts/__tests__/claude-autoheal-workflow-contract.test.ts
@@ -152,3 +152,37 @@ describe("deep review workflow", () => {
     expect(review).toContain("continue-on-error: true");
   });
 });
+
+describe("credential preflights", () => {
+  // Both repository secrets were found dead on 2026-07-31 with near-silent
+  // symptoms; the preflights make a broken credential the loudest failure.
+  test("every agent workflow probes the Anthropic API before running Claude", () => {
+    for (const [name, body] of [
+      ["claude-ci-autoheal", autoheal],
+      ["claude-code-review", review],
+      ["claude", mention],
+    ] as const) {
+      expect(body, `${name} must preflight the Anthropic credential`).toContain(
+        "https://api.anthropic.com/v1/messages",
+      );
+      expect(body, `${name} preflight must never echo the key`).not.toMatch(
+        /echo[^\n]*\$\{?ANTHROPIC_API_KEY/,
+      );
+    }
+  });
+
+  test("autoheal also validates GH_PAT and fails hard on either credential", () => {
+    expect(autoheal).toContain("https://api.github.com/user");
+    expect(autoheal).toContain('exit "$fail"');
+    // Preflight must precede checkout: an expired PAT fails checkout with a
+    // useless "could not read Username" otherwise (observed live).
+    expect(autoheal.indexOf("Preflight credentials")).toBeLessThan(
+      autoheal.indexOf("Check out develop"),
+    );
+  });
+
+  test("review skips the agent, stays green, and warns when the credential is dead", () => {
+    expect(review).toContain("steps.preflight.outputs.ok == 'true'");
+    expect(review).toContain("::warning::deep review skipped");
+  });
+});


### PR DESCRIPTION
# Relates to

Follow-up to #17390 (Claude CI auto-heal + deep PR review). Post-merge live validation found **both repository secrets the agent workflows depend on are dead**, with near-silent symptoms. This PR makes a broken credential the first and loudest failure, carrying the provider's own error text.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is built directly on the latest `origin/develop` with zero conflicts.
- [x] Verification below (tests + actionlint + biome).
- [x] A reviewer can confirm the change works from the live-run evidence below.

# Sync with develop

- [x] Commit parented on current `origin/develop`; zero conflicts.
- [x] 17/17 contract tests pass; actionlint + biome clean.

# Risks

Low. Adds diagnostic curl steps; no behavior change when credentials are healthy. The preflight bodies print the provider error JSON only — the key is never echoed (contract-tested).

# Background

## What does this PR do?

Live validation after #17390 merged (all runs linked below):

- `ANTHROPIC_API_KEY` is rejected by the Anthropic API on every call: Claude exits in ~400–500ms, `total_cost_usd: 0`, and the only visible trace is `is_error: true` with no message ([review run](https://github.com/elizaOS/eliza/actions/runs/30611656801), [@claude mention run](https://github.com/elizaOS/eliza/actions/runs/30611778341), which posted "Claude encountered an error after 0s").
- `GH_PAT` (last set 2024-11-21) is expired: autoheal's checkout dies with `fatal: could not read Username` ([autoheal run](https://github.com/elizaOS/eliza/actions/runs/30611698138)).

Changes:

1. **claude-ci-autoheal.yml** — a `Preflight credentials` step BEFORE checkout probes both the Anthropic Messages API (1-token ping against the workflow's own model) and `api.github.com/user` with GH_PAT, printing HTTP status + provider error and failing hard on either. Healing cannot work without both; failing loud and early is correct here.
2. **claude-code-review.yml** — same Anthropic probe, but advisory: on failure it emits a `::warning::deep review skipped — …` with the real error and skips the agent step, keeping `claude-review` green (it must never block merges).
3. **claude.yml** — diagnostic-only probe so an `@claude` mention failure now shows the provider's actual rejection in the log instead of a bare `is_error:true`.
4. **Contract tests** — pin all three preflights, the never-echo-the-key property, and preflight-before-checkout ordering.

## What kind of change is this?

Bug fix / diagnosability for CI automation. No runtime or UI changes.

# Documentation changes needed?

No — inline workflow comments carry the rationale.

# Testing

## Where should a reviewer start?

`packages/scripts/__tests__/claude-autoheal-workflow-contract.test.ts` ("credential preflights" describe block), then the three workflow diffs.

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/claude-autoheal-workflow-contract.test.ts
# 17 pass, 0 fail
actionlint .github/workflows/claude-ci-autoheal.yml .github/workflows/claude-code-review.yml .github/workflows/claude.yml
# clean
```

Post-merge, the preflight output on the next dispatched run is the live proof (the current key is expected to fail preflight until the secret is rotated, and the run log will state the exact provider error).

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CI workflow + test change only; nothing renders.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CI workflow + test change only; nothing renders.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing flow; observable behavior is workflow logs, linked below.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the live failing runs that motivated this fix — https://github.com/elizaOS/eliza/actions/runs/30611656801 (review, is_error:true in 498ms), https://github.com/elizaOS/eliza/actions/runs/30611698138 (autoheal, PAT checkout failure), https://github.com/elizaOS/eliza/actions/runs/30611778341 (@claude, error after 0s).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code path.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no live-model call can succeed until the ANTHROPIC_API_KEY secret is rotated; that impossibility is precisely what this PR makes diagnosable. The failing-call runs above are the real API interaction records.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the @claude error comment produced during validation — https://github.com/elizaOS/eliza/pull/17390#issuecomment-5140287375 — and the run logs linked in the backend-logs row.

# Evidence Details

## Real LLM-call trajectory

N/A - see evidence row.

## Backend + frontend logs

<details>
<summary>Live failure signatures this PR replaces with real diagnostics</summary>

```
# claude-code-review run 30611656801 (Deep review step)
{"type":"result","subtype":"success","is_error":true,"duration_ms":498,"num_turns":1,"total_cost_usd":0}
##[error]Claude result reported subtype success with is_error:true

# claude-ci-autoheal run 30611698138 (Check out develop step, GH_PAT)
##[error]fatal: could not read Username for 'https://github.com': terminal prompts disabled

# claude.yml run 30611778341 → PR comment:
"Claude encountered an error after 0s"
```
</details>

## Screenshots (before / after) + video walkthrough

N/A - CI-only change.

### Before

N/A - see above.

### After

N/A - see above.

### Walkthrough video

N/A - see above.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

- The agent pipelines remain non-functional until two credentials are fixed. CONFIRMED LIVE by this PR's own preflight run (https://github.com/elizaOS/eliza/actions/runs/30612018297): `ANTHROPIC_API_KEY` is a valid key on an account with **no API credits** — `HTTP 400 "Your credit balance is too low to access the Anthropic API"` — so the fix is purchasing credits (or pointing the secret at a funded account). `GH_PAT` (2024) is separately expired and needs rotation with `repo` + `workflow` scopes so heal PRs trigger CI. After both, the preflights turn green with zero further changes.

