### PR TITLE
fix(feed): deterministic 3d-countdown expectation off the exact boundary

### DIFF
--- a/packages/feed/apps/web/src/components/rewards/v2/__tests__/rewards-tabs.test.ts
+++ b/packages/feed/apps/web/src/components/rewards/v2/__tests__/rewards-tabs.test.ts
@@ -94,8 +94,11 @@ describe("formatCountdown", () => {
   });
 
   it("returns days remaining for >= 24h", () => {
+    // One minute past the 72h boundary: formatCountdown re-reads Date.now(),
+    // so a timestamp at exactly +72h floors to 71h ("2d") unless both reads
+    // land in the same millisecond — this test only ever passed by that race.
     const threeDaysFromNow = new Date(
-      Date.now() + 3 * 24 * 60 * 60 * 1000,
+      Date.now() + (3 * 24 * 60 + 1) * 60 * 1000,
     ).toISOString();
     expect(formatCountdown(threeDaysFromNow)).toBe("3d remaining");
   });


### PR DESCRIPTION
## Problem

`formatCountdown > returns days remaining for >= 24h` is failing the `feed compile, unit, and production image` lane on unrelated PRs (seen on #17480 and #17483 today). The test builds a timestamp at exactly `now + 72h`, but `formatCountdown` re-reads `Date.now()`, so the computed diff is always a few milliseconds under 72h and floors to 71h → `"2d remaining"`. The assertion can only pass when both `Date.now()` reads land in the same millisecond — a race, not a test.

## Fix

Move the fixture one minute past the boundary (`+72h 1m`). The sibling `25h → "1d remaining"` case already pins the floor behavior at the day threshold, so no coverage is lost.

## Validation

`bun test apps/web/src/components/rewards/v2/__tests__/rewards-tabs.test.ts` → 24 pass / 0 fail.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change, no UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change, no UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path
<!-- evidence-row:backend-logs -->
- [x] Failing-lane evidence: https://github.com/elizaOS/eliza/actions/runs/30662714669/job/91262447332 ("Expected: 3d remaining" on a PR that does not touch feed)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test suite output quoted in Validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)