### PR TITLE
fix(app): restore zero-key view workflow contracts

### DIFF
--- a/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
+++ b/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
@@ -91,6 +91,7 @@ function smokeViewObject({
   viewPath,
   componentExport,
   viewType,
+  surface,
 }) {
   const encodedId = encodeURIComponent(id);
   const query = "?v=ui-smoke";
@@ -120,6 +121,7 @@ function smokeViewObject({
         description: "Read the mounted view state.",
       },
     ],
+    ...(surface === undefined ? {} : { surface }),
     _smokePluginDirName: pluginDirName,
   };
 }
@@ -134,6 +136,7 @@ const smokeViews = smokeViewDeclarations.flatMap(
     viewPath,
     componentExport,
     modalitiesOrViewType = "gui",
+    surface,
   ]) => {
     const viewTypes = Array.isArray(modalitiesOrViewType)
       ? modalitiesOrViewType
@@ -146,6 +149,7 @@ const smokeViews = smokeViewDeclarations.flatMap(
         viewPath,
         componentExport,
         viewType,
+        surface,
       }),
     );
   },

--- a/packages/app-core/scripts/smoke-view-bundle-provenance.test.ts
+++ b/packages/app-core/scripts/smoke-view-bundle-provenance.test.ts
@@ -135,6 +135,17 @@ describe("smoke view bundle provenance over HTTP (#15791)", () => {
         expect(String(capability.description).trim()).not.toBe("");
       }
     }
+
+    const byId = new Map(
+      payload.views
+        .filter(isRecord)
+        .map((view) => [String(view.id), view] as const),
+    );
+    for (const viewId of ["feed", "orchestrator"]) {
+      expect(byId.get(viewId)?.surface).toEqual({
+        capabilities: ["agent-surface"],
+      });
+    }
   });
 
   it("audit mode returns an observable failure, never a fabricated bundle", async () => {

--- a/packages/app-core/scripts/smoke-view-declarations.mjs
+++ b/packages/app-core/scripts/smoke-view-declarations.mjs
@@ -24,9 +24,12 @@ import ts from "typescript";
 
 /**
  * One GUI declaration per shipped plugin view: `[id, label, pluginDirName,
- * path, componentExport]`. Every entry must pass `checkSmokeViewParity` — its
- * plugin directory exists and its source both declares the `id` and exports the
- * `componentExport`. Do NOT add a view here for a plugin that no longer exists.
+ * path, componentExport, viewType?, surface?]`. Every entry must pass
+ * `checkSmokeViewParity` — its plugin directory exists and its source both
+ * declares the `id` and exports the `componentExport`. Surface grants are
+ * explicit because omitting one makes the smoke registry less capable than the
+ * production manifest and can turn a valid bridge action into a false denial.
+ * Do NOT add a view here for a plugin that no longer exists.
  */
 export const smokeViewDeclarations = [
   ["birdclaw", "Birdclaw", "plugin-birdclaw", "/birdclaw", "BirdclawView"],
@@ -80,7 +83,15 @@ export const smokeViewDeclarations = [
     "/vector-browser",
     "VectorBrowserView",
   ],
-  ["feed", "Feed", "plugin-feed", "/feed", "FeedView"],
+  [
+    "feed",
+    "Feed",
+    "plugin-feed",
+    "/feed",
+    "FeedView",
+    "gui",
+    { capabilities: ["agent-surface"] },
+  ],
   ["views-manager", "Views", "plugin-app-control", "/views", "ViewManagerView"],
   [
     "screenshare",
@@ -102,6 +113,8 @@ export const smokeViewDeclarations = [
     "plugin-task-coordinator",
     "/orchestrator",
     "OrchestratorView",
+    "gui",
+    { capabilities: ["agent-surface"] },
   ],
   [
     "trajectory-logger",

--- a/packages/app/docs/LAUNCHER_VIEW_COVERAGE.md
+++ b/packages/app/docs/LAUNCHER_VIEW_COVERAGE.md
@@ -19,7 +19,12 @@ A `BUILTIN_VIEWS` entry appears in the launcher grid when the launcher filter
 plus the native-OS strip in [`useAvailableViews`](../../ui/src/hooks/useAvailableViews.ts))
 would ever place it there:
 
-- `visibleInManager !== false` (internal views are hidden from the grid), **and**
+- registry/plugin entries require `visibleInManager !== false`; manager-hidden
+  third-party views stay absent from the grid,
+- first-party shell fallbacks from `useRoutableViews` may enter the launcher
+  merge even though they are manager-hidden, after which
+  `curateLauncherPages` decides whether each routable destination gets a tile,
+  **and**
 - the id is **not** a native-OS-fork-only surface (`phone` / `messages` /
   `contacts` / `camera` are stripped on web, desktop, iOS, and stock Play-Store
   Android — they only exist on the AOSP ElizaOS fork).

--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -805,6 +805,16 @@ test.describe("assistant home app flow", () => {
     await expect(
       settingsLauncherTile.getByRole("button", { name: /Settings/i }),
     ).toBeVisible();
+    const automationsLabel = launcherTile(page, "automations").locator(
+      "[data-launcher-label]",
+    );
+    await expect(automationsLabel).toHaveText("Automations");
+    expect(
+      await automationsLabel.evaluate(
+        (label) => label.scrollWidth <= label.clientWidth,
+      ),
+      "launcher labels must fit their rendered width",
+    ).toBe(true);
     await expect(page.getByTestId("shell-home-pill")).toHaveCount(0);
     await screenshot(page, "05-views-with-pill");
 

--- a/packages/ui/src/components/pages/Launcher.test.tsx
+++ b/packages/ui/src/components/pages/Launcher.test.tsx
@@ -119,6 +119,29 @@ describe("Launcher", () => {
     ).toBe("");
   });
 
+  it("compacts long unbroken labels without shrinking ordinary or wrapped labels", () => {
+    render(
+      <Launcher
+        entries={[
+          entry("automations", "Automations"),
+          entry("settings", "Settings"),
+          entry("memory", "Memory Viewer"),
+        ]}
+        onLaunch={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText("Automations").getAttribute("data-compact-label"),
+    ).toBe("true");
+    expect(
+      screen.getByText("Settings").getAttribute("data-compact-label"),
+    ).toBeNull();
+    expect(
+      screen.getByText("Memory Viewer").getAttribute("data-compact-label"),
+    ).toBeNull();
+  });
+
   it("renders at natural height when embedded in Home's app scroller", () => {
     render(<Launcher entries={FEW} onLaunch={() => {}} embedded />);
     const page = screen.getByTestId("launcher-page-window");

--- a/packages/ui/src/components/pages/Launcher.tsx
+++ b/packages/ui/src/components/pages/Launcher.tsx
@@ -38,6 +38,9 @@ const LAUNCHER_RESPONSIVE_CSS = `
 [data-testid="launcher"] [data-launcher-label] {
   font-size: clamp(.75rem, calc(.68rem + .25cqi), .875rem);
 }
+[data-testid="launcher"] [data-launcher-label][data-compact-label="true"] {
+  font-size: .75rem;
+}
 @media (orientation: landscape) and (max-height: 520px) {
   [data-testid="launcher"] [data-launcher-icon] { width: 3.5rem; height: 3.5rem; }
 }
@@ -80,6 +83,9 @@ function viewKindBadge(entry: ViewEntry): {
 // tiles whose props actually changed, not the whole page.
 const IconTile = memo(function IconTile({ entry, onLaunch }: IconTileProps) {
   const badge = viewKindBadge(entry);
+  const hasLongUnbrokenLabel = entry.label
+    .split(/\s+/)
+    .some((word) => word.length > 10);
   // A long stationary press must NOT ghost-launch on release: the browser
   // synthesizes a compat click from that same press, and a bare onClick would
   // launch whatever tile the finger held (the gesture-matrix "no ghost-launch"
@@ -149,6 +155,7 @@ const IconTile = memo(function IconTile({ entry, onLaunch }: IconTileProps) {
             (#14427). line-clamp-2 still wraps multi-word labels. */}
         <span
           data-launcher-label=""
+          data-compact-label={hasLongUnbrokenLabel || undefined}
           className={cn(
             "line-clamp-2 max-w-[5.5rem] text-center text-xs font-semibold leading-tight tracking-normal whitespace-normal",
             WALLPAPER_TEXT.base,

--- a/packages/ui/src/components/pages/launcher-curation.test.ts
+++ b/packages/ui/src/components/pages/launcher-curation.test.ts
@@ -6,7 +6,8 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import type { ViewEntry } from "../../hooks/view-catalog";
+import type { ViewRegistryEntry } from "../../hooks/useAvailableViews";
+import { mergeViewCatalog, type ViewEntry } from "../../hooks/view-catalog";
 import {
   getInternalToolAppDescriptors,
   getInternalToolAppTargetTab,
@@ -39,6 +40,68 @@ function ids(page: ViewEntry[]): string[] {
 }
 
 const APPS_ONLY = { developer: false, preview: false } as const;
+
+function registryEntry(
+  id: string,
+  over: Partial<ViewRegistryEntry> = {},
+): ViewRegistryEntry {
+  return {
+    id,
+    label: id,
+    available: true,
+    pluginName: `@elizaos/plugin-${id}`,
+    viewType: "gui",
+    path: `/${id}`,
+    ...over,
+  };
+}
+
+describe("routable launcher catalog pipeline", () => {
+  it("surfaces shell destinations without leaking manager-hidden or curated-out views", () => {
+    const merged = mergeViewCatalog({
+      views: [
+        registryEntry("settings", {
+          builtin: true,
+          pluginName: "@elizaos/builtin",
+          visibleInManager: false,
+        }),
+        registryEntry("my-apps", {
+          builtin: true,
+          pluginName: "@elizaos/builtin",
+          visibleInManager: false,
+        }),
+        registryEntry("views", {
+          builtin: true,
+          pluginName: "@elizaos/builtin",
+          visibleInManager: false,
+        }),
+        registryEntry("database", {
+          builtin: true,
+          pluginName: "@elizaos/builtin",
+          visibleInManager: false,
+        }),
+        registryEntry("hidden-plugin", { visibleInManager: false }),
+        registryEntry("wallet", { visibleInManager: true }),
+      ],
+      catalog: [],
+      installed: [],
+      activeModality: "gui",
+      enabledKinds: APPS_ONLY,
+      visibilityScope: "routable",
+    });
+
+    const page = curateLauncherPages(merged, {
+      isAosp: false,
+      enabledKinds: APPS_ONLY,
+      cloudActive: false,
+    });
+
+    expect(ids(page)).toEqual(["settings", "wallet", "my-apps"]);
+    expect(ids(page)).not.toContain("views");
+    expect(ids(page)).not.toContain("database");
+    expect(ids(page)).not.toContain("hidden-plugin");
+  });
+});
 
 describe("curateLauncherPages", () => {
   it("puts apps then developer tools on ONE page when Developer Mode is on", () => {

--- a/packages/ui/src/hooks/useViewCatalog.ts
+++ b/packages/ui/src/hooks/useViewCatalog.ts
@@ -2,7 +2,7 @@
  * useViewCatalog — data source for the unified Launcher.
  *
  * Merges three sources into one {@link ViewEntry} list:
- *  - loaded views (`GET /api/views`, via {@link useAvailableViews}),
+ *  - routable views (the loaded registry plus built-in shell destinations),
  *  - the installable app catalog (`/api/apps`, scanned from plugin manifests on
  *    disk — no plugin load required), via {@link loadAppsCatalog},
  *  - the set of currently-active apps (`GET /api/apps/installed`).
@@ -19,7 +19,7 @@ import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
 import { loadAppsCatalog } from "../components/apps/load-apps-catalog";
 import { getActiveViewModality } from "../platform/platform-guards";
 import { useEnabledViewKinds } from "../state/useViewKinds";
-import { useAvailableViews } from "./useAvailableViews";
+import { useRoutableViews } from "./useAvailableViews";
 import { useCachedResource } from "./useCachedResource";
 import { mergeViewCatalog, type ViewEntry } from "./view-catalog";
 
@@ -47,7 +47,7 @@ export function useViewCatalog(): UseViewCatalogResult {
     loading: viewsLoading,
     error: viewsError,
     refresh: refreshViews,
-  } = useAvailableViews();
+  } = useRoutableViews();
   const enabledKinds = useEnabledViewKinds();
   const activeModality = useMemo(() => getActiveViewModality(), []);
   const appShellRoutesSupported = supportsFullAppShellRoutes(

--- a/packages/ui/src/hooks/useViewCatalog.ts
+++ b/packages/ui/src/hooks/useViewCatalog.ts
@@ -83,6 +83,7 @@ export function useViewCatalog(): UseViewCatalogResult {
       installed,
       activeModality,
       enabledKinds,
+      visibilityScope: "routable",
     });
     if (Object.keys(pending).length === 0) return merged;
     return merged.map((e) =>

--- a/packages/ui/src/hooks/view-catalog.test.ts
+++ b/packages/ui/src/hooks/view-catalog.test.ts
@@ -45,6 +45,7 @@ function merge(
     installed: opts.installed ?? [],
     activeModality: opts.activeModality ?? "gui",
     enabledKinds: opts.enabledKinds ?? { developer: false, preview: false },
+    visibilityScope: opts.visibilityScope ?? "manager",
   });
 }
 
@@ -267,6 +268,55 @@ describe("viewToEntry uses bundled icons (native 404 fix)", () => {
       ],
     });
     expect(entries).toHaveLength(0);
+  });
+
+  it("admits manager-hidden shell routes only for a routable catalog", () => {
+    const entries = mergeViewCatalog({
+      views: [
+        makeView("settings", {
+          builtin: true,
+          pluginName: "@elizaos/builtin",
+          visibleInManager: false,
+        }),
+        makeView("my-apps", {
+          builtin: true,
+          pluginName: "@elizaos/builtin",
+          visibleInManager: false,
+        }),
+      ],
+      catalog: [],
+      installed: [],
+      activeModality: "gui",
+      enabledKinds: { developer: false, preview: false },
+      visibilityScope: "routable",
+    });
+
+    expect(entries.map((entry) => entry.id)).toEqual(["settings", "my-apps"]);
+  });
+
+  it("does not let third-party views bypass manager visibility by claiming builtin metadata", () => {
+    const entries = mergeViewCatalog({
+      views: [
+        makeView("hidden-plugin", { visibleInManager: false }),
+        makeView("spoofed-builtin", {
+          builtin: true,
+          visibleInManager: false,
+        }),
+        makeView("builtin-name-without-provenance", {
+          builtin: false,
+          pluginName: "@elizaos/builtin",
+          visibleInManager: false,
+        }),
+        makeView("visible-plugin", { visibleInManager: true }),
+      ],
+      catalog: [],
+      installed: [],
+      activeModality: "gui",
+      enabledKinds: { developer: false, preview: false },
+      visibilityScope: "routable",
+    });
+
+    expect(entries.map((entry) => entry.id)).toEqual(["visible-plugin"]);
   });
 
   it("on a non-GUI surface lists only loaded views of that modality, no catalog", () => {

--- a/packages/ui/src/hooks/view-catalog.ts
+++ b/packages/ui/src/hooks/view-catalog.ts
@@ -97,6 +97,12 @@ export interface InstalledAppLike {
   name: string;
 }
 
+export type ViewCatalogVisibilityScope = "manager" | "routable";
+
+function isBuiltinShellRoute(view: ViewRegistryEntry): boolean {
+  return view.builtin === true && view.pluginName === "@elizaos/builtin";
+}
+
 export function viewToEntry(view: ViewRegistryEntry): ViewEntry {
   const heroUrl = isShellReachableImageUrl(view.heroImageUrl)
     ? view.heroImageUrl
@@ -173,6 +179,9 @@ function appToEntry(app: RegistryAppInfo, isActive: boolean): ViewEntry {
  *   appended as "Get" (or "Open" when active but viewless, e.g. external apps).
  * - The catalog is only surfaced on a GUI surface — installing is a GUI action;
  *   future non-GUI surfaces list only their loaded views.
+ * - Routable consumers may include first-party shell destinations that are
+ *   intentionally hidden from the plugin manager; launcher curation remains
+ *   responsible for deciding which of those destinations become tiles.
  */
 export function mergeViewCatalog(input: {
   views: ViewRegistryEntry[];
@@ -181,8 +190,17 @@ export function mergeViewCatalog(input: {
   activeModality: ViewModality;
   /** Which view kinds the user/​build has enabled (system+release always on). */
   enabledKinds: EnabledViewKinds;
+  /** Whether `views` is the manager registry or the shell's routable union. */
+  visibilityScope: ViewCatalogVisibilityScope;
 }): ViewEntry[] {
-  const { views, catalog, installed, activeModality, enabledKinds } = input;
+  const {
+    views,
+    catalog,
+    installed,
+    activeModality,
+    enabledKinds,
+    visibilityScope,
+  } = input;
 
   const loadedPluginNames = new Set<string>();
   for (const v of views) {
@@ -192,7 +210,12 @@ export function mergeViewCatalog(input: {
   const viewEntries: ViewEntry[] = [];
   for (const v of views) {
     if (!isViewVisible(v, enabledKinds)) continue;
-    if (v.visibleInManager === false) continue;
+    if (
+      v.visibleInManager === false &&
+      !(visibilityScope === "routable" && isBuiltinShellRoute(v))
+    ) {
+      continue;
+    }
     if ((v.viewType ?? "gui") !== activeModality) continue;
     viewEntries.push(viewToEntry(v));
   }

--- a/plugins/plugin-feed/src/components/FeedView.test.tsx
+++ b/plugins/plugin-feed/src/components/FeedView.test.tsx
@@ -3,11 +3,17 @@
 // Drives the FeedView GUI data wrapper through the
 // rendered DOM: the same component the bundle exports for both the "gui" and
 // non-embedded state. The Feed data layer (the ten `getFeed*` loaders + the
-// pause/resume control + the suggested-prompt send) is mocked at the
+// launch + pause/resume controls and suggested-prompt send) is mocked at the
 // `@elizaos/app-core/ui-compat` `client`, and the run list is injected via the
 // mocked `useAppSelector`. Asserts the populated dashboard, the autonomy toggle
-// + refresh + suggested-prompt controls reach the client with the exact args,
-// the loader-failure banner, and the no-session waiting state.
+// + refresh + suggested-prompt + spawn controls reach the client with the exact
+// args, including spawn activation through the real agent-surface registry.
+
+import {
+  AgentSurfaceProvider,
+  getViewRegistry,
+  handleAgentSurfaceCapability,
+} from "@elizaos/ui/agent-surface";
 
 import {
   cleanup,
@@ -21,6 +27,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const controlAppRun = vi.hoisted(() => vi.fn());
 const sendAppRunMessage = vi.hoisted(() => vi.fn());
+const launchApp = vi.hoisted(() => vi.fn());
 const feedClient = vi.hoisted(() => ({
   getFeedAgentStatus: vi.fn(),
   getFeedAgentSummary: vi.fn(),
@@ -33,6 +40,7 @@ const feedClient = vi.hoisted(() => ({
   getFeedAgentWallet: vi.fn(),
   getFeedAgentTradingBalance: vi.fn(),
   controlAppRun,
+  launchApp,
   sendAppRunMessage,
 }));
 
@@ -210,6 +218,16 @@ function primeClient() {
     message: "Suggestion delivered.",
     status: 202,
   });
+  launchApp.mockResolvedValue({
+    pluginInstalled: true,
+    needsRestart: false,
+    displayName: "Feed",
+    launchType: "url",
+    launchUrl: "https://feed.example",
+    viewer: null,
+    session: null,
+    run: null,
+  });
 }
 
 function makeRun(overrides: Record<string, unknown> = {}) {
@@ -372,16 +390,37 @@ describe("FeedView — GUI operator surface", () => {
 });
 
 describe("FeedView — no-session waiting state", () => {
-  it("renders the readiness empty state with an enabled Spawn agent CTA and fires no loaders", async () => {
+  it("dispatches the visible Spawn agent CTA through the real app launch handler", async () => {
     appState.appRuns = [];
     render(React.createElement(FeedView));
 
     await screen.findByText("Ready to trade?");
     const spawn = button("spawn-agent");
     expect(spawn.disabled).toBe(false);
+    fireEvent.click(spawn);
 
-    // With no run, no loaders fire and no controls are wired.
+    await waitFor(() => expect(launchApp).toHaveBeenCalledWith(APP_NAME));
     expect(feedClient.getFeedAgentStatus).not.toHaveBeenCalled();
     expect(controlAppRun).not.toHaveBeenCalled();
+  });
+
+  it("dispatches spawn-agent activation from the agent-surface bridge", async () => {
+    appState.appRuns = [];
+    render(
+      <AgentSurfaceProvider viewId="feed" viewType="gui">
+        <FeedView />
+      </AgentSurfaceProvider>,
+    );
+    await screen.findByText("Ready to trade?");
+
+    const registry = getViewRegistry("feed", "gui");
+    if (!registry) throw new Error("Feed agent-surface registry missing");
+    const result = handleAgentSurfaceCapability(registry, "agent-click", {
+      id: "spawn-agent",
+    });
+
+    expect(result).toMatchObject({ ok: true, id: "spawn-agent" });
+    await waitFor(() => expect(launchApp).toHaveBeenCalledWith(APP_NAME));
+    expect(launchApp).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/plugin-feed/src/components/FeedView.tsx
+++ b/plugins/plugin-feed/src/components/FeedView.tsx
@@ -239,6 +239,23 @@ export function FeedView() {
     [loadDashboard, run, sending],
   );
 
+  const spawnAgent = useCallback(async () => {
+    if (run) return;
+    setStatusMessage(null);
+    try {
+      await client.launchApp(FEED_APP_NAME);
+      setStatusMessage("Feed agent launch requested.");
+    } catch (error) {
+      // error-policy:J4 the launch button owns a visible status banner for an
+      // expected operator-triggered failure; the failure is never reported as success.
+      setStatusMessage(
+        error instanceof Error
+          ? error.message
+          : "Failed to launch the Feed agent.",
+      );
+    }
+  }, [run]);
+
   const onAction = useCallback(
     (action: string) => {
       if (action.startsWith("prompt:")) {
@@ -248,6 +265,9 @@ export function FeedView() {
         return;
       }
       switch (action) {
+        case "spawn":
+          void spawnAgent();
+          return;
         case "toggle-autonomy":
           void toggleAutonomy();
           return;
@@ -256,7 +276,7 @@ export function FeedView() {
           return;
       }
     },
-    [loadDashboard, sendPrompt, suggestedPrompts, toggleAutonomy],
+    [loadDashboard, sendPrompt, spawnAgent, suggestedPrompts, toggleAutonomy],
   );
 
   const snapshot: FeedSnapshot = {
@@ -278,10 +298,22 @@ export function FeedView() {
     sending,
   };
 
-  // Surface the two primary operator actions to the agent surface. Both reuse
-  // the live data-layer handlers this wrapper already owns (the same handlers
-  // the spatial Refresh / Pause-Resume buttons dispatch through `onAction`), so
-  // the agent can address them directly on the GUI surface.
+  // Spatial primitives stamp visible DOM nodes but cannot register a controlled
+  // activation callback. This descriptor routes bridge activation through the
+  // same launch handler as the visible spawn button.
+  useAgentElement<HTMLButtonElement>({
+    id: "spawn-agent",
+    role: "button",
+    label: "Spawn agent",
+    group: "feed",
+    description: "Launch a Feed agent and start its app run",
+    status: run ? "disabled" : "inactive",
+    clickable: !run,
+    onActivate: () => void spawnAgent(),
+  });
+
+  // The primary operator actions reuse the live data-layer handlers this
+  // wrapper already owns, keeping pointer and agent-driven behavior aligned.
   const refreshControl = useAgentElement<HTMLButtonElement>({
     id: "feed-refresh",
     role: "button",


### PR DESCRIPTION
## Summary

Fixes the zero-key browser failure reproduced on current develop run
[30656416185](https://github.com/elizaOS/eliza/actions/runs/30656416185) at
`bb9cc9852608b3ab73aa2b7aa1e5a298e778fda3`.

- preserve agent-surface grants in the smoke API fixture
- declare Settings and My Apps in the built-in launcher catalog
- wire Feed spawning through the real agent bridge
- separate plugin-manager visibility from shell routability
- admit hidden shell fallbacks only with verified built-in provenance
- keep long unbroken launcher labels readable at desktop and mobile sizes
- cover the bridge, catalog provenance, adversarial hidden entries, full
  merge-to-launcher curation, and rendered label width

## Exact-current binding

Evidence is bound to exact PR head
`90515dd837f51d26381eaeb400d92e2f8eed87ff`, whose third parent is the
authoritative current develop SHA
`bb9cc9852608b3ab73aa2b7aa1e5a298e778fda3`. No baseline or threshold was
changed.

Browser job
[91243170687](https://github.com/elizaOS/eliza/actions/runs/30656416185/job/91243170687)
failed at the production-facing contract: `/views` rendered a healthy launcher,
but `launcher-tile-settings` was absent after 15 seconds. Its exact screenshot,
29.68-second video, trace, accessibility snapshot, and `/api/views` response
were downloaded and manually reviewed.

Aggregate job
[91245474985](https://github.com/elizaOS/eliza/actions/runs/30656416185/job/91245474985)
is not a second defect. Its direct log records unit/UI, diagnostics,
scenario-runner, and harness E2E as successful, then propagates the browser
slice's failure.

## Root cause and contract

`useViewCatalog()` consumed `useRoutableViews()`, then `mergeViewCatalog()`
applied `visibleInManager` to every row. The local Settings/My Apps fallbacks
correctly declare `visibleInManager: false` because they are not plugin-manager
cards, but that flag does not make their shell routes unreachable.

The merge now requires `manager` or `routable` visibility scope. Routable mode
may admit a manager-hidden row only when both first-party markers are present:
`builtin: true` and `pluginName: "@elizaos/builtin"`. Hidden third-party rows
and partial provenance spoofs remain excluded. Existing launcher curation still
owns internal routes, developer/preview flags, native-only views, grouping, and
duplicate suppression.

The exact after capture exposed a pre-existing clipped `Automations` label. The
launcher now compacts only labels containing a long unbroken word, and the real
browser test asserts `scrollWidth <= clientWidth` at desktop and Pixel 7 sizes.

## Verification

- exact failed desktop Playwright case: 1/1 passed
- Pixel 7 equivalent: 1/1 passed
- exact-head recorded desktop rerun: 1/1 passed
- catalog/launcher tests: 70/70 passed
- Feed tests: 8/8 passed
- real HTTP view-stub contracts: 4/4 passed
- UI typecheck, scoped Biome, and `git diff --check`: passed
- exact renderer/browser build: passed

The isolated app-wide typecheck was not counted because unrelated workspace
packages lacked built outputs (`@elizaos/auth`, vault, optional plugins, cloud
SDK). The affected UI typecheck and exact production renderer build passed; CI
remains authoritative for the full workspace.

Closes #17451

<!-- evidence-row:before-screenshots -->
- [x] Exact develop `bb9cc985` failure: [desktop screenshot](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-bb9cc985-before-missing-settings.jpg), [29.68-second MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-bb9cc985-before-failure.mp4), and [Playwright trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-bb9cc985-before-browser-trace.zip). The populated launcher lacks Settings and My Apps.

<!-- evidence-row:after-screenshots -->
- [x] Exact head `90515dd8`: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-90515dd8-after-desktop-launcher.jpg) and [Pixel 7](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-90515dd8-after-mobile-launcher.jpg). Settings and My Apps render; Automations is complete; internal Views/Database tiles remain absent.

<!-- evidence-row:walkthrough-video -->
- [x] [9.32-second exact-head H.264 MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-90515dd8-browser-walkthrough.mp4) covers boot, assistant home, launcher, and Wallet continuation; [reviewed contact sheet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-90515dd8-browser-walkthrough-contact-sheet.jpg).

<!-- evidence-row:frontend-logs -->
- [x] Exact develop [browser job log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-bb9cc985-browser-job-91243170687.log), exact-head [browser trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-90515dd8-browser-trace.zip), and immutable [aggregate log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-bb9cc985-aggregate-job-91245474985.log). The after trace has no page error and no HTTP response at or above 400.

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic fixture and client catalog/bridge paths; no production backend behavior changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, or provider behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [Exact-current causal and manual review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-90515dd8-manual-review.md), including product/test/infrastructure classification and all verification totals.

<!-- evidence-row:ocr-review -->
- [x] Exact-head OCR independently recovers Settings, My Apps, and Automations on [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-90515dd8-after-desktop-launcher-ocr.txt) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/17452-90515dd8-after-mobile-launcher-ocr.txt); pixels were also reviewed manually.
