### PR TITLE
fix(core): keep strict tool grammars provider-legal by folding oneOf into anyOf

### DIFF
--- a/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/manifest_export.py
+++ b/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/manifest_export.py
@@ -201,7 +201,7 @@ _BENCH_UMBRELLA_AUGMENTS: dict[str, dict[str, Any]] = {
                 "description": (
                     "Either an integer passenger count or the canonical passenger array."
                 ),
-                "oneOf": [
+                "anyOf": [
                     {"type": "number"},
                     {
                         "type": "array",

--- a/packages/benchmarks/lifeops-bench/manifests/actions.manifest.json
+++ b/packages/benchmarks/lifeops-bench/manifests/actions.manifest.json
@@ -823,7 +823,7 @@
             },
             "passengers": {
               "description": "Either an integer passenger count or the canonical passenger array.",
-              "oneOf": [
+              "anyOf": [
                 {
                   "type": "number"
                 },
@@ -1381,7 +1381,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1394,7 +1394,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1407,7 +1407,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1420,7 +1420,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1433,7 +1433,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1446,7 +1446,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1459,7 +1459,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1472,7 +1472,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1914,7 +1914,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1927,7 +1927,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1940,7 +1940,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1953,7 +1953,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1966,7 +1966,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1979,7 +1979,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -1992,7 +1992,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -2005,7 +2005,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -2447,7 +2447,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -2460,7 +2460,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -2473,7 +2473,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -2486,7 +2486,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -2499,7 +2499,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -2512,7 +2512,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -2525,7 +2525,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -2538,7 +2538,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -2980,7 +2980,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -2993,7 +2993,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3006,7 +3006,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3019,7 +3019,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3032,7 +3032,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3045,7 +3045,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3058,7 +3058,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3071,7 +3071,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3513,7 +3513,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3526,7 +3526,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3539,7 +3539,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3552,7 +3552,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3565,7 +3565,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3578,7 +3578,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3591,7 +3591,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -3604,7 +3604,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4046,7 +4046,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4059,7 +4059,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4072,7 +4072,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4085,7 +4085,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4098,7 +4098,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4111,7 +4111,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4124,7 +4124,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4137,7 +4137,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4579,7 +4579,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4592,7 +4592,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4605,7 +4605,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4618,7 +4618,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4631,7 +4631,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4644,7 +4644,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4657,7 +4657,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -4670,7 +4670,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5112,7 +5112,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5125,7 +5125,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5138,7 +5138,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5151,7 +5151,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5164,7 +5164,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5177,7 +5177,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5190,7 +5190,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5203,7 +5203,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5645,7 +5645,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5658,7 +5658,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5671,7 +5671,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5684,7 +5684,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5697,7 +5697,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5710,7 +5710,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5723,7 +5723,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -5736,7 +5736,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6240,7 +6240,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6253,7 +6253,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6266,7 +6266,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6279,7 +6279,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6292,7 +6292,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6305,7 +6305,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6318,7 +6318,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6331,7 +6331,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6773,7 +6773,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6786,7 +6786,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6799,7 +6799,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6812,7 +6812,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6825,7 +6825,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6838,7 +6838,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6851,7 +6851,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -6864,7 +6864,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -7306,7 +7306,7 @@
                   "type": "boolean"
                 },
                 "recurrence": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -7319,7 +7319,7 @@
                   ]
                 },
                 "rrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -7332,7 +7332,7 @@
                   ]
                 },
                 "recurrencerule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -7345,7 +7345,7 @@
                   ]
                 },
                 "recurrence_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -7358,7 +7358,7 @@
                   ]
                 },
                 "repeat": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -7371,7 +7371,7 @@
                   ]
                 },
                 "repeats": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -7384,7 +7384,7 @@
                   ]
                 },
                 "repeatrule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -7397,7 +7397,7 @@
                   ]
                 },
                 "repeat_rule": {
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "string"
                     },
@@ -7575,7 +7575,7 @@
             },
             "range": {
               "description": "'today' | 'week' or { start, end } RFC 3339 window with explicit offsets.",
-              "oneOf": [
+              "anyOf": [
                 {
                   "type": "string",
                   "enum": ["today", "week"]
@@ -7644,7 +7644,7 @@
             },
             "range": {
               "description": "'today' | 'week' or { start, end } RFC 3339 window with explicit offsets.",
-              "oneOf": [
+              "anyOf": [
                 {
                   "type": "string",
                   "enum": ["today", "week"]
@@ -7713,7 +7713,7 @@
             },
             "range": {
               "description": "'today' | 'week' or { start, end } RFC 3339 window with explicit offsets.",
-              "oneOf": [
+              "anyOf": [
                 {
                   "type": "string",
                   "enum": ["today", "week"]
@@ -7782,7 +7782,7 @@
             },
             "range": {
               "description": "'today' | 'week' or { start, end } RFC 3339 window with explicit offsets.",
-              "oneOf": [
+              "anyOf": [
                 {
                   "type": "string",
                   "enum": ["today", "week"]

--- a/packages/core/src/runtime/__tests__/schema-compat.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-compat.test.ts
@@ -109,6 +109,61 @@ describe("normalizeSchemaForCerebras", () => {
 		expect(result.additionalProperties).toBe(false);
 	});
 
+	it("rewrites nested oneOf to anyOf under strict mode", () => {
+		// The live failure shape: a property offering string-or-array via oneOf
+		// (plugin-calendar's recurrence field) aborted every planner call on
+		// Cerebras with "'oneOf' is not permitted". Verified against the live
+		// API: the identical payload with anyOf is accepted.
+		const result = normalizeSchemaForCerebras({
+			type: "object",
+			properties: {
+				recurrence: {
+					oneOf: [
+						{ type: "string" },
+						{ type: "array", items: { type: "string" } },
+					],
+				},
+			},
+		}) as Record<string, unknown>;
+		const recurrence = (result.properties as Record<string, unknown>)
+			.recurrence as Record<string, unknown>;
+		expect(recurrence.oneOf).toBeUndefined();
+		expect(recurrence.anyOf).toHaveLength(2);
+	});
+
+	it("appends migrated oneOf branches after existing anyOf branches", () => {
+		const result = normalizeSchemaForCerebras({
+			type: "object",
+			properties: {
+				value: {
+					anyOf: [{ type: "number" }],
+					oneOf: [{ type: "string" }],
+				},
+			},
+		}) as Record<string, unknown>;
+		const value = (result.properties as Record<string, unknown>)
+			.value as Record<string, unknown>;
+		expect(value.oneOf).toBeUndefined();
+		expect(value.anyOf).toMatchObject([{ type: "number" }, { type: "string" }]);
+	});
+
+	it("keeps oneOf intact for non-strict tools", () => {
+		const result = normalizeSchemaForCerebras(
+			{
+				type: "object",
+				properties: {
+					recurrence: { oneOf: [{ type: "string" }] },
+				},
+			},
+			false,
+			{ strict: false },
+		) as Record<string, unknown>;
+		const recurrence = (result.properties as Record<string, unknown>)
+			.recurrence as Record<string, unknown>;
+		expect(recurrence.oneOf).toHaveLength(1);
+		expect(recurrence.anyOf).toBeUndefined();
+	});
+
 	it("walks every schema-bearing keyword", () => {
 		const bareObject = () => ({ type: "object" });
 		const result = normalizeSchemaForCerebras({
@@ -159,7 +214,14 @@ describe("normalizeSchemaForCerebras", () => {
 		expect((result.dependencies as Record<string, unknown>).names).toEqual([
 			"direct",
 		]);
-		for (const key of ["anyOf", "oneOf", "allOf", "prefixItems"] as const) {
+		// Strict mode folds `oneOf` into `anyOf` (Cerebras's strict grammar
+		// rejects `oneOf`), so the original anyOf branch and the migrated
+		// oneOf branch both land in anyOf and the oneOf key disappears.
+		expect(result.oneOf).toBeUndefined();
+		const anyOf = result.anyOf as unknown[];
+		expect(anyOf).toHaveLength(2);
+		for (const branch of anyOf) expectClosed(branch);
+		for (const key of ["allOf", "prefixItems"] as const) {
 			expectClosed((result[key] as unknown[])[0]);
 		}
 		for (const item of result.items as unknown[]) expectClosed(item);

--- a/packages/core/src/runtime/schema-compat.ts
+++ b/packages/core/src/runtime/schema-compat.ts
@@ -187,7 +187,20 @@ export function normalizeSchemaForCerebras(
 		};
 	}
 
-	if (options.strict !== false) enforceStrictObjectShape(node);
+	if (options.strict !== false) {
+		enforceStrictObjectShape(node);
+		// Cerebras's strict grammar compiler rejects `oneOf` outright
+		// ("Unsupported JSON schema fields ... oneOf") while accepting `anyOf`
+		// — verified against the live API with otherwise-identical payloads.
+		// The weakening from exclusive-or to inclusive-or is immaterial here:
+		// constrained generation emits a single value, and runtime validation
+		// re-checks the parsed arguments. Non-strict schemas keep `oneOf`.
+		if (Array.isArray(node.oneOf) && node.oneOf.length > 0) {
+			const existing = Array.isArray(node.anyOf) ? node.anyOf : [];
+			node.anyOf = [...existing, ...node.oneOf];
+			delete node.oneOf;
+		}
+	}
 
 	walkSchemaChildren(node, options);
 	return node;

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -30,7 +30,14 @@ export type {
  * Supports basic JSON Schema properties for parameter definition.
  */
 export interface ActionParameterSchema {
-	type: string;
+	/**
+	 * JSON Schema instance type. Optional because a schema may instead be a
+	 * pure union (`oneOf`/`anyOf`) — a sibling `type` alongside union branches
+	 * of differing types contradicts the branches, and strict provider
+	 * grammars reject the contradiction. A schema should carry `type` or a
+	 * union keyword, never neither.
+	 */
+	type?: string;
 	description?: string;
 	/** Default value if parameter is not provided */
 	default?: JsonValue | null;

--- a/plugins/plugin-calendar/src/actions/conflict-detect.ts
+++ b/plugins/plugin-calendar/src/actions/conflict-detect.ts
@@ -661,8 +661,9 @@ export function createConflictDetectAction(
         description:
           "'today' | 'week' or { start, end } RFC 3339 window with explicit offsets.",
         schema: {
-          type: "object" as const,
-          oneOf: [
+          // anyOf, not oneOf: strict-mode provider grammars reject oneOf, and
+          // a sibling `type` would contradict the string branch.
+          anyOf: [
             { type: "string" as const, enum: ["today", "week"] },
             { type: "object" as const, additionalProperties: true },
           ],

--- a/plugins/plugin-calendar/src/calendar-action-schema.ts
+++ b/plugins/plugin-calendar/src/calendar-action-schema.ts
@@ -109,9 +109,12 @@ const CALENDAR_DETAIL_RECURRENCE_KEYS = [
 const stringSchema: ActionParameterSchema = { type: "string" };
 const numberSchema: ActionParameterSchema = { type: "number" };
 const booleanSchema: ActionParameterSchema = { type: "boolean" };
+// The runtime normalizer (internal/recurrence.ts) accepts a single RRULE
+// string or an array of RFC 5545 lines, so the schema offers both branches.
+// `anyOf` rather than `oneOf`: strict-mode provider grammars (Cerebras)
+// reject `oneOf`, and a sibling `type` would contradict the array branch.
 const recurrenceSchema: ActionParameterSchema = {
-  type: "string",
-  oneOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+  anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
 };
 
 export const CALENDAR_DETAILS_PARAMETER_SCHEMA: ActionParameterSchema = {

--- a/plugins/plugin-calendar/test/conflict-detect-action.test.ts
+++ b/plugins/plugin-calendar/test/conflict-detect-action.test.ts
@@ -125,10 +125,14 @@ describe("calendar-owned CONFLICT_DETECT action", () => {
       (parameter) => parameter.name === "range",
     );
 
-    expect(range?.schema.oneOf).toEqual([
+    // anyOf, not oneOf: strict-mode provider grammars (Cerebras) reject
+    // oneOf, and the invariant under test is that both range forms are
+    // declared — not which union keyword carries them.
+    expect(range?.schema.anyOf).toEqual([
       { type: "string", enum: ["today", "week"] },
       { type: "object", additionalProperties: true },
     ]);
+    expect(range?.schema.oneOf).toBeUndefined();
   });
 
   it("fails closed when the host authorization adapter denies access", async () => {


### PR DESCRIPTION
Fixes the planner-degradation that failed every scenario in the 07-31 nightly's fast shards (`plugin-health`, `app-control`, `scenario-runner-view-chat` — run 30620091684).

## Root cause, proven against the live provider

The shard logs show every scenario degrading the same way:

```
planner failed after a substantive stage-0 answer; delivering the preserved answer
(error=Invalid schema for function 'CALENDAR': In context=('properties', 'details',
'properties', 'recurrence'), 'oneOf' is not permitted.)
```

`to-tool.ts:188` marks every planner tool `strict: true`, and Cerebras's strict grammar compiler rejects `oneOf` while accepting `anyOf`. I verified this against the live API with otherwise-identical payloads rather than inferring it:

| payload | result |
| --- | --- |
| strict + closed objects + `oneOf` | **HTTP 400** — `Unsupported JSON schema fields ... oneOf` |
| strict + closed objects + `anyOf` | **HTTP 200** |
| non-strict + `oneOf` | HTTP 200 |

So one `oneOf` anywhere in one action's schema poisons the entire planner call for every scenario that exposes that tool.

## The fix — two layers, deliberately both

**1. The seam (`schema-compat.ts`).** The strict normalizer now folds `oneOf` branches into `anyOf` (appended after any existing branches) at every depth, so no action schema can reproduce this at the wire regardless of how it is authored. This is the module's charter — it already closes objects and wraps illegal roots for exactly this provider. The exclusive-or → inclusive-or weakening is immaterial here: constrained generation emits a single value, and runtime validation re-checks the parsed arguments. Non-strict schemas keep `oneOf` untouched.

**2. The sources.** All three authored `oneOf` sites are corrected so the schemas stay honest rather than leaning on the seam:
- `plugin-calendar/src/calendar-action-schema.ts` — the failing recurrence schema, which also carried a sibling `type: "string"` contradicting its own array branch
- `plugin-calendar/src/actions/conflict-detect.ts` — `range` (named-window string or explicit RFC 3339 object)
- `lifeops-bench manifest_export.py` — the bench umbrella's `BOOK_TRAVEL.passengers`; the regenerated manifest now contains **zero** `oneOf` (there is a CI freshness gate on the committed manifest, so it is regenerated in this PR)

The conflict-detect contract test pinned the keyword; its *named* invariant — both range forms are declared — is unchanged, so it now asserts `anyOf` and the absence of `oneOf`.

## Verification

| suite | result |
| --- | --- |
| core `schema-compat` (3 new cases: nested strict rewrite, append-after-existing-`anyOf`, non-strict preservation) | **20/20** |
| core `tsc --noEmit` | clean |
| full `plugin-calendar` suite | **447 + 37 passing**, only intentional skips |
| bench python manifest/scorer suites | green |

(The full calendar run required building `@elizaos/shared`, `cloud-routing`, `contracts`, and `import-conversations` dists in the fresh worktree — all 39 initial file failures were resolution errors from missing dists, worked through to zero rather than sampled.)

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend schema/wire fix with no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend schema/wire fix with no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-exercisable flow; the change is a tool-schema normalizer and three schema declarations.
<!-- evidence-row:backend-logs -->
- [x] Failing nightly planner logs: https://github.com/elizaOS/eliza/actions/runs/30620091684 — the degradation line and the three live-API probe results are quoted verbatim above (probes against api.cerebras.ai with gemma-4-31b).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface is exercised.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/model behavior change; the planner's tool payload becomes provider-legal, and the next scheduled nightly is the live proof.
<!-- evidence-row:domain-artifacts -->
- [x] Regenerated manifest in this PR diff: https://github.com/elizaOS/eliza/pull/17484/files#diff-actions-manifest — 222 actions, zero `oneOf` (was 5); suite results tabulated above.

