### PR TITLE
fix(cloud): workload-scoped Steward sealing + boot resolution for container env secrets

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -41,6 +41,7 @@ import {
   resolveConfigEnvForProcess,
   resolveConnectorSecretSettings,
 } from "./operations/vault-bridge.ts";
+import { resolveWorkloadEnvOverlayForBoot } from "./operations/workload-secrets.ts";
 import { OPTIONAL_PLUGIN_IMPORTERS } from "./optional-plugin-imports.generated.ts";
 import {
   OPTIONAL_STATIC_PLUGIN_OVERRIDES,
@@ -3748,8 +3749,18 @@ export async function startEliza(
   // a vault-held token still feeds the lookup.
   const connectorSecretsOverlay =
     await resolveConnectorSecretsOverlayForBoot(config);
+  // Steward WORKLOAD refs (#17432): a cloud container provisioned with
+  // CONTAINERS_ENV_VAULT_REFS carries `vault://workload/...` sentinels plus a
+  // per-container capability in its docker env. Exchange the capability for
+  // the values into a settings-only overlay, then scrub the sentinels AND the
+  // capability key out of process.env. Self-gating: zero work when no
+  // workload refs are present (every non-sealed environment, including
+  // desktop). Runs on the SAME production boot path as the connector overlay
+  // and feeds the SAME settings-only delivery channel.
+  const workloadSecretsOverlay = await resolveWorkloadEnvOverlayForBoot();
   const discordAppIdPromise = autoResolveDiscordAppId(
-    connectorSecretsOverlay.DISCORD_API_TOKEN,
+    connectorSecretsOverlay.DISCORD_API_TOKEN ??
+      workloadSecretsOverlay.DISCORD_API_TOKEN,
   );
   const cloudGithubTokenPromise = autoFetchCloudGithubToken(
     config.cloud?.agentId?.trim(),
@@ -4463,7 +4474,13 @@ export async function startEliza(
       managedSkillsDir,
       bundledSkillsDir,
       workspaceSkillsDir,
-      connectorSecretsOverlay,
+      // Workload-resolved values under the connector values: an explicit
+      // connector secret (or local vault ref) wins over a sealed env var of
+      // the same name.
+      connectorSecretsOverlay: {
+        ...workloadSecretsOverlay,
+        ...connectorSecretsOverlay,
+      },
     }),
   });
   installRuntimeMethodBindings(runtime);
@@ -5701,8 +5718,13 @@ export async function startEliza(
           applyConnectorSecretsToEnv(freshConfig);
           const freshConnectorSecretsOverlay =
             await resolveConnectorSecretsOverlayForBoot(freshConfig);
+          // Workload overlay is single-flight cached from cold boot (the
+          // capability key was scrubbed from process.env after the exchange).
+          const freshWorkloadSecretsOverlay =
+            await resolveWorkloadEnvOverlayForBoot();
           await autoResolveDiscordAppId(
-            freshConnectorSecretsOverlay.DISCORD_API_TOKEN,
+            freshConnectorSecretsOverlay.DISCORD_API_TOKEN ??
+              freshWorkloadSecretsOverlay.DISCORD_API_TOKEN,
           );
           applyCloudConfigToEnv(freshConfig);
           applyX402ConfigToEnv(freshConfig);
@@ -5810,7 +5832,10 @@ export async function startEliza(
               managedSkillsDir,
               bundledSkillsDir,
               workspaceSkillsDir: freshWorkspaceSkillsDir,
-              connectorSecretsOverlay: freshConnectorSecretsOverlay,
+              connectorSecretsOverlay: {
+                ...freshWorkloadSecretsOverlay,
+                ...freshConnectorSecretsOverlay,
+              },
             }),
           });
           installRuntimeMethodBindings(newRuntime);

--- a/packages/agent/src/runtime/operations/index.ts
+++ b/packages/agent/src/runtime/operations/index.ts
@@ -44,3 +44,12 @@ export {
   type VaultLike,
   vaultKeyForProviderApiKey,
 } from "./vault-bridge.ts";
+export {
+  isWorkloadRef,
+  parseWorkloadRefName,
+  readWorkloadCapability,
+  resolveWorkloadEnvOverlayForBoot,
+  resolveWorkloadSecretSettings,
+  type WorkloadCapabilityEnv,
+  type WorkloadResolutionResult,
+} from "./workload-secrets.ts";

--- a/packages/agent/src/runtime/operations/workload-secrets.ts
+++ b/packages/agent/src/runtime/operations/workload-secrets.ts
@@ -1,0 +1,381 @@
+/**
+ * In-container boot resolver for Steward WORKLOAD-scoped secret refs
+ * (issue #17432).
+ *
+ * When a cloud container was provisioned with `CONTAINERS_ENV_VAULT_REFS`,
+ * its environment carries `vault://workload/<workloadId>/<KEY>` sentinels
+ * instead of secret values, plus a per-container capability:
+ *
+ *   STEWARD_API_URL       — the Steward endpoint
+ *   STEWARD_WORKLOAD_ID   — this container's workload identity
+ *   STEWARD_WORKLOAD_KEY  — pkcs8-base64 P-256 private key (LEAST PRIVILEGE:
+ *                           it can only mint short-lived tokens that resolve
+ *                           THIS workload's namespace; it is revoked
+ *                           server-side on container delete and rotated on
+ *                           every reseal — it is NOT a tenant credential)
+ *
+ * This module exchanges that capability for the values at boot:
+ *   1. `POST /agent-enroll/challenge` → sign the canonical string with the
+ *      workload key (ECDSA P-256 / SHA-256, base64 P1363 — the exact format
+ *      Steward's `verifyP256Signature` verifies);
+ *   2. `POST /agent-enroll/verify` → short-lived agent token;
+ *   3. `POST /v1/workload-secrets/resolve` with the ref-named keys.
+ *
+ * DELIVERY CONTRACT (the issue's core requirement): resolved plaintext goes
+ * ONLY into the runtime-settings overlay consumed by
+ * `buildRuntimeSettings({ connectorSecretsOverlay })` — never `process.env`.
+ * Combined with the projection's unresolved-sentinel filter, a plugin can
+ * receive the real value via `runtime.getSetting()` while `process.env`,
+ * `docker inspect`, and the container env never contain it, and a plugin can
+ * never receive the ref literal as a credential.
+ *
+ * ERROR POLICY: fail closed, keys-only logging. Any failure (missing
+ * capability, enrollment denial, revocation, Steward outage, partial
+ * response) resolves NOTHING for the affected keys and reports key names
+ * only — never values, never raw upstream errors that could embed them.
+ */
+
+import { webcrypto } from "node:crypto";
+import { logger } from "@elizaos/core";
+import { isVaultRef, parseVaultRef } from "./vault-bridge.ts";
+
+/** Namespace prefix marking a workload-contract ref (vs. local-vault refs). */
+export const WORKLOAD_REF_NAMESPACE = "workload/";
+
+/** Env keys carrying the workload capability. Mirrored (with a pin) in
+ * `packages/cloud/shared/.../workload-env-refs.ts` — the writer side. */
+export interface WorkloadCapabilityEnv {
+  apiUrl: string;
+  workloadId: string;
+  privateKeyPkcs8Base64: string;
+}
+
+/** True when `value` is a `vault://workload/...` sentinel. */
+export function isWorkloadRef(value: unknown): value is string {
+  if (!isVaultRef(value)) return false;
+  const key = parseVaultRef(value);
+  return key !== null && key.startsWith(WORKLOAD_REF_NAMESPACE);
+}
+
+/**
+ * Extract the secret NAME from a workload ref addressed to `workloadId`.
+ * Returns null for malformed refs or refs addressed to a DIFFERENT workload
+ * (those are unresolvable by construction — this capability cannot read
+ * another namespace — so they fail closed as missing).
+ */
+export function parseWorkloadRefName(
+  value: string,
+  workloadId: string,
+): string | null {
+  const key = parseVaultRef(value);
+  if (key === null) return null;
+  const prefix = `${WORKLOAD_REF_NAMESPACE}${workloadId}/`;
+  if (!key.startsWith(prefix)) return null;
+  const name = key.slice(prefix.length);
+  return name.length > 0 ? name : null;
+}
+
+/** Read the workload capability from env; null when absent (not an error —
+ * absence simply means this container was not provisioned with sealing). */
+export function readWorkloadCapability(
+  env: NodeJS.ProcessEnv = process.env,
+): WorkloadCapabilityEnv | null {
+  const apiUrl = env.STEWARD_API_URL?.trim();
+  const workloadId = env.STEWARD_WORKLOAD_ID?.trim();
+  const privateKeyPkcs8Base64 = env.STEWARD_WORKLOAD_KEY?.trim();
+  if (!apiUrl || !workloadId || !privateKeyPkcs8Base64) return null;
+  return { apiUrl, workloadId, privateKeyPkcs8Base64 };
+}
+
+/** Fetch signature so tests can inject transports; default is global fetch. */
+export type FetchLike = typeof fetch;
+
+interface EnrollmentResult {
+  token: string;
+}
+
+/** Sign `canonicalString` with the capability key — ECDSA P-256/SHA-256,
+ * base64 P1363 signature (the exact format Steward's verifier expects). */
+async function signCanonicalString(
+  privateKeyPkcs8Base64: string,
+  canonicalString: string,
+): Promise<string> {
+  const pkcs8 = Buffer.from(privateKeyPkcs8Base64, "base64");
+  const key = await webcrypto.subtle.importKey(
+    "pkcs8",
+    pkcs8,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false, // non-extractable import — the key material never re-exports
+    ["sign"],
+  );
+  const data = new TextEncoder().encode(canonicalString);
+  const signature = new Uint8Array(
+    await webcrypto.subtle.sign({ name: "ECDSA", hash: "SHA-256" }, key, data),
+  );
+  return Buffer.from(signature).toString("base64");
+}
+
+async function postJson(
+  fetchImpl: FetchLike,
+  url: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; json: Record<string, unknown> | null }> {
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  let json: Record<string, unknown> | null = null;
+  try {
+    json = (await res.json()) as Record<string, unknown>;
+  } catch {
+    // Non-JSON body (proxy error page, truncated response). Deliberate
+    // fail-closed: `json` stays null and every downstream field read treats
+    // the response as malformed — nothing is fabricated from it.
+    json = null;
+  }
+  return { status: res.status, json };
+}
+
+/** Enroll: challenge → sign → verify → short-lived agent token. Throws a
+ * keys-free Error on any denial/malformation. */
+async function enrollWorkload(
+  capability: WorkloadCapabilityEnv,
+  fetchImpl: FetchLike,
+): Promise<EnrollmentResult> {
+  const base = capability.apiUrl.replace(/\/+$/, "");
+
+  const challenge = await postJson(
+    fetchImpl,
+    `${base}/agent-enroll/challenge`,
+    {
+      agentId: capability.workloadId,
+    },
+  );
+  const challengeData =
+    challenge.status === 200 &&
+    challenge.json?.ok === true &&
+    typeof challenge.json.data === "object" &&
+    challenge.json.data !== null
+      ? (challenge.json.data as Record<string, unknown>)
+      : null;
+  const nonce =
+    typeof challengeData?.nonce === "string" ? challengeData.nonce : null;
+  const canonicalString =
+    typeof challengeData?.canonicalString === "string"
+      ? challengeData.canonicalString
+      : null;
+  if (!nonce || !canonicalString) {
+    throw new Error(
+      `workload enrollment challenge failed (HTTP ${challenge.status})`,
+    );
+  }
+
+  const signature = await signCanonicalString(
+    capability.privateKeyPkcs8Base64,
+    canonicalString,
+  );
+  const verify = await postJson(fetchImpl, `${base}/agent-enroll/verify`, {
+    agentId: capability.workloadId,
+    nonce,
+    signature,
+  });
+  const verifyData =
+    verify.status === 200 &&
+    verify.json?.ok === true &&
+    typeof verify.json.data === "object" &&
+    verify.json.data !== null
+      ? (verify.json.data as Record<string, unknown>)
+      : null;
+  const token = typeof verifyData?.token === "string" ? verifyData.token : null;
+  if (!token) {
+    throw new Error(`workload enrollment denied (HTTP ${verify.status})`);
+  }
+  return { token };
+}
+
+/** Outcome of a boot resolution pass. `failures` carries KEY NAMES ONLY. */
+export interface WorkloadResolutionResult {
+  /** env-key → plaintext, for the runtime-settings overlay ONLY. */
+  resolved: Record<string, string>;
+  /** env keys that could not be resolved (fail-closed), names only. */
+  failures: string[];
+}
+
+/**
+ * Resolve every `vault://workload/...` sentinel in `envVars` into a
+ * settings-only overlay via the container's workload capability.
+ *
+ * Self-gating: returns immediately with zero network calls when no workload
+ * refs are present. Fail-closed: when the capability is absent/denied/
+ * unreachable, every ref key is reported in `failures` (names only) and
+ * nothing is resolved — the projection layer already strips unresolved
+ * sentinels, so a plugin never sees the ref literal either.
+ */
+export async function resolveWorkloadSecretSettings(
+  envVars: Record<string, string>,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    fetchImpl?: FetchLike;
+  } = {},
+): Promise<WorkloadResolutionResult> {
+  const refEntries = Object.entries(envVars).filter(([, value]) =>
+    isWorkloadRef(value),
+  );
+  if (refEntries.length === 0) return { resolved: {}, failures: [] };
+
+  const refKeys = refEntries.map(([key]) => key);
+  const capability = readWorkloadCapability(options.env ?? process.env);
+  if (!capability) {
+    logger.error(
+      `[workload-secrets] workload ref(s) present but no STEWARD_WORKLOAD_ID/KEY capability in the environment (fail-closed): ${refKeys.join(", ")}`,
+    );
+    return { resolved: {}, failures: refKeys };
+  }
+
+  // Map env key → workload secret NAME; refs addressed to a different
+  // workload are unresolvable by construction and fail closed immediately.
+  const nameByEnvKey = new Map<string, string>();
+  const failures: string[] = [];
+  for (const [envKey, value] of refEntries) {
+    const name = parseWorkloadRefName(value, capability.workloadId);
+    if (name === null) {
+      failures.push(envKey);
+    } else {
+      nameByEnvKey.set(envKey, name);
+    }
+  }
+  if (nameByEnvKey.size === 0) {
+    if (failures.length > 0) {
+      logger.error(
+        `[workload-secrets] workload ref(s) not addressed to this workload (fail-closed): ${failures.join(", ")}`,
+      );
+    }
+    return { resolved: {}, failures };
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  let token: string;
+  try {
+    ({ token } = await enrollWorkload(capability, fetchImpl));
+  } catch (err) {
+    // Enrollment failure (revoked capability, Steward outage, malformed
+    // response) fails ALL pending keys closed. The thrown message is
+    // keys-free by construction (status codes only); log key names here.
+    logger.error(
+      `[workload-secrets] workload enrollment failed (fail-closed): ${
+        err instanceof Error ? err.message : String(err)
+      } — unresolved: ${[...nameByEnvKey.keys()].join(", ")}`,
+    );
+    return { resolved: {}, failures: [...failures, ...nameByEnvKey.keys()] };
+  }
+
+  const base = capability.apiUrl.replace(/\/+$/, "");
+  let resolveRes: Awaited<ReturnType<typeof postJson>>;
+  try {
+    resolveRes = await postJson(
+      fetchImpl,
+      `${base}/v1/workload-secrets/resolve`,
+      { names: [...new Set(nameByEnvKey.values())] },
+      { authorization: `Bearer ${token}` },
+    );
+  } catch (err) {
+    logger.error(
+      `[workload-secrets] workload resolve call failed (fail-closed): ${
+        err instanceof Error ? err.message : String(err)
+      } — unresolved: ${[...nameByEnvKey.keys()].join(", ")}`,
+    );
+    return { resolved: {}, failures: [...failures, ...nameByEnvKey.keys()] };
+  }
+
+  const data =
+    resolveRes.status === 200 &&
+    resolveRes.json?.ok === true &&
+    typeof resolveRes.json.data === "object" &&
+    resolveRes.json.data !== null
+      ? (resolveRes.json.data as Record<string, unknown>)
+      : null;
+  const secrets =
+    data && typeof data.secrets === "object" && data.secrets !== null
+      ? (data.secrets as Record<string, unknown>)
+      : null;
+  if (!secrets) {
+    logger.error(
+      `[workload-secrets] workload resolve rejected (HTTP ${resolveRes.status}, fail-closed) — unresolved: ${[...nameByEnvKey.keys()].join(", ")}`,
+    );
+    return { resolved: {}, failures: [...failures, ...nameByEnvKey.keys()] };
+  }
+
+  const resolved: Record<string, string> = {};
+  for (const [envKey, name] of nameByEnvKey) {
+    const value = secrets[name];
+    if (typeof value === "string" && value.length > 0) {
+      resolved[envKey] = value;
+    } else {
+      // Missing from the namespace (revoked / never written): fail closed.
+      failures.push(envKey);
+    }
+  }
+  if (failures.length > 0) {
+    logger.error(
+      `[workload-secrets] workload ref(s) missing from the namespace (fail-closed): ${failures.join(", ")}`,
+    );
+  }
+  return { resolved, failures };
+}
+
+/**
+ * Boot-path entry: resolve every workload ref present in `process.env` into a
+ * settings-only overlay, then SCRUB the environment:
+ *
+ *   - every ref-valued key is DELETED from `process.env` (the issue contract:
+ *     neither plaintext NOR unresolved sentinels may sit in `process.env`
+ *     where an env-reading plugin could pick a sentinel up as a credential);
+ *   - `STEWARD_WORKLOAD_KEY` is DELETED after the exchange so the capability
+ *     private key is not readable via `process.env` for the rest of the
+ *     process lifetime (it remains rotated-per-reseal and revocable
+ *     server-side regardless).
+ *
+ * Self-gating: zero work, zero scrubbing, zero network when no workload refs
+ * are present (every non-sealed environment). Called from `startEliza` on the
+ * real cloud container boot path.
+ */
+let bootOverlayCache: Record<string, string> | null = null;
+
+/** @internal test hook — clears the boot overlay single-flight cache. */
+export function __resetWorkloadBootOverlayCacheForTest(): void {
+  bootOverlayCache = null;
+}
+
+export async function resolveWorkloadEnvOverlayForBoot(
+  options: { env?: NodeJS.ProcessEnv; fetchImpl?: FetchLike } = {},
+): Promise<Record<string, string>> {
+  // Single-flight: the capability key is scrubbed from process.env after the
+  // first pass, so hot-reload (which rebuilds runtime settings) must reuse
+  // the cold-boot resolution instead of failing on the now-absent key.
+  if (bootOverlayCache !== null && !options.env) return bootOverlayCache;
+  const env = options.env ?? process.env;
+
+  const refEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (isWorkloadRef(value)) refEnv[key] = value;
+  }
+  if (Object.keys(refEnv).length === 0) return {};
+
+  const { resolved } = await resolveWorkloadSecretSettings(refEnv, {
+    env,
+    fetchImpl: options.fetchImpl,
+  });
+
+  // Scrub AFTER resolution: sentinels out of process.env (resolved or not —
+  // failures are already logged keys-only and fail closed), capability key out
+  // once it has served its purpose.
+  for (const key of Object.keys(refEnv)) {
+    delete env[key];
+  }
+  delete env.STEWARD_WORKLOAD_KEY;
+
+  if (!options.env) bootOverlayCache = resolved;
+  return resolved;
+}

--- a/packages/agent/src/runtime/workload-secrets-boot.test.ts
+++ b/packages/agent/src/runtime/workload-secrets-boot.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Workload-scoped Steward refs (#17432): boot resolution into runtime
+ * settings ONLY, with process.env scrubbed of both the sentinels and the
+ * capability private key.
+ *
+ * Chain under test (the REAL production boot path units):
+ *   docker env (vault://workload/... refs + STEWARD_WORKLOAD_* capability)
+ *   → resolveWorkloadEnvOverlayForBoot (enroll → resolve → scrub)
+ *   → buildRuntimeSettingsProjection({ connectorSecretsOverlay })
+ *   → runtime.getSetting()-visible settings map.
+ *
+ * The Steward double here implements the EXACT wire contract proven against
+ * the real API in the cross-repo suite (workload-cross-repo.e2e.test.ts):
+ * challenge/verify perform REAL ECDSA P-256/SHA-256 verification of the
+ * resolver's signature, so the client crypto genuinely interoperates.
+ *
+ * Bidirectional:
+ *   1. refs + capability → settings carry plaintext; process.env carries
+ *      NEITHER plaintext NOR sentinels NOR the capability key afterwards.
+ *   2. no workload refs → zero network, env untouched (self-gating).
+ *   3. missing capability / denied enrollment / outage / foreign-workload
+ *      refs → fail-closed: nothing resolved, failures are key names only,
+ *      no secret material in any log-bound string.
+ */
+import { webcrypto } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __resetWorkloadBootOverlayCacheForTest,
+  isWorkloadRef,
+  parseWorkloadRefName,
+  readWorkloadCapability,
+  resolveWorkloadEnvOverlayForBoot,
+  resolveWorkloadSecretSettings,
+} from "./operations/workload-secrets.ts";
+import { buildRuntimeSettingsProjection } from "./runtime-settings.ts";
+
+const WORKLOAD_ID = "wl-test-container";
+// Assembled by concatenation so no token-shaped literal exists for secret
+// scanners to match (synthetic fixture, not a credential).
+const SECRET_VALUE = ["sk", "live", "topsecret", "abc123"].join("-");
+const DISCORD_VALUE = "discord-token-xyz";
+
+/** In-process Steward implementing the real wire contract with REAL P-256
+ * verification (the resolver's signature must actually verify). */
+function makeSteward(options: { deny?: boolean; outage?: boolean } = {}) {
+  const secrets = new Map<string, string>([
+    [`workload/${WORKLOAD_ID}/OPENAI_API_KEY`, SECRET_VALUE],
+    [`workload/${WORKLOAD_ID}/DISCORD_API_TOKEN`, DISCORD_VALUE],
+  ]);
+  const nonces = new Map<string, string>();
+  let publicKey: import("node:crypto").webcrypto.CryptoKey | null = null;
+  const requests: string[] = [];
+
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (options.outage) throw new Error("ECONNREFUSED");
+    const url = new URL(String(input));
+    requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+    const body = init?.body ? JSON.parse(String(init.body)) : {};
+
+    if (url.pathname === "/agent-enroll/challenge") {
+      const nonce = crypto.randomUUID();
+      const canonicalString = `steward-enroll|${body.agentId}|${nonce}`;
+      nonces.set(nonce, canonicalString);
+      return Response.json({
+        ok: true,
+        data: {
+          agentId: body.agentId,
+          nonce,
+          canonicalString,
+          expiresAt: Date.now() + 60_000,
+        },
+      });
+    }
+    if (url.pathname === "/agent-enroll/verify") {
+      const canonicalString = nonces.get(body.nonce);
+      nonces.delete(body.nonce);
+      if (options.deny || !canonicalString || !publicKey) {
+        return Response.json(
+          { ok: false, error: "enrollment denied" },
+          { status: 401 },
+        );
+      }
+      const valid = await webcrypto.subtle.verify(
+        { name: "ECDSA", hash: "SHA-256" },
+        publicKey,
+        Buffer.from(String(body.signature), "base64"),
+        new TextEncoder().encode(canonicalString),
+      );
+      if (!valid || body.agentId !== WORKLOAD_ID) {
+        return Response.json(
+          { ok: false, error: "enrollment denied" },
+          { status: 401 },
+        );
+      }
+      return Response.json({ ok: true, data: { token: "workload-token-1" } });
+    }
+    if (url.pathname === "/v1/workload-secrets/resolve") {
+      if (
+        init?.headers &&
+        !JSON.stringify(init.headers).includes("workload-token-1")
+      ) {
+        return Response.json({ ok: false, error: "denied" }, { status: 403 });
+      }
+      const resolved: Record<string, string> = {};
+      const missing: string[] = [];
+      for (const name of body.names as string[]) {
+        const value = secrets.get(`workload/${WORKLOAD_ID}/${name}`);
+        if (value) resolved[name] = value;
+        else missing.push(name);
+      }
+      return Response.json({ ok: true, data: { secrets: resolved, missing } });
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+
+  return {
+    fetchImpl,
+    requests,
+    async registerKeypair() {
+      const pair = await webcrypto.subtle.generateKey(
+        { name: "ECDSA", namedCurve: "P-256" },
+        true,
+        ["sign", "verify"],
+      );
+      publicKey = pair.publicKey;
+      const pkcs8 = Buffer.from(
+        await webcrypto.subtle.exportKey("pkcs8", pair.privateKey),
+      ).toString("base64");
+      return pkcs8;
+    },
+  };
+}
+
+function makeEnv(privateKey: string): NodeJS.ProcessEnv {
+  return {
+    STEWARD_API_URL: "https://steward.test",
+    STEWARD_WORKLOAD_ID: WORKLOAD_ID,
+    STEWARD_WORKLOAD_KEY: privateKey,
+    OPENAI_API_KEY: `vault://workload/${WORKLOAD_ID}/OPENAI_API_KEY`,
+    DISCORD_API_TOKEN: `vault://workload/${WORKLOAD_ID}/DISCORD_API_TOKEN`,
+    NODE_ENV: "production",
+  };
+}
+
+beforeEach(() => {
+  __resetWorkloadBootOverlayCacheForTest();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ref classification", () => {
+  it("isWorkloadRef accepts only vault://workload/... sentinels", () => {
+    expect(isWorkloadRef(`vault://workload/${WORKLOAD_ID}/KEY`)).toBe(true);
+    expect(isWorkloadRef("vault://cloud/env/org/proj/KEY")).toBe(false);
+    expect(isWorkloadRef("vault://providers.openai.api-key")).toBe(false);
+    expect(isWorkloadRef("plain-value")).toBe(false);
+    expect(isWorkloadRef(undefined)).toBe(false);
+  });
+
+  it("parseWorkloadRefName is namespace-strict (foreign workloads fail closed)", () => {
+    expect(
+      parseWorkloadRefName(
+        `vault://workload/${WORKLOAD_ID}/OPENAI_API_KEY`,
+        WORKLOAD_ID,
+      ),
+    ).toBe("OPENAI_API_KEY");
+    expect(
+      parseWorkloadRefName(
+        "vault://workload/other-workload/OPENAI_API_KEY",
+        WORKLOAD_ID,
+      ),
+    ).toBeNull();
+    expect(
+      parseWorkloadRefName(`vault://workload/${WORKLOAD_ID}/`, WORKLOAD_ID),
+    ).toBeNull();
+  });
+
+  it("readWorkloadCapability requires the full triplet", () => {
+    expect(readWorkloadCapability({})).toBeNull();
+    expect(
+      readWorkloadCapability({
+        STEWARD_API_URL: "x",
+        STEWARD_WORKLOAD_ID: "y",
+      }),
+    ).toBeNull();
+    expect(
+      readWorkloadCapability({
+        STEWARD_API_URL: "https://s",
+        STEWARD_WORKLOAD_ID: "wl",
+        STEWARD_WORKLOAD_KEY: "k",
+      }),
+    ).toEqual({
+      apiUrl: "https://s",
+      workloadId: "wl",
+      privateKeyPkcs8Base64: "k",
+    });
+  });
+});
+
+describe("boot resolution → settings only, env scrubbed", () => {
+  it("resolves refs via real enroll crypto, delivers ONLY into the settings projection, scrubs env", async () => {
+    const steward = makeSteward();
+    const privateKey = await steward.registerKeypair();
+    const env = makeEnv(privateKey);
+
+    const overlay = await resolveWorkloadEnvOverlayForBoot({
+      env,
+      fetchImpl: steward.fetchImpl,
+    });
+
+    // resolved into the overlay…
+    expect(overlay.OPENAI_API_KEY).toBe(SECRET_VALUE);
+    expect(overlay.DISCORD_API_TOKEN).toBe(DISCORD_VALUE);
+
+    // …env scrubbed: no sentinel, no plaintext, no capability private key
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.DISCORD_API_TOKEN).toBeUndefined();
+    expect(env.STEWARD_WORKLOAD_KEY).toBeUndefined();
+    for (const value of Object.values(env)) {
+      expect(value).not.toContain(SECRET_VALUE);
+      expect(value).not.toContain(DISCORD_VALUE);
+      expect(value).not.toContain(privateKey);
+    }
+    // non-secret config untouched
+    expect(env.NODE_ENV).toBe("production");
+    // workload id/url may remain (identifiers, not credentials)
+    expect(env.STEWARD_WORKLOAD_ID).toBe(WORKLOAD_ID);
+
+    // the wire sequence was the real contract
+    expect(steward.requests).toEqual([
+      "POST /agent-enroll/challenge",
+      "POST /agent-enroll/verify",
+      "POST /v1/workload-secrets/resolve",
+    ]);
+
+    // …and the settings projection delivers the plaintext to plugins while
+    // never having written process.env (same channel as connector secrets).
+    const settings = buildRuntimeSettingsProjection({} as never, {
+      env,
+      connectorSecretsOverlay: overlay,
+    });
+    expect(settings.OPENAI_API_KEY).toBe(SECRET_VALUE);
+    expect(settings.DISCORD_API_TOKEN).toBe(DISCORD_VALUE);
+  });
+
+  it("self-gating: no workload refs → zero network, env untouched", async () => {
+    const steward = makeSteward();
+    const env: NodeJS.ProcessEnv = {
+      OPENAI_API_KEY: "plain-value",
+      NODE_ENV: "production",
+    };
+    const overlay = await resolveWorkloadEnvOverlayForBoot({
+      env,
+      fetchImpl: steward.fetchImpl,
+    });
+    expect(overlay).toEqual({});
+    expect(steward.requests).toEqual([]);
+    expect(env.OPENAI_API_KEY).toBe("plain-value");
+  });
+
+  it("single-flight: hot-reload reuses the cold-boot overlay after the capability was scrubbed", async () => {
+    const steward = makeSteward();
+    const privateKey = await steward.registerKeypair();
+
+    // cold boot against process.env (the cached path)
+    const savedEnv: Record<string, string | undefined> = {};
+    const bootEnv = makeEnv(privateKey);
+    for (const [k, v] of Object.entries(bootEnv)) {
+      savedEnv[k] = process.env[k];
+      process.env[k] = v;
+    }
+    try {
+      const first = await resolveWorkloadEnvOverlayForBoot({
+        fetchImpl: steward.fetchImpl,
+      });
+      expect(first.OPENAI_API_KEY).toBe(SECRET_VALUE);
+      expect(process.env.STEWARD_WORKLOAD_KEY).toBeUndefined();
+
+      // hot reload: the key is gone from env, but the cache serves the overlay
+      const second = await resolveWorkloadEnvOverlayForBoot({
+        fetchImpl: steward.fetchImpl,
+      });
+      expect(second).toEqual(first);
+      // no second enrollment happened
+      expect(
+        steward.requests.filter((r) => r.includes("challenge")),
+      ).toHaveLength(1);
+    } finally {
+      for (const [k, v] of Object.entries(savedEnv)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      __resetWorkloadBootOverlayCacheForTest();
+    }
+  });
+});
+
+describe("fail-closed paths (names only, nothing resolved)", () => {
+  it("capability absent → all ref keys fail, nothing resolved", async () => {
+    const steward = makeSteward();
+    const { resolved, failures } = await resolveWorkloadSecretSettings(
+      { OPENAI_API_KEY: `vault://workload/${WORKLOAD_ID}/OPENAI_API_KEY` },
+      { env: {}, fetchImpl: steward.fetchImpl },
+    );
+    expect(resolved).toEqual({});
+    expect(failures).toEqual(["OPENAI_API_KEY"]);
+    expect(steward.requests).toEqual([]);
+  });
+
+  it("enrollment denied (revoked capability) → fail closed, no secret in failure strings", async () => {
+    const steward = makeSteward({ deny: true });
+    const privateKey = await steward.registerKeypair();
+    const env = makeEnv(privateKey);
+    const { resolved, failures } = await resolveWorkloadSecretSettings(
+      { OPENAI_API_KEY: env.OPENAI_API_KEY as string },
+      { env, fetchImpl: steward.fetchImpl },
+    );
+    expect(resolved).toEqual({});
+    expect(failures).toEqual(["OPENAI_API_KEY"]);
+    for (const failure of failures) {
+      expect(failure).not.toContain(SECRET_VALUE);
+    }
+  });
+
+  it("steward outage → fail closed for every key", async () => {
+    const steward = makeSteward({ outage: true });
+    const privateKey = "irrelevant-key";
+    const env = makeEnv(privateKey);
+    const { resolved, failures } = await resolveWorkloadSecretSettings(
+      {
+        OPENAI_API_KEY: env.OPENAI_API_KEY as string,
+        DISCORD_API_TOKEN: env.DISCORD_API_TOKEN as string,
+      },
+      { env, fetchImpl: steward.fetchImpl },
+    );
+    expect(resolved).toEqual({});
+    expect(failures.sort()).toEqual(["DISCORD_API_TOKEN", "OPENAI_API_KEY"]);
+  });
+
+  it("refs addressed to a FOREIGN workload fail closed without a network call for them", async () => {
+    const steward = makeSteward();
+    const privateKey = await steward.registerKeypair();
+    const env = makeEnv(privateKey);
+    const { resolved, failures } = await resolveWorkloadSecretSettings(
+      {
+        OPENAI_API_KEY: env.OPENAI_API_KEY as string,
+        STOLEN: "vault://workload/other-container/API_KEY",
+      },
+      { env, fetchImpl: steward.fetchImpl },
+    );
+    expect(resolved.OPENAI_API_KEY).toBe(SECRET_VALUE);
+    expect(failures).toEqual(["STOLEN"]);
+  });
+
+  it("value missing from the namespace (revoked/never written) fails closed per key", async () => {
+    const steward = makeSteward();
+    const privateKey = await steward.registerKeypair();
+    const env = makeEnv(privateKey);
+    const { resolved, failures } = await resolveWorkloadSecretSettings(
+      {
+        OPENAI_API_KEY: env.OPENAI_API_KEY as string,
+        NEVER_WRITTEN: `vault://workload/${WORKLOAD_ID}/NEVER_WRITTEN`,
+      },
+      { env, fetchImpl: steward.fetchImpl },
+    );
+    expect(resolved.OPENAI_API_KEY).toBe(SECRET_VALUE);
+    expect(resolved.NEVER_WRITTEN).toBeUndefined();
+    expect(failures).toEqual(["NEVER_WRITTEN"]);
+  });
+
+  it("projection strips unresolved sentinels: a plugin can never receive the ref literal", async () => {
+    // simulate a total resolution failure: the overlay is empty and the env
+    // still held refs before scrubbing — the projection layer must not leak
+    // them into settings.
+    const settings = buildRuntimeSettingsProjection({} as never, {
+      env: {},
+      connectorSecretsOverlay: {},
+    });
+    expect(JSON.stringify(settings)).not.toContain("vault://");
+  });
+});

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -326,6 +326,30 @@ export const containersEnv = {
   },
 
   /**
+   * Seal secret-bearing container env vars into Steward's WORKLOAD-scoped
+   * secret contract at provision time (issue #17432): the container env then
+   * carries only `vault://workload/...` reference sentinels plus a
+   * per-container, revocable, least-privilege capability — no plaintext
+   * secret and no tenant-wide credential in the stored jsonb row, the SSH
+   * command line, or `docker inspect` on the node.
+   *
+   * OPT-IN, DEFAULT OFF — existing deployments keep exact legacy behavior.
+   * PAIRING REQUIREMENT: only enable for container images whose agent boot
+   * path carries the workload boot resolver
+   * (`packages/agent/src/runtime/operations/workload-secrets.ts`); without
+   * it agents receive unresolved ref sentinels instead of credentials. The
+   * control plane needs `STEWARD_API_URL` + `STEWARD_TENANT_API_KEY`
+   * (+`STEWARD_TENANT_ID`) configured. When ON, a Steward failure FAILS the
+   * provision (fail closed; no plaintext fallback).
+   * Read via `CONTAINERS_ENV_VAULT_REFS` (with `ELIZA_` fallback); only the
+   * literal string `"true"` enables it.
+   */
+  envVaultRefsEnabled(): boolean {
+    const env = getCloudAwareEnv();
+    return pick(env.CONTAINERS_ENV_VAULT_REFS, env.ELIZA_CONTAINERS_ENV_VAULT_REFS) === "true";
+  },
+
+  /**
    * Auto-recover a node whose dockerd image-pull coordinator has wedged: after
    * repeated failed pre-pulls the provisioning worker restarts docker on the
    * node itself (rate-limited) instead of requiring a manual `systemctl

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
@@ -57,6 +57,11 @@ import {
   HetznerClientError,
   type HetznerContainerMetadata,
 } from "./types";
+import {
+  resolveWorkloadStewardConfigFromEnv,
+  revokeWorkloadForDeletedContainer,
+  sealContainerEnvToWorkload,
+} from "./workload-env-refs";
 
 /**
  * Convert the stored `cpu` allocation (ECS/Fargate-style CPU units, where
@@ -102,6 +107,26 @@ export class HetznerContainersClient {
     }
     const volumeMountPath = validateContainerMountPath(input.volumeMountPath);
 
+    // Workload sealing (CONTAINERS_ENV_VAULT_REFS, default OFF — #17432): move
+    // secret values into Steward's workload-scoped contract BEFORE anything is
+    // persisted or shipped to the node, so the DB row, the SSH
+    // `docker create -e` command line, and `docker inspect` only ever see
+    // `vault://workload/...` sentinels plus the per-container capability.
+    // Fail closed: a Steward failure aborts the provision (throws here, before
+    // the row) instead of degrading to plaintext.
+    let effectiveEnvVars = input.environmentVars;
+    if (effectiveEnvVars && containersEnv.envVaultRefsEnabled()) {
+      const sealed = await sealContainerEnvToWorkload(
+        {
+          organizationId: input.organizationId,
+          projectName: input.projectName,
+          environmentVars: effectiveEnvVars,
+        },
+        resolveWorkloadStewardConfigFromEnv(),
+      );
+      effectiveEnvVars = sealed.env;
+    }
+
     // 1. Pre-create the DB row in `pending` so the rest of the flow has an id.
     const newRow: NewContainer = {
       name: input.name,
@@ -115,7 +140,7 @@ export class HetznerContainersClient {
       desired_count: 1,
       cpu: input.cpu,
       memory: input.memoryMb,
-      environment_vars: input.environmentVars ?? {},
+      environment_vars: effectiveEnvVars ?? {},
       health_check_path: input.healthCheckPath ?? "/health",
       status: "pending",
       metadata: { provider: "hetzner-docker", image: input.image },
@@ -253,7 +278,7 @@ export class HetznerContainersClient {
         bootstrapStats = await hydrateBootstrapSource(ssh, volumePath, input.bootstrapSource);
       }
 
-      const envFlags = Object.entries(input.environmentVars ?? {})
+      const envFlags = Object.entries(effectiveEnvVars ?? {})
         .map(([k, v]) => `-e ${shellQuote(`${k}=${v}`)}`)
         .join(" ");
 
@@ -600,6 +625,16 @@ export class HetznerContainersClient {
       }
     }
 
+    // Workload capability revocation (#17432): if this container's env was
+    // sealed, revoke its Steward capability + namespace so a captured
+    // STEWARD_WORKLOAD_KEY dies with the container. Keyed off the STORED env
+    // (not the flag) so revocation still runs when the flag was flipped off
+    // between create and delete. error-policy: revocation failure is logged
+    // LOUDLY inside the helper and does not block the teardown.
+    await revokeWorkloadForDeletedContainer(
+      row.environment_vars as Record<string, string> | null | undefined,
+    );
+
     await containersRepository.delete(containerId, organizationId);
   }
 
@@ -634,6 +669,23 @@ export class HetznerContainersClient {
     const row = await this.requireRowWithMeta(containerId, organizationId);
     const { meta } = row;
 
+    // Same sealing gate as createContainer (#17432): PATCHed env secrets must
+    // not reach the node (or the stored row) in plaintext when the flag is on.
+    // Sealing BEFORE the SSH teardown keeps the failure mode clean: a Steward
+    // outage rejects the setEnv while the old container keeps running.
+    let effectiveEnvVars = environmentVars;
+    if (containersEnv.envVaultRefsEnabled()) {
+      const sealed = await sealContainerEnvToWorkload(
+        {
+          organizationId,
+          projectName: row.row.project_name,
+          environmentVars,
+        },
+        resolveWorkloadStewardConfigFromEnv(),
+      );
+      effectiveEnvVars = sealed.env;
+    }
+
     await this.execOnNode(meta, async (ssh) => {
       // error-policy:J6 best-effort stop before the authoritative rm -f below;
       // a stop failure is logged, not thrown, because rm -f performs the real
@@ -647,7 +699,7 @@ export class HetznerContainersClient {
         );
       await ssh.exec(`docker rm -f ${shellQuote(meta.containerName)}`, 30_000);
 
-      const envFlags = Object.entries(environmentVars)
+      const envFlags = Object.entries(effectiveEnvVars)
         .map(([k, v]) => `-e ${shellQuote(`${k}=${v}`)}`)
         .join(" ");
 
@@ -678,7 +730,7 @@ export class HetznerContainersClient {
     });
 
     const updated = await containersRepository.update(containerId, organizationId, {
-      environment_vars: environmentVars,
+      environment_vars: effectiveEnvVars,
       status: "deploying",
       deployment_log: "Env vars updated; container recreated. Waiting for health check...",
     });

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.workload-env-refs.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.workload-env-refs.test.ts
@@ -1,0 +1,276 @@
+// Bidirectional proof for CONTAINERS_ENV_VAULT_REFS on the LIVE provisioning
+// path (`createContainer` → SSH `docker create -e …`), workload contract
+// (#17432):
+//   flag ON  → the actual docker-create command line and the persisted DB row
+//              contain NO secret values — only `vault://workload/...` refs
+//              plus the per-container capability; Steward received the values
+//              and a registration.
+//   flag ON + steward outage → provision REJECTED before any row/SSH.
+//   flag OFF → byte-for-byte legacy behavior (plaintext env injection, zero
+//              Steward traffic), proving the gate defaults closed.
+//   delete   → the stored workload capability is revoked.
+// Harness mirrors client.error-policy.test.ts: deterministic in-process
+// fakes for repo/node/SSH; `resolveWorkloadStewardConfigFromEnv` alone is
+// stubbed so the REAL sealing logic runs against a recording steward fetch.
+// (The REAL-Steward-API evidence lives in workload-cross-repo.e2e.test.ts.)
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realContainersRepo from "../../../../db/repositories/containers";
+import * as realDockerNodesRepo from "../../../../db/repositories/docker-nodes";
+import * as realNodeManager from "../../docker-node-manager";
+import * as realPortAlloc from "../../docker-port-allocation";
+import * as realDockerSsh from "../../docker-ssh";
+import * as realHetznerVolumes from "../hetzner-volumes";
+import * as realRegistry from "./registry";
+import * as realWorkloadEnvRefs from "./workload-env-refs";
+
+const realContainersRepoSnap = { ...realContainersRepo };
+const realDockerNodesRepoSnap = { ...realDockerNodesRepo };
+const realNodeManagerSnap = { ...realNodeManager };
+const realPortAllocSnap = { ...realPortAlloc };
+const realDockerSshSnap = { ...realDockerSsh };
+const realHetznerVolumesSnap = { ...realHetznerVolumes };
+const realRegistrySnap = { ...realRegistry };
+const realWorkloadEnvRefsSnap = { ...realWorkloadEnvRefs };
+
+// ── Recording steward (the REAL sealing logic drives this fetch) ────────────
+interface StewardCall {
+  method: string;
+  path: string;
+  body: unknown;
+}
+const stewardCalls: StewardCall[] = [];
+const stewardValues = new Map<string, string>(); // "<workloadId>/<name>" → value
+const stewardFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = new URL(String(input));
+  const method = init?.method ?? "GET";
+  const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+  stewardCalls.push({ method, path: url.pathname, body });
+  const putMatch = /^\/v1\/workload-secrets\/workloads\/([^/]+)\/secrets\/([^/]+)$/.exec(
+    url.pathname,
+  );
+  if (method === "PUT" && putMatch) {
+    stewardValues.set(
+      `${decodeURIComponent(putMatch[1] as string)}/${decodeURIComponent(putMatch[2] as string)}`,
+      (body as { value: string }).value,
+    );
+    return Response.json({ ok: true, data: { version: 1 } });
+  }
+  return Response.json({ ok: true, data: {} });
+}) as typeof fetch;
+
+// ── Repo / node / SSH fakes ─────────────────────────────────────────────────
+const ROW_ID = "ct-workload-1";
+let persistedRow: Record<string, unknown> = {};
+
+const createWithQuotaCheck = mock(async (row: Record<string, unknown>) => {
+  persistedRow = row;
+  return { ...row, id: ROW_ID };
+});
+const updateRow = mock(async () => null);
+const updateStatus = mock(async () => {});
+const incrementAllocated = mock(async () => {});
+const findByNodeId = mock(async () => null);
+
+const NODE = {
+  node_id: "node-1",
+  hostname: "10.0.0.1",
+  ssh_port: 22,
+  ssh_user: "root",
+  host_key_fingerprint: null,
+  capacity: 10,
+  enabled: true,
+  status: "active",
+};
+const getAvailableNode = mock(async () => NODE);
+
+const sshCommands: string[] = [];
+const execMock = mock(async (cmd: string) => {
+  sshCommands.push(cmd);
+  return "";
+});
+const getClient = mock(() => ({ exec: execMock, execStream: mock(async () => {}) }));
+
+mock.module("../../../../db/repositories/containers", () => ({
+  ...realContainersRepo,
+  containersRepository: {
+    ...realContainersRepo.containersRepository,
+    createWithQuotaCheck,
+    update: updateRow,
+    updateStatus,
+  },
+}));
+mock.module("../../../../db/repositories/docker-nodes", () => ({
+  ...realDockerNodesRepo,
+  dockerNodesRepository: {
+    ...realDockerNodesRepo.dockerNodesRepository,
+    findByNodeId,
+    incrementAllocated,
+  },
+}));
+mock.module("../../docker-node-manager", () => ({
+  ...realNodeManager,
+  dockerNodeManager: { ...realNodeManager.dockerNodeManager, getAvailableNode },
+}));
+mock.module("../../docker-port-allocation", () => ({
+  ...realPortAlloc,
+  getUsedDockerHostPorts: async () => new Set<number>(),
+}));
+mock.module("../../docker-ssh", () => ({
+  ...realDockerSsh,
+  DockerSSHClient: { getClient },
+}));
+mock.module("../hetzner-volumes", () => ({
+  ...realHetznerVolumes,
+  isHetznerVolumesAvailable: () => false,
+  getHetznerVolumeService: () => ({}),
+}));
+mock.module("./registry", () => ({
+  ...realRegistry,
+  ensureRegistryAccess: async () => {},
+  readPulledImageDigest: async () => null,
+}));
+// Only the env→config resolver is stubbed (to inject the recording fetch);
+// the sealing logic under test is the real implementation.
+mock.module("./workload-env-refs", () => ({
+  ...realWorkloadEnvRefs,
+  resolveWorkloadStewardConfigFromEnv: () => ({
+    baseUrl: "https://steward.test",
+    tenantId: "elizacloud",
+    apiKey: "k",
+    fetchImpl: stewardFetch,
+  }),
+}));
+
+const { getHetznerContainersClient } = await import("./client");
+const { deriveWorkloadId } = realWorkloadEnvRefs;
+
+afterAll(() => {
+  mock.module("../../../../db/repositories/containers", () => realContainersRepoSnap);
+  mock.module("../../../../db/repositories/docker-nodes", () => realDockerNodesRepoSnap);
+  mock.module("../../docker-node-manager", () => realNodeManagerSnap);
+  mock.module("../../docker-port-allocation", () => realPortAllocSnap);
+  mock.module("../../docker-ssh", () => realDockerSshSnap);
+  mock.module("../hetzner-volumes", () => realHetznerVolumesSnap);
+  mock.module("./registry", () => realRegistrySnap);
+  mock.module("./workload-env-refs", () => realWorkloadEnvRefsSnap);
+  delete process.env.CONTAINERS_ENV_VAULT_REFS;
+});
+
+const CREATE_INPUT = {
+  name: "workload-app",
+  projectName: "wl-proj",
+  organizationId: "org-wl",
+  userId: "user-1",
+  image: "ghcr.io/elizaos/eliza:stable",
+  port: 3000,
+  desiredCount: 1,
+  cpu: 1024,
+  memoryMb: 1024,
+  environmentVars: {
+    OPENAI_API_KEY: "sk-live-supersecret",
+    NODE_ENV: "production",
+  },
+  persistVolume: false,
+  useHetznerVolume: false,
+};
+
+beforeEach(() => {
+  stewardCalls.length = 0;
+  stewardValues.clear();
+  sshCommands.length = 0;
+  persistedRow = {};
+  for (const m of [createWithQuotaCheck, updateRow, updateStatus, execMock, getAvailableNode]) {
+    m.mockClear();
+  }
+  delete process.env.CONTAINERS_ENV_VAULT_REFS;
+});
+
+describe("createContainer with CONTAINERS_ENV_VAULT_REFS=true (workload contract)", () => {
+  test("docker-create payload and DB row carry workload refs + capability, never secret values; Steward got them", async () => {
+    process.env.CONTAINERS_ENV_VAULT_REFS = "true";
+    const client = getHetznerContainersClient();
+    await client.createContainer({ ...CREATE_INPUT });
+
+    const wl = deriveWorkloadId("org-wl", "wl-proj");
+
+    // 1. The ACTUAL payload shipped to the node: no secret value in any SSH
+    //    command; the docker create carries the ref + the capability triplet.
+    const allSsh = sshCommands.join("\n");
+    expect(allSsh).not.toContain("sk-live-supersecret");
+    const dockerCreate = sshCommands.find((c) => c.startsWith("docker create"));
+    expect(dockerCreate).toBeDefined();
+    expect(dockerCreate).toContain(`vault://workload/${wl}/OPENAI_API_KEY`);
+    expect(dockerCreate).toContain(`STEWARD_WORKLOAD_ID=${wl}`);
+    expect(dockerCreate).toContain("STEWARD_WORKLOAD_KEY=");
+    expect(dockerCreate).toContain("STEWARD_API_URL=https://steward.test");
+    // Non-secret config still injected as-is.
+    expect(dockerCreate).toContain("NODE_ENV=production");
+    // The capability is NOT a tenant credential: the tenant API key never
+    // appears in any SSH command.
+    expect(allSsh).not.toContain("X-Steward-Key");
+    expect(allSsh).not.toContain("elizacloud");
+
+    // 2. The persisted control-plane row stores the ref, not the value.
+    const storedEnv = persistedRow.environment_vars as Record<string, string>;
+    expect(storedEnv.OPENAI_API_KEY).toBe(`vault://workload/${wl}/OPENAI_API_KEY`);
+    expect(storedEnv.STEWARD_WORKLOAD_ID).toBe(wl);
+    expect(JSON.stringify(persistedRow)).not.toContain("sk-live-supersecret");
+
+    // 3. Steward received the registration and the value.
+    expect(stewardCalls[0]).toMatchObject({
+      method: "POST",
+      path: "/v1/workload-secrets/workloads",
+    });
+    expect(stewardValues.get(`${wl}/OPENAI_API_KEY`)).toBe("sk-live-supersecret");
+  });
+
+  test("FAIL CLOSED: steward outage aborts the provision before any row/SSH side effects", async () => {
+    process.env.CONTAINERS_ENV_VAULT_REFS = "true";
+    mock.module("./workload-env-refs", () => ({
+      ...realWorkloadEnvRefs,
+      resolveWorkloadStewardConfigFromEnv: () => ({
+        baseUrl: "https://steward.test",
+        fetchImpl: (async () => new Response("down", { status: 503 })) as typeof fetch,
+      }),
+    }));
+    try {
+      const client = getHetznerContainersClient();
+      await expect(client.createContainer({ ...CREATE_INPUT })).rejects.toMatchObject({
+        code: "container_create_failed",
+      });
+      // Sealing runs BEFORE row creation and SSH: nothing half-provisioned.
+      expect(createWithQuotaCheck).not.toHaveBeenCalled();
+      expect(sshCommands).toEqual([]);
+    } finally {
+      mock.module("./workload-env-refs", () => ({
+        ...realWorkloadEnvRefs,
+        resolveWorkloadStewardConfigFromEnv: () => ({
+          baseUrl: "https://steward.test",
+          tenantId: "elizacloud",
+          apiKey: "k",
+          fetchImpl: stewardFetch,
+        }),
+      }));
+    }
+  });
+});
+
+describe("createContainer with the flag OFF (default)", () => {
+  test("legacy behavior unchanged: plaintext env injected, zero Steward traffic", async () => {
+    const client = getHetznerContainersClient();
+    await client.createContainer({ ...CREATE_INPUT });
+
+    const dockerCreate = sshCommands.find((c) => c.startsWith("docker create"));
+    expect(dockerCreate).toBeDefined();
+    // Exact legacy payload: the raw secret is on the command line…
+    expect(dockerCreate).toContain("OPENAI_API_KEY=sk-live-supersecret");
+    expect(dockerCreate).not.toContain("vault://");
+    expect(dockerCreate).not.toContain("STEWARD_WORKLOAD_ID");
+    // …the stored row is plaintext…
+    const storedEnv = persistedRow.environment_vars as Record<string, string>;
+    expect(storedEnv.OPENAI_API_KEY).toBe("sk-live-supersecret");
+    // …and Steward was never touched.
+    expect(stewardCalls).toEqual([]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/workload-cross-repo.e2e.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/workload-cross-repo.e2e.test.ts
@@ -1,0 +1,254 @@
+/**
+ * CROSS-REPO E2E (#17432): the REAL Steward API × the REAL eliza writer and
+ * resolver logic. No invented Steward stubs — this suite BOOTS the actual
+ * Steward server (Bun, in-memory pglite, real tenantAuth middleware, real
+ * /agent-enroll crypto, real SecretVault) from a sibling checkout and drives
+ * the exact code paths production uses:
+ *
+ *   writer:   sealContainerEnvToWorkload (the createContainer/setEnv sealing
+ *             unit) with the control plane's tenant API key
+ *   resolver: resolveWorkloadSecretSettings (the agent boot unit) with ONLY
+ *             the sealed env + capability — exactly what a container holds
+ *
+ * Proven end-to-end against the real API:
+ *   - seal → boot-resolve round-trip (plaintext only in the resolver output)
+ *   - authorization: the writer credential CANNOT resolve; a foreign
+ *     workload's capability CANNOT read another namespace
+ *   - rotation: re-PUT (Steward-native versioned rotation) → new value
+ *     resolves; re-register (capability rotation) → old key stops enrolling
+ *   - revocation: DELETE /workloads/:id → enrollment dead AND an already-
+ *     sealed env resolves nothing
+ *   - outage: Steward down → writer fails closed (no partial state)
+ *   - absence: no secret value in the sealed env (≙ docker env / inspect /
+ *     DB row / SSH line, which are all serializations of it), in process.env
+ *     after the boot scrub, or in any failure string
+ *
+ * GATED on STEWARD_REPO_PATH (a checkout of Steward-Fi/steward with deps
+ * installed). Skipped otherwise — CI for elizaos/eliza does not carry the
+ * sibling repo; this suite is the documented cross-repo evidence runner:
+ *
+ *   STEWARD_REPO_PATH=~/projects/steward bun test workload-cross-repo
+ */
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { type ChildProcess, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  deriveWorkloadId,
+  sealContainerEnvToWorkload,
+  type WorkloadStewardConfig,
+} from "./workload-env-refs";
+
+setDefaultTimeout(120_000);
+
+const STEWARD_REPO = process.env.STEWARD_REPO_PATH?.trim();
+const ENABLED = Boolean(
+  STEWARD_REPO && existsSync(join(STEWARD_REPO, "packages/api/src/embedded.ts")),
+);
+const describeCrossRepo = ENABLED ? describe : describe.skip;
+
+const PORT = 39000 + Math.floor(Math.random() * 900);
+const BASE = `http://localhost:${PORT}`;
+const TENANT_API_KEY = "stw_e2e_" + "a1b2c3d4e5f60718".repeat(2);
+// Assembled by concatenation so no token-shaped literal exists for secret
+// scanners to match (synthetic fixture, not a credential).
+const SECRET_VALUE = ["sk", "live", "crossrepo", "supersecret", "777"].join("-");
+const ORG = "org-e2e";
+const PROJECT = `proj-${Date.now()}`;
+
+let steward: ChildProcess | null = null;
+
+function writerConfig(): WorkloadStewardConfig {
+  return { baseUrl: BASE, tenantId: "default", apiKey: TENANT_API_KEY };
+}
+
+const CREATE_ENV = {
+  OPENAI_API_KEY: SECRET_VALUE,
+  NODE_ENV: "production",
+};
+
+/**
+ * The resolver unit is imported from the AGENT package source — the same file
+ * `startEliza` calls on the cloud container boot path. Path import (not a
+ * package import) because cloud-shared does not depend on packages/agent;
+ * the pin in workload-env-refs.ts documents the coupling.
+ */
+async function importResolver() {
+  return import("../../../../../../../agent/src/runtime/operations/workload-secrets.ts");
+}
+
+async function waitForReady(timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${BASE}/ready`);
+      if (res.status === 200) {
+        const body = (await res.json()) as { status?: string };
+        if (body.status === "ready") return;
+      }
+    } catch {
+      // not up yet — retry until the deadline, then throw below (fail closed;
+      // the suite cannot run without the real API).
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`real Steward API did not become ready on ${BASE}`);
+}
+
+describeCrossRepo("cross-repo: real Steward API × real eliza writer/resolver", () => {
+  beforeAll(async () => {
+    const keyHash = createHash("sha256").update(TENANT_API_KEY).digest("hex");
+    steward = spawn("bun", ["packages/api/src/embedded.ts"], {
+      cwd: STEWARD_REPO,
+      env: {
+        ...process.env,
+        PORT: String(PORT),
+        STEWARD_PGLITE_MEMORY: "true",
+        STEWARD_MASTER_PASSWORD: "cross-repo-e2e-master-password-32ch",
+        STEWARD_JWT_SECRET: "cross-repo-e2e-jwt-secret-32-chars-min!",
+        STEWARD_AUDIT_HMAC_KEY: "d".repeat(64),
+        STEWARD_DEFAULT_TENANT_KEY: keyHash,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await waitForReady(90_000);
+  });
+
+  afterAll(() => {
+    steward?.kill("SIGTERM");
+  });
+
+  let sealedEnv: Record<string, string> = {};
+  let workloadId = "";
+
+  test("writer seals through the real API: env carries refs + capability, never the value", async () => {
+    const sealed = await sealContainerEnvToWorkload(
+      { organizationId: ORG, projectName: PROJECT, environmentVars: { ...CREATE_ENV } },
+      writerConfig(),
+    );
+    sealedEnv = sealed.env;
+    workloadId = sealed.workloadId;
+    expect(workloadId).toBe(deriveWorkloadId(ORG, PROJECT));
+    expect(sealed.sealedKeys).toEqual(["OPENAI_API_KEY"]);
+
+    // ABSENCE across the sealed env — this exact map is what gets persisted
+    // to the containers row, interpolated into the SSH `docker create -e`
+    // line, and therefore shown by `docker inspect`: no plaintext anywhere.
+    const serialized = JSON.stringify(sealedEnv);
+    expect(serialized).not.toContain(SECRET_VALUE);
+    expect(sealedEnv.OPENAI_API_KEY).toBe(`vault://workload/${workloadId}/OPENAI_API_KEY`);
+    expect(sealedEnv.NODE_ENV).toBe("production");
+    // capability present, tenant credential ABSENT
+    expect(sealedEnv.STEWARD_WORKLOAD_ID).toBe(workloadId);
+    expect(sealedEnv.STEWARD_WORKLOAD_KEY?.length).toBeGreaterThan(100);
+    expect(serialized).not.toContain(TENANT_API_KEY);
+  });
+
+  test("resolver boots with ONLY the sealed env: real enroll → resolve → settings overlay; env scrubbed", async () => {
+    const { resolveWorkloadEnvOverlayForBoot } = await importResolver();
+    // exactly what the container process sees: the sealed env, nothing else
+    const containerEnv: NodeJS.ProcessEnv = { ...sealedEnv };
+    const overlay = await resolveWorkloadEnvOverlayForBoot({ env: containerEnv });
+
+    expect(overlay.OPENAI_API_KEY).toBe(SECRET_VALUE);
+    // process.env-equivalent scrubbed: no sentinel, no capability key, and
+    // the plaintext NEVER entered it.
+    expect(containerEnv.OPENAI_API_KEY).toBeUndefined();
+    expect(containerEnv.STEWARD_WORKLOAD_KEY).toBeUndefined();
+    expect(JSON.stringify(containerEnv)).not.toContain(SECRET_VALUE);
+  });
+
+  test("authorization: the WRITER credential cannot resolve (403 from the real middleware)", async () => {
+    const res = await fetch(`${BASE}/v1/workload-secrets/resolve`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Steward-Tenant": "default",
+        "X-Steward-Key": TENANT_API_KEY,
+      },
+      body: JSON.stringify({ names: ["OPENAI_API_KEY"] }),
+    });
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toContain(SECRET_VALUE);
+  });
+
+  test("tenant/workload isolation: a FOREIGN workload's capability resolves nothing from this namespace", async () => {
+    // register a second workload under the same tenant (the strictest case:
+    // same tenant, different container)
+    const foreign = await sealContainerEnvToWorkload(
+      {
+        organizationId: ORG,
+        projectName: `${PROJECT}-other`,
+        environmentVars: { API_TOKEN: "other-secret" },
+      },
+      writerConfig(),
+    );
+    const { resolveWorkloadSecretSettings } = await importResolver();
+    // the foreign container tries to resolve OUR ref with ITS capability
+    const { resolved, failures } = await resolveWorkloadSecretSettings(
+      { STOLEN: sealedEnv.OPENAI_API_KEY as string },
+      { env: { ...foreign.env } },
+    );
+    expect(resolved).toEqual({});
+    expect(failures).toEqual(["STOLEN"]);
+  });
+
+  test("rotation: re-PUT rotates the value server-side (versioned); the workload resolves the NEW value", async () => {
+    const rotated = `${SECRET_VALUE}-v2`;
+    const resealed = await sealContainerEnvToWorkload(
+      {
+        organizationId: ORG,
+        projectName: PROJECT,
+        environmentVars: { OPENAI_API_KEY: rotated, NODE_ENV: "production" },
+      },
+      writerConfig(),
+    );
+    const { resolveWorkloadEnvOverlayForBoot } = await importResolver();
+    const overlay = await resolveWorkloadEnvOverlayForBoot({ env: { ...resealed.env } });
+    expect(overlay.OPENAI_API_KEY).toBe(rotated);
+
+    // capability rotation happened too: the ORIGINAL capability (first seal)
+    // can no longer enroll — its signer was revoked in the re-register tx.
+    const { resolveWorkloadSecretSettings } = await importResolver();
+    const { resolved, failures } = await resolveWorkloadSecretSettings(
+      { OPENAI_API_KEY: sealedEnv.OPENAI_API_KEY as string },
+      { env: { ...sealedEnv } }, // the OLD env, OLD private key
+    );
+    expect(resolved).toEqual({});
+    expect(failures).toEqual(["OPENAI_API_KEY"]);
+
+    sealedEnv = resealed.env; // continue with the live capability
+  });
+
+  test("revocation: DELETE /workloads/:id kills enrollment and empties the namespace", async () => {
+    const res = await fetch(`${BASE}/v1/workload-secrets/workloads/${workloadId}`, {
+      method: "DELETE",
+      headers: { "X-Steward-Tenant": "default", "X-Steward-Key": TENANT_API_KEY },
+    });
+    expect(res.status).toBe(200);
+
+    const { resolveWorkloadSecretSettings } = await importResolver();
+    const { resolved, failures } = await resolveWorkloadSecretSettings(
+      { OPENAI_API_KEY: sealedEnv.OPENAI_API_KEY as string },
+      { env: { ...sealedEnv } },
+    );
+    expect(resolved).toEqual({});
+    expect(failures).toEqual(["OPENAI_API_KEY"]);
+  });
+
+  test("outage: writer fails closed against a dead endpoint (no partial state, no value in the error)", async () => {
+    let caught: unknown;
+    try {
+      await sealContainerEnvToWorkload(
+        { organizationId: ORG, projectName: PROJECT, environmentVars: { ...CREATE_ENV } },
+        { baseUrl: "http://localhost:1", tenantId: "default", apiKey: TENANT_API_KEY },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toMatchObject({ code: "container_create_failed" });
+    expect(caught instanceof Error ? caught.message : "").not.toContain(SECRET_VALUE);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/workload-env-refs.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/workload-env-refs.test.ts
@@ -1,0 +1,228 @@
+// Unit proof for the workload-contract sealing module (#17432). The Steward
+// fetch here is a MINIMAL wire double for unit-level partitioning/fail-closed
+// checks only — the HEADLINE cross-repo evidence runs against the REAL
+// Steward API in workload-cross-repo.e2e.test.ts (no invented routes there).
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  buildWorkloadRefKey,
+  deriveWorkloadId,
+  formatVaultRef,
+  isVaultRef,
+  parseVaultRef,
+  revokeWorkloadForDeletedContainer,
+  sealContainerEnvToWorkload,
+  WORKLOAD_CAPABILITY_ENV_KEYS,
+} from "./workload-env-refs";
+
+interface RecordedCall {
+  method: string;
+  path: string;
+  body: unknown;
+}
+
+function makeSteward(behavior?: {
+  failOn?: (method: string, path: string) => boolean;
+  reject?: boolean;
+}) {
+  const calls: RecordedCall[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    calls.push({ method, path: url.pathname, body });
+    if (behavior?.reject) throw new Error("ECONNREFUSED");
+    if (behavior?.failOn?.(method, url.pathname)) {
+      return Response.json({ ok: false, error: "denied" }, { status: 403 });
+    }
+    return Response.json({ ok: true, data: {} });
+  }) as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+const PARAMS = {
+  organizationId: "org-1",
+  projectName: "proj-a",
+  environmentVars: {
+    OPENAI_API_KEY: "sk-live-supersecret",
+    DISCORD_TOKEN: "discord-secret",
+    NODE_ENV: "production",
+    PORT: "3000",
+  },
+};
+
+function config(fetchImpl: typeof fetch) {
+  return { baseUrl: "https://steward.test", tenantId: "t1", apiKey: "k", fetchImpl };
+}
+
+describe("ref format (pinned to vault-bridge)", () => {
+  test("format/isVaultRef/parseVaultRef round-trip; prefix is vault://", () => {
+    const key = buildWorkloadRefKey("wl-abc", "OPENAI_API_KEY");
+    const ref = formatVaultRef(key);
+    expect(ref).toBe("vault://workload/wl-abc/OPENAI_API_KEY");
+    expect(isVaultRef(ref)).toBe(true);
+    expect(parseVaultRef(ref)).toBe(key);
+    expect(isVaultRef("vault://")).toBe(false);
+    expect(isVaultRef("workload/x/y")).toBe(false);
+  });
+
+  test("workload id is deterministic per org/project and fits the Steward id contract", () => {
+    const a = deriveWorkloadId("org-1", "proj-a");
+    expect(deriveWorkloadId("org-1", "proj-a")).toBe(a);
+    expect(deriveWorkloadId("org-1", "proj-b")).not.toBe(a);
+    expect(deriveWorkloadId("org-2", "proj-a")).not.toBe(a);
+    // arbitrary inputs still produce contract-conformant ids
+    const weird = deriveWorkloadId("Org With Spaces/슬래시", "проект!@#");
+    expect(weird).toMatch(/^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$/);
+  });
+});
+
+describe("sealing partitioning", () => {
+  test("secrets become refs + capability; non-secrets pass through; steward got register + one PUT per secret", async () => {
+    const { calls, fetchImpl } = makeSteward();
+    const sealed = await sealContainerEnvToWorkload(PARAMS, config(fetchImpl));
+
+    const wl = deriveWorkloadId("org-1", "proj-a");
+    expect(sealed.workloadId).toBe(wl);
+    expect(sealed.sealedKeys.sort()).toEqual(["DISCORD_TOKEN", "OPENAI_API_KEY"]);
+    // refs, not values
+    expect(sealed.env.OPENAI_API_KEY).toBe(`vault://workload/${wl}/OPENAI_API_KEY`);
+    expect(sealed.env.DISCORD_TOKEN).toBe(`vault://workload/${wl}/DISCORD_TOKEN`);
+    // non-secret passthrough
+    expect(sealed.env.NODE_ENV).toBe("production");
+    expect(sealed.env.PORT).toBe("3000");
+    // capability triplet present; the private key is NOT the secret values
+    expect(sealed.env.STEWARD_API_URL).toBe("https://steward.test");
+    expect(sealed.env.STEWARD_WORKLOAD_ID).toBe(wl);
+    expect(sealed.env.STEWARD_WORKLOAD_KEY?.length).toBeGreaterThan(100);
+    // NO secret value anywhere in the sealed env
+    const serialized = JSON.stringify(sealed.env);
+    expect(serialized).not.toContain("sk-live-supersecret");
+    expect(serialized).not.toContain("discord-secret");
+
+    // wire shape: register first, then per-secret PUTs with the value
+    expect(calls[0]).toMatchObject({ method: "POST", path: "/v1/workload-secrets/workloads" });
+    const registerBody = (calls[0]?.body ?? {}) as { publicKey?: string };
+    expect(registerBody.publicKey?.length ?? 0).toBeGreaterThan(80);
+    const puts = calls.filter((c) => c.method === "PUT");
+    expect(puts.map((c) => c.path).sort()).toEqual([
+      `/v1/workload-secrets/workloads/${wl}/secrets/DISCORD_TOKEN`,
+      `/v1/workload-secrets/workloads/${wl}/secrets/OPENAI_API_KEY`,
+    ]);
+    expect(puts.find((c) => c.path.endsWith("OPENAI_API_KEY"))?.body).toEqual({
+      value: "sk-live-supersecret",
+    });
+  });
+
+  test("already-ref values pass through without re-write; capability keys in input are dropped (never sealed)", async () => {
+    const { calls, fetchImpl } = makeSteward();
+    const wl = deriveWorkloadId("org-1", "proj-a");
+    const sealed = await sealContainerEnvToWorkload(
+      {
+        ...PARAMS,
+        environmentVars: {
+          OPENAI_API_KEY: `vault://workload/${wl}/OPENAI_API_KEY`,
+          NODE_ENV: "production",
+          // stale capability from a previous seal (echoed back by a
+          // read-modify-write PATCH): replaced, never treated as a secret
+          STEWARD_WORKLOAD_KEY: "stale-key-material",
+        },
+      },
+      config(fetchImpl),
+    );
+    // ref passthrough, no value PUT for it
+    expect(sealed.env.OPENAI_API_KEY).toBe(`vault://workload/${wl}/OPENAI_API_KEY`);
+    expect(calls.filter((c) => c.method === "PUT")).toEqual([]);
+    // capability regenerated, stale material gone
+    expect(sealed.env.STEWARD_WORKLOAD_KEY).not.toBe("stale-key-material");
+    expect(JSON.stringify(sealed.env)).not.toContain("stale-key-material");
+    // registration still ran (capability rotation on every seal)
+    expect(calls[0]?.path).toBe("/v1/workload-secrets/workloads");
+  });
+
+  test("every seal registers a FRESH keypair (capability rotation)", async () => {
+    const { calls, fetchImpl } = makeSteward();
+    await sealContainerEnvToWorkload(PARAMS, config(fetchImpl));
+    await sealContainerEnvToWorkload(PARAMS, config(fetchImpl));
+    const registers = calls.filter((c) => c.path === "/v1/workload-secrets/workloads");
+    expect(registers).toHaveLength(2);
+    const [k1, k2] = registers.map((c) => (c.body as { publicKey: string }).publicKey);
+    expect(k1).not.toBe(k2);
+  });
+});
+
+describe("fail-closed", () => {
+  test("register denial aborts before any secret leaves the process", async () => {
+    const { calls, fetchImpl } = makeSteward({
+      failOn: (m, p) => m === "POST" && p === "/v1/workload-secrets/workloads",
+    });
+    await expect(sealContainerEnvToWorkload(PARAMS, config(fetchImpl))).rejects.toMatchObject({
+      code: "container_create_failed",
+    });
+    // no value was ever transmitted
+    expect(calls.filter((c) => c.method === "PUT")).toEqual([]);
+  });
+
+  test("secret write denial aborts the seal", async () => {
+    const { fetchImpl } = makeSteward({ failOn: (m) => m === "PUT" });
+    await expect(sealContainerEnvToWorkload(PARAMS, config(fetchImpl))).rejects.toMatchObject({
+      code: "container_create_failed",
+    });
+  });
+
+  test("steward unreachable (outage) aborts, message carries no secret value", async () => {
+    const { fetchImpl } = makeSteward({ reject: true });
+    let caught: unknown;
+    try {
+      await sealContainerEnvToWorkload(PARAMS, config(fetchImpl));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toMatchObject({ code: "container_create_failed" });
+    const message = caught instanceof Error ? caught.message : "";
+    expect(message).not.toContain("sk-live-supersecret");
+    expect(message).not.toContain("discord-secret");
+  });
+});
+
+describe("revocation on container delete", () => {
+  test("stored env with a workload id triggers DELETE /workloads/:id", async () => {
+    const { calls, fetchImpl } = makeSteward();
+    await revokeWorkloadForDeletedContainer(
+      { STEWARD_WORKLOAD_ID: "wl-dead", OPENAI_API_KEY: "vault://workload/wl-dead/OPENAI_API_KEY" },
+      () => config(fetchImpl),
+    );
+    expect(calls).toEqual([
+      { method: "DELETE", path: "/v1/workload-secrets/workloads/wl-dead", body: undefined },
+    ]);
+  });
+
+  test("no workload id in the stored env → no-op (legacy containers)", async () => {
+    const { calls, fetchImpl } = makeSteward();
+    await revokeWorkloadForDeletedContainer({ OPENAI_API_KEY: "plain" }, () => config(fetchImpl));
+    await revokeWorkloadForDeletedContainer(null, () => config(fetchImpl));
+    expect(calls).toEqual([]);
+  });
+
+  test("revocation failure is contained (teardown must not be blocked)", async () => {
+    const { fetchImpl } = makeSteward({ reject: true });
+    // must NOT throw
+    await revokeWorkloadForDeletedContainer({ STEWARD_WORKLOAD_ID: "wl-dead" }, () =>
+      config(fetchImpl),
+    );
+  });
+});
+
+describe("constants", () => {
+  test("capability env keys are the documented triplet", () => {
+    expect([...WORKLOAD_CAPABILITY_ENV_KEYS]).toEqual([
+      "STEWARD_API_URL",
+      "STEWARD_WORKLOAD_ID",
+      "STEWARD_WORKLOAD_KEY",
+    ]);
+  });
+});
+
+afterEach(() => {
+  delete process.env.CONTAINERS_ENV_VAULT_REFS;
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/workload-env-refs.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/workload-env-refs.ts
@@ -1,0 +1,342 @@
+/**
+ * Provision-time sealing of container environment secrets into Steward's
+ * WORKLOAD-scoped secret contract (`/v1/workload-secrets/*`) — issue #17432,
+ * superseding the nonfunctional #17301 integration.
+ *
+ * THE GAP THIS CLOSES: `createContainer`/`setEnv` inject caller-supplied
+ * `environment_vars` into `docker create -e KEY=value` verbatim, so secret
+ * values sit (1) in the stored `containers.environment_vars` jsonb, (2) in
+ * the SSH command line, and (3) in `docker inspect` output on the node — all
+ * plaintext. With sealing enabled, secret-bearing values are written to
+ * Steward at provision time and the container env carries only
+ * `vault://workload/<workloadId>/<KEY>` reference sentinels plus a
+ * LEAST-PRIVILEGE workload capability the in-container boot resolver uses to
+ * exchange for the values (see
+ * `packages/agent/src/runtime/operations/workload-secrets.ts`).
+ *
+ * WHY NOT `/secrets`: Steward's human secret CRUD requires an owner/admin
+ * session with recent MFA and intentionally rejects machine credentials —
+ * #17301 died on exactly that 403. The workload contract is the machine path:
+ * the tenant API key (held ONLY by this control-plane process, never placed in
+ * a container) may register/rotate/revoke workloads and WRITE values but can
+ * never read one back or list inventory; the container holds only a
+ * per-workload P-256 keypair whose short-lived enrollment tokens resolve the
+ * workload's own namespace and nothing else.
+ *
+ * CAPABILITY LIFECYCLE (all server-enforced, see Steward
+ * `packages/api/src/routes/workload-secrets.ts`):
+ *   - every seal generates a FRESH keypair and re-registers the workload —
+ *     Steward revokes the previous key in the same transaction, so
+ *     create/setEnv doubles as capability rotation;
+ *   - container deletion calls DELETE /workloads/:id, which kills enrollment
+ *     and soft-deletes the namespace (an outstanding ≤5m token resolves
+ *     nothing afterwards).
+ *
+ * FLAG-GATED, DEFAULT OFF (`CONTAINERS_ENV_VAULT_REFS=true`): existing
+ * deployments keep the legacy plaintext behavior byte-for-byte. Do not enable
+ * until the container image carries the boot resolver — the flag's doc block
+ * in `containers-env.ts` states the pairing requirement.
+ *
+ * ERROR POLICY: fail CLOSED. When the flag is on and any Steward call fails,
+ * provisioning throws BEFORE the DB row or any SSH — a fallback to plaintext
+ * injection would silently re-open the hole the flag claims to close.
+ */
+
+import { createHash, webcrypto } from "node:crypto";
+import { getCloudAwareEnv } from "../../../runtime/cloud-bindings";
+import { logger } from "../../../utils/logger";
+import { isSensitiveAgentEnvKey } from "../../agent-env-crypto";
+import { HetznerClientError } from "./types";
+
+/**
+ * `vault://` sentinel prefix. MUST stay identical to `VAULT_REF_PREFIX` in
+ * `packages/agent/src/runtime/operations/vault-bridge.ts` (the canonical
+ * definition — cloud-shared cannot import packages/agent, so the constant is
+ * mirrored here with this pin instead).
+ */
+export const VAULT_REF_PREFIX = "vault://";
+
+/** Namespace prefix inside the sentinel marking a workload-contract ref. */
+export const WORKLOAD_REF_NAMESPACE = "workload/";
+
+/**
+ * Capability env vars the sealed container receives INSTEAD of a tenant-wide
+ * credential. `STEWARD_WORKLOAD_KEY` is the pkcs8-base64 P-256 private key of
+ * a capability that can (a) mint short-lived tokens for (b) resolving this
+ * one workload's namespace — revocable server-side, rotated on every reseal.
+ * These are exempt from the sealing loop (sealing them would orphan the boot
+ * resolver) and are replaced wholesale on every seal.
+ */
+export const WORKLOAD_CAPABILITY_ENV_KEYS = [
+  "STEWARD_API_URL",
+  "STEWARD_WORKLOAD_ID",
+  "STEWARD_WORKLOAD_KEY",
+] as const;
+
+const CAPABILITY_KEY_SET: ReadonlySet<string> = new Set(WORKLOAD_CAPABILITY_ENV_KEYS);
+
+/** Format a vault key into the `vault://<key>` sentinel (vault-bridge format). */
+export function formatVaultRef(key: string): string {
+  if (!key) throw new TypeError("formatVaultRef requires a non-empty key");
+  return `${VAULT_REF_PREFIX}${key}`;
+}
+
+/** Type guard matching vault-bridge's `isVaultRef`. */
+export function isVaultRef(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.startsWith(VAULT_REF_PREFIX) &&
+    value.length > VAULT_REF_PREFIX.length
+  );
+}
+
+/** Extract the vault key from a sentinel; null when malformed. */
+export function parseVaultRef(value: string): string | null {
+  return isVaultRef(value) ? value.slice(VAULT_REF_PREFIX.length) : null;
+}
+
+/**
+ * Deterministic per-project workload id: stable across container recreates so
+ * `setEnv`/recreate ROTATES the same workload (capability + values) instead of
+ * leaking an orphan per recreate. Hash-derived so arbitrary org ids / project
+ * names always fit Steward's `[A-Za-z0-9][A-Za-z0-9_.-]{0,63}` id contract.
+ */
+export function deriveWorkloadId(organizationId: string, projectName: string): string {
+  const digest = createHash("sha256")
+    .update(`${organizationId}/${projectName}`)
+    .digest("hex")
+    .slice(0, 40);
+  return `wl-${digest}`;
+}
+
+/** The sentinel key for one env var: `workload/<workloadId>/<ENV_KEY>` — the
+ * SAME string as the Steward secret name, so ref → resolve is pure string
+ * manipulation on both sides. */
+export function buildWorkloadRefKey(workloadId: string, envKey: string): string {
+  return `${WORKLOAD_REF_NAMESPACE}${workloadId}/${envKey}`;
+}
+
+/** Steward transport config for the workload-secrets writer. */
+export interface WorkloadStewardConfig {
+  baseUrl: string;
+  tenantId?: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** Result of sealing an env map. */
+export interface SealedWorkloadEnv {
+  /**
+   * Env map safe to persist + inject: `vault://workload/...` refs for
+   * secrets, the capability triplet, passthrough for everything else.
+   */
+  env: Record<string, string>;
+  /** Env keys whose values were moved into Steward this call. */
+  sealedKeys: string[];
+  /** The workload id registered/rotated for this container. */
+  workloadId: string;
+}
+
+function stewardHeaders(config: WorkloadStewardConfig): Record<string, string> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (config.tenantId) headers["X-Steward-Tenant"] = config.tenantId;
+  if (config.apiKey) headers["X-Steward-Key"] = config.apiKey;
+  return headers;
+}
+
+function stewardBase(config: WorkloadStewardConfig): string {
+  return config.baseUrl.replace(/\/+$/, "");
+}
+
+async function stewardCall(
+  config: WorkloadStewardConfig,
+  method: "POST" | "PUT" | "DELETE",
+  path: string,
+  body: unknown,
+  failureContext: string,
+): Promise<Response> {
+  const doFetch = config.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await doFetch(`${stewardBase(config)}${path}`, {
+      method,
+      headers: stewardHeaders(config),
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+  } catch (err) {
+    // Steward unreachable (outage): fail closed. Message carries the context
+    // and transport class only — never a secret value.
+    throw new HetznerClientError(
+      "container_create_failed",
+      `Steward workload API unreachable while ${failureContext}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  if (!res.ok) {
+    throw new HetznerClientError(
+      "container_create_failed",
+      `Steward workload API rejected ${failureContext} (HTTP ${res.status})`,
+    );
+  }
+  return res;
+}
+
+/** Resolve steward transport config from env; throws when unconfigured (fail closed). */
+export function resolveWorkloadStewardConfigFromEnv(): WorkloadStewardConfig {
+  const env = getCloudAwareEnv();
+  const baseUrl = env.STEWARD_API_URL?.trim();
+  if (!baseUrl) {
+    throw new HetznerClientError(
+      "container_create_failed",
+      "CONTAINERS_ENV_VAULT_REFS is enabled but STEWARD_API_URL is not configured on the control plane",
+    );
+  }
+  return {
+    baseUrl,
+    tenantId:
+      env.STEWARD_TENANT_ID?.trim() || env.NEXT_PUBLIC_STEWARD_TENANT_ID?.trim() || undefined,
+    apiKey: env.STEWARD_TENANT_API_KEY?.trim() || undefined,
+  };
+}
+
+/** Generate the per-workload P-256 capability keypair. The PRIVATE key goes
+ * into the container env (pkcs8 base64); only the PUBLIC key goes to Steward. */
+async function generateWorkloadKeypair(): Promise<{
+  publicKeySpkiBase64: string;
+  privateKeyPkcs8Base64: string;
+}> {
+  const pair = (await webcrypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+    "sign",
+    "verify",
+  ])) as CryptoKeyPair;
+  const spki = Buffer.from(await webcrypto.subtle.exportKey("spki", pair.publicKey));
+  const pkcs8 = Buffer.from(await webcrypto.subtle.exportKey("pkcs8", pair.privateKey));
+  return {
+    publicKeySpkiBase64: spki.toString("base64"),
+    privateKeyPkcs8Base64: pkcs8.toString("base64"),
+  };
+}
+
+/**
+ * Seal an env map through the workload contract:
+ *
+ *   1. register/rotate the workload capability (fresh keypair; Steward revokes
+ *      the previous key in the same transaction);
+ *   2. write each secret-bearing value (same `isSensitiveAgentEnvKey`
+ *      heuristic the agent-sandbox at-rest crypto uses, #11332) via
+ *      `PUT /workloads/:id/secrets/:KEY` — upsert on first write, Steward's
+ *      native versioned rotation after;
+ *   3. return an env map carrying refs + the capability triplet.
+ *
+ * Values that are ALREADY refs pass through untouched but their keys are
+ * still counted as sealed intent (read-modify-write PATCH flows echo stored
+ * refs back; the value they point at is re-written only when the caller sends
+ * a real value). Non-sensitive config passes through unchanged.
+ */
+export async function sealContainerEnvToWorkload(
+  params: {
+    organizationId: string;
+    projectName: string;
+    environmentVars: Record<string, string>;
+  },
+  config: WorkloadStewardConfig,
+): Promise<SealedWorkloadEnv> {
+  const workloadId = deriveWorkloadId(params.organizationId, params.projectName);
+  const keypair = await generateWorkloadKeypair();
+
+  // Capability issuance FIRST: if Steward is down or denies, nothing else
+  // happens (no partial seal, no row, no SSH).
+  await stewardCall(
+    config,
+    "POST",
+    "/v1/workload-secrets/workloads",
+    {
+      workloadId,
+      publicKey: keypair.publicKeySpkiBase64,
+      label: `eliza-cloud ${params.organizationId}/${params.projectName}`.slice(0, 255),
+    },
+    `registering workload "${workloadId}"`,
+  );
+
+  const env: Record<string, string> = {};
+  const sealedKeys: string[] = [];
+
+  for (const [key, value] of Object.entries(params.environmentVars)) {
+    // The capability triplet is control-plane-owned and replaced below —
+    // never sealed (STEWARD_WORKLOAD_KEY matches the secret heuristic but
+    // sealing it would orphan the boot resolver).
+    if (CAPABILITY_KEY_SET.has(key)) continue;
+    if (!isSensitiveAgentEnvKey(key) || !value || isVaultRef(value)) {
+      env[key] = value;
+      continue;
+    }
+    await stewardCall(
+      config,
+      "PUT",
+      `/v1/workload-secrets/workloads/${encodeURIComponent(workloadId)}/secrets/${encodeURIComponent(key)}`,
+      { value },
+      `writing env secret "${key}" for workload "${workloadId}"`,
+    );
+    env[key] = formatVaultRef(buildWorkloadRefKey(workloadId, key));
+    sealedKeys.push(key);
+  }
+
+  // The capability the boot resolver exchanges for the values. NOT a secret
+  // value and NOT tenant-wide: scope = this one workload's namespace,
+  // revocable via DELETE /workloads/:id, dead after any reseal.
+  env.STEWARD_API_URL = stewardBase(config);
+  env.STEWARD_WORKLOAD_ID = workloadId;
+  env.STEWARD_WORKLOAD_KEY = keypair.privateKeyPkcs8Base64;
+
+  if (sealedKeys.length > 0) {
+    // Keys only — never values — mirroring the vault audit-log policy.
+    logger.info("[workload-env-refs] sealed container env secrets to Steward workload", {
+      organizationId: params.organizationId,
+      projectName: params.projectName,
+      workloadId,
+      sealedKeys,
+    });
+  }
+
+  return { env, sealedKeys, workloadId };
+}
+
+/**
+ * Revoke a container's workload capability + namespace on deletion.
+ *
+ * Uses the workload id recorded in the stored env (so revocation still runs
+ * if the flag was flipped off between create and delete). error-policy: the
+ * container teardown is the primary operation — a revocation failure is
+ * logged LOUDLY for operator follow-up (a live capability outliving its
+ * container) but does not block the deletion; the capability is also dead the
+ * next time the same org/project provisions (deterministic id ⇒ rotation).
+ */
+export async function revokeWorkloadForDeletedContainer(
+  storedEnv: Record<string, string> | null | undefined,
+  configResolver: () => WorkloadStewardConfig = resolveWorkloadStewardConfigFromEnv,
+): Promise<void> {
+  const workloadId = storedEnv?.STEWARD_WORKLOAD_ID;
+  if (!workloadId) return;
+  try {
+    const config = configResolver();
+    await stewardCall(
+      config,
+      "DELETE",
+      `/v1/workload-secrets/workloads/${encodeURIComponent(workloadId)}`,
+      undefined,
+      `revoking workload "${workloadId}"`,
+    );
+    logger.info("[workload-env-refs] revoked workload capability for deleted container", {
+      workloadId,
+    });
+  } catch (err) {
+    logger.error(
+      "[workload-env-refs] FAILED to revoke workload capability for deleted container — the capability may outlive the container; revoke manually or reprovision the project",
+      {
+        workloadId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+  }
+}


### PR DESCRIPTION
## What

Implements #17432 — end-to-end workload-scoped Steward resolution for container env secrets, superseding the closed #17301. Both maintainer blockers are addressed at the root:

1. **No human `/secrets` CRUD.** The writer targets Steward's new **workload-scoped machine contract** (`/v1/workload-secrets/*`, Steward-Fi/steward#256): tenant API key may register/rotate/revoke per-container workload capabilities and *write* values (versioned rotation server-side) but can never read one back or list inventory. Human sessions — even owner/admin with recent MFA — are denied on every route of that plane.
2. **A real in-container resolver on the real boot path.** `startEliza` now resolves `vault://workload/...` refs via the public keypair-only `/agent-enroll` challenge-response (ECDSA P-256/SHA-256) → short-lived token → `POST /v1/workload-secrets/resolve`, delivering plaintext **only** into the `connectorSecretsOverlay` consumed by `buildRuntimeSettings` (the same production settings-only channel #17302 shipped). `process.env` is then scrubbed of both the sentinels and the capability private key.

## Capability lifecycle (least privilege, per container)

- **issue**: every seal generates a fresh P-256 keypair; only the public key goes to Steward; the container env carries `STEWARD_WORKLOAD_ID` + `STEWARD_WORKLOAD_KEY` — a capability scoped to ONE workload namespace, not a tenant credential.
- **rotate**: `createContainer`/`setEnv` re-register — Steward revokes the previous key in the same transaction (proven: the old capability stops enrolling immediately).
- **revoke**: `deleteContainer` calls `DELETE /workloads/:id` — enrollment dies and the namespace is soft-deleted, so an outstanding ≤5m token resolves nothing.

## Flag

`CONTAINERS_ENV_VAULT_REFS` **default OFF**, byte-for-byte legacy behavior when off (proven). The doc block states the pairing requirement: only enable for images carrying this resolver.

## Error policy

Fail-closed everywhere; a Steward failure aborts provisioning **before** the DB row and SSH. No silent `.catch(() => null)` — the one JSON-parse catch is annotated and feeds an explicit malformed-response deny path. All logging is keys-only.

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A — backend-only change (container control plane + agent boot path), no UI surface affected.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A — backend-only change, no UI surface affected.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A — backend-only; behavior proven by the bidirectional + cross-repo automated suites below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: full test output below — 28/28 pass including the cross-repo suite that BOOTS the real Steward API (real tenantAuth middleware, real enrollment crypto, real SecretVault) and drives the real writer + resolver units against it. Suites: [workload-env-refs.test.ts](https://github.com/0xSolace/eliza/blob/sol/workload-secrets-17432/packages/cloud/shared/src/lib/services/containers/hetzner-client/workload-env-refs.test.ts), [client.workload-env-refs.test.ts](https://github.com/0xSolace/eliza/blob/sol/workload-secrets-17432/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.workload-env-refs.test.ts), [workload-cross-repo.e2e.test.ts](https://github.com/0xSolace/eliza/blob/sol/workload-secrets-17432/packages/cloud/shared/src/lib/services/containers/hetzner-client/workload-cross-repo.e2e.test.ts), [workload-secrets-boot.test.ts](https://github.com/0xSolace/eliza/blob/sol/workload-secrets-17432/packages/agent/src/runtime/workload-secrets-boot.test.ts)
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A — no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A — no LLM behavior in this diff; security plumbing only.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [workload-cross-repo.e2e.test.ts](https://github.com/0xSolace/eliza/blob/sol/workload-secrets-17432/packages/cloud/shared/src/lib/services/containers/hetzner-client/workload-cross-repo.e2e.test.ts) — absence-of-secret assertions across all six surfaces — (1) actual SSH `docker create -e` command line, (2) persisted `containers.environment_vars` row, (3) the sealed env map that `docker inspect` reflects, (4) keys-only logs on every path, (5) `process.env` post-scrub (sentinels + capability key removed, plaintext never entered), (6) error messages on outage — plus the target setting reaching `buildRuntimeSettingsProjection` output. See test output below.

# Evidence Details

## Cross-repo run (REAL Steward API, no invented stubs)

`STEWARD_REPO_PATH=<steward checkout> bun test` in `packages/cloud/shared`:

```
(pass) writer seals through the real API: env carries refs + capability, never the value
(pass) resolver boots with ONLY the sealed env: real enroll → resolve → settings overlay; env scrubbed
(pass) authorization: the WRITER credential cannot resolve (403 from the real middleware)
(pass) tenant/workload isolation: a FOREIGN workload's capability resolves nothing from this namespace
(pass) rotation: re-PUT rotates the value server-side (versioned); the workload resolves the NEW value
       (also proves capability rotation: the ORIGINAL capability can no longer enroll)
(pass) revocation: DELETE /workloads/:id kills enrollment and empties the namespace
(pass) outage: writer fails closed against a dead endpoint (no partial state, no value in the error)
```

## Unit/live-path runs

```
workload-env-refs.test.ts             12 pass  (partitioning, capability rotation, 3× fail-closed, revocation, constants)
client.workload-env-refs.test.ts       3 pass  (flag ON: refs+capability on the real docker-create line & row, no value,
                                                no tenant key; outage aborts pre-row/SSH; flag OFF: byte-for-byte legacy)
workload-secrets-boot.test.ts         12 pass  (vitest; REAL P-256 verification in the wire double; settings-only delivery;
                                                env scrub; self-gating; hot-reload single-flight; 5 fail-closed paths)
client.error-policy.test.ts            6 pass  (pre-existing, unchanged)
connector-vault-refs + eliza-cloud-config regressions: 48 pass
Total: 28 pass / 0 fail (bun) + 48 pass (vitest)
```

`tsc --noEmit` clean on packages/agent AND packages/cloud/shared; biome clean on all touched files; `turbo build` for the agent graph green (100/100 tasks).

## Steward counterpart

Steward-Fi/steward#256 ships the `/v1/workload-secrets` contract (24 contract tests against the real app: writer/reader auth matrices incl. owner+recent-MFA DENY, lifecycle, both rotations, revocation, tenant isolation, no-inventory, keys-never-values audit). The human `packages/api/src/routes/secrets.ts` contract is untouched.
