### PR TITLE
fix(ci): generate i18n outputs before filtered builds

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -108,7 +108,7 @@
 		"dist"
 	],
 	"scripts": {
-		"prebuild": "bun run --cwd ../logger build && bun run --cwd ../contracts build && bun run --cwd ../cloud/routing build && ([ -f src/i18n/generated/validation-keyword-data.ts ] || node ../shared/scripts/generate-keywords.mjs)",
+		"prebuild": "bun run --cwd ../logger build && bun run --cwd ../contracts build && bun run --cwd ../cloud/routing build && ([ -s ../shared/src/i18n/generated/validation-keyword-data.ts ] && [ -s ../shared/src/i18n/generated/validation-keyword-data.js ] && [ -s src/i18n/generated/validation-keyword-data.ts ] || node ../shared/scripts/generate-keywords.mjs)",
 		"prepublishOnly": "bun run build",
 		"build": "bun run build.ts",
 		"build:node": "bun run build.ts --node-only",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -108,7 +108,7 @@
 		"dist"
 	],
 	"scripts": {
-		"prebuild": "bun run --cwd ../logger build && bun run --cwd ../contracts build && bun run --cwd ../cloud/routing build && ([ -s ../shared/src/i18n/generated/validation-keyword-data.ts ] && [ -s ../shared/src/i18n/generated/validation-keyword-data.js ] && [ -s src/i18n/generated/validation-keyword-data.ts ] || node ../shared/scripts/generate-keywords.mjs)",
+		"prebuild": "bun run --cwd ../logger build && bun run --cwd ../contracts build && bun run --cwd ../cloud/routing build && node ../shared/scripts/generate-keywords.mjs",
 		"prepublishOnly": "bun run build",
 		"build": "bun run build.ts",
 		"build:node": "bun run build.ts --node-only",

--- a/packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
+++ b/packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
@@ -1,13 +1,20 @@
 /**
- * Verifies Turbo typecheck invocations materialize generated declarations
- * before scheduling, across every argv shape run-turbo accepts: `run <task>`,
- * bare `<task>`, and flags in any position (#15847). Real subprocesses, no
- * mocks — the fixture generator stands in for generate-keywords.mjs only so
- * tests can observe invocation counts and argv without touching src/.
+ * Verifies Turbo build/typecheck invocations materialize generated modules
+ * before scheduling, including the filtered agent-image graph from an empty
+ * generated tree. Subprocess fixtures isolate production source outputs.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  copyFile,
+  cp,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -17,7 +24,37 @@ const keywordGenerator = join(
   repoRoot,
   "packages/shared/scripts/generate-keywords.mjs",
 );
+const keywordSources = join(repoRoot, "packages/shared/src/i18n/keywords");
 const tempDirs: string[] = [];
+
+const agentImageFilters = [
+  "@elizaos/app",
+  "@elizaos/agent",
+  "@elizaos/plugin-sql",
+  "@elizaos/plugin-video",
+  "@elizaos/plugin-agent-skills",
+  "@elizaos/plugin-pdf",
+  "@elizaos/plugin-browser",
+  "@elizaos/plugin-capacitor-bridge",
+  "@elizaos/plugin-coding-tools",
+  "@elizaos/plugin-native-filesystem",
+  "@elizaos/plugin-shell",
+  "@elizaos/plugin-commands",
+  "@elizaos/plugin-computeruse",
+  "@elizaos/plugin-discord",
+  "@elizaos/plugin-edge-tts",
+  "@elizaos/plugin-elizacloud",
+  "@elizaos/plugin-imessage",
+  "@elizaos/plugin-local-inference",
+  "@elizaos/plugin-mcp",
+  "@elizaos/plugin-signal",
+  "@elizaos/plugin-streaming",
+  "@elizaos/plugin-telegram",
+  "@elizaos/plugin-whatsapp",
+  "@elizaos/plugin-wallet",
+  "@elizaos/plugin-workflow",
+  "@elizaos/plugin-x402",
+];
 
 async function fixture() {
   const dir = await mkdtemp(join(tmpdir(), "run-turbo-prerequisite-"));
@@ -52,9 +89,18 @@ afterEach(async () => {
   await Promise.all(
     tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
   );
-});
+}, 30_000);
 
-describe("run-turbo typecheck prerequisites", () => {
+describe("run-turbo generated-source prerequisites", () => {
+  test("runs the generator once before a build task", async () => {
+    const { generator, marker } = await fixture();
+
+    expect(
+      await invoke(["run", "build", "--filter=@elizaos/app"], generator),
+    ).toBe(0);
+    expect(await readFile(marker, "utf8")).toBe("generated\n");
+  });
+
   test("runs the generator once before a typecheck task", async () => {
     const { generator, marker } = await fixture();
 
@@ -144,6 +190,80 @@ describe("run-turbo typecheck prerequisites", () => {
 
     expect(await invoke(["typecheck"], generator, 7)).toBe(7);
   });
+});
+
+describe("filtered build generated outputs", () => {
+  test("materializes every consumed output before the agent-image graph starts", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "run-turbo-filtered-build-"));
+    tempDirs.push(dir);
+
+    const copiedRunTurbo = join(dir, "packages/scripts/run-turbo.mjs");
+    const copiedGenerator = join(
+      dir,
+      "packages/shared/scripts/generate-keywords.mjs",
+    );
+    const copiedKeywords = join(dir, "packages/shared/src/i18n/keywords");
+    const fakeTurbo = join(dir, "fake-turbo.mjs");
+    const turboArgsFile = join(dir, "turbo-args.json");
+    const outputs = [
+      "packages/shared/src/i18n/generated/validation-keyword-data.ts",
+      "packages/shared/src/i18n/generated/validation-keyword-data.js",
+      "packages/core/src/i18n/generated/validation-keyword-data.ts",
+    ];
+
+    await mkdir(join(dir, "packages/scripts"), { recursive: true });
+    await mkdir(join(dir, "packages/shared/scripts"), { recursive: true });
+    await copyFile(runTurbo, copiedRunTurbo);
+    await copyFile(keywordGenerator, copiedGenerator);
+    await cp(keywordSources, copiedKeywords, { recursive: true });
+    await writeFile(
+      fakeTurbo,
+      `import { readFileSync, writeFileSync } from "node:fs";\nimport { resolve } from "node:path";\nconst outputs = ${JSON.stringify(outputs)};\nfor (const output of outputs) {\n  const source = readFileSync(resolve(output), "utf8");\n  if (!source.includes("VALIDATION_KEYWORD_DOCS")) {\n    throw new Error(\`generated output is incomplete: \${output}\`);\n  }\n}\nwriteFileSync(${JSON.stringify(turboArgsFile)}, JSON.stringify(process.argv.slice(2)));\n`,
+    );
+
+    for (const output of outputs) {
+      await expect(readFile(join(dir, output), "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    }
+
+    const args = [
+      "run",
+      "build",
+      "--concurrency=8",
+      ...agentImageFilters.map((filter) => `--filter=${filter}`),
+    ];
+    const child = Bun.spawn([process.execPath, copiedRunTurbo, ...args], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        RUN_TURBO_BIN: fakeTurbo,
+        RUN_TURBO_BUN_LOCKFILE: join(dir, "absent-bun.lock"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await child.exited;
+    const stderr = await new Response(child.stderr).text();
+
+    expect(child.exitCode, stderr).toBe(0);
+    for (const output of outputs) {
+      expect(await readFile(join(dir, output), "utf8")).toContain(
+        "VALIDATION_KEYWORD_DOCS",
+      );
+    }
+    expect(
+      (await readdir(join(dir, "packages/shared/src/i18n/generated"))).sort(),
+    ).toEqual(["validation-keyword-data.js", "validation-keyword-data.ts"]);
+    expect(JSON.parse(await readFile(turboArgsFile, "utf8"))).toEqual(
+      expect.arrayContaining([
+        "run",
+        "build",
+        "--concurrency=8",
+        ...agentImageFilters.map((filter) => `--filter=${filter}`),
+      ]),
+    );
+  }, 30_000);
 });
 
 describe("generate-keywords argv contract", () => {

--- a/packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
+++ b/packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
@@ -193,6 +193,17 @@ describe("run-turbo generated-source prerequisites", () => {
 });
 
 describe("filtered build generated outputs", () => {
+  test("direct core builds never accept existing generated output as fresh", async () => {
+    const manifest = JSON.parse(
+      await readFile(join(repoRoot, "packages/core/package.json"), "utf8"),
+    );
+
+    expect(manifest.scripts.prebuild).toContain(
+      "node ../shared/scripts/generate-keywords.mjs",
+    );
+    expect(manifest.scripts.prebuild).not.toContain("[ -s");
+  });
+
   test("materializes every consumed output before the agent-image graph starts", async () => {
     const dir = await mkdtemp(join(tmpdir(), "run-turbo-filtered-build-"));
     tempDirs.push(dir);

--- a/packages/scripts/run-turbo.mjs
+++ b/packages/scripts/run-turbo.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Runs Turbo with repository-wide safeguards shared by local and CI commands.
- * Typecheck prerequisites are materialized before Turbo hashes or schedules the
- * graph so package-specific task overrides cannot race generated declarations.
+ * Generated-source prerequisites are materialized before Turbo hashes or
+ * schedules build/typecheck graphs so cached tasks and package-specific
+ * overrides cannot omit files consumed outside their owning package.
  */
 
 import { spawn, spawnSync } from "node:child_process";
@@ -78,7 +79,8 @@ const positionalArgs = turboOwnArgs.filter((arg) => !arg.startsWith("-"));
 const requestedTasks =
   positionalArgs[0] === "run" ? positionalArgs.slice(1) : positionalArgs;
 
-if (requestedTasks.includes("typecheck")) {
+const generatedSourceTasks = new Set(["build", "typecheck"]);
+if (requestedTasks.some((task) => generatedSourceTasks.has(task))) {
   const generator = process.env.RUN_TURBO_KEYWORD_GENERATOR
     ? path.resolve(process.env.RUN_TURBO_KEYWORD_GENERATOR)
     : path.join(repoRoot, "packages/shared/scripts/generate-keywords.mjs");
@@ -89,7 +91,7 @@ if (requestedTasks.includes("typecheck")) {
   });
   if (result.error) {
     console.error(
-      `[run-turbo] Failed to generate typecheck prerequisites: ${result.error.message}`,
+      `[run-turbo] Failed to generate generated-source prerequisites: ${result.error.message}`,
     );
     process.exit(1);
   }

--- a/packages/shared/scripts/generate-keywords.mjs
+++ b/packages/shared/scripts/generate-keywords.mjs
@@ -17,7 +17,14 @@
  * site cannot silently imply target selection that does not exist (#15847).
  */
 
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -282,6 +289,18 @@ function generateTypeScriptStandalone(entries, locales) {
   return `${lines.join("\n")}\n`;
 }
 
+function writeGeneratedFile(outputPath, content) {
+  const temporaryPath = `${outputPath}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporaryPath, content, "utf-8");
+    // Package builds can invoke this generator concurrently. Renaming a fully
+    // written sibling keeps every reader on either complete version.
+    renameSync(temporaryPath, outputPath);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
+}
+
 // --- Main ---
 
 console.log("Generating keyword code from JSON...\n");
@@ -294,12 +313,12 @@ mkdirSync(generatedDir, { recursive: true });
 
 const ts = generateTypeScript(entries, locales);
 const outPath = join(generatedDir, "validation-keyword-data.ts");
-writeFileSync(outPath, ts, "utf-8");
+writeGeneratedFile(outPath, ts);
 console.log(`  TypeScript (shared): ${outPath}`);
 
 const js = generateJavaScript(entries);
 const jsOutPath = join(generatedDir, "validation-keyword-data.js");
-writeFileSync(jsOutPath, js, "utf-8");
+writeGeneratedFile(jsOutPath, js);
 console.log(`  JavaScript (shared): ${jsOutPath}`);
 
 // Also generate for @elizaos/core — same data,
@@ -316,7 +335,7 @@ const tsCorePath = join(
 mkdirSync(tsCorePath, { recursive: true });
 const tsCoreContent = generateTypeScriptStandalone(entries, locales);
 const tsCoreOutPath = join(tsCorePath, "validation-keyword-data.ts");
-writeFileSync(tsCoreOutPath, tsCoreContent, "utf-8");
+writeGeneratedFile(tsCoreOutPath, tsCoreContent);
 console.log(`  TypeScript (core):   ${tsCoreOutPath}`);
 
 console.log("\nDone!");


### PR DESCRIPTION
Closes #17468

## What changed

- Generate all three validation-keyword modules before both root Turbo build and typecheck graphs, before Turbo can replay a cached producer task.
- Regenerate unconditionally for direct @elizaos/core builds so non-empty stale files are never accepted as fresh.
- Publish generated files by atomic sibling rename so concurrent package builds never expose partial contents.
- Add a real absent-output regression using the exact 26-filter Build Agent Image graph.

## Root cause

The cached @elizaos/core build task restored core-owned outputs but not its generated side effect under packages/shared. Turbo replayed successful generation logs even though packages/shared/src/i18n/generated/validation-keyword-data.js was absent, and Vite failed later in @elizaos/app.

## Validation

- Exact current head: `12d2c5f090df1b21b7d459162d55d3e3cd25967f`, rebased onto `develop` at `72d985d2fca036875308acb3eae45e1cf2c5f285` (rebased exact patch).
- Rebase verification: focused run-turbo/filtered-build/generator-argv suite 15 pass, 0 fail, 35 assertions; direct generator stable; core typecheck passes. Prior broader focused suite: 27 pass, 0 fail.
- Exact 26-filter Build Agent Turbo command from all three outputs absent: 111/111 tasks successful in 4m30; app Vite build completed.
- Direct packages/core prebuild from deliberately stale non-empty outputs regenerated all three modules; sizes 466,594 / 466,384 / 466,634 bytes and no temporary files remained.
- Turbo dry-run confirms @elizaos/core#build hashes the generator plus all five keyword JSON inputs and declares src/i18n/generated/** as outputs.
- [Build Agent Image run 30662868036](https://github.com/elizaOS/eliza/actions/runs/30662868036) on validated `ea907fe82e462df3b984572b8a85fd736eb0518f`: green in 21m02; filtered workspace build, Docker image build, real entrypoint boot, exact image push, and attestation step all passed.
- Biome check on all changed files: pass (existing run-turbo environment-variable advisories only).
- bun.lock unchanged and worktree clean.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI/build pipeline only, no UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI/build pipeline only, no UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CI/build pipeline only, no UI surface
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime behavior changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - generated modules are deterministic gitignored build intermediates; execution evidence is linked in backend logs
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual artifact
<!-- evidence-row:backend-logs -->
- [x] Exact failed production run: https://github.com/elizaOS/eliza/actions/runs/30656021813; exact passing Build Agent run: https://github.com/elizaOS/eliza/actions/runs/30662868036