### PR TITLE
fix(core): refresh document mutation authorization

### DIFF
--- a/packages/core/src/features/documents/provider.ts
+++ b/packages/core/src/features/documents/provider.ts
@@ -73,12 +73,10 @@ export const documentsProvider: Provider = {
 			};
 		}
 
-		const [relevantFragments, documents] = await Promise.all([
-			service.searchDocuments(message),
-			service.listDocuments(message, {
+		const { relevantFragments, documents } =
+			await service.composeProviderDocuments(message, {
 				limit: MAX_AVAILABLE_DOCUMENTS,
-			}),
-		]);
+			});
 		const relevantSnippets = relevantFragments
 			.slice(0, MAX_RELEVANT_SNIPPETS)
 			.map((fragment, index) => {

--- a/packages/core/src/features/documents/service-authorization.real.test.ts
+++ b/packages/core/src/features/documents/service-authorization.real.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Exercises document authorization against a real AgentRuntime and PGLite store,
+ * including same-turn membership revocation before update and delete mutations.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { AgentRuntime } from "../../runtime.ts";
+import { createTestRuntime } from "../../testing/pglite-runtime.ts";
+import { runWithTrajectoryContext } from "../../trajectory-context.ts";
+import {
+	ChannelType,
+	type Memory,
+	MemoryType,
+	type UUID,
+} from "../../types/index.ts";
+import { DocumentService } from "./service.ts";
+
+const USER_ID = "f4300000-0000-4000-8000-000000000001" as UUID;
+const WORLD_ID = "f4300000-0000-4000-8000-000000000002" as UUID;
+const ROOM_ID = "f4300000-0000-4000-8000-000000000003" as UUID;
+const UPDATE_DOCUMENT_ID = "f4300000-0000-4000-8000-000000000004" as UUID;
+const DELETE_DOCUMENT_ID = "f4300000-0000-4000-8000-000000000005" as UUID;
+
+let runtime: AgentRuntime;
+let cleanup: () => Promise<void>;
+
+function message(): Memory {
+	return {
+		id: "f4300000-0000-4000-8000-000000000006" as UUID,
+		agentId: runtime.agentId,
+		entityId: USER_ID,
+		roomId: ROOM_ID,
+		worldId: WORLD_ID,
+		content: {
+			text: "Update my private documents",
+			source: "test",
+			channelType: ChannelType.DM,
+		},
+	};
+}
+
+function userPrivateDocument(id: UUID, text: string): Memory {
+	const filename = `${id}.txt`;
+	return {
+		id,
+		agentId: runtime.agentId,
+		entityId: USER_ID,
+		roomId: ROOM_ID,
+		worldId: WORLD_ID,
+		createdAt: 1_000,
+		content: { text },
+		metadata: {
+			type: MemoryType.DOCUMENT,
+			documentId: id,
+			documentRevision: 0,
+			scope: "user-private",
+			scopedToEntityId: USER_ID,
+			addedBy: USER_ID,
+			addedByRole: "USER",
+			addedFrom: "upload",
+			addedAt: 1_000,
+			source: "test",
+			title: "Private document",
+			filename,
+			originalFilename: filename,
+			fileExt: "txt",
+			fileType: "text/plain",
+			contentType: "text/plain",
+			fileSize: Buffer.byteLength(text, "utf8"),
+			textBacked: true,
+			timestamp: 1_000,
+		},
+	};
+}
+
+beforeAll(async () => {
+	({ runtime, cleanup } = await createTestRuntime({
+		characterName: "DocumentAuthorizationTest",
+	}));
+	await runtime.ensureConnection({
+		entityId: USER_ID,
+		roomId: ROOM_ID,
+		worldId: WORLD_ID,
+		worldName: "Document authorization",
+		userName: "Document owner",
+		name: "Document owner",
+		source: "test",
+		type: ChannelType.DM,
+	});
+	await runtime.ensureWorldExists({
+		id: WORLD_ID,
+		name: "Document authorization",
+		agentId: runtime.agentId,
+		metadata: {
+			roles: { [USER_ID]: "USER" },
+			roleSources: { [USER_ID]: "manual" },
+		},
+	});
+	await runtime.createMemories([
+		{
+			memory: userPrivateDocument(UPDATE_DOCUMENT_ID, "Original update body"),
+			tableName: "documents",
+		},
+		{
+			memory: userPrivateDocument(DELETE_DOCUMENT_ID, "Original delete body"),
+			tableName: "documents",
+		},
+	]);
+}, 120_000);
+
+afterAll(async () => {
+	await cleanup();
+}, 120_000);
+
+describe("DocumentService requester authorization", () => {
+	it("denies same-turn update and delete after room membership is revoked", async () => {
+		const service = new DocumentService(runtime);
+		const membershipReads = vi.spyOn(
+			runtime.adapter,
+			"getRoomsForParticipants",
+		);
+		const request = message();
+
+		await runWithTrajectoryContext(
+			{ turnMemo: new Map<string, Promise<unknown>>() },
+			async () => {
+				await expect(
+					service.getDocumentById(UPDATE_DOCUMENT_ID, request),
+				).resolves.toMatchObject({ id: UPDATE_DOCUMENT_ID });
+
+				await expect(runtime.removeParticipant(USER_ID, ROOM_ID)).resolves.toBe(
+					true,
+				);
+
+				await expect(
+					service.updateDocument({
+						documentId: UPDATE_DOCUMENT_ID,
+						content: "Unauthorized replacement",
+						message: request,
+					}),
+				).rejects.toMatchObject({ code: "DOCUMENT_NOT_FOUND" });
+				await expect(
+					service.deleteDocument(DELETE_DOCUMENT_ID, request),
+				).rejects.toMatchObject({ code: "DOCUMENT_MUTATION_FORBIDDEN" });
+			},
+		);
+
+		expect(membershipReads).toHaveBeenCalledTimes(3);
+		const stored = await runtime.adapter.getMemoriesByIds(
+			[UPDATE_DOCUMENT_ID, DELETE_DOCUMENT_ID],
+			"documents",
+		);
+		expect(stored).toHaveLength(2);
+		expect(
+			stored.find((document) => document.id === UPDATE_DOCUMENT_ID)?.content,
+		).toMatchObject({ text: "Original update body" });
+		expect(
+			stored.find((document) => document.id === DELETE_DOCUMENT_ID)?.content,
+		).toMatchObject({ text: "Original delete body" });
+	});
+});

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -29,7 +29,6 @@ import { createUniqueUuid } from "../../entities";
 import { ElizaError } from "../../errors";
 import { logger } from "../../logger";
 import { checkSenderRole } from "../../roles";
-import { memoizeTurnWork } from "../../trajectory-context";
 import {
 	type AccessContext,
 	type Content,
@@ -249,49 +248,59 @@ export async function resolveDocumentRequester(
 	runtime: IAgentRuntime,
 	message?: Memory,
 ): Promise<DocumentRequester> {
-	// Search and inventory providers authorize the same immutable ingress
-	// message concurrently. Sharing that promise gives the entire turn one
-	// requester snapshot and avoids repeating role and membership reads.
-	const requesterKey = [
-		"documents:requester",
-		runtime.agentId,
-		message?.id ?? "no-message",
-		message?.entityId ?? runtime.agentId,
-		message?.roomId ?? "no-room",
-	].join(":");
-	return memoizeTurnWork(requesterKey, async () => {
-		const requester = await resolveDocumentRequesterRole(runtime, message);
-		if (documentRoleHasGlobalVisibility(requester.role)) {
-			return { ...requester, roomIds: [] };
-		}
-		try {
-			const roomIds = await runtime.getRoomsForParticipants([
-				requester.entityId,
-			]);
-			return {
-				...requester,
-				roomIds: [...new Set(roomIds)],
-			};
-		} catch (cause) {
-			// error-policy:J2 Preserve room-resolution context and fail the read.
-			const error = new ElizaError("Document requester room lookup failed", {
-				code: "DOCUMENT_ROOM_LOOKUP_FAILED",
-				cause,
-				context: {
-					agentId: runtime.agentId,
-					entityId: requester.entityId,
-					roomId: message?.roomId,
-				},
-				severity: "ephemeral",
-			});
-			runtime.reportError("DocumentService.resolveRequesterRooms", error, {
+	const requester = await resolveDocumentRequesterRole(runtime, message);
+	if (documentRoleHasGlobalVisibility(requester.role)) {
+		return { ...requester, roomIds: [] };
+	}
+	try {
+		const roomIds = await runtime.getRoomsForParticipants([requester.entityId]);
+		return {
+			...requester,
+			roomIds: [...new Set(roomIds)],
+		};
+	} catch (cause) {
+		// error-policy:J2 Preserve room-resolution context and fail the read.
+		const error = new ElizaError("Document requester room lookup failed", {
+			code: "DOCUMENT_ROOM_LOOKUP_FAILED",
+			cause,
+			context: {
 				agentId: runtime.agentId,
 				entityId: requester.entityId,
 				roomId: message?.roomId,
-			});
-			throw error;
-		}
-	});
+			},
+			severity: "ephemeral",
+		});
+		runtime.reportError("DocumentService.resolveRequesterRooms", error, {
+			agentId: runtime.agentId,
+			entityId: requester.entityId,
+			roomId: message?.roomId,
+		});
+		throw error;
+	}
+}
+
+type DocumentRequesterResolver = () => Promise<DocumentRequester>;
+
+/**
+ * Coalesces requester authorization only for one caller-owned read composition.
+ * Rejections are evicted so a retry re-reads the authoritative role and room
+ * membership instead of retaining a transient authorization failure.
+ */
+export function createDocumentProviderRequesterResolver(
+	runtime: IAgentRuntime,
+	message?: Memory,
+): DocumentRequesterResolver {
+	let pending: Promise<DocumentRequester> | undefined;
+	return () => {
+		if (pending) return pending;
+		const current = resolveDocumentRequester(runtime, message);
+		pending = current;
+		// error-policy:J5 callers await current; this observer only evicts a rejected read memo.
+		void current.catch(() => {
+			if (pending === current) pending = undefined;
+		});
+		return current;
+	};
 }
 
 function normalizeDocumentScope(
@@ -528,6 +537,15 @@ export class DocumentService extends Service {
 		message?: Memory,
 		options: DocumentListOptions = {},
 	): Promise<DocumentListResult> {
+		return this.listDocumentsDetailedWithRequester(options, () =>
+			resolveDocumentRequester(this.runtime, message),
+		);
+	}
+
+	private async listDocumentsDetailedWithRequester(
+		options: DocumentListOptions,
+		resolveRequester: DocumentRequesterResolver,
+	): Promise<DocumentListResult> {
 		const limit =
 			typeof options.limit === "number" && Number.isFinite(options.limit)
 				? Math.max(
@@ -559,7 +577,7 @@ export class DocumentService extends Service {
 			);
 		}
 
-		const requester = await resolveDocumentRequester(this.runtime, message);
+		const requester = await resolveRequester();
 		const query = options.query?.trim();
 		const normalizedQuery = query?.toLowerCase();
 		const queryParams: DocumentListQueryParams = {
@@ -620,6 +638,29 @@ export class DocumentService extends Service {
 				? { availableNextCursor: stored.availableNextCursor }
 				: {}),
 		};
+	}
+
+	/** Runs the DOCUMENTS provider's search and inventory reads on one snapshot. */
+	async composeProviderDocuments(
+		message: Memory,
+		listOptions: DocumentListOptions,
+	): Promise<{ relevantFragments: StoredDocument[]; documents: Memory[] }> {
+		const resolveRequester = createDocumentProviderRequesterResolver(
+			this.runtime,
+			message,
+		);
+		const [relevantFragments, listResult] = await Promise.all([
+			this.searchDocumentsWithRequester(
+				message,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				resolveRequester,
+			),
+			this.listDocumentsDetailedWithRequester(listOptions, resolveRequester),
+		]);
+		return { relevantFragments, documents: listResult.documents };
 	}
 
 	async deleteDocument(documentId: UUID, message?: Memory): Promise<void> {
@@ -1133,6 +1174,24 @@ export class DocumentService extends Service {
 		accessContext?: AccessContext,
 		options?: { turnMessageId?: UUID; signal?: AbortSignal },
 	): Promise<StoredDocument[]> {
+		return this.searchDocumentsWithRequester(
+			message,
+			scope,
+			searchMode,
+			accessContext,
+			options,
+			() => resolveDocumentRequester(this.runtime, message),
+		);
+	}
+
+	private async searchDocumentsWithRequester(
+		message: Memory,
+		scope: { roomId?: UUID; worldId?: UUID; entityId?: UUID } | undefined,
+		searchMode: SearchMode | undefined,
+		accessContext: AccessContext | undefined,
+		options: { turnMessageId?: UUID; signal?: AbortSignal } | undefined,
+		resolveRequester: DocumentRequesterResolver,
+	): Promise<StoredDocument[]> {
 		if (!message.content.text || message.content.text.trim().length === 0) {
 			logger.warn("Invalid or empty message content for document query");
 			return [];
@@ -1149,7 +1208,7 @@ export class DocumentService extends Service {
 					this.runtime,
 					accessContext,
 				)
-			: await resolveDocumentRequester(this.runtime, message);
+			: await resolveRequester();
 		const filterScope: { roomId?: UUID; worldId?: UUID; entityId?: UUID } = {};
 		if (scope?.roomId) filterScope.roomId = scope.roomId;
 		if (scope?.worldId) filterScope.worldId = scope.worldId;

--- a/packages/core/src/features/provider-io-concurrency.test.ts
+++ b/packages/core/src/features/provider-io-concurrency.test.ts
@@ -18,6 +18,7 @@ import { relationshipsProvider } from "./advanced-capabilities/providers/relatio
 import { worldProvider } from "./basic-capabilities/providers/world.ts";
 import { documentsProvider } from "./documents/provider.ts";
 import {
+	createDocumentProviderRequesterResolver,
 	DocumentService,
 	resolveDocumentRequester,
 } from "./documents/service.ts";
@@ -51,38 +52,90 @@ function deferred<T>() {
 	return { promise, resolve };
 }
 
-describe("provider database I/O concurrency", () => {
-	it("coalesces concurrent document authorization reads within one turn", async () => {
-		const getRoom = vi.fn(async () => ({ id: roomId, worldId }));
-		const getWorld = vi.fn(async () => ({
+function requesterRuntime(
+	getRoomsForParticipants: IAgentRuntime["getRoomsForParticipants"],
+): IAgentRuntime {
+	return {
+		agentId,
+		getRoom: vi.fn(async () => ({ id: roomId, worldId })),
+		getWorld: vi.fn(async () => ({
 			id: worldId,
 			name: "test world",
 			metadata: {},
-		}));
+		})),
+		getRoomsForParticipants,
+		getSetting: vi.fn(() => undefined),
+		reportError: vi.fn(),
+	} as unknown as IAgentRuntime;
+}
+
+describe("provider database I/O concurrency", () => {
+	it("coalesces document authorization only inside a caller-owned read composition", async () => {
 		const getRoomsForParticipants = vi.fn(async () => [roomId, roomId]);
-		const runtime = {
-			agentId,
-			getRoom,
-			getWorld,
-			getRoomsForParticipants,
-			getSetting: vi.fn(() => undefined),
-			reportError: vi.fn(),
-		} as unknown as IAgentRuntime;
+		const runtime = requesterRuntime(getRoomsForParticipants);
 
 		const [first, second] = await runWithTrajectoryContext(
 			{ turnMemo: new Map<string, Promise<unknown>>() },
-			() =>
-				Promise.all([
-					resolveDocumentRequester(runtime, message),
-					resolveDocumentRequester(runtime, message),
-				]),
+			() => {
+				const resolveRequester = createDocumentProviderRequesterResolver(
+					runtime,
+					message,
+				);
+				return Promise.all([resolveRequester(), resolveRequester()]);
+			},
 		);
 
 		expect(first).toEqual(second);
 		expect(first.roomIds).toEqual([roomId]);
-		expect(getRoom).toHaveBeenCalledOnce();
-		expect(getWorld).toHaveBeenCalledOnce();
 		expect(getRoomsForParticipants).toHaveBeenCalledOnce();
+
+		await resolveDocumentRequester(runtime, message);
+		expect(getRoomsForParticipants).toHaveBeenCalledTimes(2);
+	});
+
+	it("evicts rejected document requester work before a local retry", async () => {
+		const failure = new Error("membership read failed");
+		const getRoomsForParticipants = vi
+			.fn<IAgentRuntime["getRoomsForParticipants"]>()
+			.mockRejectedValueOnce(failure)
+			.mockResolvedValueOnce([roomId]);
+		const runtime = requesterRuntime(getRoomsForParticipants);
+		const resolveRequester = createDocumentProviderRequesterResolver(
+			runtime,
+			message,
+		);
+
+		await expect(
+			Promise.all([resolveRequester(), resolveRequester()]),
+		).rejects.toMatchObject({
+			code: "DOCUMENT_ROOM_LOOKUP_FAILED",
+			cause: failure,
+		});
+		await expect(resolveRequester()).resolves.toMatchObject({
+			roomIds: [roomId],
+		});
+		expect(getRoomsForParticipants).toHaveBeenCalledTimes(2);
+	});
+
+	it("creates an independent document requester snapshot for each turn", async () => {
+		const getRoomsForParticipants = vi
+			.fn<IAgentRuntime["getRoomsForParticipants"]>()
+			.mockResolvedValueOnce([roomId])
+			.mockResolvedValueOnce([]);
+		const runtime = requesterRuntime(getRoomsForParticipants);
+
+		const first = await runWithTrajectoryContext(
+			{ turnMemo: new Map<string, Promise<unknown>>() },
+			() => createDocumentProviderRequesterResolver(runtime, message)(),
+		);
+		const second = await runWithTrajectoryContext(
+			{ turnMemo: new Map<string, Promise<unknown>>() },
+			() => createDocumentProviderRequesterResolver(runtime, message)(),
+		);
+
+		expect(first.roomIds).toEqual([roomId]);
+		expect(second.roomIds).toEqual([]);
+		expect(getRoomsForParticipants).toHaveBeenCalledTimes(2);
 	});
 
 	it("starts FACTS history and identity reads together, then starts every candidate pool together", async () => {
@@ -290,19 +343,13 @@ describe("provider database I/O concurrency", () => {
 		expect(runtime.getParticipantsForRoom).not.toHaveBeenCalled();
 	});
 
-	it("starts DOCUMENTS relevance search and inventory listing together", async () => {
-		const search = deferred<Memory[]>();
-		const list = deferred<Memory[]>();
-		const started: string[] = [];
+	it("uses the DOCUMENTS service's bounded concurrent read composition", async () => {
+		const composition = deferred<{
+			relevantFragments: Memory[];
+			documents: Memory[];
+		}>();
 		const service = {
-			searchDocuments: vi.fn(() => {
-				started.push("search");
-				return search.promise;
-			}),
-			listDocuments: vi.fn(() => {
-				started.push("list");
-				return list.promise;
-			}),
+			composeProviderDocuments: vi.fn(() => composition.promise),
 		};
 		const runtime = {
 			getService: vi.fn((serviceType: string) =>
@@ -312,19 +359,23 @@ describe("provider database I/O concurrency", () => {
 
 		const resultPromise = documentsProvider.get(runtime, message, state);
 		await Promise.resolve();
-		expect(started).toEqual(["search", "list"]);
+		expect(service.composeProviderDocuments).toHaveBeenCalledWith(message, {
+			limit: 25,
+		});
 
-		search.resolve([]);
-		list.resolve([
-			{
-				id: "10000000-0000-0000-0000-000000000008" as UUID,
-				agentId,
-				entityId,
-				roomId,
-				content: { text: "Project notes" },
-				metadata: { type: MemoryType.DOCUMENT, title: "Project" },
-			},
-		]);
+		composition.resolve({
+			relevantFragments: [],
+			documents: [
+				{
+					id: "10000000-0000-0000-0000-000000000008" as UUID,
+					agentId,
+					entityId,
+					roomId,
+					content: { text: "Project notes" },
+					metadata: { type: MemoryType.DOCUMENT, title: "Project" },
+				},
+			],
+		});
 		await expect(resultPromise).resolves.toMatchObject({
 			values: { documentsAvailable: true, documentsCount: 1 },
 		});


### PR DESCRIPTION
## Summary

Fixes the authorization bypass introduced by #17426.

The merged turn-wide requester memo could be populated by a document read, then reused by update/delete after the actor’s role or room membership was revoked in the same turn. This repair:

- removes requester authorization memoization from general service methods
- keeps coalescing only inside the read-only DOCUMENTS provider composition
- evicts rejected provider-local memo entries so retries re-read authority
- makes every mutation resolve role and room membership within that mutation call before reading the target and issuing its compare-and-swap
- preserves concurrent provider search/list performance without sharing authority with writes

## Security proof

The real adversarial test uses `AgentRuntime` and PGlite:

1. read the document as an authorized requester
2. revoke role/membership
3. attempt update and delete with the same message/turn
4. verify both mutations are rejected and the document remains unchanged

Rejected-memo and cross-turn cases are also covered.

## Verification

Exact head `e8f032166f80467469692b314bcbd997e9316d6a`, directly parented on current develop:

- focused tests: 51/51 passed
- real AgentRuntime + PGlite adversarial suite: 1/1 passed
- core lint: 1,130 files clean
- core typecheck passed
- core Node, browser, edge, and testing builds passed
- `git diff --check` passed

Closes #17443

<!-- evidence-row:before-screenshots -->
- [x] N/A - core authorization service; no UI surface

<!-- evidence-row:after-screenshots -->
- [x] N/A - core authorization service; no UI surface

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend workflow

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path

<!-- evidence-row:backend-logs -->
- [x] N/A - the real AgentRuntime/PGlite test is the executable proof; no transport boundary changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt/action behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] N/A - authorization denial and unchanged PGlite rows are asserted in the real integration test

<!-- evidence-row:ocr-review -->
- [x] N/A - no visual evidence
