### PR TITLE
fix(scenario-runner): settle required plugin services before turns

### DIFF
--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -2423,19 +2423,18 @@ export async function runScenario(
       try {
         const candidate = await loadScenarioRequiredPlugin(pkg, "simulated");
         if (candidate) {
-          // `requires` names a plugin, so registration is the bar — not the
-          // startup of every service the plugin happens to ship. A plugin
-          // bundles services a given scenario never touches, and on the
-          // keyless pr-deterministic lane the credentialed ones legitimately
-          // refuse to start (BirdeyeService without BIRDEYE_API_KEY, say)
-          // while the scenario drives a different, mocked backend entirely.
-          // Gating on those would make every keyless wallet/analytics
-          // scenario unrunnable. Service-start failures still surface on
-          // their own: the runtime logs them via `AgentRuntime.serviceStart`
-          // and routes them through `reportError`, and a scenario that truly
-          // needs the service fails on its own assertions with a specific
-          // cause rather than a blanket plugin-init error.
           await runtime.registerPlugin(candidate);
+          // Required-plugin registration waits for every service attempt to
+          // settle so the first scenario turn cannot race a usable service.
+          // A plugin may also bundle credential-gated services the scenario
+          // never touches; their failures are already observable through
+          // AgentRuntime.serviceStart/reportError and do not invalidate the
+          // successfully registered actions or sibling services.
+          await Promise.allSettled(
+            (candidate.services ?? []).map((service) =>
+              runtime.getServiceLoadPromise(service.serviceType),
+            ),
+          );
           autoLoaded.add(pkg);
         }
       } catch (err) {


### PR DESCRIPTION
Closes #17405. Follow-up to #17389.

## Problem

#17389 correctly stopped treating one unavailable credential-gated sibling service as fatal to an entire required plugin, but it removed service settlement entirely. `AgentRuntime.registerPlugin()` starts services asynchronously and returns before they are ready, so the first scenario turn can race a service it actually needs.

## Fix

Wait for every declared service start attempt with `Promise.allSettled`:

- successful services are ready before the first turn;
- an unrelated credential-gated service does not invalidate the registered plugin;
- failures remain observable through `AgentRuntime.serviceStart` and `runtime.reportError`;
- a scenario that uses a failed service still fails on its own specific assertion/path.

This preserves the real improvement from #17389 without replacing the all-or-nothing failure with a startup race.

## Verification

Exact full PR scenario gate on the corrected implementation:

| lane | result |
| --- | --- |
| deterministic | **40/40** |
| corpus | **34/34** (including `wallet.token-info`) |
| orchestrator | **13/13** |
| LifeOps | **31/31** |

Also passed:

- `bun run --cwd packages/scenario-runner typecheck`
- `bunx biome check packages/scenario-runner/src/executor.ts`
- `git diff --check`

<!-- evidence-row:before-screenshots -->
N/A - scenario harness behavior only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
N/A - scenario harness behavior only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
N/A - no rendered UI changed; the complete four-lane scenario execution is the behavioral proof.

<!-- evidence-row:backend-logs -->
[Develop's original failing Zero-Key scenario run](https://github.com/elizaOS/eliza/actions/runs/30604754035) shows the unavailable Birdeye sibling killing `wallet.token-info`; the updated head's Develop PR Gate is the merge-gating execution log.

<!-- evidence-row:domain-artifacts -->
N/A - this harness-only change produces scenario reports rather than a product-domain artifact; the verified reports were 40/40, 34/34, 13/13, and 31/31.

<!-- evidence-row:frontend-logs -->
N/A - no frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
N/A - no model, prompt, action, or provider behavior changed; these are keyless deterministic-proxy lanes by design.
