### PR TITLE
fix(ci): fail safe when Hetzner fleet variable is missing

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -146,8 +146,10 @@ unconditional lint, format, typecheck, gitleaks, and script-test execution plus
 their final-gate dependency edges. The develop PR lint job also runs pinned,
 checksum-verified `actionlint` and `zizmor` binaries.
 
-The self-hosted test lanes retain the `HETZNER_FLEET_ONLINE=false` hosted-runner
-fallback for outages. Pull-request lint, format, typecheck, build, and secret
+The self-hosted test lanes require `HETZNER_FLEET_ONLINE=true` to opt into the
+Hetzner fleet. Missing, empty, and false values route to GitHub-hosted runners;
+this fail-safe default is required because repository variables are unavailable
+to fork pull requests. Pull-request lint, format, typecheck, build, and secret
 checks are the only quality checks for the proposed change; the post-merge
 workflow concentrates on running the broader test surface.
 

--- a/.github/workflows/actions-zombie-janitor.yml
+++ b/.github/workflows/actions-zombie-janitor.yml
@@ -69,6 +69,8 @@ name: Actions Zombie Janitor
 #
 # Tuning (repo variables, no code change needed):
 #   ACTIONS_JANITOR_DISABLED=true          — kill switch (both lanes)
+#   HETZNER_FLEET_ONLINE=true              — explicit opt-in for the robot lane;
+#     absent, empty, false, and noncanonical values re-home it to ubuntu-latest
 #   ACTIONS_JANITOR_ROBOT_LANE_DISABLED    — =true remaps the robot lane onto
 #     ubuntu-latest (a harmless idempotent duplicate; `matrix` is not a legal
 #     context in a job-level `if`, so the lane is disabled by re-homing it)
@@ -113,7 +115,7 @@ jobs:
           - lane: github-hosted
             runner: '["ubuntu-latest"]'
           - lane: robot-fleet
-            runner: ${{ vars.ACTIONS_JANITOR_ROBOT_LANE_DISABLED == 'true' && '["ubuntu-latest"]' || vars.ACTIONS_JANITOR_ROBOT_RUNNER_JSON || '["self-hosted","Linux","X64","hetzner-robot"]' }}
+            runner: ${{ vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-latest"]' || vars.ACTIONS_JANITOR_ROBOT_LANE_DISABLED == 'true' && '["ubuntu-latest"]' || vars.ACTIONS_JANITOR_ROBOT_RUNNER_JSON || '["self-hosted","Linux","X64","hetzner-robot"]' }}
     runs-on: ${{ fromJSON(matrix.runner) }}
     if: github.repository == 'elizaOS/eliza' && vars.ACTIONS_JANITOR_DISABLED != 'true'
     timeout-minutes: 10

--- a/.github/workflows/android-device-e2e.yml
+++ b/.github/workflows/android-device-e2e.yml
@@ -62,7 +62,7 @@ jobs:
     # Full lane runs on manual dispatch and on the weekly scheduled host-backed
     # cadence. Never on PR; PRs use the label-gated minimal smoke below.
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     permissions:
       contents: read
@@ -211,7 +211,7 @@ jobs:
   # it works on a stock x86 emulator where the embedded on-device agent SIGSEGVs).
   pr-device-smoke:
     if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:device') }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
       ELIZA_MOBILE_REPO_ROOT: ${{ github.workspace }}
@@ -281,7 +281,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'ci:device'))
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
       ELIZA_BUN_RISCV64_OPTIONAL: "1"

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -60,7 +60,7 @@ env:
 jobs:
   build-aab:
     name: Build Signed AAB
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       version_name: ${{ steps.version.outputs.name }}
       version_code: ${{ steps.version.outputs.code }}
@@ -315,7 +315,7 @@ jobs:
     name: Publish to Play Store
     needs: build-aab
     if: needs.build-aab.outputs.play_store_ready == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -367,7 +367,7 @@ jobs:
     name: Release Summary
     needs: [build-aab, publish-play-store]
     if: always()
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Summary
         run: |

--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -58,7 +58,7 @@ jobs:
   # agent from the UI.
   app-live-chat:
     name: app live chat (real local runtime)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       PGLITE_WASM_MODE: node
@@ -136,7 +136,7 @@ jobs:
   # writes WALKTHROUGH_VERDICTS.md (the PR mock lane is keyless and can't).
   walkthrough-live:
     name: full walkthrough (real backend + model + vision verdicts)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
       PGLITE_WASM_MODE: node
@@ -213,7 +213,7 @@ jobs:
   # this workflow so keyless PR lanes cannot spend Cloud credits.
   cloud-live:
     name: cloud login + provision + chat (real Eliza Cloud)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       ELIZA_UI_SMOKE_CLOUD_LIVE: "1"
@@ -295,7 +295,7 @@ jobs:
   android-local-chat:
     name: android local chat (on-device GGUF)
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_android_local_chat }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -352,7 +352,7 @@ jobs:
   # still validate, so the renderer step is best-effort.
   desktop-packaged:
     name: desktop packaged (build + boot + renderer)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
       PGLITE_WASM_MODE: node
@@ -423,7 +423,7 @@ jobs:
     name: notify on red nightly
     needs: [app-live-chat, walkthrough-live, cloud-live, desktop-packaged]
     if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/app-real-e2e.yml
+++ b/.github/workflows/app-real-e2e.yml
@@ -47,7 +47,7 @@ env:
 jobs:
   app-real-e2e:
     name: Browser-driven real app e2e (nightly)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     # NOTE: `continue-on-error` intentionally lives on the e2e run step below, NOT
     # here at the job level. Job-level soft-fail resolves the whole run to

--- a/.github/workflows/apple-store-release.yml
+++ b/.github/workflows/apple-store-release.yml
@@ -97,7 +97,7 @@ permissions:
 jobs:
   prepare:
     name: Prepare
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       version: ${{ steps.ver.outputs.version }}
       build_number: ${{ steps.ver.outputs.build_number }}
@@ -521,7 +521,7 @@ jobs:
     name: Release Summary
     needs: [prepare, build-ios, build-macos]
     if: always()
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Summary
         run: |

--- a/.github/workflows/apps-deploy-e2e.yml
+++ b/.github/workflows/apps-deploy-e2e.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   apps-deploy-e2e:
     name: Apps deploy + per-tenant DB isolation (real docker)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -61,7 +61,7 @@ jobs:
 
   tenant-db-isolation:
     name: Tenant-DB isolation — cross-tenant REVOKE CONNECT (throwaway Postgres) (#9853)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     # Lightweight pg-only proof (no docker): provision two tenants through the
     # real SqlTenantDbProvisioner against a throwaway Postgres and assert tenant

--- a/.github/workflows/arm-apps-daemon.yml
+++ b/.github/workflows/arm-apps-daemon.yml
@@ -71,7 +71,7 @@ concurrency:
 
 jobs:
   arm:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     timeout-minutes: 10
     env:

--- a/.github/workflows/arm-headscale-control-plane.yml
+++ b/.github/workflows/arm-headscale-control-plane.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   arm:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     timeout-minutes: 10
     env:

--- a/.github/workflows/attachment-journey-videos.yml
+++ b/.github/workflows/attachment-journey-videos.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   attachment-journey-videos:
     name: Attachment journey videos
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   label-pr:
     if: github.event_name == 'pull_request_target'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d
         with:
@@ -31,7 +31,7 @@ jobs:
 
   label-issue:
     if: github.event_name == 'issues'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:

--- a/.github/workflows/benchmark-orchestrator-scheduled.yml
+++ b/.github/workflows/benchmark-orchestrator-scheduled.yml
@@ -58,7 +58,7 @@ env:
 jobs:
   orchestrator-run:
     name: orchestrator-run
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     env:
       CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   benchmark:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/benchmark-weekly.yml
+++ b/.github/workflows/benchmark-weekly.yml
@@ -74,7 +74,7 @@ permissions:
 jobs:
   benchmark:
     name: EA + connector benchmark
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 240
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/browser-real-bench.yml
+++ b/.github/workflows/browser-real-bench.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   browser-real-bench:
     name: Browser benchmarks on real Chromium
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -55,7 +55,7 @@ permissions:
 
 jobs:
   build-and-push:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   build-android:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
 
     permissions:

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-deb:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
 
     permissions:

--- a/.github/workflows/build-example-app-images.yml
+++ b/.github/workflows/build-example-app-images.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   build-edad:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -212,7 +212,7 @@ jobs:
           echo "::warning::Could not set package visibility to public — set it once manually in the GHCR package settings"
 
   build-clone-ur-crush:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/build-linux-iso.yml
+++ b/.github/workflows/build-linux-iso.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   build-iso:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 300
     permissions:
       # contents: write covers softprops/action-gh-release (release upload)

--- a/.github/workflows/build-llama-ffi-android.yml
+++ b/.github/workflows/build-llama-ffi-android.yml
@@ -61,7 +61,7 @@ env:
 
 jobs:
   prepare-matrix:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
@@ -104,7 +104,7 @@ jobs:
   build:
     name: ${{ matrix.abi }}
     needs: prepare-matrix
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/build-vm-image.yml
+++ b/.github/workflows/build-vm-image.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   build-vm:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
 
     permissions:

--- a/.github/workflows/cache-key-stability.yml
+++ b/.github/workflows/cache-key-stability.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   cache-key-stability:
     name: cache-key-stability
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/cerebras-nightly.yml
+++ b/.github/workflows/cerebras-nightly.yml
@@ -59,7 +59,7 @@ env:
 jobs:
   bench:
     name: "nightly: ${{ matrix.suite }}"
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/certification-image.yml
+++ b/.github/workflows/certification-image.yml
@@ -37,7 +37,7 @@ jobs:
     # Same fleet fallback as build-agent-image: hetzner when online (the
     # image is ~15 GB with baked models and CUDA layers; hosted runners need
     # the disk-free step below to survive it).
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 180
     permissions:
       contents: read

--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -78,7 +78,7 @@ env:
 jobs:
   chat-shell-gestures:
     name: Chat shell gesture + parity e2e
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/ci-full-matrix-proof.yml
+++ b/.github/workflows/ci-full-matrix-proof.yml
@@ -43,7 +43,7 @@ env:
 jobs:
   matrix-proof:
     name: Exhaustive lane matrix proof
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:

--- a/.github/workflows/cloud-aesthetic-audit.yml
+++ b/.github/workflows/cloud-aesthetic-audit.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   cloud-aesthetic-audit:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       # Keyless: the ui-smoke stub is forced when CI=true (shouldForceStubStack).

--- a/.github/workflows/cloud-deploy-backend.yml
+++ b/.github/workflows/cloud-deploy-backend.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   determine-env:
     name: Determine Environment
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       branch: ${{ steps.env.outputs.branch }}
@@ -51,7 +51,7 @@ jobs:
 
   migrate-db:
     name: Run Database Migrations
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: determine-env
     # Job-level concurrency groups are repo-wide: this serializes an explicit
     # legacy migration against the canonical migrate-db gate in
@@ -143,7 +143,7 @@ jobs:
   deploy:
     name: Deploy to agent VPS
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_legacy_vps }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: [determine-env, migrate-db]
     environment: ${{ needs.determine-env.outputs.environment }}
     timeout-minutes: 45

--- a/.github/workflows/cloud-e2e.yml
+++ b/.github/workflows/cloud-e2e.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   e2e:
     name: Mock-stack E2E
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       NODE_ENV: test

--- a/.github/workflows/cloud-gateway-discord.yml
+++ b/.github/workflows/cloud-gateway-discord.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/cloud-gateway-webhook.yml
+++ b/.github/workflows/cloud-gateway-webhook.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -71,7 +71,7 @@ permissions:
 
 jobs:
   lint-and-types:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -89,7 +89,7 @@ jobs:
   # twice per PR on the saturated runner fleet.
 
   unit-tests:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     # Cloud unit tests can run past 25m on saturated self-hosted runners while still passing.
     timeout-minutes: 40
     env:
@@ -122,7 +122,7 @@ jobs:
         run: bun run --cwd packages/cloud/shared test:vitest
 
   integration-tests:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     env:
       NODE_ENV: test

--- a/.github/workflows/deploy-apps-worker.yml
+++ b/.github/workflows/deploy-apps-worker.yml
@@ -64,7 +64,7 @@ permissions:
 jobs:
   determine-env:
     name: Determine environment
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       branch: ${{ steps.env.outputs.branch }}
@@ -85,7 +85,7 @@ jobs:
 
   deploy:
     name: Deploy apps worker to apps-control host (${{ needs.determine-env.outputs.environment }})
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: determine-env
     environment: ${{ needs.determine-env.outputs.environment }}
     timeout-minutes: 15

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -54,7 +54,7 @@ permissions:
 jobs:
   determine-env:
     name: Determine environment
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       branch: ${{ steps.env.outputs.branch }}
@@ -111,7 +111,7 @@ jobs:
 
   deploy:
     name: Deploy worker to Hetzner host (${{ needs.determine-env.outputs.environment }} @ ${{ needs.determine-env.outputs.deployment_sha }})
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: determine-env
     environment: ${{ needs.determine-env.outputs.environment }}
     timeout-minutes: 15

--- a/.github/workflows/deploy-homepage.yml
+++ b/.github/workflows/deploy-homepage.yml
@@ -44,7 +44,7 @@ permissions:
 
 jobs:
   build-and-deploy:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - name: Checkout source repo

--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -61,7 +61,7 @@ jobs:
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it
     # queued indefinitely and pile up runs (#13617/#8501).
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     outputs:
       dev_smoke: ${{ steps.filter.outputs.dev_smoke }}
@@ -96,7 +96,7 @@ jobs:
     name: bun run dev onboarding chat
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.dev_smoke == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     env:
       PGLITE_WASM_MODE: node
@@ -167,7 +167,7 @@ jobs:
     name: Vite HMR dependency-level smoke
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.dev_smoke == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     env:
       PGLITE_WASM_MODE: node

--- a/.github/workflows/develop-exhaustive.yml
+++ b/.github/workflows/develop-exhaustive.yml
@@ -115,7 +115,7 @@ jobs:
     # Run even when a reusable lane failed so the proof enumerates every lane
     # and the result check below can name the offender; only a cancel skips it.
     if: ${{ !cancelled() }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     env:
       CI: "true"
       BUN_VERSION: "1.3.14"

--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -35,7 +35,7 @@ jobs:
   live-sweep:
     name: Post-merge live matrix
     if: github.event_name == 'workflow_dispatch' || vars.ELIZA_DEVELOP_LIVE_ENABLED == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 480
     env:
       TEST_LANE: post-merge

--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -33,7 +33,7 @@ jobs:
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it
     # queued indefinitely and pile up runs (#13617/#8501).
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
@@ -68,7 +68,7 @@ jobs:
     name: Build production Docker image (+ smoke boot)
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.docker == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     env:
       BUN_VERSION: "canary"

--- a/.github/workflows/electrobun-submodule-guard.yml
+++ b/.github/workflows/electrobun-submodule-guard.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
   verify-electrobun-pin:
     name: electrobun gitlink is fetchable
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - name: Checkout (no submodules)

--- a/.github/workflows/elizaos-os-full-release.yml
+++ b/.github/workflows/elizaos-os-full-release.yml
@@ -19,7 +19,7 @@ jobs:
   # On a 'release' event github.ref_name is the tag (e.g. v2.0.1); we strip
   # the prefix here so downstream jobs get a clean version like '2.0.1'.
   prepare:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       version: ${{ steps.parse.outputs.version }}
       tag: ${{ steps.parse.outputs.tag }}
@@ -54,7 +54,7 @@ jobs:
   verify-artifacts:
     name: Verify build artifacts exist and are non-empty
     needs: [trigger-linux-iso, trigger-debian-package, trigger-vm-image]
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - name: Download Linux ISO artifact
@@ -100,7 +100,7 @@ jobs:
   populate-and-validate-manifest:
     name: Populate manifest checksums and gate on publishable validation
     needs: [verify-artifacts]
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     permissions:
       # contents: write — required by softprops/action-gh-release to
@@ -271,7 +271,7 @@ jobs:
 
   summary:
     needs: [trigger-linux-iso, trigger-debian-package, trigger-vm-image, verify-artifacts, populate-and-validate-manifest, publish-apt]
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     if: always()
     timeout-minutes: 5
     steps:

--- a/.github/workflows/elizaos-os-release.yml
+++ b/.github/workflows/elizaos-os-release.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   validate-os-release:
     name: Validate OS release surfaces
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/external-api-live-drift.yml
+++ b/.github/workflows/external-api-live-drift.yml
@@ -70,7 +70,7 @@ env:
 jobs:
   live-drift:
     name: External-API mocks vs live APIs (nightly)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     continue-on-error: true
     steps:

--- a/.github/workflows/feed-apply-migrations.yml
+++ b/.github/workflows/feed-apply-migrations.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   migrate:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     env:
       STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
       STAGING_DIRECT_DATABASE_URL: ${{ secrets.STAGING_DIRECT_DATABASE_URL }}

--- a/.github/workflows/feed-env-audit.yml
+++ b/.github/workflows/feed-env-audit.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   env-audit:
     name: env:audit:check
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/feed-rl-training.yml
+++ b/.github/workflows/feed-rl-training.yml
@@ -48,7 +48,7 @@ jobs:
   train:
     if: ${{ vars.ENABLE_RL_TRAINING == 'true' }}
     name: Train RL Model
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 360  # 6 hours max
     
     steps:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         # actions/checkout@v4

--- a/.github/workflows/hetzner-e2e-reaper.yml
+++ b/.github/workflows/hetzner-e2e-reaper.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   reap:
     name: Sweep stale CI servers
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 10
     env:

--- a/.github/workflows/hetzner-e2e.yml
+++ b/.github/workflows/hetzner-e2e.yml
@@ -43,7 +43,7 @@ permissions:
 jobs:
   deploy:
     name: Provision + deploy + healthcheck
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 25
     outputs:
@@ -333,7 +333,7 @@ jobs:
     name: Teardown
     needs: deploy
     if: always()
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 10
     env:

--- a/.github/workflows/hetzner-provision-smoke.yml
+++ b/.github/workflows/hetzner-provision-smoke.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   provision:
     name: Provision + wait-ready + teardown (real Hetzner)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 20
     env:

--- a/.github/workflows/hetzner-sleep-wake-smoke.yml
+++ b/.github/workflows/hetzner-sleep-wake-smoke.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   sleep-wake:
     name: provision -> sleep(backup+destroy) -> wake(reprovision+restore)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 30
     env:

--- a/.github/workflows/hyperliquid-bench-live.yml
+++ b/.github/workflows/hyperliquid-bench-live.yml
@@ -62,7 +62,7 @@ env:
 jobs:
   live-bench:
     name: live-bench
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     env:
       HL_PRIVATE_KEY: ${{ secrets.HL_PRIVATE_KEY }}

--- a/.github/workflows/integration-dod-gap-issues.yml
+++ b/.github/workflows/integration-dod-gap-issues.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   sync-gap-issues:
     name: Sync gap issues from INTEGRATION_DOD_MAP.md
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/keyless-harness-e2e.yml
+++ b/.github/workflows/keyless-harness-e2e.yml
@@ -61,7 +61,7 @@ env:
 jobs:
   keyless-harness:
     name: Deterministic mock-LLM connector loops (no secret)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/kokoro-real-smoke.yml
+++ b/.github/workflows/kokoro-real-smoke.yml
@@ -71,7 +71,7 @@ env:
 jobs:
   smoke:
     name: ubuntu-22.04 fused-cpu
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     steps:
       - name: Checkout (with llama.cpp submodule)

--- a/.github/workflows/launch-hardening-8756.yml
+++ b/.github/workflows/launch-hardening-8756.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   collect:
     name: Collect #8756 evidence
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     timeout-minutes: 20
     steps:

--- a/.github/workflows/launch-qa.yml
+++ b/.github/workflows/launch-qa.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   launch-qa:
     name: Launch Docs And Static Gates
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/lifeops-bench-manifest.yml
+++ b/.github/workflows/lifeops-bench-manifest.yml
@@ -52,7 +52,7 @@ env:
 jobs:
   manifest-gate:
     name: Verify lifeops action manifest is up to date
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/lifeops-bench-multi-tier.yml
+++ b/.github/workflows/lifeops-bench-multi-tier.yml
@@ -59,7 +59,7 @@ env:
 jobs:
   resolve-inputs:
     name: "resolve-inputs"
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 2
     outputs:
       suite: ${{ steps.pick.outputs.suite }}
@@ -81,7 +81,7 @@ jobs:
   smoke-large:
     name: "tier=large"
     needs: resolve-inputs
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     steps:
       - name: Check secrets
@@ -173,7 +173,7 @@ jobs:
   smoke-frontier:
     name: "tier=frontier"
     needs: resolve-inputs
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     steps:
       - name: Check secrets
@@ -266,7 +266,7 @@ jobs:
     name: "multi-tier summary"
     needs: [resolve-inputs, smoke-large, smoke-frontier]
     if: always() && github.event_name == 'pull_request'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - name: Download large-tier artifact

--- a/.github/workflows/lifeops-bench-python.yml
+++ b/.github/workflows/lifeops-bench-python.yml
@@ -87,7 +87,7 @@ jobs:
   # ---------------------------------------------------------------------
   unit-tests:
     name: unit-tests
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -152,7 +152,7 @@ jobs:
   smoke-bench:
     name: smoke-bench
     needs: unit-tests
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -299,7 +299,7 @@ jobs:
     name: live-bench
     needs: unit-tests
     if: github.event_name == 'workflow_dispatch' && inputs.mode == 'full'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     steps:
       - name: Check live-bench secrets

--- a/.github/workflows/lifeops-bench.yml
+++ b/.github/workflows/lifeops-bench.yml
@@ -62,7 +62,7 @@ env:
 jobs:
   lifeops-bench:
     name: "lifeops-bench: ${{ matrix.agent }}"
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/lifeops-live-validation-11632.yml
+++ b/.github/workflows/lifeops-live-validation-11632.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   collect:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       CI: "true"

--- a/.github/workflows/lifeops-prompt-benchmark.yml
+++ b/.github/workflows/lifeops-prompt-benchmark.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   prompt-benchmark:
     name: prompt-benchmark
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/lifeops-quality-bench.yml
+++ b/.github/workflows/lifeops-quality-bench.yml
@@ -47,7 +47,7 @@ env:
 jobs:
   lifeops-quality-gate:
     name: triage P/R + reminder timeliness budget gate (keyless)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       PGLITE_WASM_MODE: node

--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -131,7 +131,7 @@ jobs:
   shard:
     name: Live scenarios (${{ matrix.shard }})
     needs: plan
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     # Shards run as independent jobs because a GitHub-hosted runner caps a
     # single job at six hours: the four shards run serially exceed that ceiling,
     # so no workflow-level timeout could ever let the serial lane finish. Each

--- a/.github/workflows/loadperf.yml
+++ b/.github/workflows/loadperf.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   loadperf-stack:
     name: Bundle, boot, and frontend KPIs
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -96,7 +96,7 @@ jobs:
   statesync:
     name: State-sync KPI against live stack
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.include_statesync }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/local-inference-bench.yml
+++ b/.github/workflows/local-inference-bench.yml
@@ -69,7 +69,7 @@ env:
 jobs:
   stub-validation:
     name: Harness route smoke
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -133,7 +133,7 @@ jobs:
     name: Nightly real-agent profile
     needs: stub-validation
     if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_real_agent == true) }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -320,7 +320,7 @@ jobs:
     # cost.
     name: Cuttlefish AVD profile (manual)
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_cuttlefish == true }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -380,7 +380,7 @@ jobs:
     if: >-
       (github.event_name == 'schedule' && github.event.schedule == '30 4 * * 0') ||
       (github.event_name == 'workflow_dispatch' && inputs.run_publish_models == true)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     env:
       # W5-Pipeline drops finished checkpoints under this path. The

--- a/.github/workflows/local-inference-matrix.yml
+++ b/.github/workflows/local-inference-matrix.yml
@@ -66,7 +66,7 @@ env:
 
 jobs:
   prepare-matrix:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   relative-links:
     name: Relative Markdown Links
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/memperf.yml
+++ b/.github/workflows/memperf.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   harness-gate:
     name: harness + budget regression gate (no models)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -44,7 +44,7 @@ jobs:
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it
     # queued indefinitely and pile up runs (#13617/#8501).
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     outputs:
       ios: ${{ steps.filter.outputs.ios }}
@@ -630,7 +630,7 @@ jobs:
     # cloud runtime-mode gate is a fast ubuntu job seeded with a real Cloud
     # credential rather than a browser OAuth leg.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       # Headless session seed (#13578 done-when #2): a real Cloud credential
@@ -693,7 +693,7 @@ jobs:
     name: Android Debug Build
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.android == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/mobile-resource-workbench.yml
+++ b/.github/workflows/mobile-resource-workbench.yml
@@ -55,7 +55,7 @@ concurrency:
 jobs:
   harness-smoke:
     name: harness smoke (no device)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/monetized-loop-nightly.yml
+++ b/.github/workflows/monetized-loop-nightly.yml
@@ -57,7 +57,7 @@ permissions:
 jobs:
   loop:
     name: Monetized full loop (real Hetzner)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 40
     env:
@@ -233,7 +233,7 @@ jobs:
   # until its live driver + secrets land. Mirrors cloud-e2e.yml's mock setup.
   showcase-mock:
     name: Example-apps showcase loop (mock stack)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       NODE_ENV: test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   check-commits:
     name: Check for new commits
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       has_new_commits: ${{ steps.check.outputs.has_new_commits }}
       short_sha: ${{ steps.check.outputs.short_sha }}
@@ -252,7 +252,7 @@ jobs:
     name: Create GitHub pre-release
     needs: [check-commits, build-and-test, desktop-build-matrix, publish-npm]
     if: needs.check-commits.outputs.has_new_commits == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -305,7 +305,7 @@ jobs:
     name: Cleanup old nightly releases
     needs: create-release
     if: needs.create-release.result == 'success'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -338,7 +338,7 @@ jobs:
     name: Nightly Summary
     if: always()
     needs: [check-commits, build-and-test, publish-npm, create-release, cleanup]
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Summary
         run: |

--- a/.github/workflows/orchestrator-live-multi-account.yml
+++ b/.github/workflows/orchestrator-live-multi-account.yml
@@ -48,7 +48,7 @@ env:
 jobs:
   live-multi-account:
     name: live multi-account rotation
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       ELIZA_LIVE_CLAUDE_OAUTH_TOKEN_1: ${{ secrets.ELIZA_LIVE_CLAUDE_OAUTH_TOKEN_1 }}

--- a/.github/workflows/orchestrator-multi-account.yml
+++ b/.github/workflows/orchestrator-multi-account.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   multi-account-e2e:
     name: multi-account selection e2e
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/.github/workflows/publish-android-update-manifest.yml
+++ b/.github/workflows/publish-android-update-manifest.yml
@@ -45,7 +45,7 @@ permissions:
 
 jobs:
   publish-manifest:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/publish-aosp-update-manifest.yml
+++ b/.github/workflows/publish-aosp-update-manifest.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   publish-manifest:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/publish-apt-repo.yml
+++ b/.github/workflows/publish-apt-repo.yml
@@ -58,7 +58,7 @@ permissions:
 
 jobs:
   publish-apt:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
 
     steps:
       - name: Check GPG credentials

--- a/.github/workflows/publish-example-code.yml
+++ b/.github/workflows/publish-example-code.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   check_npm:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
       version: ${{ steps.check.outputs.version }}
@@ -90,7 +90,7 @@ jobs:
   publish_npm:
     needs: check_npm
     if: needs.check_npm.outputs.should_publish == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write
       id-token: write # npm OIDC trusted publishing (SOC2 CC9.2)

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -73,7 +73,7 @@ permissions:
 jobs:
   prepare:
     name: Prepare
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       version: ${{ steps.ver.outputs.version }}
       npm_version: ${{ steps.ver.outputs.npm_version }}
@@ -148,7 +148,7 @@ jobs:
     name: Publish to PyPI
     needs: prepare
     if: inputs.pypi
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       id-token: write  # OIDC trusted publishing
     environment:
@@ -217,7 +217,7 @@ jobs:
     name: Build & Publish Snap
     needs: prepare
     if: inputs.snap
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -272,7 +272,7 @@ jobs:
     name: Build Debian Package
     needs: prepare
     if: inputs.apt
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write  # gh release upload
     steps:
@@ -387,7 +387,7 @@ jobs:
     name: Build Flatpak
     needs: prepare
     if: inputs.flatpak
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write  # gh release upload
     steps:
@@ -472,7 +472,7 @@ jobs:
     name: Publish Summary
     needs: [prepare, publish-pypi, publish-snap, build-deb, build-flatpak]
     if: always()
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Summary
         run: |

--- a/.github/workflows/publish-plugin-elizacloud.yml
+++ b/.github/workflows/publish-plugin-elizacloud.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   verify_version:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
       version: ${{ steps.check.outputs.version }}
@@ -58,7 +58,7 @@ jobs:
   publish_npm:
     needs: verify_version
     if: needs.verify_version.outputs.should_publish == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write
       id-token: write   # npm OIDC trusted publishing (SOC2 CC9.2)

--- a/.github/workflows/quality-fork.yml
+++ b/.github/workflows/quality-fork.yml
@@ -156,6 +156,10 @@ jobs:
 
       - name: Setup workspace dependencies
         uses: ./.github/actions/setup-bun-workspace
+        env:
+          # The legacy fixture bundle contains stale visual baselines; homepage
+          # tests must use the expectations committed with the checked-out SHA.
+          ELIZA_SKIP_ARTIFACT_SYNC: "1"
         with:
           bun-version: ${{ env.BUN_VERSION }}
           python-version: "3.13"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -53,7 +53,7 @@ permissions:
 jobs:
   homepage-build:
     name: Homepage Build (PR smoke)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -180,7 +180,7 @@ jobs:
 
   comment-only-diff:
     name: Comment-only diff guard
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'comment-cleanup')
     steps:
@@ -212,7 +212,7 @@ jobs:
 
   format-check:
     name: Format
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -267,7 +267,7 @@ jobs:
   # mirroring the lean install used by `format-check`.
   develop-static-gate:
     name: Develop Gate (secret scan + UI determinism)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -338,7 +338,7 @@ jobs:
   # build-enabled workspace setup rather than the lean no-postinstall path.
   develop-lint-gate:
     name: Develop Gate (lint)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/recall-bench.yml
+++ b/.github/workflows/recall-bench.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   recall-gate:
     name: recall quality + budget regression gate (no models)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -1785,7 +1785,7 @@ jobs:
     name: Publish OTA Channel Manifest
     if: ${{ success() && needs.release.result == 'success' }}
     needs: [prepare, release]
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/riscv64-smoke.yml
+++ b/.github/workflows/riscv64-smoke.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   smoke:
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'riscv64') }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     env:
       ELIZA_RISCV64_SMOKE: "1"

--- a/.github/workflows/sandbox-live-smoke.yml
+++ b/.github/workflows/sandbox-live-smoke.yml
@@ -84,7 +84,7 @@ permissions:
 jobs:
   smoke:
     name: Sandbox live smoke
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     env:
       TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'all' }}

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -63,7 +63,7 @@ jobs:
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it
     # queued indefinitely and pile up runs (#13617/#8501).
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     outputs:
       run_scenario_pr: ${{ steps.filter.outputs.run_scenario_pr }}
@@ -98,7 +98,7 @@ jobs:
     name: Zero-Key unit + UI coverage
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -140,7 +140,7 @@ jobs:
     name: Zero-Key app browser core
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -201,7 +201,7 @@ jobs:
     name: Zero-Key app browser view lifecycle
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -261,7 +261,7 @@ jobs:
     name: Zero-Key app browser all-pages
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -306,7 +306,7 @@ jobs:
     name: Zero-Key app browser feature interactions
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -351,7 +351,7 @@ jobs:
     name: Zero-Key app browser cloud keyless
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -396,7 +396,7 @@ jobs:
     name: Zero-Key app browser ratcheted
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -449,7 +449,7 @@ jobs:
     name: Zero-Key app browser auto-discovered specs
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -509,7 +509,7 @@ jobs:
     name: Zero-Key app browser dashboard device matrix
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -557,7 +557,7 @@ jobs:
     name: Zero-Key app browser Pixel-7 real-touch lane
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -615,7 +615,7 @@ jobs:
     name: Zero-Key app browser WebKit lane
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -660,7 +660,7 @@ jobs:
     name: Zero-Key accounts UI e2e (real API + pool + disk)
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -703,7 +703,7 @@ jobs:
     name: Zero-Key full-walkthrough (mock lane)
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -757,7 +757,7 @@ jobs:
     name: Zero-Key app diagnostics
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -780,7 +780,7 @@ jobs:
     name: Zero-Key scenario runner E2E
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -866,7 +866,7 @@ jobs:
       - app-diagnostics
       - scenario-runner-e2e
     if: ${{ !cancelled() && always() && needs.changes.outputs.run_scenario_pr == 'true' }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Check deterministic E2E slices
         shell: bash

--- a/.github/workflows/setup-bun-workspace-self-test.yml
+++ b/.github/workflows/setup-bun-workspace-self-test.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   protoc-github-fallback:
     name: forced protoc GitHub fallback
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/snap-publish.yml
+++ b/.github/workflows/snap-publish.yml
@@ -50,7 +50,7 @@ permissions:
 
 jobs:
   build-and-publish:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
 
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/.github/workflows/stale-base-guard.yml
+++ b/.github/workflows/stale-base-guard.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   guard:
     name: stale-base guard
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     env:
       BASE_REF: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/tee-build-deploy.yml
+++ b/.github/workflows/tee-build-deploy.yml
@@ -62,7 +62,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -107,7 +107,7 @@ jobs:
   # so it runs safely on every PR (incl. before the env HCLOUD_TOKEN exists).
   validate:
     if: github.event_name == 'pull_request'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: hashicorp/setup-terraform@v4
@@ -129,7 +129,7 @@ jobs:
   # / eliza-staging projects (see header comment).
   plan-apply:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     env:
       HCLOUD_TOKEN: ${{ secrets.HCLOUD_APPS_TOKEN }}

--- a/.github/workflows/terraform-apps-shared.yml
+++ b/.github/workflows/terraform-apps-shared.yml
@@ -82,7 +82,7 @@ jobs:
   # so it runs safely on every PR (incl. before the env HCLOUD_TOKEN exists).
   validate:
     if: github.event_name == 'pull_request'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: hashicorp/setup-terraform@v4
@@ -102,7 +102,7 @@ jobs:
   # nodes; the per-env scoping lives in apps-data-plane.
   plan-apply:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     env:
       HCLOUD_TOKEN: ${{ secrets.HCLOUD_APPS_TOKEN }}
       # R2 (S3-compatible) state backend creds.

--- a/.github/workflows/terraform-apps-state-rm.yml
+++ b/.github/workflows/terraform-apps-state-rm.yml
@@ -51,7 +51,7 @@ env:
 
 jobs:
   state-rm:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     timeout-minutes: 10
     env:

--- a/.github/workflows/terraform-control-plane.yml
+++ b/.github/workflows/terraform-control-plane.yml
@@ -81,7 +81,7 @@ jobs:
   # so it runs safely on every PR (incl. before the env HCLOUD_TOKEN exists).
   validate:
     if: github.event_name == 'pull_request'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: hashicorp/setup-terraform@v4
@@ -100,7 +100,7 @@ jobs:
   # that env's HCLOUD_TOKEN (and any required reviewers) apply to this run.
   plan-apply:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     env:
       HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/test-elizaos-setup.yml
+++ b/.github/workflows/test-elizaos-setup.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6

--- a/.github/workflows/test-flatpak.yml
+++ b/.github/workflows/test-flatpak.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build:
     name: Build & Validate Flatpak
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   validate:
     name: Validate Packaging Configs
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -59,7 +59,7 @@ jobs:
 
   build-pypi:
     name: Build & Test PyPI Package
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -159,7 +159,7 @@ jobs:
 
   build-pypi-matrix:
     name: PyPI on Python ${{ matrix.python }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     strategy:
       matrix:
         # PRs run a single Python version; pushes to main/develop run the
@@ -206,7 +206,7 @@ jobs:
 
   pack-and-test-js:
     name: Pack & Test JS Tarballs
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -277,7 +277,7 @@ jobs:
 
   elizaos-cli-global-smoke:
     name: elizaos CLI global-install smoke (node + bun)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     # forever and — since every lane needs this classifier — stalled the entire
     # ci-ok chain while the self-hosted fleet sat idle. Self-hosted when online;
     # hosted only when an operator flags the fleet down (and billing is restored).
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     outputs:
       server: ${{ steps.filter.outputs.server }}
@@ -149,7 +149,7 @@ jobs:
     # #13620/#12342: this guard protects the ordinary PR path from runner lanes
     # that collect no real tests or swallow a failure as "no tests found".
     # Keep it outside path gates and outside the opt-in `ci:full` heavy family.
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -168,7 +168,7 @@ jobs:
     name: Server Tests
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.server == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
       PGLITE_WASM_MODE: node
@@ -240,7 +240,7 @@ jobs:
     name: Client Tests
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.client == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -293,7 +293,7 @@ jobs:
     name: Plugin Tests (${{ matrix.shard }}/4)
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.plugins == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 95
     strategy:
       fail-fast: false
@@ -372,7 +372,7 @@ jobs:
       - plugin-tests
     if: ${{ !cancelled() && always() }}
     # Fleet-aware (see `changes`): hardcoded hosted froze this ci-ok dependency.
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - name: Check plugin shard results
@@ -404,7 +404,7 @@ jobs:
     name: Integration Lane (personal-assistant)
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.plugins == 'true' || needs.changes.outputs.server == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       PGLITE_WASM_MODE: node
@@ -442,7 +442,7 @@ jobs:
     name: Electrobun Desktop Contract
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.desktop == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -472,7 +472,7 @@ jobs:
     name: Zero-Key unit + UI coverage
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       TEST_LANE: "pr"
@@ -532,7 +532,7 @@ jobs:
     name: Zero-Key app browser
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     env:
       TEST_LANE: "pr"
@@ -607,7 +607,7 @@ jobs:
     name: Zero-Key diagnostics
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       TEST_LANE: "pr"
@@ -669,7 +669,7 @@ jobs:
     name: Zero-Key scenario runner
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       TEST_LANE: "pr"
@@ -743,7 +743,7 @@ jobs:
     name: Zero-Key harness E2E
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     env:
       TEST_LANE: "pr"
@@ -799,7 +799,7 @@ jobs:
       - zero-key-scenario-runner
       - zero-key-harness-e2e
     if: ${{ !cancelled() && always() && (github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true') }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Check zero-key slices
         shell: bash
@@ -829,7 +829,7 @@ jobs:
     name: Cloud Live E2E (Eliza Cloud)
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.cloud == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     outputs:
       skip: ${{ steps.cloud.outputs.skip }}
@@ -973,7 +973,7 @@ jobs:
 
   provider-live-e2e:
     name: Remote Capability Provider Live E2E
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     outputs:
       skip: ${{ steps.providers.outputs.skip }}
@@ -1104,7 +1104,7 @@ jobs:
       - cloud-live-e2e
       - provider-live-e2e
     if: always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && (needs.cloud-live-e2e.outputs.capability_skip != 'true' || needs.provider-live-e2e.outputs.skip != 'true')
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1146,7 +1146,7 @@ jobs:
   script-tests:
     name: Script Tests (Linux)
     needs: changes
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -1180,7 +1180,7 @@ jobs:
   merge-quality-gate:
     name: Merge Queue Quality Gate
     needs: changes
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -1263,7 +1263,7 @@ jobs:
     # Fleet-aware (see `changes`): the aggregate gate itself must run to report a
     # conclusion — a hardcoded hosted pin froze `ci-ok` on the billing-frozen
     # fleet (#13481), so the required check never posted and nothing could merge.
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - name: Check test results

--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -60,7 +60,7 @@ env:
 
 jobs:
   ui-fixture-e2e:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -51,7 +51,7 @@ env:
 
 jobs:
   fixture-e2e:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -48,7 +48,7 @@ env:
 
 jobs:
   story-gate:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   update-tap:
     name: Trigger Homebrew tap update
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Check credentials
         id: creds

--- a/.github/workflows/update-vendor-checksums.yml
+++ b/.github/workflows/update-vendor-checksums.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   update-checksums:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/verify-patches.yml
+++ b/.github/workflows/verify-patches.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   verify:
     name: verify patches/CHECKSUMS.sha256
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         # actions/checkout@v4

--- a/.github/workflows/view-bundle-size.yml
+++ b/.github/workflows/view-bundle-size.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   size-gate:
     name: build view bundles + budget regression gate
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/voice-bench-smoke.yml
+++ b/.github/workflows/voice-bench-smoke.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   voice-emotion-smoke:
     name: voice-emotion fixture smoke
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -77,7 +77,7 @@ jobs:
 
   voiceagentbench-smoke:
     name: voiceagentbench fixture smoke
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -118,7 +118,7 @@ jobs:
 
   voicebench-quality-unit-smoke:
     name: voicebench-quality unit smoke
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -132,7 +132,7 @@ jobs:
 
   voicebench-ts-unit:
     name: voicebench TypeScript unit (no audio)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -154,7 +154,7 @@ jobs:
 
   voice-bench-summary:
     name: voice bench smoke summary
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs:
       - voice-emotion-smoke
       - voiceagentbench-smoke

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -108,7 +108,7 @@ env:
 jobs:
   voice-platform-matrix-index:
     name: Canonical voice matrix index
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -643,7 +643,7 @@ jobs:
   voice-android-matrix:
     name: Android live-voice + native bridge matrix
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_android) || vars.ELIZA_VOICE_ANDROID_READY == '1' }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     env:
       ELIZA_VOICE_ANDROID_READY: ${{ vars.ELIZA_VOICE_ANDROID_READY }}

--- a/.github/workflows/voice-workbench.yml
+++ b/.github/workflows/voice-workbench.yml
@@ -74,7 +74,7 @@ permissions:
 jobs:
   voice-workbench:
     name: headless workbench (mocked backends)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -131,7 +131,7 @@ jobs:
   voice-workbench-real:
     name: real acoustic lane (nightly, provisioned only)
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   maintenance:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     outputs:
       attribution_snapshot: ${{ steps.attribution-boundary.outputs.snapshot }}

--- a/packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
+++ b/packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
@@ -1,0 +1,183 @@
+/** Exercises the repository-wide fail-closed contract for direct and indirect Hetzner runner routes. */
+
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  selectHetznerRunnerLabels,
+  validateHetznerFleetRouting,
+} from "../hetzner-fleet-routing-contract.mjs";
+
+const REAL_REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const HOSTED = ["ubuntu-24.04"];
+const FLEET = ["self-hosted", "hetzner-robot"];
+const SAFE_WORKFLOW = `name: Test
+jobs:
+  test:
+    runs-on: \${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+`;
+const PR_HOSTED_WORKFLOW = `name: Test
+jobs:
+  test:
+    runs-on: \${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-24.04"]' || vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+`;
+const SAFE_MATRIX_WORKFLOW = `name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        include:
+          - lane: robot-fleet
+            runner: \${{ vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-latest"]' || vars.ACTIONS_JANITOR_ROBOT_LANE_DISABLED == 'true' && '["ubuntu-latest"]' || vars.ACTIONS_JANITOR_ROBOT_RUNNER_JSON || '["self-hosted","Linux","X64","hetzner-robot"]' }}
+    runs-on: \${{ fromJSON(matrix.runner) }}
+`;
+
+function buildRepo(workflow = SAFE_WORKFLOW): string {
+  const root = mkdtempSync(join(tmpdir(), "hetzner-fleet-routing-"));
+  const workflows = join(root, ".github", "workflows");
+  mkdirSync(workflows, { recursive: true });
+  writeFileSync(join(workflows, "test.yml"), workflow);
+  return root;
+}
+
+describe("Hetzner fleet routing contract", () => {
+  test("missing, empty, false, and noncanonical values fail safely to hosted", () => {
+    for (const value of [undefined, "", "false", "TRUE", "1"]) {
+      expect(selectHetznerRunnerLabels(value)).toEqual(HOSTED);
+    }
+  });
+
+  test("only an explicit lowercase true opts into the fleet", () => {
+    expect(selectHetznerRunnerLabels("true")).toEqual(FLEET);
+  });
+
+  test("rejects the fail-open explicit-false selector", () => {
+    const root = buildRepo(
+      SAFE_WORKFLOW.replace(
+        "HETZNER_FLEET_ONLINE != 'true'",
+        "HETZNER_FLEET_ONLINE == 'false'",
+      ),
+    );
+    try {
+      expect(() => validateHetznerFleetRouting(root)).toThrow(
+        /must require explicit HETZNER_FLEET_ONLINE opt-in/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts the explicit-true opt-in selector", () => {
+    const root = buildRepo();
+    try {
+      expect(validateHetznerFleetRouting(root)).toEqual({
+        files: 1,
+        selectors: 1,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts the workflow that always hosts pull requests", () => {
+    const root = buildRepo(PR_HOSTED_WORKFLOW);
+    try {
+      expect(validateHetznerFleetRouting(root)).toEqual({
+        files: 1,
+        selectors: 1,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts an indirect matrix route with the explicit fleet opt-in", () => {
+    const root = buildRepo(SAFE_MATRIX_WORKFLOW);
+    try {
+      expect(validateHetznerFleetRouting(root)).toEqual({
+        files: 1,
+        selectors: 1,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    [
+      "hard-coded fleet labels",
+      `name: Test
+jobs:
+  test:
+    runs-on: [self-hosted, hetzner-robot]
+`,
+    ],
+    [
+      "an indirect unguarded matrix fallback",
+      SAFE_MATRIX_WORKFLOW.replace(
+        "vars.HETZNER_FLEET_ONLINE != 'true' && '[\"ubuntu-latest\"]' || ",
+        "",
+      ),
+    ],
+    [
+      "a differently named opt-in variable",
+      SAFE_MATRIX_WORKFLOW.replace(
+        "vars.HETZNER_FLEET_ONLINE",
+        "vars.ACTIONS_JANITOR_FLEET_ONLINE",
+      ),
+    ],
+    [
+      "a fleet label hidden behind a matrix reference",
+      `name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        runner:
+          - '["self-hosted","hetzner-robot"]'
+    runs-on: \${{ fromJSON(matrix.runner) }}
+`,
+    ],
+  ])("rejects %s", (_name, workflow) => {
+    const root = buildRepo(workflow);
+    try {
+      expect(() => validateHetznerFleetRouting(root)).toThrow(
+        /must require explicit HETZNER_FLEET_ONLINE opt-in/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects removal of the required janitor fleet guard", () => {
+    const root = buildRepo();
+    writeFileSync(
+      join(root, ".github", "workflows", "actions-zombie-janitor.yml"),
+      `name: Actions Zombie Janitor
+jobs:
+  reap:
+    strategy:
+      matrix:
+        include:
+          - lane: robot-fleet
+            runner: \${{ vars.ACTIONS_JANITOR_ROBOT_RUNNER_JSON || '["ubuntu-latest"]' }}
+    runs-on: \${{ fromJSON(matrix.runner) }}
+`,
+    );
+    try {
+      expect(() => validateHetznerFleetRouting(root)).toThrow(
+        /robot-fleet matrix route must retain its explicit fleet opt-in/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("the checked-in workflow set is uniformly fail-safe", () => {
+    const result = validateHetznerFleetRouting(REAL_REPO_ROOT);
+    expect(result.files).toBeGreaterThan(100);
+    expect(result.selectors).toBeGreaterThan(200);
+  });
+});

--- a/packages/scripts/ci-workflow-invariants.mjs
+++ b/packages/scripts/ci-workflow-invariants.mjs
@@ -302,6 +302,10 @@ export function validateWorkflowSources(sources) {
   const forkBuildSetup = forkBuild.steps.find(
     (step) => step?.uses === "./.github/actions/setup-bun-workspace",
   );
+  invariant(
+    forkBuildSetup?.env?.ELIZA_SKIP_ARTIFACT_SYNC === "1",
+    `${WORKFLOW_PATHS.qualityFork}: hosted build must preserve exact-head homepage baselines by skipping legacy artifact sync`,
+  );
   const forkSkillDependency = forkBuild.steps.find(
     (step) => step?.name === "Install pinned skill validator dependency",
   );

--- a/packages/scripts/ci-workflow-invariants.test.mjs
+++ b/packages/scripts/ci-workflow-invariants.test.mjs
@@ -230,6 +230,17 @@ for (const fixture of [
       /hosted build must install the hash-pinned Python 3.13 skill validator dependency/,
   },
   {
+    name: "legacy artifact sync for fork homepage validation",
+    key: "qualityFork",
+    mutate: (source) =>
+      source.replace(
+        '          ELIZA_SKIP_ARTIFACT_SYNC: "1"\n',
+        '          ELIZA_SKIP_ARTIFACT_SYNC: "0"\n',
+      ),
+    pattern:
+      /hosted build must preserve exact-head homepage baselines by skipping legacy artifact sync/,
+  },
+  {
     name: "unhashed hosted-build skill validator dependency",
     key: "qualityFork",
     mutate: (source) => source.replace(" --require-hashes", ""),

--- a/packages/scripts/hetzner-fleet-routing-contract.mjs
+++ b/packages/scripts/hetzner-fleet-routing-contract.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Verifies that GitHub Actions uses the Hetzner fleet only when the repository
+ * variable is explicitly `true`. Fork pull requests do not receive repository
+ * variables, so an empty value must fail safely to GitHub-hosted runners.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isMap, isScalar, isSeq, parseDocument } from "yaml";
+
+const HOSTED_LABELS = ["ubuntu-24.04"];
+const FLEET_LABELS = ["self-hosted", "hetzner-robot"];
+const EXPRESSION_OPEN = "$" + "{{";
+const CANONICAL_SELECTOR =
+  EXPRESSION_OPEN +
+  " fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '[\"ubuntu-24.04\"]' || '[\"self-hosted\",\"hetzner-robot\"]') }}";
+const PULL_REQUEST_HOSTED_SELECTOR =
+  EXPRESSION_OPEN +
+  " fromJSON(github.event_name == 'pull_request' && '[\"ubuntu-24.04\"]' || vars.HETZNER_FLEET_ONLINE != 'true' && '[\"ubuntu-24.04\"]' || '[\"self-hosted\",\"hetzner-robot\"]') }}";
+const JANITOR_ROBOT_SELECTOR =
+  EXPRESSION_OPEN +
+  ' vars.HETZNER_FLEET_ONLINE != \'true\' && \'["ubuntu-latest"]\' || vars.ACTIONS_JANITOR_ROBOT_LANE_DISABLED == \'true\' && \'["ubuntu-latest"]\' || vars.ACTIONS_JANITOR_ROBOT_RUNNER_JSON || \'["self-hosted","Linux","X64","hetzner-robot"]\' }}';
+const DIRECT_RUNNER_SELECTORS = new Set([
+  CANONICAL_SELECTOR,
+  PULL_REQUEST_HOSTED_SELECTOR,
+]);
+const JANITOR_WORKFLOW = "actions-zombie-janitor.yml";
+const MATRIX_RUNNER_PATH =
+  /^jobs\.[^.]+\.strategy\.matrix\.include\.\d+\.runner$/;
+const JANITOR_ROUTE_PATH =
+  /^jobs\.reap\.strategy\.matrix\.include\.\d+\.runner$/;
+
+function lineAt(source, offset) {
+  return source.slice(0, offset).split("\n").length;
+}
+
+function collectFleetRoutes(node, source, pathParts = [], routes = []) {
+  if (isScalar(node)) {
+    if (
+      typeof node.value === "string" &&
+      (node.value.includes("HETZNER_FLEET_ONLINE") ||
+        node.value.includes("hetzner-robot"))
+    ) {
+      routes.push({
+        line: lineAt(source, node.range?.[0] ?? 0),
+        path: pathParts.join("."),
+        value: node.value.replace(/\s+/g, " ").trim(),
+      });
+    }
+    return routes;
+  }
+
+  if (isMap(node)) {
+    for (const pair of node.items) {
+      const key = isScalar(pair.key) ? String(pair.key.value) : "<key>";
+      collectFleetRoutes(pair.value, source, [...pathParts, key], routes);
+    }
+    return routes;
+  }
+
+  if (isSeq(node)) {
+    node.items.forEach((item, index) => {
+      collectFleetRoutes(item, source, [...pathParts, String(index)], routes);
+    });
+  }
+
+  return routes;
+}
+
+export function selectHetznerRunnerLabels(variableValue) {
+  return variableValue === "true" ? FLEET_LABELS : HOSTED_LABELS;
+}
+
+export function validateHetznerFleetRouting(repoRoot) {
+  const workflowsDir = path.join(repoRoot, ".github", "workflows");
+  const failures = [];
+  let selectors = 0;
+  let files = 0;
+  let janitorRouteFound = false;
+  let hasJanitorWorkflow = false;
+
+  for (const name of readdirSync(workflowsDir).sort()) {
+    if (!name.endsWith(".yml") && !name.endsWith(".yaml")) continue;
+    if (name === JANITOR_WORKFLOW) hasJanitorWorkflow = true;
+    const source = readFileSync(path.join(workflowsDir, name), "utf8");
+    const document = parseDocument(source, { uniqueKeys: true });
+    if (document.errors.length > 0) {
+      throw new Error(
+        `${name}: invalid workflow YAML: ${document.errors.map((error) => error.message).join("; ")}`,
+      );
+    }
+
+    const routes = collectFleetRoutes(document.contents, source);
+    if (routes.length === 0) continue;
+    files += 1;
+    selectors += routes.length;
+
+    for (const route of routes) {
+      const directRoute =
+        /^jobs\.[^.]+\.runs-on$/.test(route.path) &&
+        DIRECT_RUNNER_SELECTORS.has(route.value);
+      const indirectRoute =
+        MATRIX_RUNNER_PATH.test(route.path) &&
+        route.value === JANITOR_ROBOT_SELECTOR;
+      const janitorRoute =
+        name === JANITOR_WORKFLOW &&
+        JANITOR_ROUTE_PATH.test(route.path) &&
+        indirectRoute;
+      if (janitorRoute) janitorRouteFound = true;
+      if (directRoute || indirectRoute) continue;
+      failures.push(`${name}:${route.line} (${route.path}): ${route.value}`);
+    }
+  }
+
+  if (hasJanitorWorkflow && !janitorRouteFound) {
+    failures.push(
+      `${JANITOR_WORKFLOW}: jobs.reap robot-fleet matrix route must retain its explicit fleet opt-in and hosted fallback`,
+    );
+  }
+
+  if (selectors === 0) {
+    throw new Error("No HETZNER_FLEET_ONLINE runner selectors were found.");
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      [
+        "Hetzner runner routing must require explicit HETZNER_FLEET_ONLINE opt-in; missing, empty, false, and noncanonical values must use a hosted runner:",
+        ...failures,
+      ].join("\n"),
+    );
+  }
+
+  return { files, selectors };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const repoRoot = path.resolve(import.meta.dirname, "../..");
+  const result = validateHetznerFleetRouting(repoRoot);
+  console.log(
+    `[hetzner-fleet-routing] verified ${result.selectors} selectors across ${result.files} workflows`,
+  );
+}


### PR DESCRIPTION
# Relates to

Closes #17439

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated verification blocker is recorded below.
- [x] A reviewer can confirm the change from the deterministic workflow scan and focused test output below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` was run post-sync; the VPS memory-limit result is documented in **Known gaps / failures**.

# Risks

Low. This changes runner selection across 113 workflow files. A structural contract test rejects noncanonical selectors and verifies every checked-in occurrence, but a malformed future selector could prevent a workflow from selecting a runner until corrected.

# Background

## What does this PR do?

- Requires an explicit `HETZNER_FLEET_ONLINE=true` before selecting the self-hosted fleet.
- Routes missing, empty, false, and noncanonical values to GitHub-hosted runners.
- Guards all 214 current selectors and adds a repository-wide regression contract.
- Documents why fork pull requests need this fail-safe default.

## What kind of change is this?

Bug fix and CI hardening.

# Documentation changes needed?

The workflow README is updated with the explicit opt-in contract and fork-PR rationale.

# Testing

## Where should a reviewer start?

Start with `packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts`, then inspect the mechanical selector changes and `.github/workflows/README.md`.

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
node packages/scripts/hetzner-fleet-routing-contract.mjs
actionlint -config-file .github/actionlint.yaml \
  -ignore 'unexpected key "queue"|label "eliza-e2e-macos" is unknown' \
  .github/workflows/*.yml .github/workflows/*.yaml
git diff --check
```

Observed results:

- Focused contract: 12 passed, 0 failed.
- Repository scan: 214 selectors verified across 113 workflows on the exact rebased head.
- Workflow lint: passed after excluding two existing `develop` findings documented below.
- Diff check: passed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - this is GitHub Actions configuration with no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - this is GitHub Actions configuration with no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - there is no interactive user flow; behavior is proved by deterministic selector tests.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no backend runtime path is changed; focused validation output is included above.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend code, request, or state transition is changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior is changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no database, generated runtime state, wallet, transaction, audio, or device output is changed.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior is changed.

## Backend + frontend logs

N/A - this is deterministic workflow metadata. The focused test and complete selector scan above are the applicable proof.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface or interactive flow is changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior is changed.

## Known gaps / failures

- `bun run test:scripts`: 1,297 passed and 2 existing `develop` failures remained: the checked-in turbo-cache contract expects a 32-minute timeout while `quality-fork.yml` contains 45, and the provisioning entrypoint test could not resolve a generated package import in this checkout. The new routing contract passed within this suite.
- `bun run verify`: 237 of 241 Turbo tasks completed before the VPS kernel killed `@elizaos/cloud-api#typecheck` with exit 137. No contribution-specific failure was reported before the memory kill.
- Raw `actionlint` reports two existing `develop` findings: unsupported `concurrency.queue` in `develop-exhaustive.yml` and the custom `eliza-e2e-macos` label in `mobile-resource-workbench.yml`. The complete workflow set passes with only those exact baseline findings excluded.

- Evidence metadata was revalidated after the exact-head fork workflow approval.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: Codex CLI 0.145.0
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

— [codex-jotrujil03]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex CLI 0.145.0","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->


# Maintainer repair verification

- Exact head: 5e19bc970808fae82a8a7fa49cb028db5349644f
- Rebased base: 0b15962910754ec947dbac0d787cdf8e47eba2c9
- The janitor matrix route now also fails closed when fleet variables are absent.
- The contract structurally inspects direct and matrix-indirect routes and rejects hard-coded labels, renamed variables, hidden matrix labels, and removed guards.
- The fork Build job now skips the legacy artifact bundle whose extraction overwrote exact-head homepage snapshots with pre-#17376 baselines. This mirrors the canonical extended Quality workflow.
- Focused Hetzner tests: 12 passed. Workflow invariant tests: 33 passed.
- Biome, diff check, and workflow parsing passed.
- The prior homepage failure was deterministic baseline corruption, not a product regression: all six expected images matched the legacy bundle while the actual page matched current develop.

<!-- evidence-head:5e19bc970808fae82a8a7fa49cb028db5349644f -->