### PR TITLE
fix(cloud-apps): separate API and callback failures

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.integration.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.integration.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Runs LIST_CLOUD_APPS in an isolated process through the real Cloud SDK and a
+ * loopback HTTP boundary so the unit suite's SDK module replacement cannot
+ * conceal the integration path.
+ */
+import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+describe("LIST_CLOUD_APPS integration", () => {
+  it("propagates delivery failure after one real SDK request and one callback", () => {
+    const fixturePath = fileURLToPath(
+      new URL(
+        "../test/fixtures/list-cloud-apps-callback-boundary.ts",
+        import.meta.url,
+      ),
+    );
+    const result = spawnSync(process.execPath, [fixturePath], {
+      encoding: "utf8",
+      env: process.env,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const evidence = JSON.parse(result.stdout) as {
+      requests: Array<{
+        path: string;
+        authorization: string | null;
+        apiKey: string | null;
+      }>;
+      delivered: string[];
+    };
+    expect(evidence.requests).toEqual([
+      {
+        path: "/api/v1/apps",
+        authorization: "Bearer eliza_loopback_key",
+        apiKey: "eliza_loopback_key",
+      },
+    ]);
+    expect(evidence.delivered).toHaveLength(1);
+    expect(evidence.delivered[0]).toContain("Delivered Once");
+    expect(evidence.delivered[0]).not.toContain("Cloud API returned an error");
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.test.ts
@@ -182,5 +182,32 @@ describe("LIST_CLOUD_APPS", () => {
       ).toBe("error");
       expect(cb.calls[0]?.text).toContain("couldn't fetch");
     });
+
+    it("does not translate a callback failure into an API error", async () => {
+      setListApps(() =>
+        Promise.resolve({
+          success: true,
+          apps: [makeApp({ name: "Delivered Once" })],
+        }),
+      );
+      const delivered: string[] = [];
+      const deliveryError = new Error("transport unavailable");
+
+      const result = listCloudAppsAction.handler(
+        keyedRuntime(),
+        makeMessage("list my cloud apps"),
+        undefined,
+        undefined,
+        async ({ text }) => {
+          delivered.push(text);
+          throw deliveryError;
+        },
+      );
+
+      await expect(result).rejects.toBe(deliveryError);
+      expect(delivered).toHaveLength(1);
+      expect(delivered[0]).toContain("Delivered Once");
+      expect(delivered[0]).not.toContain("Cloud API returned an error");
+    });
   });
 });

--- a/plugins/plugin-cloud-apps/src/actions/list-cloud-apps.ts
+++ b/plugins/plugin-cloud-apps/src/actions/list-cloud-apps.ts
@@ -79,52 +79,13 @@ export const listCloudAppsAction: Action = {
       };
     }
 
+    let response: Awaited<ReturnType<typeof client.listApps>>;
+    // error-policy:J1 The action boundary translates only the Cloud request;
+    // connector delivery remains owned by the caller and must reject unchanged.
     try {
-      const { apps } = await client.listApps();
-
-      if (!apps || apps.length === 0) {
-        await callback?.({ text: EMPTY_MESSAGE, actions: ["LIST_CLOUD_APPS"] });
-        return {
-          success: true,
-          text: "User has no Eliza Cloud apps.",
-          userFacingText: EMPTY_MESSAGE,
-          data: { count: 0, apps: [] },
-        };
-      }
-
-      const header =
-        apps.length === 1
-          ? "You have 1 app on Eliza Cloud:"
-          : `You have ${apps.length} apps on Eliza Cloud:`;
-      const body = apps.map(formatAppLine).join("\n");
-      const reply = `${header}\n${body}`;
-
-      await callback?.({ text: reply, actions: ["LIST_CLOUD_APPS"] });
-      return {
-        success: true,
-        text: `Listed ${apps.length} Eliza Cloud app(s).`,
-        userFacingText: reply,
-        verifiedUserFacing: true,
-        // A single-operation read whose reply IS the complete answer: opting
-        // into the gated evaluator skip keeps a small planner model from
-        // re-rendering the already-delivered list as a second message.
-        turnComplete: true,
-        data: {
-          count: apps.length,
-          apps: apps.map((a) => ({
-            id: a.id,
-            name: a.name,
-            slug: a.slug,
-            status: a.deployment_status,
-          })),
-        },
-      };
+      response = await client.listApps();
     } catch (err) {
-      logger.warn(
-        `[LIST_CLOUD_APPS] Failed to list apps: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
+      logger.warn({ err }, "[LIST_CLOUD_APPS] Failed to list apps");
       await callback?.({ text: ERROR_MESSAGE, actions: ["LIST_CLOUD_APPS"] });
       return {
         success: false,
@@ -134,6 +95,45 @@ export const listCloudAppsAction: Action = {
         data: { reason: "error" },
       };
     }
+
+    const { apps } = response;
+    if (!apps || apps.length === 0) {
+      await callback?.({ text: EMPTY_MESSAGE, actions: ["LIST_CLOUD_APPS"] });
+      return {
+        success: true,
+        text: "User has no Eliza Cloud apps.",
+        userFacingText: EMPTY_MESSAGE,
+        data: { count: 0, apps: [] },
+      };
+    }
+
+    const header =
+      apps.length === 1
+        ? "You have 1 app on Eliza Cloud:"
+        : `You have ${apps.length} apps on Eliza Cloud:`;
+    const body = apps.map(formatAppLine).join("\n");
+    const reply = `${header}\n${body}`;
+
+    await callback?.({ text: reply, actions: ["LIST_CLOUD_APPS"] });
+    return {
+      success: true,
+      text: `Listed ${apps.length} Eliza Cloud app(s).`,
+      userFacingText: reply,
+      verifiedUserFacing: true,
+      // A single-operation read whose reply IS the complete answer: opting
+      // into the gated evaluator skip keeps a small planner model from
+      // re-rendering the already-delivered list as a second message.
+      turnComplete: true,
+      data: {
+        count: apps.length,
+        apps: apps.map((a) => ({
+          id: a.id,
+          name: a.name,
+          slug: a.slug,
+          status: a.deployment_status,
+        })),
+      },
+    };
   },
 
   examples: [

--- a/plugins/plugin-cloud-apps/test/fixtures/list-cloud-apps-callback-boundary.ts
+++ b/plugins/plugin-cloud-apps/test/fixtures/list-cloud-apps-callback-boundary.ts
@@ -1,0 +1,64 @@
+/**
+ * Drives LIST_CLOUD_APPS through a real ElizaCloudClient and loopback HTTP
+ * server, then records how a connector delivery failure crosses the action
+ * boundary.
+ */
+
+import { makeApp, makeMessage, makeRuntime } from "../../__tests__/helpers";
+import { listCloudAppsAction } from "../../src/actions/list-cloud-apps";
+
+const requests: Array<{
+  path: string;
+  authorization: string | null;
+  apiKey: string | null;
+}> = [];
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  fetch(request) {
+    const url = new URL(request.url);
+    requests.push({
+      path: url.pathname,
+      authorization: request.headers.get("authorization"),
+      apiKey: request.headers.get("x-api-key"),
+    });
+    return Response.json({
+      success: true,
+      apps: [makeApp({ name: "Delivered Once" })],
+    });
+  },
+});
+
+try {
+  const runtime = makeRuntime({
+    ELIZAOS_CLOUD_API_KEY: "eliza_loopback_key",
+    ELIZAOS_CLOUD_BASE_URL: `http://127.0.0.1:${server.port}/api/v1`,
+  });
+  const delivered: string[] = [];
+  const deliveryError = new Error("transport unavailable");
+  let observedError: unknown;
+
+  try {
+    await listCloudAppsAction.handler(
+      runtime,
+      makeMessage("list my cloud apps"),
+      undefined,
+      undefined,
+      async ({ text }) => {
+        delivered.push(text);
+        throw deliveryError;
+      },
+    );
+  } catch (error) {
+    observedError = error;
+  }
+
+  if (observedError !== deliveryError) {
+    throw new Error(
+      "Connector delivery error did not cross the action boundary",
+    );
+  }
+  process.stdout.write(JSON.stringify({ requests, delivered }));
+} finally {
+  server.stop(true);
+}


### PR DESCRIPTION
## Summary

- keep the `client.listApps()` error translation scoped to the Cloud SDK request
- let callback/transport failures propagate to their actual delivery boundary
- prove a successful inventory followed by a rejecting callback is attempted exactly once and is not relabeled as a Cloud API failure

This is a bounded fix-forward for one defect already present on `develop` and reproduced while reviewing #17366. It relates to #17363 but does not claim to complete that issue's broader routing and planner acceptance criteria.

## Verification

Rebased base: `111e4532c6de43bdde0cc920a5a009b0f2e5eac8`.

- plugin-cloud-apps package tests — 346 passed
- deterministic unit + real loopback integration callback-boundary coverage — passed
- `bun run --cwd plugins/plugin-cloud-apps typecheck` — passed
- `bun run --cwd plugins/plugin-cloud-apps lint` — passed, no fixes applied

## Evidence

| Evidence | Status |
| --- | --- |
| Deterministic callback-boundary regression | Attached in the test suite; exact callback messages and call count asserted |
| Backend logs | N/A - the fixed path propagates the synthetic transport error instead of producing an API-error log |
| Real Cloud inventory | N/A - the defect occurs after a successful SDK response and is isolated at the callback boundary |
| Live-model trajectory | N/A - no model, prompt, routing, or planner behavior changes |
| Screenshots/video/frontend logs | N/A - no UI surface changes |
| Domain artifacts | N/A - read-only inventory action; no persisted artifact |

## Risk

The action's result shape and all API success/failure responses are unchanged. The only behavioral change is that callback failures are no longer caught by the Cloud API error handler and retried with false error copy.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend action callback boundary with no UI surface

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered interface changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-operated UI flow changed

<!-- evidence-row:backend-logs -->
- [x] N/A - callback rejection propagates to the caller without a backend log

<!-- evidence-row:frontend-logs -->
- [x] N/A - connector callback semantics changed but no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model routing, or model response behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] N/A - read-only inventory action does not create a persisted domain artifact


## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

<!-- evidence-head:ee9f881f02297935d85a79b7ed6599a2ea12eecc -->