### PR TITLE
feat(cloud): add the jobs.execution_interruptions column

### DIFF
--- a/packages/cloud/shared/src/db/migrations/0185_job_execution_interruptions.sql
+++ b/packages/cloud/shared/src/db/migrations/0185_job_execution_interruptions.sql
@@ -1,0 +1,21 @@
+-- A worker restart is an infrastructure event, not a job failure, so it must
+-- not spend the job's `attempts` budget. This column is where recovery counts
+-- restarts instead. It lives on the row rather than in the job payload because
+-- an offloaded payload cannot be read back by the recovery transaction, which
+-- left exactly the large jobs most likely to kill a worker unbounded (#17258).
+--
+-- `integer NOT NULL DEFAULT 0` is metadata-only on PG11+, so this is safe on a
+-- hot table. NOT NULL rather than nullable because the code that predates this
+-- column writes rows without it and must land on 0. No CHECK constraint: ADD
+-- CONSTRAINT full-scans under ACCESS EXCLUSIVE, and non-negativity is
+-- structural — the only writer is `+ 1`.
+--
+-- Nothing outside this file ships with the migration, not even the Drizzle
+-- schema entry. `deploy-eliza-provisioning-worker.yml` restarts the daemon on
+-- the same paths as `cloud-cf-deploy.yml` but WITHOUT `needs: migrate-db`, and
+-- Drizzle enumerates columns in every generated SELECT — so a schema entry
+-- landing here would make every typed read of `jobs` fail with 42703 against a
+-- database this migration has not reached yet. The column enters the schema
+-- with its reader, once this has deployed everywhere.
+ALTER TABLE "jobs"
+  ADD COLUMN IF NOT EXISTS "execution_interruptions" integer DEFAULT 0 NOT NULL;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1289,6 +1289,13 @@
       "when": 1785297600000,
       "tag": "0184_job_execution_leases",
       "breakpoints": true
+    },
+    {
+      "idx": 184,
+      "version": "7",
+      "when": 1785384000000,
+      "tag": "0185_job_execution_interruptions",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## What — #17473, step 1 of 2

The column, and nothing else. No Drizzle schema entry, no reader, no increment.

Worker restarts spend a job's execution-attempt budget today, which is the wrong accounting: `attempts` measures how many times the *job* was tried, and a restart is an infrastructure event the job did not cause. #17258 tried to hold that count in the job payload and was closed for it — an offloaded payload cannot be read back inside the recovery transaction, so the large jobs most likely to pressure a worker were exactly the ones left unbounded. It needs a database-owned column.

## Why the schema entry is not in this PR

`deploy-eliza-provisioning-worker.yml` restarts the provisioning daemon on the same paths as `cloud-cf-deploy.yml`, but **without** `needs: migrate-db`. Drizzle enumerates columns in every `SELECT` it generates, so a schema entry landing here would make every typed read of `jobs` fail with `42703` against a database this migration has not reached yet — recovery included, and both recovery loops rethrow when a whole batch fails.

I checked this rather than assuming it: removing the column from a test's hand-rolled `jobs` DDL while the schema entry is present produces exactly `column "execution_interruptions" of relation "jobs" does not exist / code: 42703` on ordinary reads. The column enters the schema together with its reader, once this has deployed everywhere.

## Shape

`ADD COLUMN … integer NOT NULL DEFAULT 0` is metadata-only on PG11+, so it is safe on a hot table. `NOT NULL` rather than nullable because the code that predates the column writes rows without it and must land on 0, not NULL. No `CHECK` constraint: `ADD CONSTRAINT` full-scans under `ACCESS EXCLUSIVE`, and non-negativity is structural — the only writer will be `+ 1`.

Hand-written SQL plus a journal entry, per this package's journal-based migrator (`drizzle-kit generate` is not used here).

## Tests

`drizzle-kit check` — `Everything's fine`. `migration-journal-registration.test.ts` — `3 pass / 0 fail`.

Refs #17473 [stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - migration only, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - migration only, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - migration only, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - migration only, no UI surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involved in this path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the migration IS the artifact; the column is unread until step 2

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence to OCR

<!-- evidence-row:backend-logs -->
- [x] [17473-1-migration-gates.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-3/17473-1-migration-gates.log)
