### PR TITLE
chore(coding-tools): mark unused callbacks

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/web-fetch.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.ts
@@ -160,7 +160,7 @@ export const webFetchAction: Action = {
     _message: Memory,
     _state?: State,
     options?: unknown,
-    callback?: HandlerCallback,
+    _callback?: HandlerCallback,
   ): Promise<ActionResult> => {
     if (!isCodingWebFetchEnabled()) {
       return failureToActionResult({

--- a/plugins/plugin-coding-tools/src/actions/web-search.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-search.ts
@@ -129,7 +129,7 @@ export const webSearchAction: Action = {
     _message: Memory,
     _state?: State,
     options?: unknown,
-    callback?: HandlerCallback,
+    _callback?: HandlerCallback,
   ): Promise<ActionResult> => {
     if (!isCodingWebSearchEnabled()) {
       return failureToActionResult({


### PR DESCRIPTION
# Summary

Marks the intentionally unused handler callbacks in `WEB_FETCH` and `WEB_SEARCH` with underscore-prefixed names. Signatures and runtime behavior are unchanged.

# Sync with develop

- [x] Parent is contained `origin/develop` at `030b90a5a4af`; zero conflicts.

# Testing

- Coding tools tests: 29 files, 399 passed.
- Package lint: passed.
- Package typecheck: passed.
- `git diff --check`: passed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing behavior change.
<!-- evidence-row:backend-logs -->
- [ ] N/A - identifier-only lint cleanup; handler behavior and signatures are unchanged
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action behavior, model, or prompt change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - identifier-only lint cleanup.
