### PR TITLE
fix(core): make provider deadlines cancellation-safe

### DIFF
--- a/packages/agent/src/providers/recent-conversations.ts
+++ b/packages/agent/src/providers/recent-conversations.ts
@@ -47,6 +47,8 @@ export const recentConversationsProvider: Provider = {
   contextGate: { anyOf: ["memory", "messaging"] },
   cacheStable: false,
   cacheScope: "turn",
+  timeoutMs: 8_000,
+  timeoutMode: "degrade",
   // roleGate ADMIN is enforced by applyPluginRoleGating (#12087 Item 14); the
   // declared gate is authoritative, not the handler body.
   roleGate: { minRole: "ADMIN" },

--- a/packages/agent/src/providers/relevant-conversations.ts
+++ b/packages/agent/src/providers/relevant-conversations.ts
@@ -103,6 +103,9 @@ export const relevantConversationsProvider: Provider = {
   contextGate: { anyOf: ["memory", "messaging"] },
   cacheStable: false,
   cacheScope: "turn",
+  // Semantic recall is supplemental and can include a remote embed/search.
+  timeoutMs: 10_000,
+  timeoutMode: "degrade",
   alwaysInResponseState: true,
   roleGate: { minRole: "USER" },
 

--- a/packages/core/src/__tests__/compose-state-provider-budget.test.ts
+++ b/packages/core/src/__tests__/compose-state-provider-budget.test.ts
@@ -1,8 +1,8 @@
 /**
- * Per-provider composeState time budgets: a provider that exceeds its declared
- * `timeoutMs` degrades to a `deadline_exceeded` failure record for the turn
- * while composition proceeds with every other provider's output. Uses a real
- * in-memory AgentRuntime with synthetic providers; no database or model.
+ * Per-provider composeState time budgets: fail-fast is the default, while an
+ * explicitly optional provider can publish a distinguishable unavailable
+ * result. The harness also proves cooperative work receives cancellation and
+ * cannot finish a late side effect after composition returns.
  */
 import { describe, expect, it } from "vitest";
 import { AgentRuntime } from "../runtime";
@@ -25,20 +25,39 @@ function sleep(ms: number): Promise<void> {
 }
 
 describe("composeState per-provider time budget", () => {
-	it("truncates a provider that exceeds its declared timeoutMs and keeps the fast ones", async () => {
+	it("aborts an optional provider and keeps an explicit unavailable result in deterministic order", async () => {
 		const runtime = new AgentRuntime({
 			character: { name: "budget-truncation" } as Character,
 		});
+		let lateSideEffect = false;
+		let receivedSignal: AbortSignal | undefined;
 		const slow: Provider = {
 			name: "SLOW_NETWORK",
+			position: -10,
 			timeoutMs: 300,
-			get: async () => {
-				await sleep(1_500);
+			timeoutMode: "degrade",
+			get: async (_runtime, _message, _state, context) => {
+				receivedSignal = context?.signal;
+				await new Promise<void>((resolve, reject) => {
+					const timer = setTimeout(() => {
+						lateSideEffect = true;
+						resolve();
+					}, 1_500);
+					context?.signal?.addEventListener(
+						"abort",
+						() => {
+							clearTimeout(timer);
+							reject(context.signal?.reason);
+						},
+						{ once: true },
+					);
+				});
 				return { text: "SLOW_RESULT_MUST_NOT_APPEAR", values: {}, data: {} };
 			},
 		};
 		const fast: Provider = {
 			name: "FAST_LOCAL",
+			position: 10,
 			get: async () => ({ text: "FAST_RESULT_PRESENT", values: {}, data: {} }),
 		};
 		runtime.registerProvider(slow);
@@ -55,6 +74,22 @@ describe("composeState per-provider time budget", () => {
 
 		expect(state.text).toContain("FAST_RESULT_PRESENT");
 		expect(state.text).not.toContain("SLOW_RESULT_MUST_NOT_APPEAR");
+		expect(state.text).toMatch(
+			/^\[Provider SLOW_NETWORK unavailable this turn: exceeded 300ms deadline\.\]/,
+		);
+		expect(state.data.providers).toMatchObject({
+			SLOW_NETWORK: {
+				providerOutcome: "deadline_exceeded",
+				data: {
+					available: false,
+					reason: "deadline_exceeded",
+					timeoutMs: 300,
+				},
+			},
+		});
+		expect(receivedSignal?.aborted).toBe(true);
+		await sleep(50);
+		expect(lateSideEffect).toBe(false);
 		// Compose returns at the slow provider's budget, not its full runtime.
 		expect(elapsed).toBeLessThan(1_400);
 	});
@@ -82,29 +117,128 @@ describe("composeState per-provider time budget", () => {
 		expect(state.text).toContain("WITHIN_BUDGET_PRESENT");
 	});
 
-	it("the DEFAULT budget applies to a provider with no declared timeoutMs", async () => {
-		// COMPOSE_STATE_PROVIDER_TIMEOUT_MS is captured once in a module-init
-		// IIFE (runtime.ts, reading ELIZA_COMPOSE_PROVIDER_TIMEOUT_MS), so the
-		// statically-imported AgentRuntime above has already baked in the 3s
-		// built-in default. Re-reading the env in-process requires a fresh
-		// module evaluation (vitest `vi.stubEnv` + `vi.resetModules` + dynamic
-		// import), which bun's vitest-compat runner does not support — so this
-		// test exercises the default path directly: a provider with NO declared
-		// timeoutMs that sleeps well past the built-in 3s default must be
-		// truncated to an empty contribution at the default budget. This locks
-		// the class where a no-timeoutMs provider blocks compose for the length
-		// of its own work (the available_apps 10.9s live-turn shape).
+	it("coalesced callers share one deadline and one unavailable checkpoint", async () => {
 		const runtime = new AgentRuntime({
-			character: { name: "budget-default" } as Character,
+			character: { name: "budget-coalesced" } as Character,
 		});
-		const slowNoDeclaredBudget: Provider = {
-			name: "SLOW_NO_DECLARED_BUDGET",
-			// Deliberately NO timeoutMs — this provider must fall under the
-			// module-level default budget (3s built-in).
+		let calls = 0;
+		const optional: Provider = {
+			name: "OPTIONAL_REMOTE",
+			timeoutMs: 250,
+			timeoutMode: "degrade",
+			get: async (_runtime, _message, _state, context) => {
+				calls += 1;
+				return new Promise((_, reject) => {
+					context?.signal?.addEventListener(
+						"abort",
+						() => reject(context.signal?.reason),
+						{ once: true },
+					);
+				});
+			},
+		};
+		runtime.registerProvider(optional);
+		const message = makeMessage("ffffffff-ffff-ffff-ffff-ffffffffffff");
+
+		const [first, second] = await Promise.all([
+			runtime.composeState(message, [optional.name], true),
+			runtime.composeState(message, [optional.name], true),
+		]);
+
+		expect(calls).toBe(1);
+		expect(first.text).toBe(second.text);
+		expect(first.data.providers).toMatchObject({
+			OPTIONAL_REMOTE: { providerOutcome: "deadline_exceeded" },
+		});
+	});
+
+	it("discards a non-cooperative provider's late result without rewriting the cached timeout", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "budget-late-result" } as Character,
+		});
+		let completed = false;
+		const optional: Provider = {
+			name: "NON_COOPERATIVE_READ",
+			timeoutMs: 250,
+			timeoutMode: "degrade",
 			get: async () => {
-				await sleep(4_500);
+				await sleep(450);
+				completed = true;
+				return { text: "LATE_RESULT_MUST_NOT_REPLACE_TIMEOUT" };
+			},
+		};
+		runtime.registerProvider(optional);
+		const message = makeMessage("abababab-abab-abab-abab-abababababab");
+
+		const first = await runtime.composeState(message, [optional.name], true);
+		expect(first.text).toContain("unavailable this turn");
+		expect(first.text).not.toContain("LATE_RESULT_MUST_NOT_REPLACE_TIMEOUT");
+
+		await sleep(300);
+		expect(completed).toBe(true);
+		const reused = await runtime.composeState(
+			message,
+			[optional.name],
+			true,
+			false,
+			[],
+		);
+		expect(reused.text).toBe(first.text);
+		expect(reused.text).not.toContain("LATE_RESULT_MUST_NOT_REPLACE_TIMEOUT");
+		expect(reused.data.providers).toMatchObject({
+			NON_COOPERATIVE_READ: { providerOutcome: "deadline_exceeded" },
+		});
+	});
+
+	it("does not mistake a provider-owned TimeoutError for the runtime deadline", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "budget-error-classification" } as Character,
+		});
+		const provider: Provider = {
+			name: "PLUGIN_TIMEOUT_ERROR",
+			timeoutMs: 1_000,
+			timeoutMode: "degrade",
+			get: async () => {
+				const error = new Error("plugin operation timed out");
+				error.name = "TimeoutError";
+				throw error;
+			},
+		};
+		runtime.registerProvider(provider);
+
+		const error = await runtime
+			.composeState(
+				makeMessage("acacacac-acac-acac-acac-acacacacacac"),
+				[provider.name],
+				true,
+			)
+			.catch((cause: unknown) => cause);
+
+		expect(error).toMatchObject({ code: "PROVIDER_COMPOSITION_FAILED" });
+	});
+
+	it("an explicit budget fails composition by default instead of caching partial state", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "budget-fail-default" } as Character,
+		});
+		const correctnessCritical: Provider = {
+			name: "CORRECTNESS_CRITICAL",
+			timeoutMs: 300,
+			// Deliberately no timeoutMode: fail-fast remains authoritative.
+			get: async (_runtime, _message, _state, context) => {
+				await new Promise<void>((resolve, reject) => {
+					const timer = setTimeout(resolve, 1_500);
+					context?.signal?.addEventListener(
+						"abort",
+						() => {
+							clearTimeout(timer);
+							reject(context.signal?.reason);
+						},
+						{ once: true },
+					);
+				});
 				return {
-					text: "DEFAULT_BUDGET_SLOW_MUST_NOT_APPEAR",
+					text: "FAILED_BUDGET_SLOW_MUST_NOT_APPEAR",
 					values: {},
 					data: {},
 				};
@@ -118,28 +252,43 @@ describe("composeState per-provider time budget", () => {
 				data: {},
 			}),
 		};
-		runtime.registerProvider(slowNoDeclaredBudget);
+		runtime.registerProvider(correctnessCritical);
 		runtime.registerProvider(fast);
 
 		const start = Date.now();
-		const state = await runtime.composeState(
-			makeMessage("dddddddd-dddd-dddd-dddd-dddddddddddd"),
-			null,
-			false,
-			true,
-		);
+		const message = makeMessage("dddddddd-dddd-dddd-dddd-dddddddddddd");
+		const error = await runtime
+			.composeState(message, null, false, true)
+			.catch((cause: unknown) => cause);
 		const elapsed = Date.now() - start;
 
-		// The no-timeoutMs provider is truncated to an empty contribution at
-		// the DEFAULT budget, and the fast provider's output still lands.
-		expect(state.text).toContain("FAST_RESULT_PRESENT");
-		expect(state.text).not.toContain("DEFAULT_BUDGET_SLOW_MUST_NOT_APPEAR");
-		// Compose returns at the default budget (~3s), not the provider's full
-		// 4.5s runtime — proving the default truncation fired. The lower bound
-		// pins that the applied budget was the default, not some shorter one.
-		expect(elapsed).toBeGreaterThanOrEqual(2_500);
-		expect(elapsed).toBeLessThan(4_300);
-	}, 15_000);
+		expect(error).toMatchObject({ code: "PROVIDER_DEADLINE_EXCEEDED" });
+		expect(runtime.stateCache.has(message.id as string)).toBe(false);
+		// Compose returns at the declared budget, not the provider's full 1.5s.
+		expect(elapsed).toBeLessThan(1_400);
+	});
+
+	it("preserves provider behavior when neither metadata nor an operator default declares a budget", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "budget-opt-in" } as Character,
+		});
+		const unbudgeted: Provider = {
+			name: "UNBUDGETED_COMPATIBILITY",
+			get: async () => {
+				await sleep(350);
+				return { text: "UNBUDGETED_RESULT_PRESENT" };
+			},
+		};
+		runtime.registerProvider(unbudgeted);
+
+		const state = await runtime.composeState(
+			makeMessage("adadadad-adad-adad-adad-adadadadadad"),
+			[unbudgeted.name],
+			true,
+		);
+
+		expect(state.text).toBe("UNBUDGETED_RESULT_PRESENT");
+	});
 
 	it("ignores sub-floor timeoutMs declarations instead of racing at unusable budgets", async () => {
 		const runtime = new AgentRuntime({
@@ -147,8 +296,8 @@ describe("composeState per-provider time budget", () => {
 		});
 		const declaredTooLow: Provider = {
 			name: "FLOOR_GUARDED",
-			// Below the 250ms floor — the runtime default applies instead, so
-			// this ordinary-speed provider must not be truncated.
+			// Below the 250ms floor, so this declaration is ignored rather than
+			// racing ordinary provider startup at an unusable budget.
 			timeoutMs: 1,
 			get: async () => {
 				await sleep(50);

--- a/packages/core/src/__tests__/compose-state-provider-execution.test.ts
+++ b/packages/core/src/__tests__/compose-state-provider-execution.test.ts
@@ -75,6 +75,39 @@ describe("composeState provider execution", () => {
 		await compose;
 	});
 
+	it("uses position only for render order and gives siblings the same pre-compose state", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "provider-order" } as Character,
+		});
+		const seenProviderMaps: unknown[] = [];
+		runtime.registerProvider({
+			name: "LATE_POSITION",
+			position: 20,
+			get: async (_runtime, _message, state) => {
+				seenProviderMaps.push(state.data.providers);
+				await new Promise((resolve) => setTimeout(resolve, 20));
+				return { text: "late-position" };
+			},
+		});
+		runtime.registerProvider({
+			name: "EARLY_POSITION",
+			position: -20,
+			get: async (_runtime, _message, state) => {
+				seenProviderMaps.push(state.data.providers);
+				return { text: "early-position" };
+			},
+		});
+
+		const state = await runtime.composeState(
+			makeMessage("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"),
+			["LATE_POSITION", "EARLY_POSITION"],
+			true,
+		);
+
+		expect(state.text).toBe("early-position\nlate-position");
+		expect(seenProviderMaps).toEqual([undefined, undefined]);
+	});
+
 	it("coalesces duplicate in-flight provider work for the same message", async () => {
 		const runtime = new AgentRuntime({
 			character: { name: "provider-coalescing" } as Character,
@@ -172,10 +205,14 @@ describe("composeState provider execution", () => {
 			runtime.composeState(message, ["ABORTABLE"], true),
 		);
 		await started.promise;
-		expect(receivedSignal).toBe(runtime.turnControllers.signalFor(ROOM_ID));
+		const turnSignal = runtime.turnControllers.signalFor(ROOM_ID);
+		expect(receivedSignal).toBeDefined();
+		expect(receivedSignal).not.toBe(turnSignal);
 		expect(runtime.turnControllers.abortTurn(ROOM_ID, "user stopped")).toBe(
 			true,
 		);
+		expect(receivedSignal?.aborted).toBe(true);
+		expect(receivedSignal?.reason).toBe(turnSignal?.reason);
 
 		// A designed turn abort surfaces as the abort itself (TURN_ABORTED), so
 		// the message boundary keeps its ack-and-stop contract instead of

--- a/packages/core/src/__tests__/inference-timing.test.ts
+++ b/packages/core/src/__tests__/inference-timing.test.ts
@@ -4,7 +4,7 @@
  * anomaly detection, ALS attribution across async boundaries, and the emit /
  * format / dev-payload registry. Deterministic — no live model.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
 	buildInferenceFlowBreakdown,
 	buildInferenceTimingDevPayload,
@@ -20,7 +20,6 @@ import {
 	runWithInferenceTiming,
 	timeInferenceSpan,
 } from "../inference-timing";
-import { logger } from "../logger";
 
 const tick = () => new Promise((r) => setTimeout(r, 2));
 
@@ -473,101 +472,5 @@ describe("emit + format + registry", () => {
 				execution: expect.objectContaining({ p95: 5 }),
 			}),
 		);
-	});
-});
-
-describe("post-reply tail watchdog", () => {
-	let warnSpy: ReturnType<typeof vi.spyOn>;
-
-	beforeEach(() => {
-		delete process.env.ELIZA_TURN_TAIL_BUDGET_MS;
-		warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
-	});
-
-	afterEach(() => {
-		delete process.env.ELIZA_TURN_TAIL_BUDGET_MS;
-		warnSpy.mockRestore();
-	});
-
-	/** A closed turn with reply at `replyAtMs` and total ≈ `totalMs`, plus a
-	 *  span that starts after the reply mark (the billing/persistence tail). */
-	const makeTailTurn = (args: {
-		replyAtMs: number;
-		totalMs: number;
-		tailSpanMs: number;
-	}) => {
-		const timer = new InferenceTurnTimer({
-			turnId: "tail",
-			label: "message-turn",
-			t0EpochMs: Date.now() - args.totalMs,
-		});
-		timer.mark(
-			INFERENCE_MARKS.replyDelivered,
-			timer.t0EpochMs + args.replyAtMs,
-		);
-		// recordSpan back-dates start from now, so this span's startMs lands in
-		// the tail (well after replyAtMs) for realistic totals.
-		timer.recordSpan("cloud.billing", args.tailSpanMs);
-		return timer;
-	};
-
-	it("warns with turnId, tailMs, and the post-reply spans when the tail exceeds the budget", () => {
-		const timer = makeTailTurn({
-			replyAtMs: 100,
-			totalMs: 3000,
-			tailSpanMs: 1600,
-		});
-		emitInferenceTiming(timer);
-
-		expect(warnSpy).toHaveBeenCalledTimes(1);
-		const [ctx, msg] = warnSpy.mock.calls[0] as [
-			{
-				turnId: string;
-				tailMs: number;
-				tailSpans: Array<{ name: string; durationMs: number }>;
-			},
-			string,
-		];
-		expect(ctx.turnId).toBe("tail");
-		expect(ctx.tailMs).toBeGreaterThan(500);
-		expect(ctx.tailSpans).toEqual([
-			{ name: "cloud.billing", durationMs: 1600 },
-		]);
-		expect(msg).toContain("post-reply tail");
-	});
-
-	it("does not warn when the tail is under budget", () => {
-		const timer = makeTailTurn({
-			replyAtMs: 100,
-			totalMs: 400,
-			tailSpanMs: 200,
-		});
-		emitInferenceTiming(timer);
-		expect(warnSpy).not.toHaveBeenCalled();
-	});
-
-	it("does not warn when no reply mark was recorded (guarded no-op)", () => {
-		const timer = new InferenceTurnTimer({
-			turnId: "no-reply",
-			label: "message-turn",
-			t0EpochMs: Date.now() - 3000,
-		});
-		timer.recordSpan("cloud.billing", 1600);
-		emitInferenceTiming(timer);
-		expect(warnSpy).not.toHaveBeenCalled();
-	});
-
-	it("respects ELIZA_TURN_TAIL_BUDGET_MS overrides, including 0 = disabled", () => {
-		process.env.ELIZA_TURN_TAIL_BUDGET_MS = "5000";
-		emitInferenceTiming(
-			makeTailTurn({ replyAtMs: 100, totalMs: 3000, tailSpanMs: 1600 }),
-		);
-		expect(warnSpy).not.toHaveBeenCalled();
-
-		process.env.ELIZA_TURN_TAIL_BUDGET_MS = "0";
-		emitInferenceTiming(
-			makeTailTurn({ replyAtMs: 100, totalMs: 3000, tailSpanMs: 1600 }),
-		);
-		expect(warnSpy).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/experience/providers/experienceProvider.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/providers/experienceProvider.ts
@@ -32,6 +32,8 @@ export const experienceProvider: Provider = {
 	contextGate: { anyOf: ["general"] },
 	cacheStable: false,
 	cacheScope: "turn",
+	timeoutMs: 10_000,
+	timeoutMode: "degrade",
 	roleGate: { minRole: "USER" },
 
 	async get(

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -315,6 +315,7 @@ const factsProvider: Provider = {
 	contextGate: { anyOf: ["general"] },
 	cacheStable: false,
 	cacheScope: "turn",
+	timeoutMs: 8_000,
 	roleGate: { minRole: "USER" },
 
 	get: async (

--- a/packages/core/src/features/advanced-capabilities/providers/relationships.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/relationships.ts
@@ -175,6 +175,7 @@ const relationshipsProvider: Provider = {
 	contextGate: { anyOf: ["contacts", "memory"] },
 	cacheStable: false,
 	cacheScope: "turn",
+	timeoutMs: 8_000,
 	roleGate: { minRole: "USER" },
 
 	get: async (runtime: IAgentRuntime, message: Memory) => {

--- a/packages/core/src/features/advanced-memory/providers/context-summary.ts
+++ b/packages/core/src/features/advanced-memory/providers/context-summary.ts
@@ -28,6 +28,8 @@ export const contextSummaryProvider: Provider = {
 	contextGate: { anyOf: ["general"] },
 	cacheStable: false,
 	cacheScope: "turn",
+	timeoutMs: 10_000,
+	timeoutMode: "degrade",
 	roleGate: { minRole: "USER" },
 
 	get: async (

--- a/packages/core/src/features/advanced-memory/providers/long-term-memory.ts
+++ b/packages/core/src/features/advanced-memory/providers/long-term-memory.ts
@@ -33,6 +33,8 @@ export const longTermMemoryProvider: Provider = {
 	contextGate: { anyOf: ["general"] },
 	cacheStable: false,
 	cacheScope: "turn",
+	timeoutMs: 10_000,
+	timeoutMode: "degrade",
 	roleGate: { minRole: "USER" },
 
 	get: async (

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -362,6 +362,9 @@ export const recentMessagesProvider: Provider = {
 	contextGate: { anyOf: ["memory", "messaging"] },
 	cacheStable: false,
 	cacheScope: "turn",
+	// Conversation history is correctness-critical and may span several indexed
+	// reads on remote adapters. Extend its deadline without allowing partial state.
+	timeoutMs: 8_000,
 	roleGate: { minRole: "USER" },
 
 	get: async (

--- a/packages/core/src/features/documents/provider.ts
+++ b/packages/core/src/features/documents/provider.ts
@@ -55,6 +55,9 @@ export const documentsProvider: Provider = {
 	contextGate: { anyOf: ["documents"] },
 	cacheStable: false,
 	cacheScope: "turn",
+	// Retrieval is supplemental context and may include an embedding round-trip.
+	timeoutMs: 10_000,
+	timeoutMode: "degrade",
 	roleGate: { minRole: "USER" },
 
 	get: async (runtime: IAgentRuntime, message: Memory) => {

--- a/packages/core/src/inference-timing.ts
+++ b/packages/core/src/inference-timing.ts
@@ -24,7 +24,6 @@
  */
 
 import { logger } from "./logger";
-import { readEnv } from "./utils/read-env";
 
 // ---------------------------------------------------------------------------
 // Span / mark shapes
@@ -900,36 +899,6 @@ export function formatInferenceTimingSummary(s: InferenceTurnSummary): string {
 }
 
 /**
- * Post-reply tail watchdog. The "tail" is the wall-clock time between the
- * user-visible reply mark and turn close — work (billing, persistence,
- * evaluators) the user never sees but that holds the turn open. When the tail
- * exceeds `ELIZA_TURN_TAIL_BUDGET_MS` (default 500), surface it as a WARN so
- * the class of "reply ready but the turn is still grinding" regressions is
- * visible without opting into full timing logs. Observability only — never
- * throws, never affects the turn. Set the budget to `0` (or negative) to
- * disable.
- */
-const DEFAULT_TAIL_BUDGET_MS = 500;
-
-function warnOnPostReplyTail(summary: InferenceTurnSummary): void {
-	if (summary.totalMs === null || summary.timeToReplyMs === null) return;
-	const rawBudget = readEnv("ELIZA_TURN_TAIL_BUDGET_MS");
-	const budgetMs =
-		rawBudget === undefined ? DEFAULT_TAIL_BUDGET_MS : Number(rawBudget);
-	if (!Number.isFinite(budgetMs) || budgetMs <= 0) return;
-	const tailMs = summary.totalMs - summary.timeToReplyMs;
-	if (tailMs <= budgetMs) return;
-	const replyAtMs = summary.timeToReplyMs;
-	const tailSpans = summary.spans
-		.filter((s) => s.startMs > replyAtMs)
-		.map((s) => ({ name: s.name, durationMs: s.durationMs }));
-	logger.warn(
-		{ turnId: summary.turnId, tailMs, tailSpans },
-		`[InferenceTiming] ${summary.label} post-reply tail ${tailMs}ms exceeds budget ${budgetMs}ms (reply at ${replyAtMs}ms, turn closed at ${summary.totalMs}ms)`,
-	);
-}
-
-/**
  * Close the timer, fold it into the process registry, and emit the breakdown.
  * Call once at the end of a turn. No-op-safe for an undefined timer.
  */
@@ -940,7 +909,6 @@ export function emitInferenceTiming(
 	try {
 		const summary = timer.close();
 		inferenceTimingRegistry.record(summary);
-		warnOnPostReplyTail(summary);
 		const line = formatInferenceTimingSummary(summary);
 		if (timingLogEnabled()) {
 			logger.info({ inferenceTiming: summary }, line);

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -380,6 +380,8 @@ interface InFlightProviderExecution {
 	promise: Promise<ProviderResult>;
 	startedAt: number;
 	startedAtMonotonic: number;
+	timeoutMs?: number;
+	timeoutMode: "fail" | "degrade";
 }
 
 export function calculateProviderOverlaps(
@@ -404,43 +406,82 @@ export function calculateProviderOverlaps(
 	);
 }
 
-// Per-provider composeState budget. Without an enforced deadline a provider
-// doing synchronous network work can hold every message turn hostage for tens
-// of seconds and still count as healthy (a registry refetch measured 10.9s on
-// a live turn). The default defends interactive latency; a provider with
-// legitimately slow, turn-blocking work declares its own `timeoutMs`. On
-// expiry the provider degrades to a failure record for the turn
-// (`deadline_exceeded`) and composition proceeds without it.
+// Provider authors opt into a deadline with `timeoutMs`; operators can apply a
+// global default when deployment evidence supports one. An implicit default
+// would change the semantics of every third-party provider without knowing
+// whether its context is optional or how long its backing service can take.
 const COMPOSE_STATE_PROVIDER_TIMEOUT_MS = (() => {
 	const raw = Number.parseInt(
 		process.env.ELIZA_COMPOSE_PROVIDER_TIMEOUT_MS ?? "",
 		10,
 	);
 	if (Number.isFinite(raw) && raw >= 250) return raw;
-	return 3_000;
+	return undefined;
 })();
 
-// The budget is enforced at execution creation so coalesced awaiters share
-// one deadline. The rejection carries name "TimeoutError" so the composition
-// catch classifies it as `deadline_exceeded` and degrades that provider while
-// the turn proceeds.
+class ProviderDeadlineError extends Error {
+	readonly timeoutMs: number;
+
+	constructor(providerName: string, timeoutMs: number) {
+		super(
+			`Provider "${providerName}" exceeded its ${timeoutMs}ms composeState budget`,
+		);
+		this.name = "TimeoutError";
+		this.timeoutMs = timeoutMs;
+	}
+}
+
+// The budget and its derived signal are created once per execution so
+// coalesced awaiters share one deadline. JavaScript cannot preempt a provider
+// that ignores AbortSignal, but cooperative database/network/subprocess work
+// receives the timeout immediately and the turn never waits past the budget.
 function withProviderDeadline<T>(
-	promise: Promise<T>,
-	timeoutMs: number,
+	run: (signal: AbortSignal) => Promise<T>,
+	timeoutMs: number | undefined,
 	providerName: string,
+	parentSignal?: AbortSignal,
 ): Promise<T> {
+	const controller = new AbortController();
 	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-	const deadline = new Promise<never>((_, reject) => {
-		timeoutHandle = setTimeout(() => {
-			const error = new Error(
-				`Provider "${providerName}" exceeded its ${timeoutMs}ms composeState budget`,
+	let rejectFromSignal: (() => void) | undefined;
+	const abortFromParent = () => {
+		controller.abort(
+			parentSignal?.reason ?? new Error("Provider execution aborted"),
+		);
+	};
+	if (parentSignal?.aborted) {
+		abortFromParent();
+	} else {
+		parentSignal?.addEventListener("abort", abortFromParent, { once: true });
+	}
+	const aborted = new Promise<never>((_, reject) => {
+		rejectFromSignal = () => {
+			reject(
+				controller.signal.reason ?? new Error("Provider execution aborted"),
 			);
-			error.name = "TimeoutError";
-			reject(error);
-		}, timeoutMs);
+		};
+		if (controller.signal.aborted) {
+			rejectFromSignal?.();
+			return;
+		}
+		controller.signal.addEventListener("abort", rejectFromSignal, {
+			once: true,
+		});
 	});
-	return Promise.race([promise, deadline]).finally(() => {
+	if (!controller.signal.aborted && timeoutMs !== undefined) {
+		timeoutHandle = setTimeout(() => {
+			controller.abort(new ProviderDeadlineError(providerName, timeoutMs));
+		}, timeoutMs);
+	}
+	const providerPromise = controller.signal.aborted
+		? Promise.reject(controller.signal.reason)
+		: Promise.resolve().then(() => run(controller.signal));
+	return Promise.race([providerPromise, aborted]).finally(() => {
 		if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+		if (rejectFromSignal) {
+			controller.signal.removeEventListener("abort", rejectFromSignal);
+		}
+		parentSignal?.removeEventListener("abort", abortFromParent);
 	});
 }
 const STABLE_PROMPT_TEMPLATE_KEYS = new Set([
@@ -4555,23 +4596,27 @@ export class AgentRuntime implements IAgentRuntime {
 						typeof provider.timeoutMs === "number" && provider.timeoutMs >= 250
 							? provider.timeoutMs
 							: COMPOSE_STATE_PROVIDER_TIMEOUT_MS;
+					const timeoutMode = provider.timeoutMode ?? "fail";
 					const startedAt = Date.now();
 					const startedAtMonotonic = performance.now();
-					const promise = providerSignal?.aborted
-						? Promise.reject(
-								providerSignal.reason ??
-									new Error("Provider execution aborted before start"),
-							)
-						: withProviderDeadline(
-								withProviderStep(providerRuntime, provider.name, () =>
-									provider.get(providerRuntime, message, cachedState, {
-										...(providerSignal ? { signal: providerSignal } : {}),
-									}),
-								),
-								providerBudgetMs,
-								provider.name,
-							);
-					execution = { promise, startedAt, startedAtMonotonic };
+					const promise = withProviderDeadline(
+						(signal) =>
+							withProviderStep(providerRuntime, provider.name, () =>
+								provider.get(providerRuntime, message, cachedState, {
+									signal,
+								}),
+							),
+						providerBudgetMs,
+						provider.name,
+						providerSignal,
+					);
+					execution = {
+						promise,
+						startedAt,
+						startedAtMonotonic,
+						timeoutMs: providerBudgetMs,
+						timeoutMode,
+					};
 					if (inFlightKey !== null) {
 						this.providerExecutionsInFlight.set(inFlightKey, execution);
 						const cleanup = () => {
@@ -4605,12 +4650,11 @@ export class AgentRuntime implements IAgentRuntime {
 				} catch (cause) {
 					const endedAt = Date.now();
 					const duration = performance.now() - execution.startedAtMonotonic;
-					const causeName = cause instanceof Error ? cause.name : "";
 					const outcome: ProviderExecutionOutcome = providerSignal?.aborted
 						? "aborted"
-						: causeName === "TimeoutError"
+						: cause instanceof ProviderDeadlineError
 							? "deadline_exceeded"
-							: causeName === "AbortError"
+							: cause instanceof Error && cause.name === "AbortError"
 								? "aborted"
 								: "error";
 					const code =
@@ -4637,6 +4681,8 @@ export class AgentRuntime implements IAgentRuntime {
 								roomId: message.roomId,
 								messageId: message.id,
 								outcome,
+								timeoutMs: execution.timeoutMs,
+								timeoutMode: execution.timeoutMode,
 							},
 						},
 					);
@@ -4646,18 +4692,22 @@ export class AgentRuntime implements IAgentRuntime {
 						coalesced: providerCoalesced,
 					});
 					this.reportError("AgentRuntime.composeState.provider", error);
-					if (outcome === "deadline_exceeded") {
-						// error-policy:J4 a budget overrun degrades to an empty
-						// contribution instead of failing the turn: the per-provider
-						// deadline exists to defend interactive latency, and a reply
-						// missing one provider's section is strictly better than no
-						// reply. The overrun stays observable via the span outcome and
-						// reportError above; genuine provider errors below keep the
-						// fail-fast composition contract.
+					if (
+						outcome === "deadline_exceeded" &&
+						execution.timeoutMode === "degrade" &&
+						execution.timeoutMs !== undefined
+					) {
+						// error-policy:J4 optional providers may explicitly degrade,
+						// but the prompt and structured state must remain distinguishable
+						// from a legitimate empty result for the rest of the turn.
 						return {
-							text: "",
+							text: `[Provider ${provider.name} unavailable this turn: exceeded ${execution.timeoutMs}ms deadline.]`,
 							values: {},
-							data: {},
+							data: {
+								available: false,
+								reason: "deadline_exceeded",
+								timeoutMs: execution.timeoutMs,
+							},
 							providerName: provider.name,
 							providerStartedAt: execution.startedAt,
 							providerEndedAt: endedAt,
@@ -4682,6 +4732,9 @@ export class AgentRuntime implements IAgentRuntime {
 		const failedProviderData = providerData.filter(
 			(record) => record.providerError !== undefined,
 		);
+		const degradedProviderData = providerData.filter(
+			(record) => record.providerOutcome === "deadline_exceeded",
+		);
 		for (const provider of reusedProviders) {
 			const cached = (
 				cachedState.data.providers as
@@ -4699,6 +4752,7 @@ export class AgentRuntime implements IAgentRuntime {
 			providers: providersToRun.length,
 			reused: providersToGet.length - providersToRun.length,
 			failed: failedProviderData.length,
+			degraded: degradedProviderData.length,
 		});
 
 		const currentProviderResults: Record<string, CachedProviderResult> = {
@@ -4851,7 +4905,7 @@ export class AgentRuntime implements IAgentRuntime {
 						data: {
 							textLength:
 								typeof cached?.text === "string" ? cached.text.length : 0,
-							outcome: "success",
+							outcome: cached?.providerOutcome ?? "success",
 							coalesced: false,
 							cacheHit: true,
 							...(typeof cached?.providerDurationMs === "number"

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -702,15 +702,18 @@ export interface ProviderResult {
  * Turn-scoped execution controls supplied by the runtime to every provider.
  *
  * Providers that start database, network, subprocess, or other interruptible
- * work must propagate `signal` to that boundary. The runtime never converts an
- * aborted provider into empty context: cancellation rejects state composition.
+ * work must propagate `signal` to that boundary. Parent-turn cancellation
+ * rejects state composition; a provider-owned deadline aborts this signal and
+ * is translated according to the provider's `timeoutMode`.
  */
 export interface ProviderExecutionContext {
 	signal?: AbortSignal;
 }
 
 /**
- * Provider for external data/services
+ * Provider for external data/services. `get` is a read-only context operation:
+ * it must not commit external side effects because a deadline can stop waiting
+ * for a provider that has not cooperatively observed its abort signal.
  */
 export interface Provider {
 	/** Provider name */
@@ -788,14 +791,19 @@ export interface Provider {
 
 	/**
 	 * Per-provider composeState time budget in milliseconds. When the budget
-	 * elapses the provider's contribution degrades to empty for that turn and
-	 * composition proceeds — a slow provider must never hold the message turn
-	 * hostage. Overrides the runtime default
-	 * (`ELIZA_COMPOSE_PROVIDER_TIMEOUT_MS`); declare a higher budget only for
-	 * providers whose work is legitimately slow AND worth blocking the turn
-	 * for (e.g. corpus retrieval).
+	 * elapses the runtime aborts the provider signal and stops waiting. Providers
+	 * without a budget preserve their existing runtime unless an operator sets
+	 * `ELIZA_COMPOSE_PROVIDER_TIMEOUT_MS` as a global default. Providers must
+	 * propagate `ProviderExecutionContext.signal` to interruptible boundaries.
 	 */
 	timeoutMs?: number;
+
+	/**
+	 * Timeout handling policy. The default `fail` preserves composeState's
+	 * all-or-nothing contract. `degrade` is reserved for optional providers whose
+	 * consumers can safely operate on an explicit unavailable contribution.
+	 */
+	timeoutMode?: "fail" | "degrade";
 
 	/**
 	 * Whether plugin registration should install this provider into the runtime.


### PR DESCRIPTION
Fixes #17489. Follow-up to merged #17481.

## Root cause

The merged implementation applied an implicit 3-second deadline to every provider, raced without aborting provider work, and cached a timeout as empty context. That is unsafe for correctness-critical history and for roughly 331 provider declarations whose latency semantics were never audited. The cited `available_apps` 10.9-second root path was already repaired separately by its stale-while-revalidate snapshot.

## Repair

- Deadlines are opt-in per provider; `ELIZA_COMPOSE_PROVIDER_TIMEOUT_MS` remains an explicit operator-wide override.
- Every execution receives a derived signal combining parent-turn cancellation and its deadline.
- Timeout fails composition by default, preserving all-or-nothing state and preventing partial cache writes.
- Only reviewed supplemental providers use `timeoutMode: "degrade"`; their prompt and structured state explicitly say unavailable/deadline_exceeded.
- Conversation history, facts, and relationships receive longer explicit budgets and remain fail-fast.
- Coalesced callers share one deadline. Late non-cooperative reads cannot replace the cached timeout result.
- Provider-owned errors named `TimeoutError` are no longer misclassified as runtime deadlines.
- Removes the unsupported default 500 ms post-reply WARN added by #17481; no production baseline justified that global log threshold.

Exact tested base: `22ec1c5155f8f13b6a1e34781429894d16a3e3dd`
Exact head: `3ef8a37e0ef1935f932e8e651792019937b8bd10`

## Verification

- Core focused compose budget/execution/purity/inference: 4 files, 31/31 passed.
- Core affected providers and DB I/O concurrency: 4 files, 63/63 passed.
- Agent recent/relevant conversation providers: 3 files, 8/8 passed.
- `bun run --cwd packages/core typecheck`: passed.
- `bun run --cwd packages/agent typecheck`: passed.
- `bun run --cwd packages/core build`: passed (Node/browser/edge/testing/declarations).
- `bun run --cwd packages/agent build`: passed.
- Biome check on every changed file and `git diff --check`: passed.

The deterministic benchmark proves a 300 ms optional deadline returns before 1.5-second work and a 300 ms fail deadline returns before 1.5-second work. The production trajectory claimed in #17481 was not attached and is not reproducible from this checkout, so it is not presented as evidence here.

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend runtime contract; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend runtime contract; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user interface flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend log stream exists for this runtime-only contract repair; focused in-memory AgentRuntime test output is summarized in Verification.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt or model policy change; provider availability semantics are deterministic and covered at the runtime boundary.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - provider composition emits transient prompt state and no durable domain artifact; regression results are listed in Verification.