### PR TITLE
fix(ci): tolerate the inactive LifeOps smoke latch

### DIFF
--- a/packages/app/scripts/browser-failure-policy.test.ts
+++ b/packages/app/scripts/browser-failure-policy.test.ts
@@ -6,32 +6,57 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  ExpectedDevSmokeFailureMatcher,
   isExpectedDevSmokeConsoleError,
   isExpectedDevSmokeResponse,
+  isLifeOpsActivitySignals503,
 } from "../test/dev-smoke/browser-failure-policy";
+
+const INACTIVE_BODY = JSON.stringify({
+  error:
+    "LifeOps activity signals are unavailable because the personal-assistant runtime is not active",
+});
 
 describe("development smoke browser failure policy", () => {
   it("accepts only the inactive LifeOps activity-signal response", () => {
+    const endpoint = "http://127.0.0.1:2138/api/lifeops/activity-signals";
+    expect(isExpectedDevSmokeResponse(503, endpoint, INACTIVE_BODY)).toBe(true);
+    expect(
+      isExpectedDevSmokeResponse(503, `${endpoint}?probe=1`, INACTIVE_BODY),
+    ).toBe(true);
+    expect(isExpectedDevSmokeResponse(500, endpoint, INACTIVE_BODY)).toBe(
+      false,
+    );
     expect(
       isExpectedDevSmokeResponse(
         503,
-        "http://127.0.0.1:2138/api/lifeops/activity-signals",
-      ),
-    ).toBe(true);
-    expect(
-      isExpectedDevSmokeResponse(
-        503,
-        "http://127.0.0.1:2138/api/lifeops/activity-signals?probe=1",
-      ),
-    ).toBe(true);
-    expect(
-      isExpectedDevSmokeResponse(
-        500,
-        "http://127.0.0.1:2138/api/lifeops/activity-signals",
+        "http://127.0.0.1:2138/api/status",
+        INACTIVE_BODY,
       ),
     ).toBe(false);
+  });
+
+  it("keeps same-route runtime and malformed failures fatal", () => {
+    const endpoint = "http://127.0.0.1:2138/api/lifeops/activity-signals";
+    expect(isLifeOpsActivitySignals503(503, endpoint)).toBe(true);
     expect(
-      isExpectedDevSmokeResponse(503, "http://127.0.0.1:2138/api/status"),
+      isExpectedDevSmokeResponse(
+        503,
+        endpoint,
+        JSON.stringify({ error: "Agent runtime is not available" }),
+      ),
+    ).toBe(false);
+    expect(isExpectedDevSmokeResponse(503, endpoint, "not-json")).toBe(false);
+    expect(
+      isExpectedDevSmokeResponse(
+        503,
+        endpoint,
+        JSON.stringify({
+          error:
+            "LifeOps activity signals are unavailable because the personal-assistant runtime is not active",
+          hiddenFailure: true,
+        }),
+      ),
     ).toBe(false);
   });
 
@@ -58,5 +83,32 @@ describe("development smoke browser failure policy", () => {
         "http://127.0.0.1:2138/api/lifeops/activity-signals",
       ),
     ).toBe(false);
+    expect(
+      isExpectedDevSmokeConsoleError(
+        `${resourceError} while loading another resource`,
+        "http://127.0.0.1:2138/api/lifeops/activity-signals",
+      ),
+    ).toBe(false);
+  });
+
+  it("pairs console noise one-for-one with a verified inactive response", () => {
+    const endpoint = "http://127.0.0.1:2138/api/lifeops/activity-signals";
+    const resourceError =
+      "Failed to load resource: the server responded with a status of 503 (Service Unavailable)";
+    const matcher = new ExpectedDevSmokeFailureMatcher();
+
+    expect(matcher.consumeConsoleError(resourceError, endpoint)).toBe(false);
+    expect(matcher.recordResponse(503, endpoint, INACTIVE_BODY)).toBe(true);
+    expect(matcher.consumeConsoleError(resourceError, endpoint)).toBe(true);
+    expect(matcher.consumeConsoleError(resourceError, endpoint)).toBe(false);
+
+    expect(
+      matcher.recordResponse(
+        503,
+        endpoint,
+        JSON.stringify({ error: "Agent runtime is not available" }),
+      ),
+    ).toBe(false);
+    expect(matcher.consumeConsoleError(resourceError, endpoint)).toBe(false);
   });
 });

--- a/packages/app/scripts/browser-failure-policy.test.ts
+++ b/packages/app/scripts/browser-failure-policy.test.ts
@@ -1,13 +1,14 @@
 /**
  * Unit coverage for the live development smoke's narrow optional-capability
- * failure policy.
+ * failure policy. Keeping this outside Playwright's test directory prevents
+ * its Vitest API from being collected as a browser specification.
  */
 
 import { describe, expect, it } from "vitest";
 import {
   isExpectedDevSmokeConsoleError,
   isExpectedDevSmokeResponse,
-} from "./browser-failure-policy";
+} from "../test/dev-smoke/browser-failure-policy";
 
 describe("development smoke browser failure policy", () => {
   it("accepts only the inactive LifeOps activity-signal response", () => {

--- a/packages/app/test/dev-smoke/browser-failure-policy.test.ts
+++ b/packages/app/test/dev-smoke/browser-failure-policy.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit coverage for the live development smoke's narrow optional-capability
+ * failure policy.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  isExpectedDevSmokeConsoleError,
+  isExpectedDevSmokeResponse,
+} from "./browser-failure-policy";
+
+describe("development smoke browser failure policy", () => {
+  it("accepts only the inactive LifeOps activity-signal response", () => {
+    expect(
+      isExpectedDevSmokeResponse(
+        503,
+        "http://127.0.0.1:2138/api/lifeops/activity-signals",
+      ),
+    ).toBe(true);
+    expect(
+      isExpectedDevSmokeResponse(
+        503,
+        "http://127.0.0.1:2138/api/lifeops/activity-signals?probe=1",
+      ),
+    ).toBe(true);
+    expect(
+      isExpectedDevSmokeResponse(
+        500,
+        "http://127.0.0.1:2138/api/lifeops/activity-signals",
+      ),
+    ).toBe(false);
+    expect(
+      isExpectedDevSmokeResponse(503, "http://127.0.0.1:2138/api/status"),
+    ).toBe(false);
+  });
+
+  it("uses Chromium's console location to avoid hiding unrelated 503s", () => {
+    const resourceError =
+      "Failed to load resource: the server responded with a status of 503 (Service Unavailable)";
+
+    expect(
+      isExpectedDevSmokeConsoleError(
+        resourceError,
+        "http://127.0.0.1:2138/api/lifeops/activity-signals",
+      ),
+    ).toBe(true);
+    expect(
+      isExpectedDevSmokeConsoleError(
+        resourceError,
+        "http://127.0.0.1:2138/api/status",
+      ),
+    ).toBe(false);
+    expect(isExpectedDevSmokeConsoleError(resourceError, "")).toBe(false);
+    expect(
+      isExpectedDevSmokeConsoleError(
+        "Application failed with 503",
+        "http://127.0.0.1:2138/api/lifeops/activity-signals",
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/app/test/dev-smoke/browser-failure-policy.ts
+++ b/packages/app/test/dev-smoke/browser-failure-policy.ts
@@ -1,0 +1,34 @@
+/**
+ * Classifies browser failures that the live development smoke intentionally
+ * tolerates while optional runtime capabilities are unavailable.
+ */
+
+const LIFEOPS_ACTIVITY_SIGNALS_PATH = "/api/lifeops/activity-signals";
+const RESOURCE_UNAVAILABLE_503 =
+  /^Failed to load resource: the server responded with a status of 503 /i;
+
+function hasPath(url: string, expectedPath: string): boolean {
+  try {
+    return new URL(url, "http://localhost").pathname === expectedPath;
+  } catch {
+    // error-policy:J3 Invalid browser URLs are never expected failures.
+    return false;
+  }
+}
+
+export function isExpectedDevSmokeResponse(
+  status: number,
+  url: string,
+): boolean {
+  return status === 503 && hasPath(url, LIFEOPS_ACTIVITY_SIGNALS_PATH);
+}
+
+export function isExpectedDevSmokeConsoleError(
+  text: string,
+  locationUrl: string,
+): boolean {
+  return (
+    RESOURCE_UNAVAILABLE_503.test(text) &&
+    hasPath(locationUrl, LIFEOPS_ACTIVITY_SIGNALS_PATH)
+  );
+}

--- a/packages/app/test/dev-smoke/browser-failure-policy.ts
+++ b/packages/app/test/dev-smoke/browser-failure-policy.ts
@@ -4,8 +4,10 @@
  */
 
 const LIFEOPS_ACTIVITY_SIGNALS_PATH = "/api/lifeops/activity-signals";
+const LIFEOPS_ACTIVITY_SIGNALS_INACTIVE_ERROR =
+  "LifeOps activity signals are unavailable because the personal-assistant runtime is not active";
 const RESOURCE_UNAVAILABLE_503 =
-  /^Failed to load resource: the server responded with a status of 503 /i;
+  "Failed to load resource: the server responded with a status of 503 (Service Unavailable)";
 
 function hasPath(url: string, expectedPath: string): boolean {
   try {
@@ -16,11 +18,33 @@ function hasPath(url: string, expectedPath: string): boolean {
   }
 }
 
-export function isExpectedDevSmokeResponse(
+export function isLifeOpsActivitySignals503(
   status: number,
   url: string,
 ): boolean {
   return status === 503 && hasPath(url, LIFEOPS_ACTIVITY_SIGNALS_PATH);
+}
+
+export function isExpectedDevSmokeResponse(
+  status: number,
+  url: string,
+  body: string,
+): boolean {
+  if (!isLifeOpsActivitySignals503(status, url)) return false;
+
+  try {
+    const parsed: unknown = JSON.parse(body);
+    return (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      Object.keys(parsed).length === 1 &&
+      "error" in parsed &&
+      parsed.error === LIFEOPS_ACTIVITY_SIGNALS_INACTIVE_ERROR
+    );
+  } catch {
+    // error-policy:J3 A malformed failure body is not the expected inactive signal.
+    return false;
+  }
 }
 
 export function isExpectedDevSmokeConsoleError(
@@ -28,7 +52,28 @@ export function isExpectedDevSmokeConsoleError(
   locationUrl: string,
 ): boolean {
   return (
-    RESOURCE_UNAVAILABLE_503.test(text) &&
+    text === RESOURCE_UNAVAILABLE_503 &&
     hasPath(locationUrl, LIFEOPS_ACTIVITY_SIGNALS_PATH)
   );
+}
+
+export class ExpectedDevSmokeFailureMatcher {
+  readonly #inactiveResponses = new Map<string, number>();
+
+  recordResponse(status: number, url: string, body: string): boolean {
+    if (!isExpectedDevSmokeResponse(status, url, body)) return false;
+    this.#inactiveResponses.set(
+      url,
+      (this.#inactiveResponses.get(url) ?? 0) + 1,
+    );
+    return true;
+  }
+
+  consumeConsoleError(text: string, locationUrl: string): boolean {
+    if (!isExpectedDevSmokeConsoleError(text, locationUrl)) return false;
+    const remainingMatches = this.#inactiveResponses.get(locationUrl) ?? 0;
+    if (remainingMatches === 0) return false;
+    this.#inactiveResponses.set(locationUrl, remainingMatches - 1);
+    return true;
+  }
 }

--- a/packages/app/test/dev-smoke/bun-dev-onboarding-chat.spec.ts
+++ b/packages/app/test/dev-smoke/bun-dev-onboarding-chat.spec.ts
@@ -22,7 +22,7 @@ test.describe("bun run dev onboarding chat smoke", () => {
   test("starts dev, completes onboarding, and sends a chat message", async ({
     page,
   }) => {
-    const failures = browserFailureCollector(page);
+    const failureCollector = browserFailureCollector(page);
 
     // Onboarding submission runs here (or in a sibling spec sharing this dev
     // server, whichever runs first); ensureOnboarded is idempotent.
@@ -49,6 +49,9 @@ test.describe("bun run dev onboarding chat smoke", () => {
       .filter({ hasText: RESPONSE_MARKER });
     await expect(assistantReply.first()).toBeVisible({ timeout: 180_000 });
 
-    expect(failures, "browser/runtime failures").toEqual([]);
+    expect(
+      await failureCollector.failures(),
+      "browser/runtime failures",
+    ).toEqual([]);
   });
 });

--- a/packages/app/test/dev-smoke/live-onboarding.ts
+++ b/packages/app/test/dev-smoke/live-onboarding.ts
@@ -9,6 +9,10 @@ import {
   getFirstRunProviderForLiveProvider,
   selectLiveProvider,
 } from "../../../app-core/test/helpers/live-provider";
+import {
+  isExpectedDevSmokeConsoleError,
+  isExpectedDevSmokeResponse,
+} from "./browser-failure-policy";
 
 export const API_PORT = Number(process.env.ELIZA_API_PORT || "31337");
 export const API_BASE = `http://127.0.0.1:${API_PORT}`;
@@ -29,6 +33,7 @@ export function browserFailureCollector(page: Page): string[] {
     const text = message.text();
     if (/^\[RenderTelemetry\]/.test(text)) return;
     if (/504 \(Outdated Optimize Dep\)/i.test(text)) return;
+    if (isExpectedDevSmokeConsoleError(text, message.location().url)) return;
     if (
       /^Failed to load resource: the server responded with a status of (401|404) /i.test(
         text,
@@ -42,6 +47,7 @@ export function browserFailureCollector(page: Page): string[] {
     if (response.status() === 504 && response.url().includes("/.vite/deps/")) {
       return;
     }
+    if (isExpectedDevSmokeResponse(response.status(), response.url())) return;
     if (response.status() < 500) return;
     failures.push(`${response.status()} ${response.url()}`);
   });

--- a/packages/app/test/dev-smoke/live-onboarding.ts
+++ b/packages/app/test/dev-smoke/live-onboarding.ts
@@ -10,8 +10,9 @@ import {
   selectLiveProvider,
 } from "../../../app-core/test/helpers/live-provider";
 import {
+  ExpectedDevSmokeFailureMatcher,
   isExpectedDevSmokeConsoleError,
-  isExpectedDevSmokeResponse,
+  isLifeOpsActivitySignals503,
 } from "./browser-failure-policy";
 
 export const API_PORT = Number(process.env.ELIZA_API_PORT || "31337");
@@ -23,8 +24,16 @@ export const CHAT_COMPOSER_SELECTOR =
 export type FirstRunStatus = { complete: boolean };
 export type HealthStatus = { ready?: boolean };
 
-export function browserFailureCollector(page: Page): string[] {
+export interface BrowserFailureCollector {
+  failures(): Promise<string[]>;
+}
+
+export function browserFailureCollector(page: Page): BrowserFailureCollector {
   const failures: string[] = [];
+  const pendingResponseChecks = new Set<Promise<void>>();
+  const expectedFailureMatcher = new ExpectedDevSmokeFailureMatcher();
+  const deferredConsoleErrors: Array<{ text: string; url: string }> = [];
+
   page.on("pageerror", (error) => {
     failures.push(`pageerror: ${error.message}`);
   });
@@ -33,7 +42,11 @@ export function browserFailureCollector(page: Page): string[] {
     const text = message.text();
     if (/^\[RenderTelemetry\]/.test(text)) return;
     if (/504 \(Outdated Optimize Dep\)/i.test(text)) return;
-    if (isExpectedDevSmokeConsoleError(text, message.location().url)) return;
+    const locationUrl = message.location().url;
+    if (isExpectedDevSmokeConsoleError(text, locationUrl)) {
+      deferredConsoleErrors.push({ text, url: locationUrl });
+      return;
+    }
     if (
       /^Failed to load resource: the server responded with a status of (401|404) /i.test(
         text,
@@ -47,11 +60,55 @@ export function browserFailureCollector(page: Page): string[] {
     if (response.status() === 504 && response.url().includes("/.vite/deps/")) {
       return;
     }
-    if (isExpectedDevSmokeResponse(response.status(), response.url())) return;
     if (response.status() < 500) return;
+    if (isLifeOpsActivitySignals503(response.status(), response.url())) {
+      let check: Promise<void>;
+      check = response
+        .text()
+        .then((body) => {
+          if (
+            expectedFailureMatcher.recordResponse(
+              response.status(),
+              response.url(),
+              body,
+            )
+          )
+            return;
+          failures.push(`${response.status()} ${response.url()}`);
+        })
+        .catch((error: unknown) => {
+          failures.push(
+            `${response.status()} ${response.url()} (body inspection failed: ${
+              error instanceof Error ? error.message : String(error)
+            })`,
+          );
+        })
+        .finally(() => pendingResponseChecks.delete(check));
+      pendingResponseChecks.add(check);
+      return;
+    }
     failures.push(`${response.status()} ${response.url()}`);
   });
-  return failures;
+
+  return {
+    async failures(): Promise<string[]> {
+      while (pendingResponseChecks.size > 0) {
+        await Promise.all([...pendingResponseChecks]);
+      }
+      for (const candidate of deferredConsoleErrors) {
+        if (
+          expectedFailureMatcher.consumeConsoleError(
+            candidate.text,
+            candidate.url,
+          )
+        )
+          continue;
+        failures.push(`console.error: ${candidate.text}`);
+      }
+      deferredConsoleErrors.length = 0;
+      return [...failures];
+    },
+  };
 }
 
 export async function fetchJson<T>(url: string): Promise<T> {


### PR DESCRIPTION
# Relates to

Closes #17444. Fixes develop workflow run [30626491771](https://github.com/elizaOS/eliza/actions/runs/30626491771).

# Sync with develop

- [x] Parent is exact `origin/develop` at `dc873211beec`.
- [x] The four changed files are isolated to the Dev Smoke browser collector and its tests.

# What changed

- Accept the designed LifeOps inactivity latch only when the response is `503` on the exact `/api/lifeops/activity-signals` pathname and the JSON body contains only the expected inactivity error.
- Pair each ignored Chromium resource-console error one-for-one with a verified inactive response from the same URL.
- Keep unrelated or malformed 500/503 responses, unmatched console errors, page errors, and application console errors fatal.
- Keep the Vitest policy unit test outside Playwright test discovery.

# Reproduction and verification

- Failed develop run reached the real `BUN_DEV_SMOKE_OK` reply before two designed activity-signal `503` responses tripped the collector.
- Focused exact-head policy tests: 4 passed, 19 assertions.
- Playwright exact-head collection: exactly 2 intended Dev Smoke specs.
- App script suite on the preceding equivalent policy head: 560 passed.
- Build, lint, typecheck, security, and evidence checks run on the exact head below.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-harness classification only; production pixels are unchanged.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-harness classification only; production pixels are unchanged.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no production interaction changed.
<!-- evidence-row:backend-logs -->
- [x] [Develop Dev Smoke failure](https://github.com/elizaOS/eliza/actions/runs/30626491771) records the successful real chat and exact 503 response bodies.
<!-- evidence-row:frontend-logs -->
- [x] [Develop Dev Smoke failure](https://github.com/elizaOS/eliza/actions/runs/30626491771) records the Chromium console errors and matching response URLs.
<!-- evidence-row:llm-trajectory -->
- [x] [Develop Dev Smoke failure](https://github.com/elizaOS/eliza/actions/runs/30626491771) used the live CI provider and produced `BUN_DEV_SMOKE_OK`; model behavior is unchanged.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain mutation changed.

# Merge gate

Merge only after exact-head Dev Smoke and required checks pass.

## Final exact-head rerun

- Head `c5bf2a67554e8b96291f11d1333f056df95b928f` verifies the exact inactivity body and correlates each suppressed console message with a verified response.
- Local: 4 focused tests passed with 19 assertions; Playwright lists exactly 2 intended specs; diff checks passed.
- [Exact-head Dev Smoke 30653266246](https://github.com/elizaOS/eliza/actions/runs/30653266246): real onboarding/chat and Vite HMR jobs passed.