### PR TITLE
fix(lifeops): deactivate activity routes on plugin unload

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signal-lifecycle.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signal-lifecycle.ts
@@ -1,0 +1,34 @@
+/**
+ * Owns the personal-assistant runtime state that makes activity-signal
+ * ingestion available. The activation marker is separate from the source
+ * registry so route availability follows plugin lifecycle, not retained
+ * registry data.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import {
+  createSignalSourceRegistry,
+  registerSignalSourceRegistry,
+  unregisterSignalSourceRegistry,
+} from "./registries/signal-source-registry.js";
+import { registerBuiltinSignalSources } from "./telemetry-mapping.js";
+
+const activeRuntimes = new WeakSet<IAgentRuntime>();
+
+export function activateLifeOpsActivitySignals(runtime: IAgentRuntime): void {
+  const registry = createSignalSourceRegistry();
+  registerBuiltinSignalSources(registry);
+  registerSignalSourceRegistry(runtime, registry);
+  activeRuntimes.add(runtime);
+}
+
+export function deactivateLifeOpsActivitySignals(runtime: IAgentRuntime): void {
+  activeRuntimes.delete(runtime);
+  unregisterSignalSourceRegistry(runtime);
+}
+
+export function areLifeOpsActivitySignalsActive(
+  runtime: IAgentRuntime,
+): boolean {
+  return activeRuntimes.has(runtime);
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/registries/signal-source-registry.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/registries/signal-source-registry.ts
@@ -118,8 +118,12 @@ export function getSignalSourceRegistry(
   return registries.get(runtime) ?? null;
 }
 
+export function unregisterSignalSourceRegistry(runtime: IAgentRuntime): void {
+  registries.delete(runtime);
+}
+
 export function __resetSignalSourceRegistryForTests(
   runtime: IAgentRuntime,
 ): void {
-  registries.delete(runtime);
+  unregisterSignalSourceRegistry(runtime);
 }

--- a/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
@@ -31,7 +31,7 @@ vi.mock("@elizaos/plugin-health", async (importOriginal) => ({
   createDefaultCircadianInsightContract: vi.fn(() => ({})),
 }));
 
-import { getSignalSourceRegistry } from "./lifeops/registries/signal-source-registry.js";
+import { areLifeOpsActivitySignalsActive } from "./lifeops/activity-signal-lifecycle.js";
 import { personalAssistantPlugin } from "./plugin.js";
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000ab" as UUID;
@@ -74,6 +74,11 @@ function createRecordingRuntime(): RecordingRuntime {
     getService: () => null,
     getRoom: async () => null,
     getMemories: async () => [],
+    getTasks: async () => [],
+    deleteTask: async () => undefined,
+    unregisterTaskWorker: (name: string) => {
+      taskWorkers.delete(name);
+    },
   };
   const noopCache = new Map<string, unknown>();
   const runtime = new Proxy(explicit, {
@@ -117,16 +122,16 @@ describe("personalAssistantPlugin.init scheduler identity", () => {
     await expect(worker?.shouldRun?.(runtime)).resolves.toBe(false);
   });
 
-  it("registers the activity-signal source vocabulary during full plugin initialization", async () => {
+  it("activates activity-signal routes during init and clears them during dispose", async () => {
     process.env.ELIZA_DISABLE_LIFEOPS_SCHEDULER = "1";
     const { runtime } = createRecordingRuntime();
 
+    expect(areLifeOpsActivitySignalsActive(runtime)).toBe(false);
     await personalAssistantPlugin.init?.({}, runtime);
+    expect(areLifeOpsActivitySignalsActive(runtime)).toBe(true);
 
-    const registry = getSignalSourceRegistry(runtime);
-    expect(registry).not.toBeNull();
-    expect(registry?.has("app_lifecycle")).toBe(true);
-    expect(registry?.has("page_visibility")).toBe(true);
+    await personalAssistantPlugin.dispose?.(runtime);
+    expect(areLifeOpsActivitySignalsActive(runtime)).toBe(false);
   });
 
   it("registers a LifeOps worker whose shouldRun is gated by app state when enabled", async () => {

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -110,6 +110,10 @@ import {
   ownerPrivateAction,
   ownerPrivateProvider,
 } from "./lifeops/access.js";
+import {
+  activateLifeOpsActivitySignals,
+  deactivateLifeOpsActivitySignals,
+} from "./lifeops/activity-signal-lifecycle.js";
 import { anticipationFeedbackEvaluator } from "./lifeops/anticipation/evaluator.js";
 import { createApprovalQueue } from "./lifeops/approval-queue.js";
 import { createTrackedWorkRecapDirectRoutingRule } from "./lifeops/briefing/direct-routing.js";
@@ -182,7 +186,6 @@ import {
   createAnchorRegistry,
   createEventKindRegistry,
   createFamilyRegistry,
-  createSignalSourceRegistry,
   createWorkflowStepRegistry,
   registerAnchorRegistry,
   registerAppLifeOpsAnchors,
@@ -194,7 +197,6 @@ import {
   registerDefaultWorkflowStepPack,
   registerEventKindRegistry,
   registerFamilyRegistry,
-  registerSignalSourceRegistry,
   registerWorkflowStepRegistry,
 } from "./lifeops/registries/index.js";
 import { LifeOpsRepository } from "./lifeops/repository.js";
@@ -239,7 +241,6 @@ import {
   createActivitySignalBus,
   registerActivitySignalBus,
 } from "./lifeops/signals/bus.js";
-import { registerBuiltinSignalSources } from "./lifeops/telemetry-mapping.js";
 import { threadOpsFieldEvaluator } from "./lifeops/work-threads/field-evaluator-thread-ops.js";
 import { isDarwin } from "./platform/host.js";
 import { browserBridgeProvider } from "./provider.js";
@@ -1032,12 +1033,7 @@ const rawPersonalAssistantPlugin: Plugin = {
       runtime as IAgentRuntime & { busFamilyRegistry?: typeof familyRegistry }
     ).busFamilyRegistry = familyRegistry;
 
-    // Passive activity-signal source registry — the single extension point a
-    // plugin registers a new source through (ingestion allow-list + telemetry
-    // mapper + reliability), instead of the old three-package coordinated edit.
-    const signalSourceRegistry = createSignalSourceRegistry();
-    registerBuiltinSignalSources(signalSourceRegistry);
-    registerSignalSourceRegistry(runtime, signalSourceRegistry);
+    activateLifeOpsActivitySignals(runtime);
 
     const workflowStepRegistry = createWorkflowStepRegistry();
     registerDefaultWorkflowStepPack(workflowStepRegistry);
@@ -1239,6 +1235,7 @@ const rawPersonalAssistantPlugin: Plugin = {
    * to touch those here.
    */
   dispose: async (runtime: IAgentRuntime) => {
+    deactivateLifeOpsActivitySignals(runtime);
     setRuntimeChannelInspector(runtime, null);
     unregisterMessageDraftScheduledTaskBridge(runtime);
 

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-activity-signals.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-activity-signals.test.ts
@@ -10,18 +10,22 @@
  */
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "node:net";
-import { AgentRuntime, type Character, type UUID } from "@elizaos/core";
+import {
+  AgentRuntime,
+  type Character,
+  type Plugin,
+  type UUID,
+} from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PgliteDatabaseAdapter } from "../../../plugin-sql/src/pglite/adapter.js";
 import { PGliteClientManager } from "../../../plugin-sql/src/pglite/manager.js";
 import {
-  __resetSignalSourceRegistryForTests,
-  createSignalSourceRegistry,
-  registerSignalSourceRegistry,
-} from "../lifeops/registries/signal-source-registry.js";
+  activateLifeOpsActivitySignals,
+  deactivateLifeOpsActivitySignals,
+} from "../lifeops/activity-signal-lifecycle.js";
+import { getSignalSourceRegistry } from "../lifeops/registries/signal-source-registry.js";
 import { LifeOpsRepository } from "../lifeops/repository.js";
-import { registerBuiltinSignalSources } from "../lifeops/telemetry-mapping.js";
 import {
   handleLifeOpsRoutes,
   type LifeOpsRouteContext,
@@ -119,12 +123,11 @@ describe("activity-signal ingestion e2e (real runtime + PGlite)", () => {
       character: { name: "lifeops-activity-e2e" } as Character,
       adapter,
     });
-    const registry = createSignalSourceRegistry();
-    registerBuiltinSignalSources(registry);
-    registerSignalSourceRegistry(runtime, registry);
+    activateLifeOpsActivitySignals(runtime);
   });
 
   afterEach(async () => {
+    deactivateLifeOpsActivitySignals(runtime);
     await adapter.close();
     await manager.close();
   });
@@ -236,11 +239,25 @@ describe("activity-signal ingestion e2e (real runtime + PGlite)", () => {
     expect(Number.isFinite(Date.parse(created.signal.observedAt))).toBe(true);
   });
 
-  it("fails closed without writes or runtime errors when the personal-assistant runtime is inactive", async () => {
+  it("disables routes on unload and restores them with a fresh registry on reload", async () => {
     await LifeOpsRepository.bootstrapSchema(runtime);
-    __resetSignalSourceRegistryForTests(runtime);
+    deactivateLifeOpsActivitySignals(runtime);
     const reportError = vi.spyOn(runtime, "reportError");
-    const post = buildCtx({
+    const lifecyclePlugin: Plugin = {
+      name: "lifeops-activity-signal-lifecycle-regression",
+      description: "Exercises the production activity-signal lifecycle hooks",
+      init: async (_config, pluginRuntime) => {
+        activateLifeOpsActivitySignals(pluginRuntime);
+      },
+      dispose: async (pluginRuntime) => {
+        deactivateLifeOpsActivitySignals(pluginRuntime);
+      },
+    };
+
+    await runtime.registerPlugin(lifecyclePlugin);
+    const registryBeforeUnload = getSignalSourceRegistry(runtime);
+    expect(registryBeforeUnload).not.toBeNull();
+    const activePost = buildCtx({
       method: "POST",
       pathname: "/api/lifeops/activity-signals",
       runtime,
@@ -248,41 +265,72 @@ describe("activity-signal ingestion e2e (real runtime + PGlite)", () => {
         source: "page_visibility",
         platform: "web_app",
         state: "active",
-        metadata: { reason: "focus" },
+        metadata: { phase: "before-unload" },
       },
     });
-    const readJsonBody = vi.spyOn(post.ctx, "readJsonBody");
+    expect(await handleLifeOpsRoutes(activePost.ctx)).toBe(true);
+    expect(activePost.res.statusCode).toBe(201);
 
-    expect(await handleLifeOpsRoutes(post.ctx)).toBe(true);
-    expect(post.res.statusCode).toBe(503);
-    expect(JSON.parse(post.res.body ?? "{}")).toEqual({
+    await runtime.unloadPlugin(lifecyclePlugin.name);
+    expect(getSignalSourceRegistry(runtime)).toBeNull();
+    const inactivePost = buildCtx({
+      method: "POST",
+      pathname: "/api/lifeops/activity-signals",
+      runtime,
+      body: {
+        source: "page_visibility",
+        platform: "web_app",
+        state: "background",
+        metadata: { phase: "after-unload" },
+      },
+    });
+    const readInactiveBody = vi.spyOn(inactivePost.ctx, "readJsonBody");
+    expect(await handleLifeOpsRoutes(inactivePost.ctx)).toBe(true);
+    expect(inactivePost.res.statusCode).toBe(503);
+    expect(JSON.parse(inactivePost.res.body ?? "{}")).toEqual({
       error:
         "LifeOps activity signals are unavailable because the personal-assistant runtime is not active",
     });
-    expect(readJsonBody).not.toHaveBeenCalled();
-
-    const primaryRows = await adapter
-      .getDatabase()
-      .execute(sql.raw("SELECT id FROM app_lifeops.life_activity_signals"));
-    const telemetryRows = await adapter
-      .getDatabase()
-      .execute(sql.raw("SELECT id FROM app_lifeops.life_telemetry_events"));
-    expect(primaryRows.rows).toEqual([]);
-    expect(telemetryRows.rows).toEqual([]);
-    expect(reportError).not.toHaveBeenCalled();
-    expect(runtime.getRecentReportedErrors()).toEqual([]);
-
-    const get = buildCtx({
+    expect(readInactiveBody).not.toHaveBeenCalled();
+    const inactiveGet = buildCtx({
       method: "GET",
       pathname: "/api/lifeops/activity-signals",
       runtime,
     });
-    expect(await handleLifeOpsRoutes(get.ctx)).toBe(true);
-    expect(get.res.statusCode).toBe(503);
-    expect(JSON.parse(get.res.body ?? "{}")).toEqual({
-      error:
-        "LifeOps activity signals are unavailable because the personal-assistant runtime is not active",
+    expect(await handleLifeOpsRoutes(inactiveGet.ctx)).toBe(true);
+    expect(inactiveGet.res.statusCode).toBe(503);
+
+    await runtime.reloadPlugin(lifecyclePlugin);
+    const registryAfterReload = getSignalSourceRegistry(runtime);
+    expect(registryAfterReload).not.toBeNull();
+    expect(registryAfterReload).not.toBe(registryBeforeUnload);
+    const reloadedPost = buildCtx({
+      method: "POST",
+      pathname: "/api/lifeops/activity-signals",
+      runtime,
+      body: {
+        source: "app_lifecycle",
+        platform: "desktop_app",
+        state: "active",
+        metadata: { phase: "after-reload" },
+      },
     });
+    expect(await handleLifeOpsRoutes(reloadedPost.ctx)).toBe(true);
+    expect(reloadedPost.res.statusCode).toBe(201);
+
+    const primaryRows = await adapter
+      .getDatabase()
+      .execute(
+        sql.raw(
+          "SELECT source FROM app_lifeops.life_activity_signals ORDER BY created_at",
+        ),
+      );
+    expect(primaryRows.rows).toEqual([
+      { source: "page_visibility" },
+      { source: "app_lifecycle" },
+    ]);
+    expect(reportError).not.toHaveBeenCalled();
+    expect(runtime.getRecentReportedErrors()).toEqual([]);
   });
 
   it("rejects an unknown source with 400 and persists nothing", async () => {

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
@@ -96,12 +96,12 @@ import {
   type LifeOpsGmailSpamReviewStatus,
   type VerifyLifeOpsTelegramConnectorRequest,
 } from "../contracts/index.js";
+import { areLifeOpsActivitySignalsActive } from "../lifeops/activity-signal-lifecycle.js";
 import {
   loadLifeOpsAppState,
   saveLifeOpsAppState,
 } from "../lifeops/app-state.js";
 import { probeFullDiskAccess } from "../lifeops/fda-probe.js";
-import { getSignalSourceRegistry } from "../lifeops/registries/signal-source-registry.js";
 import { LifeOpsRepository } from "../lifeops/repository.js";
 import { LifeOpsService, LifeOpsServiceError } from "../lifeops/service.js";
 
@@ -151,7 +151,7 @@ function requireActivitySignalsAvailable(ctx: LifeOpsRouteContext): boolean {
     return false;
   }
   const runtime = ctx.state.runtime;
-  if (!runtime || getSignalSourceRegistry(runtime) === null) {
+  if (!runtime || !areLifeOpsActivitySignalsActive(runtime)) {
     ctx.error(
       ctx.res,
       "LifeOps activity signals are unavailable because the personal-assistant runtime is not active",


### PR DESCRIPTION
# Relates to

Closes #17404. Fix-forward for the lifecycle residual in #17383.

# Sync with develop

- [x] Parent is contained `origin/develop` at `030b90a5a4af`; zero conflicts.
- [x] The six-file diff is isolated from unrelated local work.

# What changed

Activity-signal availability now has explicit per-runtime lifecycle state. Plugin disposal clears both activation and the signal-source registry; GET/POST routes fail with a designed 503 while inactive; reload creates a fresh registry.

The regression uses a real `AgentRuntime` with PGlite to register, unload, reject post-unload access without writes, reload, and persist through the new registration.

# Testing

- Focused lifecycle suite: 9 passed.
- `bun run --cwd plugins/plugin-personal-assistant typecheck`: passed.
- Focused Biome check: passed.
- `git diff --check`: passed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend lifecycle fix with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend lifecycle fix with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing visual workflow.
<!-- evidence-row:backend-logs -->
- [x] [17410#issuecomment-5140604424](https://github.com/elizaOS/eliza/pull/17410#issuecomment-5140604424)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [17410#issuecomment-5140604424](https://github.com/elizaOS/eliza/pull/17410#issuecomment-5140604424)

# Known gaps / failures

None. Exact-head CI must pass before merge.
