### PR TITLE
fix(ci): classify Hetzner E2E provision failures

### DIFF
--- a/.github/workflows/hetzner-e2e.yml
+++ b/.github/workflows/hetzner-e2e.yml
@@ -54,6 +54,7 @@ jobs:
       CI_SSH_PRIVATE_KEY: ${{ secrets.CI_SSH_PRIVATE_KEY }}
       CI_SSH_PUBLIC_KEY_ID: ${{ secrets.CI_SSH_PUBLIC_KEY_ID }}
       HETZNER_E2E_STATE_FILE: /tmp/hetzner-e2e-state.json
+      HETZNER_E2E_DIAGNOSTIC_FILE: /tmp/hetzner-e2e-provision-diagnostic.json
     steps:
       - name: Check secret configuration
         id: secret_config
@@ -274,6 +275,7 @@ jobs:
         if: steps.secret_config.outputs.configured == 'true' && steps.cloud_auth.outputs.ready == 'true' && steps.hcloud_auth.outputs.ready == 'true'
         run: |
           log=/tmp/hetzner-e2e-provision.log
+          rm -f "$HETZNER_E2E_DIAGNOSTIC_FILE"
           set +e
           bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.ts 2>&1 | tee "$log"
           rc=${PIPESTATUS[0]}
@@ -282,54 +284,21 @@ jobs:
             echo "provisioned=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # A rejected / expired / read-only HCLOUD_TOKEN_CI (or a deactivated project)
-          # surfaces as HTTP 401/403 missing_token / "permission denied" when CREATING the
-          # server — the read-only token preflight above can pass while this write fails.
-          # That is an operator secret problem, not a code regression, but the
-          # token is configured and rejected. Fail red for every event so the
-          # nightly cannot look healthy while real-infra coverage is disabled.
-          if grep -qE "Hetzner rejected the token|missing_token|permission denied|HTTP 401|HTTP 403|status: 401|status: 403" "$log"; then
-            echo "provisioned=false" >> "$GITHUB_OUTPUT"
-            echo "::error::Hetzner rejected HCLOUD_TOKEN_CI (HTTP 401/403); refresh the token in the ci-hetzner-e2e environment."
-            {
-              echo "### Hetzner E2E blocked by rejected Hetzner credential"
-              echo ""
-              echo "Hetzner rejected \`HCLOUD_TOKEN_CI\` (HTTP 401/403 \`missing_token\` / permission denied) when creating the server."
-              echo ""
-              echo "The token may be read-only or expired for writes. Refresh \`HCLOUD_TOKEN_CI\` in the \`ci-hetzner-e2e\` environment with a read-write CI token, or confirm the project is active."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-          # Any other provision failure is real — surface it (red).
           echo "provisioned=false" >> "$GITHUB_OUTPUT"
           exit "$rc"
 
       - name: Surface provision failure diagnostic
         if: always() && steps.secret_config.outputs.configured == 'true' && steps.cloud_auth.outputs.ready == 'true' && steps.hcloud_auth.outputs.ready == 'true' && steps.provision.outcome == 'failure'
         run: |
-          log=/tmp/hetzner-e2e-provision.log
-          {
-            echo "### Hetzner E2E provisioning failed"
-            echo ""
-            if [ -f "$log" ] && grep -qE "quota exhausted|server limit reached|limit_reached|resource_limit_exceeded|quota_exceeded" "$log"; then
-              echo "**Cause:** Hetzner project quota exhausted (server cap reached)."
+          if [ -f "$HETZNER_E2E_DIAGNOSTIC_FILE" ]; then
+            bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision-diagnostic.ts "$HETZNER_E2E_DIAGNOSTIC_FILE" >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### Hetzner E2E provisioning failed"
               echo ""
-              echo "Operator action:"
-              echo "1. Open https://console.hetzner.cloud/ and check the CI project for leaked servers (filter labels \`ci=true\`, \`workflow=hetzner-e2e\`)."
-              echo "2. Delete any leaked servers, or wait for the half-hourly reaper workflow to sweep them."
-              echo "3. Re-run this workflow."
-              echo ""
-              echo "If the project itself has a tighter cap than the fallback ladder can survive, request a quota increase from Hetzner support or rotate \`HCLOUD_TOKEN_CI\` to a project with capacity."
-            elif [ -f "$log" ] && grep -qE "Hetzner rejected the token|missing_token|HTTP 401|HTTP 403" "$log"; then
-              echo "**Cause:** Hetzner rejected the API token (HTTP 401/403)."
-              echo ""
-              echo "Operator action: refresh \`HCLOUD_TOKEN_CI\` in the \`ci-hetzner-e2e\` GitHub environment, or confirm the project is still active."
-            else
-              echo "**Cause:** see the \"Provision Hetzner server\" step log for the raw error."
-              echo ""
-              echo "If the error message is unfamiliar, check \`packages/scripts/cloud/admin/hetzner-e2e/README.md\` and the fallback ladder in \`hetzner-e2e-provision.ts\`."
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+              echo "The provisioner failed before it could write a structured diagnostic. See the \"Provision Hetzner server\" step for the preserved error."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Wait for host ready
         if: steps.provision.outputs.provisioned == 'true'

--- a/packages/scripts/cloud/admin/hetzner-e2e/README.md
+++ b/packages/scripts/cloud/admin/hetzner-e2e/README.md
@@ -1,6 +1,6 @@
 # Hetzner Agent E2E
 
-Nightly end-to-end smoke that provisions a real Hetzner cpx11 server,
+Nightly end-to-end smoke that provisions a real Hetzner cpx22 server,
 deploys a trivial agent via the Eliza Cloud staging API, runs a
 bridge-ping healthcheck plus one real chat turn (a `message.send`
 JSON-RPC through the production Worker bridge path, requiring a reply
@@ -8,6 +8,11 @@ that echoes a per-run proof token and carries no fabrication flag),
 and tears everything down. A reaper
 workflow sweeps any servers older than 60 minutes every half hour as a
 safety net.
+
+Before allocation, the provisioner also removes older servers carrying both
+`ci=true` and `workflow=hetzner-e2e`. The workflow concurrency group prevents
+official E2E runs from overlapping, and malformed or untagged inventory entries
+are never deletion candidates.
 
 The workflow gracefully skips when secrets are unset, so it can land
 on `develop` and be activated later by adding secrets. Once secrets
@@ -46,8 +51,7 @@ In the repo settings, create a new environment named
 
 ## Estimated cost
 
-Default `cx22` in `fsn1` is roughly €0.006/hr (cpx11's deprecated
-successor — comparable 2 vCPU / 4 GB footprint). A nightly run that
+Default `cpx22` in `fsn1` is a shared 2 vCPU / 4 GB server. A nightly run that
 lives ~10 minutes is **about $0.30–$1.00/month** depending on
 healthcheck duration. The reaper enforces a 60-minute upper bound so
 the worst case (a stuck workflow) is bounded at one server-hour per
@@ -55,8 +59,8 @@ run.
 
 If the requested `HETZNER_E2E_SERVER_TYPE` is deprecated or not
 offered at `HETZNER_E2E_LOCATION`, the provisioner falls back through
-a short list of known-good shared-cpu combos (cx22 in fsn1/nbg1, cax11
-ARM in fsn1/hel1/nbg1) before giving up.
+a short list of known-good shared-cpu `cpx22` locations, followed by `cpx11` in
+`hil`, before giving up.
 
 ## Manual trigger / dry run
 
@@ -74,6 +78,8 @@ intend to create a real billable server.
 - `.github/workflows/hetzner-e2e.yml` — provision + deploy + healthcheck + teardown
 - `.github/workflows/hetzner-e2e-reaper.yml` — scheduled label-selector sweep
 - `hetzner-e2e-provision.ts` — `HetznerCloudClient.createServer()`
+- `hetzner-e2e-provision-diagnostic.ts` — validated failure classification and
+  operator summary rendering
 - `hetzner-e2e-wait-ready.ts` — SSH-poll for cloud-init + Docker
 - `hetzner-e2e-deploy-agent.ts` — create + provision a trivial agent
 - `hetzner-e2e-healthcheck.ts` — single `status.get` bridge ping

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision-diagnostic.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision-diagnostic.ts
@@ -1,0 +1,218 @@
+#!/usr/bin/env bun
+/**
+ * Defines the privacy-safe provisioning failure record consumed by the Hetzner
+ * E2E workflow. The workflow renders operator guidance from this validated
+ * record instead of inferring causes from human-readable error text.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { HetznerCloudError } from "@elizaos/cloud-shared/lib/services/containers/hetzner-cloud-api";
+
+export type CapacityInventory = {
+  totalServers: number;
+  hetznerE2eServers: number;
+  otherServers: number;
+  byStatus: Record<string, number>;
+  byServerType: Record<string, number>;
+  byLocation: Record<string, number>;
+};
+
+export type ProvisionFailureKind = "authentication" | "quota" | "other";
+
+export type ProvisionFailureDiagnostic = {
+  version: 1;
+  kind: ProvisionFailureKind;
+  code: string | null;
+  status: number | null;
+  inventory: CapacityInventory | null;
+  inventoryError: {
+    code: string | null;
+    status: number | null;
+  } | null;
+};
+
+export interface CapacityDiagnosticError extends Error {
+  readonly inventory: CapacityInventory | null;
+  readonly inventoryError: unknown;
+}
+
+function errorMetadata(error: unknown): {
+  code: string | null;
+  status: number | null;
+} {
+  if (!(error instanceof HetznerCloudError)) {
+    return { code: null, status: null };
+  }
+  return {
+    code: error.code,
+    status: error.status ?? null,
+  };
+}
+
+export function buildProvisionFailureDiagnostic(
+  error: unknown,
+): ProvisionFailureDiagnostic {
+  const metadata = errorMetadata(error);
+  const kind: ProvisionFailureKind =
+    metadata.code === "quota_exceeded"
+      ? "quota"
+      : metadata.code === "missing_token"
+        ? "authentication"
+        : "other";
+  const capacityError =
+    typeof error === "object" && error !== null
+      ? (error as Partial<CapacityDiagnosticError>)
+      : null;
+  const inventory = isCapacityInventory(capacityError?.inventory)
+    ? capacityError.inventory
+    : null;
+
+  return {
+    version: 1,
+    kind,
+    ...metadata,
+    inventory,
+    inventoryError:
+      capacityError?.inventoryError === undefined
+        ? null
+        : errorMetadata(capacityError.inventoryError),
+  };
+}
+
+export function writeProvisionFailureDiagnostic(
+  path: string,
+  diagnostic: ProvisionFailureDiagnostic,
+): void {
+  writeFileSync(path, `${JSON.stringify(diagnostic)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+}
+
+function isCountMap(value: unknown): value is Record<string, number> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.entries(value).every(
+      ([key, count]) =>
+        key.length > 0 && Number.isInteger(count) && Number(count) >= 0,
+    )
+  );
+}
+
+function isCapacityInventory(value: unknown): value is CapacityInventory {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as Partial<CapacityInventory>;
+  const totalServers = Number(candidate.totalServers);
+  const hetznerE2eServers = Number(candidate.hetznerE2eServers);
+  const otherServers = Number(candidate.otherServers);
+  return (
+    Number.isInteger(candidate.totalServers) &&
+    totalServers >= 0 &&
+    Number.isInteger(candidate.hetznerE2eServers) &&
+    hetznerE2eServers >= 0 &&
+    Number.isInteger(candidate.otherServers) &&
+    otherServers >= 0 &&
+    totalServers === hetznerE2eServers + otherServers &&
+    isCountMap(candidate.byStatus) &&
+    isCountMap(candidate.byServerType) &&
+    isCountMap(candidate.byLocation) &&
+    Object.values(candidate.byStatus).reduce((sum, count) => sum + count, 0) ===
+      totalServers &&
+    Object.values(candidate.byServerType).reduce(
+      (sum, count) => sum + count,
+      0,
+    ) === totalServers &&
+    Object.values(candidate.byLocation).reduce(
+      (sum, count) => sum + count,
+      0,
+    ) === totalServers
+  );
+}
+
+function isNullableMetadata(value: unknown): boolean {
+  if (value === null) return true;
+  if (typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as { code?: unknown; status?: unknown };
+  return (
+    (candidate.code === null || typeof candidate.code === "string") &&
+    (candidate.status === null || Number.isInteger(candidate.status))
+  );
+}
+
+export function readProvisionFailureDiagnostic(
+  path: string,
+): ProvisionFailureDiagnostic {
+  const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Hetzner E2E provision diagnostic must be an object");
+  }
+  const candidate = parsed as Partial<ProvisionFailureDiagnostic>;
+  if (
+    candidate.version !== 1 ||
+    !["authentication", "quota", "other"].includes(candidate.kind ?? "") ||
+    (candidate.code !== null && typeof candidate.code !== "string") ||
+    (candidate.status !== null && !Number.isInteger(candidate.status)) ||
+    (candidate.inventory !== null &&
+      !isCapacityInventory(candidate.inventory)) ||
+    !isNullableMetadata(candidate.inventoryError)
+  ) {
+    throw new Error("Hetzner E2E provision diagnostic has an invalid shape");
+  }
+  return candidate as ProvisionFailureDiagnostic;
+}
+
+export function renderProvisionFailureSummary(
+  diagnostic: ProvisionFailureDiagnostic,
+): string {
+  const lines = ["### Hetzner E2E provisioning failed", ""];
+  if (diagnostic.kind === "quota") {
+    lines.push(
+      "**Cause:** Hetzner project quota exhausted (server cap reached).",
+      "",
+    );
+    if (diagnostic.inventory) {
+      lines.push(
+        `Sanitized capacity: ${diagnostic.inventory.totalServers} total server(s), ${diagnostic.inventory.hetznerE2eServers} tagged Hetzner E2E server(s), ${diagnostic.inventory.otherServers} other server(s).`,
+        "",
+      );
+    } else if (diagnostic.inventoryError) {
+      lines.push(
+        "The follow-up capacity inventory also failed; the quota result from the create request remains authoritative.",
+        "",
+      );
+    }
+    lines.push(
+      "Operator action:",
+      "1. Check the CI project for servers tagged `ci=true`, `workflow=hetzner-e2e` and remove only stale resources.",
+      "2. Re-run this workflow after capacity is available.",
+      "3. If no stale E2E server is consuming the limit, request a Hetzner server-limit increase for the CI project.",
+    );
+  } else if (diagnostic.kind === "authentication") {
+    lines.push(
+      "**Cause:** Hetzner rejected the API credential.",
+      "",
+      "Operator action: replace `HCLOUD_TOKEN_CI` in the `ci-hetzner-e2e` GitHub environment with an active read-write token for the intended CI project.",
+    );
+  } else {
+    lines.push(
+      "**Cause:** the provisioner returned a non-quota, non-authentication failure.",
+      "",
+      'See the "Provision Hetzner server" step for the preserved primary error.',
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+if (import.meta.main) {
+  const path = process.argv[2];
+  if (!path) {
+    throw new Error("usage: hetzner-e2e-provision-diagnostic.ts <path>");
+  }
+  process.stdout.write(
+    renderProvisionFailureSummary(readProvisionFailureDiagnostic(path)),
+  );
+}

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.test.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.test.ts
@@ -8,6 +8,12 @@ import { existsSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runHetznerE2eProvision } from "./hetzner-e2e-provision";
+import {
+  buildProvisionFailureDiagnostic,
+  readProvisionFailureDiagnostic,
+  renderProvisionFailureSummary,
+  writeProvisionFailureDiagnostic,
+} from "./hetzner-e2e-provision-diagnostic";
 
 type RecordedRequest = {
   method: string;
@@ -24,6 +30,10 @@ let originalEnv: Record<string, string | undefined>;
 const stateFile = join(
   tmpdir(),
   `hetzner-e2e-provision-http-${process.pid}.json`,
+);
+const diagnosticFile = join(
+  tmpdir(),
+  `hetzner-e2e-provision-diagnostic-${process.pid}.json`,
 );
 const testEnv = {
   HCLOUD_TOKEN_CI: "valid-ci-token",
@@ -106,6 +116,9 @@ afterEach(() => {
   if (existsSync(stateFile)) {
     rmSync(stateFile);
   }
+  if (existsSync(diagnosticFile)) {
+    rmSync(diagnosticFile);
+  }
 });
 
 describe("Hetzner E2E provision HTTP boundary", () => {
@@ -146,6 +159,27 @@ describe("Hetzner E2E provision HTTP boundary", () => {
         body: undefined,
       },
     ]);
+  });
+
+  test("does not reap incomplete or untagged inventory entries", async () => {
+    responseQueue.push(
+      Response.json({
+        servers: [
+          server({ labels: {}, name: "untagged" }),
+          server({ id: null, name: "invalid-id" }),
+          server({ created: null, name: "invalid-created" }),
+        ],
+      }),
+      Response.json({
+        server: server({ id: 99, created: new Date().toISOString() }),
+        root_password: null,
+      }),
+    );
+
+    await expect(runHetznerE2eProvision()).resolves.toMatchObject({ id: 99 });
+    expect(requests.filter((request) => request.method === "DELETE")).toEqual(
+      [],
+    );
   });
 
   test("fails before create when the labeled inventory cannot be read", async () => {
@@ -205,13 +239,37 @@ describe("Hetzner E2E provision HTTP boundary", () => {
       }),
     );
 
-    await expect(runHetznerE2eProvision()).rejects.toMatchObject({
-      message: expect.stringContaining("project quota exhausted"),
-      name: "HetznerCloudError",
+    const error = (await runHetznerE2eProvision().catch(
+      (caught) => caught,
+    )) as Error & {
+      code: string;
+      status: number;
+      cause: unknown;
+    };
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("HetznerE2eQuotaError");
+    expect(error.message).toContain("project quota exhausted");
+    expect(error.code).toBe("quota_exceeded");
+    expect(error.status).toBe(403);
+    expect(error.cause).toMatchObject({ code: "quota_exceeded" });
+    const diagnostic = buildProvisionFailureDiagnostic(error);
+    expect(diagnostic).toMatchObject({
+      kind: "quota",
       code: "quota_exceeded",
       status: 403,
-      cause: { code: "quota_exceeded" },
+      inventory: {
+        totalServers: 2,
+        hetznerE2eServers: 1,
+        otherServers: 1,
+      },
+      inventoryError: null,
     });
+    expect(renderProvisionFailureSummary(diagnostic)).toContain(
+      "Hetzner project quota exhausted",
+    );
+    expect(renderProvisionFailureSummary(diagnostic)).not.toContain(
+      "rejected the API credential",
+    );
 
     const createRequests = requests.filter(
       (request) =>
@@ -236,5 +294,134 @@ describe("Hetzner E2E provision HTTP boundary", () => {
     expect(capacityLog).not.toContain("198.51.100.77");
     expect(capacityLog).not.toContain("secret-owner");
     expect(capacityLog).not.toContain('"id":');
+  });
+
+  test("classifies a write-rejected token as authentication", async () => {
+    responseQueue.push(
+      Response.json({ servers: [] }),
+      Response.json(
+        { error: { code: "unauthorized", message: "permission denied" } },
+        { status: 403 },
+      ),
+    );
+
+    const error = await runHetznerE2eProvision().catch((caught) => caught);
+    const diagnostic = buildProvisionFailureDiagnostic(error);
+    expect(diagnostic).toMatchObject({
+      kind: "authentication",
+      code: "missing_token",
+      status: 403,
+      inventory: null,
+    });
+    expect(renderProvisionFailureSummary(diagnostic)).toContain(
+      "rejected the API credential",
+    );
+    expect(
+      requests.filter((request) => request.method === "POST"),
+    ).toHaveLength(1);
+  });
+
+  test("sanitizes incomplete capacity inventory into unknown buckets", async () => {
+    responseQueue.push(
+      Response.json({ servers: [] }),
+      Response.json(
+        { error: { code: "limit_reached", message: "server limit reached" } },
+        { status: 403 },
+      ),
+      Response.json({
+        servers: [
+          server({
+            status: null,
+            server_type: null,
+            datacenter: null,
+            labels: null,
+          }),
+          null,
+        ],
+      }),
+    );
+
+    const error = await runHetznerE2eProvision().catch((caught) => caught);
+    expect(buildProvisionFailureDiagnostic(error)).toMatchObject({
+      kind: "quota",
+      inventory: {
+        totalServers: 2,
+        hetznerE2eServers: 0,
+        otherServers: 2,
+        byStatus: { unknown: 2 },
+        byServerType: { unknown: 2 },
+        byLocation: { unknown: 2 },
+      },
+    });
+  });
+
+  test("preserves quota classification when the diagnostic inventory fails", async () => {
+    responseQueue.push(
+      Response.json({ servers: [] }),
+      Response.json(
+        { error: { code: "limit_reached", message: "server limit reached" } },
+        { status: 403 },
+      ),
+      Response.json(
+        { error: { code: "server_error", message: "inventory unavailable" } },
+        { status: 500 },
+      ),
+    );
+
+    const error = await runHetznerE2eProvision().catch((caught) => caught);
+    expect(error).toMatchObject({
+      code: "quota_exceeded",
+      status: 403,
+      cause: { code: "quota_exceeded", status: 403 },
+      inventory: null,
+      inventoryError: { code: "server_error", status: 500 },
+    });
+    const diagnostic = buildProvisionFailureDiagnostic(error);
+    expect(diagnostic).toEqual({
+      version: 1,
+      kind: "quota",
+      code: "quota_exceeded",
+      status: 403,
+      inventory: null,
+      inventoryError: { code: "server_error", status: 500 },
+    });
+    const summary = renderProvisionFailureSummary(diagnostic);
+    expect(summary).toContain("quota exhausted");
+    expect(summary).toContain("inventory also failed");
+    expect(summary).not.toContain("rejected the API credential");
+  });
+
+  test("workflow consumes structured diagnostics instead of grepping HTTP status text", () => {
+    const workflow = readFileSync(
+      join(import.meta.dir, "../../../../../.github/workflows/hetzner-e2e.yml"),
+      "utf8",
+    );
+    expect(workflow).toContain("hetzner-e2e-provision-diagnostic.ts");
+    expect(workflow).toContain('rm -f "$HETZNER_E2E_DIAGNOSTIC_FILE"');
+    expect(workflow).not.toContain("status: 401|status: 403");
+    expect(workflow).not.toContain(
+      'grep -qE "quota exhausted|server limit reached',
+    );
+  });
+
+  test("round-trips the validated diagnostic consumed by the workflow", () => {
+    const diagnostic = {
+      version: 1 as const,
+      kind: "quota" as const,
+      code: "quota_exceeded",
+      status: 403,
+      inventory: {
+        totalServers: 1,
+        hetznerE2eServers: 1,
+        otherServers: 0,
+        byStatus: { running: 1 },
+        byServerType: { cpx22: 1 },
+        byLocation: { nbg1: 1 },
+      },
+      inventoryError: null,
+    };
+
+    writeProvisionFailureDiagnostic(diagnosticFile, diagnostic);
+    expect(readProvisionFailureDiagnostic(diagnosticFile)).toEqual(diagnostic);
   });
 });

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.ts
@@ -20,6 +20,11 @@ import {
   HetznerCloudClient,
   HetznerCloudError,
 } from "@elizaos/cloud-shared/lib/services/containers/hetzner-cloud-api";
+import {
+  buildProvisionFailureDiagnostic,
+  type CapacityInventory,
+  writeProvisionFailureDiagnostic,
+} from "./hetzner-e2e-provision-diagnostic";
 import { appendStateAtomic } from "./state-file";
 
 function requireEnv(name: string): string {
@@ -79,12 +84,9 @@ function isProjectQuotaError(err: unknown): err is HetznerCloudError {
   return err instanceof HetznerCloudError && err.code === "quota_exceeded";
 }
 
-// Pre-provision reap: delete any prior CI servers older than this. Stops a
-// chain of failed runs (which leak servers because teardown only fires when
-// provision succeeds) from blocking new runs with "server limit reached".
-// 20min is well above the ~10min healthy E2E budget; anything older is
-// guaranteed dead. The half-hourly reaper workflow handles the >60min case;
-// this is the fast lane.
+// The workflow's non-overlapping concurrency guarantees that an older tagged
+// server cannot belong to another active official run when this provisioner
+// starts. The age floor still protects manually created lookalikes and clocks.
 const PRE_REAP_AGE_MS = 20 * 60 * 1000;
 
 async function preReapOldServers(client: HetznerCloudClient): Promise<void> {
@@ -94,24 +96,42 @@ async function preReapOldServers(client: HetznerCloudClient): Promise<void> {
   });
   const now = Date.now();
   for (const server of servers) {
-    const created = Date.parse(server.created);
+    const candidate = asRecord(server);
+    const labels = asRecord(candidate?.labels);
+    if (
+      labels?.ci !== "true" ||
+      labels.workflow !== "hetzner-e2e" ||
+      !Number.isSafeInteger(candidate?.id) ||
+      Number(candidate?.id) <= 0 ||
+      typeof candidate?.created !== "string"
+    ) {
+      continue;
+    }
+    const created = Date.parse(candidate.created);
     if (!Number.isFinite(created)) continue;
     if (now - created < PRE_REAP_AGE_MS) continue;
+    const name = sanitizedDimension(candidate.name);
     console.error(
-      `[hetzner-e2e-provision] pre-reap deleting ${server.id} (${server.name}) age=${Math.round((now - created) / 60000)}min`,
+      `[hetzner-e2e-provision] pre-reap deleting ${candidate.id} (${name}) age=${Math.round((now - created) / 60000)}min`,
     );
-    await client.deleteServer(server.id);
+    await client.deleteServer(Number(candidate.id));
   }
 }
 
-type CapacityInventory = {
-  totalServers: number;
-  hetznerE2eServers: number;
-  otherServers: number;
-  byStatus: Record<string, number>;
-  byServerType: Record<string, number>;
-  byLocation: Record<string, number>;
-};
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function sanitizedDimension(value: unknown): string {
+  return typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 64 &&
+    /^[A-Za-z0-9._-]+$/.test(value)
+    ? value
+    : "unknown";
+}
 
 function incrementCount(counts: Record<string, number>, key: string): void {
   counts[key] = (counts[key] ?? 0) + 1;
@@ -120,7 +140,13 @@ function incrementCount(counts: Record<string, number>, key: string): void {
 async function readSanitizedCapacityInventory(
   client: HetznerCloudClient,
 ): Promise<CapacityInventory> {
-  const servers = await client.listServers();
+  const response: unknown = await client.listServers();
+  if (!Array.isArray(response)) {
+    throw new Error(
+      "Hetzner capacity inventory did not contain a server array",
+    );
+  }
+  const servers = response;
   const inventory: CapacityInventory = {
     totalServers: servers.length,
     hetznerE2eServers: 0,
@@ -131,16 +157,24 @@ async function readSanitizedCapacityInventory(
   };
 
   for (const server of servers) {
+    const candidate = asRecord(server);
+    const labels = asRecord(candidate?.labels);
     const isHetznerE2e =
-      server.labels.ci === "true" && server.labels.workflow === "hetzner-e2e";
+      labels?.ci === "true" && labels.workflow === "hetzner-e2e";
     if (isHetznerE2e) {
       inventory.hetznerE2eServers++;
     } else {
       inventory.otherServers++;
     }
-    incrementCount(inventory.byStatus, server.status);
-    incrementCount(inventory.byServerType, server.server_type.name);
-    incrementCount(inventory.byLocation, server.datacenter.location.name);
+    const serverType = asRecord(candidate?.server_type);
+    const datacenter = asRecord(candidate?.datacenter);
+    const location = asRecord(datacenter?.location);
+    incrementCount(inventory.byStatus, sanitizedDimension(candidate?.status));
+    incrementCount(
+      inventory.byServerType,
+      sanitizedDimension(serverType?.name),
+    );
+    incrementCount(inventory.byLocation, sanitizedDimension(location?.name));
   }
 
   return inventory;
@@ -230,26 +264,27 @@ export async function runHetznerE2eProvision(): Promise<{
     } catch (err) {
       lastError = err;
       if (isProjectQuotaError(err)) {
-        let inventory: CapacityInventory;
+        let inventory: CapacityInventory | null = null;
+        let inventoryError: unknown;
         try {
           inventory = await readSanitizedCapacityInventory(client);
-        } catch (inventoryError) {
-          // error-policy:J2 Preserve both the quota failure and the failed diagnostic read.
-          throw new AggregateError(
-            [err, inventoryError],
-            "Hetzner project quota exhausted and capacity inventory could not be read",
-            { cause: err },
+        } catch (error) {
+          // error-policy:J2 The create failure remains the cause; the diagnostic failure is attached separately.
+          inventoryError = error;
+        }
+        if (inventory) {
+          console.error(
+            `[hetzner-e2e-provision] project capacity inventory: ${JSON.stringify(inventory)}`,
           );
         }
-        console.error(
-          `[hetzner-e2e-provision] project capacity inventory: ${JSON.stringify(inventory)}`,
-        );
-        throw new HetznerCloudError(
+        throw new HetznerE2eQuotaError(
           "quota_exceeded",
           `Hetzner project quota exhausted after ${attempt.serverType}@${attempt.location} (${err.message}). ` +
             "Operator action required: inspect project capacity or raise the server limit; changing location cannot bypass a project-wide quota.",
           err.status,
           err,
+          inventory,
+          inventoryError,
         );
       }
       if (!isRetryableCombo(err)) {
@@ -292,5 +327,44 @@ export async function runHetznerE2eProvision(): Promise<{
 }
 
 if (import.meta.main) {
-  console.log(JSON.stringify(await runHetznerE2eProvision()));
+  void runHetznerE2eProvision()
+    .then((result) => {
+      console.log(JSON.stringify(result));
+    })
+    .catch((error: unknown) => {
+      const diagnostic = buildProvisionFailureDiagnostic(error);
+      const diagnosticPath =
+        // biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub Actions injects this standalone script path.
+        process.env.HETZNER_E2E_DIAGNOSTIC_FILE ??
+        "/tmp/hetzner-e2e-provision-diagnostic.json";
+      try {
+        writeProvisionFailureDiagnostic(diagnosticPath, diagnostic);
+      } catch (diagnosticWriteError) {
+        // error-policy:J2 Preserve the provisioning failure if its reporting boundary also fails.
+        throw new AggregateError(
+          [error, diagnosticWriteError],
+          "Hetzner provisioning failed and its structured diagnostic could not be written",
+          { cause: error },
+        );
+      }
+      console.error(
+        `[hetzner-e2e-provision] failure diagnostic: ${JSON.stringify(diagnostic)}`,
+      );
+      console.error(error);
+      process.exitCode = 1;
+    });
+}
+
+class HetznerE2eQuotaError extends HetznerCloudError {
+  constructor(
+    code: "quota_exceeded",
+    message: string,
+    status: number | undefined,
+    cause: unknown,
+    public readonly inventory: CapacityInventory | null,
+    public readonly inventoryError: unknown,
+  ) {
+    super(code, message, status, cause);
+    this.name = "HetznerE2eQuotaError";
+  }
 }


### PR DESCRIPTION
Fixes #17456

## Outcome

Hetzner E2E provisioning failures now preserve the API error code and render operator guidance from a validated, privacy-safe diagnostic record. A quota response remains red, but it is no longer misreported as a rejected credential merely because Hetzner used HTTP 403.

The provisioner also performs a narrowly fenced cleanup of stale official E2E servers before allocation. It requires exact CI labels, a valid numeric server ID, a valid creation timestamp, and the existing age floor.

## Verification

- 19 focused provision, diagnostic, cleanup, and workflow-contract tests passed
- Biome passed
- focused TypeScript and cloud-shared typecheck passed
- actionlint, YAML parsing, and git diff --check passed
- exact head: `f92c28ffbc30d435d9eef159dc031989588f224d`
- exact parent: `bb9cc9852608b3ab73aa2b7aa1e5a298e778fda3`

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow and CLI diagnostics only; no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow and CLI diagnostics only; no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow or visual surface changed.
<!-- evidence-row:backend-logs -->
- [x] [30651120674](https://github.com/elizaOS/eliza/actions/runs/30651120674)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [30651120674](https://github.com/elizaOS/eliza/actions/runs/30651120674)

## Operator constraint

If safe stale-server cleanup finds no reclaimable official E2E server, the Hetzner project still needs a server-limit increase or manual capacity cleanup. The workflow deliberately remains red until real infrastructure can be provisioned.

