### PR TITLE
fix(ui): align the home-screen fixture catalog

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.catalog-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.catalog-stub.ts
@@ -1,35 +1,18 @@
-// Stub for the view catalog in the home-screen e2e: reports a single static
-// "weather" app entry (with a generated hero SVG) so gated home tiles render
-// deterministically without hitting the live catalog service.
-import { generateViewHeroSvgFor } from "@elizaos/shared";
+/**
+ * Deterministic catalog adapter for the real home-screen launcher fixture.
+ *
+ * Both launcher data hooks consume the same synthetic view registry so a
+ * production refactor between hook surfaces cannot silently change the fixture
+ * from a representative launcher into a one-tile catalog.
+ */
 
-const WEATHER_HERO = `data:image/svg+xml,${encodeURIComponent(
-  generateViewHeroSvgFor({
-    id: "weather",
-    label: "Weather",
-    icon: "CloudSun",
-  }),
-)}`;
+import { viewToEntry } from "../../../hooks/view-catalog";
+import { useRoutableViews } from "./home-screen-fixture.views-stub";
 
 export function useViewCatalog() {
+  const { views } = useRoutableViews();
   return {
-    entries: [
-      {
-        key: "app:weather",
-        id: "weather",
-        label: "Weather",
-        icon: "CloudSun",
-        imageUrl: WEATHER_HERO,
-        fallbackImageUrl: WEATHER_HERO,
-        hasHero: false,
-        modality: "gui",
-        state: "available",
-        kind: "app",
-        appName: "weather",
-        pluginName: "weather",
-        viewKind: "release",
-      },
-    ],
+    entries: views.map(viewToEntry),
     loading: false,
     error: null,
     refresh: () => {},


### PR DESCRIPTION
# Relates to

Closes #17429. Fixes develop workflow run [30614918045](https://github.com/elizaOS/eliza/actions/runs/30614918045).

# Sync with develop

- [x] Parent is exact origin/develop at 0eeaf00abb09; zero conflicts.
- [x] One fixture-adapter file changed; production launcher code is untouched.

# What changed

- Feed useViewCatalog() and useRoutableViews() from the same representative fixture registry.
- Use the production viewToEntry adapter so the fixture exercises real launcher catalog semantics.
- Preserve every existing curation, deduplication, glyph, touch, long-press, desktop, and frame-budget assertion.

# Reproduction and verification

- Exact develop baseline: 3/3 failures, one tile, identical long-press timeout.
- Exact develop plus fix: 3/3 passes, 15 tiles, zero page errors.
- Current checkout home-screen E2E: passed.
- UI typecheck: passed.
- Focused launcher tests: 17 passed.
- Corrected mobile launcher screenshot manually reviewed.
- git diff --check: passed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] [Failed exact-develop workflow and artifacts](https://github.com/elizaOS/eliza/actions/runs/30614918045).
<!-- evidence-row:after-screenshots -->
- [x] N/A - production UI bytes are unchanged; this repairs the E2E fixture registry.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - fixture-only correction with no production interaction change.
<!-- evidence-row:backend-logs -->
- [x] [Failed exact-develop log](https://github.com/elizaOS/eliza/actions/runs/30614918045/job/91105798409) and exact-head PR rerun.
<!-- evidence-row:frontend-logs -->
- [x] [Exact-head UI Fixture E2E run (green, browser console + page-error assertions)](https://github.com/elizaOS/eliza/actions/runs/30616630883).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head Home-screen real-touch E2E screenshots + report (workflow artifacts)](https://github.com/elizaOS/eliza/actions/runs/30616630883#artifacts).

# Known gaps / failures

No production code changes. Merge only after the exact-head UI Fixture E2E job passes.
