### PR TITLE
fix: flatten build merge preserves sibling bundles; curated-app lookup works cross-instance

### DIFF
--- a/packages/agent/src/api/server-helpers-swarm.test.ts
+++ b/packages/agent/src/api/server-helpers-swarm.test.ts
@@ -165,9 +165,42 @@ describe("handleSwarmSynthesis", () => {
       },
     );
 
-    expect(routed).toEqual([
-      "make an app showcasing eliza — stopped before completion.",
-    ]);
+    expect(routed).toEqual(["app — stopped before completion."]);
+  });
+
+  it("never relays a kickoff-prompt originalTask raw (live incident shape)", async () => {
+    const workdir = await seedClaudeTranscript("irrelevant narration");
+    const kickoff =
+      "--- Swarm Coordination ---\nNamed coding sub-agent in a task swarm. Keep working until the task is finished or genuinely blocked.\n\nBuild sweeptune.\nWhen done print: APP_CREATE_DONE {\"appName\":\"sweeptune\",\"files\":[\"src/App.tsx\"]}";
+    const routed: string[] = [];
+
+    await handleSwarmSynthesis(
+      { runtime },
+      {
+        tasks: [
+          {
+            sessionId: "pty-kickoff",
+            label: "",
+            agentType: "elizaos",
+            originalTask: kickoff,
+            status: "stopped",
+            completionSummary: "",
+            workdir,
+          },
+        ],
+        total: 1,
+        completed: 0,
+        stopped: 1,
+        errored: 0,
+      },
+      async (text) => {
+        routed.push(text);
+      },
+    );
+
+    expect(routed).toEqual(["coding task — stopped before completion."]);
+    expect(routed[0]).not.toContain("Swarm Coordination");
+    expect(routed[0]).not.toContain("APP_CREATE_DONE");
   });
 
   it("strips captured tool-output envelopes from the completionSummary, preserving evidence URLs (#11578)", async () => {

--- a/packages/agent/src/api/server-helpers-swarm.test.ts
+++ b/packages/agent/src/api/server-helpers-swarm.test.ts
@@ -171,7 +171,7 @@ describe("handleSwarmSynthesis", () => {
   it("never relays a kickoff-prompt originalTask raw (live incident shape)", async () => {
     const workdir = await seedClaudeTranscript("irrelevant narration");
     const kickoff =
-      "--- Swarm Coordination ---\nNamed coding sub-agent in a task swarm. Keep working until the task is finished or genuinely blocked.\n\nBuild sweeptune.\nWhen done print: APP_CREATE_DONE {\"appName\":\"sweeptune\",\"files\":[\"src/App.tsx\"]}";
+      '--- Swarm Coordination ---\nNamed coding sub-agent in a task swarm. Keep working until the task is finished or genuinely blocked.\n\nBuild sweeptune.\nWhen done print: APP_CREATE_DONE {"appName":"sweeptune","files":["src/App.tsx"]}';
     const routed: string[] = [];
 
     await handleSwarmSynthesis(

--- a/packages/agent/src/api/server-helpers-swarm.ts
+++ b/packages/agent/src/api/server-helpers-swarm.ts
@@ -405,6 +405,7 @@ function selectConnectorFallback(payload: {
 
 async function buildSynthesisResultText(payload: {
   tasks: Array<{
+    label?: string;
     originalTask: string;
     completionSummary: string;
     validationSummary?: string;
@@ -421,6 +422,7 @@ async function buildSynthesisResultText(payload: {
 }
 
 async function buildTaskResultLine(task: {
+  label?: string;
   originalTask: string;
   completionSummary: string;
   validationSummary?: string;
@@ -436,7 +438,19 @@ async function buildTaskResultLine(task: {
   // user-actionable payload such a task owns; otherwise state what happened.
   if (task.status !== "completed") {
     if (validationSummary) return validationSummary;
-    return `${task.originalTask} — ${task.status} before completion.`;
+    // originalTask can be the ENTIRE composed kickoff prompt (the tasks.ts
+    // "--- Swarm Coordination ---" scaffold plus embedded examples) — relaying
+    // it raw posted a wall of prompt text to a live Discord room. Prefer the
+    // spawn label; a kickoff-shaped originalTask is never usable, otherwise a
+    // single capped line keeps the lifecycle notice a notice.
+    const label = task.label?.trim();
+    const firstLine = task.originalTask.split("\n", 1)[0]?.trim() ?? "";
+    const ask =
+      label ||
+      (task.originalTask.includes("--- Swarm Coordination ---")
+        ? "coding task"
+        : firstLine.slice(0, 140) || "coding task");
+    return `${ask} — ${task.status} before completion.`;
   }
   // Defense-in-depth for issue elizaOS/eliza#11578: strip any captured
   // `[tool output: …]` envelope blocks from the completionSummary before it is

--- a/packages/scripts/__tests__/flatten-tsc-package-output.test.ts
+++ b/packages/scripts/__tests__/flatten-tsc-package-output.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Verifies flatten-tsc-package-output merges nested tsc output into dist
+ * without destroying sibling bundler-owned files that share a subdirectory
+ * name with the tsc declarations. Runs the real script as a subprocess
+ * against a deterministic temp workspace.
+ */
+import { execFile } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, test } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const scriptPath = join(testDir, "..", "flatten-tsc-package-output.mjs");
+const cleanupHelperPath = join(testDir, "..", "rm-path-recursive.mjs");
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function writeFixture(root: string, relativePath: string, contents: string) {
+  const target = join(root, relativePath);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, contents);
+}
+
+// The script resolves the workspace root by walking up from cwd to the first
+// package.json with a `workspaces` key, then invokes
+// packages/scripts/rm-path-recursive.mjs relative to that root — so the fake
+// workspace needs both the manifest and a copy of the cleanup helper.
+function createFakeWorkspace(): string {
+  const root = mkdtempSync(join(tmpdir(), "eliza-flatten-tsc-"));
+  temporaryDirectories.push(root);
+  writeFixture(
+    root,
+    "package.json",
+    JSON.stringify({ workspaces: ["packages/*"] }),
+  );
+  mkdirSync(join(root, "packages", "scripts"), { recursive: true });
+  copyFileSync(
+    cleanupHelperPath,
+    join(root, "packages", "scripts", "rm-path-recursive.mjs"),
+  );
+  return root;
+}
+
+async function runFlatten(root: string, packageDir: string) {
+  await execFileAsync(process.execPath, [scriptPath, packageDir], {
+    cwd: root,
+  });
+}
+
+describe("flatten-tsc-package-output", () => {
+  test("directory merge preserves pre-existing sibling files while adding tsc output", async () => {
+    const root = createFakeWorkspace();
+    const dist = join(root, "packages", "demo", "dist");
+
+    // Bundler-owned file already in dist/workers before the flatten runs.
+    writeFixture(
+      root,
+      "packages/demo/dist/workers/app-worker-entry.js",
+      "bundler output\n",
+    );
+    // Nested tsc output sharing the `workers` subdirectory name.
+    writeFixture(
+      root,
+      "packages/demo/dist/packages/demo/src/workers/app-worker.d.ts",
+      "export declare const worker: string;\n",
+    );
+    writeFixture(
+      root,
+      "packages/demo/dist/packages/demo/src/index.js",
+      "flattened entry\n",
+    );
+
+    await runFlatten(root, "packages/demo");
+
+    expect(
+      readFileSync(join(dist, "workers", "app-worker-entry.js"), "utf8"),
+    ).toBe("bundler output\n");
+    expect(readFileSync(join(dist, "workers", "app-worker.d.ts"), "utf8")).toBe(
+      "export declare const worker: string;\n",
+    );
+    expect(readFileSync(join(dist, "index.js"), "utf8")).toBe(
+      "flattened entry\n",
+    );
+    expect(existsSync(join(dist, "packages"))).toBe(false);
+  });
+
+  test("a flattened file replaces a stale same-name file", async () => {
+    const root = createFakeWorkspace();
+    const dist = join(root, "packages", "demo", "dist");
+
+    writeFixture(root, "packages/demo/dist/index.js", "stale\n");
+    writeFixture(root, "packages/demo/dist/nested/inner.js", "stale inner\n");
+    writeFixture(
+      root,
+      "packages/demo/dist/packages/demo/src/index.js",
+      "fresh\n",
+    );
+    writeFixture(
+      root,
+      "packages/demo/dist/packages/demo/src/nested/inner.js",
+      "fresh inner\n",
+    );
+
+    await runFlatten(root, "packages/demo");
+
+    expect(readFileSync(join(dist, "index.js"), "utf8")).toBe("fresh\n");
+    expect(readFileSync(join(dist, "nested", "inner.js"), "utf8")).toBe(
+      "fresh inner\n",
+    );
+  });
+
+  test("a same-name file blocking a directory merge is cleared", async () => {
+    const root = createFakeWorkspace();
+    const dist = join(root, "packages", "demo", "dist");
+
+    // dist/nested exists so the top-level entry takes the merge path, and
+    // dist/nested/types is a FILE where tsc output needs a directory.
+    writeFixture(root, "packages/demo/dist/nested/keep.js", "keep\n");
+    writeFixture(root, "packages/demo/dist/nested/types", "blocking file\n");
+    writeFixture(
+      root,
+      "packages/demo/dist/packages/demo/src/nested/types/index.d.ts",
+      "export type Demo = string;\n",
+    );
+    writeFixture(
+      root,
+      "packages/demo/dist/packages/demo/src/index.js",
+      "entry\n",
+    );
+
+    await runFlatten(root, "packages/demo");
+
+    expect(statSync(join(dist, "nested", "types")).isDirectory()).toBe(true);
+    expect(
+      readFileSync(join(dist, "nested", "types", "index.d.ts"), "utf8"),
+    ).toBe("export type Demo = string;\n");
+    expect(readFileSync(join(dist, "nested", "keep.js"), "utf8")).toBe(
+      "keep\n",
+    );
+  });
+});

--- a/packages/scripts/flatten-tsc-package-output.mjs
+++ b/packages/scripts/flatten-tsc-package-output.mjs
@@ -76,6 +76,28 @@ async function hasFlatEntryPoint() {
   );
 }
 
+// Move every file from srcDir into destDir, recursing into subdirectories and
+// overwriting same-named files, WITHOUT deleting unrelated files already in
+// destDir. Replacing the whole directory here destroyed sibling bundler
+// output that shares a dist subdirectory with the tsc declarations — e.g.
+// plugin-app-control's tsup-built dist/workers/app-worker-entry.js was wiped
+// by the d.ts move, so the app worker could never spawn at runtime.
+async function mergeInto(srcDir, destDir) {
+  await fs.mkdir(destDir, { recursive: true });
+  const entries = await fs.readdir(srcDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const from = path.join(srcDir, entry.name);
+    const to = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      await mergeInto(from, to);
+    } else {
+      await removePathRecursive(to);
+      await retryTransientFsOperation(() => fs.rename(from, to));
+    }
+  }
+  await fs.rmdir(srcDir).catch(() => {});
+}
+
 async function flattenNestedSource() {
   const entries = await fs.readdir(nestedSourceDir);
   for (const entry of entries) {
@@ -100,6 +122,14 @@ async function flattenNestedSource() {
       throw error;
     }
 
+    const [stagingStat, targetStat] = await Promise.all([
+      fs.stat(stagingEntry).catch(() => null),
+      fs.stat(targetEntry).catch(() => null),
+    ]);
+    if (stagingStat?.isDirectory() && targetStat?.isDirectory()) {
+      await mergeInto(stagingEntry, targetEntry);
+      continue;
+    }
     await removePathRecursive(targetEntry);
     await retryTransientFsOperation(() => fs.rename(stagingEntry, targetEntry));
   }

--- a/packages/scripts/flatten-tsc-package-output.mjs
+++ b/packages/scripts/flatten-tsc-package-output.mjs
@@ -89,6 +89,12 @@ async function mergeInto(srcDir, destDir) {
     const from = path.join(srcDir, entry.name);
     const to = path.join(destDir, entry.name);
     if (entry.isDirectory()) {
+      // A same-name FILE at the destination blocks the recursive mkdir —
+      // clear it first, mirroring the non-directory branch.
+      const destStat = await fs.stat(to).catch(() => null);
+      if (destStat && !destStat.isDirectory()) {
+        await removePathRecursive(to);
+      }
       await mergeInto(from, to);
     } else {
       await removePathRecursive(to);

--- a/packages/shared/src/contracts/apps.curated-cross-instance.test.ts
+++ b/packages/shared/src/contracts/apps.curated-cross-instance.test.ts
@@ -9,27 +9,25 @@ import { describe, expect, it, vi } from "vitest";
 import type { ElizaCuratedAppDefinition } from "./apps.ts";
 
 describe("curated app registry across module instances", () => {
-	it("resolves an app registered through a different copy of this module", async () => {
-		vi.resetModules();
-		const first = await import("./apps.ts");
-		const def = {
-			slug: "xinst-app",
-			canonicalName: "xinst-app",
-			aliases: [],
-			directory: "/tmp/xinst-app",
-			displayName: "XInst",
-			isolation: "none",
-			trust: "external",
-		} as unknown as ElizaCuratedAppDefinition;
-		first.registerCuratedApp(def);
+  it("resolves an app registered through a different copy of this module", async () => {
+    vi.resetModules();
+    const first = await import("./apps.ts");
+    const def = {
+      slug: "xinst-app",
+      canonicalName: "xinst-app",
+      aliases: [],
+      directory: "/tmp/xinst-app",
+      displayName: "XInst",
+      isolation: "none",
+      trust: "external",
+    } as unknown as ElizaCuratedAppDefinition;
+    first.registerCuratedApp(def);
 
-		vi.resetModules();
-		const second = await import("./apps.ts");
-		expect(second.normalizeElizaCuratedAppName("xinst-app")).toBe(
-			"xinst-app",
-		);
-		expect(
-			second.getCuratedAppDefinitions().some((d) => d.slug === "xinst-app"),
-		).toBe(true);
-	});
+    vi.resetModules();
+    const second = await import("./apps.ts");
+    expect(second.normalizeElizaCuratedAppName("xinst-app")).toBe("xinst-app");
+    expect(
+      second.getCuratedAppDefinitions().some((d) => d.slug === "xinst-app"),
+    ).toBe(true);
+  });
 });

--- a/packages/shared/src/contracts/apps.curated-cross-instance.test.ts
+++ b/packages/shared/src/contracts/apps.curated-cross-instance.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression: the curated-app registry store is a Symbol.for global shared by
+ * every loaded copy of this module, but the name-lookup map is module-local.
+ * An app registered through one module instance must still resolve from a
+ * second, freshly loaded instance (the live dual src/dist module graph), or
+ * launch fails with "not found in the registry" for a registered app.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ElizaCuratedAppDefinition } from "./apps.ts";
+
+describe("curated app registry across module instances", () => {
+	it("resolves an app registered through a different copy of this module", async () => {
+		vi.resetModules();
+		const first = await import("./apps.ts");
+		const def = {
+			slug: "xinst-app",
+			canonicalName: "xinst-app",
+			aliases: [],
+			directory: "/tmp/xinst-app",
+			displayName: "XInst",
+			isolation: "none",
+			trust: "external",
+		} as unknown as ElizaCuratedAppDefinition;
+		first.registerCuratedApp(def);
+
+		vi.resetModules();
+		const second = await import("./apps.ts");
+		expect(second.normalizeElizaCuratedAppName("xinst-app")).toBe(
+			"xinst-app",
+		);
+		expect(
+			second.getCuratedAppDefinitions().some((d) => d.slug === "xinst-app"),
+		).toBe(true);
+	});
+});

--- a/packages/shared/src/contracts/apps.ts
+++ b/packages/shared/src/contracts/apps.ts
@@ -813,6 +813,15 @@ export function getElizaCuratedAppDefinition(
   const trimmed = value.trim();
   if (!trimmed) return null;
 
+  // The registered-apps store is a Symbol.for global shared across every
+  // loaded copy of this module, but the lookup map below is module-local and
+  // only rebuilt by the copy that registerCuratedApp ran in. Fold the global
+  // store in before every lookup so an app registered through one module
+  // instance (e.g. a plugin's dist bundle) resolves from another (e.g. the
+  // launcher's source instance) — otherwise launch fails with
+  // "not found in the registry" for an app that IS registered.
+  _rebuildCuratedAppLookup();
+
   const directMatch = ELIZA_CURATED_APP_DEFINITION_BY_KEY.get(
     trimmed.toLowerCase(),
   );


### PR DESCRIPTION
## Problem

Two infrastructure bugs, both bisect/red-green proven on a live install:

1. **The flatten build step destroys sibling bundler output.** `flatten-tsc-package-output.mjs` *replaces* whole dist subdirectories when moving tsc declarations up. Any package whose bundler emits into a dist subdir the declarations also use loses that output on every build — concretely, plugin-app-control's tsup-built `dist/workers/app-worker-entry.js` was deleted on every build, so the app worker could never spawn (`ModuleNotFound` at runtime) and every launch check failed. Bisect: worker present after tsup, present after tsc, **gone after flatten**.
2. **Runtime-registered curated apps resolve to null at launch.** The registered-apps store is a `Symbol.for` global shared across every loaded copy of `@elizaos/shared`, but the name-lookup map is module-local and only rebuilt by the copy `registerCuratedApp` ran in. Under a dual module graph (one plugin loading the dist bundle, another the source), an app registered by plugin-app-control resolved to `null` in plugin-app-manager's launcher — `App "<name>" not found in the registry` for an app that IS in the persisted registry.

## Fix

- `flattenNestedSource` **merges** directories file-by-file instead of replacing them (unrelated files in the destination survive; same-named files are overwritten). A same-name FILE blocking a directory merge is cleared first (review finding: recursive mkdir otherwise throws unhandled EEXIST).
- `getElizaCuratedAppDefinition` folds the global store into the local lookup map before every lookup, so any module instance resolves apps registered through any other instance.

## Testing

- Red-green: the new cross-instance test (`apps.curated-cross-instance.test.ts`, two fresh module instances via `vi.resetModules`) **fails on the old code, passes now**; contracts suite **507** green.
- Flatten fix bisect-proven on the live install (worker bundle survives the full build pipeline; `ls dist/workers/` before/after in the commit message); every app launch check on the fixed install now spawns the worker without `ModuleNotFound`.

## Also in this PR: swarm synthesis no longer relays raw kickoff prompts

The live incident that motivated the flatten fix surfaced a third bug, fixed here too: the swarm-synthesis lifecycle fallback in `buildTaskResultLine` ([packages/agent/src/api/server-helpers-swarm.ts](https://github.com/elizaOS/eliza/blob/fix/dist-merge-and-curated-registry/packages/agent/src/api/server-helpers-swarm.ts)) posted `${originalTask} — <status> before completion.` for non-completed tasks — but `originalTask` can be the ENTIRE composed kickoff prompt (the tasks.ts `--- Swarm Coordination ---` scaffold plus embedded prompt examples), which got relayed verbatim as a wall of prompt text into a live Discord room. The non-completed branch now prefers the spawn `label`; if the task text is kickoff-shaped (contains `--- Swarm Coordination ---`) it falls back to `"coding task"`, otherwise it uses a 140-char cap of the first line. A regression test pins the exact incident shape (swarm suite 21 green).

## Review follow-ups (post-review commit)

- Reformatted `packages/shared/src/contracts/apps.curated-cross-instance.test.ts` with Biome (was tab-indented; the lint lane was red).
- Added [packages/scripts/\_\_tests\_\_/flatten-tsc-package-output.test.ts](https://github.com/elizaOS/eliza/blob/fix/dist-merge-and-curated-registry/packages/scripts/__tests__/flatten-tsc-package-output.test.ts): deterministic temp-workspace test running the real script as a subprocess, covering (a) directory merge preserves pre-existing sibling files while adding tsc output, (b) file-replaces-file, (c) a same-name file blocking a directory merge is cleared. 3/3 green.

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - build tooling + registry resolution; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - build tooling + registry resolution; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow; deterministic red-green tests attached instead.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changed; deterministic red-green tests attached (the live symptom that motivated it: `Launch error: App "glowbox" not found in the registry` from session 4bf1ccb2).
<!-- evidence-row:backend-logs -->
- [x] <details><summary>live log excerpt</summary><pre>BEFORE: [app-worker-host] bootstrap spawn failed for slug=sweeptune: ModuleNotFound resolving ".../plugin-app-control/dist/workers/app-worker-entry.js" (entry point)
AFTER:  zero ModuleNotFound across boots; worker spawns succeed</pre></details> Fixed script: [flatten-tsc-package-output.mjs](https://github.com/elizaOS/eliza/blob/fix/dist-merge-and-curated-registry/packages/scripts/flatten-tsc-package-output.mjs).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client in the changed path.
<!-- evidence-row:domain-artifacts -->
- [x] Red-green cross-instance test: [apps.curated-cross-instance.test.ts](https://github.com/elizaOS/eliza/blob/fix/dist-merge-and-curated-registry/packages/shared/src/contracts/apps.curated-cross-instance.test.ts) — fails on the old lookup, passes with the fix; worker bundle survives the full build (bisect in the commit message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

