### PR TITLE
fix(scenarios): enforce required service readiness

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -954,6 +954,7 @@
         "@elizaos/plugin-sql": "workspace:*",
         "@elizaos/plugin-todos": "workspace:*",
         "@elizaos/plugin-video": "workspace:*",
+        "@elizaos/plugin-wallet": "workspace:*",
         "@elizaos/plugin-workflow": "workspace:*",
         "ws": "^8.19.0",
       },

--- a/packages/core/src/__tests__/service-start-concurrency.test.ts
+++ b/packages/core/src/__tests__/service-start-concurrency.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Verifies production service startup ordering and ownership with real runtime
+ * lifecycle calls. Implementations launch concurrently, readiness drains the
+ * whole set, and plugin teardown targets instances by class rather than timing.
+ */
+
+import { describe, expect, it } from "vitest";
+import { nativeRuntimeFeaturePluginNames } from "../plugins/native-features";
+import { AgentRuntime } from "../runtime";
+import type { Memory, Provider, ServiceTypeName, UUID } from "../types";
+import { Service } from "../types/service";
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((promiseResolve) => {
+		resolve = promiseResolve;
+	});
+	return { promise, resolve };
+}
+
+describe("AgentRuntime service startup", () => {
+	it("starts cross-plugin siblings once in parallel and preserves registration order", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+		const firstStartup = deferred<FirstService>();
+		const secondStartup = deferred<SecondService>();
+		const starts: string[] = [];
+		const stops: string[] = [];
+
+		class FirstService extends Service {
+			static override serviceType = "parallel-start-test";
+			static override allowsMultiple = true;
+			capabilityDescription = "first registered implementation";
+
+			static override async start(): Promise<FirstService> {
+				starts.push("first");
+				return firstStartup.promise;
+			}
+
+			override async stop(): Promise<void> {
+				stops.push("first");
+			}
+		}
+
+		class SecondService extends Service {
+			static override serviceType = "parallel-start-test";
+			static override allowsMultiple = true;
+			capabilityDescription = "second registered implementation";
+
+			static override async start(): Promise<SecondService> {
+				starts.push("second");
+				return secondStartup.promise;
+			}
+
+			override async stop(): Promise<void> {
+				stops.push("second");
+			}
+		}
+
+		try {
+			await runtime.registerPlugin({
+				name: "parallel-start-first",
+				description: "Registers the first implementation",
+				services: [FirstService],
+			});
+			await runtime.registerPlugin({
+				name: "parallel-start-second",
+				description: "Registers the second implementation",
+				services: [SecondService],
+			});
+
+			const firstLoad = runtime.getServiceLoadPromise(FirstService.serviceType);
+			const concurrentLoad = runtime.getServiceLoadPromise(
+				FirstService.serviceType,
+			);
+			await Promise.resolve();
+			expect(starts.sort()).toEqual(["first", "second"]);
+
+			let ready = false;
+			void firstLoad.then(() => {
+				ready = true;
+			});
+			const second = new SecondService(runtime);
+			secondStartup.resolve(second);
+			await secondStartup.promise;
+			await Promise.resolve();
+			expect(ready).toBe(false);
+
+			const first = new FirstService(runtime);
+			firstStartup.resolve(first);
+			await expect(Promise.all([firstLoad, concurrentLoad])).resolves.toEqual([
+				first,
+				first,
+			]);
+			expect(runtime.getServicesByType(FirstService.serviceType)).toEqual([
+				first,
+				second,
+			]);
+			expect(starts.sort()).toEqual(["first", "second"]);
+
+			await runtime.unloadPlugin("parallel-start-first");
+			expect(stops).toEqual(["first"]);
+			expect(runtime.getServicesByType(FirstService.serviceType)).toEqual([
+				second,
+			]);
+		} finally {
+			await runtime.stop({ fast: true });
+		}
+	});
+
+	it("starts a sibling registered after the first implementation is already running", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+		let firstStarts = 0;
+		let secondStarts = 0;
+
+		class FirstService extends Service {
+			static override serviceType = "late-sibling-start-test";
+			static override allowsMultiple = true;
+			capabilityDescription = "first registered implementation";
+
+			static override async start(
+				runtime: AgentRuntime,
+			): Promise<FirstService> {
+				firstStarts += 1;
+				return new FirstService(runtime);
+			}
+
+			override async stop(): Promise<void> {}
+		}
+
+		class SecondService extends Service {
+			static override serviceType = "late-sibling-start-test";
+			static override allowsMultiple = true;
+			capabilityDescription = "late registered implementation";
+
+			static override async start(
+				runtime: AgentRuntime,
+			): Promise<SecondService> {
+				secondStarts += 1;
+				return new SecondService(runtime);
+			}
+
+			override async stop(): Promise<void> {}
+		}
+
+		try {
+			await runtime.registerService(FirstService);
+			const first = await runtime.getServiceLoadPromise(
+				FirstService.serviceType,
+			);
+			expect(first).toBeInstanceOf(FirstService);
+			expect(firstStarts).toBe(1);
+
+			await runtime.registerService(SecondService);
+			const resolved = await runtime.getServiceLoadPromise(
+				FirstService.serviceType,
+			);
+
+			expect(resolved).toBe(first);
+			expect(firstStarts).toBe(1);
+			expect(secondStarts).toBe(1);
+			expect(runtime.getServicesByType(FirstService.serviceType)).toEqual([
+				first,
+				expect.any(SecondService),
+			]);
+		} finally {
+			await runtime.stop({ fast: true });
+		}
+	});
+
+	it("fails closed when a configured tool-policy service fails to start", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+
+		class FailingPolicyService extends Service {
+			static override serviceType = "tool_policy";
+			capabilityDescription = "always fails to start";
+
+			static override async start(): Promise<FailingPolicyService> {
+				throw new Error("policy start boom");
+			}
+
+			override async stop(): Promise<void> {}
+		}
+
+		try {
+			await runtime.registerPlugin({
+				name: "failing-policy",
+				description: "Registers a tool_policy service whose start throws",
+				services: [FailingPolicyService],
+			});
+
+			const actions = await runtime.getFilteredActions({});
+			expect(actions).toEqual([]);
+
+			const verdict = await runtime.isActionAllowed("ANY_ACTION");
+			expect(verdict).toEqual({
+				allowed: false,
+				reason: "Tool policy service failed to start",
+			});
+
+			const scopes = runtime
+				.getRecentReportedErrors()
+				.map((entry) => entry.scope);
+			expect(scopes).toContain("AgentRuntime.getFilteredActions");
+			expect(scopes).toContain("AgentRuntime.isActionAllowed");
+		} finally {
+			await runtime.stop({ fast: true });
+		}
+	});
+
+	it("completes composeState when the trajectories service fails to start", async () => {
+		const runtime = new AgentRuntime({
+			logLevel: "fatal",
+			enableTrajectories: false,
+		});
+		await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+
+		class FailingTrajectoriesService extends Service {
+			static override serviceType = "trajectories";
+			capabilityDescription = "always fails to start";
+
+			static override async start(): Promise<FailingTrajectoriesService> {
+				throw new Error("trajectory logger boom");
+			}
+
+			override async stop(): Promise<void> {}
+		}
+
+		try {
+			// The plugin borrows the native trajectories plugin name so the
+			// feature gate reads enabled while the only implementation fails.
+			await runtime.registerPlugin({
+				name: nativeRuntimeFeaturePluginNames.trajectories,
+				description: "Registers a trajectories service whose start throws",
+				services: [FailingTrajectoriesService],
+			});
+
+			const probe: Provider = {
+				name: "PROBE",
+				get: async () => ({ text: "probe-ran", values: {}, data: {} }),
+			};
+			runtime.registerProvider(probe);
+
+			const message: Memory = {
+				id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID,
+				entityId: "22222222-2222-2222-2222-222222222222" as UUID,
+				roomId: "11111111-1111-1111-1111-111111111111" as UUID,
+				content: { text: "gm" },
+			};
+			const state = await runtime.composeState(message, ["PROBE"], true);
+			expect(state.text).toContain("probe-ran");
+
+			const scopes = runtime
+				.getRecentReportedErrors()
+				.map((entry) => entry.scope);
+			expect(scopes).toContain("AgentRuntime.composeState.trajectories");
+		} finally {
+			await runtime.stop({ fast: true });
+		}
+	});
+
+	it("serves an already-started instance during initialize without awaiting the init barrier", async () => {
+		class StartedPolicyService extends Service {
+			static override serviceType = "tool_policy";
+			capabilityDescription = "already-running policy stand-in";
+
+			override async stop(): Promise<void> {}
+
+			isToolAllowed(): { allowed: boolean; reason: string } {
+				return { allowed: true, reason: "stub policy" };
+			}
+		}
+
+		const verdictDuringInit =
+			deferred<Awaited<ReturnType<AgentRuntime["isActionAllowed"]>>>();
+		const runtime = new AgentRuntime({
+			logLevel: "fatal",
+			plugins: [
+				{
+					name: "init-gate",
+					description:
+						"Exercises the tool-policy path while initialize() is still running",
+					init: async () => {
+						// The instance is already up before the init barrier resolves;
+						// the lookup must take the fast path instead of deadlocking on
+						// initPromise (which this very init call is blocking).
+						runtime.services.set("tool_policy" as ServiceTypeName, [
+							new StartedPolicyService(runtime),
+						]);
+						verdictDuringInit.resolve(
+							await runtime.isActionAllowed("ANY_ACTION"),
+						);
+					},
+				},
+			],
+		});
+
+		try {
+			const init = runtime.initialize({
+				allowNoDatabase: true,
+				skipMigrations: true,
+			});
+			const verdict = await verdictDuringInit.promise;
+			expect(verdict).toEqual({ allowed: true, reason: "stub policy" });
+			await init;
+		} finally {
+			await runtime.stop({ fast: true });
+		}
+	});
+});

--- a/packages/core/src/plugin-lifecycle.ts
+++ b/packages/core/src/plugin-lifecycle.ts
@@ -131,6 +131,9 @@ type RuntimePrivateState = {
 	servicePromises: Map<ServiceTypeName, Promise<Service>>;
 	servicePromiseHandlers: Map<ServiceTypeName, RuntimeServicePromiseHandler>;
 	startingServices: Map<ServiceTypeName, Promise<Service | null>>;
+	startingServiceClasses: Map<RuntimeServiceClass, Promise<Service>>;
+	serviceInstancesByClass: Map<RuntimeServiceClass, Service>;
+	failedServiceClasses: Set<RuntimeServiceClass>;
 	serviceRegistrationStatus: Map<
 		ServiceTypeName,
 		RuntimeServiceRegistrationStatus
@@ -589,23 +592,23 @@ async function stopOwnedServices(
 		}
 
 		const ownedClassSet = new Set(ownedClasses);
-		const removalIndices: number[] = [];
-		currentClasses.forEach((serviceClass, index) => {
-			if (ownedClassSet.has(serviceClass)) {
-				removalIndices.push(index);
-			}
-		});
-
 		const instances = runtime.services.get(key) ?? [];
-		for (const removalIndex of [...removalIndices].sort((a, b) => b - a)) {
-			const instance = instances[removalIndex];
+		for (const ownedClass of ownedClasses) {
+			const instance = privateState.serviceInstancesByClass.get(ownedClass);
 			if (instance && typeof instance.stop === "function") {
 				await instance.stop();
 			}
-			instances.splice(removalIndex, 1);
+			if (instance) {
+				const instanceIndex = instances.indexOf(instance);
+				if (instanceIndex !== -1) {
+					instances.splice(instanceIndex, 1);
+				}
+				privateState.serviceInstancesByClass.delete(ownedClass);
+			}
 		}
 
 		for (const ownedClass of ownedClasses) {
+			privateState.failedServiceClasses.delete(ownedClass);
 			if (typeof ownedClass.stopRuntime === "function") {
 				await ownedClass.stopRuntime(runtime);
 			}
@@ -1083,9 +1086,36 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 	runtimeWithLifecycle.registerPlugin = (async (plugin: Plugin) => {
 		const pluginsBefore = new Set(runtimeWithLifecycle.plugins);
 		const routesBefore = new Set(runtimeWithLifecycle.routes);
+		const serviceClassCountsBefore = new Map<RuntimeServiceClass, number>();
+		for (const classes of privateState.serviceTypes.values()) {
+			for (const serviceClass of classes) {
+				serviceClassCountsBefore.set(
+					serviceClass,
+					(serviceClassCountsBefore.get(serviceClass) ?? 0) + 1,
+				);
+			}
+		}
 		const capture: RuntimePluginRegistrationCapture = {
 			ownership: createEmptyOwnership(plugin),
 			adapterBefore: runtimeWithLifecycle.adapter,
+		};
+		const captureDeclaredServices = (): void => {
+			for (const serviceClass of plugin.services ?? []) {
+				const serviceType = serviceClass.serviceType as ServiceTypeName;
+				const registeredCount = (
+					privateState.serviceTypes.get(serviceType) ?? []
+				).filter((candidate) => candidate === serviceClass).length;
+				if (
+					registeredCount <= (serviceClassCountsBefore.get(serviceClass) ?? 0)
+				) {
+					continue;
+				}
+				serviceClassOwners.set(serviceClass, capture.ownership.pluginName);
+				pushUniqueService(capture.ownership.services, {
+					serviceType,
+					serviceClass,
+				});
+			}
 		};
 
 		try {
@@ -1098,6 +1128,7 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 				pluginsBefore,
 				routesBefore,
 			);
+			captureDeclaredServices();
 			if (
 				capture.ownership.registeredPlugin ||
 				capture.ownership.actions.length > 0 ||
@@ -1125,6 +1156,7 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 				pluginsBefore,
 				routesBefore,
 			);
+			captureDeclaredServices();
 			await teardownPluginOwnership(runtimeWithLifecycle, capture.ownership, {
 				allowAdapterUnload: true,
 				removeOwnership: true,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1358,8 +1358,11 @@ export class AgentRuntime implements IAgentRuntime {
 	private settings: RuntimeSettings;
 	private servicePromiseHandlers = new Map<string, ServicePromiseHandler>(); // Combined handlers for resolve/reject
 	private servicePromises = new Map<string, Promise<Service>>(); // read
-	/** In-flight service start promises; dedupes concurrent getService() for the same type. */
+	/** Full settlement of each type's current parallel startup set, used by teardown. */
 	private startingServices = new Map<string, Promise<Service | null>>();
+	private startingServiceClasses = new Map<ServiceClass, Promise<Service>>();
+	private serviceInstancesByClass = new Map<ServiceClass, Service>();
+	private failedServiceClasses = new Set<ServiceClass>();
 	private serviceRegistrationStatus = new Map<
 		ServiceTypeName,
 		"pending" | "registering" | "registered" | "failed"
@@ -2478,6 +2481,7 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 		}
 		if (pluginToRegister.services) {
+			const serviceTypesToStart = new Set<ServiceTypeName>();
 			for (const service of pluginToRegister.services) {
 				const serviceType = service.serviceType as ServiceTypeName;
 
@@ -2508,12 +2512,13 @@ export class AgentRuntime implements IAgentRuntime {
 					);
 					services.push(service);
 				}
+				serviceTypesToStart.add(serviceType);
+			}
 
-				// Eagerly kick off service start so it is available via the
-				// sync getService() by the time actions/routes need it.
-				// Fire-and-forget: cannot await here because _runServiceStart
-				// awaits initPromise which resolves after initialize() completes
-				// (after all registerPlugin calls finish). Awaiting would deadlock.
+			// Register every sibling implementation before startup takes a class
+			// snapshot, otherwise the first declaration can fail before a later
+			// implementation of the same service type is visible.
+			for (const serviceType of serviceTypesToStart) {
 				this._ensureServiceStarted(serviceType).catch((err) => {
 					// error-policy:J5 eager startup is fire-and-forget; _runServiceStart
 					// reports the failure and service-load callers observe the rejection.
@@ -2715,6 +2720,9 @@ export class AgentRuntime implements IAgentRuntime {
 		this.servicePromises.clear();
 		this.servicePromiseHandlers.clear();
 		this.startingServices.clear();
+		this.startingServiceClasses.clear();
+		this.serviceInstancesByClass.clear();
+		this.failedServiceClasses.clear();
 	}
 
 	private async _stopServiceInstance(
@@ -4009,9 +4017,20 @@ export class AgentRuntime implements IAgentRuntime {
 		worldPolicy?: ToolPolicyConfig;
 		roomPolicy?: ToolPolicyConfig;
 	}): Promise<Action[]> {
-		const policyService = (await this._ensureServiceStarted(
-			"tool_policy",
-		)) as ToolPolicyService | null;
+		let policyService: ToolPolicyService | null;
+		try {
+			policyService = (await this._ensureServiceStarted(
+				"tool_policy",
+			)) as ToolPolicyService | null;
+		} catch (error) {
+			// error-policy:J4 explicit user-facing degrade — a tool_policy service
+			// that was configured but failed to start cannot safely authorize tools.
+			// Keep the turn alive with no executable actions and surface the failure.
+			this.reportError("AgentRuntime.getFilteredActions", error, {
+				serviceType: "tool_policy",
+			});
+			return [];
+		}
 
 		if (!policyService || !context) {
 			return [...this.actions];
@@ -4038,9 +4057,23 @@ export class AgentRuntime implements IAgentRuntime {
 			roomPolicy?: ToolPolicyConfig;
 		},
 	): Promise<{ allowed: boolean; reason: string }> {
-		const policyService = (await this._ensureServiceStarted(
-			"tool_policy",
-		)) as ToolPolicyService | null;
+		let policyService: ToolPolicyService | null;
+		try {
+			policyService = (await this._ensureServiceStarted(
+				"tool_policy",
+			)) as ToolPolicyService | null;
+		} catch (error) {
+			// error-policy:J4 explicit user-facing degrade — a tool_policy service
+			// that was configured but failed to start cannot safely authorize tools.
+			// Deny the action and surface the service failure.
+			this.reportError("AgentRuntime.isActionAllowed", error, {
+				serviceType: "tool_policy",
+			});
+			return {
+				allowed: false,
+				reason: "Tool policy service failed to start",
+			};
+		}
 
 		if (!policyService) {
 			return { allowed: true, reason: "No policy service available" };
@@ -4851,9 +4884,20 @@ export class AgentRuntime implements IAgentRuntime {
 		);
 
 		// Optional trajectory logging service; absent unless configured.
-		const trajLogger = (await this._ensureServiceStarted("trajectories")) as
-			| (Service & TrajectoryProviderAccessLogger)
-			| null;
+		let trajLogger: (Service & TrajectoryProviderAccessLogger) | null;
+		try {
+			trajLogger = (await this._ensureServiceStarted("trajectories")) as
+				| (Service & TrajectoryProviderAccessLogger)
+				| null;
+		} catch (error) {
+			// error-policy:J7 diagnostics-must-not-kill-the-loop — a trajectory
+			// logger that fails to start must never abort composeState; continue
+			// without provider-access logging. Surfaced via reportError.
+			this.reportError("AgentRuntime.composeState.trajectories", error, {
+				serviceType: "trajectories",
+			});
+			trajLogger = null;
+		}
 		const composeStartedAt = Date.now();
 		const providerSignal =
 			this.turnControllers.signalFor(message.roomId) ??
@@ -5375,41 +5419,115 @@ export class AgentRuntime implements IAgentRuntime {
 		return newState;
 	}
 
-	/** Lazy service start: used internally by _ensureServiceStarted / getServiceLoadPromise. */
-	/** Dedupes concurrent starts for the same type via startingServices so only one start runs. */
+	/** Starts every pending implementation in parallel and waits for the full set. */
 	private async _ensureServiceStarted(
 		serviceType: ServiceTypeName | string,
 	): Promise<Service | null> {
 		if (this.stopped) return null;
 		if (!this.isNativeFeatureServiceEnabled(serviceType)) return null;
 		const key = this.resolveServiceTypeAlias(serviceType) as ServiceTypeName;
-		const instances = this.services.get(key);
-		if (instances && instances.length > 0) {
-			return instances[0];
-		}
+		// Fast path: a service that is already registered and running is returned
+		// immediately WITHOUT awaiting initPromise. Callers inside initialize()
+		// (plugin init -> getFilteredActions) would otherwise deadlock on the
+		// still-unresolved init barrier even though the instance is already up.
+		const alreadyRunning = this.services.get(key)?.[0];
+		if (alreadyRunning && this.initResolver) return alreadyRunning;
+		await this.initPromise;
+		if (this.stopped) return null;
 		const classes = this.serviceTypes.get(key);
 		if (!classes || classes.length === 0) {
 			return null;
 		}
-		let inFlight = this.startingServices.get(key);
-		if (!inFlight) {
-			// Start ALL registered service classes for this type, not just the first.
-			// This supports multiple services of the same type (e.g. multiple wallet services).
-			inFlight = (async () => {
-				let first: Service | null = null;
-				for (const cls of classes) {
-					const result = await this._runServiceStart(key, serviceType, cls);
-					if (result && !first) first = result;
-				}
-				return first;
-			})();
-			this.startingServices.set(key, inFlight);
+		const startedImplementation = classes
+			.map((serviceClass) => this.serviceInstancesByClass.get(serviceClass))
+			.find((service): service is Service => service !== undefined);
+		const starts = classes.map((serviceClass) => {
+			const started = this.serviceInstancesByClass.get(serviceClass);
+			if (started) return Promise.resolve(started);
+			const pending = this.startingServiceClasses.get(serviceClass);
+			if (pending) return pending;
+			if (
+				startedImplementation &&
+				this.failedServiceClasses.has(serviceClass)
+			) {
+				return Promise.resolve(startedImplementation);
+			}
+
+			const start = this._runServiceStart(key, serviceType, serviceClass).then(
+				(service) => {
+					if (!service) {
+						throw new Error(
+							`Service implementation ${serviceClass.name || "<anonymous>"} did not start`,
+						);
+					}
+					this.failedServiceClasses.delete(serviceClass);
+					return service;
+				},
+				(error) => {
+					this.failedServiceClasses.add(serviceClass);
+					throw error;
+				},
+			);
+			this.startingServiceClasses.set(serviceClass, start);
+			void start.then(
+				() => this.startingServiceClasses.delete(serviceClass),
+				() => this.startingServiceClasses.delete(serviceClass),
+			);
+			return start;
+		});
+
+		const settlement = Promise.allSettled(starts);
+		const allStarts = settlement.then((results) => {
+			const firstSuccessful = results.find(
+				(result): result is PromiseFulfilledResult<Service> =>
+					result.status === "fulfilled",
+			)?.value;
+			return firstSuccessful ?? null;
+		});
+		this.startingServices.set(key, allStarts);
+		void allStarts.then(() => {
+			if (this.startingServices.get(key) === allStarts) {
+				this.startingServices.delete(key);
+			}
+		});
+
+		const settled = await settlement;
+		const first = this.services.get(key)?.[0] ?? null;
+		if (first) {
+			this.serviceRegistrationStatus.set(key, "registered");
+			const handler = this.servicePromiseHandlers.get(key);
+			if (handler) {
+				handler.resolve(first);
+				this.servicePromiseHandlers.delete(key);
+			}
+			return first;
 		}
-		try {
-			return await inFlight;
-		} finally {
-			this.startingServices.delete(key);
+
+		const cause = new AggregateError(
+			settled.flatMap((result) =>
+				result.status === "rejected" ? [result.reason] : [],
+			),
+			`All implementations of service ${String(serviceType)} failed`,
+		);
+		const startupError = new ElizaError(
+			`Service ${String(serviceType)} not found or failed to start`,
+			{
+				code: "SERVICE_START_FAILED",
+				context: {
+					serviceType: String(serviceType),
+					implementationCount: classes.length,
+				},
+				cause,
+			},
+		);
+		const handler = this.servicePromiseHandlers.get(key);
+		if (handler) {
+			handler.reject(startupError);
+			this.servicePromiseHandlers.delete(key);
+			this.servicePromises.delete(key);
 		}
+		this.serviceRegistrationStatus.set(key, "failed");
+		throw startupError;
 	}
 
 	/** Runs one service start; used by _ensureServiceStarted with startingServices dedupe. */
@@ -5418,8 +5536,9 @@ export class AgentRuntime implements IAgentRuntime {
 		serviceType: string,
 		serviceDef: ServiceClass,
 	): Promise<Service | null> {
-		this.serviceRegistrationStatus.set(key, "registering");
-		await this.initPromise;
+		if ((this.services.get(key)?.length ?? 0) === 0) {
+			this.serviceRegistrationStatus.set(key, "registering");
+		}
 		if (typeof serviceDef.start !== "function") {
 			this.serviceRegistrationStatus.set(key, "failed");
 			throw new ElizaError("Service class has no static start method", {
@@ -5429,8 +5548,9 @@ export class AgentRuntime implements IAgentRuntime {
 		}
 		try {
 			if (this.stopped) {
-				this.serviceRegistrationStatus.set(key, "failed");
-				return null;
+				throw new Error(
+					`Runtime stopped before service ${String(serviceType)} could start`,
+				);
 			}
 			const serviceInstance = await serviceDef.start(this);
 			if (!serviceInstance) {
@@ -5446,25 +5566,21 @@ export class AgentRuntime implements IAgentRuntime {
 					serviceInstance,
 					"late service start after runtime stop",
 				);
-				this.serviceRegistrationStatus.set(key, "failed");
-				return null;
+				throw new Error(
+					`Runtime stopped while service ${String(serviceType)} was starting`,
+				);
 			}
-			if (!this.services.has(key)) {
-				this.services.set(key, []);
-			}
-			const serviceList = this.services.get(key);
-			if (serviceList) {
-				serviceList.push(serviceInstance);
-			}
-			const handler = this.servicePromiseHandlers.get(serviceType);
-			if (handler) {
-				handler.resolve(serviceInstance);
-				this.servicePromiseHandlers.delete(serviceType);
-			}
+			this.serviceInstancesByClass.set(serviceDef, serviceInstance);
+			const orderedInstances = (this.serviceTypes.get(key) ?? []).flatMap(
+				(serviceClass) => {
+					const instance = this.serviceInstancesByClass.get(serviceClass);
+					return instance ? [instance] : [];
+				},
+			);
+			this.services.set(key, orderedInstances);
 			if (serviceDef.registerSendHandlers) {
 				serviceDef.registerSendHandlers(this, serviceInstance);
 			}
-			this.serviceRegistrationStatus.set(key, "registered");
 			return serviceInstance;
 		} catch (error) {
 			// error-policy:J2 service startup adds service identity and preserves the cause

--- a/packages/scenario-runner/package.json
+++ b/packages/scenario-runner/package.json
@@ -99,6 +99,7 @@
     "@elizaos/plugin-workflow": "workspace:*",
     "@elizaos/plugin-todos": "workspace:*",
     "@elizaos/plugin-video": "workspace:*",
+    "@elizaos/plugin-wallet": "workspace:*",
     "@elizaos/plugin-sql": "workspace:*",
     "ws": "^8.19.0",
     "@elizaos/auth": "workspace:*"

--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -532,6 +532,17 @@ export type ScenarioPersonalityExpect = {
   judgeKwargs?: Record<string, unknown>;
 };
 
+/** Runtime capabilities that must be ready before scenario turns execute. */
+export type ScenarioRequirements = {
+  /** Plugin packages that the runner may load when they are not registered. */
+  plugins?: readonly string[];
+  /**
+   * Service types whose startup must complete successfully before execution.
+   * Services omitted here are optional even when a required plugin declares them.
+   */
+  services?: readonly string[];
+};
+
 export type ScenarioDefinition = {
   id: string;
   title: string;
@@ -577,8 +588,8 @@ export type ScenarioDefinition = {
    * isolates every scenario per process regardless.
    */
   isolation?: "per-scenario" | "shared-runtime" | "worker";
-  /** Plugins that must be registered before the scenario runs (skip otherwise). */
-  requires?: { plugins?: string[] };
+  /** Plugins and service capabilities required before the scenario runs. */
+  requires?: ScenarioRequirements;
   rooms?: ScenarioRoomSpec[];
   /** Personality corpus metadata (live-only judge bridge). */
   scope?: "user" | "mixed";

--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -282,6 +282,47 @@ function validateScenarioStatus(value) {
   return status;
 }
 
+function validateScenarioRequirements(value) {
+  const requires = value?.requires;
+  if (requires === undefined) {
+    return;
+  }
+  if (
+    requires === null ||
+    typeof requires !== "object" ||
+    Array.isArray(requires)
+  ) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" has invalid requires; expected { plugins?: string[], services?: string[] }`,
+    );
+  }
+  const unknownKeys = Object.keys(requires).filter(
+    (key) => key !== "plugins" && key !== "services",
+  );
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" has unknown requires field(s): ${unknownKeys.join(", ")}`,
+    );
+  }
+  for (const key of ["plugins", "services"]) {
+    const requirements = requires[key];
+    if (requirements === undefined) {
+      continue;
+    }
+    if (
+      !Array.isArray(requirements) ||
+      requirements.some(
+        (requirement) =>
+          typeof requirement !== "string" || requirement.trim().length === 0,
+      )
+    ) {
+      throw new Error(
+        `scenario "${value?.id ?? "<unknown>"}" has invalid requires.${key}; expected non-empty strings`,
+      );
+    }
+  }
+}
+
 /**
  * Resolve a scenario's platform-gated deferral, if any. A deferred scenario is
  * a live-only scenario that additionally cannot run in any current lane because
@@ -331,6 +372,9 @@ export function scenario(value) {
     scenarioTier(value);
     // Validate pending/active inventory status before loader filtering relies on it.
     validateScenarioStatus(value);
+    // Required services are a runtime preflight contract, not an implicit
+    // consequence of whichever plugin happened to register them first.
+    validateScenarioRequirements(value);
     // Validate the deferral shape (and lane compatibility) eagerly too.
     scenarioDeferral(value);
   }

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -679,10 +679,14 @@ export async function runCli(
 
   const reports: ScenarioReport[] = [];
   let interruptedSignal: NodeJS.Signals | undefined;
+  const runAbortController = new AbortController();
   const onInterrupt = (signal: NodeJS.Signals): void => {
     interruptedSignal = signal;
+    runAbortController.abort(
+      new Error(`Scenario run interrupted by ${signal}`),
+    );
     process.stderr.write(
-      `[eliza-scenarios] received ${signal}; finishing the current scenario, writing checkpoint evidence, then stopping.\n`,
+      `[eliza-scenarios] received ${signal}; cancelling the current scenario, writing checkpoint evidence, then stopping.\n`,
     );
   };
   process.once("SIGINT", onInterrupt);
@@ -729,6 +733,7 @@ export async function runCli(
         providerName,
         minJudgeScore,
         turnTimeoutMs,
+        abortSignal: runAbortController.signal,
         executionProfile,
         runDir: effectiveRunDir,
       });

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -59,6 +59,7 @@ import {
   pluginPackageIsRegistered,
   resolveRequiredPluginPackages,
 } from "./required-plugins.ts";
+import { waitForScenarioRequiredServices } from "./required-services.ts";
 import { applyScenarioSeedStep } from "./seeds.ts";
 import type {
   FinalCheckReport,
@@ -72,6 +73,7 @@ export interface ExecutorOptions {
   providerName: string;
   minJudgeScore: number;
   turnTimeoutMs: number;
+  abortSignal?: AbortSignal;
   executionProfile?: ScenarioExecutionProfile;
   runDir?: string;
 }
@@ -2424,17 +2426,6 @@ export async function runScenario(
         const candidate = await loadScenarioRequiredPlugin(pkg, "simulated");
         if (candidate) {
           await runtime.registerPlugin(candidate);
-          // Required-plugin registration waits for every service attempt to
-          // settle so the first scenario turn cannot race a usable service.
-          // A plugin may also bundle credential-gated services the scenario
-          // never touches; their failures are already observable through
-          // AgentRuntime.serviceStart/reportError and do not invalidate the
-          // successfully registered actions or sibling services.
-          await Promise.allSettled(
-            (candidate.services ?? []).map((service) =>
-              runtime.getServiceLoadPromise(service.serviceType),
-            ),
-          );
           autoLoaded.add(pkg);
         }
       } catch (err) {
@@ -2454,6 +2445,7 @@ export async function runScenario(
       report.skipReason = `required plugin(s) not registered: ${missing.join(",")}`;
       return report;
     }
+    await waitForScenarioRequiredServices(runtime, scenario, opts.abortSignal);
 
     // Re-attach interceptor so any actions registered by seed plugins are wrapped.
     interceptor.detach();

--- a/packages/scenario-runner/src/index.ts
+++ b/packages/scenario-runner/src/index.ts
@@ -33,6 +33,11 @@ export {
   writeReport,
   writeScenarioRunViewer,
 } from "./reporter.ts";
+export {
+  resolveRequiredServiceTypes,
+  ScenarioRequiredServicePreflightError,
+  waitForScenarioRequiredServices,
+} from "./required-services.ts";
 export type {
   AggregateReport,
   FinalCheckReport,

--- a/packages/scenario-runner/src/required-services.test.ts
+++ b/packages/scenario-runner/src/required-services.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Required-service preflight regressions over real AgentRuntime instances.
+ * Service classes are deterministic; registration, startup, retry, and stop
+ * all use the production runtime lifecycle.
+ */
+
+import {
+  AgentRuntime,
+  ElizaError,
+  type IAgentRuntime,
+  type Plugin,
+  Service,
+} from "@elizaos/core";
+import {
+  type ScenarioDefinition,
+  scenario,
+} from "@elizaos/scenario-runner/schema";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  resolveRequiredServiceTypes,
+  ScenarioRequiredServicePreflightError,
+  waitForScenarioRequiredServices,
+} from "./required-services.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
+
+function scenarioWithServices(
+  id: string,
+  services: readonly string[],
+): ScenarioDefinition {
+  return {
+    id,
+    title: id,
+    domain: "required-service-preflight",
+    requires: { services },
+    turns: [],
+  };
+}
+
+async function createRuntime(): Promise<AgentRuntime> {
+  const runtime = new AgentRuntime({ logLevel: "fatal" });
+  await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+  return runtime;
+}
+
+describe("scenario required-service contract", () => {
+  it("accepts typed services and rejects malformed runtime definitions", () => {
+    const definition = scenario({
+      id: "typed-services",
+      title: "typed services",
+      domain: "required-service-preflight",
+      requires: {
+        plugins: ["@elizaos/plugin-wallet"],
+        services: ["wallet-backend"],
+      },
+      turns: [],
+    });
+    expect(resolveRequiredServiceTypes(definition)).toEqual(["wallet-backend"]);
+
+    expect(() =>
+      scenario({
+        ...definition,
+        id: "malformed-services",
+        requires: { services: ["wallet-backend", ""] },
+      } as unknown as ScenarioDefinition),
+    ).toThrow("invalid requires.services");
+    expect(() =>
+      scenario({
+        ...definition,
+        id: "misspelled-services",
+        requires: { service: ["wallet-backend"] },
+      } as unknown as ScenarioDefinition),
+    ).toThrow("unknown requires field(s): service");
+  });
+});
+
+describe("required-service readiness", () => {
+  const runtimes: AgentRuntime[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      runtimes.splice(0).map((runtime) => runtime.stop({ fast: true })),
+    );
+  });
+
+  it("waits for delayed startup on a newly registered plugin", async () => {
+    const runtime = await createRuntime();
+    runtimes.push(runtime);
+    const startup = deferred<DelayedService>();
+
+    class DelayedService extends Service {
+      static override serviceType = "scenario-delayed";
+      capabilityDescription = "delayed required service";
+
+      static override async start(): Promise<DelayedService> {
+        return startup.promise;
+      }
+
+      override async stop(): Promise<void> {}
+    }
+
+    await runtime.registerPlugin({
+      name: "scenario-delayed-plugin",
+      description: "Registers a delayed service",
+      services: [DelayedService],
+    });
+
+    let settled = false;
+    const preflight = waitForScenarioRequiredServices(
+      runtime,
+      scenarioWithServices("delayed", [DelayedService.serviceType]),
+    ).finally(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    startup.resolve(new DelayedService(runtime));
+    const services = await preflight;
+    expect(services.get(DelayedService.serviceType)).toBeInstanceOf(
+      DelayedService,
+    );
+  });
+
+  it("waits for a service from a plugin registered before this scenario", async () => {
+    const runtime = await createRuntime();
+    runtimes.push(runtime);
+    const startup = deferred<PreRegisteredService>();
+
+    class PreRegisteredService extends Service {
+      static override serviceType = "scenario-pre-registered";
+      capabilityDescription = "pre-registered required service";
+
+      static override async start(): Promise<PreRegisteredService> {
+        return startup.promise;
+      }
+
+      override async stop(): Promise<void> {}
+    }
+
+    await runtime.registerPlugin({
+      name: "scenario-pre-registered-plugin",
+      description: "Registers before scenario preflight",
+      services: [PreRegisteredService],
+    });
+    await waitForScenarioRequiredServices(
+      runtime,
+      scenarioWithServices("unrelated-a", []),
+    );
+
+    const required = waitForScenarioRequiredServices(
+      runtime,
+      scenarioWithServices("required-b", [PreRegisteredService.serviceType]),
+    );
+    startup.resolve(new PreRegisteredService(runtime));
+    await expect(required).resolves.toEqual(
+      new Map([
+        [
+          PreRegisteredService.serviceType,
+          expect.any(PreRegisteredService) as PreRegisteredService,
+        ],
+      ]),
+    );
+  });
+
+  it("accepts a later plugin implementation when an earlier sibling fails", async () => {
+    const runtime = await createRuntime();
+    runtimes.push(runtime);
+    const optionalCause = new Error("optional implementation unavailable");
+    let failingStarts = 0;
+
+    class FailingOptionalService extends Service {
+      static override serviceType = "scenario-sibling";
+      static override allowsMultiple = true;
+      capabilityDescription = "failing optional implementation";
+
+      static override async start(): Promise<FailingOptionalService> {
+        failingStarts += 1;
+        throw optionalCause;
+      }
+
+      override async stop(): Promise<void> {}
+    }
+
+    class HealthyRequiredService extends Service {
+      static override serviceType = "scenario-sibling";
+      static override allowsMultiple = true;
+      capabilityDescription = "healthy required implementation";
+
+      static override async start(
+        runtime: IAgentRuntime,
+      ): Promise<HealthyRequiredService> {
+        return new HealthyRequiredService(runtime);
+      }
+
+      override async stop(): Promise<void> {}
+    }
+
+    await runtime.registerPlugin({
+      name: "scenario-failing-sibling-plugin",
+      description: "Registers an unavailable implementation",
+      services: [FailingOptionalService],
+    });
+    await runtime.registerPlugin({
+      name: "scenario-healthy-sibling-plugin",
+      description: "Registers a later healthy implementation",
+      services: [HealthyRequiredService],
+    });
+    const services = await waitForScenarioRequiredServices(
+      runtime,
+      scenarioWithServices("sibling", [HealthyRequiredService.serviceType]),
+    );
+
+    expect(services.get(HealthyRequiredService.serviceType)).toBeInstanceOf(
+      HealthyRequiredService,
+    );
+    expect(runtime.getServiceRegistrationStatus("scenario-sibling")).toBe(
+      "registered",
+    );
+    expect(runtime.getRecentReportedErrors()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: optionalCause.message }),
+      ]),
+    );
+    await expect(
+      runtime.getServiceLoadPromise("scenario-sibling"),
+    ).resolves.toBeInstanceOf(HealthyRequiredService);
+    expect(failingStarts).toBe(1);
+  });
+
+  it("preserves the original startup cause in a typed preflight failure", async () => {
+    const runtime = await createRuntime();
+    runtimes.push(runtime);
+    const startup = deferred<NeverStartsService>();
+    const startupCause = new Error("credential rejected by provider");
+
+    class NeverStartsService extends Service {
+      static override serviceType = "scenario-failed";
+      capabilityDescription = "required service that fails";
+
+      static override async start(): Promise<NeverStartsService> {
+        return startup.promise;
+      }
+
+      override async stop(): Promise<void> {}
+    }
+
+    await runtime.registerPlugin({
+      name: "scenario-failed-plugin",
+      description: "Registers a failed required service",
+      services: [NeverStartsService],
+    });
+    const preflight = waitForScenarioRequiredServices(
+      runtime,
+      scenarioWithServices("failed", [NeverStartsService.serviceType]),
+    );
+    startup.reject(startupCause);
+
+    try {
+      await preflight;
+      throw new Error("expected required-service preflight to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ScenarioRequiredServicePreflightError);
+      const preflightError = error as ScenarioRequiredServicePreflightError;
+      expect(preflightError.code).toBe(
+        "SCENARIO_REQUIRED_SERVICE_PREFLIGHT_FAILED",
+      );
+      expect(preflightError.cause).toBeInstanceOf(ElizaError);
+      const runtimeError = preflightError.cause as ElizaError;
+      expect(runtimeError.code).toBe("SERVICE_START_FAILED");
+      expect(runtimeError.cause).toBeInstanceOf(AggregateError);
+      // Each per-implementation failure is wrapped in a typed ElizaError that
+      // adds service identity; the original startup cause must remain
+      // reachable through the cause chain.
+      const chainContains = (error: unknown): boolean => {
+        if (error === startupCause) return true;
+        if (error instanceof AggregateError) {
+          return error.errors.some(chainContains);
+        }
+        if (error instanceof Error && error.cause !== undefined) {
+          return chainContains(error.cause);
+        }
+        return false;
+      };
+      expect(chainContains(runtimeError.cause)).toBe(true);
+    }
+  });
+
+  it("retries startup after an initialization failure", async () => {
+    const runtime = await createRuntime();
+    runtimes.push(runtime);
+    const firstAttempt = deferred<RetryService>();
+    let attempts = 0;
+
+    class RetryService extends Service {
+      static override serviceType = "scenario-retry";
+      capabilityDescription = "transiently failing required service";
+
+      static override async start(
+        runtime: IAgentRuntime,
+      ): Promise<RetryService> {
+        attempts += 1;
+        if (attempts === 1) {
+          return firstAttempt.promise;
+        }
+        return new RetryService(runtime);
+      }
+
+      override async stop(): Promise<void> {}
+    }
+
+    await runtime.registerPlugin({
+      name: "scenario-retry-plugin",
+      description: "Registers a transiently failing service",
+      services: [RetryService],
+    });
+    const definition = scenarioWithServices("retry", [
+      RetryService.serviceType,
+    ]);
+    const failed = waitForScenarioRequiredServices(runtime, definition);
+    firstAttempt.reject(new Error("transient startup failure"));
+    await expect(failed).rejects.toBeInstanceOf(
+      ScenarioRequiredServicePreflightError,
+    );
+
+    await expect(
+      waitForScenarioRequiredServices(runtime, definition),
+    ).resolves.toEqual(
+      new Map([
+        [RetryService.serviceType, expect.any(RetryService) as RetryService],
+      ]),
+    );
+    expect(attempts).toBe(2);
+  });
+
+  it("lets the execution owner cancel a never-settling wait", async () => {
+    const runtime = await createRuntime();
+    runtimes.push(runtime);
+
+    class HangingService extends Service {
+      static override serviceType = "scenario-hanging";
+      capabilityDescription = "never-settling required service";
+
+      static override async start(): Promise<HangingService> {
+        return new Promise(() => {});
+      }
+
+      override async stop(): Promise<void> {}
+    }
+
+    await runtime.registerPlugin({
+      name: "scenario-hanging-plugin",
+      description: "Registers a never-settling service",
+      services: [HangingService],
+    });
+
+    const controller = new AbortController();
+    const preflight = waitForScenarioRequiredServices(
+      runtime,
+      scenarioWithServices("hanging", [HangingService.serviceType]),
+      controller.signal,
+    );
+    controller.abort(new Error("scenario runner stopped"));
+
+    await expect(preflight).rejects.toMatchObject({
+      code: "SCENARIO_REQUIRED_SERVICE_PREFLIGHT_FAILED",
+      cause: expect.objectContaining({
+        code: "SCENARIO_REQUIRED_SERVICE_ABORTED",
+      }),
+    });
+    await runtime.stop({ fast: true });
+    runtimes.pop();
+  });
+
+  it("is independent of required-scenario order in a shared runtime", async () => {
+    async function run(requiredFirst: boolean): Promise<string[]> {
+      const runtime = await createRuntime();
+      const startup = deferred<OrderedService>();
+      const observations: string[] = [];
+
+      class OrderedService extends Service {
+        static override serviceType = "scenario-ordered";
+        capabilityDescription = "order-independent required service";
+
+        static override async start(): Promise<OrderedService> {
+          return startup.promise;
+        }
+
+        override async stop(): Promise<void> {}
+      }
+
+      await runtime.registerPlugin({
+        name: `scenario-ordered-plugin-${requiredFirst}`,
+        description: "Registers an order-independent service",
+        services: [OrderedService],
+      });
+      const required = async () => {
+        const pending = waitForScenarioRequiredServices(
+          runtime,
+          scenarioWithServices("ordered-required", [
+            OrderedService.serviceType,
+          ]),
+        );
+        startup.resolve(new OrderedService(runtime));
+        await pending;
+        observations.push("required-ready");
+      };
+      const optional = async () => {
+        await waitForScenarioRequiredServices(
+          runtime,
+          scenarioWithServices("ordered-optional", []),
+        );
+        observations.push("optional-ready");
+      };
+
+      if (requiredFirst) {
+        await required();
+        await optional();
+      } else {
+        await optional();
+        await required();
+      }
+      await runtime.stop({ fast: true });
+      return observations.sort();
+    }
+
+    await expect(run(true)).resolves.toEqual([
+      "optional-ready",
+      "required-ready",
+    ]);
+    await expect(run(false)).resolves.toEqual([
+      "optional-ready",
+      "required-ready",
+    ]);
+  });
+
+  it("keeps credentialless signing and Birdeye optional for token analytics", async () => {
+    const runtime = await createRuntime();
+    runtimes.push(runtime);
+    const { default: walletPlugin } = (await import(
+      "@elizaos/plugin-wallet"
+    )) as { default: Plugin };
+
+    await runtime.registerPlugin(walletPlugin);
+    const services = await waitForScenarioRequiredServices(
+      runtime,
+      scenarioWithServices("credentialless-wallet", ["token-info"]),
+    );
+
+    const tokenInfo = services.get("token-info");
+    expect(tokenInfo).toBeDefined();
+    expect(tokenInfo).toBe(runtime.getService("token-info"));
+    await expect(
+      runtime.getServiceLoadPromise("birdeye"),
+    ).rejects.toMatchObject({
+      code: "SERVICE_START_FAILED",
+      cause: expect.any(AggregateError),
+    });
+  });
+});

--- a/packages/scenario-runner/src/required-services.ts
+++ b/packages/scenario-runner/src/required-services.ts
@@ -1,0 +1,129 @@
+/**
+ * Enforces scenario-declared service readiness before any turn executes.
+ * Required service types are checked on every scenario, including when their
+ * plugin was registered by an earlier scenario in the shared runtime.
+ */
+
+import { type AgentRuntime, ElizaError, type Service } from "@elizaos/core";
+import type { ScenarioDefinition } from "@elizaos/scenario-runner/schema";
+
+type RequiredServiceFailure = {
+  serviceType: string;
+  error: unknown;
+};
+
+/** Typed boundary failure for required scenario service startup. */
+export class ScenarioRequiredServicePreflightError extends ElizaError {
+  override readonly name = "ScenarioRequiredServicePreflightError";
+  readonly serviceTypes: readonly string[];
+
+  constructor(failures: readonly RequiredServiceFailure[]) {
+    const serviceTypes = failures.map(({ serviceType }) => serviceType);
+    const cause =
+      failures.length === 1
+        ? failures[0].error
+        : new AggregateError(
+            failures.map(({ error }) => error),
+            "Multiple required scenario services failed preflight",
+          );
+    super(
+      `Required scenario service preflight failed: ${serviceTypes.join(", ")}`,
+      {
+        code: "SCENARIO_REQUIRED_SERVICE_PREFLIGHT_FAILED",
+        context: { serviceTypes },
+        cause,
+      },
+    );
+    this.serviceTypes = serviceTypes;
+  }
+}
+
+export function resolveRequiredServiceTypes(
+  scenario: ScenarioDefinition,
+): string[] {
+  const services = scenario.requires?.services;
+  if (!Array.isArray(services)) {
+    return [];
+  }
+  return [
+    ...new Set(services.map((service) => service.trim()).filter(Boolean)),
+  ].sort();
+}
+
+async function waitForService(
+  runtime: Pick<AgentRuntime, "getServiceLoadPromise">,
+  serviceType: string,
+  signal?: AbortSignal,
+): Promise<Service> {
+  const servicePromise = runtime.getServiceLoadPromise(serviceType);
+  if (!signal) {
+    return servicePromise;
+  }
+  const aborted = () =>
+    new ElizaError(
+      `Required scenario service "${serviceType}" wait was cancelled by its owner`,
+      {
+        code: "SCENARIO_REQUIRED_SERVICE_ABORTED",
+        context: { serviceType },
+        cause:
+          signal.reason instanceof Error
+            ? signal.reason
+            : new Error(
+                String(signal.reason ?? "Scenario execution cancelled"),
+              ),
+      },
+    );
+  if (signal.aborted) {
+    throw aborted();
+  }
+  return new Promise<Service>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(aborted());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    servicePromise.then(
+      (service) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(service);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+/**
+ * Wait for every explicitly required service. The execution owner may cancel
+ * the wait; service startup itself remains owned by the runtime lifecycle.
+ */
+export async function waitForScenarioRequiredServices(
+  runtime: Pick<AgentRuntime, "getServiceLoadPromise">,
+  scenario: ScenarioDefinition,
+  signal?: AbortSignal,
+): Promise<ReadonlyMap<string, Service>> {
+  const serviceTypes = resolveRequiredServiceTypes(scenario);
+  const settled = await Promise.allSettled(
+    serviceTypes.map(async (serviceType) => {
+      const service = await waitForService(runtime, serviceType, signal);
+      return [serviceType, service] as const;
+    }),
+  );
+  const failures: RequiredServiceFailure[] = [];
+  const services = new Map<string, Service>();
+  for (let index = 0; index < settled.length; index += 1) {
+    const result = settled[index];
+    const serviceType = serviceTypes[index];
+    if (result.status === "fulfilled") {
+      services.set(result.value[0], result.value[1]);
+    } else {
+      failures.push({ serviceType, error: result.reason });
+    }
+  }
+  if (failures.length > 0) {
+    throw new ScenarioRequiredServicePreflightError(failures);
+  }
+  return services;
+}

--- a/packages/scripts/run-scenarios-isolated.mjs
+++ b/packages/scripts/run-scenarios-isolated.mjs
@@ -97,6 +97,7 @@ for (const id of ids) {
     "/tmp",
     `scenario-isolated-${id.replace(/[^a-z0-9._-]/gi, "_")}.json`,
   );
+  fs.rmSync(tmpReport, { force: true });
   const child = spawnSync(
     "bun",
     [CLI, "run", dir, "--scenario", id, "--report", tmpReport],

--- a/plugins/plugin-wallet/test/scenarios/token-info-live-proof.scenario.ts
+++ b/plugins/plugin-wallet/test/scenarios/token-info-live-proof.scenario.ts
@@ -1,0 +1,64 @@
+/**
+ * Exercises wallet token discovery through a live model and the public
+ * DexScreener service so required-service readiness is proven on the real path.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+// Public USDC ERC-20 contract address on Ethereum mainnet — not a credential.
+const TOKEN_ADDRESS = "0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"; // gitleaks:allow
+
+export default scenario({
+  lane: "live-only",
+  id: "wallet.token-info-live-proof",
+  title: "Wallet token info through live Cerebras and DexScreener",
+  domain: "wallet",
+  tags: ["wallet", "live-model", "live-api"],
+  description:
+    "Routes a USDC lookup through the live model and the wallet plugin's public DexScreener service.",
+  requires: {
+    plugins: ["@elizaos/plugin-wallet"],
+    services: ["token-info"],
+  },
+  isolation: "per-scenario",
+  rooms: [
+    { id: "main", source: "dashboard", channelType: "DM", title: "Wallet" },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "lookup",
+      text: `Use the WALLET tool to fetch current DexScreener token information for USDC at ${TOKEN_ADDRESS}.`,
+      content: { action: "token_info", address: TOKEN_ADDRESS },
+      assertTurn: (turn) => {
+        const call = turn.actionsCalled.find(
+          (candidate) => candidate.actionName === "WALLET_TOKEN_INFO",
+        );
+        if (!call) {
+          return `Expected WALLET_TOKEN_INFO but got: ${turn.actionsCalled
+            .map((candidate) => candidate.actionName)
+            .join(", ")}`;
+        }
+        if (!call.result?.success) {
+          return `WALLET_TOKEN_INFO failed: ${call.error?.message ?? call.result?.text ?? "unknown error"}`;
+        }
+        const data = call.result.data as
+          | { subaction?: unknown; pairs?: unknown }
+          | undefined;
+        if (data?.subaction !== "token_info") {
+          return `Expected token_info result, got ${String(data?.subaction)}`;
+        }
+        if (!Array.isArray(data.pairs) || data.pairs.length === 0) {
+          return "DexScreener returned no live USDC pairs";
+        }
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: "WALLET_TOKEN_INFO",
+      status: "success",
+      minCount: 1,
+    },
+  ],
+});

--- a/plugins/plugin-wallet/test/scenarios/token-info.scenario.ts
+++ b/plugins/plugin-wallet/test/scenarios/token-info.scenario.ts
@@ -70,7 +70,10 @@ export default scenario({
   description:
     "Looks up token information through the WALLET action (action=token_info) against a scoped mock of the DexScreener API — keyless, no signer, no live network.",
 
-  requires: { plugins: ["@elizaos/plugin-wallet"] },
+  requires: {
+    plugins: ["@elizaos/plugin-wallet"],
+    services: ["token-info"],
+  },
   isolation: "per-scenario",
 
   seed: [


### PR DESCRIPTION
# Relates to

Closes #17419. Completes the required-service readiness contract left partial by #17407.

# Sync with develop

- [x] Merged `origin/develop` at `19a7d875838`; restored `packages/cloud/shared` files that earlier stale merges had silently reverted.
- [x] The prior registration workaround is replaced by explicit scenario requirements.
- [x] Exact-head test, build, and live-model evidence is attached below.

# What changed

- Add a typed `requires.services` scenario contract and schema validation.
- Wait for required services under the owning execution signal whether their plugin is newly or previously registered.
- Preserve individual startup causes through typed preflight and aggregate errors.
- Treat sibling service implementations as alternatives while continuing to start siblings registered after initialization.
- Fail configured tool policy closed when its service cannot start.
- Remove the revision's explicit test races and per-test deadlines.
- Declare the scenario runner's wallet dependency and use its documented package root.
- Add a live-only Cerebras + public DexScreener token-info scenario with exact action and result assertions.

# Testing

- Required-service focused suite: 9 passed, 0 failed.
- Core service-concurrency suite: 5 passed, 0 failed.
- Dependency-closed Turbo build: 104/104 packages passed.
- Core typecheck and scenario-runner build: passed.
- Changed-file Biome and `git diff --check`: passed.
- Live Cerebras `gemma-4-31b` + live DexScreener scenario: 1 passed, 0 failed; 5,602 ms scenario duration, 3,129 ms trajectory latency, 1 successful tool call, 0 tool failures.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - scenario/runtime backend contract with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - scenario/runtime backend contract with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual flow.
<!-- evidence-row:backend-logs -->
- [x] Local run at head `d6d3507721f`:

  <details>
  <summary>required-services, service-start-concurrency, and restored inference-billing-ledger suites</summary>

  ```text
  packages/scenario-runner> vitest run src/required-services.test.ts
   Test Files  1 passed (1)
        Tests  9 passed (9)
     Duration  12.87s

  packages/core> vitest run src/__tests__/service-start-concurrency.test.ts
   Test Files  1 passed (1)
        Tests  5 passed (5)
     Duration  7.72s

  packages/cloud/shared> bun test src/lib/services/__tests__/inference-billing-ledger.test.ts
   30 pass
   0 fail
   103 expect() calls
  Ran 30 tests across 1 file. [3.94s]
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/17427-tj-202c86501638d4.json
<!-- evidence-row:domain-artifacts -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/17427-pr17427-live-cerebras-4.json

# Known gaps / failures

None in the changed path. The live run accurately remains ineligible as signed provider-qualified release evidence because the in-process runner is not the external qualification controller; it is valid real-model and real-provider behavioral evidence.


<!-- evidence-head:d6d3507721febfada5150d487e3bc0e85e2bdf24 -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@c276b7c1f42b927e7f167f00cd70daea47aa9513:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`
