### PR TITLE
perf(core): parallelize provider database reads

### DIFF
--- a/packages/core/scripts/provider-latency-report.test.ts
+++ b/packages/core/scripts/provider-latency-report.test.ts
@@ -19,10 +19,34 @@ interface ProviderLatencyReport {
 	}>;
 	execution: string;
 	reusedProviderResultsPerSample: { min: number; max: number };
-	effectiveParallelism: { mean: number };
+	effectiveParallelism: { count: number };
+	freshComposeWallMs: { count: number };
+	reusedComposeWallMs: { count: number };
 }
 
 describe("provider latency report process", () => {
+	it("rejects invalid sample settings instead of silently using defaults", () => {
+		const script = path.resolve(
+			import.meta.dirname,
+			"provider-latency-report.ts",
+		);
+		const result = spawnSync("bun", [script], {
+			cwd: path.resolve(import.meta.dirname, "../../.."),
+			encoding: "utf8",
+			env: {
+				...process.env,
+				ELIZA_PROVIDER_LATENCY_SAMPLES: "invalid",
+			},
+			timeout: 120_000,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain(
+			"ELIZA_PROVIDER_LATENCY_SAMPLES must be a positive integer",
+		);
+	});
+
 	it("executes every provider in parallel and proves the warm-cache pass", () => {
 		const script = path.resolve(
 			import.meta.dirname,
@@ -60,11 +84,16 @@ describe("provider latency report process", () => {
 		rmSync(reportDirectory, { recursive: true });
 
 		expect(report.samples).toBe(1);
-		expect(report.providerCount).toBeGreaterThanOrEqual(20);
 		expect(report.providers).toHaveLength(report.providerCount);
+		expect(report.providers.map((provider) => provider.providerName)).toEqual(
+			expect.arrayContaining(["DOCUMENTS", "FACTS", "RELATIONSHIPS", "WORLD"]),
+		);
 		expect(
 			report.providers.every((provider) => provider.latencyMs.count === 1),
 		).toBe(true);
+		expect(report.freshComposeWallMs.count).toBe(report.samples);
+		expect(report.reusedComposeWallMs.count).toBe(report.samples);
+		expect(report.effectiveParallelism.count).toBe(report.samples);
 		expect(report.execution).toContain("production turn context");
 		expect(report.reusedProviderResultsPerSample.min).toBe(
 			report.providerCount,
@@ -72,6 +101,5 @@ describe("provider latency report process", () => {
 		expect(report.reusedProviderResultsPerSample.max).toBe(
 			report.providerCount,
 		);
-		expect(report.effectiveParallelism.mean).toBeGreaterThan(1);
 	});
 });

--- a/packages/core/scripts/provider-latency-report.ts
+++ b/packages/core/scripts/provider-latency-report.ts
@@ -36,8 +36,15 @@ function readPositiveInteger(name: string, fallback: number): number {
 	if (rawValue === undefined) {
 		return fallback;
 	}
-	const value = Number.parseInt(rawValue, 10);
-	return Number.isFinite(value) && value > 0 ? value : fallback;
+	const value = Number(rawValue);
+	if (!Number.isSafeInteger(value) || value <= 0) {
+		throw new Error(`${name} must be a positive integer`);
+	}
+	return value;
+}
+
+function rounded(value: number): number {
+	return Math.round(value * 1_000) / 1_000;
 }
 
 function percentile(sorted: readonly number[], value: number): number {
@@ -52,12 +59,14 @@ function distribution(samples: readonly number[]): Distribution {
 	const sorted = [...samples].sort((a, b) => a - b);
 	return {
 		count: sorted.length,
-		min: sorted[0] as number,
-		p50: percentile(sorted, 50),
-		p95: percentile(sorted, 95),
-		p99: percentile(sorted, 99),
-		max: sorted.at(-1) as number,
-		mean: sorted.reduce((sum, value) => sum + value, 0) / sorted.length,
+		min: rounded(sorted[0] as number),
+		p50: rounded(percentile(sorted, 50)),
+		p95: rounded(percentile(sorted, 95)),
+		p99: rounded(percentile(sorted, 99)),
+		max: rounded(sorted.at(-1) as number),
+		mean: rounded(
+			sorted.reduce((sum, value) => sum + value, 0) / sorted.length,
+		),
 	};
 }
 

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -19,6 +19,7 @@
  * lane gate is structural (extractor-assigned category + ownership + prior),
  * and the responding model decides which surfaced preferences apply.
  */
+import { ElizaError } from "../../../errors.ts";
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
 import type {
@@ -322,12 +323,20 @@ const factsProvider: Provider = {
 		_state: State,
 	): Promise<ProviderResult> => {
 		try {
-			const recentMessages = await runtime.getMemories({
+			const recentMessagesPromise = runtime.getMemories({
 				tableName: "messages",
 				roomId: message.roomId,
 				limit: 10,
 				unique: false,
 			});
+			const relatedEntityIdsPromise = getRelatedEntityIds(
+				runtime,
+				message.entityId,
+			);
+			const [recentMessages, relatedEntityIds] = await Promise.all([
+				recentMessagesPromise,
+				relatedEntityIdsPromise,
+			]);
 
 			// Build the lexical query from the current message and recent context.
 			const lastMessageLines: string[] = [];
@@ -368,10 +377,6 @@ const factsProvider: Provider = {
 			// turns. Misattribution is prevented at render time instead — facts
 			// are attributed by provenance, so room facts about other participants
 			// never render under the sender's header.
-			const relatedEntityIds = await getRelatedEntityIds(
-				runtime,
-				message.entityId,
-			);
 			const [roomFacts, ...entityFactPools] = await Promise.all([
 				runtime.getMemories({
 					tableName: "facts",
@@ -535,17 +540,18 @@ const factsProvider: Provider = {
 				},
 				text,
 			};
-		} catch (error) {
-			return {
-				values: { facts: "" },
-				data: {
-					facts: [],
-					durableFacts: [],
-					currentFacts: [],
-					error: error instanceof Error ? error.message : String(error),
+		} catch (cause) {
+			// error-policy:J2 Add provider scope before the message boundary reports the failed turn.
+			throw new ElizaError("Facts provider read failed", {
+				code: "FACTS_PROVIDER_READ_FAILED",
+				cause,
+				context: {
+					agentId: runtime.agentId,
+					entityId: message.entityId,
+					roomId: message.roomId,
 				},
-				text: "No facts available.",
-			};
+				severity: "ephemeral",
+			});
 		}
 	},
 };

--- a/packages/core/src/features/advanced-capabilities/providers/relationships.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/relationships.ts
@@ -75,18 +75,20 @@ async function formatRelationships(
 		),
 	);
 
-	// Fetch all required entities in a single batch operation
-	const entities = await Promise.all(
-		uniqueEntityIds.map((id) => runtime.getEntityById(id)),
-	);
+	// Relationship fan-out can contain dozens of counterparts. One adapter
+	// query keeps provider latency constant instead of paying one SQL round-trip
+	// per entity.
+	const entities =
+		uniqueEntityIds.length > 0
+			? await runtime.getEntitiesByIds(uniqueEntityIds)
+			: [];
 
 	// Create a lookup map for efficient access
-	const entityMap = new Map<string, Entity | null>();
-	entities.forEach((entity, index) => {
-		if (entity) {
-			entityMap.set(uniqueEntityIds[index], entity);
-		}
-	});
+	const entityMap = new Map<string, Entity>(
+		entities.flatMap((entity) =>
+			entity.id === undefined ? [] : [[entity.id, entity] as const],
+		),
+	);
 
 	const formatMetadata = (metadata?: Metadata) => {
 		if (!metadata) return "";

--- a/packages/core/src/features/basic-capabilities/providers/world.ts
+++ b/packages/core/src/features/basic-capabilities/providers/world.ts
@@ -118,6 +118,10 @@ export const worldProvider: Provider = {
 				text: "Unable to retrieve world information - world not found",
 			} as ProviderResult;
 		}
+		const [worldRooms, participants] = await Promise.all([
+			runtime.getRooms(worldId),
+			runtime.getParticipantsForRoom(message.roomId),
+		]);
 
 		logger.debug(
 			{
@@ -129,8 +133,6 @@ export const worldProvider: Provider = {
 			"Found world",
 		);
 
-		// Get all rooms in the current world
-		const worldRooms = await runtime.getRooms(worldId);
 		logger.debug(
 			{
 				src: "plugin:basic-capabilities:provider:world",
@@ -141,8 +143,6 @@ export const worldProvider: Provider = {
 			"Found rooms in world",
 		);
 
-		// Get participants for the current room
-		const participants = await runtime.getParticipantsForRoom(message.roomId);
 		logger.debug(
 			{
 				src: "plugin:basic-capabilities:provider:world",

--- a/packages/core/src/features/documents/provider.ts
+++ b/packages/core/src/features/documents/provider.ts
@@ -73,7 +73,13 @@ export const documentsProvider: Provider = {
 			};
 		}
 
-		const relevantSnippets = (await service.searchDocuments(message))
+		const [relevantFragments, documents] = await Promise.all([
+			service.searchDocuments(message),
+			service.listDocuments(message, {
+				limit: MAX_AVAILABLE_DOCUMENTS,
+			}),
+		]);
+		const relevantSnippets = relevantFragments
 			.slice(0, MAX_RELEVANT_SNIPPETS)
 			.map((fragment, index) => {
 				const metadata = fragment.metadata as
@@ -95,9 +101,6 @@ export const documentsProvider: Provider = {
 				};
 			});
 
-		const documents = await service.listDocuments(message, {
-			limit: MAX_AVAILABLE_DOCUMENTS,
-		});
 		const summaries = documents
 			.filter((memory) => memory.metadata?.type === MemoryType.DOCUMENT)
 			.map(summarizeDocument);

--- a/packages/core/src/features/documents/service-list.test.ts
+++ b/packages/core/src/features/documents/service-list.test.ts
@@ -378,6 +378,48 @@ describe("DocumentService list semantics", () => {
 		]);
 	});
 
+	it("does not expose foreign-agent or non-document rows through delete errors", async () => {
+		const { runtime, service } = await makeHarness();
+		const hiddenDocument = documentMemory(20, {
+			entityId: OTHER_USER_ID,
+			metadata: { scope: "owner-private" },
+		});
+		const foreignDocument = documentMemory(21, {
+			agentId: OTHER_AGENT_ID,
+		});
+		const nonDocument = documentMemory(22, {
+			metadata: {
+				type: MemoryType.FRAGMENT,
+				documentId: hiddenDocument.id,
+				position: 0,
+			},
+		});
+		await seedDocuments(runtime, [
+			hiddenDocument,
+			foreignDocument,
+			nonDocument,
+		]);
+		vi.spyOn(runtime, "getRoom").mockResolvedValue({
+			id: ROOM_A,
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+		} as Room);
+		vi.spyOn(runtime, "getWorld").mockResolvedValue({
+			id: WORLD_ID,
+			agentId: AGENT_ID,
+			metadata: { roles: { [USER_ID]: "USER" } },
+		} as World);
+
+		await expect(
+			service.deleteDocument(hiddenDocument.id as UUID, userMessage()),
+		).rejects.toMatchObject({ code: "DOCUMENT_MUTATION_FORBIDDEN" });
+		for (const memory of [foreignDocument, nonDocument]) {
+			await expect(
+				service.deleteDocument(memory.id as UUID, userMessage()),
+			).rejects.toMatchObject({ code: "DOCUMENT_NOT_FOUND" });
+		}
+	});
+
 	it("rejects offsets and query inputs outside the bounded contract", async () => {
 		const { service } = await makeHarness();
 

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -29,6 +29,7 @@ import { createUniqueUuid } from "../../entities";
 import { ElizaError } from "../../errors";
 import { logger } from "../../logger";
 import { checkSenderRole } from "../../roles";
+import { memoizeTurnWork } from "../../trajectory-context";
 import {
 	type AccessContext,
 	type Content,
@@ -248,35 +249,49 @@ export async function resolveDocumentRequester(
 	runtime: IAgentRuntime,
 	message?: Memory,
 ): Promise<DocumentRequester> {
-	const requester = await resolveDocumentRequesterRole(runtime, message);
-	if (documentRoleHasGlobalVisibility(requester.role)) {
-		return { ...requester, roomIds: [] };
-	}
-	try {
-		const roomIds = await runtime.getRoomsForParticipants([requester.entityId]);
-		return {
-			...requester,
-			roomIds: [...new Set(roomIds)],
-		};
-	} catch (cause) {
-		// error-policy:J2 Preserve room-resolution context and fail the read.
-		const error = new ElizaError("Document requester room lookup failed", {
-			code: "DOCUMENT_ROOM_LOOKUP_FAILED",
-			cause,
-			context: {
+	// Search and inventory providers authorize the same immutable ingress
+	// message concurrently. Sharing that promise gives the entire turn one
+	// requester snapshot and avoids repeating role and membership reads.
+	const requesterKey = [
+		"documents:requester",
+		runtime.agentId,
+		message?.id ?? "no-message",
+		message?.entityId ?? runtime.agentId,
+		message?.roomId ?? "no-room",
+	].join(":");
+	return memoizeTurnWork(requesterKey, async () => {
+		const requester = await resolveDocumentRequesterRole(runtime, message);
+		if (documentRoleHasGlobalVisibility(requester.role)) {
+			return { ...requester, roomIds: [] };
+		}
+		try {
+			const roomIds = await runtime.getRoomsForParticipants([
+				requester.entityId,
+			]);
+			return {
+				...requester,
+				roomIds: [...new Set(roomIds)],
+			};
+		} catch (cause) {
+			// error-policy:J2 Preserve room-resolution context and fail the read.
+			const error = new ElizaError("Document requester room lookup failed", {
+				code: "DOCUMENT_ROOM_LOOKUP_FAILED",
+				cause,
+				context: {
+					agentId: runtime.agentId,
+					entityId: requester.entityId,
+					roomId: message?.roomId,
+				},
+				severity: "ephemeral",
+			});
+			runtime.reportError("DocumentService.resolveRequesterRooms", error, {
 				agentId: runtime.agentId,
 				entityId: requester.entityId,
 				roomId: message?.roomId,
-			},
-			severity: "ephemeral",
-		});
-		runtime.reportError("DocumentService.resolveRequesterRooms", error, {
-			agentId: runtime.agentId,
-			entityId: requester.entityId,
-			roomId: message?.roomId,
-		});
-		throw error;
-	}
+			});
+			throw error;
+		}
+	});
 }
 
 function normalizeDocumentScope(
@@ -617,14 +632,14 @@ export class DocumentService extends Service {
 			requesterRole: requester.role,
 		});
 		if (!document) {
-			// The read above is scoped to the requester, so a document the caller
-			// cannot READ is indistinguishable from one that does not exist — and
-			// reporting NOT_FOUND here made the adapter's `forbidden` verdict
-			// unreachable for exactly the case it exists for (a non-owner trying to
-			// delete a global / owner-private document). Distinguish the two with an
-			// unscoped existence probe so the mutation wall renders the real reason.
-			const existsUnscoped = await this.runtime.getMemoryById(documentId);
-			if (existsUnscoped) {
+			// A hidden document owned by this runtime is a forbidden mutation, while
+			// foreign-agent and non-document rows remain indistinguishable from a
+			// missing UUID. This preserves tenant isolation across the unscoped probe.
+			const existingUnscoped = await this.runtime.getMemoryById(documentId);
+			if (
+				existingUnscoped?.agentId === this.runtime.agentId &&
+				readDocumentMutationSnapshot(existingUnscoped)
+			) {
 				throw new ElizaError(
 					`Document ${documentId} cannot be deleted by this requester`,
 					{

--- a/packages/core/src/features/provider-io-concurrency.test.ts
+++ b/packages/core/src/features/provider-io-concurrency.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Verifies the slow provider I/O plans by observing when real provider calls
+ * start, without wall-clock thresholds or substituted provider implementations.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { runWithTrajectoryContext } from "../trajectory-context.ts";
+import type {
+	Entity,
+	IAgentRuntime,
+	Memory,
+	Relationship,
+	State,
+	UUID,
+} from "../types/index.ts";
+import { ChannelType, MemoryType } from "../types/index.ts";
+import { factsProvider } from "./advanced-capabilities/providers/facts.ts";
+import { relationshipsProvider } from "./advanced-capabilities/providers/relationships.ts";
+import { worldProvider } from "./basic-capabilities/providers/world.ts";
+import { documentsProvider } from "./documents/provider.ts";
+import {
+	DocumentService,
+	resolveDocumentRequester,
+} from "./documents/service.ts";
+
+const agentId = "10000000-0000-0000-0000-000000000001" as UUID;
+const entityId = "10000000-0000-0000-0000-000000000002" as UUID;
+const secondEntityId = "10000000-0000-0000-0000-000000000003" as UUID;
+const thirdEntityId = "10000000-0000-0000-0000-000000000004" as UUID;
+const roomId = "10000000-0000-0000-0000-000000000005" as UUID;
+const worldId = "10000000-0000-0000-0000-000000000006" as UUID;
+
+const state: State = { values: {}, data: {}, text: "" };
+const message: Memory = {
+	id: "10000000-0000-0000-0000-000000000007" as UUID,
+	agentId,
+	entityId,
+	roomId,
+	worldId,
+	content: {
+		text: "What do we know about the project?",
+		senderName: "Alice",
+		channelType: ChannelType.DM,
+	},
+};
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((fulfill) => {
+		resolve = fulfill;
+	});
+	return { promise, resolve };
+}
+
+describe("provider database I/O concurrency", () => {
+	it("coalesces concurrent document authorization reads within one turn", async () => {
+		const getRoom = vi.fn(async () => ({ id: roomId, worldId }));
+		const getWorld = vi.fn(async () => ({
+			id: worldId,
+			name: "test world",
+			metadata: {},
+		}));
+		const getRoomsForParticipants = vi.fn(async () => [roomId, roomId]);
+		const runtime = {
+			agentId,
+			getRoom,
+			getWorld,
+			getRoomsForParticipants,
+			getSetting: vi.fn(() => undefined),
+			reportError: vi.fn(),
+		} as unknown as IAgentRuntime;
+
+		const [first, second] = await runWithTrajectoryContext(
+			{ turnMemo: new Map<string, Promise<unknown>>() },
+			() =>
+				Promise.all([
+					resolveDocumentRequester(runtime, message),
+					resolveDocumentRequester(runtime, message),
+				]),
+		);
+
+		expect(first).toEqual(second);
+		expect(first.roomIds).toEqual([roomId]);
+		expect(getRoom).toHaveBeenCalledOnce();
+		expect(getWorld).toHaveBeenCalledOnce();
+		expect(getRoomsForParticipants).toHaveBeenCalledOnce();
+	});
+
+	it("starts FACTS history and identity reads together, then starts every candidate pool together", async () => {
+		const history = deferred<Memory[]>();
+		const identities = deferred<UUID[]>();
+		const candidatePools = new Map<
+			string,
+			ReturnType<typeof deferred<Memory[]>>
+		>();
+		const started: string[] = [];
+		const getMemories = vi.fn(
+			(params: { tableName: string; roomId?: UUID; entityId?: UUID }) => {
+				if (params.tableName === "messages") {
+					started.push("history");
+					return history.promise;
+				}
+				const key = params.roomId
+					? `room:${params.roomId}`
+					: `entity:${params.entityId}`;
+				started.push(key);
+				const pending = deferred<Memory[]>();
+				candidatePools.set(key, pending);
+				return pending.promise;
+			},
+		);
+		const getMemberEntityIds = vi.fn(() => {
+			started.push("identities");
+			return identities.promise;
+		});
+		const runtime = {
+			agentId,
+			character: { name: "Eliza" },
+			getService: vi.fn((serviceType: string) =>
+				serviceType === "relationships" ? { getMemberEntityIds } : null,
+			),
+			getMemories,
+		} as unknown as IAgentRuntime;
+
+		const resultPromise = factsProvider.get(runtime, message, state);
+		await Promise.resolve();
+		expect(started).toEqual(["history", "identities"]);
+
+		history.resolve([]);
+		identities.resolve([secondEntityId]);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(started).toEqual(
+			expect.arrayContaining([
+				`room:${roomId}`,
+				`entity:${entityId}`,
+				`entity:${secondEntityId}`,
+			]),
+		);
+		expect(candidatePools).toHaveLength(3);
+
+		for (const pending of candidatePools.values()) pending.resolve([]);
+		await expect(resultPromise).resolves.toMatchObject({
+			text: "No facts available.",
+		});
+	});
+
+	it("surfaces FACTS database failures instead of fabricating empty context", async () => {
+		const failure = new Error("facts database unavailable");
+		const runtime = {
+			agentId,
+			getService: vi.fn(() => null),
+			getMemories: vi.fn(async () => {
+				throw failure;
+			}),
+		} as unknown as IAgentRuntime;
+
+		await expect(
+			factsProvider.get(runtime, message, state),
+		).rejects.toMatchObject({
+			code: "FACTS_PROVIDER_READ_FAILED",
+			cause: failure,
+		});
+	});
+
+	it("loads every RELATIONSHIPS counterpart with one batch query", async () => {
+		const relationships: Relationship[] = [
+			{
+				sourceEntityId: entityId,
+				targetEntityId: secondEntityId,
+				tags: ["friend"],
+				metadata: { interactions: 3 },
+			},
+			{
+				sourceEntityId: entityId,
+				targetEntityId: thirdEntityId,
+				tags: ["coworker"],
+				metadata: { interactions: 2 },
+			},
+		];
+		const entities: Entity[] = [
+			{ id: secondEntityId, names: ["Bob"], metadata: {} },
+			{ id: thirdEntityId, names: ["Carol"], metadata: {} },
+		];
+		const getEntitiesByIds = vi.fn(async () => entities);
+		const getEntityById = vi.fn(async () => null);
+		const runtime = {
+			agentId,
+			character: { name: "Eliza" },
+			getService: vi.fn(() => null),
+			getRelationships: vi.fn(async () => relationships),
+			getEntitiesByIds,
+			getEntityById,
+		} as unknown as IAgentRuntime;
+
+		const result = await relationshipsProvider.get(runtime, message, state);
+
+		expect(getEntitiesByIds).toHaveBeenCalledOnce();
+		expect(getEntitiesByIds).toHaveBeenCalledWith([
+			secondEntityId,
+			thirdEntityId,
+		]);
+		expect(getEntityById).not.toHaveBeenCalled();
+		expect(result.text).toContain("Bob");
+		expect(result.text).toContain("Carol");
+	});
+
+	it("does not send an empty RELATIONSHIPS batch for self-only records", async () => {
+		const getEntitiesByIds = vi.fn(async () => []);
+		const runtime = {
+			agentId,
+			character: { name: "Eliza" },
+			getService: vi.fn(() => null),
+			getRelationships: vi.fn(async () => [
+				{
+					sourceEntityId: entityId,
+					targetEntityId: entityId,
+					tags: ["self"],
+					metadata: {},
+				},
+			]),
+			getEntitiesByIds,
+		} as unknown as IAgentRuntime;
+
+		await relationshipsProvider.get(runtime, message, state);
+		expect(getEntitiesByIds).not.toHaveBeenCalled();
+	});
+
+	it("starts WORLD room-list and participant reads together after the authoritative world exists", async () => {
+		const world = deferred<{ id: UUID; name: string }>();
+		const rooms =
+			deferred<Array<{ id: UUID; name: string; type: ChannelType }>>();
+		const participants = deferred<UUID[]>();
+		const started: string[] = [];
+		const runtime = {
+			agentId,
+			getRoom: vi.fn(async () => ({
+				id: roomId,
+				name: "general",
+				type: ChannelType.GROUP,
+				worldId,
+			})),
+			getWorld: vi.fn(() => {
+				started.push("world");
+				return world.promise;
+			}),
+			getRooms: vi.fn(() => {
+				started.push("rooms");
+				return rooms.promise;
+			}),
+			getParticipantsForRoom: vi.fn(() => {
+				started.push("participants");
+				return participants.promise;
+			}),
+		} as unknown as IAgentRuntime;
+
+		const resultPromise = worldProvider.get(runtime, message, state);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(started).toEqual(["world"]);
+
+		world.resolve({ id: worldId, name: "test world" });
+		await Promise.resolve();
+		expect(started).toEqual(["world", "rooms", "participants"]);
+		rooms.resolve([{ id: roomId, name: "general", type: ChannelType.GROUP }]);
+		participants.resolve([entityId]);
+		await expect(resultPromise).resolves.toMatchObject({
+			data: { world: { name: "test world" } },
+		});
+	});
+
+	it("does not start dependent WORLD reads when the world does not exist", async () => {
+		const runtime = {
+			agentId,
+			getRoom: vi.fn(async () => ({
+				id: roomId,
+				name: "general",
+				type: ChannelType.GROUP,
+				worldId,
+			})),
+			getWorld: vi.fn(async () => null),
+			getRooms: vi.fn(),
+			getParticipantsForRoom: vi.fn(),
+		} as unknown as IAgentRuntime;
+
+		await expect(
+			worldProvider.get(runtime, message, state),
+		).resolves.toMatchObject({
+			text: "Unable to retrieve world information - world not found",
+		});
+		expect(runtime.getRooms).not.toHaveBeenCalled();
+		expect(runtime.getParticipantsForRoom).not.toHaveBeenCalled();
+	});
+
+	it("starts DOCUMENTS relevance search and inventory listing together", async () => {
+		const search = deferred<Memory[]>();
+		const list = deferred<Memory[]>();
+		const started: string[] = [];
+		const service = {
+			searchDocuments: vi.fn(() => {
+				started.push("search");
+				return search.promise;
+			}),
+			listDocuments: vi.fn(() => {
+				started.push("list");
+				return list.promise;
+			}),
+		};
+		const runtime = {
+			getService: vi.fn((serviceType: string) =>
+				serviceType === DocumentService.serviceType ? service : null,
+			),
+		} as unknown as IAgentRuntime;
+
+		const resultPromise = documentsProvider.get(runtime, message, state);
+		await Promise.resolve();
+		expect(started).toEqual(["search", "list"]);
+
+		search.resolve([]);
+		list.resolve([
+			{
+				id: "10000000-0000-0000-0000-000000000008" as UUID,
+				agentId,
+				entityId,
+				roomId,
+				content: { text: "Project notes" },
+				metadata: { type: MemoryType.DOCUMENT, title: "Project" },
+			},
+		]);
+		await expect(resultPromise).resolves.toMatchObject({
+			values: { documentsAvailable: true, documentsCount: 1 },
+		});
+	});
+});


### PR DESCRIPTION
Closes #17425
Part of #17308

## What changed

- starts independent FACTS history/identity reads together, then all fact candidate pools together
- batches RELATIONSHIPS counterpart lookup into one adapter query
- preserves WORLD's authoritative world dependency, then overlaps room and participant reads
- overlaps DOCUMENTS search and inventory while coalescing their immutable requester authorization per turn
- preserves document tenant isolation in the unscoped mutation existence probe
- converts FACTS database failure from fabricated healthy-empty context into a typed `ElizaError`
- hardens the all-provider telemetry report: invalid sample settings fail, values use stable precision, and fresh vs maximum-reuse behavior is verified structurally without latency thresholds

## Critical scope decisions

This does not start WORLD-dependent reads before the world exists, and it does not remove or reassign relationship components. Those are semantic changes, not latency refactors. It also does not add response timeouts or numeric CI ratchets.

## Exact telemetry

Real `AgentRuntime + plugin-sql/PGLite`, 24/24 registered providers, 3 warmups + 30 samples:

- fresh compose: p50 9.228 ms, p95 47.300 ms, max 151.354 ms
- maximum-reuse compose: p50 0.092 ms, p95 0.329 ms, max 11.492 ms
- maximum-reuse cache hits: 24/24 providers in all 30 samples
- effective parallelism p50: 4.895x
- target provider p50: DOCUMENTS 9.054 ms, FACTS 5.127 ms, RELATIONSHIPS 5.059 ms, WORLD 3.671 ms

Live Cerebras `gemma-4-31b`, production generateChatResponse path, second isolated 30-turn run:

- 30/30 exact streamed output == final output == PGLite row
- 30 unique durable rows; all 30 IDs returned by message service; 0 failures
- wall p50 606.054 ms, p95 1683.498 ms, max 1844.435 ms
- LLM inference p50 508 ms, p95 1650 ms, max 1807 ms
- message-service overhead p50 3 ms, p95 25 ms, max 43 ms

Direct Cerebras control, 30 requests, no response timeout:

- 30/30 successful
- total p50 257.18 ms, p95 522.34 ms, max 1315.46 ms
- first token p50 235.09 ms, p95 521.96 ms, max 1200 ms

The slow full-runtime tail is dominated by the remote LLM. The direct control independently captured a 1.315 s Cerebras outlier. The all-provider sweep after a growing conversation also shows correlated PGLite queue stalls across multiple providers; the isolated provider report above is the clean code-path comparison.

## Verification

- focused provider/document tests: 23 passed, 0 failed, 90 assertions
- full `@elizaos/core` suite: 448/448 files, 4,391 passed, 1 skipped
- `bun run verify`: 579/579 tasks; anti-larp scanned 8,822 test files; 28/28 dist consumers
- core typecheck and all build targets passed

## Evidence checklist

- Real-LLM trajectory: attached below after PR creation
- Backend logs: telemetry artifacts contain per-turn stage/provider spans and durable row proof
- Frontend console/network logs: N/A - no frontend change
- Screenshots/video: N/A - no UI change
- Domain artifacts: exact PGLite persisted row IDs and message-service acknowledgement are included in the trajectory
- Native/platform evidence: N/A - core provider path only

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core provider scheduling has no visual surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core provider scheduling has no visual surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - core provider scheduling has no visual surface

<!-- evidence-row:backend-logs -->
- [x] [17426-provider-concurrency-root-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17426-provider-concurrency-root-verify.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser runtime changed

<!-- evidence-row:llm-trajectory -->
- [x] [17426-174-provider-cerebras-trajectory-r2.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17426-174-provider-cerebras-trajectory-r2.json)

<!-- evidence-row:domain-artifacts -->
- [x] [17426-174-provider-telemetry.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17426-174-provider-telemetry.json)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or user-visible text changed
