### PR TITLE
fix(agent): fail divergent append-only chat streams

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -128,6 +128,7 @@ import type { ChatImageAttachment } from "./server-types.ts";
 export type { ChatImageAttachment, LogEntry };
 
 const DEFAULT_CONVERSATION_TITLE_TIMEOUT_MS = 5_000;
+const CHAT_APPEND_ONLY_STREAM_DIVERGENCE = "CHAT_APPEND_ONLY_STREAM_DIVERGENCE";
 
 type LocalInferenceChatApi = Pick<
   LocalInferenceRouteApi,
@@ -941,6 +942,15 @@ export interface ChatGenerateOptions {
   resolveNoResponseText?: () => string;
   preferredLanguage?: string;
   timeoutDuration?: number;
+}
+
+function isAppendOnlyStreamDivergenceError(
+  error: unknown,
+): error is ElizaError {
+  return (
+    error instanceof ElizaError &&
+    error.code === CHAT_APPEND_ONLY_STREAM_DIVERGENCE
+  );
 }
 
 // LogEntry is canonical in @elizaos/shared and re-exported above.
@@ -2846,8 +2856,9 @@ async function generateChatResponseWithTiming(
     const originalUserText = String(extractCompatTextContent(message.content));
     type StreamSource = "unset" | "callback" | "onStreamChunk";
     let responseText = "";
-    // Snapshot transports can replace responseText; SSE transports can only
-    // append, so their delivered prefix must be tracked independently.
+    // Snapshot consumers can replace prior text. Append-only transports need
+    // their independently observed prefix so finalization can prove the
+    // authoritative reply still matches bytes that have left the process.
     let appendOnlyText = "";
     let firstVisibleReplyMarked = false;
     let forcedWalletExecutionText = false;
@@ -2894,8 +2905,10 @@ async function generateChatResponseWithTiming(
       if (!chunk) return;
       markFirstVisibleReply();
       responseText += chunk;
-      appendOnlyText += chunk;
-      opts?.onChunk?.(chunk);
+      if (opts?.onChunk) {
+        opts.onChunk(chunk);
+        appendOnlyText += chunk;
+      }
     };
     const emitSnapshot = (text: string): void => {
       if (!text) return;
@@ -3692,31 +3705,30 @@ async function generateChatResponseWithTiming(
       result?.actionResults,
       resultContentCandidates,
     );
-    if (finalText && transcriptVisibility !== "internal") {
-      markFirstVisibleReply();
-    }
-    if (
-      !opts?.onSnapshot &&
-      opts?.onChunk &&
-      transcriptVisibility !== "internal" &&
-      finalText !== appendOnlyText
-    ) {
-      if (finalText.startsWith(appendOnlyText)) {
-        const delta = finalText.slice(appendOnlyText.length);
-        if (delta) {
-          appendOnlyText = finalText;
-          opts.onChunk(delta);
-        }
-      } else {
-        runtime.logger.debug(
+
+    if (opts?.onChunk && !opts.onSnapshot) {
+      const authoritativeText =
+        transcriptVisibility === "internal" ? "" : finalText;
+      if (!authoritativeText.startsWith(appendOnlyText)) {
+        throw new ElizaError(
+          "Append-only chat stream diverged from the authoritative final reply",
           {
-            src: "eliza-api",
-            emittedChars: appendOnlyText.length,
-            finalChars: finalText.length,
-            messageId: message.id,
+            code: CHAT_APPEND_ONLY_STREAM_DIVERGENCE,
+            severity: "fatal",
+            context: {
+              emittedChars: appendOnlyText.length,
+              finalChars: authoritativeText.length,
+              messageId: message.id,
+              roomId: message.roomId,
+            },
           },
-          "[eliza-api] Held final reply rewrite from append-only stream",
         );
+      }
+      const remainingText = authoritativeText.slice(appendOnlyText.length);
+      if (remainingText) {
+        markFirstVisibleReply();
+        opts.onChunk(remainingText);
+        appendOnlyText += remainingText;
       }
     }
 
@@ -4435,12 +4447,19 @@ export async function handleChatRoutes(
               JSON.stringify({
                 error: {
                   message: getErrorMessage(err),
-                  type: "server_error",
+                  type: isAppendOnlyStreamDivergenceError(err)
+                    ? "stream_error"
+                    : "server_error",
+                  ...(isAppendOnlyStreamDivergenceError(err)
+                    ? { code: err.code }
+                    : {}),
                 },
               }),
             );
           }
-          writeSseData(res, "[DONE]");
+          if (!isAppendOnlyStreamDivergenceError(err)) {
+            writeSseData(res, "[DONE]");
+          }
         }
       } finally {
         res.end();
@@ -4815,7 +4834,15 @@ export async function handleChatRoutes(
               res,
               {
                 type: "error",
-                error: { type: "server_error", message: getErrorMessage(err) },
+                error: {
+                  type: isAppendOnlyStreamDivergenceError(err)
+                    ? "stream_error"
+                    : "server_error",
+                  message: getErrorMessage(err),
+                  ...(isAppendOnlyStreamDivergenceError(err)
+                    ? { code: err.code }
+                    : {}),
+                },
               },
               "error",
             );

--- a/packages/agent/test/api/agent-message-route.test.ts
+++ b/packages/agent/test/api/agent-message-route.test.ts
@@ -167,15 +167,27 @@ function createMessageService(
   } as unknown as MessageService;
 }
 
-function createCallbackMessageService(reply: string): MessageService {
-  const content = { text: reply, actions: ["REPLY"] };
+function createCallbackMessageService(
+  finalReply: string,
+  streamedReply?: string,
+): MessageService {
+  const finalContent = { text: finalReply, actions: ["REPLY"] };
   return {
     async handleMessage(_runtime, _message, callback) {
-      await callback?.(content);
+      if (streamedReply) {
+        await callback?.({
+          text: streamedReply,
+          actions: ["REPLY"],
+          merge: "append",
+        });
+      }
+      await callback?.(finalContent);
       return {
         didRespond: true,
-        responseContent: content,
-        responseMessages: [{ id: stringToUuid("callback-reply-msg"), content }],
+        responseContent: finalContent,
+        responseMessages: [
+          { id: stringToUuid("callback-reply-msg"), content: finalContent },
+        ],
       };
     },
     shouldRespond: () => ({
@@ -566,6 +578,52 @@ describe("compatibility transport transcript visibility", () => {
     expect(text).toBe("callback reply");
   });
 
+  it("ends an OpenAI-compatible divergent stream with an observable error, not success", async () => {
+    const agentId = stringToUuid("openai-divergent-callback-agent") as UUID;
+    const runtime = createRuntime(agentId, {
+      messageService: createCallbackMessageService(
+        "authoritative final reply",
+        "provisional streamed reply",
+      ),
+    });
+    const { record, invoke } = createCtx({
+      method: "POST",
+      pathname: "/v1/chat/completions",
+      body: {
+        model: "eliza",
+        stream: true,
+        messages: [{ role: "user", content: "Change the callback reply" }],
+      },
+      runtime,
+    });
+
+    expect(await invoke()).toBe(true);
+    const frames = parseSseJsonFrames(record) as Array<{
+      error?: { type?: string; code?: string };
+      choices?: Array<{
+        delta?: { content?: string };
+        finish_reason?: string | null;
+      }>;
+    }>;
+    const streamedText = frames
+      .flatMap((frame) => frame.choices ?? [])
+      .map((choice) => choice.delta?.content ?? "")
+      .join("");
+    expect(streamedText).toBe("provisional streamed reply");
+    expect(frames).toContainEqual({
+      error: expect.objectContaining({
+        type: "stream_error",
+        code: "CHAT_APPEND_ONLY_STREAM_DIVERGENCE",
+      }),
+    });
+    expect(
+      frames
+        .flatMap((frame) => frame.choices ?? [])
+        .some((choice) => choice.finish_reason === "stop"),
+    ).toBe(false);
+    expect(record.writes.join("")).not.toContain("data: [DONE]");
+  });
+
   it("streams callback-only replies through the Anthropic-compatible transport", async () => {
     const agentId = stringToUuid("anthropic-callback-agent") as UUID;
     const runtime = createRuntime(agentId, {
@@ -594,6 +652,51 @@ describe("compatibility transport transcript visibility", () => {
       .map((frame) => frame.delta?.text ?? "")
       .join("");
     expect(text).toBe("callback reply");
+  });
+
+  it("ends an Anthropic-compatible divergent stream with an error before completion", async () => {
+    const agentId = stringToUuid("anthropic-divergent-callback-agent") as UUID;
+    const runtime = createRuntime(agentId, {
+      messageService: createCallbackMessageService(
+        "authoritative final reply",
+        "provisional streamed reply",
+      ),
+    });
+    const { record, invoke } = createCtx({
+      method: "POST",
+      pathname: "/v1/messages",
+      body: {
+        model: "eliza",
+        max_tokens: 128,
+        stream: true,
+        messages: [{ role: "user", content: "Change the callback reply" }],
+      },
+      runtime,
+    });
+
+    expect(await invoke()).toBe(true);
+    const frames = parseSseJsonFrames(record) as Array<{
+      type?: string;
+      delta?: { text?: string };
+      error?: { type?: string; code?: string };
+    }>;
+    const streamedText = frames
+      .filter((frame) => frame.type === "content_block_delta")
+      .map((frame) => frame.delta?.text ?? "")
+      .join("");
+    expect(streamedText).toBe("provisional streamed reply");
+    expect(frames).toContainEqual({
+      type: "error",
+      error: expect.objectContaining({
+        type: "stream_error",
+        code: "CHAT_APPEND_ONLY_STREAM_DIVERGENCE",
+      }),
+    });
+    expect(frames.map((frame) => frame.type)).not.toContain(
+      "content_block_stop",
+    );
+    expect(frames.map((frame) => frame.type)).not.toContain("message_delta");
+    expect(frames.map((frame) => frame.type)).not.toContain("message_stop");
   });
 
   it("returns empty OpenAI-compatible non-streaming content for an internal turn", async () => {

--- a/packages/agent/test/api/chat-routes-usage.test.ts
+++ b/packages/agent/test/api/chat-routes-usage.test.ts
@@ -317,6 +317,82 @@ describe("generateChatResponse usage reporting", () => {
     expect(onChunk).toHaveBeenCalledWith("Search complete.");
   });
 
+  it("fails append-only finalization when emitted callback bytes diverge", async () => {
+    const onChunk = vi.fn();
+    const runtime = createRuntime({
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback?.({
+            text: "provisional streamed reply",
+            actions: ["REPLY"],
+            merge: "append",
+          });
+          await callback?.({
+            text: "authoritative final reply",
+            actions: ["REPLY"],
+          });
+          return {
+            didRespond: true,
+            responseContent: {
+              actions: ["REPLY"],
+              text: "authoritative final reply",
+            },
+            responseMessages: [],
+          };
+        }),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    await expect(
+      generateChatResponse(runtime, createChatMessage("hello"), "Chat Agent", {
+        onChunk,
+      }),
+    ).rejects.toMatchObject({
+      code: "CHAT_APPEND_ONLY_STREAM_DIVERGENCE",
+    });
+    expect(onChunk).toHaveBeenCalledTimes(1);
+    expect(onChunk).toHaveBeenCalledWith("provisional streamed reply");
+  });
+
+  it("preserves divergent callback replacement for snapshot-capable consumers", async () => {
+    const onChunk = vi.fn();
+    const onSnapshot = vi.fn();
+    const runtime = createRuntime({
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback?.({
+            text: "provisional streamed reply",
+            actions: ["REPLY"],
+            merge: "append",
+          });
+          await callback?.({
+            text: "authoritative final reply",
+            actions: ["REPLY"],
+          });
+          return {
+            didRespond: true,
+            responseContent: {
+              actions: ["REPLY"],
+              text: "authoritative final reply",
+            },
+            responseMessages: [],
+          };
+        }),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("hello"),
+      "Chat Agent",
+      { onChunk, onSnapshot },
+    );
+
+    expect(result.text).toBe("authoritative final reply");
+    expect(onChunk).toHaveBeenCalledWith("provisional streamed reply");
+    expect(onSnapshot).toHaveBeenLastCalledWith("authoritative final reply");
+  });
+
   it("records an attributed visible callback only when its action succeeded", async () => {
     const runtime = createRuntime({
       messageService: {
@@ -445,40 +521,6 @@ describe("generateChatResponse usage reporting", () => {
     expect(onChunk).toHaveBeenCalledWith("streamed final");
     expect(result.usedActionCallbacks).toBeUndefined();
     expect(result.actionCallbackHistory).toBeUndefined();
-  });
-
-  it("does not append a final rewrite to incompatible streamed bytes", async () => {
-    const onChunk = vi.fn();
-    const runtime = createRuntime({
-      messageService: {
-        handleMessage: vi.fn(async (_runtime, _message, _callback, options) => {
-          await options?.onStreamChunk?.("draft reply");
-          return {
-            didRespond: true,
-            responseContent: { text: "authoritative reply" },
-            responseMessages: [],
-          };
-        }),
-      } as NonNullable<AgentRuntime["messageService"]>,
-    });
-
-    const result = await generateChatResponse(
-      runtime,
-      createChatMessage("rewrite"),
-      "Chat Agent",
-      { onChunk },
-    );
-
-    expect(result.text).toBe("authoritative reply");
-    expect(onChunk).toHaveBeenCalledTimes(1);
-    expect(onChunk).toHaveBeenCalledWith("draft reply");
-    expect(runtime.logger.debug).toHaveBeenCalledWith(
-      expect.objectContaining({
-        emittedChars: "draft reply".length,
-        finalChars: "authoritative reply".length,
-      }),
-      "[eliza-api] Held final reply rewrite from append-only stream",
-    );
   });
 
   it("replaces progress delivery with the final result without action evidence", async () => {


### PR DESCRIPTION
# Relates to

Part of #17308. Supersedes the incomplete reconciliation behavior in #17397.

# Sync with develop

- [x] Parent is contained `origin/develop` at `0eeaf00abb0`; zero conflicts.
- [x] Three-file diff is isolated from unrelated local work.

# What changed

- Reconcile callback-only replies and authoritative prefix extensions.
- Preserve replacement semantics for snapshot-capable consumers.
- Emit a typed protocol error when a final reply rewrites bytes already sent to append-only OpenAI/Anthropic SSE consumers.
- Suppress normal OpenAI `[DONE]`/`stop` and Anthropic `end_turn`/`message_stop` after divergence.
- Add adversarial endpoint regressions for both compatibility protocols.

# Testing

- 140 focused tests passed across six SSE/chat suites after the final rebase.
- `bun run verify`: 579/579 tasks passed; anti-larp scanned 8,821 test files; 28/28 dist consumers.
- Focused Biome check: passed.
- `git diff --check`: passed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - protocol/backend fix with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - protocol/backend fix with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual flow.
<!-- evidence-row:backend-logs -->
- [x] [17416-root-verify-rebased.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17416-root-verify-rebased.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] [17416-cerebras-compat-sse.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17416-cerebras-compat-sse.json)
<!-- evidence-row:domain-artifacts -->
- [x] [17416-focused-rebased.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17416-focused-rebased.log)

# Exact-head live evidence

A real listening API server, AgentRuntime, PGLite, plugin-openai, and Cerebras `gemma-4-31b` exercised both compatibility endpoints with no response timeout: 10/10 exact proof responses, no error frames. OpenAI completed 5/5 with p50 569.248 ms and Anthropic completed 5/5 with p50 617.742 ms. Adversarial deterministic endpoint tests separately prove divergence emits the typed terminal error and suppresses false success frames.

