### PR TITLE
fix(agent): complete chat cancellation ownership

### DIFF
--- a/packages/agent/scripts/cerebras-chat-flow-latency.ts
+++ b/packages/agent/scripts/cerebras-chat-flow-latency.ts
@@ -19,6 +19,7 @@ import {
   InferenceTurnTimer,
   inferenceTimingRegistry,
   type Memory,
+  ModelType,
   runWithInferenceTiming,
   type UUID,
 } from "@elizaos/core";
@@ -310,6 +311,132 @@ async function main(): Promise<void> {
       );
     }
 
+    const cancellationProof = `CANCEL-${randomUUID()}`;
+    const cancellationMessage = createMessageMemory({
+      id: randomUUID() as UUID,
+      entityId,
+      roomId,
+      content: {
+        text: `Write a detailed response that ends with ${cancellationProof}.`,
+        source: "cerebras_cancellation_audit",
+        channelType: ChannelType.DM,
+      },
+    });
+    const cancellationController = new AbortController();
+    const cancellationReason = new Error(
+      "Cancellation probe owner disconnected",
+    );
+    cancellationReason.name = "AbortError";
+    const originalUseModel = runtime.useModel.bind(runtime);
+    let cancellationTimer: ReturnType<typeof setTimeout> | undefined;
+    let liveModelInvocationObserved = false;
+    let invokedModelType: string | null = null;
+    let modelSignalWasAlreadyAborted = false;
+    runtime.useModel = (async (modelType, params) => {
+      const pending = originalUseModel(modelType, params);
+      if (
+        !liveModelInvocationObserved &&
+        modelType === ModelType.RESPONSE_HANDLER
+      ) {
+        liveModelInvocationObserved = true;
+        invokedModelType = modelType;
+        modelSignalWasAlreadyAborted =
+          typeof params === "object" &&
+          params !== null &&
+          "signal" in params &&
+          params.signal instanceof AbortSignal &&
+          params.signal.aborted;
+        cancellationTimer = setTimeout(() => {
+          cancellationController.abort(cancellationReason);
+        }, 25);
+      }
+      return await pending;
+    }) as typeof runtime.useModel;
+
+    const cancellationStartedAt = performance.now();
+    let cancellationError: unknown;
+    try {
+      await generateChatResponse(
+        runtime,
+        cancellationMessage as Memory,
+        runtime.character.name,
+        { abortSignal: cancellationController.signal },
+      );
+      throw new Error("Cancellation probe unexpectedly completed");
+    } catch (error) {
+      cancellationError = error;
+    } finally {
+      runtime.useModel = originalUseModel;
+      if (cancellationTimer) clearTimeout(cancellationTimer);
+    }
+    const cancellationWallMs = performance.now() - cancellationStartedAt;
+    if (!liveModelInvocationObserved) {
+      throw new Error(
+        "Cancellation probe aborted before a live RESPONSE_HANDLER invocation",
+      );
+    }
+    if (!cancellationController.signal.aborted) {
+      throw new Error("Cancellation probe did not abort its owner signal");
+    }
+    if (
+      cancellationError !== cancellationReason &&
+      (!(cancellationError instanceof Error) ||
+        !cancellationError.message.includes(cancellationReason.message))
+    ) {
+      throw new Error(
+        `Cancellation probe rejected with the wrong reason: ${String(cancellationError)}`,
+      );
+    }
+    const cancellationQuiescenceStartedAt = performance.now();
+    const cancellationBackgroundTasks = await drainPostDeliveryTasks(runtime);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const cancellationBackgroundQuiescenceMs =
+      performance.now() - cancellationQuiescenceStartedAt;
+    const memoriesAfterCancellation = await runtime.getMemories({
+      roomId,
+      tableName: "messages",
+      limit: 100,
+    });
+    const lateCancellationReplies = memoriesAfterCancellation.filter(
+      (memory) =>
+        memory.entityId === runtime.agentId &&
+        String((memory.content as { text?: unknown }).text ?? "").includes(
+          cancellationProof,
+        ),
+    );
+    if (lateCancellationReplies.length > 0) {
+      throw new Error(
+        `Cancelled live turn persisted a late assistant reply: ${JSON.stringify(
+          lateCancellationReplies.map((memory) => memory.id),
+        )}`,
+      );
+    }
+    const cancellationProbe = {
+      proof: cancellationProof,
+      execution:
+        "production generateChatResponse path; owner abort scheduled after the live RESPONSE_HANDLER invocation began",
+      liveModelInvocationObserved,
+      invokedModelType,
+      modelSignalWasAlreadyAborted,
+      ownerSignalAborted: cancellationController.signal.aborted,
+      rejection: {
+        name:
+          cancellationError instanceof Error
+            ? cancellationError.name
+            : typeof cancellationError,
+        message:
+          cancellationError instanceof Error
+            ? cancellationError.message
+            : String(cancellationError),
+      },
+      wallMs: rounded(cancellationWallMs),
+      backgroundTasks: cancellationBackgroundTasks,
+      backgroundQuiescenceMs: rounded(cancellationBackgroundQuiescenceMs),
+      lateAssistantPersistenceIds: lateCancellationReplies.map(
+        (memory) => memory.id,
+      ),
+    };
+
     const registeredProviderNames = runtime.providers.map(
       (provider) => provider.name,
     );
@@ -373,6 +500,7 @@ async function main(): Promise<void> {
       >,
       spanHistograms: chatTelemetry.spanHistograms,
       providerTelemetry: chatTelemetry.providers,
+      cancellationProbe,
       allProviderSweep: {
         execution:
           "every registered provider explicitly selected and executed concurrently by AgentRuntime.composeState",

--- a/packages/agent/src/api/__tests__/conversation-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-streaming.test.ts
@@ -1415,6 +1415,53 @@ describe("generateChatResponse token streaming", () => {
     expect(signalFromOptions?.aborted).toBe(true);
   });
 
+  it("propagates caller cancellation into chat pre-handlers", async () => {
+    let preHandlerStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      preHandlerStarted = resolve;
+    });
+    let signalFromPreHandler: AbortSignal | undefined;
+    const handleMessage = vi.fn();
+    const runtime = createRuntime({
+      drainChatPreHandlers: vi.fn(async (context) => {
+        signalFromPreHandler = context.abortSignal;
+        preHandlerStarted?.();
+        await new Promise<void>((_resolve, reject) => {
+          context.abortSignal?.addEventListener(
+            "abort",
+            () => reject(context.abortSignal?.reason),
+            { once: true },
+          );
+        });
+        return null;
+      }),
+      messageService: {
+        handleMessage,
+        shouldRespond: () => ({
+          shouldRespond: true,
+          skipEvaluation: true,
+          reason: "streaming-test",
+        }),
+        deleteMessage: async () => undefined,
+        clearChannel: async () => undefined,
+      },
+    });
+
+    const caller = new AbortController();
+    const generation = generateChatResponse(
+      runtime,
+      createChatMessage("cancel the pre-handler"),
+      "Streaming Agent",
+      { abortSignal: caller.signal },
+    );
+    await started;
+    caller.abort(new DOMException("Client disconnected", "AbortError"));
+
+    await expect(generation).rejects.toThrow("Client disconnected");
+    expect(signalFromPreHandler?.aborted).toBe(true);
+    expect(handleMessage).not.toHaveBeenCalled();
+  });
+
   it("rejects ingress hook failures before starting message generation", async () => {
     const hookFailure = new Error("trajectory persistence failed");
     const handleMessage = vi.fn(async () => ({

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -131,6 +131,77 @@ type LocalInferenceChatApi = Pick<
   "getLocalInferenceChatStatus" | "handleLocalInferenceChatCommand"
 >;
 
+interface StreamingResponseAbortTracker {
+  signal: AbortSignal;
+  dispose: () => void;
+  markCompleted: () => void;
+}
+
+type AbortEventSource = {
+  on?: (event: string, listener: () => void) => unknown;
+  off?: (event: string, listener: () => void) => unknown;
+};
+
+function createStreamingResponseAbortTracker(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  operation: string,
+): StreamingResponseAbortTracker {
+  const controller = new AbortController();
+  const registrations: Array<{
+    source: AbortEventSource;
+    event: string;
+    listener: () => void;
+  }> = [];
+  let completed = false;
+
+  const abort = () => {
+    if (!completed && !controller.signal.aborted) {
+      controller.abort(new Error(`${operation} client disconnected`));
+    }
+  };
+  const register = (
+    source: AbortEventSource | null | undefined,
+    event: string,
+    listener: () => void,
+  ) => {
+    if (typeof source?.on !== "function") return;
+    source.on(event, listener);
+    registrations.push({ source, event, listener });
+  };
+  const onResponseClose = () => {
+    if (!res.writableEnded) abort();
+  };
+
+  // IncomingMessage.close describes request-body completion on current Node
+  // and Bun releases, not the lifetime of the streamed response. The response
+  // and socket events remain live after body parsing and therefore own
+  // disconnect cancellation.
+  register(req, "aborted", abort);
+  register(req, "error", abort);
+  register(res, "close", onResponseClose);
+  register(res, "error", abort);
+  register(req.socket, "close", abort);
+  register(req.socket, "error", abort);
+
+  if (req.aborted || req.destroyed || res.destroyed) {
+    abort();
+  }
+
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      for (const { source, event, listener } of registrations) {
+        source.off?.(event, listener);
+      }
+      registrations.length = 0;
+    },
+    markCompleted: () => {
+      completed = true;
+    },
+  };
+}
+
 let localInferenceChatApiPromise: Promise<LocalInferenceChatApi> | null = null;
 
 /**
@@ -2793,6 +2864,7 @@ async function generateChatResponseWithTiming(
   }
   let closeResponseFinalization: (() => void) | undefined;
   try {
+    generationAbortController.signal.throwIfAborted();
     const originalUserText = String(extractCompatTextContent(message.content));
     type StreamSource = "unset" | "callback" | "onStreamChunk";
     let responseText = "";
@@ -2936,9 +3008,9 @@ async function generateChatResponseWithTiming(
       replaceCallbackText(incoming);
     };
 
-    // Trajectory/session persistence is part of accepting an API turn. A hook
-    // failure must reject before generation rather than produce an answer whose
-    // ingress record is missing.
+    // Inbound event consumers may persist correlation state or apply
+    // turn-shaping policy. Generation cannot safely continue when that
+    // prerequisite fails.
     if (typeof runtime.emitEvent === "function") {
       await timeInferenceSpan("chat:ingress:received-event", () =>
         runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
@@ -2947,6 +3019,7 @@ async function generateChatResponseWithTiming(
         }),
       );
     }
+    generationAbortController.signal.throwIfAborted();
     const trajectoryStepId = readMessageTrajectoryStepId(message);
     const trajectoryContext =
       typeof trajectoryStepId === "string" && trajectoryStepId.trim().length > 0
@@ -2964,6 +3037,7 @@ async function generateChatResponseWithTiming(
           opts,
         }),
     );
+    generationAbortController.signal.throwIfAborted();
     if (androidDirectResult) {
       try {
         if (
@@ -3048,15 +3122,18 @@ async function generateChatResponseWithTiming(
     const generationCapture = await withModelUsageCapture(runtime, () =>
       Promise.resolve(
         runWithTrajectoryContext(trajectoryContext, async () => {
+          generationAbortController.signal.throwIfAborted();
           // Plugin-registered chat pre-handlers (generic direct-dispatch
           // extension point): drained by priority before normal action
           // processing; the first non-null result resolves the turn.
           const preHandlerResult = await runtime.drainChatPreHandlers({
             runtime,
             message,
+            abortSignal: generationAbortController.signal,
             appendText: replaceCallbackText,
             replaceText: emitSnapshot,
           });
+          generationAbortController.signal.throwIfAborted();
           if (preHandlerResult) {
             const directText = preHandlerResult.responseText;
             const finalText = isClientVisibleNoResponse(directText)
@@ -3147,8 +3224,12 @@ async function generateChatResponseWithTiming(
                     name: createTaskAction.name,
                     params: directTaskParameters,
                   },
-                  { actions: [createTaskAction] },
+                  {
+                    actions: [createTaskAction],
+                    abortSignal: generationAbortController.signal,
+                  },
                 );
+                generationAbortController.signal.throwIfAborted();
                 const finalText =
                   actionResponseText ||
                   directActionResult.text ||
@@ -3220,6 +3301,7 @@ async function generateChatResponseWithTiming(
               ),
             { phase: "pre-model" },
           );
+          generationAbortController.signal.throwIfAborted();
           result = await timeInferenceSpan(
             "chat:message-service",
             async () =>
@@ -3292,6 +3374,7 @@ async function generateChatResponseWithTiming(
               ),
             { phase: "message" },
           );
+          generationAbortController.signal.throwIfAborted();
 
           // Ensure MESSAGE_SENT hooks run for API chat flows.
           try {
@@ -4129,10 +4212,11 @@ export async function handleChatRoutes(
 
     if (wantsStream) {
       initSse(res);
-      const disconnectController = new AbortController();
-      req.on("close", () => {
-        disconnectController.abort(new Error("Client disconnected"));
-      });
+      const disconnectTracker = createStreamingResponseAbortTracker(
+        req,
+        res,
+        "OpenAI-compatible stream",
+      );
 
       const sendChunk = (
         delta: Record<string, unknown>,
@@ -4211,7 +4295,7 @@ export async function handleChatRoutes(
             message,
             state.agentName,
             {
-              abortSignal: disconnectController.signal,
+              abortSignal: disconnectTracker.signal,
               onChunk: (chunk) => {
                 fullText += chunk;
                 if (chunk) sendChunk({ content: chunk }, null);
@@ -4247,7 +4331,7 @@ export async function handleChatRoutes(
         sendChunk({}, "stop");
         writeSseData(res, "[DONE]");
       } catch (err) {
-        if (!disconnectController.signal.aborted) {
+        if (!disconnectTracker.signal.aborted) {
           if (isLocalInferenceError(err)) {
             const { getLocalInferenceChatStatus } =
               await getLocalInferenceChatApi();
@@ -4297,6 +4381,8 @@ export async function handleChatRoutes(
           }
         }
       } finally {
+        disconnectTracker.markCompleted();
+        disconnectTracker.dispose();
         res.end();
       }
       return true;
@@ -4499,10 +4585,11 @@ export async function handleChatRoutes(
 
     if (wantsStream) {
       initSse(res);
-      const disconnectController = new AbortController();
-      req.on("close", () => {
-        disconnectController.abort(new Error("Client disconnected"));
-      });
+      const disconnectTracker = createStreamingResponseAbortTracker(
+        req,
+        res,
+        "Anthropic-compatible stream",
+      );
 
       try {
         if (!state.runtime) {
@@ -4607,7 +4694,7 @@ export async function handleChatRoutes(
             message,
             state.agentName,
             {
-              abortSignal: disconnectController.signal,
+              abortSignal: disconnectTracker.signal,
               onChunk: onDelta,
               resolveNoResponseText: () =>
                 resolveNoResponseFallback(state.logBuffer, runtime),
@@ -4650,7 +4737,7 @@ export async function handleChatRoutes(
         );
         writeSseJson(res, { type: "message_stop" }, "message_stop");
       } catch (err) {
-        if (!disconnectController.signal.aborted) {
+        if (!disconnectTracker.signal.aborted) {
           if (isNoProviderError(err)) {
             writeSseJson(
               res,
@@ -4684,6 +4771,8 @@ export async function handleChatRoutes(
           }
         }
       } finally {
+        disconnectTracker.markCompleted();
+        disconnectTracker.dispose();
         res.end();
       }
       return true;

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -4161,17 +4161,16 @@ export async function startApiServer(opts?: {
   }
   logger.debug(`[eliza-api] Server created (${Date.now() - apiStartTime}ms)`);
 
-  // Model work is cancelled by the request's AbortSignal and provider/socket
-  // failures, not an elapsed wall-clock guess. Disable Node's whole-request and
-  // idle-socket deadlines so they cannot sever a healthy streamed turn while
-  // the runtime is still producing output. Header and post-response keepalive
-  // limits remain transport hygiene and do not cap model execution.
-  server.requestTimeout = 0;
+  // requestTimeout bounds receipt of the request body; Node does not apply it
+  // to time spent generating the response. Keep that slow-upload protection
+  // while leaving the idle socket deadline disabled for long model turns.
+  // Generation itself is cancelled by the request owner's AbortSignal.
+  server.requestTimeout = 300_000;
   server.headersTimeout = 60_000;
   server.keepAliveTimeout = 60_000;
   server.timeout = 0;
   logger.debug(
-    "[eliza-api] Server lifecycle: requestTimeout=disabled, idleTimeout=disabled, headersTimeout=60000ms, keepAliveTimeout=60000ms",
+    "[eliza-api] Server lifecycle: requestTimeout=300000ms, idleTimeout=disabled, headersTimeout=60000ms, keepAliveTimeout=60000ms",
   );
 
   const broadcastWs = (payload: unknown): void => {

--- a/packages/agent/test/api/agent-message-route.test.ts
+++ b/packages/agent/test/api/agent-message-route.test.ts
@@ -70,6 +70,8 @@ function createMockReq(
       }
     } else if (event === "end") {
       setImmediate(() => listener());
+    } else {
+      http.IncomingMessage.prototype.on.call(req, event, listener);
     }
     return req;
   }) as never;
@@ -307,6 +309,7 @@ function createCtx(opts: {
   };
 
   return {
+    req,
     record,
     state,
     invoke: () =>
@@ -576,6 +579,110 @@ describe("compatibility transport transcript visibility", () => {
       .map((choice) => choice.delta?.content ?? "")
       .join("");
     expect(text).toBe("callback reply");
+  });
+
+  it("cancels an OpenAI-compatible stream when the request is aborted", async () => {
+    const agentId = stringToUuid("openai-disconnect-agent") as UUID;
+    let generationStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      generationStarted = resolve;
+    });
+    let observedSignal: AbortSignal | undefined;
+    const runtime = createRuntime(agentId, {
+      messageService: {
+        async handleMessage(_runtime, _message, _callback, options) {
+          observedSignal = options?.abortSignal;
+          generationStarted?.();
+          await new Promise<void>((_resolve, reject) => {
+            options?.abortSignal?.addEventListener(
+              "abort",
+              () => reject(options.abortSignal?.reason),
+              { once: true },
+            );
+          });
+          throw new Error("unreachable");
+        },
+        shouldRespond: () => ({
+          shouldRespond: true,
+          skipEvaluation: true,
+          reason: "test",
+        }),
+        deleteMessage: async () => undefined,
+        clearChannel: async () => undefined,
+      } as unknown as MessageService,
+    });
+    const { req, record, invoke } = createCtx({
+      method: "POST",
+      pathname: "/v1/chat/completions",
+      body: {
+        model: "eliza",
+        stream: true,
+        messages: [{ role: "user", content: "Cancel this turn" }],
+      },
+      runtime,
+    });
+
+    const pending = invoke();
+    await started;
+    req.emit("aborted");
+
+    await expect(pending).resolves.toBe(true);
+    expect(observedSignal?.aborted).toBe(true);
+    expect(record.writes.join("")).not.toContain("data: [DONE]");
+  });
+
+  it("does not treat normal request close as an OpenAI stream disconnect", async () => {
+    const agentId = stringToUuid("openai-request-close-agent") as UUID;
+    let releaseGeneration: (() => void) | undefined;
+    const release = new Promise<void>((resolve) => {
+      releaseGeneration = resolve;
+    });
+    let generationStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      generationStarted = resolve;
+    });
+    let observedSignal: AbortSignal | undefined;
+    const runtime = createRuntime(agentId, {
+      messageService: {
+        async handleMessage(_runtime, _message, _callback, options) {
+          observedSignal = options?.abortSignal;
+          generationStarted?.();
+          await release;
+          return {
+            didRespond: true,
+            responseContent: { text: "still connected" },
+            responseMessages: [],
+          };
+        },
+        shouldRespond: () => ({
+          shouldRespond: true,
+          skipEvaluation: true,
+          reason: "test",
+        }),
+        deleteMessage: async () => undefined,
+        clearChannel: async () => undefined,
+      } as unknown as MessageService,
+    });
+    const { req, record, invoke } = createCtx({
+      method: "POST",
+      pathname: "/v1/chat/completions",
+      body: {
+        model: "eliza",
+        stream: true,
+        messages: [{ role: "user", content: "Finish normally" }],
+      },
+      runtime,
+    });
+
+    const pending = invoke();
+    await started;
+    req.emit("close");
+    expect(observedSignal?.aborted).toBe(false);
+    releaseGeneration?.();
+
+    await expect(pending).resolves.toBe(true);
+    expect(record.writes.join("")).toContain("still connected");
+    expect(record.writes.join("")).toContain("data: [DONE]");
   });
 
   it("ends an OpenAI-compatible divergent stream with an observable error, not success", async () => {

--- a/packages/core/src/runtime/chat-pre-handler-registry.ts
+++ b/packages/core/src/runtime/chat-pre-handler-registry.ts
@@ -48,7 +48,9 @@ export class ChatPreHandlerRegistry {
 		ctx: ChatPreHandlerContext,
 	): Promise<ChatPreHandlerResult | null> {
 		for (const handler of this.list()) {
+			ctx.abortSignal?.throwIfAborted();
 			const result = await handler.tryHandle(ctx);
+			ctx.abortSignal?.throwIfAborted();
 			if (result) return result;
 		}
 		return null;

--- a/packages/core/src/services/message.runtime-failure-suppression.test.ts
+++ b/packages/core/src/services/message.runtime-failure-suppression.test.ts
@@ -201,6 +201,40 @@ describe("v5 runtime failure before a respond decision", () => {
 		expect(result.didRespond).toBe(true);
 		expect(visibleTexts).toHaveLength(1);
 	});
+
+	it("propagates caller cancellation without generating a failure reply", async () => {
+		const runtime = makeFailingRuntime(makeRoom(ChannelType.DM));
+		const controller = new AbortController();
+		const abortReason = new DOMException("client disconnected", "AbortError");
+		const modelCallTypes: string[] = [];
+		runtime.useModel = vi.fn(async (modelType: unknown) => {
+			modelCallTypes.push(String(modelType));
+			if (String(modelType) !== "RESPONSE_HANDLER") return [];
+			controller.abort(abortReason);
+			throw abortReason;
+		}) as IAgentRuntime["useModel"];
+		const service = new DefaultMessageService();
+		const deliveries: Content[] = [];
+
+		await expect(
+			service.handleMessage(
+				runtime,
+				makeMessage({ channelType: ChannelType.DM }),
+				async (content) => {
+					deliveries.push(content);
+					return [];
+				},
+				{ abortSignal: controller.signal },
+			),
+		).rejects.toMatchObject({
+			code: "TURN_ABORTED",
+			reason: "client disconnected",
+		});
+		expect(
+			modelCallTypes.filter((modelType) => modelType !== "TEXT_EMBEDDING"),
+		).toEqual(["RESPONSE_HANDLER"]);
+		expect(deliveries).toEqual([]);
+	});
 });
 
 describe("planner failure after a promoted stage-1 answer", () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -11446,6 +11446,15 @@ export class DefaultMessageService implements IMessageService {
 					state = outcome.result.state;
 				}
 			} catch (error) {
+				const callerSignal = getStreamingContext()?.abortSignal;
+				if (callerSignal?.aborted) {
+					const reason = callerSignal.reason;
+					throw reason instanceof TurnAbortedError
+						? reason
+						: new TurnAbortedError(
+								reason instanceof Error ? reason.message : String(reason),
+							);
+				}
 				if (
 					error instanceof TurnAbortedError ||
 					(isRecord(error) && error.code === "TURN_ABORTED")

--- a/packages/core/src/types/chat-pre-handler.ts
+++ b/packages/core/src/types/chat-pre-handler.ts
@@ -21,6 +21,8 @@ import type { IAgentRuntime } from "./runtime";
 export interface ChatPreHandlerContext {
 	runtime: IAgentRuntime;
 	message: Memory;
+	/** Cancellation owned by the request or host that started this turn. */
+	abortSignal?: AbortSignal;
 	/**
 	 * Append text to the in-flight response stream (e.g. a loading hint the user
 	 * sees immediately). Mirrors the chat loop's incremental callback path.

--- a/plugins/plugin-openai/__tests__/streamstructured-tool-input-delta.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/streamstructured-tool-input-delta.shape.test.ts
@@ -138,6 +138,42 @@ describe("streamStructured tool-input-delta forwarding", () => {
     expect(chunks.every((c) => typeof c === "string" && c.length > 0)).toBe(true);
   }, 20_000);
 
+  it("keeps the structured text companion rejection handled when the stream aborts", async () => {
+    const abortError = new Error("client disconnected");
+    abortError.name = "AbortError";
+    const companionRejectors: Array<(error: unknown) => void> = [];
+    const companion = () =>
+      new Promise<never>((_resolve, reject) => {
+        companionRejectors.push(reject);
+      });
+    aiMocks.streamText.mockResolvedValue({
+      textStream: (async function* textStream() {})(),
+      fullStream: (async function* fullStream() {
+        for (const reject of companionRejectors) reject(abortError);
+        await Promise.reject(abortError);
+        yield { type: "finish", finishReason: "error" };
+      })(),
+      text: companion(),
+      toolCalls: companion(),
+      finishReason: companion(),
+      usage: companion(),
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    const stream = (await handleTextSmall(createRuntime(), {
+      prompt: "abort structured stream",
+      stream: true,
+      streamStructured: true,
+      toolChoice: "required",
+    } as never)) as {
+      textStream: AsyncIterable<string>;
+      text: Promise<string>;
+    };
+
+    await expect(collect(stream)).rejects.toBe(abortError);
+    await expect(stream.text).rejects.toBe(abortError);
+  }, 20_000);
+
   it("without streamStructured: textStream path is used and fullStream is never consumed", async () => {
     let fullStreamTouched = false;
     aiMocks.streamText.mockImplementation(() =>

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -1933,6 +1933,13 @@ async function generateTextByModelType(
     // promises defused so an errored, unconsumed result cannot surface as an
     // unhandled rejection.
     let result!: Awaited<ReturnType<typeof streamText>>;
+    const observeStreamCompanions = (streamResult: Awaited<ReturnType<typeof streamText>>) => ({
+      text: handledPromise(streamResult.text),
+      usage: handledPromise(streamResult.usage),
+      finishReason: handledPromise(streamResult.finishReason),
+      toolCalls: handledPromise(streamResult.toolCalls),
+    });
+    let streamCompanions!: ReturnType<typeof observeStreamCompanions>;
     let streamIterator!: AsyncIterator<unknown>;
     let firstItem: IteratorResult<unknown> | undefined;
     for (let attempt = 0; ; attempt++) {
@@ -1944,6 +1951,10 @@ async function generateTextByModelType(
           capturedStreamError = error;
         },
       });
+      // Companion promises can reject at the same instant as the first stream
+      // pull. Observe them before that pull so an owner abort never becomes an
+      // unhandled rejection while textStream remains the authoritative error.
+      streamCompanions = observeStreamCompanions(result);
       const source = params.streamStructured === true ? result.fullStream : result.textStream;
       streamIterator = (source as AsyncIterable<unknown>)[Symbol.asyncIterator]();
       try {
@@ -1960,12 +1971,6 @@ async function generateTextByModelType(
         !isTransientProviderError(capturedStreamError)
       ) {
         break;
-      }
-      for (const companion of [result.text, result.usage, result.finishReason, result.toolCalls]) {
-        void Promise.resolve(companion).catch(() => {
-          // error-policy:J5 suppression — this attempt is being abandoned and
-          // retried; its failure is observed via capturedStreamError.
-        });
       }
       const backoffMs = Math.min(3000, 300 * 2 ** attempt) + Math.floor(Math.random() * 200);
       logger.warn(
@@ -1992,6 +1997,7 @@ async function generateTextByModelType(
       resolveStructuredText = resolve;
       rejectStructuredText = reject;
     });
+    const handledStructuredTextPromise = handledPromise(structuredTextPromise);
     const settleStructuredText = (error?: unknown): void => {
       if (params.streamStructured !== true || structuredTextSettled) return;
       structuredTextSettled = true;
@@ -2001,14 +2007,14 @@ async function generateTextByModelType(
       }
       resolveStructuredText(restoreResponseText(responseChunks.join("")));
     };
-    const sdkTextPromise = handledPromise(result.text);
+    const sdkTextPromise = streamCompanions.text;
     const textPromise =
       params.streamStructured === true
-        ? structuredTextPromise
+        ? handledStructuredTextPromise
         : handledMappedPromise(sdkTextPromise, restoreResponseText);
-    const rawUsagePromise = handledPromise(result.usage);
-    const rawFinishReasonPromise = handledPromise(result.finishReason);
-    const rawToolCallsPromise = handledPromise(result.toolCalls);
+    const rawUsagePromise = streamCompanions.usage;
+    const rawFinishReasonPromise = streamCompanions.finishReason;
+    const rawToolCallsPromise = streamCompanions.toolCalls;
     const restoredToolCallsPromise = handledMappedPromise(rawToolCallsPromise, (toolCalls) =>
       restoreRecordArgToolCalls(toolCalls, normalizedToolResult.recordArgTransformsByTool)
     );

--- a/plugins/plugin-training/src/core/roleplay-executor.ts
+++ b/plugins/plugin-training/src/core/roleplay-executor.ts
@@ -730,9 +730,11 @@ export async function executeRoleplayEpisode(
 
     const callbackContents: Content[] = [];
     const abortSignal =
-      options.timeoutMs === undefined
-        ? undefined
-        : AbortSignal.timeout(options.timeoutMs);
+      typeof options.timeoutMs === "number" &&
+      Number.isFinite(options.timeoutMs) &&
+      options.timeoutMs > 0
+        ? AbortSignal.timeout(Math.floor(options.timeoutMs))
+        : undefined;
     const result = await runtime.messageService.handleMessage(
       runtime,
       message,


### PR DESCRIPTION
Completes #17428 after #17431.

## What this corrects

#17431 removed guessed wall-clock generation deadlines, but the merge still left four cancellation defects:

- Node's `requestTimeout` had been disabled even though it bounds request-body receipt, not response generation, removing slow-upload protection without helping long model turns.
- OpenAI- and Anthropic-compatible SSE routes used `IncomingMessage.close` as the response-lifetime signal. On current Node/Bun that event describes completion of the request body, so normal requests could be cancelled and real response disconnects could be missed.
- owner cancellation was not checked around chat pre-handlers, direct action dispatch, document augmentation, or message-service boundaries.
- provider aborts surfaced inside `DefaultMessageService` as generic v5 runtime failures, which triggered four fallback model calls on an already-aborted signal. In structured OpenAI streaming, companion promises could also reject before observers were attached and crash Bun as unhandled rejections.

This corrective change keeps the 300-second request-body guard, makes the response/socket own SSE disconnect cancellation, propagates the same owner signal through every pre-model checkpoint, classifies aborted provider work as `TURN_ABORTED` before fallback generation, and observes AI SDK companion promises before the first stream pull.

## Verification

Exact branch head: `2453242ff580109dd3f4e4d9196486e56a5a47e0`

- `bun run verify`: 579/579 tasks; 8,823-test anti-larp scan clean; 28/28 dist-path consumers
- focused agent cancellation/streaming/usage/evidence tests: 104/104
- focused core message-service tests: 5/5
- focused OpenAI structured-stream tests: 4/4
- core, OpenAI, shared, app, and training package typechecks: green
- real Cerebras wire abort: 1/1 (request reached the provider path before owner cancellation)
- app audit: 253/254 captures passed; the single aggregate failure is unrelated existing UI debt in `plugin-calendar-gui` density plus a `plugin-notes-gui` hover timeout. This PR changes no rendered component.
- `git diff --check`: green

## Live Cerebras proof

The production `generateChatResponse` path ran with a real `AgentRuntime`, `plugin-openai`, PGLite, Cerebras `gemma-4-31b`, and both removed timeout aliases deliberately set to `1` ms.

The normal turn completed with exact stream/final/persistence parity. The cancellation probe waited until the live `RESPONSE_HANDLER` invocation had begun, aborted the request owner, observed a `TURN_ABORTED` rejection in 45.166 ms, drained background work, waited another 256.031 ms for quiescence, and found zero late assistant persistence IDs.

The attached JSON contains model/provider identity, usage, spans, the persisted normal response ID, cancellation timing, rejection, background-task count, and post-cancellation persistence query. The attached log is the corresponding structured runtime trace.

- JSON SHA-256: `632b07c17fdf353f92f0c77632bd45d432cd5a7181e4f9a57d62acee1bbb8a37`
- log SHA-256: `3e3c40067b9af88304fcd1ef54a2956a014e09c4874f70414f53c8af487facd1`

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend lifecycle correction; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend lifecycle correction; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend lifecycle exercised through real provider telemetry and persistence artifacts

<!-- evidence-row:backend-logs -->
- [x] [17436-pr17431-cerebras-cancellation.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17436-pr17431-cerebras-cancellation.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime or rendered behavior changed

<!-- evidence-row:llm-trajectory -->
- [x] [17436-pr17431-cerebras-cancellation.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17436-pr17431-cerebras-cancellation.json)

<!-- evidence-row:domain-artifacts -->
- [x] [17436-pr17431-cerebras-cancellation.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17436-pr17431-cerebras-cancellation.json)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshot evidence; no rendered UI changed
