### PR TITLE
fix: app-build pipeline reliability — winnable verification, fresh-deploy guarantee, human voice

### DIFF
--- a/packages/agent/src/api/server-helpers-swarm.ts
+++ b/packages/agent/src/api/server-helpers-swarm.ts
@@ -476,9 +476,17 @@ async function buildTaskResultLine(task: {
       : completionSummary;
   }
   if (validationSummary) return validationSummary;
+  // Same rule as the non-completed branch: originalTask can be the entire
+  // composed kickoff prompt — never echo it raw. Prefer the label; a
+  // kickoff-shaped task is unusable; otherwise one capped line.
+  const taskLine = task.originalTask.includes("--- Swarm Coordination ---")
+    ? task.label?.trim() || "Task completed."
+    : task.originalTask.split("\n", 1)[0]?.trim().slice(0, 140) ||
+      task.label?.trim() ||
+      "Task completed.";
   const portMatch = task.originalTask.match(/port\s+(\d+)/i);
   const port = portMatch?.[1];
-  if (!port) return task.originalTask;
+  if (!port) return taskLine;
   if (await isPortServing(port)) {
     const host = process.env.ELIZA_PUBLIC_HOST ?? "localhost";
     return `built and serving at http://${host}:${port}`;

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -262,6 +262,10 @@ export {
 	SIMPLE_CONTEXT_ID,
 	type V5MessageHandlerOutput,
 } from "./runtime/message-handler";
+// The planner's generic failed-tool apology is exported so relay/delivery
+// layers (message service, orchestrator completion relays) can recognize it
+// by identity and drop it as redundant next to an authoritative outcome.
+export { FAILED_TOOL_FALLBACK_MESSAGE } from "./runtime/planner-loop";
 export * from "./runtime/response-grammar";
 export * from "./runtime/response-handler-evaluators";
 export * from "./runtime/response-handler-field-evaluator";

--- a/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
@@ -227,6 +227,68 @@ describe("planner-loop failed-operation correlation", () => {
 		expect(result.finalMessage).toContain("APP_CREATE_DONE");
 	});
 
+	it("keeps description operative for tools whose description is the mutation payload", async () => {
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce(
+					plannerToolCall("task-a", "TASKS_CREATE", {
+						description: "Repair project A",
+					}),
+				)
+				.mockResolvedValueOnce(
+					plannerToolCall("task-b", "TASKS_CREATE", {
+						description: "Repair project B",
+					}),
+				)
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "reply",
+							name: "REPLY",
+							arguments: { text: "Both repair tasks were created." },
+						},
+					],
+				}),
+		};
+		const taskFailure = "Project A task creation failed.";
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall: vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: false,
+					error: "task-a-failure",
+					text: taskFailure,
+					userFacingText: taskFailure,
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "Project B task created.",
+					userFacingText: "Project B task created.",
+				}),
+			evaluate: vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: false,
+					decision: "CONTINUE",
+					thought: "Create the other task.",
+				})
+				.mockResolvedValueOnce({
+					success: false,
+					decision: "CONTINUE",
+					thought: "Invalid evaluator envelope.",
+					protocolFailure: true,
+				}),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(taskFailure);
+		expect(result.finalMessage).not.toContain("Both repair tasks");
+	});
+
 	it("keeps a failed SHELL command authoritative when an unrelated command succeeds before REPLY", async () => {
 		const runtime = {
 			useModel: vi

--- a/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
@@ -152,6 +152,81 @@ describe("planner-loop failed-operation correlation", () => {
 		expect(runtime.useModel).toHaveBeenCalledTimes(3);
 	});
 
+	it("clears a failure when the retry differs only in free-text description narration (live incident: builders re-narrate retried commands, and the stale failure authority replaced their terminal completion proof)", async () => {
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "verify-1",
+							name: "SHELL",
+							arguments: {
+								action: "run",
+								command: "bun run typecheck && bun run lint && bun run test",
+								description: "Run the verification commands",
+							},
+						},
+					],
+				})
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "verify-2",
+							name: "SHELL",
+							arguments: {
+								action: "run",
+								command: "bun run typecheck && bun run lint && bun run test",
+								description: "Re-run verification after formatting fixes",
+							},
+						},
+					],
+				})
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "reply",
+							name: "REPLY",
+							arguments: { text: 'APP_CREATE_DONE {"appName":"demo"}' },
+						},
+					],
+				}),
+		};
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall: vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: false,
+					error: "lint failed",
+					text: "biome check failed on generated code",
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "all checks pass",
+				}),
+			evaluate: vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: false,
+					decision: "CONTINUE",
+					thought: "Fix formatting and re-run.",
+				})
+				.mockResolvedValueOnce({
+					success: false,
+					decision: "CONTINUE",
+					thought: "Emit the completion proof.",
+				}),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toContain("APP_CREATE_DONE");
+	});
+
 	it("keeps a failed SHELL command authoritative when an unrelated command succeeds before REPLY", async () => {
 		const runtime = {
 			useModel: vi

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3238,8 +3238,16 @@ function isStructuredInteractionPayload(value: string | undefined): boolean {
 
 function plannerToolOperationKey(toolCall: PlannerToolCall): string {
 	// A successful sibling mutation must not erase an authoritative failure for
-	// another entity; key order is irrelevant, but every argument value matters.
-	return `${toolCall.name.toUpperCase()}|${stableJsonStringify(toolCall.params ?? {})}`;
+	// another entity; key order is irrelevant and every OPERATIVE argument
+	// matters. Free-text narration params are excluded: models re-narrate the
+	// same retried operation with different wording, and keying on that text
+	// left logically-resolved failures "unresolved" forever — the failure
+	// authority then replaced the turn's terminal REPLY (e.g. a structured
+	// completion proof) with the generic fallback, failing verifications whose
+	// checks had all passed.
+	const params = { ...(toolCall.params ?? {}) };
+	delete (params as Record<string, unknown>).description;
+	return `${toolCall.name.toUpperCase()}|${stableJsonStringify(params)}`;
 }
 
 function handleRequiredToolPlannerMiss(params: {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3246,7 +3246,13 @@ function plannerToolOperationKey(toolCall: PlannerToolCall): string {
 	// completion proof) with the generic fallback, failing verifications whose
 	// checks had all passed.
 	const params = { ...(toolCall.params ?? {}) };
-	delete (params as Record<string, unknown>).description;
+	// SHELL defines description as an execution label; other tools may use the
+	// same field as the payload itself (for example TASKS_CREATE). Keeping this
+	// allow-list tool-specific prevents unrelated mutations from sharing failure
+	// authority merely because their schemas reuse a common field name.
+	if (toolCall.name.toUpperCase() === "SHELL") {
+		delete (params as Record<string, unknown>).description;
+	}
 	return `${toolCall.name.toUpperCase()}|${stableJsonStringify(params)}`;
 }
 

--- a/packages/elizaos/templates/min-project/vite.config.ts
+++ b/packages/elizaos/templates/min-project/vite.config.ts
@@ -6,6 +6,9 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  // Relative base: scaffolded apps deploy under sub-paths (/apps/<slug>/);
+  // vite's default "/" emits root-absolute /assets/... URLs that 404 there.
+  base: "./",
   plugins: [react()],
   server: {
     port: 5173,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -686,10 +686,10 @@ describe("SwarmCoordinatorService", () => {
           sessionId: "sess-validated",
           label: "build-site",
           status: "completed",
-          // The verdict exists ONLY on the custom-validator record (the raw
-          // task_complete was withheld until validation) — it must lead, with
-          // the agent's own deliverable preserved after it.
-          completionSummary: "App verification passed.\n\ndeployed",
+          // A PASS verdict is plumbing — the agent's own deliverable is the
+          // user's proof and posts alone. (Fail verdicts keep the explicit
+          // verdict text; the verdict still exists on the validator record.)
+          completionSummary: "deployed",
           roomId: "origin-room-7",
           replyToExternalMessageId: "discord-msg-7",
         },
@@ -1029,7 +1029,9 @@ describe("SwarmCoordinatorService", () => {
 
     expect(fired).toHaveBeenCalledTimes(1);
     const summary = fired.mock.calls[0][0].tasks[0].completionSummary;
-    expect(summary.startsWith("App verification passed.")).toBe(true);
+    // Pass verdicts no longer prefix the deliverable; the head of the
+    // deliverable itself must survive the cap.
+    expect(summary).not.toContain("App verification passed.");
     expect(summary).toContain("Built the demo app end to end.");
     expect(summary).not.toContain("[output elided");
     expect(summary.length).toBeLessThanOrEqual(2000);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/transcript-sanitizer.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/transcript-sanitizer.test.ts
@@ -154,3 +154,29 @@ describe("sanitizeCompletionRelay", () => {
     expect(sanitizeCompletionRelay(null)).toBe("");
   });
 });
+
+describe("stripEnvelopeSummaryLines", () => {
+  it("strips summarizeEnvelope machine lines from a chat relay (live incident shape)", () => {
+    const relayed = [
+      "starfall is live.",
+      "",
+      "link: https://nubilio.org/apps/starfall/",
+      "workdir: /home/milady/.eliza/workspaces/task-241a6410",
+      "diff: 12 files changed",
+      "files: 12",
+      "tests: bun run test → exit 0",
+      "criteria: 3/3 met",
+    ].join("\n");
+    const out = sanitizeCompletionRelay(relayed);
+    expect(out).toContain("starfall is live.");
+    expect(out).toContain("link: https://nubilio.org/apps/starfall/");
+    expect(out).not.toContain("workdir:");
+    expect(out).not.toContain("diff:");
+    expect(out).not.toContain("criteria:");
+  });
+
+  it("leaves builder prose mentioning tests untouched", () => {
+    const prose = "All tests pass now; the tests: they were flaky before.";
+    expect(sanitizeCompletionRelay(prose)).toBe(prose);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/transcript-sanitizer.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/transcript-sanitizer.test.ts
@@ -180,3 +180,26 @@ describe("stripEnvelopeSummaryLines", () => {
     expect(sanitizeCompletionRelay(prose)).toBe(prose);
   });
 });
+
+describe("stripStructuredProofLines", () => {
+  it("strips APP_CREATE_DONE proof lines and surfaces liveUrl as prose", () => {
+    const relayed = [
+      "App verification passed.",
+      "",
+      'APP_CREATE_DONE {"appName":"ocean-wave-loop","files":["src/index.tsx"],"tests":{"passed":2,"failed":0},"liveUrl":"https://nubilio.org/apps/ocean-wave-loop/"}',
+    ].join("\n");
+    const out = sanitizeCompletionRelay(relayed);
+    expect(out).not.toContain("APP_CREATE_DONE");
+    expect(out).toContain("Live at https://nubilio.org/apps/ocean-wave-loop/");
+  });
+
+  it("does not duplicate a URL already stated in prose", () => {
+    const relayed = [
+      "The app is live at https://nubilio.org/apps/foo/",
+      'APP_CREATE_DONE {"appName":"foo","liveUrl":"https://nubilio.org/apps/foo/"}',
+    ].join("\n");
+    const out = sanitizeCompletionRelay(relayed);
+    expect(out.match(/nubilio\.org\/apps\/foo/g)).toHaveLength(1);
+    expect(out).not.toContain("APP_CREATE_DONE");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -2247,9 +2247,21 @@ export class SubAgentRouter extends Service {
       cachedDead.length > 0
         ? `\nThese URL(s) are stale cached 404s. Their exact filenames are unavailable for this retry; do not recreate them and do not leave any HTML reference pointing to them. Create fresh asset filenames in the same app directory (for example, add a version suffix), update every HTML reference to the fresh filenames, then verify the fresh public URLs:\n${formatDeadLines(cachedDead)}\n`
         : "";
+    // A root-absolute asset path under a sub-path deploy is the dominant
+    // real-world cause of a dead sub-resource (vite base "/" emitting
+    // /assets/... for a page served at /apps/<slug>/). Name that diagnosis
+    // explicitly — the generic "files missing, create them" framing sent
+    // every retry rebuilding fresh files without ever touching the base,
+    // burning the whole retry budget on an unfixable path.
+    const rootAbsoluteDead = missingDead.some((d) =>
+      /^https?:\/\/[^/]+\/(?:assets|static)\//.test(d.url),
+    );
+    const basePathHint = rootAbsoluteDead
+      ? `\nAt least one dead URL is a ROOT-absolute asset path (e.g. /assets/…) while the page is served under a sub-path. This is a build base-path problem, NOT a missing file: rebuild with a relative base (vite: \`--base ./\` or base: "./" in vite.config), redeploy the build output, and verify the page's referenced asset URLs resolve UNDER the page's own path.\n`
+      : "";
     const missingFeedback =
       missingDead.length > 0
-        ? `\nThese URL(s) are not reachable, which means the corresponding files are missing, empty, or served from the wrong path. Create or fix every one of these files in the location the task specifies, then verify each file exists and is non-empty:\n${formatDeadLines(missingDead)}\n`
+        ? `\nThese URL(s) are not reachable:\n${formatDeadLines(missingDead)}\n${basePathHint || "\nThe corresponding files are missing, empty, or served from the wrong path. Create or fix every one of these files in the location the task specifies, then verify each file exists and is non-empty.\n"}`
         : "";
     const retryTask = `--- VERIFICATION FEEDBACK (retry ${nextRetry}/${maxRetries}) ---
 The previous attempt reported the task complete, but verification failed. This feedback overrides conflicting filename or URL instructions in the original task.${cachedFeedback}${missingFeedback}

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -17,6 +17,7 @@ import type {
   SwarmEventListener,
 } from "@elizaos/core";
 import {
+  FAILED_TOOL_FALLBACK_MESSAGE,
   ElizaError,
   logger,
   Service,
@@ -949,6 +950,23 @@ export class SwarmCoordinatorService
       return;
     }
 
+    // A verify-retry session reports its outcome under the ORIGINAL session's
+    // validated completion (dispatchCustomValidatorResult runs on the lineage
+    // root, which claims the synthesis slot). The retry session's own teardown
+    // `stopped` is plumbing — synthesizing it posts a false
+    // "<label> — stopped before completion." into a room that already received
+    // the pass verdict. A retry that genuinely dies without ANY lineage
+    // completion still synthesizes: the root never claimed the slot.
+    if (event === "stopped") {
+      const retryOf = readString(
+        await this.getFreshSessionMetadata(sessionId),
+        "retryOfSessionId",
+      );
+      if (retryOf && this.synthesizedCompletionSessions.has(retryOf)) {
+        return;
+      }
+    }
+
     // Ownership rule (issue elizaOS/eliza#11634): the sub-agent-router owns the
     // completion→chat post for origin-routed sessions — it is origin-aware,
     // dedupe-keyed, respawn/retry-suppressing, and feeds the planner's clean
@@ -1078,9 +1096,17 @@ export class SwarmCoordinatorService
     const bodyBudget = validatorVerdict
       ? DEFAULT_MAX_RELAY_CHARS - validatorVerdict.length - 2
       : DEFAULT_MAX_RELAY_CHARS;
-    const sanitizedBody = rawSummary
+    let sanitizedBody = rawSummary
       ? sanitizeCompletionRelay(rawSummary, bodyBudget)
       : "";
+    // A retried lineage can leave the planner's generic failed-tool apology as
+    // the root session's finalText; next to a pass verdict it contradicts the
+    // outcome ("verification passed" + "the runtime step failed"). Identity
+    // match on the exported constant — the same recognition the message
+    // service uses to drop it as redundant.
+    if (validatorVerdict && sanitizedBody === FAILED_TOOL_FALLBACK_MESSAGE) {
+      sanitizedBody = "";
+    }
     const sanitizedSummary = validatorVerdict
       ? sanitizedBody && sanitizedBody !== validatorVerdict
         ? `${validatorVerdict}\n\n${sanitizedBody}`

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -1124,9 +1124,17 @@ export class SwarmCoordinatorService
     if (validatorVerdict && sanitizedBody === FAILED_TOOL_FALLBACK_MESSAGE) {
       sanitizedBody = "";
     }
+    // A PASS verdict never prefixes the deliverable: the body ("live at
+    // <url>") IS the user's proof, and the verifier status line is plumbing.
+    // Fail verdicts keep the explicit verdict text — there the status is the
+    // actionable content.
+    const isPassVerdict =
+      validatorVerdict.length > 0 && terminalStatus === "completed";
     const sanitizedSummary = validatorVerdict
       ? sanitizedBody && sanitizedBody !== validatorVerdict
-        ? `${validatorVerdict}\n\n${sanitizedBody}`
+        ? isPassVerdict
+          ? sanitizedBody
+          : `${validatorVerdict}\n\n${sanitizedBody}`
         : validatorVerdict
       : sanitizedBody;
     if (validatorVerdict && terminalStatus === "completed") {

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -258,6 +258,10 @@ export class SwarmCoordinatorService
   private swarmCompleteCallback: SwarmCompleteCallback | null = null;
   private readonly inFlightDecisionSessions = new Set<string>();
   private readonly synthesizedCompletionSessions = new Set<string>();
+  // Sessions that already posted a body-less "App verification passed."
+  // A multi-turn builder re-validates on every turn; repeating the bare
+  // verdict is noise, while a verdict carrying a deliverable always posts.
+  private readonly postedBareValidatorPass = new Set<string>();
   // Sessions whose latest terminal event was ceded to the sub-agent-router
   // (the router-owned skip in `runSwarmComplete`). The one-shot runners
   // (runPromptAndClose / runPromptViaSmithers in actions/tasks.ts) ALWAYS stop
@@ -380,6 +384,7 @@ export class SwarmCoordinatorService
     this.swarmCompleteCallback = null;
     this.inFlightDecisionSessions.clear();
     this.synthesizedCompletionSessions.clear();
+    this.postedBareValidatorPass.clear();
     this.routerCededTerminalSessions.clear();
     this.terminalCompletionChains.clear();
     this.enrichmentMetadataCache.clear();
@@ -1112,6 +1117,12 @@ export class SwarmCoordinatorService
         ? `${validatorVerdict}\n\n${sanitizedBody}`
         : validatorVerdict
       : sanitizedBody;
+    if (validatorVerdict && !sanitizedBody && terminalStatus === "completed") {
+      if (this.postedBareValidatorPass.has(sessionId)) {
+        return;
+      }
+      this.postedBareValidatorPass.add(sessionId);
+    }
     const completionSummary =
       sanitizedSummary ||
       (terminalStatus === "completed"

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -17,8 +17,8 @@ import type {
   SwarmEventListener,
 } from "@elizaos/core";
 import {
-  FAILED_TOOL_FALLBACK_MESSAGE,
   ElizaError,
+  FAILED_TOOL_FALLBACK_MESSAGE,
   logger,
   Service,
   SWARM_COORDINATOR_SERVICE_TYPE,

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -736,8 +736,13 @@ export class SwarmCoordinatorService
       // Session resumed: the ceded-terminal marker belongs to the PREVIOUS
       // turn. A genuine user stop on this new turn — which the router never
       // posts — must synthesize again, so the marker must not outlive the turn
-      // whose teardown it suppresses.
+      // whose teardown it suppresses. Same rule for the validator-pass
+      // markers: a pass suppresses only the teardown stop of the turn it
+      // verified; new work on the reused session re-arms both the stop notice
+      // and the bare-pass feedback.
       this.routerCededTerminalSessions.delete(sessionId);
+      this.validatorPassSessions.delete(sessionId);
+      this.postedBareValidatorPass.delete(sessionId);
     }
 
     const enrichedData = this.shouldEnrichEvent(event)

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -262,6 +262,11 @@ export class SwarmCoordinatorService
   // A multi-turn builder re-validates on every turn; repeating the bare
   // verdict is noise, while a verdict carrying a deliverable always posts.
   private readonly postedBareValidatorPass = new Set<string>();
+  // Sessions whose validator PASS (bare or body-carrying) has posted. Unlike
+  // the synthesis dedupe slot this never re-arms on resume: once a create/edit
+  // task has publicly passed, its eventual teardown `stopped` is plumbing and
+  // must not synthesize a false "<label> — stopped before completion."
+  private readonly validatorPassSessions = new Set<string>();
   // Sessions whose latest terminal event was ceded to the sub-agent-router
   // (the router-owned skip in `runSwarmComplete`). The one-shot runners
   // (runPromptAndClose / runPromptViaSmithers in actions/tasks.ts) ALWAYS stop
@@ -385,6 +390,7 @@ export class SwarmCoordinatorService
     this.inFlightDecisionSessions.clear();
     this.synthesizedCompletionSessions.clear();
     this.postedBareValidatorPass.clear();
+    this.validatorPassSessions.clear();
     this.routerCededTerminalSessions.clear();
     this.terminalCompletionChains.clear();
     this.enrichmentMetadataCache.clear();
@@ -963,11 +969,18 @@ export class SwarmCoordinatorService
     // the pass verdict. A retry that genuinely dies without ANY lineage
     // completion still synthesizes: the root never claimed the slot.
     if (event === "stopped") {
+      if (this.validatorPassSessions.has(sessionId)) {
+        return;
+      }
       const retryOf = readString(
         await this.getFreshSessionMetadata(sessionId),
         "retryOfSessionId",
       );
-      if (retryOf && this.synthesizedCompletionSessions.has(retryOf)) {
+      if (
+        retryOf &&
+        (this.synthesizedCompletionSessions.has(retryOf) ||
+          this.validatorPassSessions.has(retryOf))
+      ) {
         return;
       }
     }
@@ -1117,11 +1130,14 @@ export class SwarmCoordinatorService
         ? `${validatorVerdict}\n\n${sanitizedBody}`
         : validatorVerdict
       : sanitizedBody;
-    if (validatorVerdict && !sanitizedBody && terminalStatus === "completed") {
-      if (this.postedBareValidatorPass.has(sessionId)) {
-        return;
+    if (validatorVerdict && terminalStatus === "completed") {
+      this.validatorPassSessions.add(sessionId);
+      if (!sanitizedBody) {
+        if (this.postedBareValidatorPass.has(sessionId)) {
+          return;
+        }
+        this.postedBareValidatorPass.add(sessionId);
       }
-      this.postedBareValidatorPass.add(sessionId);
     }
     const completionSummary =
       sanitizedSummary ||

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -258,10 +258,6 @@ export class SwarmCoordinatorService
   private swarmCompleteCallback: SwarmCompleteCallback | null = null;
   private readonly inFlightDecisionSessions = new Set<string>();
   private readonly synthesizedCompletionSessions = new Set<string>();
-  // Sessions that already posted a body-less "App verification passed."
-  // A multi-turn builder re-validates on every turn; repeating the bare
-  // verdict is noise, while a verdict carrying a deliverable always posts.
-  private readonly postedBareValidatorPass = new Set<string>();
   // Sessions whose validator PASS (bare or body-carrying) has posted. Unlike
   // the synthesis dedupe slot this never re-arms on resume: once a create/edit
   // task has publicly passed, its eventual teardown `stopped` is plumbing and
@@ -389,7 +385,6 @@ export class SwarmCoordinatorService
     this.swarmCompleteCallback = null;
     this.inFlightDecisionSessions.clear();
     this.synthesizedCompletionSessions.clear();
-    this.postedBareValidatorPass.clear();
     this.validatorPassSessions.clear();
     this.routerCededTerminalSessions.clear();
     this.terminalCompletionChains.clear();
@@ -742,7 +737,6 @@ export class SwarmCoordinatorService
       // and the bare-pass feedback.
       this.routerCededTerminalSessions.delete(sessionId);
       this.validatorPassSessions.delete(sessionId);
-      this.postedBareValidatorPass.delete(sessionId);
     }
 
     const enrichedData = this.shouldEnrichEvent(event)
@@ -1137,11 +1131,12 @@ export class SwarmCoordinatorService
       : sanitizedBody;
     if (validatorVerdict && terminalStatus === "completed") {
       this.validatorPassSessions.add(sessionId);
+      // A body-less pass is machine plumbing — the user asked for an outcome,
+      // not a verifier status line. The deliverable-carrying completion (the
+      // "live at <url>" summary) is the sole chat post; fail verdicts still
+      // escalate below.
       if (!sanitizedBody) {
-        if (this.postedBareValidatorPass.has(sessionId)) {
-          return;
-        }
-        this.postedBareValidatorPass.add(sessionId);
+        return;
       }
     }
     const completionSummary =

--- a/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
@@ -77,16 +77,40 @@ export function elideLongBlocks(
 }
 
 /**
- * Full relay-sanitization pipeline: strip envelope blocks, then hard-cap the
- * remainder. Returns "" when nothing survives (callers substitute their own
- * default, e.g. "Task completed.").
+ * Strip the orchestrator's OWN completion-envelope summary lines
+ * (summarizeEnvelope in completion-envelope.ts: `diff: …`, `workdir: …`,
+ * `files: N`, `tests: …`, `criteria: N/M met`, …). Those lines are verifier/log
+ * machine format, not model prose — when a completion summary carries them into
+ * a chat relay the user sees internal paths and counters. Line-anchored on the
+ * exact canonical field prefixes so builder prose is untouched.
+ */
+const ENVELOPE_SUMMARY_LINE =
+  /^(?:diff|workdir|files|verifiedFiles|tests|criteria|unmet|risks|UNVERIFIED missing): /;
+
+export function stripEnvelopeSummaryLines(text: string): string {
+  if (!text) return "";
+  return text
+    .split("\n")
+    .filter((line) => !ENVELOPE_SUMMARY_LINE.test(line.trim()))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Full relay-sanitization pipeline: strip envelope blocks and envelope summary
+ * lines, then hard-cap the remainder. Returns "" when nothing survives
+ * (callers substitute their own default, e.g. "Task completed.").
  */
 export function sanitizeCompletionRelay(
   text: string | undefined | null,
   maxChars: number = DEFAULT_MAX_RELAY_CHARS,
 ): string {
   if (!text) return "";
-  return elideLongBlocks(stripToolTranscript(text), maxChars);
+  return elideLongBlocks(
+    stripEnvelopeSummaryLines(stripToolTranscript(text)),
+    maxChars,
+  );
 }
 
 export { TOOL_OUTPUT_END_MARKER };

--- a/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
@@ -118,7 +118,10 @@ export function stripStructuredProofLines(text: string): string {
     const url = line.match(/"liveUrl"\s*:\s*"([^"]+)"/)?.[1];
     if (url) liveUrls.push(url);
   }
-  let out = kept.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+  let out = kept
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
   for (const url of liveUrls) {
     if (!out.includes(url)) {
       out = out ? `${out}\nLive at ${url}` : `Live at ${url}`;

--- a/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
@@ -98,9 +98,40 @@ export function stripEnvelopeSummaryLines(text: string): string {
 }
 
 /**
- * Full relay-sanitization pipeline: strip envelope blocks and envelope summary
- * lines, then hard-cap the remainder. Returns "" when nothing survives
- * (callers substitute their own default, e.g. "Task completed.").
+ * Strip the canonical structured-proof completion lines our create prompts
+ * demand from builders (`APP_CREATE_DONE {...}` / `PLUGIN_CREATE_DONE {...}`).
+ * They are machine proof for the validator, not chat. When a stripped line
+ * carries a `liveUrl` the user-facing text keeps that one load-bearing fact as
+ * plain prose (unless the surrounding text already states the URL).
+ */
+const STRUCTURED_PROOF_LINE = /^(?:APP|PLUGIN)_CREATE_DONE\s*\{/;
+
+export function stripStructuredProofLines(text: string): string {
+  if (!text) return "";
+  const kept: string[] = [];
+  const liveUrls: string[] = [];
+  for (const line of text.split("\n")) {
+    if (!STRUCTURED_PROOF_LINE.test(line.trim())) {
+      kept.push(line);
+      continue;
+    }
+    const url = line.match(/"liveUrl"\s*:\s*"([^"]+)"/)?.[1];
+    if (url) liveUrls.push(url);
+  }
+  let out = kept.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+  for (const url of liveUrls) {
+    if (!out.includes(url)) {
+      out = out ? `${out}\nLive at ${url}` : `Live at ${url}`;
+    }
+  }
+  return out;
+}
+
+/**
+ * Full relay-sanitization pipeline: strip envelope blocks, envelope summary
+ * lines, and structured-proof lines, then hard-cap the remainder. Returns ""
+ * when nothing survives (callers substitute their own default, e.g.
+ * "Task completed.").
  */
 export function sanitizeCompletionRelay(
   text: string | undefined | null,
@@ -108,7 +139,7 @@ export function sanitizeCompletionRelay(
 ): string {
   if (!text) return "";
   return elideLongBlocks(
-    stripEnvelopeSummaryLines(stripToolTranscript(text)),
+    stripStructuredProofLines(stripEnvelopeSummaryLines(stripToolTranscript(text))),
     maxChars,
   );
 }

--- a/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
@@ -104,7 +104,7 @@ export function stripEnvelopeSummaryLines(text: string): string {
  * carries a `liveUrl` the user-facing text keeps that one load-bearing fact as
  * plain prose (unless the surrounding text already states the URL).
  */
-const STRUCTURED_PROOF_LINE = /^(?:APP|PLUGIN)_CREATE_DONE\s*\{/;
+const STRUCTURED_PROOF_LINE = /(?:APP|PLUGIN)_CREATE_DONE\s*\{/;
 
 export function stripStructuredProofLines(text: string): string {
   if (!text) return "";
@@ -138,10 +138,18 @@ export function sanitizeCompletionRelay(
   maxChars: number = DEFAULT_MAX_RELAY_CHARS,
 ): string {
   if (!text) return "";
-  return elideLongBlocks(
-    stripStructuredProofLines(stripEnvelopeSummaryLines(stripToolTranscript(text))),
-    maxChars,
+  const stripped = stripStructuredProofLines(
+    stripEnvelopeSummaryLines(stripToolTranscript(text)),
   );
+  let out = elideLongBlocks(stripped, maxChars);
+  // The liveUrl rescue appends at the tail, which is exactly what elision
+  // truncates — re-assert it after the cap so the one load-bearing fact
+  // survives an oversized deliverable (bounded overshoot: one URL line).
+  const liveUrl = stripped.match(/^Live at (\S+)$/m)?.[1];
+  if (liveUrl && !out.includes(liveUrl)) {
+    out = `${out}\nLive at ${liveUrl}`;
+  }
+  return out;
 }
 
 export { TOOL_OUTPUT_END_MARKER };

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -272,6 +272,12 @@ async function extractNames(
 }
 
 interface DispatchInput {
+	/**
+	 * Verification profile for the dispatched build. Fresh directory scaffolds
+	 * use "build" (launch/browser checks need a runtime launcher these apps do
+	 * not have); edits to an installed, launchable app keep "full".
+	 */
+	verifyProfile: "build" | "full";
 	runtime: IAgentRuntime;
 	prompt: string;
 	label: string;
@@ -392,6 +398,7 @@ async function dispatchCodingAgent({
 	appName,
 	originRoomId,
 	callback,
+	verifyProfile,
 }: DispatchInput): Promise<DispatchResult> {
 	const createTaskName = findAsyncCodingDelegationActionName(runtime.actions);
 	const createTask = runtime.actions.find((a) => a.name === createTaskName);
@@ -420,7 +427,7 @@ async function dispatchCodingAgent({
 			validator: {
 				service: "app-verification",
 				method: "verifyApp",
-				params: { workdir, appName, profile: "full" },
+				params: { workdir, appName, profile: verifyProfile },
 			},
 			maxRetries: 2,
 			onVerificationFail: "retry",
@@ -490,13 +497,36 @@ async function dispatchCodingAgent({
 	return { dispatched: true, agents };
 }
 
+/**
+ * Optional static-publish target for finished builds. When both are configured
+ * (settings or env), the builder is instructed to copy the production build to
+ * `<dir>/<appName>/` and report the resulting `<urlBase>/<appName>/` link in
+ * its completion line — this is what turns "verification passed" into a URL
+ * the user can open. Unset on installs with no static host: the prompt then
+ * omits the deploy step entirely.
+ */
+function resolvePublishTarget(
+	runtime: IAgentRuntime,
+): { dir: string; urlBase: string } | null {
+	const dir =
+		(runtime.getSetting("APP_PUBLISH_DIR") as string | undefined)?.trim() ||
+		process.env.ELIZA_APP_PUBLISH_DIR?.trim();
+	const urlBase =
+		(runtime.getSetting("APP_PUBLISH_URL_BASE") as string | undefined)?.trim() ||
+		process.env.ELIZA_APP_PUBLISH_URL_BASE?.trim();
+	if (!dir || !urlBase) return null;
+	return { dir, urlBase: urlBase.replace(/\/+$/, "") };
+}
+
 function buildCreatePrompt(
 	intent: string,
 	appName: string,
 	displayName: string,
 	workdir: string,
+	publish: { dir: string; urlBase: string } | null,
 ): string {
-	return [
+	const liveUrl = publish ? `${publish.urlBase}/${appName}/` : null;
+	const lines = [
 		"task: build_eliza_app",
 		`appName: ${appName}`,
 		`displayName: ${displayName}`,
@@ -509,10 +539,24 @@ function buildCreatePrompt(
 		"  bun run typecheck",
 		"  bun run lint",
 		"  bun run test",
+	];
+	if (publish && liveUrl) {
+		lines.push(
+			"deployRule: after the commands pass, run `bun run build` and copy the production build output (the built index.html and assets, NOT sources)",
+			`  to ${publish.dir}/${appName}/ so it is served at ${liveUrl} — then verify that URL returns HTTP 200 before completing`,
+		);
+	}
+	lines.push(
 		"completionRule: after all commands pass, emit exactly one completion line in this canonical schema",
-		`APP_CREATE_DONE {"appName":"${appName}","files":["src/App.tsx"],"tests":{"passed":1,"failed":0},"lint":"ok","typecheck":"ok"}`,
+		`APP_CREATE_DONE {"appName":"${appName}","files":["src/App.tsx"],"tests":{"passed":1,"failed":0},"lint":"ok","typecheck":"ok"${liveUrl ? `,"liveUrl":"${liveUrl}"` : ""}}`,
 		"completionFields: files are relative to sourceDir; do not emit legacy name, testsPassed, or lintClean fields",
-	].join("\n");
+	);
+	if (liveUrl) {
+		lines.push(
+			`userReport: in your final summary, state the app is live at ${liveUrl}`,
+		);
+	}
+	return lines.join("\n");
 }
 
 function buildEditPrompt(
@@ -726,10 +770,12 @@ async function createNewApp({
 	// the create dispatch.
 	await snapshotAppWorkdir(runtime, workdir, name, true, originRoomId);
 
-	const prompt = buildCreatePrompt(intent, name, displayName, workdir);
+	const publish = resolvePublishTarget(runtime);
+	const prompt = buildCreatePrompt(intent, name, displayName, workdir, publish);
 	const dispatch = await dispatchCodingAgent({
 		runtime,
 		prompt,
+		verifyProfile: "build",
 		label: `create-app:${name}`,
 		workdir,
 		appName: name,
@@ -824,6 +870,7 @@ async function editExistingApp({
 	const dispatch = await dispatchCodingAgent({
 		runtime,
 		prompt,
+		verifyProfile: "full",
 		label: `edit-app:${app.name}`,
 		workdir,
 		appName: app.name,

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -802,7 +802,7 @@ async function createNewApp({
 	// identifiers in a user-visible message read as a malfunction. The
 	// verified+turnComplete contract makes the callback the turn's single
 	// delivery (the gated evaluator skip), same as LIST_CLOUD_APPS.
-	const text = `Building ${displayName} now — I'll post the link once it's live (usually takes a few minutes).`;
+	const text = `Building ${displayName} now — I'll post the link once it's live.`;
 	const dispatchDetail = `Started app create task for ${displayName} at ${workdir}. Task session ${task.sessionId} is ${task.status}; verification runs when it emits APP_CREATE_DONE.`;
 	await callback?.({ text });
 	logger.info(
@@ -900,7 +900,7 @@ async function editExistingApp({
 
 	const task = dispatch.agents[0];
 	// Same single-human-sentence contract as the create path above.
-	const text = `Updating ${app.displayName} now — I'll post the link once the changes are live (usually takes a few minutes).`;
+	const text = `Updating ${app.displayName} now — I'll post the link once the changes are live.`;
 	const dispatchDetail = `Started app edit task for ${app.displayName} at ${workdir}. Task session ${task.sessionId} is ${task.status}; verification runs when it emits APP_CREATE_DONE.`;
 	await callback?.({ text });
 	logger.info(

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -542,8 +542,8 @@ function buildCreatePrompt(
 	];
 	if (publish && liveUrl) {
 		lines.push(
-			"deployRule: after the commands pass, run `bun run build` and copy the production build output (the built index.html and assets, NOT sources)",
-			`  to ${publish.dir}/${appName}/ so it is served at ${liveUrl} — then verify that URL returns HTTP 200 before completing`,
+			"deployRule: after the commands pass, run `bun run build -- --base ./` (the relative base is REQUIRED — an absolute /assets/ base white-screens under the publish path) and copy the production build output (the built index.html and assets, NOT sources)",
+			`  to ${publish.dir}/${appName}/ so it is served at ${liveUrl} — then verify that URL returns HTTP 200 AND that its referenced .js asset URL returns HTTP 200 before completing`,
 		);
 	}
 	lines.push(

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -20,7 +20,7 @@ import {
 	type AppControlClient,
 	createAppControlClient,
 } from "../client/api.js";
-import { readStringOption } from "../params.js";
+import { readOptionalRefOption, readStringOption } from "../params.js";
 import type { InstalledAppInfo } from "../types.js";
 import {
 	findAsyncCodingDelegationActionName,
@@ -508,11 +508,13 @@ async function dispatchCodingAgent({
 function resolvePublishTarget(
 	runtime: IAgentRuntime,
 ): { dir: string; urlBase: string } | null {
+	const dirSetting = runtime.getSetting("APP_PUBLISH_DIR");
+	const urlSetting = runtime.getSetting("APP_PUBLISH_URL_BASE");
 	const dir =
-		(runtime.getSetting("APP_PUBLISH_DIR") as string | undefined)?.trim() ||
+		(typeof dirSetting === "string" ? dirSetting.trim() : "") ||
 		process.env.ELIZA_APP_PUBLISH_DIR?.trim();
 	const urlBase =
-		(runtime.getSetting("APP_PUBLISH_URL_BASE") as string | undefined)?.trim() ||
+		(typeof urlSetting === "string" ? urlSetting.trim() : "") ||
 		process.env.ELIZA_APP_PUBLISH_URL_BASE?.trim();
 	if (!dir || !urlBase) return null;
 	return { dir, urlBase: urlBase.replace(/\/+$/, "") };
@@ -867,10 +869,18 @@ async function editExistingApp({
 	await snapshotAppWorkdir(runtime, workdir, app.name, false, originRoomId);
 
 	const prompt = buildEditPrompt(intent, app, workdir);
+	// A workdir scaffolded by the create flow (SCAFFOLD.md marker) has no
+	// runtime launcher, so "full" verification (launch/browser) fails by
+	// design — the same loop the create path escaped. Installed launchable
+	// apps keep the full profile.
+	const scaffolded = await fs
+		.stat(path.join(workdir, "SCAFFOLD.md"))
+		.then(() => true)
+		.catch(() => false);
 	const dispatch = await dispatchCodingAgent({
 		runtime,
 		prompt,
-		verifyProfile: "full",
+		verifyProfile: scaffolded ? "build" : "full",
 		label: `edit-app:${app.name}`,
 		workdir,
 		appName: app.name,
@@ -946,7 +956,7 @@ export async function runCreate({
 		typeof message.roomId === "string" ? message.roomId : runtime.agentId;
 	const userText = (message.content.text ?? "").trim();
 	const explicitChoice = readStringOption(options, "choice");
-	const explicitEditTarget = readStringOption(options, "editTarget");
+	const explicitEditTarget = readOptionalRefOption(options, "editTarget");
 	const explicitIntent = readStringOption(options, "intent");
 
 	const appClient = client ?? createAppControlClient();

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -555,7 +555,7 @@ function buildCreatePrompt(
 	);
 	if (liveUrl) {
 		lines.push(
-			`userReport: your final summary is read by a normal person in chat. ONE casual line only, like: your app's live: ${liveUrl} — no technical wording (never say "verification", "commands", "deployed", "assets", "workdir").`,
+			`userReport: AFTER the APP_CREATE_DONE line (which is machine-required and must always be emitted), add exactly one casual line for the user, like: your app's live: ${liveUrl} — that user line must have no technical wording (never say "verification", "commands", "deployed", "assets", "workdir").`,
 		);
 	}
 	return lines.join("\n");

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -555,7 +555,7 @@ function buildCreatePrompt(
 	);
 	if (liveUrl) {
 		lines.push(
-			`userReport: in your final summary, state the app is live at ${liveUrl}`,
+			`userReport: your final summary is read by a normal person in chat. ONE casual line only, like: your app's live: ${liveUrl} — no technical wording (never say "verification", "commands", "deployed", "assets", "workdir").`,
 		);
 	}
 	return lines.join("\n");

--- a/plugins/plugin-app-control/src/actions/app.test.ts
+++ b/plugins/plugin-app-control/src/actions/app.test.ts
@@ -40,7 +40,7 @@ describe("APP action role policy", () => {
 		expect(result).toEqual(
 			expect.objectContaining({
 				success: false,
-				text: expect.stringContaining("only the owner"),
+				text: expect.stringContaining("only my owner"),
 			}),
 		);
 		expect(client.listInstalledApps).not.toHaveBeenCalled();

--- a/plugins/plugin-app-control/src/actions/views-create.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.ts
@@ -736,7 +736,7 @@ async function createNewViewPlugin({
 	// Chat gets one human sentence; the dispatch detail (workdir, session id)
 	// stays planner-facing in the result text — internal identifiers in a
 	// user-visible message read as a malfunction. Same contract as APP create.
-	const text = `Building the ${displayName} view now — I'll let you know once it's ready (usually takes a few minutes).`;
+	const text = `Building the ${displayName} view now — I'll let you know once it's ready.`;
 	const dispatchDetail = `Started view create task for ${displayName} at ${workdir}. Task session ${task.sessionId} is ${task.status}.`;
 	await callback?.({ text });
 	logger.info(

--- a/plugins/plugin-app-control/src/params.test.ts
+++ b/plugins/plugin-app-control/src/params.test.ts
@@ -8,6 +8,7 @@ import {
 	extractCloseTarget,
 	extractLaunchTarget,
 	normalizeActionOptions,
+	readOptionalRefOption,
 	readStringOption,
 } from "./params.js";
 
@@ -90,18 +91,22 @@ describe("extractCloseTarget", () => {
 	});
 });
 
-describe("readStringOption sentinel handling", () => {
-	it("treats planner-emitted absent-value strings as not provided", () => {
+describe("option sentinel handling", () => {
+	it("readOptionalRefOption treats planner-emitted absent-value strings as not provided", () => {
 		for (const sentinel of ["None", "null", "undefined", " none "]) {
-			expect(readStringOption({ editTarget: sentinel }, "editTarget")).toBe(
-				null,
-			);
+			expect(
+				readOptionalRefOption({ editTarget: sentinel }, "editTarget"),
+			).toBe(null);
 		}
 	});
 
-	it("keeps real values intact", () => {
-		expect(readStringOption({ editTarget: "my-app" }, "editTarget")).toBe(
+	it("readOptionalRefOption keeps real values intact", () => {
+		expect(readOptionalRefOption({ editTarget: "my-app" }, "editTarget")).toBe(
 			"my-app",
 		);
+	});
+
+	it("readStringOption keeps literal 'none' — a legitimate value for settings/colors", () => {
+		expect(readStringOption({ value: "none" }, "value")).toBe("none");
 	});
 });

--- a/plugins/plugin-app-control/src/params.test.ts
+++ b/plugins/plugin-app-control/src/params.test.ts
@@ -89,3 +89,19 @@ describe("extractCloseTarget", () => {
 		});
 	});
 });
+
+describe("readStringOption sentinel handling", () => {
+	it("treats planner-emitted absent-value strings as not provided", () => {
+		for (const sentinel of ["None", "null", "undefined", " none "]) {
+			expect(readStringOption({ editTarget: sentinel }, "editTarget")).toBe(
+				null,
+			);
+		}
+	});
+
+	it("keeps real values intact", () => {
+		expect(readStringOption({ editTarget: "my-app" }, "editTarget")).toBe(
+			"my-app",
+		);
+	});
+});

--- a/plugins/plugin-app-control/src/params.ts
+++ b/plugins/plugin-app-control/src/params.ts
@@ -82,12 +82,6 @@ export function normalizeActionOptions(
 	return options;
 }
 
-// Planner models emit stringified absent-values ("None", "null", "undefined")
-// for optional parameters they do not use. Treating those as real values sent
-// e.g. editTarget:"None" down the strict edit path, where a cold-registry read
-// timed out and failed the whole create. They mean "not provided".
-const ABSENT_SENTINELS = new Set(["none", "null", "undefined"]);
-
 export function readStringOption(
 	options: Record<string, unknown> | undefined,
 	key: string,
@@ -97,10 +91,23 @@ export function readStringOption(
 	const value = normalized[key];
 	if (typeof value !== "string") return null;
 	const trimmed = value.trim();
-	if (trimmed.length === 0 || ABSENT_SENTINELS.has(trimmed.toLowerCase())) {
-		return null;
-	}
-	return trimmed;
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+// Planner models emit stringified absent-values ("None", "null", "undefined")
+// for OPTIONAL parameters they do not use. Only reference-style options
+// (editTarget, runId, …) opt into this filter: a value like "none" is a
+// legitimate literal for settings values, colors, and search queries, so the
+// shared readStringOption must never swallow it.
+const ABSENT_SENTINELS = new Set(["none", "null", "undefined"]);
+
+export function readOptionalRefOption(
+	options: Record<string, unknown> | undefined,
+	key: string,
+): string | null {
+	const value = readStringOption(options, key);
+	if (value && ABSENT_SENTINELS.has(value.toLowerCase())) return null;
+	return value;
 }
 
 export function extractLaunchTarget(

--- a/plugins/plugin-app-control/src/params.ts
+++ b/plugins/plugin-app-control/src/params.ts
@@ -82,6 +82,12 @@ export function normalizeActionOptions(
 	return options;
 }
 
+// Planner models emit stringified absent-values ("None", "null", "undefined")
+// for optional parameters they do not use. Treating those as real values sent
+// e.g. editTarget:"None" down the strict edit path, where a cold-registry read
+// timed out and failed the whole create. They mean "not provided".
+const ABSENT_SENTINELS = new Set(["none", "null", "undefined"]);
+
 export function readStringOption(
 	options: Record<string, unknown> | undefined,
 	key: string,
@@ -91,7 +97,10 @@ export function readStringOption(
 	const value = normalized[key];
 	if (typeof value !== "string") return null;
 	const trimmed = value.trim();
-	return trimmed.length > 0 ? trimmed : null;
+	if (trimmed.length === 0 || ABSENT_SENTINELS.has(trimmed.toLowerCase())) {
+		return null;
+	}
+	return trimmed;
 }
 
 export function extractLaunchTarget(

--- a/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -317,6 +317,87 @@ describeIntegration("AppVerificationService.verifyApp (integration)", () => {
 			expect(result.retryablePromptForChild).toContain(
 				'APP_CREATE_DONE {"appName":"<package-name>"',
 			);
+		},
+		120_000,
+	);
+});
+
+describeIntegration("verifyProject publish step (containment + staged swap)", () => {
+	const service = new AppVerificationService(noopRuntime);
+	const publishRoot = mkdtempSync(path.join(tmpdir(), "app-verify-publish-"));
+
+	function makeApp(): string {
+		const workdir = mkdtempSync(path.join(tmpdir(), "app-verify-app-"));
+		writeFileSync(
+			path.join(workdir, "package.json"),
+			JSON.stringify({
+				name: "publish-fixture",
+				version: "0.0.0",
+				type: "module",
+				scripts: { build: "node -e \"process.exit(0)\"" },
+			}),
+		);
+		mkdirSync(path.join(workdir, "dist"), { recursive: true });
+		writeFileSync(
+			path.join(workdir, "dist", "index.html"),
+			"<!doctype html><title>fixture</title>",
+		);
+		return workdir;
+	}
+
+	afterAll(() => {
+		rmSync(publishRoot, { recursive: true, force: true });
+	});
+
+	itIf(pkgManagerAvailable)(
+		"refuses an appName that resolves outside the publish root",
+		async () => {
+			const prev = process.env.ELIZA_APP_PUBLISH_DIR;
+			process.env.ELIZA_APP_PUBLISH_DIR = publishRoot;
+			try {
+				const result = await service.verifyProject({
+					workdir: makeApp(),
+					appName: "../outside",
+					projectKind: "app",
+					checks: [{ kind: "build" }],
+					requireStructuredProof: false,
+				});
+				expect(result.verdict).toBe("fail");
+				const publish = result.checks.find((c) => c.kind === "publish");
+				expect(publish?.passed).toBe(false);
+				expect(publish?.output).toContain("outside the publish root");
+				expect(existsSync(path.join(publishRoot, "..", "outside"))).toBe(false);
+			} finally {
+				process.env.ELIZA_APP_PUBLISH_DIR = prev;
+			}
+		},
+		120_000,
+	);
+
+	itIf(pkgManagerAvailable)(
+		"staged swap removes obsolete files from the previous live build",
+		async () => {
+			const prev = process.env.ELIZA_APP_PUBLISH_DIR;
+			process.env.ELIZA_APP_PUBLISH_DIR = publishRoot;
+			try {
+				const live = path.join(publishRoot, "swap-app");
+				mkdirSync(live, { recursive: true });
+				writeFileSync(path.join(live, "obsolete.js"), "stale");
+				const result = await service.verifyProject({
+					workdir: makeApp(),
+					appName: "swap-app",
+					projectKind: "app",
+					checks: [{ kind: "build" }],
+					requireStructuredProof: false,
+				});
+				expect(result.verdict).toBe("pass");
+				const publish = result.checks.find((c) => c.kind === "publish");
+				expect(publish?.passed).toBe(true);
+				expect(existsSync(path.join(live, "index.html"))).toBe(true);
+				expect(existsSync(path.join(live, "obsolete.js"))).toBe(false);
+			} finally {
+				process.env.ELIZA_APP_PUBLISH_DIR = prev;
+			}
 		},
 		120_000,
 	);

--- a/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
@@ -3,7 +3,14 @@
  */
 
 import { execFile } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -38,7 +45,7 @@ if (!pkgManagerAvailable) {
 	process.env.SKIP_REASON ||= "bun or npm required to verify scaffolds";
 }
 
-const noopRuntime = {} as IAgentRuntime;
+const noopRuntime = { getSetting: () => undefined } as unknown as IAgentRuntime;
 
 const PASS_TS = `
 export type Greeting = { hello: string };
@@ -179,6 +186,91 @@ describeIntegration("AppVerificationService.verifyApp (integration)", () => {
 			expect(
 				result.checks.find((check) => check.kind === "build")?.passed,
 			).toBe(true);
+		},
+		120_000,
+	);
+
+	itIf(pkgManagerAvailable)(
+		"publishes the artifact produced by the passing build using the runtime setting",
+		async () => {
+			const workdir = mkdtempSync(path.join(tmpdir(), "verify-app-publish-"));
+			const publishRoot = mkdtempSync(
+				path.join(tmpdir(), "verify-app-publish-root-"),
+			);
+			writeMinimalTsProject(workdir, PASS_TS);
+			writeFileSync(
+				path.join(workdir, "build-shim.mjs"),
+				`import { mkdirSync, writeFileSync } from "node:fs"; mkdirSync("dist", { recursive: true }); writeFileSync("dist/index.html", "fresh-build"); process.stdout.write("build ok\\n");\n`,
+				"utf8",
+			);
+			const publishService = new AppVerificationService({
+				getSetting: (key: string) =>
+					key === "APP_PUBLISH_DIR" ? publishRoot : undefined,
+			} as unknown as IAgentRuntime);
+
+			const result = await publishService.verifyApp({
+				workdir,
+				appName: "fresh-app",
+				profile: "build",
+				runId: "int-app-publish",
+				packageManager: "npm",
+				structuredProof: {
+					kind: "APP_CREATE_DONE",
+					appName: "fresh-app",
+					files: ["src.ts"],
+					typecheck: "ok",
+					lint: "ok",
+					tests: { passed: 2, failed: 0 },
+				},
+			});
+
+			expect(result.verdict).toBe("pass");
+			expect(result.checks.at(-1)).toEqual(
+				expect.objectContaining({ kind: "publish", passed: true }),
+			);
+			expect(
+				readFileSync(path.join(publishRoot, "fresh-app", "index.html"), "utf8"),
+			).toBe("fresh-build");
+			await publishService.cleanup();
+		},
+		120_000,
+	);
+
+	itIf(pkgManagerAvailable)(
+		"does not publish a stale dist artifact when the fast profile did not build",
+		async () => {
+			const workdir = mkdtempSync(path.join(tmpdir(), "verify-app-fast-"));
+			const publishRoot = mkdtempSync(
+				path.join(tmpdir(), "verify-app-fast-root-"),
+			);
+			writeMinimalTsProject(workdir, PASS_TS);
+			mkdirSync(path.join(workdir, "dist"));
+			writeFileSync(
+				path.join(workdir, "dist", "index.html"),
+				"stale-build",
+				"utf8",
+			);
+			const publishService = new AppVerificationService({
+				getSetting: (key: string) =>
+					key === "APP_PUBLISH_DIR" ? publishRoot : undefined,
+			} as unknown as IAgentRuntime);
+
+			const result = await publishService.verifyApp({
+				workdir,
+				appName: "stale-app",
+				profile: "fast",
+				runId: "int-app-fast-no-publish",
+				packageManager: "npm",
+			});
+
+			expect(result.verdict).toBe("pass");
+			expect(result.checks.some((check) => check.kind === "publish")).toBe(
+				false,
+			);
+			expect(() =>
+				readFileSync(path.join(publishRoot, "stale-app", "index.html")),
+			).toThrow();
+			await publishService.cleanup();
 		},
 		120_000,
 	);

--- a/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
@@ -203,6 +203,12 @@ describeIntegration("AppVerificationService.verifyApp (integration)", () => {
 				`import { mkdirSync, writeFileSync } from "node:fs"; mkdirSync("dist", { recursive: true }); writeFileSync("dist/index.html", "fresh-build"); process.stdout.write("build ok\\n");\n`,
 				"utf8",
 			);
+			mkdirSync(path.join(publishRoot, "fresh-app"));
+			writeFileSync(
+				path.join(publishRoot, "fresh-app", "obsolete.js"),
+				"old-build",
+				"utf8",
+			);
 			const publishService = new AppVerificationService({
 				getSetting: (key: string) =>
 					key === "APP_PUBLISH_DIR" ? publishRoot : undefined,
@@ -231,6 +237,63 @@ describeIntegration("AppVerificationService.verifyApp (integration)", () => {
 			expect(
 				readFileSync(path.join(publishRoot, "fresh-app", "index.html"), "utf8"),
 			).toBe("fresh-build");
+			expect(() =>
+				readFileSync(path.join(publishRoot, "fresh-app", "obsolete.js")),
+			).toThrow();
+			await publishService.cleanup();
+		},
+		120_000,
+	);
+
+	itIf(pkgManagerAvailable)(
+		"rejects an app name that would escape the configured publish root",
+		async () => {
+			const workdir = mkdtempSync(
+				path.join(tmpdir(), "verify-app-containment-"),
+			);
+			const publishRoot = mkdtempSync(
+				path.join(tmpdir(), "verify-app-containment-root-"),
+			);
+			const outsideName = `${path.basename(publishRoot)}-outside`;
+			const maliciousAppName = `../${outsideName}`;
+			writeMinimalTsProject(workdir, PASS_TS);
+			writeFileSync(
+				path.join(workdir, "build-shim.mjs"),
+				`import { mkdirSync, writeFileSync } from "node:fs"; mkdirSync("dist", { recursive: true }); writeFileSync("dist/index.html", "fresh-build"); process.stdout.write("build ok\\n");\n`,
+				"utf8",
+			);
+			const publishService = new AppVerificationService({
+				getSetting: (key: string) =>
+					key === "APP_PUBLISH_DIR" ? publishRoot : undefined,
+			} as unknown as IAgentRuntime);
+
+			const result = await publishService.verifyApp({
+				workdir,
+				appName: maliciousAppName,
+				profile: "build",
+				runId: "int-app-publish-containment",
+				packageManager: "npm",
+				structuredProof: {
+					kind: "APP_CREATE_DONE",
+					appName: maliciousAppName,
+					files: ["src.ts"],
+					typecheck: "ok",
+					lint: "ok",
+					tests: { passed: 2, failed: 0 },
+				},
+			});
+
+			expect(result.verdict).toBe("fail");
+			expect(result.checks.at(-1)).toEqual(
+				expect.objectContaining({
+					kind: "publish",
+					passed: false,
+					output: expect.stringContaining("one direct child"),
+				}),
+			);
+			expect(() =>
+				readFileSync(path.join(publishRoot, "..", outsideName, "index.html")),
+			).toThrow();
 			await publishService.cleanup();
 		},
 		120_000,

--- a/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
@@ -477,83 +477,89 @@ describeIntegration("AppVerificationService.verifyApp (integration)", () => {
 	);
 });
 
-describeIntegration("verifyProject publish step (containment + staged swap)", () => {
-	const service = new AppVerificationService(noopRuntime);
-	const publishRoot = mkdtempSync(path.join(tmpdir(), "app-verify-publish-"));
+describeIntegration(
+	"verifyProject publish step (containment + staged swap)",
+	() => {
+		const service = new AppVerificationService(noopRuntime);
+		const publishRoot = mkdtempSync(path.join(tmpdir(), "app-verify-publish-"));
 
-	function makeApp(): string {
-		const workdir = mkdtempSync(path.join(tmpdir(), "app-verify-app-"));
-		writeFileSync(
-			path.join(workdir, "package.json"),
-			JSON.stringify({
-				name: "publish-fixture",
-				version: "0.0.0",
-				type: "module",
-				scripts: { build: "node -e \"process.exit(0)\"" },
-			}),
+		function makeApp(): string {
+			const workdir = mkdtempSync(path.join(tmpdir(), "app-verify-app-"));
+			writeFileSync(
+				path.join(workdir, "package.json"),
+				JSON.stringify({
+					name: "publish-fixture",
+					version: "0.0.0",
+					type: "module",
+					scripts: { build: 'node -e "process.exit(0)"' },
+				}),
+			);
+			mkdirSync(path.join(workdir, "dist"), { recursive: true });
+			writeFileSync(
+				path.join(workdir, "dist", "index.html"),
+				"<!doctype html><title>fixture</title>",
+			);
+			return workdir;
+		}
+
+		afterAll(() => {
+			rmSync(publishRoot, { recursive: true, force: true });
+		});
+
+		itIf(pkgManagerAvailable)(
+			"refuses an appName that resolves outside the publish root",
+			async () => {
+				const prev = process.env.ELIZA_APP_PUBLISH_DIR;
+				process.env.ELIZA_APP_PUBLISH_DIR = publishRoot;
+				const outsideName = `${path.basename(publishRoot)}-outside`;
+				try {
+					const result = await service.verifyProject({
+						workdir: makeApp(),
+						appName: `../${outsideName}`,
+						projectKind: "app",
+						checks: [{ kind: "build" }],
+						requireStructuredProof: false,
+					});
+					expect(result.verdict).toBe("fail");
+					const publish = result.checks.find((c) => c.kind === "publish");
+					expect(publish?.passed).toBe(false);
+					expect(publish?.output).toContain("outside the publish root");
+					expect(existsSync(path.join(publishRoot, "..", outsideName))).toBe(
+						false,
+					);
+				} finally {
+					process.env.ELIZA_APP_PUBLISH_DIR = prev;
+				}
+			},
+			120_000,
 		);
-		mkdirSync(path.join(workdir, "dist"), { recursive: true });
-		writeFileSync(
-			path.join(workdir, "dist", "index.html"),
-			"<!doctype html><title>fixture</title>",
+
+		itIf(pkgManagerAvailable)(
+			"staged swap removes obsolete files from the previous live build",
+			async () => {
+				const prev = process.env.ELIZA_APP_PUBLISH_DIR;
+				process.env.ELIZA_APP_PUBLISH_DIR = publishRoot;
+				try {
+					const live = path.join(publishRoot, "swap-app");
+					mkdirSync(live, { recursive: true });
+					writeFileSync(path.join(live, "obsolete.js"), "stale");
+					const result = await service.verifyProject({
+						workdir: makeApp(),
+						appName: "swap-app",
+						projectKind: "app",
+						checks: [{ kind: "build" }],
+						requireStructuredProof: false,
+					});
+					expect(result.verdict).toBe("pass");
+					const publish = result.checks.find((c) => c.kind === "publish");
+					expect(publish?.passed).toBe(true);
+					expect(existsSync(path.join(live, "index.html"))).toBe(true);
+					expect(existsSync(path.join(live, "obsolete.js"))).toBe(false);
+				} finally {
+					process.env.ELIZA_APP_PUBLISH_DIR = prev;
+				}
+			},
+			120_000,
 		);
-		return workdir;
-	}
-
-	afterAll(() => {
-		rmSync(publishRoot, { recursive: true, force: true });
-	});
-
-	itIf(pkgManagerAvailable)(
-		"refuses an appName that resolves outside the publish root",
-		async () => {
-			const prev = process.env.ELIZA_APP_PUBLISH_DIR;
-			process.env.ELIZA_APP_PUBLISH_DIR = publishRoot;
-			try {
-				const result = await service.verifyProject({
-					workdir: makeApp(),
-					appName: "../outside",
-					projectKind: "app",
-					checks: [{ kind: "build" }],
-					requireStructuredProof: false,
-				});
-				expect(result.verdict).toBe("fail");
-				const publish = result.checks.find((c) => c.kind === "publish");
-				expect(publish?.passed).toBe(false);
-				expect(publish?.output).toContain("outside the publish root");
-				expect(existsSync(path.join(publishRoot, "..", "outside"))).toBe(false);
-			} finally {
-				process.env.ELIZA_APP_PUBLISH_DIR = prev;
-			}
-		},
-		120_000,
-	);
-
-	itIf(pkgManagerAvailable)(
-		"staged swap removes obsolete files from the previous live build",
-		async () => {
-			const prev = process.env.ELIZA_APP_PUBLISH_DIR;
-			process.env.ELIZA_APP_PUBLISH_DIR = publishRoot;
-			try {
-				const live = path.join(publishRoot, "swap-app");
-				mkdirSync(live, { recursive: true });
-				writeFileSync(path.join(live, "obsolete.js"), "stale");
-				const result = await service.verifyProject({
-					workdir: makeApp(),
-					appName: "swap-app",
-					projectKind: "app",
-					checks: [{ kind: "build" }],
-					requireStructuredProof: false,
-				});
-				expect(result.verdict).toBe("pass");
-				const publish = result.checks.find((c) => c.kind === "publish");
-				expect(publish?.passed).toBe(true);
-				expect(existsSync(path.join(live, "index.html"))).toBe(true);
-				expect(existsSync(path.join(live, "obsolete.js"))).toBe(false);
-			} finally {
-				process.env.ELIZA_APP_PUBLISH_DIR = prev;
-			}
-		},
-		120_000,
-	);
-});
+	},
+);

--- a/plugins/plugin-app-control/src/services/app-verification.ts
+++ b/plugins/plugin-app-control/src/services/app-verification.ts
@@ -1296,11 +1296,21 @@ export class AppVerificationService extends Service {
 		// the real game sat in dist). Copy-after-pass is deterministic and
 		// idempotent; a failed copy fails the run — "passed" while the live
 		// page is stale would be a false verdict.
-		const publishRoot = process.env.ELIZA_APP_PUBLISH_DIR?.trim();
+		// Settings-first with env fallback, mirroring resolvePublishTarget on
+		// the prompt side — a settings-only install must get the authoritative
+		// re-publish, not just the deploy prompt (review finding on #17479).
+		const publishSetting = this.runtime.getSetting("APP_PUBLISH_DIR");
+		const publishRoot =
+			(typeof publishSetting === "string" ? publishSetting.trim() : "") ||
+			process.env.ELIZA_APP_PUBLISH_DIR?.trim();
+		// Only a profile that actually rebuilt dist may publish it — a "fast"
+		// pass would ship whatever stale dist was lying around.
+		const builtFresh = results.some((r) => r.kind === "build" && r.passed);
 		if (
 			verdict === "pass" &&
 			projectKind === "app" &&
 			publishRoot &&
+			builtFresh &&
 			opts.appName
 		) {
 			const publishStart = nowMs();

--- a/plugins/plugin-app-control/src/services/app-verification.ts
+++ b/plugins/plugin-app-control/src/services/app-verification.ts
@@ -816,7 +816,7 @@ function shouldRequireStructuredProof(
 	}
 	if (opts.structuredProof !== undefined) return true;
 	if (projectKind === "plugin") return true;
-	return opts.profile === "full";
+	return opts.profile === "full" || opts.profile === "build";
 }
 
 function proofField(proof: Record<string, unknown>, field: string): unknown {

--- a/plugins/plugin-app-control/src/services/app-verification.ts
+++ b/plugins/plugin-app-control/src/services/app-verification.ts
@@ -51,6 +51,7 @@ export type VerificationCheckKind =
 	| "typecheck"
 	| "lint"
 	| "test"
+	| "publish"
 	| "build"
 	| "launch"
 	| "browser"
@@ -1283,9 +1284,51 @@ export class AppVerificationService extends Service {
 			}
 		}
 
-		const verdict: "pass" | "fail" = results.every((r) => r.passed)
+		let verdict: "pass" | "fail" = results.every((r) => r.passed)
 			? "pass"
 			: "fail";
+
+		// Authoritative static publish (opt-in via ELIZA_APP_PUBLISH_DIR): when
+		// every check passed, the verifier itself ships the freshly built dist
+		// to the publish target. The builder's own deploy step is best-effort —
+		// a model can copy before its final rebuild and serve a stale bundle
+		// (live incident: comet-catch published the scaffold placeholder while
+		// the real game sat in dist). Copy-after-pass is deterministic and
+		// idempotent; a failed copy fails the run — "passed" while the live
+		// page is stale would be a false verdict.
+		const publishRoot = process.env.ELIZA_APP_PUBLISH_DIR?.trim();
+		if (
+			verdict === "pass" &&
+			projectKind === "app" &&
+			publishRoot &&
+			opts.appName
+		) {
+			const publishStart = nowMs();
+			const fs = await import("node:fs/promises");
+			const distDir = path.join(opts.workdir, "dist");
+			const target = path.join(publishRoot, opts.appName);
+			let publishLog = `Publishing ${distDir} -> ${target}\n`;
+			let published = false;
+			try {
+				await fs.access(path.join(distDir, "index.html"));
+				await fs.mkdir(target, { recursive: true });
+				await fs.cp(distDir, target, { recursive: true });
+				published = true;
+				publishLog += "Publish complete.\n";
+			} catch (err) {
+				// error-policy:J1 boundary — a publish failure becomes a failed
+				// check on the result, never a silent pass with a stale page.
+				publishLog += `Publish error: ${err instanceof Error ? err.message : String(err)}\n`;
+				verdict = "fail";
+			}
+			results.push({
+				kind: "publish",
+				passed: published,
+				durationMs: nowMs() - publishStart,
+				output: truncate(publishLog, OUTPUT_INLINE_LIMIT),
+				outputPath: await persistOutput(dir, "publish", publishLog),
+			});
+		}
 
 		const result: VerificationResult = {
 			verdict,

--- a/plugins/plugin-app-control/src/services/app-verification.ts
+++ b/plugins/plugin-app-control/src/services/app-verification.ts
@@ -79,7 +79,7 @@ export type CheckResult = {
 	testSummary?: TestRunSummary;
 };
 
-export type VerificationProfile = "fast" | "full";
+export type VerificationProfile = "fast" | "build" | "full";
 export type ProjectKind = "app" | "plugin";
 export type StructuredProofKind = "APP_CREATE_DONE" | "PLUGIN_CREATE_DONE";
 
@@ -168,6 +168,18 @@ function expandProfile(
 	}
 	if (profile === "fast" || profile === undefined) {
 		return [{ kind: "typecheck" }, { kind: "lint" }];
+	}
+	// "build": everything verifiable in-place for a scaffolded directory app.
+	// The launch/browser checks require a runtime launcher for the app; fresh
+	// directory scaffolds have none (the worker host only executes plugin
+	// exports), so including them makes every first build fail-by-design.
+	if (profile === "build") {
+		return [
+			{ kind: "typecheck" },
+			{ kind: "lint" },
+			{ kind: "test" },
+			{ kind: "build" },
+		];
 	}
 	const checks: VerificationCheck[] = [
 		{ kind: "typecheck" },

--- a/plugins/plugin-app-control/src/services/app-verification.ts
+++ b/plugins/plugin-app-control/src/services/app-verification.ts
@@ -5,6 +5,7 @@
  */
 
 import { type ExecFileOptions, execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -46,6 +47,23 @@ const TIMEOUTS = {
 } as const;
 
 const HEALTHY_STATUSES = new Set(["running", "connected", "active", "ready"]);
+
+function resolveDirectPublishTarget(
+	publishRoot: string,
+	appName: string,
+): {
+	root: string;
+	target: string;
+} {
+	const root = path.resolve(publishRoot);
+	const target = path.resolve(root, appName);
+	if (path.dirname(target) !== root || path.basename(target) !== appName) {
+		throw new Error(
+			"App publish name must be one direct child of the publish root",
+		);
+	}
+	return { root, target };
+}
 
 export type VerificationCheckKind =
 	| "typecheck"
@@ -1299,10 +1317,7 @@ export class AppVerificationService extends Service {
 		// Settings-first with env fallback, mirroring resolvePublishTarget on
 		// the prompt side — a settings-only install must get the authoritative
 		// re-publish, not just the deploy prompt (review finding on #17479).
-		const publishSetting =
-			typeof this.runtime.getSetting === "function"
-				? this.runtime.getSetting("APP_PUBLISH_DIR")
-				: undefined;
+		const publishSetting = this.runtime.getSetting("APP_PUBLISH_DIR");
 		const publishRoot =
 			(typeof publishSetting === "string" ? publishSetting.trim() : "") ||
 			process.env.ELIZA_APP_PUBLISH_DIR?.trim();
@@ -1319,52 +1334,62 @@ export class AppVerificationService extends Service {
 			const publishStart = nowMs();
 			const fs = await import("node:fs/promises");
 			const distDir = path.join(opts.workdir, "dist");
-			// Containment: appName is caller input — resolve and require the
-			// target to stay inside the publish root so a traversal-shaped name
-			// ("../outside") can never write beside it.
-			const publishRootReal = path.resolve(publishRoot);
-			const target = path.resolve(publishRootReal, opts.appName);
-			let publishLog = `Publishing ${distDir} -> ${target}\n`;
+			let staging: string | undefined;
+			let publishLog = `Publishing ${distDir} for ${opts.appName}\n`;
 			let published = false;
 			try {
-				if (
-					target === publishRootReal ||
-					!target.startsWith(publishRootReal + path.sep)
-				) {
-					throw new Error(
-						`app name ${JSON.stringify(opts.appName)} resolves outside the publish root`,
-					);
-				}
-				await fs.access(path.join(distDir, "index.html"));
-				// Staged replacement: copy into a sibling staging dir, then swap.
-				// Overlaying the live dir in place preserved obsolete files from
-				// earlier builds and exposed a partially copied mixed build while
-				// the copy ran; the swap keeps the live dir whole-old or whole-new.
-				const staging = `${target}.staging-${runId}`;
-				const retired = `${target}.retired-${runId}`;
-				await fs.rm(staging, { recursive: true, force: true });
-				await fs.cp(distDir, staging, { recursive: true });
-				const hadPrevious = await fs.access(target).then(
-					() => true,
-					() => false,
+				const { root, target } = resolveDirectPublishTarget(
+					publishRoot,
+					opts.appName,
 				);
-				if (hadPrevious) await fs.rename(target, retired);
+				await fs.access(path.join(distDir, "index.html"));
+				await fs.mkdir(root, { recursive: true });
+				staging = await fs.mkdtemp(path.join(root, ".publish-stage-"));
+				await fs.cp(distDir, staging, { recursive: true });
+				await fs.access(path.join(staging, "index.html"));
+
+				// Keep copy work outside the live directory. The two same-filesystem
+				// renames prevent clients from observing a mixed old/new file tree;
+				// the backup also makes the swap recoverable if activation fails.
+				await fs.mkdir(target, { recursive: true });
+				const backup = path.join(root, `.publish-backup-${randomUUID()}`);
+				await fs.rename(target, backup);
 				try {
 					await fs.rename(staging, target);
-				} catch (swapErr) {
-					// Restore the previous live build before failing the check so
-					// a botched swap never leaves the app missing entirely.
-					if (hadPrevious) await fs.rename(retired, target);
-					throw swapErr;
+					staging = undefined;
+				} catch (error) {
+					// error-policy:J2 restore the previously live tree before adding
+					// publish-swap context to the activation failure.
+					await fs.rename(backup, target);
+					throw new Error("Failed to activate staged app publish", {
+						cause: error,
+					});
 				}
-				// error-policy:J6 best-effort teardown — the retired copy is dead
-				// weight once the swap landed.
-				await fs.rm(retired, { recursive: true, force: true }).catch(() => {});
+				try {
+					await fs.rm(backup, { recursive: true, force: true });
+				} catch (error) {
+					// error-policy:J6 the new tree is already live; abandoned backup
+					// cleanup is observable but must not roll back a valid publish.
+					logger.warn(
+						`[AppVerificationService] Failed to remove publish backup ${backup}: ${error instanceof Error ? error.message : String(error)}`,
+					);
+				}
 				published = true;
-				publishLog += "Publish complete (staged swap).\n";
+				publishLog += `Publish complete: ${target}.\n`;
 			} catch (err) {
 				// error-policy:J1 boundary — a publish failure becomes a failed
 				// check on the result, never a silent pass with a stale page.
+				if (staging) {
+					try {
+						await fs.rm(staging, { recursive: true, force: true });
+					} catch (cleanupError) {
+						// error-policy:J6 staging cleanup is best-effort after the
+						// publish failure has already been made observable below.
+						logger.warn(
+							`[AppVerificationService] Failed to remove publish staging ${staging}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+						);
+					}
+				}
 				publishLog += `Publish error: ${err instanceof Error ? err.message : String(err)}\n`;
 				verdict = "fail";
 			}

--- a/plugins/plugin-app-control/src/services/app-verification.ts
+++ b/plugins/plugin-app-control/src/services/app-verification.ts
@@ -1299,7 +1299,10 @@ export class AppVerificationService extends Service {
 		// Settings-first with env fallback, mirroring resolvePublishTarget on
 		// the prompt side — a settings-only install must get the authoritative
 		// re-publish, not just the deploy prompt (review finding on #17479).
-		const publishSetting = this.runtime.getSetting("APP_PUBLISH_DIR");
+		const publishSetting =
+			typeof this.runtime.getSetting === "function"
+				? this.runtime.getSetting("APP_PUBLISH_DIR")
+				: undefined;
 		const publishRoot =
 			(typeof publishSetting === "string" ? publishSetting.trim() : "") ||
 			process.env.ELIZA_APP_PUBLISH_DIR?.trim();
@@ -1316,15 +1319,49 @@ export class AppVerificationService extends Service {
 			const publishStart = nowMs();
 			const fs = await import("node:fs/promises");
 			const distDir = path.join(opts.workdir, "dist");
-			const target = path.join(publishRoot, opts.appName);
+			// Containment: appName is caller input — resolve and require the
+			// target to stay inside the publish root so a traversal-shaped name
+			// ("../outside") can never write beside it.
+			const publishRootReal = path.resolve(publishRoot);
+			const target = path.resolve(publishRootReal, opts.appName);
 			let publishLog = `Publishing ${distDir} -> ${target}\n`;
 			let published = false;
 			try {
+				if (
+					target === publishRootReal ||
+					!target.startsWith(publishRootReal + path.sep)
+				) {
+					throw new Error(
+						`app name ${JSON.stringify(opts.appName)} resolves outside the publish root`,
+					);
+				}
 				await fs.access(path.join(distDir, "index.html"));
-				await fs.mkdir(target, { recursive: true });
-				await fs.cp(distDir, target, { recursive: true });
+				// Staged replacement: copy into a sibling staging dir, then swap.
+				// Overlaying the live dir in place preserved obsolete files from
+				// earlier builds and exposed a partially copied mixed build while
+				// the copy ran; the swap keeps the live dir whole-old or whole-new.
+				const staging = `${target}.staging-${runId}`;
+				const retired = `${target}.retired-${runId}`;
+				await fs.rm(staging, { recursive: true, force: true });
+				await fs.cp(distDir, staging, { recursive: true });
+				const hadPrevious = await fs.access(target).then(
+					() => true,
+					() => false,
+				);
+				if (hadPrevious) await fs.rename(target, retired);
+				try {
+					await fs.rename(staging, target);
+				} catch (swapErr) {
+					// Restore the previous live build before failing the check so
+					// a botched swap never leaves the app missing entirely.
+					if (hadPrevious) await fs.rename(retired, target);
+					throw swapErr;
+				}
+				// error-policy:J6 best-effort teardown — the retired copy is dead
+				// weight once the swap landed.
+				await fs.rm(retired, { recursive: true, force: true }).catch(() => {});
 				published = true;
-				publishLog += "Publish complete.\n";
+				publishLog += "Publish complete (staged swap).\n";
 			} catch (err) {
 				// error-policy:J1 boundary — a publish failure becomes a failed
 				// check on the result, never a silent pass with a stale page.

--- a/plugins/plugin-app-control/src/services/app-verification.ts
+++ b/plugins/plugin-app-control/src/services/app-verification.ts
@@ -59,7 +59,7 @@ function resolveDirectPublishTarget(
 	const target = path.resolve(root, appName);
 	if (path.dirname(target) !== root || path.basename(target) !== appName) {
 		throw new Error(
-			"App publish name must be one direct child of the publish root",
+			"App publish name resolves outside the publish root or is not one direct child",
 		);
 	}
 	return { root, target };


### PR DESCRIPTION
## Problem

A "make me a tiny app" request on a live bot exposed a chain of defects that made first builds slow, leaky, or falsely failed — measured live at 192s+ with a wasted 67s retry loop, versus ~71s clean:

1. **Unwinnable creates**: fresh directory scaffolds have no runtime launcher (the worker host executes plugin exports only), so the `full` profile's launch/browser checks failed by design → every create burned its retry budget and reported "stopped" for apps that were fine.
2. **Stale deploys**: the builder's own deploy step is model-ordered; a live build (`comet-catch`) copied dist **6 seconds before its final rebuild** and shipped the scaffold placeholder while the real app sat in `dist/`.
3. **Planner-loop failure authority ate completion proofs**: `plannerToolOperationKey` keyed failures on ALL params including the free-text `description` — models re-narrate retried commands, so logically-resolved failures stayed authoritative and the terminal `APP_CREATE_DONE` REPLY was replaced with the generic fallback → verification failed on proof-missing while every check passed.
4. **Vite base-path**: the scaffold's default absolute `/assets/` paths 404 under a `/apps/<slug>/` deploy prefix (white-screened pages); the dead-sub-resource retry prompt misdiagnosed it as "missing files", so retries could never fix it.
5. **Sentinel option values**: planners emit `editTarget:"None"` (stringified absent); treating it as a real edit target sent creates down the strict edit path into a cold-registry timeout.
6. **Chat jargon**: verifier status lines ("App verification passed."), duration parentheticals, and machine proof lines reached the user.

## Fix

- New `build` verification profile (typecheck+lint+test+build) for fresh scaffolds; edits of scaffold-marked workdirs use it too; installed launchable apps keep `full`. The `build` profile **requires the structured proof** like `full` (review finding: self-reported success must not skip it).
- **Authoritative publish**: opt-in via `APP_PUBLISH_DIR`/`APP_PUBLISH_URL_BASE` settings (or `ELIZA_APP_PUBLISH_*` env) — the create prompt carries a deploy contract (relative-base build, copy, HTTP 200 + asset 200 checks, live URL in the completion), and `verifyProject` itself re-publishes the fresh dist after a pass as a recorded `publish` check. A failed copy fails the run; a stale page can no longer pass.
- `plannerToolOperationKey` excludes the free-text `description` narration param for `SHELL` only; payload-bearing fields on other tools remain operative, with red-green coverage for both cases.
- Scaffold template ships `base: "./"`; the retry prompt names the base-path diagnosis with the exact dead URL.
- `readOptionalRefOption` filters `"None"/"null"/"undefined"` for reference-style options only (the shared `readStringOption` keeps literal `"none"` — a legitimate settings/color value; review finding).
- Chat surface: one clean ack ("Building X now — I'll post the link once it's live."), one final casual line with the live URL; pass verdicts and machine proof lines never post.

## Testing

- Exact head `6f147d854b387acac002caf7e17cd4d1d0efece1` on base `44e6088774ea79bd2c0fa2aa004ecad181fdbbab`: publish containment/staged-swap regressions **2/2** pass; previously timing-out app-control files rerun **258/258** pass; app-control tsc clean; core failure-correlation **13/13** pass; transcript sanitizer **20/20** pass; affected-file Biome and diff checks clean. The broad 1,633-test package run completed **1,627 pass / 6 timeout-only failures** under concurrent local load; all 258 tests across those six files then passed in 16.34s on the exact head.
- Full dependency build: **71/71 packages** passed before the final unrelated develop sync; the exact-head focused suites and type checks above were rerun after that sync.
- **Live ladder on a production Discord bot** (all URLs independently probed 200): lavalamp **79s**, kaleido **97s**, snowglobe **71s**, neonpulse **65s**, comet-catch (game, real test failure caught by the verifier and fixed by the builder mid-run) **235s** — final arc is exactly two messages: ack → "your app's live: <url>". Freshness proven post-fix: bubblepop deployed with zero scaffold-placeholder content.

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before: live page `https://nubilio.org/apps/comet-catch/` served the scaffold placeholder ("This Eliza app was scaffolded from packages/elizaos/templates/min-project") while the built game sat in dist — reproduced and captured in the deployed-vs-dist asset-hash comparison in the PR description (copied 18:55:46 vs rebuilt 18:55:52).
<!-- evidence-row:after-screenshots -->
- [x] After: [nubilio.org/apps/comet-catch](https://nubilio.org/apps/comet-catch/) serves the real app (relative-base assets, page 200 + asset 200); verifier `publish` check recorded per run in `app-verifications/verify-*/publish.log`.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend pipeline change; the end-to-end flow is Discord request → live URL, evidenced by the reproducible live ladder above (any reviewer can probe the URLs).
<!-- evidence-row:llm-trajectory -->
- [x] Live builder trajectories (production Cerebras stack): `tj-0de5f04d7f2897` (98.9s build session, 29 planner calls / 27 tool execs), `tj-dfd5a5984e3f3b` (the `editTarget:"None"` timeout at 2020ms = the 2s deadline). The op-key incident shape is pinned red-green in [planner-loop-failure-correlation.test.ts](https://github.com/elizaOS/eliza/blob/fix/app-build-reliability/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts); sentinel handling in [params.test.ts](https://github.com/elizaOS/eliza/blob/fix/app-build-reliability/plugins/plugin-app-control/src/params.test.ts).
<!-- evidence-row:backend-logs -->
- [x] <details><summary>live log excerpts</summary><pre>BEFORE: [verify] probe https://nubilio.org/assets/index-CHNr9-MR.js -> HTTP 404 (identical at 16:43:43 / 16:44:17 / 16:44:47 — whole retry budget burned on an unfixable base path)
BEFORE: verifyProject verdict=fail structured-proof: Missing APP_CREATE_DONE proof (typecheck/lint/test all passing in the same run)
AFTER:  verifyProject verdict=pass incl. the new publish check; [ACPX:SUB-AGENT-ROUTER] registered built app slug=bubblepop url=https://nubilio.org/apps/bubblepop/</pre></details> Verifier contract in [app-verification.ts](https://github.com/elizaOS/eliza/blob/fix/app-build-reliability/plugins/plugin-app-control/src/services/app-verification.ts).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client in the changed path.
<!-- evidence-row:domain-artifacts -->
- [x] Live apps produced by the fixed pipeline, all HTTP 200: https://nubilio.org/apps/lavalamp/ https://nubilio.org/apps/mouse-kaleidoscope/ https://nubilio.org/apps/snowglobe/ https://nubilio.org/apps/neon-pulse/ https://nubilio.org/apps/comet-catch/ https://nubilio.org/apps/bubblepop/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
