### PR TITLE
registry: add 4 x402 third-party plugins (v0.2.0, real payment flow fixed)

### DIFF
--- a/packages/registry/entries/third-party/vohlsyr__plugin-chainscope.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-chainscope.json
@@ -4,6 +4,6 @@
   "kind": "plugin",
   "description": "Multi-chain wallet and transaction intelligence with OFAC sanctions screening via ChainScope, paid per call in USDC on Base through x402.",
   "homepage": "https://chainsscope.duckdns.org",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "tags": ["x402", "blockchain", "wallet", "multi-chain", "payments"]
 }

--- a/packages/registry/entries/third-party/vohlsyr__plugin-chainscope.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-chainscope.json
@@ -1,0 +1,9 @@
+{
+  "package": "@vohlsyr/plugin-chainscope",
+  "repository": "github:Vohlsyr/plugin-chainscope",
+  "kind": "plugin",
+  "description": "Multi-chain wallet and transaction intelligence with OFAC sanctions screening via ChainScope, paid per call in USDC on Base through x402.",
+  "homepage": "https://chainsscope.duckdns.org",
+  "version": "0.1.0",
+  "tags": ["x402", "blockchain", "wallet", "multi-chain", "payments"]
+}

--- a/packages/registry/entries/third-party/vohlsyr__plugin-concordance.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-concordance.json
@@ -4,6 +4,6 @@
   "kind": "plugin",
   "description": "Cross-source search and claim corroboration across 18 real-time data sources via Concordance, paid per call in USDC on Base through x402 -- no API keys.",
   "homepage": "https://concordancehq.duckdns.org",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "tags": ["x402", "search", "data", "corroboration", "payments"]
 }

--- a/packages/registry/entries/third-party/vohlsyr__plugin-concordance.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-concordance.json
@@ -1,0 +1,9 @@
+{
+  "package": "@vohlsyr/plugin-concordance",
+  "repository": "github:Vohlsyr/plugin-concordance",
+  "kind": "plugin",
+  "description": "Cross-source search and claim corroboration across 18 real-time data sources via Concordance, paid per call in USDC on Base through x402 -- no API keys.",
+  "homepage": "https://concordancehq.duckdns.org",
+  "version": "0.1.0",
+  "tags": ["x402", "search", "data", "corroboration", "payments"]
+}

--- a/packages/registry/entries/third-party/vohlsyr__plugin-trading-strategy-data.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-trading-strategy-data.json
@@ -4,6 +4,6 @@
   "kind": "plugin",
   "description": "Backtestable crypto trend signals and on-demand backtesting for BTC/ETH/SOL/XRP/ADA via Trading Strategy Data, paid per call in USDC on Base through x402.",
   "homepage": "https://strategysignals.duckdns.org",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "tags": ["x402", "trading", "crypto", "backtest", "payments"]
 }

--- a/packages/registry/entries/third-party/vohlsyr__plugin-trading-strategy-data.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-trading-strategy-data.json
@@ -1,0 +1,9 @@
+{
+  "package": "@vohlsyr/plugin-trading-strategy-data",
+  "repository": "github:Vohlsyr/plugin-trading-strategy-data",
+  "kind": "plugin",
+  "description": "Backtestable crypto trend signals and on-demand backtesting for BTC/ETH/SOL/XRP/ADA via Trading Strategy Data, paid per call in USDC on Base through x402.",
+  "homepage": "https://strategysignals.duckdns.org",
+  "version": "0.1.0",
+  "tags": ["x402", "trading", "crypto", "backtest", "payments"]
+}

--- a/packages/registry/entries/third-party/vohlsyr__plugin-trustfetch.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-trustfetch.json
@@ -1,0 +1,9 @@
+{
+  "package": "@vohlsyr/plugin-trustfetch",
+  "repository": "github:Vohlsyr/plugin-trustfetch",
+  "kind": "plugin",
+  "description": "Prompt-injection scanning and clean webpage fetching for AI agents via TrustFetch, paid per call in USDC on Base through x402.",
+  "homepage": "https://trustfetch.duckdns.org",
+  "version": "0.1.0",
+  "tags": ["x402", "security", "prompt-injection", "web-fetch", "payments"]
+}

--- a/packages/registry/entries/third-party/vohlsyr__plugin-trustfetch.json
+++ b/packages/registry/entries/third-party/vohlsyr__plugin-trustfetch.json
@@ -4,6 +4,6 @@
   "kind": "plugin",
   "description": "Prompt-injection scanning and clean webpage fetching for AI agents via TrustFetch, paid per call in USDC on Base through x402.",
   "homepage": "https://trustfetch.duckdns.org",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "tags": ["x402", "security", "prompt-injection", "web-fetch", "payments"]
 }

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -524,7 +524,7 @@
         "repo": "@vohlsyr/plugin-chainscope",
         "v0": null,
         "v1": null,
-        "v2": "0.1.0"
+        "v2": "0.2.0"
       },
       "supports": {
         "v0": false,
@@ -569,7 +569,7 @@
         "repo": "@vohlsyr/plugin-concordance",
         "v0": null,
         "v1": null,
-        "v2": "0.1.0"
+        "v2": "0.2.0"
       },
       "supports": {
         "v0": false,
@@ -614,7 +614,7 @@
         "repo": "@vohlsyr/plugin-trading-strategy-data",
         "v0": null,
         "v1": null,
-        "v2": "0.1.0"
+        "v2": "0.2.0"
       },
       "supports": {
         "v0": false,
@@ -659,7 +659,7 @@
         "repo": "@vohlsyr/plugin-trustfetch",
         "v0": null,
         "v1": null,
-        "v2": "0.1.0"
+        "v2": "0.2.0"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -507,6 +507,186 @@
       "registryKind": "plugin",
       "directory": "adapters/eliza"
     },
+    "@vohlsyr/plugin-chainscope": {
+      "git": {
+        "repo": "Vohlsyr/plugin-chainscope",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@vohlsyr/plugin-chainscope",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Multi-chain wallet and transaction intelligence with OFAC sanctions screening via ChainScope, paid per call in USDC on Base through x402.",
+      "homepage": "https://chainsscope.duckdns.org",
+      "topics": [
+        "x402",
+        "blockchain",
+        "wallet",
+        "multi-chain",
+        "payments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
+    "@vohlsyr/plugin-concordance": {
+      "git": {
+        "repo": "Vohlsyr/plugin-concordance",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@vohlsyr/plugin-concordance",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Cross-source search and claim corroboration across 18 real-time data sources via Concordance, paid per call in USDC on Base through x402 -- no API keys.",
+      "homepage": "https://concordancehq.duckdns.org",
+      "topics": [
+        "x402",
+        "search",
+        "data",
+        "corroboration",
+        "payments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
+    "@vohlsyr/plugin-trading-strategy-data": {
+      "git": {
+        "repo": "Vohlsyr/plugin-trading-strategy-data",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@vohlsyr/plugin-trading-strategy-data",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Backtestable crypto trend signals and on-demand backtesting for BTC/ETH/SOL/XRP/ADA via Trading Strategy Data, paid per call in USDC on Base through x402.",
+      "homepage": "https://strategysignals.duckdns.org",
+      "topics": [
+        "x402",
+        "trading",
+        "crypto",
+        "backtest",
+        "payments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
+    "@vohlsyr/plugin-trustfetch": {
+      "git": {
+        "repo": "Vohlsyr/plugin-trustfetch",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@vohlsyr/plugin-trustfetch",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Prompt-injection scanning and clean webpage fetching for AI agents via TrustFetch, paid per call in USDC on Base through x402.",
+      "homepage": "https://trustfetch.duckdns.org",
+      "topics": [
+        "x402",
+        "security",
+        "prompt-injection",
+        "web-fetch",
+        "payments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@wasmagent/eliza-rollout-plugin": {
       "git": {
         "repo": "WasmAgent/wasmagent-js",


### PR DESCRIPTION
Re-submission after review on the previous PR (closed, same branch) found a real bug: the paid action could not actually complete a payment against the registered client. Root cause and fix, in full:

**Root cause (3 stacked wire-format mismatches between x402-fetch@1.2.0 and our server's actual V2 contract):**
1. Our server sends the 402 challenge only in the `Payment-Required` **header** (empty JSON body) -- `x402-fetch`'s `wrapFetchWithPayment()` only reads the body.
2. Our server's `network` field is CAIP-2 (`eip155:8453`); the JS client matches against short names (`base`).
3. The actual current V2 `PaymentPayload` schema is `{x402Version, payload, accepted: <full requirements object>}` -- not the `{x402Version, scheme, network, payload}` shape `x402-fetch`'s client produces. `find_matching_requirements()` reads `payload.accepted.*` server-side *before* ever contacting the facilitator.

**Fix:** each plugin now builds the request/pay/retry flow directly on `x402/client`'s lower-level primitives (`createPaymentHeader`, `selectPaymentRequirements`) instead of the higher-level wrapper, and assembles the correct V2 wire payload by hand. Verified by reading the actual Python x402 SDK source (`x402/schemas/payments.py`, `x402/server_base.py`) against the JS client source, not by guessing.

**Real, complete, funded end-to-end proof for all 4 (not just the one endpoint requested) -- real wallet, real signed payment, real settlement, real data, real Base mainnet transactions:**

| Plugin | Price | Transaction |
|---|---|---|
| plugin-concordance | $0.01 | `0x2d8d014d369647cf1bc2af2850c085e37531f5015dd1bf32ae9724ddd0049af9` |
| plugin-trading-strategy-data | $0.04 | settled (verified via balance delta) |
| plugin-trustfetch | $0.03 | `0x0ad45a40b9b0302d076a472bc90e511c934133f7fd6a1b339f0f1586412b67fe` |
| plugin-chainscope | $0.03 | `0x67e9ce78bde5b018da842afbf2e7bfd3a60f7d32593359e71e57f3f834814e80` |

All 4 verifiable on Base mainnet (network `eip155:8453`).

**On the supply-chain concerns raised:** all 4 repos/npm packages were young at first submission -- they're now a few days older, with real commit history from this fix. `npm publish --provenance` genuinely requires a supported CI OIDC identity (GitHub Actions/GitLab) and cannot be produced by a local `npm publish`; happy to wire up a publish workflow as a follow-up if that's wanted, but did not want to block this fix on it. The four domains remain DuckDNS subdomains -- a real, known limitation, disclosed rather than hidden.

Mechanics re-verified: `bun run --cwd packages/registry validate` (34 entries), `bun run --cwd packages/registry generate` (pure additions/version bumps, no unrelated reformatting).