### PR TITLE
fix(ci): align fork timeout contract

### DIFF
--- a/packages/scripts/__tests__/ci-turbo-cache-contract.test.ts
+++ b/packages/scripts/__tests__/ci-turbo-cache-contract.test.ts
@@ -237,7 +237,7 @@ describe("ci-turbo-cache-contract", () => {
     )?.[0];
     expect(typecheckJob).toMatch(/cache-bun-install:\s*["']false["']/);
     expect(buildJob).toMatch(/cache-bun-install:\s*["']false["']/);
-    expect(buildJob).toMatch(/timeout-minutes:\s*32/);
+    expect(buildJob).toMatch(/timeout-minutes:\s*45/);
     expect(buildJob).toMatch(/run:\s*bun run build/);
     expect(buildJob).toMatch(/run:\s*bun run test:e2e --workers=2/);
     expect(buildJob).not.toMatch(/continue-on-error|\|\| true/);


### PR DESCRIPTION
Repairs the real post-merge script-test failure exposed by Tests run 30664993399 after #17485.

#17485 intentionally increased the fork build timeout from 32 to 45 minutes based on measured cold build plus homepage smoke duration, but its real-tree CI contract retained the old numeric assertion. This aligns the assertion with the production workflow while preserving the cache-disable, full-build, homepage-test, and fail-closed checks.

Exact head `52011afae471c03cfe12aa4dac48c1189e0554a0`, rebased on `27332fa4015e72a406e3153ebe616bfea84ffa40`.

Validation:
- `bun test packages/scripts/__tests__/ci-turbo-cache-contract.test.ts` - 10 pass, 0 fail, 26 assertions
- `bunx @biomejs/biome check packages/scripts/__tests__/ci-turbo-cache-contract.test.ts` - exit 0 (seven pre-existing warnings)
- `git diff --check` - pass

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only CI contract correction; no UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only CI contract correction; no UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing workflow
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path
<!-- evidence-row:backend-logs -->
- [x] [Failing post-merge Tests run](https://github.com/elizaOS/eliza/actions/runs/30664993399)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the test-only assertion correction produces no durable domain artifact; its focused contract result is recorded above
