### PR TITLE
test(cloud): give the isolated-postgres teardown hook a realistic budget

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-lock.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-lock.integration.test.ts
@@ -133,6 +133,11 @@ if (!postgres) {
   jobsRepository = jobsModule.jobsRepository;
 }
 
+// 60s like the schema-push beforeAll: teardown drains live pool connections,
+// terminates straggler backends, drops the isolated database, and stops the
+// server — the final lease/quiescence test leaves real in-flight work behind,
+// and on an I/O-loaded CI host that sequence routinely blows the 5s default
+// hook budget, failing the whole suite as "(unnamed)" after every test passed.
 afterAll(async () => {
   await closeDatabaseConnectionsForTests?.();
   if (postgres && isolatedDatabaseName) {
@@ -143,7 +148,7 @@ afterAll(async () => {
   for (const [name, value] of Object.entries(ORIGINAL_ENV)) {
     restoreEnv(name as keyof typeof ORIGINAL_ENV, value);
   }
-});
+}, 60_000);
 
 const realPostgres = postgres ? describe : describe.skip;
 


### PR DESCRIPTION
## Problem

The `agent-sandboxes-stuck-provisioning-lock.integration.test.ts` suite fails intermittently in the **PostgreSQL lifecycle barrier** e2e lane as:

```
(fail) (unnamed) [5000.29ms]
  ^ a beforeEach/afterEach hook timed out for this test.
 4 pass
 1 fail
```

— after **every named test passed**. Two independent hits this morning, on unrelated PRs:

- PR #17256's lane: [job 91095243269](https://github.com/elizaOS/eliza/actions/runs/30601684340/job/91095243269) — `(unnamed) [5000.29ms]`
- PR #17349's lane: [job 91116502922](https://github.com/elizaOS/eliza/actions/runs/30617154040/job/91116502922) — `(unnamed) [5000.38ms]`

The timing-out hook is the file's top-level `afterAll`: it drains live pool connections, `pg_terminate_backend`s stragglers, drops the isolated database, and stops the server — immediately after the quiescence test that deliberately leaves in-flight lease work behind. Under CI host load (see the I/O-starvation receipts in #17421) that sequence routinely exceeds bun's **5s default hook budget**. The schema-push `beforeAll` in the same file already carries a 60s budget; the teardown didn't.

## Fix

Give the `afterAll` the same 60s budget, with a comment explaining why. No assertion is weakened — the hook still fails loudly if teardown genuinely wedges past 60s, and every lifecycle assertion is untouched.

## Verification

- `bun test packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-lock.integration.test.ts` locally (no real postgres on this host): file parses, harness skips cleanly by design — `0 fail / 5 skip`.
- The real-postgres path runs in the e2e lane on this PR; the two CI receipts above are the fail-on-base proof (same code, 5s hook, loaded runner → fail).
- `HookOptions`/timeout second-arg confirmed against `bun-types/test.d.ts` and the in-file `beforeAll(…, 60_000)` precedent.

<!-- evidence-row:before-screenshots -->
N/A - test-harness-only change; no UI surface.

<!-- evidence-row:after-screenshots -->
N/A - test-harness-only change; no UI surface.

<!-- evidence-row:walkthrough-video -->
N/A - no user-exercisable flow; CI test-lane reliability fix.

<!-- evidence-row:backend-logs -->
Fail-on-base CI receipts linked above: [17256's lane](https://github.com/elizaOS/eliza/actions/runs/30601684340/job/91095243269) and [17349's lane](https://github.com/elizaOS/eliza/actions/runs/30617154040/job/91116502922), both `(unnamed) ~5000ms` hook timeouts after 4/4 passing tests.

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface.

<!-- evidence-row:llm-trajectory -->
N/A - no agent/action/prompt/model behavior involved.

<!-- evidence-row:domain-artifacts -->
The real-postgres suite result is the domain artifact: fail-on-base runs [17256's lane](https://github.com/elizaOS/eliza/actions/runs/30601684340/job/91095243269) and [17349's lane](https://github.com/elizaOS/eliza/actions/runs/30617154040/job/91116502922) (4 pass + hook timeout at ~5000ms), and this PR's own e2e lane re-runs the same suite with the 60s teardown budget.

