### PR TITLE
fix(cloud): settle dependent rows when recovery flips a job to failed

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -803,4 +803,163 @@ describe("jobsRepository.recoverStaleJobs", () => {
       primarySpy.mockRestore();
     }
   });
+  test(
+    "a recovery that exhausts attempts settles the dependent row in the SAME transaction",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const jobId = "00000000-0000-4000-8000-000000180901";
+      await seedJob({ id: jobId, maxAttempts: 1, type: "agent_delete" });
+
+      const seen: Array<{ id: string; type: string; error: string }> = [];
+      const recovered = await repo.recoverStaleJobs({
+        type: "agent_delete",
+        staleThresholdMs: 1,
+        buildFailureWriteback: (hydratedJob, error) => {
+          seen.push({ id: hydratedJob.id, type: hydratedJob.type, error });
+          return async (tx, failedJob) => {
+            await tx
+              .update(jobs)
+              .set({ webhook_status: `settled:${failedJob.status}` })
+              .where(eq(jobs.id, failedJob.id));
+          };
+        },
+      });
+
+      expect(recovered).toBe(0);
+      expect(seen).toEqual([
+        {
+          id: jobId,
+          type: "agent_delete",
+          error: "Job timed out 1 times - max attempts reached",
+        },
+      ]);
+      const [row] = await dbWrite.select().from(jobs).where(eq(jobs.id, jobId));
+      expect(row.status).toBe("failed");
+      // The dependent write landed with the flip, not after it, and the
+      // writeback saw the POST-flip row — same contract as incrementAttempt.
+      expect(row.webhook_status).toBe("settled:failed");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a writeback that throws rolls the job flip back instead of half-settling it",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const jobId = "00000000-0000-4000-8000-000000180902";
+      await seedJob({ id: jobId, maxAttempts: 1, type: "agent_delete" });
+
+      await expect(
+        repo.recoverStaleJobs({
+          type: "agent_delete",
+          staleThresholdMs: 1,
+          buildFailureWriteback: () => async () => {
+            throw new Error("dependent row is locked");
+          },
+        }),
+      ).rejects.toThrow("failed for every job in the batch");
+
+      const [row] = await dbWrite.select().from(jobs).where(eq(jobs.id, jobId));
+      // Both writes rolled back together: the next sweep retries the pair.
+      expect(row.status).toBe("in_progress");
+      expect(row.attempts).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "one poisoned job does not starve the sweep, but an all-failed batch still throws",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const poisoned = "00000000-0000-4000-8000-000000180903";
+      const healthy = "00000000-0000-4000-8000-000000180904";
+      await seedJob({ id: poisoned, maxAttempts: 1, type: "agent_delete" });
+      await seedJob({ id: healthy, maxAttempts: 1, type: "agent_delete" });
+
+      const recovered = await repo.recoverStaleJobs({
+        type: "agent_delete",
+        staleThresholdMs: 1,
+        buildFailureWriteback: (hydratedJob) =>
+          hydratedJob.id === poisoned
+            ? async () => {
+                throw new Error("dependent row is locked");
+              }
+            : undefined,
+      });
+
+      expect(recovered).toBe(0);
+      const [poisonedRow] = await dbWrite.select().from(jobs).where(eq(jobs.id, poisoned));
+      const [healthyRow] = await dbWrite.select().from(jobs).where(eq(jobs.id, healthy));
+      expect(poisonedRow.status).toBe("in_progress");
+      expect(healthyRow.status).toBe("failed");
+
+      // Now poison BOTH: a batch where every job failed is an outage, and the
+      // caller must see it rather than read a silent zero.
+      await dbWrite.execute("DELETE FROM jobs;");
+      await seedJob({ id: poisoned, maxAttempts: 1, type: "agent_delete" });
+      await seedJob({ id: healthy, maxAttempts: 1, type: "agent_delete" });
+      await expect(
+        repo.recoverStaleJobs({
+          type: "agent_delete",
+          staleThresholdMs: 1,
+          buildFailureWriteback: () => async () => {
+            throw new Error("database is down");
+          },
+        }),
+      ).rejects.toThrow("failed for every job in the batch");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a recovery that only retries never asks for a dependent-row writeback",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const jobId = "00000000-0000-4000-8000-000000180905";
+      await seedJob({ id: jobId, maxAttempts: 3, type: "agent_delete" });
+
+      let builds = 0;
+      const recovered = await repo.recoverStaleJobs({
+        type: "agent_delete",
+        staleThresholdMs: 1,
+        buildFailureWriteback: () => {
+          builds += 1;
+          return undefined;
+        },
+      });
+
+      expect(recovered).toBe(1);
+      expect(builds).toBe(0);
+      const [row] = await dbWrite.select().from(jobs).where(eq(jobs.id, jobId));
+      expect(row.status).toBe("pending");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "startup recovery fires the post-commit hook only for a flip that committed",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const failing = "00000000-0000-4000-8000-000000180906";
+      const retrying = "00000000-0000-4000-8000-000000180907";
+      await seedJob({ id: failing, maxAttempts: 1, type: "agent_delete" });
+      await seedJob({ id: retrying, maxAttempts: 3, type: "agent_delete" });
+
+      const committed: string[] = [];
+      const recovered = await repo.recoverInProgressJobsStartedBefore({
+        type: "agent_delete",
+        startedBefore: new Date("2021-01-01T00:00:00.000Z"),
+        buildFailureWriteback: () => async () => {},
+        onPermanentFailure: async (failedJob) => {
+          committed.push(failedJob.id);
+        },
+      });
+
+      expect(recovered).toBe(1);
+      expect(committed).toEqual([failing]);
+      const [retryingRow] = await dbWrite.select().from(jobs).where(eq(jobs.id, retrying));
+      expect(retryingRow.status).toBe("pending");
+    },
+    PGLITE_TIMEOUT,
+  );
 });

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -6,6 +6,7 @@
 
 import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { eq, type SQL } from "drizzle-orm";
+import { type RuntimeR2Bucket, setRuntimeR2Bucket } from "../../../lib/storage/r2-runtime-binding";
 import { jobExecutionLeases } from "../../schemas/job-execution-leases";
 import { type Job, jobs } from "../../schemas/jobs";
 
@@ -22,6 +23,34 @@ const SOURCE_DIGEST = `sha256:${"a".repeat(64)}`;
 const TARGET_DIGEST = `sha256:${"b".repeat(64)}`;
 const JOB_STARTED_AT = new Date("2020-01-01T00:00:00.000Z");
 const JOB_UPDATED_AT = new Date("2020-01-01T00:01:00.000Z");
+const HEAVY_PAYLOAD_ENV = [
+  "SQL_HEAVY_PAYLOAD_STORAGE",
+  "SQL_HEAVY_PAYLOAD_MIN_BYTES",
+  "SQL_HEAVY_PAYLOAD_INLINE_PREVIEW_BYTES",
+] as const;
+
+function memoryBucket(objects: Map<string, string>): RuntimeR2Bucket {
+  return {
+    async get(key) {
+      const value = objects.get(key);
+      return value === undefined
+        ? null
+        : {
+            async text() {
+              return value;
+            },
+          };
+    },
+    async put(key, value) {
+      objects.set(key, typeof value === "string" ? value : String(value ?? ""));
+      return {};
+    },
+    async delete(key) {
+      objects.delete(key);
+      return {};
+    },
+  };
+}
 
 let dbWrite: typeof import("../../client").dbWrite;
 let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
@@ -35,6 +64,7 @@ async function seedJob(params: {
   type?: string;
   data?: Record<string, unknown>;
   dataStorage?: string;
+  dataKey?: string;
   result?: Record<string, unknown>;
   resultStorage?: string;
   organizationId?: string;
@@ -49,6 +79,7 @@ async function seedJob(params: {
     status: "in_progress",
     data: params.data ?? {},
     data_storage: params.dataStorage ?? "inline",
+    data_key: params.dataKey,
     result: params.result,
     result_storage: params.resultStorage ?? "inline",
     attempts: params.attempts ?? 0,
@@ -804,40 +835,80 @@ describe("jobsRepository.recoverStaleJobs", () => {
     }
   });
   test(
-    "a recovery that exhausts attempts settles the dependent row in the SAME transaction",
+    "a permanent flip hands the writeback and the hook the hydrated, post-flip job",
     async () => {
       expect(pgliteReady).toBe(true);
       const jobId = "00000000-0000-4000-8000-000000180901";
-      await seedJob({ id: jobId, maxAttempts: 1, type: "agent_delete" });
-
-      const seen: Array<{ id: string; type: string; error: string }> = [];
-      const recovered = await repo.recoverStaleJobs({
-        type: "agent_delete",
-        staleThresholdMs: 1,
-        buildFailureWriteback: (hydratedJob, error) => {
-          seen.push({ id: hydratedJob.id, type: hydratedJob.type, error });
-          return async (tx, failedJob) => {
-            await tx
-              .update(jobs)
-              .set({ webhook_status: `settled:${failedJob.status}` })
-              .where(eq(jobs.id, failedJob.id));
-          };
-        },
-      });
-
-      expect(recovered).toBe(0);
-      expect(seen).toEqual([
-        {
+      const dataKey = `job-payloads/${ORG_ID}/2020-01-01/${jobId}/data.json`;
+      // Production offloads job payloads, and the row then keeps only the
+      // indexed envelope. Anything reading the RAW row back — the post-commit
+      // cache eviction reads `containerId` this way — sees a payload with the
+      // offloaded fields missing.
+      const blobPayload = {
+        agentId: AGENT_ID,
+        organizationId: ORG_ID,
+        userId: ACTOR_ID,
+        deleteVolumes: true,
+      };
+      setRuntimeR2Bucket(memoryBucket(new Map([[dataKey, JSON.stringify(blobPayload)]])));
+      process.env.SQL_HEAVY_PAYLOAD_STORAGE = "r2";
+      process.env.SQL_HEAVY_PAYLOAD_MIN_BYTES = "1";
+      process.env.SQL_HEAVY_PAYLOAD_INLINE_PREVIEW_BYTES = "0";
+      try {
+        await seedJob({
           id: jobId,
+          maxAttempts: 1,
           type: "agent_delete",
-          error: "Job timed out 1 times - max attempts reached",
-        },
-      ]);
-      const [row] = await dbWrite.select().from(jobs).where(eq(jobs.id, jobId));
-      expect(row.status).toBe("failed");
-      // The dependent write landed with the flip, not after it, and the
-      // writeback saw the POST-flip row — same contract as incrementAttempt.
-      expect(row.webhook_status).toBe("settled:failed");
+          data: { agentId: AGENT_ID, organizationId: ORG_ID, userId: ACTOR_ID },
+          dataStorage: "r2",
+          dataKey,
+        });
+
+        const built: Array<{ data: unknown; error: string }> = [];
+        const settled: Array<{ status: string; data: unknown; error: string | null }> = [];
+        const committed: Array<{ data: unknown; error: string | null }> = [];
+        const recovered = await repo.recoverStaleJobs({
+          type: "agent_delete",
+          staleThresholdMs: 1,
+          buildFailureWriteback: (hydratedJob, error) => {
+            built.push({ data: hydratedJob.data, error });
+            return async (tx, failedJob) => {
+              settled.push({
+                status: failedJob.status,
+                data: failedJob.data,
+                error: failedJob.error,
+              });
+              await tx
+                .update(jobs)
+                .set({ webhook_status: `settled:${failedJob.status}` })
+                .where(eq(jobs.id, failedJob.id));
+            };
+          },
+          onPermanentFailure: async (failedJob) => {
+            committed.push({ data: failedJob.data, error: failedJob.error });
+          },
+        });
+
+        expect(recovered).toBe(0);
+        const timeout = "Job timed out 1 times - max attempts reached";
+        expect(built).toEqual([{ data: blobPayload, error: timeout }]);
+        // hydrateJob(updated) equivalence: blob payload, plaintext error, and
+        // the POST-flip status — the same value incrementAttempt passes.
+        expect(settled).toEqual([{ status: "failed", data: blobPayload, error: timeout }]);
+        // The post-commit hook reads job data too, so it gets the same value.
+        expect(committed).toEqual([{ data: blobPayload, error: timeout }]);
+
+        const [row] = await dbWrite.select().from(jobs).where(eq(jobs.id, jobId));
+        expect(row.status).toBe("failed");
+        // The row itself carries the pointer, so the assertions above are about
+        // the reconstruction and not an accidentally inline payload.
+        expect(row.error_storage).toBe("r2");
+        expect(row.data).toEqual({ agentId: AGENT_ID, organizationId: ORG_ID, userId: ACTOR_ID });
+        expect(row.webhook_status).toBe("settled:failed");
+      } finally {
+        setRuntimeR2Bucket(null);
+        for (const key of HEAVY_PAYLOAD_ENV) delete process.env[key];
+      }
     },
     PGLITE_TIMEOUT,
   );
@@ -912,10 +983,53 @@ describe("jobsRepository.recoverStaleJobs", () => {
   );
 
   test(
-    "a recovery that only retries never asks for a dependent-row writeback",
+    "a writeback that cannot be built leaves the job in_progress instead of flipping it unsettled",
     async () => {
       expect(pgliteReady).toBe(true);
-      const jobId = "00000000-0000-4000-8000-000000180905";
+      const unbuildable = "00000000-0000-4000-8000-000000180905";
+      const healthy = "00000000-0000-4000-8000-000000180908";
+      await seedJob({ id: unbuildable, maxAttempts: 1, type: "agent_delete" });
+      await seedJob({ id: healthy, maxAttempts: 1, type: "agent_delete" });
+
+      const recovered = await repo.recoverStaleJobs({
+        type: "agent_delete",
+        staleThresholdMs: 1,
+        buildFailureWriteback: (hydratedJob) => {
+          // What an offloaded payload that no longer resolves produces: the
+          // hydration yields the reduced envelope and the reader rejects it.
+          if (hydratedJob.id === unbuildable) {
+            throw new Error(`Invalid job data for job ${hydratedJob.id}`);
+          }
+          return async (tx, failedJob) => {
+            await tx
+              .update(jobs)
+              .set({ webhook_status: "settled" })
+              .where(eq(jobs.id, failedJob.id));
+          };
+        },
+      });
+
+      expect(recovered).toBe(0);
+      const [unbuildableRow] = await dbWrite.select().from(jobs).where(eq(jobs.id, unbuildable));
+      const [healthyRow] = await dbWrite.select().from(jobs).where(eq(jobs.id, healthy));
+      // A job whose dependent row cannot be settled must not reach a terminal
+      // state: the live path leaves it in_progress too, and the next sweep
+      // retries the pair.
+      expect(unbuildableRow).toMatchObject({
+        status: "in_progress",
+        attempts: 0,
+        webhook_status: null,
+      });
+      expect(healthyRow).toMatchObject({ status: "failed", webhook_status: "settled" });
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a recovery that only retries never hydrates for a writeback",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const jobId = "00000000-0000-4000-8000-000000180909";
       await seedJob({ id: jobId, maxAttempts: 3, type: "agent_delete" });
 
       let builds = 0;
@@ -924,7 +1038,7 @@ describe("jobsRepository.recoverStaleJobs", () => {
         staleThresholdMs: 1,
         buildFailureWriteback: () => {
           builds += 1;
-          return undefined;
+          return async () => {};
         },
       });
 
@@ -932,6 +1046,7 @@ describe("jobsRepository.recoverStaleJobs", () => {
       expect(builds).toBe(0);
       const [row] = await dbWrite.select().from(jobs).where(eq(jobs.id, jobId));
       expect(row.status).toBe("pending");
+      expect(row.webhook_status).toBeNull();
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -901,7 +901,7 @@ export class JobsRepository {
     maxAttempts?: number;
     /** Settles dependent rows for jobs this sweep flips to `failed`. */
     buildFailureWriteback?: RecoveryFailureWritebackBuilder;
-    /** Post-commit hook for a flip that committed (cache eviction, metrics). */
+    /** Post-commit hook for a committed flip (cache eviction); gets the hydrated job. */
     onPermanentFailure?: (failedJob: Job) => Promise<void>;
   }): Promise<number> {
     const staleThreshold = new Date(Date.now() - filters.staleThresholdMs);
@@ -1018,7 +1018,7 @@ export class JobsRepository {
     maxAttempts?: number;
     /** Settles dependent rows for jobs this sweep flips to `failed`. */
     buildFailureWriteback?: RecoveryFailureWritebackBuilder;
-    /** Post-commit hook for a flip that committed (cache eviction, metrics). */
+    /** Post-commit hook for a committed flip (cache eviction); gets the hydrated job. */
     onPermanentFailure?: (failedJob: Job) => Promise<void>;
   }): Promise<number> {
     const conditions = [
@@ -1117,7 +1117,9 @@ export class JobsRepository {
    * Resolves the dependent-row writeback for a job about to be flipped to
    * `failed`. Hydration happens HERE, outside the recovery transaction: the
    * blob store has no timeout and the transaction holds the agent-lifecycle
-   * advisory lock.
+   * advisory lock. A throw lands before the flip is attempted, so the job stays
+   * `in_progress` for the next sweep instead of reaching a terminal state with
+   * its dependent row unsettled — the live path fails the same way.
    */
   private async prepareRecoveryWriteback(
     job: Job,
@@ -1125,22 +1127,8 @@ export class JobsRepository {
     build: RecoveryFailureWritebackBuilder | undefined,
   ): Promise<{ onFailedInTx?: JobFailureWriteback; hydratedJob?: Job }> {
     if (!build) return {};
-    try {
-      const hydratedJob = await hydrateJob(job);
-      return { onFailedInTx: build(hydratedJob, error), hydratedJob };
-    } catch (buildError) {
-      // error-policy:J4/J7 degrade-with-signal — the flip must not be held
-      // hostage by an unbuildable writeback.
-      logger.error(
-        "[jobs] Failure-writeback build threw; flipping the job WITHOUT settling its dependent row",
-        {
-          jobId: job.id,
-          type: job.type,
-          error: buildError instanceof Error ? buildError.message : String(buildError),
-        },
-      );
-      return {};
-    }
+    const hydratedJob = await hydrateJob(job);
+    return { onFailedInTx: build(hydratedJob, error), hydratedJob };
   }
 
   private async recoverJobFromSnapshot(params: {
@@ -1263,23 +1251,25 @@ export class JobsRepository {
             ),
           );
       }
+      // `incrementAttempt` hands `hydrateJob(updated)` to its writeback AND to
+      // its caller, and the post-commit hook reads fields an offloaded row does
+      // not keep — container_provision's `containerId` is not on the inline
+      // allowlist. Rebuild that value without an in-transaction blob read:
+      // recovery never touches `data`/`result`, so the pre-transaction
+      // hydration of those two is byte-identical, and the fresh `error` is the
+      // plaintext just written, offloaded or not.
+      const recoveredJob: Job = params.hydratedJob
+        ? {
+            ...updated,
+            data: params.hydratedJob.data,
+            result: params.hydratedJob.result,
+            error: params.error,
+          }
+        : updated;
       if (params.isFailed && params.onFailedInTx) {
-        // `incrementAttempt` hands the writeback `hydrateJob(updated)`. Rebuild
-        // exactly that value without an in-transaction blob read: recovery
-        // never touches `data`/`result`, so the pre-transaction hydration of
-        // those two is byte-identical, and the fresh `error` is the plaintext
-        // just written — offloaded or not.
-        const failedJob: Job = params.hydratedJob
-          ? {
-              ...updated,
-              data: params.hydratedJob.data,
-              result: params.hydratedJob.result,
-              error: params.error,
-            }
-          : updated;
-        await params.onFailedInTx(tx, failedJob);
+        await params.onFailedInTx(tx, recoveredJob);
       }
-      return updated;
+      return recoveredJob;
     });
   }
 

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -19,6 +19,7 @@ import {
   offloadJsonField,
   offloadTextField,
 } from "../../lib/storage/object-store";
+import { logger } from "../../lib/utils/logger";
 import type { DbTransaction } from "../client";
 import { sqlRows } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
@@ -28,6 +29,23 @@ import type { Job, NewJob } from "../schemas/jobs";
 import { jobs } from "../schemas/jobs";
 
 export type { Job, NewJob };
+
+/**
+ * Settles the rows that depend on a job the recovery sweep just flipped to
+ * `failed`. Runs inside the recovery transaction, so it commits with the flip
+ * or rolls back with it — the same contract as `incrementAttempt`.
+ */
+export type JobFailureWriteback = (tx: DbTransaction, failedJob: Job) => Promise<void>;
+
+/**
+ * Builds the writeback for one job. Called OUTSIDE the transaction so the
+ * caller can read blob-offloaded payloads without holding the lifecycle lock.
+ * Returns undefined for job types that own no dependent row.
+ */
+export type RecoveryFailureWritebackBuilder = (
+  hydratedJob: Job,
+  error: string,
+) => JobFailureWriteback | undefined;
 
 export const DEFAULT_JOB_EXECUTION_LEASE_MS = 60_000;
 export const JOB_EXECUTION_RECOVERY_GRACE_MS = 30_000;
@@ -881,6 +899,10 @@ export class JobsRepository {
     organizationId?: string;
     staleThresholdMs: number;
     maxAttempts?: number;
+    /** Settles dependent rows for jobs this sweep flips to `failed`. */
+    buildFailureWriteback?: RecoveryFailureWritebackBuilder;
+    /** Post-commit hook for a flip that committed (cache eviction, metrics). */
+    onPermanentFailure?: (failedJob: Job) => Promise<void>;
   }): Promise<number> {
     const staleThreshold = new Date(Date.now() - filters.staleThresholdMs);
     const conditions = [
@@ -910,6 +932,7 @@ export class JobsRepository {
       .where(and(...conditions));
 
     let recoveredCount = 0;
+    let sweepFailures = 0;
 
     // Process each stale job, incrementing attempts and failing if max reached
     for (const job of staleJobs) {
@@ -923,16 +946,60 @@ export class JobsRepository {
           ? `Job timed out ${newAttempts} times - max attempts reached`
           : `Job timed out - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
       const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
-      const updated = await this.recoverJobFromSnapshot({
-        job,
-        startedBefore: staleThreshold,
-        isFailed,
-        newAttempts,
-        error: timeoutError,
-        recoveryFence,
+      // Per-job isolation so one poisoned payload cannot starve the sweep. A
+      // batch where EVERY job failed is an infrastructure outage instead, and
+      // that signal must keep reaching the caller, so it is counted and
+      // rethrown below.
+      try {
+        const { onFailedInTx, hydratedJob } = isFailed
+          ? await this.prepareRecoveryWriteback(job, timeoutError, filters.buildFailureWriteback)
+          : {};
+        const updated = await this.recoverJobFromSnapshot({
+          job,
+          startedBefore: staleThreshold,
+          isFailed,
+          newAttempts,
+          error: timeoutError,
+          recoveryFence,
+          onFailedInTx,
+          hydratedJob,
+        });
+        if (updated && !isFailed) {
+          recoveredCount++;
+        }
+        if (updated && isFailed && filters.onPermanentFailure) {
+          try {
+            await filters.onPermanentFailure(updated);
+          } catch (hookError) {
+            // error-policy:J7 the recovery itself committed; only the
+            // post-commit hook failed.
+            logger.warn("[jobs] Post-failure hook failed after a committed recovery", {
+              jobId: job.id,
+              type: job.type,
+              error: hookError instanceof Error ? hookError.message : String(hookError),
+            });
+          }
+        }
+      } catch (error) {
+        // error-policy:J1/J7 per-job isolation with the outage signal kept.
+        sweepFailures++;
+        logger.error("[jobs] Stale-job recovery failed for one job; continuing sweep", {
+          jobId: job.id,
+          type: job.type,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    if (sweepFailures > 0) {
+      logger.error("[jobs] Stale-job sweep finished degraded", {
+        swept: staleJobs.length,
+        failed: sweepFailures,
       });
-      if (updated && !isFailed) {
-        recoveredCount++;
+      if (sweepFailures === staleJobs.length) {
+        throw new Error(
+          `Stale-job recovery failed for every job in the batch (${sweepFailures}/${staleJobs.length})`,
+        );
       }
     }
 
@@ -949,6 +1016,10 @@ export class JobsRepository {
     organizationId?: string;
     startedBefore: Date;
     maxAttempts?: number;
+    /** Settles dependent rows for jobs this sweep flips to `failed`. */
+    buildFailureWriteback?: RecoveryFailureWritebackBuilder;
+    /** Post-commit hook for a flip that committed (cache eviction, metrics). */
+    onPermanentFailure?: (failedJob: Job) => Promise<void>;
   }): Promise<number> {
     const conditions = [
       eq(jobs.type, filters.type),
@@ -972,6 +1043,7 @@ export class JobsRepository {
       .where(and(...conditions));
 
     let recoveredCount = 0;
+    let sweepFailures = 0;
 
     for (const job of interruptedJobs) {
       const resumeCommittedCanary = hasRecoverableAdminCanaryCutover(job);
@@ -984,20 +1056,91 @@ export class JobsRepository {
           ? `Job interrupted by worker restart ${newAttempts} times - max attempts reached`
           : `Job interrupted by worker restart - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
       const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
-      const updated = await this.recoverJobFromSnapshot({
-        job,
-        startedBefore: filters.startedBefore,
-        isFailed,
-        newAttempts,
-        error,
-        recoveryFence,
+      // Per-job isolation with the outage signal preserved — same policy as
+      // the stale sweep.
+      try {
+        const { onFailedInTx, hydratedJob } = isFailed
+          ? await this.prepareRecoveryWriteback(job, error, filters.buildFailureWriteback)
+          : {};
+        const updated = await this.recoverJobFromSnapshot({
+          job,
+          startedBefore: filters.startedBefore,
+          isFailed,
+          newAttempts,
+          error,
+          recoveryFence,
+          onFailedInTx,
+          hydratedJob,
+        });
+        if (updated && !isFailed) {
+          recoveredCount++;
+        }
+        if (updated && isFailed && filters.onPermanentFailure) {
+          try {
+            await filters.onPermanentFailure(updated);
+          } catch (hookError) {
+            // error-policy:J7 the recovery committed; only the hook failed.
+            logger.warn("[jobs] Post-failure hook failed after a committed recovery", {
+              jobId: job.id,
+              type: job.type,
+              error: hookError instanceof Error ? hookError.message : String(hookError),
+            });
+          }
+        }
+      } catch (loopError) {
+        // error-policy:J1/J7 per-job isolation with the outage signal kept.
+        sweepFailures++;
+        logger.error("[jobs] Startup recovery failed for one job; continuing sweep", {
+          jobId: job.id,
+          type: job.type,
+          error: loopError instanceof Error ? loopError.message : String(loopError),
+        });
+      }
+    }
+
+    if (sweepFailures > 0) {
+      logger.error("[jobs] Startup recovery sweep finished degraded", {
+        swept: interruptedJobs.length,
+        failed: sweepFailures,
       });
-      if (updated && !isFailed) {
-        recoveredCount++;
+      if (sweepFailures === interruptedJobs.length) {
+        throw new Error(
+          `Startup recovery failed for every job in the batch (${sweepFailures}/${interruptedJobs.length})`,
+        );
       }
     }
 
     return recoveredCount;
+  }
+
+  /**
+   * Resolves the dependent-row writeback for a job about to be flipped to
+   * `failed`. Hydration happens HERE, outside the recovery transaction: the
+   * blob store has no timeout and the transaction holds the agent-lifecycle
+   * advisory lock.
+   */
+  private async prepareRecoveryWriteback(
+    job: Job,
+    error: string,
+    build: RecoveryFailureWritebackBuilder | undefined,
+  ): Promise<{ onFailedInTx?: JobFailureWriteback; hydratedJob?: Job }> {
+    if (!build) return {};
+    try {
+      const hydratedJob = await hydrateJob(job);
+      return { onFailedInTx: build(hydratedJob, error), hydratedJob };
+    } catch (buildError) {
+      // error-policy:J4/J7 degrade-with-signal — the flip must not be held
+      // hostage by an unbuildable writeback.
+      logger.error(
+        "[jobs] Failure-writeback build threw; flipping the job WITHOUT settling its dependent row",
+        {
+          jobId: job.id,
+          type: job.type,
+          error: buildError instanceof Error ? buildError.message : String(buildError),
+        },
+      );
+      return {};
+    }
   }
 
   private async recoverJobFromSnapshot(params: {
@@ -1007,7 +1150,15 @@ export class JobsRepository {
     newAttempts: number;
     error: string;
     recoveryFence: SQL;
-  }): Promise<boolean> {
+    /**
+     * Settles the dependent row when this recovery flips the job to `failed`.
+     * Runs inside the recovery transaction, only after the CAS matched, so a
+     * throw rolls back BOTH the status flip and the dependent write.
+     */
+    onFailedInTx?: JobFailureWriteback;
+    /** Hydrated snapshot for the writeback; resolved outside the transaction. */
+    hydratedJob?: Job;
+  }): Promise<Job | undefined> {
     const payload = await prepareJobPayload({ error: params.error }, params.job);
     const requiresExecutionLease = hasDetachedProvisioningExecution(params.job.type);
     return dbWrite.transaction(async (tx) => {
@@ -1036,7 +1187,7 @@ export class JobsRepository {
         )
         .for("update")
         .limit(1);
-      if (!lockedJob) return false;
+      if (!lockedJob) return undefined;
       if (requiresExecutionLease && params.job.execution_generation) {
         const [liveLease] = await tx
           .select({ jobId: jobExecutionLeases.job_id })
@@ -1050,7 +1201,7 @@ export class JobsRepository {
             ),
           )
           .limit(1);
-        if (liveLease) return false;
+        if (liveLease) return undefined;
       }
       const [updated] = await tx
         .update(jobs)
@@ -1082,8 +1233,8 @@ export class JobsRepository {
               : sql`TRUE`,
           ),
         )
-        .returning({ id: jobs.id });
-      if (!updated) return false;
+        .returning();
+      if (!updated) return undefined;
       if (requiresExecutionLease) {
         await tx
           .delete(jobExecutionLeases)
@@ -1112,7 +1263,23 @@ export class JobsRepository {
             ),
           );
       }
-      return true;
+      if (params.isFailed && params.onFailedInTx) {
+        // `incrementAttempt` hands the writeback `hydrateJob(updated)`. Rebuild
+        // exactly that value without an in-transaction blob read: recovery
+        // never touches `data`/`result`, so the pre-transaction hydration of
+        // those two is byte-identical, and the fresh `error` is the plaintext
+        // just written — offloaded or not.
+        const failedJob: Job = params.hydratedJob
+          ? {
+              ...updated,
+              data: params.hydratedJob.data,
+              result: params.hydratedJob.result,
+              error: params.error,
+            }
+          : updated;
+        await params.onFailedInTx(tx, failedJob);
+      }
+      return updated;
     });
   }
 

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -36,6 +36,7 @@ import {
   jobsRepository,
   type NewJob,
   prepareJobInsertData,
+  type RecoveryFailureWritebackBuilder,
   StaleJobExecutionError,
 } from "../../db/repositories/jobs";
 import {
@@ -1030,6 +1031,31 @@ const SHARED_IMAGE_CHANGE_JOB_TYPES: ProvisioningJobType[] = [
   JOB_TYPES.AGENT_UPGRADE,
   JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
 ];
+
+/**
+ * Job types whose permanent failure has to settle a dependent status row. This
+ * list and the arms of `buildPermanentFailureWriteback` are ONE mapping; the
+ * exhaustiveness check in that switch fails the build if they drift apart.
+ * Recovery consults it per TYPE because resolving a writeback first hydrates
+ * the job's blob-offloaded payload, and a type owning no dependent row would
+ * pay those object-store reads only to be handed `undefined` — which would
+ * also make the stale sweep hydrate for lanes it deliberately leaves gated.
+ */
+const DEPENDENT_ROW_JOB_TYPES = [
+  JOB_TYPES.AGENT_PROVISION,
+  JOB_TYPES.AGENT_RESTART,
+  JOB_TYPES.AGENT_UPGRADE,
+  JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
+  JOB_TYPES.APP_DEPLOY,
+  JOB_TYPES.CONTAINER_PROVISION,
+  JOB_TYPES.AGENT_DELETE,
+] as const satisfies readonly ProvisioningJobType[];
+
+type DependentRowJobType = (typeof DEPENDENT_ROW_JOB_TYPES)[number];
+
+function ownsDependentRow(jobType: string): jobType is DependentRowJobType {
+  return (DEPENDENT_ROW_JOB_TYPES as readonly string[]).includes(jobType);
+}
 export class ProvisioningJobService {
   private readonly executionOverride?: (job: Job) => Promise<void>;
   private readonly executionTimeoutMs: (jobType: string) => number;
@@ -2858,8 +2884,7 @@ export class ProvisioningJobService {
       const recovered = await jobsRepository.recoverInProgressJobsStartedBefore({
         type: jobType,
         startedBefore,
-        buildFailureWriteback: (hydratedJob, error) =>
-          this.buildPermanentFailureWriteback(hydratedJob, error),
+        buildFailureWriteback: this.dependentRowWritebackBuilder(jobType),
         onPermanentFailure: (failedJob) => this.evictAppCachesAfterPermanentFailure(failedJob),
       });
       totalRecovered += recovered;
@@ -3061,13 +3086,14 @@ export class ProvisioningJobService {
    * Builds the in-transaction dependent-row writeback for a job that has just
    * exhausted its retries. Returned callback runs INSIDE incrementAttempt's
    * transaction (atomic with the job-status `failed` flip). Returns undefined
-   * for job types that have no dependent status row to flip.
+   * for job types outside `DEPENDENT_ROW_JOB_TYPES`, which own no such row.
    */
   private buildPermanentFailureWriteback(
     job: Job,
     errorMsg: string,
     upgradeFailure?: UpgradeFailedError,
   ): ((tx: DbTransaction, failedJob: Job) => Promise<void>) | undefined {
+    if (!ownsDependentRow(job.type)) return undefined;
     switch (job.type) {
       // Mark the sandbox "error" so the UI reflects reality instead of staying
       // stuck in "provisioning".
@@ -3318,9 +3344,27 @@ export class ProvisioningJobService {
           );
         };
       }
-      default:
-        return undefined;
+      default: {
+        // The guard above already excluded every non-dependent type, so a new
+        // arm added to DEPENDENT_ROW_JOB_TYPES without a case here fails to
+        // compile rather than silently skipping its dependent row.
+        const unhandled: never = job.type;
+        throw new Error(`No permanent-failure writeback for job type ${String(unhandled)}`);
+      }
     }
+  }
+
+  /**
+   * Resolves the writeback builder for one job TYPE, before the sweep has a job
+   * in hand. A type owning no dependent row gets no builder at all: the
+   * repository must hydrate a job's blob-offloaded payload before it can call
+   * one, and the object store has no timeout.
+   */
+  private dependentRowWritebackBuilder(
+    jobType: string,
+  ): RecoveryFailureWritebackBuilder | undefined {
+    if (!ownsDependentRow(jobType)) return undefined;
+    return (hydratedJob, error) => this.buildPermanentFailureWriteback(hydratedJob, error);
   }
 
   private async assertNoConflictingLifecycleExecution(job: Job): Promise<void> {
@@ -5081,8 +5125,7 @@ export class ProvisioningJobService {
         staleThresholdMs: COLD_BOOT_JOB_TYPES.has(jobType)
           ? COLD_BOOT_STALE_JOB_THRESHOLD_MS
           : DEFAULT_STALE_JOB_THRESHOLD_MS,
-        buildFailureWriteback: (hydratedJob, error) =>
-          this.buildPermanentFailureWriteback(hydratedJob, error),
+        buildFailureWriteback: this.dependentRowWritebackBuilder(jobType),
         onPermanentFailure: (failedJob) => this.evictAppCachesAfterPermanentFailure(failedJob),
       });
       totalRecovered += recovered;

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -2858,6 +2858,9 @@ export class ProvisioningJobService {
       const recovered = await jobsRepository.recoverInProgressJobsStartedBefore({
         type: jobType,
         startedBefore,
+        buildFailureWriteback: (hydratedJob, error) =>
+          this.buildPermanentFailureWriteback(hydratedJob, error),
+        onPermanentFailure: (failedJob) => this.evictAppCachesAfterPermanentFailure(failedJob),
       });
       totalRecovered += recovered;
     }
@@ -3018,19 +3021,27 @@ export class ProvisioningJobService {
       ),
     );
 
-    // app_deploy keeps a post-commit cache invalidation (the apps read
-    // cache is invalidated outside the DB transaction); the row flip
-    // itself already committed atomically inside onFailedInTx above.
-    if (updated?.status === "failed" && job.type === JOB_TYPES.APP_DEPLOY) {
+    if (updated?.status === "failed") {
+      await this.evictAppCachesAfterPermanentFailure(job);
+    }
+  }
+
+  /**
+   * Post-commit read-cache eviction for a job whose dependent row was just
+   * flipped by the in-transaction writeback. The `apps` read cache lives
+   * outside the DB transaction, so it can only be evicted once the flip is
+   * durable — for app_deploy because appsService owns that cache, and for
+   * container_provision because its writeback updates apps.deployment_status
+   * with a raw in-tx statement that bypasses appsService entirely (otherwise
+   * the deploy-status route keeps reporting `building` until the 5-min TTL).
+   */
+  private async evictAppCachesAfterPermanentFailure(job: Job): Promise<void> {
+    if (job.type === JOB_TYPES.APP_DEPLOY) {
       const { appId } = readAppDeployJobData(job);
       await appsService.invalidateCache(appId);
+      return;
     }
-    // container_provision flips apps.deployment_status with a raw in-tx
-    // update (bypassing the appsService cache), so evict the app read cache
-    // here too — otherwise the cache-backed deploy-status route keeps
-    // reporting `building` until the 5-min TTL. The in-tx writeback already
-    // org-scoped the flip; an appId that matched no app is a harmless evict.
-    if (updated?.status === "failed" && job.type === JOB_TYPES.CONTAINER_PROVISION) {
+    if (job.type === JOB_TYPES.CONTAINER_PROVISION) {
       const { containerId } = readContainerProvisionJobData(job);
       const [row] = await dbWrite
         .select({ projectName: containers.project_name })
@@ -3038,6 +3049,8 @@ export class ProvisioningJobService {
         .where(eq(containers.id, containerId))
         .limit(1);
       const appId = row?.projectName;
+      // The in-tx writeback already org-scoped the flip; an appId that matched
+      // no app is a harmless evict.
       if (appId && isValidUUID(appId)) {
         await appsService.invalidateCache(appId);
       }
@@ -5068,6 +5081,9 @@ export class ProvisioningJobService {
         staleThresholdMs: COLD_BOOT_JOB_TYPES.has(jobType)
           ? COLD_BOOT_STALE_JOB_THRESHOLD_MS
           : DEFAULT_STALE_JOB_THRESHOLD_MS,
+        buildFailureWriteback: (hydratedJob, error) =>
+          this.buildPermanentFailureWriteback(hydratedJob, error),
+        onPermanentFailure: (failedJob) => this.evictAppCachesAfterPermanentFailure(failedJob),
       });
       totalRecovered += recovered;
     }

--- a/packages/scripts/cloud/admin/daemons/apps-provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/apps-provisioning-worker.ts
@@ -181,6 +181,42 @@ async function pollCycle(
   }
 }
 
+/**
+ * One-shot recovery of the executions a previous process left `in_progress`.
+ * Guarded because it sits between boot and the poll loop: the sweep throws when
+ * every job in a batch failed, and on a lane this small that batch is routinely
+ * one row. Rethrowing here exits the process, systemd restarts into the same
+ * row, and the lane claims nothing at all — strictly worse than booting with
+ * that row still stale, which the poll cycle's stale sweep retries anyway.
+ */
+export async function recoverInterruptedExecutions(
+  logger: WorkerLogger,
+  loadWorkerDeps: typeof loadDeps = loadDeps,
+): Promise<void> {
+  try {
+    const { provisioningJobService } = await loadWorkerDeps();
+    const recovered =
+      await provisioningJobService.recoverInterruptedJobsOnStartup(
+        workerStartedAt,
+        APPS_JOB_TYPES,
+      );
+    if (recovered > 0) {
+      logger.warn(
+        "[apps-worker] recovered interrupted executions from prior process",
+        {
+          recovered,
+        },
+      );
+    }
+  } catch (error) {
+    // error-policy:J1 process boundary — the sibling control-plane worker wraps
+    // the same sweep in runBoundedPhase; this lane had no equivalent.
+    logger.error("[apps-worker] startup interrupted-job recovery failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 async function main(): Promise<void> {
   loadLocalEnv(import.meta.url);
 
@@ -197,20 +233,7 @@ async function main(): Promise<void> {
 
   armed = await armAppsDeployBackend(logger);
   if (armed) {
-    const { provisioningJobService } = await loadDeps();
-    const recovered =
-      await provisioningJobService.recoverInterruptedJobsOnStartup(
-        workerStartedAt,
-        APPS_JOB_TYPES,
-      );
-    if (recovered > 0) {
-      logger.warn(
-        "[apps-worker] recovered interrupted executions from prior process",
-        {
-          recovered,
-        },
-      );
-    }
+    await recoverInterruptedExecutions(logger);
   }
 
   if (config.runOnce) {

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -879,17 +879,47 @@ describe("managed dedicated canary diagnostic", () => {
     ).toThrow("unrelated newer job");
   });
 
+  // The recovery sweep now runs the same dependent-row writeback the live
+  // execution path runs, so a recovery-authored terminal failure IS a
+  // legitimate envelope source.
   test.each([
-    "Job timed out 3 times - max attempts reached",
-    "Job interrupted by worker restart 3 times - max attempts reached",
-  ])("rejects a recovery-generated terminal job as wrapper source", (cause) => {
-    expect(() =>
-      sanitizeManagedDedicatedCanaryDiagnostic(
+    ["Job timed out 3 times - max attempts reached", "timeout"],
+    [
+      "Job interrupted by worker restart 3 times - max attempts reached",
+      "worker_restart_interrupted",
+    ],
+  ])(
+    "accepts a recovery-generated terminal job as wrapper source",
+    (cause, code) => {
+      const evidence = sanitizeManagedDedicatedCanaryDiagnostic(
         correlatedPermanentDeleteInput(cause),
         SUFFIX,
-      ),
-    ).toThrow("does not correlate");
-  });
+      );
+      expect(evidence.sandbox.errorCode).toBe(code as never);
+      expect(evidence.jobs[0]).toMatchObject({
+        status: "failed",
+        errorCode: code,
+      });
+    },
+  );
+
+  // The attempt count a terminal message carries is fenced job-side, before
+  // wrapper correlation ever runs — which is what lets the correlation itself
+  // stay a plain raw-equality check.
+  test.each([
+    "Job timed out 2 times - max attempts reached",
+    "Job interrupted by worker restart 4 times - max attempts reached",
+  ])(
+    "rejects a terminal wrapper source whose attempt count disagrees",
+    (cause) => {
+      expect(() =>
+        sanitizeManagedDedicatedCanaryDiagnostic(
+          correlatedPermanentDeleteInput(cause),
+          SUFFIX,
+        ),
+      ).toThrow("terminal counters disagree");
+    },
+  );
 
   test("rejects coarse-code and equal-profile matches with different raw causes", () => {
     const known = correlatedPermanentDeleteInput(

--- a/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
+++ b/packages/scripts/cloud/admin/managed-dedicated-canary-diagnostic.ts
@@ -432,10 +432,15 @@ function classifySandboxError(
   // Recovery preserves the last permanent failure while adding newer jobs, so
   // raw equality and counters identify its writer without exposing another
   // arbitrary-text profile or assuming the retained writer is still newest.
+  // A recovery-authored terminal failure is a legitimate envelope cause too:
+  // the recovery sweep now runs the same dependent-row writeback the live
+  // execution path runs. It needs no extra counter fence — job-level
+  // validation already pins a terminal message's own attempt count to the
+  // job's attempts and maxAttempts, which the equalities below pin to the
+  // envelope's.
   const sourceIndex = jobs.findIndex(
     ({ diagnostic, rawError }) =>
       typeof rawError === "string" &&
-      classifyTerminalFailure(rawError) === null &&
       rawError === envelope.cause &&
       diagnostic.status === "failed" &&
       diagnostic.attempts === envelope.attempts &&


### PR DESCRIPTION
## What — #17253 §3

**Supersedes #17263.** That PR was branched on top of the rejected #17258, so its diff still carried the interruption-counter design you turned down. This is a clean re-cut on current `develop`: writeback only, no counter, none of the #17258 commits. The durable counter is a separate lot and will land on its own once this is in.

The live execution path already settles a job's dependent status row atomically with its permanent-failure flip — `incrementAttempt(…, onFailedInTx)` flips an APP_DEPLOY's app off `building` in the same transaction as the job's `failed` write. The recovery sweeps did not: `recoverJobFromSnapshot` was a bare update, so a recovered-to-failed APP_DEPLOY left its app `building` and every redeploy 409'd until manual SQL. The code names this gap itself (the `reEnqueueFailedDeletions` rationale) and explicitly rejects sweeps as the primary signal. Recovery now speaks the same contract.

## Design

- **Same contract, second caller.** The writeback runs inside the recovery transaction, only after the CAS matched. A throw rolls back the flip and the dependent write together, so the next sweep retries the pair rather than leaving half a state change behind. The CAS itself is untouched.
- **Hydration stays outside the transaction.** Builders read payloads eagerly and an offloaded CONTAINER_PROVISION payload keeps `containerId` only in the blob store, which has no timeout — and the transaction holds the agent-lifecycle advisory lock. So the builder runs on the hydrated job, before the transaction opens.
- **The value the writeback receives equals `hydrateJob(updated)` exactly**, rebuilt with no in-transaction blob read: recovery never touches `data`/`result`, so the pre-transaction hydration of those two is byte-identical, and the fresh `error` is the plaintext just written. That same value is what `recoverJobFromSnapshot` returns, so the post-commit cache eviction sees what the live path sees.
- **Per-job isolation, outage still audible.** One poisoned payload rolls back its own job only. A batch where *every* job failed throws — that is an infrastructure outage and the caller alerts on it.
- **Fail-closed, like the live path.** A writeback that cannot be built leaves the job `in_progress` for the next sweep. Flipping it without settling its dependent row is the exact half-state this change exists to remove, so there is no degrade branch.
- **Recovery asks per job TYPE whether a dependent row exists**, before it hydrates anything. Types that own none get no builder and pay no object-store reads — which also keeps true the invariant that lets the stale sweep skip lane filtering (flipping a stuck row back to `pending` stays DB-only). The type list and the switch arms are one mapping; the switch fails to compile if they drift.
- **The apps daemon got the process boundary it was missing.** Startup recovery was called with no handler, so an all-failed batch — routinely one row on a lane that small — exited the process, systemd restarted into the same row, and the lane claimed nothing. Its sibling worker already wraps the same sweep.

Recovery has no `UpgradeFailedError`, which lands AGENT_UPGRADE on the rollback-safe default: re-armable marker, never `status='error'` on a possibly-live agent.

## What changed since #17263, beyond dropping the counter

The first cut of this work had four defects of its own, found by adversarially verifying it rather than trusting the green suite:

1. The post-commit hook was handed the **raw** row while the in-transaction writeback got the hydrated one. Production offloads payloads, so `readContainerProvisionJobData` threw on every offloaded job and was swallowed by its own J7 warn — the deploy-status route kept reporting `building` for the full cache TTL, precisely the failure that hook exists to prevent.
2. The hydration guard **degraded open**: an unreachable blob store meant the job still flipped to `failed` with its dependent row untouched, and because the degrade sat one frame below the per-job catch it never counted toward the all-failed signal, so the sweep returned a healthy-looking number.
3. Resolving a writeback hydrated **every** job type, including lanes deliberately left gated, falsifying the in-repo comment that justifies not lane-filtering the stale sweep.
4. The apps daemon crash loop above.

## Tests

`18 pass / 0 fail` on the recovery harness, `16 pass` on the service writeback seams, `208 pass` on the canary diagnostic sanitizer, `6 pass` on the apps worker.

The offloaded path is now driven for real against an in-memory bucket — every previous fixture was `inline`, which is exactly what made defect 1 invisible. Reverting the hydrated return turns that test red. The test that could not fail (it passed on base too) was replaced by one proving the fail-closed behavior.

The full `src/db/repositories` batch run shows 11 failures **on `develop` as well** — pre-existing cross-file pollution in batch mode, unrelated to this diff; the same run adds 6 passing tests and no new failures.

The canary diagnostic stops refusing recovery-authored terminal failures as permanent-delete envelope sources, since recovery is now a legitimate writer of them. No fence was weakened: job-level validation already pins a terminal message's own attempt count to the job's `attempts` and `max_attempts`, which the correlation equalities pin to the envelope's.

Refs #17253 · Supersedes #17263 [stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend-only change, no UI surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involved in this path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - covered by backend-logs test run

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to OCR

<!-- evidence-row:backend-logs -->
- [x] [17253-3-recovery-writeback-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17253-3-recovery-writeback-tests.log)
