### PR TITLE
fix(app): clear calendar and notes audit debt

### DIFF
--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -1420,7 +1420,7 @@ test.describe("all-views aesthetic audit (#8796)", () => {
           });
           await manageSources.click();
           await page
-            .getByText("New calendars are included automatically")
+            .getByText("New calendars join automatically")
             .waitFor({ state: "visible", timeout: 5_000 });
           paint = await readPaint();
         }

--- a/packages/app/test/ui-smoke/brand-color-scans.spec.ts
+++ b/packages/app/test/ui-smoke/brand-color-scans.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Exercises the real browser hover scanner against named icon-only controls,
+ * including an initially offscreen target and a blocked interaction.
+ */
+
+import { expect, test } from "@playwright/test";
+import { collectHoverViolations } from "./helpers/brand-color-scans";
+
+test("centers and names an offscreen icon-only orange control", async ({
+  page,
+}) => {
+  await page.setContent(`
+    <style>
+      #scrollport { height: 100px; overflow: auto; }
+      #spacer { height: 240px; }
+      #target { width: 44px; height: 44px; background: rgb(255, 88, 0); }
+      #target:hover { background: rgb(0, 0, 0); }
+    </style>
+    <div id="scrollport">
+      <div id="spacer"></div>
+      <button id="target" aria-label="Use orange color">
+        <svg aria-hidden="true"></svg>
+      </button>
+    </div>
+  `);
+
+  const finding = await collectHoverViolations(page);
+
+  expect(finding.hoverFailures).toEqual([]);
+  expect(finding.violations).toHaveLength(1);
+  expect(finding.violations[0]).toContain('"Use orange color" orange→black');
+});
+
+test("reports a named icon-only control when hover remains blocked", async ({
+  page,
+}) => {
+  await page.setContent(`
+    <button
+      aria-label="Blocked orange action"
+      style="width:44px;height:44px;background:rgb(255,88,0)"
+    >
+      <svg aria-hidden="true"></svg>
+    </button>
+    <div style="position:fixed;inset:0;z-index:2"></div>
+  `);
+
+  const finding = await collectHoverViolations(page);
+
+  expect(finding.violations).toEqual([]);
+  expect(finding.hoverFailures).toHaveLength(1);
+  expect(finding.hoverFailures[0]).toContain('"Blocked orange action"');
+});

--- a/packages/app/test/ui-smoke/helpers/brand-color-scans.ts
+++ b/packages/app/test/ui-smoke/helpers/brand-color-scans.ts
@@ -51,8 +51,23 @@ export async function collectHoverViolations(
       .evaluate((el) => getComputedStyle(el).backgroundColor)
       .catch(() => "");
     if (bucket(rest) !== "orange") continue; // only orange-resting buttons matter
+    const label = (
+      (await btn.getAttribute("aria-label")) ||
+      (await btn.getAttribute("data-agent-label")) ||
+      (await btn.getAttribute("title")) ||
+      (await btn.innerText())
+    )
+      .trim()
+      .slice(0, 48);
     let hoverError: string | null = null;
     try {
+      await btn.evaluate((element) => {
+        element.scrollIntoView({
+          block: "center",
+          inline: "center",
+          behavior: "instant",
+        });
+      });
       await btn.hover({ timeout: 1000 });
     } catch (error) {
       hoverError = (error instanceof Error ? error.message : String(error))
@@ -62,7 +77,6 @@ export async function collectHoverViolations(
     if (hoverError !== null) {
       // The hover never applied, so reading the "hover" background would just
       // re-read the rest color and vacuously pass. Surface the probe failure.
-      const label = (await btn.innerText().catch(() => "")).slice(0, 24);
       hoverFailures.push(`"${label}" hover probe failed: ${hoverError}`);
       continue;
     }
@@ -71,7 +85,6 @@ export async function collectHoverViolations(
       .catch(() => "");
     const dest = bucket(hover);
     if (dest === "black" || dest === "white" || dest === "transparent") {
-      const label = (await btn.innerText().catch(() => "")).slice(0, 24);
       violations.push(`"${label}" orange→${dest} (${rest} -> ${hover})`);
     }
   }

--- a/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
@@ -179,7 +179,7 @@ export function CalendarSpatialView({
             {snapshot.refreshing ? "Refreshing…" : "Refresh"}
           </Button>
         </HStack>
-        {snapshot.sources.length > 0 ? (
+        {!snapshot.sourceManager.open && snapshot.sources.length > 0 ? (
           <List gap={0}>
             {snapshot.sources.map((source) => (
               <HStack key={source.id} gap={1} align="center">
@@ -192,7 +192,9 @@ export function CalendarSpatialView({
               </HStack>
             ))}
           </List>
-        ) : snapshot.status !== "loading" && snapshot.status !== "error" ? (
+        ) : !snapshot.sourceManager.open &&
+          snapshot.status !== "loading" &&
+          snapshot.status !== "error" ? (
           <Text style="caption" tone="muted">
             {snapshot.status === "unavailable"
               ? "No connected source details are available."
@@ -223,8 +225,8 @@ export function CalendarSpatialView({
         {snapshot.sourceManager.open ? (
           <>
             <Text style="caption" tone="muted">
-              New calendars are included automatically. Exclude one to remove it
-              from the combined calendar.
+              New calendars join automatically. Exclude one from the combined
+              calendar.
             </Text>
 
             {snapshot.sourceManager.status === "loading" ? (
@@ -294,9 +296,6 @@ export function CalendarSpatialView({
                             ? " · Primary"
                             : ""}
                         </Text>
-                        <Text style="caption" tone="muted">
-                          {source.providerLabel} · {source.accountLabel}
-                        </Text>
                       </VStack>
                       {source.toggleAvailable ? (
                         <Button
@@ -319,17 +318,32 @@ export function CalendarSpatialView({
                           Inclusion unavailable
                         </Text>
                       )}
+                      <Button
+                        variant="ghost"
+                        tone="default"
+                        agent={`source-details:${source.actionId}`}
+                        onPress={dispatch(`source-details:${source.actionId}`)}
+                      >
+                        {source.detailsOpen ? "Hide details" : "Show details"}
+                      </Button>
                     </HStack>
-                    <Text style="caption" tone={source.tone}>
-                      {source.accessLabel} · {source.visibilityLabel} ·{" "}
-                      {source.statusLabel} · {source.freshnessLabel}
-                    </Text>
+                    {source.detailsOpen ? (
+                      <>
+                        <Text style="caption" tone="muted">
+                          {source.providerLabel} · {source.accountLabel}
+                        </Text>
+                        <Text style="caption" tone={source.tone}>
+                          {source.accessLabel} · {source.visibilityLabel} ·{" "}
+                          {source.statusLabel} · {source.freshnessLabel}
+                        </Text>
+                      </>
+                    ) : null}
                     {source.mutationError ? (
                       <Text style="caption" tone="danger">
                         {source.mutationError}
                       </Text>
                     ) : null}
-                    {source.reconnectConnectorId ? (
+                    {source.detailsOpen && source.reconnectConnectorId ? (
                       <Button
                         variant="ghost"
                         tone="default"
@@ -340,7 +354,7 @@ export function CalendarSpatialView({
                       >
                         Reconnect Google Calendar
                       </Button>
-                    ) : source.reconnectUnavailable ? (
+                    ) : source.detailsOpen && source.reconnectUnavailable ? (
                       <Text style="caption" tone="muted">
                         Reconnect unavailable here.
                       </Text>

--- a/plugins/plugin-calendar/src/components/calendar/CalendarView.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarView.test.tsx
@@ -440,9 +440,15 @@ describe("CalendarView (unified spatial wrapper)", () => {
     fireEvent.click(agent("manage-sources"));
 
     const manager = agent("calendar-source-manager");
-    expect(manager.textContent).toContain(
-      "New calendars are included automatically",
+    expect(manager.textContent).toContain("New calendars join automatically");
+    expect(manager.textContent).not.toContain("work@example.com");
+    const detailButtons = manager.querySelectorAll(
+      '[data-agent-id^="source-details:calendar-source-"]',
     );
+    expect(detailButtons).toHaveLength(2);
+    for (const details of detailButtons) {
+      fireEvent.click(details);
+    }
     expect(manager.textContent).toContain("Google Calendar");
     expect(manager.textContent).toContain("work@example.com");
     expect(manager.textContent).toContain("Owner");
@@ -457,6 +463,30 @@ describe("CalendarView (unified spatial wrapper)", () => {
     expect(toggles).toHaveLength(2);
     expect(document.body.innerHTML).not.toContain("grant-family");
     expect(document.body.innerHTML).not.toContain("account-family");
+  });
+
+  it("replaces duplicate source-health rows with the expanded source hierarchy", () => {
+    render(<CalendarView />);
+
+    const sources = agent("calendar-sources");
+    expect(within(sources).getByText("Google · Work")).toBeTruthy();
+
+    fireEvent.click(agent("manage-sources"));
+
+    expect(within(sources).queryByText("Google · Work")).toBeNull();
+    const manager = agent("calendar-source-manager");
+    expect(manager.textContent).not.toContain("work@example.com");
+    const details = manager.querySelector(
+      '[data-agent-id^="source-details:calendar-source-"]',
+    ) as HTMLElement | null;
+    expect(details).toBeTruthy();
+    fireEvent.click(details as HTMLElement);
+    expect(
+      within(manager).getByText("Google Calendar · work@example.com"),
+    ).toBeTruthy();
+    expect(manager.textContent).toContain(
+      "Owner · Event details · Current · just now",
+    );
   });
 
   it("routes a safe spatial source action to the exact account and refreshes feed truth", async () => {
@@ -543,6 +573,13 @@ describe("CalendarView (unified spatial wrapper)", () => {
 
     render(<CalendarView />);
     fireEvent.click(agent("manage-sources"));
+    const details = document.querySelectorAll(
+      '[data-agent-id^="source-details:calendar-source-"]',
+    );
+    expect(details).toHaveLength(2);
+    for (const button of details) {
+      fireEvent.click(button);
+    }
     const reconnect = document.querySelector(
       '[data-agent-id^="source-reconnect:calendar-source-"]',
     ) as HTMLElement | null;

--- a/plugins/plugin-calendar/src/components/calendar/CalendarView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarView.tsx
@@ -137,6 +137,9 @@ export function CalendarView() {
   const sourcePreferences = useCalendarSources();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [sourceManagerOpen, setSourceManagerOpen] = useState(false);
+  const [expandedSourceIds, setExpandedSourceIds] = useState<
+    ReadonlySet<string>
+  >(new Set());
   const [joiningIds, setJoiningIds] = useState<ReadonlySet<string>>(new Set());
   const [liveEventIds, setLiveEventIds] = useState<ReadonlySet<string>>(
     new Set(),
@@ -245,6 +248,7 @@ export function CalendarView() {
         const identityKey = source ? calendarSourceIdentityKey(source) : null;
         return {
           ...row,
+          detailsOpen: expandedSourceIds.has(row.actionId),
           pending: identityKey
             ? sourcePreferences.pendingKeys.has(identityKey)
             : false,
@@ -254,6 +258,7 @@ export function CalendarView() {
         };
       }),
     [
+      expandedSourceIds,
       sourceManagerModel,
       sourcePreferences.mutationErrors,
       sourcePreferences.pendingKeys,
@@ -275,6 +280,16 @@ export function CalendarView() {
 
   const onAction = useCallback(
     (action: string) => {
+      if (action.startsWith("source-details:")) {
+        const actionId = action.slice("source-details:".length);
+        setExpandedSourceIds((current) => {
+          const next = new Set(current);
+          if (next.has(actionId)) next.delete(actionId);
+          else next.add(actionId);
+          return next;
+        });
+        return;
+      }
       if (action.startsWith("source-toggle:")) {
         void toggleCalendarSource(action.slice("source-toggle:".length));
         return;

--- a/plugins/plugin-calendar/src/components/calendar/source-manager.ts
+++ b/plugins/plugin-calendar/src/components/calendar/source-manager.ts
@@ -51,6 +51,7 @@ export interface CalendarSourceManagerModel {
 
 export interface CalendarSourceManagerSnapshotRow
   extends CalendarSourceManagerRow {
+  detailsOpen: boolean;
   pending: boolean;
   mutationError: string | null;
 }

--- a/plugins/plugin-simple-views/src/views/NotesView.tsx
+++ b/plugins/plugin-simple-views/src/views/NotesView.tsx
@@ -293,8 +293,6 @@ export function NotesView() {
               display: "grid",
               gap: 13,
               padding: 16,
-              position: "sticky",
-              top: 12,
             }}
           >
             <div

--- a/plugins/plugin-simple-views/src/views/SimpleViewsViews.test.tsx
+++ b/plugins/plugin-simple-views/src/views/SimpleViewsViews.test.tsx
@@ -96,6 +96,18 @@ describe("Simple Views state labels", () => {
     ).toBeNull();
   });
 
+  it("gives compact note controls native accessible names", () => {
+    stateHook.mockReturnValue(hookState({ snapshot: snapshot(1) }));
+
+    const notes = render(<NotesView />);
+    const yellow = notes.container.querySelector(
+      '[aria-label="Use yellow color"]',
+    );
+
+    expect(yellow).toBeTruthy();
+    expect(yellow?.textContent).toBe("");
+  });
+
   it.each([
     { height: 499, label: "compact", width: 315 },
     { height: 800, label: "desktop", width: 1280 },

--- a/plugins/plugin-simple-views/src/views/viewPrimitives.tsx
+++ b/plugins/plugin-simple-views/src/views/viewPrimitives.tsx
@@ -144,6 +144,7 @@ export function AgentAction({
       type="button"
       {...control.agentProps}
       {...rest}
+      aria-label={rest["aria-label"] ?? (compact ? agentLabel : undefined)}
       disabled={disabled}
       onClick={onClick}
       style={{


### PR DESCRIPTION
# Relates to

Closes #17401. Unblocks the exact-head visual audit required by #17387.

# Sync with develop

- [x] Final head is `be619041cb014aeae8de00682d17f73e6d644e4e`, parent `7d1b321a2bf2f1ca41a28534c8c758ef3760d200`; zero conflicts.
- [x] The ten-file diff is byte-identical to the reviewed implementation; intervening develop commits touch none of its paths.

# What changed

- Calendar source management uses summary-first disclosures while retaining metadata/actions under Show details.
- Mobile-landscape density falls from 8.0204 to 5.9546, below the existing 6.7748 ratchet without updating the baseline.
- Notes compact controls expose accessible names, remain scrollable in short viewports, and use deterministic centered hover probes.
- Browser regressions cover offscreen icon-only hover and named failure reporting.

# Testing

- Calendar: 484 passed; lint/typecheck passed.
- Simple Views: 39 passed; lint/typecheck passed.
- App lint/typecheck passed.
- Scanner Playwright: 2 passed.
- Full audit: 253 view cases passed; final strict calendar/Notes audit: 8 passed with zero hover/ratchet failures.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] [Exact-parent desktop/mobile contact sheet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17418-calendar-notes-before-contact-sheet.jpg); all 18 full-page captures are in the [evidence bundle](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17418-calendar-notes-evidence-67696aea.tar.gz).
<!-- evidence-row:after-screenshots -->
- [x] [Exact-head desktop/mobile contact sheet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17418-calendar-notes-after-contact-sheet.jpg); all 18 full-page captures are in the [evidence bundle](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17418-calendar-notes-evidence-67696aea.tar.gz).
<!-- evidence-row:walkthrough-video -->
- [x] [Exact-head Calendar/Notes interaction walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17418-calendar-notes-walkthrough.mp4) (H.264, 26.88 s).
<!-- evidence-row:backend-logs -->
- [x] N/A - UI and audit-harness change with no backend path.
<!-- evidence-row:frontend-logs -->
- [x] [Console log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17418-calendar-notes-head-console.json) and [network log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17418-calendar-notes-head-network.json): zero errors, page errors, HTTP errors, or non-abort failures.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Head audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17418-calendar-notes-head-report.json), [parent report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17418-calendar-notes-parent-report.json), [manual review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17418-calendar-notes-manual-review.md), and [checksums](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17418-calendar-notes-sha256s.txt).

# Known gaps / failures

Exact-revision evidence is uploaded and manually reviewed: strict audit 8/8, broken=0, needs-work=0, hover failures=0, ratchet failures=0, horizontal overflow=0; 36 before/after full-page screenshots and the walkthrough are clean. No ratchet baseline was relaxed. The final re-cut preserves the reviewed ten-file diff byte-for-byte over current develop.