### PR TITLE
fix(ci): restore fail-closed correctness controls

### DIFF
--- a/.github/actions/cloud-setup-test-env/action.yml
+++ b/.github/actions/cloud-setup-test-env/action.yml
@@ -22,6 +22,19 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Verify PostgreSQL container runtime
+      if: inputs.setup-db == 'true' && inputs.db-backend == 'postgres'
+      shell: bash
+      run: |
+        if ! command -v docker >/dev/null 2>&1; then
+          echo "::error::PostgreSQL-backed cloud tests require the Docker CLI."
+          exit 1
+        fi
+        if ! docker info >/dev/null 2>&1; then
+          echo "::error::PostgreSQL-backed cloud tests require access to the Docker daemon."
+          exit 1
+        fi
+
     - uses: actions/setup-node@v6
       with:
         node-version: "22"
@@ -29,14 +42,6 @@ runs:
     - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       with:
         bun-version: ${{ inputs.bun-version }}
-
-    - name: Cache Bun install
-      uses: actions/cache@v5
-      with:
-        path: ~/.bun/install/cache
-        key: bun-${{ runner.os }}-${{ hashFiles('packages/cloud/shared/bun.lock') }}
-        restore-keys: |
-          bun-${{ runner.os }}-
 
     - name: Install dependencies
       shell: bash

--- a/.github/scripts/install-workflow-linters.sh
+++ b/.github/scripts/install-workflow-linters.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Installs checksum-pinned workflow linters for the current supported runner.
+
+set -euo pipefail
+
+ACTIONLINT_VERSION="1.7.12"
+ZIZMOR_VERSION="1.28.0"
+destination="${1:-${RUNNER_TEMP:-/tmp}/workflow-linters}"
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)
+    actionlint_asset="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+    actionlint_sha="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+    zizmor_asset="zizmor-x86_64-unknown-linux-gnu.tar.gz"
+    zizmor_sha="e87b67160194884e375a46a12c57ccc904f762b53845f254fab7f17d98809c09"
+    ;;
+  Linux-aarch64|Linux-arm64)
+    actionlint_asset="actionlint_${ACTIONLINT_VERSION}_linux_arm64.tar.gz"
+    actionlint_sha="325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6"
+    zizmor_asset="zizmor-aarch64-unknown-linux-gnu.tar.gz"
+    zizmor_sha="324e43770cfacf4216f8aefb287263b5b5c733c85b03bf7583b5cc4a0460239e"
+    ;;
+  Darwin-x86_64)
+    actionlint_asset="actionlint_${ACTIONLINT_VERSION}_darwin_amd64.tar.gz"
+    actionlint_sha="5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644"
+    zizmor_asset="zizmor-x86_64-apple-darwin.tar.gz"
+    zizmor_sha="40a58d8560d65c71357b3977d0da425773bf8f10bf1ffd38099d963d3afdf3aa"
+    ;;
+  Darwin-arm64)
+    actionlint_asset="actionlint_${ACTIONLINT_VERSION}_darwin_arm64.tar.gz"
+    actionlint_sha="aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f"
+    zizmor_asset="zizmor-aarch64-apple-darwin.tar.gz"
+    zizmor_sha="54949bbd6b4c8527046bb8990bac9e0dab3eec787640f4e6199ae121dd1040be"
+    ;;
+  *)
+    printf 'unsupported workflow-linter host: %s-%s\n' "$(uname -s)" "$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$destination"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+download_and_verify() {
+  local url="$1"
+  local expected="$2"
+  local output="$3"
+  curl --fail --location --silent --show-error --retry 3 --output "$output" "$url"
+  local actual
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$output" | awk '{print $1}')"
+  else
+    actual="$(shasum -a 256 "$output" | awk '{print $1}')"
+  fi
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'checksum mismatch for %s: expected %s, got %s\n' "$url" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+actionlint_archive="$scratch/$actionlint_asset"
+zizmor_archive="$scratch/$zizmor_asset"
+download_and_verify \
+  "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${actionlint_asset}" \
+  "$actionlint_sha" \
+  "$actionlint_archive"
+download_and_verify \
+  "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/${zizmor_asset}" \
+  "$zizmor_sha" \
+  "$zizmor_archive"
+
+tar -xzf "$actionlint_archive" -C "$scratch" actionlint
+tar -xzf "$zizmor_archive" -C "$scratch" zizmor
+install -m 0755 "$scratch/actionlint" "$destination/actionlint"
+install -m 0755 "$scratch/zizmor" "$destination/zizmor"
+printf '%s\n' "$destination"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,6 +8,8 @@ This directory contains GitHub Actions workflows for the elizaOS project (v2.0.0
 |----------|---------|---------|
 | `ci.yaml` | Push/PR to main | Main-specific CI - typecheck, tests, lint, build, dev startup |
 | `develop-pr.yml` | PR to develop | Lightweight lint, typecheck, and build checks |
+| `develop-pr-gate.yml` | PR target to develop, manual canaries | Base-trusted exact-head aggregate for merge-critical PR checks |
+| `stale-base-guard.yml` | PRs | Content-level silent-revert detection with explicit acknowledgement |
 | `test.yml` | Push to develop, manual, schedule | Broader post-merge develop tests; live jobs are separate |
 | `quality.yml` | PR to main, push main/develop, manual | Extended format, homepage, secret, UI-determinism, and lint checks |
 | `scenario-pr.yml` | PR to main, push develop, manual/schedule | Secret-free deterministic scenario/browser E2E gate |
@@ -115,13 +117,23 @@ this org, #13481). Pre-merge checks remain independent of the exhaustive fleet:
   `windows-desktop-preload-smoke.yml` run on `ubuntu-24.04`. They are git-diff +
   node scripts with no self-hosted needs; pinning them to the fleet (#8501) once
   left every downstream job queued indefinitely and gridlocked develop.
+- **`Develop PR Gate`** is a read-only `pull_request_target` aggregate. It
+  checks out only the base SHA and binds every required result to the PR's exact
+  head SHA, owning workflow, GitHub Actions app, trigger, and terminal success.
+  Missing, stale, skipped, cancelled, timed-out, and failed checks stay red.
 - **`ci-ok`** and `plugin-tests-status` remain result roll-ups inside the
-  post-merge `test.yml` orchestrator. They report branch health after a develop
-  push; they are not pre-merge policy checks.
+  post-merge `test.yml` orchestrator. `ci-ok` also depends on the unconditional
+  repo-wide quality job and Linux script-test inventory.
 
-Pull requests expose the direct lint, format, typecheck, build, security, title,
-and evidence checks that produced each result. There is no polling status
-aggregate or inferred source-to-test change policy.
+The standalone stale-base workflow detects byte-identical historical blob
+restoration inside a PR diff, including the fresh-merge-base failure shape from
+#11271. It intentionally has no commit-count or elapsed-time threshold. The
+`stale-base-ack` label records a deliberate human override.
+
+`packages/scripts/ci-workflow-invariants.mjs` parses workflow YAML and enforces
+unconditional lint, format, typecheck, gitleaks, and script-test execution plus
+their final-gate dependency edges. The develop PR lint job also runs pinned,
+checksum-verified `actionlint` and `zizmor` binaries.
 
 The self-hosted test lanes retain the `HETZNER_FLEET_ONLINE=false` hosted-runner
 fallback for outages. Pull-request lint, format, typecheck, build, and secret
@@ -153,6 +165,14 @@ the exact candidate head passes and a maintainer manually reviews the downloaded
 artifacts. Only then may the old leg be retired and the inventory's
 `migrationState` changed. A code-only/non-GPU contract pass is not hardware
 proof and must not close #16449.
+
+`local-inference-matrix.yml` separately protects host execution on changed
+local-inference code. Every selected runner builds `llama-server` from the exact
+native gitlink, verifies a revision- and SHA-256-pinned smoke model, requires two
+successful variants with three samples each, compares backend-specific median
+ratios against the same-run baseline, and uploads an attestation containing the
+binary, model, report, source, workflow, and host identities. Empty caches,
+missing binaries, skipped variants, zero-work reports, and unverified bytes fail.
 
 ### PR Path Gates
 

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -136,7 +136,9 @@ jobs:
         run: bun run test:cloud:integration
 
   e2e-tests:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    # This lane starts a real pgvector container. Generic fleet labels do not
+    # attest Docker-daemon access, so use GitHub's Docker-capable image.
+    runs-on: ubuntu-24.04
     timeout-minutes: 35
     needs: [lint-and-types]
     env:
@@ -146,6 +148,7 @@ jobs:
       - uses: ./.github/actions/cloud-setup-test-env
         with:
           setup-db: "true"
+          db-backend: "postgres"
       - name: Run PostgreSQL lifecycle barrier tests
         env:
           APPS_TENANT_DB_TEST_DSN: postgresql://postgres@127.0.0.1:5432/postgres

--- a/.github/workflows/develop-pr-gate.yml
+++ b/.github/workflows/develop-pr-gate.yml
@@ -1,0 +1,72 @@
+# Base-trusted aggregate for the lightweight develop pull-request gate. It
+# observes GitHub check metadata only: the privileged pull_request_target job
+# never checks out or executes pull-request code, receives no secrets, and has
+# read-only permissions. The stable job stays pending until every component is
+# terminal and fails for every outcome except success.
+name: Develop PR Gate
+
+on:
+  # zizmor: ignore[dangerous-triggers] This read-only job checks out only the
+  # base SHA and observes exact-head check metadata; PR code and secrets never run.
+  pull_request_target:
+    branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      canary:
+        description: Deterministic terminal-state canary (success is the only green outcome)
+        required: true
+        type: choice
+        options:
+          - success
+          - missing
+          - cancelled
+          - timed-out
+          - failed
+          - skipped
+          - pending-timeout
+
+concurrency:
+  group: develop-pr-gate-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
+permissions:
+  contents: read
+  checks: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  gate:
+    name: Develop PR Gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      AGGREGATE_EVENT_NAME: ${{ github.event_name }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      PR_ACTION: ${{ github.event.action || '' }}
+      PR_UPDATED_AT: ${{ github.event.pull_request.updated_at || '' }}
+      POLL_TIMEOUT_SECONDS: "2400"
+      POLL_INTERVAL_SECONDS: "30"
+      CANARY_SCENARIO: ${{ github.event_name == 'workflow_dispatch' && inputs.canary || '' }}
+    steps:
+      - name: Check out the trusted aggregate implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24.15.0"
+
+      - name: Verify the aggregate state machine and workflow contract
+        run: node packages/scripts/develop-pr-aggregate.self-test.mjs
+
+      - name: Evaluate required develop checks
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node packages/scripts/develop-pr-aggregate.mjs

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -71,6 +71,7 @@ jobs:
           -config-file .github/actionlint.yaml
           .github/workflows/develop-pr.yml
           .github/workflows/develop-pr-gate.yml
+          .github/workflows/cloud-tests.yml
           .github/workflows/gitleaks.yml
           .github/workflows/local-inference-matrix.yml
           .github/workflows/stale-base-guard.yml

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -59,6 +59,32 @@ jobs:
       - name: Run runner-workspace cleanup smoke
         run: ./packages/deploy/runner-workspace-cleanup/smoke-test.sh
 
+      - name: Validate merge-critical workflow invariants
+        run: node packages/scripts/ci-workflow-invariants.mjs
+
+      - name: Install pinned workflow linters
+        run: .github/scripts/install-workflow-linters.sh "$RUNNER_TEMP/workflow-linters"
+
+      - name: Run actionlint on merge-critical workflows
+        run: >-
+          "$RUNNER_TEMP/workflow-linters/actionlint"
+          -config-file .github/actionlint.yaml
+          .github/workflows/develop-pr.yml
+          .github/workflows/develop-pr-gate.yml
+          .github/workflows/gitleaks.yml
+          .github/workflows/local-inference-matrix.yml
+          .github/workflows/stale-base-guard.yml
+          .github/workflows/test.yml
+
+      - name: Run zizmor on base-trusted workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          "$RUNNER_TEMP/workflow-linters/zizmor"
+          --offline
+          .github/workflows/develop-pr-gate.yml
+          .github/workflows/stale-base-guard.yml
+
   typecheck:
     runs-on: ubuntu-latest
     # 35 not 20: at --concurrency=4 a near-total affected cone (~250 packages)

--- a/.github/workflows/local-inference-matrix.yml
+++ b/.github/workflows/local-inference-matrix.yml
@@ -1,8 +1,8 @@
 name: Local Inference Matrix
 
-# Runs the local-inference smoke and ablation variant suite. Each leg uploads
-# raw throughput telemetry for comparison and fails only when setup or an
-# executable variant fails.
+# Builds a host-compatible fork binary, verifies a pinned model, executes a
+# non-empty ablation set, checks same-run relative performance, and uploads an
+# attestation binding the exact source, bytes, host, and report.
 #
 # Triggers:
 #   - workflow_dispatch (always; needed for macOS/CUDA cost control)
@@ -14,8 +14,8 @@ name: Local Inference Matrix
 #   - ubuntu-latest CUDA only runs when the PR carries the `gpu` label
 #     (and a self-hosted GPU runner with the `gpu` runner labels is online).
 #   - macos-14 Metal only runs on workflow_dispatch (Apple Silicon cost).
-# CUDA and Metal entries are continue-on-error until self-hosted runners
-# are wired up so the workflow stays green on CPU only.
+# Optional legs are omitted unless selected; once selected, every leg is
+# required so unsupported binaries, models, or variants cannot pass silently.
 #
 # Note: Job-level `if:` cannot reference `matrix` (GitHub Actions limitation).
 # Optional legs are added by `prepare-matrix` via JSON so only requested
@@ -35,11 +35,15 @@ on:
         type: boolean
         default: false
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
+      - "plugins/plugin-local-inference/native/**"
       - "packages/app-core/src/services/local-inference/**"
       - "packages/scripts/local-inference-ablation.mjs"
       - "packages/scripts/local-inference-ablation.config.json"
+      - "packages/scripts/local-inference-attest.mjs"
+      - "packages/scripts/local-inference-performance-check.mjs"
+      - "packages/scripts/local-inference-performance-policy.json"
       - "packages/scripts/local-inference-smoke.mjs"
       - ".github/workflows/local-inference-matrix.yml"
 
@@ -57,6 +61,8 @@ env:
   # Smoke model: small enough to download and run on a CPU runner in seconds.
   SMOKE_MODEL_REPO: "bartowski/SmolLM2-360M-Instruct-GGUF"
   SMOKE_MODEL_FILE: "SmolLM2-360M-Instruct-Q4_K_M.gguf"
+  SMOKE_MODEL_REVISION: "7be6f65f1db715fe5dc5a4634c0d459b4eed42ec"
+  SMOKE_MODEL_SHA256: "2fa3f013dcdd7b99f9b237717fa0b12d75bbb89984cc1274be1471a465bac9c2"
 
 jobs:
   prepare-matrix:
@@ -105,7 +111,7 @@ jobs:
                 backend: "cuda",
                 target: "linux-x64-cuda",
                 timeout: 120,
-                "continue-on-error": true,
+                "continue-on-error": false,
               });
             }
 
@@ -116,7 +122,7 @@ jobs:
                 backend: "metal",
                 target: "darwin-arm64-metal",
                 timeout: 120,
-                "continue-on-error": true,
+                "continue-on-error": false,
               });
             }
 
@@ -137,6 +143,9 @@ jobs:
         with:
           submodules: false
           show-progress: false
+
+      - name: Checkout exact native inference source
+        run: git submodule update --init --depth=1 plugins/plugin-local-inference/native/llama.cpp
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -185,18 +194,61 @@ jobs:
           fi
           hf --help >/dev/null
 
-      - name: Cache local-inference state (binaries + models)
+      - name: Cache pinned local-inference model
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
-          path: ${{ env.ELIZA_STATE_DIR }}/local-inference
-          key: local-inference-${{ matrix.target }}-${{ env.SMOKE_MODEL_FILE }}
+          path: ${{ env.ELIZA_STATE_DIR }}/local-inference/models
+          key: local-inference-model-${{ env.SMOKE_MODEL_SHA256 }}
           restore-keys: |
-            local-inference-${{ matrix.target }}-${{ env.SMOKE_MODEL_FILE }}-
-            local-inference-${{ matrix.target }}-
+            local-inference-model-
 
-      - name: Smoke probe binaries
+      - name: Build host-compatible llama-server from the exact gitlink
+        env:
+          BACKEND: ${{ matrix.backend }}
+          TARGET: ${{ matrix.target }}
         run: |
-          bun ./packages/scripts/local-inference-smoke.mjs
+          set -euo pipefail
+          SOURCE_DIR="plugins/plugin-local-inference/native/llama.cpp"
+          BUILD_DIR="$RUNNER_TEMP/llama-build-${TARGET}"
+          BINARY_DIR="${ELIZA_STATE_DIR}/local-inference/bin/mtp/${TARGET}"
+          cmake_args=(
+            -S "$SOURCE_DIR"
+            -B "$BUILD_DIR"
+            -G Ninja
+            -DCMAKE_BUILD_TYPE=Release
+            -DBUILD_SHARED_LIBS=OFF
+            -DLLAMA_BUILD_SERVER=ON
+            -DLLAMA_BUILD_TESTS=OFF
+            -DLLAMA_BUILD_EXAMPLES=OFF
+            -DLLAMA_CURL=OFF
+            -DGGML_NATIVE=OFF
+          )
+          case "$BACKEND" in
+            cpu)
+              cmake_args+=( -DGGML_CUDA=OFF -DGGML_METAL=OFF )
+              ;;
+            cuda)
+              cmake_args+=( -DGGML_CUDA=ON -DGGML_METAL=OFF )
+              ;;
+            metal)
+              cmake_args+=( -DGGML_CUDA=OFF -DGGML_METAL=ON -DGGML_METAL_EMBED_LIBRARY=ON )
+              ;;
+            *)
+              echo "unsupported matrix backend: $BACKEND" >&2
+              exit 1
+              ;;
+          esac
+          cmake "${cmake_args[@]}"
+          cmake --build "$BUILD_DIR" --config Release --target llama-server --parallel 4
+          test -x "$BUILD_DIR/bin/llama-server"
+          mkdir -p "$BINARY_DIR"
+          install -m 0755 "$BUILD_DIR/bin/llama-server" "$BINARY_DIR/llama-server"
+          SOURCE_SHA="$(git -C "$SOURCE_DIR" rev-parse HEAD)"
+          printf 'INFERENCE_SOURCE_SHA=%s\n' "$SOURCE_SHA" >> "$GITHUB_ENV"
+          printf 'INFERENCE_BINARY=%s\n' "$BINARY_DIR/llama-server" >> "$GITHUB_ENV"
+
+      - name: Require a host-compatible executable
+        run: bun ./packages/scripts/local-inference-smoke.mjs
 
       - name: Download smoke GGUF (cached)
         run: |
@@ -209,18 +261,62 @@ jobs:
             exit 0
           fi
           hf download "${SMOKE_MODEL_REPO}" "${SMOKE_MODEL_FILE}" \
+            --revision "$SMOKE_MODEL_REVISION" \
             --local-dir "$MODEL_DIR"
           ls -lh "$MODEL_DIR/${SMOKE_MODEL_FILE}"
 
-      - name: Run ablation (--quick)
+      - name: Verify pinned model bytes
         run: |
           set -euo pipefail
           MODEL_PATH="${ELIZA_STATE_DIR}/local-inference/models/${SMOKE_MODEL_FILE}"
+          if command -v sha256sum >/dev/null 2>&1; then
+            ACTUAL_SHA="$(sha256sum "$MODEL_PATH" | awk '{print $1}')"
+          else
+            ACTUAL_SHA="$(shasum -a 256 "$MODEL_PATH" | awk '{print $1}')"
+          fi
+          test "$ACTUAL_SHA" = "$SMOKE_MODEL_SHA256"
+
+      - name: Run required ablation variants
+        env:
+          BACKEND: ${{ matrix.backend }}
+        run: |
+          set -euo pipefail
+          MODEL_PATH="${ELIZA_STATE_DIR}/local-inference/models/${SMOKE_MODEL_FILE}"
+          case "$BACKEND" in
+            metal) VARIANTS="baseline_f16_kv,stock_no_fa" ;;
+            cpu|cuda|rocm) VARIANTS="baseline_f16_kv,turbo4_polar_kv" ;;
+            *) echo "unsupported performance backend: $BACKEND" >&2; exit 1 ;;
+          esac
           node ./packages/scripts/local-inference-ablation.mjs \
-            --backend ${{ matrix.backend }} \
+            --backend "$BACKEND" \
+            --binary "$INFERENCE_BINARY" \
             --model "$MODEL_PATH" \
             --quick \
+            --runs 3 \
+            --variants "$VARIANTS" \
+            --require-all \
             --out-dir artifacts/local-inference-ablation
+          REPORT_PATH="$(find artifacts/local-inference-ablation -maxdepth 1 -type f -name '*-${{ matrix.backend }}.json' -print -quit)"
+          test -n "$REPORT_PATH"
+          printf 'INFERENCE_REPORT=%s\n' "$REPORT_PATH" >> "$GITHUB_ENV"
+
+      - name: Check runner-relative performance
+        run: >-
+          node packages/scripts/local-inference-performance-check.mjs
+          "$INFERENCE_REPORT"
+          packages/scripts/local-inference-performance-policy.json
+
+      - name: Attest executable, model, report, source, and host
+        run: >-
+          node packages/scripts/local-inference-attest.mjs
+          --binary "$INFERENCE_BINARY"
+          --model "${ELIZA_STATE_DIR}/local-inference/models/${SMOKE_MODEL_FILE}"
+          --report "$INFERENCE_REPORT"
+          --backend "${{ matrix.backend }}"
+          --expected-model-sha256 "$SMOKE_MODEL_SHA256"
+          --source-sha "$INFERENCE_SOURCE_SHA"
+          --workflow-sha "${{ github.sha }}"
+          --out artifacts/local-inference-ablation/attestation.json
 
       - name: Upload ablation artifact
         if: ${{ always() }}
@@ -228,5 +324,5 @@ jobs:
         with:
           name: local-inference-ablation-${{ matrix.target }}
           path: artifacts/local-inference-ablation/*.json
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/stale-base-guard.yml
+++ b/.github/workflows/stale-base-guard.yml
@@ -1,0 +1,114 @@
+# Stale Base Guard
+#
+# Blocks the PR #11271 failure mode: a PR whose tree carries stale file
+# contents (an old checkout committed onto a fresh-looking base), so that
+# squash-merging it silently reverts work already merged on the target branch.
+# #11271 landed 304 files (+6,532/−21,579) titled as a small cloud-refund
+# refactor; its merge-base was 8 minutes old, so no base-age check could have
+# caught it — the reverts were inside the PR's own diff. Restoration epic:
+# #11419; this guard is the final acceptance criterion of #11376.
+#
+# What runs (packages/scripts/stale-base-guard.mjs, plumbing-only, seconds):
+#   Silent-revert detection — fail when the PR sets a file byte-identically
+#      back to an older blob from the target branch's history, discarding
+#      newer merged work. Re-land/heal PRs (restoring work a clobber reverted)
+#      pass; deletion-only findings are non-blocking notices unless a
+#      modification-revert corroborates the stale-tree signature.
+# Override: apply the `stale-base-ack` label for a deliberate revert — the
+# guard then passes with loud warnings instead of failing.
+#
+# The guard script + self-test are taken from the BASE branch, so a PR cannot
+# neuter the logic that gates it (bootstrap exception: while the base branch
+# predates the guard, the PR's own copy is used, with a notice). History is
+# fetched blobless (--filter=blob:none): the detector compares object ids only
+# and never reads file contents (~15 MB, a few seconds for the 1500-commit
+# window on this repo; the whole job runs well under a minute).
+name: Stale Base Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+concurrency:
+  group: stale-base-guard-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: stale-base guard
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 10
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      ACK: ${{ contains(github.event.pull_request.labels.*.name, 'stale-base-ack') && '1' || '' }}
+    steps:
+      - name: Checkout target branch (guard logic comes from the base, not the PR)
+        # actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          # The guard disables lazy promisor fetches while it runs. Fetch the
+          # same bounded history window up front so merge commits can resolve
+          # their parents without network fallback.
+          fetch-depth: 1500
+          filter: blob:none
+          submodules: false
+          persist-credentials: false
+
+      # The guard steps below invoke `node` directly, but self-hosted
+      # (hetzner-robot) runners are not guaranteed to have Node on PATH, so
+      # the self-test step fails with "node: command not found". Set up Node
+      # explicitly; this workflow does not use setup-bun-workspace.
+      - name: Setup Node.js
+        # actions/setup-node@v4 (48b55a0)
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24"
+
+      - name: Fetch PR head + bounded history (blobless)
+        run: |
+          set -euo pipefail
+          git fetch --quiet --no-tags --filter=blob:none --depth=1500 origin \
+            "$HEAD_SHA" \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+      - name: Snapshot the guard from the base branch
+        run: |
+          set -euo pipefail
+          if [ -f packages/scripts/stale-base-guard.mjs ]; then
+            cp packages/scripts/stale-base-guard.mjs \
+               packages/scripts/stale-base-guard.self-test.mjs \
+               "$RUNNER_TEMP/"
+          else
+            # Bootstrap: the base branch predates the guard — only possible on
+            # the PR that first lands it (and forks of that moment). Uses the
+            # PR's own copy; lazy blob fetch is allowed for just these two reads.
+            echo "::notice::stale-base guard is not on the base branch yet — bootstrapping the script from the PR head."
+            git show "${HEAD_SHA}:packages/scripts/stale-base-guard.mjs" \
+              > "$RUNNER_TEMP/stale-base-guard.mjs"
+            git show "${HEAD_SHA}:packages/scripts/stale-base-guard.self-test.mjs" \
+              > "$RUNNER_TEMP/stale-base-guard.self-test.mjs"
+          fi
+
+      - name: Self-test the guard on fixture repos
+        run: node "$RUNNER_TEMP/stale-base-guard.self-test.mjs"
+
+      - name: Detect content-level silent reverts
+        env:
+          # The detector is plumbing-only; hard-disable promisor blob fetches
+          # so an accidental content read fails loudly instead of hitting the
+          # network.
+          GIT_NO_LAZY_FETCH: "1"
+        run: |
+          set -euo pipefail
+          node "$RUNNER_TEMP/stale-base-guard.mjs" \
+            --base "refs/remotes/origin/${BASE_REF}" \
+            --head "$HEAD_SHA" \
+            --window 1200 \
+            ${ACK:+--ack} \
+            --github \
+            --summary "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,12 @@ jobs:
       - name: Validate CI Bun version pin contract
         run: node packages/scripts/ci-bun-version-contract.mjs
 
+      - name: Install workflow-invariants parser dependency
+        run: npm install --prefix "$RUNNER_TEMP/workflow-invariants-deps" --no-save --no-package-lock --ignore-scripts yaml@2.9.0
+
       - name: Validate merge-critical workflow invariants
+        env:
+          NODE_PATH: ${{ runner.temp }}/workflow-invariants-deps/node_modules
         run: node packages/scripts/ci-workflow-invariants.mjs
 
       - name: Validate zero-key command ownership contract

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Validate CI Bun version pin contract
         run: node packages/scripts/ci-bun-version-contract.mjs
 
+      - name: Validate merge-critical workflow invariants
+        run: node packages/scripts/ci-workflow-invariants.mjs
+
       - name: Validate zero-key command ownership contract
         run: node packages/scripts/ci-zero-key-command-ownership-contract.mjs
 
@@ -1134,12 +1137,114 @@ jobs:
         if: needs.provider-live-e2e.result == 'success' && needs.provider-live-e2e.outputs.skip != 'true'
         run: bun run test:remote-capabilities:validate-live-reports --kind provider --expect-count 3..4 --max-age-minutes 120 --max-future-minutes 5 --allowed-providers e2b,home-machine,mobile-companion,desktop-companion --require-providers e2b,home-machine,mobile-companion --require-ci --require-file-identity reports/remote-capabilities/providers
 
+  script-tests:
+    name: Script Tests (Linux)
+    needs: changes
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+
+      - name: Run the complete isolated script-test inventory
+        run: bun run test:scripts
+
+      - name: Upload script-test evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: script-tests-linux
+          path: reports/script-tests/
+          if-no-files-found: error
+          retention-days: 7
+
+  merge-quality-gate:
+    name: Merge Queue Quality Gate
+    needs: changes
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Repo-wide biome lint (read-only)
+        run: bun run lint:check
+
+      - name: Repo-wide biome format check
+        run: bun run format:check
+
+      - name: Repo-wide typecheck
+        run: NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --concurrency=4
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          GITLEAKS_VERSION=8.30.1
+          curl --fail --location --silent --show-error --retry 3 \
+            --output "$RUNNER_TEMP/gitleaks.tar.gz" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$RUNNER_TEMP" gitleaks
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$RUNNER_TEMP/gitleaks" "$HOME/.local/bin/gitleaks"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Secret scan (gitleaks)
+        env:
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          parent_count="$(git rev-list --parents -n 1 "$CURRENT_SHA" | wc -w | tr -d ' ')"
+          if [ "$parent_count" -gt 2 ]; then
+            RANGE_ARGS=(--log-opts "-m -p -1 ${CURRENT_SHA}")
+          elif [ "$parent_count" -eq 2 ]; then
+            RANGE_ARGS=(--log-opts "-1 ${CURRENT_SHA}")
+          else
+            echo "gitleaks: root baseline was already scanned incrementally"
+            exit 0
+          fi
+          gitleaks detect \
+            --config .gitleaks.toml \
+            --source . \
+            --verbose \
+            --redact \
+            --report-format sarif \
+            --report-path gitleaks.sarif \
+            --no-banner \
+            "${RANGE_ARGS[@]}"
+
   ci-ok:
     name: ci-ok
     if: ${{ !cancelled() && always() }}
     needs:
       - changes
       - test-runner-vacuous-green-guard
+      - script-tests
+      - merge-quality-gate
       - server-tests
       - client-tests
       - plugin-tests-status
@@ -1162,6 +1267,8 @@ jobs:
           echo "=== Required test job results ==="
           echo "changes:          ${{ needs.changes.result }}"
           echo "runner guard:     ${{ needs.test-runner-vacuous-green-guard.result }}"
+          echo "script-tests:     ${{ needs.script-tests.result }}"
+          echo "merge-quality-gate:${{ needs.merge-quality-gate.result }}"
           echo "server-tests:     ${{ needs.server-tests.result }}"
           echo "client-tests:     ${{ needs.client-tests.result }}"
           echo "plugin-tests:     ${{ needs.plugin-tests-status.result }}"
@@ -1177,6 +1284,8 @@ jobs:
           for pair in \
             "changes:${{ needs.changes.result }}" \
             "test-runner-vacuous-green-guard:${{ needs.test-runner-vacuous-green-guard.result }}" \
+            "script-tests:${{ needs.script-tests.result }}" \
+            "merge-quality-gate:${{ needs.merge-quality-gate.result }}" \
             "server-tests:${{ needs.server-tests.result }}" \
             "client-tests:${{ needs.client-tests.result }}" \
             "plugin-tests:${{ needs.plugin-tests-status.result }}" \

--- a/packages/scripts/ci-workflow-invariants.mjs
+++ b/packages/scripts/ci-workflow-invariants.mjs
@@ -13,6 +13,8 @@ import { parseDocument } from "yaml";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
 const WORKFLOW_PATHS = Object.freeze({
+  cloudSetup: ".github/actions/cloud-setup-test-env/action.yml",
+  cloudTests: ".github/workflows/cloud-tests.yml",
   develop: ".github/workflows/develop-pr.yml",
   gitleaks: ".github/workflows/gitleaks.yml",
   tests: ".github/workflows/test.yml",
@@ -22,7 +24,7 @@ function invariant(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-export function parseWorkflow(relativePath, source) {
+function parseYamlMapping(relativePath, source) {
   const document = parseDocument(source, {
     maxAliasCount: 0,
     prettyErrors: true,
@@ -39,6 +41,11 @@ export function parseWorkflow(relativePath, source) {
     value && typeof value === "object" && !Array.isArray(value),
     `${relativePath}: workflow root must be a mapping`,
   );
+  return value;
+}
+
+export function parseWorkflow(relativePath, source) {
+  const value = parseYamlMapping(relativePath, source);
   invariant(
     value.jobs && typeof value.jobs === "object" && !Array.isArray(value.jobs),
     `${relativePath}: jobs must be a mapping`,
@@ -93,9 +100,96 @@ function normalizedNeeds(job) {
 }
 
 export function validateWorkflowSources(sources) {
+  const cloudSetup = parseYamlMapping(
+    WORKFLOW_PATHS.cloudSetup,
+    sources.cloudSetup,
+  );
+  const cloudTests = parseWorkflow(
+    WORKFLOW_PATHS.cloudTests,
+    sources.cloudTests,
+  );
   const develop = parseWorkflow(WORKFLOW_PATHS.develop, sources.develop);
   const gitleaks = parseWorkflow(WORKFLOW_PATHS.gitleaks, sources.gitleaks);
   const tests = parseWorkflow(WORKFLOW_PATHS.tests, sources.tests);
+
+  const cloudE2e = requireJob(
+    cloudTests,
+    WORKFLOW_PATHS.cloudTests,
+    "e2e-tests",
+  );
+  invariant(
+    cloudE2e["runs-on"] === "ubuntu-24.04",
+    `${WORKFLOW_PATHS.cloudTests}: jobs.e2e-tests must use the Docker-capable ubuntu-24.04 runner`,
+  );
+  const cloudSetupInvocation = cloudE2e.steps.find(
+    (step) => step?.uses === "./.github/actions/cloud-setup-test-env",
+  );
+  invariant(
+    cloudSetupInvocation?.with?.["setup-db"] === "true" &&
+      cloudSetupInvocation.with["db-backend"] === "postgres",
+    `${WORKFLOW_PATHS.cloudTests}: jobs.e2e-tests must explicitly request real PostgreSQL`,
+  );
+  requireCommand(
+    cloudE2e,
+    WORKFLOW_PATHS.cloudTests,
+    "e2e-tests",
+    "agent-sandboxes-stuck-provisioning-lock.integration.test.ts",
+  );
+  requireCommand(
+    cloudE2e,
+    WORKFLOW_PATHS.cloudTests,
+    "e2e-tests",
+    "bun run test:cloud:e2e",
+  );
+
+  invariant(
+    cloudSetup.runs?.using === "composite" &&
+      Array.isArray(cloudSetup.runs.steps),
+    `${WORKFLOW_PATHS.cloudSetup}: runs.steps must be a composite step list`,
+  );
+  const cloudSetupSteps = cloudSetup.runs.steps;
+  const dockerPreflightIndex = cloudSetupSteps.findIndex(
+    (step) => typeof step?.run === "string" && step.run.includes("docker info"),
+  );
+  invariant(
+    dockerPreflightIndex === 0,
+    `${WORKFLOW_PATHS.cloudSetup}: Docker daemon preflight must run before setup, install, cache, or build work`,
+  );
+  const dockerPreflight = cloudSetupSteps[dockerPreflightIndex];
+  invariant(
+    dockerPreflight.if ===
+      "inputs.setup-db == 'true' && inputs.db-backend == 'postgres'",
+    `${WORKFLOW_PATHS.cloudSetup}: Docker preflight must cover every PostgreSQL setup`,
+  );
+  invariant(
+    dockerPreflight["continue-on-error"] !== true &&
+      !/(?:\|\|\s*true\b|;\s*true\b|set\s+\+e\b)/.test(dockerPreflight.run),
+    `${WORKFLOW_PATHS.cloudSetup}: Docker preflight must fail closed`,
+  );
+  invariant(
+    !cloudSetupSteps.some((step) => step?.uses?.startsWith("actions/cache@")),
+    `${WORKFLOW_PATHS.cloudSetup}: multi-gigabyte Bun install archives are prohibited`,
+  );
+  const postgresStart = cloudSetupSteps.find(
+    (step) =>
+      typeof step?.run === "string" &&
+      step.run.includes("docker run") &&
+      step.run.includes("pgvector/pgvector:pg16"),
+  );
+  invariant(
+    postgresStart?.if ===
+      "inputs.setup-db == 'true' && inputs.db-backend == 'postgres'",
+    `${WORKFLOW_PATHS.cloudSetup}: real pgvector startup must cover PostgreSQL setup`,
+  );
+  const migrations = cloudSetupSteps.find(
+    (step) =>
+      typeof step?.run === "string" && step.run.includes("bun run db:migrate"),
+  );
+  invariant(
+    migrations?.if === "inputs.setup-db == 'true'" &&
+      migrations["continue-on-error"] !== true,
+    `${WORKFLOW_PATHS.cloudSetup}: database migrations must remain fail-closed for setup-db`,
+  );
 
   const lint = requireJob(develop, WORKFLOW_PATHS.develop, "lint");
   requireCommand(lint, WORKFLOW_PATHS.develop, "lint", "bun run lint:check");
@@ -165,6 +259,14 @@ export function validateWorkflowSources(sources) {
 
 export function run(repoRoot = REPO_ROOT) {
   return validateWorkflowSources({
+    cloudSetup: readFileSync(
+      path.join(repoRoot, WORKFLOW_PATHS.cloudSetup),
+      "utf8",
+    ),
+    cloudTests: readFileSync(
+      path.join(repoRoot, WORKFLOW_PATHS.cloudTests),
+      "utf8",
+    ),
     develop: readFileSync(path.join(repoRoot, WORKFLOW_PATHS.develop), "utf8"),
     gitleaks: readFileSync(
       path.join(repoRoot, WORKFLOW_PATHS.gitleaks),

--- a/packages/scripts/ci-workflow-invariants.mjs
+++ b/packages/scripts/ci-workflow-invariants.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Enforces merge-critical GitHub Actions behavior from parsed workflow YAML.
+ * The contract rejects missing dependency edges and conditional or permissive
+ * quality steps, so formatting, lint, typecheck, secrets, and script tests
+ * cannot silently disappear while the workflow still parses.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseDocument } from "yaml";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
+const WORKFLOW_PATHS = Object.freeze({
+  develop: ".github/workflows/develop-pr.yml",
+  gitleaks: ".github/workflows/gitleaks.yml",
+  tests: ".github/workflows/test.yml",
+});
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+export function parseWorkflow(relativePath, source) {
+  const document = parseDocument(source, {
+    maxAliasCount: 0,
+    prettyErrors: true,
+    schema: "core",
+    uniqueKeys: true,
+  });
+  if (document.errors.length > 0) {
+    throw new Error(
+      `${relativePath}: invalid YAML: ${document.errors.map((error) => error.message).join("; ")}`,
+    );
+  }
+  const value = document.toJS({ maxAliasCount: 0 });
+  invariant(
+    value && typeof value === "object" && !Array.isArray(value),
+    `${relativePath}: workflow root must be a mapping`,
+  );
+  invariant(
+    value.jobs && typeof value.jobs === "object" && !Array.isArray(value.jobs),
+    `${relativePath}: jobs must be a mapping`,
+  );
+  return value;
+}
+
+function requireJob(workflow, workflowPath, jobName) {
+  const job = workflow.jobs[jobName];
+  invariant(
+    job && typeof job === "object",
+    `${workflowPath}: missing jobs.${jobName}`,
+  );
+  invariant(
+    job.if === undefined,
+    `${workflowPath}: jobs.${jobName} may not declare if`,
+  );
+  invariant(
+    job["continue-on-error"] !== true,
+    `${workflowPath}: jobs.${jobName} may not continue on error`,
+  );
+  invariant(
+    Array.isArray(job.steps) && job.steps.length > 0,
+    `${workflowPath}: jobs.${jobName} must contain steps`,
+  );
+  return job;
+}
+
+function requireCommand(job, workflowPath, jobName, command) {
+  const step = job.steps.find(
+    (candidate) =>
+      typeof candidate?.run === "string" && candidate.run.includes(command),
+  );
+  invariant(step, `${workflowPath}: jobs.${jobName} must execute ${command}`);
+  invariant(
+    step.if === undefined,
+    `${workflowPath}: ${command} may not be conditional`,
+  );
+  invariant(
+    step["continue-on-error"] !== true,
+    `${workflowPath}: ${command} may not continue on error`,
+  );
+  invariant(
+    !/(?:\|\|\s*true\b|;\s*true\b|set\s+\+e\b)/.test(step.run),
+    `${workflowPath}: ${command} is wrapped by a success-forcing shell construct`,
+  );
+}
+
+function normalizedNeeds(job) {
+  if (typeof job.needs === "string") return [job.needs];
+  return Array.isArray(job.needs) ? job.needs : [];
+}
+
+export function validateWorkflowSources(sources) {
+  const develop = parseWorkflow(WORKFLOW_PATHS.develop, sources.develop);
+  const gitleaks = parseWorkflow(WORKFLOW_PATHS.gitleaks, sources.gitleaks);
+  const tests = parseWorkflow(WORKFLOW_PATHS.tests, sources.tests);
+
+  const lint = requireJob(develop, WORKFLOW_PATHS.develop, "lint");
+  requireCommand(lint, WORKFLOW_PATHS.develop, "lint", "bun run lint:check");
+  requireCommand(lint, WORKFLOW_PATHS.develop, "lint", "bun run format:check");
+
+  const typecheck = requireJob(develop, WORKFLOW_PATHS.develop, "typecheck");
+  requireCommand(
+    typecheck,
+    WORKFLOW_PATHS.develop,
+    "typecheck",
+    "run typecheck",
+  );
+
+  const secrets = requireJob(gitleaks, WORKFLOW_PATHS.gitleaks, "gitleaks");
+  requireCommand(
+    secrets,
+    WORKFLOW_PATHS.gitleaks,
+    "gitleaks",
+    "gitleaks detect",
+  );
+
+  const quality = requireJob(tests, WORKFLOW_PATHS.tests, "merge-quality-gate");
+  requireCommand(
+    quality,
+    WORKFLOW_PATHS.tests,
+    "merge-quality-gate",
+    "bun run lint:check",
+  );
+  requireCommand(
+    quality,
+    WORKFLOW_PATHS.tests,
+    "merge-quality-gate",
+    "bun run format:check",
+  );
+  requireCommand(
+    quality,
+    WORKFLOW_PATHS.tests,
+    "merge-quality-gate",
+    "run typecheck",
+  );
+  requireCommand(
+    quality,
+    WORKFLOW_PATHS.tests,
+    "merge-quality-gate",
+    "gitleaks detect",
+  );
+
+  const scripts = requireJob(tests, WORKFLOW_PATHS.tests, "script-tests");
+  requireCommand(
+    scripts,
+    WORKFLOW_PATHS.tests,
+    "script-tests",
+    "bun run test:scripts",
+  );
+
+  const finalGate = tests.jobs["ci-ok"];
+  invariant(finalGate, `${WORKFLOW_PATHS.tests}: missing jobs.ci-ok`);
+  const needs = normalizedNeeds(finalGate);
+  for (const dependency of ["merge-quality-gate", "script-tests"]) {
+    invariant(
+      needs.includes(dependency),
+      `${WORKFLOW_PATHS.tests}: jobs.ci-ok must need ${dependency}`,
+    );
+  }
+  return { ok: true };
+}
+
+export function run(repoRoot = REPO_ROOT) {
+  return validateWorkflowSources({
+    develop: readFileSync(path.join(repoRoot, WORKFLOW_PATHS.develop), "utf8"),
+    gitleaks: readFileSync(
+      path.join(repoRoot, WORKFLOW_PATHS.gitleaks),
+      "utf8",
+    ),
+    tests: readFileSync(path.join(repoRoot, WORKFLOW_PATHS.tests), "utf8"),
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  run();
+  process.stdout.write(
+    "ci-workflow-invariants: merge-critical workflow contract passed\n",
+  );
+}

--- a/packages/scripts/ci-workflow-invariants.mjs
+++ b/packages/scripts/ci-workflow-invariants.mjs
@@ -7,9 +7,16 @@
  */
 
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { parseDocument } from "yaml";
+
+// createRequire, not a bare ESM import: the `changes` job runs this script
+// without a workspace install, providing the parser via NODE_PATH — which
+// only CommonJS resolution consults. With a workspace install the normal
+// upward node_modules walk finds the same package.
+const require = createRequire(import.meta.url);
+const { parseDocument } = require("yaml");
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
 const WORKFLOW_PATHS = Object.freeze({

--- a/packages/scripts/ci-workflow-invariants.test.mjs
+++ b/packages/scripts/ci-workflow-invariants.test.mjs
@@ -1,0 +1,70 @@
+/**
+ * Mutates real workflow YAML to prove merge-critical policy regressions fail.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { validateWorkflowSources } from "./ci-workflow-invariants.mjs";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const sources = {
+  develop: readFileSync(
+    path.join(root, ".github/workflows/develop-pr.yml"),
+    "utf8",
+  ),
+  gitleaks: readFileSync(
+    path.join(root, ".github/workflows/gitleaks.yml"),
+    "utf8",
+  ),
+  tests: readFileSync(path.join(root, ".github/workflows/test.yml"), "utf8"),
+};
+
+test("accepts the repository workflow graph", () => {
+  assert.deepEqual(validateWorkflowSources(sources), { ok: true });
+});
+
+for (const fixture of [
+  {
+    name: "conditional lint",
+    key: "develop",
+    mutate: (source) =>
+      source.replace(
+        "      - name: Run lint (read-only)\n",
+        "      - name: Run lint (read-only)\n        if: false\n",
+      ),
+    pattern: /lint:check may not be conditional/,
+  },
+  {
+    name: "permissive gitleaks",
+    key: "gitleaks",
+    mutate: (source) =>
+      source.replace(
+        "          gitleaks detect",
+        "          gitleaks detect || true",
+      ),
+    pattern: /success-forcing/,
+  },
+  {
+    name: "missing quality dependency",
+    key: "tests",
+    mutate: (source) => source.replace("      - merge-quality-gate\n", ""),
+    pattern: /ci-ok must need merge-quality-gate/,
+  },
+  {
+    name: "skipped script tests",
+    key: "tests",
+    mutate: (source) =>
+      source.replace("  script-tests:\n", "  script-tests:\n    if: false\n"),
+    pattern: /script-tests may not declare if/,
+  },
+]) {
+  test(`rejects ${fixture.name}`, () => {
+    const mutated = {
+      ...sources,
+      [fixture.key]: fixture.mutate(sources[fixture.key]),
+    };
+    assert.throws(() => validateWorkflowSources(mutated), fixture.pattern);
+  });
+}

--- a/packages/scripts/ci-workflow-invariants.test.mjs
+++ b/packages/scripts/ci-workflow-invariants.test.mjs
@@ -10,6 +10,14 @@ import { validateWorkflowSources } from "./ci-workflow-invariants.mjs";
 
 const root = path.resolve(import.meta.dirname, "../..");
 const sources = {
+  cloudSetup: readFileSync(
+    path.join(root, ".github/actions/cloud-setup-test-env/action.yml"),
+    "utf8",
+  ),
+  cloudTests: readFileSync(
+    path.join(root, ".github/workflows/cloud-tests.yml"),
+    "utf8",
+  ),
   develop: readFileSync(
     path.join(root, ".github/workflows/develop-pr.yml"),
     "utf8",
@@ -26,6 +34,56 @@ test("accepts the repository workflow graph", () => {
 });
 
 for (const fixture of [
+  {
+    name: "generic runner admission for PostgreSQL e2e",
+    key: "cloudTests",
+    mutate: (source) =>
+      source.replace(
+        "    runs-on: ubuntu-24.04\n",
+        "    runs-on: self-hosted\n",
+      ),
+    pattern: /must use the Docker-capable ubuntu-24.04 runner/,
+  },
+  {
+    name: "late Docker capability preflight",
+    key: "cloudSetup",
+    mutate: (source) =>
+      source.replace(
+        "  steps:\n    - name: Verify PostgreSQL container runtime\n",
+        '  steps:\n    - uses: actions/setup-node@v6\n      with:\n        node-version: "22"\n    - name: Verify PostgreSQL container runtime\n',
+      ),
+    pattern: /Docker daemon preflight must run before/,
+  },
+  {
+    name: "Bun install archive cache",
+    key: "cloudSetup",
+    mutate: (source) =>
+      source.replace(
+        "    - name: Install dependencies\n",
+        "    - uses: actions/cache@v5\n      with:\n        path: ~/.bun/install/cache\n        key: bun-Linux-global\n    - name: Install dependencies\n",
+      ),
+    pattern: /multi-gigabyte Bun install archives are prohibited/,
+  },
+  {
+    name: "degraded Cloud e2e database backend",
+    key: "cloudTests",
+    mutate: (source) =>
+      source.replace(
+        '          db-backend: "postgres"\n',
+        '          db-backend: "pglite"\n',
+      ),
+    pattern: /must explicitly request real PostgreSQL/,
+  },
+  {
+    name: "skipped Cloud database migrations",
+    key: "cloudSetup",
+    mutate: (source) =>
+      source.replace(
+        "    - name: Run database migrations\n      if: inputs.setup-db == 'true'\n",
+        "    - name: Run database migrations\n      if: false\n",
+      ),
+    pattern: /database migrations must remain fail-closed/,
+  },
   {
     name: "conditional lint",
     key: "develop",

--- a/packages/scripts/develop-pr-aggregate-workflow-contract.mjs
+++ b/packages/scripts/develop-pr-aggregate-workflow-contract.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * Static contract for the base-trusted develop pull-request aggregate.
+ * It binds the stable check name to a hosted, read-only workflow and verifies
+ * that every polled context still belongs to an always-emitted owner workflow
+ * with the activity types modeled by the aggregate state machine.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  AGGREGATE_TRIGGER_ACTIONS,
+  CANARY_SCENARIOS,
+  DEFAULT_PULL_REQUEST_ACTIONS,
+  REQUIRED_CHECKS,
+} from "./develop-pr-aggregate.mjs";
+
+const DEFAULT_REPO_ROOT = resolve(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "..",
+  "..",
+);
+const AGGREGATE_WORKFLOW = ".github/workflows/develop-pr-gate.yml";
+export const TRUSTED_BASE_REF_LINE =
+  "ref: $" + "{{ github.event.pull_request.base.sha || github.sha }}";
+export const OBSERVED_HEAD_LINE =
+  "HEAD_SHA: $" + "{{ github.event.pull_request.head.sha || github.sha }}";
+export const DISPATCH_CANARY_LINE =
+  "CANARY_SCENARIO: $" +
+  "{{ github.event_name == 'workflow_dispatch' && inputs.canary || '' }}";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assert(condition, message) {
+  if (!condition) fail(message);
+}
+
+function assertIncludes(text, fragment, message) {
+  assert(text.includes(fragment), `${message}: missing ${fragment}`);
+}
+
+function assertEqual(actual, expected, message) {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  assert(
+    actualJson === expectedJson,
+    `${message}: expected ${expectedJson}, got ${actualJson}`,
+  );
+}
+
+function unquote(value) {
+  return value.trim().replace(/^(?:"([\s\S]*)"|'([\s\S]*)')$/, "$1$2");
+}
+
+function inlineList(block, key, fallback = null) {
+  const match = block.match(
+    new RegExp(`^\\s{4}${key}:\\s*\\[([^\\]]*)\\]\\s*$`, "m"),
+  );
+  if (!match) return fallback;
+  return match[1].split(",").map(unquote).filter(Boolean);
+}
+
+function eventBlock(text, eventName, workflowPath) {
+  const lines = text.split(/\r?\n/);
+  const onIndex = lines.indexOf("on:");
+  assert(onIndex >= 0, `${workflowPath}: missing on mapping`);
+  const eventIndex = lines.findIndex(
+    (line, index) => index > onIndex && line === `  ${eventName}:`,
+  );
+  assert(eventIndex >= 0, `${workflowPath}: missing on.${eventName}`);
+  const selected = [];
+  for (let index = eventIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^\S/.test(line) || /^ {2}\S/.test(line)) break;
+    selected.push(line);
+  }
+  return selected.join("\n");
+}
+
+function count(text, pattern) {
+  return Array.from(text.matchAll(pattern)).length;
+}
+
+export function validateAggregateWorkflow(workflow) {
+  assertIncludes(workflow, "name: Develop PR Gate", "workflow name");
+  assertIncludes(
+    workflow,
+    "  pull_request_target:",
+    "base-trusted pull-request trigger",
+  );
+  assert(
+    !/^ {2}pull_request:/m.test(workflow),
+    "aggregate must not run PR-controlled workflow code via pull_request",
+  );
+  const targetBlock = eventBlock(
+    workflow,
+    "pull_request_target",
+    AGGREGATE_WORKFLOW,
+  );
+  assertEqual(
+    inlineList(targetBlock, "branches"),
+    ["develop"],
+    "aggregate target branches",
+  );
+  assertEqual(
+    inlineList(targetBlock, "types"),
+    AGGREGATE_TRIGGER_ACTIONS,
+    "aggregate activity types",
+  );
+  assert(
+    !/^\s+(paths|paths-ignore):/m.test(targetBlock),
+    "aggregate trigger must always emit; paths filters are forbidden",
+  );
+  assertIncludes(workflow, "  workflow_dispatch:", "canary dispatch trigger");
+  for (const scenario of CANARY_SCENARIOS) {
+    assertIncludes(workflow, `          - ${scenario}`, `canary ${scenario}`);
+  }
+
+  assertIncludes(workflow, "  contents: read", "contents permission");
+  assertIncludes(workflow, "  checks: read", "checks permission");
+  assertIncludes(workflow, "  actions: read", "actions permission");
+  assertIncludes(workflow, "  pull-requests: read", "pull-request permission");
+  assert(
+    !/^\s+[a-z-]+:\s*write\s*$/m.test(workflow),
+    "aggregate token permissions must remain read-only",
+  );
+  assert(
+    !workflow.includes("${{ secrets."),
+    "aggregate must not receive repository or organization secrets",
+  );
+
+  assertIncludes(workflow, "    name: Develop PR Gate", "stable job name");
+  assertIncludes(workflow, "    runs-on: ubuntu-24.04", "hosted runner");
+  assertIncludes(workflow, "    timeout-minutes: 45", "bounded timeout");
+  assertEqual(
+    count(workflow, /uses:\s*actions\/checkout@/g),
+    1,
+    "aggregate checkout count",
+  );
+  assertIncludes(workflow, TRUSTED_BASE_REF_LINE, "trusted base checkout ref");
+  assertIncludes(
+    workflow,
+    "persist-credentials: false",
+    "checkout credential isolation",
+  );
+  assert(
+    !workflow.includes("allow-unsafe-pr-checkout"),
+    "aggregate may never opt into an untrusted pull-request checkout",
+  );
+  assertIncludes(workflow, OBSERVED_HEAD_LINE, "PR head observation target");
+  assertIncludes(
+    workflow,
+    "node packages/scripts/develop-pr-aggregate.self-test.mjs",
+    "deterministic state-machine self-test",
+  );
+  assertIncludes(
+    workflow,
+    "node packages/scripts/develop-pr-aggregate.mjs",
+    "aggregate runner",
+  );
+  assertIncludes(
+    workflow,
+    DISPATCH_CANARY_LINE,
+    "dispatch-only canary boundary",
+  );
+}
+
+function validateOwnerWorkflow(text, workflowPath, expectedActions) {
+  const block = eventBlock(text, "pull_request", workflowPath);
+  const branches = inlineList(block, "branches", []);
+  assert(
+    branches.length === 0 || branches.includes("develop"),
+    `${workflowPath}: pull_request trigger does not cover develop`,
+  );
+  assert(
+    !/^\s+(paths|paths-ignore):/m.test(block),
+    `${workflowPath}: required owner may not disappear behind a path filter`,
+  );
+  assertEqual(
+    inlineList(block, "types", DEFAULT_PULL_REQUEST_ACTIONS),
+    expectedActions,
+    `${workflowPath}: modeled pull_request activity types`,
+  );
+}
+
+export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
+  const read = (relativePath) =>
+    readFileSync(resolve(repoRoot, relativePath), "utf8");
+  const aggregateWorkflow = read(AGGREGATE_WORKFLOW);
+  validateAggregateWorkflow(aggregateWorkflow);
+
+  const checksByWorkflow = Map.groupBy(
+    REQUIRED_CHECKS,
+    ({ workflowPath }) => workflowPath,
+  );
+  for (const [workflowPath, checks] of checksByWorkflow) {
+    const workflow = read(workflowPath);
+    const expectedActions = checks[0].triggerActions;
+    for (const check of checks) {
+      assertEqual(
+        check.triggerActions,
+        expectedActions,
+        `${workflowPath}: contexts disagree about owner activity types`,
+      );
+      const marker =
+        check.context === "lint" ||
+        check.context === "typecheck" ||
+        check.context === "build" ||
+        check.context === "check-pr-evidence" ||
+        check.context === "check-pr-title"
+          ? `  ${check.context}:`
+          : `name: ${check.context}`;
+      assertIncludes(
+        workflow,
+        marker,
+        `${workflowPath}: owner for ${check.context}`,
+      );
+    }
+    validateOwnerWorkflow(workflow, workflowPath, expectedActions);
+  }
+
+  const contexts = REQUIRED_CHECKS.map(({ context }) => context);
+  assertEqual(
+    new Set(contexts).size,
+    contexts.length,
+    "required context names must be unique",
+  );
+  assert(
+    !contexts.includes("Develop PR Gate"),
+    "aggregate must not require its own check context",
+  );
+  return { ok: true, contexts };
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const result = runContract();
+  console.log(
+    `develop-pr aggregate workflow contract passed (${result.contexts.length} contexts)`,
+  );
+}

--- a/packages/scripts/develop-pr-aggregate.mjs
+++ b/packages/scripts/develop-pr-aggregate.mjs
@@ -1,0 +1,597 @@
+#!/usr/bin/env node
+/**
+ * Fail-closed state machine for the hosted develop pull-request aggregate.
+ * The base-trusted workflow supplies the PR head SHA, while this module binds
+ * each required check to its owning workflow and waits for one terminal result
+ * per context. Missing and non-success terminal states never become green.
+ */
+import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const GITHUB_ACTIONS_APP_ID = 15368;
+export const DEFAULT_PULL_REQUEST_ACTIONS = [
+  "opened",
+  "synchronize",
+  "reopened",
+];
+
+const DEVELOP_PR_ACTIONS = [
+  "opened",
+  "synchronize",
+  "reopened",
+  "ready_for_review",
+];
+const PR_METADATA_ACTIONS = [
+  "opened",
+  "edited",
+  "synchronize",
+  "reopened",
+  "ready_for_review",
+  "labeled",
+  "unlabeled",
+];
+const STALE_BASE_ACTIONS = [
+  "opened",
+  "synchronize",
+  "reopened",
+  "ready_for_review",
+  "labeled",
+  "unlabeled",
+];
+
+export const REQUIRED_CHECKS = Object.freeze([
+  {
+    context: "lint",
+    workflowPath: ".github/workflows/develop-pr.yml",
+    triggerActions: DEVELOP_PR_ACTIONS,
+  },
+  {
+    context: "typecheck",
+    workflowPath: ".github/workflows/develop-pr.yml",
+    triggerActions: DEVELOP_PR_ACTIONS,
+  },
+  {
+    context: "build",
+    workflowPath: ".github/workflows/develop-pr.yml",
+    triggerActions: DEVELOP_PR_ACTIONS,
+  },
+  {
+    context: "gitleaks",
+    workflowPath: ".github/workflows/gitleaks.yml",
+    triggerActions: DEFAULT_PULL_REQUEST_ACTIONS,
+  },
+  {
+    context: "check-pr-evidence",
+    workflowPath: ".github/workflows/pr.yaml",
+    triggerActions: PR_METADATA_ACTIONS,
+  },
+  {
+    context: "check-pr-title",
+    workflowPath: ".github/workflows/pr.yaml",
+    triggerActions: PR_METADATA_ACTIONS,
+  },
+  {
+    context: "stale-base guard",
+    workflowPath: ".github/workflows/stale-base-guard.yml",
+    triggerActions: STALE_BASE_ACTIONS,
+  },
+]);
+
+export const AGGREGATE_TRIGGER_ACTIONS = Object.freeze(
+  Array.from(
+    new Set(REQUIRED_CHECKS.flatMap(({ triggerActions }) => triggerActions)),
+  ),
+);
+
+export const CANARY_SCENARIOS = Object.freeze([
+  "success",
+  "missing",
+  "cancelled",
+  "timed-out",
+  "failed",
+  "skipped",
+  "pending-timeout",
+]);
+
+const SUCCESS_CONCLUSION = "success";
+const COMPLETED_STATUS = "completed";
+const API_VERSION = "2022-11-28";
+const PAGE_SIZE = 100;
+const MAX_PAGES = 10;
+const FRESHNESS_SKEW_MS = 10_000;
+const DEFAULT_TERMINAL_SETTLE_MS = 15_000;
+const DEFAULT_API_MAX_ATTEMPTS = 5;
+const DEFAULT_API_RETRY_BASE_MS = 1_000;
+const DEFAULT_API_RETRY_CAP_MS = 8_000;
+
+function parseTimestamp(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function latestById(runs) {
+  return runs.reduce(
+    (latest, run) =>
+      latest === null || Number(run.id) > Number(latest.id) ? run : latest,
+    null,
+  );
+}
+
+function detailForRun(run) {
+  return run.details_url || `check-run ${run.id}`;
+}
+
+function waitingResult(required, code, detail, run = null) {
+  return {
+    ...required,
+    state: "waiting",
+    code,
+    detail,
+    url: run?.details_url ?? null,
+  };
+}
+
+function failedResult(required, code, detail, run = null) {
+  return {
+    ...required,
+    state: "failed",
+    code,
+    detail,
+    url: run?.details_url ?? null,
+  };
+}
+
+/**
+ * Evaluates one API snapshot. Callers decide when the polling deadline has
+ * elapsed; before then, missing/queued/stale observations remain waiting.
+ */
+export function evaluateAggregate({
+  checkRuns,
+  headSha,
+  eventAction,
+  eventUpdatedAt,
+  nowMs,
+  deadlineReached = false,
+  terminalSettleMs = DEFAULT_TERMINAL_SETTLE_MS,
+}) {
+  const eventUpdatedMs = parseTimestamp(eventUpdatedAt);
+  const freshAfterMs =
+    eventUpdatedMs === null ? null : eventUpdatedMs - FRESHNESS_SKEW_MS;
+
+  const results = REQUIRED_CHECKS.map((required) => {
+    const candidates = checkRuns.filter(
+      (run) =>
+        run.name === required.context &&
+        Number(run.app_id) === GITHUB_ACTIONS_APP_ID &&
+        run.workflow_path === required.workflowPath &&
+        run.workflow_event === "pull_request" &&
+        run.workflow_head_sha === headSha,
+    );
+    const run = latestById(candidates);
+
+    if (run === null) {
+      const detail = `no GitHub Actions check run from ${required.workflowPath}`;
+      return deadlineReached
+        ? failedResult(required, "missing", detail)
+        : waitingResult(required, "missing", detail);
+    }
+
+    const freshRunRequired = required.triggerActions.includes(eventAction);
+    const startedMs = parseTimestamp(run.started_at);
+    if (
+      freshRunRequired &&
+      (freshAfterMs === null || startedMs === null || startedMs < freshAfterMs)
+    ) {
+      const detail = `latest owner run predates ${eventAction} event`;
+      return deadlineReached
+        ? failedResult(required, "stale-event-result", detail, run)
+        : waitingResult(required, "stale-event-result", detail, run);
+    }
+
+    if (run.status !== COMPLETED_STATUS) {
+      const detail = `${detailForRun(run)} is ${run.status || "unknown"}`;
+      return deadlineReached
+        ? failedResult(required, "pending-timeout", detail, run)
+        : waitingResult(required, "pending", detail, run);
+    }
+
+    if (run.conclusion === SUCCESS_CONCLUSION) {
+      return {
+        ...required,
+        state: "passed",
+        code: "success",
+        detail: `${detailForRun(run)} concluded success`,
+        url: run.details_url ?? null,
+      };
+    }
+
+    const completedMs = parseTimestamp(run.completed_at);
+    if (
+      !deadlineReached &&
+      completedMs !== null &&
+      nowMs - completedMs < terminalSettleMs
+    ) {
+      return waitingResult(
+        required,
+        "terminal-settling",
+        `${detailForRun(run)} concluded ${run.conclusion || "unknown"}; waiting briefly for a superseding rerun`,
+        run,
+      );
+    }
+
+    if (run.conclusion === "skipped") {
+      return failedResult(
+        required,
+        "skipped-forbidden",
+        `${detailForRun(run)} was skipped; required workflows must classify paths inside an always-emitted job`,
+        run,
+      );
+    }
+
+    return failedResult(
+      required,
+      `terminal-${run.conclusion || "unknown"}`,
+      `${detailForRun(run)} concluded ${run.conclusion || "unknown"}`,
+      run,
+    );
+  });
+
+  const failed = results.filter(({ state }) => state === "failed");
+  const waiting = results.filter(({ state }) => state === "waiting");
+  return {
+    verdict:
+      failed.length > 0
+        ? "failure"
+        : waiting.length > 0
+          ? "waiting"
+          : "success",
+    results,
+    counts: {
+      passed: results.length - failed.length - waiting.length,
+      waiting: waiting.length,
+      failed: failed.length,
+    },
+  };
+}
+
+function extractWorkflowRunId(detailsUrl) {
+  if (typeof detailsUrl !== "string") return null;
+  const match = detailsUrl.match(/\/actions\/runs\/(\d+)\/job\/\d+/);
+  return match ? Number(match[1]) : null;
+}
+
+function apiHeaders(token) {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "User-Agent": "elizaOS-develop-pr-aggregate",
+    "X-GitHub-Api-Version": API_VERSION,
+  };
+}
+
+function isRetryableApiStatus(status) {
+  return status === 429 || status >= 500;
+}
+
+function retryDelayMs(response, attempt, baseDelayMs, nowMs) {
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    const hintedMs = Number.isFinite(seconds)
+      ? seconds * 1_000
+      : Date.parse(retryAfter) - nowMs;
+    if (Number.isFinite(hintedMs) && hintedMs > 0) {
+      return Math.min(hintedMs, DEFAULT_API_RETRY_CAP_MS);
+    }
+  }
+
+  return Math.min(baseDelayMs * 2 ** (attempt - 1), DEFAULT_API_RETRY_CAP_MS);
+}
+
+export async function requestJson(
+  url,
+  token,
+  {
+    fetchImpl = globalThis.fetch,
+    sleepImpl = sleep,
+    maxAttempts = DEFAULT_API_MAX_ATTEMPTS,
+    baseDelayMs = DEFAULT_API_RETRY_BASE_MS,
+    now = Date.now,
+  } = {},
+) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let response;
+    try {
+      response = await fetchImpl(url, { headers: apiHeaders(token) });
+    } catch (error) {
+      if (attempt === maxAttempts) {
+        throw new Error(
+          `GitHub API request failed for ${url} after ${maxAttempts} attempts: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
+        );
+      }
+      const delayMs = Math.min(
+        baseDelayMs * 2 ** (attempt - 1),
+        DEFAULT_API_RETRY_CAP_MS,
+      );
+      console.warn(
+        `GitHub API request failed for ${url}; retrying in ${delayMs}ms (attempt ${attempt}/${maxAttempts})`,
+      );
+      await sleepImpl(delayMs);
+      continue;
+    }
+
+    if (response.ok) return response.json();
+
+    const body = await response.text();
+    const detail = `GitHub API ${response.status} for ${url}: ${body.slice(0, 500)}`;
+    if (!isRetryableApiStatus(response.status) || attempt === maxAttempts) {
+      throw new Error(detail);
+    }
+
+    const delayMs = retryDelayMs(response, attempt, baseDelayMs, now());
+    console.warn(
+      `${detail}; retrying in ${delayMs}ms (attempt ${attempt}/${maxAttempts})`,
+    );
+    await sleepImpl(delayMs);
+  }
+
+  throw new Error(`GitHub API retry loop exhausted for ${url}`);
+}
+
+export async function loadOwnedCheckRuns({
+  repository,
+  headSha,
+  token,
+  workflowRunCache = new Map(),
+}) {
+  const requiredNames = new Set(REQUIRED_CHECKS.map(({ context }) => context));
+  const rawRuns = [];
+
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const url =
+      `https://api.github.com/repos/${repository}/commits/${headSha}/check-runs` +
+      `?filter=all&per_page=${PAGE_SIZE}&page=${page}&app_id=${GITHUB_ACTIONS_APP_ID}`;
+    const payload = await requestJson(url, token);
+    const pageRuns = Array.isArray(payload.check_runs)
+      ? payload.check_runs
+      : [];
+    rawRuns.push(...pageRuns.filter(({ name }) => requiredNames.has(name)));
+    // total_count covers every Actions check on the commit, while rawRuns is
+    // intentionally narrowed to required names. Page fullness is therefore
+    // the reliable pagination boundary for this filtered in-memory set.
+    if (pageRuns.length < PAGE_SIZE) {
+      break;
+    }
+  }
+
+  const runIds = new Set(
+    rawRuns
+      .map(({ details_url: detailsUrl }) => extractWorkflowRunId(detailsUrl))
+      .filter((runId) => runId !== null),
+  );
+  for (const runId of runIds) {
+    if (workflowRunCache.has(runId)) continue;
+    const workflowRun = await requestJson(
+      `https://api.github.com/repos/${repository}/actions/runs/${runId}`,
+      token,
+    );
+    workflowRunCache.set(runId, {
+      path: workflowRun.path,
+      event: workflowRun.event,
+      headSha: workflowRun.head_sha,
+    });
+  }
+
+  return rawRuns.map((run) => {
+    const workflowRunId = extractWorkflowRunId(run.details_url);
+    const owner =
+      workflowRunId === null ? null : workflowRunCache.get(workflowRunId);
+    return {
+      ...run,
+      app_id: run.app?.id,
+      workflow_path: owner?.path ?? null,
+      workflow_event: owner?.event ?? null,
+      workflow_head_sha: owner?.headSha ?? null,
+    };
+  });
+}
+
+function escapeCell(value) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+export function renderSummary(evaluation, { headSha, eventAction, attempt }) {
+  const lines = [
+    "### Develop PR Gate",
+    "",
+    `- Head SHA: \`${headSha}\``,
+    `- Pull-request action: \`${eventAction}\``,
+    `- Poll attempt: ${attempt}`,
+    `- Verdict: **${evaluation.verdict}**`,
+    `- Passed / waiting / failed: ${evaluation.counts.passed} / ${evaluation.counts.waiting} / ${evaluation.counts.failed}`,
+    "",
+    "| Required context | Owning workflow | State | Detail |",
+    "| --- | --- | --- | --- |",
+  ];
+  for (const result of evaluation.results) {
+    const detail = result.url
+      ? `[${escapeCell(result.detail)}](${result.url})`
+      : escapeCell(result.detail);
+    lines.push(
+      `| ${escapeCell(result.context)} | \`${escapeCell(result.workflowPath)}\` | ${result.state} | ${detail} |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function writeSummary(summary) {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub creates this per-job file outside Turbo's cache contract.
+  const path = process.env.GITHUB_STEP_SUMMARY;
+  if (path) writeFileSync(path, summary);
+}
+
+function positiveInteger(value, name, fallback) {
+  const resolved = value === undefined || value === "" ? fallback : value;
+  if (!/^\d+$/.test(String(resolved)) || Number(resolved) <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return Number(resolved);
+}
+
+function validateProductionEnvironment(env) {
+  if (env.AGGREGATE_EVENT_NAME !== "pull_request_target") {
+    throw new Error("production aggregate requires pull_request_target");
+  }
+  if (!/^\d+$/.test(env.PR_NUMBER ?? "")) {
+    throw new Error("PR_NUMBER must be a pull request number");
+  }
+  if (!/^[0-9a-f]{40}$/.test(env.HEAD_SHA ?? "")) {
+    throw new Error("HEAD_SHA must be a full commit SHA");
+  }
+  if (!/^[^/]+\/[^/]+$/.test(env.GITHUB_REPOSITORY ?? "")) {
+    throw new Error("GITHUB_REPOSITORY must be owner/repository");
+  }
+  if (!AGGREGATE_TRIGGER_ACTIONS.includes(env.PR_ACTION)) {
+    throw new Error(`unsupported pull-request action: ${env.PR_ACTION}`);
+  }
+  if (parseTimestamp(env.PR_UPDATED_AT) === null) {
+    throw new Error("PR_UPDATED_AT must be an ISO timestamp");
+  }
+  if (!env.GITHUB_TOKEN) throw new Error("GITHUB_TOKEN is required");
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function buildCanaryCheckRuns(scenario, nowMs) {
+  if (!CANARY_SCENARIOS.includes(scenario)) {
+    throw new Error(`unsupported canary scenario: ${scenario}`);
+  }
+  const startedAt = new Date(nowMs - 60_000).toISOString();
+  const completedAt = new Date(nowMs - 30_000).toISOString();
+  const runs = REQUIRED_CHECKS.map((required, index) => ({
+    id: 10_000 + index,
+    name: required.context,
+    app_id: GITHUB_ACTIONS_APP_ID,
+    workflow_path: required.workflowPath,
+    workflow_event: "pull_request",
+    workflow_head_sha: "a".repeat(40),
+    status: COMPLETED_STATUS,
+    conclusion: SUCCESS_CONCLUSION,
+    started_at: startedAt,
+    completed_at: completedAt,
+    details_url: `https://github.example/actions/runs/1/job/${10_000 + index}`,
+  }));
+  const targetIndex = runs.findIndex(({ name }) => name === "gitleaks");
+  if (scenario === "missing") runs.splice(targetIndex, 1);
+  if (scenario === "cancelled") runs[targetIndex].conclusion = "cancelled";
+  if (scenario === "timed-out") runs[targetIndex].conclusion = "timed_out";
+  if (scenario === "failed") runs[targetIndex].conclusion = "failure";
+  if (scenario === "skipped") runs[targetIndex].conclusion = "skipped";
+  if (scenario === "pending-timeout") {
+    runs[targetIndex].status = "in_progress";
+    runs[targetIndex].conclusion = null;
+    runs[targetIndex].completed_at = null;
+  }
+  return runs;
+}
+
+async function runCanary(scenario) {
+  const nowMs = Date.now();
+  const evaluation = evaluateAggregate({
+    checkRuns: buildCanaryCheckRuns(scenario, nowMs),
+    headSha: "a".repeat(40),
+    eventAction: "synchronize",
+    eventUpdatedAt: new Date(nowMs - 90_000).toISOString(),
+    nowMs,
+    deadlineReached: true,
+    terminalSettleMs: 0,
+  });
+  const summary = renderSummary(evaluation, {
+    headSha: "synthetic-canary",
+    eventAction: scenario,
+    attempt: 1,
+  });
+  writeSummary(summary);
+  console.log(summary);
+  return evaluation.verdict === "success" ? 0 : 1;
+}
+
+async function runProduction(env) {
+  validateProductionEnvironment(env);
+  const timeoutSeconds = positiveInteger(
+    env.POLL_TIMEOUT_SECONDS,
+    "POLL_TIMEOUT_SECONDS",
+    2_400,
+  );
+  const intervalSeconds = positiveInteger(
+    env.POLL_INTERVAL_SECONDS,
+    "POLL_INTERVAL_SECONDS",
+    30,
+  );
+  const deadlineMs = Date.now() + timeoutSeconds * 1_000;
+  const workflowRunCache = new Map();
+  let attempt = 1;
+
+  while (true) {
+    const nowMs = Date.now();
+    const checkRuns = await loadOwnedCheckRuns({
+      repository: env.GITHUB_REPOSITORY,
+      headSha: env.HEAD_SHA,
+      token: env.GITHUB_TOKEN,
+      workflowRunCache,
+    });
+    const deadlineReached = nowMs >= deadlineMs;
+    const evaluation = evaluateAggregate({
+      checkRuns,
+      headSha: env.HEAD_SHA,
+      eventAction: env.PR_ACTION,
+      eventUpdatedAt: env.PR_UPDATED_AT,
+      nowMs,
+      deadlineReached,
+    });
+    const summary = renderSummary(evaluation, {
+      headSha: env.HEAD_SHA,
+      eventAction: env.PR_ACTION,
+      attempt,
+    });
+    writeSummary(summary);
+    console.log(
+      `Develop PR Gate poll ${attempt}: passed=${evaluation.counts.passed} waiting=${evaluation.counts.waiting} failed=${evaluation.counts.failed}`,
+    );
+    for (const result of evaluation.results) {
+      console.log(
+        `${result.state.toUpperCase()} ${result.context}: ${result.detail}`,
+      );
+    }
+
+    if (evaluation.verdict === "success") return 0;
+    if (evaluation.verdict === "failure") return 1;
+
+    attempt += 1;
+    await sleep(
+      Math.min(intervalSeconds * 1_000, Math.max(1, deadlineMs - nowMs)),
+    );
+  }
+}
+
+export async function main(env = process.env) {
+  const canary = env.CANARY_SCENARIO;
+  if (canary) {
+    if (env.AGGREGATE_EVENT_NAME !== "workflow_dispatch") {
+      throw new Error("canary scenarios are restricted to workflow_dispatch");
+    }
+    return runCanary(canary);
+  }
+  return runProduction(env);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  process.exitCode = await main();
+}

--- a/packages/scripts/develop-pr-aggregate.self-test.mjs
+++ b/packages/scripts/develop-pr-aggregate.self-test.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * Deterministic contract tests for the develop PR aggregate state machine and
+ * its base-trusted workflow. Synthetic check snapshots cover every terminal
+ * class without calling GitHub or waiting for real runner timeouts.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  buildCanaryCheckRuns,
+  CANARY_SCENARIOS,
+  evaluateAggregate,
+  GITHUB_ACTIONS_APP_ID,
+  REQUIRED_CHECKS,
+  renderSummary,
+  requestJson,
+} from "./develop-pr-aggregate.mjs";
+import {
+  OBSERVED_HEAD_LINE,
+  runContract,
+  TRUSTED_BASE_REF_LINE,
+  validateAggregateWorkflow,
+} from "./develop-pr-aggregate-workflow-contract.mjs";
+
+const NOW_MS = Date.parse("2026-07-14T01:00:00Z");
+const HEAD_SHA = "a".repeat(40);
+const EVENT_UPDATED_AT = new Date(NOW_MS - 90_000).toISOString();
+
+function evaluate(checkRuns, overrides = {}) {
+  return evaluateAggregate({
+    checkRuns,
+    headSha: HEAD_SHA,
+    eventAction: "synchronize",
+    eventUpdatedAt: EVENT_UPDATED_AT,
+    nowMs: NOW_MS,
+    terminalSettleMs: 0,
+    ...overrides,
+  });
+}
+
+function successRuns() {
+  return buildCanaryCheckRuns("success", NOW_MS);
+}
+
+function resultFor(evaluation, context) {
+  const result = evaluation.results.find((entry) => entry.context === context);
+  assert(result, `missing result for ${context}`);
+  return result;
+}
+
+const allGreen = evaluate(successRuns());
+assert.equal(allGreen.verdict, "success");
+assert.deepEqual(allGreen.counts, { passed: 7, waiting: 0, failed: 0 });
+
+const missingBeforeDeadline = evaluate(buildCanaryCheckRuns("missing", NOW_MS));
+assert.equal(missingBeforeDeadline.verdict, "waiting");
+assert.equal(resultFor(missingBeforeDeadline, "gitleaks").code, "missing");
+const missingAtDeadline = evaluate(buildCanaryCheckRuns("missing", NOW_MS), {
+  deadlineReached: true,
+});
+assert.equal(missingAtDeadline.verdict, "failure");
+assert.equal(resultFor(missingAtDeadline, "gitleaks").code, "missing");
+
+const pendingBeforeDeadline = evaluate(
+  buildCanaryCheckRuns("pending-timeout", NOW_MS),
+);
+assert.equal(pendingBeforeDeadline.verdict, "waiting");
+assert.equal(resultFor(pendingBeforeDeadline, "gitleaks").code, "pending");
+const pendingAtDeadline = evaluate(
+  buildCanaryCheckRuns("pending-timeout", NOW_MS),
+  { deadlineReached: true },
+);
+assert.equal(pendingAtDeadline.verdict, "failure");
+assert.equal(resultFor(pendingAtDeadline, "gitleaks").code, "pending-timeout");
+
+for (const [scenario, code] of [
+  ["cancelled", "terminal-cancelled"],
+  ["timed-out", "terminal-timed_out"],
+  ["failed", "terminal-failure"],
+  ["skipped", "skipped-forbidden"],
+]) {
+  const evaluation = evaluate(buildCanaryCheckRuns(scenario, NOW_MS), {
+    deadlineReached: true,
+  });
+  assert.equal(evaluation.verdict, "failure", scenario);
+  assert.equal(resultFor(evaluation, "gitleaks").code, code, scenario);
+}
+
+// Every remaining GitHub conclusion that is neither success nor skipped must
+// still fail closed through the generic terminal branch, so an unexpected or
+// future conclusion string can never be mistaken for a pass.
+for (const conclusion of [
+  "neutral",
+  "action_required",
+  "startup_failure",
+  "stale",
+]) {
+  const runs = successRuns();
+  runs.find(({ name }) => name === "gitleaks").conclusion = conclusion;
+  const evaluation = evaluate(runs, { deadlineReached: true });
+  assert.equal(evaluation.verdict, "failure", conclusion);
+  assert.equal(
+    resultFor(evaluation, "gitleaks").code,
+    `terminal-${conclusion}`,
+    conclusion,
+  );
+}
+
+const settlingRuns = buildCanaryCheckRuns("cancelled", NOW_MS);
+const cancelled = settlingRuns.find(({ name }) => name === "gitleaks");
+cancelled.completed_at = new Date(NOW_MS - 5_000).toISOString();
+const settling = evaluate(settlingRuns, { terminalSettleMs: 15_000 });
+assert.equal(settling.verdict, "waiting");
+assert.equal(resultFor(settling, "gitleaks").code, "terminal-settling");
+
+const rerunRuns = buildCanaryCheckRuns("failed", NOW_MS);
+const oldFailure = rerunRuns.find(({ name }) => name === "gitleaks");
+rerunRuns.push({
+  ...oldFailure,
+  id: Number(oldFailure.id) + 10_000,
+  conclusion: "success",
+});
+assert.equal(evaluate(rerunRuns).verdict, "success");
+
+const wrongOwnerRuns = successRuns();
+const wrongOwner = wrongOwnerRuns.find(({ name }) => name === "gitleaks");
+wrongOwner.workflow_path = ".github/workflows/untrusted.yml";
+const wrongOwnerEvaluation = evaluate(wrongOwnerRuns);
+assert.equal(wrongOwnerEvaluation.verdict, "waiting");
+assert.equal(resultFor(wrongOwnerEvaluation, "gitleaks").code, "missing");
+
+const wrongAppRuns = successRuns();
+wrongAppRuns.find(({ name }) => name === "gitleaks").app_id =
+  GITHUB_ACTIONS_APP_ID + 1;
+assert.equal(resultFor(evaluate(wrongAppRuns), "gitleaks").code, "missing");
+
+const editedRuns = successRuns();
+const editedStale = evaluate(editedRuns, {
+  eventAction: "edited",
+  eventUpdatedAt: new Date(NOW_MS - 10_000).toISOString(),
+});
+assert.equal(editedStale.verdict, "waiting");
+assert.equal(editedStale.counts.waiting, 2);
+assert.equal(resultFor(editedStale, "lint").state, "passed");
+for (const context of ["check-pr-evidence", "check-pr-title"]) {
+  const oldRun = editedRuns.find(({ name }) => name === context);
+  editedRuns.push({
+    ...oldRun,
+    id: Number(oldRun.id) + 20_000,
+    started_at: new Date(NOW_MS - 5_000).toISOString(),
+    completed_at: new Date(NOW_MS - 1_000).toISOString(),
+  });
+}
+assert.equal(
+  evaluate(editedRuns, {
+    eventAction: "edited",
+    eventUpdatedAt: new Date(NOW_MS - 10_000).toISOString(),
+  }).verdict,
+  "success",
+);
+
+const contexts = REQUIRED_CHECKS.map(({ context }) => context);
+assert.equal(new Set(contexts).size, contexts.length);
+assert(!contexts.includes("Develop PR Gate"));
+assert.deepEqual(CANARY_SCENARIOS, [
+  "success",
+  "missing",
+  "cancelled",
+  "timed-out",
+  "failed",
+  "skipped",
+  "pending-timeout",
+]);
+
+const summary = renderSummary(allGreen, {
+  headSha: HEAD_SHA,
+  eventAction: "synchronize",
+  attempt: 1,
+});
+assert.match(summary, /Verdict: \*\*success\*\*/);
+
+const apiAttempts = [];
+const retrySleeps = [];
+const retriedPayload = await requestJson(
+  "https://api.github.test/check-runs",
+  "test-token",
+  {
+    fetchImpl: async () => {
+      apiAttempts.push(Date.now());
+      if (apiAttempts.length < 3) {
+        return new Response("temporarily unavailable", { status: 503 });
+      }
+      return Response.json({ check_runs: [] });
+    },
+    sleepImpl: async (delayMs) => retrySleeps.push(delayMs),
+    maxAttempts: 3,
+    baseDelayMs: 5,
+  },
+);
+assert.deepEqual(retriedPayload, { check_runs: [] });
+assert.equal(apiAttempts.length, 3);
+assert.deepEqual(retrySleeps, [5, 10]);
+
+let permanentAttempts = 0;
+await assert.rejects(
+  requestJson("https://api.github.test/missing", "test-token", {
+    fetchImpl: async () => {
+      permanentAttempts += 1;
+      return new Response("not found", { status: 404 });
+    },
+    sleepImpl: async () => assert.fail("404 responses must not be retried"),
+  }),
+  /GitHub API 404/,
+);
+assert.equal(permanentAttempts, 1);
+
+const workflowPath = fileURLToPath(
+  new URL("../../.github/workflows/develop-pr-gate.yml", import.meta.url),
+);
+const workflow = readFileSync(workflowPath, "utf8");
+validateAggregateWorkflow(workflow);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace("  pull_request_target:", "  pull_request:"),
+    ),
+  /pull_request_target|PR-controlled/,
+);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace("  checks: read", "  checks: write"),
+    ),
+  /checks permission|read-only/,
+);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace(
+        TRUSTED_BASE_REF_LINE,
+        OBSERVED_HEAD_LINE.replace("HEAD_SHA: ", "ref: "),
+      ),
+    ),
+  /trusted base checkout ref/,
+);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace(
+        "    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled]",
+        "    types: [opened, synchronize]",
+      ),
+    ),
+  /aggregate activity types/,
+);
+
+assert.deepEqual(runContract(), { ok: true, contexts });
+console.log("develop-pr aggregate self-test passed");

--- a/packages/scripts/develop-pr-aggregate.test.mjs
+++ b/packages/scripts/develop-pr-aggregate.test.mjs
@@ -1,0 +1,10 @@
+/**
+ * Bun coverage entrypoint for the deterministic develop PR aggregate contract.
+ * The same assertions run directly under Node in the bootstrap integrity lane;
+ * this wrapper lets the changed-file gate measure the implementation they load.
+ */
+import { test } from "bun:test";
+
+test("develop PR aggregate contract and transient API retries", async () => {
+  await import("./develop-pr-aggregate.self-test.mjs");
+});

--- a/packages/scripts/local-inference-ablation.mjs
+++ b/packages/scripts/local-inference-ablation.mjs
@@ -26,6 +26,11 @@ const DEFAULT_VARIANTS = [
     args: [],
   },
   {
+    name: "stock_no_fa",
+    label: "target only, f16 KV, flash attention disabled",
+    args: ["-fa", "off"],
+  },
+  {
     name: "turbo4_polar_kv",
     label: "target only, Turbo/Polar KV turbo4",
     args: ["--cache-type-k", "tbq4_0", "--cache-type-v", "tbq4_0"],
@@ -636,18 +641,26 @@ async function main() {
 
   printSummary(report.variants);
 
+  const skipped = report.variants.filter((row) => row.skipped);
+  const failed = report.variants.filter((row) => !row.skipped && !row.ok);
+  const executed = report.variants.filter(
+    (row) => row.ok === true && !row.skipped,
+  );
+  report.executedVariantCount = executed.length;
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   const outPath = path.join(args.outDir, `${stamp}-${args.backend}.json`);
   fs.writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`);
   console.log(`\nWrote ${outPath}`);
 
-  const skipped = report.variants.filter((row) => row.skipped);
-  const failed = report.variants.filter((row) => !row.skipped && !row.ok);
   let exitCode = 0;
   if (failed.length > 0) {
     console.error(
       `[ablation] ${failed.length} variant(s) failed: ${failed.map((row) => row.name).join(", ")}`,
     );
+    exitCode = 1;
+  }
+  if (executed.length === 0) {
+    console.error("[ablation] zero variants executed successfully");
     exitCode = 1;
   }
   if (args.requireAll && skipped.length > 0) {

--- a/packages/scripts/local-inference-attest.mjs
+++ b/packages/scripts/local-inference-attest.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Binds a local-inference report to executable and model bytes from one host.
+ * The manifest records cryptographic identities and refuses a mismatched model,
+ * non-executable binary, incompatible report host, or zero successful variants.
+ */
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  createReadStream,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || !value)
+      throw new Error(`missing value for ${key ?? "argument"}`);
+    args[key.slice(2)] = value;
+  }
+  for (const key of [
+    "binary",
+    "model",
+    "report",
+    "backend",
+    "expected-model-sha256",
+    "source-sha",
+    "workflow-sha",
+    "out",
+  ]) {
+    if (!args[key]) throw new Error(`--${key} is required`);
+  }
+  return args;
+}
+
+async function sha256(file) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(file)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+export async function attest(args) {
+  const binary = path.resolve(args.binary);
+  const model = path.resolve(args.model);
+  const reportPath = path.resolve(args.report);
+  const binaryStat = statSync(binary);
+  if (!binaryStat.isFile() || (binaryStat.mode & 0o111) === 0)
+    throw new Error("binary is not an executable file");
+  const probe = spawnSync(binary, ["--version"], {
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  if (probe.error || probe.status !== 0)
+    throw new Error(
+      `binary is not host-executable: ${probe.error?.message ?? `exit ${probe.status}`}`,
+    );
+  const modelSha256 = await sha256(model);
+  if (modelSha256 !== args["expected-model-sha256"])
+    throw new Error(`model SHA-256 mismatch: ${modelSha256}`);
+  const report = JSON.parse(readFileSync(reportPath, "utf8"));
+  if (
+    report?.hardware?.platform !== process.platform ||
+    report?.hardware?.arch !== process.arch
+  ) {
+    throw new Error("report host does not match attesting host");
+  }
+  if (report?.hardware?.backend !== args.backend)
+    throw new Error("report backend does not match attestation");
+  const executedVariants =
+    report.variants?.filter((row) => row.ok === true && row.skipped !== true)
+      .length ?? 0;
+  if (executedVariants < 1)
+    throw new Error("report contains zero successful variants");
+  const manifest = {
+    schemaVersion: 1,
+    createdAt: new Date().toISOString(),
+    workflowSha: args["workflow-sha"],
+    sourceSha: args["source-sha"],
+    host: {
+      platform: process.platform,
+      arch: process.arch,
+      hostname: os.hostname(),
+      backend: args.backend,
+    },
+    binary: {
+      path: binary,
+      bytes: binaryStat.size,
+      sha256: await sha256(binary),
+      version: `${probe.stdout ?? ""}\n${probe.stderr ?? ""}`
+        .trim()
+        .split(/\r?\n/)[0],
+    },
+    model: { path: model, bytes: statSync(model).size, sha256: modelSha256 },
+    report: {
+      path: reportPath,
+      bytes: statSync(reportPath).size,
+      sha256: await sha256(reportPath),
+      executedVariants,
+    },
+  };
+  writeFileSync(args.out, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+if (import.meta.main) {
+  try {
+    await attest(parseArgs(process.argv.slice(2)));
+  } catch (error) {
+    process.stderr.write(
+      `[local-inference-attest] ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/packages/scripts/local-inference-attest.test.mjs
+++ b/packages/scripts/local-inference-attest.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * Verifies byte, host, backend, executable, and positive-execution attestation.
+ */
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { attest } from "./local-inference-attest.mjs";
+
+const platformTest = process.platform === "win32" ? test.skip : test;
+
+platformTest(
+  "attests exact bytes and rejects mismatched or empty evidence",
+  async () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "local-inference-attest-"),
+    );
+    try {
+      const binary = path.join(root, "llama-server");
+      const model = path.join(root, "model.gguf");
+      const report = path.join(root, "report.json");
+      const out = path.join(root, "attestation.json");
+      fs.writeFileSync(binary, "#!/bin/sh\necho 'llama version fixture'\n");
+      fs.chmodSync(binary, 0o755);
+      fs.writeFileSync(model, "model-bytes");
+      fs.writeFileSync(
+        report,
+        JSON.stringify({
+          hardware: {
+            platform: process.platform,
+            arch: process.arch,
+            backend: "cpu",
+          },
+          variants: [{ name: "baseline", ok: true, runs: [{ tokPerSec: 1 }] }],
+        }),
+      );
+      const expected = createHash("sha256").update("model-bytes").digest("hex");
+      const args = {
+        binary,
+        model,
+        report,
+        backend: "cpu",
+        "expected-model-sha256": expected,
+        "source-sha": "a".repeat(40),
+        "workflow-sha": "b".repeat(40),
+        out,
+      };
+      const manifest = await attest(args);
+      assert.equal(manifest.model.sha256, expected);
+      assert.equal(manifest.report.executedVariants, 1);
+      assert.equal(
+        JSON.parse(fs.readFileSync(out, "utf8")).binary.version,
+        "llama version fixture",
+      );
+      await assert.rejects(
+        attest({ ...args, "expected-model-sha256": "0".repeat(64) }),
+        /model SHA-256 mismatch/,
+      );
+      fs.writeFileSync(
+        report,
+        JSON.stringify({
+          hardware: {
+            platform: process.platform,
+            arch: process.arch,
+            backend: "cpu",
+          },
+          variants: [],
+        }),
+      );
+      await assert.rejects(attest(args), /zero successful variants/);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/scripts/local-inference-performance-check.mjs
+++ b/packages/scripts/local-inference-performance-check.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Evaluates local-inference throughput relative to a same-run baseline.
+ * Backend-specific median ratios absorb runner class and machine speed while
+ * positive sample and variant counts prevent empty or one-shot green reports.
+ */
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function positiveSamples(row, minimum) {
+  invariant(
+    row?.ok === true && row.skipped !== true,
+    `${row?.name ?? "variant"} did not execute successfully`,
+  );
+  invariant(Array.isArray(row.runs), `${row.name} has no run samples`);
+  const samples = row.runs.map(({ tokPerSec }) => tokPerSec);
+  invariant(
+    samples.length >= minimum,
+    `${row.name} has ${samples.length} samples; expected at least ${minimum}`,
+  );
+  invariant(
+    samples.every((value) => Number.isFinite(value) && value > 0),
+    `${row.name} contains non-positive throughput`,
+  );
+  return samples;
+}
+
+function median(values) {
+  const ordered = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(ordered.length / 2);
+  return ordered.length % 2 === 0
+    ? (ordered[middle - 1] + ordered[middle]) / 2
+    : ordered[middle];
+}
+
+export function evaluatePerformance(report, policy) {
+  const backend = report?.hardware?.backend;
+  const ratios = policy?.backends?.[backend];
+  invariant(
+    ratios && typeof ratios === "object",
+    `no performance policy for backend ${backend ?? "<missing>"}`,
+  );
+  invariant(Array.isArray(report.variants), "report has no variants");
+  const executed = report.variants.filter(
+    (row) => row.ok === true && row.skipped !== true,
+  );
+  invariant(
+    executed.length >= policy.minimumExecutedVariants,
+    `only ${executed.length} variants executed; expected at least ${policy.minimumExecutedVariants}`,
+  );
+  const byName = new Map(executed.map((row) => [row.name, row]));
+  const baseline = byName.get(policy.baseline);
+  invariant(baseline, `required baseline ${policy.baseline} did not execute`);
+  const baselineMedian = median(
+    positiveSamples(baseline, policy.minimumSamplesPerVariant),
+  );
+  const comparisons = [];
+  for (const [name, minimumRatio] of Object.entries(ratios)) {
+    invariant(
+      Number.isFinite(minimumRatio) && minimumRatio > 0,
+      `invalid ${backend}/${name} ratio`,
+    );
+    const row = byName.get(name);
+    invariant(row, `required comparison variant ${name} did not execute`);
+    const variantMedian = median(
+      positiveSamples(row, policy.minimumSamplesPerVariant),
+    );
+    const actualRatio = variantMedian / baselineMedian;
+    invariant(
+      actualRatio >= minimumRatio,
+      `${backend}/${name} median ratio ${actualRatio.toFixed(3)} is below ${minimumRatio.toFixed(3)}`,
+    );
+    comparisons.push({
+      name,
+      medianTokPerSec: variantMedian,
+      ratio: actualRatio,
+      minimumRatio,
+    });
+  }
+  return {
+    backend,
+    baseline: policy.baseline,
+    baselineMedianTokPerSec: baselineMedian,
+    executedVariants: executed.length,
+    comparisons,
+  };
+}
+
+function main(argv) {
+  const [reportPath, policyPath] = argv;
+  invariant(
+    reportPath && policyPath,
+    "usage: local-inference-performance-check.mjs <report.json> <policy.json>",
+  );
+  const result = evaluatePerformance(
+    JSON.parse(readFileSync(reportPath, "utf8")),
+    JSON.parse(readFileSync(policyPath, "utf8")),
+  );
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(
+      `[local-inference-performance] ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/packages/scripts/local-inference-performance-check.test.mjs
+++ b/packages/scripts/local-inference-performance-check.test.mjs
@@ -1,0 +1,91 @@
+/**
+ * Exercises relative local-inference performance policy and vacuous reports.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { evaluatePerformance } from "./local-inference-performance-check.mjs";
+
+const policy = {
+  baseline: "baseline",
+  minimumExecutedVariants: 2,
+  minimumSamplesPerVariant: 3,
+  backends: { cpu: { optimized: 0.75 } },
+};
+const row = (name, samples) => ({
+  name,
+  ok: true,
+  runs: samples.map((tokPerSec) => ({ tokPerSec })),
+});
+
+test("uses same-run medians rather than absolute runner speed", () => {
+  for (const scale of [0.25, 1, 100]) {
+    const result = evaluatePerformance(
+      {
+        hardware: { backend: "cpu" },
+        variants: [
+          row(
+            "baseline",
+            [8, 10, 12].map((v) => v * scale),
+          ),
+          row(
+            "optimized",
+            [7, 8, 9].map((v) => v * scale),
+          ),
+        ],
+      },
+      policy,
+    );
+    assert.equal(result.comparisons[0].ratio, 0.8);
+  }
+});
+
+test("rejects empty, skipped, undersampled, and regressed reports", () => {
+  assert.throws(
+    () =>
+      evaluatePerformance(
+        { hardware: { backend: "cpu" }, variants: [] },
+        policy,
+      ),
+    /only 0 variants/,
+  );
+  assert.throws(
+    () =>
+      evaluatePerformance(
+        {
+          hardware: { backend: "cpu" },
+          variants: [
+            row("baseline", [1, 1, 1]),
+            { name: "optimized", skipped: true },
+          ],
+        },
+        policy,
+      ),
+    /only 1 variants/,
+  );
+  assert.throws(
+    () =>
+      evaluatePerformance(
+        {
+          hardware: { backend: "cpu" },
+          variants: [row("baseline", [1, 1]), row("optimized", [1, 1, 1])],
+        },
+        policy,
+      ),
+    /expected at least 3/,
+  );
+  assert.throws(
+    () =>
+      evaluatePerformance(
+        {
+          hardware: { backend: "cpu" },
+          variants: [
+            row("baseline", [10, 10, 10]),
+            row("optimized", [5, 5, 5]),
+          ],
+        },
+        policy,
+      ),
+    /below 0.750/,
+  );
+});

--- a/packages/scripts/local-inference-performance-policy.json
+++ b/packages/scripts/local-inference-performance-policy.json
@@ -1,0 +1,11 @@
+{
+  "baseline": "baseline_f16_kv",
+  "minimumExecutedVariants": 2,
+  "minimumSamplesPerVariant": 3,
+  "backends": {
+    "cpu": { "turbo4_polar_kv": 0.45 },
+    "cuda": { "turbo4_polar_kv": 0.6 },
+    "metal": { "stock_no_fa": 0.6 },
+    "rocm": { "turbo4_polar_kv": 0.55 }
+  }
+}

--- a/packages/scripts/local-inference-smoke.mjs
+++ b/packages/scripts/local-inference-smoke.mjs
@@ -8,9 +8,8 @@
  * the fork build step to fail fast on broken binaries.
  *
  * Exit-code contract:
- *   0  no targets found, or every target produced a recognizable version line.
- *   1  at least one target's binary failed to execute or did not print a
- *      recognizable version line.
+ *   0  at least one host-compatible target passed every executable probe.
+ *   1  no compatible target exists, or any compatible executable probe fails.
  */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
@@ -134,10 +133,11 @@ function main() {
   const root = mtpRoot();
   const targets = listTargets(root);
   if (targets.length === 0) {
-    console.log(`no targets found under ${root}, skipping`);
-    process.exit(0);
+    console.log(`FAIL no targets found under ${root}`);
+    process.exit(1);
   }
   let allOk = true;
+  let compatibleTargets = 0;
   for (const target of targets) {
     if (!targetMatchesHost(target)) {
       console.log(
@@ -145,9 +145,14 @@ function main() {
       );
       continue;
     }
+    compatibleTargets += 1;
     const targetDir = path.join(root, target);
     const ok = probeTarget(targetDir, target);
     if (!ok) allOk = false;
+  }
+  if (compatibleTargets === 0) {
+    console.log(`FAIL no target matches ${process.platform}-${process.arch}`);
+    allOk = false;
   }
   process.exit(allOk ? 0 : 1);
 }

--- a/packages/scripts/script-test-isolation.test.mjs
+++ b/packages/scripts/script-test-isolation.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * Proves Bun's parallel file mode isolates process-global script-test state.
+ * Four synchronized fixture suites must have distinct PIDs while one mutates
+ * cwd, environment, globals, module state, signal handlers, and scratch files.
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+test("parallel script suites run in isolated worker processes", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "script-test-isolation-"));
+  try {
+    fs.mkdirSync(path.join(root, "changed-cwd"));
+    fs.writeFileSync(
+      path.join(root, "state.mjs"),
+      "export const state = { value: 0 };\n",
+    );
+    for (let index = 0; index < 4; index += 1) {
+      const mutation =
+        index === 0
+          ? `
+  process.env.ELIZA_SCRIPT_ISOLATION_PROBE = "mutated";
+  globalThis.__elizaScriptIsolationProbe = "mutated";
+  state.value = 1;
+  process.on("SIGUSR2", () => {});
+  process.chdir(path.join(root, "changed-cwd"));
+`
+          : `
+  expect(process.env.ELIZA_SCRIPT_ISOLATION_PROBE).toBeUndefined();
+  expect(globalThis.__elizaScriptIsolationProbe).toBeUndefined();
+  expect(state.value).toBe(0);
+  expect(process.listenerCount("SIGUSR2")).toBe(0);
+  expect(fs.realpathSync(process.cwd())).toBe(fs.realpathSync(root));
+`;
+      fs.writeFileSync(
+        path.join(root, `worker-${index}.test.mjs`),
+        `import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { state } from "./state.mjs";
+
+const root = ${JSON.stringify(root)};
+fs.writeFileSync(path.join(root, "pid-${index}"), String(process.pid));
+
+test("worker ${index} remains process-isolated", async () => {
+${mutation}
+  const deadline = Date.now() + 10_000;
+  while (fs.readdirSync(root).filter((name) => name.startsWith("pid-")).length < 4) {
+    if (Date.now() > deadline) throw new Error("parallel workers did not rendezvous");
+    await Bun.sleep(20);
+  }
+  const pids = fs.readdirSync(root)
+    .filter((name) => name.startsWith("pid-"))
+    .map((name) => fs.readFileSync(path.join(root, name), "utf8"));
+  expect(new Set(pids).size).toBe(4);
+});
+`,
+      );
+    }
+
+    const result = spawnSync(
+      "bun",
+      [
+        "test",
+        "--parallel=4",
+        ...Array.from({ length: 4 }, (_, index) => `worker-${index}.test.mjs`),
+      ],
+      { cwd: root, encoding: "utf8", timeout: 20_000 },
+    );
+    assert.equal(
+      result.status,
+      0,
+      `isolation fixture failed:\n${result.stdout}\n${result.stderr}`,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/scripts/stale-base-guard.mjs
+++ b/packages/scripts/stale-base-guard.mjs
@@ -1,0 +1,482 @@
+#!/usr/bin/env node
+/**
+ * Stale-base guard (#11376 final acceptance criterion).
+ *
+ * Blocks the PR #11271 failure mode: a PR whose commits carry stale file
+ * contents (an old checkout committed onto a fresh-looking base) so that
+ * merging it silently reverts work already merged on the target branch.
+ * #11271's merge-base was only 8 minutes old — the staleness was inside the
+ * PR's own tree — so a merge-base age check alone can never catch it. This
+ * guard therefore uses content identity rather than branch age or distance:
+ *
+ * (Files the PR leaves untouched relative to its merge-base are safe by
+ * construction: GitHub's squash/merge machinery three-way-merges, so a
+ * base-side-only change always keeps the target branch's version. The
+ * dangerous reverts are always inside the PR's own diff — verified against
+ * the real #11271 squash, whose 304-file diff contained every revert.)
+ *
+ * 1. SILENT-REVERT DETECTION (the core). For every file the PR modifies or
+ *    deletes, walk the target branch's first-parent history (bounded window)
+ *    and flag the file when the PR's final blob is byte-identical to an OLDER
+ *    historical blob — i.e. the PR discards newer merged work by restoring a
+ *    previous version. A file is NOT flagged when the target's current blob
+ *    is itself a re-occurrence of an even older blob than the one the PR
+ *    restores (the "heal" case: develop is sitting on clobbered content and
+ *    the PR restores the newer work — e.g. the #11427/#11430/#11433 re-land
+ *    PRs). Files the PR adds are never flagged: no merged work can be lost by
+ *    an addition.
+ *
+ *    Deletions of recently-added files match this shape too (the pre-add
+ *    state is "absent"), but deliberate reworks legitimately delete young
+ *    files (live example: PR #11523 deleting tests #11174 added hours
+ *    earlier). A byte-identical *modification* revert, by contrast, is never
+ *    produced by honest editing. So deletion findings only BLOCK when at
+ *    least one modification-revert corroborates the stale-tree signature
+ *    (a stale checkout reverts modified files en masse — #11271 had 200+);
+ *    deletion-only findings surface as loud non-blocking notices.
+ *
+ * Override: the `stale-base-ack` label (--ack) downgrades failures to loud
+ * warnings — for deliberate revert PRs.
+ *
+ * Plumbing-only (oid comparisons, no blob content reads): works in a blobless
+ * (--filter=blob:none) shallow clone; the history walk stops gracefully at a
+ * shallow boundary.
+ *
+ * Usage:
+ *   node packages/scripts/stale-base-guard.mjs \
+ *     --base <target-tip-ref> --head <pr-head-ref> \
+ *     [--merge-base <ref>] [--window 1200] \
+ *     [--ack] [--github] [--summary <path>] [--json <path>] [--repo <dir>]
+ *
+ * Exit codes: 0 = pass (or acked), 1 = findings, 2 = usage/internal error.
+ */
+import { spawnSync } from "node:child_process";
+import { appendFileSync, writeFileSync } from "node:fs";
+
+const RAW_STATUS_CANDIDATES = new Set(["M", "D", "T"]);
+const MAX_INLINE_ANNOTATIONS = 20;
+const PATHSPEC_CHUNK = 500;
+
+function parseArgs(argv) {
+  const args = {
+    window: 1200,
+    ack: false,
+    github: false,
+    repo: process.cwd(),
+    json: null,
+    summary: null,
+    base: null,
+    head: null,
+    mergeBase: null,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => {
+      i += 1;
+      if (i >= argv.length) throw new Error(`missing value for ${a}`);
+      return argv[i];
+    };
+    switch (a) {
+      case "--base":
+        args.base = next();
+        break;
+      case "--head":
+        args.head = next();
+        break;
+      case "--merge-base":
+        args.mergeBase = next();
+        break;
+      case "--window":
+        args.window = Number(next());
+        break;
+      case "--ack":
+        args.ack = true;
+        break;
+      case "--github":
+        args.github = true;
+        break;
+      case "--json":
+        args.json = next();
+        break;
+      case "--summary":
+        args.summary = next();
+        break;
+      case "--repo":
+        args.repo = next();
+        break;
+      default:
+        throw new Error(`unknown argument: ${a}`);
+    }
+  }
+  if (!args.base || !args.head) {
+    throw new Error("--base and --head are required");
+  }
+  for (const [name, v] of [["--window", args.window]]) {
+    if (!Number.isFinite(v) || v < 0)
+      throw new Error(`${name} must be a non-negative number`);
+  }
+  return args;
+}
+
+function git(repo, gitArgs, { allowFail = false } = {}) {
+  const res = spawnSync("git", gitArgs, {
+    cwd: repo,
+    encoding: "buffer",
+    maxBuffer: 1024 * 1024 * 512,
+  });
+  if (res.error) throw res.error;
+  if (res.status !== 0) {
+    if (allowFail) return null;
+    throw new Error(
+      `git ${gitArgs.join(" ")} exited ${res.status}: ${res.stderr.toString("utf8").trim()}`,
+    );
+  }
+  return res.stdout;
+}
+
+function gitText(repo, gitArgs, opts) {
+  const out = git(repo, gitArgs, opts);
+  return out === null ? null : out.toString("utf8").trim();
+}
+
+const isNullOid = (oid) => /^0+$/.test(oid);
+const oidEq = (a, b) => {
+  const aNull = isNullOid(a);
+  const bNull = isNullOid(b);
+  if (aNull || bNull) return aNull && bNull;
+  return a === b;
+};
+
+/** Parse `git {diff,log} --raw -z --no-abbrev` token streams. */
+function splitNul(buf) {
+  const tokens = [];
+  let start = 0;
+  for (let i = 0; i < buf.length; i++) {
+    if (buf[i] === 0) {
+      tokens.push(buf.subarray(start, i).toString("utf8"));
+      start = i + 1;
+    }
+  }
+  if (start < buf.length) tokens.push(buf.subarray(start).toString("utf8"));
+  return tokens;
+}
+
+function parseRawHeader(token) {
+  // ":<oldmode> <newmode> <oldoid> <newoid> <status>" (status has no score with --no-renames)
+  const parts = token.replace(/^\n/, "").slice(1).split(" ");
+  if (parts.length < 5) return null;
+  return {
+    oldMode: parts[0],
+    newMode: parts[1],
+    oldOid: parts[2],
+    newOid: parts[3],
+    status: parts[4].trim(),
+  };
+}
+
+/** git diff --raw between two commits -> [{status, oldOid, newOid, path}] */
+function diffRaw(repo, from, to) {
+  const buf = git(repo, [
+    "diff",
+    "--raw",
+    "-z",
+    "--no-abbrev",
+    "--no-renames",
+    from,
+    to,
+  ]);
+  const tokens = splitNul(buf);
+  const entries = [];
+  for (let i = 0; i + 1 < tokens.length; i += 2) {
+    const header = parseRawHeader(tokens[i]);
+    if (!header)
+      throw new Error(
+        `unparseable raw diff header: ${JSON.stringify(tokens[i])}`,
+      );
+    entries.push({ ...header, path: tokens[i + 1] });
+  }
+  return entries;
+}
+
+/**
+ * First-parent history walk of `tip` (bounded by `window` commits) restricted
+ * to `paths`. Returns Map(path -> [{sha, ct, oldOid, newOid}] newest-first).
+ */
+function historyWalk(repo, tip, window, paths) {
+  const byPath = new Map(paths.map((p) => [p, []]));
+  // Bound the walk: use tip~window..tip when that commit exists; otherwise
+  // (short or shallow history) walk everything available — `git log` stops at
+  // a shallow boundary on its own.
+  const boundary = gitText(
+    repo,
+    ["rev-parse", "--verify", "--quiet", `${tip}~${window}`],
+    {
+      allowFail: true,
+    },
+  );
+  const range = boundary ? `${tip}~${window}..${tip}` : tip;
+  for (let i = 0; i < paths.length; i += PATHSPEC_CHUNK) {
+    const chunk = paths.slice(i, i + PATHSPEC_CHUNK);
+    const buf = git(repo, [
+      "log",
+      "--first-parent",
+      "--no-abbrev",
+      "--no-renames",
+      "--raw",
+      "-z",
+      "--format=\u0001%H %ct",
+      range,
+      "--",
+      ...chunk.map((p) => `:(literal)${p}`),
+    ]);
+    let current = null;
+    const tokens = splitNul(buf);
+    for (let t = 0; t < tokens.length; t++) {
+      const token = tokens[t];
+      if (token.startsWith("\u0001")) {
+        // Token may be "\x01<sha> <ct>" possibly followed by "\n" remnants.
+        const [sha, ct] = token.slice(1).trim().split(" ");
+        current = { sha, ct: Number(ct) };
+        continue;
+      }
+      const header = parseRawHeader(token);
+      if (!header)
+        throw new Error(`unparseable raw log header: ${JSON.stringify(token)}`);
+      const path = tokens[t + 1];
+      t += 1;
+      if (!current) throw new Error("raw log entry before any commit header");
+      const list = byPath.get(path);
+      if (list) {
+        list.push({
+          sha: current.sha,
+          ct: current.ct,
+          oldOid: header.oldOid,
+          newOid: header.newOid,
+        });
+      }
+    }
+  }
+  return byPath;
+}
+
+function parseCommit(repo, sha) {
+  const raw = gitText(repo, ["cat-file", "commit", sha]);
+  const [headers, message = ""] = raw.split(/\n\n/, 2);
+  const committer = headers
+    .split("\n")
+    .find((line) => line.startsWith("committer "));
+  if (!committer) throw new Error(`commit ${sha} has no committer header`);
+  const match = committer.match(/ (\d+) ([+-]\d{4})$/);
+  if (!match) throw new Error(`commit ${sha} has invalid committer header`);
+  const subject = message.split("\n")[0] ?? "";
+  return {
+    sha,
+    ct: Number(match[1]),
+    date: formatGitIso(match[1], match[2]),
+    subject,
+  };
+}
+
+function formatGitIso(timestamp, tz) {
+  const offsetMinutes = Number(tz.slice(1, 3)) * 60 + Number(tz.slice(3, 5));
+  const signedOffsetMinutes = tz.startsWith("-")
+    ? -offsetMinutes
+    : offsetMinutes;
+  const localMs = Number(timestamp) * 1000 + signedOffsetMinutes * 60 * 1000;
+  return `${new Date(localMs).toISOString().replace(".000Z", "")}${tz.slice(0, 3)}:${tz.slice(3)}`;
+}
+
+function commitMeta(repo, sha) {
+  const parsed = parseCommit(repo, sha);
+  return { ...parsed, shortSha: parsed.sha.slice(0, 10) };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repo = args.repo;
+
+  const base = gitText(repo, [
+    "rev-parse",
+    "--verify",
+    `${args.base}^{commit}`,
+  ]);
+  const head = gitText(repo, [
+    "rev-parse",
+    "--verify",
+    `${args.head}^{commit}`,
+  ]);
+  const mergeBase = args.mergeBase
+    ? gitText(repo, ["rev-parse", "--verify", `${args.mergeBase}^{commit}`])
+    : gitText(repo, ["merge-base", base, head], { allowFail: true });
+  if (!mergeBase) {
+    // No merge-base in the fetched history: the branch point is beyond the
+    // fetch window — that alone is a (severe) staleness failure.
+    return report(args, {
+      base,
+      head,
+      mergeBase: null,
+      history: {
+        failed: true,
+        reason:
+          "no merge-base found in the available history, so content-level revert detection cannot run",
+      },
+      revertFindings: [],
+      deletionNotices: [],
+    });
+  }
+
+  // --- Silent-revert detection ---------------------------------------------
+  const prDiff = diffRaw(repo, mergeBase, head);
+  const candidates = prDiff.filter((e) => RAW_STATUS_CANDIDATES.has(e.status));
+  const history = historyWalk(
+    repo,
+    mergeBase,
+    args.window,
+    candidates.map((c) => c.path),
+  );
+  const revertFindings = [];
+  for (const entry of candidates) {
+    const changes = history.get(entry.path) ?? [];
+    if (changes.length === 0) continue; // last change predates the window
+    const cur = entry.oldOid; // blob at merge-base
+    const prBlob = entry.newOid; // blob at PR head (all-zero when deleted)
+    // olds[i] = the content the file had BEFORE changes[i] (newest-first).
+    const idx = changes.findIndex((c) => oidEq(c.oldOid, prBlob));
+    if (idx === -1) continue; // novel content — a normal edit
+    // Heal case: the target's current blob is itself a re-occurrence of
+    // content OLDER than what the PR restores (target sits on clobbered
+    // content; the PR moves the file forward again).
+    const heals = changes.slice(idx + 1).some((c) => oidEq(c.oldOid, cur));
+    if (heals) continue;
+    revertFindings.push({
+      path: entry.path,
+      status: entry.status,
+      prBlob: isNullOid(prBlob) ? null : prBlob,
+      discards: changes.slice(0, idx + 1).map((c) => commitMeta(repo, c.sha)),
+    });
+  }
+
+  // Deletions only block when a modification-revert corroborates the
+  // stale-tree signature; alone they are loud notices (see header comment).
+  const corroborated = revertFindings.some((f) => f.status !== "D");
+  const deletionNotices = corroborated
+    ? []
+    : revertFindings.filter((f) => f.status === "D");
+  const blockingFindings = corroborated ? revertFindings : [];
+
+  return report(args, {
+    base,
+    head,
+    mergeBase,
+    history: { failed: false, reason: null },
+    revertFindings: blockingFindings,
+    deletionNotices,
+  });
+}
+
+function report(args, result) {
+  const { history, revertFindings, deletionNotices } = result;
+  const failed = history.failed || revertFindings.length > 0;
+  const verdict = !failed ? "pass" : args.ack ? "acked" : "fail";
+  const out = { ...result, ack: args.ack, verdict };
+  if (args.json) writeFileSync(args.json, `${JSON.stringify(out, null, 2)}\n`);
+
+  const emit = (line) => process.stdout.write(`${line}\n`);
+  const annotate = (kind, msg) => {
+    if (args.github) emit(`::${kind}::${msg.replaceAll("\n", "%0A")}`);
+    else emit(`${kind.toUpperCase()}: ${msg}`);
+  };
+  const level = args.ack ? "warning" : "error";
+
+  emit(
+    `stale-base guard: base=${result.base?.slice(0, 10)} head=${result.head?.slice(0, 10)} merge-base=${result.mergeBase ? result.mergeBase.slice(0, 10) : "NONE"}`,
+  );
+
+  if (history.failed) {
+    annotate(
+      level,
+      `stale-base guard — HISTORY UNAVAILABLE: ${history.reason}. Fetch enough target and head history, then rerun the guard.`,
+    );
+  }
+  for (const f of revertFindings.slice(0, MAX_INLINE_ANNOTATIONS)) {
+    const newest = f.discards[0];
+    annotate(
+      level,
+      `stale-base guard — SILENT REVERT: this PR sets \`${f.path}\` back to a blob the target branch already moved past, discarding ${f.discards.length} merged change(s) — newest: ${newest.shortSha} "${newest.subject}" (${newest.date}). This is the #11271 failure mode (stale checkout committed over merged work). Rebase/restore the file, or apply the \`stale-base-ack\` label if the revert is deliberate.`,
+    );
+  }
+  if (revertFindings.length > MAX_INLINE_ANNOTATIONS) {
+    annotate(
+      level,
+      `stale-base guard: ${revertFindings.length - MAX_INLINE_ANNOTATIONS} more silent-revert findings — see the step summary.`,
+    );
+  }
+  for (const f of deletionNotices.slice(0, MAX_INLINE_ANNOTATIONS)) {
+    annotate(
+      "notice",
+      `stale-base guard: this PR deletes \`${f.path}\`, which the target branch added/changed recently (${f.discards[0].shortSha} "${f.discards[0].subject}"). Not blocking — no stale-tree corroboration — but confirm the deletion is intended.`,
+    );
+  }
+  if (verdict === "acked") {
+    annotate(
+      "warning",
+      "stale-base guard: failures OVERRIDDEN by the `stale-base-ack` label. Merged work MAY be silently discarded — a human has asserted the reverts above are deliberate.",
+    );
+  }
+  if (verdict === "pass")
+    emit("stale-base guard: PASS — no content-level silent reverts.");
+
+  if (args.summary) {
+    const lines = [
+      "## Stale-base guard",
+      "",
+      `Verdict: **${verdict.toUpperCase()}**`,
+      "",
+      `- base: \`${result.base}\``,
+      `- head: \`${result.head}\``,
+      `- merge-base: \`${result.mergeBase ?? "none found"}\``,
+      "",
+    ];
+    if (history.failed)
+      lines.push(`⛔ **History unavailable**: ${history.reason}`, "");
+    if (revertFindings.length > 0) {
+      lines.push(
+        `⛔ **Silent reverts** (${revertFindings.length} file(s) set back to pre-merge blobs):`,
+        "",
+        "| File | Discarded merged change(s) |",
+        "| --- | --- |",
+      );
+      for (const f of revertFindings) {
+        const discards = f.discards
+          .map((d) => `${d.shortSha} ${d.subject.replaceAll("|", "\\|")}`)
+          .join("<br>");
+        lines.push(`| \`${f.path}\` | ${discards} |`);
+      }
+      lines.push("");
+    }
+    if (deletionNotices.length > 0) {
+      lines.push(
+        `ℹ️ Non-blocking: deletes recently-added file(s) — confirm intended: ${deletionNotices.map((f) => `\`${f.path}\``).join(", ")}`,
+        "",
+      );
+    }
+    if (verdict === "acked") {
+      lines.push(
+        "⚠️ Overridden by the `stale-base-ack` label — reverts asserted deliberate.",
+        "",
+      );
+    }
+    appendFileSync(args.summary, `${lines.join("\n")}\n`);
+  }
+
+  process.exitCode = verdict === "fail" ? 1 : 0;
+}
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(
+    `stale-base-guard: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exitCode = 2;
+}

--- a/packages/scripts/stale-base-guard.self-test.mjs
+++ b/packages/scripts/stale-base-guard.self-test.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * Self-test for stale-base-guard.mjs (#11376). Builds throwaway fixture repos
+ * in a temp dir and asserts the guard's verdicts on every behavior class:
+ * clean edits, the #11271 stale-tree clobber shape, heal/re-land PRs,
+ * deletion-only PRs, additions, window bounding, unavailable history, and the
+ * `stale-base-ack` override. Runs in CI before the guard itself.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(
+  new URL("./stale-base-guard.mjs", import.meta.url),
+);
+const roots = [];
+let hourCounter = 0;
+
+function sh(cwd, cmd, args, env = {}) {
+  const res = spawnSync(cmd, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+  if (res.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed in ${cwd}: ${res.stderr || res.stdout}`,
+    );
+  }
+  return res.stdout.trim();
+}
+
+function git(dir, args, env) {
+  return sh(dir, "git", args, env);
+}
+
+function mkRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "stale-base-guard-fixture-"));
+  roots.push(dir);
+  git(dir, ["init", "-q", "-b", "develop"]);
+  git(dir, ["config", "user.email", "guard-selftest@example.invalid"]);
+  git(dir, ["config", "user.name", "stale-base-guard self-test"]);
+  return dir;
+}
+
+/** Commit file writes (string) and deletions (null), with a deterministic clock. */
+function commit(dir, files, message, { hoursFromEpoch } = {}) {
+  for (const [path, content] of Object.entries(files)) {
+    if (content === null) {
+      git(dir, ["rm", "-q", path]);
+    } else {
+      sh(dir, "node", [
+        "-e",
+        "require('fs').writeFileSync(process.argv[1], process.argv[2])",
+        path,
+        content,
+      ]);
+      git(dir, ["add", path]);
+    }
+  }
+  hourCounter = hoursFromEpoch ?? hourCounter + 1;
+  const date = new Date(Date.UTC(2026, 0, 1, hourCounter)).toISOString();
+  git(dir, ["commit", "-q", "--allow-empty", "-m", message], {
+    GIT_AUTHOR_DATE: date,
+    GIT_COMMITTER_DATE: date,
+  });
+  return git(dir, ["rev-parse", "HEAD"]);
+}
+
+function runGuard(dir, { base, head, extra = [] }) {
+  const json = join(dir, "guard-result.json");
+  const res = spawnSync(
+    process.execPath,
+    [
+      script,
+      "--repo",
+      dir,
+      "--base",
+      base,
+      "--head",
+      head,
+      "--json",
+      json,
+      ...extra,
+    ],
+    { encoding: "utf8" },
+  );
+  if (res.status === 2 || res.error) {
+    throw new Error(`guard errored: ${res.stderr || res.stdout}`);
+  }
+  return { status: res.status, result: JSON.parse(readFileSync(json, "utf8")) };
+}
+
+const findingPaths = (result) =>
+  result.revertFindings.map((f) => f.path).sort();
+const noticePaths = (result) =>
+  result.deletionNotices.map((f) => f.path).sort();
+
+/**
+ * The shared fixture mirrors the #11271 shape:
+ *   c0: a,b,d,new-era files at v0
+ *   c1: a -> alpha-1
+ *   c2: b -> beta-1, adds new.txt
+ *   c3: a -> alpha-2            <- develop tip (fresh base for the PR)
+ */
+function baseFixture() {
+  const dir = mkRepo();
+  const c0 = commit(
+    dir,
+    { "a.txt": "alpha-0", "b.txt": "beta-0", "d.txt": "delta-0" },
+    "c0",
+  );
+  const c1 = commit(dir, { "a.txt": "alpha-1" }, "c1");
+  const c2 = commit(dir, { "b.txt": "beta-1", "new.txt": "nu-0" }, "c2");
+  const c3 = commit(dir, { "a.txt": "alpha-2" }, "c3");
+  return { dir, c0, c1, c2, c3 };
+}
+
+function branchFrom(dir, name, start) {
+  git(dir, ["checkout", "-q", "-b", name, start]);
+}
+
+// --- 1. Clean edit on a fresh base passes -----------------------------------
+{
+  const { dir, c3 } = baseFixture();
+  branchFrom(dir, "pr", c3);
+  commit(dir, { "a.txt": "alpha-3-novel" }, "pr: novel edit");
+  const { status, result } = runGuard(dir, { base: c3, head: "pr" });
+  assert.equal(status, 0, "clean edit must pass");
+  assert.equal(result.verdict, "pass");
+  assert.equal(result.history.failed, false);
+  console.log("ok 1 - clean edit on fresh base passes");
+}
+
+// --- 2. Stale-tree clobber on a fresh base fails (the #11271 shape) ---------
+{
+  const { dir, c3 } = baseFixture();
+  branchFrom(dir, "pr", c3);
+  commit(
+    dir,
+    {
+      "a.txt": "alpha-1", // byte-identical revert past c3
+      "b.txt": "beta-0", // byte-identical revert past c2
+      "new.txt": null, // deletes the file c2 added
+      "c-new.txt": "gamma-0", // addition — never flagged
+      "d.txt": "delta-1", // novel edit — never flagged
+    },
+    "pr: stale checkout committed over merged work",
+  );
+  const { status, result } = runGuard(dir, { base: c3, head: "pr" });
+  assert.equal(status, 1, "stale-tree clobber must fail");
+  assert.equal(result.verdict, "fail");
+  assert.equal(result.history.failed, false);
+  assert.deepEqual(findingPaths(result), ["a.txt", "b.txt", "new.txt"]);
+  const byPath = Object.fromEntries(
+    result.revertFindings.map((f) => [f.path, f]),
+  );
+  assert.equal(byPath["a.txt"].discards[0].subject, "c3");
+  assert.equal(byPath["b.txt"].discards[0].subject, "c2");
+  assert.equal(byPath["new.txt"].discards[0].subject, "c2");
+  // With --ack the same PR is loudly allowed.
+  const acked = runGuard(dir, { base: c3, head: "pr", extra: ["--ack"] });
+  assert.equal(acked.status, 0, "stale-base-ack must override");
+  assert.equal(acked.result.verdict, "acked");
+  console.log(
+    "ok 2 - stale-tree clobber fails; stale-base-ack overrides loudly",
+  );
+}
+
+// --- 3. Heal PR (re-land clobbered work) passes ------------------------------
+{
+  const { dir } = baseFixture();
+  const c4 = commit(
+    dir,
+    { "a.txt": "alpha-1" },
+    "c4: clobber lands on develop",
+  );
+  branchFrom(dir, "pr", c4);
+  commit(dir, { "a.txt": "alpha-2" }, "pr: re-land the clobbered work");
+  const { status, result } = runGuard(dir, { base: c4, head: "pr" });
+  assert.equal(
+    status,
+    0,
+    `heal PR must pass: ${JSON.stringify(result.revertFindings)}`,
+  );
+  assert.equal(result.verdict, "pass");
+  console.log("ok 3 - heal PR (restore past a clobber) passes");
+}
+
+// --- 4. Deletion-only PR: non-blocking notice --------------------------------
+{
+  const { dir, c3 } = baseFixture();
+  branchFrom(dir, "pr", c3);
+  commit(
+    dir,
+    { "new.txt": null, "d.txt": "delta-rework" },
+    "pr: deliberate rework deletes young file",
+  );
+  const { status, result } = runGuard(dir, { base: c3, head: "pr" });
+  assert.equal(status, 0, "deletion-only PR must not block");
+  assert.equal(result.verdict, "pass");
+  assert.deepEqual(findingPaths(result), []);
+  assert.deepEqual(noticePaths(result), ["new.txt"]);
+  console.log("ok 4 - deletion-only PR passes with a notice");
+}
+
+// --- 5. Re-adding a previously deleted file passes (additions skipped) -------
+{
+  const dir = mkRepo();
+  commit(dir, { "z.txt": "zeta-0" }, "add z");
+  const tip = commit(dir, { "z.txt": null }, "delete z");
+  branchFrom(dir, "pr", tip);
+  commit(dir, { "z.txt": "zeta-0" }, "pr: resurrect z byte-identically");
+  const { status, result } = runGuard(dir, { base: tip, head: "pr" });
+  assert.equal(status, 0, "re-add must pass");
+  assert.equal(result.verdict, "pass");
+  console.log("ok 5 - byte-identical re-add of a deleted file passes");
+}
+
+// --- 6. Window bounds the history walk ---------------------------------------
+{
+  const { dir, c3 } = baseFixture();
+  branchFrom(dir, "pr", c3);
+  commit(
+    dir,
+    { "a.txt": "alpha-1", "b.txt": "beta-0" },
+    "pr: stale content, but window only sees c3",
+  );
+  const { status, result } = runGuard(dir, {
+    base: c3,
+    head: "pr",
+    extra: ["--window", "1"],
+  });
+  // c3 (a.txt) is inside the 1-commit window; c2 (b.txt) is outside it.
+  assert.equal(status, 1);
+  assert.deepEqual(findingPaths(result), ["a.txt"]);
+  console.log("ok 6 - --window bounds how far back reverts are detected");
+}
+
+// --- 7. No merge-base fails closed because content cannot be checked ----------
+{
+  const { dir, c3 } = baseFixture();
+  git(dir, ["checkout", "-q", "--orphan", "pr"]);
+  commit(dir, { "o.txt": "orphan" }, "unrelated history");
+  const { status, result } = runGuard(dir, { base: c3, head: "pr" });
+  assert.equal(status, 1, "missing merge-base must fail");
+  assert.equal(result.history.failed, true);
+  assert.match(result.history.reason, /no merge-base/);
+  const acked = runGuard(dir, { base: c3, head: "pr", extra: ["--ack"] });
+  assert.equal(acked.status, 0);
+  console.log("ok 7 - missing merge-base fails closed; ack overrides");
+}
+
+for (const dir of roots) rmSync(dir, { recursive: true, force: true });
+console.log("stale-base-guard self-test: 7/7 passed");


### PR DESCRIPTION
Closes #17457

## Summary
- restore the read-only, base-trusted Develop PR aggregate with exact-head and owning-workflow identity checks plus missing/skipped/cancelled/timeout/spoof canaries
- restore content-based silent-revert detection and `stale-base-ack` without the disputed numeric age heuristic
- parse merge-critical workflows as YAML and run checksum-pinned actionlint/zizmor while enforcing unconditional lint, format, typecheck, gitleaks, Linux script tests, and final dependency edges
- build a host-compatible llama.cpp binary from the exact gitlink, pin and hash the smoke model, require positive backend-valid variants, compare same-run medians, and attest all bytes
- add adversarial Bun process-isolation coverage and an unconditional Linux `test:scripts` lane

## Validation
- base: `ba3f094640a810ab5b75b20b3bb38a7007cd72a7`
- head: `025690af892785c864005c80b0e8cbbb163b286f`
- aggregate self-test: pass, including transient API retries and terminal-state canaries
- stale-base self-test: 7/7 pass
- focused Bun tests: 10 pass, 0 fail
- `bun run test:scripts`: 1265 pass, 9 documented environment-gated skips, 0 fail, 24583 assertions
- actionlint 1.7.12: pass on all merge-critical workflows
- zizmor 1.28.0 offline: no findings (one documented dangerous-trigger ignore and one suppression)
- `bun run lint`: 235/235 tasks
- `bun run build`: 176/176 tasks; view bundle guard 27/27
- `bun run typecheck`: 344/344 tasks

## Native inference evidence
Built source `32b78e44bf54906329cdf85de0e7fca04bb91b11` as Darwin arm64 Metal and executed the pinned SmolLM2 GGUF. Model SHA-256: `2fa3f013dcdd7b99f9b237717fa0b12d75bbb89984cc1274be1471a465bac9c2`. Executable: 25,735,280 bytes, SHA-256 `12c962ee055fbeac05c865c3d2e8bf2ea355c5e31ec6b693d8634ff2331ea6e7`. Report SHA-256: `d2d7cb4f3592f59305decc7cbf1b7305bf57f9d6c04dab931896daf096b3ba3b`. Three-run medians were 347.529 tok/s baseline and 297.950 tok/s without flash attention, ratio 0.857 against the Metal floor 0.600.

Metal intentionally uses the stock-KV no-flash-attention comparison because the repository backend decision record documents TBQ KV as unsupported on Metal; CPU/CUDA remain required to execute baseline plus TurboQuant.

## Evidence applicability
- UI screenshots/video: N/A - workflow and script-only change
- frontend/backend application logs: N/A - no application runtime path changed
- real model path: covered by the native host build, exact-model inference runs, performance report, and cryptographic attestation above
- domain artifacts: attestation binds workflow/source, host/backend, executable, model, report, positive variant count, and all SHA-256 identities

<!-- evidence-row:before-screenshots -->
- [ ] N/A - workflow and script-only change; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - workflow and script-only change; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow changed

<!-- evidence-row:backend-logs -->
- [x] [17474-2026-07-31T19-00-25-133Z-metal.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-3/17474-2026-07-31T19-00-25-133Z-metal.json)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - native inference benchmark does not enter the agent planner or trajectory pipeline

<!-- evidence-row:domain-artifacts -->
- [x] [17474-attestation.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-3/17474-attestation.json)

### Fresh-runner parser follow-up

The workflow-invariants parser is pinned to `yaml@2.9.0` in runner temp and resolved with `createRequire`, because the changes job intentionally runs without a workspace install and bare ESM imports do not consult `NODE_PATH`. Verified independently with an isolated temp install and no workspace resolution.

Post-rebase validation: workflow invariant tests 10/10, local-inference/script-isolation tests 4/4, Develop PR aggregate self-test, stale-base guard 7/7, Biome, and diff hygiene all passed.