### PR TITLE
fix(ci): scope the fork homepage smoke and stop mid-suite cancellations

### DIFF
--- a/.github/workflows/quality-fork.yml
+++ b/.github/workflows/quality-fork.yml
@@ -134,14 +134,17 @@ jobs:
     name: Build
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
-    # Fresh attempt 3 completed the entire two-worker suite and failed closed
-    # on three bounded mobile visual diffs in 25m38s total. Retain the complete
-    # 48-test suite and a finite 32m ceiling, a measured 25% cold-run margin.
-    timeout-minutes: 32
+    # A cold workspace build alone has taken 13m and the two-worker homepage
+    # suite 25m38s total; the old 32m ceiling cancelled real runs mid-suite
+    # whenever both were cold (observed on #17157 and #17256). 45m covers the
+    # measured worst case of each phase with margin; homepage-scope gating
+    # below keeps non-homepage PRs from paying the suite at all.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           submodules: false
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -161,17 +164,52 @@ jobs:
       - name: Build
         run: bun run build
 
+      # Mirrors quality.yml's homepage-scope gate: the homepage Playwright
+      # suite only proves anything when a homepage release surface changed,
+      # and unconditionally running it burned ~20 runner-minutes per fork PR
+      # while pushing cold runs past the job ceiling.
+      - name: Check homepage smoke scope
+        id: homepage-scope
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          if merge_base="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"; then
+            changed_files="$(git diff --name-only "${merge_base}" HEAD)"
+          else
+            echo "No merge base found with origin/${{ github.base_ref }}; falling back to direct base/head diff." >&2
+            changed_files="$(git diff --name-only "origin/${{ github.base_ref }}" HEAD)"
+          fi
+          if grep -Eq '^(packages/homepage/|packages/shared/|packages/app-core/scripts/write-homepage-release-data\.mjs|\.github/workflows/(deploy-homepage|release-electrobun|release-orchestrator|quality-fork)\.yml)' <<< "${changed_files}"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip unrelated homepage smoke
+        if: steps.homepage-scope.outputs.run != 'true'
+        run: echo "Skipping homepage smoke; this PR does not touch homepage release surfaces."
+
       - name: Build homepage
+        if: steps.homepage-scope.outputs.run == 'true'
         working-directory: packages/homepage
         run: bun run build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install homepage browser
+        if: steps.homepage-scope.outputs.run == 'true'
         working-directory: packages/homepage
         run: ./node_modules/.bin/playwright install chromium
 
       - name: Test homepage downloads
+        if: steps.homepage-scope.outputs.run == 'true'
         working-directory: packages/homepage
         # The provisioned runner reported six default workers. Heavy animated
         # visual routes then contended, timed out, and multiplied into retries.


### PR DESCRIPTION
## Problem

The Quality (Fork) `Build` job runs the full homepage Playwright suite unconditionally on every fork PR. A cold workspace build (13m observed on [#17256's run](https://github.com/elizaOS/eliza/actions/runs/30660727620/job/91256069256)) plus the two-worker suite (25m38s observed per the job's own comment) cannot fit the 32m ceiling, so runs get cancelled mid-suite at "Test homepage downloads" — this killed the Build check on #17157 and #17256, neither of which touches any homepage surface.

## Fix

- Port `quality.yml`'s homepage-scope gate to `quality-fork.yml`: the homepage build/browser-install/e2e steps only run when the merge-base diff touches a homepage release surface (`packages/homepage/`, `packages/shared/`, `write-homepage-release-data.mjs`, the release workflows) or this workflow itself.
- `fetch-depth: 0` on checkout so the merge-base computation works.
- Raise the ceiling to 45m for runs that legitimately pay both cold phases.

Non-homepage fork PRs stop burning ~20 runner-minutes per push and stop failing on an unrelated timeout.

## Validation

- YAML parses cleanly.
- `quality-fork-browser-contract`, `ci-path-gate` self-test, `ci-workflow-dedup-contract`, `ci-turbo-cache-contract`, and `ci-bun-version-contract` all pass against the edited file.
- Gate script is byte-identical in structure to the proven `quality.yml` gate (same fetch/merge-base/fallback/grep shape), with the workflow itself added to the pattern so future edits to the fork smoke exercise it.

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow only, no UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow only, no UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - CI workflow only
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path
<!-- evidence-row:backend-logs -->
- [x] Cancelled-run evidence: https://github.com/elizaOS/eliza/actions/runs/30660727620/job/91256069256 (step timings show 13m build + 17.5m suite hitting the 32m ceiling)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/agent behavior
<!-- evidence-row:domain-artifacts -->
- [x] N/A - CI workflow-only change; the contract-script outputs are quoted in the Validation section and the cancelled-run step timings are linked in the backend-logs row: https://github.com/elizaOS/eliza/actions/runs/30660727620/job/91256069256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
