### PR TITLE
feat(ui): boot fresh installs to Ember Night

### DIFF
--- a/packages/ui/src/state/background-catalog.test.ts
+++ b/packages/ui/src/state/background-catalog.test.ts
@@ -84,19 +84,26 @@ describe("background catalog (#13538)", () => {
     }
   });
 
-  it("the boot default is the Canopy jungle wallpaper over the black base", () => {
-    // The app boots to the Canopy photo wallpaper (misty jungle river valley).
+  it("the boot default is the Ember Night sunset wallpaper over the black base", () => {
+    // The app boots to the Ember Night sunset wallpaper (warm orange clouds).
     // The base color stays black so the host-chrome FOUC/manifest baseline is
-    // unchanged and the black→image settle is invisible at boot.
+    // unchanged and the black→image settle stays quiet at boot.
     expect(DEFAULT_BACKGROUND_CONFIG.mode).toBe("image");
     expect(DEFAULT_BACKGROUND_CONFIG.color).toBe("#000000");
-    expect(DEFAULT_BACKGROUND_CONFIG.imageUrl).toBe("/wallpapers/canopy.webp");
-    // The Ember Night gallery tile still resolves to the served sunset asset.
+    expect(DEFAULT_BACKGROUND_CONFIG.imageUrl).toBe("/bg-sunset.webp");
+    // DIVERGENCE GUARD: the boot config must equal the catalog default
+    // entry's render source. The old phone/desktop mismatch came from
+    // DEFAULT_BACKGROUND_CONFIG (Canopy) disagreeing with the catalog's
+    // declared default id (ember-night); this pins the two together.
     const def = BACKGROUND_CATALOG.find(
       (e) => e.id === DEFAULT_BACKGROUND_CATALOG_ID,
     );
     expect(def?.kind).toBe("image");
     expect(def?.source).toBe("/bg-sunset.webp");
+    expect(DEFAULT_BACKGROUND_CONFIG.imageUrl).toBe(def?.source);
+    // Canopy remains a selectable gallery scene, just not the default.
+    const canopy = BACKGROUND_CATALOG.find((e) => e.id === "canopy");
+    expect(canopy?.source).toBe("/wallpapers/canopy.webp");
   });
 
   it("resolveCatalogEntry matches by id, label, and fuzzy name", () => {

--- a/packages/ui/src/state/persistence.background.test.ts
+++ b/packages/ui/src/state/persistence.background.test.ts
@@ -15,7 +15,7 @@ import {
   DEFAULT_BACKGROUND_CONFIG,
 } from "./ui-preferences";
 
-// The boot default is the Canopy jungle wallpaper, returned for
+// The boot default is the Ember Night sunset wallpaper, returned for
 // empty/absent/unusable-record input.
 const DEFAULT = DEFAULT_BACKGROUND_CONFIG;
 // A present-but-malformed config still collapses to the plain shader field (a
@@ -153,8 +153,8 @@ describe("background config persistence", () => {
   });
 });
 
-describe("boot-default migration (black shader → Canopy, one-shot)", () => {
-  it("rewrites a persisted old-default black shader to the Canopy default once", () => {
+describe("boot-default migration (black shader → boot default, one-shot)", () => {
+  it("rewrites a persisted old-default black shader to the boot default once", () => {
     // The previous boot default was eagerly persisted on first boot, so an
     // install that never chose a background stores exactly this shape.
     localStorage.setItem(
@@ -185,6 +185,60 @@ describe("boot-default migration (black shader → Canopy, one-shot)", () => {
   it("a fresh install is stamped migrated on first load (later black picks stick)", () => {
     expect(loadBackgroundConfig()).toEqual(DEFAULT);
     saveBackgroundConfig({ mode: "shader", color: DEFAULT_BACKGROUND_COLOR });
+    expect(loadBackgroundConfig()).toEqual({
+      mode: "shader",
+      color: DEFAULT_BACKGROUND_COLOR,
+    });
+  });
+});
+
+describe("fresh-default flip to Ember Night preserves every stored preference", () => {
+  // Per the #17143 review: a stored Canopy (or any wallpaper) record carries
+  // no provenance distinguishing "old default" from "deliberate user pick",
+  // so the default flip must NOT migrate stored values — fresh installs only.
+  it("a fresh install (nothing stored) boots to the sunset default", () => {
+    expect(loadBackgroundConfig()).toEqual({
+      mode: "image",
+      color: "#000000",
+      imageUrl: "/bg-sunset.webp",
+    });
+  });
+
+  it("a stored Canopy wallpaper is preserved verbatim across repeated loads", () => {
+    const canopy = {
+      mode: "image",
+      color: "#000000",
+      imageUrl: "/wallpapers/canopy.webp",
+    } as const;
+    localStorage.setItem("eliza:ui-background", JSON.stringify(canopy));
+    // First load must not rewrite it…
+    expect(loadBackgroundConfig()).toEqual(canopy);
+    // …and neither may any subsequent ordinary load (no one-shot rewrite,
+    // no deferred persistence of a different value underneath it).
+    expect(loadBackgroundConfig()).toEqual(canopy);
+    expect(
+      JSON.parse(localStorage.getItem("eliza:ui-background") ?? "null"),
+    ).toEqual(canopy);
+  });
+
+  it("a stored non-default wallpaper pick (Reef) is preserved untouched", () => {
+    const reef = {
+      mode: "image",
+      color: "#000000",
+      imageUrl: "/wallpapers/reef.webp",
+    } as const;
+    localStorage.setItem("eliza:ui-background", JSON.stringify(reef));
+    expect(loadBackgroundConfig()).toEqual(reef);
+  });
+
+  it("a stored deliberate black shader (post-v2 stamp) is preserved", () => {
+    // An install that already ran the v2 migration and then deliberately
+    // picked black keeps black — the default flip adds no new migration.
+    localStorage.setItem("eliza:ui-background-default-v2", "1");
+    localStorage.setItem(
+      "eliza:ui-background",
+      JSON.stringify({ mode: "shader", color: DEFAULT_BACKGROUND_COLOR }),
+    );
     expect(loadBackgroundConfig()).toEqual({
       mode: "shader",
       color: DEFAULT_BACKGROUND_COLOR,

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -227,13 +227,10 @@ export function normalizeBackgroundConfig(value: unknown): BackgroundConfig {
   return { mode: "shader", color };
 }
 
-// One-shot boot-default migration flag. The boot default changed from the
-// black ember shader to the Canopy wallpaper, but the previous default was
-// eagerly persisted on first boot — "never chose a background" is stored as
-// exactly {mode:"shader", color:#000000} and is indistinguishable from a
-// deliberate pick of the plain black field. The migration rewrites that one
-// shape to the new default a single time; the flag guarantees a user who
-// deliberately returns to the black shader AFTERWARDS keeps it forever.
+// Early builds eagerly persisted untouched fresh state as the exact black
+// shader shape, making it indistinguishable from an intentional selection.
+// This flag permits one safe normalization of that shape. Wallpaper records
+// are never remapped because they lack selected-vs-default provenance.
 const UI_BACKGROUND_DEFAULT_MIGRATION_KEY = "eliza:ui-background-default-v2";
 
 export function loadBackgroundConfig(): BackgroundConfig {
@@ -244,8 +241,8 @@ export function loadBackgroundConfig(): BackgroundConfig {
         UI_BACKGROUND_DEFAULT_MIGRATION_KEY,
       );
       if (!migrated) {
-        // Stamp on the first load either way: a fresh install starts on the
-        // new default, so any later shader-black pick is deliberate.
+        // Stamping before a future selection preserves deliberate black-shader
+        // choices while keeping the normalization one-shot.
         shellLocalStorage.setItem(UI_BACKGROUND_DEFAULT_MIGRATION_KEY, "1");
       }
       if (!raw) return { ...DEFAULT_BACKGROUND_CONFIG };

--- a/packages/ui/src/state/ui-preferences.ts
+++ b/packages/ui/src/state/ui-preferences.ts
@@ -85,8 +85,8 @@ export const DEFAULT_BACKGROUND_GLOW = "#ff6a1f";
 /**
  * The shader-mode config for the black ember field: the fallback when an
  * image background is cleared or fails to load, and the base the color
- * swatches and the glsl fallback resolve to. (The boot default is the Canopy
- * wallpaper — see {@link DEFAULT_BACKGROUND_CONFIG}.)
+ * swatches and the glsl fallback resolve to. (The boot default is the Ember
+ * Night sunset wallpaper — see {@link DEFAULT_BACKGROUND_CONFIG}.)
  */
 export const DEFAULT_SHADER_BACKGROUND_CONFIG: BackgroundConfig = {
   mode: "shader",
@@ -94,16 +94,10 @@ export const DEFAULT_SHADER_BACKGROUND_CONFIG: BackgroundConfig = {
 };
 
 /**
- * The curated "Ember Night" wallpaper: a warm sunset in the clouds, served as
- * a same-origin static asset from `packages/app/public`. It renders the
- * `ember-night` gallery tile (no longer the boot default — the app boots to
- * the Canopy wallpaper). A served, code-free, same-origin image the apply
- * channel already trusts (same class as the gradient data URLs and the
- * `/api/media/<hash>` uploads) — it carries no GLSL source or preset id, so the
- * confinement invariants (#11088 / #13523) hold. The bytes live in `public/`
- * (served, cacheable), never in the JS bundle. When the image is cleared or
- * fails to load the shell falls back to the shader field
- * ({@link DEFAULT_SHADER_BACKGROUND_CONFIG}).
+ * The curated "Ember Night" wallpaper is both the gallery tile and the
+ * fresh-install background. Serving this code-free asset from the app origin
+ * keeps it outside the JS bundle and within the image confinement boundary.
+ * The shader field remains the fallback when the image cannot render.
  */
 const SUNSET_WALLPAPER_URL = "/bg-sunset.webp";
 
@@ -134,20 +128,17 @@ const PHOTO_WALLPAPER_IDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * The boot default background: the "Canopy" photo wallpaper — a misty jungle
- * river valley in deep, layered greens — over the black base color. The base
- * stays {@link DEFAULT_BACKGROUND_COLOR} so every piece of host chrome that
- * tracks it (launch FOUC guard, PWA theme-color, manifest, native splashes)
- * keeps its black baseline, and canopy's near-black darkest tones make the
- * black→image settle invisible at boot. If the image is cleared or fails to
- * load the shell falls back to the shader ember field
- * ({@link DEFAULT_SHADER_BACKGROUND_CONFIG}); every other curated scene stays
- * a user-selectable gallery option.
+ * Fresh installs use the "Ember Night" sunset wallpaper over the same black
+ * base used by host chrome and native launch surfaces, preventing a bright
+ * transition while the asset loads. Persisted backgrounds remain authoritative:
+ * without selected-vs-default provenance, changing an existing wallpaper would
+ * overwrite an intentional choice. The catalog default id and this fallback
+ * therefore describe new state only and must stay aligned.
  */
 export const DEFAULT_BACKGROUND_CONFIG: BackgroundConfig = {
   mode: "image",
   color: DEFAULT_BACKGROUND_COLOR,
-  imageUrl: photoWallpaperUrl("canopy"),
+  imageUrl: SUNSET_WALLPAPER_URL,
 };
 
 /* ── Background catalog (curated + metadata) ──────────────────────────── */

--- a/packages/ui/src/state/useDisplayPreferences.background.test.tsx
+++ b/packages/ui/src/state/useDisplayPreferences.background.test.tsx
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 describe("useDisplayPreferences — background history + undo", () => {
-  it("starts on the boot default (Canopy wallpaper) with nothing to undo", () => {
+  it("starts on the boot default (Ember Night sunset wallpaper) with nothing to undo", () => {
     const { result } = renderHook(() => useDisplayPreferences());
     expect(result.current.state.backgroundConfig).toEqual(
       DEFAULT_BACKGROUND_CONFIG,


### PR DESCRIPTION
## What

Same-repository port of #17434, preserving Sol’s implementation and tests while expressing the background-default rationale as durable design documentation.

Fresh installs now use the catalog’s declared `ember-night` sunset wallpaper instead of the divergent Canopy fallback. Every stored preference remains untouched; no migration attempts to guess whether a stored Canopy/black value was deliberate.

## Why this port

#17434 is fork-owned and cannot be rebased by this review lane. Its five implementation/test blobs were byte-identical at reviewed head `2bfdefb13c594d9c457809ef3cdf0c2cb9e7ba69`. The final reviewed head is `4d1d7567b340eca66be150ba8e562f9388814099`, parent `bb9cc9852608b3ab73aa2b7aa1e5a298e778fda3`; implementation and tests remain behavior-identical, while two comment blocks now state durable provenance and migration invariants. Rendered evidence remains bound to `2bfdefb1` because the implementation blobs and relevant UI behavior are unchanged.

## Final verification

- focused background/default/persistence tests: 3 files, 43/43 passed
- fresh-profile browser evidence: desktop 1440×900 and mobile 390×844
- initial background storage: absent on both profiles
- rendered/persisted background: `/bg-sunset.webp` on both profiles; asset response 200
- browser diagnostics: 0 console errors, 0 warnings, 0 non-2xx responses, 0 unexpected boot failures, 0 steady-state request failures
- manual comparison against #17434 before/after: correct Canopy → Ember Night delta; no clipping, overlap, overflow, or interaction regression
- implementation and test logic is byte-identical to the reviewed implementation; two comment blocks contain documentation-only cleanup
- final head: `4d1d7567b340eca66be150ba8e562f9388814099`; parent: `bb9cc9852608b3ab73aa2b7aa1e5a298e778fda3`

Credits: @0xSolace. Supersedes #17434 and re-cuts #17143.

<!-- evidence-row:before-screenshots -->
- [x] #17434 reviewed Canopy reference: [desktop 1440×900](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17434-before-desktop.png) · [mobile 390×844](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17434-before-mobile.png)

<!-- evidence-row:after-screenshots -->
- [x] Exact head `2bfdefb1`, Ember Night fresh profile: [desktop 1440×900](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17454-2bfdefb1-after-desktop.png) · [mobile 390×844](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17454-2bfdefb1-after-mobile.png)

<!-- evidence-row:walkthrough-video -->
- [x] N/A - one fresh-install default constant; before/after screenshots fully show the visual delta and no interaction flow changed. The evidence gate accepts this scoped N/A.

<!-- evidence-row:frontend-logs -->
- [x] Exact-head [console capture](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17454-2bfdefb1-browser-console.json) · [network capture](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17454-2bfdefb1-browser-network.json) · [Playwright log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17454-2bfdefb1-playwright.log). Zero console errors/warnings, non-2xx responses, unexpected boot failures, or steady-state request failures. The captured `net::ERR_ABORTED` boot events are the expected one-time build-stamp reload.

<!-- evidence-row:backend-logs -->
- [x] N/A - frontend-only default; the browser fixture intercepts the unchanged API boundary.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior.

<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head verification record](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17454-2bfdefb1-verification.json) · [43/43 focused test log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17454-2bfdefb1-focused-ui-tests.log) · [manual comparison](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17454-2bfdefb1-manual-review.json) · [SHA-256 manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17454-2bfdefb1-sha256s.txt)

<!-- evidence-row:ocr-review -->
- [x] Exact-head cropped/upscaled Tesseract read the greeting, sign-in prompt, Cloud CTA, and locked-composer text on [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17454-2bfdefb1-ocr-desktop-review.txt) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17454-2bfdefb1-ocr-mobile-review.txt); manual pixel review confirms all foreground copy is legible.
