### PR TITLE
fix(ci): fail fast on Hetzner project quota

### DIFF
--- a/.github/workflows/hetzner-sleep-wake-smoke.yml
+++ b/.github/workflows/hetzner-sleep-wake-smoke.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Write + back up agent state from A
         if: steps.provision_a.outputs.provisioned == 'true'
         run: |
-          IP_A=$(jq -r .ip "$HETZNER_E2E_STATE_FILE"); ID_A=$(jq -r .id "$HETZNER_E2E_STATE_FILE")
+          IP_A=$(jq -r .ip "$HETZNER_E2E_STATE_FILE"); ID_A=$(jq -er .server_id "$HETZNER_E2E_STATE_FILE")
           echo "box A: id=$ID_A ip=$IP_A"
           echo "$ID_A" > /tmp/box-a-id
           # Simulate agent state (mirrors AgentBackupStateData shape).
@@ -257,7 +257,7 @@ jobs:
       - name: Restore backup onto B + verify state survived
         if: steps.provision_a.outputs.provisioned == 'true'
         run: |
-          IP_B=$(jq -r .ip "$HETZNER_E2E_STATE_FILE"); ID_B=$(jq -r .id "$HETZNER_E2E_STATE_FILE")
+          IP_B=$(jq -r .ip "$HETZNER_E2E_STATE_FILE"); ID_B=$(jq -er .server_id "$HETZNER_E2E_STATE_FILE")
           ID_A=$(cat /tmp/box-a-id)
           echo "box B: id=$ID_B ip=$IP_B (was A id=$ID_A)"
           [ "$ID_B" != "$ID_A" ] || { echo "::error::wake did not create a NEW box"; exit 1; }

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.test.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Provisioning cleanup, quota, and diagnostics contracts exercised through
+ * the real Hetzner client with only its HTTP boundary replaced.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runHetznerE2eProvision } from "./hetzner-e2e-provision";
+
+type RecordedRequest = {
+  method: string;
+  url: string;
+  body: unknown;
+};
+
+let originalFetch: typeof globalThis.fetch;
+let originalConsoleError: typeof console.error;
+let responseQueue: Response[];
+let requests: RecordedRequest[];
+let errorLogs: string[];
+let originalEnv: Record<string, string | undefined>;
+const stateFile = join(
+  tmpdir(),
+  `hetzner-e2e-provision-http-${process.pid}.json`,
+);
+const testEnv = {
+  HCLOUD_TOKEN_CI: "valid-ci-token",
+  CI_SSH_PUBLIC_KEY_ID: "123",
+  GITHUB_RUN_ID: "test-run",
+  HETZNER_E2E_LOCATION: "nbg1",
+  HETZNER_E2E_SERVER_TYPE: "cpx22",
+  HETZNER_E2E_STATE_FILE: stateFile,
+} as const;
+
+function setEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+function server(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id: 42,
+    name: "ci-hetzner-e2e-server",
+    status: "running",
+    created: "2000-01-01T00:00:00.000Z",
+    public_net: {
+      ipv4: { ip: "203.0.113.10", blocked: false },
+      ipv6: null,
+    },
+    server_type: { id: 1, name: "cpx22" },
+    datacenter: {
+      id: 1,
+      name: "nbg1-dc3",
+      location: { id: 1, name: "nbg1", city: "Nuremberg", country: "DE" },
+    },
+    labels: { ci: "true", workflow: "hetzner-e2e" },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  originalConsoleError = console.error;
+  responseQueue = [];
+  requests = [];
+  errorLogs = [];
+  originalEnv = Object.fromEntries(
+    Object.keys(testEnv).map((name) => [name, process.env[name]]),
+  );
+  for (const [name, value] of Object.entries(testEnv)) {
+    setEnv(name, value);
+  }
+
+  globalThis.fetch = mock(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        method: init?.method ?? "GET",
+        url: String(input),
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      const response = responseQueue.shift();
+      if (!response) {
+        throw new Error("No Hetzner response queued");
+      }
+      return response;
+    },
+  ) as unknown as typeof globalThis.fetch;
+  console.error = mock((...args: unknown[]) => {
+    errorLogs.push(args.map(String).join(" "));
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.error = originalConsoleError;
+  for (const [name, value] of Object.entries(originalEnv)) {
+    setEnv(name, value);
+  }
+  if (existsSync(stateFile)) {
+    rmSync(stateFile);
+  }
+});
+
+describe("Hetzner E2E provision HTTP boundary", () => {
+  test("reaps only stale servers returned by the CI label selector", async () => {
+    responseQueue.push(
+      Response.json({
+        servers: [
+          server(),
+          server({
+            id: 43,
+            name: "recent",
+            created: new Date().toISOString(),
+          }),
+        ],
+      }),
+      new Response(null, { status: 204 }),
+      Response.json({
+        server: server({ id: 99, created: new Date().toISOString() }),
+        root_password: null,
+      }),
+    );
+
+    await expect(runHetznerE2eProvision()).resolves.toMatchObject({ id: 99 });
+    const persistedState = JSON.parse(readFileSync(stateFile, "utf8"));
+    expect(persistedState).toMatchObject({
+      server_id: 99,
+    });
+    expect(persistedState).not.toHaveProperty("id");
+
+    expect(requests[0]).toMatchObject({
+      method: "GET",
+      url: "https://api.hetzner.cloud/v1/servers?label_selector=ci=true,workflow=hetzner-e2e",
+    });
+    expect(requests.filter((request) => request.method === "DELETE")).toEqual([
+      {
+        method: "DELETE",
+        url: "https://api.hetzner.cloud/v1/servers/42",
+        body: undefined,
+      },
+    ]);
+  });
+
+  test("fails before create when the labeled inventory cannot be read", async () => {
+    responseQueue.push(
+      Response.json(
+        { error: { code: "server_error", message: "inventory unavailable" } },
+        { status: 500 },
+      ),
+    );
+
+    await expect(runHetznerE2eProvision()).rejects.toMatchObject({
+      code: "server_error",
+      status: 500,
+    });
+    expect(requests.map((request) => request.method)).toEqual(["GET"]);
+  });
+
+  test("fails before create when reaping a stale labeled server fails", async () => {
+    responseQueue.push(
+      Response.json({ servers: [server()] }),
+      Response.json(
+        { error: { code: "conflict", message: "server locked" } },
+        { status: 409 },
+      ),
+    );
+
+    await expect(runHetznerE2eProvision()).rejects.toMatchObject({
+      code: "server_error",
+      status: 409,
+    });
+    expect(requests.map((request) => request.method)).toEqual([
+      "GET",
+      "DELETE",
+    ]);
+  });
+
+  test("limit_reached stops location retries and logs only sanitized capacity", async () => {
+    responseQueue.push(
+      Response.json({ servers: [] }),
+      Response.json(
+        { error: { code: "limit_reached", message: "server limit reached" } },
+        { status: 403 },
+      ),
+      Response.json({
+        servers: [
+          server({
+            id: 700,
+            name: "private-production-name",
+            public_net: {
+              ipv4: { ip: "198.51.100.77", blocked: false },
+              ipv6: null,
+            },
+            labels: { owner: "secret-owner" },
+          }),
+          server({ id: 701 }),
+        ],
+      }),
+    );
+
+    await expect(runHetznerE2eProvision()).rejects.toMatchObject({
+      message: expect.stringContaining("project quota exhausted"),
+      name: "HetznerCloudError",
+      code: "quota_exceeded",
+      status: 403,
+      cause: { code: "quota_exceeded" },
+    });
+
+    const createRequests = requests.filter(
+      (request) =>
+        request.method === "POST" && request.url.endsWith("/servers"),
+    );
+    expect(createRequests).toHaveLength(1);
+    expect(createRequests[0]?.body).toMatchObject({
+      server_type: "cpx22",
+      location: "nbg1",
+    });
+    expect(requests.at(-1)).toMatchObject({
+      method: "GET",
+      url: "https://api.hetzner.cloud/v1/servers",
+    });
+
+    const capacityLog = errorLogs.find((line) =>
+      line.includes("project capacity inventory"),
+    );
+    expect(capacityLog).toContain('"totalServers":2');
+    expect(capacityLog).toContain('"hetznerE2eServers":1');
+    expect(capacityLog).not.toContain("private-production-name");
+    expect(capacityLog).not.toContain("198.51.100.77");
+    expect(capacityLog).not.toContain("secret-owner");
+    expect(capacityLog).not.toContain('"id":');
+  });
+});

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.ts
@@ -7,12 +7,13 @@
  *   CI_SSH_PUBLIC_KEY_ID       - Numeric Hetzner SSH key id (one-time uploaded)
  *   GITHUB_RUN_ID              - run id, embedded in labels
  *   HETZNER_E2E_LOCATION       - default fsn1
- *   HETZNER_E2E_SERVER_TYPE    - default cx22 (cpx11 was deprecated)
+ *   HETZNER_E2E_SERVER_TYPE    - default cpx22
  *   HETZNER_E2E_IMAGE          - default ubuntu-24.04
  *
- * On success: prints `{id, ip}` JSON to stdout AND writes the server id
- * into the state file IMMEDIATELY after the create-call returns, before
- * any further work — so a crash never leaks a server.
+ * On success the CLI prints `{id, ip}` JSON and writes the canonical
+ * `server_id` into the state file immediately after creation. Project-wide
+ * quota failures stop after one create attempt and report only aggregate
+ * capacity data so private server details never enter CI logs.
  */
 
 import {
@@ -24,8 +25,7 @@ import { appendStateAtomic } from "./state-file";
 function requireEnv(name: string): string {
   const value = process.env[name];
   if (!value) {
-    console.error(`[hetzner-e2e-provision] missing env: ${name}`);
-    process.exit(1);
+    throw new Error(`[hetzner-e2e-provision] missing env: ${name}`);
   }
   return value;
 }
@@ -50,22 +50,10 @@ const SERVER_TYPE_FALLBACKS: ReadonlyArray<{
   { serverType: "cpx11", location: "hil" }, // US-West fallback
 ];
 
-// Conditions under which we should try the next fallback combo. Covers
-// Hetzner's "this server type can't be created here" and "this server
-// type is going away" responses — both render the requested combo
-// unusable and a different shared-cpu type / location is the natural
-// remediation. We also treat project-wide quota exhaustion as retryable
-// because the pre-reap pass runs immediately before the loop: if it
-// freed any slots, the next attempt may now fit under the cap. The
-// fallback ladder is finite (~5 combos) so a genuinely exhausted project
-// will still surface as the last combo's error after the loop exits.
-// Pure auth / billing failures (HTTP 401, real 403 without limit code)
-// are NOT in this list — those are surfaced unchanged so the operator
-// fixes the underlying account issue.
+// Only placement-specific failures can improve by changing type or location.
+// Project quota, authentication, and billing failures apply to every combo and
+// must stop immediately so CI does not issue redundant create requests.
 function isRetryableCombo(err: unknown): boolean {
-  if (err instanceof HetznerCloudError && err.code === "quota_exceeded") {
-    return true;
-  }
   // "error during placement" (HTTP 412) is Hetzner's transient signal that the
   // requested type can't be placed in that location right now — a different
   // location usually succeeds, so keep walking the fallback ladder instead of
@@ -83,15 +71,12 @@ function isRetryableCombo(err: unknown): boolean {
     message.includes("is deprecated") ||
     message.includes("server_type_deprecated") ||
     message.includes("resource_unavailable") ||
-    message.includes("not_found") || // Hetzner returns 404 when a deprecated type is fully removed
-    // Hetzner returns HTTP 403 with body `{ error: { code: "limit_reached",
-    // message: "server limit reached" } }` when the project cap is hit.
-    // Match both the apiCode and the human message so we stay correct even
-    // if mapStatusToCode is bypassed (e.g. transport layer wraps the body).
-    message.includes("server limit reached") ||
-    message.includes("limit_reached") ||
-    message.includes("resource_limit_exceeded")
+    message.includes("not_found") // Hetzner returns 404 when a deprecated type is fully removed
   );
+}
+
+function isProjectQuotaError(err: unknown): err is HetznerCloudError {
+  return err instanceof HetznerCloudError && err.code === "quota_exceeded";
 }
 
 // Pre-provision reap: delete any prior CI servers older than this. Stops a
@@ -102,17 +87,11 @@ function isRetryableCombo(err: unknown): boolean {
 // this is the fast lane.
 const PRE_REAP_AGE_MS = 20 * 60 * 1000;
 
-async function preReapOldServers(
-  client: InstanceType<typeof HetznerCloudClient>,
-): Promise<void> {
-  const servers = await client
-    .listServers({ ci: "true", workflow: "hetzner-e2e" })
-    .catch((err: unknown) => {
-      console.warn(
-        `[hetzner-e2e-provision] pre-reap listServers failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return [] as Awaited<ReturnType<typeof client.listServers>>;
-    });
+async function preReapOldServers(client: HetznerCloudClient): Promise<void> {
+  const servers = await client.listServers({
+    ci: "true",
+    workflow: "hetzner-e2e",
+  });
   const now = Date.now();
   for (const server of servers) {
     const created = Date.parse(server.created);
@@ -121,17 +100,56 @@ async function preReapOldServers(
     console.error(
       `[hetzner-e2e-provision] pre-reap deleting ${server.id} (${server.name}) age=${Math.round((now - created) / 60000)}min`,
     );
-    try {
-      await client.deleteServer(server.id);
-    } catch (err) {
-      console.warn(
-        `[hetzner-e2e-provision] pre-reap delete ${server.id} failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    await client.deleteServer(server.id);
   }
 }
 
-async function main(): Promise<void> {
+type CapacityInventory = {
+  totalServers: number;
+  hetznerE2eServers: number;
+  otherServers: number;
+  byStatus: Record<string, number>;
+  byServerType: Record<string, number>;
+  byLocation: Record<string, number>;
+};
+
+function incrementCount(counts: Record<string, number>, key: string): void {
+  counts[key] = (counts[key] ?? 0) + 1;
+}
+
+async function readSanitizedCapacityInventory(
+  client: HetznerCloudClient,
+): Promise<CapacityInventory> {
+  const servers = await client.listServers();
+  const inventory: CapacityInventory = {
+    totalServers: servers.length,
+    hetznerE2eServers: 0,
+    otherServers: 0,
+    byStatus: {},
+    byServerType: {},
+    byLocation: {},
+  };
+
+  for (const server of servers) {
+    const isHetznerE2e =
+      server.labels.ci === "true" && server.labels.workflow === "hetzner-e2e";
+    if (isHetznerE2e) {
+      inventory.hetznerE2eServers++;
+    } else {
+      inventory.otherServers++;
+    }
+    incrementCount(inventory.byStatus, server.status);
+    incrementCount(inventory.byServerType, server.server_type.name);
+    incrementCount(inventory.byLocation, server.datacenter.location.name);
+  }
+
+  return inventory;
+}
+
+export async function runHetznerE2eProvision(): Promise<{
+  id: number;
+  ip: string;
+}> {
   const token = requireEnv("HCLOUD_TOKEN_CI");
   const sshKeyId = Number.parseInt(requireEnv("CI_SSH_PUBLIC_KEY_ID"), 10);
   if (!Number.isFinite(sshKeyId)) {
@@ -140,12 +158,16 @@ async function main(): Promise<void> {
     );
   }
 
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: This standalone GitHub Actions script is outside Turbo task caching.
   const runId = process.env.GITHUB_RUN_ID ?? `local-${Date.now()}`;
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: This standalone GitHub Actions script is outside Turbo task caching.
   const requestedLocation = process.env.HETZNER_E2E_LOCATION ?? "fsn1";
   // cx22 is now deprecated; cpx22 (x86 2 vCPU / 4 GB) is the current shared
   // type available across fsn1/hel1/nbg1 per GET /v1/datacenters. Operators can
   // still pin a specific type via env.
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: This standalone GitHub Actions script is outside Turbo task caching.
   const requestedServerType = process.env.HETZNER_E2E_SERVER_TYPE ?? "cpx22";
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: This standalone GitHub Actions script is outside Turbo task caching.
   const image = process.env.HETZNER_E2E_IMAGE ?? "ubuntu-24.04";
   const createdAt = new Date().toISOString();
 
@@ -178,8 +200,6 @@ async function main(): Promise<void> {
   let server: Awaited<ReturnType<typeof client.createServer>>["server"] | null =
     null;
   let lastError: unknown;
-  let serverType = requestedServerType;
-  let location = requestedLocation;
   for (const attempt of attempts) {
     try {
       const created = await client.createServer({
@@ -198,8 +218,6 @@ async function main(): Promise<void> {
         },
       });
       server = created.server;
-      serverType = attempt.serverType;
-      location = attempt.location;
       if (
         attempt.serverType !== requestedServerType ||
         attempt.location !== requestedLocation
@@ -211,6 +229,29 @@ async function main(): Promise<void> {
       break;
     } catch (err) {
       lastError = err;
+      if (isProjectQuotaError(err)) {
+        let inventory: CapacityInventory;
+        try {
+          inventory = await readSanitizedCapacityInventory(client);
+        } catch (inventoryError) {
+          // error-policy:J2 Preserve both the quota failure and the failed diagnostic read.
+          throw new AggregateError(
+            [err, inventoryError],
+            "Hetzner project quota exhausted and capacity inventory could not be read",
+            { cause: err },
+          );
+        }
+        console.error(
+          `[hetzner-e2e-provision] project capacity inventory: ${JSON.stringify(inventory)}`,
+        );
+        throw new HetznerCloudError(
+          "quota_exceeded",
+          `Hetzner project quota exhausted after ${attempt.serverType}@${attempt.location} (${err.message}). ` +
+            "Operator action required: inspect project capacity or raise the server limit; changing location cannot bypass a project-wide quota.",
+          err.status,
+          err,
+        );
+      }
       if (!isRetryableCombo(err)) {
         // Surface a hint before propagating: a non-retryable failure on
         // the first attempt is almost always an auth/account problem
@@ -232,23 +273,6 @@ async function main(): Promise<void> {
     }
   }
   if (!server) {
-    // Layer 2 diagnostic: when every fallback combo also failed with
-    // quota_exceeded, the operator needs a single actionable next step —
-    // not a stack of "unavailable" lines that look like a transient API
-    // glitch. Refresh `HCLOUD_TOKEN_CI` only if the token's project no
-    // longer matches the CI project; otherwise delete leaked servers in
-    // the Hetzner console (https://console.hetzner.cloud/) and re-run.
-    if (
-      lastError instanceof HetznerCloudError &&
-      lastError.code === "quota_exceeded"
-    ) {
-      throw new Error(
-        `Hetzner project quota exhausted across all fallback combos (last error: ${lastError.message}). ` +
-          "Operator action required: pre-reap freed nothing in 20min window, and the workflow cannot proceed. " +
-          "Check https://console.hetzner.cloud/ for leaked CI servers (label ci=true, workflow=hetzner-e2e), " +
-          "or rotate HCLOUD_TOKEN_CI if it now points to a project with a tighter cap.",
-      );
-    }
     throw lastError instanceof Error
       ? lastError
       : new Error("Hetzner provisioning failed across all fallback combos");
@@ -264,7 +288,9 @@ async function main(): Promise<void> {
     run_id: String(runId),
   });
 
-  console.log(JSON.stringify({ id: server.id, ip }));
+  return { id: server.id, ip };
 }
 
-await main();
+if (import.meta.main) {
+  console.log(JSON.stringify(await runHetznerE2eProvision()));
+}

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-sleep-wake-workflow.test.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-sleep-wake-workflow.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Pins the workflow to the canonical state-file field written by the Hetzner
+ * provisioner so missing or malformed server identifiers fail immediately.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const workflow = readFileSync(
+  new URL(
+    "../../../../../.github/workflows/hetzner-sleep-wake-smoke.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("Hetzner sleep-wake workflow state contract", () => {
+  test("reads both server identifiers strictly from server_id", () => {
+    const strictServerIdReads =
+      workflow.match(
+        /ID_[AB]=\$\(jq -er \.server_id "\$HETZNER_E2E_STATE_FILE"\)/g,
+      ) ?? [];
+
+    expect(strictServerIdReads).toHaveLength(2);
+    expect(workflow).not.toContain("jq -r .id");
+    expect(workflow).not.toContain("jq -er .id");
+  });
+});


### PR DESCRIPTION
# Relates to

Relates to #15603. Fixes the deterministic code defects exposed by the current Hetzner capacity failure; project capacity itself remains an operator action.

# Sync with develop

- [x] Parent is current `origin/develop` at `5997c1f399c4`; zero conflicts.
- [x] Four-file diff is isolated from unrelated local work.

# What changed

- Read the canonical state field with strict `jq -er .server_id` for both boxes.
- Propagate pre-reap list/delete failures instead of fabricating an empty inventory.
- Stop after one create attempt on project-wide quota exhaustion instead of retrying locations that share the same quota.
- Emit sanitized aggregate capacity counts without server names, IPs, labels, or IDs.
- Add real client/HTTP-boundary and workflow contract regressions.

# Testing

- Focused tests: 10 passed, 0 failed, 36 assertions.
- Strict standalone TypeScript check: passed.
- Focused Biome check: passed.
- `actionlint`: passed.
- `git diff --check`: passed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI/provisioning backend change with no UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI/provisioning backend change with no UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow.
<!-- evidence-row:backend-logs -->
- [x] [15603](https://github.com/elizaOS/eliza/issues/15603)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or requests changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [hetzner-e2e-provision.test.ts](https://github.com/elizaOS/eliza/blob/966bebd710059d7966ba5b8bf27a6128c1212f8e/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.test.ts)

# Known gaps / failures

The Hetzner project is still at its server quota. An operator must free/rehome capacity or rotate `HCLOUD_TOKEN_CI` to a dedicated project; this PR intentionally does not broaden destructive reaping.
