### PR TITLE
fix(ui): reject stale cloud-agent refreshes

### DIFF
--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -3,11 +3,13 @@
 /**
  * Covers CloudAgentsSection rename (client call + persisted active-server label
  * sync, no-op on unchanged/empty names, error revert) and suspend/resume
- * lifecycle (direct-path client calls, error surfacing, status re-sync). jsdom
- * render with the app store, cloud API client, and persistence mocked.
+ * lifecycle (direct-path client calls, error surfacing, status re-sync), and
+ * safe teardown while a list request is pending. jsdom renders with the app
+ * store, cloud API client, and persistence mocked.
  */
 
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -784,6 +786,56 @@ describe("CloudAgentsSection load state (error vs empty)", () => {
       expect(screen.getByTestId("cloud-agent-rename-agent-1")).toBeTruthy(),
     );
     expect(screen.queryByTestId("cloud-agents-error")).toBeNull();
+  });
+
+  it("discards a list response that settles after unmount", async () => {
+    let resolveFetch:
+      | ((value: { success: true; data: [] }) => void)
+      | undefined;
+    const pendingFetch = new Promise<{ success: true; data: [] }>((resolve) => {
+      resolveFetch = resolve;
+    });
+    clientMock.getCloudCompatAgents.mockReturnValue(pendingFetch);
+
+    const view = render(<CloudAgentsSection />);
+    await waitFor(() =>
+      expect(clientMock.getCloudCompatAgents).toHaveBeenCalledTimes(1),
+    );
+    view.unmount();
+
+    await act(async () => {
+      resolveFetch?.({ success: true, data: [] });
+      await pendingFetch;
+    });
+  });
+
+  it("does not let an older list response overwrite a newer refresh", async () => {
+    let resolveInitial:
+      | ((value: { success: true; data: [] }) => void)
+      | undefined;
+    const initialFetch = new Promise<{ success: true; data: [] }>((resolve) => {
+      resolveInitial = resolve;
+    });
+    clientMock.getCloudCompatAgents
+      .mockReturnValueOnce(initialFetch)
+      .mockResolvedValueOnce({
+        success: true,
+        data: [agent({ agent_name: "Newest" })],
+      });
+
+    render(<CloudAgentsSection />);
+    await waitFor(() =>
+      expect(clientMock.getCloudCompatAgents).toHaveBeenCalledTimes(1),
+    );
+    fireEvent.click(screen.getByText("Refresh"));
+    await waitFor(() => expect(screen.getByText("Newest")).toBeTruthy());
+
+    await act(async () => {
+      resolveInitial?.({ success: true, data: [] });
+      await initialFetch;
+    });
+    expect(screen.getByText("Newest")).toBeTruthy();
+    expect(screen.queryByTestId("cloud-agents-empty")).toBeNull();
   });
 });
 

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -16,7 +16,7 @@ import {
   RefreshCw,
   Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { client } from "../../api";
 import {
   getCloudAuthToken,
@@ -110,15 +110,19 @@ export function CloudAgentsSection() {
   // The agent currently being woken (resumed + readiness-polled) before we
   // switch to it. Drives the "Waking <name>…" row state.
   const [wakingId, setWakingId] = useState<string | null>(null);
+  const refreshRequestIdRef = useRef(0);
   const activeId = useMemo(() => activeCloudAgentId(), []);
 
   const cloudApiBase = getBootConfig().cloudApiBase || "https://elizacloud.ai";
 
   const refresh = useCallback(async () => {
+    const requestId = ++refreshRequestIdRef.current;
+    const ownsRefreshState = () => refreshRequestIdRef.current === requestId;
     setLoading(true);
     setLoadError(null);
     try {
       const res = await client.getCloudCompatAgents();
+      if (!ownsRefreshState()) return;
       // A failed fetch is NOT an empty list — surface it so the user can retry
       // instead of seeing the indistinguishable "No cloud agents yet" copy.
       if (!res.success) {
@@ -131,18 +135,25 @@ export function CloudAgentsSection() {
       );
       setAgents(list);
     } catch (err) {
+      if (!ownsRefreshState()) return;
       setLoadError(
         err instanceof Error
           ? err.message
           : "Could not load your cloud agents.",
       );
     } finally {
-      setLoading(false);
+      if (ownsRefreshState()) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
     void refresh();
+    return () => {
+      // Strict Mode can clean up and restart this effect while the first
+      // request is still live. Invalidating its ownership prevents that stale
+      // result from updating either an unmounted view or the restarted effect.
+      refreshRequestIdRef.current += 1;
+    };
   }, [refresh]);
 
   const setLocalStatus = useCallback((agentId: string, status: string) => {


### PR DESCRIPTION
## Summary

Prevents stale Cloud Agents list requests from mutating the Settings view after unmount or overwriting a newer refresh.

- discard a list response that settles after `CloudAgentsSection` unmounts
- prevent an older request from replacing a newer refresh result
- keep loading/error ownership with the latest request
- add deferred-response teardown and overlapping-refresh regression tests

This PR was recut after final review found that an earlier test-only conversation-idempotency change blessed retrying a turn whose model work had already completed. That unrelated test change was removed; production disconnect durability is being repaired at its actual boundary in #17467.

## Verification

Exact head: `241c79185372fdd3ff35b2d55908608fb9cf5d5e`
Exact parent: `bb9cc9852608b3ab73aa2b7aa1e5a298e778fda3`

The two UI blobs are byte-identical to the previously validated head `e69076bcd5f68f9814bd1bca192fdf3cdc477182`, so its rendered/browser artifacts remain behavior-bound. Fresh exact-head CI is required after the recut.

- focused Cloud Agents tests: 26/26 passed on the identical UI blobs
- UI typecheck passed on the identical UI blobs
- Biome and `git diff --check` passed
- browser proof: a deferred HTTP 200 settled after navigation/unmount with zero `console.error` and zero `pageerror`

<!-- evidence-row:before-screenshots -->
- [x] PR-base desktop and mobile: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-before-desktop.png) · [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-before-mobile.png)

<!-- evidence-row:after-screenshots -->
- [x] Identical UI-blob desktop and mobile: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-after-desktop.png) · [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-after-mobile.png)

<!-- evidence-row:walkthrough-video -->
- [x] [Cloud Agents deferred-refresh walkthrough (MP4)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-walkthrough.mp4) · [video probe](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-walkthrough-probe.json) · [review contact sheet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-walkthrough-contact-sheet.jpg)

<!-- evidence-row:frontend-logs -->
- [x] [Console/network timeline](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-after-frontend-console-network.json) · [browser run](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-after-browser-run.log)

<!-- evidence-row:backend-logs -->
- [x] N/A - no backend files or runtime behavior changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or agent-loop behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [Focused UI tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-focused-ui-tests.log) · [SHA-256 manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-sha256.txt)

<!-- evidence-row:ocr-review -->
- [x] [Manual OCR and visual review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-ocr-manual-review.md) · [desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-before-desktop-ocr.txt) / [after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-after-desktop-ocr.txt) · [mobile before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-before-mobile-ocr.txt) / [after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17450-f3d0480-after-mobile-ocr.txt)
