### PR TITLE
feat(ui): boot fresh installs to the Ember Night sunset default (orange clouds)

### DIFF
--- a/packages/ui/src/state/background-catalog.test.ts
+++ b/packages/ui/src/state/background-catalog.test.ts
@@ -84,19 +84,26 @@ describe("background catalog (#13538)", () => {
     }
   });
 
-  it("the boot default is the Canopy jungle wallpaper over the black base", () => {
-    // The app boots to the Canopy photo wallpaper (misty jungle river valley).
+  it("the boot default is the Ember Night sunset wallpaper over the black base", () => {
+    // The app boots to the Ember Night sunset wallpaper (warm orange clouds).
     // The base color stays black so the host-chrome FOUC/manifest baseline is
-    // unchanged and the black→image settle is invisible at boot.
+    // unchanged and the black→image settle stays quiet at boot.
     expect(DEFAULT_BACKGROUND_CONFIG.mode).toBe("image");
     expect(DEFAULT_BACKGROUND_CONFIG.color).toBe("#000000");
-    expect(DEFAULT_BACKGROUND_CONFIG.imageUrl).toBe("/wallpapers/canopy.webp");
-    // The Ember Night gallery tile still resolves to the served sunset asset.
+    expect(DEFAULT_BACKGROUND_CONFIG.imageUrl).toBe("/bg-sunset.webp");
+    // DIVERGENCE GUARD: the boot config must equal the catalog default
+    // entry's render source. The old phone/desktop mismatch came from
+    // DEFAULT_BACKGROUND_CONFIG (Canopy) disagreeing with the catalog's
+    // declared default id (ember-night); this pins the two together.
     const def = BACKGROUND_CATALOG.find(
       (e) => e.id === DEFAULT_BACKGROUND_CATALOG_ID,
     );
     expect(def?.kind).toBe("image");
     expect(def?.source).toBe("/bg-sunset.webp");
+    expect(DEFAULT_BACKGROUND_CONFIG.imageUrl).toBe(def?.source);
+    // Canopy remains a selectable gallery scene, just not the default.
+    const canopy = BACKGROUND_CATALOG.find((e) => e.id === "canopy");
+    expect(canopy?.source).toBe("/wallpapers/canopy.webp");
   });
 
   it("resolveCatalogEntry matches by id, label, and fuzzy name", () => {

--- a/packages/ui/src/state/persistence.background.test.ts
+++ b/packages/ui/src/state/persistence.background.test.ts
@@ -15,7 +15,7 @@ import {
   DEFAULT_BACKGROUND_CONFIG,
 } from "./ui-preferences";
 
-// The boot default is the Canopy jungle wallpaper, returned for
+// The boot default is the Ember Night sunset wallpaper, returned for
 // empty/absent/unusable-record input.
 const DEFAULT = DEFAULT_BACKGROUND_CONFIG;
 // A present-but-malformed config still collapses to the plain shader field (a
@@ -153,8 +153,8 @@ describe("background config persistence", () => {
   });
 });
 
-describe("boot-default migration (black shader → Canopy, one-shot)", () => {
-  it("rewrites a persisted old-default black shader to the Canopy default once", () => {
+describe("boot-default migration (black shader → boot default, one-shot)", () => {
+  it("rewrites a persisted old-default black shader to the boot default once", () => {
     // The previous boot default was eagerly persisted on first boot, so an
     // install that never chose a background stores exactly this shape.
     localStorage.setItem(
@@ -185,6 +185,60 @@ describe("boot-default migration (black shader → Canopy, one-shot)", () => {
   it("a fresh install is stamped migrated on first load (later black picks stick)", () => {
     expect(loadBackgroundConfig()).toEqual(DEFAULT);
     saveBackgroundConfig({ mode: "shader", color: DEFAULT_BACKGROUND_COLOR });
+    expect(loadBackgroundConfig()).toEqual({
+      mode: "shader",
+      color: DEFAULT_BACKGROUND_COLOR,
+    });
+  });
+});
+
+describe("fresh-default flip to Ember Night preserves every stored preference", () => {
+  // Per the #17143 review: a stored Canopy (or any wallpaper) record carries
+  // no provenance distinguishing "old default" from "deliberate user pick",
+  // so the default flip must NOT migrate stored values — fresh installs only.
+  it("a fresh install (nothing stored) boots to the sunset default", () => {
+    expect(loadBackgroundConfig()).toEqual({
+      mode: "image",
+      color: "#000000",
+      imageUrl: "/bg-sunset.webp",
+    });
+  });
+
+  it("a stored Canopy wallpaper is preserved verbatim across repeated loads", () => {
+    const canopy = {
+      mode: "image",
+      color: "#000000",
+      imageUrl: "/wallpapers/canopy.webp",
+    } as const;
+    localStorage.setItem("eliza:ui-background", JSON.stringify(canopy));
+    // First load must not rewrite it…
+    expect(loadBackgroundConfig()).toEqual(canopy);
+    // …and neither may any subsequent ordinary load (no one-shot rewrite,
+    // no deferred persistence of a different value underneath it).
+    expect(loadBackgroundConfig()).toEqual(canopy);
+    expect(
+      JSON.parse(localStorage.getItem("eliza:ui-background") ?? "null"),
+    ).toEqual(canopy);
+  });
+
+  it("a stored non-default wallpaper pick (Reef) is preserved untouched", () => {
+    const reef = {
+      mode: "image",
+      color: "#000000",
+      imageUrl: "/wallpapers/reef.webp",
+    } as const;
+    localStorage.setItem("eliza:ui-background", JSON.stringify(reef));
+    expect(loadBackgroundConfig()).toEqual(reef);
+  });
+
+  it("a stored deliberate black shader (post-v2 stamp) is preserved", () => {
+    // An install that already ran the v2 migration and then deliberately
+    // picked black keeps black — the default flip adds no new migration.
+    localStorage.setItem("eliza:ui-background-default-v2", "1");
+    localStorage.setItem(
+      "eliza:ui-background",
+      JSON.stringify({ mode: "shader", color: DEFAULT_BACKGROUND_COLOR }),
+    );
     expect(loadBackgroundConfig()).toEqual({
       mode: "shader",
       color: DEFAULT_BACKGROUND_COLOR,

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -227,13 +227,21 @@ export function normalizeBackgroundConfig(value: unknown): BackgroundConfig {
   return { mode: "shader", color };
 }
 
-// One-shot boot-default migration flag. The boot default changed from the
-// black ember shader to the Canopy wallpaper, but the previous default was
+// One-shot boot-default migration flag (v2 era). The boot default changed
+// from the black ember shader to a wallpaper, but the previous default was
 // eagerly persisted on first boot — "never chose a background" is stored as
 // exactly {mode:"shader", color:#000000} and is indistinguishable from a
 // deliberate pick of the plain black field. The migration rewrites that one
-// shape to the new default a single time; the flag guarantees a user who
-// deliberately returns to the black shader AFTERWARDS keeps it forever.
+// shape to the current boot default a single time; the flag guarantees a
+// user who deliberately returns to the black shader AFTERWARDS keeps it
+// forever.
+//
+// NOTE (#17143 review): the later Canopy→Ember Night default flip is
+// deliberately NOT a migration. A stored Canopy record carries no provenance
+// distinguishing "old default" from "deliberate user pick", so only the
+// fresh-install fallback (DEFAULT_BACKGROUND_CONFIG) changed; every stored
+// preference — including Canopy — is preserved verbatim. Migrating stored
+// defaults requires explicit selected-vs-default provenance first.
 const UI_BACKGROUND_DEFAULT_MIGRATION_KEY = "eliza:ui-background-default-v2";
 
 export function loadBackgroundConfig(): BackgroundConfig {

--- a/packages/ui/src/state/ui-preferences.ts
+++ b/packages/ui/src/state/ui-preferences.ts
@@ -85,8 +85,8 @@ export const DEFAULT_BACKGROUND_GLOW = "#ff6a1f";
 /**
  * The shader-mode config for the black ember field: the fallback when an
  * image background is cleared or fails to load, and the base the color
- * swatches and the glsl fallback resolve to. (The boot default is the Canopy
- * wallpaper — see {@link DEFAULT_BACKGROUND_CONFIG}.)
+ * swatches and the glsl fallback resolve to. (The boot default is the Ember
+ * Night sunset wallpaper — see {@link DEFAULT_BACKGROUND_CONFIG}.)
  */
 export const DEFAULT_SHADER_BACKGROUND_CONFIG: BackgroundConfig = {
   mode: "shader",
@@ -96,8 +96,8 @@ export const DEFAULT_SHADER_BACKGROUND_CONFIG: BackgroundConfig = {
 /**
  * The curated "Ember Night" wallpaper: a warm sunset in the clouds, served as
  * a same-origin static asset from `packages/app/public`. It renders the
- * `ember-night` gallery tile (no longer the boot default — the app boots to
- * the Canopy wallpaper). A served, code-free, same-origin image the apply
+ * `ember-night` gallery tile AND the boot default ({@link
+ * DEFAULT_BACKGROUND_CONFIG}). A served, code-free, same-origin image the apply
  * channel already trusts (same class as the gradient data URLs and the
  * `/api/media/<hash>` uploads) — it carries no GLSL source or preset id, so the
  * confinement invariants (#11088 / #13523) hold. The bytes live in `public/`
@@ -134,20 +134,30 @@ const PHOTO_WALLPAPER_IDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * The boot default background: the "Canopy" photo wallpaper — a misty jungle
- * river valley in deep, layered greens — over the black base color. The base
- * stays {@link DEFAULT_BACKGROUND_COLOR} so every piece of host chrome that
- * tracks it (launch FOUC guard, PWA theme-color, manifest, native splashes)
- * keeps its black baseline, and canopy's near-black darkest tones make the
- * black→image settle invisible at boot. If the image is cleared or fails to
- * load the shell falls back to the shader ember field
- * ({@link DEFAULT_SHADER_BACKGROUND_CONFIG}); every other curated scene stays
- * a user-selectable gallery option.
+ * The boot default background: the "Ember Night" sunset wallpaper — warm
+ * orange sunset in the clouds — over the black base color, matching the
+ * catalog's declared default id ({@link DEFAULT_BACKGROUND_CATALOG_ID}), so
+ * the boot config and the catalog default can never diverge again (the
+ * Canopy-vs-ember skew behind the phone/desktop mismatch). The base stays
+ * {@link DEFAULT_BACKGROUND_COLOR} so every piece of host chrome that tracks
+ * it (launch FOUC guard, PWA theme-color, manifest, native splashes) keeps
+ * its black baseline, and the sunset's dark lower field keeps the black→image
+ * settle quiet at boot. If the image is cleared or fails to load the shell
+ * falls back to the shader ember field
+ * ({@link DEFAULT_SHADER_BACKGROUND_CONFIG}); every other curated scene —
+ * including Canopy — stays a user-selectable gallery option.
+ *
+ * FRESH-INSTALL ONLY: this constant is the fallback when no background is
+ * persisted. Every persisted preference — including a stored Canopy or plain
+ * black shader record — is preserved untouched by `loadBackgroundConfig`,
+ * because a stored value carries no provenance distinguishing "old default"
+ * from "deliberate user pick" (per the #17143 review). A migration of stored
+ * defaults requires explicit selected-vs-default provenance first.
  */
 export const DEFAULT_BACKGROUND_CONFIG: BackgroundConfig = {
   mode: "image",
   color: DEFAULT_BACKGROUND_COLOR,
-  imageUrl: photoWallpaperUrl("canopy"),
+  imageUrl: SUNSET_WALLPAPER_URL,
 };
 
 /* ── Background catalog (curated + metadata) ──────────────────────────── */

--- a/packages/ui/src/state/useDisplayPreferences.background.test.tsx
+++ b/packages/ui/src/state/useDisplayPreferences.background.test.tsx
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 describe("useDisplayPreferences — background history + undo", () => {
-  it("starts on the boot default (Canopy wallpaper) with nothing to undo", () => {
+  it("starts on the boot default (Ember Night sunset wallpaper) with nothing to undo", () => {
     const { result } = renderHook(() => useDisplayPreferences());
     expect(result.current.state.backgroundConfig).toEqual(
       DEFAULT_BACKGROUND_CONFIG,


### PR DESCRIPTION
## What

Boot **fresh installs** to the **Ember Night sunset (orange clouds)** wallpaper instead of the green Canopy default — the safe recut of #17143 in exactly the shape the closing review prescribed: **change the fresh-install default only; preserve every ambiguous stored preference.**

## Why

`DEFAULT_BACKGROUND_CONFIG` (`packages/ui/src/state/ui-preferences.ts`) pointed at `/wallpapers/canopy.webp` while the catalog's declared default id (`DEFAULT_BACKGROUND_CATALOG_ID` in `@elizaos/shared`) is `ember-night` → `/bg-sunset.webp`. That disagreement is the root cause of the phone-orange / desktop-green divergence (older installs persisted the ember default; fresh surfaces boot Canopy). This PR pins the two together.

## What changed vs #17143 (per the closing review)

- **No migration at all.** The #17143 one-load v3 migration is gone. The review found it (a) didn't persist, so Canopy returned on the next load, and (b) could overwrite deliberate Canopy/black picks because stored records carry no selected-vs-default provenance. Both hazards are structurally impossible here: `loadBackgroundConfig` is untouched except for the doc comment; only the fallback constant changed.
- **Every stored preference is preserved verbatim** — including stored Canopy and post-v2 deliberate black. Tests pin this bidirectionally (see below).
- A future migration of stored defaults requires explicit provenance first; documented at both the constant and the migration flag.

## Files

- `packages/ui/src/state/ui-preferences.ts` — `DEFAULT_BACKGROUND_CONFIG.imageUrl` → `SUNSET_WALLPAPER_URL`; doc comments
- `packages/ui/src/state/persistence.ts` — comment only (records the no-migration decision)
- 3 test files

## Tests (packages/ui, full-deps worktree at current develop)

- `background-catalog.test.ts` — boot default is `/bg-sunset.webp` **and equals the catalog default entry's source** (permanent divergence guard); Canopy stays a selectable gallery scene. 10/10.
- `persistence.background.test.ts` — new suite "fresh-default flip preserves every stored preference": fresh install → sunset; **stored Canopy survives repeated loads verbatim (localStorage byte-checked)**; stored Reef untouched; post-v2 deliberate black untouched. 19/19.
- `useDisplayPreferences.background.test.tsx` — 14/14.
- Bidirectional: with the `ui-preferences.ts` change reverted (tests kept), the fresh-install case fails (`expected "/wallpapers/canopy.webp" to be "/bg-sunset.webp"`) while all preservation cases still pass — proving the preservation guarantees don't depend on the flip.
- Full `packages/ui` `src/state` + `src/backgrounds` sweep: **115 files / 1129 tests green**. `tsc --noEmit` green. Biome clean.

## Visual evidence

Live vite dev server at this head, fresh profile (nothing persisted), desktop 1440×900 + mobile 390×844. Before shots captured at the same server with only `ui-preferences.ts` reverted.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Canopy (green) default at the same head with only `ui-preferences.ts` reverted: [desktop 1440×900](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17434-before-desktop.png) · [mobile 390×844](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17434-before-mobile.png)

<!-- evidence-row:after-screenshots -->
- [x] Ember Night sunset (orange clouds) default, fresh profile: [desktop 1440×900](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17434-after-desktop.png) · [mobile 390×844](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17434-after-mobile.png)

<!-- evidence-row:walkthrough-video -->
- [x] N/A - one constant changed; the before/after screenshots fully capture the visual delta (default background on the sign-in surface); no interaction flow changed.

<!-- evidence-row:backend-logs -->
- [x] N/A - frontend-only change; no backend path involved.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no console/log behavior changed; vitest output in the Tests section is the proof surface.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model-facing surface; static default constant.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - vitest bidirectional proof in the Tests section (fresh-install case red with the flip reverted; preservation cases green both ways; 1129-test package sweep green).

<!-- evidence-row:ocr-review -->
- [x] OCR text readout (tesseract) on the after shots: desktop and mobile both read "Hi, I'm Eliza. / Let's get you signed in. / Sign in to Eliza Cloud / Sign in to start chatting" — all foreground copy legible over the sunset wallpaper.

Re-cut of #17143. [sol-orange-clouds]

