### PR TITLE
fix(ci): declare example-code's typecheck dependency on its builds

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -305,6 +305,10 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
+    "@elizaos/example-code#typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "@elizaos/plugin-tailscale#typecheck": {
       "dependsOn": ["@elizaos/plugin-tunnel#build"],
       "outputs": []


### PR DESCRIPTION
## What

`typecheck` fails intermittently on `develop` with an error that has nothing to do with the diff under test:

```
@elizaos/example-code:typecheck: src/lib/agent.ts(137,16): error TS7016:
  Could not find a declaration file for module '@elizaos/plugin-goals'.
  '.../plugins/plugin-goals/dist/index.js' implicitly has an 'any' type.
```

Observed on [#17380](https://github.com/elizaOS/eliza/pull/17380), whose diff touches only credit-exhaustion reply copy. The same head **passed** typecheck 24 minutes earlier and failed on the next run — same commit, opposite result.

## Root cause — a missing edge, surfacing as a race

`@elizaos/example-code` depends on `@elizaos/plugin-goals` (`package.json:44`), whose types resolve to `dist/index.d.ts`.

The global `typecheck` task's `dependsOn` (`turbo.json:266`) is a **fixed allowlist of nine packages** — core, shared, ui, app-core, plugin-agent-skills, plugin-app-manager, plugin-inbox, plugin-sql, plugin-task-coordinator — not `^build`. `plugin-goals` is not among them, so nothing orders its build ahead of `example-code`'s typecheck.

It still gets built, because plenty of other packages depend on it — just **concurrently**. And its build is three sequential steps:

```json
"build": "bun run build:js && bun run build:views && bun run build:types"
```

`build:types` is what emits the `.d.ts`. So there is a real window where `dist/index.js` exists and `dist/index.d.ts` does not. A typecheck landing in that window resolves the import to the bare `.js` and raises TS7016.

That matches the failure exactly: CI reported `dist/index.js` **present** but untyped — not a missing build, a *half-finished* one. It also explains why this never reproduces locally: a full `bun run build` completes plugin-goals before anything typechecks.

## Fix

Declare the dependency:

```json
"@elizaos/example-code#typecheck": {
  "dependsOn": ["^build"],
  "outputs": []
}
```

Same remedy already applied to `app-core`, `app`, `cloud-api`, `cloud-shared`, `plugin-discord`, `plugin-contacts`, and others — this package was simply missed.

## Verification

Reproducing the *race* deterministically isn't practical, so I verified the causal chain instead: that the edge was absent, that it is now present, and that the lane succeeds from a cold `dist`.

<details><summary>dependency edge, before and after</summary><pre>
BEFORE — @elizaos/example-code#typecheck had no plugin-goals dependency;
         the global typecheck allowlist (turbo.json:266) omits it.

AFTER  — $ node packages/scripts/run-turbo.mjs run typecheck \
             --filter=@elizaos/example-code --dry=text
  @elizaos/example-code#typecheck
    Dependencies = @elizaos/core#build, @elizaos/plugin-agent-orchestrator#build,
                   @elizaos/plugin-anthropic#build, @elizaos/plugin-coding-tools#build,
                   @elizaos/plugin-goals#build, @elizaos/plugin-mcp#build,
                   @elizaos/plugin-openai#build, @elizaos/plugin-shell#build,
                   @elizaos/plugin-sql#build
</pre></details>

<details><summary>cold-dist run: build is ordered first and the lane passes</summary><pre>
$ rm -rf plugins/plugin-goals/dist
$ node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/example-code

@elizaos/plugin-goals:build: [rewrite-dist-relative-imports] rewrote 8 file(s)
@elizaos/example-code:typecheck: cache miss, executing 3970373dec068fd0
@elizaos/example-code:typecheck: $ tsc --noEmit

 Tasks:    65 successful, 65 total
 Time:     4m29.497s

$ ls plugins/plugin-goals/dist/index.d.ts
plugins/plugin-goals/dist/index.d.ts
</pre></details>

Note the ordering in that transcript: `plugin-goals:build` completes **before** `example-code:typecheck` starts. That edge is the whole fix.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - build-graph configuration only; `turbo.json` has no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - build-graph configuration only; `turbo.json` has no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the observable behavior is task scheduling order, shown in the transcripts above.
<!-- evidence-row:backend-logs -->
- [x] Turbo scheduling output from a cold `dist`, showing the build ordered ahead of the typecheck.
  <details><summary>turbo run typecheck --filter=@elizaos/example-code</summary><pre>
  $ rm -rf plugins/plugin-goals/dist
  $ node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/example-code
  @elizaos/plugin-goals:build: [rewrite-dist-relative-imports] rewrote 8 file(s)
  @elizaos/example-code:typecheck: cache miss, executing 3970373dec068fd0
  @elizaos/example-code:typecheck: $ tsc --noEmit
   Tasks:    65 successful, 65 total
   Time:     4m29.497s
  </pre></details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser surface; this is a monorepo task-graph declaration consumed by turbo.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior is touched.
<!-- evidence-row:domain-artifacts -->
- [x] The artifact is the resolved task graph and the emitted declaration file.
  <details><summary>edge + emitted .d.ts</summary><pre>
  $ ... --dry=text | grep plugin-goals
  Dependencies = ..., @elizaos/plugin-goals#build, ...
  $ ls plugins/plugin-goals/dist/index.d.ts
  plugins/plugin-goals/dist/index.d.ts     # emitted by build:types before typecheck ran
  </pre></details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
