### PR TITLE
fix(eliza-computer): close the production-credential trust boundary in the eliza.army deploy job

### DIFF
--- a/.github/workflows/CHANGELOG.md
+++ b/.github/workflows/CHANGELOG.md
@@ -20,6 +20,27 @@ do not have to carry CI-only history.
 
 ### Changed
 
+- `eliza-computer.yml` no longer lets a candidate ref supply the code that runs
+  beside production Cloudflare credentials. The deploy job now checks out
+  `refs/heads/develop`, verifies through the API that the checkout is current
+  `origin/develop`, and rejects any `production-candidate` dispatch from another
+  ref. A candidate branch contributes only the immutable artifact built by the
+  secretless `quality` job; the protected admission step accepts it by run
+  identity (`candidate_run_id`) after checking the run is a completed,
+  successful, non-`pull_request`, same-repository run of this workflow whose
+  head SHA is the current head of an open same-repository PR into `develop`.
+  This replaces the previous `candidate_pr` flow, whose admission check ran
+  inside the candidate-controlled workflow definition and could be modified or
+  bypassed by the candidate it was meant to gate.
+
+- The `eliza-computer.yml` deploy job resolves Wrangler from `bun.lock` instead
+  of `bunx wrangler@4.100.0`. It runs `bun install --frozen-lockfile` for the
+  package, executes `packages/eliza-computer/node_modules/.bin/wrangler`, and
+  asserts the binary reports the pinned version before any credential is used,
+  so the secret-bearing lane can no longer re-resolve executable content from a
+  registry at deploy time. `wrangler@4.100.0` is now an explicit
+  `@elizaos/eliza-computer` devDependency matching the existing root override.
+
 - Interactive `@claude` assistance is opt-in behind
   `CLAUDE_INTERACTIVE_ENABLED=true`. Its pinned third-party action retains a
   broad runner filesystem-read boundary that is not confined to the repository,

--- a/.github/workflows/eliza-computer.yml
+++ b/.github/workflows/eliza-computer.yml
@@ -25,15 +25,15 @@ on:
   workflow_dispatch:
     inputs:
       release_mode:
-        description: "Run checks only, or promote this exact ref as a protected production candidate"
+        description: "Run checks only, or publish a bundle to production (production releases must be dispatched from develop)"
         required: true
         default: quality-only
         type: choice
         options:
           - quality-only
           - production-candidate
-      candidate_pr:
-        description: "Open same-repository PR number into develop (required for non-develop production candidates)"
+      candidate_run_id:
+        description: "Optional eliza.army run ID whose already-built bundle should be published instead of this run's bundle. The run must be a successful eliza.army run in this repository whose head SHA is the head of an open same-repository PR into develop."
         required: false
         default: ""
         type: string
@@ -46,6 +46,7 @@ permissions:
   contents: read
   issues: read
   pull-requests: read
+  actions: read
 
 env:
   CI: "true"
@@ -172,28 +173,59 @@ jobs:
       name: eliza-army-production
       url: https://eliza.army
     steps:
-      - name: Checkout exact deployment tooling
+      # SECURITY BOUNDARY. Everything this job executes must come from the
+      # protected default branch, never from the ref under test. A candidate
+      # branch may not supply the workflow definition, the admission check, the
+      # deployment scripts, or the dependency manifest that runs beside
+      # production Cloudflare credentials. The candidate contributes exactly one
+      # thing: an immutable build artifact produced by a secretless quality job,
+      # which this job admits by identity and republishes byte-for-byte.
+      - name: Checkout protected deployment tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ github.sha }}
+          ref: refs/heads/develop
           fetch-depth: 0
           persist-credentials: false
           submodules: false
 
-      - name: Verify deployment checkout
+      - name: Verify deployment tooling is the protected branch
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          checked_out_sha="$(git rev-parse HEAD)"
-          if [ "$checked_out_sha" != "$GITHUB_SHA" ]; then
-            echo "::error::Deployment checkout $checked_out_sha does not match the verified workflow SHA $GITHUB_SHA."
+          response="$RUNNER_TEMP/eliza-computer-develop-ref.json"
+          status="$(
+            curl --silent --show-error \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --output "$response" \
+              --write-out "%{http_code}" \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GITHUB_TOKEN" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/commits/develop"
+          )"
+          if [ "$status" != "200" ]; then
+            echo "::error::Protected develop lookup failed with HTTP $status."
             exit 1
           fi
+          expected_sha="$(
+            node -e 'const value=JSON.parse(require("node:fs").readFileSync(process.argv[1],"utf8")); if (typeof value.sha !== "string" || !/^[0-9a-f]{40}$/.test(value.sha)) throw new TypeError("develop commit response omitted a valid sha"); process.stdout.write(value.sha)' "$response"
+          )"
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [ "$checked_out_sha" != "$expected_sha" ]; then
+            echo "::error::Deployment tooling checkout $checked_out_sha is not current origin/develop $expected_sha."
+            exit 1
+          fi
+          printf '%s\n' "Deployment tooling pinned to protected develop $checked_out_sha."
 
       - name: Admit release authority
+        id: admit
         env:
-          CANDIDATE_PR: ${{ inputs.candidate_pr }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_MODE: ${{ inputs.release_mode }}
+          THIS_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -209,8 +241,8 @@ jobs:
                 echo "::error::A manual production release requires release_mode=production-candidate."
                 exit 1
               fi
-              if [ "$GITHUB_REF_TYPE" != "branch" ]; then
-                echo "::error::A production candidate must be dispatched from a branch, not $GITHUB_REF_TYPE."
+              if [ "$GITHUB_REF" != "refs/heads/develop" ]; then
+                echo "::error::Production releases must be dispatched from develop so the workflow definition, admission check, and deployment scripts are the protected ones. To publish a candidate branch bundle, dispatch from develop and pass its eliza.army run ID as candidate_run_id."
                 exit 1
               fi
               ;;
@@ -220,87 +252,165 @@ jobs:
               ;;
           esac
 
-          if [ "$GITHUB_REF" = "refs/heads/develop" ]; then
+          if [ -z "$CANDIDATE_RUN_ID" ]; then
+            printf '%s\n' "bundle_run_id=$THIS_RUN_ID" >> "$GITHUB_OUTPUT"
+            printf '%s\n' "bundle_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            printf '%s\n' "Publishing this run's develop bundle for $GITHUB_SHA."
             exit 0
           fi
 
-          if ! [[ "$CANDIDATE_PR" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::A non-develop production candidate requires a numeric candidate_pr input."
+          if ! [[ "$CANDIDATE_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::candidate_run_id must be a numeric Actions run ID."
             exit 1
           fi
 
-          response="$RUNNER_TEMP/eliza-computer-candidate-pr.json"
-          status="$(
-            curl --silent --show-error \
-              --connect-timeout 10 \
-              --max-time 30 \
-              --output "$response" \
-              --write-out "%{http_code}" \
-              --header "Accept: application/vnd.github+json" \
-              --header "Authorization: Bearer $GITHUB_TOKEN" \
-              --header "X-GitHub-Api-Version: 2022-11-28" \
-              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$CANDIDATE_PR"
-          )"
-          if [ "$status" != "200" ]; then
-            echo "::error::Candidate PR #$CANDIDATE_PR lookup failed with HTTP $status."
-            exit 1
-          fi
+          fetch_json() {
+            local url="$1"
+            local destination="$2"
+            local status
+            status="$(
+              curl --silent --show-error \
+                --connect-timeout 10 \
+                --max-time 30 \
+                --output "$destination" \
+                --write-out "%{http_code}" \
+                --header "Accept: application/vnd.github+json" \
+                --header "Authorization: Bearer $GITHUB_TOKEN" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                "$url"
+            )"
+            if [ "$status" != "200" ]; then
+              echo "::error::$url lookup failed with HTTP $status."
+              return 1
+            fi
+          }
 
-          node --input-type=module - \
-            "$response" \
-            "$GITHUB_SHA" \
-            "$GITHUB_REF_NAME" \
-            "$GITHUB_REPOSITORY" <<'NODE'
+          run_response="$RUNNER_TEMP/eliza-computer-candidate-run.json"
+          fetch_json \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runs/$CANDIDATE_RUN_ID" \
+            "$run_response"
+
+          candidate_sha="$(
+            node --input-type=module - "$run_response" "$GITHUB_WORKFLOW_REF" <<'NODE'
           import { readFileSync } from "node:fs";
 
-          const [responsePath, expectedSha, expectedBranch, expectedRepository] =
-            process.argv.slice(2);
-          const pullRequest = JSON.parse(readFileSync(responsePath, "utf8"));
+          const [responsePath, workflowRef] = process.argv.slice(2);
+          const run = JSON.parse(readFileSync(responsePath, "utf8"));
           const failures = [];
+          const expectedWorkflowPath = workflowRef.split("@")[0].split("/").slice(2).join("/");
 
-          if (pullRequest.state !== "open") failures.push("state is not open");
-          if (pullRequest.base?.ref !== "develop") failures.push("base is not develop");
-          if (pullRequest.base?.repo?.full_name !== expectedRepository) {
-            failures.push("base repository does not match this repository");
+          if (run.status !== "completed") failures.push("run is not completed");
+          if (run.conclusion !== "success") failures.push("run did not succeed");
+          if (run.path !== expectedWorkflowPath) {
+            failures.push(`run built ${run.path}, not ${expectedWorkflowPath}`);
           }
-          if (pullRequest.head?.repo?.full_name !== expectedRepository) {
-            failures.push("head repository is not this repository");
+          if (run.event === "pull_request" || run.event === "pull_request_target") {
+            failures.push(`run event ${run.event} is not an admissible bundle source`);
           }
-          if (pullRequest.head?.ref !== expectedBranch) {
-            failures.push("head branch does not match the dispatched branch");
+          if (typeof run.head_sha !== "string" || !/^[0-9a-f]{40}$/.test(run.head_sha)) {
+            failures.push("run head SHA is missing or malformed");
           }
-          if (pullRequest.head?.sha !== expectedSha) {
-            failures.push("head SHA does not match the quality-tested SHA");
+          if (run.head_repository?.full_name !== run.repository?.full_name) {
+            failures.push("run head repository is not this repository");
           }
 
           if (failures.length > 0) {
             process.stderr.write(
-              `::error::Candidate PR admission failed: ${failures.join("; ")}.\n`,
+              `::error::Candidate run admission failed: ${failures.join("; ")}.\n`,
+            );
+            process.exit(1);
+          }
+          process.stdout.write(run.head_sha);
+          NODE
+          )"
+
+          pulls_response="$RUNNER_TEMP/eliza-computer-candidate-pulls.json"
+          fetch_json \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/commits/$candidate_sha/pulls?per_page=100" \
+            "$pulls_response"
+
+          node --input-type=module - \
+            "$pulls_response" \
+            "$candidate_sha" \
+            "$GITHUB_REPOSITORY" <<'NODE'
+          import { readFileSync } from "node:fs";
+
+          const [responsePath, candidateSha, expectedRepository] = process.argv.slice(2);
+          const pullRequests = JSON.parse(readFileSync(responsePath, "utf8"));
+
+          if (!Array.isArray(pullRequests)) {
+            process.stderr.write("::error::Candidate pull-request lookup was malformed.\n");
+            process.exit(1);
+          }
+
+          const admissible = pullRequests.some(
+            (pullRequest) =>
+              pullRequest.state === "open" &&
+              pullRequest.base?.ref === "develop" &&
+              pullRequest.base?.repo?.full_name === expectedRepository &&
+              pullRequest.head?.repo?.full_name === expectedRepository &&
+              pullRequest.head?.sha === candidateSha,
+          );
+
+          if (!admissible) {
+            process.stderr.write(
+              `::error::${candidateSha} is not the current head of an open same-repository pull request into develop.\n`,
             );
             process.exit(1);
           }
           NODE
 
           git fetch --force --no-tags origin \
-            develop:refs/remotes/origin/develop
+            "$candidate_sha" develop:refs/remotes/origin/develop
           behind_count="$(
-            git rev-list --count "$GITHUB_SHA..refs/remotes/origin/develop"
+            git rev-list --count "$candidate_sha..refs/remotes/origin/develop"
           )"
           if [ "$behind_count" != "0" ]; then
-            echo "::error::Candidate $GITHUB_SHA is $behind_count commit(s) behind current origin/develop."
+            echo "::error::Candidate $candidate_sha is $behind_count commit(s) behind current origin/develop."
             exit 1
           fi
+
+          printf '%s\n' "bundle_run_id=$CANDIDATE_RUN_ID" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "bundle_sha=$candidate_sha" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "Publishing candidate bundle from run $CANDIDATE_RUN_ID for $candidate_sha."
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
-      - name: Download verified Pages bundle
+      # The secret-bearing lane must never resolve executable content from a
+      # registry at deploy time. Install the locked wrangler from the protected
+      # branch's bun.lock and run that exact binary. Do not reintroduce bunx.
+      - name: Install locked release tooling
+        run: |
+          bun install --frozen-lockfile --ignore-scripts \
+            --filter @elizaos/eliza-computer
+
+      - name: Verify the locked wrangler executable
+        env:
+          EXPECTED_WRANGLER_VERSION: "4.100.0"
+        run: |
+          set -euo pipefail
+          wrangler_bin="packages/eliza-computer/node_modules/.bin/wrangler"
+          if [ ! -x "$wrangler_bin" ]; then
+            echo "::error::The locked wrangler executable is missing at $wrangler_bin; the frozen install did not provide release tooling."
+            exit 1
+          fi
+          installed_version="$("$wrangler_bin" --version | tail -n 1 | tr -d '[:space:]')"
+          if [ "$installed_version" != "$EXPECTED_WRANGLER_VERSION" ]; then
+            echo "::error::Locked wrangler is $installed_version; the release contract requires $EXPECTED_WRANGLER_VERSION."
+            exit 1
+          fi
+          printf '%s\n' "$PWD/packages/eliza-computer/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Download admitted Pages bundle
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: eliza-computer-pages-${{ github.run_id }}
+          name: eliza-computer-pages-${{ steps.admit.outputs.bundle_run_id }}
           path: packages/eliza-computer/dist
+          run-id: ${{ steps.admit.outputs.bundle_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Require scoped Cloudflare credentials
         env:
@@ -340,7 +450,8 @@ jobs:
               fi
               ;;
             404)
-              bunx wrangler@4.100.0 pages project create eliza-computer \
+              packages/eliza-computer/node_modules/.bin/wrangler \
+                pages project create eliza-computer \
                 --production-branch=develop
               ;;
             *)
@@ -355,16 +466,17 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BUNDLE_SHA: ${{ steps.admit.outputs.bundle_sha }}
         # wrangler.toml owns pages_build_output_dir. A positional directory
         # bypasses that deployment contract and must not be added here.
         run: |
           set -euo pipefail
           printf '%s\n' "started_at=$(node -e 'process.stdout.write(Date.now().toString())')" >> "$GITHUB_OUTPUT"
           for attempt in 1 2 3; do
-            if bunx wrangler@4.100.0 pages deploy \
+            if ./node_modules/.bin/wrangler pages deploy \
               --project-name=eliza-computer \
               --branch=develop \
-              --commit-hash="$GITHUB_SHA" \
+              --commit-hash="$BUNDLE_SHA" \
               --commit-dirty=false; then
               exit 0
             fi
@@ -382,6 +494,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DEPLOYMENT_NOT_BEFORE: ${{ steps.pages-deploy.outputs.started_at }}
+          BUNDLE_SHA: ${{ steps.admit.outputs.bundle_sha }}
         run: |
           set -euo pipefail
           response="$RUNNER_TEMP/eliza-computer-production-deployments.json"
@@ -399,12 +512,12 @@ jobs:
             if [ "$status" = "200" ]; then
               if deployment="$(
                 node packages/eliza-computer/scripts/select-pages-deployment.mjs \
-                  "$response" "$GITHUB_SHA" "$DEPLOYMENT_NOT_BEFORE"
+                  "$response" "$BUNDLE_SHA" "$DEPLOYMENT_NOT_BEFORE"
               )"; then
                 IFS=$'\t' read -r deployment_id deployment_url deployment_created_on <<< "$deployment"
                 printf '%s\n' "deployment_id=$deployment_id" >> "$GITHUB_OUTPUT"
                 printf '%s\n' "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
-                echo "::notice::Cloudflare production deployment $deployment_id for $GITHUB_SHA is successful at $deployment_url"
+                echo "::notice::Cloudflare production deployment $deployment_id for $BUNDLE_SHA is successful at $deployment_url"
                 {
                   echo "Cloudflare deployment: \`$deployment_id\`"
                   echo
@@ -423,13 +536,15 @@ jobs:
             else
               echo "::warning::Cloudflare deployment metadata lookup returned HTTP $status."
             fi
-            echo "::warning::Successful production metadata for $GITHUB_SHA is not visible yet (attempt $attempt/18)."
+            echo "::warning::Successful production metadata for $BUNDLE_SHA is not visible yet (attempt $attempt/18)."
             sleep 5
           done
-          echo "::error::Cloudflare did not report a new, successful, clean production deployment for commit $GITHUB_SHA."
+          echo "::error::Cloudflare did not report a new, successful, clean production deployment for commit $BUNDLE_SHA."
           exit 1
 
       - name: Verify published skill and leaderboard
+        env:
+          BUNDLE_SHA: ${{ steps.admit.outputs.bundle_sha }}
         run: |
           set -euo pipefail
           verify_download() {
@@ -445,7 +560,7 @@ jobs:
                 --max-time 30 \
                 --header "Cache-Control: no-cache" \
                 --header "Pragma: no-cache" \
-                "https://eliza.army${remote_path}?verify=$GITHUB_SHA-$GITHUB_RUN_ATTEMPT-$attempt" \
+                "https://eliza.army${remote_path}?verify=$BUNDLE_SHA-$GITHUB_RUN_ATTEMPT-$attempt" \
                 --output "$received" &&
                 cmp --silent "$expected" "$received"; then
                 return 0

--- a/bun.lock
+++ b/bun.lock
@@ -994,6 +994,7 @@
         "playwright": "^1.61.0",
         "typescript": "^6.0.3",
         "vitest": "^4.0.18",
+        "wrangler": "4.100.0",
       },
     },
     "packages/eliza-hub": {

--- a/packages/eliza-computer/AGENTS.md
+++ b/packages/eliza-computer/AGENTS.md
@@ -110,41 +110,61 @@ before changing the allowlist, Pages, zones, nameservers, DNSSEC, custom
 domains, or registrar state.
 
 Push and schedule releases are restricted to `develop`; pull-request runs
-never deploy. Manual dispatch defaults to `quality-only`. The explicit
-`production-candidate` mode exists so a PR can collect real production evidence
-before merge without weakening those automatic paths. It quality-tests and
-deploys one immutable `github.sha`. A non-`develop` candidate must name a
-currently open same-repository PR into `develop`; the workflow verifies that
-the PR head branch and SHA exactly match the dispatched ref and that the
-candidate is zero commits behind a freshly fetched `origin/develop`. Any
-missing, stale, forked, closed, or mismatched PR fails before Cloudflare is
-called.
+never deploy. Manual dispatch defaults to `quality-only`, and every
+`production-candidate` dispatch must also come from `develop`. The deploy job
+is a trust boundary: it checks out `refs/heads/develop`, verifies that checkout
+is current `origin/develop` through the API, and only then enters the
+production environment. A candidate ref never supplies the workflow definition,
+the admission check, or the deployment scripts that run beside Cloudflare
+credentials.
 
-A release operator promotes a non-`develop` candidate with this procedure:
+A candidate branch contributes exactly one thing: an immutable build artifact
+produced by the secretless `quality` job. To publish it, a release operator
+dispatches from `develop` with `release_mode=production-candidate` and the
+candidate's eliza.army run ID in `candidate_run_id`. The protected admission
+check then requires that run to be a completed, successful, same-repository
+`eliza-computer.yml` run that was not triggered by `pull_request`, and requires
+its head SHA to be the current head of an open same-repository PR into
+`develop` that is zero commits behind a freshly fetched `origin/develop`. Any
+missing, stale, forked, closed, failed, or mismatched run fails before
+Cloudflare is called. Because the branch is never dispatched directly, the
+environment deployment-branch allowlist keeps `develop` as its only entry; it
+never needs a temporary candidate branch.
+
+A release operator promotes a candidate bundle with this procedure:
 
 1. Rebase the branch onto current `origin/develop` and confirm its open PR
    targets `develop`.
-2. Review the exact candidate SHA's workflow, `wrangler.toml`, and every script
-   the deploy job executes against `origin/develop`. The candidate supplies its
-   workflow definition, so the protected environment's operator review is the
-   trust boundary; never allowlist a ref with unapproved release-authority or
-   credential-handling changes.
-3. Temporarily add that exact branch name to the environment deployment-branch
-   allowlist. Never add a wildcard, branch family, fork head, or tag.
-4. Dispatch this workflow from that branch with
-   `release_mode=production-candidate` and its PR number. Confirm the quality
-   and deploy jobs name the expected SHA; satisfy any configured environment
-   review without bypassing protection.
-5. Remove the temporary branch entry as soon as the run reaches a terminal
-   state. If the candidate will not merge, dispatch the current `develop` ref
-   in `production-candidate` mode to restore the canonical production build.
+2. Let the candidate's own PR run of this workflow finish its `quality` job,
+   and note that run ID. That job holds no secrets.
+3. Dispatch this workflow **from `develop`** with
+   `release_mode=production-candidate` and `candidate_run_id` set to that run
+   ID. Confirm the admission step names the expected candidate SHA; satisfy any
+   configured environment review without bypassing protection.
+4. If the candidate will not merge, dispatch `develop` again with an empty
+   `candidate_run_id` to restore the canonical production build.
+
+Release tooling is resolved from the lockfile, never from a registry. The
+deploy job runs `bun install --frozen-lockfile` for this package and executes
+`packages/eliza-computer/node_modules/.bin/wrangler`, asserting the binary
+reports the pinned `4.100.0` before any credential is used. Never reintroduce
+`bunx wrangler@...` in a secret-bearing lane: it re-resolves executable content
+at deploy time and bypasses the reviewed lockfile.
 
 Do not deploy production from a package script or a local working tree. The
-workflow checks out the exact tested Actions SHA, downloads the verified build,
-and lets `wrangler.toml` select the Pages output directory before binding that
-deployment to the same commit SHA. The release stays failed until Cloudflare's
-API reports a new, clean, successful production deployment for that exact SHA;
-the workflow records its deployment ID and immutable Pages URL.
+workflow downloads the admitted build and lets `wrangler.toml` select the Pages
+output directory before binding that deployment to the admitted bundle SHA. The
+release stays failed until Cloudflare's API reports a new, clean, successful
+production deployment for that exact SHA; the workflow records its deployment
+ID and immutable Pages URL.
+
+`eliza.army` and `eliza.app` are two separate Cloudflare Pages projects and
+must not be conflated. This workflow owns only the `eliza-computer` project
+(public authority `https://eliza.army`), built from `packages/eliza-computer`
+as a standalone Vite site. `deploy-homepage.yml` independently owns the
+`eliza-app-home` project serving `eliza.app`, built from `packages/homepage`.
+Their path filters are disjoint, so neither deploy can preempt or overwrite the
+other.
 
 The production domain is registered with Cloudflare Registrar in the same
 account as the Pages project. The internal project slug remains

--- a/packages/eliza-computer/CLAUDE.md
+++ b/packages/eliza-computer/CLAUDE.md
@@ -110,41 +110,61 @@ before changing the allowlist, Pages, zones, nameservers, DNSSEC, custom
 domains, or registrar state.
 
 Push and schedule releases are restricted to `develop`; pull-request runs
-never deploy. Manual dispatch defaults to `quality-only`. The explicit
-`production-candidate` mode exists so a PR can collect real production evidence
-before merge without weakening those automatic paths. It quality-tests and
-deploys one immutable `github.sha`. A non-`develop` candidate must name a
-currently open same-repository PR into `develop`; the workflow verifies that
-the PR head branch and SHA exactly match the dispatched ref and that the
-candidate is zero commits behind a freshly fetched `origin/develop`. Any
-missing, stale, forked, closed, or mismatched PR fails before Cloudflare is
-called.
+never deploy. Manual dispatch defaults to `quality-only`, and every
+`production-candidate` dispatch must also come from `develop`. The deploy job
+is a trust boundary: it checks out `refs/heads/develop`, verifies that checkout
+is current `origin/develop` through the API, and only then enters the
+production environment. A candidate ref never supplies the workflow definition,
+the admission check, or the deployment scripts that run beside Cloudflare
+credentials.
 
-A release operator promotes a non-`develop` candidate with this procedure:
+A candidate branch contributes exactly one thing: an immutable build artifact
+produced by the secretless `quality` job. To publish it, a release operator
+dispatches from `develop` with `release_mode=production-candidate` and the
+candidate's eliza.army run ID in `candidate_run_id`. The protected admission
+check then requires that run to be a completed, successful, same-repository
+`eliza-computer.yml` run that was not triggered by `pull_request`, and requires
+its head SHA to be the current head of an open same-repository PR into
+`develop` that is zero commits behind a freshly fetched `origin/develop`. Any
+missing, stale, forked, closed, failed, or mismatched run fails before
+Cloudflare is called. Because the branch is never dispatched directly, the
+environment deployment-branch allowlist keeps `develop` as its only entry; it
+never needs a temporary candidate branch.
+
+A release operator promotes a candidate bundle with this procedure:
 
 1. Rebase the branch onto current `origin/develop` and confirm its open PR
    targets `develop`.
-2. Review the exact candidate SHA's workflow, `wrangler.toml`, and every script
-   the deploy job executes against `origin/develop`. The candidate supplies its
-   workflow definition, so the protected environment's operator review is the
-   trust boundary; never allowlist a ref with unapproved release-authority or
-   credential-handling changes.
-3. Temporarily add that exact branch name to the environment deployment-branch
-   allowlist. Never add a wildcard, branch family, fork head, or tag.
-4. Dispatch this workflow from that branch with
-   `release_mode=production-candidate` and its PR number. Confirm the quality
-   and deploy jobs name the expected SHA; satisfy any configured environment
-   review without bypassing protection.
-5. Remove the temporary branch entry as soon as the run reaches a terminal
-   state. If the candidate will not merge, dispatch the current `develop` ref
-   in `production-candidate` mode to restore the canonical production build.
+2. Let the candidate's own PR run of this workflow finish its `quality` job,
+   and note that run ID. That job holds no secrets.
+3. Dispatch this workflow **from `develop`** with
+   `release_mode=production-candidate` and `candidate_run_id` set to that run
+   ID. Confirm the admission step names the expected candidate SHA; satisfy any
+   configured environment review without bypassing protection.
+4. If the candidate will not merge, dispatch `develop` again with an empty
+   `candidate_run_id` to restore the canonical production build.
+
+Release tooling is resolved from the lockfile, never from a registry. The
+deploy job runs `bun install --frozen-lockfile` for this package and executes
+`packages/eliza-computer/node_modules/.bin/wrangler`, asserting the binary
+reports the pinned `4.100.0` before any credential is used. Never reintroduce
+`bunx wrangler@...` in a secret-bearing lane: it re-resolves executable content
+at deploy time and bypasses the reviewed lockfile.
 
 Do not deploy production from a package script or a local working tree. The
-workflow checks out the exact tested Actions SHA, downloads the verified build,
-and lets `wrangler.toml` select the Pages output directory before binding that
-deployment to the same commit SHA. The release stays failed until Cloudflare's
-API reports a new, clean, successful production deployment for that exact SHA;
-the workflow records its deployment ID and immutable Pages URL.
+workflow downloads the admitted build and lets `wrangler.toml` select the Pages
+output directory before binding that deployment to the admitted bundle SHA. The
+release stays failed until Cloudflare's API reports a new, clean, successful
+production deployment for that exact SHA; the workflow records its deployment
+ID and immutable Pages URL.
+
+`eliza.army` and `eliza.app` are two separate Cloudflare Pages projects and
+must not be conflated. This workflow owns only the `eliza-computer` project
+(public authority `https://eliza.army`), built from `packages/eliza-computer`
+as a standalone Vite site. `deploy-homepage.yml` independently owns the
+`eliza-app-home` project serving `eliza.app`, built from `packages/homepage`.
+Their path filters are disjoint, so neither deploy can preempt or overwrite the
+other.
 
 The production domain is registered with Cloudflare Registrar in the same
 account as the Pages project. The internal project slug remains

--- a/packages/eliza-computer/package.json
+++ b/packages/eliza-computer/package.json
@@ -44,7 +44,8 @@
     "jsdom": "^29.0.0",
     "playwright": "^1.61.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "wrangler": "4.100.0"
   },
   "elizaos": {
     "scripts": {

--- a/packages/eliza-computer/scripts/deployment-contract.test.mjs
+++ b/packages/eliza-computer/scripts/deployment-contract.test.mjs
@@ -32,19 +32,58 @@ const qualityJob = workflow.slice(
 const deployJob = workflow.slice(workflow.indexOf("\n  deploy:"));
 
 describe("eliza.army deployment contract", () => {
-  it("deploys only the exact tested SHA through wrangler.toml", () => {
+  it("deploys only the admitted bundle SHA through wrangler.toml", () => {
     expect(qualityJob).toContain(`ref: ${"$"}{{ github.sha }}`);
     expect(qualityJob).toContain("does not match the event SHA $GITHUB_SHA");
-    expect(deployJob).toContain(`ref: ${"$"}{{ github.sha }}`);
     expect(deployJob).toContain('checked_out_sha="$(git rev-parse HEAD)"');
-    expect(deployJob).toContain("bunx wrangler@4.100.0 pages deploy \\");
+    expect(deployJob).toContain("./node_modules/.bin/wrangler pages deploy \\");
     expect(deployJob).not.toContain("pages deploy dist");
-    expect(deployJob).toContain('--commit-hash="$GITHUB_SHA"');
+    expect(deployJob).toContain('--commit-hash="$BUNDLE_SHA"');
     expect(deployJob).toContain("--commit-dirty=false");
     expect(deployJob).toContain("select-pages-deployment.mjs");
     expect(deployJob).toContain("new, successful, clean production deployment");
     expect(wranglerConfiguration).toContain(
       'pages_build_output_dir = "./dist"',
+    );
+  });
+
+  it("runs the secret-bearing lane from protected-branch code only", () => {
+    // The candidate ref must never supply the workflow definition, the
+    // admission check, or the deployment scripts that execute beside the
+    // production Cloudflare credentials.
+    expect(deployJob).toContain("ref: refs/heads/develop");
+    expect(deployJob).not.toContain(`ref: ${"$"}{{ github.sha }}`);
+    expect(deployJob).toContain("is not current origin/develop");
+    expect(deployJob).toContain(
+      "Production releases must be dispatched from develop",
+    );
+  });
+
+  it("resolves release tooling from the lockfile, never from a registry", () => {
+    expect(deployJob).toContain(
+      "bun install --frozen-lockfile --ignore-scripts",
+    );
+    expect(deployJob).toContain(
+      "packages/eliza-computer/node_modules/.bin/wrangler",
+    );
+    expect(deployJob).toContain('EXPECTED_WRANGLER_VERSION: "4.100.0"');
+    expect(deployJob).toContain("the release contract requires");
+    expect(deployJob).not.toContain("bunx wrangler");
+    expect(packageManifest.devDependencies.wrangler).toBe("4.100.0");
+  });
+
+  it("admits a candidate bundle by run identity, not by candidate code", () => {
+    expect(deployJob).toContain("candidate_run_id");
+    expect(deployJob).toContain('run.conclusion !== "success"');
+    expect(deployJob).toContain("run.path !== expectedWorkflowPath");
+    expect(deployJob).toContain(
+      "run.head_repository?.full_name !== run.repository?.full_name",
+    );
+    expect(deployJob).toContain(
+      "is not the current head of an open same-repository pull request into develop",
+    );
+    expect(deployJob).toContain(
+      `run-id: ${"$"}{{ steps.admit.outputs.bundle_run_id }}`,
     );
   });
 
@@ -64,23 +103,22 @@ describe("eliza.army deployment contract", () => {
     expect(deployJob).toContain("name: eliza-army-production");
   });
 
-  it("admits a manual non-develop candidate only from a current same-repository PR", () => {
+  it("admits a manual candidate bundle only from a current same-repository PR", () => {
     expect(workflow).toContain("default: quality-only");
     expect(workflow).toContain("- production-candidate");
-    expect(workflow).toContain("candidate_pr:");
-    expect(deployJob).toContain('if [ "$GITHUB_REF_TYPE" != "branch" ]; then');
+    expect(workflow).toContain("candidate_run_id:");
+    expect(workflow).not.toContain("candidate_pr:");
     expect(deployJob).toContain(
-      'if ! [[ "$CANDIDATE_PR" =~ ^[1-9][0-9]*$ ]]; then',
+      'if ! [[ "$CANDIDATE_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then',
     );
-    expect(deployJob).toContain('pullRequest.state !== "open"');
-    expect(deployJob).toContain('pullRequest.base?.ref !== "develop"');
+    expect(deployJob).toContain('pullRequest.state === "open"');
+    expect(deployJob).toContain('pullRequest.base?.ref === "develop"');
     expect(deployJob).toContain(
-      "pullRequest.head?.repo?.full_name !== expectedRepository",
+      "pullRequest.head?.repo?.full_name === expectedRepository",
     );
-    expect(deployJob).toContain("pullRequest.head?.sha !== expectedSha");
-    expect(deployJob).toContain("pullRequest.head?.ref !== expectedBranch");
+    expect(deployJob).toContain("pullRequest.head?.sha === candidateSha");
     expect(deployJob).toContain(
-      'git rev-list --count "$GITHUB_SHA..refs/remotes/origin/develop"',
+      'git rev-list --count "$candidate_sha..refs/remotes/origin/develop"',
     );
     expect(deployJob).toContain('if [ "$behind_count" != "0" ]; then');
   });
@@ -99,7 +137,7 @@ describe("eliza.army deployment contract", () => {
     expect(verificationStep).toContain('--header "Cache-Control: no-cache"');
     expect(verificationStep).toContain('--header "Pragma: no-cache"');
     expect(verificationStep).toContain(
-      "?verify=$GITHUB_SHA-$GITHUB_RUN_ATTEMPT-$attempt",
+      "?verify=$BUNDLE_SHA-$GITHUB_RUN_ATTEMPT-$attempt",
     );
     expect(verificationStep).toContain("--connect-timeout 10");
     expect(verificationStep).toContain("--max-time 30");


### PR DESCRIPTION
Targets `feat/eliza-army` (#17424), not `develop`. Additive commit on top of `c209783`; no rewrite of that branch's history.

Closes the two merge-blocking P1 findings raised on #17424 against the deploy job that holds production Cloudflare credentials. They are fixed in one commit because they interlock: a frozen install is only meaningful once the lockfile it reads is itself protected.

# Relates to

#17424 (this PR targets that branch). Blockers from https://github.com/elizaOS/eliza/pull/17424#issuecomment-5145308602 and https://github.com/elizaOS/eliza/pull/17424#issuecomment-5145330738.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-20250514`
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Risks

Medium-to-large in blast radius, risk-reducing in direction. This changes a production deploy path under `.github/workflows`, so it needs human review and must not be auto-merged. It does not weaken any existing check; every change either tightens a boundary or holds it. The operational surface that changes is the release runbook (operators now dispatch from `develop` with a `candidate_run_id` instead of dispatching from the candidate branch), so a release operator should confirm that flow before the next promotion.

# Background

## What does this PR do?

### [P1] Candidate-controlled workflow code entered the production-secret job

A manually selected candidate SHA supplied `.github/workflows/eliza-computer.yml` and every deployment script, and the job then entered the production environment and received Cloudflare credentials. The admission check ran *inside* the candidate-controlled definition, so the candidate could modify or bypass the check meant to gate it. Human environment approval reduced likelihood but was not a code-enforced trust boundary.

The deploy job now:

- checks out `refs/heads/develop` and verifies through the API that the checkout is current `origin/develop`;
- rejects any `production-candidate` dispatch from a ref other than `develop`;
- accepts a candidate's build **by run identity** through a new `candidate_run_id` input, replacing `candidate_pr`.

The candidate contributes exactly one thing: the immutable artifact built by the secretless `quality` job. The protected admission step requires that run to be completed, successful, same-repository, not `pull_request`/`pull_request_target`, and a run of *this* workflow file, and requires its head SHA to be the current head of an open same-repository PR into `develop` that is zero commits behind a freshly fetched `origin/develop`. Deploy metadata, byte verification, and the Cloudflare commit hash all bind to the admitted bundle SHA.

Side benefit: because a candidate branch is never dispatched directly, the `eliza-army-production` deployment-branch allowlist keeps `develop` as its only entry and no longer needs the temporary-allowlist step the old runbook described.

### [P1] Production resolved Wrangler outside `bun.lock`

The job ran `bunx wrangler@4.100.0` *after* entering the production environment, so the secret-bearing lane could re-resolve executable content from a registry at deploy time. Per the correction on #17424, wrangler was already in `bun.lock` via the root override; the defect was that the job never installed from the lock and never invoked the installed binary.

Now: `bun install --frozen-lockfile --ignore-scripts --filter @elizaos/eliza-computer`, then execute `packages/eliza-computer/node_modules/.bin/wrangler` for both the project-create and deploy paths. A preceding step asserts the binary reports the pinned version and fails **before** any credential is used. `wrangler@4.100.0` becomes an explicit `@elizaos/eliza-computer` devDependency matching the existing root override, which adds exactly one line to `bun.lock`.

## What kind of change is this?

Bug fixes (security boundary repair in CI/CD), plus the documentation that describes the corrected release procedure.

## Two-project topology (re: the #17413 "packages/homepage/dist" note)

`eliza.army` and `eliza.app` are **separate** Cloudflare Pages projects and this deploy does not fight the existing homepage topology:

- `eliza-computer.yml` → project `eliza-computer` → `eliza.army`, built from `packages/eliza-computer` (standalone Vite site, `wrangler.toml` owns `pages_build_output_dir = "./dist"`).
- `deploy-homepage.yml` → project `eliza-app-home` → `eliza.app`, built from `packages/homepage`.

Their `paths:` filters are disjoint, so neither can preempt or overwrite the other. Documented in `packages/eliza-computer/AGENTS.md` so the two projects are not conflated later.

# Documentation changes needed?

Done in this PR. `packages/eliza-computer/AGENTS.md` and `CLAUDE.md` carry the corrected release runbook and the two-project topology; `.github/workflows/CHANGELOG.md` records the CI policy change.

# Testing

## Where should a reviewer start?

`.github/workflows/eliza-computer.yml`, the `deploy:` job. Read it as a security boundary: confirm nothing executed in that job originates from the candidate ref, and that no credential is referenced before the admission and wrangler-version steps have passed. Then read `packages/eliza-computer/scripts/deployment-contract.test.mjs`, which is what keeps those properties from regressing.

## Detailed testing steps

- `packages/eliza-computer` suite: **99/99 pass** (`deployment-contract.test.mjs` 9/9)
- `tsc -b` clean; `biome check .` clean across 32 files
- CI contracts pass: `ci-bun-version-contract` (36 concrete pins in lockstep), `ci-workflow-dedup-contract`, `ci-merge-gate-contract`, `develop-pr-aggregate-workflow-contract`, `quality-fork-browser-contract`
- **Frozen filtered install** exercised from a clean checkout at bun `1.3.14` (the repo's pinned CI version): 402 packages, **zero** lockfile drift, `wrangler --version` → `4.100.0`
- **Fail-closed proof:** reverted each fix in a scratch tree and confirmed the matching contract test fails. Restoring `bunx wrangler` → 2 failures; restoring `ref: ${{ github.sha }}` in the deploy job → 1 failure.
- **Admission logic unit-tested against real API payloads:** 8/8 candidate-run cases and 8/8 PR-association cases behaved correctly. Rejected as expected: failed run, in-progress run, different workflow file, `pull_request` event, `pull_request_target` event, malformed head SHA, fork head repository, empty PR list, closed PR, base `main`, fork head, stale head SHA, fork base repository.
- Both embedded Node heredocs pass `node --check`.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no rendered-UI source file is touched. The diff is one workflow YAML, one contract test (.mjs), package.json/bun.lock, and three markdown docs; there is no user-visible surface to screenshot.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered-UI source file is touched, so there is no after state to capture. The eliza.army site output is byte-identical: this PR changes only how the already-built bundle is admitted and published, never how it is built.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - the changed surface is a GitHub Actions deploy job with no interactive user flow. The equivalent proof is the contract-test fail-closed demonstration recorded under Detailed testing steps.`
<!-- evidence-row:backend-logs -->
- [x] Real execution output of the changed install path, from a clean checkout at the repo's pinned bun `1.3.14`, plus the fail-closed demonstration:

<details>
<summary>Frozen filtered install + locked wrangler resolution</summary>

```
$ bun install --frozen-lockfile --ignore-scripts --filter @elizaos/eliza-computer
+ tsx@4.23.1
+ typescript@6.0.3 (v7.0.2 available)
+ vite@8.0.16 (v8.2.0 available)
+ vitest@4.1.5 (v4.1.10 available)
+ yaml@2.9.0

402 packages installed [2.26s]
EXIT=0

$ ls -la packages/eliza-computer/node_modules/.bin/wrangler
... packages/eliza-computer/node_modules/.bin/wrangler -> ../wrangler/bin/wrangler.js

$ ./packages/eliza-computer/node_modules/.bin/wrangler --version
4.100.0

$ git diff --stat bun.lock
 bun.lock | 1 +
 1 file changed, 1 insertion(+)
```

</details>

<details>
<summary>Fail-closed proof: restoring `bunx wrangler` breaks the contract</summary>

```
×  deploys only the admitted bundle SHA through wrangler.toml
✓  runs the secret-bearing lane from protected-branch code only
×  resolves release tooling from the lockfile, never from a registry
✓  admits a candidate bundle by run identity, not by candidate code
Tests  2 failed | 7 passed (9)
```

</details>

<details>
<summary>Fail-closed proof: restoring `ref: ${{ github.sha }}` in the deploy job</summary>

```
×  runs the secret-bearing lane from protected-branch code only
Tests  1 failed | 8 passed (9)
```

</details>

<details>
<summary>Package suite + CI contracts</summary>

```
Test Files  8 passed (8)
     Tests  99 passed (99)

ci-bun-version-contract                       PASS
ci-workflow-dedup-contract                    PASS
ci-merge-gate-contract                        PASS
develop-pr-aggregate-workflow-contract        PASS
quality-fork-browser-contract                 PASS
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code path is exercised. This PR contains no browser-executed change; the deploy job's published bytes are unchanged.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code is touched. The diff is CI workflow configuration, a contract test, dependency pinning, and docs.`
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact for this change is the admission logic verified against real GitHub API payloads:

<details>
<summary>Candidate-run admission: 8/8 correct</summary>

```
OK    baseline (should PASS): admitted=true expected=true
OK    failed conclusion: admitted=false      ::error::run did not succeed.
OK    in progress: admitted=false            ::error::run is not completed.
OK    different workflow file: admitted=false ::error::run built .github/workflows/evil.yml, not .github/workflows/eliza-computer.yml.
OK    pull_request event: admitted=false     ::error::run event pull_request is not an admissible bundle source.
OK    pull_request_target event: admitted=false
OK    malformed head_sha: admitted=false     ::error::run head SHA is missing or malformed.
OK    fork head repository: admitted=false   ::error::run head repository is not this repository.

ALL ADMISSION CASES CORRECT
```

</details>

<details>
<summary>PR-association admission: 8/8 correct</summary>

```
OK    baseline open same-repo PR (PASS): admitted=true
OK    empty list: admitted=false
OK    closed PR: admitted=false
OK    targets main not develop: admitted=false
OK    fork head repo: admitted=false
OK    PR head moved past this sha: admitted=false
OK    base repo is a fork: admitted=false
OK    one bad one good: admitted=true

ALL PR-ASSOCIATION CASES CORRECT
```

</details>

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change in this diff.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered-UI source file is touched; the published site bytes are unchanged by this PR.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.`

## Known gaps / failures

- A live end-to-end production deploy through the new admission path has **not** been run from this PR, because doing so would require the `eliza-army-production` credentials and a release operator. The install path, the wrangler resolution, and every admission predicate are verified above against real payloads and a real frozen install; the remaining unverified step is the Cloudflare API call itself, which is unchanged apart from which binary invokes it and which SHA it binds to.
- This PR deliberately fixes **only** the two deploy-credential P1s. The other findings on #17424 (skill-review `pull_request_target` exposure, score gameability, evidence authenticity, claim squatting, installer checksum root, denylist candidate selection, and the P2 set) are untouched, so #17424 should stay draft.

# Deploy Notes

The release runbook changes. Operators no longer dispatch from the candidate branch; they dispatch from `develop` with `release_mode=production-candidate` and `candidate_run_id` set to the candidate's already-finished `quality` run. `AGENTS.md` and `CLAUDE.md` are updated to match. The `eliza-army-production` deployment-branch allowlist should keep `develop` as its only entry.

`permissions:` gains `actions: read` so the protected job can inspect the candidate run and download its artifact cross-run.

## ⚠️ Requires human merge

This touches `.github/workflows`. **No auto-merge.** Please review the deploy job as a security boundary, not a refactor, and confirm dual review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
