### PR TITLE
fix(core): Stage-1 always renders CURRENT_TIME — delete the prose-regex intent gate

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -3053,7 +3053,13 @@ describe("runV5MessageRuntimeStage1", () => {
 		});
 	});
 
-	it("includes CURRENT_TIME in Stage 1 only for direct date/time/year questions", async () => {
+	it("renders CURRENT_TIME in Stage 1 for every turn, regardless of phrasing", async () => {
+		// Live incident (tj-a82f2bfeaf021c): a regex gate only re-included
+		// CURRENT_TIME for messages matching a "time question" pattern, so
+		// "whats todays date and time?" (no apostrophe) lost the time block
+		// and the model hallucinated a two-week-old date — while the system
+		// prompt asserts the context ALWAYS carries a CURRENT_TIME signal.
+		// The signal is unconditional now; no prose matching may gate it.
 		const makeTimeState = (): State => ({
 			values: { availableContexts: "simple, general" },
 			data: {
@@ -3074,31 +3080,24 @@ describe("runV5MessageRuntimeStage1", () => {
 				extra: { requiresTool: false },
 			});
 
-		const dateRuntime = makeRuntime([response()]);
-		await runV5MessageRuntimeStage1({
-			runtime: dateRuntime,
-			message: makeMessage({ text: "What year is it?" }),
-			state: makeTimeState(),
-			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
-		});
-		const dateParams = useModelCalls(dateRuntime)[0]?.[1] as {
-			messages?: Array<{ content?: string | null }>;
-		};
-		expect(dateParams.messages?.[1]?.content ?? "").toContain("# Current Time");
-
-		const genericRuntime = makeRuntime([response()]);
-		await runV5MessageRuntimeStage1({
-			runtime: genericRuntime,
-			message: makeMessage({ text: "Tell me a short joke." }),
-			state: makeTimeState(),
-			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
-		});
-		const genericParams = useModelCalls(genericRuntime)[0]?.[1] as {
-			messages?: Array<{ content?: string | null }>;
-		};
-		expect(genericParams.messages?.[1]?.content ?? "").not.toContain(
-			"# Current Time",
-		);
+		// The incident phrasing (fails any "looks like a time question" regex)
+		// and a message with no time intent at all must both see the block.
+		for (const text of [
+			"whats todays date and time?",
+			"Tell me a short joke.",
+		]) {
+			const runtime = makeRuntime([response()]);
+			await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage({ text }),
+				state: makeTimeState(),
+				responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+			});
+			const params = useModelCalls(runtime)[0]?.[1] as {
+				messages?: Array<{ content?: string | null }>;
+			};
+			expect(params.messages?.[1]?.content ?? "").toContain("# Current Time");
+		}
 	});
 
 	it("current_turn_boundary allows recall questions to read from visible prior_message blocks", async () => {

--- a/packages/core/src/__tests__/stage1-provider-execution.test.ts
+++ b/packages/core/src/__tests__/stage1-provider-execution.test.ts
@@ -1,10 +1,13 @@
 /**
  * Proves the Stage-1 provider exclusions are EXECUTION exclusions, not just
  * render exclusions: `stage1ResponseStateProviderNames` subtracts the
- * stage-1-excluded providers from the compose include list (so ENTITIES /
- * CURRENT_TIME never run for a turn that dies at Stage 1), while the planner
- * pass still composes them via composeState's cached-state merge. Uses a real
- * in-memory AgentRuntime with call-counting providers; no database or model.
+ * stage-1-excluded providers from the compose include list (so ENTITIES
+ * never runs for a turn that dies at Stage 1), while the planner pass still
+ * composes them via composeState's cached-state merge. Also pins that
+ * CURRENT_TIME is unconditionally composed — the system prompt promises a
+ * time signal in every runtime context, so no message phrasing may drop it.
+ * Uses a real in-memory AgentRuntime with call-counting providers; no
+ * database or model.
  */
 import { describe, expect, it } from "vitest";
 import { AgentRuntime } from "../runtime";
@@ -56,7 +59,6 @@ describe("stage1ResponseStateProviderNames", () => {
 		);
 
 		expect(names).not.toContain("ENTITIES");
-		expect(names).not.toContain("CURRENT_TIME");
 		expect(names).not.toContain("DOCUMENTS");
 		// Stage 1 still composes what it renders and routes on.
 		expect(names).toContain("RECENT_MESSAGES");
@@ -64,15 +66,25 @@ describe("stage1ResponseStateProviderNames", () => {
 		expect(names).toContain("ATTACHMENTS");
 	});
 
-	it("keeps CURRENT_TIME when the user is asking about the time", () => {
+	it("always includes CURRENT_TIME regardless of message phrasing", () => {
+		// Live incident: a regex gate re-included CURRENT_TIME only for
+		// messages that "looked like" time questions, so the apostrophe-free
+		// "whats todays date and time?" lost the time block and the model
+		// hallucinated a stale date. The signal must not depend on prose.
 		const runtime = { providers: [] } as unknown as IAgentRuntime;
-		const names = stage1ResponseStateProviderNames(
-			runtime,
-			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", "what time is it?"),
-		);
-
-		expect(names).toContain("CURRENT_TIME");
-		expect(names).not.toContain("ENTITIES");
+		for (const text of [
+			"gm",
+			"whats todays date and time?",
+			"what time is it?",
+			"tell me a short joke",
+		]) {
+			const names = stage1ResponseStateProviderNames(
+				runtime,
+				makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", text),
+			);
+			expect(names).toContain("CURRENT_TIME");
+			expect(names).not.toContain("ENTITIES");
+		}
 	});
 
 	it("includes always-on plugin providers unless they are stage-1-excluded", () => {
@@ -116,7 +128,9 @@ describe("stage1ResponseStateProviderNames", () => {
 
 		// Stage-1 compose: excluded providers never execute, so a turn that
 		// ends at Stage 1 (group noise → IGNORE) does none of their work and
-		// its prompt footprint drops accordingly.
+		// its prompt footprint drops accordingly. CURRENT_TIME is NOT excluded
+		// — it composes on every turn so the simple path can honor the system
+		// prompt's promise of a live time signal.
 		const stage1State = await runtime.composeState(
 			message,
 			stage1Names,
@@ -124,17 +138,18 @@ describe("stage1ResponseStateProviderNames", () => {
 			false,
 		);
 		expect(entities.calls()).toBe(0);
-		expect(currentTime.calls()).toBe(0);
+		expect(currentTime.calls()).toBe(1);
 		expect(facts.calls()).toBe(1);
 		expect(recent.calls()).toBe(1);
 		expect(stage1State.text).not.toContain("ENTITIES#");
-		expect(stage1State.text).not.toContain("CURRENT_TIME#");
+		expect(stage1State.text).toContain("CURRENT_TIME#1");
 		expect(stage1State.text).toContain("FACTS#1");
 
 		// Planner recompose (mirrors selectV5PlannerStateProviderNames re-adding
 		// the core response providers, with RECENT_MESSAGES refreshed): the
 		// excluded providers are not in the turn cache, so they run now — once —
-		// and reach the planner prompt; the already-composed FACTS is reused.
+		// and reach the planner prompt; the already-composed FACTS and
+		// CURRENT_TIME are reused from the turn cache.
 		const plannerState = await runtime.composeState(
 			message,
 			[...stage1Names, "ENTITIES", "CURRENT_TIME"],

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -849,12 +849,9 @@ const MODEL_CONTEXT_PROVIDER_EXCLUSION_SET = new Set<string>(
 );
 
 /**
- * Stage 1 (messageHandler / shouldRespond) does NOT need wall-clock,
- * room entities, or document store context. It just decides
- * processMessage + which contexts apply. Excluding these from the
- * Stage 1 prompt keeps the user message byte-stable across responses
- * (no per-call CURRENT_TIME drift) so the provider's prefix cache
- * grows with the conversation rather than resetting every turn.
+ * Stage 1 (messageHandler / shouldRespond) does NOT need room entities
+ * or document store context. It just decides processMessage + which
+ * contexts apply.
  *
  * These exclusions apply to COMPOSITION as well as rendering:
  * `composeResponseState` subtracts them from the include list it hands
@@ -866,32 +863,23 @@ const MODEL_CONTEXT_PROVIDER_EXCLUSION_SET = new Set<string>(
  * planner recompose runs any provider missing from the turn's cached
  * state (see composeState's refreshProviders contract in runtime.ts).
  *
+ * CURRENT_TIME is deliberately NOT excluded: the system prompt promises
+ * a CURRENT_TIME signal in every runtime context (see the date/time
+ * exception in packages/prompts), and simple-path turns run exactly one
+ * compose pass — excluding it here turns a missing provider into a
+ * confidently hallucinated timestamp. A prose gate that re-included it
+ * only for messages that "looked like" time questions silently dropped
+ * the signal on near-miss phrasings ("whats todays date and time?").
+ * The provider is pure synchronous formatting, and the prefix-cache cost
+ * is nil in practice: FACTS is BM25-ranked per message and renders
+ * adjacent to CURRENT_TIME, so the user-message bytes already churn at
+ * that position every turn.
+ *
  * Note: we still keep FACTS composed and rendered — Stage 1 may need a
  * grounded fact to discriminate ambiguous routing, and stored facts must
  * be recallable on the simple path (see CORE_RESPONSE_STATE_PROVIDERS).
  */
-const STAGE1_EXTRA_PROVIDER_EXCLUSIONS = [
-	"CURRENT_TIME",
-	"ENTITIES",
-	"DOCUMENTS",
-] as const;
-
-function isCurrentTimeQuestion(message: Memory): boolean {
-	const text = message.content.text?.toLowerCase() ?? "";
-	if (!text) return false;
-	return /\b(?:what(?:'s| is)?|tell me|give me|do you know|current)\b[\s\S]{0,80}\b(?:date|time|year|day|today)\b/.test(
-		text,
-	);
-}
-
-function stage1ProviderExclusionsForMessage(message: Memory): string[] {
-	const exclusions = [...STAGE1_EXTRA_PROVIDER_EXCLUSIONS];
-	if (isCurrentTimeQuestion(message)) {
-		const index = exclusions.indexOf("CURRENT_TIME");
-		if (index >= 0) exclusions.splice(index, 1);
-	}
-	return exclusions;
-}
+const STAGE1_EXTRA_PROVIDER_EXCLUSIONS = ["ENTITIES", "DOCUMENTS"] as const;
 function hasInboundBenchmarkContext(message: Memory): boolean {
 	const metadata = message.metadata as Record<string, unknown> | undefined;
 	const benchmarkContext = metadata?.benchmarkContext;
@@ -1111,7 +1099,7 @@ export function stage1ResponseStateProviderNames(
 	runtime: IAgentRuntime,
 	message: Memory,
 ): string[] {
-	const exclusions = new Set(stage1ProviderExclusionsForMessage(message));
+	const exclusions = new Set<string>(STAGE1_EXTRA_PROVIDER_EXCLUSIONS);
 	return [
 		...CORE_RESPONSE_STATE_PROVIDERS,
 		...alwaysOnResponseStateProviderNames(runtime),
@@ -4103,8 +4091,7 @@ export async function renderMessageHandlerStablePrefix(
 		state,
 		userRoles: [senderRole],
 		availableContexts,
-		extraProviderExclusions:
-			stage1ProviderExclusionsForMessage(syntheticMessage),
+		extraProviderExclusions: STAGE1_EXTRA_PROVIDER_EXCLUSIONS,
 	});
 	const rendered = renderContextObject(context);
 	const stableSegments = rendered.promptSegments.filter(
@@ -7023,7 +7010,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		...args,
 		userRoles: [senderRole],
 		availableContexts,
-		extraProviderExclusions: stage1ProviderExclusionsForMessage(args.message),
+		extraProviderExclusions: STAGE1_EXTRA_PROVIDER_EXCLUSIONS,
 	});
 	const stage1PreprocessStartedAt = performance.now();
 


### PR DESCRIPTION
## Problem

Live production incident from a 30-scenario battery: "whats todays date and time?" was answered **"sunday, july 20, 2026. 10:42 am."** — 11 days wrong, wrong weekday — while the runtime's system prompt explicitly promises a time signal is always present.

Root cause: Stage-1 excluded `CURRENT_TIME` behind a prose-regex that guessed whether the user's message was a time question (`isCurrentTimeQuestion`). Any phrasing the regex missed dropped the clock from context, and the model hallucinated a date with full confidence.

## Fix

The intent-guess regex and the `CURRENT_TIME` entry in `STAGE1_EXTRA_PROVIDER_EXCLUSIONS` are deleted. The time provider is pure synchronous formatting (sub-millisecond, ~60 tokens), so it now renders on **every** Stage-1/simple-path turn — matching the system-prompt contract and the planner path, which already always included it. The expensive `ENTITIES`/`DOCUMENTS` exclusions are retained; the provider budget/degrade machinery is untouched.

## Testing

- New tests pin the incident: the exact live phrasing (and a no-time-intent message) must render `# Current Time` into the model messages — **red on pre-fix code** (the removed regex rejects both phrasings).
- `stage1-provider-execution` 4/4, `message-runtime-stage1` 102/102, budget/purity/refresh regression suites 32/32, tsc clean.
- **Live re-probe post-fix on a production Discord bot**: same question → "saturday, august 1, 2026. 02:06 utc." — correct date, weekday, and time.

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend context-composition change; user-visible surface is Discord message text, quoted above and pinned in tests.
<!-- evidence-row:after-screenshots -->
- [x] N/A - see live re-probe under domain artifacts.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow; deterministic red-green tests attached.
<!-- evidence-row:llm-trajectory -->
- [x] Live production trajectory of the incident turn shows the rendered context missing the time block for the miss-phrasing; post-fix probes render it every turn. Contract pinned in [stage1-provider-execution.test.ts](https://github.com/elizaOS/eliza/blob/fix/stage1-current-time/packages/core/src/__tests__/stage1-provider-execution.test.ts) and [message-runtime-stage1.test.ts](https://github.com/elizaOS/eliza/blob/fix/stage1-current-time/packages/core/src/__tests__/message-runtime-stage1.test.ts).
<!-- evidence-row:backend-logs -->
- [x] <details><summary>live before/after</summary><pre>BEFORE: "whats todays date and time?" → "sunday, july 20, 2026. 10:42 am." (actual: friday, july 31)
AFTER:  same question → "saturday, august 1, 2026. 02:06 utc." (correct)</pre></details> Changed selection logic: [message.ts](https://github.com/elizaOS/eliza/blob/fix/stage1-current-time/packages/core/src/services/message.ts).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client in the changed path.
<!-- evidence-row:domain-artifacts -->
- [x] Production Discord re-probe transcript (2026-08-01 battery follow-up): correct date/weekday/time on the first try; the incident phrasing is pinned end-to-end in [message-runtime-stage1.test.ts](https://github.com/elizaOS/eliza/blob/fix/stage1-current-time/packages/core/src/__tests__/message-runtime-stage1.test.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
