### PR TITLE
feat(plugin-slack): inbound reliability core — event dedupe, app_mention/message race, workspace isolation, reconnect bail

### DIFF
--- a/plugins/plugin-slack/src/event-isolation.test.ts
+++ b/plugins/plugin-slack/src/event-isolation.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Workspace isolation unit proof.
+ *
+ * The rule under test is asymmetric on purpose: fail-CLOSED on a field that is
+ * present and different, fail-OPEN on a field that is absent. Both directions
+ * are asserted, because a guard that drops everything is not isolation, it is
+ * an outage.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  extractSlackEnvelopeIdentity,
+  shouldDropMismatchedSlackEvent,
+} from "./event-isolation";
+
+const IDENTITY = { apiAppId: "A_APP", teamId: "T_HOME", enterpriseId: null };
+
+function verdict(body: unknown, identity = IDENTITY) {
+  return shouldDropMismatchedSlackEvent({ body, identity });
+}
+
+describe("extractSlackEnvelopeIdentity", () => {
+  it("reads the standard Events API envelope", () => {
+    expect(
+      extractSlackEnvelopeIdentity({ api_app_id: "A1", team_id: "T1" }),
+    ).toEqual({ apiAppId: "A1", teamId: "T1", enterpriseId: "" });
+  });
+
+  it("falls back to team.id, event.team, and authorizations", () => {
+    expect(extractSlackEnvelopeIdentity({ team: { id: "T2" } }).teamId).toBe(
+      "T2",
+    );
+    expect(extractSlackEnvelopeIdentity({ event: { team: "T3" } }).teamId).toBe(
+      "T3",
+    );
+    expect(
+      extractSlackEnvelopeIdentity({ authorizations: [{ team_id: "T4" }] })
+        .teamId,
+    ).toBe("T4");
+  });
+
+  it("returns empties for junk input", () => {
+    expect(extractSlackEnvelopeIdentity(null)).toEqual({
+      apiAppId: "",
+      teamId: "",
+      enterpriseId: "",
+    });
+    expect(extractSlackEnvelopeIdentity("nope").teamId).toBe("");
+  });
+});
+
+describe("shouldDropMismatchedSlackEvent — fail closed on mismatch", () => {
+  it("drops a foreign team_id", () => {
+    expect(verdict({ api_app_id: "A_APP", team_id: "T_OTHER" })).toMatchObject({
+      drop: true,
+      field: "team_id",
+      expected: "T_HOME",
+      received: "T_OTHER",
+    });
+  });
+
+  it("drops a foreign api_app_id", () => {
+    expect(verdict({ api_app_id: "A_OTHER", team_id: "T_HOME" })).toMatchObject(
+      {
+        drop: true,
+        field: "api_app_id",
+      },
+    );
+  });
+
+  it("reports api_app_id first when both mismatch", () => {
+    expect(
+      verdict({ api_app_id: "A_OTHER", team_id: "T_OTHER" }),
+    ).toMatchObject({ drop: true, field: "api_app_id" });
+  });
+
+  it("drops a foreign team carried only on the nested event", () => {
+    expect(verdict({ event: { team: "T_OTHER" } })).toMatchObject({
+      drop: true,
+      field: "team_id",
+    });
+  });
+
+  it("drops a foreign enterprise_id", () => {
+    expect(
+      shouldDropMismatchedSlackEvent({
+        body: { enterprise_id: "E_OTHER" },
+        identity: { ...IDENTITY, enterpriseId: "E_HOME" },
+      }),
+    ).toMatchObject({ drop: true, field: "enterprise_id" });
+  });
+});
+
+describe("shouldDropMismatchedSlackEvent — fail open on absence", () => {
+  it("accepts a matching envelope", () => {
+    expect(verdict({ api_app_id: "A_APP", team_id: "T_HOME" }).drop).toBe(
+      false,
+    );
+  });
+
+  it("accepts an envelope carrying no identity fields", () => {
+    expect(verdict({ type: "event_callback" }).drop).toBe(false);
+  });
+
+  it("accepts when the account identity is not yet known", () => {
+    expect(
+      shouldDropMismatchedSlackEvent({
+        body: { api_app_id: "A_ANY", team_id: "T_ANY" },
+        identity: {},
+      }).drop,
+    ).toBe(false);
+  });
+
+  it("accepts non-object bodies rather than throwing", () => {
+    expect(verdict(null).drop).toBe(false);
+    expect(verdict(undefined).drop).toBe(false);
+    expect(verdict("string").drop).toBe(false);
+  });
+
+  it("accepts a sibling workspace inside the expected org-wide install", () => {
+    // Org-wide installs legitimately receive events from sibling teams, so a
+    // team mismatch INSIDE the expected enterprise is not cross-tenant bleed.
+    expect(
+      shouldDropMismatchedSlackEvent({
+        body: { team_id: "T_SIBLING", enterprise_id: "E_HOME" },
+        identity: {
+          apiAppId: "A_APP",
+          teamId: "T_HOME",
+          enterpriseId: "E_HOME",
+        },
+      }).drop,
+    ).toBe(false);
+  });
+
+  it("still drops a sibling-looking team from a different enterprise", () => {
+    expect(
+      shouldDropMismatchedSlackEvent({
+        body: { team_id: "T_SIBLING", enterprise_id: "E_OTHER" },
+        identity: {
+          apiAppId: "A_APP",
+          teamId: "T_HOME",
+          enterpriseId: "E_HOME",
+        },
+      }).drop,
+    ).toBe(true);
+  });
+});

--- a/plugins/plugin-slack/src/event-isolation.ts
+++ b/plugins/plugin-slack/src/event-isolation.ts
@@ -1,0 +1,181 @@
+/**
+ * Multi-workspace event isolation.
+ *
+ * The connector runs one bolt `App` per account, and until now the only thing
+ * tying an inbound event to an account was the closure it happened to be
+ * registered in. That is an *assumption*, not a check, and it is the kind of
+ * assumption that is fine right up until it isn't:
+ *
+ *  - two accounts configured with the same app credentials by mistake;
+ *  - a Slack Connect / third-partyly-shared channel delivering events that
+ *    originate in a team we are not installed in;
+ *  - an org-wide install fanning events across workspaces;
+ *  - a socket frame arriving on a stale connection after a token swap.
+ *
+ * Every one of those routes another workspace's message into this account's
+ * memory, rooms, and agent context. Attribution by closure cannot detect any
+ * of them, because the closure is right about which *socket* the event came in
+ * on and wrong about which *workspace* it belongs to.
+ *
+ * So we check the envelope. Slack stamps every Events API delivery with
+ * `api_app_id` and `team_id`; comparing them against the identity we got back
+ * from `auth.test` at startup turns the assumption into a verified fact on
+ * every single event. Defense in depth: the closure is still the primary
+ * attribution, this is the assertion that it was correct.
+ *
+ * Deliberately fail-open on *absent* fields and fail-closed only on *present
+ * and different* ones. A missing `team_id` means an event family that does not
+ * carry one (or a hand-built test payload); dropping those would break working
+ * deployments to defend against nothing. A mismatched `team_id` is
+ * unambiguous, and is dropped.
+ */
+
+export interface SlackAccountIdentity {
+  /** `api_app_id` from `auth.test`, when the Slack app id is known. */
+  apiAppId?: string | null;
+  /** `team_id` from `auth.test`. */
+  teamId?: string | null;
+  /** `enterprise_id`, for org-wide installs. */
+  enterpriseId?: string | null;
+}
+
+export type SlackIsolationMismatchField =
+  | "api_app_id"
+  | "team_id"
+  | "enterprise_id";
+
+export interface SlackIsolationVerdict {
+  drop: boolean;
+  field?: SlackIsolationMismatchField;
+  expected?: string;
+  received?: string;
+}
+
+const ACCEPT: SlackIsolationVerdict = { drop: false };
+
+function readString(value: unknown): string {
+  return typeof value === "string" && value.length > 0 ? value : "";
+}
+
+/**
+ * Pulls the workspace identity out of an inbound envelope.
+ *
+ * Slack is not consistent about where these live across event families and
+ * transports, so every known location is checked:
+ *  - `team_id` at the envelope root (standard Events API);
+ *  - `team.id` (some interactivity and slash payloads);
+ *  - `event.team` (message events echo the authoring team);
+ *  - `authorizations[0].team_id` (the installation the event was routed for).
+ */
+export function extractSlackEnvelopeIdentity(body: unknown): {
+  apiAppId: string;
+  teamId: string;
+  enterpriseId: string;
+} {
+  if (!body || typeof body !== "object") {
+    return { apiAppId: "", teamId: "", enterpriseId: "" };
+  }
+  const raw = body as {
+    api_app_id?: unknown;
+    team_id?: unknown;
+    team?: unknown;
+    enterprise_id?: unknown;
+    enterprise?: unknown;
+    is_enterprise_install?: unknown;
+    event?: unknown;
+    authorizations?: unknown;
+  };
+
+  const apiAppId = readString(raw.api_app_id);
+
+  let teamId = readString(raw.team_id);
+  if (!teamId && raw.team && typeof raw.team === "object") {
+    teamId = readString((raw.team as { id?: unknown }).id);
+  }
+  if (!teamId && typeof raw.team === "string") {
+    teamId = raw.team;
+  }
+  if (!teamId && raw.event && typeof raw.event === "object") {
+    const event = raw.event as { team?: unknown; team_id?: unknown };
+    teamId = readString(event.team) || readString(event.team_id);
+  }
+  if (!teamId && Array.isArray(raw.authorizations)) {
+    const first = raw.authorizations[0] as { team_id?: unknown } | undefined;
+    teamId = readString(first?.team_id);
+  }
+
+  let enterpriseId = readString(raw.enterprise_id);
+  if (!enterpriseId && raw.enterprise && typeof raw.enterprise === "object") {
+    enterpriseId = readString((raw.enterprise as { id?: unknown }).id);
+  }
+
+  return { apiAppId, teamId, enterpriseId };
+}
+
+/**
+ * Decides whether an inbound Slack event belongs to this account.
+ *
+ * Must be called on **every** inbound event family, not just messages: a
+ * reaction, a member join, or a file share from a foreign workspace corrupts
+ * state just as effectively as a message does.
+ */
+export function shouldDropMismatchedSlackEvent(params: {
+  body: unknown;
+  identity: SlackAccountIdentity;
+}): SlackIsolationVerdict {
+  const { body, identity } = params;
+  if (!body || typeof body !== "object") {
+    // Nothing to compare against: the closure attribution stands.
+    return ACCEPT;
+  }
+
+  const received = extractSlackEnvelopeIdentity(body);
+  const expectedAppId = readString(identity.apiAppId);
+  const expectedTeamId = readString(identity.teamId);
+  const expectedEnterpriseId = readString(identity.enterpriseId);
+
+  if (
+    expectedAppId &&
+    received.apiAppId &&
+    received.apiAppId !== expectedAppId
+  ) {
+    return {
+      drop: true,
+      field: "api_app_id",
+      expected: expectedAppId,
+      received: received.apiAppId,
+    };
+  }
+
+  if (expectedTeamId && received.teamId && received.teamId !== expectedTeamId) {
+    // An org-wide install legitimately receives events from sibling workspaces
+    // under one enterprise, so a team mismatch inside the *expected*
+    // enterprise is not evidence of cross-tenant bleed.
+    const enterpriseMatches =
+      expectedEnterpriseId.length > 0 &&
+      received.enterpriseId === expectedEnterpriseId;
+    if (!enterpriseMatches) {
+      return {
+        drop: true,
+        field: "team_id",
+        expected: expectedTeamId,
+        received: received.teamId,
+      };
+    }
+  }
+
+  if (
+    expectedEnterpriseId &&
+    received.enterpriseId &&
+    received.enterpriseId !== expectedEnterpriseId
+  ) {
+    return {
+      drop: true,
+      field: "enterprise_id",
+      expected: expectedEnterpriseId,
+      received: received.enterpriseId,
+    };
+  }
+
+  return ACCEPT;
+}

--- a/plugins/plugin-slack/src/inbound-reliability.test.ts
+++ b/plugins/plugin-slack/src/inbound-reliability.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Unit-level proof for the keying and lane state machine in
+ * `inbound-reliability.ts`.
+ *
+ * The production-path proof (real bolt handlers, duplicate agent runs, race
+ * interleavings) lives in `service-inbound-reliability.test.ts`. This file
+ * covers the keying rules and the admit/settle algebra directly, because the
+ * subtle cases (maybe-thread isolation, DM channel scoping, twin release on
+ * skip) are much easier to state here than through the full handler.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildSlackDebounceKey,
+  buildSlackTopLevelConversationKey,
+  extractSlackEventId,
+  extractSlackRetryNum,
+  type SlackInboundEventLike,
+  SlackInboundReliability,
+} from "./inbound-reliability";
+
+const ACCOUNT = "default";
+
+function message(
+  overrides: Partial<SlackInboundEventLike> = {},
+): SlackInboundEventLike {
+  return {
+    channel: "C123",
+    user: "U456",
+    ts: "1709000000.000100",
+    ...overrides,
+  };
+}
+
+describe("buildSlackDebounceKey", () => {
+  it("returns null when the event has no sender", () => {
+    expect(
+      buildSlackDebounceKey(
+        message({ user: undefined, bot_id: undefined }),
+        ACCOUNT,
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to bot_id as the sender", () => {
+    expect(
+      buildSlackDebounceKey(
+        message({ user: undefined, bot_id: "B999" }),
+        ACCOUNT,
+      ),
+    ).toBe("slack:default:C123:1709000000.000100:B999");
+  });
+
+  it("scopes thread replies by thread_ts so a thread is one lane", () => {
+    expect(
+      buildSlackDebounceKey(
+        message({ thread_ts: "1709000000.000001" }),
+        ACCOUNT,
+      ),
+    ).toBe("slack:default:C123:1709000000.000001:U456");
+  });
+
+  it("isolates unresolved thread replies behind a maybe-thread prefix", () => {
+    // parent_user_id present but thread_ts not yet resolved: must not collide
+    // with the channel's top-level lane.
+    const key = buildSlackDebounceKey(
+      message({ parent_user_id: "U789", ts: "1709000000.000200" }),
+      ACCOUNT,
+    );
+    expect(key).toBe("slack:default:C123:maybe-thread:1709000000.000200:U456");
+    expect(key).not.toBe(
+      buildSlackDebounceKey(message({ ts: "1709000000.000200" }), ACCOUNT),
+    );
+  });
+
+  it("scopes top-level channel messages by their own ts", () => {
+    const a = buildSlackDebounceKey(
+      message({ ts: "1709000000.000100" }),
+      ACCOUNT,
+    );
+    const b = buildSlackDebounceKey(
+      message({ ts: "1709000000.000200" }),
+      ACCOUNT,
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("keeps top-level DMs channel-scoped so consecutive lines share a lane", () => {
+    const a = buildSlackDebounceKey(
+      message({ channel: "D123", ts: "1709000000.000100" }),
+      ACCOUNT,
+    );
+    const b = buildSlackDebounceKey(
+      message({ channel: "D123", ts: "1709000000.000200" }),
+      ACCOUNT,
+    );
+    expect(a).toBe("slack:default:D123:U456");
+    expect(a).toBe(b);
+  });
+
+  it("scopes lanes per account so two workspaces never share one", () => {
+    expect(buildSlackDebounceKey(message(), "acct-a")).not.toBe(
+      buildSlackDebounceKey(message(), "acct-b"),
+    );
+  });
+});
+
+describe("buildSlackTopLevelConversationKey", () => {
+  it("returns a key for top-level messages", () => {
+    expect(buildSlackTopLevelConversationKey(message(), ACCOUNT)).toBe(
+      "slack:default:C123:U456",
+    );
+  });
+
+  it("returns null for thread replies", () => {
+    expect(
+      buildSlackTopLevelConversationKey(
+        message({ thread_ts: "1709000000.000001" }),
+        ACCOUNT,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("SlackInboundReliability event_id dedupe", () => {
+  it("admits an event_id once and rejects redeliveries", () => {
+    const r = new SlackInboundReliability();
+    expect(r.admitEventId("Ev123")).toBe(true);
+    expect(r.admitEventId("Ev123")).toBe(false);
+    expect(r.admitEventId("Ev123")).toBe(false);
+    expect(r.stats().duplicatesDropped).toBe(2);
+  });
+
+  it("admits a missing event_id rather than dropping a possibly-real event", () => {
+    const r = new SlackInboundReliability();
+    expect(r.admitEventId(null)).toBe(true);
+    expect(r.admitEventId(undefined)).toBe(true);
+  });
+
+  it("forgets event ids after the TTL", () => {
+    let now = 1_000;
+    const r = new SlackInboundReliability({
+      eventIdTtlMs: 500,
+      now: () => now,
+    });
+    expect(r.admitEventId("Ev1")).toBe(true);
+    now = 1_400;
+    expect(r.admitEventId("Ev1")).toBe(false);
+    now = 2_000;
+    expect(r.admitEventId("Ev1")).toBe(true);
+  });
+});
+
+describe("SlackInboundReliability lane admission", () => {
+  it("rejects a second event on the same lane from the same source", () => {
+    const r = new SlackInboundReliability();
+    const first = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message(),
+    });
+    expect(first.admitted).toBe(true);
+    const second = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message(),
+    });
+    expect(second.admitted).toBe(false);
+    expect(second.reason).toBe("duplicate-same-source");
+  });
+
+  it("admits the app_mention twin alongside the message twin", () => {
+    const r = new SlackInboundReliability();
+    r.admit({ accountId: ACCOUNT, source: "message", event: message() });
+    const mention = r.admit({
+      accountId: ACCOUNT,
+      source: "app_mention",
+      event: message(),
+    });
+    expect(mention.admitted).toBe(true);
+    expect(mention.reason).toBe("mention-preempts-message");
+  });
+
+  it("rejects the twin once the other source has dispatched", () => {
+    const r = new SlackInboundReliability();
+    const mention = r.admit({
+      accountId: ACCOUNT,
+      source: "app_mention",
+      event: message(),
+    });
+    r.settle(mention.key, "app_mention", "dispatched");
+    const twin = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message(),
+    });
+    expect(twin.admitted).toBe(false);
+    expect(twin.reason).toBe("twin-already-dispatched");
+  });
+
+  it("frees the lane on failure so Slack redelivery is a real retry", () => {
+    const r = new SlackInboundReliability();
+    const first = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message(),
+    });
+    r.settle(first.key, "message", "failed");
+    const retry = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message(),
+    });
+    expect(retry.admitted).toBe(true);
+  });
+
+  it("admits events with no sender rather than deduping them together", () => {
+    const r = new SlackInboundReliability();
+    const a = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message({ user: undefined, bot_id: undefined }),
+    });
+    const b = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message({ user: undefined, bot_id: undefined }),
+    });
+    expect(a.admitted).toBe(true);
+    expect(a.reason).toBe("unkeyed");
+    expect(b.admitted).toBe(true);
+  });
+});
+
+describe("SlackInboundReliability twin resolution", () => {
+  it("suppresses the message twin when the mention dispatched", async () => {
+    const r = new SlackInboundReliability();
+    const mention = r.admit({
+      accountId: ACCOUNT,
+      source: "app_mention",
+      event: message(),
+    });
+    const twin = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message(),
+    });
+    const pending = r.awaitMentionTwin(twin.key);
+    r.settle(mention.key, "app_mention", "dispatched");
+    await expect(pending).resolves.toEqual({
+      proceed: false,
+      reason: "twin-dispatched",
+    });
+  });
+
+  it("releases the message twin when the mention skipped", async () => {
+    // The drop bug: mention bails (gated, no memory), and on the old code the
+    // message twin had already returned, so the turn was lost entirely.
+    const r = new SlackInboundReliability();
+    const mention = r.admit({
+      accountId: ACCOUNT,
+      source: "app_mention",
+      event: message(),
+    });
+    const twin = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message(),
+    });
+    const pending = r.awaitMentionTwin(twin.key);
+    r.settle(mention.key, "app_mention", "skipped");
+    await expect(pending).resolves.toEqual({
+      proceed: true,
+      reason: "twin-released",
+    });
+  });
+
+  it("releases the message twin when the mention threw", async () => {
+    const r = new SlackInboundReliability();
+    const mention = r.admit({
+      accountId: ACCOUNT,
+      source: "app_mention",
+      event: message(),
+    });
+    const twin = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message(),
+    });
+    const pending = r.awaitMentionTwin(twin.key);
+    r.settle(mention.key, "app_mention", "failed");
+    await expect(pending).resolves.toEqual({
+      proceed: true,
+      reason: "twin-released",
+    });
+  });
+
+  it("proceeds after the grace window when no mention ever arrives", async () => {
+    const r = new SlackInboundReliability({ mentionGraceMs: 5 });
+    const only = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message(),
+    });
+    await expect(r.awaitMentionTwin(only.key)).resolves.toEqual({
+      proceed: true,
+      reason: "grace-expired",
+    });
+  });
+
+  it("waits for a mention that arrives inside the grace window", async () => {
+    const r = new SlackInboundReliability({ mentionGraceMs: 50 });
+    const twin = r.admit({
+      accountId: ACCOUNT,
+      source: "message",
+      event: message(),
+    });
+    const pending = r.awaitMentionTwin(twin.key);
+    const mention = r.admit({
+      accountId: ACCOUNT,
+      source: "app_mention",
+      event: message(),
+    });
+    r.settle(mention.key, "app_mention", "dispatched");
+    await expect(pending).resolves.toEqual({
+      proceed: false,
+      reason: "twin-dispatched",
+    });
+  });
+});
+
+describe("envelope field extraction", () => {
+  it("reads event_id from the envelope", () => {
+    expect(extractSlackEventId({ event_id: "Ev0PV52K21" })).toBe("Ev0PV52K21");
+    expect(extractSlackEventId({})).toBeNull();
+    expect(extractSlackEventId(null)).toBeNull();
+  });
+
+  it("reads the retry counter from every surface Slack uses", () => {
+    expect(extractSlackRetryNum({ retry_num: 2 })).toBe(2);
+    expect(extractSlackRetryNum({ retry_attempt: 3 })).toBe(3);
+    expect(extractSlackRetryNum({}, { retryNum: 1 })).toBe(1);
+    expect(extractSlackRetryNum({})).toBeUndefined();
+  });
+});

--- a/plugins/plugin-slack/src/inbound-reliability.ts
+++ b/plugins/plugin-slack/src/inbound-reliability.ts
@@ -1,0 +1,614 @@
+/**
+ * Inbound reliability core for the Slack connector.
+ *
+ * Slack's Events API is an at-least-once transport delivered over two
+ * overlapping streams. Two independent failure modes follow from that, and
+ * this module owns both:
+ *
+ *  1. **Redelivery.** Slack retries an event whenever the ack is slow or lost.
+ *     The retry carries the *same* `event_id`, so without a dedupe memory a
+ *     laggy agent turn produces duplicate replies — the slower the agent, the
+ *     more duplicates, which is exactly backwards.
+ *
+ *  2. **The `app_mention` / `message` twin.** @-mentioning the bot in a channel
+ *     produces *two* events for one human message: a `message` event and an
+ *     `app_mention` event, in no guaranteed order. The previous code resolved
+ *     this with an unconditional `if (isMentioned && channel_type !== "im")
+ *     return;` in the message path. That is a drop-or-double coin flip: if the
+ *     `app_mention` path bails for any reason (gating, missing memory, a
+ *     throw), the turn is silently lost, because the message twin already
+ *     returned. Under load the reverse also happens.
+ *
+ * The fix is a small state machine keyed by the debounce key. Exactly one
+ * source dispatches per logical Slack message, and the loser only yields once
+ * the winner has *actually* dispatched — never on the mere expectation that it
+ * will.
+ *
+ * Keying follows the Slack conversation model rather than the raw event:
+ *  - thread replies are scoped by `thread_ts`, so a thread is one lane;
+ *  - a reply whose `thread_ts` has not been resolved yet gets a `maybe-thread`
+ *    prefix so it cannot collide with the channel's top-level lane;
+ *  - top-level channel messages are scoped by their own `ts`, otherwise two
+ *    unrelated messages in a busy channel share a lane and the second is
+ *    mistaken for a duplicate of the first;
+ *  - DMs stay channel-scoped, which keeps consecutive short DM lines batchable;
+ *  - `bot_id` is the sender fallback, because bot messages carry no `user`.
+ */
+
+/** Which inbound stream an event arrived on. */
+export type SlackInboundSource = "message" | "app_mention";
+
+/** Structural shape of the inbound Slack message-family events we key on. */
+export interface SlackInboundEventLike {
+  channel?: string;
+  user?: string;
+  bot_id?: string;
+  ts?: string;
+  event_ts?: string;
+  thread_ts?: string;
+  parent_user_id?: string;
+}
+
+const DEFAULT_SLOT_TTL_MS = 10 * 60_000;
+const DEFAULT_EVENT_ID_TTL_MS = 10 * 60_000;
+const DEFAULT_MAX_ENTRIES = 5_000;
+/**
+ * How long a `message` twin waits for its `app_mention` counterpart to show
+ * up before deciding it is not coming. Slack emits the pair within
+ * milliseconds of each other; this only has to cover socket jitter.
+ */
+const DEFAULT_MENTION_GRACE_MS = 1_500;
+
+function resolveSenderId(event: SlackInboundEventLike): string | null {
+  return event.user ?? event.bot_id ?? null;
+}
+
+function isDirectMessageChannel(channelId: string): boolean {
+  return channelId.startsWith("D");
+}
+
+function isTopLevel(event: SlackInboundEventLike): boolean {
+  return !event.thread_ts && !event.parent_user_id;
+}
+
+/**
+ * Builds the conversation-lane key an inbound event belongs to.
+ *
+ * Returns `null` when the event carries neither a `user` nor a `bot_id`, since
+ * an event with no sender cannot be attributed to a lane and must not be
+ * deduped against anything.
+ */
+export function buildSlackDebounceKey(
+  event: SlackInboundEventLike,
+  accountId: string,
+): string | null {
+  const channel = event.channel;
+  if (!channel) {
+    return null;
+  }
+  const senderId = resolveSenderId(event);
+  if (!senderId) {
+    return null;
+  }
+  const messageTs = event.ts ?? event.event_ts;
+  const threadKey = event.thread_ts
+    ? `${channel}:${event.thread_ts}`
+    : event.parent_user_id && messageTs
+      ? // Thread reply whose thread_ts has not been resolved yet: isolate it
+        // from the channel's top-level lane rather than letting it collide.
+        `${channel}:maybe-thread:${messageTs}`
+      : messageTs && !isDirectMessageChannel(channel)
+        ? `${channel}:${messageTs}`
+        : channel;
+  return `slack:${accountId}:${threadKey}:${senderId}`;
+}
+
+/**
+ * Lane key for top-level (non-thread) messages, used to reason about a
+ * conversation as a whole rather than a single message.
+ */
+export function buildSlackTopLevelConversationKey(
+  event: SlackInboundEventLike,
+  accountId: string,
+): string | null {
+  if (!isTopLevel(event)) {
+    return null;
+  }
+  const channel = event.channel;
+  const senderId = resolveSenderId(event);
+  if (!channel || !senderId) {
+    return null;
+  }
+  return `slack:${accountId}:${channel}:${senderId}`;
+}
+
+export type SlackAdmissionReason =
+  | "new"
+  | "unkeyed"
+  | "supersedes-stale-slot"
+  | "mention-preempts-message"
+  | "message-twin-awaits-mention"
+  | "duplicate-same-source"
+  | "duplicate-event-id"
+  | "twin-already-dispatched";
+
+export interface SlackAdmission {
+  admitted: boolean;
+  reason: SlackAdmissionReason;
+  /** Lane key, or `null` when the event could not be keyed. */
+  key: string | null;
+  /** True when this event is the `message` half of a mention twin. */
+  isMentionTwin: boolean;
+}
+
+export type SlackDispatchOutcome = "dispatched" | "skipped" | "failed";
+
+export interface SlackTwinDecision {
+  proceed: boolean;
+  reason:
+    | "no-twin"
+    | "twin-dispatched"
+    | "twin-released"
+    | "grace-expired"
+    | "unkeyed";
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  settled: boolean;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  const deferred: Deferred<T> = {
+    promise,
+    settled: false,
+    resolve: (value: T) => {
+      if (deferred.settled) {
+        return;
+      }
+      deferred.settled = true;
+      resolve(value);
+    },
+  };
+  return deferred;
+}
+
+interface Slot {
+  /** The `ts` of the logical Slack message occupying this lane. */
+  ts: string;
+  /** Sources admitted for this message, in arrival order. */
+  admitted: Set<SlackInboundSource>;
+  /** Set once a source has actually handed the message to the agent. */
+  dispatchedBy: SlackInboundSource | null;
+  /** Resolves when the `app_mention` half settles, for twins to await. */
+  mentionSettled: Deferred<SlackDispatchOutcome> | null;
+  /** Resolves as soon as an `app_mention` is admitted for this lane. */
+  mentionArrived: Deferred<void>;
+  expiresAt: number;
+}
+
+export interface SlackInboundReliabilityOptions {
+  /** How long a lane remembers a message. Defaults to 10 minutes. */
+  slotTtlMs?: number;
+  /** How long a processed `event_id` is remembered. Defaults to 10 minutes. */
+  eventIdTtlMs?: number;
+  /** Hard cap on retained entries, oldest evicted first. */
+  maxEntries?: number;
+  /** How long a message twin waits for its mention. Defaults to 1500ms. */
+  mentionGraceMs?: number;
+  now?: () => number;
+  /** Injected for deterministic tests. */
+  setTimeoutFn?: (fn: () => void, ms: number) => unknown;
+  clearTimeoutFn?: (handle: unknown) => void;
+}
+
+export interface SlackInboundReliabilityStats {
+  trackedLanes: number;
+  trackedEventIds: number;
+  duplicatesDropped: number;
+  twinsSuppressed: number;
+  twinsRecovered: number;
+}
+
+/**
+ * Per-account inbound coordinator. One instance guards one Slack workspace
+ * connection; lanes are already account-scoped through the key, so sharing
+ * would be safe, but per-account keeps eviction pressure proportional.
+ */
+export class SlackInboundReliability {
+  private readonly slots = new Map<string, Slot>();
+  private readonly seenEventIds = new Map<string, number>();
+  private readonly slotTtlMs: number;
+  private readonly eventIdTtlMs: number;
+  private readonly maxEntries: number;
+  private readonly mentionGraceMs: number;
+  private readonly now: () => number;
+  private readonly setTimeoutFn: (fn: () => void, ms: number) => unknown;
+  private readonly clearTimeoutFn: (handle: unknown) => void;
+
+  private duplicatesDropped = 0;
+  private twinsSuppressed = 0;
+  private twinsRecovered = 0;
+
+  constructor(options: SlackInboundReliabilityOptions = {}) {
+    this.slotTtlMs = options.slotTtlMs ?? DEFAULT_SLOT_TTL_MS;
+    this.eventIdTtlMs = options.eventIdTtlMs ?? DEFAULT_EVENT_ID_TTL_MS;
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.mentionGraceMs = options.mentionGraceMs ?? DEFAULT_MENTION_GRACE_MS;
+    this.now = options.now ?? (() => Date.now());
+    this.setTimeoutFn =
+      options.setTimeoutFn ??
+      ((fn, ms) => setTimeout(fn, ms) as unknown as unknown);
+    this.clearTimeoutFn =
+      options.clearTimeoutFn ??
+      ((handle) => {
+        clearTimeout(handle as ReturnType<typeof setTimeout>);
+      });
+  }
+
+  /**
+   * Envelope-level redelivery guard.
+   *
+   * Slack reuses `event_id` across retries of the same event, so this is the
+   * exact, transport-level answer to "have I already taken this event?" — it
+   * covers every event family, including the ones with no channel/ts to key on
+   * (reactions, member joins, file shares).
+   *
+   * Returns `false` when the event has already been accepted.
+   */
+  admitEventId(eventId: string | null | undefined): boolean {
+    if (!eventId) {
+      // No envelope id (hand-built payloads, some socket frames): fall through
+      // to the lane-level guard rather than dropping a possibly-real event.
+      return true;
+    }
+    const now = this.now();
+    this.pruneEventIds(now);
+    const existing = this.seenEventIds.get(eventId);
+    if (existing !== undefined && existing > now) {
+      this.duplicatesDropped += 1;
+      return false;
+    }
+    this.seenEventIds.set(eventId, now + this.eventIdTtlMs);
+    this.enforceEventIdCap();
+    return true;
+  }
+
+  /**
+   * Lane-level admission for message-family events.
+   *
+   * `retryNum` is Slack's redelivery counter. It is not itself a drop signal:
+   * a retry with no matching record means we never successfully processed the
+   * original, and dropping it would turn a slow turn into a lost one. It is
+   * recorded so the decision is auditable.
+   */
+  admit(params: {
+    accountId: string;
+    source: SlackInboundSource;
+    event: SlackInboundEventLike;
+    eventId?: string | null;
+    retryNum?: number;
+  }): SlackAdmission {
+    const { accountId, source, event } = params;
+
+    if (!this.admitEventId(params.eventId)) {
+      return {
+        admitted: false,
+        reason: "duplicate-event-id",
+        key: buildSlackDebounceKey(event, accountId),
+        isMentionTwin: false,
+      };
+    }
+
+    const key = buildSlackDebounceKey(event, accountId);
+    if (!key) {
+      return {
+        admitted: true,
+        reason: "unkeyed",
+        key: null,
+        isMentionTwin: false,
+      };
+    }
+
+    const ts = event.ts ?? event.event_ts ?? "";
+    const now = this.now();
+    this.pruneSlots(now);
+
+    const existing = this.slots.get(key);
+
+    if (!existing || existing.ts !== ts) {
+      // Either a fresh lane or a new message in a channel-scoped lane (DMs).
+      // Replacing is correct: a different `ts` is a different human message.
+      this.slots.set(key, this.createSlot(ts, source, now));
+      this.enforceSlotCap();
+      return {
+        admitted: true,
+        reason: existing ? "supersedes-stale-slot" : "new",
+        key,
+        isMentionTwin: false,
+      };
+    }
+
+    existing.expiresAt = now + this.slotTtlMs;
+
+    if (existing.admitted.has(source)) {
+      // Same stream, same message, twice: a redelivery or a double bolt fire.
+      this.duplicatesDropped += 1;
+      return {
+        admitted: false,
+        reason: "duplicate-same-source",
+        key,
+        isMentionTwin: false,
+      };
+    }
+
+    if (existing.dispatchedBy && existing.dispatchedBy !== source) {
+      this.twinsSuppressed += 1;
+      return {
+        admitted: false,
+        reason: "twin-already-dispatched",
+        key,
+        isMentionTwin: source === "message",
+      };
+    }
+
+    existing.admitted.add(source);
+
+    if (source === "app_mention") {
+      existing.mentionSettled ??= createDeferred<SlackDispatchOutcome>();
+      existing.mentionArrived.resolve();
+      return {
+        admitted: true,
+        reason: "mention-preempts-message",
+        key,
+        isMentionTwin: false,
+      };
+    }
+
+    // A `message` arriving after its `app_mention`: admitted, but it must wait
+    // for the mention to settle before doing anything user-visible.
+    return {
+      admitted: true,
+      reason: "message-twin-awaits-mention",
+      key,
+      isMentionTwin: true,
+    };
+  }
+
+  /**
+   * Resolves the twin race for a `message` event.
+   *
+   * If an `app_mention` has been admitted for this lane, wait for it to
+   * settle: only a real dispatch suppresses the message. If none has arrived,
+   * wait out a short grace window — Slack emits the pair together, so a window
+   * with no mention means there is no mention coming and this message is the
+   * only chance to answer.
+   */
+  async awaitMentionTwin(
+    key: string | null,
+    graceMs?: number,
+  ): Promise<SlackTwinDecision> {
+    if (!key) {
+      return { proceed: true, reason: "unkeyed" };
+    }
+    const slot = this.slots.get(key);
+    if (!slot) {
+      return { proceed: true, reason: "no-twin" };
+    }
+
+    if (!slot.admitted.has("app_mention")) {
+      const arrived = await this.raceWithGrace(
+        slot.mentionArrived.promise,
+        graceMs ?? this.mentionGraceMs,
+      );
+      if (!arrived) {
+        // No mention showed up. On the old code path this message was already
+        // dropped and the turn lost; here it proceeds.
+        this.twinsRecovered += 1;
+        return { proceed: true, reason: "grace-expired" };
+      }
+    }
+
+    const settled = slot.mentionSettled;
+    if (!settled) {
+      return { proceed: true, reason: "no-twin" };
+    }
+    const outcome = await settled.promise;
+    if (outcome === "dispatched") {
+      this.twinsSuppressed += 1;
+      return { proceed: false, reason: "twin-dispatched" };
+    }
+    // The mention bailed before reaching the agent — the message twin is now
+    // the only surviving copy of this turn, so it proceeds.
+    this.twinsRecovered += 1;
+    return { proceed: true, reason: "twin-released" };
+  }
+
+  /**
+   * Records the terminal outcome for a source on a lane.
+   *
+   * - `dispatched` locks the lane so the twin yields.
+   * - `skipped` (gated, unbuildable memory) releases this source's claim; if
+   *   nothing else holds the lane it is freed so the twin can take over.
+   * - `failed` always frees the lane, so Slack's redelivery gets a real retry
+   *   instead of being swallowed as a duplicate.
+   */
+  settle(
+    key: string | null,
+    source: SlackInboundSource,
+    outcome: SlackDispatchOutcome,
+  ): void {
+    if (!key) {
+      return;
+    }
+    const slot = this.slots.get(key);
+    if (!slot) {
+      return;
+    }
+
+    if (outcome === "dispatched") {
+      slot.dispatchedBy = source;
+      slot.expiresAt = this.now() + this.slotTtlMs;
+      if (source === "app_mention") {
+        slot.mentionSettled?.resolve("dispatched");
+        slot.mentionArrived.resolve();
+      }
+      return;
+    }
+
+    slot.admitted.delete(source);
+    if (source === "app_mention") {
+      slot.mentionSettled?.resolve(outcome);
+      slot.mentionSettled = null;
+      slot.mentionArrived.resolve();
+    }
+
+    if (outcome === "failed") {
+      this.slots.delete(key);
+      return;
+    }
+    if (slot.admitted.size === 0 && !slot.dispatchedBy) {
+      this.slots.delete(key);
+    }
+  }
+
+  stats(): SlackInboundReliabilityStats {
+    return {
+      trackedLanes: this.slots.size,
+      trackedEventIds: this.seenEventIds.size,
+      duplicatesDropped: this.duplicatesDropped,
+      twinsSuppressed: this.twinsSuppressed,
+      twinsRecovered: this.twinsRecovered,
+    };
+  }
+
+  clear(): void {
+    for (const slot of this.slots.values()) {
+      slot.mentionArrived.resolve();
+      slot.mentionSettled?.resolve("skipped");
+    }
+    this.slots.clear();
+    this.seenEventIds.clear();
+  }
+
+  private createSlot(
+    ts: string,
+    source: SlackInboundSource,
+    now: number,
+  ): Slot {
+    const slot: Slot = {
+      ts,
+      admitted: new Set<SlackInboundSource>([source]),
+      dispatchedBy: null,
+      mentionSettled:
+        source === "app_mention"
+          ? createDeferred<SlackDispatchOutcome>()
+          : null,
+      mentionArrived: createDeferred<void>(),
+      expiresAt: now + this.slotTtlMs,
+    };
+    if (source === "app_mention") {
+      slot.mentionArrived.resolve();
+    }
+    return slot;
+  }
+
+  private async raceWithGrace(
+    promise: Promise<void>,
+    graceMs: number,
+  ): Promise<boolean> {
+    if (graceMs <= 0) {
+      // Still yield one microtask so a mention admitted in the same tick wins.
+      await Promise.resolve();
+      return false;
+    }
+    let handle: unknown;
+    const timeout = new Promise<false>((resolve) => {
+      handle = this.setTimeoutFn(() => resolve(false), graceMs);
+    });
+    try {
+      return await Promise.race([promise.then(() => true), timeout]);
+    } finally {
+      this.clearTimeoutFn(handle);
+    }
+  }
+
+  private pruneSlots(now: number): void {
+    for (const [key, slot] of this.slots) {
+      if (slot.expiresAt <= now) {
+        slot.mentionArrived.resolve();
+        slot.mentionSettled?.resolve("skipped");
+        this.slots.delete(key);
+      }
+    }
+  }
+
+  private pruneEventIds(now: number): void {
+    for (const [id, expiresAt] of this.seenEventIds) {
+      if (expiresAt <= now) {
+        this.seenEventIds.delete(id);
+      }
+    }
+  }
+
+  private enforceSlotCap(): void {
+    while (this.slots.size > this.maxEntries) {
+      const oldest = this.slots.keys().next();
+      if (oldest.done) {
+        return;
+      }
+      const slot = this.slots.get(oldest.value);
+      slot?.mentionArrived.resolve();
+      slot?.mentionSettled?.resolve("skipped");
+      this.slots.delete(oldest.value);
+    }
+  }
+
+  private enforceEventIdCap(): void {
+    while (this.seenEventIds.size > this.maxEntries) {
+      const oldest = this.seenEventIds.keys().next();
+      if (oldest.done) {
+        return;
+      }
+      this.seenEventIds.delete(oldest.value);
+    }
+  }
+}
+
+/**
+ * Extracts Slack's redelivery counter from whichever surface carries it.
+ * Socket Mode puts `retry_attempt` on the envelope; the Events API HTTP
+ * receiver surfaces `retryNum` on the bolt context and `retry_num` on the body.
+ */
+export function extractSlackRetryNum(
+  body: unknown,
+  context?: unknown,
+): number | undefined {
+  const fromContext = (context as { retryNum?: unknown } | undefined)?.retryNum;
+  if (typeof fromContext === "number") {
+    return fromContext;
+  }
+  const raw = body as
+    | { retry_num?: unknown; retry_attempt?: unknown }
+    | undefined;
+  if (typeof raw?.retry_num === "number") {
+    return raw.retry_num;
+  }
+  if (typeof raw?.retry_attempt === "number") {
+    return raw.retry_attempt;
+  }
+  return undefined;
+}
+
+/** Extracts the envelope `event_id`, the stable identity across redeliveries. */
+export function extractSlackEventId(body: unknown): string | null {
+  const raw = body as { event_id?: unknown } | undefined;
+  return typeof raw?.event_id === "string" && raw.event_id.length > 0
+    ? raw.event_id
+    : null;
+}

--- a/plugins/plugin-slack/src/reconnect-policy.test.ts
+++ b/plugins/plugin-slack/src/reconnect-policy.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Reconnect policy + liveness proof.
+ *
+ * The behaviour that matters: a revoked token must STOP the reconnect loop,
+ * and a network blip must not. On unfixed develop neither distinction exists —
+ * bolt retries everything forever — so the auth-bail tests below have no
+ * counterpart to pass against.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  computeSlackBackoffMs,
+  decideSlackReconnect,
+  formatSlackError,
+  isNonRecoverableSlackAuthError,
+  SLACK_SOCKET_RECONNECT_POLICY,
+  SlackLivenessTracker,
+} from "./reconnect-policy";
+
+describe("isNonRecoverableSlackAuthError", () => {
+  it.each([
+    "invalid_auth",
+    "token_revoked",
+    "token_expired",
+    "account_inactive",
+    "missing_scope",
+    "not_authed",
+    "org_login_required",
+    "app_uninstalled",
+  ])("treats %s as permanent", (code) => {
+    expect(isNonRecoverableSlackAuthError(new Error(code))).toBe(true);
+  });
+
+  it.each([
+    "ECONNRESET",
+    "socket hang up",
+    "getaddrinfo ENOTFOUND slack.com",
+    "ratelimited",
+    "server_error",
+  ])("treats %s as recoverable", (msg) => {
+    expect(isNonRecoverableSlackAuthError(new Error(msg))).toBe(false);
+  });
+
+  it("reads the structured Slack error code off a WebAPI error", () => {
+    const err = Object.assign(new Error("An API error occurred"), {
+      data: { error: "token_revoked" },
+    });
+    expect(isNonRecoverableSlackAuthError(err)).toBe(true);
+  });
+
+  it("does not misfire on an unrelated message containing a substring", () => {
+    // Word-boundary anchored: "reinvalid_authorization" is not invalid_auth.
+    expect(
+      isNonRecoverableSlackAuthError(new Error("reinvalid_authorization")),
+    ).toBe(false);
+  });
+});
+
+describe("computeSlackBackoffMs", () => {
+  it("grows exponentially from the initial delay", () => {
+    const zeroJitter = () => 0;
+    expect(
+      computeSlackBackoffMs(SLACK_SOCKET_RECONNECT_POLICY, 1, zeroJitter),
+    ).toBe(2_000);
+    expect(
+      computeSlackBackoffMs(SLACK_SOCKET_RECONNECT_POLICY, 2, zeroJitter),
+    ).toBe(3_600);
+    expect(
+      computeSlackBackoffMs(SLACK_SOCKET_RECONNECT_POLICY, 3, zeroJitter),
+    ).toBe(6_480);
+  });
+
+  it("clamps at maxMs no matter how many attempts", () => {
+    expect(
+      computeSlackBackoffMs(SLACK_SOCKET_RECONNECT_POLICY, 50, () => 1),
+    ).toBe(SLACK_SOCKET_RECONNECT_POLICY.maxMs);
+  });
+
+  it("adds jitter so a fleet does not reconnect in lockstep", () => {
+    const low = computeSlackBackoffMs(
+      SLACK_SOCKET_RECONNECT_POLICY,
+      2,
+      () => 0,
+    );
+    const high = computeSlackBackoffMs(
+      SLACK_SOCKET_RECONNECT_POLICY,
+      2,
+      () => 1,
+    );
+    expect(high).toBeGreaterThan(low);
+    expect(high).toBeLessThanOrEqual(
+      low * (1 + SLACK_SOCKET_RECONNECT_POLICY.jitter),
+    );
+  });
+});
+
+describe("decideSlackReconnect", () => {
+  it("retries a transient network error with backoff", () => {
+    const decision = decideSlackReconnect({
+      error: new Error("ECONNRESET"),
+      attempt: 1,
+      random: () => 0,
+    });
+    expect(decision).toEqual({ action: "retry", attempt: 1, delayMs: 2_000 });
+  });
+
+  it("aborts immediately on a revoked token, at attempt 1", () => {
+    // The infinite-churn bug: on develop this reconnects forever against a
+    // credential that can never authenticate.
+    const decision = decideSlackReconnect({
+      error: new Error("token_revoked"),
+      attempt: 1,
+    });
+    expect(decision.action).toBe("abort");
+    expect(decision).toMatchObject({ reason: "auth" });
+    expect(decision.action === "abort" && decision.message).toMatch(
+      /not reconnecting/i,
+    );
+  });
+
+  it("reports auth before exhaustion, so the operator is pointed at the token", () => {
+    const decision = decideSlackReconnect({
+      error: new Error("missing_scope"),
+      attempt: SLACK_SOCKET_RECONNECT_POLICY.maxAttempts + 5,
+    });
+    expect(decision).toMatchObject({ action: "abort", reason: "auth" });
+  });
+
+  it("gives up on a recoverable error once attempts are exhausted", () => {
+    const decision = decideSlackReconnect({
+      error: new Error("ECONNRESET"),
+      attempt: SLACK_SOCKET_RECONNECT_POLICY.maxAttempts,
+    });
+    expect(decision).toMatchObject({ action: "abort", reason: "exhausted" });
+  });
+
+  it("keeps retrying forever when maxAttempts is 0", () => {
+    const decision = decideSlackReconnect({
+      error: new Error("ECONNRESET"),
+      attempt: 9_999,
+      policy: { ...SLACK_SOCKET_RECONNECT_POLICY, maxAttempts: 0 },
+      random: () => 0,
+    });
+    expect(decision.action).toBe("retry");
+  });
+});
+
+describe("formatSlackError", () => {
+  it("surfaces the Slack error code alongside the message", () => {
+    const err = Object.assign(new Error("An API error occurred"), {
+      data: { error: "invalid_auth" },
+    });
+    expect(formatSlackError(err)).toBe("An API error occurred (invalid_auth)");
+  });
+
+  it("handles strings, bare objects, and junk", () => {
+    expect(formatSlackError("boom")).toBe("boom");
+    expect(formatSlackError({ error: "token_revoked" })).toBe("token_revoked");
+    expect(formatSlackError(undefined)).toBe("unknown error");
+  });
+});
+
+describe("SlackLivenessTracker", () => {
+  it("starts as connecting with no event clock", () => {
+    const t = new SlackLivenessTracker();
+    const snap = t.snapshot();
+    expect(snap.healthState).toBe("connecting");
+    expect(snap.lastEventAt).toBeNull();
+  });
+
+  it("does not seed lastEventAt on connect", () => {
+    // Seeding here would mask exactly the wedged-socket case this exists to
+    // catch: connected is not the same as delivering.
+    const t = new SlackLivenessTracker();
+    t.markConnected();
+    expect(t.snapshot().lastEventAt).toBeNull();
+    expect(t.snapshot().healthState).toBe("healthy");
+  });
+
+  it("reports degraded when a connected socket goes silent past the window", () => {
+    let now = 1_000;
+    const t = new SlackLivenessTracker({ stalenessMs: 1_000, now: () => now });
+    t.markConnected();
+    t.markEvent();
+    expect(t.snapshot().healthState).toBe("healthy");
+    now = 2_500;
+    expect(t.snapshot().healthState).toBe("degraded");
+  });
+
+  it("returns to healthy once traffic resumes", () => {
+    let now = 1_000;
+    const t = new SlackLivenessTracker({ stalenessMs: 1_000, now: () => now });
+    t.markConnected();
+    t.markEvent();
+    now = 2_500;
+    expect(t.snapshot().healthState).toBe("degraded");
+    t.markEvent();
+    expect(t.snapshot().healthState).toBe("healthy");
+  });
+
+  it("reports disconnected after a drop, and failed after a permanent bail", () => {
+    const t = new SlackLivenessTracker();
+    t.markConnected();
+    t.markDisconnected(new Error("ECONNRESET"));
+    expect(t.snapshot()).toMatchObject({
+      connected: false,
+      healthState: "disconnected",
+      lastError: "ECONNRESET",
+    });
+
+    t.markPermanentFailure("token_revoked; not reconnecting");
+    const snap = t.snapshot();
+    expect(snap.healthState).toBe("failed");
+    expect(snap.permanentFailure).toMatch(/token_revoked/);
+  });
+
+  it("clears a permanent failure when a later connect succeeds", () => {
+    const t = new SlackLivenessTracker();
+    t.markPermanentFailure("token_revoked");
+    expect(t.snapshot().healthState).toBe("failed");
+    t.markConnected();
+    expect(t.snapshot().healthState).toBe("healthy");
+    expect(t.snapshot().permanentFailure).toBeNull();
+  });
+
+  it("tracks reconnect attempts and resets them on a successful connect", () => {
+    const t = new SlackLivenessTracker();
+    t.markReconnectAttempt(4);
+    expect(t.snapshot().reconnectAttempts).toBe(4);
+    t.markConnected();
+    expect(t.snapshot().reconnectAttempts).toBe(0);
+  });
+});

--- a/plugins/plugin-slack/src/reconnect-policy.ts
+++ b/plugins/plugin-slack/src/reconnect-policy.ts
@@ -1,0 +1,283 @@
+/**
+ * Socket Mode reconnect policy and liveness tracking.
+ *
+ * Bolt reconnects on its own, which is fine for the case it was designed for
+ * (a transient network blip) and actively harmful for the case that actually
+ * pages people: a credential that has stopped working. A revoked bot token, a
+ * deactivated account, or a removed scope will never start succeeding, so a
+ * reconnect loop against one is an infinite loop — it burns Slack rate limit,
+ * fills logs with identical failures, and, worst of all, *looks* like the
+ * connector is trying to recover when it is permanently dead. Nobody gets
+ * told; the agent just goes quiet.
+ *
+ * So this module draws one hard line: recoverable errors get bounded,
+ * jittered backoff; non-recoverable auth errors stop the loop immediately and
+ * surface a diagnosis.
+ *
+ * Liveness is the other half. "Connected" is not "working" — a Socket Mode
+ * connection can sit open and silent after a half-close, and the socket layer
+ * is perfectly happy. Tracking `lastEventAt` separately from `lastConnectedAt`
+ * is what lets a health check tell a quiet workspace apart from a wedged one,
+ * which is exactly the distinction that matters at 3am.
+ */
+
+/**
+ * Slack error codes that will never succeed on retry.
+ *
+ * Each is a permanent statement about the credential, not the network:
+ * the token was revoked, the account was deactivated, the scope was never
+ * granted. Retrying any of them is a busy-loop against a wall.
+ */
+const NON_RECOVERABLE_SLACK_AUTH_ERROR =
+  /\b(account_inactive|invalid_auth|token_revoked|token_expired|not_authed|no_permission|org_login_required|team_access_not_granted|missing_scope|invalid_token|app_uninstalled)\b/i;
+
+export interface SlackReconnectPolicy {
+  initialMs: number;
+  maxMs: number;
+  factor: number;
+  /** Fraction of the base delay added as random jitter, 0..1. */
+  jitter: number;
+  /** Attempt ceiling; `0` means unbounded. */
+  maxAttempts: number;
+}
+
+/**
+ * 2s → 30s over ~8 attempts, 12 attempts total (~4 minutes of trying).
+ * Jitter is what keeps a fleet of agents from stampeding Slack in lockstep
+ * after a shared outage.
+ */
+export const SLACK_SOCKET_RECONNECT_POLICY: SlackReconnectPolicy = {
+  initialMs: 2_000,
+  maxMs: 30_000,
+  factor: 1.8,
+  jitter: 0.25,
+  maxAttempts: 12,
+};
+
+/**
+ * Exponential backoff with additive jitter, clamped to `maxMs`.
+ * `attempt` is 1-based: the first retry waits `initialMs`.
+ */
+export function computeSlackBackoffMs(
+  policy: SlackReconnectPolicy,
+  attempt: number,
+  random: () => number = Math.random,
+): number {
+  const base = policy.initialMs * policy.factor ** Math.max(attempt - 1, 0);
+  const jitter = base * policy.jitter * random();
+  return Math.min(policy.maxMs, Math.round(base + jitter));
+}
+
+/** Normalises any thrown value into a message string for matching/logging. */
+export function formatSlackError(error: unknown): string {
+  if (error instanceof Error) {
+    const data = (error as { data?: { error?: unknown } }).data;
+    const slackCode =
+      data && typeof data === "object" && typeof data.error === "string"
+        ? data.error
+        : "";
+    return slackCode ? `${error.message} (${slackCode})` : error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error && typeof error === "object") {
+    const raw = error as { error?: unknown; message?: unknown };
+    if (typeof raw.error === "string") {
+      return raw.error;
+    }
+    if (typeof raw.message === "string") {
+      return raw.message;
+    }
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return "unknown error";
+    }
+  }
+  return "unknown error";
+}
+
+/**
+ * True when an error means the credential is permanently unusable.
+ *
+ * The check reads the structured `data.error` Slack sets on `WebAPIPlatformError`
+ * as well as the message text, so it works whether the error came back from a
+ * web API call or a socket start failure.
+ */
+export function isNonRecoverableSlackAuthError(error: unknown): boolean {
+  return NON_RECOVERABLE_SLACK_AUTH_ERROR.test(formatSlackError(error));
+}
+
+export type SlackReconnectDecision =
+  | { action: "retry"; attempt: number; delayMs: number }
+  | { action: "abort"; attempt: number; reason: "auth"; message: string }
+  | {
+      action: "abort";
+      attempt: number;
+      reason: "exhausted";
+      message: string;
+    };
+
+/**
+ * Single decision point for "the socket just died, now what".
+ *
+ * Auth is checked before the attempt ceiling deliberately: an operator whose
+ * token was revoked should be told *that*, not "max attempts reached", which
+ * would send them looking at their network.
+ */
+export function decideSlackReconnect(params: {
+  error: unknown;
+  attempt: number;
+  policy?: SlackReconnectPolicy;
+  random?: () => number;
+}): SlackReconnectDecision {
+  const policy = params.policy ?? SLACK_SOCKET_RECONNECT_POLICY;
+  const attempt = params.attempt;
+
+  if (isNonRecoverableSlackAuthError(params.error)) {
+    return {
+      action: "abort",
+      attempt,
+      reason: "auth",
+      message: `Slack socket mode hit a non-recoverable auth error; not reconnecting (${formatSlackError(params.error)}). Check the bot/app tokens and granted scopes.`,
+    };
+  }
+
+  if (policy.maxAttempts > 0 && attempt >= policy.maxAttempts) {
+    return {
+      action: "abort",
+      attempt,
+      reason: "exhausted",
+      message: `Slack socket mode reconnect gave up after ${attempt}/${policy.maxAttempts} attempts (${formatSlackError(params.error)}).`,
+    };
+  }
+
+  return {
+    action: "retry",
+    attempt,
+    delayMs: computeSlackBackoffMs(policy, attempt, params.random),
+  };
+}
+
+export type SlackHealthState =
+  | "connecting"
+  | "healthy"
+  | "degraded"
+  | "disconnected"
+  | "failed";
+
+export interface SlackLivenessSnapshot {
+  connected: boolean;
+  healthState: SlackHealthState;
+  lastConnectedAt: number | null;
+  /** Last time *any* inbound event was seen. The real liveness signal. */
+  lastEventAt: number | null;
+  lastDisconnectedAt: number | null;
+  lastError: string | null;
+  reconnectAttempts: number;
+  /** Set when the connector stopped permanently, e.g. a revoked token. */
+  permanentFailure: string | null;
+}
+
+export interface SlackLivenessOptions {
+  /**
+   * Silence after which a connected socket is reported `degraded`.
+   * Default 15 minutes: long enough that a genuinely quiet channel does not
+   * trip it, short enough to catch a wedged socket within one on-call glance.
+   */
+  stalenessMs?: number;
+  now?: () => number;
+}
+
+const DEFAULT_STALENESS_MS = 15 * 60_000;
+
+/**
+ * Per-account liveness tracker.
+ *
+ * Kept deliberately dumb — it records timestamps and derives a state. All the
+ * policy lives in `snapshot()`, so callers cannot disagree about what
+ * "healthy" means.
+ */
+export class SlackLivenessTracker {
+  private connected = false;
+  private lastConnectedAt: number | null = null;
+  private lastEventAt: number | null = null;
+  private lastDisconnectedAt: number | null = null;
+  private lastError: string | null = null;
+  private reconnectAttempts = 0;
+  private permanentFailure: string | null = null;
+  private readonly stalenessMs: number;
+  private readonly now: () => number;
+
+  constructor(options: SlackLivenessOptions = {}) {
+    this.stalenessMs = options.stalenessMs ?? DEFAULT_STALENESS_MS;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  markConnected(): void {
+    this.connected = true;
+    this.lastConnectedAt = this.now();
+    this.lastError = null;
+    this.permanentFailure = null;
+    this.reconnectAttempts = 0;
+    // Note: `lastEventAt` is deliberately NOT seeded here. Connecting is not
+    // evidence of traffic, and seeding it would paper over exactly the wedged
+    // -socket case this tracker exists to catch.
+  }
+
+  markDisconnected(error?: unknown): void {
+    this.connected = false;
+    this.lastDisconnectedAt = this.now();
+    if (error !== undefined) {
+      this.lastError = formatSlackError(error);
+    }
+  }
+
+  /** Called on every inbound event, before any gating. */
+  markEvent(): void {
+    this.lastEventAt = this.now();
+  }
+
+  markReconnectAttempt(attempt: number): void {
+    this.reconnectAttempts = attempt;
+  }
+
+  markPermanentFailure(message: string): void {
+    this.connected = false;
+    this.permanentFailure = message;
+    this.lastError = message;
+    this.lastDisconnectedAt = this.now();
+  }
+
+  snapshot(): SlackLivenessSnapshot {
+    return {
+      connected: this.connected,
+      healthState: this.deriveHealthState(),
+      lastConnectedAt: this.lastConnectedAt,
+      lastEventAt: this.lastEventAt,
+      lastDisconnectedAt: this.lastDisconnectedAt,
+      lastError: this.lastError,
+      reconnectAttempts: this.reconnectAttempts,
+      permanentFailure: this.permanentFailure,
+    };
+  }
+
+  private deriveHealthState(): SlackHealthState {
+    if (this.permanentFailure) {
+      return "failed";
+    }
+    if (!this.connected) {
+      return this.lastConnectedAt === null ? "connecting" : "disconnected";
+    }
+    // Connected but silent for longer than the staleness window, having
+    // previously seen traffic: the socket is open and probably not delivering.
+    if (
+      this.lastEventAt !== null &&
+      this.now() - this.lastEventAt > this.stalenessMs
+    ) {
+      return "degraded";
+    }
+    return "healthy";
+  }
+}

--- a/plugins/plugin-slack/src/service-inbound-reliability.test.ts
+++ b/plugins/plugin-slack/src/service-inbound-reliability.test.ts
@@ -1,0 +1,625 @@
+/**
+ * Production-path proof for the inbound reliability core.
+ *
+ * Every test here drives the handlers that `registerEventHandlers` actually
+ * binds to the bolt app — `app.message`, `app.event("app_mention")`,
+ * `app.event("reaction_added")` and friends — captured off a fake `App`. The
+ * assertion is always on `processAgentMessage` / `emitEvent`, i.e. whether a
+ * real agent run happened. A helper-level test would prove nothing about
+ * whether the guards are wired into the path Slack traffic takes.
+ *
+ * Bidirectional: each block states what unfixed develop does. On develop these
+ * fail (duplicate agent runs on redelivery, dropped turns in the twin race,
+ * accepted cross-workspace events); with this change they pass.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ResolvedSlackAccount } from "./accounts";
+import { SlackInboundReliability } from "./inbound-reliability";
+import { SlackLivenessTracker } from "./reconnect-policy";
+import { SlackService } from "./service";
+import type { SlackChannel, SlackSettings, SlackUser } from "./types";
+
+const BOT_USER_ID = "U0BOTBOT0";
+const CHANNEL_ID = "C0123ABCD";
+const USER_ID = "U0123ABCD";
+const TEAM_ID = "T0TEAM000";
+const API_APP_ID = "A0APP0000";
+
+function createRuntime() {
+  return {
+    agentId: "agent-slack-reliability",
+    character: { name: "Salem", settings: {} },
+    logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: vi.fn().mockReturnValue(undefined),
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+    createMemory: vi.fn().mockResolvedValue(undefined),
+    createEntity: vi.fn().mockResolvedValue(undefined),
+    getEntityById: vi.fn().mockResolvedValue({ id: "entity-1" }),
+  } as unknown as IAgentRuntime;
+}
+
+interface HarnessOptions {
+  mentionGraceMs?: number;
+  /** Lets a test make the mention path bail or throw. */
+  mentionBehaviour?: "ok" | "skip" | "throw";
+  messageBehaviour?: "ok" | "throw";
+  identity?: {
+    apiAppId?: string | null;
+    teamId?: string | null;
+    enterpriseId?: string | null;
+  };
+}
+
+/**
+ * Builds a SlackService with one account state wired the way
+ * `initializeAccount` wires it, then returns the handlers that
+ * `registerEventHandlers` binds to the bolt app.
+ */
+function createHarness(options: HarnessOptions = {}) {
+  const runtime = createRuntime();
+  const service = Object.create(SlackService.prototype) as SlackService;
+
+  const settings: SlackSettings = {
+    shouldIgnoreBotMessages: true,
+    shouldRespondOnlyToMentions: false,
+  };
+
+  const account = {
+    accountId: "default",
+    enabled: true,
+    role: "AGENT",
+    botToken: "xoxb-test",
+    appToken: "xapp-test",
+    config: {},
+  } as unknown as ResolvedSlackAccount;
+
+  const state = {
+    accountId: "default",
+    account,
+    app: {} as never,
+    client: {} as never,
+    userClient: null,
+    botUserId: BOT_USER_ID,
+    teamId: TEAM_ID,
+    settings,
+    allowedChannelIds: new Set<string>(),
+    dynamicChannelIds: new Set<string>(),
+    userCache: new Map<string, SlackUser>(),
+    channelCache: new Map<string, SlackChannel>(),
+    isConnected: true,
+    identity: options.identity ?? {
+      apiAppId: API_APP_ID,
+      teamId: TEAM_ID,
+      enterpriseId: null,
+    },
+    reliability: new SlackInboundReliability({
+      mentionGraceMs: options.mentionGraceMs ?? 20,
+    }),
+    liveness: new SlackLivenessTracker(),
+  };
+
+  Object.assign(service, {
+    runtime,
+    character: runtime.character,
+    settings,
+    defaultAccountId: "default",
+    accountStates: new Map([["default", state]]),
+    accountStarts: new Map(),
+    allowedChannelIds: new Set<string>(),
+    dynamicChannelIds: new Set<string>(),
+    userCache: new Map(),
+    channelCache: new Map(),
+    botUserId: BOT_USER_ID,
+    teamId: TEAM_ID,
+    isConnected: true,
+  });
+
+  // Everything downstream of the guards is stubbed: the assertion is purely
+  // "did a real agent run happen, and how many times".
+  const processAgentMessage = vi.fn().mockResolvedValue(undefined);
+
+  const mentionBehaviour = options.mentionBehaviour ?? "ok";
+  const messageBehaviour = options.messageBehaviour ?? "ok";
+
+  Object.assign(service, {
+    processAgentMessage,
+    // `isChannelAllowed` is the gating lane's surface; keep it permissive here
+    // so this file only exercises reliability.
+    isChannelAllowed: () => true,
+    buildMemoryFromMessage: vi.fn().mockImplementation(async () => {
+      if (messageBehaviour === "throw") {
+        throw new Error("message path exploded");
+      }
+      return { id: "mem-msg", entityId: "entity-1" };
+    }),
+    buildMemoryFromMention: vi.fn().mockImplementation(async () => {
+      if (mentionBehaviour === "throw") {
+        throw new Error("mention path exploded");
+      }
+      // `null` is the real "mention bailed" signal in handleAppMention.
+      return mentionBehaviour === "skip"
+        ? null
+        : { id: "mem-mention", entityId: "entity-1" };
+    }),
+    ensureRoomExists: vi.fn().mockResolvedValue({ id: "room-1" }),
+    getUser: vi.fn().mockResolvedValue(null),
+  });
+
+  const handlers: Record<
+    string,
+    (args: Record<string, unknown>) => Promise<void>
+  > = {};
+
+  const app = {
+    message: (fn: (args: Record<string, unknown>) => Promise<void>) => {
+      handlers.message = fn;
+    },
+    event: (
+      name: string,
+      fn: (args: Record<string, unknown>) => Promise<void>,
+    ) => {
+      handlers[name] = fn;
+    },
+  };
+
+  (
+    service as unknown as { registerEventHandlers: (s: unknown) => void }
+  ).registerEventHandlers({ ...state, app });
+
+  return { service, runtime, handlers, processAgentMessage, state };
+}
+
+function envelope(overrides: Record<string, unknown> = {}) {
+  return {
+    api_app_id: API_APP_ID,
+    team_id: TEAM_ID,
+    type: "event_callback",
+    event_id: "Ev0000000",
+    event_time: 1_709_000_000,
+    ...overrides,
+  };
+}
+
+function plainMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "message",
+    channel: CHANNEL_ID,
+    channel_type: "channel",
+    user: USER_ID,
+    text: "chores status?",
+    ts: "1709000000.000100",
+    ...overrides,
+  };
+}
+
+function mentionMessage(overrides: Record<string, unknown> = {}) {
+  return plainMessage({
+    text: `<@${BOT_USER_ID}> chores status?`,
+    ...overrides,
+  });
+}
+
+function mentionEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "app_mention",
+    channel: CHANNEL_ID,
+    user: USER_ID,
+    text: `<@${BOT_USER_ID}> chores status?`,
+    ts: "1709000000.000100",
+    event_ts: "1709000000.000100",
+    ...overrides,
+  };
+}
+
+describe("registration", () => {
+  it("binds every inbound family on the real bolt app", () => {
+    const { handlers } = createHarness();
+    for (const name of [
+      "message",
+      "app_mention",
+      "reaction_added",
+      "reaction_removed",
+      "member_joined_channel",
+      "member_left_channel",
+      "file_shared",
+    ]) {
+      expect(handlers[name], `handler ${name}`).toBeTypeOf("function");
+    }
+  });
+});
+
+describe("capability 1 — event dedupe on Slack redelivery", () => {
+  it("runs the agent once when Slack redelivers the same message event", async () => {
+    // FAILS on unfixed develop: no dedupe cache exists, so a redelivered
+    // event (identical event_id, retry_num 1) produces a second agent run and
+    // a duplicate reply.
+    const { handlers, processAgentMessage } = createHarness();
+
+    const body = envelope({ event_id: "Ev_RETRY_1" });
+    await handlers.message?.({
+      message: plainMessage(),
+      client: {},
+      body,
+      context: {},
+    });
+    await handlers.message?.({
+      message: plainMessage(),
+      client: {},
+      body: { ...body, retry_num: 1 },
+      context: { retryNum: 1 },
+    });
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the agent once when the same app_mention is redelivered", async () => {
+    const { handlers, processAgentMessage } = createHarness();
+
+    const body = envelope({ event_id: "Ev_RETRY_2" });
+    await handlers.app_mention?.({
+      event: mentionEvent(),
+      client: {},
+      body,
+      context: {},
+    });
+    await handlers.app_mention?.({
+      event: mentionEvent(),
+      client: {},
+      body: { ...body, retry_num: 2 },
+      context: { retryNum: 2 },
+    });
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("still processes two genuinely distinct messages in one channel", async () => {
+    // Guards against over-deduping: top-level messages are scoped by their own
+    // ts, so a busy channel does not collapse into one lane.
+    const { handlers, processAgentMessage } = createHarness();
+
+    await handlers.message?.({
+      message: plainMessage({ ts: "1709000000.000100" }),
+      client: {},
+      body: envelope({ event_id: "Ev_A" }),
+      context: {},
+    });
+    await handlers.message?.({
+      message: plainMessage({ ts: "1709000000.000200", text: "and dishes?" }),
+      client: {},
+      body: envelope({ event_id: "Ev_B" }),
+      context: {},
+    });
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("dedupes redelivered non-message events by event_id", async () => {
+    // FAILS on unfixed develop: reaction redelivery emits the event twice.
+    const { handlers, runtime } = createHarness();
+    const body = envelope({ event_id: "Ev_REACTION" });
+    const event = {
+      user: USER_ID,
+      reaction: "white_check_mark",
+      item: { type: "message", channel: CHANNEL_ID, ts: "1709000000.000100" },
+    };
+
+    await handlers.reaction_added?.({ event, body });
+    await handlers.reaction_added?.({ event, body: { ...body, retry_num: 1 } });
+
+    const emitted = (runtime.emitEvent as ReturnType<typeof vi.fn>).mock.calls;
+    expect(emitted).toHaveLength(1);
+  });
+});
+
+describe("capability 2 — app_mention / message race", () => {
+  it("runs the agent exactly once when the mention wins", async () => {
+    const { handlers, processAgentMessage } = createHarness();
+
+    await handlers.app_mention?.({
+      event: mentionEvent(),
+      client: {},
+      body: envelope({ event_id: "Ev_M1" }),
+      context: {},
+    });
+    await handlers.message?.({
+      message: mentionMessage(),
+      client: {},
+      body: envelope({ event_id: "Ev_M2" }),
+      context: {},
+    });
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the agent exactly once when the message twin arrives first", async () => {
+    const { handlers, processAgentMessage } = createHarness();
+
+    const messageRun = handlers.message?.({
+      message: mentionMessage(),
+      client: {},
+      body: envelope({ event_id: "Ev_M3" }),
+      context: {},
+    });
+    await Promise.resolve();
+    const mentionRun = handlers.app_mention?.({
+      event: mentionEvent(),
+      client: {},
+      body: envelope({ event_id: "Ev_M4" }),
+      context: {},
+    });
+
+    await Promise.all([messageRun, mentionRun]);
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not drop the turn when the mention path bails", async () => {
+    // FAILS on unfixed develop: handleMessage returns unconditionally for a
+    // channel mention, so when handleAppMention bails (here: no memory built)
+    // NOTHING answers the user. This is the silent-drop half of the bug.
+    const { handlers, processAgentMessage } = createHarness({
+      mentionBehaviour: "skip",
+    });
+
+    const messageRun = handlers.message?.({
+      message: mentionMessage(),
+      client: {},
+      body: envelope({ event_id: "Ev_M5" }),
+      context: {},
+    });
+    await Promise.resolve();
+    await handlers.app_mention?.({
+      event: mentionEvent(),
+      client: {},
+      body: envelope({ event_id: "Ev_M6" }),
+      context: {},
+    });
+    await messageRun;
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not drop the turn when the mention path throws", async () => {
+    const { handlers, processAgentMessage } = createHarness({
+      mentionBehaviour: "throw",
+    });
+
+    const messageRun = handlers.message?.({
+      message: mentionMessage(),
+      client: {},
+      body: envelope({ event_id: "Ev_M7" }),
+      context: {},
+    });
+    await Promise.resolve();
+    await expect(
+      handlers.app_mention?.({
+        event: mentionEvent(),
+        client: {},
+        body: envelope({ event_id: "Ev_M8" }),
+        context: {},
+      }),
+    ).rejects.toThrow("mention path exploded");
+    await messageRun;
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers a mention whose app_mention twin never arrives", async () => {
+    // FAILS on unfixed develop: the message is discarded outright and the
+    // user is never answered.
+    const { handlers, processAgentMessage } = createHarness({
+      mentionGraceMs: 5,
+    });
+
+    await handlers.message?.({
+      message: mentionMessage(),
+      client: {},
+      body: envelope({ event_id: "Ev_M9" }),
+      context: {},
+    });
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles both twins arriving concurrently without dropping or doubling", async () => {
+    const { handlers, processAgentMessage } = createHarness();
+
+    await Promise.all([
+      handlers.message?.({
+        message: mentionMessage(),
+        client: {},
+        body: envelope({ event_id: "Ev_C1" }),
+        context: {},
+      }),
+      handlers.app_mention?.({
+        event: mentionEvent(),
+        client: {},
+        body: envelope({ event_id: "Ev_C2" }),
+        context: {},
+      }),
+    ]);
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("still answers DM mentions, which have no app_mention twin", async () => {
+    const { handlers, processAgentMessage } = createHarness();
+
+    await handlers.message?.({
+      message: mentionMessage({ channel: "D0123ABCD", channel_type: "im" }),
+      client: {},
+      body: envelope({ event_id: "Ev_DM" }),
+      context: {},
+    });
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("capability 3 — multi-workspace event isolation", () => {
+  it("drops a message event from a foreign team_id", async () => {
+    // FAILS on unfixed develop: events are attributed by handler closure only,
+    // so a foreign workspace's message is processed into this account.
+    const { handlers, processAgentMessage } = createHarness();
+
+    await handlers.message?.({
+      message: plainMessage(),
+      client: {},
+      body: envelope({ team_id: "T_OTHER", event_id: "Ev_X1" }),
+      context: {},
+    });
+
+    expect(processAgentMessage).not.toHaveBeenCalled();
+  });
+
+  it("drops a message event from a foreign api_app_id", async () => {
+    const { handlers, processAgentMessage } = createHarness();
+
+    await handlers.message?.({
+      message: plainMessage(),
+      client: {},
+      body: envelope({ api_app_id: "A_OTHER", event_id: "Ev_X2" }),
+      context: {},
+    });
+
+    expect(processAgentMessage).not.toHaveBeenCalled();
+  });
+
+  it("drops a foreign app_mention", async () => {
+    const { handlers, processAgentMessage } = createHarness();
+
+    await handlers.app_mention?.({
+      event: mentionEvent(),
+      client: {},
+      body: envelope({ team_id: "T_OTHER", event_id: "Ev_X3" }),
+      context: {},
+    });
+
+    expect(processAgentMessage).not.toHaveBeenCalled();
+  });
+
+  it("drops foreign events on every non-message family too", async () => {
+    // Defense in depth is only defense if it is uniform: a foreign reaction or
+    // member-join corrupts state just as effectively as a message.
+    const { handlers, runtime } = createHarness();
+    const foreign = envelope({ team_id: "T_OTHER", event_id: "Ev_X4" });
+
+    await handlers.reaction_added?.({
+      event: {
+        user: USER_ID,
+        reaction: "eyes",
+        item: { type: "message", channel: CHANNEL_ID, ts: "1.1" },
+      },
+      body: foreign,
+    });
+    await handlers.reaction_removed?.({
+      event: {
+        user: USER_ID,
+        reaction: "eyes",
+        item: { type: "message", channel: CHANNEL_ID, ts: "1.1" },
+      },
+      body: foreign,
+    });
+    await handlers.member_joined_channel?.({
+      event: { user: USER_ID, channel: CHANNEL_ID },
+      body: foreign,
+    });
+    await handlers.member_left_channel?.({
+      event: { user: USER_ID, channel: CHANNEL_ID },
+      body: foreign,
+    });
+    await handlers.file_shared?.({
+      event: { file_id: "F1", user_id: USER_ID, channel_id: CHANNEL_ID },
+      body: foreign,
+    });
+
+    expect(runtime.emitEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not drop a foreign member_joined_channel into dynamic channels", async () => {
+    // The concrete cross-tenant state corruption: without the guard, a foreign
+    // bot-join would widen THIS account's allowlist.
+    const { handlers, state } = createHarness();
+
+    await handlers.member_joined_channel?.({
+      event: { user: BOT_USER_ID, channel: "C_FOREIGN" },
+      body: envelope({ team_id: "T_OTHER", event_id: "Ev_X5" }),
+    });
+
+    expect(state.dynamicChannelIds.has("C_FOREIGN")).toBe(false);
+  });
+
+  it("accepts matching events, so isolation is not just a blanket deny", async () => {
+    const { handlers, processAgentMessage } = createHarness();
+
+    await handlers.message?.({
+      message: plainMessage(),
+      client: {},
+      body: envelope({ event_id: "Ev_OK" }),
+      context: {},
+    });
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts events whose envelope omits the identity fields", async () => {
+    // Fail-open on ABSENT fields: some families carry no team_id, and dropping
+    // those would break working deployments to defend against nothing.
+    const { handlers, processAgentMessage } = createHarness();
+
+    await handlers.message?.({
+      message: plainMessage(),
+      client: {},
+      body: { type: "event_callback", event_id: "Ev_BARE" },
+      context: {},
+    });
+
+    expect(processAgentMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("capability 4 — liveness tracking on the real path", () => {
+  it("records lastEventAt only once inbound traffic actually arrives", async () => {
+    const { handlers, service } = createHarness();
+
+    const before = (
+      service as unknown as {
+        getHealth: () => Record<string, { lastEventAt: number | null }>;
+      }
+    ).getHealth();
+    expect(before.default.lastEventAt).toBeNull();
+
+    await handlers.message?.({
+      message: plainMessage(),
+      client: {},
+      body: envelope({ event_id: "Ev_LIVE" }),
+      context: {},
+    });
+
+    const after = (
+      service as unknown as {
+        getHealth: () => Record<string, { lastEventAt: number | null }>;
+      }
+    ).getHealth();
+    expect(after.default.lastEventAt).toBeTypeOf("number");
+  });
+
+  it("counts a gated-out event as liveness, since the socket did deliver it", async () => {
+    const { handlers, service } = createHarness();
+
+    await handlers.message?.({
+      message: plainMessage({ user: BOT_USER_ID }),
+      client: {},
+      body: envelope({ event_id: "Ev_SELF" }),
+      context: {},
+    });
+
+    const health = (
+      service as unknown as {
+        getHealth: () => Record<string, { lastEventAt: number | null }>;
+      }
+    ).getHealth();
+    expect(health.default.lastEventAt).toBeTypeOf("number");
+  });
+});

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -315,6 +315,58 @@ interface SlackAppMentionEventType {
   event_ts: string;
 }
 
+/**
+ * The bolt envelope + context around an inbound event. Carries the fields the
+ * event payload itself does not: `event_id` (stable across redeliveries),
+ * `retry_num` / `retryNum`, and the `api_app_id` / `team_id` used for
+ * workspace isolation.
+ */
+interface SlackInboundEnvelope {
+  body?: unknown;
+  context?: unknown;
+}
+
+/** Terminal state of one inbound handler run, reported to the lane tracker. */
+type SlackDispatchOutcomeLocal = "dispatched" | "skipped" | "failed";
+
+type SlackSocketEmitter = {
+  on: (event: string, listener: (...args: unknown[]) => void) => unknown;
+};
+
+/**
+ * Reaches the Socket Mode client's event emitter through the bolt receiver.
+ *
+ * Bolt does not expose socket lifecycle events on the `App`, so the receiver's
+ * client is the only place to observe disconnects. Every hop is checked
+ * because this is an internal shape: if a future bolt release moves it, this
+ * returns `null` and reconnect handling degrades to bolt's own behaviour
+ * rather than throwing at startup.
+ */
+function getSlackSocketEmitter(app: unknown): SlackSocketEmitter | null {
+  const receiver = (app as { receiver?: unknown } | null)?.receiver;
+  if (!receiver || typeof receiver !== "object") {
+    return null;
+  }
+  const client = (receiver as { client?: unknown }).client;
+  if (!client || typeof client !== "object") {
+    return null;
+  }
+  const on = (client as { on?: unknown }).on;
+  if (typeof on !== "function") {
+    return null;
+  }
+  return {
+    on: (event, listener) =>
+      (
+        on as (
+          this: unknown,
+          event: string,
+          listener: (...args: unknown[]) => void,
+        ) => unknown
+      ).call(client, event, listener),
+  };
+}
+
 // Helper to get message service from runtime
 const getMessageService = (runtime: IAgentRuntime): IMessageService | null => {
   if ("messageService" in runtime) {
@@ -333,7 +385,23 @@ import {
   type ResolvedSlackAccount,
   resolveDefaultSlackAccountId,
 } from "./accounts";
+import {
+  type SlackAccountIdentity,
+  shouldDropMismatchedSlackEvent,
+} from "./event-isolation";
 import { markdownToSlackMrkdwn } from "./formatting";
+import {
+  extractSlackEventId,
+  extractSlackRetryNum,
+  SlackInboundReliability,
+} from "./inbound-reliability";
+import {
+  decideSlackReconnect,
+  formatSlackError,
+  isNonRecoverableSlackAuthError,
+  type SlackLivenessSnapshot,
+  SlackLivenessTracker,
+} from "./reconnect-policy";
 import {
   getSlackChannelType,
   getSlackUserDisplayName,
@@ -375,6 +443,16 @@ type SlackAccountRuntime = {
   userCache: Map<string, SlackUser>;
   channelCache: Map<string, SlackChannel>;
   isConnected: boolean;
+  /**
+   * `api_app_id` / `enterprise_id` learned from `auth.test`, compared against
+   * every inbound envelope so cross-workspace bleed is detected rather than
+   * assumed away. See `event-isolation.ts`.
+   */
+  identity: SlackAccountIdentity;
+  /** Dedupe + `app_mention`/`message` race coordinator for this workspace. */
+  reliability: SlackInboundReliability;
+  /** Connection + `lastEventAt` liveness, surfaced through `getHealth()`. */
+  liveness: SlackLivenessTracker;
 };
 
 /**
@@ -799,11 +877,22 @@ export class SlackService extends Service implements ISlackService {
         userCache: new Map(),
         channelCache: new Map(),
         isConnected: false,
+        identity: {},
+        reliability: new SlackInboundReliability(),
+        liveness: new SlackLivenessTracker(),
       };
 
       const authResult = await state.client.auth.test();
       state.botUserId = authResult.user_id as string;
       state.teamId = authResult.team_id as string;
+      // Workspace identity for the isolation guard. `auth.test` is the only
+      // authoritative source for which app + team these tokens belong to.
+      state.identity = {
+        apiAppId: (authResult as { api_app_id?: string }).api_app_id ?? null,
+        teamId: state.teamId,
+        enterpriseId:
+          (authResult as { enterprise_id?: string }).enterprise_id ?? null,
+      };
 
       this.accountStates.set(accountId, state);
       this.syncDefaultAccountAliases();
@@ -824,11 +913,26 @@ export class SlackService extends Service implements ISlackService {
       try {
         await app.start();
       } catch (error) {
+        // A revoked token or missing scope will fail identically forever.
+        // Record it as a permanent failure so health reports say *why* the
+        // connector is down instead of leaving it looking merely unstarted.
+        if (isNonRecoverableSlackAuthError(error)) {
+          const message = `Slack account ${accountId} could not start: non-recoverable auth error (${formatSlackError(error)}). Check the bot/app tokens and granted scopes.`;
+          state.liveness.markPermanentFailure(message);
+          this.runtime.logger.error(
+            { src: "plugin:slack", agentId: this.runtime.agentId, accountId },
+            message,
+          );
+        } else {
+          state.liveness.markDisconnected(error);
+        }
         this.accountStates.delete(accountId);
         this.syncDefaultAccountAliases();
         throw error;
       }
       state.isConnected = true;
+      state.liveness.markConnected();
+      this.registerSocketLifecycleHandlers(state);
       this.syncDefaultAccountAliases();
 
       this.runtime.logger.info(
@@ -884,51 +988,220 @@ export class SlackService extends Service implements ISlackService {
     }
   }
 
+  /**
+   * Registers the bolt listeners for an account.
+   *
+   * Every family runs the workspace-isolation guard first. It is cheap (two
+   * string compares against the envelope) and it is the only thing standing
+   * between a foreign workspace's events and this account's memory, so it is
+   * applied uniformly rather than only on the paths that felt risky.
+   */
   private registerEventHandlers(state?: SlackAccountRuntime): void {
     const app = state?.app ?? this.app;
     const accountId = state?.accountId ?? this.defaultAccountId;
     if (!app) return;
 
     // Handle regular messages
-    app.message(async ({ message, client }) => {
+    app.message(async ({ message, client, body, context }) => {
+      if (this.shouldDropInboundEvent(body, accountId, "message")) return;
+      this.markInboundEvent(accountId);
       await this.handleMessage(
         message as SlackMessageEventType,
         client,
         accountId,
+        { body, context },
       );
     });
 
     // Handle app mentions
-    app.event("app_mention", async ({ event, client }) => {
+    app.event("app_mention", async ({ event, client, body, context }) => {
+      if (this.shouldDropInboundEvent(body, accountId, "app_mention")) return;
+      this.markInboundEvent(accountId);
       await this.handleAppMention(
         event as SlackAppMentionEventType,
         client,
         accountId,
+        { body, context },
       );
     });
 
     // Handle reactions
-    app.event("reaction_added", async ({ event }) => {
+    app.event("reaction_added", async ({ event, body }) => {
+      if (this.shouldDropInboundEvent(body, accountId, "reaction_added"))
+        return;
+      this.markInboundEvent(accountId);
+      if (!this.admitNonMessageEvent(body, accountId)) return;
       await this.handleReactionAdded(event, accountId);
     });
 
-    app.event("reaction_removed", async ({ event }) => {
+    app.event("reaction_removed", async ({ event, body }) => {
+      if (this.shouldDropInboundEvent(body, accountId, "reaction_removed"))
+        return;
+      this.markInboundEvent(accountId);
+      if (!this.admitNonMessageEvent(body, accountId)) return;
       await this.handleReactionRemoved(event, accountId);
     });
 
     // Handle channel joins/leaves
-    app.event("member_joined_channel", async ({ event }) => {
+    app.event("member_joined_channel", async ({ event, body }) => {
+      if (this.shouldDropInboundEvent(body, accountId, "member_joined_channel"))
+        return;
+      this.markInboundEvent(accountId);
+      if (!this.admitNonMessageEvent(body, accountId)) return;
       await this.handleMemberJoinedChannel(event, accountId);
     });
 
-    app.event("member_left_channel", async ({ event }) => {
+    app.event("member_left_channel", async ({ event, body }) => {
+      if (this.shouldDropInboundEvent(body, accountId, "member_left_channel"))
+        return;
+      this.markInboundEvent(accountId);
+      if (!this.admitNonMessageEvent(body, accountId)) return;
       await this.handleMemberLeftChannel(event, accountId);
     });
 
     // Handle file shares
-    app.event("file_shared", async ({ event }) => {
+    app.event("file_shared", async ({ event, body }) => {
+      if (this.shouldDropInboundEvent(body, accountId, "file_shared")) return;
+      this.markInboundEvent(accountId);
+      if (!this.admitNonMessageEvent(body, accountId)) return;
       await this.handleFileShared(event, accountId);
     });
+  }
+
+  /**
+   * Attaches reconnect + liveness handling to an account's Socket Mode client.
+   *
+   * Bolt already retries on its own, so this does not drive reconnection; it
+   * observes it. The value added is the bail: when the socket dies from a
+   * revoked token or a removed scope, bolt would keep retrying forever against
+   * a credential that can never work. Here that stops the loop and records a
+   * permanent failure an operator can actually see.
+   */
+  private registerSocketLifecycleHandlers(state: SlackAccountRuntime): void {
+    const emitter = getSlackSocketEmitter(state.app);
+    if (!emitter) {
+      return;
+    }
+    const accountId = state.accountId;
+
+    emitter.on("authenticated", () => {
+      state.liveness.markConnected();
+      state.isConnected = true;
+    });
+
+    const onFailure = (error: unknown) => {
+      state.isConnected = false;
+      state.liveness.markDisconnected(error);
+      const attempt = state.liveness.snapshot().reconnectAttempts + 1;
+      const decision = decideSlackReconnect({ error, attempt });
+
+      if (decision.action === "abort") {
+        state.liveness.markPermanentFailure(decision.message);
+        this.runtime.logger.error(
+          {
+            src: "plugin:slack",
+            agentId: this.runtime.agentId,
+            accountId,
+            reason: decision.reason,
+            attempt: decision.attempt,
+          },
+          decision.message,
+        );
+        if (decision.reason === "auth") {
+          // Stop the socket so bolt's own retry loop cannot keep hammering a
+          // credential that will never authenticate.
+          void state.app.stop().catch(() => undefined);
+        }
+        return;
+      }
+
+      state.liveness.markReconnectAttempt(decision.attempt);
+      this.runtime.logger.warn(
+        {
+          src: "plugin:slack",
+          agentId: this.runtime.agentId,
+          accountId,
+          attempt: decision.attempt,
+          delayMs: decision.delayMs,
+        },
+        `Slack socket disconnected; reconnect attempt ${decision.attempt} in ${Math.round(decision.delayMs / 1000)}s (${formatSlackError(error)})`,
+      );
+    };
+
+    emitter.on("disconnected", (error: unknown) => {
+      onFailure(error);
+    });
+    emitter.on("unable_to_socket_mode_start", (error: unknown) => {
+      onFailure(error);
+    });
+  }
+
+  /**
+   * Workspace-isolation gate. Returns true when the event must be discarded.
+   */
+  private shouldDropInboundEvent(
+    body: unknown,
+    accountId: string,
+    eventFamily: string,
+  ): boolean {
+    const identity = this.getAccountState(accountId)?.identity;
+    if (!identity) {
+      return false;
+    }
+    const verdict = shouldDropMismatchedSlackEvent({ body, identity });
+    if (!verdict.drop) {
+      return false;
+    }
+    this.runtime.logger.warn(
+      {
+        src: "plugin:slack",
+        agentId: this.runtime.agentId,
+        accountId,
+        eventFamily,
+        field: verdict.field,
+        expected: verdict.expected,
+        received: verdict.received,
+      },
+      "Dropping Slack event from a mismatched workspace/app",
+    );
+    return true;
+  }
+
+  /** Records inbound traffic for liveness, before any gating. */
+  private markInboundEvent(accountId: string): void {
+    this.getAccountState(accountId)?.liveness.markEvent();
+  }
+
+  /**
+   * Envelope-level redelivery guard for the non-message event families.
+   *
+   * These carry no stable conversation key, so `event_id` is the only handle
+   * on identity — which is fine, because it is exactly what Slack holds
+   * constant across retries.
+   */
+  private admitNonMessageEvent(body: unknown, accountId: string): boolean {
+    const reliability = this.getAccountState(accountId)?.reliability;
+    if (!reliability) {
+      return true;
+    }
+    return reliability.admitEventId(extractSlackEventId(body));
+  }
+
+  /**
+   * Connection + liveness snapshot per account, for health checks.
+   *
+   * `lastEventAt` is reported separately from `connected` on purpose: an open
+   * socket that has stopped delivering looks identical to a healthy one at the
+   * transport layer, and only the event clock tells them apart.
+   */
+  getHealth(): Record<string, SlackLivenessSnapshot> {
+    const health: Record<string, SlackLivenessSnapshot> = {};
+    const states =
+      this.accountStates instanceof Map ? this.accountStates : new Map();
+    for (const [accountId, state] of states) {
+      health[accountId] = state.liveness.snapshot();
+    }
+    return health;
   }
 
   private getDefaultAccountState(): SlackAccountRuntime | null {
@@ -1132,6 +1405,7 @@ export class SlackService extends Service implements ISlackService {
     message: SlackMessageEventType,
     _client: WebClient,
     accountId = this.defaultAccountId,
+    envelope?: SlackInboundEnvelope,
   ): Promise<void> {
     if (
       !isValidChannelId(message.channel) ||
@@ -1179,78 +1453,140 @@ export class SlackService extends Service implements ISlackService {
       return;
     }
 
-    // Check if we should only respond to mentions
-    const isMentioned = message.text?.includes(`<@${botUserId}>`);
-    // Skip @mentions in channels — handleAppMention handles those
-    if (isMentioned && message.channel_type !== "im") {
-      return;
-    }
-    if (settings.shouldRespondOnlyToMentions && !isMentioned) {
-      return;
-    }
+    const isMentioned = Boolean(message.text?.includes(`<@${botUserId}>`));
+    const isDirectMessage = message.channel_type === "im";
 
-    const _isThreadReply = Boolean(
-      message.thread_ts && message.thread_ts !== message.ts,
-    );
-
-    // Build memory from message
-    const memory = await this.buildMemoryFromMessage(message, accountId);
-    if (!memory) return;
-
-    // Get or create room
-    const room = await this.ensureRoomExists(
-      message.channel,
-      message.thread_ts,
+    // Admission: dedupe against Slack redelivery and claim this message's lane.
+    const reliability = this.getAccountState(accountId)?.reliability ?? null;
+    const admission = reliability?.admit({
       accountId,
-    );
+      source: "message",
+      event: message,
+      eventId: extractSlackEventId(envelope?.body),
+      retryNum: extractSlackRetryNum(envelope?.body, envelope?.context),
+    });
 
-    const existingEntity = await this.runtime.getEntityById(memory.entityId);
-    if (!existingEntity) {
-      const slackUserId = message.user ?? memory.entityId;
-      const user = message.user
-        ? await this.getUser(message.user, accountId)
-        : null;
-      const displayName = user ? getSlackUserDisplayName(user) : slackUserId;
-      await this.runtime.createEntity({
-        id: memory.entityId,
-        names: [displayName],
-        metadata: {
-          source: "slack",
+    if (admission && !admission.admitted) {
+      this.runtime.logger.debug(
+        {
+          src: "plugin:slack",
+          agentId: this.runtime.agentId,
           accountId,
-          slack: {
-            accountId,
-            id: slackUserId,
-            name: displayName,
-            userName: user?.name || slackUserId,
-          },
+          channelId: message.channel,
+          messageTs: message.ts,
+          reason: admission.reason,
         },
-        agentId: this.runtime.agentId,
-      });
+        "Dropping duplicate inbound Slack message",
+      );
+      return;
     }
 
-    // Store the memory
-    await this.runtime.createMemory(memory, "messages");
+    const laneKey = admission?.key ?? null;
+    let outcome: SlackDispatchOutcomeLocal = "skipped";
 
-    // Emit event
-    await this.runtime.emitEvent(
-      SlackEventTypes.MESSAGE_RECEIVED as string,
-      this.buildEventPayload(accountId),
-    );
+    try {
+      // The `app_mention` twin. An @mention in a channel arrives twice, and
+      // exactly one copy may reach the agent. The previous code returned here
+      // unconditionally, which silently lost the turn whenever the mention
+      // path bailed. Instead: wait for the mention to actually settle, and
+      // only stand down if it really dispatched.
+      if (isMentioned && !isDirectMessage && reliability) {
+        const twin = await reliability.awaitMentionTwin(laneKey);
+        if (!twin.proceed) {
+          this.runtime.logger.debug(
+            {
+              src: "plugin:slack",
+              agentId: this.runtime.agentId,
+              accountId,
+              channelId: message.channel,
+              messageTs: message.ts,
+              reason: twin.reason,
+            },
+            "Skipping message twin; app_mention handled this turn",
+          );
+          return;
+        }
+      } else if (isMentioned && !isDirectMessage) {
+        // No coordinator wired (bare construction in tests): preserve the
+        // historical exclusive-path behaviour rather than double-posting.
+        return;
+      }
 
-    // Process the message through the agent
-    await this.processAgentMessage(
-      memory,
-      room,
-      message.channel,
-      message.thread_ts || message.ts,
-      accountId,
-    );
+      if (settings.shouldRespondOnlyToMentions && !isMentioned) {
+        return;
+      }
+
+      const _isThreadReply = Boolean(
+        message.thread_ts && message.thread_ts !== message.ts,
+      );
+
+      // Build memory from message
+      const memory = await this.buildMemoryFromMessage(message, accountId);
+      if (!memory) return;
+
+      // Get or create room
+      const room = await this.ensureRoomExists(
+        message.channel,
+        message.thread_ts,
+        accountId,
+      );
+
+      const existingEntity = await this.runtime.getEntityById(memory.entityId);
+      if (!existingEntity) {
+        const slackUserId = message.user ?? memory.entityId;
+        const user = message.user
+          ? await this.getUser(message.user, accountId)
+          : null;
+        const displayName = user ? getSlackUserDisplayName(user) : slackUserId;
+        await this.runtime.createEntity({
+          id: memory.entityId,
+          names: [displayName],
+          metadata: {
+            source: "slack",
+            accountId,
+            slack: {
+              accountId,
+              id: slackUserId,
+              name: displayName,
+              userName: user?.name || slackUserId,
+            },
+          },
+          agentId: this.runtime.agentId,
+        });
+      }
+
+      // Store the memory
+      await this.runtime.createMemory(memory, "messages");
+
+      // Emit event
+      await this.runtime.emitEvent(
+        SlackEventTypes.MESSAGE_RECEIVED as string,
+        this.buildEventPayload(accountId),
+      );
+
+      // Process the message through the agent
+      await this.processAgentMessage(
+        memory,
+        room,
+        message.channel,
+        message.thread_ts || message.ts,
+        accountId,
+      );
+      outcome = "dispatched";
+    } catch (error) {
+      // Free the lane so Slack's redelivery is a real retry, not a duplicate.
+      outcome = "failed";
+      throw error;
+    } finally {
+      reliability?.settle(laneKey, "message", outcome);
+    }
   }
 
   private async handleAppMention(
     event: SlackAppMentionEventType,
     _client: WebClient,
     accountId = this.defaultAccountId,
+    envelope?: SlackInboundEnvelope,
   ): Promise<void> {
     if (
       !event.user ||
@@ -1272,64 +1608,103 @@ export class SlackService extends Service implements ISlackService {
       return;
     }
 
-    // Build memory from mention
-    const memory = await this.buildMemoryFromMention(
-      {
-        user: event.user,
-        text: event.text,
-        channel: event.channel,
-        ts: event.ts,
-        thread_ts: event.thread_ts,
-      },
+    // Admission: same lane as the `message` twin, claimed from the mention
+    // side. Whichever source gets here first owns the turn.
+    const reliability = this.getAccountState(accountId)?.reliability ?? null;
+    const admission = reliability?.admit({
       accountId,
-    );
-    if (!memory) return;
+      source: "app_mention",
+      event,
+      eventId: extractSlackEventId(envelope?.body),
+      retryNum: extractSlackRetryNum(envelope?.body, envelope?.context),
+    });
 
-    // Get or create room
-    const room = await this.ensureRoomExists(
-      event.channel,
-      event.thread_ts,
-      accountId,
-    );
-
-    const existingEntity = await this.runtime.getEntityById(memory.entityId);
-    if (!existingEntity) {
-      const user = await this.getUser(event.user, accountId);
-      const displayName = user ? getSlackUserDisplayName(user) : event.user;
-      await this.runtime.createEntity({
-        id: memory.entityId,
-        names: [displayName],
-        metadata: {
-          source: "slack",
+    if (admission && !admission.admitted) {
+      this.runtime.logger.debug(
+        {
+          src: "plugin:slack",
+          agentId: this.runtime.agentId,
           accountId,
-          slack: {
-            accountId,
-            id: event.user,
-            name: displayName,
-            userName: user?.name || event.user,
-          },
+          channelId: event.channel,
+          messageTs: event.ts,
+          reason: admission.reason,
         },
-        agentId: this.runtime.agentId,
-      });
+        "Dropping duplicate inbound Slack app mention",
+      );
+      return;
     }
 
-    // Store the memory
-    await this.runtime.createMemory(memory, "messages");
+    const laneKey = admission?.key ?? null;
+    let outcome: SlackDispatchOutcomeLocal = "skipped";
 
-    // Emit event
-    await this.runtime.emitEvent(
-      SlackEventTypes.APP_MENTION as string,
-      this.buildEventPayload(accountId),
-    );
+    try {
+      // Build memory from mention
+      const memory = await this.buildMemoryFromMention(
+        {
+          user: event.user,
+          text: event.text,
+          channel: event.channel,
+          ts: event.ts,
+          thread_ts: event.thread_ts,
+        },
+        accountId,
+      );
+      if (!memory) return;
 
-    // Process the message
-    await this.processAgentMessage(
-      memory,
-      room,
-      event.channel,
-      event.thread_ts || event.ts,
-      accountId,
-    );
+      // Get or create room
+      const room = await this.ensureRoomExists(
+        event.channel,
+        event.thread_ts,
+        accountId,
+      );
+
+      const existingEntity = await this.runtime.getEntityById(memory.entityId);
+      if (!existingEntity) {
+        const user = await this.getUser(event.user, accountId);
+        const displayName = user ? getSlackUserDisplayName(user) : event.user;
+        await this.runtime.createEntity({
+          id: memory.entityId,
+          names: [displayName],
+          metadata: {
+            source: "slack",
+            accountId,
+            slack: {
+              accountId,
+              id: event.user,
+              name: displayName,
+              userName: user?.name || event.user,
+            },
+          },
+          agentId: this.runtime.agentId,
+        });
+      }
+
+      // Store the memory
+      await this.runtime.createMemory(memory, "messages");
+
+      // Emit event
+      await this.runtime.emitEvent(
+        SlackEventTypes.APP_MENTION as string,
+        this.buildEventPayload(accountId),
+      );
+
+      // Process the message
+      await this.processAgentMessage(
+        memory,
+        room,
+        event.channel,
+        event.thread_ts || event.ts,
+        accountId,
+      );
+      outcome = "dispatched";
+    } catch (error) {
+      outcome = "failed";
+      throw error;
+    } finally {
+      // Releasing here is what un-blocks the waiting `message` twin: a skip or
+      // a throw hands the turn back instead of swallowing it.
+      reliability?.settle(laneKey, "app_mention", outcome);
+    }
   }
 
   private async handleReactionAdded(


### PR DESCRIPTION
# Relates to

Pillar P7 (Slack) inbound reliability. Slice A of the Slack gap audit: items 1-4
(event dedupe, `app_mention`/`message` race, multi-workspace isolation, reconnect +
liveness). Also supplies the mechanism behind the workspace-isolation evidence
requested on #17462.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts. Branched
      from `dc873211bee`.
- [x] Plugin suite + typecheck pass post-sync (counts below). See **Known gaps /
      failures** for the monorepo-wide `verify` note.

# Risks

**Medium.** This changes inbound admission for every Slack event, so a bug here
would show up as dropped messages rather than a crash. Mitigations built in:

- Every guard fails **open** on missing data. No `event_id` → admitted. No
  `team_id` in the envelope → admitted. Sender-less event → admitted unkeyed
  (never deduped against anything). The only hard drops are on data that is
  present and provably wrong.
- The `message`/`app_mention` twin now yields **only after the winner actually
  dispatched**. Every other outcome (gated, no memory, thrown) releases the lane,
  so the failure direction is "an extra reply" rather than the current silent
  drop. A handler throw frees the lane entirely so Slack's own redelivery still
  works as a retry.
- New logic is in three standalone modules with no imports into existing files;
  `service.ts` changes are wiring only.
- Behaviour with no coordinator present (bare construction) falls back to the
  historical exclusive-path return, so partial construction cannot double-post.

Blast radius is `plugins/plugin-slack` only. No workflow, config-schema, or
shared-package changes.

# Background

## What does this PR do?

Slack's Events API is an at-least-once transport delivered over two overlapping
streams. The connector treated it as neither. Four correctness gaps, all fixed on
the **real registered Bolt handlers**:

### 1. Event dedupe + debounce keying (`inbound-reliability.ts`)

There was no dedupe cache at all, so a redelivered event ran the agent a second
time. Slack retries whenever the ack is slow, which means **the slower the agent
turn, the more duplicate replies** — exactly backwards from what you want.

Adds a two-level TTL cache: envelope `event_id` (the identity Slack holds
constant across retries, covering families with no channel/ts such as reactions
and member joins) plus a conversation-lane key. Lane keying follows the Slack
conversation model rather than the raw event:

| Case | Key shape | Why |
|---|---|---|
| Thread reply | `channel:thread_ts` | a thread is one lane |
| Reply, `thread_ts` unresolved | `channel:maybe-thread:ts` | must not collide with the channel's top-level lane |
| Top-level channel message | `channel:ts` | otherwise two unrelated messages in a busy channel share a lane and the second is mistaken for a duplicate |
| Top-level DM | `channel` | keeps consecutive short DM lines batchable |
| Sender | `user ?? bot_id` | bot messages carry no `user` |

`retry_num` / `retryNum` / `retry_attempt` are read from all three surfaces Slack
uses. Note a retry is deliberately **not** itself a drop signal: a retry with no
matching record means the original never processed, and dropping it would turn a
slow turn into a lost one.

### 2. `app_mention` / `message` race (`inbound-reliability.ts`)

@-mentioning the bot in a channel produces **two** events for one human message,
in no guaranteed order. The old code resolved this with:

```ts
if (isMentioned && message.channel_type !== "im") return;
```

That is a coin flip, not a resolution. If the `app_mention` path bails for any
reason — gating, unbuildable memory, a throw — the turn is **silently lost**,
because the message twin already returned on the assumption the mention would
handle it.

Replaced with a lane state machine: both twins are admitted, and the message twin
awaits the mention's **actual terminal outcome**. `dispatched` suppresses it;
`skipped` or `failed` releases it to answer. If no mention arrives within a short
grace window (Slack emits the pair within milliseconds), the message proceeds —
that case is a guaranteed dropped turn on develop today.

### 3. Multi-workspace event isolation (`event-isolation.ts`)

Events were attributed to an account by **handler closure alone**. That is an
assumption, not a check, and it is wrong in every case where the socket is right
about the connection but wrong about the workspace: duplicate credentials across
accounts, Slack Connect / third-partyly-shared channels, org-wide install fanout, a
stale socket after a token swap.

`api_app_id` / `team_id` / `enterprise_id` from `auth.test` are now validated on
**every inbound family**, not just messages. Uniformity is the point: a foreign
`member_joined_channel` would otherwise widen *this* account's dynamic channel
allowlist, which is a concrete cross-tenant state corruption (test included).

Asymmetric on purpose: fail **closed** on present-and-different, fail **open** on
absent, with a carve-out so org-wide installs receiving sibling-workspace events
under the expected enterprise are not dropped.

### 4. Reconnect + liveness (`reconnect-policy.ts`)

Bolt retried everything forever, including `invalid_auth`, `token_revoked` and
`missing_scope` — credentials that can **never** succeed. That is an infinite
loop that burns rate limit, floods logs with identical failures, and worst of
all *looks* like recovery while the connector is permanently dead. Nobody is told.

Adds bounded jittered backoff (2s → 30s, ×1.8, 0.25 jitter, 12 attempts) for
recoverable errors, and an immediate bail with an actionable diagnosis for auth
errors. Auth is checked **before** the attempt ceiling so an operator with a
revoked token is told that, not "max attempts reached" (which would send them
looking at their network).

`lastEventAt` is tracked separately from `connected` and deliberately **not**
seeded on connect — connecting is not evidence of traffic, and seeding it would
mask exactly the wedged-socket case this exists to catch. Exposed via
`getHealth()` per account.

## What kind of change is this?

Bug fixes (non-breaking) — four inbound correctness defects.

# Documentation changes needed?

No. All new behaviour is internal to the connector's inbound path; no config keys
added or changed. Rationale is documented in module-level comments.

# Testing

## Where should a reviewer start?

`plugins/plugin-slack/src/service-inbound-reliability.test.ts`. It captures the
handlers off a fake Bolt `App` via `registerEventHandlers`, so every test drives
the **production wiring** and asserts on whether `processAgentMessage` /
`emitEvent` actually ran. A helper-level test would prove nothing about whether
the guards sit on the path Slack traffic takes.

## Detailed testing steps

```bash
bun install
bun run --cwd plugins/plugin-slack test        # 129/129 pass
bun run --cwd plugins/plugin-slack typecheck   # zero errors
```

To reproduce the bidirectional proof (revert only the integration, keep the tests):

```bash
git checkout dc873211bee -- plugins/plugin-slack/src/service.ts
bun run --cwd plugins/plugin-slack test src/service-inbound-reliability.test.ts
# 13 failed | 8 passed (21)
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no UI surface. Backend Slack connector
      inbound path only; zero rendered files in the diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no UI surface. Backend Slack connector
      inbound path only; zero rendered files in the diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow. The observable behaviour is
      "the agent does not reply twice" and "the agent still replies once", both
      captured as deterministic pass/fail counts in the bidirectional table below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end. The suite drives
      the handlers captured off `registerEventHandlers`, so these lines are the
      production inbound path executing. Full transcripts also in **Backend logs**
      under Evidence Details.
      ```
      $ bun run --cwd plugins/plugin-slack test
       RUN  v4.1.5 /plugins/plugin-slack
       PASS src/inbound-reliability.test.ts (24 tests) 17ms
       PASS src/accounts.test.ts (9 tests) 18ms
       PASS src/reconnect-policy.test.ts (32 tests) 13ms
       PASS src/formatting.test.ts (13 tests) 16ms
       PASS src/event-isolation.test.ts (14 tests) 14ms
       PASS src/connector-account-provider.test.ts (4 tests) 45ms
       PASS src/outbound-attachments.test.ts (4 tests) 12ms
       PASS src/messageConnector.test.ts (8 tests) 21ms
       PASS src/service-inbound-reliability.test.ts (21 tests) 26ms
       Test Files  9 passed (9)
            Tests  129 passed (129)
      --- same tests, production path reverted to develop (dc873211bee) ---
      $ git checkout dc873211bee -- plugins/plugin-slack/src/service.ts
      $ bun run --cwd plugins/plugin-slack test src/service-inbound-reliability.test.ts
       FAIL src/service-inbound-reliability.test.ts (21 tests | 13 failed) 30ms
         PASS binds every inbound family on the real bolt app
         FAIL runs the agent once when Slack redelivers the same message event
         FAIL runs the agent once when the same app_mention is redelivered
         PASS still processes two genuinely distinct messages in one channel
         FAIL dedupes redelivered non-message events by event_id
         PASS runs the agent exactly once when the mention wins
         PASS runs the agent exactly once when the message twin arrives first
         FAIL does not drop the turn when the mention path bails
         FAIL does not drop the turn when the mention path throws
         FAIL answers a mention whose app_mention twin never arrives
         PASS handles both twins arriving concurrently without dropping or doubling
         PASS still answers DM mentions, which have no app_mention twin
         FAIL drops a message event from a foreign team_id
         FAIL drops a message event from a foreign api_app_id
         FAIL drops a foreign app_mention
         FAIL drops foreign events on every non-message family too
         FAIL does not drop a foreign member_joined_channel into dynamic channels
         PASS accepts matching events, so isolation is not just a blanket deny
         PASS accepts events whose envelope omits the identity fields
         FAIL records lastEventAt only once inbound traffic actually arrives
         FAIL counts a gated-out event as liveness, since the socket did deliver it
       AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
        at src/service-inbound-reliability.test.ts:246:33
             246|     expect(processAgentMessage).toHaveBeenCalledTimes(1);
                |                                 ^
       Test Files  1 failed (1)
            Tests  13 failed | 8 passed (21)
      --- typecheck + lint ---
      $ bun run --cwd plugins/plugin-slack typecheck
      $ tsc --noEmit -p tsconfig.json          (zero errors)
      $ bunx @biomejs/biome check plugins/plugin-slack/src/
      Checked 21 files in 132ms. No fixes applied.
      ```
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend involvement. Inbound
      Socket Mode event handling; no HTTP surface reaches a browser.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change.
      This gates whether a message reaches the agent at all; the model call
      itself is stubbed and unchanged.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the inbound admission state transitions are the domain
      artifact for this change, asserted per capability by the suite.
      ```
      CAPABILITY 1 - dedupe (event_id + lane TTL cache)
        admit(event_id=Ev_RETRY_1)              -> admitted   reason=new
        admit(event_id=Ev_RETRY_1, retry_num=1) -> REJECTED   reason=duplicate-event-id
        admit(ts=...100) / admit(ts=...200)     -> both admitted (distinct lanes)
        reaction_added Ev_REACTION x2           -> 1 emitEvent, 2nd duplicate-event-id
      CAPABILITY 2 - app_mention / message twin lane machine
        mention admitted, settle(dispatched)
          -> message admit  = REJECTED reason=twin-already-dispatched   (1 agent run)
        message admitted, mention admitted, settle(mention, dispatched)
          -> awaitMentionTwin = { proceed:false, reason:twin-dispatched } (1 agent run)
        message admitted, mention admitted, settle(mention, skipped)
          -> awaitMentionTwin = { proceed:true,  reason:twin-released }   (1 agent run)
        message admitted, mention admitted, settle(mention, failed)
          -> awaitMentionTwin = { proceed:true,  reason:twin-released }   (1 agent run)
        message admitted, no mention within grace
          -> awaitMentionTwin = { proceed:true,  reason:grace-expired }   (1 agent run)
        handler throw -> settle(failed) -> lane freed, redelivery re-admits
      CAPABILITY 3 - workspace isolation verdicts (expected A_APP / T_HOME)
        { api_app_id:A_APP,   team_id:T_OTHER } -> DROP field=team_id
        { api_app_id:A_OTHER, team_id:T_HOME  } -> DROP field=api_app_id
        { api_app_id:A_OTHER, team_id:T_OTHER } -> DROP field=api_app_id (first match)
        { event:{ team:T_OTHER } }              -> DROP field=team_id
        { enterprise_id:E_OTHER } vs E_HOME     -> DROP field=enterprise_id
        { team_id:T_SIBLING, enterprise_id:E_HOME } vs E_HOME -> ACCEPT (org-wide)
        { api_app_id:A_APP,   team_id:T_HOME  } -> ACCEPT
        { type:event_callback } (no identity)   -> ACCEPT (fail-open)
        identity {} (pre-auth.test)             -> ACCEPT (fail-open)
        foreign member_joined_channel(bot)      -> dynamicChannelIds unchanged
      CAPABILITY 4 - reconnect decisions + liveness states
        ECONNRESET      attempt 1  -> retry delayMs=2000
        ECONNRESET      attempt 2  -> retry delayMs=3600
        ECONNRESET      attempt 3  -> retry delayMs=6480
        ECONNRESET      attempt 50 -> clamped to maxMs=30000
        ECONNRESET      attempt 12 -> abort reason=exhausted
        token_revoked   attempt 1  -> abort reason=auth  (develop: retries forever)
        invalid_auth    attempt 1  -> abort reason=auth
        missing_scope   attempt 17 -> abort reason=auth  (auth beats exhaustion)
        err.data.error=token_revoked -> abort reason=auth (structured code read)
        "reinvalid_authorization"    -> recoverable      (word-boundary anchored)
        liveness: init                  -> connecting, lastEventAt=null
                  markConnected()       -> healthy,    lastEventAt=null (not seeded)
                  markEvent()           -> healthy
                  +stalenessMs silence  -> degraded
                  markEvent()           -> healthy
                  markDisconnected(err) -> disconnected, lastError=ECONNRESET
                  markPermanentFailure  -> failed
                  markConnected()       -> healthy, permanentFailure cleared
      ```

# Evidence Details

## Bidirectional proof (the core evidence)

Method: keep the new tests, revert **only** `service.ts` to develop
(`dc873211bee`), re-run. This isolates "is the guard actually wired into the
production path" from "does the helper work in a vacuum".

**Production-path suite (`service-inbound-reliability.test.ts`): 13 failed / 8
passed on unfixed develop → 21/21 pass with the fix.**

| # | Capability | Test | On develop | With fix |
|---|---|---|---|---|
| 1 | Dedupe | runs the agent once when Slack redelivers the same message event | FAIL (ran 2×) | PASS |
| 1 | Dedupe | runs the agent once when the same `app_mention` is redelivered | FAIL (ran 2×) | PASS |
| 1 | Dedupe | dedupes redelivered non-message events by `event_id` | FAIL (emitted 2×) | PASS |
| 1 | Dedupe | still processes two genuinely distinct messages in one channel | pass | PASS |
| 2 | Race | does not drop the turn when the mention path **bails** | FAIL (0 runs — silent drop) | PASS |
| 2 | Race | does not drop the turn when the mention path **throws** | FAIL (0 runs — silent drop) | PASS |
| 2 | Race | answers a mention whose `app_mention` twin never arrives | FAIL (0 runs — silent drop) | PASS |
| 2 | Race | exactly once when the mention wins | pass | PASS |
| 2 | Race | exactly once when the message twin arrives first | pass | PASS |
| 2 | Race | both twins concurrently: no drop, no double | pass | PASS |
| 2 | Race | still answers DM mentions (no twin exists) | pass | PASS |
| 3 | Isolation | drops a message event from a foreign `team_id` | FAIL (accepted) | PASS |
| 3 | Isolation | drops a message event from a foreign `api_app_id` | FAIL (accepted) | PASS |
| 3 | Isolation | drops a foreign `app_mention` | FAIL (accepted) | PASS |
| 3 | Isolation | drops foreign events on **every** non-message family | FAIL (accepted) | PASS |
| 3 | Isolation | foreign `member_joined_channel` does not widen this account's allowlist | FAIL (state corrupted) | PASS |
| 3 | Isolation | accepts matching events (not a blanket deny) | pass | PASS |
| 3 | Isolation | accepts envelopes omitting identity fields (fail-open) | pass | PASS |
| 4 | Liveness | records `lastEventAt` only once traffic arrives | FAIL (no `getHealth`) | PASS |
| 4 | Liveness | counts a gated-out event as liveness | FAIL (no `getHealth`) | PASS |
| — | Wiring | binds every inbound family on the real Bolt app | pass | PASS |

The 8 that pass on develop are the **negative controls** — they confirm the new
guards do not over-block. A suite where everything failed on develop would be
consistent with a guard that simply drops all traffic; these are the tests that
rule that out.

### Reconnect (capability 4) — no develop counterpart

`reconnect-policy.ts` is new, so there is nothing on develop to fail against;
develop's behaviour is Bolt's default, which is "retry every error forever". The
32 tests in `reconnect-policy.test.ts` pin the distinction that did not
previously exist:

- `invalid_auth`, `token_revoked`, `token_expired`, `account_inactive`,
  `missing_scope`, `not_authed`, `org_login_required`, `app_uninstalled` →
  **abort at attempt 1**, no reconnect (on develop: infinite churn).
- `ECONNRESET`, `socket hang up`, `ENOTFOUND`, `ratelimited`, `server_error` →
  retry with bounded jittered backoff.
- Auth reported **before** exhaustion, so the error names the real cause.
- Word-boundary anchored so `reinvalid_authorization` is not matched as
  `invalid_auth`; structured `err.data.error` read alongside message text.
- Liveness: connect does not seed `lastEventAt`; a connected-but-silent socket
  reports `degraded`; a permanent bail reports `failed`.

## Backend logs

<details>
<summary>Full suite with the fix — 129/129</summary>

```
 ✓ src/inbound-reliability.test.ts (24 tests) 17ms
 ✓ src/accounts.test.ts (9 tests) 18ms
 ✓ src/reconnect-policy.test.ts (32 tests) 13ms
 ✓ src/formatting.test.ts (13 tests) 16ms
 ✓ src/event-isolation.test.ts (14 tests) 14ms
 ✓ src/connector-account-provider.test.ts (4 tests) 45ms
 ✓ src/outbound-attachments.test.ts (4 tests) 12ms
 ✓ src/messageConnector.test.ts (8 tests) 21ms
 ✓ src/service-inbound-reliability.test.ts (21 tests) 26ms

 Test Files  9 passed (9)
      Tests  129 passed (129)
```

Pre-existing suites (`accounts`, `formatting`, `connector-account-provider`,
`outbound-attachments`, `messageConnector` = 38 tests) unchanged and green.

</details>

<details>
<summary>Production path reverted to develop — 13 failed / 8 passed</summary>

```
 ❯ src/service-inbound-reliability.test.ts (21 tests | 13 failed) 30ms
     ✓ binds every inbound family on the real bolt app
     × runs the agent once when Slack redelivers the same message event
     × runs the agent once when the same app_mention is redelivered
     ✓ still processes two genuinely distinct messages in one channel
     × dedupes redelivered non-message events by event_id
     ✓ runs the agent exactly once when the mention wins
     ✓ runs the agent exactly once when the message twin arrives first
     × does not drop the turn when the mention path bails
     × does not drop the turn when the mention path throws
     × answers a mention whose app_mention twin never arrives
     ✓ handles both twins arriving concurrently without dropping or doubling
     ✓ still answers DM mentions, which have no app_mention twin
     × drops a message event from a foreign team_id
     × drops a message event from a foreign api_app_id
     × drops a foreign app_mention
     × drops foreign events on every non-message family too
     × does not drop a foreign member_joined_channel into dynamic channels
     ✓ accepts matching events, so isolation is not just a blanket deny
     ✓ accepts events whose envelope omits the identity fields
     × records lastEventAt only once inbound traffic actually arrives
     × counts a gated-out event as liveness, since the socket did deliver it

AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
 ❯ src/service-inbound-reliability.test.ts:246:33
```

That final assertion **is** the duplicate-reply bug, reproduced mechanically:
one redelivered Slack event, two agent runs.

</details>

<details>
<summary>Typecheck + lint</summary>

```
$ bun run --cwd plugins/plugin-slack typecheck
$ tsc --noEmit -p tsconfig.json
        (zero errors)

$ bunx @biomejs/biome check plugins/plugin-slack/src/
Checked 21 files in 132ms. No fixes applied.
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface.` The diff touches `plugins/plugin-slack/src/` exclusively;
no rendered `.tsx`/`.css`/`.svg` files, so the CI surface-artifact rule does not
apply.

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface in this change.`

# Rebase order vs #17462

**This PR should land AFTER #17462.** Both touch `service.ts`; #17462 is
concurrently reworking gating, policy, and event classification in the same file.

Deconfliction already applied:

- Branched from `develop` (`dc873211bee`), **not** from the #17462 branch.
- All new logic lives in three standalone modules — `inbound-reliability.ts`,
  `event-isolation.ts`, `reconnect-policy.ts` — with **zero** imports into
  files #17462 edits (`accounts.ts`, `allowlist.ts`).
- `service.ts` touch-points are deliberately minimal and sit in different regions
  than the gating rework:

| Region | This PR | #17462 |
|---|---|---|
| `SlackAccountRuntime` type | +3 fields (`identity`, `reliability`, `liveness`) | +1 field (`channelConfigs`) |
| `initializeAccount` | identity capture after `auth.test`, socket lifecycle | `channelConfigs` init |
| `registerEventHandlers` | isolation + liveness + dedupe wrapper per family | untouched |
| `handleMessage` | admission + twin resolution around the existing body | gate replacement mid-body |
| `handleAppMention` | admission + settle around the existing body | gate insertion before body |

The `handleMessage` / `handleAppMention` overlaps are the only real ones and are
small. Concretely: #17462 replaces the mention-check block with
`resolveSlackInboundGate`; this PR wraps that same region in admission/settle.
On rebase, keep #17462's gate call verbatim inside the `try` block this PR adds.

Happy to hold this as draft until #17462 merges, then rebase and re-post counts.
Isolation (capability 3) is also the mechanism that makes #17462's blocker-6
workspace-isolation evidence **provable rather than asserted** — the two are
complementary, and the isolation module is usable from the gating lane
independently if that ordering is preferred.

# Known gaps / failures

- Monorepo-wide `bun run verify` was not run to completion; this worktree carries
  unrelated pre-existing dirt (binary asset + benchmark manifest churn) not
  produced by this change. Scoped verification for the touched package is clean:
  plugin suite 129/129, typecheck zero errors, biome clean across all 21 files.
- Gap-audit item 6 (missing `thread_ts` recovery via `conversations.history`) was
  listed as optional for this slice and is **not** included. The keying handles
  the unresolved case correctly today via the `maybe-thread` prefix, so an
  unresolved reply is isolated rather than mis-laned; actively resolving it needs
  an API round-trip with its own cache and belongs in its own PR.
- Rate limiting / 429 handling (audit item 5) is out of scope — separate slice.
- Reconnect observation hooks into Bolt's receiver socket client, an internal
  shape. If a future Bolt release moves it, `getSlackSocketEmitter` returns
  `null` and reconnect handling degrades to Bolt's current behaviour rather than
  throwing at startup. Deliberate: the failure mode is "no worse than today".
