### PR TITLE
fix(core): rename effectiveParallelism to providerSpanOverlap

### DIFF
--- a/packages/core/scripts/provider-latency-report.test.ts
+++ b/packages/core/scripts/provider-latency-report.test.ts
@@ -1,8 +1,9 @@
 /**
  * Process contract for the provider latency CLI against the real PGlite-backed
- * runtime, including full-provider execution, warm-cache coverage, and observed
- * parallelism. The sample count stays minimal because distribution quality is
- * established by the operator benchmark rather than this structural gate.
+ * runtime, including full-provider execution, warm-cache coverage, and
+ * provider-span overlap. The sample count stays minimal because distribution
+ * quality is established by the operator benchmark rather than this structural
+ * gate.
  */
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
@@ -19,7 +20,7 @@ interface ProviderLatencyReport {
 	}>;
 	execution: string;
 	reusedProviderResultsPerSample: { min: number; max: number };
-	effectiveParallelism: { count: number };
+	providerSpanOverlap: { count: number };
 	freshComposeWallMs: { count: number };
 	reusedComposeWallMs: { count: number };
 }
@@ -93,7 +94,7 @@ describe("provider latency report process", () => {
 		).toBe(true);
 		expect(report.freshComposeWallMs.count).toBe(report.samples);
 		expect(report.reusedComposeWallMs.count).toBe(report.samples);
-		expect(report.effectiveParallelism.count).toBe(report.samples);
+		expect(report.providerSpanOverlap.count).toBe(report.samples);
 		expect(report.execution).toContain("production turn context");
 		expect(report.reusedProviderResultsPerSample.min).toBe(
 			report.providerCount,

--- a/packages/core/scripts/provider-latency-report.ts
+++ b/packages/core/scripts/provider-latency-report.ts
@@ -5,7 +5,7 @@
  * Each sample composes a fresh message with the full provider inventory, then
  * repeats that composition inside the same production turn context. The report
  * separates first execution from reuse, ranks providers by p95, and includes
- * aggregate wall time and observed concurrency.
+ * aggregate wall time and provider-span overlap.
  */
 import { randomUUID } from "node:crypto";
 import { writeFile } from "node:fs/promises";
@@ -111,7 +111,7 @@ async function main(): Promise<void> {
 		const wallSamples: number[] = [];
 		const cachedWallSamples: number[] = [];
 		const cachedProviderCounts: number[] = [];
-		const concurrencySamples: number[] = [];
+		const spanOverlapSamples: number[] = [];
 		const iterations = warmupCount + sampleCount;
 
 		for (let iteration = 0; iteration < iterations; iteration += 1) {
@@ -169,7 +169,10 @@ async function main(): Promise<void> {
 				samplesByProvider.get(providerName)?.push(span.durationMs);
 				summedProviderMs += span.durationMs;
 			}
-			concurrencySamples.push(
+			// Summed span time over wall time measures how much provider spans
+			// overlap, not how many database calls actually executed concurrently:
+			// spans can overlap while their adapter reads still serialize.
+			spanOverlapSamples.push(
 				wallMs > 0 ? summedProviderMs / wallMs : summedProviderMs,
 			);
 		}
@@ -195,7 +198,7 @@ async function main(): Promise<void> {
 			freshComposeWallMs: distribution(wallSamples),
 			reusedComposeWallMs: distribution(cachedWallSamples),
 			reusedProviderResultsPerSample: distribution(cachedProviderCounts),
-			effectiveParallelism: distribution(concurrencySamples),
+			providerSpanOverlap: distribution(spanOverlapSamples),
 			providers,
 		};
 		const serialized = `${JSON.stringify(output, null, 2)}\n`;


### PR DESCRIPTION
# Relates to

Closes #17443 (residual scope). Items 1–4 of that issue's required repair — read-composition-scoped memoization, uncached mutation-path authorization, the real AgentRuntime + PGLite adversarial test, and rejected-memo/cross-turn coverage — already landed in merged PR #17453 (`7d1b321a2`), whose `Closes #17443` did not auto-close the issue. This PR completes the one outstanding item: renaming the `effectiveParallelism` metric, and attaches an independent re-run of the #17453 adversarial coverage as verification.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change renames one output field (`effectiveParallelism` → `providerSpanOverlap`) and one local variable in the operator benchmark CLI `packages/core/scripts/provider-latency-report.ts`, plus its process-contract test. Repo-wide search shows no other consumer of the field name. No runtime, provider, or authorization behavior changes.

# Background

## What does this PR do?

Completes the last required repair item of #17443: "Rename or redefine `effectiveParallelism`: the current metric is provider-span overlap and does not prove concurrent database execution."

The metric divides summed provider span time by composition wall time. Overlapping spans do not prove concurrently executing database reads — adapter calls can still serialize under overlapping spans — so the old name overclaimed what the benchmark measures. The field is now `providerSpanOverlap`, the sample variable is `spanOverlapSamples`, the file header says "provider-span overlap" instead of "observed concurrency", and a comment at the computation states exactly what the ratio does and does not prove.

## What kind of change is this?

Improvements (metric naming accuracy in an operator benchmark; non-breaking — the report JSON is written to an operator-chosen path and has no in-repo consumer of the renamed field).

# Documentation changes needed?

My changes do not require a change to the project documentation. The report field is documented by the script and its test, both updated here.

# Testing

## Where should a reviewer start?

`packages/core/scripts/provider-latency-report.test.ts` — the process-contract test spawns the real CLI against the real PGLite-backed runtime and asserts the report shape, including the renamed `providerSpanOverlap` distribution.

## Detailed testing steps

```bash
bun run --cwd packages/core test -- scripts/provider-latency-report.test.ts
bun run --cwd packages/core test -- src/features/documents/service-authorization.real.test.ts src/features/provider-io-concurrency.test.ts
bun run --cwd packages/core typecheck
bun run --cwd packages/core lint
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - operator benchmark CLI metric rename; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - operator benchmark CLI metric rename; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the change is a report field rename in a benchmark script.
<!-- evidence-row:backend-logs -->
- [x] Real CLI run output attached below: the process-contract test executes the actual script against a real PGLite runtime; the focused-test log is in Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed; the diff touches a benchmark script's output field name and comments only.
<!-- evidence-row:domain-artifacts -->
- [x] Generated report JSON excerpt attached below showing the `providerSpanOverlap` distribution emitted by the real run.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

Backend: focused vitest run of the process-contract test (spawns the real CLI, real PGLite runtime) plus the re-run of the #17443 adversarial authorization suites:

<details>
<summary>Focused test runs on exact head f45c536501ab14ef22f7ca8909995f341dc58269 (rebased on origin/develop, zero conflicts)</summary>

Process-contract test — spawns the real CLI twice (invalid-settings rejection + full run against the real PGLite-backed runtime):

```text
$ node ../scripts/run-vitest.mjs run scripts/provider-latency-report.test.ts

 RUN  v4.1.5 /Users/thescoho/Developer/eliza/packages/core

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  09:49:26
   Duration  2.78s (transform 21ms, setup 0ms, import 28ms, tests 2.66s, environment 0ms)
```

Independent re-run of the #17443 adversarial coverage that landed in #17453 — real AgentRuntime + PGLite (`VITEST_LANE=post-merge`):

```text
$ node ../scripts/run-vitest.mjs run src/features/documents/service-authorization.real.test.ts

 RUN  v4.1.5 /Users/thescoho/Developer/eliza/packages/core

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  09:49:27
   Duration  8.60s (transform 5.44s, setup 0ms, import 2.54s, tests 5.95s, environment 0ms)
```

Requester-coalescing unit coverage (rejected-memo eviction + cross-turn isolation among them):

```text
$ node ../scripts/run-vitest.mjs run src/features/documents/service-authorization.real.test.ts src/features/provider-io-concurrency.test.ts

 RUN  v4.1.5 /Users/thescoho/Developer/eliza/packages/core

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Duration  666ms
```

Gates:

```text
bun run --cwd packages/core typecheck   → passed (exit 0)
bun run --cwd packages/core lint        → passed (exit 0, 1,131 files)
biome check packages/core/scripts/provider-latency-report.ts
            packages/core/scripts/provider-latency-report.test.ts
                                        → Checked 2 files in 50ms. No fixes applied.
```

</details>

Domain artifact — a real CLI run on this head (`ELIZA_PROVIDER_LATENCY_SAMPLES=2`, `ELIZA_PROVIDER_LATENCY_WARMUPS=1`) emits the renamed distribution and no `effectiveParallelism` key:

<details>
<summary>report.json excerpt (24 providers, real AgentRuntime + plugin-sql/PGLite)</summary>

```json
{
  "runtime": "AgentRuntime + plugin-sql/PGLite",
  "execution": "all registered providers via parallel composeState in one production turn context per sample",
  "warmups": 1,
  "samples": 2,
  "providerCount": 24,
  "freshComposeWallMs": { "count": 2, "min": 10.176, "p50": 10.176, "p95": 11.466, "p99": 11.466, "max": 11.466, "mean": 10.821 },
  "reusedComposeWallMs": { "count": 2, "min": 0.101, "p50": 0.101, "p95": 0.275, "p99": 0.275, "max": 0.275, "mean": 0.188 },
  "providerSpanOverlap": { "count": 2, "min": 6.607, "p50": 6.607, "p95": 7.093, "p99": 7.093, "max": 7.093, "mean": 6.85 }
}
```

</details>

Frontend: N/A - no frontend path.

## Screenshots (before / after) + video walkthrough

N/A - benchmark CLI metric rename; no rendered surface.

## Audio / voice walkthrough

N/A - no voice path.

## Known gaps / failures

- Full workspace `bun run verify` was not run; the change is scoped to `packages/core/scripts/`, and the package gates above (core typecheck, core lint, direct Biome check on both changed files, focused vitest suites) all pass on the exact rebased head. Repo-wide search shows no other consumer of the renamed field.
- `bun install` on this machine required a follow-up `bun run --cwd packages/core prebuild` and `build` before the process-contract test could spawn the CLI (missing generated `validation-keyword-data.ts` and unbuilt `@elizaos/core` dist). Both are documented package setup steps, unrelated to this diff.

---

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->
