### PR TITLE
fix(cloud): strongly order onboarding deliveries

### DIFF
--- a/packages/agent/src/api/memory-remember-idempotency.test.ts
+++ b/packages/agent/src/api/memory-remember-idempotency.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Exercises the remember HTTP handler's stable-write contract with an
+ * in-memory runtime boundary: a retried key returns the original memory and
+ * never issues a second create.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import type { MemoryRouteContext } from "./memory-routes.ts";
+import { handleMemoryRoutes } from "./memory-routes.ts";
+
+function contextFor(args: {
+  body: Record<string, unknown>;
+  memories: Map<UUID, Memory>;
+  createMemory: ReturnType<typeof mock>;
+  response: { value?: unknown };
+}): MemoryRouteContext {
+  const runtime = {
+    agentId: "11111111-1111-4111-8111-111111111111" as UUID,
+    character: { name: "Eliza" },
+    ensureConnection: mock(async () => undefined),
+    getMemoryById: mock(async (id: UUID) => args.memories.get(id) ?? null),
+    createMemory: args.createMemory,
+  } as unknown as AgentRuntime;
+  return {
+    req: {} as never,
+    res: {} as never,
+    method: "POST",
+    pathname: "/api/memory/remember",
+    url: new URL("https://agent.test/api/memory/remember"),
+    runtime,
+    agentName: "Eliza",
+    json: (_res, value) => {
+      args.response.value = value;
+    },
+    error: (_res, message, status) => {
+      throw new Error(`unexpected ${status}: ${message}`);
+    },
+    readJsonBody: async <T extends object>() => args.body as T,
+  };
+}
+
+describe("POST /api/memory/remember idempotency", () => {
+  test("replays one stable memory for a reused key", async () => {
+    const memories = new Map<UUID, Memory>();
+    const createMemory = mock(async (memory: Memory) => {
+      if (!memory.id)
+        throw new Error("remember handler produced a memory without an id");
+      memories.set(memory.id, memory);
+      return memory.id;
+    });
+    const firstResponse: { value?: unknown } = {};
+    const first = contextFor({
+      body: {
+        text: "Onboarding transcript",
+        idempotencyKey: "onboarding:session-1",
+      },
+      memories,
+      createMemory,
+      response: firstResponse,
+    });
+    expect(await handleMemoryRoutes(first)).toBe(true);
+    expect(firstResponse.value).toEqual(
+      expect.objectContaining({ ok: true, replayed: false }),
+    );
+
+    const secondResponse: { value?: unknown } = {};
+    const second = contextFor({
+      body: {
+        text: "changed retry body",
+        idempotencyKey: "onboarding:session-1",
+      },
+      memories,
+      createMemory,
+      response: secondResponse,
+    });
+    expect(await handleMemoryRoutes(second)).toBe(true);
+    expect(secondResponse.value).toEqual(
+      expect.objectContaining({
+        ok: true,
+        id: (firstResponse.value as { id: UUID }).id,
+        text: "Onboarding transcript",
+        replayed: true,
+      }),
+    );
+    expect(createMemory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -456,8 +456,26 @@ export async function handleMemoryRoutes(
     }
     const text = parsedRem.data.text;
     const createdAt = Date.now();
+    const memoryId = parsedRem.data.idempotencyKey
+      ? (stringToUuid(
+          `${HASH_MEMORY_SOURCE}:${runtime.agentId}:${parsedRem.data.idempotencyKey}`,
+        ) as UUID)
+      : (crypto.randomUUID() as UUID);
+    const existing = parsedRem.data.idempotencyKey
+      ? await runtime.getMemoryById(memoryId)
+      : null;
+    if (existing) {
+      json(res, {
+        ok: true,
+        id: existing.id,
+        text: existing.content.text ?? text,
+        createdAt: existing.createdAt,
+        replayed: true,
+      });
+      return true;
+    }
     const message = createMessageMemory({
-      id: crypto.randomUUID() as UUID,
+      id: memoryId,
       entityId,
       roomId,
       content: {
@@ -472,6 +490,7 @@ export async function handleMemoryRoutes(
       id: message.id,
       text,
       createdAt,
+      replayed: false,
     });
     return true;
   }

--- a/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Exercises the real onboarding state machine through its Durable Object
+ * owner, including concurrent turn ordering and transport replay.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { OnboardingChatResult } from "@/lib/services/eliza-app/onboarding-chat";
+import { OnboardingSessionCoordinator } from "../src/onboarding-session-coordinator";
+
+class TestStorage {
+  private readonly values = new Map<string, unknown>();
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const value = this.values.get(key);
+    return value === undefined ? undefined : (structuredClone(value) as T);
+  }
+
+  async put(key: string, value: unknown): Promise<void> {
+    this.values.set(key, structuredClone(value));
+  }
+}
+
+function createCoordinatorHarness(): {
+  coordinator: OnboardingSessionCoordinator;
+  objectByName(name: string): OnboardingSessionCoordinator;
+} {
+  const objects = new Map<string, OnboardingSessionCoordinator>();
+  const env: Record<string, unknown> = {};
+  const objectByName = (name: string): OnboardingSessionCoordinator => {
+    let object = objects.get(name);
+    if (!object) {
+      object = new OnboardingSessionCoordinator(
+        { storage: new TestStorage() } as unknown as DurableObjectState,
+        env as never,
+      );
+      objects.set(name, object);
+    }
+    return object;
+  };
+  env.ONBOARDING_SESSIONS = {
+    getByName: (name: string) => ({
+      fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+        objectByName(name).fetch(new Request(input, init)),
+    }),
+  };
+  return {
+    coordinator: objectByName("platform:discord:user-1"),
+    objectByName,
+  };
+}
+
+function turn(
+  coordinator: OnboardingSessionCoordinator,
+  message: string,
+  idempotencyKey: string,
+): Promise<Response> {
+  return coordinator.fetch(
+    new Request("https://onboarding.test/turn", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessionId: "platform:discord:user-1",
+        input: {
+          sessionId: "platform:discord:user-1",
+          message,
+          platform: "discord",
+          platformUserId: "user-1",
+          trustedPlatformIdentity: true,
+          idempotencyKey,
+        },
+      }),
+    }),
+  );
+}
+
+async function readResult(response: Response): Promise<OnboardingChatResult> {
+  return (await response.json()) as OnboardingChatResult;
+}
+
+describe("OnboardingSessionCoordinator", () => {
+  test("serializes concurrent turns and replays a delivery exactly once", async () => {
+    const harness = createCoordinatorHarness();
+    const { coordinator } = harness;
+    const [firstResponse, secondResponse] = await Promise.all([
+      turn(coordinator, "My name is Sam", "discord:message-1"),
+      turn(coordinator, "Tell me more", "discord:message-2"),
+    ]);
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    const first = await readResult(firstResponse);
+    const second = await readResult(secondResponse);
+    expect(first.session.history).toHaveLength(2);
+    expect(second.session.history).toHaveLength(4);
+    expect(
+      second.session.history.map(
+        (message: { content: string }) => message.content,
+      ),
+    ).toEqual(expect.arrayContaining(["My name is Sam", "Tell me more"]));
+    const continuationToken = first.session.continuationToken;
+    if (!continuationToken)
+      throw new Error("platform session has no continuation token");
+    const continuation = await harness
+      .objectByName(continuationToken)
+      .fetch(
+        new Request("https://onboarding.test/resolve", { method: "POST" }),
+      );
+    expect((await continuation.json()) as unknown).toEqual({
+      sessionId: "platform:discord:user-1",
+    });
+
+    const replayResponse = await turn(
+      coordinator,
+      "this changed payload must not execute",
+      "discord:message-1",
+    );
+    expect(replayResponse.status).toBe(200);
+    const replay = await readResult(replayResponse);
+    expect(replay.reply).toBe(first.reply);
+    expect(replay.session).toEqual(first.session);
+
+    const thirdResponse = await turn(
+      coordinator,
+      "Third turn",
+      "discord:message-3",
+    );
+    const third = await readResult(thirdResponse);
+    expect(third.session.history).toHaveLength(6);
+    expect(
+      third.session.history.filter(
+        (message: { content: string }) => message.content === "My name is Sam",
+      ),
+    ).toHaveLength(1);
+    expect(
+      third.session.history.some(
+        (message: { content: string }) =>
+          message.content === "this changed payload must not execute",
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/cloud/api/eliza-app/onboarding/chat/route.ts
+++ b/packages/cloud/api/eliza-app/onboarding/chat/route.ts
@@ -82,6 +82,7 @@ app.post("/", async (c) => {
     }
 
     const caller = await resolveCaller(c);
+    const idempotencyKey = c.req.header("Idempotency-Key")?.trim();
     const result = await runOnboardingChat({
       sessionId: parsed.data.sessionId,
       message: parsed.data.message,
@@ -90,6 +91,7 @@ app.post("/", async (c) => {
       platformDisplayName: parsed.data.platformDisplayName,
       authenticatedUser: caller.authenticatedUser,
       trustedPlatformIdentity: caller.trustedPlatformIdentity,
+      idempotencyKey: idempotencyKey || undefined,
     });
 
     return c.json({

--- a/packages/cloud/api/scripts/onboarding-latency-report.ts
+++ b/packages/cloud/api/scripts/onboarding-latency-report.ts
@@ -1,0 +1,154 @@
+/**
+ * Measures the strongly ordered onboarding turn path without pass/fail gates.
+ * The harness uses real state-machine and Durable Object code with an
+ * in-memory storage implementation so results isolate application overhead.
+ */
+
+import { OnboardingSessionCoordinator } from "../src/onboarding-session-coordinator";
+
+class BenchmarkStorage {
+  private readonly values = new Map<string, unknown>();
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const value = this.values.get(key);
+    return value === undefined ? undefined : (structuredClone(value) as T);
+  }
+
+  async put(key: string, value: unknown): Promise<void> {
+    this.values.set(key, structuredClone(value));
+  }
+}
+
+function createHarness(): (name: string) => OnboardingSessionCoordinator {
+  const objects = new Map<string, OnboardingSessionCoordinator>();
+  const env: Record<string, unknown> = {
+    CEREBRAS_API_KEY: "configured-but-unused",
+  };
+  const objectByName = (name: string): OnboardingSessionCoordinator => {
+    let object = objects.get(name);
+    if (!object) {
+      object = new OnboardingSessionCoordinator(
+        { storage: new BenchmarkStorage() } as unknown as DurableObjectState,
+        env as never,
+      );
+      objects.set(name, object);
+    }
+    return object;
+  };
+  env.ONBOARDING_SESSIONS = {
+    getByName: (name: string) => ({
+      fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+        objectByName(name).fetch(new Request(input, init)),
+    }),
+  };
+  return objectByName;
+}
+
+async function turn(
+  coordinator: OnboardingSessionCoordinator,
+  message: string,
+  idempotencyKey: string,
+): Promise<void> {
+  const response = await coordinator.fetch(
+    new Request("https://onboarding.benchmark/turn", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessionId: "platform:discord:benchmark-user",
+        input: {
+          sessionId: "platform:discord:benchmark-user",
+          message,
+          platform: "discord",
+          platformUserId: "benchmark-user",
+          platformDisplayName: "Benchmark User",
+          trustedPlatformIdentity: true,
+          idempotencyKey,
+        },
+      }),
+    }),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `benchmark turn failed (${response.status}): ${await response.text()}`,
+    );
+  }
+  await response.arrayBuffer();
+}
+
+function summarize(samples: number[]): Record<string, number> {
+  const sorted = [...samples].sort((left, right) => left - right);
+  const percentile = (value: number): number =>
+    sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * value))] ?? 0;
+  const rounded = (value: number): number => Number(value.toFixed(3));
+  return {
+    count: samples.length,
+    meanMs: rounded(
+      samples.reduce((sum, sample) => sum + sample, 0) / samples.length,
+    ),
+    p50Ms: rounded(percentile(0.5)),
+    p95Ms: rounded(percentile(0.95)),
+    maxMs: rounded(sorted.at(-1) ?? 0),
+  };
+}
+
+async function sample(operation: () => Promise<void>): Promise<number> {
+  const startedAt = performance.now();
+  await operation();
+  return performance.now() - startedAt;
+}
+
+const objectByName = createHarness();
+const coordinator = objectByName("platform:discord:benchmark-user");
+const coldTurnMs = await sample(() =>
+  turn(coordinator, "My name is Benchmark User", "discord:cold"),
+);
+
+const uniqueSamples: number[] = [];
+for (let index = 0; index < 100; index += 1) {
+  uniqueSamples.push(
+    await sample(() =>
+      turn(coordinator, `unique turn ${index}`, `discord:unique-${index}`),
+    ),
+  );
+}
+
+const replaySamples: number[] = [];
+for (let index = 0; index < 100; index += 1) {
+  replaySamples.push(
+    await sample(() =>
+      turn(coordinator, "ignored replay body", "discord:unique-99"),
+    ),
+  );
+}
+
+const burstStartedAt = performance.now();
+const burstSamples = await Promise.all(
+  Array.from({ length: 32 }, (_, index) =>
+    sample(() =>
+      turn(coordinator, `burst turn ${index}`, `discord:burst-${index}`),
+    ),
+  ),
+);
+const burstWallMs = performance.now() - burstStartedAt;
+
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      generatedAt: new Date().toISOString(),
+      runtime: `bun ${Bun.version}`,
+      modelConfiguration:
+        "CEREBRAS_API_KEY present; onboarding performs zero model calls",
+      coldTurnMs: Number(coldTurnMs.toFixed(3)),
+      sequentialUnique: summarize(uniqueSamples),
+      cachedReplay: summarize(replaySamples),
+      parallelBurst: {
+        concurrency: burstSamples.length,
+        wallMs: Number(burstWallMs.toFixed(3)),
+        perRequest: summarize(burstSamples),
+      },
+    },
+    null,
+    2,
+  )}\n`,
+);
+process.exit(0);

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -19,6 +19,7 @@ import { serveBlobHostRequest } from "./blob-host";
 
 export { AnonymousChatGate } from "./anonymous-chat-gate";
 export { InferenceAdmissionGate } from "./inference-admission-gate";
+export { OnboardingSessionCoordinator } from "./onboarding-session-coordinator";
 export { SharedRuntimeConversation } from "./shared-runtime-conversation";
 
 let appPromise: Promise<Hono<AppEnv>> | undefined;

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -5,13 +5,10 @@
  */
 
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
-import {
-  loadCachedOnboardingSession,
-  mirrorOnboardingSessionToCache,
-  type OnboardingChatInput,
-  type OnboardingChatResult,
-  type OnboardingSession,
-  runOnboardingChatWithStore,
+import type {
+  OnboardingChatInput,
+  OnboardingChatResult,
+  OnboardingSession,
 } from "@/lib/services/eliza-app/onboarding-chat";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -132,12 +129,20 @@ export class OnboardingSessionCoordinator {
         );
       }
     }
+    const { mirrorOnboardingSessionToCache } = await import(
+      "@/lib/services/eliza-app/onboarding-chat"
+    );
     await mirrorOnboardingSessionToCache(session);
   }
 
   private async runTurn(
     request: CoordinatorRequest,
   ): Promise<OnboardingChatResult> {
+    // The Worker entrypoint must remain free of global-scope service
+    // initialization. Loading onboarding inside the request preserves the
+    // bootstrap boundary used by the main Hono application.
+    const { loadCachedOnboardingSession, runOnboardingChatWithStore } =
+      await import("@/lib/services/eliza-app/onboarding-chat");
     const ledger = await this.state.storage.get<CoordinatorLedger>(LEDGER_KEY);
     if (ledger && request.input.idempotencyKey) {
       const replay = ledger.results.find(

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -1,0 +1,238 @@
+/**
+ * Strongly orders every turn for one onboarding session. Durable storage owns
+ * the transcript and replay ledger; KV is only a compatibility mirror for
+ * browser continuation-token lookup and migration from pre-coordinator data.
+ */
+
+import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import {
+  loadCachedOnboardingSession,
+  mirrorOnboardingSessionToCache,
+  type OnboardingChatInput,
+  type OnboardingChatResult,
+  type OnboardingSession,
+  runOnboardingChatWithStore,
+} from "@/lib/services/eliza-app/onboarding-chat";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+interface CoordinatorRequest {
+  input: OnboardingChatInput;
+  sessionId: string;
+}
+
+interface ReplayEntry {
+  key: string;
+  result: Omit<OnboardingChatResult, "session">;
+  session: Omit<OnboardingSession, "history">;
+  historyEndMessageId: string;
+  historyTail: OnboardingSession["history"];
+}
+
+interface CoordinatorLedger {
+  session: OnboardingSession;
+  results: ReplayEntry[];
+}
+
+const LEDGER_KEY = "ledger";
+const REDIRECT_KEY = "continuation-session-id";
+const MAX_REPLAY_RESULTS = 64;
+
+function storedReplay(key: string, result: OnboardingChatResult): ReplayEntry {
+  const { session, ...stored } = result;
+  const { history, ...sessionMetadata } = session;
+  const historyEndMessageId = history.at(-1)?.id;
+  if (!historyEndMessageId) {
+    throw new Error("onboarding result has no stable history marker");
+  }
+  return {
+    key,
+    result: stored,
+    session: sessionMetadata,
+    historyEndMessageId,
+    historyTail: history.slice(-2),
+  };
+}
+
+function replayResult(
+  entry: ReplayEntry,
+  currentSession: OnboardingSession,
+): OnboardingChatResult {
+  const historyEnd = currentSession.history.findIndex(
+    (message) => message.id === entry.historyEndMessageId,
+  );
+  return {
+    ...entry.result,
+    session: {
+      ...entry.session,
+      // The marker is retained for every normal replay-window turn. The compact
+      // tail keeps a coherent response if many non-idempotent web turns trim it
+      // without growing the ledger by duplicating whole 200-message histories.
+      history:
+        historyEnd >= 0
+          ? currentSession.history.slice(0, historyEnd + 1)
+          : entry.historyTail,
+    },
+  };
+}
+
+function isCoordinatorRequest(value: unknown): value is CoordinatorRequest {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.sessionId === "string" &&
+    record.sessionId.length >= 8 &&
+    record.sessionId.length <= 180 &&
+    typeof record.input === "object" &&
+    record.input !== null
+  );
+}
+
+export class OnboardingSessionCoordinator {
+  private readonly state: DurableObjectState;
+  private readonly env: AppEnv["Bindings"];
+  private operationQueue: Promise<void> = Promise.resolve();
+
+  constructor(state: DurableObjectState, env: AppEnv["Bindings"]) {
+    this.state = state;
+    this.env = env;
+  }
+
+  private async serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.operationQueue;
+    let release: () => void = () => undefined;
+    this.operationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async publishSession(session: OnboardingSession): Promise<void> {
+    if (session.continuationToken && session.id.startsWith("platform:")) {
+      const namespace = this.env.ONBOARDING_SESSIONS;
+      if (!namespace) {
+        throw new Error(
+          "ONBOARDING_SESSIONS binding is unavailable inside coordinator",
+        );
+      }
+      const bound = await namespace
+        .getByName(session.continuationToken)
+        .fetch("https://onboarding.internal/bind", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ sessionId: session.id }),
+        });
+      if (!bound.ok) {
+        throw new Error(
+          `onboarding continuation binding failed (${bound.status})`,
+        );
+      }
+    }
+    await mirrorOnboardingSessionToCache(session);
+  }
+
+  private async runTurn(
+    request: CoordinatorRequest,
+  ): Promise<OnboardingChatResult> {
+    const ledger = await this.state.storage.get<CoordinatorLedger>(LEDGER_KEY);
+    if (ledger && request.input.idempotencyKey) {
+      const replay = ledger.results.find(
+        (entry) => entry.key === request.input.idempotencyKey,
+      );
+      if (replay) {
+        await this.publishSession(ledger.session);
+        return replayResult(replay, ledger.session);
+      }
+    }
+
+    let nextSession =
+      ledger?.session ?? (await loadCachedOnboardingSession(request.sessionId));
+    const result = await runOnboardingChatWithStore(
+      request.input,
+      request.sessionId,
+      {
+        load: async () => nextSession,
+        save: async (session) => {
+          nextSession = session;
+        },
+      },
+    );
+
+    const results = ledger?.results ? [...ledger.results] : [];
+    if (request.input.idempotencyKey) {
+      results.push(storedReplay(request.input.idempotencyKey, result));
+      if (results.length > MAX_REPLAY_RESULTS) {
+        results.splice(0, results.length - MAX_REPLAY_RESULTS);
+      }
+    }
+    const stored: CoordinatorLedger = { session: result.session, results };
+    await this.state.storage.put(LEDGER_KEY, stored);
+    await this.publishSession(result.session);
+    return result;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    return this.serialize(async () => {
+      try {
+        const pathname = new URL(request.url).pathname;
+        if (request.method !== "POST") {
+          return Response.json({ error: "Not found" }, { status: 404 });
+        }
+        if (pathname === "/resolve") {
+          const sessionId = await this.state.storage.get<string>(REDIRECT_KEY);
+          return sessionId
+            ? Response.json({ sessionId })
+            : Response.json(
+                { error: "Continuation not found" },
+                { status: 404 },
+              );
+        }
+        if (pathname === "/bind") {
+          const body: unknown = await request.json();
+          const sessionId =
+            body && typeof body === "object" && "sessionId" in body
+              ? (body as { sessionId?: unknown }).sessionId
+              : undefined;
+          if (
+            typeof sessionId !== "string" ||
+            !sessionId.startsWith("platform:") ||
+            sessionId.length > 180
+          ) {
+            return Response.json(
+              { error: "Invalid continuation binding" },
+              { status: 400 },
+            );
+          }
+          await this.state.storage.put(REDIRECT_KEY, sessionId);
+          return Response.json({ success: true });
+        }
+        if (pathname !== "/turn") {
+          return Response.json({ error: "Not found" }, { status: 404 });
+        }
+        const body: unknown = await request.json();
+        if (!isCoordinatorRequest(body)) {
+          return Response.json(
+            { error: "Invalid coordinator request" },
+            { status: 400 },
+          );
+        }
+        const result = await runWithCloudBindingsAsync(this.env, () =>
+          this.runTurn(body),
+        );
+        return Response.json(result);
+      } catch (error) {
+        // error-policy:J1 Durable Object transport boundary; inner onboarding
+        // failures remain observable as a failed request and are never replaced
+        // with an empty or successful-looking result.
+        return Response.json(
+          { error: error instanceof Error ? error.message : String(error) },
+          { status: 500 },
+        );
+      }
+    });
+  }
+}

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -113,6 +113,10 @@ class_name = "InferenceAdmissionGate"
 name = "ANONYMOUS_CHAT_GATES"
 class_name = "AnonymousChatGate"
 
+[[durable_objects.bindings]]
+name = "ONBOARDING_SESSIONS"
+class_name = "OnboardingSessionCoordinator"
+
 [[migrations]]
 tag = "shared-runtime-conversations-v1"
 new_sqlite_classes = ["SharedRuntimeConversation"]
@@ -124,6 +128,10 @@ new_sqlite_classes = ["InferenceAdmissionGate"]
 [[migrations]]
 tag = "anonymous-chat-gates-v1"
 new_sqlite_classes = ["AnonymousChatGate"]
+
+[[migrations]]
+tag = "onboarding-session-coordinator-v1"
+new_sqlite_classes = ["OnboardingSessionCoordinator"]
 
 # General API limits and queues may use Railway Redis via REDIS_URL. Inference
 # routes never connect to it: Cloudflare Rate Limiting bindings protect ingress,
@@ -506,6 +514,10 @@ class_name = "InferenceAdmissionGate"
 name = "ANONYMOUS_CHAT_GATES"
 class_name = "AnonymousChatGate"
 
+[[env.staging.durable_objects.bindings]]
+name = "ONBOARDING_SESSIONS"
+class_name = "OnboardingSessionCoordinator"
+
 [[env.staging.ratelimits]]
 name = "GLOBAL_RATE_LIMITER"
 namespace_id = "1615311"
@@ -696,6 +708,10 @@ class_name = "InferenceAdmissionGate"
 [[env.production.durable_objects.bindings]]
 name = "ANONYMOUS_CHAT_GATES"
 class_name = "AnonymousChatGate"
+
+[[env.production.durable_objects.bindings]]
+name = "ONBOARDING_SESSIONS"
+class_name = "OnboardingSessionCoordinator"
 
 [[env.production.ratelimits]]
 name = "GLOBAL_RATE_LIMITER"

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
@@ -438,6 +438,7 @@ describe("AgentGatewayRouterService phone routing", () => {
         platformUserId: "+1 (555) 555-0100",
         sessionId: "platform:blooio:+1 (555) 555-0100",
         trustedPlatformIdentity: true,
+        idempotencyKey: "blooio:msg-1",
       }),
     );
   });
@@ -465,6 +466,7 @@ describe("AgentGatewayRouterService phone routing", () => {
     expect(runOnboardingChat).toHaveBeenCalledWith(
       expect.objectContaining({
         trustedPlatformIdentity: true,
+        idempotencyKey: "blooio:msg-1",
       }),
     );
   });
@@ -503,6 +505,8 @@ describe("AgentGatewayRouterService phone routing", () => {
           userId: "known-user",
           organizationId: "known-org",
         },
+        trustedPlatformIdentity: true,
+        idempotencyKey: "blooio:msg-1",
       }),
     );
   });
@@ -586,6 +590,8 @@ describe("AgentGatewayRouterService phone routing", () => {
           userId: "known-user",
           organizationId: "known-org",
         },
+        trustedPlatformIdentity: true,
+        idempotencyKey: "blooio:msg-1",
       }),
     );
   });
@@ -659,6 +665,7 @@ describe("AgentGatewayRouterService discord DM onboarding (#17341)", () => {
         platformDisplayName: "New User",
         sessionId: "platform:discord:discord-user-1",
         trustedPlatformIdentity: true,
+        idempotencyKey: "discord:msg-1",
       }),
     );
   });
@@ -684,6 +691,8 @@ describe("AgentGatewayRouterService discord DM onboarding (#17341)", () => {
       expect.objectContaining({
         platform: "discord",
         authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        trustedPlatformIdentity: true,
+        idempotencyKey: "discord:msg-1",
       }),
     );
   });

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
@@ -655,6 +655,7 @@ export class AgentGatewayRouterService {
           platformDisplayName: args.sender.displayName ?? args.sender.username,
           sessionId: `platform:discord:${args.sender.id}`,
           trustedPlatformIdentity: true,
+          idempotencyKey: `discord:${args.messageId}`,
         });
         return {
           handled: true,
@@ -681,10 +682,12 @@ export class AgentGatewayRouterService {
           platformUserId: args.sender.id,
           platformDisplayName: args.sender.displayName ?? args.sender.username,
           sessionId: `platform:discord:${args.sender.id}`,
+          trustedPlatformIdentity: true,
           authenticatedUser: {
             userId: resolved.userId,
             organizationId: resolved.organizationId,
           },
+          idempotencyKey: `discord:${args.messageId}`,
         });
         return {
           handled: true,
@@ -779,6 +782,9 @@ export class AgentGatewayRouterService {
         platformUserId: args.from,
         sessionId: `platform:${args.provider}:${args.from}`,
         trustedPlatformIdentity: true,
+        idempotencyKey: args.providerMessageId
+          ? `${args.provider}:${args.providerMessageId}`
+          : undefined,
       });
 
       return {
@@ -799,6 +805,9 @@ export class AgentGatewayRouterService {
           platformUserId: args.from,
           sessionId: `platform:${args.provider}:${args.from}`,
           trustedPlatformIdentity: true,
+          idempotencyKey: args.providerMessageId
+            ? `${args.provider}:${args.providerMessageId}`
+            : undefined,
         });
 
         return {
@@ -822,10 +831,14 @@ export class AgentGatewayRouterService {
           platform: args.provider,
           platformUserId: args.from,
           sessionId: `platform:${args.provider}:${args.from}`,
+          trustedPlatformIdentity: true,
           authenticatedUser: {
             userId: resolved.userId,
             organizationId: resolved.organizationId,
           },
+          idempotencyKey: args.providerMessageId
+            ? `${args.provider}:${args.providerMessageId}`
+            : undefined,
         });
 
         return {
@@ -924,10 +937,14 @@ export class AgentGatewayRouterService {
         platform: args.provider,
         platformUserId: args.from,
         sessionId: `platform:${args.provider}:${args.from}`,
+        trustedPlatformIdentity: true,
         authenticatedUser: {
           userId: resolved.userId,
           organizationId: resolved.organizationId,
         },
+        idempotencyKey: args.providerMessageId
+          ? `${args.provider}:${args.providerMessageId}`
+          : undefined,
       });
 
       return {

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
@@ -10,7 +10,6 @@ const sessionCache = new Map<string, unknown>();
 const ensureElizaAppProvisioning = mock();
 const getElizaAppProvisioningStatus = mock();
 const linkPhoneToUser = mock();
-const generateText = mock();
 const launchManagedElizaAgent = mock();
 let cloudEnv: Record<string, string | undefined> = {};
 const REAL_CLOUD_BINDINGS = { ...realCloudBindings };
@@ -27,15 +26,6 @@ mock.module("../../cache/client", () => ({
 mock.module("../../runtime/cloud-bindings", () => ({
   ...REAL_CLOUD_BINDINGS,
   getCloudAwareEnv: mock(() => cloudEnv),
-}));
-
-mock.module("@ai-sdk/openai", () => ({
-  createOpenAI: mock(() => ({ chat: mock(() => "mock-model") })),
-  openai: mock(() => "mock-openai-model"),
-}));
-
-mock.module("ai", () => ({
-  generateText,
 }));
 
 mock.module("../eliza-managed-launch", () => ({
@@ -81,7 +71,6 @@ describe("onboarding-chat phone-link error policy", () => {
     ensureElizaAppProvisioning.mockReset();
     getElizaAppProvisioningStatus.mockReset();
     linkPhoneToUser.mockReset();
-    generateText.mockReset();
     launchManagedElizaAgent.mockReset();
     ensureElizaAppProvisioning.mockResolvedValue(provisioning());
     getElizaAppProvisioningStatus.mockResolvedValue(provisioning());

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -16,7 +16,6 @@ const ensureElizaAppProvisioning = mock();
 const getElizaAppProvisioningStatus = mock();
 const findOrCreateByPhone = mock();
 const linkPhoneToUser = mock();
-const generateText = mock();
 const launchManagedElizaAgent = mock();
 const loggerWarn = mock();
 let cloudEnv: Record<string, string | undefined> = {};
@@ -58,34 +57,6 @@ mock.module("../../utils/logger", () => ({
   },
 }));
 
-mock.module("@ai-sdk/openai", () => ({
-  createOpenAI: mock(() => ({
-    chat: mock(() => "mock-model"),
-  })),
-  openai: mock(() => "mock-openai-model"),
-}));
-
-class MockAPICallError extends Error {}
-class MockRetryError extends Error {}
-
-mock.module("ai", () => ({
-  APICallError: MockAPICallError,
-  Output: {
-    json: mock(() => ({})),
-    object: mock((value: unknown) => value),
-  },
-  RetryError: MockRetryError,
-  convertToModelMessages: mock((messages: unknown) => messages),
-  embed: mock(async () => ({ embedding: [] })),
-  embedMany: mock(async () => ({ embeddings: [] })),
-  generateText,
-  jsonSchema: mock((schema: unknown) => schema),
-  streamText: mock(() => {
-    throw new Error("streamText is outside this onboarding-chat test fixture");
-  }),
-  wrapLanguageModel: mock(({ model }: { model: unknown }) => model),
-}));
-
 mock.module("../eliza-managed-launch", () => ({
   launchManagedElizaAgent,
 }));
@@ -114,7 +85,6 @@ describe("runOnboardingChat", () => {
     findOrCreateByPhone.mockReset();
     linkPhoneToUser.mockReset();
     linkPhoneToUser.mockResolvedValue({ success: true });
-    generateText.mockReset();
     launchManagedElizaAgent.mockReset();
     loggerWarn.mockReset();
     cloudEnv = {};
@@ -174,16 +144,20 @@ describe("runOnboardingChat", () => {
     expect(findOrCreateByPhone).not.toHaveBeenCalled();
   });
 
-  test("forces the exact login URL when generated copy rewrites link punctuation", async () => {
+  test("stays deterministic and model-free even when a Cerebras key is configured", async () => {
     cloudEnv = {
       CEREBRAS_API_KEY: "test-key",
       ELIZA_ONBOARDING_APP_URL: "https://elizaos-homepage.pages.dev",
     };
-    generateText.mockResolvedValue({
-      text: "Nice to meet you. Connect here: https://elizaos‑homepage.pages.dev/get‑started/?onboardingSession=platform%3Ablooio%3A%2B14155550123",
+    const first = await runOnboardingChat({
+      message: "My name is Sam",
+      platform: "blooio",
+      platformUserId: "+14155550123",
+      sessionId: "platform:blooio:+14155550123",
+      trustedPlatformIdentity: true,
     });
-
-    const result = await runOnboardingChat({
+    sessionCache.clear();
+    const second = await runOnboardingChat({
       message: "My name is Sam",
       platform: "blooio",
       platformUserId: "+14155550123",
@@ -191,145 +165,12 @@ describe("runOnboardingChat", () => {
       trustedPlatformIdentity: true,
     });
 
-    expect(result.requiresLogin).toBe(true);
-    expect(result.reply).toContain(result.loginUrl);
-    expect(result.reply).not.toContain("elizaos‑homepage");
-    expect(result.reply).not.toContain("get‑started");
-  });
-
-  test("removes markdown punctuation around generated login URLs", async () => {
-    cloudEnv = {
-      CEREBRAS_API_KEY: "test-key",
-      ELIZA_ONBOARDING_APP_URL: "https://elizaos-homepage.pages.dev",
-    };
-    generateText.mockResolvedValue({
-      text: "Nice to meet you. Connect here: **https://elizaos-homepage.pages.dev/get-started/?onboardingSession=platform%3Ablooio%3A%2B14155550123**",
-    });
-
-    const result = await runOnboardingChat({
-      message: "My name is Sam",
-      platform: "blooio",
-      platformUserId: "+14155550123",
-      sessionId: "platform:blooio:+14155550123",
-      trustedPlatformIdentity: true,
-    });
-
-    expect(result.reply.endsWith(`Connect Eliza Cloud here: ${result.loginUrl}`)).toBe(true);
-    expect(result.reply).not.toContain(`${result.loginUrl}**`);
-  });
-
-  test("removes orphaned markdown lines after replacing generated login URLs", async () => {
-    cloudEnv = {
-      CEREBRAS_API_KEY: "test-key",
-      ELIZA_ONBOARDING_APP_URL: "https://elizaos-homepage.pages.dev",
-    };
-    generateText.mockResolvedValue({
-      text: [
-        "Nice to meet you.",
-        "**https://elizaos-homepage.pages.dev/get-started/?onboardingSession=platform%3Ablooio%3A%2B14155550123",
-        "Your starter credit will be ready.",
-      ].join("\n"),
-    });
-
-    const result = await runOnboardingChat({
-      message: "My name is Sam",
-      platform: "blooio",
-      platformUserId: "+14155550123",
-      sessionId: "platform:blooio:+14155550123",
-      trustedPlatformIdentity: true,
-    });
-
-    expect(result.reply).toContain("Nice to meet you.");
-    expect(result.reply).toContain("Your starter credit will be ready.");
-    expect(result.reply).toContain(result.loginUrl);
-    expect(result.reply).not.toMatch(/^\s*[*_`~]+\s*$/m);
-  });
-
-  test("enforces exact starter credit copy before the login URL", async () => {
-    cloudEnv = {
-      CEREBRAS_API_KEY: "test-key",
-      ELIZA_ONBOARDING_APP_URL: "https://elizaos-homepage.pages.dev",
-    };
-    generateText.mockResolvedValue({
-      text: [
-        "Pricing is usage‑based cloud credits, and new users start with a complimentary $5 credit.",
-        "Connect here: https://elizaos-homepage.pages.dev/get-started/?onboardingSession=platform%3Ablooio%3A%2B14155550123",
-      ].join("\n"),
-    });
-
-    const result = await runOnboardingChat({
-      message: "My name is Sam",
-      platform: "blooio",
-      platformUserId: "+14155550123",
-      sessionId: "platform:blooio:+14155550123",
-      trustedPlatformIdentity: true,
-    });
-
-    expect(result.reply).toContain("usage-based cloud credits");
-    expect(result.reply).toContain("$5 free credit");
-    expect(result.reply).toContain(result.loginUrl);
-  });
-
-  test("forces generated SMS onboarding replies to ASCII text", async () => {
-    cloudEnv = {
-      CEREBRAS_API_KEY: "test-key",
-      ELIZA_ONBOARDING_APP_URL: "https://elizaos-homepage.pages.dev",
-    };
-    generateText.mockResolvedValue({
-      text: [
-        "Hi Sam!",
-        "Eliza Cloud gives you a private “Eliza” agent that lives in its own cloud container.",
-        "It can help with tasks—all just for you.",
-        "You’re getting **$5 of free credits** to try it out.",
-        "Connect here: https://elizaos-homepage.pages.dev/get-started/?onboardingSession=platform%3Ablooio%3A%2B14155550123",
-      ].join("\n"),
-    });
-
-    const result = await runOnboardingChat({
-      message: "My name is Sam",
-      platform: "blooio",
-      platformUserId: "+14155550123",
-      sessionId: "platform:blooio:+14155550123",
-      trustedPlatformIdentity: true,
-    });
-
-    expect(result.reply).toContain("Hi Sam!");
-    expect(result.reply).toContain('private "Eliza" agent');
-    expect(result.reply).toContain("tasks-all just for you");
-    expect(result.reply).toContain("You're getting $5 of free credits");
-    expect(result.reply).not.toContain("**");
-    expect(result.reply).not.toMatch(/[^\x09\x0A\x0D\x20-\x7E]/);
-  });
-
-  test("sanitizes duplicated URL schemes from generated onboarding replies", async () => {
-    cloudEnv = { CEREBRAS_API_KEY: "test-key" };
-    generateText.mockResolvedValue({
-      text: "Open <httpshttps://elizacloud.ai/dashboard/agents>.",
-    });
-    findOrCreateByPhone.mockResolvedValue({
-      user: { id: "user-1", name: null },
-      organization: { id: "org-1" },
-    });
-    ensureElizaAppProvisioning.mockResolvedValue({
-      status: "provisioning",
-      agentId: "agent-1",
-      bridgeUrl: null,
-      sandbox: null,
-    });
-
-    const result = await runOnboardingChat({
-      message: "My name is Sam",
-      platform: "blooio",
-      platformUserId: "+14155550123",
-      sessionId: "platform:blooio:+14155550123",
-      trustedPlatformIdentity: true,
-      authenticatedUser: {
-        userId: "user-1",
-        organizationId: "org-1",
-      },
-    });
-
-    expect(result.reply).toBe("Open <https://elizacloud.ai/dashboard/agents>.");
+    expect(first.reply.replace(first.loginUrl, "<login>")).toBe(
+      second.reply.replace(second.loginUrl, "<login>"),
+    );
+    expect(first.reply).toContain("$5 free credit");
+    expect(first.reply.endsWith(`Connect Eliza Cloud here: ${first.loginUrl}`)).toBe(true);
+    expect(first.reply).not.toMatch(/[^\x09\x0A\x0D\x20-\x7E]/);
   });
 
   test("copies the onboarding transcript into memory once the provisioned agent is running", async () => {
@@ -853,11 +694,12 @@ describe("runOnboardingChat", () => {
       ]);
       expect(typeof a.reply).toBe("string");
       expect(typeof b.reply).toBe("string");
-      expect(a.session.history).toHaveLength(2);
-      expect(b.session.history).toHaveLength(2);
-      // Last write wins on the KV cache: exactly one turn's messages persist.
+      expect([a.session.history.length, b.session.history.length].sort()).toEqual([2, 4]);
       const cached = getCachedSession(PLATFORM_SESSION);
-      expect(cached.history.length).toBe(2);
+      expect(cached.history.length).toBe(4);
+      expect(cached.history.map((message) => message.content)).toEqual(
+        expect.arrayContaining(["first hello", "second hello"]),
+      );
     });
   });
 
@@ -905,11 +747,7 @@ describe("runOnboardingChat", () => {
     });
 
     test("insufficient-credits reply is deterministic and points at billing", async () => {
-      // With a live Cerebras client configured, only the deterministic
-      // early-return keeps the model out of the money-state reply; without
-      // this key the not-called assertion below is vacuously true.
       cloudEnv = { CEREBRAS_API_KEY: "test-key" };
-      generateText.mockResolvedValue({ text: "model-improvised billing copy" });
       ensureElizaAppProvisioning.mockResolvedValue({
         status: "insufficient_credits",
         agentId: null,
@@ -926,7 +764,6 @@ describe("runOnboardingChat", () => {
       });
       expect(result.provisioning.status).toBe("insufficient_credits");
       expect(result.handoffComplete).toBe(false);
-      expect(generateText).not.toHaveBeenCalled();
       expect(result.reply).toContain("You're out of credits, Sam.");
       expect(result.reply).toContain("/dashboard/billing");
       expect(result.reply).toContain("usage-based:");
@@ -1044,48 +881,6 @@ describe("runOnboardingChat", () => {
       } finally {
         globalThis.fetch = originalFetch;
       }
-    });
-  });
-
-  describe("generated reply hardening", () => {
-    test("LLM failure falls back and still ends with the exact login link", async () => {
-      cloudEnv = { CEREBRAS_API_KEY: "test-key" };
-      generateText.mockRejectedValue(new Error("cerebras down"));
-      const result = await runTrustedPhoneTurn("My name is Sam");
-      expect(result.reply).toContain("Nice to meet you, Sam");
-      expect(result.reply.endsWith(`Connect Eliza Cloud here: ${result.loginUrl}`)).toBe(true);
-    });
-
-    test("an emoji-only LLM reply falls back to deterministic copy", async () => {
-      cloudEnv = { CEREBRAS_API_KEY: "test-key" };
-      generateText.mockResolvedValue({ text: " 🎉🎉 " });
-      const result = await runTrustedPhoneTurn("My name is Sam");
-      expect(result.reply).toContain("Nice to meet you, Sam");
-      expect(result.reply.endsWith(`Connect Eliza Cloud here: ${result.loginUrl}`)).toBe(true);
-    });
-
-    test("an LLM reply that is only a URL still produces a non-empty reply with the login link", async () => {
-      cloudEnv = { CEREBRAS_API_KEY: "test-key" };
-      generateText.mockResolvedValue({ text: "https://elsewhere.example/start-here" });
-      const result = await runTrustedPhoneTurn("My name is Sam");
-      expect(result.reply.length).toBeGreaterThan(0);
-      expect(result.reply).not.toContain("elsewhere.example");
-      expect(result.reply).toContain("$5 free credit");
-      expect(result.reply.endsWith(`Connect Eliza Cloud here: ${result.loginUrl}`)).toBe(true);
-    });
-
-    test("an LLM reply with multiple URLs keeps exactly one URL: the login link", async () => {
-      cloudEnv = { CEREBRAS_API_KEY: "test-key" };
-      generateText.mockResolvedValue({
-        text: [
-          "Visit https://a.example/one and https://b.example/two now!",
-          "Also check https://c.example today.",
-        ].join("\n"),
-      });
-      const result = await runTrustedPhoneTurn("My name is Sam");
-      const urlMatches = result.reply.match(/https?:\/\//g) ?? [];
-      expect(urlMatches).toHaveLength(1);
-      expect(result.reply.endsWith(`Connect Eliza Cloud here: ${result.loginUrl}`)).toBe(true);
     });
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -1,9 +1,19 @@
-// Coordinates cloud service onboarding chat behavior behind route handlers.
-import { createOpenAI } from "@ai-sdk/openai";
-import { generateText } from "ai";
+/**
+ * Runs the onboarding state machine and persists its transcript. Worker
+ * deployments delegate each session to one Durable Object; local callers use
+ * an in-process keyed queue over the cache-backed store.
+ */
+
+import type {
+  RuntimeDurableObjectNamespace,
+  RuntimeDurableObjectStub,
+} from "../../../types/cloud-worker-env";
 import { cache } from "../../cache/client";
-import { CEREBRAS_DEFAULT_TEXT_MODEL } from "../../models";
-import { getCloudAwareEnv } from "../../runtime/cloud-bindings";
+import {
+  getCloudAwareEnv,
+  getCloudBinding,
+  hasCloudBindingsContext,
+} from "../../runtime/cloud-bindings";
 import { logger } from "../../utils/logger";
 import { launchManagedElizaAgent } from "../eliza-managed-launch";
 import {
@@ -17,6 +27,8 @@ export type OnboardingChatRole = "user" | "assistant";
 export type OnboardingPlatform = "web" | "telegram" | "discord" | "whatsapp" | "twilio" | "blooio";
 
 export interface OnboardingChatMessage {
+  /** Stable marker used to reconstruct idempotent response snapshots. */
+  id?: string;
   role: OnboardingChatRole;
   content: string;
   createdAt: string;
@@ -61,6 +73,8 @@ export interface OnboardingChatInput {
     organizationId: string;
   } | null;
   trustedPlatformIdentity?: boolean;
+  /** Stable transport delivery id. Replays return the original result. */
+  idempotencyKey?: string;
 }
 
 export interface OnboardingChatResult {
@@ -82,8 +96,6 @@ const MAX_HISTORY_MESSAGES = 200;
  * raw connector payloads, so the session store enforces its own bound.
  */
 const MAX_MESSAGE_LENGTH = 4000;
-const CEREBRAS_BASE_URL = "https://api.cerebras.ai/v1";
-const CEREBRAS_MODEL = CEREBRAS_DEFAULT_TEXT_MODEL;
 const DEFAULT_ONBOARDING_APP_URL = "https://app.elizacloud.ai";
 const ELIZA_APP_INITIAL_CREDIT_USD = "$5";
 const ELIZA_APP_PRICING_SUMMARY =
@@ -95,6 +107,10 @@ function sessionCacheKey(sessionId: string): string {
 
 function continuationCacheKey(token: string): string {
   return `eliza-app:onboarding-continuation:${token}`;
+}
+
+function resultCacheKey(sessionId: string, idempotencyKey: string): string {
+  return `eliza-app:onboarding-result:${sessionId}:${idempotencyKey}`;
 }
 
 function nowIso(): string {
@@ -170,6 +186,18 @@ async function resolveSessionId(input: OnboardingChatInput): Promise<string> {
     input.trustedPlatformIdentity !== true &&
     input.sessionId?.trim() === sessionId
   ) {
+    const coordinator = onboardingCoordinator();
+    if (coordinator) {
+      const response = await coordinator
+        .getByName(sessionId)
+        .fetch("https://onboarding.internal/resolve", { method: "POST" });
+      if (response.ok) {
+        const resolved: unknown = await response.json();
+        if (isOnboardingContinuation(resolved)) {
+          return resolved.sessionId;
+        }
+      }
+    }
     const continuation = await cache.get<unknown>(continuationCacheKey(sessionId));
     if (isOnboardingContinuation(continuation)) {
       return continuation.sessionId;
@@ -178,11 +206,13 @@ async function resolveSessionId(input: OnboardingChatInput): Promise<string> {
   return sessionId;
 }
 
-async function loadSession(sessionId: string): Promise<OnboardingSession | null> {
+export async function loadCachedOnboardingSession(
+  sessionId: string,
+): Promise<OnboardingSession | null> {
   return cache.get<OnboardingSession>(sessionCacheKey(sessionId));
 }
 
-async function saveSession(session: OnboardingSession): Promise<void> {
+export async function mirrorOnboardingSessionToCache(session: OnboardingSession): Promise<void> {
   if (session.continuationToken && session.id.startsWith(PLATFORM_SESSION_PREFIX)) {
     await cache.set(
       continuationCacheKey(session.continuationToken),
@@ -209,7 +239,10 @@ function appendMessage(
   return {
     ...session,
     updatedAt: nowIso(),
-    history: trimHistory([...session.history, { role, content: message, createdAt: nowIso() }]),
+    history: trimHistory([
+      ...session.history,
+      { id: crypto.randomUUID(), role, content: message, createdAt: nowIso() },
+    ]),
   };
 }
 
@@ -393,15 +426,6 @@ async function maybeLinkAuthenticatedPlatformIdentity(
   return session;
 }
 
-function getCerebrasClient(): ReturnType<typeof createOpenAI> | null {
-  const env = getCloudAwareEnv();
-  if (!env.CEREBRAS_API_KEY) return null;
-  return createOpenAI({
-    apiKey: env.CEREBRAS_API_KEY,
-    baseURL: CEREBRAS_BASE_URL,
-  });
-}
-
 function getOnboardingAppUrl(): string {
   const env = getCloudAwareEnv();
   const configured =
@@ -459,90 +483,17 @@ function sanitizeReplyText(reply: string): string {
     .trim();
 }
 
-function mentionsStarterCredit(text: string): boolean {
-  return /\$5\b[\s\S]{0,80}\bfree\b[\s\S]{0,80}\bcredits?\b/i.test(text);
-}
-
-function ensureExactLoginUrl(reply: string, loginUrl: string): string {
-  const sanitized = sanitizeReplyText(reply);
-
-  let withoutGeneratedUrls = sanitized
-    .replace(/https?:\/\/\S+/g, "")
-    .replace(/^\s*[*_`~]+\s*$/gm, "")
-    .replace(/[ \t]+$/gm, "")
-    .trim();
-  if (!mentionsStarterCredit(withoutGeneratedUrls)) {
-    withoutGeneratedUrls = `${withoutGeneratedUrls ? `${withoutGeneratedUrls}\n\n` : ""}You get ${ELIZA_APP_INITIAL_CREDIT_USD} free credit to try it.`;
-  }
-  return `${withoutGeneratedUrls ? `${withoutGeneratedUrls}\n\n` : ""}Connect Eliza Cloud here: ${loginUrl}`;
-}
-
-async function generateOnboardingReply(args: {
+function generateOnboardingReply(args: {
   session: OnboardingSession;
   provisioning: ElizaAppProvisioningStatus;
   requiresLogin: boolean;
   loginUrl: string;
-  controlPanelUrl: string;
-  launchUrl: string | null;
   handoffComplete: boolean;
-  preferredNameCaptured: boolean;
-}): Promise<string> {
-  // Fallback replies go through the same ASCII/markdown sanitizer as
-  // generated ones so the SMS-safety invariant holds on every reply path
-  // (session names captured before sanitization could carry non-ASCII).
-  if (!args.preferredNameCaptured) {
-    return sanitizeReplyText(fallbackReply(args));
-  }
-
-  // Out-of-credits is a money-state reply: keep it deterministic (exact
-  // billing link, no invented amounts) instead of letting the model
-  // improvise billing copy.
-  if (args.provisioning.status === "insufficient_credits") {
-    return sanitizeReplyText(fallbackReply(args));
-  }
-
-  const client = getCerebrasClient();
-  if (!client) return sanitizeReplyText(fallbackReply(args));
-
-  try {
-    const { text } = await generateText({
-      model: client.chat(CEREBRAS_MODEL),
-      system: `You are the Eliza Cloud onboarding agent. Keep onboarding smooth and conversational.
-
-Goals:
-- Learn the user's preferred name.
-- Briefly explain the product: a private Eliza Cloud agent in its own cloud container that can text, remember context, and work for the user.
-- Briefly explain pricing: usage-based cloud credits; new users get ${ELIZA_APP_INITIAL_CREDIT_USD} free credit to try it.
-- If the user's preferred name is unknown, ask what to call them and do not claim their container is provisioning or running yet.
-- If not logged in, ask them to connect Eliza Cloud and give this private link: ${args.loginUrl}
-- If logged in, explain that their personal Eliza container is provisioning and their starter credit is available.
-- If running, announce the container is running and that the onboarding conversation was copied into agent memory.
-- Keep responses short, warm, and direct.
-
-State:
-- Known name: ${args.session.name ?? "unknown"}
-- Preferred name captured: ${args.preferredNameCaptured ? "yes" : "no"}
-- Logged in: ${args.requiresLogin ? "no" : "yes"}
-- Container status: ${args.provisioning.status}
-- Control panel: ${args.controlPanelUrl}
-- Agent launch URL: ${args.launchUrl ?? "not ready"}`,
-      messages: args.session.history.map((message) => ({
-        role: message.role,
-        content: message.content,
-      })),
-    });
-    const sanitized = sanitizeReplyText(text);
-    if (!sanitized) return fallbackReply(args);
-    return args.requiresLogin ? ensureExactLoginUrl(sanitized, args.loginUrl) : sanitized;
-  } catch (error) {
-    // error-policy:J4 the model is a non-essential enhancement over the always-
-    // valid deterministic fallbackReply; an LLM/transport failure degrades to
-    // that designed reply instead of failing the onboarding turn.
-    logger.warn("[eliza-app onboarding] generation failed; using fallback", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return sanitizeReplyText(fallbackReply(args));
-  }
+}): string {
+  // This is a finite product state machine, not an open-ended generation task.
+  // Deterministic copy prevents model latency, cost amplification, invented
+  // billing claims, and non-repeatable responses on transport replay.
+  return sanitizeReplyText(fallbackReply(args));
 }
 
 function transcriptText(session: OnboardingSession): string {
@@ -588,8 +539,10 @@ async function copyTranscriptToManagedAgent(session: OnboardingSession): Promise
           Authorization: `Bearer ${launch.connection.token}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ text: transcriptText(session) }),
-        signal: AbortSignal.timeout(20_000),
+        body: JSON.stringify({
+          text: transcriptText(session),
+          idempotencyKey: `onboarding-handoff:${session.id}`,
+        }),
       },
     );
 
@@ -646,9 +599,18 @@ function newSession(id: string, input: OnboardingChatInput): OnboardingSession {
   };
 }
 
-export async function runOnboardingChat(input: OnboardingChatInput): Promise<OnboardingChatResult> {
-  let sessionId = await resolveSessionId(input);
-  let session = await loadSession(sessionId);
+export interface OnboardingSessionStore {
+  load(sessionId: string): Promise<OnboardingSession | null>;
+  save(session: OnboardingSession): Promise<void>;
+}
+
+export async function runOnboardingChatWithStore(
+  input: OnboardingChatInput,
+  resolvedSessionId: string,
+  store: OnboardingSessionStore,
+): Promise<OnboardingChatResult> {
+  let sessionId = resolvedSessionId;
+  let session = await store.load(sessionId);
 
   // An untrusted caller must never create a platform-scoped session. Opaque
   // browser credentials resolve to an existing platform session above.
@@ -769,19 +731,16 @@ export async function runOnboardingChat(input: OnboardingChatInput): Promise<Onb
     )}`,
   );
   const panelUrl = controlPanelUrl(session.agentId);
-  const reply = await generateOnboardingReply({
+  const reply = generateOnboardingReply({
     session,
     provisioning,
     requiresLogin,
     loginUrl,
-    controlPanelUrl: panelUrl,
-    launchUrl,
     handoffComplete,
-    preferredNameCaptured,
   });
 
   session = appendMessage(session, "assistant", reply);
-  await saveSession(session);
+  await store.save(session);
 
   return {
     session,
@@ -793,4 +752,90 @@ export async function runOnboardingChat(input: OnboardingChatInput): Promise<Onb
     provisioning,
     handoffComplete,
   };
+}
+
+const localQueues = new Map<string, Promise<void>>();
+
+async function serializeLocal<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+  const previous = localQueues.get(sessionId) ?? Promise.resolve();
+  let release: () => void = () => undefined;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.then(() => current);
+  localQueues.set(sessionId, queued);
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (localQueues.get(sessionId) === queued) {
+      localQueues.delete(sessionId);
+    }
+  }
+}
+
+function onboardingCoordinator(): RuntimeDurableObjectNamespace | undefined {
+  return getCloudBinding<RuntimeDurableObjectNamespace>("ONBOARDING_SESSIONS");
+}
+
+async function readCoordinatorResult(response: Response): Promise<OnboardingChatResult> {
+  if (!response.ok) {
+    throw new Error(`onboarding session coordinator failed (${response.status})`);
+  }
+  return (await response.json()) as OnboardingChatResult;
+}
+
+async function runViaCoordinator(
+  stub: RuntimeDurableObjectStub,
+  input: OnboardingChatInput,
+  sessionId: string,
+): Promise<OnboardingChatResult> {
+  return readCoordinatorResult(
+    await stub.fetch("https://onboarding.internal/turn", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input, sessionId }),
+    }),
+  );
+}
+
+export async function runOnboardingChat(input: OnboardingChatInput): Promise<OnboardingChatResult> {
+  const idempotencyKey = input.idempotencyKey?.trim();
+  if (idempotencyKey && idempotencyKey.length > 256) {
+    throw new Error("Onboarding idempotency key exceeds 256 characters");
+  }
+  const normalizedInput = {
+    ...input,
+    idempotencyKey: idempotencyKey || undefined,
+  };
+  const sessionId = await resolveSessionId(normalizedInput);
+  const coordinator = onboardingCoordinator();
+  if (coordinator) {
+    return runViaCoordinator(coordinator.getByName(sessionId), normalizedInput, sessionId);
+  }
+  if (hasCloudBindingsContext()) {
+    throw new Error("ONBOARDING_SESSIONS binding is required in Worker deployments");
+  }
+
+  return serializeLocal(sessionId, async () => {
+    if (normalizedInput.idempotencyKey) {
+      const replay = await cache.get<OnboardingChatResult>(
+        resultCacheKey(sessionId, normalizedInput.idempotencyKey),
+      );
+      if (replay) return replay;
+    }
+    const result = await runOnboardingChatWithStore(normalizedInput, sessionId, {
+      load: loadCachedOnboardingSession,
+      save: mirrorOnboardingSessionToCache,
+    });
+    if (normalizedInput.idempotencyKey) {
+      await cache.set(
+        resultCacheKey(sessionId, normalizedInput.idempotencyKey),
+        result,
+        SESSION_TTL_SECONDS,
+      );
+    }
+    return result;
+  });
 }

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -70,6 +70,9 @@ export interface Bindings {
    */
   ANONYMOUS_CHAT_GATES?: RuntimeDurableObjectNamespace;
 
+  /** One strongly ordered transcript and replay ledger per onboarding session. */
+  ONBOARDING_SESSIONS?: RuntimeDurableObjectNamespace;
+
   // ---- Cloudflare machine-local protective rate limits ----
   GLOBAL_RATE_LIMITER?: RuntimeRateLimitBinding;
   CHAT_ROUTE_RATE_LIMITER?: RuntimeRateLimitBinding;

--- a/packages/shared/src/contracts/memory-routes.test.ts
+++ b/packages/shared/src/contracts/memory-routes.test.ts
@@ -1,8 +1,8 @@
 /**
  * Contract tests for the memory route request schemas: remember (create) and
  * patch (edit). Both require a non-blank text field that is trimmed, reject
- * whitespace-only text with the canonical message, and reject any extra field
- * (e.g. source/embedding). Pure in-process schema parsing — no server or mocks.
+ * whitespace-only text with the canonical message, and reject unknown fields.
+ * Pure in-process schema parsing — no server or mocks.
  */
 import { describe, expect, it } from "vitest";
 import {
@@ -15,6 +15,15 @@ describe("PostMemoryRememberRequestSchema", () => {
     expect(
       PostMemoryRememberRequestSchema.parse({ text: "  hello  " }),
     ).toEqual({ text: "hello" });
+  });
+
+  it("accepts and trims an optional idempotency key", () => {
+    expect(
+      PostMemoryRememberRequestSchema.parse({
+        text: " hello ",
+        idempotencyKey: " onboarding:session-a ",
+      }),
+    ).toEqual({ text: "hello", idempotencyKey: "onboarding:session-a" });
   });
 
   it("rejects whitespace-only text", () => {

--- a/packages/shared/src/contracts/memory-routes.ts
+++ b/packages/shared/src/contracts/memory-routes.ts
@@ -2,7 +2,7 @@
  * Zod schemas for the memory HTTP write surface.
  *
  * Routes covered:
- *   POST  /api/memory/remember   { text }
+ *   POST  /api/memory/remember   { text, idempotencyKey? }
  *   PATCH /api/memories/:id      { text }
  *
  * The DELETE /api/memories/:id route has no body and isn't covered.
@@ -13,9 +13,13 @@ import z from "zod";
 export const PostMemoryRememberRequestSchema = z
   .object({
     text: z.string().regex(/\S/, "text is required"),
+    idempotencyKey: z.string().trim().min(1).max(256).optional(),
   })
   .strict()
-  .transform((value) => ({ text: value.text.trim() }));
+  .transform((value) => ({
+    text: value.text.trim(),
+    ...(value.idempotencyKey ? { idempotencyKey: value.idempotencyKey } : {}),
+  }));
 
 export const PatchMemoryRequestSchema = z
   .object({


### PR DESCRIPTION
Fixes #17447\n\n## Outcome\n\nDiscord, phone, and web onboarding now share one strongly ordered session owner. Independent identities still run in parallel; turns for the same identity are serialized because concurrent transcript mutations cannot safely be parallel.\n\nThis replaces the prior cache read/mutate/write behavior, which allowed concurrent deliveries to overwrite each other, and removes Cerebras generation from the finite onboarding state machine entirely.\n\n## Deep fixes\n\n- Adds one Cloudflare Durable Object per onboarding session as the authoritative transcript and compact replay ledger.\n- Keeps KV only as a compatibility mirror and one-time migration source; correctness no longer depends on eventually consistent cache reads.\n- Uses a separate Durable Object lookup for opaque browser continuation tokens, so platform session IDs remain private and continuation is strongly consistent.\n- Adds transport idempotency keys:\n  - Discord: message ID\n  - Twilio/Blooio: provider message ID\n  - public API: Idempotency-Key\n- Preserves trusted platform identity across every authenticated gateway onboarding branch.\n- Makes onboarding copy deterministic. A configured CEREBRAS_API_KEY results in zero model calls, avoiding latency, cost, invented billing copy, and replay divergence.\n- Makes transcript handoff idempotent using a stable memory ID and removes the arbitrary 20-second request timeout.\n- Stores compact replay snapshots rather than duplicating the entire retained transcript for every delivery.\n- Fails Worker deployments when the required Durable Object binding is absent instead of silently reverting to cache-only correctness.\n\n## Verification\n\n- bun run verify\n  - 579/579 Turbo build and typecheck tasks successful\n  - all lint, dependency, alias, script, view, focused-test, and dist-path audits passed\n- Focused tests: 59 passed, 0 failed, 277 assertions\n  - Durable Object concurrent ordering and exact replay\n  - onboarding state machine and error-policy behavior\n  - gateway trusted identity and transport idempotency\n  - memory remember stable-write contract\n  - shared request schema\n- bun run --cwd packages/cloud/api build\n- bun run --cwd packages/cloud/shared typecheck\n\n## Telemetry\n\nCommand: bun packages/cloud/api/scripts/onboarding-latency-report.ts\n\nThe harness executes the real onboarding state machine and Durable Object implementation with in-memory Durable Object storage to isolate application overhead. CEREBRAS_API_KEY is present in the harness and the code makes zero model calls.\n\n- cold turn: 80.828 ms\n- 100 unique sequential turns: mean 0.528 ms, p50 0.515 ms, p95 0.932 ms, max 2.907 ms\n- 100 idempotent replays: mean 0.373 ms, p50 0.314 ms, p95 0.611 ms, max 1.862 ms\n- 32-delivery same-session burst: 22.311 ms wall time\n- burst per request including required queue wait: mean 12.178 ms, p50 13.293 ms, p95 21.819 ms, max 22.188 ms\n\nThis is a report, not a latency threshold or CI gate.\n\n## Evidence\n\n| Evidence | Result |\n| --- | --- |\n| Real model trajectory | N/A - deterministic finite state machine now intentionally performs zero LLM calls |\n| Backend logs | Focused tests and benchmark exercise the production state-machine and coordinator code |\n| Frontend console/network logs | N/A - no frontend changes |\n| Desktop/mobile screenshots | N/A - no UI changes |\n| Video walkthrough | N/A - no UI or device behavior changed |\n| Domain artifact | Tests inspect the retained ordered transcript, replay ledger behavior, continuation mapping, and exactly-once memory write |\n\n## Review notes\n\nThere is no response deadline, timeout fallback, latency threshold, CI ratchet, or synthetic success path in this change. Persistence is committed before compatibility mirrors are published; a failed mirror returns a real failure, and an idempotent retry republishes from durable state.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI or rendered surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI or rendered surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI or device flow changed

<!-- evidence-row:backend-logs -->
- [x] [17458-17447-onboarding-latency.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17458-17447-onboarding-latency.json)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic finite onboarding state machine intentionally performs zero model calls

<!-- evidence-row:domain-artifacts -->
- [x] [17458-17447-onboarding-latency.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/17458-17447-onboarding-latency.json)
