### PR TITLE
fix(agent): preserve completed turns across disconnects

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
@@ -26,8 +26,18 @@
  */
 
 import http from "node:http";
-import type { Action, AgentRuntime, Memory } from "@elizaos/core";
-import { logger, stringToUuid, type UUID } from "@elizaos/core";
+import type {
+  Action,
+  AgentRuntime,
+  EffectReceipt,
+  Memory,
+} from "@elizaos/core";
+import {
+  executePlannedToolCall,
+  logger,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
 import {
   afterAll,
   afterEach,
@@ -707,6 +717,127 @@ describe("conversation-route chat idempotency wiring", () => {
       }),
     ]);
   });
+
+  it.each([
+    { failure: "transport abort", abortTransport: true },
+    { failure: "message-service exception", abortTransport: false },
+  ])(
+    "SSE: a receipt-backed planner action survives a post-commit $failure",
+    async ({ failure, abortTransport }) => {
+      const { state, handleMessage, createMemory } = createHarness();
+      let releaseAfterCommit: (() => void) | undefined;
+      const afterCommitGate = new Promise<void>((resolve) => {
+        releaseAfterCommit = resolve;
+      });
+      let notifyCommitted: (() => void) | undefined;
+      const committed = new Promise<void>((resolve) => {
+        notifyCommitted = resolve;
+      });
+      const receipt: EffectReceipt = {
+        receiptId: `receipt-post-commit-${failure}`,
+        operation: "test.reminder.create",
+        resource: { kind: "test.reminder", id: "reminder-1" },
+        artifacts: [],
+        outcome: "applied",
+        idempotency: {
+          key: `conversation-post-commit-${failure}`,
+          replayed: false,
+        },
+        observedAt: "2026-07-31T19:00:00.000Z",
+        commit: {
+          kind: "durable",
+          id: "reminder-1",
+          committedAt: "2026-07-31T19:00:00.000Z",
+        },
+      };
+      const actionText = "Reminder created for 9:00 AM.";
+      const actionHandler = vi.fn(
+        async (
+          _runtime: unknown,
+          _message: unknown,
+          _state: unknown,
+          _options: unknown,
+          callback?: (content: { text: string }) => Promise<unknown>,
+        ) => {
+          await callback?.({ text: actionText });
+          return {
+            success: true,
+            text: actionText,
+            userFacingText: actionText,
+            verifiedUserFacing: true,
+            effectReceipts: [receipt],
+            userFacingEffectReceiptIds: [receipt.receiptId],
+          };
+        },
+      );
+      const action: Action = {
+        name: "CREATE_REMINDER",
+        description: "Create a reminder.",
+        similes: [],
+        examples: [],
+        tags: ["capability:schedule", "effect:receipt-required"],
+        validate: async () => true,
+        handler: actionHandler as Action["handler"],
+      };
+      (state.runtime as AgentRuntime).actions.push(action);
+
+      handleMessage.mockImplementation(
+        async (
+          runtime: AgentRuntime,
+          message: Memory,
+          callback: Parameters<Action["handler"]>[4],
+          options?: {
+            abortSignal?: AbortSignal;
+            onSettledActionResult?: (result: unknown) => void;
+          },
+        ) => {
+          await executePlannedToolCall(
+            runtime,
+            {
+              message,
+              state: { values: {}, data: {}, text: "" },
+              userRoles: ["OWNER"],
+              activeContexts: ["general"],
+              callback,
+            },
+            { name: action.name, params: {} },
+            {
+              actions: [action],
+              abortSignal: options?.abortSignal,
+              onSettledResult: options?.onSettledActionResult,
+            },
+          );
+          notifyCommitted?.();
+          await afterCommitGate;
+          if (abortTransport) options?.abortSignal?.throwIfAborted();
+          throw new Error("message service stopped after action settlement");
+        },
+      );
+      const body = {
+        text: "remind me at 9",
+        clientMessageId: `planner-action-post-commit-${failure}`,
+      };
+
+      await runRoute("POST", STREAM_PATH, state, body, async (req) => {
+        await committed;
+        if (abortTransport) req.emit("aborted");
+        releaseAfterCommit?.();
+      });
+      const persistsAfterDisconnect = createMemory.mock.calls.length;
+
+      const retry = await runRoute("POST", STREAM_PATH, state, body);
+      expect(actionHandler).toHaveBeenCalledTimes(1);
+      expect(handleMessage).toHaveBeenCalledTimes(1);
+      expect(createMemory).toHaveBeenCalledTimes(persistsAfterDisconnect);
+      expect(parseDataFrames(retry.record)).toEqual([
+        expect.objectContaining({
+          type: "done",
+          fullText: actionText,
+          messageId: expect.any(String),
+        }),
+      ]);
+    },
+  );
 
   it("SSE: a late disconnect binds a safe outcome without starting fallback actions", async () => {
     const { state, handleMessage, createMemory } = createHarness();

--- a/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
@@ -26,7 +26,7 @@
  */
 
 import http from "node:http";
-import type { AgentRuntime, Memory } from "@elizaos/core";
+import type { Action, AgentRuntime, Memory } from "@elizaos/core";
 import { logger, stringToUuid, type UUID } from "@elizaos/core";
 import {
   afterAll,
@@ -703,6 +703,67 @@ describe("conversation-route chat idempotency wiring", () => {
       expect.objectContaining({
         type: "done",
         fullText: "durable reply",
+        messageId: expect.any(String),
+      }),
+    ]);
+  });
+
+  it("SSE: a late disconnect binds a safe outcome without starting fallback actions", async () => {
+    const { state, handleMessage, createMemory } = createHarness();
+    const fallbackHandler = vi.fn(async () => ({
+      success: true,
+      text: "Block started.",
+    }));
+    (state.runtime as AgentRuntime).actions.push({
+      name: "BLOCK",
+      description: "Start a website block.",
+      similes: [],
+      examples: [],
+      validate: async () => true,
+      handler: fallbackHandler,
+    } satisfies Action);
+    let releaseTurn: (() => void) | undefined;
+    const turnGate = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    handleMessage.mockImplementationOnce(async () => {
+      await turnGate;
+      return {
+        didRespond: true,
+        responseContent: {
+          text: "Starting the block now.",
+          actions: ["BLOCK"],
+        },
+        responseMessages: [],
+      };
+    });
+    const body = {
+      text: "block distractions",
+      clientMessageId: "disconnect-before-fallback-1",
+    };
+    const safeOutcome = [
+      "I could not complete that request because the model returned actions that were not executed.",
+      "Unexecuted actions: BLOCK.",
+      "No side effects were applied.",
+    ].join("\n");
+
+    await runRoute("POST", STREAM_PATH, state, body, (req) => {
+      req.emit("aborted");
+      releaseTurn?.();
+    });
+    const persistsAfterDisconnect = createMemory.mock.calls.length;
+
+    expect(fallbackHandler).not.toHaveBeenCalled();
+    expect(persistsAfterDisconnect).toBeGreaterThan(0);
+
+    const retry = await runRoute("POST", STREAM_PATH, state, body);
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(fallbackHandler).not.toHaveBeenCalled();
+    expect(createMemory).toHaveBeenCalledTimes(persistsAfterDisconnect);
+    expect(parseDataFrames(retry.record)).toEqual([
+      expect.objectContaining({
+        type: "done",
+        fullText: safeOutcome,
         messageId: expect.any(String),
       }),
     ]);

--- a/packages/agent/src/api/__tests__/conversation-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-streaming.test.ts
@@ -9,6 +9,7 @@
 
 import type http from "node:http";
 import {
+  type Action,
   type AgentRuntime,
   ChannelType,
   type Content,
@@ -999,6 +1000,36 @@ describe("generateChatResponse token streaming", () => {
     );
   });
 
+  it("finalizes an Android local result that wins the cancellation race", async () => {
+    const caller = new AbortController();
+    const useModel = createUseModelMock(async () => {
+      caller.abort(new DOMException("socket closed", "AbortError"));
+      return "Local reply completed.";
+    });
+    const runtime = createRuntime({
+      getSetting: (key: string) => {
+        const values: Record<string, string> = {
+          ELIZA_MOBILE_PLATFORM: "android",
+          ELIZA_LOCAL_LLAMA: "1",
+          ELIZA_MOBILE_LOCAL_DIRECT_REPLY: "1",
+        };
+        return values[key] ?? null;
+      },
+      useModel,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("answer locally"),
+      "Streaming Agent",
+      { abortSignal: caller.signal },
+    );
+
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(result.text).toBe("Local reply completed.");
+    expect(result.localInference?.provider).toBe("mobile-local-direct-reply");
+  });
+
   it("includes only six bounded recent messages and preserves multi-sentence replies", async () => {
     const roomId = stringToUuid("room");
     const memories = Array.from({ length: 8 }, (_, index) => {
@@ -1415,6 +1446,55 @@ describe("generateChatResponse token streaming", () => {
     expect(signalFromOptions?.aborted).toBe(true);
   });
 
+  it("finalizes a message result that wins the race with caller cancellation", async () => {
+    const caller = new AbortController();
+    const chunks: string[] = [];
+    const handleMessage = vi.fn(
+      async (
+        _runtime: unknown,
+        _message: unknown,
+        _callback: unknown,
+        options?: {
+          onStreamChunk?: (chunk: string) => Promise<void> | void;
+        },
+      ) => {
+        await options?.onStreamChunk?.("completed reply");
+        caller.abort(new DOMException("socket closed", "AbortError"));
+        return {
+          didRespond: true,
+          responseContent: { text: "completed reply" },
+          responseMessages: [],
+        };
+      },
+    );
+    const runtime = createRuntime({
+      messageService: {
+        handleMessage,
+        shouldRespond: () => ({
+          shouldRespond: true,
+          skipEvaluation: true,
+          reason: "streaming-test",
+        }),
+        deleteMessage: async () => undefined,
+        clearChannel: async () => undefined,
+      },
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("finish this request"),
+      "Streaming Agent",
+      {
+        abortSignal: caller.signal,
+        onChunk: (chunk) => chunks.push(chunk),
+      },
+    );
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(chunks).toEqual(["completed reply"]);
+    expect(result.text).toBe("completed reply");
+  });
+
   it("propagates caller cancellation into chat pre-handlers", async () => {
     let preHandlerStarted: (() => void) | undefined;
     const started = new Promise<void>((resolve) => {
@@ -1460,6 +1540,81 @@ describe("generateChatResponse token streaming", () => {
     await expect(generation).rejects.toThrow("Client disconnected");
     expect(signalFromPreHandler?.aborted).toBe(true);
     expect(handleMessage).not.toHaveBeenCalled();
+  });
+
+  it("finalizes a pre-handler result that wins the cancellation race", async () => {
+    const caller = new AbortController();
+    const handleMessage = vi.fn();
+    const drainChatPreHandlers = vi.fn(async () => {
+      caller.abort(new DOMException("socket closed", "AbortError"));
+      return { responseText: "direct result completed" };
+    });
+    const runtime = createRuntime({
+      drainChatPreHandlers,
+      messageService: {
+        handleMessage,
+        shouldRespond: () => ({
+          shouldRespond: true,
+          skipEvaluation: true,
+          reason: "streaming-test",
+        }),
+        deleteMessage: async () => undefined,
+        clearChannel: async () => undefined,
+      },
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("run the direct handler"),
+      "Streaming Agent",
+      { abortSignal: caller.signal },
+    );
+
+    expect(drainChatPreHandlers).toHaveBeenCalledTimes(1);
+    expect(handleMessage).not.toHaveBeenCalled();
+    expect(result.text).toBe("direct result completed");
+  });
+
+  it("finalizes a committed direct action across a late cancellation", async () => {
+    const caller = new AbortController();
+    const actionHandler = vi.fn(async () => {
+      caller.abort(new DOMException("socket closed", "AbortError"));
+      return {
+        success: true,
+        text: "Task committed.",
+        data: { actionName: "START_CODING_TASK" },
+      };
+    });
+    const action = {
+      name: "START_CODING_TASK",
+      description: "Create a coding task.",
+      similes: [],
+      examples: [],
+      validate: async () => true,
+      handler: actionHandler,
+    } satisfies Action;
+    const runtime = createRuntime({
+      actions: [action],
+      getService: vi.fn((serviceType: string) =>
+        serviceType === "SWARM_COORDINATOR" ? ({} as never) : null,
+      ) as AgentRuntime["getService"],
+    });
+    const message = createChatMessage("build the durable fix");
+    message.entityId = runtime.agentId;
+    message.content = {
+      ...message.content,
+      metadata: { intent: "create_task" },
+    };
+
+    const result = await generateChatResponse(
+      runtime,
+      message,
+      "Streaming Agent",
+      { abortSignal: caller.signal },
+    );
+
+    expect(actionHandler).toHaveBeenCalledTimes(1);
+    expect(result.text).toBe("Task committed.");
   });
 
   it("rejects ingress hook failures before starting message generation", async () => {

--- a/packages/agent/src/api/__tests__/conversation-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-streaming.test.ts
@@ -1495,6 +1495,67 @@ describe("generateChatResponse token streaming", () => {
     expect(result.text).toBe("completed reply");
   });
 
+  it("fails closed instead of starting fallback actions after cancellation", async () => {
+    const caller = new AbortController();
+    const fallbackHandler = vi.fn(async () => ({
+      success: true,
+      text: "Block started.",
+    }));
+    const useModel = createUseModelMock(async () =>
+      JSON.stringify({ response: "I started the block." }),
+    );
+    const runtime = createRuntime({
+      actions: [
+        {
+          name: "BLOCK",
+          description: "Start a website block.",
+          similes: [],
+          examples: [],
+          validate: async () => true,
+          handler: fallbackHandler,
+        } satisfies Action,
+      ],
+      useModel,
+      messageService: {
+        handleMessage: vi.fn(async () => {
+          caller.abort(new DOMException("socket closed", "AbortError"));
+          return {
+            didRespond: true,
+            responseContent: {
+              text: "Starting the block now.",
+              actions: ["BLOCK"],
+            },
+            responseMessages: [],
+          };
+        }),
+        shouldRespond: () => ({
+          shouldRespond: true,
+          skipEvaluation: true,
+          reason: "streaming-test",
+        }),
+        deleteMessage: async () => undefined,
+        clearChannel: async () => undefined,
+      },
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("block distractions"),
+      "Streaming Agent",
+      { abortSignal: caller.signal },
+    );
+
+    expect(fallbackHandler).not.toHaveBeenCalled();
+    expect(useModel).not.toHaveBeenCalled();
+    expect(result.text).toBe(
+      [
+        "I could not complete that request because the model returned actions that were not executed.",
+        "Unexecuted actions: BLOCK.",
+        "No side effects were applied.",
+      ].join("\n"),
+    );
+  });
+
   it("propagates caller cancellation into chat pre-handlers", async () => {
     let preHandlerStarted: (() => void) | undefined;
     const started = new Promise<void>((resolve) => {

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -1063,6 +1063,8 @@ function recoverSettledMutatingActionTurn(
       .reverse()
       .find((result) => hasAppliedUserFacingEffectProof(result, allReceipts));
   } catch (error) {
+    // error-policy:J4 conflicting receipt evidence degrades to the explicit
+    // post-commit interruption reply rather than inventing action-specific text.
     runtime.logger.warn(
       {
         src: "eliza-api",
@@ -3473,6 +3475,8 @@ async function generateChatResponseWithTiming(
               { phase: "message" },
             );
           } catch (error) {
+            // error-policy:J1 this API boundary preserves a proven committed
+            // effect while translating later turn failure into a durable reply.
             const recovery = recoverSettledMutatingActionTurn(
               runtime,
               settledActionResults,

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -3037,8 +3037,10 @@ async function generateChatResponseWithTiming(
           opts,
         }),
     );
-    generationAbortController.signal.throwIfAborted();
     if (androidDirectResult) {
+      // A successful model return commits the turn even when transport
+      // cancellation races with that return. Discarding it here would release
+      // the retry key and bill the same completed work a second time.
       try {
         if (
           androidDirectResult.responseContent &&
@@ -3071,6 +3073,7 @@ async function generateChatResponseWithTiming(
       }
       return androidDirectResult;
     }
+    generationAbortController.signal.throwIfAborted();
 
     let result:
       | Awaited<
@@ -3133,8 +3136,10 @@ async function generateChatResponseWithTiming(
             appendText: replaceCallbackText,
             replaceText: emitSnapshot,
           });
-          generationAbortController.signal.throwIfAborted();
           if (preHandlerResult) {
+            // A handler that returns a terminal reply owns completion. A late
+            // disconnect must not erase a completed direct dispatch and cause
+            // the client retry to execute it again.
             const directText = preHandlerResult.responseText;
             const finalText = isClientVisibleNoResponse(directText)
               ? directText || "(no response)"
@@ -3148,6 +3153,7 @@ async function generateChatResponseWithTiming(
             forcedWalletExecutionText = isClientVisibleNoResponse(directText);
             return;
           }
+          generationAbortController.signal.throwIfAborted();
 
           // Direct dispatch for explicit task creation intent from UI
           const contentMetadata = message.content.metadata as
@@ -3229,7 +3235,9 @@ async function generateChatResponseWithTiming(
                     abortSignal: generationAbortController.signal,
                   },
                 );
-                generationAbortController.signal.throwIfAborted();
+                // The action has already returned a committed result. Keep
+                // finalizing it if the transport disappears at this boundary
+                // so reconnect cannot repeat an external side effect.
                 const finalText =
                   actionResponseText ||
                   directActionResult.text ||
@@ -3374,7 +3382,10 @@ async function generateChatResponseWithTiming(
               ),
             { phase: "message" },
           );
-          generationAbortController.signal.throwIfAborted();
+          // handleMessage returning successfully is the turn's completion
+          // barrier. Providers and actions receive the owner signal and reject
+          // unfinished work; a successful return must survive a late transport
+          // abort so persistence and idempotent replay can finish exactly once.
 
           // Ensure MESSAGE_SENT hooks run for API chat flows.
           try {

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -739,6 +739,7 @@ async function rewriteDirectActionCallbackText(args: {
   actionName: string;
   text: string;
   content?: Content;
+  abortSignal?: AbortSignal;
 }): Promise<string> {
   const text = args.text.trim();
   if (!text) return args.text;
@@ -749,6 +750,7 @@ async function rewriteDirectActionCallbackText(args: {
         : "";
     return `I ran ${args.actionName} and got a result, but I couldn't format the details cleanly here.${error}`;
   };
+  if (args.abortSignal?.aborted) return fallback();
   try {
     const raw = await args.runtime.useModel(ModelType.TEXT_SMALL, {
       prompt: [
@@ -777,6 +779,7 @@ async function rewriteDirectActionCallbackText(args: {
         })}`,
       ].join("\n"),
       maxTokens: 260,
+      signal: args.abortSignal,
       providerOptions: { eliza: { thinking: "off" } },
     });
     const parsed = JSON.parse(String(raw).trim()) as { response?: unknown };
@@ -3044,6 +3047,7 @@ async function generateChatResponseWithTiming(
       try {
         if (
           androidDirectResult.responseContent &&
+          !generationAbortController.signal.aborted &&
           typeof runtime.emitEvent === "function"
         ) {
           const memoryLike = createMessageMemory({
@@ -3219,6 +3223,7 @@ async function generateChatResponseWithTiming(
                             actionName: createTaskAction.name,
                             text: chunk,
                             content,
+                            abortSignal: generationAbortController.signal,
                           });
                         applyCallbackTextUpdate(content, voicedChunk);
                         actionResponseText = responseText;
@@ -3255,6 +3260,7 @@ async function generateChatResponseWithTiming(
             // Fall through to normal LLM-based routing if coordinator not available
           }
 
+          generationAbortController.signal.throwIfAborted();
           const localInferenceIntent = detectLocalInferenceCommandIntent(
             originalUserText,
             {
@@ -3264,6 +3270,7 @@ async function generateChatResponseWithTiming(
           if (localInferenceIntent) {
             const { handleLocalInferenceChatCommand } =
               await getLocalInferenceChatApi();
+            generationAbortController.signal.throwIfAborted();
             const localResult = await handleLocalInferenceChatCommand(
               localInferenceIntent,
               originalUserText,
@@ -3382,10 +3389,10 @@ async function generateChatResponseWithTiming(
               ),
             { phase: "message" },
           );
-          // handleMessage returning successfully is the turn's completion
-          // barrier. Providers and actions receive the owner signal and reject
-          // unfinished work; a successful return must survive a late transport
-          // abort so persistence and idempotent replay can finish exactly once.
+          // A successful return preserves the completed model/message result,
+          // but it is not permission to start optional post-processing after a
+          // disconnect. The remaining path finalizes that result and only runs
+          // new work while the owner signal is live.
 
           // Ensure MESSAGE_SENT hooks run for API chat flows.
           try {
@@ -3421,6 +3428,7 @@ async function generateChatResponseWithTiming(
                   : [];
             if (
               messagesToEmit.length > 0 &&
+              !generationAbortController.signal.aborted &&
               typeof runtime.emitEvent === "function"
             ) {
               for (const responseMessage of messagesToEmit) {
@@ -3505,7 +3513,10 @@ async function generateChatResponseWithTiming(
                 });
               let successfulFallbackActions = new Set<string>();
 
-              if (selfControlFallbackActions.length > 0) {
+              if (
+                selfControlFallbackActions.length > 0 &&
+                !generationAbortController.signal.aborted
+              ) {
                 const fallbackExecutions = await executeFallbackParsedActions(
                   runtime,
                   message,
@@ -3513,6 +3524,7 @@ async function generateChatResponseWithTiming(
                   appendIncomingText,
                   recordActionCallback,
                   {
+                    abortSignal: generationAbortController.signal,
                     getCurrentText: () => responseText || modelText,
                   },
                 );
@@ -3675,10 +3687,9 @@ async function generateChatResponseWithTiming(
     }
 
     const noResponseFallback = opts?.resolveNoResponseText?.();
-    const exactDocumentValue = await resolveExactDocumentValueForChat(
-      runtime,
-      message,
-    );
+    const exactDocumentValue = generationAbortController.signal.aborted
+      ? null
+      : await resolveExactDocumentValueForChat(runtime, message);
     const normalizedResponseText = trimWalletProgressPrefix(
       exactDocumentValue || responseText || resultText || "",
     );

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -27,6 +27,7 @@ import {
   executePlannedToolCall,
   getInferenceTimer,
   getSwarmCoordinatorService,
+  hasAppliedUserFacingEffectProof,
   INFERENCE_MARKS,
   INSUFFICIENT_CREDITS_REPLY,
   InferenceTurnTimer,
@@ -40,10 +41,12 @@ import {
   type RolesWorldMetadata,
   type RouteRequestContext,
   recordOwnerGrant,
+  revertedEffectReceiptIds,
   runWithInferenceTiming,
   runWithTrajectoryContext,
   stringToUuid,
   type TrustedApiPrincipal,
+  tagsMayProduceEffects,
   timeInferenceSpan,
   trackPostDeliveryTask,
   type UUID,
@@ -1011,6 +1014,80 @@ export interface ChatGenerateOptions {
   abortSignal?: AbortSignal;
   resolveNoResponseText?: () => string;
   preferredLanguage?: string;
+}
+
+const POST_COMMIT_INTERRUPTED_REPLY =
+  "The action finished before the response was interrupted. It was not run again.";
+
+function recoverSettledMutatingActionTurn(
+  runtime: AgentRuntime,
+  settledResults: readonly ActionResult[],
+): {
+  text: string;
+  actionResults: ActionResult[];
+  actionNames: string[];
+} | null {
+  const allReceipts = settledResults.flatMap(
+    (result) => result.effectReceipts ?? [],
+  );
+  const revertedReceiptIds = revertedEffectReceiptIds(allReceipts);
+  const actionByName = new Map(
+    runtime.actions.map((action) => [action.name, action]),
+  );
+  const committedResults = settledResults.filter((result) => {
+    const receipts = result.effectReceipts ?? [];
+    const hasActiveAppliedReceipt = receipts.some(
+      (receipt) =>
+        receipt.outcome === "applied" &&
+        !revertedReceiptIds.has(receipt.receiptId),
+    );
+    if (receipts.length > 0) return hasActiveAppliedReceipt;
+    if (
+      result.data?.reconciliationRequired === true &&
+      result.data?.retryable === false
+    ) {
+      return true;
+    }
+    const actionName =
+      typeof result.data?.actionName === "string" ? result.data.actionName : "";
+    return (
+      result.success !== false &&
+      tagsMayProduceEffects(actionByName.get(actionName)?.tags)
+    );
+  });
+  if (committedResults.length === 0) return null;
+
+  let verifiedResult: ActionResult | undefined;
+  try {
+    verifiedResult = [...committedResults]
+      .reverse()
+      .find((result) => hasAppliedUserFacingEffectProof(result, allReceipts));
+  } catch (error) {
+    runtime.logger.warn(
+      {
+        src: "eliza-api",
+        error: getErrorMessage(error),
+      },
+      "Conflicting action receipts prevented exact post-commit reply recovery",
+    );
+  }
+  const verifiedText = verifiedResult?.userFacingText?.trim();
+  const actionNames = Array.from(
+    new Set(
+      committedResults
+        .map((result) =>
+          typeof result.data?.actionName === "string"
+            ? result.data.actionName
+            : "",
+        )
+        .filter((name) => name.length > 0),
+    ),
+  );
+  return {
+    text: verifiedText || POST_COMMIT_INTERRUPTED_REPLY,
+    actionResults: [...settledResults],
+    actionNames,
+  };
 }
 
 function isAppendOnlyStreamDivergenceError(
@@ -3086,6 +3163,7 @@ async function generateChatResponseWithTiming(
           >
         >
       | undefined;
+    const settledActionResults: ActionResult[] = [];
     let capturedUsage: CapturedModelUsage | null = null;
     const recordActionCallback = (
       actionTag: string,
@@ -3317,78 +3395,113 @@ async function generateChatResponseWithTiming(
             { phase: "pre-model" },
           );
           generationAbortController.signal.throwIfAborted();
-          result = await timeInferenceSpan(
-            "chat:message-service",
-            async () =>
-              runtime.messageService?.handleMessage(
-                runtime,
-                generationMessage,
-                async (content: Content, actionName?: string) => {
-                  if (content.transcriptVisibility === "internal") {
-                    return [];
-                  }
+          try {
+            result = await timeInferenceSpan(
+              "chat:message-service",
+              async () =>
+                runtime.messageService?.handleMessage(
+                  runtime,
+                  generationMessage,
+                  async (content: Content, actionName?: string) => {
+                    if (content.transcriptVisibility === "internal") {
+                      return [];
+                    }
 
-                  const chunk = extractCompatTextContent(content);
-                  const visibleChunk = isInternalStructuredStreamText(chunk)
-                    ? ""
-                    : chunk;
-                  const attributedActionName = normalizeActionName(actionName);
-                  const progressCallback = isProgressActionCallback(content);
-                  if (!visibleChunk) {
-                    if (attributedActionName) {
-                      recordActionCallback(attributedActionName, false);
-                    }
-                    return [];
-                  }
-                  if (!claimStreamSource("callback")) {
-                    if (attributedActionName) {
-                      recordActionCallback(attributedActionName, false);
-                    }
-                    return [];
-                  }
-                  if (!progressCallback) {
-                    visibleCallbackDeliveries += 1;
-                  }
-                  applyCallbackTextUpdate(content, visibleChunk);
-                  if (attributedActionName) {
-                    recordActionCallback(
-                      attributedActionName,
-                      !progressCallback,
-                      progressCallback ? undefined : visibleChunk,
-                    );
-                  }
-                  return [];
-                },
-                {
-                  abortSignal: generationAbortController.signal,
-                  keepExistingResponses: true,
-                  onStreamChunk: opts?.onChunk
-                    ? async (
-                        chunk: string,
-                        _messageId?: string,
-                        accumulated?: string,
-                      ) => {
-                        if (!chunk) return;
-                        if (isInternalStructuredStreamText(chunk)) {
-                          // A native planner/tool step, not visible reply text:
-                          // fork it onto the working indicator + inline tool row
-                          // instead of leaking JSON into the bubble.
-                          const events =
-                            chatEventsFromStructuredStreamText(chunk);
-                          if (events?.status) emitStatus(events.status);
-                          if (events?.toolEvent) {
-                            opts?.onToolEvent?.(events.toolEvent);
-                          }
-                          return;
-                        }
-                        if (!claimStreamSource("onStreamChunk")) return;
-                        appendIncomingText(chunk, accumulated);
+                    const chunk = extractCompatTextContent(content);
+                    const visibleChunk = isInternalStructuredStreamText(chunk)
+                      ? ""
+                      : chunk;
+                    const attributedActionName =
+                      normalizeActionName(actionName);
+                    const progressCallback = isProgressActionCallback(content);
+                    if (!visibleChunk) {
+                      if (attributedActionName) {
+                        recordActionCallback(attributedActionName, false);
                       }
-                    : undefined,
-                },
-              ),
-            { phase: "message" },
-          );
+                      return [];
+                    }
+                    if (!claimStreamSource("callback")) {
+                      if (attributedActionName) {
+                        recordActionCallback(attributedActionName, false);
+                      }
+                      return [];
+                    }
+                    if (!progressCallback) {
+                      visibleCallbackDeliveries += 1;
+                    }
+                    applyCallbackTextUpdate(content, visibleChunk);
+                    if (attributedActionName) {
+                      recordActionCallback(
+                        attributedActionName,
+                        !progressCallback,
+                        progressCallback ? undefined : visibleChunk,
+                      );
+                    }
+                    return [];
+                  },
+                  {
+                    abortSignal: generationAbortController.signal,
+                    keepExistingResponses: true,
+                    onSettledActionResult: (actionResult) => {
+                      settledActionResults.push(actionResult);
+                    },
+                    onStreamChunk: opts?.onChunk
+                      ? async (
+                          chunk: string,
+                          _messageId?: string,
+                          accumulated?: string,
+                        ) => {
+                          if (!chunk) return;
+                          if (isInternalStructuredStreamText(chunk)) {
+                            // A native planner/tool step, not visible reply text:
+                            // fork it onto the working indicator + inline tool row
+                            // instead of leaking JSON into the bubble.
+                            const events =
+                              chatEventsFromStructuredStreamText(chunk);
+                            if (events?.status) emitStatus(events.status);
+                            if (events?.toolEvent) {
+                              opts?.onToolEvent?.(events.toolEvent);
+                            }
+                            return;
+                          }
+                          if (!claimStreamSource("onStreamChunk")) return;
+                          appendIncomingText(chunk, accumulated);
+                        }
+                      : undefined,
+                  },
+                ),
+              { phase: "message" },
+            );
+          } catch (error) {
+            const recovery = recoverSettledMutatingActionTurn(
+              runtime,
+              settledActionResults,
+            );
+            if (!recovery) throw error;
+            responseText = recovery.text;
+            result = {
+              didRespond: true,
+              responseContent: {
+                text: recovery.text,
+                ...(recovery.actionNames.length > 0
+                  ? { actions: recovery.actionNames }
+                  : {}),
+              },
+              responseMessages: [],
+              actionResults: recovery.actionResults,
+              mode: "actions",
+            } as typeof result;
+            runtime.logger.warn(
+              {
+                src: "eliza-api",
+                messageId: message.id,
+                roomId: message.roomId,
+                actionNames: recovery.actionNames,
+                error: getErrorMessage(error),
+              },
+              "Recovered a settled mutating action after message processing stopped",
+            );
+          }
           // A successful return preserves the completed model/message result,
           // but it is not permission to start optional post-processing after a
           // disconnect. The remaining path finalizes that result and only runs

--- a/packages/agent/src/api/fallback-action-helpers.test.ts
+++ b/packages/agent/src/api/fallback-action-helpers.test.ts
@@ -6,7 +6,12 @@
  * mocks; no live model.
  */
 import type { Action, AgentRuntime } from "@elizaos/core";
-import { createMessageMemory, ModelType, stringToUuid } from "@elizaos/core";
+import {
+  createMessageMemory,
+  EventType,
+  ModelType,
+  stringToUuid,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { executeFallbackParsedActions } from "./fallback-action-helpers.ts";
 
@@ -168,5 +173,62 @@ describe("executeFallbackParsedActions", () => {
       undefined,
     );
     expect(appended).toEqual(["I enabled the block."]);
+  });
+
+  it("does not enter the action handler when cancellation wins during preflight", async () => {
+    const caller = new AbortController();
+    const handler = vi.fn(async () => ({ success: true, text: "committed" }));
+    const action: Action = {
+      name: "CANCELLED_FALLBACK",
+      description: "An action whose validation races with cancellation.",
+      validate: vi.fn(async () => {
+        caller.abort(new DOMException("socket closed", "AbortError"));
+        return true;
+      }),
+      handler,
+    };
+    const runtime = {
+      agentId: stringToUuid("cancelled-fallback-agent"),
+      actions: [action],
+      character: { name: "Example" },
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      getRoom: vi.fn(async () => null),
+      getWorld: vi.fn(async () => null),
+      getSetting: vi.fn(() => undefined),
+      getService: vi.fn(() => null),
+      emitEvent: vi.fn(async () => undefined),
+      useModel: vi.fn(),
+    } as unknown as AgentRuntime;
+    const appended: string[] = [];
+
+    const executions = await executeFallbackParsedActions(
+      runtime,
+      createMessageMemory({
+        id: stringToUuid("cancelled-fallback-message"),
+        entityId: stringToUuid("cancelled-fallback-user"),
+        roomId: stringToUuid("cancelled-fallback-room"),
+        content: { text: "run it", source: "test" },
+      }),
+      [{ name: action.name }],
+      (incoming) => appended.push(incoming),
+      vi.fn(),
+      { abortSignal: caller.signal },
+    );
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(runtime.useModel).not.toHaveBeenCalled();
+    expect(runtime.emitEvent).not.toHaveBeenCalledWith(
+      EventType.ACTION_STARTED,
+      expect.anything(),
+    );
+    expect(appended).toEqual([]);
+    expect(executions).toEqual([
+      { actionName: "CANCELLED_FALLBACK", success: false },
+    ]);
   });
 });

--- a/packages/agent/src/api/fallback-action-helpers.ts
+++ b/packages/agent/src/api/fallback-action-helpers.ts
@@ -29,6 +29,7 @@ async function rewriteFallbackActionText(args: {
   actionName: string;
   text: string;
   content?: Content;
+  abortSignal?: AbortSignal;
 }): Promise<string> {
   const text = args.text.trim();
   if (!text) return args.text;
@@ -39,7 +40,12 @@ async function rewriteFallbackActionText(args: {
         : "";
     return `I ran ${args.actionName} and got a result, but I couldn't format the details cleanly here.${error}`;
   };
-  if (typeof args.runtime.useModel !== "function") return fallback();
+  if (
+    args.abortSignal?.aborted ||
+    typeof args.runtime.useModel !== "function"
+  ) {
+    return fallback();
+  }
 
   try {
     const raw = await args.runtime.useModel(ModelType.TEXT_SMALL, {
@@ -69,6 +75,7 @@ async function rewriteFallbackActionText(args: {
         })}`,
       ].join("\n"),
       maxTokens: 260,
+      signal: args.abortSignal,
       providerOptions: { eliza: { thinking: "off" } },
     });
     const parsed = JSON.parse(String(raw).trim()) as { response?: unknown };
@@ -142,6 +149,7 @@ export async function executeFallbackParsedActions(
   appendIncomingText: (incoming: string) => void,
   onActionCallback: (actionTag: string, hasText: boolean) => void,
   options?: {
+    abortSignal?: AbortSignal;
     getCurrentText?: () => string;
     onCallbackText?: (incoming: string) => void;
   },
@@ -164,6 +172,7 @@ export async function executeFallbackParsedActions(
   }
 
   for (const parsed of parsedActions) {
+    if (options?.abortSignal?.aborted) break;
     if (
       parsed.name === "REPLY" ||
       parsed.name === "NONE" ||
@@ -178,13 +187,33 @@ export async function executeFallbackParsedActions(
     const action =
       (await resolveBuiltInFallbackAction(parsed.name)) ??
       lookup.get(parsed.name);
+    if (options?.abortSignal?.aborted) break;
     if (!action || typeof action.handler !== "function") continue;
+    const actionHandler = action.handler;
     const parsedParameters = { ...(parsed.parameters ?? {}) };
     if (action.name === "BLOCK" && !Object.hasOwn(parsedParameters, "action")) {
       parsedParameters.action = "block";
     }
 
     let callbackSeen = false;
+    const actionValidate = action.validate;
+    const abortAwareAction = options?.abortSignal
+      ? {
+          ...action,
+          validate: async (
+            ...args: Parameters<NonNullable<Action["validate"]>>
+          ) => {
+            options.abortSignal?.throwIfAborted();
+            const valid = actionValidate ? await actionValidate(...args) : true;
+            options.abortSignal?.throwIfAborted();
+            return valid;
+          },
+          handler: (...args: Parameters<NonNullable<Action["handler"]>>) => {
+            options.abortSignal?.throwIfAborted();
+            return actionHandler(...args);
+          },
+        }
+      : action;
     const actionResult = await executePlannedToolCall(
       runtime,
       {
@@ -213,6 +242,7 @@ export async function executeFallbackParsedActions(
               actionName: actionTag,
               text: chunk,
               content: contentRecord as Content,
+              abortSignal: options?.abortSignal,
             });
             (options?.onCallbackText ?? appendIncomingText)(voicedChunk);
           }
@@ -220,7 +250,10 @@ export async function executeFallbackParsedActions(
         },
       },
       { name: action.name, params: parsedParameters },
-      { actions: [action] },
+      {
+        actions: [abortAwareAction],
+        abortSignal: options?.abortSignal,
+      },
     );
     const actionSucceeded = Boolean(
       actionResult &&
@@ -235,6 +268,7 @@ export async function executeFallbackParsedActions(
           : parsed.name,
       success: actionSucceeded,
     });
+    if (options?.abortSignal?.aborted && !actionSucceeded) break;
     if (!callbackSeen) {
       const currentText = options?.getCurrentText?.() ?? "";
       const fallbackText =
@@ -258,6 +292,7 @@ export async function executeFallbackParsedActions(
             runtime,
             actionName: parsed.name,
             text: fallbackText,
+            abortSignal: options?.abortSignal,
           });
           appendIncomingText(
             currentText.trim().length > 0

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -3625,6 +3625,7 @@ describe("runV5MessageRuntimeStage1", () => {
 			},
 		] as IAgentRuntime["actions"];
 		const earlyReply = vi.fn(async () => undefined);
+		const onSettledActionResult = vi.fn();
 
 		const result = await runV5MessageRuntimeStage1({
 			runtime,
@@ -3632,12 +3633,22 @@ describe("runV5MessageRuntimeStage1", () => {
 			state: makeState(),
 			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
 			onResponseHandlerEarlyReply: earlyReply,
+			onSettledActionResult,
 		});
 
 		expect(earlyReply).toHaveBeenCalledWith(
 			expect.objectContaining({ text: "On it." }),
 		);
 		expect(result.kind).toBe("planned_reply");
+		expect(onSettledActionResult).toHaveBeenCalledTimes(1);
+		expect(onSettledActionResult).toHaveBeenCalledWith(
+			expect.objectContaining({
+				success: true,
+				effectReceipts: [
+					expect.objectContaining({ receiptId: "receipt-reminder-1" }),
+				],
+			}),
+		);
 		if (result.kind === "planned_reply") {
 			expect(result.result.responseContent?.text).toBe(canonicalText);
 			expect(result.result.responseContent?.effectReceiptIds).toEqual([

--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -152,6 +152,35 @@ describe("executePlannedToolCall", () => {
 		expect(handler).not.toHaveBeenCalled();
 	});
 
+	it("does not start an action or publish a settlement when cancellation wins during validation", async () => {
+		const abortController = new AbortController();
+		const abortReason = new Error("transport disconnected before commit");
+		const handler = vi.fn(async () => ({ success: true }));
+		const onSettledResult = vi.fn();
+		const action = makeAction({
+			name: "CREATE_TASK",
+			validate: async () => {
+				abortController.abort(abortReason);
+				return true;
+			},
+			handler,
+		});
+
+		await expect(
+			executePlannedToolCall(
+				makeRuntime([action]),
+				{ message: makeMessage() },
+				{ name: action.name, params: {} },
+				{
+					abortSignal: abortController.signal,
+					onSettledResult,
+				},
+			),
+		).rejects.toBe(abortReason);
+		expect(handler).not.toHaveBeenCalled();
+		expect(onSettledResult).not.toHaveBeenCalled();
+	});
+
 	it("drops undeclared planner wrapper args without weakening strict validation", async () => {
 		const handler = vi.fn(async () => ({ success: true }));
 		const action = makeAction({
@@ -1129,6 +1158,7 @@ describe("executePlannedToolCall", () => {
 	it("suppresses sensitive action result data in ACTION_COMPLETED events", async () => {
 		const emitEvent = vi.fn(async () => {});
 		const onToolResult = vi.fn();
+		const onSettledResult = vi.fn();
 		const action = makeAction({
 			name: "DECLARE_SUB_AGENT_CREDENTIAL_SCOPE",
 			suppressActionResultClipboard: true,
@@ -1151,6 +1181,7 @@ describe("executePlannedToolCall", () => {
 					runtime,
 					{ message: makeMessage() },
 					{ name: "DECLARE_SUB_AGENT_CREDENTIAL_SCOPE", params: {} },
+					{ onSettledResult },
 				),
 		);
 
@@ -1197,6 +1228,14 @@ describe("executePlannedToolCall", () => {
 			}),
 		);
 		expect(JSON.stringify(onToolResult.mock.calls)).not.toContain(
+			"secret-token",
+		);
+		expect(onSettledResult).toHaveBeenCalledWith({
+			success: true,
+			text: "declared",
+			data: { actionName: "DECLARE_SUB_AGENT_CREDENTIAL_SCOPE" },
+		});
+		expect(JSON.stringify(onSettledResult.mock.calls)).not.toContain(
 			"secret-token",
 		);
 	});
@@ -1283,6 +1322,7 @@ describe("executePlannedToolCall", () => {
 		let participants = [owner, agent];
 		const emitEvent = vi.fn(async () => {});
 		const onToolResult = vi.fn();
+		const onSettledResult = vi.fn();
 		const callback = vi.fn(async () => []);
 		const action = makeAction({
 			name: "OWNER_PRIVATE",
@@ -1327,6 +1367,7 @@ describe("executePlannedToolCall", () => {
 					runtime,
 					{ message: turn, callback, userRoles: ["OWNER"] },
 					{ name: action.name, params: {} },
+					{ onSettledResult },
 				),
 		);
 
@@ -1346,10 +1387,15 @@ describe("executePlannedToolCall", () => {
 		const observable = JSON.stringify({
 			callback: callback.mock.calls,
 			events: emitEvent.mock.calls,
+			settlement: onSettledResult.mock.calls,
 			streaming: onToolResult.mock.calls,
 			result,
 		});
 		expect(observable).not.toContain("OWNER_PRIVATE_CANARY");
+		expect(onSettledResult).toHaveBeenCalledWith({
+			success: true,
+			data: { actionName: "OWNER_PRIVATE" },
+		});
 	});
 
 	it("emits failed ACTION_COMPLETED events with string errors for thrown handlers", async () => {

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -261,6 +261,8 @@ function publishSettledResult(
 				actionName: action.name,
 			});
 		} catch (reportingError) {
+			// error-policy:J7 diagnostics failure is logged locally because the
+			// already-settled action result must remain authoritative to callers.
 			runtime.logger.error(
 				{
 					src: "execute-planned-tool-call",

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -71,6 +71,14 @@ export interface ExecutePlannedToolCallContext {
 export type ExecutePlannedToolCallOptions = HandlerOptions & {
 	actions?: readonly Action[];
 	onStreamChunk?: StreamChunkCallback;
+	abortSignal?: AbortSignal;
+	/**
+	 * Observes the normalized handler result immediately after settlement and
+	 * before post-execution bookkeeping can fail. Sensitive and owner-exclusive
+	 * payloads are projected before observation. The observer is isolated from
+	 * action execution and is never forwarded into HandlerOptions.
+	 */
+	onSettledResult?: (result: ActionResult) => void;
 };
 
 function isContentRecord(value: unknown): value is Record<string, unknown> {
@@ -162,6 +170,14 @@ export function projectActionResultForClipboard(
 			? result.data.actionName
 			: undefined;
 	const safeActionName = actionName ?? resultActionName;
+	const safeControlData = {
+		...(safeActionName ? { actionName: safeActionName } : {}),
+		...(result.data?.outcomeUnknown === true ? { outcomeUnknown: true } : {}),
+		...(result.data?.retryable === false ? { retryable: false } : {}),
+		...(result.data?.reconciliationRequired === true
+			? { reconciliationRequired: true }
+			: {}),
+	};
 	return {
 		success: result.success,
 		...(result.text !== undefined ? { text: result.text } : {}),
@@ -182,7 +198,9 @@ export function projectActionResultForClipboard(
 					userFacingEffectReceiptIds: result.userFacingEffectReceiptIds,
 				}
 			: {}),
-		...(safeActionName ? { data: { actionName: safeActionName } } : {}),
+		...(Object.keys(safeControlData).length > 0
+			? { data: safeControlData }
+			: {}),
 		...(result.turnComplete !== undefined
 			? { turnComplete: result.turnComplete }
 			: {}),
@@ -190,6 +208,70 @@ export function projectActionResultForClipboard(
 			? { continueChain: result.continueChain }
 			: {}),
 	};
+}
+
+function projectSettledResultForObserver(
+	action: Action,
+	result: ActionResult,
+): ActionResult {
+	const projected = projectActionResultForClipboard(
+		action,
+		result,
+		action.name,
+	);
+	if (action.disclosureGate?.require !== "owner_exclusive") return projected;
+	const controlData = {
+		actionName: action.name,
+		...(result.data?.outcomeUnknown === true ? { outcomeUnknown: true } : {}),
+		...(result.data?.retryable === false ? { retryable: false } : {}),
+		...(result.data?.reconciliationRequired === true
+			? { reconciliationRequired: true }
+			: {}),
+	};
+
+	return {
+		success: projected.success,
+		...(projected.effectReceipts !== undefined
+			? { effectReceipts: projected.effectReceipts }
+			: {}),
+		data: controlData,
+		...(projected.turnComplete !== undefined
+			? { turnComplete: projected.turnComplete }
+			: {}),
+		...(projected.continueChain !== undefined
+			? { continueChain: projected.continueChain }
+			: {}),
+	};
+}
+
+function publishSettledResult(
+	runtime: IAgentRuntime,
+	action: Action,
+	result: ActionResult,
+	observer: ((result: ActionResult) => void) | undefined,
+): void {
+	if (!observer) return;
+	try {
+		observer(projectSettledResultForObserver(action, result));
+	} catch (error) {
+		// error-policy:J7 completion observers provide durability bookkeeping;
+		// they must remain observable without changing the settled action result.
+		try {
+			runtime.reportError("ActionSettlementObserver", error, {
+				actionName: action.name,
+			});
+		} catch (reportingError) {
+			runtime.logger.error(
+				{
+					src: "execute-planned-tool-call",
+					action: action.name,
+					error: stringifyError(error),
+					reportingError: stringifyError(reportingError),
+				},
+				"Action settlement observer and error reporting both failed",
+			);
+		}
+	}
 }
 
 function readMetadataString(message: Memory, key: string): string | undefined {
@@ -260,6 +342,7 @@ export async function executePlannedToolCall(
 	toolCall: PlannerToolCall | PlannedToolCall,
 	options: ExecutePlannedToolCallOptions = {},
 ): Promise<ActionResult> {
+	options.abortSignal?.throwIfAborted();
 	const action = (options.actions ?? runtime.actions).find(
 		(candidate) => candidate.name === toolCall.name,
 	);
@@ -321,7 +404,11 @@ export async function executePlannedToolCall(
 		action.parameters && action.parameters.length > 0
 			? (validation.args as ActionParameters | undefined)
 			: undefined;
-	const { actions: _scopedActions, ...handlerOptionOverrides } = options;
+	const {
+		actions: _scopedActions,
+		onSettledResult,
+		...handlerOptionOverrides
+	} = options;
 	const handlerOptions: HandlerOptions = {
 		...handlerOptionOverrides,
 		parameters,
@@ -379,6 +466,7 @@ export async function executePlannedToolCall(
 			),
 		);
 	}
+	options.abortSignal?.throwIfAborted();
 
 	const messageId = executorCtx.message.id as UUID | undefined;
 	const roomId = executorCtx.message.roomId as UUID;
@@ -448,6 +536,7 @@ export async function executePlannedToolCall(
 				runtime,
 				executorCtx.message,
 				async () => {
+					options.abortSignal?.throwIfAborted();
 					// Egress (#10469): this is the true execution boundary. Restore real
 					// secrets into the handler args ONLY here — the model, transcripts, logs,
 					// and trajectory upstream kept the placeholders. Fail loud if the model
@@ -492,6 +581,9 @@ export async function executePlannedToolCall(
 				},
 			),
 	});
+	// The handler result is the completion barrier. Publish it before event
+	// emission or disclosure revalidation can strand a committed side effect.
+	publishSettledResult(runtime, action, resultForEvent, onSettledResult);
 	if (ownerExclusive) {
 		const disclosure = await revalidateOwnerExclusiveDisclosure(
 			runtime,
@@ -554,7 +646,6 @@ export async function executePlannedToolCall(
 			});
 		}
 	}
-
 	return emitToolResult(toolCall, resultForEvent, {
 		suppressData: suppressActionResult,
 	});

--- a/packages/core/src/services/message.shortcut-gate.test.ts
+++ b/packages/core/src/services/message.shortcut-gate.test.ts
@@ -12,6 +12,7 @@ import {
 	runWithStreamingContext,
 } from "../streaming-context";
 import type { Action } from "../types/components";
+import type { EffectReceipt } from "../types/effects";
 import { EventType } from "../types/events";
 import type { Memory, State, UUID } from "../types/index";
 import { runShortcutGate } from "./message";
@@ -123,6 +124,60 @@ describe("runShortcutGate (#8791 pre-LLM gate)", () => {
 			EventType.ACTION_COMPLETED,
 			EventType.SLASH_COMMAND_INVOKED,
 		]);
+	});
+
+	it("publishes a receipt-backed shortcut settlement before later turn work", async () => {
+		const receipt: EffectReceipt = {
+			receiptId: "receipt-shortcut-create-1",
+			operation: "test.shortcut.create",
+			resource: { kind: "test.shortcut", id: "created-1" },
+			artifacts: [],
+			idempotency: { key: "shortcut-create-1", replayed: false },
+			observedAt: "2026-07-31T19:00:00.000Z",
+			outcome: "applied",
+			commit: {
+				kind: "durable",
+				id: "created-1",
+				committedAt: "2026-07-31T19:00:00.000Z",
+			},
+		};
+		const text = "Shortcut item created.";
+		const action = echoAction();
+		action.tags = ["capability:write", "effect:receipt-required"];
+		action.handler = async (_rt, _message, _state, _options, callback) => {
+			await callback?.({ text });
+			return {
+				success: true,
+				text,
+				userFacingText: text,
+				verifiedUserFacing: true,
+				effectReceipts: [receipt],
+				userFacingEffectReceiptIds: [receipt.receiptId],
+			};
+		};
+		const onSettledActionResult = vi.fn();
+		const { runtime } = makeRuntime({ actions: [action] });
+
+		const result = await runShortcutGate({
+			// biome-ignore lint/suspicious/noExplicitAny: minimal fake runtime
+			runtime: runtime as any,
+			message: msg("/echo create"),
+			state: {} as State,
+			responseId,
+			senderRole: "OWNER",
+			onSettledActionResult,
+		});
+
+		expect(result?.kind).toBe("direct_reply");
+		expect(onSettledActionResult).toHaveBeenCalledTimes(1);
+		expect(onSettledActionResult).toHaveBeenCalledWith(
+			expect.objectContaining({
+				success: true,
+				effectReceipts: [
+					expect.objectContaining({ receiptId: receipt.receiptId }),
+				],
+			}),
+		);
 	});
 
 	it("returns null for a non-command message (turn proceeds to the LLM)", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1381,6 +1381,7 @@ type ResolvedMessageOptions = {
 	 * in-flight inference. Sourced from `MessageProcessingOptions.abortSignal`.
 	 */
 	abortSignal?: AbortSignal;
+	onSettledActionResult?: (result: ActionResult) => void;
 };
 
 function normalizeShouldRespondModelType(
@@ -6134,6 +6135,7 @@ async function runDeterministicPlannerFallback(args: {
 	trajectoryId?: string;
 	plannerLoopConfig?: PlannerLoopParams["config"];
 	callback?: HandlerCallback;
+	onSettledActionResult?: (result: ActionResult) => void;
 	plannerError: unknown;
 }): Promise<PlannerLoopResult | null> {
 	const requiredToolMiss = isRequiredToolMissLimit(args.plannerError);
@@ -6216,7 +6218,12 @@ async function runDeterministicPlannerFallback(args: {
 			...(args.callback ? { callback: args.callback } : {}),
 		}),
 		plannerRuntime: args.plannerRuntime,
-		executorOptions: { actions: args.actions },
+		executorOptions: {
+			actions: args.actions,
+			...(args.onSettledActionResult
+				? { onSettledResult: args.onSettledActionResult }
+				: {}),
+		},
 		evaluatorEffects: args.evaluatorEffects,
 		recorder: args.recorder,
 		trajectoryId: args.trajectoryId,
@@ -6816,6 +6823,7 @@ export async function runShortcutGate(args: {
 	state: State;
 	responseId: UUID;
 	senderRole: RoleGateRole;
+	onSettledActionResult?: (result: ActionResult) => void;
 }): Promise<V5MessageRuntimeStage1Result | null> {
 	if (process.env.ELIZA_SHORTCUTS_DISABLED === "1") return null;
 	const text = getUserMessageText(args.message) ?? "";
@@ -6863,7 +6871,12 @@ export async function runShortcutGate(args: {
 			name: action.name,
 			params: { ...target.parameters, ...match.parameters },
 		},
-		{ actions: [action] },
+		{
+			actions: [action],
+			...(args.onSettledActionResult
+				? { onSettledResult: args.onSettledActionResult }
+				: {}),
+		},
 	);
 	if (captured === undefined) {
 		const executionError = shortcutActionResult.data?.error;
@@ -6994,6 +7007,7 @@ export async function runV5MessageRuntimeStage1(args: {
 	callback?: HandlerCallback;
 	deliveredVisibleTexts?: Set<string>;
 	plannerLoopConfig?: PlannerLoopParams["config"];
+	onSettledActionResult?: (result: ActionResult) => void;
 	onResponseHandlerEarlyReply?: (
 		event: ResponseHandlerEarlyReplyEvent,
 	) => Promise<void> | void;
@@ -8171,7 +8185,14 @@ export async function runV5MessageRuntimeStage1(args: {
 											: {}),
 									}),
 									plannerRuntime,
-									executorOptions: { actions: exposedPlannerActions },
+									executorOptions: {
+										actions: exposedPlannerActions,
+										...(args.onSettledActionResult
+											? {
+													onSettledResult: args.onSettledActionResult,
+												}
+											: {}),
+									},
 									evaluatorEffects,
 									recorder,
 									trajectoryId,
@@ -8212,6 +8233,9 @@ export async function runV5MessageRuntimeStage1(args: {
 				trajectoryId,
 				plannerLoopConfig: args.plannerLoopConfig,
 				...(recordingCallback ? { callback: recordingCallback } : {}),
+				...(args.onSettledActionResult
+					? { onSettledActionResult: args.onSettledActionResult }
+					: {}),
 				plannerError: error,
 			});
 			if (!fallbackResult) {
@@ -10576,6 +10600,11 @@ export class DefaultMessageService implements IMessageService {
 						),
 					shouldRespondModel: resolvedShouldRespondModel,
 					...(options?.abortSignal ? { abortSignal: options.abortSignal } : {}),
+					...(options?.onSettledActionResult
+						? {
+								onSettledActionResult: options.onSettledActionResult,
+							}
+						: {}),
 				};
 
 				const deliveredVisibleTexts = new Set<string>();
@@ -11385,6 +11414,9 @@ export class DefaultMessageService implements IMessageService {
 				state,
 				responseId,
 				senderRole: shortcutSenderRole,
+				...(opts.onSettledActionResult
+					? { onSettledActionResult: opts.onSettledActionResult }
+					: {}),
 			});
 			if (shortcutOutcome && shortcutOutcome.kind === "direct_reply") {
 				strategyResult = shortcutOutcome.result;
@@ -11413,6 +11445,11 @@ export class DefaultMessageService implements IMessageService {
 							responseId,
 							...(callback ? { callback } : {}),
 							deliveredVisibleTexts,
+							...(opts.onSettledActionResult
+								? {
+										onSettledActionResult: opts.onSettledActionResult,
+									}
+								: {}),
 							onResponseHandlerEarlyReply: deliverResponseHandlerEarlyReply,
 						}),
 					),

--- a/packages/core/src/types/message-service.ts
+++ b/packages/core/src/types/message-service.ts
@@ -35,6 +35,11 @@ export interface MessageProcessingOptions {
 	/** Signal to abort message processing */
 	abortSignal?: AbortSignal;
 	/**
+	 * Receives each action result as soon as its handler boundary settles. Hosts
+	 * use this to retain committed-effect knowledge if later turn work aborts.
+	 */
+	onSettledActionResult?: (result: ActionResult) => void;
+	/**
 	 * When true, do not discard responses when a newer message is being processed (same as BASIC_CAPABILITIES_KEEP_RESP).
 	 * @default resolved from runtime.getSetting("BASIC_CAPABILITIES_KEEP_RESP") if not set
 	 */


### PR DESCRIPTION
Fixes #17466.

## Root cause

`#17436` correctly propagated transport cancellation into unfinished chat work, but several post-operation `throwIfAborted()` checks could discard a result that had already returned successfully. In the conversation SSE path that leaves no bound terminal outcome, releases the `clientMessageId`, and lets the reconnect execute and bill the completed turn again. The same ordering risk affected local-direct model results, direct pre-handler replies, and committed direct actions.

Removing those checks exposed a second boundary: `handleMessage` can return an executable fallback action payload. Its model result must survive a late disconnect, but the API must not interpret that completed result as permission to start a new fallback action after cancellation. The repaired boundary preserves completed work, fails unstarted fallback actions closed, and continues only pure/durable finalization.

A deeper audit found that action effect receipts were transient results, not durable replay records: if a planner or shortcut action settled and `DefaultMessageService` later aborted or threw, the route still had no outcome to bind and could repeat the external effect. The executor now publishes a privacy-projected settlement checkpoint synchronously at the handler completion barrier, before event emission or disclosure revalidation. The route uses applied receipts, terminal reconciliation results, or mutation capability tags as fail-closed proof; only receipt-verified text is replayed exactly.

Confirmed develop failures:

- [Tests run 30651472223, Server Tests job 91225793055](https://github.com/elizaOS/eliza/actions/runs/30651472223/job/91225793055)
- [Tests run 30656416185, Server Tests job 91243170836](https://github.com/elizaOS/eliza/actions/runs/30656416185/job/91243170836)

Both failed the same `conversation-idempotency` assertion: 21/22 passed, while `completed turn survives transport disconnect` observed two `handleMessage` calls.

## Change

- Preserve successful message/model/pre-handler/action returns across late transport cancellation so persistence and exact-key replay complete once.
- Never start fallback actions after cancellation; guard both action validation and the real handler so a cancellation racing during preflight cannot cross the execution boundary.
- Fail an unstarted fallback payload closed with an explicit durable `No side effects were applied` outcome, which reconnects replay without another model turn.
- Skip optional post-result work after cancellation: fallback/direct-action voice models, synthetic `MESSAGE_SENT` hooks, and exact-document lookup. Required persistence/idempotency finalization remains transport-independent.
- Keep cancellation checks before local-command work and after paths report `not handled`; unfinished message/pre-handler work still receives the owner signal.
- Thread settled-action checkpoints through planner execution, deterministic planner fallback, nested planner calls, and `runShortcutGate`; sensitive and owner-exclusive payloads remain projected.
- Persist a terminal conversation outcome when later message-service work aborts or throws after a mutating action settles, preventing same-key retries from repeating the side effect.

## Verification

Exact base: `fda23a875638b1a693cd72f248acac29aa10a640`  
Exact head: `21f39bb5d0700150bc36c98506ac1a390201f4c9`

- Before fix on develop: exact route test failed 10/10 attempts; expected one `handleMessage`, observed two.
- Original completed-turn race plus the executable-fallback abort race remain green.
- Real receipt-backed planner action followed by transport abort and by an ordinary message-service exception both replay without a second handler call; the two adversarial cases passed 5 repeated isolated runs each.
- Agent focused files passed independently: idempotency 25/25, streaming 39/39, fallback helper 3/3.
- Core focused files passed independently: executor 54/54, planner Stage-1 102/102, shortcut gate 14/14.
- Package-order runner: batches 1-47 passed one file per process, including the 23-test idempotency batch and 39-test streaming batch; fallback helper and its neighboring batches 92-94 also passed.
- `bun run --cwd packages/core build`: passed for Node, browser, edge, testing, and declarations.
- `bun run --cwd packages/agent build`: passed.
- `bun run --cwd packages/core lint`: 1,130 files clean.
- `bun run --cwd packages/agent lint`: 798 files clean.
- `bun run --cwd packages/core typecheck`: passed.
- `bun run --cwd packages/agent typecheck`: passed.
- `git diff --check`: passed.

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend transport/idempotency lifecycle; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend transport/idempotency lifecycle; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-interface flow changed; exact route behavior is covered by the linked workflow logs and deterministic route harness

<!-- evidence-row:backend-logs -->
- [x] [First develop Server Tests failure](https://github.com/elizaOS/eliza/actions/runs/30651472223/job/91225793055) and [second develop Server Tests failure](https://github.com/elizaOS/eliza/actions/runs/30656416185/job/91243170836)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or runtime changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, provider, model selection, or model output behavior changed; this fixes ownership after terminal operations return

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no external artifact is produced; route tests assert durable assistant memory, stable clientMessageId replay, no fallback handler call, and exactly one message-service invocation

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence or rendered surface