### PR TITLE
fix: enforce the single-voice delivery contract across the action surface (149 sites)

### DIFF
--- a/packages/agent/src/actions/contact.ts
+++ b/packages/agent/src/actions/contact.ts
@@ -1059,9 +1059,15 @@ async function handleUpdateContactInfo(
     });
   }
 
+  // The update confirmation is the complete answer to a single-operation
+  // turn: verified + turnComplete make the callback the sole delivery instead
+  // of double-messaging with the evaluator.
   return {
     success: true,
     text: responseText,
+    userFacingText: responseText,
+    verifiedUserFacing: true,
+    turnComplete: true,
     values: {
       contactId: contact.entityId,
       updatedFieldsStr: Object.keys(updateData).join(","),
@@ -1125,15 +1131,18 @@ async function handleUpdateComponent(
       createdAt: existing.createdAt,
     });
 
+    const updatedText = `I've updated the ${componentType} information for ${entityName}.`;
     if (callback) {
-      await callback({
-        text: `I've updated the ${componentType} information for ${entityName}.`,
-        action: CONTACT_ACTION,
-      });
+      await callback({ text: updatedText, action: CONTACT_ACTION });
     }
+    // Same single-delivery contract as handleUpdate: the confirmation is the
+    // complete answer to the turn.
     return {
       success: true,
-      text: `Updated ${componentType} information for ${entityName}.`,
+      text: updatedText,
+      userFacingText: updatedText,
+      verifiedUserFacing: true,
+      turnComplete: true,
       values: {
         success: true,
         entityId,
@@ -1167,15 +1176,16 @@ async function handleUpdateComponent(
     createdAt: Date.now(),
   });
 
+  const addedText = `I've added new ${componentType} information for ${entityName}.`;
   if (callback) {
-    await callback({
-      text: `I've added new ${componentType} information for ${entityName}.`,
-      action: CONTACT_ACTION,
-    });
+    await callback({ text: addedText, action: CONTACT_ACTION });
   }
   return {
     success: true,
-    text: `Added new ${componentType} information for ${entityName}.`,
+    text: addedText,
+    userFacingText: addedText,
+    verifiedUserFacing: true,
+    turnComplete: true,
     values: {
       success: true,
       entityId,
@@ -1222,13 +1232,13 @@ async function handleDelete(
     callback,
   });
   if (decision.status !== "confirmed") {
+    // requireConfirmation already fired the confirm prompt on the pending
+    // path — a second callback here showed the user the identical prompt
+    // twice. Pending/cancel detail stays planner-facing.
     const text =
       decision.status === "pending"
-        ? `${confirmPrompt} Reply yes to confirm or no to cancel.`
-        : "Contact delete cancelled.";
-    if (callback) {
-      await callback({ text, action: CONTACT_ACTION });
-    }
+        ? `Asked the user to confirm removing ${deleteTarget}; wait for their yes/no reply.`
+        : "The user cancelled the contact deletion; nothing was removed.";
     return {
       success: decision.status === "pending",
       text,
@@ -1271,15 +1281,18 @@ async function handleDelete(
         "delete",
       );
     }
+    const removedText = `I've removed ${contactName} from your contacts.`;
     if (callback) {
-      await callback({
-        text: `I've removed ${contactName} from your contacts.`,
-        action: CONTACT_ACTION,
-      });
+      await callback({ text: removedText, action: CONTACT_ACTION });
     }
+    // The removal confirmation is the complete answer to a single-operation
+    // turn: verified + turnComplete make the callback the sole delivery.
     return {
       success: true,
-      text: `Removed contact ${contactName}.`,
+      text: removedText,
+      userFacingText: removedText,
+      verifiedUserFacing: true,
+      turnComplete: true,
       values: { contactId: contact.entityId },
       data: {
         actionName: CONTACT_ACTION,

--- a/packages/agent/src/actions/logs.ts
+++ b/packages/agent/src/actions/logs.ts
@@ -191,29 +191,21 @@ function setLogLevel(
   const requested =
     typeof params.level === "string" ? params.level.toLowerCase() : "";
   if (!LOG_LEVELS.includes(requested as LogLevel)) {
-    if (callback) {
-      callback({
-        text: `Please specify a valid log level: ${LOG_LEVELS.join(", ")}.`,
-        action: "LOGS_SET_LEVEL_FAILED",
-      });
-    }
-    return failure("Invalid log level.", "LOGS_SET_LEVEL_FAILED", {
-      validLevels: [...LOG_LEVELS],
-    });
+    // Planner-facing only: the canned level list read as tool-speak in chat
+    // next to the evaluator's in-voice reply. The evaluator owns asking.
+    return failure(
+      `No valid log level in the request; ask the user for one of: ${LOG_LEVELS.join(", ")}.`,
+      "LOGS_SET_LEVEL_FAILED",
+      { validLevels: [...LOG_LEVELS] },
+    );
   }
   const level = requested as LogLevel;
   const targetRoomId = params.roomId ?? message.roomId;
 
   const overrides = (runtime as RuntimeWithOverrides).logLevelOverrides;
   if (!overrides) {
-    if (callback) {
-      callback({
-        text: "Dynamic log levels are not supported by this runtime version.",
-        action: "LOGS_SET_LEVEL_FAILED",
-      });
-    }
     return failure(
-      "Dynamic log levels are not supported by this runtime version.",
+      "Dynamic log levels are not supported by this runtime version; tell the user log-level changes are unavailable here.",
       "LOGS_SET_LEVEL_FAILED",
     );
   }
@@ -226,15 +218,22 @@ function setLogLevel(
   }
   elizaLogger.info(`[LOGS] level set to ${level} for room ${targetRoomId}`);
 
+  const changedText = `Log level changed to **${level.toUpperCase()}** for this room.`;
   if (callback) {
     callback({
-      text: `Log level changed to **${level.toUpperCase()}** for this room.`,
+      text: changedText,
       action: "LOGS_SET_LEVEL",
     });
   }
+  // The confirmation is the complete answer to a single-operation turn:
+  // verified + turnComplete make the callback the sole delivery instead of
+  // double-messaging with the evaluator.
   return {
     success: true,
-    text: `Log level changed to ${level.toUpperCase()} for this room.`,
+    text: changedText,
+    userFacingText: changedText,
+    verifiedUserFacing: true,
+    turnComplete: true,
     values: { level },
     data: { actionName: "LOGS", op: "set_level", level, roomId: targetRoomId },
   };
@@ -284,12 +283,7 @@ export const logsAction: Action = {
         | undefined) ?? {};
     const op = params.action ?? params.subaction ?? params.op;
     if (!op || !LOGS_OPS.includes(op)) {
-      if (callback) {
-        callback({
-          text: `Unknown LOGS action. Use one of: ${LOGS_OPS.join(", ")}.`,
-          action: "LOGS_INVALID",
-        });
-      }
+      // Planner-facing only: internal op names are tool-speak, not chat.
       return failure(`Unknown LOGS op: ${String(op)}`, "LOGS_INVALID", {
         validOps: [...LOGS_OPS],
       });

--- a/packages/core/src/features/advanced-capabilities/actions/role.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/role.ts
@@ -430,13 +430,13 @@ async function applyAssignments(args: {
 	const { runtime, message, assignments, op, callback } = args;
 
 	const resolved = await resolveWorldForMessage(runtime, message);
+	// Planner-facing only: the canned "no world context" boilerplate shipped
+	// visibly next to the evaluator's own error reply. The evaluator owns
+	// phrasing the failure to the user, in voice.
 	if (!resolved) {
-		await callback?.({
-			text: "Cannot manage roles — no world context for this room.",
-		});
 		return {
 			success: false,
-			text: "World not found",
+			text: "Cannot manage roles — no world context for this room; tell the user roles are unavailable here.",
 			error: "WORLD_NOT_FOUND",
 			data: { actionName: "ROLE", op },
 		};
@@ -444,12 +444,9 @@ async function applyAssignments(args: {
 
 	const { world, metadata } = resolved;
 	if (!world) {
-		await callback?.({
-			text: "Cannot manage roles — no world context for this room.",
-		});
 		return {
 			success: false,
-			text: "World not found",
+			text: "Cannot manage roles — no world context for this room; tell the user roles are unavailable here.",
 			error: "WORLD_NOT_FOUND",
 			data: { actionName: "ROLE", op },
 		};
@@ -469,12 +466,9 @@ async function applyAssignments(args: {
 	// gate and contradicted the declaration. Per-assignment `canModifyRole` below
 	// still bounds which target roles an OWNER may set.
 	if (requesterRole !== "OWNER") {
-		await callback?.({
-			text: "Only OWNERs can manage roles.",
-		});
 		return {
 			success: false,
-			text: "Insufficient permissions",
+			text: "Only OWNERs can manage roles; tell the user they lack permission.",
 			error: "INSUFFICIENT_PERMISSIONS",
 			data: { actionName: "ROLE", op, requesterRole },
 		};
@@ -546,20 +540,21 @@ async function applyAssignments(args: {
 		);
 	}
 
-	const summary =
-		op === "revoke"
-			? `Revoked ${successes.length} role(s)`
-			: `Updated ${successes.length} role(s)`;
+	const summary = `${op === "revoke" ? "Revoked" : "Updated"} ${successes.length} role${successes.length === 1 ? "" : "s"}${failures.length > 0 ? `; ${failures.length} failed` : ""}.`;
 
-	await callback?.({
-		text:
-			failures.length > 0 ? `${summary}; ${failures.length} failed.` : summary,
-		actions: ["ROLE"],
-	});
+	await callback?.({ text: summary, actions: ["ROLE"] });
 
+	// The role-change confirmation is the complete answer to a
+	// single-operation turn: verified + turnComplete make the callback the
+	// sole delivery instead of double-messaging with the evaluator (the gate
+	// still requires success, so the all-failed case falls back to the
+	// evaluator's in-voice reply).
 	return {
 		success: successes.length > 0,
 		text: summary,
+		userFacingText: summary,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			successCount: successes.length,
 			failureCount: failures.length,
@@ -581,25 +576,39 @@ async function handleList(args: {
 }): Promise<ActionResult> {
 	const { runtime, message, callback } = args;
 	const resolved = await resolveWorldForMessage(runtime, message);
+	// Planner-facing only: "No world context found." is internal-state
+	// tool-speak; the evaluator owns phrasing the failure to the user.
 	if (!resolved) {
-		await callback?.({ text: "No world context found." });
 		return {
 			success: false,
-			text: "World not found",
+			text: "No world context found for this room; tell the user roles are unavailable here.",
 			error: "WORLD_NOT_FOUND",
 			data: { actionName: "ROLE", op: "list" },
 		};
 	}
 	const roles = resolved.metadata.roles ?? {};
 	const entries = Object.entries(roles);
-	const text =
-		entries.length === 0
-			? "No role assignments."
-			: entries.map(([entityId, role]) => `${entityId}: ${role}`).join("\n");
+	// Resolve display names so chat sees "Pat: ADMIN", not a raw UUID dump;
+	// unresolvable entities fall back to the id.
+	const lines = await Promise.all(
+		entries.map(async ([entityId, role]) => {
+			const entity =
+				typeof runtime.getEntityById === "function"
+					? await runtime.getEntityById(entityId as UUID)
+					: null;
+			return `${entity?.names?.[0] ?? entityId}: ${role}`;
+		}),
+	);
+	const text = entries.length === 0 ? "No role assignments." : lines.join("\n");
 	await callback?.({ text, actions: ["ROLE"] });
+	// The roles list is the complete answer to a single-operation turn:
+	// verified + turnComplete make the callback the sole delivery.
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: { roleCount: entries.length },
 		data: {
 			actionName: "ROLE",
@@ -734,9 +743,12 @@ export const roleAction: Action = {
 		});
 
 		if (assignments.length === 0) {
+			// Planner-facing only: extraction-error boilerplate ("User X not
+			// found.") shipped visibly next to the evaluator's reply. The
+			// evaluator owns asking the user, in voice.
 			const reason =
-				errors[0] ?? "No valid role assignments derived from the request.";
-			await callback?.({ text: reason });
+				errors[0] ??
+				"No valid role assignments derived from the request; ask the user who to change and to what role.";
 			return {
 				success: false,
 				text: reason,

--- a/packages/core/src/features/advanced-capabilities/personality/actions/character.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/character.ts
@@ -246,8 +246,9 @@ export const characterAction: Action = {
 		const rawOp = params.action ?? params.subaction ?? params.op;
 		const op = isCharacterOp(rawOp) ? rawOp : null;
 		if (!op) {
+			// Planner-facing only: a missing op is a planner error, not something
+			// the chat user should see as raw tool-speak.
 			const text = `CHARACTER requires an action: ${CHARACTER_OPS.join(", ")}.`;
-			await callback?.({ text, thought: "Missing or invalid action" });
 			return {
 				text,
 				success: false,
@@ -369,7 +370,6 @@ async function runUpdateIdentity(
 	if (!name && !systemPrompt) {
 		const text =
 			"Either `name` or `system` must be provided to update_identity.";
-		await callback?.({ text, thought: "Missing parameters" });
 		return {
 			text,
 			success: false,
@@ -390,8 +390,8 @@ async function runUpdateIdentity(
 	if (!persistence) {
 		if (name) character.name = previousName;
 		if (systemPrompt) character.system = previousSystem;
-		const text = "Character persistence service is not available.";
-		await callback?.({ text, thought: "Persistence service unavailable" });
+		const text =
+			"Character persistence service is not available; tell the user the identity change can't be saved right now.";
 		return {
 			text,
 			success: false,
@@ -408,8 +408,7 @@ async function runUpdateIdentity(
 	if (!result.success) {
 		if (name) character.name = previousName;
 		if (systemPrompt) character.system = previousSystem;
-		const text = `Failed to persist identity: ${result.error ?? "unknown error"}`;
-		await callback?.({ text, thought: "Persistence failed" });
+		const text = `Failed to persist identity: ${result.error ?? "unknown error"}; tell the user the change didn't save.`;
 		return {
 			text,
 			success: false,
@@ -434,8 +433,14 @@ async function runUpdateIdentity(
 		thought: "Identity updated",
 		actions: ["CHARACTER"],
 	});
+	// The confirmation is the complete answer to a single-operation turn:
+	// verified + turnComplete make the callback the sole delivery instead of
+	// double-messaging with the evaluator.
 	return {
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		success: true,
 		values: { updated },
 		data: { action: "CHARACTER", op: "update_identity", updated },
@@ -480,7 +485,6 @@ async function runPersist(
 
 	if (Object.keys(patch).length === 0) {
 		const text = "No character fields to persist.";
-		await callback?.({ text, thought: "Empty patch" });
 		return {
 			text,
 			success: true,
@@ -491,8 +495,7 @@ async function runPersist(
 
 	const result = await persistCharacterPatch(runtime, patch);
 	if (!result.success) {
-		const text = `I couldn't persist the character: ${result.error ?? "unknown error"}`;
-		await callback?.({ text, thought: "Persistence failed" });
+		const text = `Failed to persist the character: ${result.error ?? "unknown error"}; tell the user the save didn't go through.`;
 		return {
 			text,
 			success: false,
@@ -510,6 +513,9 @@ async function runPersist(
 	});
 	return {
 		text: summary,
+		userFacingText: summary,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		success: true,
 		values: { fieldsPersisted: persistedFields, count: persistedFields.length },
 		data: {
@@ -666,11 +672,8 @@ async function runModify(
 					"Applying selective modifications after safety filtering",
 				);
 			} else {
-				await callback?.({
-					text: responseText,
-					thought: `Rejected modification: ${safety.concerns.join(", ")}`,
-					actions: [],
-				});
+				// Planner-facing only: the safety-eval prose (concerns + reasoning)
+				// stays in the result for the evaluator to voice, not dumped in chat.
 				logger.warn(
 					{
 						messageText: messageText.substring(0, 100),
@@ -700,8 +703,7 @@ async function runModify(
 
 		const validation = fileManager.validateModification(modification);
 		if (!validation.valid) {
-			const text = `I can't make those changes because: ${validation.errors.join(", ")}`;
-			await callback?.({ text, thought: "Validation failed" });
+			const text = `The requested changes failed validation: ${validation.errors.join(", ")}; tell the user which parts can't be applied.`;
 			return {
 				text,
 				values: {
@@ -722,8 +724,7 @@ async function runModify(
 		const result = await fileManager.applyModification(modification);
 
 		if (!result.success) {
-			const text = `I couldn't update my character: ${result.error}`;
-			await callback?.({ text, thought: "File modification failed" });
+			const text = `Character update failed: ${result.error}; tell the user the change didn't apply.`;
 			return {
 				text,
 				values: { success: false, error: result.error },
@@ -738,8 +739,9 @@ async function runModify(
 		}
 
 		const summary = summarizeModification(modification);
+		const successText = `I've successfully updated my character. ${summary}`;
 		await callback?.({
-			text: `I've successfully updated my character. ${summary}`,
+			text: successText,
 			thought: `Applied character modification: ${summary}`,
 			actions: ["CHARACTER"],
 		});
@@ -779,7 +781,10 @@ async function runModify(
 		}
 
 		return {
-			text: `I've successfully updated my character. ${summary}`,
+			text: successText,
+			userFacingText: successText,
+			verifiedUserFacing: true,
+			turnComplete: true,
 			values: {
 				success: true,
 				modificationsApplied: true,
@@ -805,11 +810,7 @@ async function runModify(
 			"Error in CHARACTER.modify",
 		);
 		const text =
-			"I encountered an error while trying to modify my character. Please try again.";
-		await callback?.({
-			text,
-			thought: `Error: ${(error as Error).message}`,
-		});
+			"Character modification failed with an unexpected error; tell the user it didn't go through and they can try again.";
 		return {
 			text,
 			values: { success: false, error: (error as Error).message },
@@ -1418,12 +1419,17 @@ async function handlePreferenceReset(
 	});
 
 	if (existingPrefs.length === 0) {
+		const noPrefsText =
+			"You don't have any custom interaction preferences set.";
 		await callback?.({
-			text: "You don't have any custom interaction preferences set.",
+			text: noPrefsText,
 			thought: "No preferences to reset",
 		});
 		return {
 			text: "No preferences to reset",
+			userFacingText: noPrefsText,
+			verifiedUserFacing: true,
+			turnComplete: true,
 			success: true,
 			values: { resetCount: 0 },
 			data: { action: "CHARACTER", op: "modify" },
@@ -1445,14 +1451,18 @@ async function handlePreferenceReset(
 		}
 	}
 
+	const clearedText = `I've cleared ${deletedCount} custom interaction preference(s). I'll go back to my default interaction style with you.`;
 	await callback?.({
-		text: `I've cleared ${deletedCount} custom interaction preference(s). I'll go back to my default interaction style with you.`,
+		text: clearedText,
 		thought: `Reset ${deletedCount} user preferences`,
 		actions: ["CHARACTER"],
 	});
 
 	return {
 		text: `Reset ${deletedCount} preferences`,
+		userFacingText: clearedText,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		success: true,
 		values: { resetCount: deletedCount },
 		data: { action: "CHARACTER", op: "modify" },
@@ -1468,12 +1478,8 @@ async function handleUserPreference(
 	try {
 		const preference = await parseUserPreference(runtime, message, messageText);
 		if (!preference) {
-			await callback?.({
-				text: "I couldn't understand your preference. Could you be more specific? For example: 'be more formal with me' or 'don't use emojis when talking to me'.",
-				thought: "Failed to parse user preference",
-			});
 			return {
-				text: "Could not parse preference",
+				text: "No clear interaction preference found in the request; ask the user to state it specifically (e.g. 'be more formal with me').",
 				success: false,
 				values: { error: "parse_failed" },
 				data: { action: "CHARACTER", op: "modify" },
@@ -1492,12 +1498,8 @@ async function handleUserPreference(
 		});
 
 		if (existingPrefs.length >= MAX_PREFS_PER_USER) {
-			await callback?.({
-				text: `You already have ${MAX_PREFS_PER_USER} interaction preferences set. Please clear some first by saying "reset my interaction preferences".`,
-				thought: "User exceeded maximum preference count",
-			});
 			return {
-				text: "Preference limit reached",
+				text: `Preference limit reached (${MAX_PREFS_PER_USER}); tell the user to clear some existing interaction preferences before adding more.`,
 				success: false,
 				values: { error: "limit_exceeded", count: existingPrefs.length },
 				data: { action: "CHARACTER", op: "modify" },
@@ -1510,12 +1512,17 @@ async function handleUserPreference(
 		});
 
 		if (isDuplicate) {
+			const duplicateText =
+				"I already have that preference noted for our interactions.";
 			await callback?.({
-				text: "I already have that preference noted for our interactions.",
+				text: duplicateText,
 				thought: "Duplicate preference detected",
 			});
 			return {
 				text: "Preference already exists",
+				userFacingText: duplicateText,
+				verifiedUserFacing: true,
+				turnComplete: true,
 				success: true,
 				values: { duplicate: true },
 				data: { action: "CHARACTER", op: "modify" },
@@ -1540,14 +1547,18 @@ async function handleUserPreference(
 			USER_PREFS_TABLE,
 		);
 
+		const storedText = `Got it! I'll remember that for our interactions: "${preference.text}". This only affects how I interact with you, not my core personality.`;
 		await callback?.({
-			text: `Got it! I'll remember that for our interactions: "${preference.text}". This only affects how I interact with you, not my core personality.`,
+			text: storedText,
 			thought: `Stored per-user preference: ${preference.text}`,
 			actions: ["CHARACTER"],
 		});
 
 		return {
 			text: `Stored user preference: ${preference.text}`,
+			userFacingText: storedText,
+			verifiedUserFacing: true,
+			turnComplete: true,
 			success: true,
 			values: {
 				preferenceStored: true,
@@ -1570,12 +1581,8 @@ async function handleUserPreference(
 			{ error: error instanceof Error ? error.message : String(error) },
 			"Error storing user preference",
 		);
-		await callback?.({
-			text: "I encountered an error saving your preference. Please try again.",
-			thought: `Error in user preference handler: ${(error as Error).message}`,
-		});
 		return {
-			text: "Error storing preference",
+			text: "Storing the preference failed with an unexpected error; tell the user it didn't save and they can try again.",
 			success: false,
 			values: { error: (error as Error).message },
 			data: { action: "CHARACTER", op: "modify" },

--- a/packages/core/src/features/advanced-capabilities/personality/actions/character.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/character.ts
@@ -624,9 +624,11 @@ async function runModify(
 		}
 
 		if (!modification) {
+			// Planner-facing only: the canned clarification read as corporate
+			// boilerplate in chat next to the evaluator's in-voice reply (a live
+			// double message). The evaluator owns asking the user, in voice.
 			const text =
-				"I don't see any clear modification instructions. Could you be more specific about how you'd like me to change?";
-			await callback?.({ text, thought: "No valid modification found" });
+				"No clear modification instructions found in the request; ask the user to be specific about how they'd like the character to change.";
 			return {
 				text,
 				values: { success: false, error: "no_modification_found" },

--- a/packages/core/src/features/advanced-planning/actions/plan.ts
+++ b/packages/core/src/features/advanced-planning/actions/plan.ts
@@ -245,7 +245,7 @@ async function handleCreate(
 
 	if (callback) {
 		await callback({
-			text: `I've created a comprehensive project plan with ${phases.length} phase(s).`,
+			text: `I've drafted a plan with ${phases.length} ${phases.length === 1 ? "phase" : "phases"} to build on.`,
 			actions: ["PLAN"],
 			source: "planning",
 		});
@@ -619,19 +619,25 @@ export const planAction: Action = {
 		} catch (error) {
 			const errorMessage =
 				error instanceof Error ? error.message : String(error);
-			const text = `Failed to ${subaction} plan: ${errorMessage}`;
+			// Continuation is suppressed on this action, so this callback is the
+			// turn's sole delivery and can't be dropped — keep it human-worded and
+			// leave the raw error planner-facing in the result.
 			if (callback) {
 				await callback({
-					text,
+					text: `I couldn't ${subaction} that plan — something went wrong on my end.`,
 					actions: ["PLAN"],
 					source: "planning",
 				});
 			}
-			return planningFailureResult("PLAN", text, {
-				errorCode: "plan_action_failed",
-				errorMessage,
-				[CANONICAL_SUBACTION_KEY]: subaction,
-			});
+			return planningFailureResult(
+				"PLAN",
+				`Failed to ${subaction} plan: ${errorMessage}`,
+				{
+					errorCode: "plan_action_failed",
+					errorMessage,
+					[CANONICAL_SUBACTION_KEY]: subaction,
+				},
+			);
 		}
 
 		return planningFailureResult(

--- a/packages/core/src/features/autonomy/action.ts
+++ b/packages/core/src/features/autonomy/action.ts
@@ -350,7 +350,17 @@ export const enableAutonomousModeAction: Action = {
 		if (callback) {
 			await callback({ text, data });
 		}
-		return { success: true, text, data };
+		// The confirmation is the complete answer to a single-operation turn:
+		// verified + turnComplete make the callback the sole delivery instead of
+		// double-messaging with the evaluator.
+		return {
+			success: true,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			data,
+		};
 	},
 };
 
@@ -403,6 +413,14 @@ export const disableAutonomousModeAction: Action = {
 		if (callback) {
 			await callback({ text, data });
 		}
-		return { success: true, text, data };
+		// Same single-delivery contract as the enable path.
+		return {
+			success: true,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			data,
+		};
 	},
 };

--- a/packages/core/src/features/basic-capabilities/actions/choice.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.ts
@@ -237,15 +237,22 @@ export const choiceAction: Action = {
 
 			if (selectedOption === "ABORT") {
 				await runtime.deleteTask(selectedTaskId);
+				const cancelledText = `Task "${selectedTask.name}" has been cancelled.`;
 				if (callback) {
 					await callback({
-						text: `Task "${selectedTask.name}" has been cancelled.`,
+						text: cancelledText,
 						actions: ["CHOOSE_OPTION_CANCELLED"],
 						source: message.content.source,
 					});
 				}
+				// The cancellation confirmation is the complete answer to a
+				// single-operation turn: verified + turnComplete make the callback
+				// the sole delivery instead of double-messaging with the evaluator.
 				return {
-					text: `Task "${selectedTask.name}" has been cancelled`,
+					text: cancelledText,
+					userFacingText: cancelledText,
+					verifiedUserFacing: true,
+					turnComplete: true,
 					values: {
 						success: true,
 						taskAborted: true,
@@ -294,13 +301,9 @@ export const choiceAction: Action = {
 					selectedTask,
 				);
 			}
-			if (callback) {
-				await callback({
-					text: `Selected option: ${selectedOption} for task: ${selectedTask.name}`,
-					actions: ["CHOOSE_OPTION"],
-					source: message.content.source,
-				});
-			}
+			// No visible callback: "Selected option: X for task: Y" is tool-speak,
+			// and the evaluator's in-voice reply is the user's single answer. The
+			// selection detail stays planner-facing in the result text.
 			return {
 				text: `Selected option: ${selectedOption} for task: ${selectedTask.name}`,
 				values: {
@@ -346,11 +349,18 @@ export const choiceAction: Action = {
 			});
 		}
 
+		// The options menu IS the designed ask the user must answer (same shape
+		// as the two-phase confirm prompts): verified + turnComplete make it the
+		// turn's sole delivery instead of pairing it with a second evaluator
+		// reply. The un-selected state stays visible to the planner in data.
 		return {
-			text: "No valid option selected",
+			text: "No valid option selected; asked the user to pick from the open task menus",
+			userFacingText: optionsText,
+			verifiedUserFacing: true,
+			turnComplete: true,
 			values: {
-				success: false,
-				error: "NO_SELECTION",
+				success: true,
+				awaitingSelection: true,
 				availableTasksCount: tasksWithOptions.length,
 			},
 			data: {
@@ -358,7 +368,7 @@ export const choiceAction: Action = {
 				error: "No valid selection made",
 				availableTaskNames: formattedTasks.map((t) => t.name),
 			},
-			success: false,
+			success: true,
 		};
 	},
 

--- a/packages/core/src/features/basic-capabilities/actions/choice.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.ts
@@ -178,13 +178,8 @@ export const choiceAction: Action = {
 			const taskInfo = taskMap.get(taskId);
 
 			if (!taskInfo) {
-				if (callback) {
-					await callback({
-						text: `Could not find a task matching ID: ${taskId}. Please try again.`,
-						actions: ["SELECT_OPTION_ERROR"],
-						source: message.content.source,
-					});
-				}
+				// No visible callback: the model-emitted taskId is planner detail
+				// the user never typed; the evaluator delivers the miss in voice.
 				return {
 					text: `Could not find task with ID: ${taskId}`,
 					values: {
@@ -279,11 +274,8 @@ export const choiceAction: Action = {
 						stateForCanExecute,
 					);
 					if (!allowed) {
-						if (callback) {
-							await callback({
-								text: "You don't have permission to execute this task.",
-							});
-						}
+						// No visible callback: the evaluator delivers the
+						// permission denial in voice, once.
 						return {
 							text: "You don't have permission to execute this task.",
 							values: { success: false, error: "FORBIDDEN" },

--- a/packages/core/src/features/documents/__tests__/actions-routing.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-routing.test.ts
@@ -411,7 +411,9 @@ describe("documentAction.handler structured routing", () => {
 			error: "missing_sub_action",
 			missing: ["query"],
 		});
-		expect(clarifications).toHaveLength(1);
+		// Planner-facing contract: the clarification ask rides result.text;
+		// no visible callback fires (the evaluator voices the question).
+		expect(clarifications).toHaveLength(0);
 	});
 
 	it("asks for clarification when write has no text the extractor can supply", async () => {
@@ -447,7 +449,9 @@ describe("documentAction.handler structured routing", () => {
 			error: "missing_sub_action",
 			missing: ["text"],
 		});
-		expect(clarifications).toHaveLength(1);
+		// Planner-facing contract: the clarification ask rides result.text;
+		// no visible callback fires (the evaluator voices the question).
+		expect(clarifications).toHaveLength(0);
 	});
 
 	it("forwards a structured documentId to read without scanning the text", async () => {

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -491,12 +491,14 @@ async function handleSearch(
 	service: DocumentService,
 	message: Memory,
 	params: DocumentActionParameters,
-	callback?: HandlerCallback,
+	_callback?: HandlerCallback,
 ): Promise<ActionResult> {
 	const query = getQuery(params);
 	if (!query) {
-		const text = "What would you like me to search for in documents?";
-		await emit(callback, { text });
+		// Planner-facing only: canned clarifications double-message next to the
+		// evaluator's in-voice reply. The evaluator owns asking the user, in voice.
+		const text =
+			"No search query found in the request; ask the user what they'd like to search for in documents.";
 		return result(false, text, "search", {
 			values: { error: "missing_query" },
 		});
@@ -524,7 +526,8 @@ async function handleSearch(
 			: `Found ${visible.length} document fragment(s) for "${query}":\n\n${visible
 					.map((item, index) => `${index + 1}. ${item.content.text ?? ""}`)
 					.join("\n\n")}`;
-	await emit(callback, { text, actions: ["DOCUMENT"] });
+	// No visible callback: fragments are intermediate retrieval data for the
+	// planner to synthesize into the answer, not the answer itself.
 	return result(true, text, "search", {
 		values: { query, results: visible },
 		data: { query, results: visible },
@@ -535,24 +538,24 @@ async function handleRead(
 	service: DocumentService,
 	message: Memory,
 	params: DocumentActionParameters,
-	callback?: HandlerCallback,
+	_callback?: HandlerCallback,
 ): Promise<ActionResult> {
 	const documentId = getDocumentId(params, message);
 	if (!documentId) {
-		const text = "I need a valid document id to read.";
-		await emit(callback, { text });
+		const text =
+			"No valid document id found in the request; ask the user which document to read.";
 		return result(false, text, "read", { values: { error: "invalid_id" } });
 	}
 
 	const document = await service.getDocumentById(documentId, message);
 	if (!document) {
-		const text = `Document ${documentId} not found.`;
-		await emit(callback, { text });
+		const text = `Document ${documentId} was not found; tell the user it doesn't exist.`;
 		return result(false, text, "read", { values: { error: "not_found" } });
 	}
 
+	// No visible callback: dumping the raw document text as a chat bubble is
+	// not the answer — the planner presents the content in voice.
 	const text = document.content.text ?? "";
-	await emit(callback, { text, actions: ["DOCUMENT"] });
 	return result(true, text, "read", {
 		values: { documentId, textLength: text.length },
 		data: { document },
@@ -568,8 +571,8 @@ async function handleWrite(
 ): Promise<ActionResult> {
 	const text = getCleanWriteText(params);
 	if (!text) {
-		const response = "I need non-empty text to create a document.";
-		await emit(callback, { text: response });
+		const response =
+			"No document text found in the request; ask the user what the document should contain.";
 		return result(false, response, "write", {
 			values: { error: "missing_text" },
 		});
@@ -584,7 +587,6 @@ async function handleWrite(
 		scopedToEntityId,
 	);
 	if (accessError) {
-		await emit(callback, { text: accessError });
 		return result(false, accessError, "write", {
 			values: { error: "forbidden" },
 		});
@@ -623,9 +625,15 @@ async function handleWrite(
 		},
 	});
 
-	const response = `Created document "${title}" with ${stored.fragmentCount} fragment(s). Document id: ${stored.clientDocumentId}.`;
+	// Humanized single delivery: the save confirmation is the complete answer,
+	// so verified + turnComplete keep the evaluator from double-messaging. The
+	// UUID and fragment count stay planner-facing in values/data.
+	const response = `Saved "${title}" to your documents.`;
 	await emit(callback, { text: response, actions: ["DOCUMENT"] });
 	return result(true, response, "write", {
+		userFacingText: response,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			documentId: stored.clientDocumentId,
 			fragmentCount: stored.fragmentCount,
@@ -645,13 +653,13 @@ async function handleEdit(
 	const documentId = getDocumentId(params, message);
 	const text = typeof params.text === "string" ? params.text : params.content;
 	if (!documentId) {
-		const response = "I need a valid document id to edit.";
-		await emit(callback, { text: response });
+		const response =
+			"No valid document id found in the request; ask the user which document to edit.";
 		return result(false, response, "edit", { values: { error: "invalid_id" } });
 	}
 	if (typeof text !== "string" || !text.trim()) {
-		const response = "I need non-empty text to update the document.";
-		await emit(callback, { text: response });
+		const response =
+			"No replacement text found in the request; ask the user what the document should say.";
 		return result(false, response, "edit", {
 			values: { error: "missing_text" },
 		});
@@ -662,9 +670,14 @@ async function handleEdit(
 		content: text.trim(),
 		message,
 	});
-	const response = `Updated document ${updated.documentId}. Re-fragmented into ${updated.fragmentCount} piece(s).`;
+	// Humanized single delivery: the update confirmation is the complete
+	// answer; the UUID and fragment count stay planner-facing in values.
+	const response = "Updated the document.";
 	await emit(callback, { text: response, actions: ["DOCUMENT"] });
 	return result(true, response, "edit", {
+		userFacingText: response,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			documentId: updated.documentId,
 			fragmentCount: updated.fragmentCount,
@@ -680,8 +693,8 @@ async function handleDelete(
 ): Promise<ActionResult> {
 	const documentId = getDocumentId(params, message);
 	if (!documentId) {
-		const text = "I need a valid document id to delete.";
-		await emit(callback, { text });
+		const text =
+			"No valid document id found in the request; ask the user which document to delete.";
 		return result(false, text, "delete", { values: { error: "invalid_id" } });
 	}
 
@@ -697,24 +710,29 @@ async function handleDelete(
 		const code = error instanceof ElizaError ? error.code : undefined;
 		if (code === "DOCUMENT_MUTATION_FORBIDDEN") {
 			const text =
-				"Only the owner can edit or delete global and owner-private documents.";
-			await emit(callback, { text });
+				"Only the owner can edit or delete global and owner-private documents; tell the user this one is off limits.";
 			return result(false, text, "delete", {
 				values: { error: "forbidden", documentId },
 			});
 		}
 		if (code === "DOCUMENT_NOT_FOUND") {
-			const text = `No document ${documentId} to delete.`;
-			await emit(callback, { text });
+			const text = `Document ${documentId} was not found; tell the user there's nothing to delete.`;
 			return result(false, text, "delete", {
 				values: { error: "not_found", documentId },
 			});
 		}
 		throw error;
 	}
-	const text = `Deleted document ${documentId}.`;
+	// Humanized single delivery: the delete confirmation is the complete
+	// answer; the UUID stays planner-facing in values.
+	const text = "Deleted the document.";
 	await emit(callback, { text, actions: ["DOCUMENT"] });
-	return result(true, text, "delete", { values: { documentId } });
+	return result(true, text, "delete", {
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
+		values: { documentId },
+	});
 }
 
 function parseTimestampParam(value: unknown): number | undefined {
@@ -823,7 +841,12 @@ async function handleList(
 			: {}),
 	};
 	await emit(callback, { text, actions: ["DOCUMENT"] });
+	// The listing IS the complete answer: verified + turnComplete make the
+	// callback the sole delivery instead of double-messaging with the evaluator.
 	return result(true, text, "list", {
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: listData,
 		data: listData,
 	});
@@ -840,8 +863,8 @@ async function handleImportFile(
 	const content =
 		typeof params.content === "string" ? params.content.trim() : "";
 	if (!filePath && !content) {
-		const text = "I need a file path or text content to import.";
-		await emit(callback, { text });
+		const text =
+			"No file path or text content found in the request; ask the user what to import.";
 		return result(false, text, "import_file", {
 			values: { error: "missing_source" },
 		});
@@ -856,7 +879,6 @@ async function handleImportFile(
 		scopedToEntityId,
 	);
 	if (accessError) {
-		await emit(callback, { text: accessError });
 		return result(false, accessError, "import_file", {
 			values: { error: "forbidden" },
 		});
@@ -871,8 +893,7 @@ async function handleImportFile(
 	);
 	if (filePath) {
 		if (!fs.existsSync(filePath)) {
-			const text = `I couldn't find the file at ${filePath}.`;
-			await emit(callback, { text });
+			const text = `No file exists at ${filePath}; tell the user it couldn't be found.`;
 			return result(false, text, "import_file", {
 				values: { error: "not_found" },
 			});
@@ -887,9 +908,14 @@ async function handleImportFile(
 			},
 		});
 		const filename = path.basename(filePath);
-		const text = `Imported "${filename}" with ${stored.fragmentCount} fragment(s). Document id: ${stored.clientDocumentId}.`;
+		// Humanized single delivery: the import confirmation is the complete
+		// answer; the UUID and fragment count stay planner-facing in values.
+		const text = `Imported "${filename}" into your documents.`;
 		await emit(callback, { text, actions: ["DOCUMENT"] });
 		return result(true, text, "import_file", {
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
 			values: {
 				documentId: stored.clientDocumentId,
 				fragmentCount: stored.fragmentCount,
@@ -922,9 +948,12 @@ async function handleImportFile(
 			textBacked: true,
 		},
 	});
-	const text = `Imported "${title}" with ${stored.fragmentCount} fragment(s). Document id: ${stored.clientDocumentId}.`;
+	const text = `Imported "${title}" into your documents.`;
 	await emit(callback, { text, actions: ["DOCUMENT"] });
 	return result(true, text, "import_file", {
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			documentId: stored.clientDocumentId,
 			fragmentCount: stored.fragmentCount,
@@ -943,8 +972,8 @@ async function handleImportUrl(
 ): Promise<ActionResult> {
 	const url = getUrl(params, message);
 	if (!url) {
-		const text = "I need a URL to import.";
-		await emit(callback, { text });
+		const text =
+			"No URL found in the request; ask the user which URL to import.";
 		return result(false, text, "import_url", {
 			values: { error: "missing_url" },
 		});
@@ -962,7 +991,6 @@ async function handleImportUrl(
 		scopedToEntityId,
 	);
 	if (accessError) {
-		await emit(callback, { text: accessError });
 		return result(false, accessError, "import_url", {
 			values: { error: "forbidden" },
 		});
@@ -1003,9 +1031,14 @@ async function handleImportUrl(
 			: fetched.contentType === "html"
 				? "page"
 				: "document";
-	const text = `Imported ${label} from ${url}. Stored as ${fetched.filename} with ${stored.fragmentCount} fragment(s).`;
+	// Humanized single delivery: the import confirmation is the complete
+	// answer; filename and fragment count stay planner-facing in values.
+	const text = `Imported the ${label} from ${url} into your documents.`;
 	await emit(callback, { text, actions: ["DOCUMENT"] });
 	return result(true, text, "import_url", {
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			documentId: stored.clientDocumentId,
 			fragmentCount: stored.fragmentCount,
@@ -1214,8 +1247,10 @@ export const documentAction: Action = {
 		);
 
 		if (!service) {
-			const text = "Documents service not available.";
-			await emit(callback, { text });
+			// Planner-facing only: infrastructure-speak next to the evaluator's
+			// reply was a live double message. The evaluator explains in voice.
+			const text =
+				"The documents service is not available; tell the user documents can't be used right now.";
 			return result(false, text, "search", {
 				values: { error: "service_unavailable" },
 			});
@@ -1233,7 +1268,6 @@ export const documentAction: Action = {
 			subactions: DOCUMENT_SUBACTIONS,
 		});
 		if (!resolved.ok) {
-			await emit(callback, { text: resolved.clarification });
 			return result(false, resolved.clarification, "search", {
 				values: { error: "missing_sub_action", missing: resolved.missing },
 			});
@@ -1262,10 +1296,10 @@ export const documentAction: Action = {
 			}
 		} catch (error) {
 			logger.error({ error }, `Error in DOCUMENT ${subaction} action`);
-			const text = `I couldn't ${subaction.replace("_", " ")} documents: ${
+			// Planner-facing only: internal exception text must not leak to chat.
+			const text = `The documents ${subaction.replace("_", " ")} operation failed: ${
 				error instanceof Error ? error.message : String(error)
 			}`;
-			await emit(callback, { text });
 			return result(false, text, subaction, {
 				error: error instanceof Error ? error.message : String(error),
 				values: {

--- a/packages/core/src/features/messaging/triage/actions/listInbox.ts
+++ b/packages/core/src/features/messaging/triage/actions/listInbox.ts
@@ -83,7 +83,7 @@ export const listInboxAction: Action = {
 		_message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	): Promise<ActionResult> => {
 		try {
 			const params = parseListInboxParams(options);
@@ -114,14 +114,13 @@ export const listInboxAction: Action = {
 				`[ListInbox] returning ${trimmed.length} of ${unread.length} unread message(s)`,
 			);
 
+			// No visible callback: the bare count is tool-speak next to the
+			// evaluator's actual inbox rundown. The summary stays planner-facing
+			// in the result text with the messages in data.
 			const text =
 				trimmed.length === 0
 					? "No unread messages across connected platforms."
-					: `You have ${unread.length} unread across ${new Set(unread.map((m) => m.source)).size} platform(s).`;
-
-			if (callback) {
-				await callback({ text, action: "MESSAGE" });
-			}
+					: `${unread.length} unread message(s) across ${new Set(unread.map((m) => m.source)).size} platform(s); details in data.messages.`;
 
 			return {
 				success: true,

--- a/packages/core/src/features/messaging/triage/actions/manageMessage.ts
+++ b/packages/core/src/features/messaging/triage/actions/manageMessage.ts
@@ -186,9 +186,8 @@ export const manageMessageAction: Action = {
 			logger.info(
 				`[ManageMessage] op=${opLabel} messageId=${parsed.messageId} not ok: ${text}`,
 			);
-			if (callback) {
-				await callback({ text, action: "MESSAGE" });
-			}
+			// No visible callback: raw service reasons are tool-speak. The failure
+			// stays planner-facing so the evaluator phrases it once, in voice.
 			return {
 				success: false,
 				text,
@@ -201,14 +200,34 @@ export const manageMessageAction: Action = {
 			};
 		}
 
-		const text = `Applied ${opLabel} to message ${messageId}.`;
+		const text =
+			{
+				archive: "Archived that message.",
+				trash: "Moved that message to trash.",
+				spam: "Marked that message as spam.",
+				mark_read:
+					parsed.operation.kind === "mark_read" && !parsed.operation.read
+						? "Marked it unread."
+						: "Marked it read.",
+				label_add: "Added the label.",
+				label_remove: "Removed the label.",
+				tag_add: "Tagged that message.",
+				tag_remove: "Removed the tag.",
+				mute_thread: "Muted that thread.",
+				unsubscribe: "Unsubscribed from that sender.",
+			}[opLabel] ?? "Done.";
 		logger.info(`[ManageMessage] op=${opLabel} messageId=${messageId} ok`);
 		if (callback) {
 			await callback({ text, action: "MESSAGE" });
 		}
+		// The confirmation is the complete answer: verified + turnComplete make
+		// it the sole delivery; the op kind and message id stay in data.
 		return {
 			success: true,
 			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
 			data: {
 				ok: true,
 				messageId,

--- a/packages/core/src/features/messaging/triage/actions/respondToMessage.ts
+++ b/packages/core/src/features/messaging/triage/actions/respondToMessage.ts
@@ -166,16 +166,22 @@ export const respondToMessageAction: Action = {
 						externalId: r.sentExternalId ?? `pending:${r.draftId}`,
 					})),
 				);
-				const text = `Reply drafted on ${record.source} and pending approval (request ${enq.requestId}).`;
+				const text = `I've drafted the reply on ${record.source} — it's waiting for approval before it goes out.`;
 				logger.info(
 					`[RespondToMessage] policy hold: draftId=${record.draftId} requestId=${enq.requestId}`,
 				);
 				if (callback) {
 					await callback({ text, action: "MESSAGE" });
 				}
+				// The hold notice is a completed user-facing ask: verified +
+				// turnComplete make it the sole delivery; the pending state and
+				// request id stay machine-readable in data.
 				return {
-					success: false,
-					text,
+					success: true,
+					text: `Reply drafted on ${record.source} and pending approval (request ${enq.requestId}).`,
+					userFacingText: text,
+					verifiedUserFacing: true,
+					turnComplete: true,
 					continueChain: false,
 					data: {
 						requiresConfirmation: true,
@@ -198,9 +204,14 @@ export const respondToMessageAction: Action = {
 		if (callback) {
 			await callback({ text, action: "MESSAGE" });
 		}
+		// The sent confirmation is the complete answer to a single-operation
+		// turn: verified + turnComplete make it the sole delivery.
 		return {
 			success: true,
 			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
 			data: {
 				draftId: sent.draftId,
 				source: sent.source,

--- a/packages/core/src/features/messaging/triage/actions/searchMessages.ts
+++ b/packages/core/src/features/messaging/triage/actions/searchMessages.ts
@@ -112,7 +112,7 @@ export const searchMessagesAction: Action = {
 		_message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	): Promise<ActionResult> => {
 		const filters = parseSearchMessagesParams(options);
 		const service = getDefaultTriageService();
@@ -128,10 +128,8 @@ export const searchMessagesAction: Action = {
 			`[SearchMessages] ${hits.length} hits across [${[...sourcesHit].join(",")}]`,
 		);
 
-		if (callback) {
-			await callback({ text, action: "MESSAGE" });
-		}
-
+		// No visible callback: the match count is not the user's answer — the
+		// evaluator presents the matches from data.messages in voice.
 		return {
 			success: true,
 			text,

--- a/packages/core/src/features/messaging/triage/actions/sendDraft.ts
+++ b/packages/core/src/features/messaging/triage/actions/sendDraft.ts
@@ -382,14 +382,20 @@ export const sendDraftAction: Action = {
 		}
 
 		if (!parsed.confirmed) {
-			const text = `Confirmation required before sending draft ${parsed.draftId}. Preview: ${existing.preview}`;
+			// The confirm prompt is the designed ask the user must answer:
+			// verified + turnComplete make it the sole delivery, worded like a
+			// person asking; the draftId stays planner-facing in data.
+			const text = `Here's what I'm about to send: ${existing.preview} — want me to send it?`;
 			logger.info(`[SendDraft] confirmation gate: draftId=${parsed.draftId}`);
 			if (callback) {
 				await callback({ text, action: "MESSAGE" });
 			}
 			return {
-				success: false,
+				success: true,
 				text,
+				userFacingText: text,
+				verifiedUserFacing: true,
+				turnComplete: true,
 				continueChain: false,
 				data: {
 					requiresConfirmation: true,
@@ -424,7 +430,11 @@ export const sendDraftAction: Action = {
 						externalId: rec.sentExternalId ?? `pending:${rec.draftId}`,
 					})),
 				);
-				const text = `Draft ${parsed.draftId} pending owner approval (request ${enq.requestId}).`;
+				// The pending-approval notice is the complete answer to this turn:
+				// verified + turnComplete make it the sole delivery, human-worded;
+				// draft/request ids stay planner-facing in data.
+				const text =
+					"This one needs the owner's approval before it goes out — I've requested it and will send it once approved.";
 				logger.info(
 					`[SendDraft] policy hold: draftId=${parsed.draftId} requestId=${enq.requestId}`,
 				);
@@ -432,8 +442,11 @@ export const sendDraftAction: Action = {
 					await callback({ text, action: "MESSAGE" });
 				}
 				return {
-					success: false,
+					success: true,
 					text,
+					userFacingText: text,
+					verifiedUserFacing: true,
+					turnComplete: true,
 					continueChain: false,
 					data: {
 						requiresConfirmation: true,
@@ -448,7 +461,10 @@ export const sendDraftAction: Action = {
 		}
 
 		const sent = await service.sendDraft(runtime, parsed.draftId);
-		const text = `Sent draft ${parsed.draftId} on ${sent.source}.`;
+		// The sent confirmation is the complete answer to a single-operation
+		// turn: verified + turnComplete make it the sole delivery; the draftId
+		// stays planner-facing in data.
+		const text = "Sent it.";
 		logger.info(
 			`[SendDraft] sent draftId=${parsed.draftId} externalId=${sent.sentExternalId ?? "unknown"}`,
 		);
@@ -458,6 +474,9 @@ export const sendDraftAction: Action = {
 		return {
 			success: true,
 			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
 			data: {
 				draftId: sent.draftId,
 				source: sent.source,

--- a/packages/core/src/features/messaging/triage/actions/triageMessages.ts
+++ b/packages/core/src/features/messaging/triage/actions/triageMessages.ts
@@ -62,7 +62,7 @@ export const triageMessagesAction: Action = {
 		_message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	): Promise<ActionResult> => {
 		const params = parseTriageParams(options);
 		const service = getDefaultTriageService();
@@ -79,13 +79,8 @@ export const triageMessagesAction: Action = {
 
 		logger.info(`[TriageMessages] ${summary}`);
 
-		if (callback) {
-			await callback({
-				text: summary,
-				action: "MESSAGE",
-			});
-		}
-
+		// No visible callback: "Fetched N message(s)" is tool progress-speak —
+		// the evaluator's triage summary is the user's single answer.
 		return {
 			success: true,
 			text: summary,

--- a/packages/core/src/features/oauth/actions/await-oauth-callback.ts
+++ b/packages/core/src/features/oauth/actions/await-oauth-callback.ts
@@ -80,7 +80,7 @@ export const awaitOAuthCallbackAction: Action = {
 		_message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	) => {
 		const params = readParams(options);
 		const bus = runtime.getService<Service & OAuthCallbackBusClient>(
@@ -126,13 +126,12 @@ export const awaitOAuthCallbackAction: Action = {
 			receivedAt: result.receivedAt,
 		};
 
+		// No visible callback: intent-id/status vocabulary is internal plumbing.
+		// The evaluator voices the outcome; the detail stays planner-facing.
 		const text =
 			result.status === "bound"
 				? `OAuth intent ${oauthIntentId} bound.`
 				: `OAuth intent ${oauthIntentId} ended in status ${result.status}${result.error ? `: ${result.error}` : ""}.`;
-		if (callback) {
-			await callback({ text, action: "AWAIT_OAUTH_CALLBACK" });
-		}
 
 		return {
 			success: result.status === "bound",

--- a/packages/core/src/features/oauth/actions/bind-oauth-credential.ts
+++ b/packages/core/src/features/oauth/actions/bind-oauth-credential.ts
@@ -89,7 +89,7 @@ export const bindOAuthCredentialAction: Action = {
 		_message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	) => {
 		const params = readParams(options);
 		const client = runtime.getService<Service & OAuthIntentsClient>(
@@ -132,10 +132,9 @@ export const bindOAuthCredentialAction: Action = {
 			`[BIND_OAUTH_CREDENTIAL] oauthIntentId=${oauthIntentId} connectorIdentityId=${connectorIdentityId}`,
 		);
 
+		// No visible callback: two raw internal ids are pure plumbing status. The
+		// evaluator voices the outcome; the detail stays planner-facing.
 		const text = `Bound OAuth intent ${oauthIntentId} to ${connectorIdentityId}.`;
-		if (callback) {
-			await callback({ text, action: "BIND_OAUTH_CREDENTIAL" });
-		}
 
 		return {
 			success: true,

--- a/packages/core/src/features/oauth/actions/create-oauth-intent.test.ts
+++ b/packages/core/src/features/oauth/actions/create-oauth-intent.test.ts
@@ -69,9 +69,9 @@ describe("CREATE_OAUTH_INTENT", () => {
 
 		expect(result.success).toBe(true);
 		expect(create).toHaveBeenCalledTimes(1);
-		expect(callback).toHaveBeenCalledWith(
-			expect.objectContaining({ action: "CREATE_OAUTH_INTENT" }),
-		);
+		// No visible callback: delivery-target machinery is planner-facing
+		// (the evaluator voices the user-facing message).
+		expect(callback).not.toHaveBeenCalled();
 		expect(result.data?.actionName).toBe("CREATE_OAUTH_INTENT");
 		expect(result.data?.oauthIntentId).toBe("oauth_1");
 		expect(result.data?.eligibleDeliveryTargets).toContain("dm");

--- a/packages/core/src/features/oauth/actions/create-oauth-intent.ts
+++ b/packages/core/src/features/oauth/actions/create-oauth-intent.ts
@@ -195,7 +195,7 @@ export const createOAuthIntentAction: Action = {
 		_message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	) => {
 		const params = readParams(options);
 		const client = runtime.getService<Service & OAuthIntentsClient>(
@@ -225,10 +225,9 @@ export const createOAuthIntentAction: Action = {
 			`[CREATE_OAUTH_INTENT] oauthIntentId=${envelope.oauthIntentId} provider=${envelope.provider}`,
 		);
 
+		// No visible callback: intent creation is an intermediate step (the link
+		// is still undelivered), so the id/provider detail stays planner-facing.
 		const text = `Created OAuth intent ${envelope.oauthIntentId} for ${envelope.provider}.`;
-		if (callback) {
-			await callback({ text, action: "CREATE_OAUTH_INTENT" });
-		}
 
 		return {
 			success: true,

--- a/packages/core/src/features/oauth/actions/deliver-oauth-link.ts
+++ b/packages/core/src/features/oauth/actions/deliver-oauth-link.ts
@@ -132,7 +132,7 @@ export const deliverOAuthLinkAction: Action = {
 		message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	) => {
 		const params = readParams(options);
 		const client = runtime.getService<Service & OAuthIntentsClient>(
@@ -221,12 +221,11 @@ export const deliverOAuthLinkAction: Action = {
 			`[DELIVER_OAUTH_LINK] oauthIntentId=${oauthIntentId} target=${target} delivered=${result.delivered}`,
 		);
 
+		// No visible callback: the delivered link itself is the user-facing
+		// artifact; this status line (and any raw failure) stays planner-facing.
 		const text = result.delivered
 			? `Delivered OAuth link ${oauthIntentId} via ${target}.`
 			: `Failed to deliver OAuth link ${oauthIntentId} via ${target}${result.error ? `: ${result.error}` : ""}.`;
-		if (callback) {
-			await callback({ text, action: "DELIVER_OAUTH_LINK" });
-		}
 
 		return {
 			success: result.delivered,

--- a/packages/core/src/features/oauth/actions/revoke-oauth-credential.ts
+++ b/packages/core/src/features/oauth/actions/revoke-oauth-credential.ts
@@ -78,7 +78,7 @@ export const revokeOAuthCredentialAction: Action = {
 		_message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	) => {
 		const params = readParams(options);
 		const client = runtime.getService<Service & OAuthIntentsClient>(
@@ -111,12 +111,11 @@ export const revokeOAuthCredentialAction: Action = {
 			`[REVOKE_OAUTH_CREDENTIAL] oauthIntentId=${oauthIntentId} revoked=${result.revoked}`,
 		);
 
+		// No visible callback: raw intent-id revoke status is tool-speak. The
+		// evaluator voices the outcome; the detail stays planner-facing.
 		const text = result.revoked
 			? `Revoked OAuth credential ${oauthIntentId}.`
 			: `Failed to revoke OAuth credential ${oauthIntentId}${result.error ? `: ${result.error}` : ""}.`;
-		if (callback) {
-			await callback({ text, action: "REVOKE_OAUTH_CREDENTIAL" });
-		}
 
 		return {
 			success: result.revoked,

--- a/packages/core/src/features/payments/actions/payment.test.ts
+++ b/packages/core/src/features/payments/actions/payment.test.ts
@@ -98,9 +98,9 @@ describe("PAYMENT", () => {
 
 		expect(result.success).toBe(true);
 		expect(create).toHaveBeenCalledTimes(1);
-		expect(callback).toHaveBeenCalledWith(
-			expect.objectContaining({ action: "PAYMENT" }),
-		);
+		// No visible callback: delivery-target machinery is planner-facing
+		// (the evaluator voices the user-facing message).
+		expect(callback).not.toHaveBeenCalled();
 		expect(result.data?.actionName).toBe("PAYMENT");
 		expect(result.data?.paymentAction).toBe("create_request");
 		expect(result.data?.paymentRequestId).toBe("pay_1");

--- a/packages/core/src/features/payments/actions/payment.ts
+++ b/packages/core/src/features/payments/actions/payment.ts
@@ -3,6 +3,10 @@
  *
  * Routes all payment operations through a single structural discriminator:
  * `action=create_request|deliver_link|verify_payload|settle|await_callback|cancel_request`.
+ *
+ * Results are planner-facing only: raw request ids, cent amounts, and
+ * settlement statuses are tool-speak, so no handler emits a visible callback —
+ * the evaluator phrases the user-facing reply from the result text.
  */
 
 import { logger } from "../../../logger.ts";
@@ -14,7 +18,6 @@ import type {
 } from "../../../sensitive-requests/dispatch-registry.ts";
 import type {
 	Action,
-	HandlerCallback,
 	HandlerOptions,
 	IAgentRuntime,
 	JsonValue,
@@ -223,19 +226,9 @@ function dataFor(action: PaymentAction, data: Record<string, unknown> = {}) {
 	return { actionName: "PAYMENT", paymentAction: action, ...data };
 }
 
-async function maybeCallback(
-	callback: HandlerCallback | undefined,
-	text: string,
-) {
-	if (callback) {
-		await callback({ text, action: "PAYMENT" });
-	}
-}
-
 async function handleCreateRequest(
 	runtime: IAgentRuntime,
 	params: PaymentParams,
-	callback?: HandlerCallback,
 ) {
 	const action: PaymentAction = "create_request";
 	const client = runtime.getService<Service & PaymentRequestsClient>(
@@ -269,7 +262,6 @@ async function handleCreateRequest(
 	);
 
 	const text = `Created payment request ${envelope.paymentRequestId} for ${envelope.amountCents} ${envelope.currency}.`;
-	await maybeCallback(callback, text);
 
 	return {
 		success: true,
@@ -287,7 +279,6 @@ async function handleDeliverLink(
 	runtime: IAgentRuntime,
 	message: Memory,
 	params: PaymentParams,
-	callback?: HandlerCallback,
 ) {
 	const action: PaymentAction = "deliver_link";
 	const client = runtime.getService<Service & PaymentRequestsClient>(
@@ -379,7 +370,6 @@ async function handleDeliverLink(
 	const text = result.delivered
 		? `Delivered payment request ${paymentRequestId} via ${target}.`
 		: `Failed to deliver payment request ${paymentRequestId} via ${target}${result.error ? `: ${result.error}` : ""}.`;
-	await maybeCallback(callback, text);
 
 	return {
 		success: result.delivered,
@@ -395,7 +385,6 @@ async function handleDeliverLink(
 async function handleVerifyPayload(
 	runtime: IAgentRuntime,
 	params: PaymentParams,
-	callback?: HandlerCallback,
 ) {
 	const action: PaymentAction = "verify_payload";
 	const bus = runtime.getService<Service & PaymentBusClient>(
@@ -428,7 +417,6 @@ async function handleVerifyPayload(
 	const text = verification.valid
 		? `Payment proof for ${paymentRequestId} is valid.`
 		: `Payment proof for ${paymentRequestId} is invalid${verification.error ? `: ${verification.error}` : ""}.`;
-	await maybeCallback(callback, text);
 
 	return {
 		success: verification.valid,
@@ -442,11 +430,7 @@ async function handleVerifyPayload(
 	};
 }
 
-async function handleSettle(
-	runtime: IAgentRuntime,
-	params: PaymentParams,
-	callback?: HandlerCallback,
-) {
+async function handleSettle(runtime: IAgentRuntime, params: PaymentParams) {
 	const action: PaymentAction = "settle";
 	const settler = runtime.getService<Service & PaymentSettler>(
 		PAYMENT_SETTLER_SERVICE,
@@ -483,7 +467,6 @@ async function handleSettle(
 		settlement.status === "settled"
 			? `Payment ${paymentRequestId} settled${settlement.txRef ? ` (tx ${settlement.txRef})` : ""}.`
 			: `Payment ${paymentRequestId} settle attempt ended with status ${settlement.status}${settlement.error ? `: ${settlement.error}` : ""}.`;
-	await maybeCallback(callback, text);
 
 	return {
 		success: settlement.status === "settled",
@@ -495,7 +478,6 @@ async function handleSettle(
 async function handleAwaitCallback(
 	runtime: IAgentRuntime,
 	params: PaymentParams,
-	callback?: HandlerCallback,
 ) {
 	const action: PaymentAction = "await_callback";
 	const bus = runtime.getService<Service & PaymentBusClient>(
@@ -546,7 +528,6 @@ async function handleAwaitCallback(
 		settlement.status === "settled"
 			? `Payment ${paymentRequestId} settled.`
 			: `Payment ${paymentRequestId} ended in status ${settlement.status}${settlement.error ? `: ${settlement.error}` : ""}.`;
-	await maybeCallback(callback, text);
 
 	return {
 		success: settlement.status === "settled",
@@ -558,7 +539,6 @@ async function handleAwaitCallback(
 async function handleCancelRequest(
 	runtime: IAgentRuntime,
 	params: PaymentParams,
-	callback?: HandlerCallback,
 ) {
 	const action: PaymentAction = "cancel_request";
 	const client = runtime.getService<Service & PaymentRequestsClient>(
@@ -594,7 +574,6 @@ async function handleCancelRequest(
 	);
 
 	const text = `Payment request ${paymentRequestId} is now ${envelope.status}.`;
-	await maybeCallback(callback, text);
 
 	return {
 		success: envelope.status === "canceled",
@@ -811,7 +790,6 @@ export const paymentAction: Action = {
 		message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
 	) => {
 		const params = readParams(options);
 		const action = normalizePaymentAction(params.action);
@@ -825,17 +803,17 @@ export const paymentAction: Action = {
 
 		switch (action) {
 			case "create_request":
-				return handleCreateRequest(runtime, params, callback);
+				return handleCreateRequest(runtime, params);
 			case "deliver_link":
-				return handleDeliverLink(runtime, message, params, callback);
+				return handleDeliverLink(runtime, message, params);
 			case "verify_payload":
-				return handleVerifyPayload(runtime, params, callback);
+				return handleVerifyPayload(runtime, params);
 			case "settle":
-				return handleSettle(runtime, params, callback);
+				return handleSettle(runtime, params);
 			case "await_callback":
-				return handleAwaitCallback(runtime, params, callback);
+				return handleAwaitCallback(runtime, params);
 			case "cancel_request":
-				return handleCancelRequest(runtime, params, callback);
+				return handleCancelRequest(runtime, params);
 		}
 	},
 

--- a/packages/core/src/features/plugin-config/actions/activate-plugin-if-ready.ts
+++ b/packages/core/src/features/plugin-config/actions/activate-plugin-if-ready.ts
@@ -73,7 +73,7 @@ export const activatePluginIfReadyAction: Action = {
 		_message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	) => {
 		const params = readParams(options);
 		const pluginName =
@@ -110,10 +110,9 @@ export const activatePluginIfReadyAction: Action = {
 			logger.info(
 				`[ActivatePluginIfReady] plugin=${pluginName} not_ready missing=${status.missing.length}`,
 			);
-			const text = `Plugin '${pluginName}' is not ready. Missing: ${status.missing.join(", ")}.`;
-			if (callback) {
-				await callback({ text, action: "ACTIVATE_PLUGIN_IF_READY" });
-			}
+			// Planner-facing only: the raw missing-key list is not the user's
+			// answer; the evaluator phrases what is still needed in voice.
+			const text = `Plugin '${pluginName}' is not ready. Missing: ${status.missing.join(", ")}; ask the user to provide these settings.`;
 			return {
 				success: false,
 				text,
@@ -151,11 +150,9 @@ export const activatePluginIfReadyAction: Action = {
 
 		logger.info(`[ActivatePluginIfReady] plugin=${pluginName} activated`);
 
+		// Planner-facing only: the terse status is tool-speak; the evaluator's
+		// in-voice reply is the user's single confirmation.
 		const text = `Plugin '${pluginName}' activated.`;
-		if (callback) {
-			await callback({ text, action: "ACTIVATE_PLUGIN_IF_READY" });
-		}
-
 		return {
 			success: true,
 			text,

--- a/packages/core/src/features/plugin-config/actions/deliver-plugin-config-form.ts
+++ b/packages/core/src/features/plugin-config/actions/deliver-plugin-config-form.ts
@@ -129,7 +129,7 @@ export const deliverPluginConfigFormAction: Action = {
 		message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	) => {
 		const params = readParams(options);
 		const pluginName =
@@ -173,10 +173,9 @@ export const deliverPluginConfigFormAction: Action = {
 			requirements.required.includes(k),
 		);
 		if (missingRequired.length === 0) {
-			const text = `Plugin '${pluginName}' has no missing required config keys.`;
-			if (callback) {
-				await callback({ text, action: "DELIVER_PLUGIN_CONFIG_FORM" });
-			}
+			// Planner-facing only: the no-op status is tool-speak that
+			// double-messaged next to the evaluator's in-voice reply.
+			const text = `Plugin '${pluginName}' has no missing required config keys; nothing to deliver.`;
 			return {
 				success: true,
 				text,
@@ -244,10 +243,9 @@ export const deliverPluginConfigFormAction: Action = {
 			`[DeliverPluginConfigForm] plugin=${pluginName} target=${target} delivered=${deliveredCount}/${entries.length}`,
 		);
 
+		// No visible callback: the dispatch adapter already delivers the config
+		// form itself; announcing dispatch counts double-messaged next to it.
 		const text = `Dispatched ${deliveredCount}/${entries.length} config request(s) for '${pluginName}' via ${target}.`;
-		if (callback) {
-			await callback({ text, action: "DELIVER_PLUGIN_CONFIG_FORM" });
-		}
 
 		return {
 			success: deliveredCount === entries.length,

--- a/packages/core/src/features/plugin-config/actions/poll-plugin-config-status.ts
+++ b/packages/core/src/features/plugin-config/actions/poll-plugin-config-status.ts
@@ -70,7 +70,7 @@ export const pollPluginConfigStatusAction: Action = {
 		_message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	) => {
 		const params = readParams(options);
 		const pluginName =
@@ -107,13 +107,11 @@ export const pollPluginConfigStatusAction: Action = {
 			`[PollPluginConfigStatus] plugin=${pluginName} ready=${status.ready} missing=${status.missing.length}`,
 		);
 
+		// Planner-facing only: a poll probe's status is planner input, not a chat
+		// bubble — the raw key list double-messaged next to the evaluator's reply.
 		const text = status.ready
 			? `Plugin '${pluginName}' is ready.`
 			: `Plugin '${pluginName}' still missing: ${status.missing.join(", ")}.`;
-
-		if (callback) {
-			await callback({ text, action: "POLL_PLUGIN_CONFIG_STATUS" });
-		}
 
 		return {
 			success: true,

--- a/packages/core/src/features/plugin-config/actions/probe-plugin-config-requirements.ts
+++ b/packages/core/src/features/plugin-config/actions/probe-plugin-config-requirements.ts
@@ -71,7 +71,7 @@ export const probePluginConfigRequirementsAction: Action = {
 		_message: Memory,
 		_state?: State,
 		options?: HandlerOptions,
-		callback?: HandlerCallback,
+		_callback?: HandlerCallback,
 	) => {
 		const params = readParams(options);
 		const pluginName =
@@ -111,14 +111,12 @@ export const probePluginConfigRequirementsAction: Action = {
 			`[ProbePluginConfigRequirements] plugin=${pluginName} required=${requirements.required.length} missing=${requirements.missing.length}`,
 		);
 
+		// Planner-facing only: raw env-key names are probe input for the planner,
+		// not the user's answer.
 		const text =
 			requirements.missing.length === 0
 				? `Plugin '${pluginName}' has all required config keys.`
 				: `Plugin '${pluginName}' is missing: ${requirements.missing.join(", ")}.`;
-
-		if (callback) {
-			await callback({ text, action: "PROBE_PLUGIN_CONFIG_REQUIREMENTS" });
-		}
 
 		return {
 			success: true,

--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/core-status.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/core-status.ts
@@ -20,16 +20,16 @@ export interface CoreStatusInput {
 	callback?: HandlerCallback;
 }
 
+// Planner-facing only: the status dump (paths, commit, version) is planner
+// input, not a chat bubble — it double-messaged next to the evaluator's reply.
 export async function runCoreStatus({
 	runtime,
-	callback,
 }: CoreStatusInput): Promise<ActionResult> {
 	const service = runtime.getService(
 		"core_manager",
 	) as CoreManagerService | null;
 	if (!service) {
 		const text = "Core manager service not available";
-		await callback?.({ text });
 		return { success: false, text };
 	}
 
@@ -54,7 +54,6 @@ export async function runCoreStatus({
 	}
 
 	const text = lines.join("\n");
-	await callback?.({ text });
 	return {
 		success: true,
 		text,

--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/create.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/create.ts
@@ -545,14 +545,15 @@ async function createNewPlugin({
 		callback,
 	});
 	if (dispatch.dispatched === false) {
+		// Planner-facing only: raw paths/reasons are tool-speak; the evaluator
+		// explains the failure to the user in voice.
 		const text = `Scaffolded ${displayName} at ${workdir}, but could not dispatch a coding agent: ${dispatch.reason}.`;
-		await callback?.({ text });
 		return { success: false, text, values: { mode: "create", workdir } };
 	}
 
 	const task = dispatch.agents[0];
+	// Planner-facing only: session ids and internal event names stay out of chat.
 	const text = `Started plugin create task for ${displayName} at ${workdir}. Task session ${task.sessionId} is ${task.status}; verification will run when it emits PLUGIN_CREATE_DONE.`;
-	await callback?.({ text });
 	logger.info(
 		`[plugin-manager] PLUGIN/create new name=${packageName} workdir=${workdir} session=${task.sessionId}`,
 	);
@@ -590,8 +591,7 @@ async function editExistingPlugin({
 	callback?: HandlerCallback;
 }): Promise<ActionResult> {
 	if (!plugin.path) {
-		const text = `Plugin "${plugin.name}" has no local source path. Eject it before editing.`;
-		await callback?.({ text });
+		const text = `Plugin "${plugin.name}" has no local source path; tell the user it must be ejected before editing.`;
 		return { success: false, text };
 	}
 	const dispatch = await dispatchCodingAgent({
@@ -604,12 +604,10 @@ async function editExistingPlugin({
 	});
 	if (dispatch.dispatched === false) {
 		const text = `Could not dispatch a coding agent to edit ${plugin.name}: ${dispatch.reason}.`;
-		await callback?.({ text });
 		return { success: false, text };
 	}
 	const task = dispatch.agents[0];
 	const text = `Started plugin edit task for ${plugin.name} at ${plugin.path}. Task session ${task.sessionId} is ${task.status}; verification will run when it emits PLUGIN_CREATE_DONE.`;
-	await callback?.({ text });
 	return {
 		success: true,
 		text,
@@ -681,8 +679,7 @@ export async function runCreate({
 				plugin.path === choice?.pluginPath,
 		);
 		if (!target) {
-			const text = `Plugin edit target "${normalized}" is no longer available.`;
-			await callback?.({ text });
+			const text = `Plugin edit target "${normalized}" is no longer available; tell the user that option has gone stale.`;
 			return { success: false, text };
 		}
 		return editExistingPlugin({
@@ -700,16 +697,16 @@ export async function runCreate({
 			(plugin) => plugin.name === targetName || plugin.path === targetName,
 		);
 		if (!target) {
-			const text = `Cannot find a local plugin named "${targetName}".`;
-			await callback?.({ text });
+			const text = `Cannot find a local plugin named "${targetName}"; tell the user no such plugin exists locally.`;
 			return { success: false, text };
 		}
 		return editExistingPlugin({ runtime, intent, plugin: target, callback });
 	}
 
 	if (!intent) {
-		const text = "Tell me what plugin you want to build.";
-		await callback?.({ text });
+		// Planner-facing only: the evaluator owns asking the user, in voice.
+		const text =
+			"No plugin intent found in the request; ask the user what plugin they want to build.";
 		return { success: false, text };
 	}
 
@@ -743,9 +740,15 @@ export async function runCreate({
 		matches,
 	);
 	await callback?.({ text });
+	// The choice block IS the designed ask the user must answer: verified +
+	// turnComplete make it the turn's sole delivery instead of pairing it with
+	// a second evaluator reply generated from a placeholder.
 	return {
 		success: true,
-		text: "Picking next step...",
+		text: "Asked the user to pick: create a new plugin, edit an existing match, or cancel.",
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: { mode: "create", subMode: "choice", matchCount: matches.length },
 		data: { choices, intent },
 	};

--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/eject.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/eject.ts
@@ -47,16 +47,20 @@ export async function runEject({
 		return { success: false, text };
 	}
 
+	// Human wording, no raw path or commit hash (those stay in values/data);
+	// verified + turnComplete make the confirmation the sole delivery.
 	const text =
-		`Ejected ${result.pluginName} to ${result.ejectedPath} ` +
-		`(commit ${result.upstreamCommit.slice(0, 8)})` +
+		`Ejected ${result.pluginName} — the local copy is ready to edit.` +
 		(result.requiresRestart
-			? "\nRestart required to load the local copy."
+			? " A restart is needed to load the local copy."
 			: "");
 	await callback?.({ text });
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			mode: "eject",
 			name: result.pluginName,

--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/install.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/install.ts
@@ -64,13 +64,19 @@ export async function runInstall({
 		return { success: false, text };
 	}
 
+	// Human wording, no raw filesystem path (that stays in values/data); the
+	// confirmation is the complete answer, so verified + turnComplete make it
+	// the sole delivery instead of double-messaging with the evaluator.
 	const text =
-		`Installed ${result.pluginName}@${result.version} at ${result.installPath}` +
-		(result.requiresRestart ? "\nRestart required to activate." : "");
+		`Installed ${result.pluginName} (v${result.version}).` +
+		(result.requiresRestart ? " A restart is needed before it's active." : "");
 	await callback?.({ text });
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			mode: "install",
 			name: result.pluginName,

--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/list-ejected.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/list-ejected.ts
@@ -35,7 +35,17 @@ export async function runListEjected({
 	if (plugins.length === 0) {
 		const text = "No ejected plugins found.";
 		await callback?.({ text });
-		return { success: true, text, values: { mode: "list_ejected", count: 0 } };
+		// The empty-result message is the complete answer: verified +
+		// turnComplete make it the sole delivery instead of double-messaging
+		// with the evaluator.
+		return {
+			success: true,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { mode: "list_ejected", count: 0 },
+		};
 	}
 
 	const list = plugins
@@ -43,9 +53,14 @@ export async function runListEjected({
 		.join("\n");
 	const text = `Ejected plugins (${plugins.length}):\n${list}`;
 	await callback?.({ text });
+	// The listing IS the complete answer: verified + turnComplete make it the
+	// sole delivery.
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: { mode: "list_ejected", count: plugins.length },
 		data: { plugins },
 	};

--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/list.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/list.ts
@@ -25,8 +25,9 @@ export async function runList({
 		"plugin_manager",
 	) as PluginManagerService | null;
 	if (!service) {
+		// Planner-facing only: raw service-availability tool-speak stays out of
+		// chat; the evaluator owns telling the user, in voice.
 		const text = "Plugin manager service not available";
-		await callback?.({ text });
 		return { success: false, text };
 	}
 
@@ -37,7 +38,17 @@ export async function runList({
 	if (all.length === 0 && installed.length === 0) {
 		const text = "No plugins are loaded or installed.";
 		await callback?.({ text });
-		return { success: true, text, values: { mode: "list", count: 0 } };
+		// The listing is the complete answer to a single-operation turn: verified
+		// + turnComplete make the callback the sole delivery instead of
+		// double-messaging with the evaluator.
+		return {
+			success: true,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { mode: "list", count: 0 },
+		};
 	}
 
 	if (all.length > 0) {
@@ -60,6 +71,9 @@ export async function runList({
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			mode: "list",
 			loadedCount: all.length,

--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/reinject.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/reinject.ts
@@ -46,13 +46,18 @@ export async function runReinject({
 		return { success: false, text };
 	}
 
+	// Human wording, no raw removed-path (it stays in values/data); verified +
+	// turnComplete make the confirmation the sole delivery.
 	const text =
-		`Reinjected ${result.pluginName} (removed ${result.removedPath})` +
-		(result.requiresRestart ? "\nRestart required." : "");
+		`Reinjected ${result.pluginName} — back on the standard installed version.` +
+		(result.requiresRestart ? " A restart is needed to pick it up." : "");
 	await callback?.({ text });
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			mode: "reinject",
 			name: result.pluginName,

--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/runtime-state.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/runtime-state.ts
@@ -131,9 +131,14 @@ export async function runPluginStatus({
 
 		const text = lines.join("\n");
 		await callback?.({ text });
+		// The status dump IS the answer: verified + turnComplete make it the
+		// sole delivery instead of double-messaging with the evaluator.
 		return {
 			success: true,
 			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
 			values: {
 				mode: "status",
 				name,
@@ -169,9 +174,13 @@ export async function runPluginStatus({
 		`  ejected: ${ejected.length}`,
 	].join("\n");
 	await callback?.({ text });
+	// Same single-delivery contract as the per-plugin status dump.
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			mode: "status",
 			totalPlugins: all.length,
@@ -235,9 +244,13 @@ export async function runPluginDetails({
 
 	const text = lines.join("\n");
 	await callback?.({ text });
+	// Same single-delivery contract as the status dumps.
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			mode: "details",
 			name: registry?.name ?? state?.name ?? name,
@@ -280,11 +293,16 @@ async function setPluginEnabled({
 			await service.unloadPlugin({ pluginId: state.id });
 		}
 		const updated = service.getPlugin(state.id);
-		const text = `Plugin ${state.name} ${enabled ? "enabled" : "disabled"} (${updated?.status ?? state.status}).`;
+		const text = `${enabled ? "Enabled" : "Disabled"} the ${state.name} plugin.`;
 		await callback?.({ text });
+		// The confirmation is the complete answer: verified + turnComplete make
+		// it the sole delivery; the raw status stays in values.
 		return {
 			success: true,
 			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
 			values: {
 				mode: enabled ? "enable" : "disable",
 				name: state.name,
@@ -294,11 +312,13 @@ async function setPluginEnabled({
 		};
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		const text = `Failed to ${enabled ? "enable" : "disable"} ${state.name}: ${message}`;
-		await callback?.({ text });
+		// Humanized callback; the raw error stays planner-facing in the result.
+		await callback?.({
+			text: `I couldn't ${enabled ? "enable" : "disable"} the ${state.name} plugin — something went wrong on my end.`,
+		});
 		return {
 			success: false,
-			text,
+			text: `Failed to ${enabled ? "enable" : "disable"} ${state.name}: ${message}`,
 			error: message,
 			values: { name: state.name, enabled },
 		};

--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/search.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/search.ts
@@ -46,7 +46,17 @@ export async function runSearch({
 	if (results.length === 0) {
 		const text = `No plugins found matching "${query}". Try keywords like database, twitter, solana, voice.`;
 		await callback?.({ text });
-		return { success: true, text, values: { mode: "search", count: 0 } };
+		// The empty-result message is the complete answer: verified +
+		// turnComplete make it the sole delivery instead of double-messaging
+		// with the evaluator.
+		return {
+			success: true,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { mode: "search", count: 0 },
+		};
 	}
 
 	const lines: string[] = [
@@ -67,9 +77,14 @@ export async function runSearch({
 
 	const text = lines.join("\n");
 	await callback?.({ text });
+	// The results listing IS the complete answer: verified + turnComplete
+	// make it the sole delivery.
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: { mode: "search", count: results.length, query },
 		data: { results },
 	};

--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/sync.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/sync.ts
@@ -46,13 +46,18 @@ export async function runSync({
 		return { success: false, text };
 	}
 
+	// Human wording, no commit-hash git-jargon (it stays in values/data);
+	// verified + turnComplete make the confirmation the sole delivery.
 	const text =
-		`Synced ${result.pluginName}: ${result.upstreamCommits} new upstream commit(s) at ${result.commitHash.slice(0, 8)}` +
-		(result.requiresRestart ? "\nRestart required." : "");
+		`Synced ${result.pluginName} with ${result.upstreamCommits} new upstream update(s).` +
+		(result.requiresRestart ? " A restart is needed to pick them up." : "");
 	await callback?.({ text });
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			mode: "sync",
 			name: result.pluginName,

--- a/packages/core/src/features/plugin-manager/actions/plugin.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin.ts
@@ -616,9 +616,18 @@ export function createPluginAction(deps: PluginActionDeps = {}): Action {
 			callback?: HandlerCallback,
 		): Promise<ActionResult> => {
 			if (!(await canManagePlugins(runtime, message))) {
-				const text = "Permission denied: only the owner may manage plugins.";
+				const text = "Sorry — plugin management is owner-only.";
 				await callback?.({ text });
-				return { success: false, text };
+				// The refusal is the complete answer: verified + turnComplete make
+				// it the sole delivery; the denial stays machine-readable in values.
+				return {
+					success: true,
+					text: "Permission denied: only the owner may manage plugins.",
+					userFacingText: text,
+					verifiedUserFacing: true,
+					turnComplete: true,
+					values: { permissionDenied: true },
+				};
 			}
 
 			const text = message.content.text ?? "";
@@ -669,12 +678,12 @@ export function createPluginAction(deps: PluginActionDeps = {}): Action {
 			});
 
 			if (!resolved.ok) {
-				const reply =
-					'Tell me which plugin operation to run. Try: "install @elizaos/plugin-discord", "list ejected plugins", "search for plugins for blockchain", "create a new plugin for X".';
-				await callback?.({ text: reply });
+				// Planner-facing only: the canned clarification boilerplate was a
+				// live double message next to the evaluator's in-voice reply. The
+				// evaluator owns asking the user, in voice.
 				return {
 					success: false,
-					text: reply,
+					text: "No clear plugin operation found in the request; ask the user whether they want to install, eject, list, search for, or create a plugin.",
 					data: { action: "clarify", missing: resolved.missing },
 				};
 			}

--- a/packages/core/src/features/plugin-manager/plugin-manager-routing.test.ts
+++ b/packages/core/src/features/plugin-manager/plugin-manager-routing.test.ts
@@ -183,6 +183,9 @@ describe("MANAGE_PLUGINS subaction routing", () => {
 		expect(result?.success).toBe(false);
 		expect(result?.data?.action).toBe("clarify");
 		expect(calls.installed).toHaveLength(0);
-		expect(replies.join("\n")).toContain("which plugin operation");
+		// Planner-facing contract: the clarification rides the result; no
+		// visible callback fires (the evaluator voices the question).
+		expect(replies).toHaveLength(0);
+		expect(String(result?.data?.action)).toBe("clarify");
 	});
 });

--- a/packages/core/src/features/secrets/actions/check-secret.ts
+++ b/packages/core/src/features/secrets/actions/check-secret.ts
@@ -106,9 +106,15 @@ export async function checkSecretHandler(
 		await callback({ text, action: "SECRETS" });
 	}
 
+	// The check result is the complete answer to a single-operation turn:
+	// verified + turnComplete make the callback the sole delivery instead of
+	// double-messaging with the evaluator.
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		data: { actionName: "SECRETS", action: "check", present, missing },
 	};
 }

--- a/packages/core/src/features/secrets/actions/get-secret.ts
+++ b/packages/core/src/features/secrets/actions/get-secret.ts
@@ -97,9 +97,15 @@ export async function getSecretHandler(
 		await callback({ text, action: "SECRETS" });
 	}
 
+	// The (masked) value readout is the complete answer to a single-operation
+	// turn: verified + turnComplete make the callback the sole delivery and
+	// keep the evaluator from re-echoing the masked value.
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		data: {
 			actionName: "SECRETS",
 			action: "get",

--- a/packages/core/src/features/secrets/actions/list-secrets.ts
+++ b/packages/core/src/features/secrets/actions/list-secrets.ts
@@ -108,9 +108,15 @@ export async function listSecretsHandler(
 		await callback({ text, action: "SECRETS" });
 	}
 
+	// The list summary is the complete answer to a single-operation turn:
+	// verified + turnComplete make the callback the sole delivery instead of
+	// double-messaging with the evaluator.
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		data: {
 			actionName: "SECRETS",
 			action: "list",

--- a/packages/core/src/features/secrets/actions/manage-secret.ts
+++ b/packages/core/src/features/secrets/actions/manage-secret.ts
@@ -279,14 +279,11 @@ export const secretsAction: Action = {
 			logger.warn(
 				"[SECRETS] Missing or unknown action; expected one of: get, set, delete, list, check, mirror, request",
 			);
-			const text =
-				"I'm not sure what secret operation you want. Choose get, set, delete, list, check, mirror, or request.";
-			if (callback) {
-				await callback({ text, action: "SECRETS" });
-			}
+			// Planner-facing only: the canned op menu is raw tool-speak a chat
+			// user never asked for. The evaluator owns asking the user, in voice.
 			return {
 				success: false,
-				text,
+				text: "No clear secret operation found in the request; ask the user whether they want to get, set, delete, list, check, mirror, or request a secret.",
 				data: { actionName: "SECRETS", action: null },
 			};
 		}

--- a/packages/core/src/features/secrets/actions/mirror-secret-to-vault.ts
+++ b/packages/core/src/features/secrets/actions/mirror-secret-to-vault.ts
@@ -138,13 +138,11 @@ export async function mirrorSecretToVaultHandler(
 		logger.warn(
 			`[SECRETS:mirror] Vault service '${vaultName}' is not available or does not implement setSecret`,
 		);
-		const text = `Vault service '${vaultName}' is not available.`;
-		if (callback) {
-			await callback({ text, action: "SECRETS" });
-		}
+		// Planner-facing only: the raw vault-service name is internal tool-speak
+		// that read as a double message next to the evaluator's in-voice reply.
 		return {
 			success: false,
-			text,
+			text: `Vault service '${vaultName}' is not available; tell the user the secret could not be mirrored because the vault backend is unavailable.`,
 			data: { actionName: "SECRETS", action: "mirror", mirrored: false },
 		};
 	}

--- a/packages/core/src/features/secrets/actions/request-secret.ts
+++ b/packages/core/src/features/secrets/actions/request-secret.ts
@@ -107,9 +107,15 @@ export async function requestSecretHandler(
 			if (exists) {
 				const text = `The secret '${key}' is already available. You can use it now.`;
 				if (callback) await callback({ text, action: "SECRETS" });
+				// The already-available confirmation is the complete answer to a
+				// single-operation turn: verified + turnComplete make the callback
+				// the sole delivery instead of double-messaging with the evaluator.
 				return {
 					success: true,
 					text,
+					userFacingText: text,
+					verifiedUserFacing: true,
+					turnComplete: true,
 					data: {
 						actionName: "SECRETS",
 						action: "request",

--- a/packages/core/src/features/secrets/actions/set-secret.ts
+++ b/packages/core/src/features/secrets/actions/set-secret.ts
@@ -70,15 +70,11 @@ export async function setSecretHandler(
 	const secretsService =
 		runtime.getService<SecretsService>(SECRETS_SERVICE_TYPE);
 	if (!secretsService) {
-		if (callback) {
-			await callback({
-				text: "Secret management is not available. Please ensure the secrets plugin is properly configured.",
-				action: "SECRETS",
-			});
-		}
+		// Planner-facing only: plugin-config boilerplate is not actionable for
+		// a chat user; the evaluator phrases the failure in voice.
 		return {
 			success: false,
-			text: "Secrets service not available",
+			text: "Secrets service is unavailable; tell the user secrets can't be stored right now.",
 			data: { actionName: "SECRETS", action: "set" },
 		};
 	}
@@ -176,29 +172,19 @@ export async function setSecretHandler(
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error);
 		logger.error(`[SECRETS:set] Failed to extract secrets: ${errorMessage}`);
-		if (callback) {
-			await callback({
-				text: 'I had trouble understanding the secret you wanted to set. Could you please provide it in a clearer format? For example: "Set my OPENAI_API_KEY to sk-..."',
-				action: "SECRETS",
-			});
-		}
+		// Planner-facing only: the canned clarification double-messaged next to
+		// the evaluator's in-voice reply. The evaluator owns asking the user.
 		return {
 			success: false,
-			text: "Failed to extract secrets from message",
+			text: 'Failed to extract secrets from the message; ask the user to restate it with a key and value, like "Set my OPENAI_API_KEY to sk-...".',
 			data: { actionName: "SECRETS", action: "set" },
 		};
 	}
 
 	if (extracted.secrets.length === 0) {
-		if (callback) {
-			await callback({
-				text: 'I couldn\'t find any secrets to set in your message. Please provide a key and value, like: "Set my OPENAI_API_KEY to sk-..."',
-				action: "SECRETS",
-			});
-		}
 		return {
 			success: false,
-			text: "No secrets found in message",
+			text: 'No secrets found in the message; ask the user to provide a key and value, like "Set my OPENAI_API_KEY to sk-...".',
 			data: { actionName: "SECRETS", action: "set" },
 		};
 	}
@@ -274,9 +260,15 @@ export async function setSecretHandler(
 		});
 	}
 
+	// The store confirmation is the complete answer to a single-operation
+	// turn: verified + turnComplete make the callback the sole delivery
+	// instead of double-confirming a secret write with an evaluator paraphrase.
 	return {
 		success: successful.length > 0,
 		text: responseText,
+		userFacingText: responseText,
+		verifiedUserFacing: true,
+		turnComplete: successful.length > 0,
 		data: { actionName: "SECRETS", action: "set", results },
 	};
 }

--- a/packages/core/src/features/trust/actions/roles.ts
+++ b/packages/core/src/features/trust/actions/roles.ts
@@ -110,13 +110,11 @@ export async function updateRoleHandler(
 
 	const channelType = message.content.channelType as ChannelType;
 	if (channelType !== ChannelType.GROUP && channelType !== ChannelType.WORLD) {
-		await callback?.({
-			text: "Role assignment only works in a group or world channel.",
-			actions: ["TRUST"],
-			source: "discord",
-		});
+		// Planner-facing only: channel/server plumbing is tool-speak; the
+		// evaluator explains the limitation to the user in voice.
 		return {
 			success: false,
+			text: "Role assignment only works in a group or world channel; tell the user roles can't be changed here.",
 			data: {
 				actionName: "TRUST",
 				subaction: "update_role",
@@ -129,13 +127,9 @@ export async function updateRoleHandler(
 	const { roomId } = message;
 	const serverId = message.content.serverId as string;
 	if (!serverId) {
-		await callback?.({
-			text: "Role assignment requires a serverId on the message.",
-			actions: ["TRUST"],
-			source: "discord",
-		});
 		return {
 			success: false,
+			text: "Role assignment requires a serverId on the message; tell the user roles can't be changed from this channel.",
 			data: {
 				actionName: "TRUST",
 				subaction: "update_role",
@@ -155,11 +149,9 @@ export async function updateRoleHandler(
 
 	if (!world) {
 		logger.error("World not found");
-		await callback?.({
-			text: "I couldn't find the world. This action only works in a world.",
-		});
 		return {
 			success: false,
+			text: "World not found; tell the user role assignment isn't available here.",
 			data: {
 				actionName: "TRUST",
 				subaction: "update_role",
@@ -254,13 +246,9 @@ export async function updateRoleHandler(
 		: extractRoleAssignments(parsed);
 
 	if (!result.length) {
-		await callback?.({
-			text: "No valid role assignments found in the request.",
-			actions: ["TRUST"],
-			source: "discord",
-		});
 		return {
 			success: false,
+			text: "No valid role assignments found in the request; ask the user who should get which role.",
 			data: {
 				actionName: "TRUST",
 				subaction: "update_role",
@@ -277,6 +265,7 @@ export async function updateRoleHandler(
 		newRole: Role;
 	}> = [];
 
+	const summaryLines: string[] = [];
 	for (const assignment of result) {
 		const targetEntity = entities.find((e) => e.id === assignment.entityId);
 		if (!targetEntity) {
@@ -287,11 +276,9 @@ export async function updateRoleHandler(
 		const currentRole = world.metadata.roles[assignment.entityId];
 
 		if (!canModifyRole(requesterRole, currentRole, assignment.newRole)) {
-			await callback?.({
-				text: `You don't have permission to change ${targetEntity.names[0]}'s role to ${assignment.newRole}.`,
-				actions: ["TRUST"],
-				source: "discord",
-			});
+			summaryLines.push(
+				`You don't have permission to change ${targetEntity.names[0]}'s role to ${assignment.newRole}.`,
+			);
 			continue;
 		}
 
@@ -304,11 +291,9 @@ export async function updateRoleHandler(
 			newRole: assignment.newRole,
 		});
 
-		await callback?.({
-			text: `Updated ${targetEntity.names[0]}'s role to ${assignment.newRole}.`,
-			actions: ["TRUST"],
-			source: "discord",
-		});
+		summaryLines.push(
+			`Updated ${targetEntity.names[0]}'s role to ${assignment.newRole}.`,
+		);
 	}
 
 	if (worldUpdated) {
@@ -316,18 +301,45 @@ export async function updateRoleHandler(
 		logger.info(`Updated roles in world metadata for server ${serverId}`);
 	}
 
+	if (!worldUpdated) {
+		return {
+			success: false,
+			data: {
+				actionName: "TRUST",
+				subaction: "update_role",
+				success: false,
+				updatedRoles,
+				totalProcessed: result.length,
+				totalUpdated: 0,
+			},
+			text: summaryLines.length
+				? summaryLines.join("\n")
+				: "No roles were updated.",
+		};
+	}
+
+	// One aggregated confirmation instead of a bubble per assignment: verified +
+	// turnComplete make it the turn's sole delivery instead of double-messaging
+	// with the evaluator.
+	const summaryText = summaryLines.join("\n");
+	await callback?.({
+		text: summaryText,
+		actions: ["TRUST"],
+		source: "discord",
+	});
 	return {
-		success: worldUpdated,
+		success: true,
+		userFacingText: summaryText,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		data: {
 			actionName: "TRUST",
 			subaction: "update_role",
-			success: worldUpdated,
+			success: true,
 			updatedRoles,
 			totalProcessed: result.length,
 			totalUpdated: updatedRoles.length,
 		},
-		text: worldUpdated
-			? `Successfully updated ${updatedRoles.length} role(s).`
-			: "No roles were updated.",
+		text: summaryText,
 	};
 }

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -243,6 +243,10 @@ async function saveAttachmentAsDocument(params: {
 	actionParams: Record<string, unknown>;
 	callback?: HandlerCallback;
 }): Promise<ActionResult> {
+	// suppressPostActionContinuation makes these callbacks the turn's sole
+	// delivery — removing them would end the turn silently, so the failure
+	// texts stay visible but in voice, marked verified (no turnComplete: the
+	// results are failures).
 	if (!params.content.trim()) {
 		const text = missingReadableContentMessage(params.records);
 		await params.callback?.({
@@ -253,6 +257,8 @@ async function saveAttachmentAsDocument(params: {
 		return {
 			success: false,
 			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
 			data: {
 				actionName: "ATTACHMENT",
 				action: "save_as_document",
@@ -265,7 +271,8 @@ async function saveAttachmentAsDocument(params: {
 		DocumentService.serviceType,
 	);
 	if (!service) {
-		const text = "Documents service not available.";
+		const text =
+			"I can't save documents right now — document storage isn't available.";
 		await params.callback?.({
 			text,
 			actions: ["ATTACHMENT_SAVE_AS_DOCUMENT_FAILED"],
@@ -274,6 +281,8 @@ async function saveAttachmentAsDocument(params: {
 		return {
 			success: false,
 			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
 			error: "DOCUMENTS_SERVICE_UNAVAILABLE",
 			data: { actionName: "ATTACHMENT", action: "save_as_document" },
 		};
@@ -318,7 +327,10 @@ async function saveAttachmentAsDocument(params: {
 			attachmentTitles: params.records.map(titleForRecord),
 		},
 	});
-	const text = `Saved "${title}" as a document. Document id: ${stored.clientDocumentId}.`;
+	// No raw UUID in chat — the document id stays planner-facing in data. The
+	// save confirmation is the complete answer to a single-operation turn:
+	// verified + turnComplete make it the sole delivery.
+	const text = `Saved "${title}" as a document.`;
 	await params.callback?.({
 		text,
 		actions: ["ATTACHMENT_SAVE_AS_DOCUMENT_SUCCESS"],
@@ -327,6 +339,9 @@ async function saveAttachmentAsDocument(params: {
 	return {
 		success: true,
 		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		data: {
 			actionName: "ATTACHMENT",
 			action: "save_as_document",
@@ -406,9 +421,18 @@ export const readAttachmentAction: Action = {
 						source: message.content.source,
 					});
 				}
+				// The attachment menu (or "nothing to read") IS the answer the
+				// user must act on: verified + turnComplete make it the sole
+				// delivery instead of pairing it with a second evaluator reply.
 				return {
-					success: false,
-					text: fallback,
+					success: true,
+					text: attachments.length
+						? "No attachment matched; showed the user the available attachments to pick from"
+						: fallback,
+					userFacingText: fallback,
+					verifiedUserFacing: true,
+					turnComplete: true,
+					values: { awaitingSelection: attachments.length > 0 },
 					data: { actionName: "ATTACHMENT", action },
 				};
 			}
@@ -485,9 +509,14 @@ export const readAttachmentAction: Action = {
 				});
 			}
 
+			// The read answer is the complete answer to a single-operation turn:
+			// verified + turnComplete make the callback the sole delivery.
 			return {
 				success: true,
 				text: visibleText,
+				userFacingText: visibleText,
+				verifiedUserFacing: true,
+				turnComplete: true,
 				data: {
 					actionName: "ATTACHMENT",
 					action: "read",

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -757,10 +757,13 @@ async function runCreateLegacy(
 ): Promise<ActionResult> {
   const service = getAcpService(runtime);
   if (!service) {
-    const text =
-      "ACP subprocess service is not available. Install acpx and ensure @elizaos/plugin-agent-orchestrator is loaded.";
-    await callbackText(callback, text);
-    return errorResult("SERVICE_UNAVAILABLE");
+    // Planner-facing only: the install boilerplate is dev tool-speak in chat
+    // next to the evaluator's in-voice reply. The evaluator owns telling the
+    // user coding tasks are unavailable.
+    return errorResult(
+      "SERVICE_UNAVAILABLE",
+      "ACP subprocess service is not available (acpx missing or plugin not loaded); tell the user coding tasks cannot run right now.",
+    );
   }
 
   const text = messageText(message);
@@ -1201,9 +1204,15 @@ async function runCreateLegacy(
   const proseText = `Created task agent${results.length > 1 ? "s" : ""}.${widgetBlock}`;
   await callbackText(callback, proseText);
 
+  // The creation ack is the complete answer to a single-operation turn:
+  // verified + turnComplete make the callback the sole delivery instead of
+  // double-messaging with the evaluator's paraphrase.
   return {
     success: true,
     text: proseText,
+    userFacingText: proseText,
+    verifiedUserFacing: true,
+    turnComplete: true,
     data: {
       agents: results,
       taskId: threadId,
@@ -1909,17 +1918,19 @@ async function runSpawnAgent(
       },
     };
   } catch (error) {
-    // error-policy:J1 spawn action boundary → user-facing error message + a
-    // structured failure result.
+    // error-policy:J1 spawn action boundary → structured failure to the
+    // planner; no visible callback (see runSend's catch) — the evaluator
+    // reports the failure in voice instead of a raw canned bubble.
     const messageTextValue = failureMessage(error);
     const code = isAuthError(error) ? "INVALID_CREDENTIALS" : messageTextValue;
-    await callbackText(
-      callback,
-      isAuthError(error)
-        ? "Invalid credentials for task agent."
+    return {
+      success: false,
+      error: code,
+      text: isAuthError(error)
+        ? "Task-agent credentials are invalid; tell the user the coding agent could not authenticate."
         : `Failed to spawn agent: ${messageTextValue}`,
-    );
-    return { success: false, error: code, continueChain: false };
+      continueChain: false,
+    };
   }
 }
 
@@ -1931,12 +1942,14 @@ async function runSend(
   state: State | undefined,
   params: Record<string, unknown>,
   content: Record<string, unknown>,
-  callback: HandlerCallback | undefined,
+  _callback: HandlerCallback | undefined,
 ): Promise<ActionResult> {
   const service = getAcpService(runtime);
   if (!service) {
-    await callbackText(callback, "ACP service is not available.");
-    return errorResult("SERVICE_UNAVAILABLE");
+    // Planner-facing only throughout runSend: acks and guards are progress
+    // notes, not the user's answer — the evaluator's in-voice reply is the
+    // turn's single delivery.
+    return errorResult("SERVICE_UNAVAILABLE", "ACP service is not available.");
   }
 
   try {
@@ -1950,20 +1963,19 @@ async function runSend(
 
     if (!target.session) {
       if (target.missingId) {
-        const text = `Session ${target.missingId} not found.`;
-        await callbackText(callback, text);
-        return errorResult("SESSION_NOT_FOUND");
+        return errorResult(
+          "SESSION_NOT_FOUND",
+          `Session ${target.missingId} not found.`,
+        );
       }
-      await callbackText(
-        callback,
-        "No active task-agent sessions. Spawn an agent first.",
+      return errorResult(
+        "NO_SESSION",
+        "No active task-agent sessions; spawn an agent first.",
       );
-      return errorResult("NO_SESSION");
     }
 
     if (keys) {
       await service.sendKeysToSession(target.session.id, keys);
-      await callbackText(callback, "Sent key sequence");
       return {
         success: true,
         text: "Sent key sequence",
@@ -1978,7 +1990,6 @@ async function runSend(
     if (textInput) {
       await service.sendToSession(target.session.id, textInput);
       const text = task ? "Assigned new task to agent" : "Sent input to agent";
-      await callbackText(callback, text);
       return {
         success: true,
         text,
@@ -2056,8 +2067,7 @@ async function runStopAgent(
 ): Promise<ActionResult> {
   const service = getAcpService(runtime);
   if (!service) {
-    await callbackText(callback, "ACP service is not available.");
-    return errorResult("SERVICE_UNAVAILABLE");
+    return errorResult("SERVICE_UNAVAILABLE", "ACP service is not available.");
   }
 
   try {
@@ -2076,9 +2086,18 @@ async function runStopAgent(
           }
         ).codingSession = undefined;
       if (state) (state as { codingSessions?: unknown }).codingSessions = [];
-      const text = `Stopped ${sessions.length} sessions`;
+      // The stop confirmation is the complete answer to a single-operation
+      // turn: verified + turnComplete make the callback the sole delivery.
+      const text = `Stopped ${sessions.length} task agent${sessions.length === 1 ? "" : "s"}.`;
       await callbackText(callback, text);
-      return { success: true, text, data: { stoppedCount: sessions.length } };
+      return {
+        success: true,
+        text,
+        userFacingText: text,
+        verifiedUserFacing: true,
+        turnComplete: true,
+        data: { stoppedCount: sessions.length },
+      };
     }
 
     const requestedId =
@@ -2091,12 +2110,20 @@ async function runStopAgent(
 
     if (!target) {
       if (requestedId) {
-        const text = `Session ${requestedId} not found.`;
-        await callbackText(callback, text);
-        return errorResult("SESSION_NOT_FOUND");
+        return errorResult(
+          "SESSION_NOT_FOUND",
+          `Session ${requestedId} not found.`,
+        );
       }
-      await callbackText(callback, "No sessions to stop");
-      return { success: true, text: "No sessions to stop" };
+      const noneText = "There are no task agents running.";
+      await callbackText(callback, noneText);
+      return {
+        success: true,
+        text: noneText,
+        userFacingText: noneText,
+        verifiedUserFacing: true,
+        turnComplete: true,
+      };
     }
 
     await service.stopSession(target.id);
@@ -2106,17 +2133,21 @@ async function runStopAgent(
     ) {
       (state as { codingSession?: unknown }).codingSession = undefined;
     }
-    await callbackText(callback, `Stopped task-agent session ${target.id}.`);
+    const stoppedText = "Stopped the task agent.";
+    await callbackText(callback, stoppedText);
     return {
       success: true,
-      text: `Stopped session ${target.id}`,
+      text: stoppedText,
+      userFacingText: stoppedText,
+      verifiedUserFacing: true,
+      turnComplete: true,
       data: { sessionId: target.id, agentType: String(target.agentType) },
     };
   } catch (error) {
-    // error-policy:J1 stop action boundary → user-facing error + structured failure.
+    // error-policy:J1 stop action boundary → structured failure to the
+    // planner; the evaluator reports the failure in voice.
     const msg = failureMessage(error);
-    await callbackText(callback, `Failed to stop agent: ${msg}`);
-    return { success: false, error: msg };
+    return { success: false, error: msg, text: `Failed to stop agent: ${msg}` };
   }
 }
 
@@ -2201,8 +2232,7 @@ async function runCancel(
 ): Promise<ActionResult> {
   const service = getAcpService(runtime);
   if (!service) {
-    await callbackText(callback, "ACP service is not available.");
-    return errorResult("SERVICE_UNAVAILABLE");
+    return errorResult("SERVICE_UNAVAILABLE", "ACP service is not available.");
   }
 
   try {
@@ -2222,11 +2252,16 @@ async function runCancel(
           service.stopSession(session.id));
         stoppedSessions.push(session.id);
       }
-      const text = `Canceled ${stoppedSessions.length} task(s).`;
+      // The cancel confirmation is the complete answer to a single-operation
+      // turn: verified + turnComplete make the callback the sole delivery.
+      const text = `Canceled ${stoppedSessions.length} task${stoppedSessions.length === 1 ? "" : "s"}.`;
       await callbackText(callback, text);
       return {
         success: true,
         text,
+        userFacingText: text,
+        verifiedUserFacing: true,
+        turnComplete: true,
         data: { canceledCount: stoppedSessions.length, stoppedSessions },
       };
     }
@@ -2242,22 +2277,28 @@ async function runCancel(
         : newestSession(sessions);
 
     if (!target) {
+      // Planner-facing only: the not-found guard next to the evaluator's
+      // in-voice reply was a double message.
       const code = sessionId ? "SESSION_NOT_FOUND" : "TASK_NOT_FOUND";
-      const text = sessionId
-        ? `Session ${sessionId} not found.`
-        : "No matching task found.";
-      await callbackText(callback, text);
-      return errorResult(code);
+      return errorResult(
+        code,
+        sessionId
+          ? `Session ${sessionId} not found.`
+          : "No matching task found.",
+      );
     }
 
     await (service.cancelSession?.(target.id) ??
       service.stopSession(target.id));
     const id = threadId ?? target.id;
-    const text = `Canceled task ${id}`;
+    const text = `Canceled task ${id}.`;
     await callbackText(callback, text);
     return {
       success: true,
       text,
+      userFacingText: text,
+      verifiedUserFacing: true,
+      turnComplete: true,
       data: {
         ...(threadId ? { threadId } : {}),
         sessionId: target.id,
@@ -2266,10 +2307,14 @@ async function runCancel(
       },
     };
   } catch (error) {
-    // error-policy:J1 cancel action boundary → user-facing error + structured failure.
+    // error-policy:J1 cancel action boundary → structured failure to the
+    // planner; the evaluator reports the failure in voice.
     const msg = failureMessage(error);
-    await callbackText(callback, `Failed to cancel task: ${msg}`);
-    return { success: false, error: msg };
+    return {
+      success: false,
+      error: msg,
+      text: `Failed to cancel task: ${msg}`,
+    };
   }
 }
 
@@ -2790,9 +2835,9 @@ async function runControl(
   );
 
   if (!action) {
+    // Planner-facing only: the evaluator owns asking the user, in voice.
     const msg =
-      "No task-control action was specified. Use pause, stop, resume, continue, archive, or reopen.";
-    if (callback) await callback({ text: msg });
+      "No task-control action was specified; ask the user whether they want to pause, stop, resume, continue, archive, or reopen the task.";
     return failureResult("TASKS:control", "INVALID_OPERATION", msg, {
       reason: "invalid_operation",
     });
@@ -2832,12 +2877,11 @@ async function runControl(
       try {
         resumedTask = await taskService.resumeTask(controlTaskId);
       } catch (err) {
-        // error-policy:J1 control action boundary → warns + user-facing error +
-        // structured failure result.
+        // error-policy:J1 control action boundary → warns + structured failure
+        // to the planner; the evaluator reports the failure in voice.
         const errMsg = err instanceof Error ? err.message : String(err);
         coreLogger.warn(`[TASKS:control] resume failed: ${errMsg}`);
         const out = `Failed to resume coding task ${controlTaskId}: ${errMsg}`;
-        if (callback) await callback({ text: out });
         return failureResult("TASKS:control", "LIFECYCLE_FAILED", out, {
           reason: "lifecycle_failed",
           taskId: controlTaskId,
@@ -2853,11 +2897,16 @@ async function runControl(
   );
   if (!target.session) {
     if (resumedTask && controlTaskId) {
-      const out = `Resumed coding task ${controlTaskId}. No active ACP session to instruct — the task is unpaused.`;
+      const out = "Resumed the coding task.";
       if (callback) await callback({ text: out });
       return {
         success: true,
-        text: out,
+        // Planner-facing text keeps the id for follow-ups; the visible layer
+        // stays human.
+        text: `Resumed coding task ${controlTaskId}`,
+        userFacingText: out,
+        verifiedUserFacing: true,
+        turnComplete: true,
         data: {
           actionName: "TASKS:control",
           action,
@@ -2866,10 +2915,11 @@ async function runControl(
         },
       };
     }
+    // Planner-facing only: the not-found guard next to the evaluator's
+    // in-voice reply was a double message.
     const msg = target.missingId
       ? `Session ${target.missingId} not found.`
       : "No active ACP session found.";
-    if (callback) await callback({ text: msg });
     return failureResult("TASKS:control", "SESSION_NOT_FOUND", msg, {
       reason: "session_not_found",
       action,
@@ -2888,19 +2938,24 @@ async function runControl(
   let responseText = "";
   if (action === "stop") {
     await service.stopSession(target.session.id);
-    responseText = `Stopped ACP session ${target.session.id}.`;
+    responseText = "Stopped the coding task.";
   } else {
     const nextInstruction =
       instruction?.trim() || "Continue with the current task.";
     await service.sendToSession(target.session.id, nextInstruction);
-    responseText = `Sent follow-up instructions to ACP session ${target.session.id}.`;
+    responseText = "Passed your follow-up instructions to the coding agent.";
     data = { ...data, instruction: nextInstruction };
   }
 
+  // The control outcome is the complete answer to a single-operation turn:
+  // verified + turnComplete make the callback the sole delivery.
   if (callback) await callback({ text: responseText });
   return {
     success: true,
     text: responseText,
+    userFacingText: responseText,
+    verifiedUserFacing: true,
+    turnComplete: true,
     data: data as ActionResult["data"],
   };
 }
@@ -2946,7 +3001,8 @@ async function runShare(
     `Workspace: ${target.session.workdir}`,
   ].join("\n");
 
-  if (callback) await callback({ text: responseText });
+  // No visible callback: session internals and absolute paths are
+  // planner-facing detail — the evaluator voices what the user needs.
   return {
     success: true,
     text: responseText,
@@ -3016,12 +3072,14 @@ async function runProvisionWorkspace(
   }
 
   const useWorktree = paramUseWorktree ?? content.useWorktree === true;
+  // Planner-facing only for these guards: canned parameter clarifications in
+  // chat next to the evaluator's in-voice reply were a double message.
   if (!repo && !useWorktree) {
-    if (callback)
-      await callback({
-        text: "Please specify a repository URL or use worktree mode with a parent workspace.",
-      });
-    return { success: false, error: "MISSING_REPO" };
+    return {
+      success: false,
+      error: "MISSING_REPO",
+      text: "No repository URL found in the request; ask the user which repository to provision (or to use worktree mode with a parent workspace).",
+    };
   }
 
   if (repo) {
@@ -3029,11 +3087,11 @@ async function runProvisionWorkspace(
     const ALLOWED_DOMAINS =
       /^https?:\/\/(github\.com|gitlab\.com|bitbucket\.org)\//i;
     if (!ALLOWED_DOMAINS.test(repo)) {
-      if (callback)
-        await callback({
-          text: "Repository URL must be from github.com, gitlab.com, or bitbucket.org.",
-        });
-      return { success: false, error: "INVALID_REPO_DOMAIN" };
+      return {
+        success: false,
+        error: "INVALID_REPO_DOMAIN",
+        text: "The repository URL is not from github.com, gitlab.com, or bitbucket.org; ask the user for a supported repository URL.",
+      };
     }
   }
 
@@ -3042,21 +3100,21 @@ async function runProvisionWorkspace(
     if (state?.codingWorkspace) {
       parentWorkspaceId = (state.codingWorkspace as { id: string }).id;
     } else {
-      if (callback)
-        await callback({
-          text: "Worktree mode requires a parent workspace. Clone a repo first or specify parentWorkspaceId.",
-        });
-      return { success: false, error: "MISSING_PARENT" };
+      return {
+        success: false,
+        error: "MISSING_PARENT",
+        text: "Worktree mode requires a parent workspace; ask the user to clone a repo first or provide parentWorkspaceId.",
+      };
     }
   }
   if (useWorktree && !repo && parentWorkspaceId) {
     const parentWorkspace = workspaceService.getWorkspace(parentWorkspaceId);
     if (!parentWorkspace) {
-      if (callback)
-        await callback({
-          text: `Parent workspace ${parentWorkspaceId} not found.`,
-        });
-      return { success: false, error: "WORKSPACE_NOT_FOUND" };
+      return {
+        success: false,
+        error: "WORKSPACE_NOT_FOUND",
+        text: `Parent workspace ${parentWorkspaceId} not found.`,
+      };
     }
     repo = parentWorkspace.repo;
   }
@@ -3086,17 +3144,21 @@ async function runProvisionWorkspace(
       };
     }
 
-    if (callback)
-      await callback({
-        text:
-          `Created workspace at ${workspace.path.slice(0, WORKSPACE_PATH_MAX_CHARS)}\n` +
-          `Branch: ${workspace.branch}\n` +
-          `Type: ${workspace.isWorktree ? "worktree" : "clone"}`,
-      });
+    const createdText =
+      `Created workspace at ${workspace.path.slice(0, WORKSPACE_PATH_MAX_CHARS)}\n` +
+      `Branch: ${workspace.branch}\n` +
+      `Type: ${workspace.isWorktree ? "worktree" : "clone"}`;
+    if (callback) await callback({ text: createdText });
 
+    // The provisioning confirmation is the complete answer to a
+    // single-operation turn: verified + turnComplete make the callback the
+    // sole delivery.
     return {
       success: true,
-      text: `Created workspace ${workspace.id}`,
+      text: createdText,
+      userFacingText: createdText,
+      verifiedUserFacing: true,
+      turnComplete: true,
       data: {
         workspaceId: workspace.id,
         path: workspace.path.slice(0, WORKSPACE_PATH_MAX_CHARS),
@@ -3170,31 +3232,38 @@ async function runSubmitWorkspace(
   if (!workspaceId) {
     const workspaces = workspaceService.listWorkspaces();
     if (workspaces.length === 0) {
-      if (callback)
-        await callback({
-          text: "No workspaces available. Provision a workspace first.",
-        });
-      return { success: false, error: "NO_WORKSPACE" };
+      // Planner-facing only: the guard next to the evaluator's in-voice reply
+      // was a double message.
+      return {
+        success: false,
+        error: "NO_WORKSPACE",
+        text: "No workspaces available; provision a workspace first.",
+      };
     }
     workspaceId = workspaces[workspaces.length - 1].id;
   }
 
   const workspace = workspaceService.getWorkspace(workspaceId);
   if (!workspace) {
-    if (callback)
-      await callback({ text: `Workspace ${workspaceId} not found.` });
-    return { success: false, error: "WORKSPACE_NOT_FOUND" };
+    return {
+      success: false,
+      error: "WORKSPACE_NOT_FOUND",
+      text: `Workspace ${workspaceId} not found.`,
+    };
   }
 
   try {
     const status = await workspaceService.getStatus(workspaceId);
 
     if (status.clean && status.staged.length === 0) {
-      if (callback)
-        await callback({ text: "No changes to commit in this workspace." });
+      const noChangesText = "No changes to commit in this workspace.";
+      if (callback) await callback({ text: noChangesText });
       return {
         success: true,
-        text: "No changes to commit",
+        text: noChangesText,
+        userFacingText: noChangesText,
+        verifiedUserFacing: true,
+        turnComplete: true,
         data: { workspaceId, status },
       };
     }
@@ -3232,28 +3301,22 @@ async function runSubmitWorkspace(
       });
     }
 
-    if (callback) {
-      if (prInfo) {
-        await callback({
-          text:
-            `Workspace finalized!\n` +
-            `Commit: ${commitHash.slice(0, 8)}\n` +
-            `PR #${prInfo.number}: ${prInfo.url}`,
-        });
-      } else {
-        await callback({
-          text:
-            `Workspace changes committed and pushed.\n` +
-            `Commit: ${commitHash.slice(0, 8)}`,
-        });
-      }
-    }
+    const finalizedText = prInfo
+      ? `Workspace finalized!\n` +
+        `Commit: ${commitHash.slice(0, 8)}\n` +
+        `PR #${prInfo.number}: ${prInfo.url}`
+      : `Workspace changes committed and pushed.\n` +
+        `Commit: ${commitHash.slice(0, 8)}`;
+    if (callback) await callback({ text: finalizedText });
 
+    // The finalize confirmation is the complete answer to a single-operation
+    // turn: verified + turnComplete make the callback the sole delivery.
     return {
       success: true,
-      text: prInfo
-        ? `Created PR #${prInfo.number}`
-        : "Changes committed and pushed",
+      text: finalizedText,
+      userFacingText: finalizedText,
+      verifiedUserFacing: true,
+      turnComplete: true,
       data: {
         workspaceId,
         commitHash,
@@ -3261,11 +3324,14 @@ async function runSubmitWorkspace(
       },
     };
   } catch (error) {
-    // error-policy:J1 submit action boundary → user-facing error + structured failure.
+    // error-policy:J1 submit action boundary → structured failure to the
+    // planner; the evaluator reports the failure in voice.
     const errorMessage = error instanceof Error ? error.message : String(error);
-    if (callback)
-      await callback({ text: `Failed to finalize workspace: ${errorMessage}` });
-    return { success: false, error: "FINALIZE_FAILED" };
+    return {
+      success: false,
+      error: "FINALIZE_FAILED",
+      text: `Failed to finalize workspace: ${errorMessage}`,
+    };
   }
 }
 
@@ -3378,20 +3444,30 @@ async function handleIssueAction(
               });
               created.push(issue);
             }
-            if (callback) {
-              const summary = created
-                .map((i) => `#${i.number}: ${i.title}\n  ${i.url}`)
-                .join("\n");
-              await callback({
-                text: `Created ${created.length} issues:\n${summary}`,
-              });
-            }
-            return { success: true, data: { issues: created } };
+            // Create/list/get answers are the complete answer to the turn:
+            // verified + turnComplete make the callback the sole delivery.
+            // Missing-param clarifications stay planner-facing — the
+            // evaluator owns asking the user, in voice.
+            const summary = created
+              .map((i) => `#${i.number}: ${i.title}\n  ${i.url}`)
+              .join("\n");
+            const bulkText = `Created ${created.length} issues:\n${summary}`;
+            if (callback) await callback({ text: bulkText });
+            return {
+              success: true,
+              text: bulkText,
+              userFacingText: bulkText,
+              verifiedUserFacing: true,
+              turnComplete: true,
+              data: { issues: created },
+            };
           }
 
-          if (callback)
-            await callback({ text: "Issue title is required for create." });
-          return { success: false, error: "MISSING_TITLE" };
+          return {
+            success: false,
+            error: "MISSING_TITLE",
+            text: "No issue title found in the request; ask the user what the issue title should be.",
+          };
         }
 
         const labels = parseLabels(params.labels);
@@ -3400,11 +3476,16 @@ async function handleIssueAction(
           body: body ?? "",
           labels: labels.length > 0 ? labels : undefined,
         });
-        if (callback)
-          await callback({
-            text: `Created issue #${issue.number}: ${issue.title}\n${issue.url}`,
-          });
-        return { success: true, data: { issue } };
+        const createdText = `Created issue #${issue.number}: ${issue.title}\n${issue.url}`;
+        if (callback) await callback({ text: createdText });
+        return {
+          success: true,
+          text: createdText,
+          userFacingText: createdText,
+          verifiedUserFacing: true,
+          turnComplete: true,
+          data: { issue },
+        };
       }
 
       case "list": {
@@ -3416,43 +3497,56 @@ async function handleIssueAction(
             labels: labels.length > 0 ? labels : undefined,
           })
         ).slice(0, ISSUE_RESULT_LIMIT);
-        if (callback) {
-          if (issues.length === 0) {
-            await callback({
-              text: `No ${stateFilter} issues found in ${repo}.`,
-            });
-          } else {
-            const summary = issues
-              .map(
-                (i) =>
-                  `#${i.number} [${i.state}] ${i.title}${i.labels.length > 0 ? ` (${i.labels.join(", ")})` : ""}`,
-              )
-              .join("\n");
-            await callback({ text: `Issues in ${repo}:\n${summary}` });
-          }
-        }
-        return { success: true, data: { issues } };
+        const listText =
+          issues.length === 0
+            ? `No ${stateFilter} issues found in ${repo}.`
+            : `Issues in ${repo}:\n${issues
+                .map(
+                  (i) =>
+                    `#${i.number} [${i.state}] ${i.title}${i.labels.length > 0 ? ` (${i.labels.join(", ")})` : ""}`,
+                )
+                .join("\n")}`;
+        if (callback) await callback({ text: listText });
+        return {
+          success: true,
+          text: listText,
+          userFacingText: listText,
+          verifiedUserFacing: true,
+          turnComplete: true,
+          data: { issues },
+        };
       }
 
       case "get": {
         const issueNumber = Number(params.issueNumber);
         if (!issueNumber) {
-          if (callback) await callback({ text: "Issue number is required." });
-          return { success: false, error: "MISSING_ISSUE_NUMBER" };
+          return {
+            success: false,
+            error: "MISSING_ISSUE_NUMBER",
+            text: "No issue number found in the request; ask the user which issue they mean.",
+          };
         }
         const issue = await service.getIssue(repo, issueNumber);
-        if (callback)
-          await callback({
-            text: `Issue #${issue.number}: ${issue.title} [${issue.state}]\n\n${issue.body.slice(0, ISSUE_BODY_MAX_CHARS)}\n\nLabels: ${issue.labels.join(", ") || "none"}\n${issue.url}`,
-          });
-        return { success: true, data: { issue } };
+        const issueText = `Issue #${issue.number}: ${issue.title} [${issue.state}]\n\n${issue.body.slice(0, ISSUE_BODY_MAX_CHARS)}\n\nLabels: ${issue.labels.join(", ") || "none"}\n${issue.url}`;
+        if (callback) await callback({ text: issueText });
+        return {
+          success: true,
+          text: issueText,
+          userFacingText: issueText,
+          verifiedUserFacing: true,
+          turnComplete: true,
+          data: { issue },
+        };
       }
 
       case "update": {
         const issueNumber = Number(params.issueNumber);
         if (!issueNumber) {
-          if (callback) await callback({ text: "Issue number is required." });
-          return { success: false, error: "MISSING_ISSUE_NUMBER" };
+          return {
+            success: false,
+            error: "MISSING_ISSUE_NUMBER",
+            text: "No issue number found in the request; ask the user which issue they mean.",
+          };
         }
         const labels = parseLabels(params.labels);
         const issue = await service.updateIssue(repo, issueNumber, {
@@ -3471,11 +3565,11 @@ async function handleIssueAction(
         const issueNumber = Number(params.issueNumber);
         const body = params.body as string;
         if (!issueNumber || !body) {
-          if (callback)
-            await callback({
-              text: "Issue number and comment body are required.",
-            });
-          return { success: false, error: "MISSING_PARAMS" };
+          return {
+            success: false,
+            error: "MISSING_PARAMS",
+            text: "Missing the issue number or comment body; ask the user for both.",
+          };
         }
         const comment = await service.addComment(repo, issueNumber, body);
         if (callback)
@@ -3488,8 +3582,11 @@ async function handleIssueAction(
       case "close": {
         const issueNumber = Number(params.issueNumber);
         if (!issueNumber) {
-          if (callback) await callback({ text: "Issue number is required." });
-          return { success: false, error: "MISSING_ISSUE_NUMBER" };
+          return {
+            success: false,
+            error: "MISSING_ISSUE_NUMBER",
+            text: "No issue number found in the request; ask the user which issue they mean.",
+          };
         }
         const issue = await service.closeIssue(repo, issueNumber);
         if (callback)
@@ -3502,8 +3599,11 @@ async function handleIssueAction(
       case "reopen": {
         const issueNumber = Number(params.issueNumber);
         if (!issueNumber) {
-          if (callback) await callback({ text: "Issue number is required." });
-          return { success: false, error: "MISSING_ISSUE_NUMBER" };
+          return {
+            success: false,
+            error: "MISSING_ISSUE_NUMBER",
+            text: "No issue number found in the request; ask the user which issue they mean.",
+          };
         }
         const issue = await service.reopenIssue(repo, issueNumber);
         if (callback)
@@ -3517,9 +3617,11 @@ async function handleIssueAction(
         const issueNumber = Number(params.issueNumber);
         const labels = parseLabels(params.labels);
         if (!issueNumber || labels.length === 0) {
-          if (callback)
-            await callback({ text: "Issue number and labels are required." });
-          return { success: false, error: "MISSING_PARAMS" };
+          return {
+            success: false,
+            error: "MISSING_PARAMS",
+            text: "Missing the issue number or labels; ask the user for both.",
+          };
         }
         await service.addLabels(repo, issueNumber, labels);
         if (callback)

--- a/plugins/plugin-app-control/src/actions/agent-switch.ts
+++ b/plugins/plugin-app-control/src/actions/agent-switch.ts
@@ -196,10 +196,20 @@ export function createAgentSwitchAction(
 				options,
 			);
 			if (!profile) {
+				// The ask IS the turn's complete answer: verified + turnComplete
+				// make the callback the sole delivery instead of double-messaging
+				// with the evaluator; the un-resolved state stays in values.
 				const reply =
 					'Tell me which agent to switch to — e.g. "switch to my cloud agent" or "use the laptop runtime".';
 				await callback?.({ text: reply });
-				return { success: false, text: reply };
+				return {
+					success: true,
+					text: "No target agent named; asked the user which agent to switch to.",
+					userFacingText: reply,
+					verifiedUserFacing: true,
+					turnComplete: true,
+					values: { awaitingProfile: true },
+				};
 			}
 
 			logger.info(`[plugin-app-control] AGENT_SWITCH profile="${profile}"`);
@@ -207,20 +217,31 @@ export function createAgentSwitchAction(
 			try {
 				const outcome = await switchAgent(profile);
 				if (!outcome.ok) {
+					// Refusals stay unsuccessful for the planner, but the narration
+					// is already in-voice — verified provenance stops the evaluator
+					// from re-voicing it as a second message.
 					const reply = narrateRefusal(outcome.reason, profile);
 					await callback?.({ text: reply });
 					return {
 						success: false,
 						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
 						values: { profile, reason: outcome.reason },
 					};
 				}
 				const label = outcome.profileLabel ?? outcome.profileId ?? profile;
 				const reply = `Switched the app to "${label}".`;
 				await callback?.({ text: reply });
+				// The switch confirmation is the complete answer to a
+				// single-operation turn: verified + turnComplete make the callback
+				// the sole delivery instead of double-messaging with the evaluator.
 				return {
 					success: true,
 					text: reply,
+					userFacingText: reply,
+					verifiedUserFacing: true,
+					turnComplete: true,
 					values: {
 						profile,
 						profileId: outcome.profileId,

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -680,9 +680,19 @@ async function createNewApp({
 	// half-created app dir behind.
 	const preflight = await preflightCodingDispatch(runtime);
 	if (!preflight.ok) {
+		// The setup guidance IS the complete answer to this turn (the user must
+		// act before a build can start): verified + turnComplete make the
+		// callback the sole delivery; the failure stays machine-visible in data.
 		const text = `I can't build an app yet. ${preflight.guidance.join(" ")}`;
 		await callback?.({ text });
-		return { success: false, text };
+		return {
+			success: true,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			data: { preflightFailed: true },
+		};
 	}
 
 	const { name, displayName } = await extractNames(runtime, intent);
@@ -690,9 +700,18 @@ async function createNewApp({
 	const template = await resolveScaffoldTemplateDir(repoRoot, "min-project");
 	const templateSrc = template.dir;
 	if (!templateSrc) {
+		// Same contract as the preflight guidance above: the explanation is the
+		// turn's complete answer.
 		const text = `I can't scaffold a new app: ${templateMissingGuidance("min-project", template.tried)}`;
 		await callback?.({ text });
-		return { success: false, text };
+		return {
+			success: true,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			data: { templateMissing: true },
+		};
 	}
 
 	const { workdir, appDirName } = await findFreeWorkdir(repoRoot, name);
@@ -961,9 +980,17 @@ export async function runCreate({
 		.join(" — ");
 	const intent = explicitIntent || composedIntent || userText;
 	if (!intent) {
+		// The ask is already in-voice; verified provenance stops the evaluator
+		// from re-voicing it as a second message. The result stays unsuccessful
+		// so callers still see the create did not start.
 		const text = "Tell me what app you want to build.";
 		await callback?.({ text });
-		return { success: false, text };
+		return {
+			success: false,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+		};
 	}
 
 	// Explicit edit hint short-circuits the picker.

--- a/plugins/plugin-app-control/src/actions/app-launch.ts
+++ b/plugins/plugin-app-control/src/actions/app-launch.ts
@@ -26,22 +26,41 @@ export async function runLaunch({
 }: RunLaunchInput): Promise<ActionResult> {
 	const target = extractLaunchTarget(message, options);
 	if (!target) {
-		const text =
-			'I need the app name to launch. Try: "launch shopify" or pass { app: "feed" }.';
+		// The clarification IS the designed ask the user must answer: verified +
+		// turnComplete make it the turn's sole delivery instead of pairing it
+		// with a second evaluator reply.
+		const text = 'Which app should I launch? For example: "launch shopify".';
 		await callback?.({ text });
-		return { success: false, text };
+		return {
+			success: true,
+			text: "No app name found in the launch request; asked the user which app to launch",
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { awaitingAppName: true },
+		};
 	}
 
 	const installed = await client.listInstalledApps();
 	const resolution = resolveInstalledApp(target, installed);
 
 	if (resolution.kind === "ambiguous") {
+		// Same contract as the missing-name clarify: the candidate menu is the
+		// complete answer the user must pick from.
 		const candidates = resolution.candidates ?? [];
 		const text = `"${target}" matches multiple apps:\n${formatAppCandidates(
 			candidates,
 		)}\nPlease specify which one.`;
 		await callback?.({ text });
-		return { success: false, text, data: { candidates } };
+		return {
+			success: true,
+			text: `"${target}" matched multiple installed apps; asked the user to pick one`,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { awaitingAppChoice: true },
+			data: { candidates },
+		};
 	}
 
 	if (resolution.kind === "none") {

--- a/plugins/plugin-app-control/src/actions/app-load-from-directory.ts
+++ b/plugins/plugin-app-control/src/actions/app-load-from-directory.ts
@@ -179,10 +179,21 @@ export async function runLoadFromDirectory({
 }: RunLoadFromDirectoryInput): Promise<ActionResult> {
 	const directory = readStringOption(options, "directory");
 	if (!directory) {
+		// The path ask is the designed answer the user must respond to: verified
+		// + turnComplete make the callback the sole delivery instead of pairing
+		// it with a second evaluator reply, and the wording stays free of raw
+		// option-JSON tool-speak.
 		const text =
-			'I need an absolute directory path. Try: pass { directory: "/abs/path/to/apps" }.';
+			"Which folder should I load apps from? I need the full absolute path.";
 		await callback?.({ text });
-		return { success: false, text };
+		return {
+			success: true,
+			text: "No directory provided; asked the user for the absolute apps folder path.",
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { awaitingDirectory: true },
+		};
 	}
 
 	if (!path.isAbsolute(directory)) {
@@ -195,9 +206,17 @@ export async function runLoadFromDirectory({
 		APP_REGISTRY_SERVICE_TYPE,
 	) as AppRegistryService | null;
 	if (!service) {
-		const text = "AppRegistryService is not registered; cannot load apps.";
+		// Chat gets one human sentence without the internal service name; the
+		// machine detail stays planner-facing in the result text.
+		const text =
+			"I can't load apps right now — app loading isn't available in this build.";
 		await callback?.({ text });
-		return { success: false, text };
+		return {
+			success: false,
+			text: "AppRegistryService is not registered; cannot load apps.",
+			userFacingText: text,
+			verifiedUserFacing: true,
+		};
 	}
 
 	const { apps: discovered, rejectedManifests } = await discoverApps(directory);

--- a/plugins/plugin-app-control/src/actions/app-relaunch.ts
+++ b/plugins/plugin-app-control/src/actions/app-relaunch.ts
@@ -47,10 +47,19 @@ export async function runRelaunch({
 		extractLaunchTarget(message, options);
 
 	if (!target && !explicitRunId) {
-		const text =
-			'I need an app name or runId to relaunch. Try: "relaunch shopify".';
+		const text = "Which app should I relaunch?";
 		await callback?.({ text });
-		return { success: false, text };
+		// The clarify question is the designed ask the user must answer: verified
+		// + turnComplete make it the sole delivery instead of pairing it with a
+		// second evaluator reply.
+		return {
+			success: true,
+			text: "No app name in the relaunch request; asked the user which app to relaunch",
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { awaitingAppName: true },
+		};
 	}
 
 	let appName = target ?? "";
@@ -63,7 +72,15 @@ export async function runRelaunch({
 				candidates,
 			)}\nPlease specify which one.`;
 			await callback?.({ text });
-			return { success: false, text, data: { candidates } };
+			return {
+				success: true,
+				text: `"${target}" matched multiple installed apps; asked the user which one to relaunch`,
+				userFacingText: text,
+				verifiedUserFacing: true,
+				turnComplete: true,
+				values: { awaitingSelection: true },
+				data: { candidates },
+			};
 		}
 		appName = resolution.match?.name ?? target;
 	}
@@ -93,9 +110,16 @@ export async function runRelaunch({
 	}
 
 	if (!appName) {
-		const text = `Stopped run ${explicitRunId} but no app name was supplied to relaunch.`;
+		const text = "I stopped that run, but which app should I relaunch?";
 		await callback?.({ text });
-		return { success: false, text };
+		return {
+			success: true,
+			text: `Stopped run ${explicitRunId} but no app name was supplied; asked the user which app to relaunch`,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { awaitingAppName: true },
+		};
 	}
 
 	const launch = await client.launchApp(appName);
@@ -105,6 +129,7 @@ export async function runRelaunch({
 		: `Relaunched ${launch.displayName}.`;
 
 	let verifySection = "";
+	let verifyFailDetail: string | undefined;
 	const wantsVerify =
 		options?.verify === true || readStringOption(options, "verify") === "true";
 	if (wantsVerify) {
@@ -125,11 +150,15 @@ export async function runRelaunch({
 					appName,
 					profile: "fast",
 				});
-				verifySection = `\nVerify (fast): ${verifyResult.verdict}${
+				// retryablePromptForChild is written for a child coding agent — it
+				// stays planner-facing in the result; the visible line stays human.
+				verifySection =
 					verifyResult.verdict === "fail"
-						? `\n${verifyResult.retryablePromptForChild}`
-						: ""
-				}`;
+						? "\nA quick verification check failed after the relaunch — the app may not be fully working yet."
+						: "\nA quick verification check passed.";
+				if (verifyResult.verdict === "fail") {
+					verifyFailDetail = verifyResult.retryablePromptForChild;
+				}
 			}
 		}
 	}
@@ -142,7 +171,7 @@ export async function runRelaunch({
 
 	return {
 		success: true,
-		text,
+		text: verifyFailDetail ? `${text}\n${verifyFailDetail}` : text,
 		values: {
 			mode: "relaunch",
 			appName,

--- a/plugins/plugin-app-control/src/actions/app.ts
+++ b/plugins/plugin-app-control/src/actions/app.ts
@@ -322,7 +322,7 @@ export function createAppAction(deps: AppActionDeps = {}): Action {
 		): Promise<ActionResult> => {
 			const actionOptions = normalizeActionOptions(options);
 			if (!(await canManageApps(runtime, message))) {
-				const text = "Permission denied: only the owner may manage apps.";
+				const text = "Sorry — only my owner can manage apps.";
 				await callback?.({ text });
 				return { success: false, text };
 			}
@@ -348,9 +348,11 @@ export function createAppAction(deps: AppActionDeps = {}): Action {
 
 			const mode = inferMode(text, actionOptions);
 			if (!mode) {
+				// Planner-facing only: the canned mode menu double-messaged next to
+				// the evaluator's in-voice clarification. The evaluator owns asking
+				// the user, in voice.
 				const reply =
-					'Tell me which app to control. Try: "launch shopify", "list running apps", "create a new note-taking app".';
-				await callback?.({ text: reply });
+					"No app-control mode could be inferred; ask the user whether they want to launch, relaunch, list, load, or create an app.";
 				return { success: false, text: reply };
 			}
 

--- a/plugins/plugin-app-control/src/actions/background.ts
+++ b/plugins/plugin-app-control/src/actions/background.ts
@@ -755,10 +755,18 @@ export function createBackgroundAction(
 			);
 
 			if (!plan) {
+				// The ask is already in-voice; verified provenance stops the
+				// evaluator from re-voicing it as a second message. The result
+				// stays unsuccessful so callers see nothing was applied.
 				const reply =
 					'Tell me how to change the background — e.g. "make the background teal", "use this photo", "generate a misty forest", or "undo".';
 				await callback?.({ text: reply });
-				return { success: false, text: reply };
+				return {
+					success: false,
+					text: reply,
+					userFacingText: reply,
+					verifiedUserFacing: true,
+				};
 			}
 
 			logger.info(
@@ -768,23 +776,47 @@ export function createBackgroundAction(
 			);
 
 			try {
+				// Every outcome reply below is the complete answer to a
+				// single-operation turn: verified + turnComplete make the callback
+				// the sole delivery instead of double-messaging with the evaluator.
 				if (plan.op === "undo") {
 					await emit({ op: "undo" });
 					const reply = "Reverted the background to the previous one.";
 					await callback?.({ text: reply });
-					return { success: true, text: reply, values: { op: "undo" } };
+					return {
+						success: true,
+						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
+						values: { op: "undo" },
+					};
 				}
 				if (plan.op === "redo") {
 					await emit({ op: "redo" });
 					const reply = "Re-applied the background you undid.";
 					await callback?.({ text: reply });
-					return { success: true, text: reply, values: { op: "redo" } };
+					return {
+						success: true,
+						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
+						values: { op: "redo" },
+					};
 				}
 				if (plan.op === "reset") {
 					await emit({ op: "reset" });
 					const reply = "Reset the background to the default.";
 					await callback?.({ text: reply });
-					return { success: true, text: reply, values: { op: "reset" } };
+					return {
+						success: true,
+						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
+						values: { op: "reset" },
+					};
 				}
 				if (plan.op === "navigate-upload") {
 					// No image to apply — take the user to the Background view, where
@@ -796,6 +828,9 @@ export function createBackgroundAction(
 					return {
 						success: true,
 						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
 						values: { op: "navigate-upload", viewId: "background" },
 					};
 				}
@@ -804,10 +839,20 @@ export function createBackgroundAction(
 					// The [BACKGROUND] marker is parsed by the UI into the
 					// BackgroundSettingsControls filmstrip; the picks it makes drive the
 					// same persisted background config globally (no view event needed).
+					// The [BACKGROUND] marker must reach chat verbatim (the UI parses
+					// it into the filmstrip), so userFacingText carries the exact
+					// callback string.
 					const reply =
 						"Here are your background options — pick one:\n\n[BACKGROUND]";
 					await callback?.({ text: reply });
-					return { success: true, text: reply, values: { op: "pick" } };
+					return {
+						success: true,
+						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
+						values: { op: "pick" },
+					};
 				}
 				if ("mode" in plan && plan.mode === "catalog") {
 					// Named curated-catalog entry. The renderer resolves catalogId →
@@ -818,6 +863,9 @@ export function createBackgroundAction(
 					return {
 						success: true,
 						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
 						values: { op: "set", mode: "catalog", catalogId: plan.catalogId },
 					};
 				}
@@ -830,6 +878,9 @@ export function createBackgroundAction(
 					return {
 						success: true,
 						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
 						values: { op: "set", mode: "glsl", presetId: plan.presetId },
 					};
 				}
@@ -841,6 +892,9 @@ export function createBackgroundAction(
 					return {
 						success: true,
 						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
 						values: { op: "set", mode: "glsl", tweak: plan.tweakLabel },
 					};
 				}
@@ -851,6 +905,9 @@ export function createBackgroundAction(
 					return {
 						success: true,
 						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
 						values: { op: "set", mode: "shader", color: plan.color },
 					};
 				}
@@ -861,6 +918,9 @@ export function createBackgroundAction(
 					return {
 						success: true,
 						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
 						values: { op: "set", mode: "image" },
 						data: { imageUrl: plan.imageUrl },
 					};
@@ -873,6 +933,9 @@ export function createBackgroundAction(
 				return {
 					success: true,
 					text: reply,
+					userFacingText: reply,
+					verifiedUserFacing: true,
+					turnComplete: true,
 					values: { op: "set", mode: "image" },
 					data: { imageUrl: url, prompt: plan.generatePrompt },
 				};

--- a/plugins/plugin-app-control/src/actions/model-switch.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.ts
@@ -251,10 +251,20 @@ export function createModelSwitchAction(
 				options,
 			);
 			if (!request) {
+				// The ask IS the turn's complete answer: verified + turnComplete
+				// make the callback the sole delivery instead of double-messaging
+				// with the evaluator; the un-resolved state stays in values.
 				const reply =
 					'Tell me where to run inference — "switch to the local model" or "use Eliza Cloud". You can also name a tier, e.g. "use eliza-1-4b".';
 				await callback?.({ text: reply });
-				return { success: false, text: reply };
+				return {
+					success: true,
+					text: "No inference target named; asked the user where to run inference.",
+					userFacingText: reply,
+					verifiedUserFacing: true,
+					turnComplete: true,
+					values: { awaitingTarget: true },
+				};
 			}
 
 			const refusal = sanctionedModelError(request.target, request.model);
@@ -284,9 +294,15 @@ export function createModelSwitchAction(
 				}
 				const reply = narrate(outcome);
 				await callback?.({ text: reply });
+				// The switch confirmation is the complete answer to a
+				// single-operation turn: verified + turnComplete make the callback
+				// the sole delivery instead of double-messaging with the evaluator.
 				return {
 					success: true,
 					text: reply,
+					userFacingText: reply,
+					verifiedUserFacing: true,
+					turnComplete: true,
 					values: {
 						target: outcome.target ?? request.target,
 						model: outcome.model,

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -2134,7 +2134,9 @@ describe("SETTINGS action: set on delegated/readonly/unwired sections", () => {
 		expect(routeFetch).not.toHaveBeenCalled();
 		expect(result?.success).toBe(false);
 		expect(result?.data).toMatchObject({ delegateTo: "PLUGIN" });
-		expect(texts.join(" ")).toContain("PLUGIN");
+		// Planner-facing contract: routing guidance never posts to chat.
+		expect(texts).toHaveLength(0);
+		expect(result?.text).toContain("PLUGIN");
 	});
 
 	it("delegates vault settings to SECRETS, not the browser credential action", async () => {
@@ -2146,7 +2148,8 @@ describe("SETTINGS action: set on delegated/readonly/unwired sections", () => {
 		expect(routeFetch).not.toHaveBeenCalled();
 		expect(result?.success).toBe(false);
 		expect(result?.data).toMatchObject({ delegateTo: "SECRETS" });
-		expect(texts.join(" ")).toContain("SECRETS");
+		expect(texts).toHaveLength(0);
+		expect(result?.text).toContain("SECRETS");
 	});
 
 	it("refuses to write a read-only section", async () => {
@@ -2156,7 +2159,8 @@ describe("SETTINGS action: set on delegated/readonly/unwired sections", () => {
 			value: "on",
 		});
 		expect(result?.success).toBe(false);
-		expect(texts.join(" ")).toContain("read-only");
+		expect(texts).toHaveLength(0);
+		expect(result?.text).toContain("read-only");
 	});
 
 	it("refuses every unwired gap section with its stated reason", async () => {

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -1804,9 +1804,9 @@ async function handleSet(
 	callback: HandlerCallback | undefined,
 ): Promise<ActionResult> {
 	if (!request.sectionId) {
+		// Planner-facing only: the evaluator owns asking the user, in voice.
 		const reply =
-			"Tell me which settings section to change (e.g. permissions, model, background).";
-		await callback?.({ text: reply });
+			"No settings section named in the request; ask the user which section to change (e.g. permissions, model, background).";
 		return { success: false, text: reply };
 	}
 	const cap = SETTINGS_WRITE_REGISTRY[request.sectionId];
@@ -1815,8 +1815,8 @@ async function handleSet(
 		// Point the planner at the dedicated action rather than duplicating its
 		// write. routingHint already prefers that action; this is the safety net
 		// for when the planner reached SETTINGS anyway.
+		// Planner-facing only: raw action names are routing guidance, not chat.
 		const reply = `Changing ${request.sectionId} runs through the ${cap.action} action — ${cap.summary}`;
-		await callback?.({ text: reply });
 		return {
 			success: false,
 			text: reply,
@@ -1826,7 +1826,6 @@ async function handleSet(
 
 	if (cap.kind === "readonly") {
 		const reply = `${request.sectionId} is read-only: ${cap.summary}`;
-		await callback?.({ text: reply });
 		return { success: false, text: reply };
 	}
 
@@ -1927,8 +1926,8 @@ function handleGet(
 	callback: HandlerCallback | undefined,
 ): ActionResult {
 	if (!request.sectionId) {
-		const reply = "Which settings section do you want to read?";
-		void callback?.({ text: reply });
+		const reply =
+			"No settings section named in the request; ask the user which section they want to read.";
 		return { success: false, text: reply };
 	}
 	const cap = SETTINGS_WRITE_REGISTRY[request.sectionId];
@@ -1942,6 +1941,9 @@ function handleGet(
 				: cap.summary;
 	const reply = `${label}: ${summary}`;
 	void callback?.({ text: reply });
+	// Deliberately un-gated: get is a capability probe the planner composes
+	// with (the write-capability data is machine-facing), unlike list/set
+	// which own their canonical reply.
 	return {
 		success: true,
 		text: reply,

--- a/plugins/plugin-app-control/src/actions/views-create.packaged.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.packaged.test.ts
@@ -188,7 +188,8 @@ describe("runViewsCreate from a packaged install", () => {
 		// The coding agent was dispatched against that workdir.
 		expect(dispatched).toHaveLength(1);
 		expect(String(dispatched[0].task)).toContain(`sourceDir: ${workdir}`);
-		expect(texts.join("\n")).toContain("Started view create task");
+		// Human-voiced dispatch message (single-delivery contract).
+		expect(texts.join("\n")).toContain("view now");
 	});
 
 	it("answers with setup guidance and scaffolds nothing when the orchestrator is missing", async () => {

--- a/plugins/plugin-app-control/src/actions/views-create.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.ts
@@ -733,7 +733,11 @@ async function createNewViewPlugin({
 	}
 
 	const task = dispatch.agents[0];
-	const text = `Started view create task for ${displayName} at ${workdir}. Task session ${task.sessionId} is ${task.status}.`;
+	// Chat gets one human sentence; the dispatch detail (workdir, session id)
+	// stays planner-facing in the result text — internal identifiers in a
+	// user-visible message read as a malfunction. Same contract as APP create.
+	const text = `Building the ${displayName} view now — I'll let you know once it's ready (usually takes a few minutes).`;
+	const dispatchDetail = `Started view create task for ${displayName} at ${workdir}. Task session ${task.sessionId} is ${task.status}.`;
 	await callback?.({ text });
 	logger.info(
 		`[plugin-app-control] VIEWS/create new name=${name} workdir=${workdir} session=${task.sessionId}`,
@@ -741,7 +745,10 @@ async function createNewViewPlugin({
 
 	return {
 		success: true,
-		text,
+		text: dispatchDetail,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
 		values: {
 			mode: "create",
 			subMode: "new",

--- a/plugins/plugin-app-control/src/actions/views-delete.ts
+++ b/plugins/plugin-app-control/src/actions/views-delete.ts
@@ -454,7 +454,9 @@ export async function runViewsDelete({
 		pluginName: view.pluginName,
 	});
 
-	const text = `Are you sure you want to delete the ${view.label} view (${view.pluginName})? Confirm with confirm=true, or cancel with confirm=false.`;
+	// The chat bubble stays human (no confirm=true/plugin-name tool syntax);
+	// the confirm mechanics live in the planner-facing result text.
+	const text = `Are you sure you want to delete the ${view.label} view? Say yes to delete it or no to keep it.`;
 	await callback?.({ text });
 	logger.info(
 		`[plugin-app-control] VIEWS/delete awaiting confirmation viewId=${view.id} pluginName=${view.pluginName} room=${roomId}`,
@@ -462,7 +464,7 @@ export async function runViewsDelete({
 
 	return {
 		success: true,
-		text,
+		text: `Asked the user to confirm deleting ${view.label} (${view.pluginName}); re-run with confirm=true to delete or confirm=false to cancel.`,
 		values: {
 			mode: "delete",
 			subMode: "confirm",

--- a/plugins/plugin-app-control/src/actions/views-edit.ts
+++ b/plugins/plugin-app-control/src/actions/views-edit.ts
@@ -267,7 +267,9 @@ async function dispatchEditAgent({
 	}
 
 	const task = agents[0];
-	const text = `Started view edit task for ${view.label} at ${workdir}. Task session ${task.sessionId} is ${task.status}.`;
+	// Session ids and workdirs read as a malfunction in a chat bubble; the
+	// machine detail stays planner-facing in values/data.
+	const text = `Started editing ${view.label} — I'll report back here when the change is done.`;
 	await callback?.({ text });
 	logger.info(
 		`[plugin-app-control] VIEWS/edit viewId=${view.id} workdir=${workdir} session=${task.sessionId}`,
@@ -317,7 +319,7 @@ export async function runViewsEdit({
 	const resolution = resolveTargetView(targetStr, views);
 
 	if (resolution.kind === "none") {
-		const text = `No view matches "${targetStr}". Try \`action=list\` to see available views.`;
+		const text = `I couldn't find a view matching "${targetStr}". Ask me to list the views to see what's available.`;
 		await callback?.({ text });
 		return { success: false, text, data: { target: targetStr } };
 	}

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -456,7 +456,7 @@ describe("view management actions", () => {
 			});
 			expect(callback).toHaveBeenCalledWith(
 				expect.objectContaining({
-					text: expect.stringContaining("Started view create task"),
+					text: expect.stringContaining("view now"),
 				}),
 			);
 		} finally {

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -1962,8 +1962,8 @@ async function runViewsLayout({
 	if (targets.length < 2 && !singleViewPlacement) {
 		const reply =
 			mode === "split"
-				? 'Tell me two views to split, e.g. action=split views=["notes","calendar"] layout=horizontal.'
-				: 'Tell me two or more views to tile, e.g. action=tile views=["notes","calendar"].';
+				? 'Tell me which two views to put side by side — for example, "split notes and calendar".'
+				: 'Tell me which views to tile together — for example, "tile notes and calendar".';
 		await callback?.({ text: reply });
 		return {
 			success: false,

--- a/plugins/plugin-coding-tools/src/actions/edit.ts
+++ b/plugins/plugin-coding-tools/src/actions/edit.ts
@@ -188,11 +188,17 @@ export async function editFileHandler(
   const text = `Replaced ${replacements} occurrence${replacements === 1 ? "" : "s"} in ${resolved} (first at line ${firstLine})`;
   if (callback) await callback({ text, source: "coding-tools" });
 
-  return userFacingSuccessResult(text, {
-    path: resolved,
-    replacements,
-    firstLine,
-    addedLines,
-    removedLines,
-  });
+  // Same single-delivery contract as the write op: the edit confirmation is
+  // the complete answer to a single-operation turn.
+  return {
+    ...userFacingSuccessResult(text, {
+      path: resolved,
+      replacements,
+      firstLine,
+      addedLines,
+      removedLines,
+    }),
+    verifiedUserFacing: true,
+    turnComplete: true,
+  };
 }

--- a/plugins/plugin-coding-tools/src/actions/enter-worktree.ts
+++ b/plugins/plugin-coding-tools/src/actions/enter-worktree.ts
@@ -101,7 +101,7 @@ export async function enterWorktreeHandler(
   message: Memory,
   _state: State | undefined,
   options: unknown,
-  callback?: HandlerCallback,
+  _callback?: HandlerCallback,
 ): Promise<ActionResult> {
   const conversationId = conversationIdFromMessage(message);
   if (!conversationId) {
@@ -168,8 +168,8 @@ export async function enterWorktreeHandler(
       0,
       maxActionResultBytes,
     );
-  if (callback) await callback({ text, source: "coding-tools" });
-
+  // No visible callback: the enter confirmation is intermediate coding-flow
+  // detail; the evaluator's in-voice reply is the user's single answer.
   return successActionResult(text, {
     worktreePath,
     branch: name,

--- a/plugins/plugin-coding-tools/src/actions/exit-worktree.ts
+++ b/plugins/plugin-coding-tools/src/actions/exit-worktree.ts
@@ -30,7 +30,7 @@ export async function exitWorktreeHandler(
   message: Memory,
   _state: State | undefined,
   options: unknown,
-  callback?: HandlerCallback,
+  _callback?: HandlerCallback,
 ): Promise<ActionResult> {
   const conversationId =
     message.roomId !== undefined && message.roomId !== null
@@ -112,8 +112,8 @@ export async function exitWorktreeHandler(
       ? `Exited and removed worktree ${popped.entered}; cwd -> ${popped.previousCwd}`
       : `Exited worktree ${popped.entered}; cwd -> ${popped.previousCwd}`
   ).slice(0, maxActionResultBytes);
-  if (callback) await callback({ text, source: "coding-tools" });
-
+  // No visible callback: the exit confirmation is intermediate coding-flow
+  // detail; the evaluator's in-voice reply is the user's single answer.
   return successActionResult(text, {
     exited: popped.entered,
     restoredTo: popped.previousCwd,

--- a/plugins/plugin-coding-tools/src/actions/file.ts
+++ b/plugins/plugin-coding-tools/src/actions/file.ts
@@ -235,14 +235,20 @@ async function deviceFileHandler(
     const bytes = Buffer.byteLength(content, encoding);
     const text = `Wrote ${bytes} byte${bytes === 1 ? "" : "s"} to ${path}`;
     if (callback) await callback({ text, source: "coding-tools" });
-    return userFacingSuccessResult(text, {
-      action: "FILE",
-      target: "device",
-      operation,
-      path,
-      encoding,
-      bytes,
-    });
+    // Same single-delivery contract as the workspace write op: the write
+    // confirmation is the complete answer to a single-operation turn.
+    return {
+      ...userFacingSuccessResult(text, {
+        action: "FILE",
+        target: "device",
+        operation,
+        path,
+        encoding,
+        bytes,
+      }),
+      verifiedUserFacing: true,
+      turnComplete: true,
+    };
   }
 
   const entries = await bridge.list(path);

--- a/plugins/plugin-coding-tools/src/actions/write.ts
+++ b/plugins/plugin-coding-tools/src/actions/write.ts
@@ -183,8 +183,17 @@ export async function writeFileHandler(
     );
   if (callback) await callback({ text, source: "coding-tools" });
 
-  return userFacingSuccessResult(text, {
-    path: resolved,
-    bytes,
-  });
+  // The write confirmation is the complete answer to a single-operation turn:
+  // verified + turnComplete make the callback the sole delivery (the live bug
+  // was "Wrote N bytes to <path>" followed by an evaluator "done. <path>").
+  // Multi-step coding turns keep their evaluator — the gate requires a sole
+  // completed tool with a drained queue.
+  return {
+    ...userFacingSuccessResult(text, {
+      path: resolved,
+      bytes,
+    }),
+    verifiedUserFacing: true,
+    turnComplete: true,
+  };
 }


### PR DESCRIPTION
## Problem

Actions across the whole surface violated the single-voice delivery contract proven in #17330/#17331: a visible callback fired with planner-facing text (raw action names, internal ids, canned boilerplate), and the evaluator then composed its own in-voice reply — so users got tool-speak, a guaranteed double message, or both. A live sweep verified **154 real violations across 64 action files** (character, documents, tasks, roles, payments, oauth, secrets, plugin-manager, triage, app-control, coding-tools, contact, logs, choice, plan, autonomy, working-memory).

## Fix

One contract, applied at every site:

- If the callback **is** the complete verified answer → `userFacingText` + `verifiedUserFacing: true` (+ `turnComplete: true` for single-op turns) makes it the turn's sole delivery (the gated evaluator skip).
- If it is **not** the user's answer → the detail moves to planner-facing `result.text` only; no visible callback fires; the evaluator voices the reply.

Deliberately NOT changed (design-reviewed): the #16563 fenced shell/read transcript relays (genuine user-facing terminal output), the SETTINGS `get` capability probe (planner-composable read), and planner-facing ids in `result.text` (e.g. resumed-task id — the planner needs it; only the visible layer is human). ~15 tests updated where they pinned the old leaky behavior.

## Testing

- Suites on the integrated branch: core features **831**, app-control **1574**, coding-tools **397**, agent actions **163**, orchestrator regression lane **110** — green.
- **Live on a production Discord bot**: the CHOOSE_OPTION double-message repro returns exactly ONE message post-fix; LIST_CLOUD_APPS, FILE write, and app-create acks each deliver a single in-voice message with the evaluator-skip confirmed in the trajectory (`tj-92765ac355dc7d`: tool-owned `userFacingText` + gated FINISH).

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/runtime change only (core/plugin .ts); the user-visible surface is Discord message composition, evidenced under domain artifacts.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/runtime change only; see domain artifacts.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no repo UI flow; behavior is Discord message cardinality/voice, evidenced via trajectories and logs.
<!-- evidence-row:llm-trajectory -->
- [x] Live production trajectories (Cerebras gemma/glm stack): `tj-92765ac355dc7d` shows the planner tool returning `userFacingText` + `verifiedUserFacing` and the evaluator stage logging "Gated FINISH: … evaluator LLM call skipped." Contract pinned in updated routing tests, e.g. [actions-routing.test.ts](https://github.com/elizaOS/eliza/blob/fix/single-voice-contract-sweep/packages/core/src/features/documents/__tests__/actions-routing.test.ts) and [payment.test.ts](https://github.com/elizaOS/eliza/blob/fix/single-voice-contract-sweep/packages/core/src/features/payments/actions/payment.test.ts). End-to-end product of the contract: [nubilio.org/apps/bubblepop](https://nubilio.org/apps/bubblepop/) built via a single-voice turn.
<!-- evidence-row:backend-logs -->
- [x] <details><summary>live log excerpt</summary><pre>EVAL: Gated FINISH: queue drained successfully with a terminal action-owned userFacingText; evaluator LLM call skipped.
[SERVICE:MESSAGE] one outbound send per turn across the battery (math / cloud-apps / FILE write / create ack)</pre></details> Assertions live in [plugin-manager-routing.test.ts](https://github.com/elizaOS/eliza/blob/fix/single-voice-contract-sweep/packages/core/src/features/plugin-manager/plugin-manager-routing.test.ts).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client in the changed path.
<!-- evidence-row:domain-artifacts -->
- [x] Live apps produced by turns running this contract, independently probed HTTP 200: [bubblepop](https://nubilio.org/apps/bubblepop/), [neon-pulse](https://nubilio.org/apps/neon-pulse/), [mouse-kaleidoscope](https://nubilio.org/apps/mouse-kaleidoscope/) — each request → exactly two messages (ack, link), zero evaluator double-posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
