### PR TITLE
fix(routing): arbitrate Cloud Apps navigation safely

### DIFF
--- a/packages/app/src/cloud-apps-view.test.ts
+++ b/packages/app/src/cloud-apps-view.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Native Cloud Apps destination registration against the real app-shell registry.
+ */
+
+import { listAppShellPages } from "@elizaos/ui/app-shell-registry";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/ui/platform", () => ({
+  getFrontendPlatform: () => "ios",
+}));
+
+beforeAll(async () => {
+  await import("./cloud-apps-view");
+});
+
+describe("Cloud Apps native destination", () => {
+  it("registers a bundled app-shell page at the path emitted by VIEWS", () => {
+    const page = listAppShellPages().find((entry) => entry.id === "cloud-apps");
+
+    expect(page).toMatchObject({
+      id: "cloud-apps",
+      pluginId: "@elizaos/app",
+      label: "Cloud Apps",
+      path: "/cloud-apps",
+    });
+    expect(page?.loader).toBeTypeOf("function");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-nav-intent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-nav-intent.test.ts
@@ -14,6 +14,8 @@ describe("resolveSharedNavIntent", () => {
     ["go home", "chat", undefined],
     ["what's on my calendar", "calendar", undefined],
     ["open my inbox", "inbox", undefined],
+    ["open cloud apps", "cloud-apps", undefined],
+    ["打开云应用", "cloud-apps", undefined],
     // Multilingual (matcher parity)
     ["muéstrame mi calendario", "calendar", undefined],
     ["打开设置", "settings", undefined],
@@ -100,6 +102,14 @@ describe("resolveSharedNavIntent", () => {
     // through to the LLM turn.
     "open the camera",
     "take a photo",
+    "list my cloud apps",
+    "show my cloud apps",
+    "list my deployed apps",
+    "do not open cloud apps",
+    "how do I open cloud apps?",
+    "when I open cloud apps it crashes",
+    "open cloud apps documentation",
+    "open the cloud app Acme",
   ])("falls through to the LLM for %j", (message) => {
     expect(resolveSharedNavIntent(message)).toBeNull();
   });
@@ -142,5 +152,17 @@ describe("resolveSharedNavIntent", () => {
     const result = navIntentActionResult(intent!);
     expect(result.values.viewId).toBe("settings");
     expect(result.values.subview).toBe("voice");
+  });
+
+  test("Cloud Apps carries the host-owned canonical path", () => {
+    const intent = resolveSharedNavIntent("open cloud apps");
+    expect(intent).toMatchObject({
+      viewId: "cloud-apps",
+      viewPath: "/cloud-apps",
+    });
+    expect(navIntentActionResult(intent!).values).toMatchObject({
+      viewId: "cloud-apps",
+      viewPath: "/cloud-apps",
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-nav-intent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-nav-intent.ts
@@ -33,6 +33,8 @@ import { matchViewCommand } from "@elizaos/shared/views/view-command-matcher";
 export interface SharedNavIntent {
   /** Client view id resolved against the routable registry (settings, inventory, chat, …). */
   viewId: string;
+  /** Canonical client path for a host-owned destination. */
+  viewPath?: string;
   /** Optional settings sub-section token to deep-link (e.g. "voice"). */
   subview?: string;
   /** Human label used in the confirmation reply. */
@@ -95,7 +97,12 @@ export function resolveSharedNavIntent(message: string | undefined): SharedNavIn
   const target = SHARED_NAV_TARGETS[matcherId];
   if (!target) return null;
 
-  return { viewId: target.viewId, label: target.label, reply: navReply(target.label) };
+  return {
+    viewId: target.viewId,
+    ...(target.viewPath ? { viewPath: target.viewPath } : {}),
+    label: target.label,
+    reply: navReply(target.label),
+  };
 }
 
 /**
@@ -110,7 +117,13 @@ export function navIntentActionResult(intent: SharedNavIntent): {
   actionName: "VIEWS";
   success: true;
   text: string;
-  values: { mode: "show"; viewId: string; subview?: string; source: "agent" };
+  values: {
+    mode: "show";
+    viewId: string;
+    viewPath?: string;
+    subview?: string;
+    source: "agent";
+  };
 } {
   return {
     actionName: "VIEWS",
@@ -119,6 +132,7 @@ export function navIntentActionResult(intent: SharedNavIntent): {
     values: {
       mode: "show",
       viewId: intent.viewId,
+      ...(intent.viewPath ? { viewPath: intent.viewPath } : {}),
       ...(intent.subview ? { subview: intent.subview } : {}),
       source: "agent",
     },

--- a/packages/shared/src/views/shared-nav-targets.ts
+++ b/packages/shared/src/views/shared-nav-targets.ts
@@ -7,17 +7,21 @@
  * navigation — the designed not-found render for unclaimed /apps/<slug> routes
  * is #17033 — so every entry here must be client-resolvable. Matcher ids and
  * client ids are separate namespaces — the matcher's "wallet" resolves to the
- * builtin "inventory" tab — so this table is the single translation point, and
- * it deliberately omits matcher ids with no shared-tier client surface (e.g.
- * "help", "camera") so those utterances fall through to the normal LLM turn
- * instead of navigating nowhere (#17032). The vocabulary is pinned by the
- * cross-package contract test packages/ui/src/shared-nav-contract.test.ts.
+ * builtin "inventory" tab — so this table is the single translation point.
+ * Host-owned destinations also carry their canonical path because they are not
+ * guaranteed to exist in every platform's in-process view registry. Matcher
+ * ids with no shared-tier client surface (e.g. "help", "camera") are omitted
+ * so those utterances fall through to the normal LLM turn instead of navigating
+ * nowhere (#17032). The vocabulary is pinned by the cross-package contract test
+ * packages/ui/src/shared-nav-contract.test.ts.
  */
 
 /** A client-resolvable navigation target for one matcher id. */
 export interface SharedNavTarget {
   /** View id the client resolves against its routable view registry. */
   viewId: string;
+  /** Canonical path when the destination is host-owned rather than registry-owned. */
+  viewPath?: string;
   /** Human label used in confirmation copy ("Opening <label> for you."). */
   label: string;
 }
@@ -83,6 +87,11 @@ export const SHARED_NAV_TARGETS: Readonly<Record<string, SharedNavTarget>> = {
   transcripts: { viewId: "transcripts", label: "Transcripts" },
   character: { viewId: "character", label: "Character" },
   automations: { viewId: "automations", label: "Automations" },
+  "cloud-apps": {
+    viewId: "cloud-apps",
+    viewPath: "/cloud-apps",
+    label: "Cloud Apps",
+  },
   chat: { viewId: "chat", label: "Home" },
   // "camera" is deliberately absent: the camera view is an AOSP-fork-only
   // native surface, and AOSP devices run dedicated local runtimes whose real

--- a/packages/shared/src/views/view-command-matcher.ts
+++ b/packages/shared/src/views/view-command-matcher.ts
@@ -980,6 +980,150 @@ function nounAlt(items: readonly string[]): string {
 const VERB_ALT = alt(NAV_VERBS);
 const VW_ALT = alt(VIEW_WORDS);
 const POSS_ALT = alt(POSSESSIVES);
+const CLOUD_APPS_VIEW_ID = "cloud-apps";
+const CLOUD_APPS_STRONG_NAV_VERBS = [
+  // en
+  "open",
+  "go to",
+  "goto",
+  "take me to",
+  "navigate to",
+  "switch to",
+  "bring up",
+  "pull up",
+  "jump to",
+  "head to",
+  "get me to",
+  "send me to",
+  "let's go to",
+  "lets go to",
+  "change to",
+  "launch",
+  "back to",
+  "return to",
+  // es
+  "abre",
+  "abrir",
+  "ábreme",
+  "abreme",
+  "ir a",
+  "ve a",
+  "llévame a",
+  "llevame a",
+  "cambia a",
+  // pt
+  "abra",
+  "vá para",
+  "va para",
+  "vai para",
+  "me leva para",
+  "muda para",
+  // fr
+  "ouvre",
+  "ouvrir",
+  "va à",
+  "va a",
+  "amène-moi à",
+  "accède à",
+  // de
+  "öffne",
+  "öffnen",
+  "offne",
+  "geh zu",
+  "bring mich zu",
+  "wechsle zu",
+  // zh
+  "打开",
+  "打開",
+  "切换到",
+  "切換到",
+  "进入",
+  "進入",
+  "转到",
+  "轉到",
+  "跳转到",
+  "去",
+  // ja
+  "開いて",
+  "開く",
+  "ひらいて",
+  "に移動",
+  "に行って",
+  // ko
+  "열어",
+  "열어줘",
+  "열기",
+  "로 이동",
+  "으로 이동",
+  "가줘",
+  // vi
+  "mở",
+  "đi tới",
+  "đi đến",
+  "chuyển sang",
+  // tl
+  "buksan",
+  "pumunta sa",
+  "dalhin mo ako sa",
+] as const;
+const CLOUD_APPS_ARTICLES = [
+  "the",
+  "my",
+  "las",
+  "mis",
+  "os",
+  "meus",
+  "les",
+  "mes",
+  "die",
+  "meine",
+  "ang",
+] as const;
+const CLOUD_APPS_PARTICLES = [
+  "を",
+  "へ",
+  "に",
+  "은",
+  "는",
+  "이",
+  "가",
+  "을",
+  "를",
+  "로",
+  "으로",
+] as const;
+const CLOUD_APPS_COURTESY = [
+  "please",
+  "por favor",
+  "s'il vous plaît",
+  "s il vous plait",
+  "bitte",
+] as const;
+const CLOUD_APPS_NOUNS = VIEW_NOUNS[CLOUD_APPS_VIEW_ID].filter(
+  // A singular cloud app takes an app name ("open the cloud app Acme") and is
+  // an APP/domain request, never a request for the inventory studio.
+  (noun) => noun !== "cloud app",
+);
+const CLOUD_APPS_VERB_ALT = alt(CLOUD_APPS_STRONG_NAV_VERBS);
+const CLOUD_APPS_NOUN_ALT = nounAlt(CLOUD_APPS_NOUNS);
+const CLOUD_APPS_MENTION_RE = new RegExp(
+  nounAlt(VIEW_NOUNS[CLOUD_APPS_VIEW_ID]),
+  "iu",
+);
+const CLOUD_APPS_ARTICLE_ALT = alt(CLOUD_APPS_ARTICLES);
+const CLOUD_APPS_PARTICLE_ALT = rawAlt(CLOUD_APPS_PARTICLES);
+const CLOUD_APPS_COURTESY_ALT = alt(CLOUD_APPS_COURTESY);
+const CLOUD_APPS_EDGE = `[\\s\\p{P}]*`;
+const CLOUD_APPS_OPTIONAL_COURTESY = `(?:(?:${CLOUD_APPS_COURTESY_ALT})[\\s\\p{P}]+)?`;
+const CLOUD_APPS_OPTIONAL_ARTICLE = `(?:(?:${CLOUD_APPS_ARTICLE_ALT})[\\s\\p{P}]+)?`;
+const CLOUD_APPS_OPTIONAL_PARTICLE = `(?:${CLOUD_APPS_PARTICLE_ALT})?`;
+const CLOUD_APPS_COMMAND_RE = new RegExp(
+  [
+    `^${CLOUD_APPS_EDGE}${CLOUD_APPS_OPTIONAL_COURTESY}(?:${CLOUD_APPS_VERB_ALT})[\\s\\p{P}]*${CLOUD_APPS_OPTIONAL_ARTICLE}(?:${CLOUD_APPS_NOUN_ALT})${CLOUD_APPS_EDGE}(?:(?:${CLOUD_APPS_COURTESY_ALT})${CLOUD_APPS_EDGE})?$`,
+    `^${CLOUD_APPS_EDGE}${CLOUD_APPS_OPTIONAL_COURTESY}(?:${CLOUD_APPS_NOUN_ALT})${CLOUD_APPS_OPTIONAL_PARTICLE}[\\s\\p{P}]*(?:${CLOUD_APPS_VERB_ALT})${CLOUD_APPS_EDGE}(?:(?:${CLOUD_APPS_COURTESY_ALT})${CLOUD_APPS_EDGE})?$`,
+  ].join("|"),
+  "iu",
+);
 const COMPANION_ACTION_VERBS = new Set([
   "DRAW",
   "GENERATE",
@@ -1014,19 +1158,19 @@ interface CompiledView {
 //   whole message == noun (just "settings")
 // Gaps use [\s\S]{0,N} so CJK (no spaces) and short filler both match, while
 // staying tight enough to avoid cross-clause false positives.
-const COMPILED: CompiledView[] = VIEW_PRIORITY.filter((v) => VIEW_NOUNS[v]).map(
-  (viewId) => {
-    const N = nounAlt(VIEW_NOUNS[viewId]);
-    const pattern = [
-      `(?:${VERB_ALT})[\\s\\S]{0,16}?(?:${N})`,
-      `(?:${N})[\\s\\S]{0,8}?(?:${VERB_ALT})`,
-      `(?:${POSS_ALT})[\\s\\S]{0,4}?(?:${N})`,
-      `(?:${N})[\\s\\S]{0,4}?(?:${VW_ALT})`,
-      `^[\\s\\p{P}]*(?:${N})[\\s\\p{P}]*$`,
-    ].join("|");
-    return { viewId, re: new RegExp(pattern, "iu") };
-  },
-);
+const COMPILED: CompiledView[] = VIEW_PRIORITY.filter(
+  (v) => v !== CLOUD_APPS_VIEW_ID && VIEW_NOUNS[v],
+).map((viewId) => {
+  const N = nounAlt(VIEW_NOUNS[viewId]);
+  const pattern = [
+    `(?:${VERB_ALT})[\\s\\S]{0,16}?(?:${N})`,
+    `(?:${N})[\\s\\S]{0,8}?(?:${VERB_ALT})`,
+    `(?:${POSS_ALT})[\\s\\S]{0,4}?(?:${N})`,
+    `(?:${N})[\\s\\S]{0,4}?(?:${VW_ALT})`,
+    `^[\\s\\p{P}]*(?:${N})[\\s\\p{P}]*$`,
+  ].join("|");
+  return { viewId, re: new RegExp(pattern, "iu") };
+});
 
 // Bare "go back" is the conversational counterpart of the shell's Home affordance.
 // Browser/OS history remains a client-owned gesture, so this exact whole-message
@@ -1049,6 +1193,14 @@ export function matchViewCommand(text: string | undefined): string | null {
   if (looksLikeCompanionActionRequest(lower)) return null;
   if (BARE_HOME_NAVIGATION.test(lower)) return "chat";
   const variants = [lower, stripDiacritics(lower)];
+  if (variants.some((variant) => CLOUD_APPS_COMMAND_RE.test(variant))) {
+    return CLOUD_APPS_VIEW_ID;
+  }
+  // A Cloud Apps phrase that is not the strict command above belongs to normal
+  // action planning. Do not let another noun in the same sentence ("help",
+  // "documentation") hijack it into an unrelated deterministic view.
+  if (variants.some((variant) => CLOUD_APPS_MENTION_RE.test(variant)))
+    return null;
   for (const { viewId, re } of COMPILED) {
     for (const v of variants) {
       if (re.test(v)) return viewId;

--- a/packages/ui/src/cloud/applications/ApplicationsPage.tsx
+++ b/packages/ui/src/cloud/applications/ApplicationsPage.tsx
@@ -35,59 +35,71 @@ export default function ApplicationsPage() {
   return (
     <AppsPageWrapper>
       <DashboardPageContainer className="space-y-4 md:space-y-6">
-        <DashboardStatGrid data-onboarding="apps-stats">
-          <DashboardStatCard
-            label={t("cloud.apps.stat.totalApps", {
-              defaultValue: "Total Apps",
-            })}
-            value={apps.length}
-            icon={<Grid3x3 className="h-5 w-5 text-muted" />}
-          />
-          <DashboardStatCard
-            label={t("cloud.apps.stat.activeApps", {
-              defaultValue: "Active Apps",
-            })}
-            value={activeCount}
-            icon={<Activity className="h-5 w-5 text-green-500" />}
-          />
-          <DashboardStatCard
-            label={t("cloud.apps.stat.totalUsers", {
-              defaultValue: "Total Users",
-            })}
-            value={totalUsers.toLocaleString()}
-            icon={<Users className="h-5 w-5 text-muted" />}
-          />
-          <DashboardStatCard
-            label={t("cloud.apps.stat.totalRequests", {
-              defaultValue: "Total Requests",
-            })}
-            value={totalRequests.toLocaleString()}
-            icon={<TrendingUp className="h-5 w-5 text-purple-500" />}
-          />
-        </DashboardStatGrid>
-        {!session.ready || isLoading ? (
+        {!session.ready ? (
           <AppsSkeleton />
-        ) : isError ? (
+        ) : !session.authenticated ? (
           <DashboardErrorState
-            message={
-              error instanceof Error
-                ? error.message
-                : t("cloud.apps.error.load", {
-                    defaultValue: "Failed to load apps",
-                  })
-            }
-          />
-        ) : apps.length === 0 ? (
-          // Apps are created BY the agent (chat: "build me an app…"), never
-          // from the console — the dashboard only manages what exists.
-          <AppsEmptyState
-            description={t("cloud.apps.emptyAgentHint", {
-              defaultValue:
-                "Ask your Eliza agent to build and deploy an app — it will show up here to manage, monetize, and share.",
+            message={t("cloud.apps.signInRequired", {
+              defaultValue: "Sign in to Eliza Cloud to manage Cloud Apps.",
             })}
           />
         ) : (
-          <AppsTable apps={apps} />
+          <>
+            <DashboardStatGrid data-onboarding="apps-stats">
+              <DashboardStatCard
+                label={t("cloud.apps.stat.totalApps", {
+                  defaultValue: "Total Apps",
+                })}
+                value={apps.length}
+                icon={<Grid3x3 className="h-5 w-5 text-muted" />}
+              />
+              <DashboardStatCard
+                label={t("cloud.apps.stat.activeApps", {
+                  defaultValue: "Active Apps",
+                })}
+                value={activeCount}
+                icon={<Activity className="h-5 w-5 text-green-500" />}
+              />
+              <DashboardStatCard
+                label={t("cloud.apps.stat.totalUsers", {
+                  defaultValue: "Total Users",
+                })}
+                value={totalUsers.toLocaleString()}
+                icon={<Users className="h-5 w-5 text-muted" />}
+              />
+              <DashboardStatCard
+                label={t("cloud.apps.stat.totalRequests", {
+                  defaultValue: "Total Requests",
+                })}
+                value={totalRequests.toLocaleString()}
+                icon={<TrendingUp className="h-5 w-5 text-purple-500" />}
+              />
+            </DashboardStatGrid>
+            {isLoading ? (
+              <AppsSkeleton />
+            ) : isError ? (
+              <DashboardErrorState
+                message={
+                  error instanceof Error
+                    ? error.message
+                    : t("cloud.apps.error.load", {
+                        defaultValue: "Failed to load apps",
+                      })
+                }
+              />
+            ) : apps.length === 0 ? (
+              // Apps are created BY the agent (chat: "build me an app…"), never
+              // from the console — the dashboard only manages what exists.
+              <AppsEmptyState
+                description={t("cloud.apps.emptyAgentHint", {
+                  defaultValue:
+                    "Ask your Eliza agent to build and deploy an app — it will show up here to manage, monetize, and share.",
+                })}
+              />
+            ) : (
+              <AppsTable apps={apps} />
+            )}
+          </>
         )}
       </DashboardPageContainer>
     </AppsPageWrapper>

--- a/packages/ui/src/cloud/applications/NativeAppsStudio.test.tsx
+++ b/packages/ui/src/cloud/applications/NativeAppsStudio.test.tsx
@@ -99,4 +99,16 @@ describe("NativeAppsStudio — native Applications mount", () => {
     await waitFor(() => expect(apiMock).toHaveBeenCalledWith("/api/v1/apps"));
     expect(screen.queryByText("Smoke Test App")).toBeNull();
   });
+
+  it("shows an explicit signed-out state without requesting an inventory", async () => {
+    window.localStorage.removeItem(STEWARD_TOKEN_KEY);
+
+    render(<NativeAppsStudio />);
+
+    expect(
+      await screen.findByText("Sign in to Eliza Cloud to manage Cloud Apps."),
+    ).toBeTruthy();
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(screen.queryByText("Total Apps")).toBeNull();
+  });
 });

--- a/packages/ui/src/cloud/register-all.test.ts
+++ b/packages/ui/src/cloud/register-all.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { registerAllCloudSurfaces } from "./register-all";
-import { listCloudRoutes } from "./shell/cloud-route-registry";
+import { getCloudRoute, listCloudRoutes } from "./shell/cloud-route-registry";
 
 /**
  * Guards the boot-time wiring: every cloud domain must register its routes when
@@ -39,6 +39,7 @@ describe("registerAllCloudSurfaces", () => {
       "dashboard/connectors",
       "dashboard/organization",
       "dashboard/api-explorer",
+      "cloud-apps",
       "dashboard/apps",
       "dashboard/admin",
       "approve/:approvalId",
@@ -52,6 +53,18 @@ describe("registerAllCloudSurfaces", () => {
     ]) {
       expect(paths, `missing route ${p}`).toContain(p);
     }
+  });
+
+  it("keeps the web Cloud Apps handoff on the live Applications surface", () => {
+    registerAllCloudSurfaces();
+    const cloudApps = getCloudRoute("cloud-apps");
+    const retiredConsoleApps = getCloudRoute("dashboard/apps");
+
+    expect(cloudApps).toMatchObject({
+      path: "cloud-apps",
+      group: "dashboard",
+    });
+    expect(cloudApps?.element).not.toBe(retiredConsoleApps?.element);
   });
 
   it("keeps legacy-only spellings as redirects, not routes", () => {

--- a/packages/ui/src/cloud/register-all.ts
+++ b/packages/ui/src/cloud/register-all.ts
@@ -69,6 +69,12 @@ export function registerAllCloudSurfaces(): void {
   // same-path registration wins) so a stale /dashboard/apps link redirects to
   // the dashboard. The applications components stay for the native eliza app.
   const AppsMovedRoute = lazy(() => import("./applications/AppsMovedRoute"));
+  const CloudAppsRoute = lazy(() => import("./applications/ApplicationsPage"));
+  registerCloudRoute({
+    path: "cloud-apps",
+    element: CloudAppsRoute,
+    group: "dashboard",
+  });
   registerCloudRoute({
     path: APPLICATIONS_LIST_ROUTE_PATH,
     element: AppsMovedRoute,

--- a/packages/ui/src/shared-nav-contract.test.ts
+++ b/packages/ui/src/shared-nav-contract.test.ts
@@ -48,6 +48,11 @@ interface PluginViewPin {
   sources: string[];
 }
 
+interface HostViewPin {
+  path: string;
+  source: string;
+}
+
 // Views declared by dedicated-runtime plugins (unavailable to a pure Tier-0
 // client, but resolvable wherever the owning plugin is loaded). The literal
 // map is the expectation; the fs read below is the pin — each declaring source
@@ -80,6 +85,16 @@ const PLUGIN_VIEW_TARGETS: Record<string, PluginViewPin> = {
   },
 };
 
+// Host-owned pages are bundled by packages/app rather than declared by a
+// plugin. The native shell registers this path in-process; the web shell turns
+// the same path into a compatibility redirect to its authenticated cloud route.
+const HOST_VIEW_TARGETS: Record<string, HostViewPin> = {
+  "cloud-apps": {
+    path: "/cloud-apps",
+    source: "packages/app/src/cloud-apps-view.ts",
+  },
+};
+
 // This test only runs in-repo, so the monorepo root is a fixed hop above this
 // file (packages/ui/src → repo root) and a missing source file is a hard fail,
 // never a skip.
@@ -94,10 +109,13 @@ describe("shared-tier nav vocabulary contract", () => {
     for (const [matcherId, target] of Object.entries(SHARED_NAV_TARGETS)) {
       const builtin = builtinById.get(target.viewId);
       const pluginPin = PLUGIN_VIEW_TARGETS[target.viewId];
+      const hostPin = HOST_VIEW_TARGETS[target.viewId];
       expect(
-        builtin !== undefined || pluginPin !== undefined,
+        builtin !== undefined ||
+          pluginPin !== undefined ||
+          hostPin !== undefined,
         `SHARED_NAV_TARGETS["${matcherId}"] emits viewId "${target.viewId}", ` +
-          "which is neither a builtin shell view nor a known plugin view — " +
+          "which is neither a builtin shell view nor a known plugin/host view — " +
           "the client would blind-navigate to /apps/<id> (not-found render: #17033)",
       ).toBe(true);
       if (builtin) {
@@ -106,6 +124,12 @@ describe("shared-tier nav vocabulary contract", () => {
           `builtin viewId "${target.viewId}" is registered at "${builtin.path}", ` +
             `expected "${BUILTIN_NAV_PATHS[target.viewId]}"`,
         ).toBe(BUILTIN_NAV_PATHS[target.viewId]);
+      }
+      if (hostPin) {
+        expect(
+          target.viewPath,
+          `host-owned target "${target.viewId}" must carry its canonical path`,
+        ).toBe(hostPin.path);
       }
     }
   });
@@ -172,6 +196,19 @@ describe("shared-tier nav vocabulary contract", () => {
           `plugin view "${viewId}": ${source} no longer declares path: "${pin.path}"`,
         ).toBe(true);
       }
+    }
+  });
+
+  it("every host view pin is still registered at its client path", () => {
+    for (const [viewId, pin] of Object.entries(HOST_VIEW_TARGETS)) {
+      const filePath = resolve(REPO_ROOT, pin.source);
+      expect(
+        existsSync(filePath),
+        `host view "${viewId}": declaring source ${pin.source} is missing`,
+      ).toBe(true);
+      const contents = readFileSync(filePath, "utf8");
+      expect(contents).toContain(`id: "${viewId}"`);
+      expect(contents).toContain(`path: "${pin.path}"`);
     }
   });
 

--- a/packages/ui/src/view-action-handoff.test.ts
+++ b/packages/ui/src/view-action-handoff.test.ts
@@ -93,6 +93,29 @@ describe("view action handoff", () => {
     });
   });
 
+  it("dispatches a shared host destination at its canonical path", () => {
+    const dispatch = vi.fn();
+    const sharedCloudApps: ChatActionResultSummary = {
+      actionName: "VIEWS",
+      success: true,
+      values: {
+        mode: "show",
+        viewId: "cloud-apps",
+        viewPath: "/cloud-apps",
+        source: "agent",
+      },
+    };
+
+    expect(dispatchViewActionHandoffDirect([sharedCloudApps], dispatch)).toBe(
+      true,
+    );
+    expect(dispatch).toHaveBeenCalledWith({
+      viewId: "cloud-apps",
+      viewPath: "/cloud-apps",
+      source: "agent",
+    });
+  });
+
   it("does not duplicate history when the WebSocket already switched the route", async () => {
     const dispatch = vi.fn();
 

--- a/packages/ui/src/view-action-handoff.ts
+++ b/packages/ui/src/view-action-handoff.ts
@@ -31,6 +31,7 @@ interface CurrentViewResponse {
 
 export interface ViewActionHandoff {
   viewId: string;
+  viewPath?: string;
   subview?: string;
 }
 
@@ -53,8 +54,13 @@ export function findViewActionHandoff(
     const mode = readString(result.values?.mode)?.toLowerCase();
     const viewId = readString(result.values?.viewId);
     if ((mode === "show" || mode === "open") && viewId) {
+      const viewPath = readString(result.values?.viewPath);
       const subview = readString(result.values?.subview);
-      return { viewId, ...(subview ? { subview } : {}) };
+      return {
+        viewId,
+        ...(viewPath ? { viewPath } : {}),
+        ...(subview ? { subview } : {}),
+      };
     }
   }
   return null;
@@ -216,10 +222,10 @@ export async function dispatchViewActionHandoff(
  * `dispatchViewActionHandoff` would throw `VIEW_HANDOFF_CURRENT_VIEW_HTTP_FAILED`
  * on the missing endpoint and the navigation would never fire. The shared
  * runtime already resolved the target deterministically and stamped it into the
- * summary (`values.viewId` [+ `values.subview`]), so the client trusts it and
- * dispatches the navigate event straight through. The App shell's
- * NAVIGATE_VIEW_EVENT handler resolves the builtin viewId → path (and a Settings
- * `subview` → section) with no server call.
+ * summary (`values.viewId` plus optional path/subview), so the client trusts it
+ * and dispatches the navigate event straight through. Registry-owned views are
+ * resolved by id; host-owned views carry their canonical path so web and native
+ * shells land on the same destination without a server call.
  *
  * Returns true when a navigation was dispatched, false when the summary carried
  * no show/open VIEWS handoff.
@@ -233,6 +239,7 @@ export function dispatchViewActionHandoffDirect(
   dispatch({
     viewId: handoff.viewId,
     source: "agent",
+    ...(handoff.viewPath ? { viewPath: handoff.viewPath } : {}),
     ...(handoff.subview ? { subview: handoff.subview } : {}),
   });
   return true;

--- a/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
+++ b/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
@@ -43,11 +43,6 @@ describe("matchViewCommand — explicit user examples", () => {
 		["show my knowledge hub", "documents"],
 		["switch to focus mode", "focus"],
 		["open my goals", "goals"],
-		["open cloud apps", "cloud-apps"],
-		["show my cloud applications", "cloud-apps"],
-		["go to the app studio", "cloud-apps"],
-		["show my deployed apps", "cloud-apps"],
-		["go to app deployments", "cloud-apps"],
 		["open plugins", "plugins-page"],
 		// coding cockpit — wins over task-coordinator's bare "coding"
 		["open the cockpit", "cockpit"],
@@ -97,11 +92,6 @@ describe("matchViewCommand — multilingual", () => {
 		["mở ứng dụng đám mây", "cloud-apps"],
 		// tl
 		["buksan ang settings", "settings"],
-		["abre aplicaciones en la nube", "cloud-apps"],
-		["ouvre les applications cloud", "cloud-apps"],
-		["打开云应用", "cloud-apps"],
-		["クラウドアプリを開いて", "cloud-apps"],
-		["클라우드 앱 열어", "cloud-apps"],
 	];
 	for (const [text, view] of cases) {
 		it(`"${text}" → ${view}`, () => {
@@ -131,6 +121,55 @@ describe("matchViewCommand — localized Knowledge labels", () => {
 	);
 });
 
+describe("matchViewCommand — Cloud Apps navigation arbitration", () => {
+	const commands = [
+		"open cloud apps",
+		"please navigate to the cloud applications",
+		"go to my deployed apps",
+		"go to the app studio",
+		"go to app deployments",
+		"abre las aplicaciones en la nube",
+		"abra aplicativos na nuvem",
+		"ouvre les applications cloud",
+		"öffne cloud-anwendungen",
+		"打开云应用",
+		"クラウドアプリを開いて",
+		"클라우드 앱 열어",
+		"mở ứng dụng đám mây",
+	] as const;
+
+	it.each(commands)("%j opens the Cloud Apps studio", (text) => {
+		expect(matchViewCommand(text)).toBe("cloud-apps");
+	});
+
+	const inventoryOrNonNavigation = [
+		"cloud apps",
+		"my cloud apps",
+		"list my cloud apps",
+		"show my cloud apps",
+		"list my deployed apps",
+		"what cloud apps do I have?",
+		"do not open cloud apps",
+		"don't open cloud apps",
+		"how do I open cloud apps?",
+		"tell me how to open cloud apps",
+		"if I open cloud apps, will I be charged?",
+		"when I open cloud apps it crashes",
+		"help me open cloud apps",
+		"open cloud apps documentation",
+		"open the cloud app Acme",
+		"abre la documentación de aplicaciones en la nube",
+		"云应用怎么打开",
+	] as const;
+
+	it.each(inventoryOrNonNavigation)(
+		"%j stays in normal action planning",
+		(text) => {
+			expect(matchViewCommand(text)).toBeNull();
+		},
+	);
+});
+
 describe("matchViewCommand — generated verb×view coverage (English)", () => {
 	const verbs = [
 		"open",
@@ -141,6 +180,7 @@ describe("matchViewCommand — generated verb×view coverage (English)", () => {
 		"switch to",
 	];
 	for (const viewId of MATCHER_VIEW_IDS) {
+		if (viewId === "cloud-apps") continue;
 		// Use the first English-ish noun (index 0 is the canonical English term).
 		const noun = __matcherData.VIEW_NOUNS[viewId][0];
 		for (const verb of verbs) {

--- a/plugins/plugin-app-control/src/actions/view-matrix.fixtures.ts
+++ b/plugins/plugin-app-control/src/actions/view-matrix.fixtures.ts
@@ -42,6 +42,8 @@ export interface NounRecallCase {
 	noun: string;
 	/** Phrases that must all resolve (recall) — verb, possessive, bare forms. */
 	phrases: { verb: string; possessive: string; bare: string };
+	/** This view requires an explicit strong navigation verb. */
+	navigationOnly?: boolean;
 }
 
 /**
@@ -55,6 +57,7 @@ export function nounRecallCases(): NounRecallCase[] {
 	for (const viewId of MATCHER_VIEW_IDS) {
 		const nouns = __matcherData.VIEW_NOUNS[viewId] ?? [];
 		for (const noun of nouns) {
+			if (viewId === "cloud-apps" && noun === "cloud app") continue;
 			cases.push({
 				viewId,
 				noun,
@@ -63,6 +66,7 @@ export function nounRecallCases(): NounRecallCase[] {
 					possessive: `my ${noun}`,
 					bare: noun,
 				},
+				...(viewId === "cloud-apps" ? { navigationOnly: true } : {}),
 			});
 		}
 	}
@@ -126,6 +130,34 @@ export const CURATED_MULTILINGUAL: readonly CuratedCase[] = [
 	{ viewId: "settings", lang: "ko", phrase: "설정 열어" },
 	{ viewId: "settings", lang: "vi", phrase: "mở cài đặt" },
 	{ viewId: "settings", lang: "tl", phrase: "buksan ang mga setting" },
+	// cloud apps — navigation grammar is intentionally strong-verb-only so
+	// inventory utterances remain available to LIST_CLOUD_APPS.
+	{ viewId: "cloud-apps", lang: "en", phrase: "open cloud apps" },
+	{
+		viewId: "cloud-apps",
+		lang: "es",
+		phrase: "abre las aplicaciones en la nube",
+	},
+	{
+		viewId: "cloud-apps",
+		lang: "pt",
+		phrase: "abra aplicativos na nuvem",
+	},
+	{
+		viewId: "cloud-apps",
+		lang: "fr",
+		phrase: "ouvre les applications cloud",
+	},
+	{ viewId: "cloud-apps", lang: "de", phrase: "öffne cloud-anwendungen" },
+	{ viewId: "cloud-apps", lang: "zh", phrase: "打开云应用" },
+	{ viewId: "cloud-apps", lang: "ja", phrase: "クラウドアプリを開いて" },
+	{ viewId: "cloud-apps", lang: "ko", phrase: "클라우드 앱 열어" },
+	{
+		viewId: "cloud-apps",
+		lang: "vi",
+		phrase: "mở ứng dụng đám mây",
+	},
+	{ viewId: "cloud-apps", lang: "tl", phrase: "buksan ang cloud apps" },
 ];
 
 /**
@@ -138,6 +170,13 @@ export const NEGATIVE_CONTROLS: readonly {
 }[] = [
 	{ lang: "en", phrase: "what's the weather like today" },
 	{ lang: "en", phrase: "tell me a joke" },
+	{ lang: "en", phrase: "list my cloud apps" },
+	{ lang: "en", phrase: "show my cloud apps" },
+	{ lang: "en", phrase: "do not open cloud apps" },
+	{ lang: "en", phrase: "how do I open cloud apps?" },
+	{ lang: "en", phrase: "when I open cloud apps it crashes" },
+	{ lang: "en", phrase: "open cloud apps documentation" },
+	{ lang: "en", phrase: "open the cloud app Acme" },
 	{ lang: "es", phrase: "cuéntame un chiste" },
 	{ lang: "pt", phrase: "como está o tempo hoje" },
 	{ lang: "fr", phrase: "raconte-moi une blague" },

--- a/plugins/plugin-app-control/src/actions/view-matrix.test.ts
+++ b/plugins/plugin-app-control/src/actions/view-matrix.test.ts
@@ -32,8 +32,8 @@ describe("view matrix — exhaustive noun recall (every view × every language n
 	});
 
 	it.each(RECALL_CASES)(
-		"resolves $viewId noun '$noun' via verb/possessive/bare forms",
-		({ phrases }) => {
+		"resolves $viewId noun '$noun' under its arbitration policy",
+		({ viewId, phrases, navigationOnly }) => {
 			// Every noun must be reachable through an explicit verb and a possessive,
 			// and as a bare whole-message noun. The resolved view must be registered
 			// (a higher-priority view may legitimately win a shared substring, but it
@@ -41,6 +41,12 @@ describe("view matrix — exhaustive noun recall (every view × every language n
 			const verb = matchViewCommand(phrases.verb);
 			const poss = matchViewCommand(phrases.possessive);
 			const bare = matchViewCommand(phrases.bare);
+			if (navigationOnly) {
+				expect(verb, `verb form: "${phrases.verb}"`).toBe(viewId);
+				expect(poss, `inventory form: "${phrases.possessive}"`).toBeNull();
+				expect(bare, `bare form: "${phrases.bare}"`).toBeNull();
+				return;
+			}
 			expect(verb, `verb form: "${phrases.verb}"`).not.toBeNull();
 			expect(poss, `possessive form: "${phrases.possessive}"`).not.toBeNull();
 			expect(bare, `bare form: "${phrases.bare}"`).not.toBeNull();

--- a/plugins/plugin-app-control/src/actions/view-routing-benchmark.test.ts
+++ b/plugins/plugin-app-control/src/actions/view-routing-benchmark.test.ts
@@ -154,7 +154,7 @@ function runBenchmark(): {
 	};
 
 	// Exhaustive noun recall: every view × every multilingual noun × forms.
-	for (const { viewId, phrases } of nounRecallCases()) {
+	for (const { viewId, phrases, navigationOnly } of nounRecallCases()) {
 		record(
 			viewId,
 			"und",
@@ -162,6 +162,7 @@ function runBenchmark(): {
 			phrases.verb,
 			resolveIntentView(phrases.verb),
 		);
+		if (navigationOnly) continue;
 		record(
 			viewId,
 			"und",

--- a/plugins/plugin-app-control/src/evaluators/view-command-shortcut.test.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-command-shortcut.test.ts
@@ -72,6 +72,7 @@ describe("viewCommandShortcutEvaluator — forces VIEWS on explicit commands", (
 		["설정 열어", "settings"],
 		["設定を開いて", "settings"],
 		["open app builder", "task-coordinator"],
+		["open cloud apps", "cloud-apps"],
 	];
 	for (const [text, view] of commands) {
 		it(`"${text}" forces VIEWS`, async () => {
@@ -166,5 +167,19 @@ describe("viewCommandShortcutEvaluator — overrides weak-model STOP", () => {
 				params: { action: "show", view: "settings" },
 			},
 		});
+	});
+
+	it.each([
+		"list my cloud apps",
+		"show my cloud apps",
+		"list my deployed apps",
+	])("preserves LIST_CLOUD_APPS planning for %j", async (text) => {
+		expect(
+			await run(text, {
+				extraActions: ["LIST_CLOUD_APPS"],
+				candidateActions: ["LIST_CLOUD_APPS"],
+				parentActionHints: ["LIST_CLOUD_APPS"],
+			}),
+		).toBeNull();
 	});
 });


### PR DESCRIPTION
# Relates to

Closes #17409. Fix-forward for merged #17388.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5` (completion lane), earlier heads `anthropic/claude-opus` sessions on this machine
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- Merged onto current `origin/develop`; the earlier develop merges on this branch had resurrected files develop deleted (including secret-bearing benchmark fixtures) and reverted #17906, so the branch was rebuilt as a single clean commit on current develop carrying only the 17-file routing/arbitration diff.
- Current diff vs `origin/develop` is exactly the 17 routing/matcher/UI files listed in the Files tab.

# What changed

- Cloud Apps uses strict anchored navigation grammar and strong navigation verbs across en/es/pt/fr/de/zh/ja/ko/vi/tl.
- Inventory/list/show intents preserve `LIST_CLOUD_APPS` rather than being cleared by `VIEWS`.
- Negations, instructions, conditional/support reports, docs requests, and named-app requests remain with the planner/action path.
- Shared routing maps only to verified web/native destinations (`shared-nav-targets.ts`).
- The live web surface registers `/cloud-apps` (previously an unregistered route), and the page renders an explicit signed-out state instead of claiming a successful unavailable route.
- Direct view-action handoff dispatches the canonical host view path and tags agent-sourced navigation (`source: "agent"`).

# Testing

- `plugins/plugin-app-control` actions + evaluators: 1537 tests passed (matcher, matrix, routing benchmark, shortcut evaluator, views management).
- `packages/cloud/shared` shared-nav-intent (bun test): 58 passed, 1633 assertions.
- `packages/ui` handoff/contract/register-all/NativeAppsStudio: 21 passed.
- `packages/app` cloud-apps-view: 1 passed; `packages/shared`: 118 files / 1328 tests passed.
- Turbo typecheck green for `@elizaos/shared`, `@elizaos/ui`, `@elizaos/app`, `@elizaos/cloud-shared`, `@elizaos/plugin-app-control`; Biome clean on the touched files.

# Evidence Gate

<!-- evidence-head:c45303fc2eaa10f2ca1a1bca17df99eb3d81cdc2 -->

<!-- evidence-row:before-screenshots -->
- [x] Develop-state renderer (branch UI files reverted to `origin/develop`), authed test shell, `/cloud-apps` desktop + mobile — the route is unregistered before this PR:
  ![before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17420-before-cloud-apps-desktop.png)
  ![before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17420-before-cloud-apps-mobile.png)

<!-- evidence-row:after-screenshots -->
- [x] Exact-head renderer, authed test shell, `/cloud-apps` desktop + mobile — registered Cloud Apps page with stats and app list:
  ![after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17420-after-cloud-apps-desktop.png)
  ![after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17420-after-cloud-apps-mobile.png)

<!-- evidence-row:walkthrough-video -->
- [x] Exact-head walkthrough (home boot then `/cloud-apps` at desktop and mobile viewports, real ui-smoke live stack): https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17420-after-walkthrough.webm

<!-- evidence-row:backend-logs -->
- [x] [Shared-runtime nav-intent + UI contract transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17420-backend-shared-runtime-transcript.log)

<details><summary>Backend shared-runtime routing test output (excerpt)</summary>

```text
=== backend: cloud shared-runtime nav-intent suite (bun test, real contract) ===
bun test v1.3.14 (0d9b296a)
 58 pass
 0 fail
 1633 expect() calls
Ran 58 tests across 1 file.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] [Frontend console + network capture from the exact-head walk](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17420-frontend-console-network.log)

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic routing/arbitration change; no model or prompt behavior involved anywhere in the diff.

<!-- evidence-row:domain-artifacts -->
- [x] [Full verbose matcher/matrix/benchmark transcript, 1039 cases](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17420-matcher-matrix-verbose.log)

<!-- evidence-row:ocr-review -->
- [x] OCR text readout (tesseract) of the before/after desktop + mobile captures, manually reviewed for garbled or clipped UI text: [OCR readout](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17420-ocr-review.txt)

# Known gaps / failures

None in the delivered scope. The native (Capacitor) surface shares the same registered route table; native-only visual capture is covered by the existing app audit lanes.
