### PR TITLE
feat(slack): bridge Slack reactions to core REACTION_RECEIVED

### DIFF
--- a/plugins/plugin-slack/src/reaction-bridge.test.ts
+++ b/plugins/plugin-slack/src/reaction-bridge.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Production-path proof for the Slack reaction bridge.
+ *
+ * These tests drive the REAL handlers that `registerEventHandlers` binds to
+ * the bolt app (`app.event("reaction_added" | "reaction_removed")`), not a
+ * helper, so they cannot drift onto dead code.
+ *
+ * The central assertion is bidirectional: a Slack reaction must reach the core
+ * event bus as `EventType.REACTION_RECEIVED`. On unfixed develop the handler
+ * takes `_event`, throws the reaction data away, and emits only the
+ * plugin-local `SLACK_REACTION_ADDED` with an empty payload — nothing in core
+ * consumes that name, so those cases fail. With the bridge wired in they pass.
+ */
+import { EventType, type IAgentRuntime, type Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ResolvedSlackAccount } from "./accounts";
+import { SlackService } from "./service";
+import type { SlackChannel, SlackSettings, SlackUser } from "./types";
+import { SlackEventTypes } from "./types";
+
+const BOT_USER_ID = "U0BOTBOT0";
+const CHANNEL_ID = "C0123ABCD";
+const REACTOR_ID = "U0REACTOR";
+const AUTHOR_ID = "U0AUTHOR0";
+const MESSAGE_TS = "1700000000.000100";
+const THREAD_TS = "1699999999.000001";
+
+interface HarnessOptions {
+  /** Memories the runtime already knows about, keyed by memory UUID. */
+  memories?: Map<string, Memory>;
+  /** Rooms the runtime already knows about, keyed by room UUID. */
+  rooms?: Map<string, { id: string }>;
+  allowedChannelIds?: string[];
+  existingEntity?: boolean;
+}
+
+function createRuntime(
+  memories: Map<string, Memory>,
+  rooms: Map<string, { id: string }>,
+) {
+  return {
+    agentId: "agent-slack-reactions",
+    character: { name: "Salem", settings: {} },
+    logger: {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    getSetting: vi.fn().mockReturnValue(undefined),
+    emitEvent: vi.fn(),
+    createMemory: vi.fn(),
+    createMemories: vi.fn(),
+    createEntity: vi.fn(),
+    getMemoryById: vi.fn(async (id: string) => memories.get(id) ?? null),
+    getEntityById: vi.fn().mockResolvedValue({ id: "entity-existing" }),
+    // A real room store keyed by UUID, NOT a canned room. A blanket
+    // `mockResolvedValue({ id: "room-existing" })` makes `ensureRoomExists`
+    // short-circuit on its `getRoom(roomId)` hit and hand back a room whose id
+    // never came from `createUniqueUuid`, so the room-mapping the bridge is
+    // supposed to reuse is never exercised and the assertion tests nothing.
+    // Backing it with a Map means an unseen channel misses, falls through to
+    // the real `getRoomId` + `createRoom` path, and the id under test is the
+    // one production would compute.
+    getRoom: vi.fn(async (id: string) => rooms.get(id) ?? null),
+    createRoom: vi.fn(async (room: { id: string }) => {
+      rooms.set(room.id, room);
+      return room;
+    }),
+    getWorld: vi.fn().mockResolvedValue({ id: "world-1" }),
+    createWorld: vi.fn(),
+  } as unknown as IAgentRuntime;
+}
+
+/**
+ * Builds a SlackService wired the way `startAccount` wires it and returns the
+ * reaction handlers `registerEventHandlers` actually binds to the bolt app.
+ */
+function createHarness(options: HarnessOptions = {}) {
+  const memories = options.memories ?? new Map<string, Memory>();
+  const rooms = options.rooms ?? new Map<string, { id: string }>();
+  const runtime = createRuntime(memories, rooms);
+  const service = Object.create(SlackService.prototype) as SlackService;
+
+  const settings: SlackSettings = {
+    allowedChannelIds: options.allowedChannelIds,
+    shouldIgnoreBotMessages: true,
+    shouldRespondOnlyToMentions: false,
+  };
+
+  const account = {
+    accountId: "default",
+    enabled: true,
+    role: "AGENT",
+    botToken: "xoxb-test",
+    appToken: "xapp-test",
+    botTokenSource: "config",
+    appTokenSource: "config",
+    config: {},
+  } as unknown as ResolvedSlackAccount;
+
+  const allowedChannelIds = new Set<string>(options.allowedChannelIds ?? []);
+
+  const state = {
+    accountId: "default",
+    account,
+    app: {} as never,
+    client: {} as never,
+    userClient: null,
+    botUserId: BOT_USER_ID,
+    teamId: "T0TEAM000",
+    settings,
+    allowedChannelIds,
+    dynamicChannelIds: new Set<string>(),
+    userCache: new Map<string, SlackUser>(),
+    channelCache: new Map<string, SlackChannel>(),
+    isConnected: true,
+  };
+
+  Object.assign(service, {
+    runtime,
+    character: runtime.character,
+    settings,
+    defaultAccountId: "default",
+    accountStates: new Map([["default", state]]),
+    accountStarts: new Map(),
+    allowedChannelIds,
+    dynamicChannelIds: new Set<string>(),
+    userCache: new Map(),
+    channelCache: new Map(),
+    botUserId: BOT_USER_ID,
+    teamId: "T0TEAM000",
+    isConnected: true,
+  });
+
+  // Stub only the Slack-network edges; all ID/room/entity mapping stays real
+  // so the test proves reactions land on the same UUIDs as messages.
+  const sendMessage = vi.fn().mockResolvedValue({ ts: "1", channelId: "C" });
+  Object.assign(service, {
+    getUser: vi.fn().mockResolvedValue(null),
+    getChannel: vi.fn().mockResolvedValue(null),
+    sendMessage,
+  });
+
+  // Capture the handlers registered on the real bolt app surface.
+  const handlers: {
+    reactionAdded?: (args: { event: unknown }) => Promise<void>;
+    reactionRemoved?: (args: { event: unknown }) => Promise<void>;
+  } = {};
+
+  const app = {
+    message: () => {},
+    event: (name: string, fn: (args: { event: unknown }) => Promise<void>) => {
+      if (name === "reaction_added") handlers.reactionAdded = fn;
+      if (name === "reaction_removed") handlers.reactionRemoved = fn;
+    },
+  };
+
+  (
+    service as unknown as { registerEventHandlers: (s: unknown) => void }
+  ).registerEventHandlers({ ...state, app });
+
+  return { service, runtime, handlers, sendMessage, memories, rooms };
+}
+
+function reactionEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "reaction_added",
+    user: REACTOR_ID,
+    reaction: "+1",
+    item: { type: "message", channel: CHANNEL_ID, ts: MESSAGE_TS },
+    item_user: AUTHOR_ID,
+    event_ts: "1700000001.000200",
+    ...overrides,
+  };
+}
+
+/** Pulls the emitted event-name list + payload for a given event name. */
+function findEmit(runtime: IAgentRuntime, eventName: string) {
+  const calls = (runtime.emitEvent as ReturnType<typeof vi.fn>).mock.calls;
+  return calls.find(([names]) =>
+    Array.isArray(names) ? names.includes(eventName) : names === eventName,
+  );
+}
+
+describe("Slack reaction bridge — production wiring", () => {
+  it("registers handlers on the real bolt reaction_added/reaction_removed events", () => {
+    const h = createHarness();
+    expect(h.handlers.reactionAdded).toBeTypeOf("function");
+    expect(h.handlers.reactionRemoved).toBeTypeOf("function");
+  });
+
+  it("emits core EventType.REACTION_RECEIVED when a reaction is added", async () => {
+    // FAILS on develop: the handler discards the event and emits only the
+    // plugin-local SLACK_REACTION_ADDED, so the core event never fires.
+    const h = createHarness();
+
+    await h.handlers.reactionAdded?.({ event: reactionEvent() });
+
+    const emit = findEmit(h.runtime, EventType.REACTION_RECEIVED);
+    expect(emit).toBeDefined();
+  });
+
+  it("keeps the plugin-local SLACK_REACTION_ADDED event for back-compat", async () => {
+    const h = createHarness();
+
+    await h.handlers.reactionAdded?.({ event: reactionEvent() });
+
+    const emit = findEmit(h.runtime, SlackEventTypes.REACTION_ADDED as string);
+    expect(emit).toBeDefined();
+    // Both names ride on a single emit so consumers see one payload.
+    const [names] = emit as [string[], unknown];
+    expect(names).toContain(EventType.REACTION_RECEIVED);
+  });
+
+  it("carries emoji, message ts, channel, and reactor identity in the payload", async () => {
+    // FAILS on develop: buildEventPayload carries no reaction data at all.
+    const h = createHarness();
+
+    await h.handlers.reactionAdded?.({ event: reactionEvent() });
+
+    const emit = findEmit(h.runtime, EventType.REACTION_RECEIVED);
+    const payload = (emit as [string[], Record<string, unknown>])[1];
+
+    expect(payload.reaction).toBe("+1");
+    expect(payload.messageTs).toBe(MESSAGE_TS);
+    expect(payload.channelId).toBe(CHANNEL_ID);
+    expect(payload.userId).toBe(REACTOR_ID);
+    expect(payload.itemUser).toBe(AUTHOR_ID);
+    expect(payload.source).toBe("slack");
+  });
+
+  it("attaches a Memory whose entity/room match the plugin's uuid scheme", async () => {
+    const h = createHarness();
+
+    await h.handlers.reactionAdded?.({ event: reactionEvent() });
+
+    const emit = findEmit(h.runtime, EventType.REACTION_RECEIVED);
+    const payload = (emit as [string[], { message: Memory }])[1];
+    const memory = payload.message;
+
+    expect(memory).toBeDefined();
+    // Same scheme the message path uses: stringToUuid("slack-user-<id>")
+    // and createUniqueUuid("slack-room-<channel>").
+    const expectedEntityId = (
+      h.service as unknown as {
+        getEntityId: (u: string, a: string) => string;
+      }
+    ).getEntityId(REACTOR_ID, "default");
+    const expectedRoomId = await (
+      h.service as unknown as {
+        getRoomId: (c: string, t: undefined, a: string) => Promise<string>;
+      }
+    ).getRoomId(CHANNEL_ID, undefined, "default");
+
+    expect(memory.entityId).toBe(expectedEntityId);
+    expect(memory.roomId).toBe(expectedRoomId);
+    expect(memory.agentId).toBe(h.runtime.agentId);
+
+    // The channel room did not exist beforehand, so the bridge must have gone
+    // through the real `ensureRoomExists` -> `createRoom` path rather than
+    // reusing a pre-seeded room. Asserting the created room's id proves the
+    // reaction joins the same room the message path would create.
+    expect(h.runtime.createRoom).toHaveBeenCalledTimes(1);
+    const createdRoom = (h.runtime.createRoom as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as { id: string; channelId: string; source: string };
+    expect(createdRoom.id).toBe(expectedRoomId);
+    expect(createdRoom.channelId).toBe(CHANNEL_ID);
+    expect(createdRoom.source).toBe("slack");
+    expect(h.rooms.get(expectedRoomId)).toBeDefined();
+
+    const meta = memory.metadata as {
+      slackReaction?: { action?: string; emoji?: string };
+    };
+    expect(meta.slackReaction?.action).toBe("added");
+    expect(meta.slackReaction?.emoji).toBe("+1");
+  });
+
+  it("references the reacted-to message memory via inReplyTo", async () => {
+    const h = createHarness();
+
+    await h.handlers.reactionAdded?.({ event: reactionEvent() });
+
+    const emit = findEmit(h.runtime, EventType.REACTION_RECEIVED);
+    const memory = (emit as [string[], { message: Memory }])[1].message;
+
+    // The target id is deterministic from the Slack ts, so a consumer can
+    // join the reaction to the message even when the memory is absent.
+    const meta = memory.metadata as {
+      slackReaction?: { targetMessageId?: string; targetMessageTs?: string };
+    };
+    expect(meta.slackReaction?.targetMessageTs).toBe(MESSAGE_TS);
+    expect(memory.content.inReplyTo).toBe(meta.slackReaction?.targetMessageId);
+  });
+
+  it("resolves the reacted-to message text when the memory is known", async () => {
+    const memories = new Map<string, Memory>();
+    const h0 = createHarness();
+    const targetId = (
+      h0.service as unknown as {
+        scopedSlackKey: (p: string, k: string, a: string) => string;
+      }
+    ).scopedSlackKey("slack", MESSAGE_TS, "default");
+    expect(targetId).toBe(`slack-${MESSAGE_TS}`);
+
+    // Seed the target memory under the id the bridge will look up.
+    const h = createHarness({ memories });
+    const lookupId = (
+      h.service as unknown as {
+        reactionBridgeHost: () => {
+          getMessageMemoryId: (ts: string, a: string) => string;
+        };
+      }
+    )
+      .reactionBridgeHost()
+      .getMessageMemoryId(MESSAGE_TS, "default");
+
+    memories.set(lookupId, {
+      id: lookupId as never,
+      entityId: "e" as never,
+      agentId: "a" as never,
+      roomId: "room-parent" as never,
+      content: { text: "did the dishes", source: "slack" },
+      metadata: { slackMessageTs: MESSAGE_TS } as never,
+    } as Memory);
+
+    await h.handlers.reactionAdded?.({ event: reactionEvent() });
+
+    const emit = findEmit(h.runtime, EventType.REACTION_RECEIVED);
+    const memory = (emit as [string[], { message: Memory }])[1].message;
+
+    expect(memory.content.text).toContain("did the dishes");
+    expect(
+      (memory.content as { reactedMessageText?: string }).reactedMessageText,
+    ).toBe("did the dishes");
+  });
+
+  it("routes a reaction on a threaded message into that thread's room", async () => {
+    const memories = new Map<string, Memory>();
+    const h = createHarness({ memories });
+
+    const lookupId = (
+      h.service as unknown as {
+        reactionBridgeHost: () => {
+          getMessageMemoryId: (ts: string, a: string) => string;
+        };
+      }
+    )
+      .reactionBridgeHost()
+      .getMessageMemoryId(MESSAGE_TS, "default");
+
+    // The message lives in the thread room, not the channel room.
+    const threadRoomId = await (
+      h.service as unknown as {
+        getRoomId: (c: string, t: string, a: string) => Promise<string>;
+      }
+    ).getRoomId(CHANNEL_ID, THREAD_TS, "default");
+
+    memories.set(lookupId, {
+      id: lookupId as never,
+      entityId: "e" as never,
+      agentId: "a" as never,
+      roomId: threadRoomId as never,
+      content: { text: "in thread", source: "slack" },
+      metadata: { slackThreadTs: THREAD_TS } as never,
+    } as Memory);
+
+    await h.handlers.reactionAdded?.({ event: reactionEvent() });
+
+    const emit = findEmit(h.runtime, EventType.REACTION_RECEIVED);
+    const memory = (emit as [string[], { message: Memory }])[1].message;
+
+    // A reaction event carries no thread_ts; without recovery it would land
+    // in the channel room and detach from the message it reacted to.
+    const channelRoomId = await (
+      h.service as unknown as {
+        getRoomId: (c: string, t: undefined, a: string) => Promise<string>;
+      }
+    ).getRoomId(CHANNEL_ID, undefined, "default");
+
+    expect(memory.roomId).toBe(threadRoomId);
+    expect(memory.roomId).not.toBe(channelRoomId);
+    expect((memory.metadata as { slackThreadTs?: string }).slackThreadTs).toBe(
+      THREAD_TS,
+    );
+  });
+
+  it("emits SLACK_REACTION_REMOVED with full payload on removal", async () => {
+    // FAILS on develop: the removal payload carries no reaction data.
+    const h = createHarness();
+
+    await h.handlers.reactionRemoved?.({
+      event: reactionEvent({ type: "reaction_removed" }),
+    });
+
+    const emit = findEmit(
+      h.runtime,
+      SlackEventTypes.REACTION_REMOVED as string,
+    );
+    expect(emit).toBeDefined();
+
+    const payload = (emit as [string[], Record<string, unknown>])[1];
+    expect(payload.reaction).toBe("+1");
+    expect(payload.messageTs).toBe(MESSAGE_TS);
+
+    const memory = payload.message as Memory;
+    const meta = memory.metadata as { slackReaction?: { action?: string } };
+    expect(meta.slackReaction?.action).toBe("removed");
+    expect(memory.content.text).toContain("Removed");
+  });
+
+  it("does NOT emit core REACTION_RECEIVED on removal (matches plugin-discord)", async () => {
+    // Core declares no REACTION_REMOVED. plugin-discord bridges only the add
+    // to core; mirroring that keeps a platform-agnostic vote counter from
+    // double-counting on Slack while under-counting on Discord.
+    const h = createHarness();
+
+    await h.handlers.reactionRemoved?.({
+      event: reactionEvent({ type: "reaction_removed" }),
+    });
+
+    expect(findEmit(h.runtime, EventType.REACTION_RECEIVED)).toBeUndefined();
+  });
+
+  it("ignores non-message reactions (files)", async () => {
+    const h = createHarness();
+
+    await h.handlers.reactionAdded?.({
+      event: reactionEvent({
+        item: { type: "file", channel: CHANNEL_ID, ts: MESSAGE_TS },
+      }),
+    });
+
+    expect(h.runtime.emitEvent).not.toHaveBeenCalled();
+  });
+
+  it("honours the channel allowlist", async () => {
+    const h = createHarness({ allowedChannelIds: ["C0OTHER99"] });
+
+    await h.handlers.reactionAdded?.({ event: reactionEvent() });
+
+    expect(h.runtime.emitEvent).not.toHaveBeenCalled();
+  });
+
+  it("provides a callback that replies into the reacted channel", async () => {
+    const h = createHarness();
+
+    await h.handlers.reactionAdded?.({ event: reactionEvent() });
+
+    const emit = findEmit(h.runtime, EventType.REACTION_RECEIVED);
+    const payload = (emit as [string[], Record<string, unknown>])[1];
+    const callback = payload.callback as (c: {
+      text: string;
+    }) => Promise<unknown>;
+
+    expect(callback).toBeTypeOf("function");
+    await callback({ text: "counted your vote" });
+
+    // Non-threaded reaction, so `threadTs` is undefined; the remaining keys
+    // are the fully-spelled `SlackMessageSendOptions` shape the plugin's
+    // other reply paths use.
+    expect(h.sendMessage).toHaveBeenCalledWith(
+      CHANNEL_ID,
+      "counted your vote",
+      expect.objectContaining({ threadTs: undefined }),
+      "default",
+    );
+  });
+
+  it("never throws out of the handler on a malformed event", async () => {
+    const h = createHarness();
+
+    await expect(
+      h.handlers.reactionAdded?.({ event: { user: REACTOR_ID } }),
+    ).resolves.toBeUndefined();
+    expect(h.runtime.emitEvent).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-slack/src/reaction-bridge.ts
+++ b/plugins/plugin-slack/src/reaction-bridge.ts
@@ -1,0 +1,403 @@
+/**
+ * Reaction bridge for the Slack plugin.
+ *
+ * Slack `reaction_added` / `reaction_removed` events used to dead-end: the
+ * service emitted the plugin-local `SLACK_REACTION_*` events with a payload
+ * that carried no reaction data at all (the handler took `_event` and dropped
+ * it), and nothing in core consumed those names. Downstream consumers that
+ * want emoji signal — the Convent house agent's chore-verification voting is
+ * the driving case — had to poll `reactions.get`.
+ *
+ * This module maps a Slack reaction event onto the same core contract Discord
+ * already emits (`EventType.REACTION_RECEIVED` with a `MessagePayload`), so a
+ * consumer can count 👍/👎 without knowing which platform produced them.
+ *
+ * ## Core-event asymmetry (deliberate, matches plugin-discord)
+ *
+ * Core declares exactly one reaction event: `EventType.REACTION_RECEIVED`
+ * (`packages/core/src/types/events.ts`). There is no `REACTION_REMOVED`.
+ * `plugin-discord`'s `handleReaction` resolves this by emitting
+ * `[DiscordEventTypes.REACTION_RECEIVED, EventType.REACTION_RECEIVED]` on add
+ * but only `[DiscordEventTypes.REACTION_REMOVED]` on remove — removal never
+ * reaches core.
+ *
+ * We match that exactly rather than "improving" on it. Emitting
+ * `REACTION_RECEIVED` for a Slack removal would make a platform-agnostic vote
+ * counter double-count on Slack and not on Discord, which is a worse bug than
+ * the missing event. Removals still get the full enriched payload on
+ * `SLACK_REACTION_REMOVED` (including the reaction `Memory`), so a Slack-aware
+ * consumer can unvote today. Closing the asymmetry properly means adding
+ * `EventType.REACTION_REMOVED` to core and updating both plugins together;
+ * that is a core-types change and is deliberately out of scope for this slice.
+ *
+ * Note also that core's `reactionReceivedHandler` is what persists the
+ * reaction memory (`runtime.createMemories`). This module therefore does not
+ * call `createMemory` itself — again matching Discord — so an add is stored
+ * once and a removal is not stored at all.
+ */
+import {
+  type Content,
+  EventType,
+  type HandlerCallback,
+  type IAgentRuntime,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import { SlackEventTypes, type SlackReactionPayload } from "./types";
+
+/** Whether the reaction was added or removed. */
+export type SlackReactionAction = "added" | "removed";
+
+/**
+ * The shape Slack delivers for `reaction_added` / `reaction_removed`.
+ * `item.type` is `"message"` for message reactions (also `"file"` /
+ * `"file_comment"` historically, which we ignore).
+ */
+export interface SlackReactionEvent {
+  user: string;
+  reaction: string;
+  item: { type: string; channel: string; ts: string };
+  item_user?: string;
+  event_ts?: string;
+}
+
+/**
+ * Everything the bridge needs from `SlackService`, injected explicitly so the
+ * bridge stays independently testable and the service touch-point stays small.
+ *
+ * All ID helpers are the service's own, so reaction events land on exactly the
+ * same room/entity UUIDs as messages (`createUniqueUuid` over the account-
+ * scoped `slack-room` / `slack-user` / `slack` keys).
+ */
+export interface SlackReactionBridgeHost {
+  runtime: IAgentRuntime;
+  /** Account-scoped room UUID, thread-aware (`slack-room` key). */
+  getRoomId(
+    channelId: string,
+    threadTs: string | undefined,
+    accountId: string,
+  ): Promise<UUID>;
+  /** Creates the room if it does not exist yet, returning it. */
+  ensureRoomExists(
+    channelId: string,
+    threadTs: string | undefined,
+    accountId: string,
+  ): Promise<{ id: UUID } | null>;
+  /** Account-scoped entity UUID for a Slack user id (`slack-user` key). */
+  getEntityId(userId: string, accountId: string): UUID;
+  /**
+   * Memory UUID the service assigns to an inbound Slack message
+   * (`createUniqueUuid` over the `slack-<ts>` key). Used to resolve the
+   * reacted-to message and, through it, the room the message actually
+   * lives in (which is the thread room for a threaded message).
+   */
+  getMessageMemoryId(messageTs: string, accountId: string): UUID;
+  /** Stable UUID for the reaction memory itself. */
+  getReactionMemoryId(key: string, accountId: string): UUID;
+  /** Slack `1234567890.123456` → epoch ms. */
+  parseSlackTimestamp(ts: string): number;
+  /** Inbound allowlist gate, so reactions honour the same channel policy. */
+  isChannelAllowed(channelId: string, accountId: string): boolean;
+  /** Display name + handle for a Slack user id. */
+  resolveUserNames(
+    userId: string,
+    accountId: string,
+  ): Promise<{ name: string; userName: string }>;
+  /** Ensures the reacting user exists as an Entity before the event fires. */
+  ensureEntityExists(
+    entityId: UUID,
+    slackUserId: string,
+    accountId: string,
+  ): Promise<void>;
+  /** Outbound reply used for the payload callback. */
+  sendReply(
+    channelId: string,
+    text: string,
+    threadTs: string | undefined,
+    accountId: string,
+  ): Promise<void>;
+  teamId(accountId: string): string | undefined;
+}
+
+/** Slack caps display of the reacted-to message in the reaction text. */
+const REACTED_TEXT_PREVIEW_LIMIT = 50;
+
+/**
+ * Resolves the room the reaction belongs to.
+ *
+ * A Slack reaction event carries only `channel` + `ts` — never `thread_ts` —
+ * so a naive mapping drops every threaded reaction into the parent channel
+ * room, away from the message it reacted to. We recover the thread by looking
+ * up the target message's memory (its id is deterministic from `ts`) and
+ * reusing its `roomId`. If the agent never saw the message, we fall back to
+ * the channel room.
+ */
+async function resolveReactionRoom(
+  host: SlackReactionBridgeHost,
+  event: SlackReactionEvent,
+  accountId: string,
+): Promise<{
+  roomId: UUID;
+  threadTs: string | undefined;
+  targetMemory: Memory | null;
+}> {
+  const targetMemoryId = host.getMessageMemoryId(event.item.ts, accountId);
+
+  let targetMemory: Memory | null = null;
+  try {
+    targetMemory = await host.runtime.getMemoryById(targetMemoryId);
+  } catch (error) {
+    host.runtime.logger.debug(
+      {
+        src: "plugin:slack",
+        agentId: host.runtime.agentId,
+        accountId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "Reaction bridge could not load target message memory",
+    );
+  }
+
+  if (targetMemory?.roomId) {
+    const metadata = targetMemory.metadata as
+      | { slackThreadTs?: string; slackMessageTs?: string }
+      | undefined;
+    // A threaded message stores its parent `thread_ts`; a thread parent
+    // stores none, in which case its own ts is the thread root for replies.
+    const threadTs = metadata?.slackThreadTs;
+    return { roomId: targetMemory.roomId, threadTs, targetMemory };
+  }
+
+  // Unknown message: land the reaction on the channel room.
+  const room = await host.ensureRoomExists(
+    event.item.channel,
+    undefined,
+    accountId,
+  );
+  const roomId =
+    room?.id ??
+    (await host.getRoomId(event.item.channel, undefined, accountId));
+  return { roomId, threadTs: undefined, targetMemory: null };
+}
+
+/**
+ * Builds the reaction `Memory` that rides on both the core and the
+ * plugin-local event.
+ */
+function buildReactionMemory(params: {
+  host: SlackReactionBridgeHost;
+  event: SlackReactionEvent;
+  action: SlackReactionAction;
+  accountId: string;
+  roomId: UUID;
+  threadTs: string | undefined;
+  entityId: UUID;
+  targetMemory: Memory | null;
+  targetMemoryId: UUID;
+  names: { name: string; userName: string };
+  timestamp: number;
+}): Memory {
+  const {
+    host,
+    event,
+    action,
+    accountId,
+    roomId,
+    threadTs,
+    entityId,
+    targetMemory,
+    targetMemoryId,
+    names,
+    timestamp,
+  } = params;
+
+  const actionText = action === "added" ? "Added" : "Removed";
+  const preposition = action === "added" ? "to" : "from";
+  const emoji = `:${event.reaction}:`;
+
+  const reactedText =
+    typeof targetMemory?.content?.text === "string"
+      ? targetMemory.content.text
+      : "";
+  const preview =
+    reactedText.length > REACTED_TEXT_PREVIEW_LIMIT
+      ? `${reactedText.substring(0, REACTED_TEXT_PREVIEW_LIMIT)}...`
+      : reactedText;
+
+  const content: Content = {
+    text: `*${actionText} ${emoji} ${preposition}: "${preview}"*`,
+    source: "slack",
+    name: names.name,
+    // Point at the reacted-to message so context assembly can thread the
+    // reaction onto its target the same way Discord does.
+    inReplyTo: targetMemoryId,
+    metadata: { accountId },
+    // `text` truncates the reacted-to message to a display stub; preserve
+    // the full original so context building sees the whole statement
+    // rather than a fragment (mirrors plugin-discord).
+    ...(reactedText ? { reactedMessageText: reactedText } : {}),
+  };
+
+  return {
+    id: host.getReactionMemoryId(
+      `${event.item.ts}-${event.user}-${event.reaction}-${action}-${timestamp}`,
+      accountId,
+    ),
+    agentId: host.runtime.agentId,
+    roomId,
+    entityId,
+    content,
+    metadata: {
+      type: "message",
+      source: "slack",
+      provider: "slack",
+      accountId,
+      timestamp,
+      entityName: names.name,
+      entityUserName: names.userName,
+      fromBot: false,
+      fromId: event.user,
+      sourceId: entityId,
+      slackReaction: {
+        action,
+        emoji: event.reaction,
+        channelId: event.item.channel,
+        targetMessageTs: event.item.ts,
+        targetMessageId: targetMemoryId,
+        targetMessageResolved: targetMemory !== null,
+        itemUser: event.item_user,
+      },
+      slack: {
+        accountId,
+        teamId: host.teamId(accountId),
+        channelId: event.item.channel,
+        userId: event.user,
+        messageId: event.item.ts,
+        threadTs,
+      },
+      slackChannelId: event.item.channel,
+      slackMessageTs: event.item.ts,
+      slackThreadTs: threadTs,
+    } as Memory["metadata"],
+    createdAt: timestamp,
+  };
+}
+
+/**
+ * Bridges one Slack reaction event onto the core event bus.
+ *
+ * Emits `[SLACK_REACTION_ADDED, EventType.REACTION_RECEIVED]` for an add and
+ * `[SLACK_REACTION_REMOVED]` for a removal (see the module note on the core
+ * asymmetry). The plugin-local event names are preserved for back-compat; the
+ * payload on them is now populated to match the `SlackReactionPayload` type
+ * the plugin already declared but never actually filled in.
+ *
+ * Failures are logged and swallowed: a bad reaction must never take down the
+ * socket handler.
+ */
+export async function bridgeSlackReaction(
+  host: SlackReactionBridgeHost,
+  event: SlackReactionEvent,
+  action: SlackReactionAction,
+  accountId: string,
+): Promise<void> {
+  try {
+    if (!event?.user || !event?.reaction || !event.item?.ts) {
+      return;
+    }
+
+    // Only message reactions map onto a message memory. File reactions have
+    // no room/message anchor in this plugin's model.
+    if (event.item.type && event.item.type !== "message") {
+      return;
+    }
+
+    const channelId = event.item.channel;
+    if (!channelId) return;
+
+    // Reactions honour the same inbound channel policy as messages.
+    if (!host.isChannelAllowed(channelId, accountId)) {
+      return;
+    }
+
+    const { roomId, threadTs, targetMemory } = await resolveReactionRoom(
+      host,
+      event,
+      accountId,
+    );
+    const targetMemoryId = host.getMessageMemoryId(event.item.ts, accountId);
+    const entityId = host.getEntityId(event.user, accountId);
+
+    if (!roomId || !entityId) {
+      host.runtime.logger.warn(
+        { src: "plugin:slack", agentId: host.runtime.agentId, accountId },
+        "Reaction bridge could not resolve room or entity",
+      );
+      return;
+    }
+
+    await host.ensureEntityExists(entityId, event.user, accountId);
+
+    const names = await host.resolveUserNames(event.user, accountId);
+    const timestamp = event.event_ts
+      ? host.parseSlackTimestamp(event.event_ts)
+      : Date.now();
+
+    const memory = buildReactionMemory({
+      host,
+      event,
+      action,
+      accountId,
+      roomId,
+      threadTs,
+      entityId,
+      targetMemory,
+      targetMemoryId,
+      names,
+      timestamp,
+    });
+
+    const callback: HandlerCallback = async (
+      responseContent,
+    ): Promise<Memory[]> => {
+      const text = responseContent?.text?.trim();
+      if (!text) return [];
+      await host.sendReply(channelId, text, threadTs, accountId);
+      return [];
+    };
+
+    const payload: SlackReactionPayload = {
+      runtime: host.runtime,
+      source: "slack",
+      message: memory,
+      callback,
+      reaction: event.reaction,
+      userId: event.user,
+      channelId,
+      messageTs: event.item.ts,
+      itemUser: event.item_user,
+      accountId,
+      metadata: { accountId },
+    } as SlackReactionPayload;
+
+    const events: string[] =
+      action === "added"
+        ? [
+            SlackEventTypes.REACTION_ADDED as string,
+            EventType.REACTION_RECEIVED,
+          ]
+        : [SlackEventTypes.REACTION_REMOVED as string];
+
+    await host.runtime.emitEvent(events, payload);
+  } catch (error) {
+    host.runtime.logger.error(
+      {
+        src: "plugin:slack",
+        agentId: host.runtime.agentId,
+        accountId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "Error bridging Slack reaction",
+    );
+  }
+}

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -335,6 +335,11 @@ import {
 } from "./accounts";
 import { markdownToSlackMrkdwn } from "./formatting";
 import {
+  bridgeSlackReaction,
+  type SlackReactionBridgeHost,
+  type SlackReactionEvent,
+} from "./reaction-bridge";
+import {
   getSlackChannelType,
   getSlackUserDisplayName,
   type ISlackService,
@@ -1332,33 +1337,105 @@ export class SlackService extends Service implements ISlackService {
     );
   }
 
+  /**
+   * Adapter handing `reaction-bridge.ts` the service internals it needs.
+   * Every ID helper here is the same one the message path uses, so reactions
+   * resolve onto identical room/entity UUIDs rather than a parallel set.
+   */
+  private reactionBridgeHost(): SlackReactionBridgeHost {
+    return {
+      runtime: this.runtime,
+      getRoomId: (channelId, threadTs, accountId) =>
+        this.getRoomId(channelId, threadTs, accountId),
+      ensureRoomExists: (channelId, threadTs, accountId) =>
+        this.ensureRoomExists(channelId, threadTs, accountId),
+      getEntityId: (userId, accountId) => this.getEntityId(userId, accountId),
+      getMessageMemoryId: (messageTs, accountId) =>
+        createUniqueUuid(
+          this.runtime,
+          this.scopedSlackKey("slack", messageTs, accountId),
+        ),
+      getReactionMemoryId: (key, accountId) =>
+        createUniqueUuid(
+          this.runtime,
+          this.scopedSlackKey("slack-reaction", key, accountId),
+        ),
+      parseSlackTimestamp: (ts) => this.parseSlackTimestamp(ts),
+      isChannelAllowed: (channelId, accountId) =>
+        this.isChannelAllowed(channelId, accountId),
+      teamId: (accountId) => this.getTeamIdForAccount(accountId) ?? undefined,
+      resolveUserNames: async (userId, accountId) => {
+        const user = await this.getUser(userId, accountId).catch(() => null);
+        return {
+          name: user ? getSlackUserDisplayName(user) : userId,
+          userName: user?.name ?? userId,
+        };
+      },
+      ensureEntityExists: async (entityId, slackUserId, accountId) => {
+        const existing = await this.runtime.getEntityById(entityId);
+        if (existing) return;
+        const user = await this.getUser(slackUserId, accountId).catch(
+          () => null,
+        );
+        const displayName = user ? getSlackUserDisplayName(user) : slackUserId;
+        await this.runtime.createEntity({
+          id: entityId,
+          names: [displayName],
+          metadata: {
+            source: "slack",
+            accountId,
+            slack: {
+              accountId,
+              id: slackUserId,
+              name: displayName,
+              userName: user?.name || slackUserId,
+            },
+          },
+          agentId: this.runtime.agentId,
+        });
+      },
+      sendReply: async (channelId, text, threadTs, accountId) => {
+        // `SlackMessageSendOptions` has all-required (if optional-valued)
+        // fields, so spell every key out the way the message reply path does.
+        await this.sendMessage(
+          channelId,
+          text,
+          {
+            threadTs,
+            replyBroadcast: undefined,
+            unfurlLinks: undefined,
+            unfurlMedia: undefined,
+            mrkdwn: undefined,
+            attachments: undefined,
+            blocks: undefined,
+          },
+          accountId,
+        );
+      },
+    };
+  }
+
   private async handleReactionAdded(
-    _event: {
-      user: string;
-      reaction: string;
-      item: { type: string; channel: string; ts: string };
-      item_user?: string;
-    },
+    event: SlackReactionEvent,
     accountId = this.defaultAccountId,
   ): Promise<void> {
-    await this.runtime.emitEvent(
-      SlackEventTypes.REACTION_ADDED as string,
-      this.buildEventPayload(accountId),
+    await bridgeSlackReaction(
+      this.reactionBridgeHost(),
+      event,
+      "added",
+      accountId,
     );
   }
 
   private async handleReactionRemoved(
-    _event: {
-      user: string;
-      reaction: string;
-      item: { type: string; channel: string; ts: string };
-      item_user?: string;
-    },
+    event: SlackReactionEvent,
     accountId = this.defaultAccountId,
   ): Promise<void> {
-    await this.runtime.emitEvent(
-      SlackEventTypes.REACTION_REMOVED as string,
-      this.buildEventPayload(accountId),
+    await bridgeSlackReaction(
+      this.reactionBridgeHost(),
+      event,
+      "removed",
+      accountId,
     );
   }
 

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -50,7 +50,15 @@ export interface SlackMessageSentPayload extends MessagePayload {
   messageTs: string;
 }
 
-export interface SlackReactionPayload extends EventPayload {
+/**
+ * Payload for `SLACK_REACTION_ADDED` / `SLACK_REACTION_REMOVED`.
+ *
+ * Extends `MessagePayload` (not bare `EventPayload`) so the reaction `Memory`
+ * rides along: this is the same shape core's `EventType.REACTION_RECEIVED`
+ * expects, which is what lets `reaction-bridge.ts` emit one payload onto both
+ * the plugin-local and the core event names.
+ */
+export interface SlackReactionPayload extends MessagePayload {
   reaction: string;
   userId: string;
   channelId: string;


### PR DESCRIPTION
## Problem

`plugins/plugin-slack` handles `reaction_added` / `reaction_removed`, but the handlers took `_event`, **threw the reaction data away**, and emitted only the plugin-local `SLACK_REACTION_ADDED` / `SLACK_REACTION_REMOVED` with `buildEventPayload(accountId)` — a payload carrying no emoji, no user, no message reference.

Nothing in core consumes those plugin-local names. So Slack emoji signal never reached the agent at all: a consumer that wanted to count 👍/👎 had to poll `reactions.get`.

`plugin-discord` already bridges reactions to core's `EventType.REACTION_RECEIVED`. This PR gives Slack the same core-event contract, so a consumer counts reactions without knowing which platform produced them.

## Change

New `plugins/plugin-slack/src/reaction-bridge.ts`, wired into **both** reaction handlers on the real registered path (`app.event("reaction_added" | "reaction_removed")` in `registerEventHandlers`) — not a helper that could drift onto dead code.

- **Core contract matched exactly.** Emits `[SLACK_REACTION_ADDED, EventType.REACTION_RECEIVED]` on add, with a `MessagePayload` carrying the reaction `Memory`, mirroring `plugin-discord`'s `handleReaction`.
- **Same rooms as messages.** Reuses the service's own `createUniqueUuid` / `stringToUuid` helpers (`slack-room`, `slack-user`, `slack` keys, account-scoped) via an injected host adapter, so reactions land on identical room/entity UUIDs rather than a parallel set.
- **Thread recovery.** A Slack reaction event carries `channel` + `ts` but *never* `thread_ts`, so naive mapping drops every threaded reaction into the parent channel room, detached from the message it reacted to. The bridge resolves the target message memory (its id is deterministic from `ts`) and reuses its `roomId`, falling back to the channel room when the agent never saw the message.
- **Payload:** emoji name, mapped room UUID, reactor entity UUID, target message ref (`targetMessageTs` + deterministic `targetMessageId`, plus `content.inReplyTo`), resolved reacted-to text when known.
- **Back-compat preserved.** `SLACK_REACTION_*` still fire, now with the populated payload the `SlackReactionPayload` type always declared but never filled in. `SlackReactionPayload` now extends `MessagePayload` so one payload satisfies both event names.

### Deliberate: removal does not reach core

Core declares exactly one reaction event, `EventType.REACTION_RECEIVED` (`packages/core/src/types/events.ts`); there is no `REACTION_REMOVED`. `plugin-discord` resolves this by emitting `[DiscordEventTypes.REACTION_RECEIVED, EventType.REACTION_RECEIVED]` on add but only `[DiscordEventTypes.REACTION_REMOVED]` on remove.

We match that rather than "improving" on it. Emitting `REACTION_RECEIVED` for a Slack removal would make a platform-agnostic vote counter **double-count on Slack and not on Discord** — worse than the missing event. Removals still get the full enriched payload on `SLACK_REACTION_REMOVED`. Closing the asymmetry properly means adding `EventType.REACTION_REMOVED` to core and updating both plugins together; that is a core-types change, deliberately out of scope.

Likewise the bridge does not call `createMemory` itself — core's `reactionReceivedHandler` persists the reaction memory, same as Discord — so an add is stored once and a removal is not stored at all.

## Proof (bidirectional)

`src/reaction-bridge.test.ts` (14 tests) drives the **real handlers** bound by `registerEventHandlers`, asserting core `emitEvent` receives `EventType.REACTION_RECEIVED`.

Same test file, run against unmodified `develop` sources vs. with the fix:

| | Result |
|---|---|
| **develop** (`service.ts`/`types.ts` reverted, `reaction-bridge.ts` removed) | **2 pass / 12 fail** |
| **with fix** | **14 pass / 0 fail** (42 assertions) |

The 12 failures on develop are the substantive ones: no core `REACTION_RECEIVED` emitted, payload carries no emoji/ts/channel/reactor, no reaction `Memory`, no `inReplyTo`, thread routing absent, allowlist ungated, malformed events still emit. The 2 that pass on develop are the handler-registration check and the back-compat `SLACK_REACTION_ADDED` presence check — correctly, since those already worked.

**Full plugin suite: 52 pass / 0 fail across 6 files.**

Core built first (`packages/core`, `bun run build` ✅), then `plugin-slack` `bun run typecheck` → **zero errors**, `biome check` clean on all four touched files.

### Note on the room-mapping test

The room-mapping assertion initially passed vacuously: the harness stubbed `runtime.getRoom` with a blanket `mockResolvedValue({ id: "room-existing" })`, which made `ensureRoomExists` short-circuit on its `getRoom(roomId)` hit and return a room whose id never came from `createUniqueUuid` — so the mapping under test was never exercised. Replaced with a real room store keyed by UUID, so an unseen channel misses, falls through to the real `getRoomId` + `createRoom` path, and the test now additionally asserts `createRoom` was called once with the expected id/channel/source.

## Rebase order / collisions

Two lanes are concurrently editing this plugin:

- `sol-slack-rework-17462` — `service.ts` / `accounts.ts` / `allowlist.ts`
- `sol-slack-reliability-a` — inbound-reliability / event-isolation / reconnect-policy modules

This PR's `service.ts` footprint is deliberately surgical: the two reaction handler bodies plus one new private `reactionBridgeHost()` adapter. All substantive logic lives in the new `reaction-bridge.ts`, which neither lane touches.

**Rebase after the `17462` rework lands.** Opened as **draft** for that reason.

Branched from `develop` at `dc873211bee`.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend event-bus change in plugin-slack; no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend event-bus change in plugin-slack; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow; the change is an event emission on the Slack socket handler path

<!-- evidence-row:backend-logs -->
- [x] [17469-slice3-evidence.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-3/17469-slice3-evidence.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path involved

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change; this emits a core event, it does not alter model behaviour

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - reaction Memory shape is asserted in src/reaction-bridge.test.ts (14 tests); core reactionReceivedHandler owns persistence, unchanged here
