### PR TITLE
fix(agent): make chat generation cancellation-owned

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-streaming.test.ts
@@ -576,7 +576,6 @@ describe("generateChatResponse token streaming", () => {
       createChatMessage("hi"),
       "Streaming Agent",
       {
-        timeoutDuration: 5_000,
         onChunk: (chunk) => {
           chunks.push(chunk);
         },
@@ -636,7 +635,6 @@ describe("generateChatResponse token streaming", () => {
       createChatMessage("repeat"),
       "Streaming Agent",
       {
-        timeoutDuration: 5_000,
         onChunk: (chunk) => {
           runningTotal += chunk;
         },
@@ -697,7 +695,6 @@ describe("generateChatResponse token streaming", () => {
       createChatMessage("open notes"),
       "Streaming Agent",
       {
-        timeoutDuration: 5_000,
         onChunk: (chunk) => chunks.push(chunk),
         onSnapshot: (text) => snapshots.push(text),
       },
@@ -739,7 +736,6 @@ describe("generateChatResponse token streaming", () => {
       createChatMessage("typo"),
       "Streaming Agent",
       {
-        timeoutDuration: 5_000,
         onChunk: (chunk) => chunks.push(chunk),
         onSnapshot: (text) => snapshots.push(text),
       },
@@ -782,7 +778,6 @@ describe("generateChatResponse token streaming", () => {
       createChatMessage("preserve repeated characters"),
       "Streaming Agent",
       {
-        timeoutDuration: 5_000,
         onChunk: (chunk) => chunks.push(chunk),
         onSnapshot: (text) => snapshots.push(text),
       },
@@ -824,7 +819,6 @@ describe("generateChatResponse token streaming", () => {
       createChatMessage("preserve token boundaries"),
       "Streaming Agent",
       {
-        timeoutDuration: 5_000,
         onChunk: (chunk) => chunks.push(chunk),
       },
     );
@@ -859,7 +853,6 @@ describe("generateChatResponse token streaming", () => {
       runtime,
       message,
       "Streaming Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(getActionResults).toHaveBeenCalledWith(message.id);
@@ -912,7 +905,6 @@ describe("generateChatResponse token streaming", () => {
       runtime,
       message,
       "Streaming Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.actionResults).toEqual([
@@ -959,7 +951,6 @@ describe("generateChatResponse token streaming", () => {
       message,
       "Streaming Agent",
       {
-        timeoutDuration: 5_000,
         onChunk: (chunk) => {
           chunks.push(chunk);
         },
@@ -1045,9 +1036,7 @@ describe("generateChatResponse token streaming", () => {
       runtime,
       message,
       "Streaming Agent",
-      {
-        timeoutDuration: 5_000,
-      },
+      {},
     );
 
     const params = useModel.mock.calls[0]?.[1] as {
@@ -1114,7 +1103,6 @@ describe("generateChatResponse token streaming", () => {
       runtime,
       message,
       "Streaming Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(runtime.reportError).toHaveBeenCalledWith(
@@ -1163,14 +1151,11 @@ describe("generateChatResponse token streaming", () => {
     } as typeof withAttachment.content;
     const overlong = createChatMessage("x".repeat(701));
 
-    await generateChatResponse(runtime, withAttachment, "Streaming Agent", {
-      timeoutDuration: 5_000,
-    });
+    await generateChatResponse(runtime, withAttachment, "Streaming Agent", {});
     const result = await generateChatResponse(
       runtime,
       overlong,
       "Streaming Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(useModel).not.toHaveBeenCalled();
@@ -1211,13 +1196,11 @@ describe("generateChatResponse token streaming", () => {
       runtime,
       createChatMessage("what is the weather today?"),
       "Streaming Agent",
-      { timeoutDuration: 5_000 },
     );
     const local = await generateChatResponse(
       runtime,
       createChatMessage("are you running locally on this device today?"),
       "Streaming Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(handleMessage).toHaveBeenCalledTimes(1);
@@ -1259,7 +1242,6 @@ describe("generateChatResponse token streaming", () => {
       runtime,
       createChatMessage("say <end_of_turn> safely"),
       "Streaming Agent",
-      { timeoutDuration: 5_000 },
     );
 
     const params = useModel.mock.calls[0]?.[1] as { prompt: string };
@@ -1287,7 +1269,6 @@ describe("generateChatResponse token streaming", () => {
       runtime,
       createChatMessage("can you answer locally?"),
       "Streaming Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(useModel).toHaveBeenCalledWith(
@@ -1337,7 +1318,6 @@ describe("generateChatResponse token streaming", () => {
       runtime,
       createChatMessage("what did I just say?"),
       "Streaming Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(useModel).not.toHaveBeenCalled();
@@ -1377,7 +1357,6 @@ describe("generateChatResponse token streaming", () => {
       runtime,
       createChatMessage("remember that my favorite model is eliza"),
       "Streaming Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(useModel).not.toHaveBeenCalled();
@@ -1385,23 +1364,23 @@ describe("generateChatResponse token streaming", () => {
     expect(result.text).toBe("I need the normal runtime for that.");
   });
 
-  it("aborts the message runtime when the chat generation timeout fires", async () => {
+  it("propagates caller cancellation into the message runtime", async () => {
     let signalFromOptions: AbortSignal | undefined;
-    let observedAbort: (() => void) | undefined;
-    const abortObserved = new Promise<void>((resolve) => {
-      observedAbort = resolve;
+    let runtimeStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      runtimeStarted = resolve;
     });
 
     const runtime = createRuntime({
       messageService: {
         async handleMessage(_runtime, _message, _callback, options) {
           signalFromOptions = options?.abortSignal;
-          await new Promise<void>((resolve) => {
+          runtimeStarted?.();
+          await new Promise<void>((_resolve, reject) => {
             options?.abortSignal?.addEventListener(
               "abort",
               () => {
-                observedAbort?.();
-                resolve();
+                reject(options.abortSignal?.reason);
               },
               { once: true },
             );
@@ -1422,19 +1401,51 @@ describe("generateChatResponse token streaming", () => {
       },
     });
 
+    const caller = new AbortController();
+    const generation = generateChatResponse(
+      runtime,
+      createChatMessage("cancel this request"),
+      "Streaming Agent",
+      { abortSignal: caller.signal },
+    );
+    await started;
+    caller.abort(new DOMException("Client disconnected", "AbortError"));
+
+    await expect(generation).rejects.toThrow("Client disconnected");
+    expect(signalFromOptions?.aborted).toBe(true);
+  });
+
+  it("rejects ingress hook failures before starting message generation", async () => {
+    const hookFailure = new Error("trajectory persistence failed");
+    const handleMessage = vi.fn(async () => ({
+      didRespond: true,
+      responseContent: { text: "must not be generated" },
+      responseMessages: [],
+    }));
+    const runtime = createRuntime({
+      emitEvent: vi.fn(async () => {
+        throw hookFailure;
+      }),
+      messageService: {
+        handleMessage,
+        shouldRespond: () => ({
+          shouldRespond: true,
+          skipEvaluation: true,
+          reason: "streaming-test",
+        }),
+        deleteMessage: async () => undefined,
+        clearChannel: async () => undefined,
+      },
+    });
+
     await expect(
       generateChatResponse(
         runtime,
-        createChatMessage("timeout"),
+        createChatMessage("persist ingress first"),
         "Streaming Agent",
-        {
-          timeoutDuration: 10,
-        },
       ),
-    ).rejects.toThrow("Chat generation timed out after 10ms");
-
-    await abortObserved;
-    expect(signalFromOptions?.aborted).toBe(true);
+    ).rejects.toBe(hookFailure);
+    expect(handleMessage).not.toHaveBeenCalled();
   });
 });
 
@@ -1488,7 +1499,6 @@ describe("generateConversationTitle", () => {
         runtime,
         "Can you answer from the local voice backend?",
         "Streaming Agent",
-        { timeoutMs: 5_000 },
       ),
     ).resolves.toBe("Local Voice Chat");
     expect(useModel).toHaveBeenCalledWith(
@@ -1529,12 +1539,12 @@ describe("generateConversationTitle", () => {
       runtime,
       "Could you say hello?",
       "Streaming Agent",
-      { signal: controller.signal, timeoutMs: 30_000 },
+      { signal: controller.signal },
     );
 
     controller.abort(new DOMException("client left", "AbortError"));
 
-    await expect(pending).resolves.toBeNull();
+    await expect(pending).rejects.toThrow("client left");
     expect(signalFromParams?.aborted).toBe(true);
   });
 });

--- a/packages/agent/src/api/alias-aware-env-reads.test.ts
+++ b/packages/agent/src/api/alias-aware-env-reads.test.ts
@@ -6,8 +6,8 @@
  * exported helpers (`resolveCorsOrigin`, `pairingEnabled`, `resolveTerminalRunRejection`,
  * `extractAuthToken`, `isWebSocketAuthorized`, `resolveWalletExportRejection`,
  * `resolveMcpTerminalAuthorizationRejection`) against a live `process.env`; the
- * server.ts/tui/chat-routes port + chat-timeout reads are covered through the same
- * `readAliasedEnv` primitive they call plus the alias-aware `resolveDesktopApiPort`.
+ * server.ts/tui port reads are covered through the same `readAliasedEnv`
+ * primitive they call plus the alias-aware `resolveDesktopApiPort`.
  */
 import type http from "node:http";
 import {
@@ -45,8 +45,6 @@ const TOUCHED_ENV_KEYS = [
   "ELIZA_ALLOW_WS_QUERY_TOKEN",
   "MILADY_API_PORT",
   "ELIZA_API_PORT",
-  "MILADY_CHAT_GENERATION_TIMEOUT_MS",
-  "ELIZA_CHAT_GENERATION_TIMEOUT_MS",
   "MILADY_API_TOKEN",
   "ELIZA_API_TOKEN",
   "ELIZA_API_BIND",
@@ -265,11 +263,9 @@ describe("#13422 P3 — alias-aware boot-critical env reads", () => {
     });
   });
 
-  describe("readAliasedEnv primitive — ELIZA_API_PORT / ELIZA_CHAT_GENERATION_TIMEOUT_MS", () => {
-    // server.ts (port selection + HTTP request timeout), tui/agent-terminal-tui.ts
-    // (port selection), and chat-routes.ts (generation timeout) all migrated to the
-    // exact `readAliasedEnv("ELIZA_API_PORT")` / `readAliasedEnv("ELIZA_CHAT_GENERATION_TIMEOUT_MS")`
-    // calls exercised here; the port selection also feeds the alias-aware resolveDesktopApiPort.
+  describe("readAliasedEnv primitive — ELIZA_API_PORT", () => {
+    // The server and terminal use this exact read, and the result also feeds
+    // the alias-aware desktop port resolver.
     it("resolves ELIZA_API_PORT from the branded alias, honors ELIZA precedence, and writes no mirror", () => {
       process.env.MILADY_API_PORT = "45999";
       expect(readAliasedEnv("ELIZA_API_PORT")).toBe("45999");
@@ -279,15 +275,6 @@ describe("#13422 P3 — alias-aware boot-critical env reads", () => {
       process.env.ELIZA_API_PORT = "31337";
       expect(readAliasedEnv("ELIZA_API_PORT")).toBe("31337");
       expect(resolveDesktopApiPort(process.env)).toBe(31337);
-    });
-
-    it("resolves ELIZA_CHAT_GENERATION_TIMEOUT_MS from the branded alias, honors ELIZA precedence, and writes no mirror", () => {
-      process.env.MILADY_CHAT_GENERATION_TIMEOUT_MS = "123456";
-      expect(readAliasedEnv("ELIZA_CHAT_GENERATION_TIMEOUT_MS")).toBe("123456");
-      expect(process.env.ELIZA_CHAT_GENERATION_TIMEOUT_MS).toBeUndefined();
-
-      process.env.ELIZA_CHAT_GENERATION_TIMEOUT_MS = "180000";
-      expect(readAliasedEnv("ELIZA_CHAT_GENERATION_TIMEOUT_MS")).toBe("180000");
     });
   });
 });

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -31,7 +31,6 @@ import {
   INSUFFICIENT_CREDITS_REPLY,
   InferenceTurnTimer,
   isRateLimitError,
-  logger,
   MESSAGE_SOURCE_CLIENT_CHAT,
   type Memory,
   ModelType,
@@ -63,7 +62,6 @@ import {
   extractAssistantReplyText,
   isLinkedAccountProviderId,
   normalizeCharacterLanguage,
-  readAliasedEnv,
   resolveStreamingUpdate,
 } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
@@ -127,9 +125,7 @@ import type { ChatImageAttachment } from "./server-types.ts";
 
 export type { ChatImageAttachment, LogEntry };
 
-const DEFAULT_CONVERSATION_TITLE_TIMEOUT_MS = 5_000;
 const CHAT_APPEND_ONLY_STREAM_DIVERGENCE = "CHAT_APPEND_ONLY_STREAM_DIVERGENCE";
-
 type LocalInferenceChatApi = Pick<
   LocalInferenceRouteApi,
   "getLocalInferenceChatStatus" | "handleLocalInferenceChatCommand"
@@ -941,7 +937,6 @@ export interface ChatGenerateOptions {
   abortSignal?: AbortSignal;
   resolveNoResponseText?: () => string;
   preferredLanguage?: string;
-  timeoutDuration?: number;
 }
 
 function isAppendOnlyStreamDivergenceError(
@@ -1881,57 +1876,6 @@ function getProviderIssueChatReply(): string {
   return PROVIDER_ISSUE_CHAT_REPLY;
 }
 
-function resolveChatGenerationTimeoutMs(explicit?: number): number {
-  if (
-    typeof explicit === "number" &&
-    Number.isFinite(explicit) &&
-    explicit > 0
-  ) {
-    return Math.max(1, Math.floor(explicit));
-  }
-
-  const fromEnv = readAliasedEnv("ELIZA_CHAT_GENERATION_TIMEOUT_MS");
-  if (!fromEnv) return 0;
-
-  const parsed = Number.parseInt(fromEnv, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return 0;
-  }
-
-  return Math.max(1_000, parsed);
-}
-
-function createChatGenerationTimeoutError(timeoutMs: number): Error {
-  return new Error(`Chat generation timed out after ${timeoutMs}ms`);
-}
-
-async function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  createError: () => Error,
-  onTimeout?: () => void,
-): Promise<T> {
-  if (timeoutMs <= 0) {
-    return promise;
-  }
-  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_resolve, reject) => {
-        timeoutHandle = setTimeout(() => {
-          onTimeout?.();
-          reject(createError());
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeoutHandle) {
-      clearTimeout(timeoutHandle);
-    }
-  }
-}
-
 export function getChatFailureReply(
   err: unknown,
   logBuffer: LogEntry[],
@@ -2831,10 +2775,6 @@ async function generateChatResponseWithTiming(
   agentName: string,
   opts?: ChatGenerateOptions,
 ): Promise<ChatGenerationResult> {
-  const generationTimeoutMs = resolveChatGenerationTimeoutMs(
-    opts?.timeoutDuration,
-  );
-  let generationTimedOut = false;
   const generationAbortController = new AbortController();
   const abortGeneration = (reason?: unknown): void => {
     if (!generationAbortController.signal.aborted) {
@@ -2996,23 +2936,15 @@ async function generateChatResponseWithTiming(
       replaceCallbackText(incoming);
     };
 
-    // Emit inbound events so trajectory/session hooks run for API chat.
-    try {
-      if (typeof runtime.emitEvent === "function") {
-        await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
+    // Trajectory/session persistence is part of accepting an API turn. A hook
+    // failure must reject before generation rather than produce an answer whose
+    // ingress record is missing.
+    if (typeof runtime.emitEvent === "function") {
+      await timeInferenceSpan("chat:ingress:received-event", () =>
+        runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
           message,
           source: messageSource,
-        });
-      }
-    } catch (err) {
-      runtime.logger.warn(
-        {
-          err,
-          src: "eliza-api",
-          messageId: message.id,
-          roomId: message.roomId,
-        },
-        "Failed to emit MESSAGE_RECEIVED event",
+        }),
       );
     }
     const trajectoryStepId = readMessageTrajectoryStepId(message);
@@ -3114,478 +3046,444 @@ async function generateChatResponseWithTiming(
     const fallbackSuccessfulActionNames = new Set<string>();
 
     const generationCapture = await withModelUsageCapture(runtime, () =>
-      withTimeout(
-        Promise.resolve(
-          runWithTrajectoryContext(trajectoryContext, async () => {
-            // Plugin-registered chat pre-handlers (generic direct-dispatch
-            // extension point): drained by priority before normal action
-            // processing; the first non-null result resolves the turn.
-            const preHandlerResult = await runtime.drainChatPreHandlers({
-              runtime,
-              message,
-              appendText: replaceCallbackText,
-              replaceText: emitSnapshot,
-            });
-            if (preHandlerResult) {
-              const directText = preHandlerResult.responseText;
-              const finalText = isClientVisibleNoResponse(directText)
-                ? directText || "(no response)"
-                : directText;
-              result = {
-                didRespond: true,
-                responseContent: { text: finalText },
-                responseMessages: [],
-              } as typeof result;
-              responseText = finalText;
-              forcedWalletExecutionText = isClientVisibleNoResponse(directText);
-              return;
-            }
+      Promise.resolve(
+        runWithTrajectoryContext(trajectoryContext, async () => {
+          // Plugin-registered chat pre-handlers (generic direct-dispatch
+          // extension point): drained by priority before normal action
+          // processing; the first non-null result resolves the turn.
+          const preHandlerResult = await runtime.drainChatPreHandlers({
+            runtime,
+            message,
+            appendText: replaceCallbackText,
+            replaceText: emitSnapshot,
+          });
+          if (preHandlerResult) {
+            const directText = preHandlerResult.responseText;
+            const finalText = isClientVisibleNoResponse(directText)
+              ? directText || "(no response)"
+              : directText;
+            result = {
+              didRespond: true,
+              responseContent: { text: finalText },
+              responseMessages: [],
+            } as typeof result;
+            responseText = finalText;
+            forcedWalletExecutionText = isClientVisibleNoResponse(directText);
+            return;
+          }
 
-            // Direct dispatch for explicit task creation intent from UI
-            const contentMetadata = message.content.metadata as
-              | Record<string, unknown>
-              | undefined;
-            if (contentMetadata?.intent === "create_task") {
-              const coordinator = getSwarmCoordinatorService(runtime);
-              if (coordinator) {
-                const createTaskAction =
-                  runtime.actions.find(
-                    (a) => a.name.toUpperCase() === "START_CODING_TASK",
-                  ) ??
-                  runtime.actions.find(
-                    (a) => a.name.toUpperCase() === "CREATE_TASK",
-                  );
-                if (createTaskAction) {
-                  runtime.logger.info(
-                    {
-                      src: "eliza-api",
-                      agentType: contentMetadata.agentType,
-                      intent: "create_task",
-                    },
-                    "[eliza-api] Direct dispatch START_CODING_TASK from UI intent",
-                  );
-                  let actionResponseText = "";
-                  const declaredParameters = new Set(
-                    createTaskAction.parameters?.map(
-                      (parameter) => parameter.name,
-                    ) ?? [],
-                  );
-                  const directTaskParameters: Record<string, unknown> = {};
-                  if (declaredParameters.has("action")) {
-                    directTaskParameters.action = "create";
-                  } else if (declaredParameters.has("op")) {
-                    directTaskParameters.op = "create";
-                  }
-                  if (
-                    declaredParameters.has("task") &&
-                    typeof message.content.text === "string"
-                  ) {
-                    directTaskParameters.task = message.content.text;
-                  }
-                  if (
-                    declaredParameters.has("agentType") &&
-                    typeof contentMetadata.agentType === "string"
-                  ) {
-                    directTaskParameters.agentType = contentMetadata.agentType;
-                  }
-                  const directActionResult = await executePlannedToolCall(
-                    runtime,
-                    {
-                      message,
-                      activeContexts: createTaskAction.contexts ?? [
-                        "code",
-                        "automation",
-                      ],
-                      callback: async (content: Content) => {
-                        if (generationTimedOut) {
-                          throw createChatGenerationTimeoutError(
-                            generationTimeoutMs,
-                          );
-                        }
-
-                        const chunk = extractCompatTextContent(content);
-                        if (chunk) {
-                          const voicedChunk =
-                            await rewriteDirectActionCallbackText({
-                              runtime,
-                              actionName: createTaskAction.name,
-                              text: chunk,
-                              content,
-                            });
-                          applyCallbackTextUpdate(content, voicedChunk);
-                          actionResponseText = responseText;
-                        }
-                        return [];
-                      },
-                    },
-                    {
-                      name: createTaskAction.name,
-                      params: directTaskParameters,
-                    },
-                    { actions: [createTaskAction] },
-                  );
-                  const finalText =
-                    actionResponseText ||
-                    directActionResult.text ||
-                    responseText ||
-                    "Task created.";
-                  result = {
-                    didRespond: true,
-                    responseContent: { text: finalText },
-                    responseMessages: [],
-                  } as typeof result;
-                  responseText = finalText;
-                  return;
+          // Direct dispatch for explicit task creation intent from UI
+          const contentMetadata = message.content.metadata as
+            | Record<string, unknown>
+            | undefined;
+          if (contentMetadata?.intent === "create_task") {
+            const coordinator = getSwarmCoordinatorService(runtime);
+            if (coordinator) {
+              const createTaskAction =
+                runtime.actions.find(
+                  (a) => a.name.toUpperCase() === "START_CODING_TASK",
+                ) ??
+                runtime.actions.find(
+                  (a) => a.name.toUpperCase() === "CREATE_TASK",
+                );
+              if (createTaskAction) {
+                runtime.logger.info(
+                  {
+                    src: "eliza-api",
+                    agentType: contentMetadata.agentType,
+                    intent: "create_task",
+                  },
+                  "[eliza-api] Direct dispatch START_CODING_TASK from UI intent",
+                );
+                let actionResponseText = "";
+                const declaredParameters = new Set(
+                  createTaskAction.parameters?.map(
+                    (parameter) => parameter.name,
+                  ) ?? [],
+                );
+                const directTaskParameters: Record<string, unknown> = {};
+                if (declaredParameters.has("action")) {
+                  directTaskParameters.action = "create";
+                } else if (declaredParameters.has("op")) {
+                  directTaskParameters.op = "create";
                 }
-              }
-              // Fall through to normal LLM-based routing if coordinator not available
-            }
-
-            const localInferenceIntent = detectLocalInferenceCommandIntent(
-              originalUserText,
-              {
-                localInferenceContext: hasLocalInferenceMetadata(message),
-              },
-            );
-            if (localInferenceIntent) {
-              const { handleLocalInferenceChatCommand } =
-                await getLocalInferenceChatApi();
-              const localResult = await handleLocalInferenceChatCommand(
-                localInferenceIntent,
-                originalUserText,
-              );
-              emitSnapshot(localResult.text);
-              result = {
-                didRespond: true,
-                responseContent: {
-                  text: localResult.text,
-                  source: MESSAGE_SOURCE_CLIENT_CHAT,
-                  actions: ["REPLY"],
-                  localInference: localResult.localInference as
-                    | Record<string, unknown>
-                    | undefined,
-                  failureKind:
-                    localResult.localInference.status === "failed" ||
-                    localResult.localInference.status === "no_space"
-                      ? "local_inference"
-                      : undefined,
-                } as Content,
-                responseMessages: [],
-              } as typeof result;
-              responseText = localResult.text;
-              return;
-            }
-
-            const languageAugmentedMessage =
-              maybeAugmentChatMessageWithLanguage(
-                message,
-                opts?.preferredLanguage,
-              );
-            const walletAugmentedMessage =
-              maybeAugmentChatMessageWithWalletContext(
-                runtime,
-                languageAugmentedMessage,
-              );
-            const generationMessage = await timeInferenceSpan(
-              "chat:document-augmentation",
-              () =>
-                maybeAugmentChatMessageWithDocuments(
+                if (
+                  declaredParameters.has("task") &&
+                  typeof message.content.text === "string"
+                ) {
+                  directTaskParameters.task = message.content.text;
+                }
+                if (
+                  declaredParameters.has("agentType") &&
+                  typeof contentMetadata.agentType === "string"
+                ) {
+                  directTaskParameters.agentType = contentMetadata.agentType;
+                }
+                const directActionResult = await executePlannedToolCall(
                   runtime,
-                  walletAugmentedMessage,
-                  { signal: generationAbortController.signal },
-                ),
-              { phase: "pre-model" },
-            );
-            result = await timeInferenceSpan(
-              "chat:message-service",
-              async () =>
-                runtime.messageService?.handleMessage(
-                  runtime,
-                  generationMessage,
-                  async (content: Content, actionName?: string) => {
-                    if (generationTimedOut) {
-                      throw createChatGenerationTimeoutError(
-                        generationTimeoutMs,
-                      );
-                    }
-                    if (content.transcriptVisibility === "internal") {
-                      return [];
-                    }
-
-                    const chunk = extractCompatTextContent(content);
-                    const visibleChunk = isInternalStructuredStreamText(chunk)
-                      ? ""
-                      : chunk;
-                    const attributedActionName =
-                      normalizeActionName(actionName);
-                    const progressCallback = isProgressActionCallback(content);
-                    if (!visibleChunk) {
-                      if (attributedActionName) {
-                        recordActionCallback(attributedActionName, false);
+                  {
+                    message,
+                    activeContexts: createTaskAction.contexts ?? [
+                      "code",
+                      "automation",
+                    ],
+                    callback: async (content: Content) => {
+                      const chunk = extractCompatTextContent(content);
+                      if (chunk) {
+                        const voicedChunk =
+                          await rewriteDirectActionCallbackText({
+                            runtime,
+                            actionName: createTaskAction.name,
+                            text: chunk,
+                            content,
+                          });
+                        applyCallbackTextUpdate(content, voicedChunk);
+                        actionResponseText = responseText;
                       }
                       return [];
-                    }
-                    if (!claimStreamSource("callback")) {
-                      if (attributedActionName) {
-                        recordActionCallback(attributedActionName, false);
-                      }
-                      return [];
-                    }
-                    if (!progressCallback) {
-                      visibleCallbackDeliveries += 1;
-                    }
-                    applyCallbackTextUpdate(content, visibleChunk);
-                    if (attributedActionName) {
-                      recordActionCallback(
-                        attributedActionName,
-                        !progressCallback,
-                        progressCallback ? undefined : visibleChunk,
-                      );
-                    }
-                    return [];
+                    },
                   },
                   {
-                    ...(generationTimeoutMs > 0
-                      ? { timeoutDuration: generationTimeoutMs }
-                      : {}),
-                    abortSignal: generationAbortController.signal,
-                    keepExistingResponses: true,
-                    onStreamChunk: opts?.onChunk
-                      ? async (
-                          chunk: string,
-                          _messageId?: string,
-                          accumulated?: string,
-                        ) => {
-                          if (generationTimedOut) {
-                            throw createChatGenerationTimeoutError(
-                              generationTimeoutMs,
-                            );
-                          }
-                          if (!chunk) return;
-                          if (isInternalStructuredStreamText(chunk)) {
-                            // A native planner/tool step, not visible reply text:
-                            // fork it onto the working indicator + inline tool row
-                            // instead of leaking JSON into the bubble.
-                            const events =
-                              chatEventsFromStructuredStreamText(chunk);
-                            if (events?.status) emitStatus(events.status);
-                            if (events?.toolEvent) {
-                              opts?.onToolEvent?.(events.toolEvent);
-                            }
-                            return;
-                          }
-                          if (!claimStreamSource("onStreamChunk")) return;
-                          appendIncomingText(chunk, accumulated);
-                        }
-                      : undefined,
+                    name: createTaskAction.name,
+                    params: directTaskParameters,
                   },
-                ),
-              { phase: "message" },
+                  { actions: [createTaskAction] },
+                );
+                const finalText =
+                  actionResponseText ||
+                  directActionResult.text ||
+                  responseText ||
+                  "Task created.";
+                result = {
+                  didRespond: true,
+                  responseContent: { text: finalText },
+                  responseMessages: [],
+                } as typeof result;
+                responseText = finalText;
+                return;
+              }
+            }
+            // Fall through to normal LLM-based routing if coordinator not available
+          }
+
+          const localInferenceIntent = detectLocalInferenceCommandIntent(
+            originalUserText,
+            {
+              localInferenceContext: hasLocalInferenceMetadata(message),
+            },
+          );
+          if (localInferenceIntent) {
+            const { handleLocalInferenceChatCommand } =
+              await getLocalInferenceChatApi();
+            const localResult = await handleLocalInferenceChatCommand(
+              localInferenceIntent,
+              originalUserText,
+            );
+            emitSnapshot(localResult.text);
+            result = {
+              didRespond: true,
+              responseContent: {
+                text: localResult.text,
+                source: MESSAGE_SOURCE_CLIENT_CHAT,
+                actions: ["REPLY"],
+                localInference: localResult.localInference as
+                  | Record<string, unknown>
+                  | undefined,
+                failureKind:
+                  localResult.localInference.status === "failed" ||
+                  localResult.localInference.status === "no_space"
+                    ? "local_inference"
+                    : undefined,
+              } as Content,
+              responseMessages: [],
+            } as typeof result;
+            responseText = localResult.text;
+            return;
+          }
+
+          const languageAugmentedMessage = maybeAugmentChatMessageWithLanguage(
+            message,
+            opts?.preferredLanguage,
+          );
+          const walletAugmentedMessage =
+            maybeAugmentChatMessageWithWalletContext(
+              runtime,
+              languageAugmentedMessage,
+            );
+          const generationMessage = await timeInferenceSpan(
+            "chat:document-augmentation",
+            () =>
+              maybeAugmentChatMessageWithDocuments(
+                runtime,
+                walletAugmentedMessage,
+                { signal: generationAbortController.signal },
+              ),
+            { phase: "pre-model" },
+          );
+          result = await timeInferenceSpan(
+            "chat:message-service",
+            async () =>
+              runtime.messageService?.handleMessage(
+                runtime,
+                generationMessage,
+                async (content: Content, actionName?: string) => {
+                  if (content.transcriptVisibility === "internal") {
+                    return [];
+                  }
+
+                  const chunk = extractCompatTextContent(content);
+                  const visibleChunk = isInternalStructuredStreamText(chunk)
+                    ? ""
+                    : chunk;
+                  const attributedActionName = normalizeActionName(actionName);
+                  const progressCallback = isProgressActionCallback(content);
+                  if (!visibleChunk) {
+                    if (attributedActionName) {
+                      recordActionCallback(attributedActionName, false);
+                    }
+                    return [];
+                  }
+                  if (!claimStreamSource("callback")) {
+                    if (attributedActionName) {
+                      recordActionCallback(attributedActionName, false);
+                    }
+                    return [];
+                  }
+                  if (!progressCallback) {
+                    visibleCallbackDeliveries += 1;
+                  }
+                  applyCallbackTextUpdate(content, visibleChunk);
+                  if (attributedActionName) {
+                    recordActionCallback(
+                      attributedActionName,
+                      !progressCallback,
+                      progressCallback ? undefined : visibleChunk,
+                    );
+                  }
+                  return [];
+                },
+                {
+                  abortSignal: generationAbortController.signal,
+                  keepExistingResponses: true,
+                  onStreamChunk: opts?.onChunk
+                    ? async (
+                        chunk: string,
+                        _messageId?: string,
+                        accumulated?: string,
+                      ) => {
+                        if (!chunk) return;
+                        if (isInternalStructuredStreamText(chunk)) {
+                          // A native planner/tool step, not visible reply text:
+                          // fork it onto the working indicator + inline tool row
+                          // instead of leaking JSON into the bubble.
+                          const events =
+                            chatEventsFromStructuredStreamText(chunk);
+                          if (events?.status) emitStatus(events.status);
+                          if (events?.toolEvent) {
+                            opts?.onToolEvent?.(events.toolEvent);
+                          }
+                          return;
+                        }
+                        if (!claimStreamSource("onStreamChunk")) return;
+                        appendIncomingText(chunk, accumulated);
+                      }
+                    : undefined,
+                },
+              ),
+            { phase: "message" },
+          );
+
+          // Ensure MESSAGE_SENT hooks run for API chat flows.
+          try {
+            const responseMessages = Array.isArray(result?.responseMessages)
+              ? (result.responseMessages as Array<{
+                  id?: string;
+                  content?: Content;
+                }>)
+              : [];
+            const fallbackResponseContent =
+              result?.responseContent &&
+              typeof result.responseContent === "object"
+                ? (result.responseContent as Content)
+                : responseText
+                  ? ({ text: responseText } as Content)
+                  : null;
+            // Safety net ONLY for flows where the message handler produced no
+            // responseMessages of its own. When responseMessages exist the
+            // handler already emitted MESSAGE_SENT for each (message.ts), so
+            // re-emitting them here double-fires MESSAGE_SENT for one reply
+            // (eliza#10313). Emit just the synthetic fallback in the
+            // no-responseMessages case.
+            const messagesToEmit =
+              responseMessages.length > 0
+                ? []
+                : fallbackResponseContent
+                  ? [
+                      {
+                        id: crypto.randomUUID(),
+                        content: fallbackResponseContent,
+                      },
+                    ]
+                  : [];
+            if (
+              messagesToEmit.length > 0 &&
+              typeof runtime.emitEvent === "function"
+            ) {
+              for (const responseMessage of messagesToEmit) {
+                const memoryLike = createMessageMemory({
+                  id:
+                    (responseMessage.id as UUID | undefined) ??
+                    (crypto.randomUUID() as UUID),
+                  roomId: message.roomId,
+                  entityId: runtime.agentId,
+                  content: markSyntheticChatFailureContent(
+                    ensureMessageMemoryContent(
+                      responseMessage.content ?? { text: "" },
+                    ),
+                  ),
+                });
+                memoryLike.metadata = message.metadata;
+                await runtime.emitEvent(EventType.MESSAGE_SENT, {
+                  message: memoryLike,
+                  source: messageSource,
+                });
+              }
+            }
+          } catch (err) {
+            runtime.logger.warn(
+              {
+                err,
+                src: "eliza-api",
+                messageId: message.id,
+                roomId: message.roomId,
+              },
+              "Failed to emit MESSAGE_SENT event",
+            );
+          }
+          // Post-process fallback actions
+          if (result) {
+            const rc = result.responseContent as Record<string, unknown> | null;
+            const resultRecord = asRecord(result);
+            runtime.logger.info(
+              {
+                src: "eliza-api",
+                mode: resultRecord?.mode,
+                actions: rc?.actions,
+                hasText: Boolean(rc?.text),
+              },
+              "[eliza-api] Chat response metadata",
             );
 
-            // Ensure MESSAGE_SENT hooks run for API chat flows.
-            try {
-              const responseMessages = Array.isArray(result?.responseMessages)
-                ? (result.responseMessages as Array<{
-                    id?: string;
-                    content?: Content;
-                  }>)
-                : [];
-              const fallbackResponseContent =
-                result?.responseContent &&
-                typeof result.responseContent === "object"
-                  ? (result.responseContent as Content)
-                  : responseText
-                    ? ({ text: responseText } as Content)
-                    : null;
-              // Safety net ONLY for flows where the message handler produced no
-              // responseMessages of its own. When responseMessages exist the
-              // handler already emitted MESSAGE_SENT for each (message.ts), so
-              // re-emitting them here double-fires MESSAGE_SENT for one reply
-              // (eliza#10313). Emit just the synthetic fallback in the
-              // no-responseMessages case.
-              const messagesToEmit =
-                responseMessages.length > 0
-                  ? []
-                  : fallbackResponseContent
-                    ? [
-                        {
-                          id: crypto.randomUUID(),
-                          content: fallbackResponseContent,
-                        },
-                      ]
-                    : [];
-              if (
-                messagesToEmit.length > 0 &&
-                typeof runtime.emitEvent === "function"
-              ) {
-                for (const responseMessage of messagesToEmit) {
-                  const memoryLike = createMessageMemory({
-                    id:
-                      (responseMessage.id as UUID | undefined) ??
-                      (crypto.randomUUID() as UUID),
-                    roomId: message.roomId,
-                    entityId: runtime.agentId,
-                    content: markSyntheticChatFailureContent(
-                      ensureMessageMemoryContent(
-                        responseMessage.content ?? { text: "" },
-                      ),
-                    ),
-                  });
-                  memoryLike.metadata = message.metadata;
-                  await runtime.emitEvent(EventType.MESSAGE_SENT, {
-                    message: memoryLike,
-                    source: messageSource,
-                  });
+            const rawActionsPayload = rc?.actions ?? resultRecord?.actions;
+            const modelText = String(
+              extractCompatTextContent(result.responseContent),
+            );
+            const parsedFallbackActions = parseFallbackActionBlocks(
+              rawActionsPayload,
+              modelText,
+            );
+            const actionNameLookup = buildRuntimeActionNameLookup(runtime);
+            const successfulActionNames = listSuccessfulActionNames(
+              runtime,
+              typeof message.id === "string" ? message.id : undefined,
+              result.actionResults,
+              actionNameLookup,
+            );
+
+            const executableFallbackActions = parsedFallbackActions.filter(
+              (action) => {
+                if (!isExecutableFallbackAction(action)) {
+                  return false;
                 }
-              }
-            } catch (err) {
-              runtime.logger.warn(
-                {
-                  err,
-                  src: "eliza-api",
-                  messageId: message.id,
-                  roomId: message.roomId,
-                },
-                "Failed to emit MESSAGE_SENT event",
-              );
-            }
-            // Post-process fallback actions
-            if (result) {
-              const rc = result.responseContent as Record<
-                string,
-                unknown
-              > | null;
-              const resultRecord = asRecord(result);
-              runtime.logger.info(
-                {
-                  src: "eliza-api",
-                  mode: resultRecord?.mode,
-                  actions: rc?.actions,
-                  hasText: Boolean(rc?.text),
-                },
-                "[eliza-api] Chat response metadata",
-              );
-
-              const rawActionsPayload = rc?.actions ?? resultRecord?.actions;
-              const modelText = String(
-                extractCompatTextContent(result.responseContent),
-              );
-              const parsedFallbackActions = parseFallbackActionBlocks(
-                rawActionsPayload,
-                modelText,
-              );
-              const actionNameLookup = buildRuntimeActionNameLookup(runtime);
-              const successfulActionNames = listSuccessfulActionNames(
-                runtime,
-                typeof message.id === "string" ? message.id : undefined,
-                result.actionResults,
-                actionNameLookup,
-              );
-
-              const executableFallbackActions = parsedFallbackActions.filter(
-                (action) => {
-                  if (!isExecutableFallbackAction(action)) {
-                    return false;
-                  }
+                const canonicalName =
+                  actionNameLookup.get(normalizeActionName(action.name)) ??
+                  normalizeActionName(action.name);
+                return !successfulActionNames.has(canonicalName);
+              },
+            );
+            if (executableFallbackActions.length > 0) {
+              const selfControlFallbackActions =
+                executableFallbackActions.filter((action) => {
                   const canonicalName =
                     actionNameLookup.get(normalizeActionName(action.name)) ??
                     normalizeActionName(action.name);
-                  return !successfulActionNames.has(canonicalName);
-                },
-              );
-              if (executableFallbackActions.length > 0) {
-                const selfControlFallbackActions =
-                  executableFallbackActions.filter((action) => {
-                    const canonicalName =
-                      actionNameLookup.get(normalizeActionName(action.name)) ??
-                      normalizeActionName(action.name);
-                    return canonicalName === "BLOCK";
-                  });
-                let successfulFallbackActions = new Set<string>();
+                  return canonicalName === "BLOCK";
+                });
+              let successfulFallbackActions = new Set<string>();
 
-                if (selfControlFallbackActions.length > 0) {
-                  const fallbackExecutions = await executeFallbackParsedActions(
-                    runtime,
-                    message,
-                    selfControlFallbackActions,
-                    appendIncomingText,
-                    recordActionCallback,
-                    {
-                      getCurrentText: () => responseText || modelText,
-                    },
-                  );
-                  successfulFallbackActions = new Set(
-                    fallbackExecutions
-                      .filter((execution) => execution.success)
-                      .map((execution) => {
-                        const normalizedName = normalizeActionName(
-                          execution.actionName,
-                        );
-                        return (
-                          actionNameLookup.get(normalizedName) ?? normalizedName
-                        );
-                      })
-                      .filter((name) => name.length > 0),
-                  );
-                  for (const actionName of successfulFallbackActions) {
-                    fallbackSuccessfulActionNames.add(actionName);
-                  }
-                }
-
-                const remainingExecutableFallbackActions =
-                  executableFallbackActions.filter((action) => {
-                    const canonicalName =
-                      actionNameLookup.get(normalizeActionName(action.name)) ??
-                      normalizeActionName(action.name);
-                    if (canonicalName === "BLOCK") {
-                      return !successfulFallbackActions.has(canonicalName);
-                    }
-                    return true;
-                  });
-
-                if (remainingExecutableFallbackActions.length > 0) {
-                  runtime.logger.error(
-                    {
-                      src: "eliza-api",
-                      parsedActions: remainingExecutableFallbackActions.map(
-                        (a) => a.name,
-                      ),
-                    },
-                    "[eliza-api] Unexecuted action payload detected; failing closed",
-                  );
-                  const failureText = buildUnexecutedActionPayloadReply(
-                    remainingExecutableFallbackActions.map(
-                      (action) => action.name,
-                    ),
-                  );
-                  if (opts?.onSnapshot) {
-                    emitSnapshot(failureText);
-                  } else {
-                    responseText = failureText;
-                  }
-                  blockedUnexecutedActionPayload = true;
-                }
-                if (
-                  remainingExecutableFallbackActions.some(
-                    (action) =>
-                      normalizeActionName(action.name) === "CHECK_BALANCE",
-                  )
-                ) {
-                  forcedWalletExecutionText = true;
+              if (selfControlFallbackActions.length > 0) {
+                const fallbackExecutions = await executeFallbackParsedActions(
+                  runtime,
+                  message,
+                  selfControlFallbackActions,
+                  appendIncomingText,
+                  recordActionCallback,
+                  {
+                    getCurrentText: () => responseText || modelText,
+                  },
+                );
+                successfulFallbackActions = new Set(
+                  fallbackExecutions
+                    .filter((execution) => execution.success)
+                    .map((execution) => {
+                      const normalizedName = normalizeActionName(
+                        execution.actionName,
+                      );
+                      return (
+                        actionNameLookup.get(normalizedName) ?? normalizedName
+                      );
+                    })
+                    .filter((name) => name.length > 0),
+                );
+                for (const actionName of successfulFallbackActions) {
+                  fallbackSuccessfulActionNames.add(actionName);
                 }
               }
+
+              const remainingExecutableFallbackActions =
+                executableFallbackActions.filter((action) => {
+                  const canonicalName =
+                    actionNameLookup.get(normalizeActionName(action.name)) ??
+                    normalizeActionName(action.name);
+                  if (canonicalName === "BLOCK") {
+                    return !successfulFallbackActions.has(canonicalName);
+                  }
+                  return true;
+                });
+
+              if (remainingExecutableFallbackActions.length > 0) {
+                runtime.logger.error(
+                  {
+                    src: "eliza-api",
+                    parsedActions: remainingExecutableFallbackActions.map(
+                      (a) => a.name,
+                    ),
+                  },
+                  "[eliza-api] Unexecuted action payload detected; failing closed",
+                );
+                const failureText = buildUnexecutedActionPayloadReply(
+                  remainingExecutableFallbackActions.map(
+                    (action) => action.name,
+                  ),
+                );
+                if (opts?.onSnapshot) {
+                  emitSnapshot(failureText);
+                } else {
+                  responseText = failureText;
+                }
+                blockedUnexecutedActionPayload = true;
+              }
+              if (
+                remainingExecutableFallbackActions.some(
+                  (action) =>
+                    normalizeActionName(action.name) === "CHECK_BALANCE",
+                )
+              ) {
+                forcedWalletExecutionText = true;
+              }
             }
-          }),
-        ),
-        generationTimeoutMs,
-        () => createChatGenerationTimeoutError(generationTimeoutMs),
-        () => {
-          generationTimedOut = true;
-          abortGeneration(
-            createChatGenerationTimeoutError(generationTimeoutMs),
-          );
-        },
+          }
+        }),
       ),
     );
     capturedUsage = generationCapture.usage;
@@ -3926,54 +3824,6 @@ export async function generateChatResponse(
 
 interface ConversationTitleGenerationOptions {
   signal?: AbortSignal;
-  timeoutMs?: number;
-}
-
-function createConversationTitleAbortSignal(
-  options: ConversationTitleGenerationOptions = {},
-): { signal: AbortSignal; cleanup: () => void } {
-  const controller = new AbortController();
-  const abortFromCaller = () => {
-    controller.abort(options.signal?.reason ?? new Error("Request aborted"));
-  };
-  if (options.signal?.aborted) {
-    abortFromCaller();
-  } else {
-    options.signal?.addEventListener("abort", abortFromCaller, { once: true });
-  }
-
-  const timeoutMs =
-    typeof options.timeoutMs === "number" &&
-    Number.isFinite(options.timeoutMs) &&
-    options.timeoutMs > 0
-      ? Math.floor(options.timeoutMs)
-      : DEFAULT_CONVERSATION_TITLE_TIMEOUT_MS;
-  const timer = setTimeout(() => {
-    controller.abort(
-      new DOMException(
-        `Conversation title generation timed out after ${timeoutMs}ms`,
-        "TimeoutError",
-      ),
-    );
-  }, timeoutMs);
-  (timer as { unref?: () => void }).unref?.();
-
-  return {
-    signal: controller.signal,
-    cleanup: () => {
-      clearTimeout(timer);
-      options.signal?.removeEventListener("abort", abortFromCaller);
-    },
-  };
-}
-
-function isAbortLikeError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  return (
-    err.name === "AbortError" ||
-    err.name === "TimeoutError" ||
-    err.message.toLowerCase().includes("aborted")
-  );
 }
 
 export async function generateConversationTitle(
@@ -3993,41 +3843,26 @@ User message: "${userMessage}"
 
 Title:`;
 
-  const abort = createConversationTitleAbortSignal(options);
-  try {
-    const title = await runtime.useModel(modelClass, {
-      prompt,
-      maxTokens: 20,
-      temperature: 0.7,
-      signal: abort.signal,
-    });
+  const title = await runtime.useModel(modelClass, {
+    prompt,
+    maxTokens: 20,
+    temperature: 0.7,
+    signal: options?.signal,
+  });
 
-    if (!title) return null;
+  if (!title) return null;
 
-    let cleanTitle = title.trim();
-    if (
-      (cleanTitle.startsWith('"') && cleanTitle.endsWith('"')) ||
-      (cleanTitle.startsWith("'") && cleanTitle.endsWith("'"))
-    ) {
-      cleanTitle = cleanTitle.slice(1, -1);
-    }
-
-    if (!cleanTitle || cleanTitle.length > 50) return null;
-
-    return cleanTitle;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (isAbortLikeError(err)) {
-      logger.info(
-        `[eliza] Conversation title generation cancelled: ${message}`,
-      );
-    } else {
-      logger.warn(`[eliza] Failed to generate conversation title: ${message}`);
-    }
-    return null;
-  } finally {
-    abort.cleanup();
+  let cleanTitle = title.trim();
+  if (
+    (cleanTitle.startsWith('"') && cleanTitle.endsWith('"')) ||
+    (cleanTitle.startsWith("'") && cleanTitle.endsWith("'"))
+  ) {
+    cleanTitle = cleanTitle.slice(1, -1);
   }
+
+  if (!cleanTitle || cleanTitle.length > 50) return null;
+
+  return cleanTitle;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -3938,22 +3938,16 @@ export async function handleConversationRoutes(
       }
       // Get the last user message to use as the prompt for generation
       let prompt = "A generic conversation";
-      try {
-        const memories = await state.runtime.getMemories({
-          roomId: conv.roomId,
-          tableName: "messages",
-          limit: 5,
-        });
-        const lastUserMemory = memories.find(
-          (m) => m.entityId !== state.runtime?.agentId,
-        );
-        if (lastUserMemory?.content?.text) {
-          prompt = String(lastUserMemory.content.text);
-        }
-      } catch (err) {
-        logger.warn(
-          `[conversations] Failed to fetch context for title generation: ${err instanceof Error ? err.message : String(err)}`,
-        );
+      const memories = await state.runtime.getMemories({
+        roomId: conv.roomId,
+        tableName: "messages",
+        limit: 5,
+      });
+      const lastUserMemory = memories.find(
+        (m) => m.entityId !== state.runtime?.agentId,
+      );
+      if (lastUserMemory?.content?.text) {
+        prompt = String(lastUserMemory.content.text);
       }
 
       const titleAbortTracker = createRequestDisconnectAbortTracker({

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -4161,64 +4161,17 @@ export async function startApiServer(opts?: {
   }
   logger.debug(`[eliza-api] Server created (${Date.now() - apiStartTime}ms)`);
 
-  // Node's `http.createServer` defaults are tuned for snappy web traffic:
-  //   - requestTimeout: 300_000 ms (5 min) — closes the socket if the
-  //     full request hasn't completed in 5 minutes.
-  //   - headersTimeout: 60_000 ms — closes the socket if headers
-  //     haven't arrived in 60 s.
-  //   - keepAliveTimeout: 5_000 ms — closes idle connections after 5 s.
-  //
-  // Local-inference chat completions on AOSP cuttlefish CPU routinely
-  // run 5–25 minutes per turn (planner + action evaluator + reply,
-  // each with a 9k-token prompt prefilled at ~20 tok/s). The 300 s
-  // requestTimeout aborts the response mid-generation and the client
-  // sees `fetch failed` while the agent's chat-routes timeout
-  // (ELIZA_CHAT_GENERATION_TIMEOUT_MS, default 180 s, AOSP override
-  // 1_800_000 ms = 30 min) is still ticking. The result: the device
-  // does the work, the model produces a reply, but the HTTP socket
-  // is already closed by the time the reply is ready.
-  //
-  // Read overrides from env so non-AOSP deploys keep tighter defaults,
-  // and AOSP can pass a generous bound that matches the chat-routes
-  // generation budget. ELIZA_HTTP_REQUEST_TIMEOUT_MS is the canonical
-  // override; falls back to ELIZA_CHAT_GENERATION_TIMEOUT_MS + 60 s
-  // slack so a single env var can drive the whole pipeline.
-  const requestTimeoutEnvRaw =
-    process.env.ELIZA_HTTP_REQUEST_TIMEOUT_MS?.trim() ?? "";
-  const chatTimeoutEnvRaw =
-    readAliasedEnv("ELIZA_CHAT_GENERATION_TIMEOUT_MS") ?? "";
-  const requestTimeoutMs = (() => {
-    const explicit = Number.parseInt(requestTimeoutEnvRaw, 10);
-    if (Number.isFinite(explicit) && explicit > 0) return explicit;
-    const chatTimeout = Number.parseInt(chatTimeoutEnvRaw, 10);
-    if (Number.isFinite(chatTimeout) && chatTimeout > 0) {
-      // 60 s slack covers the round-trip overhead between chat-routes
-      // resolving the generation promise and the response actually
-      // landing on the wire.
-      return chatTimeout + 60_000;
-    }
-    // No override and no chat-timeout hint — keep Node's default
-    // (300_000 ms / 5 min) which matches the upstream behavior.
-    return 300_000;
-  })();
-  // headersTimeout MUST be ≤ requestTimeout per Node docs. We give it
-  // a 60 s lower bound so a slow client header upload doesn't cap the
-  // long-tail decode budget.
-  const headersTimeoutMs = Math.min(60_000, requestTimeoutMs);
-  // keepAliveTimeout is for IDLE connections after a response. Bumping
-  // it doesn't help long-running requests but keeps connections warm
-  // for chat-completion clients that fire repeated turns.
-  const keepAliveTimeoutMs = 60_000;
-  server.requestTimeout = requestTimeoutMs;
-  server.headersTimeout = headersTimeoutMs;
-  server.keepAliveTimeout = keepAliveTimeoutMs;
-  // server.timeout is the IDLE socket timeout (legacy). Setting to 0
-  // disables it; we want long-running requests to ride on the
-  // requestTimeout above instead. Default in Node 22 is 0 already, but
-  // pin explicitly for clarity.
+  // Model work is cancelled by the request's AbortSignal and provider/socket
+  // failures, not an elapsed wall-clock guess. Disable Node's whole-request and
+  // idle-socket deadlines so they cannot sever a healthy streamed turn while
+  // the runtime is still producing output. Header and post-response keepalive
+  // limits remain transport hygiene and do not cap model execution.
+  server.requestTimeout = 0;
+  server.headersTimeout = 60_000;
+  server.keepAliveTimeout = 60_000;
   server.timeout = 0;
   logger.debug(
-    `[eliza-api] Server timeouts: requestTimeout=${requestTimeoutMs}ms, headersTimeout=${headersTimeoutMs}ms, keepAliveTimeout=${keepAliveTimeoutMs}ms`,
+    "[eliza-api] Server lifecycle: requestTimeout=disabled, idleTimeout=disabled, headersTimeout=60000ms, keepAliveTimeout=60000ms",
   );
 
   const broadcastWs = (payload: unknown): void => {

--- a/packages/agent/test/api/chat-routes-usage.test.ts
+++ b/packages/agent/test/api/chat-routes-usage.test.ts
@@ -98,7 +98,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("hello"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.usage).toMatchObject({
@@ -148,12 +147,8 @@ describe("generateChatResponse usage reporting", () => {
     });
 
     const [first, second] = await Promise.all([
-      generateChatResponse(runtime, createChatMessage("first"), "Chat Agent", {
-        timeoutDuration: 5_000,
-      }),
-      generateChatResponse(runtime, createChatMessage("second"), "Chat Agent", {
-        timeoutDuration: 5_000,
-      }),
+      generateChatResponse(runtime, createChatMessage("first"), "Chat Agent"),
+      generateChatResponse(runtime, createChatMessage("second"), "Chat Agent"),
     ]);
 
     expect(first.usage).toMatchObject({
@@ -184,9 +179,7 @@ describe("generateChatResponse usage reporting", () => {
     });
     const message = createChatMessage("count this prompt");
 
-    const result = await generateChatResponse(runtime, message, "Chat Agent", {
-      timeoutDuration: 5_000,
-    });
+    const result = await generateChatResponse(runtime, message, "Chat Agent");
 
     expect(result.usage).toMatchObject({
       promptTokens: estimateTokenCount("count this prompt"),
@@ -216,7 +209,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("hello"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result).toMatchObject({
@@ -419,7 +411,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("hello"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result).toMatchObject({
@@ -448,7 +439,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("hello"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toBe("final reply");
@@ -478,7 +468,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("hello"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toBe("final reply");
@@ -514,7 +503,7 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("search"),
       "Chat Agent",
-      { timeoutDuration: 5_000, onChunk },
+      { onChunk },
     );
 
     expect(result.text).toBe("streamed final");
@@ -550,7 +539,7 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("search"),
       "Chat Agent",
-      { timeoutDuration: 5_000, onSnapshot },
+      { onSnapshot },
     );
 
     expect(result.text).toBe("Search complete.");
@@ -586,7 +575,6 @@ describe("generateChatResponse usage reporting", () => {
         runtime,
         createChatMessage("run it"),
         "Chat Agent",
-        { timeoutDuration: 5_000 },
       );
 
       expect(result.usedActionCallbacks).toBeUndefined();
@@ -628,7 +616,7 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("what apps are available?"),
       "Chat Agent",
-      { timeoutDuration: 5_000, onChunk },
+      { onChunk },
     );
 
     expect(result.text).toBe(inventory);
@@ -667,7 +655,7 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("what apps are available?"),
       "Chat Agent",
-      { timeoutDuration: 5_000, onChunk },
+      { onChunk },
     );
 
     expect(result.text).toBe(summary);
@@ -695,7 +683,7 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("what apps are available?"),
       "Chat Agent",
-      { timeoutDuration: 5_000, onChunk },
+      { onChunk },
     );
 
     expect(result.transcriptVisibility).toBe("internal");
@@ -738,7 +726,7 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("what apps are available?"),
       "Chat Agent",
-      { timeoutDuration: 5_000, onChunk },
+      { onChunk },
     );
 
     expect(result.text).toBe(inventory);
@@ -769,7 +757,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("send funds"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toContain("actions that were not executed");
@@ -809,7 +796,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("send funds"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toContain("actions that were not executed");
@@ -847,7 +833,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("send funds"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toContain("actions that were not executed");
@@ -877,7 +862,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("send funds"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toBe("Action completed by core.");
@@ -914,7 +898,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("send funds"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toContain("actions that were not executed");
@@ -952,7 +935,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("run the mixed action"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.usedActionCallbacks).toBe(true);
@@ -978,9 +960,7 @@ describe("generateChatResponse usage reporting", () => {
       } as NonNullable<AgentRuntime["messageService"]>,
     });
 
-    const result = await generateChatResponse(runtime, message, "Chat Agent", {
-      timeoutDuration: 5_000,
-    });
+    const result = await generateChatResponse(runtime, message, "Chat Agent");
 
     expect(result.text).toBe("Action completed from recorded alias.");
     expect(runtime.logger.error).not.toHaveBeenCalledWith(
@@ -1008,9 +988,7 @@ describe("generateChatResponse usage reporting", () => {
       } as NonNullable<AgentRuntime["messageService"]>,
     });
 
-    const result = await generateChatResponse(runtime, message, "Chat Agent", {
-      timeoutDuration: 5_000,
-    });
+    const result = await generateChatResponse(runtime, message, "Chat Agent");
 
     expect(result.text).toBe("Action completed from recorded result.");
     expect(runtime.getActionResults).toHaveBeenCalledWith(message.id);
@@ -1042,9 +1020,7 @@ describe("generateChatResponse usage reporting", () => {
     });
     const message = createChatMessage("check my wallet balance");
 
-    const result = await generateChatResponse(runtime, message, "Chat Agent", {
-      timeoutDuration: 5_000,
-    });
+    const result = await generateChatResponse(runtime, message, "Chat Agent");
 
     expect(result.text).toBe("Your wallet balance is 4 SOL.");
     expect(result.persistedResponseMessageIds).toEqual([persistedId]);
@@ -1094,7 +1070,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("send 1 SOL to this wallet"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toBe("The transfer was submitted.");
@@ -1132,7 +1107,6 @@ describe("generateChatResponse usage reporting", () => {
         runtime,
         createChatMessage(prompt),
         "Chat Agent",
-        { timeoutDuration: 5_000 },
       );
 
       expect(result.text).toBe(responseText);
@@ -1163,7 +1137,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("buy ETH on Hyperliquid"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toContain("no wallet action actually ran");
@@ -1200,7 +1173,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("buy ETH on Hyperliquid"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toBe("The Hyperliquid order flow is active.");
@@ -1237,7 +1209,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("execute this onchain governance proposal"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toBe("The governance proposal was executed.");
@@ -1272,7 +1243,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("execute this onchain governance proposal"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toContain("no wallet action actually ran");
@@ -1301,7 +1271,6 @@ describe("generateChatResponse usage reporting", () => {
       runtime,
       createChatMessage("send 1 SOL to this wallet"),
       "Chat Agent",
-      { timeoutDuration: 5_000 },
     );
 
     expect(result.text).toContain("no wallet action actually ran");
@@ -1342,7 +1311,6 @@ describe("generateChatResponse usage reporting", () => {
         runtime,
         createChatMessage("send 1 SOL to this wallet"),
         "Chat Agent",
-        { timeoutDuration: 5_000 },
       );
 
       expect(result.text).toContain("no wallet action actually ran");
@@ -1372,7 +1340,6 @@ describe("generateChatResponse usage reporting", () => {
         runtime,
         createChatMessage("check my wallet balance"),
         "Chat Agent",
-        { timeoutDuration: 5_000 },
       );
 
       expect(result.text).toContain("no wallet action actually ran");

--- a/packages/app/src/brand-env.test.ts
+++ b/packages/app/src/brand-env.test.ts
@@ -47,9 +47,6 @@ describe("buildBrandEnvAliases", () => {
     expect(aliases.get("ACME_CLOUD_MANAGED_AGENTS_API_SEGMENT")).toBe(
       "ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT",
     );
-    expect(aliases.get("ACME_CHAT_GENERATION_TIMEOUT_MS")).toBe(
-      "ELIZA_CHAT_GENERATION_TIMEOUT_MS",
-    );
     expect(aliases.get("ACME_SKIP_LOCAL_PLUGIN_ROLES")).toBe(
       "ELIZA_SKIP_LOCAL_PLUGIN_ROLES",
     );

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1371,7 +1371,6 @@ function _resolvePromptAttachments(
  */
 type ResolvedMessageOptions = {
 	maxRetries: number;
-	timeoutDuration: number;
 	continueAfterActions: boolean;
 	keepExistingResponses: boolean;
 	onStreamChunk?: StreamChunkCallback;
@@ -10564,10 +10563,6 @@ export class DefaultMessageService implements IMessageService {
 
 				const opts: ResolvedMessageOptions = {
 					maxRetries: options?.maxRetries ?? 3,
-					// A turn has no implicit wall-clock deadline. Callers that own a
-					// real execution budget may provide one explicitly; cancellation
-					// otherwise travels through abortSignal.
-					timeoutDuration: options?.timeoutDuration ?? 0,
 					continueAfterActions:
 						options?.continueAfterActions ??
 						parseBooleanFromText(
@@ -10596,8 +10591,6 @@ export class DefaultMessageService implements IMessageService {
 					recordDeliveredVisibleText,
 				);
 
-				// Set up timeout monitoring
-				let timeoutId: NodeJS.Timeout | undefined;
 				// A host route may open the timer before calling the message service so
 				// augmentation and response normalization share this same timeline.
 				// Only the layer that creates the timer closes and persists it.
@@ -10680,26 +10673,6 @@ export class DefaultMessageService implements IMessageService {
 							} as RunEventPayload),
 						),
 					);
-
-					const timeoutPromise = new Promise<never>((_, reject) => {
-						if (opts.timeoutDuration <= 0) return;
-						timeoutId = setTimeout(async () => {
-							await runtime.emitEvent(EventType.RUN_TIMEOUT, {
-								runtime,
-								source: "messageHandler",
-								runId,
-								messageId: message.id,
-								roomId: message.roomId,
-								entityId: message.entityId,
-								startTime,
-								status: "timeout",
-								endTime: Date.now(),
-								duration: Date.now() - startTime,
-								error: "Run exceeded timeout",
-							} as RunEventPayload);
-							reject(new Error("Run exceeded timeout"));
-						}, opts.timeoutDuration);
-					});
 
 					// Structured streaming is handled by dynamicPromptExecFromState for
 					// text fields. Native v5 planner/tool/evaluator events use the same
@@ -10792,13 +10765,7 @@ export class DefaultMessageService implements IMessageService {
 						},
 					);
 
-					const result = await Promise.race([
-						processingPromise,
-						timeoutPromise,
-					]);
-
-					// Clean up timeout
-					clearTimeout(timeoutId);
+					const result = await processingPromise;
 
 					// Voice: Handle the rest of the message
 					if (firstSentenceSent && result.responseContent?.text) {
@@ -10874,8 +10841,6 @@ export class DefaultMessageService implements IMessageService {
 
 					return result;
 				} finally {
-					clearTimeout(timeoutId);
-
 					// Close + emit the per-turn latency breakdown. Detached side
 					// effects (post-turn evaluators) intentionally run after this and
 					// are NOT counted in turn latency — that is the proof they don't

--- a/packages/core/src/types/message-service.ts
+++ b/packages/core/src/types/message-service.ts
@@ -21,7 +21,6 @@ import type { State } from "./state";
  */
 export interface MessageProcessingOptions {
 	maxRetries?: number;
-	timeoutDuration?: number;
 	useMultiStep?: boolean;
 	maxMultiStepIterations?: number;
 	shouldRespondModel?: ShouldRespondModelType;

--- a/packages/shared/src/config/brand-env-aliases.ts
+++ b/packages/shared/src/config/brand-env-aliases.ts
@@ -21,10 +21,6 @@ export const BRAND_ENV_ALIAS_DEFINITIONS = [
     elizaKey: "ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT",
   },
   {
-    brandSuffix: "CHAT_GENERATION_TIMEOUT_MS",
-    elizaKey: "ELIZA_CHAT_GENERATION_TIMEOUT_MS",
-  },
-  {
     brandSuffix: "SKIP_LOCAL_PLUGIN_ROLES",
     elizaKey: "ELIZA_SKIP_LOCAL_PLUGIN_ROLES",
   },

--- a/plugins/plugin-training/src/core/roleplay-executor.ts
+++ b/plugins/plugin-training/src/core/roleplay-executor.ts
@@ -729,6 +729,10 @@ export async function executeRoleplayEpisode(
     };
 
     const callbackContents: Content[] = [];
+    const abortSignal =
+      options.timeoutMs === undefined
+        ? undefined
+        : AbortSignal.timeout(options.timeoutMs);
     const result = await runtime.messageService.handleMessage(
       runtime,
       message,
@@ -736,7 +740,7 @@ export async function executeRoleplayEpisode(
         callbackContents.push(content);
         return [];
       },
-      options.timeoutMs ? { timeoutDuration: options.timeoutMs } : undefined,
+      abortSignal ? { abortSignal } : undefined,
     );
 
     const trajectory = await waitForTrajectoryDetail(logger, trajectoryId);


### PR DESCRIPTION
Closes #17428.

## What changed

- removes the route-level chat generation deadline and both branded timeout environment aliases
- removes the independent `MessageService` deadline so one turn has one owner
- propagates caller cancellation through a single `AbortSignal` to document augmentation, model generation, planner execution, and streaming
- disables Node's whole-request and idle-socket deadlines for streaming chat while retaining bounded header and keep-alive handling
- makes ingress trajectory-hook failure reject before generation instead of returning an answer whose ingress record is missing
- makes conversation-title generation follow the caller lifecycle instead of an unrelated 5 second timer
- preserves the training roleplay API's explicit timeout option by expressing it as caller-owned `AbortSignal.timeout(...)`

## Why

A fixed response deadline cannot distinguish a dead request from a healthy long generation. Racing a timeout against generation can return an error while model/tool work, persistence, and callbacks continue in the background. The request/disconnect owner now controls cancellation, and downstream work receives that same signal.

## Verification

Exact branch head: `fc8a537438c670c30637542f267f8d9782bef15d`

- `bun run verify`: green; 579/579 Turbo tasks, 8,822-test anti-larp scan clean, 28/28 dist-path consumers
- focused agent streaming, usage, and alias tests: 99/99
- append-only SSE contract tests: 26/26
- app brand environment tests: 2/2
- `packages/agent`, `packages/core`, and `plugins/plugin-training` typechecks: green
- `git diff --check`: green

## Live Cerebras proof

Production `generateChatResponse` path using `gemma-4-31b`, real `AgentRuntime`, `plugin-openai`, and PGLite. Both old timeout variables were deliberately set to `1` millisecond:

```text
ELIZA_CHAT_GENERATION_TIMEOUT_MS=1
MILADY_CHAT_GENERATION_TIMEOUT_MS=1
```

Results after 3 warmups and 30 measured turns:

- 30/30 exact unique replies; 0 failures; 0 persistence parity mismatches
- 30 unique persisted response IDs, all returned by the API
- wall time: p50 520.865 ms, p95 865.170 ms, max 995.981 ms
- TTFT: p50 507 ms, p95 850 ms, max 989 ms
- LLM: p50 477.953 ms, p95 841.887 ms, max 975 ms
- all-provider sweep: p50 9.192 ms, p95 10.704 ms, max 21.932 ms
- message ingress persistence: p50 1.939 ms, p95 4.725 ms, max 5.518 ms
- delivery persistence: p50 3 ms, p95 8 ms, max 8 ms
- exclusive message-service overhead: p50 2.948 ms, p95 5 ms, max 5 ms

Artifacts:

- [structured telemetry JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17428-cerebras-chat-lifecycle.json) — SHA-256 `55660634caf02a684576c9cd486cccec3b0981beb8fe44dacbbf60fd5f0c8c56`
- [structured runtime log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17428-cerebras-chat-lifecycle.log) — SHA-256 `f2252d3abec24e395c50080082c61930d577314f29d2099af972c0ad84d3dff9`

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Real LLM trajectory | Attached above; manually reviewed for exact response, persistence IDs, timing spans, and errors |
| Backend structured logs | Attached above |
| Frontend console/network logs | N/A — no frontend behavior or UI code changed |
| Screenshots/video | N/A — lifecycle/backend-only change with no rendered surface |
| Domain artifacts | PGLite persisted response IDs and request/result parity are included in the telemetry JSON |

## Follow-up found during review

The live run also exposed a separate billing/telemetry defect: model usage is labeled `RESPONSE_HANDLER` instead of `gemma-4-31b`, so pricing lookup defaults cost to zero. That is not hidden in this PR and will be fixed as a separate billing-critical change because it crosses the model usage/event contract rather than request lifetime.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only lifecycle change; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only lifecycle change; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only lifecycle change exercised through live API telemetry

<!-- evidence-row:backend-logs -->
- [x] [17428-cerebras-chat-lifecycle.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17428-cerebras-chat-lifecycle.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or rendered behavior changed

<!-- evidence-row:llm-trajectory -->
- [x] [17428-cerebras-chat-lifecycle.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17428-cerebras-chat-lifecycle.json)

<!-- evidence-row:domain-artifacts -->
- [x] [17428-cerebras-chat-lifecycle.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17428-cerebras-chat-lifecycle.json)
