### PR TITLE
fix(ui): keep notification collapse fade symmetric

### DIFF
--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1930,7 +1930,16 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.getByText("Urgent mail").closest("li")).toBe(
       priorityRow.closest("li"),
     );
-    expect(quietGroup?.style.opacity).toBe("0");
+    // The shell stays mounted at full opacity so its rounded rim does not
+    // darken; the card information fades through the shared settle variable.
+    expect(quietGroup?.style.opacity).toBe("1");
+    expect(
+      Number.parseFloat(
+        quietGroup?.style.getPropertyValue(
+          "--eliza-notif-group-content-visibility",
+        ) ?? "1",
+      ),
+    ).toBeLessThan(1);
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("1");
     finishShadeCollapse();
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
@@ -1970,13 +1979,20 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(prioritySurface?.className).toContain("eliza-notif-glass");
     expect(prioritySurface?.style.opacity).toBe("1");
     expect(priorityGroupContent?.style.opacity).toBe("1");
+    expect(
+      Number.parseFloat(
+        priorityGroupContent?.style.getPropertyValue(
+          "--eliza-notif-group-content-visibility",
+        ) ?? "1",
+      ),
+    ).toBeLessThan(1);
     const overpullCountOpacity = Number.parseFloat(
       screen.getByTestId("notifications-count").style.opacity,
     );
     expect(overpullCountOpacity).toBe(0);
     const peeks = screen.getAllByTestId("notification-stack-peek");
-    expect(peeks[0].style.opacity).toBe("1");
-    expect(peeks[1].style.opacity).toBe("1");
+    expect(Number.parseFloat(peeks[0].style.opacity)).toBeLessThan(1);
+    expect(Number.parseFloat(peeks[1].style.opacity)).toBeLessThan(1);
 
     fireEvent.pointerUp(list, {
       pointerType: "mouse",
@@ -1986,6 +2002,37 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     });
     expect(list.getAttribute("data-shade-dragging")).toBeNull();
     expect(list.hasAttribute("data-shade-settling")).toBe(true);
+    expect(priorityGroupContent?.style.opacity).toBe("1");
+    expect(
+      priorityGroupContent?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ),
+    ).toBe("0");
+    const settledContentRule = list.parentElement
+      ?.querySelector("style")
+      ?.textContent?.match(
+        /\.eliza-notif-scroll\[data-shade-settling\][^{}]*\.eliza-notif-row-content\s*\{([^}]*)\}/,
+      )?.[1];
+    expect(settledContentRule).toContain("transition:");
+    expect(settledContentRule).toContain("opacity");
+    expect(settledContentRule).not.toContain(
+      "--eliza-notif-group-content-visibility",
+    );
+    const settledSurfaceRule = [
+      ...(list.parentElement
+        ?.querySelector("style")
+        ?.textContent?.matchAll(
+          /\.eliza-notif-scroll:is\(\[data-shade-dragging\], \[data-shade-settling\]\)[^{}]*\.eliza-notif-row-surface\s*\{([^}]*)\}/g,
+        ) ?? []),
+    ]
+      .map((match) => match[1])
+      .find((rule) => rule.includes("opacity:"));
+    expect(settledSurfaceRule).toContain("opacity:");
+    expect(settledSurfaceRule).toContain("!important");
+    expect(settledSurfaceRule).toContain("transition:");
+    expect(list.parentElement?.querySelector("style")?.textContent).toContain(
+      ".eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-surface",
+    );
     finishShadeCollapse();
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getByTestId("notification-row")).toBe(priorityRow);
@@ -2261,7 +2308,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     });
 
     expect(list.hasAttribute("data-shade-settling")).toBe(true);
-    expect(agentGroup?.style.opacity).toBe("0");
+    expect(agentGroup?.style.opacity).toBe("1");
     expect(
       agentGroup?.style.getPropertyValue(
         "--eliza-notif-group-content-visibility",
@@ -2379,8 +2426,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.getAllByTestId("notification-row")[0]).toBe(priorityRow);
     const peeks = screen.getAllByTestId("notification-stack-peek");
     expect(peeks).toHaveLength(2);
-    expect(peeks[0]?.style.opacity).toBe("1");
-    expect(peeks[1]?.style.opacity).toBe("1");
+    expect(peeks[0]?.style.opacity).toBe("0");
+    expect(peeks[1]?.style.opacity).toBe("0");
     for (const row of screen.getAllByTestId("notification-row").slice(1)) {
       const container = row.closest("[data-notif-row]") as HTMLElement;
       expect(container.style.opacity).toBe("0");

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2027,10 +2027,10 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     ]
       .map((match) => match[1])
       .find((rule) => rule.includes("opacity:"));
-    expect(settledSurfaceRule).toBeUndefined();
-    expect(
-      list.parentElement?.querySelector("style")?.textContent,
-    ).not.toContain(
+    expect(settledSurfaceRule).toContain("opacity:");
+    expect(settledSurfaceRule).toContain("!important");
+    expect(settledSurfaceRule).toContain("transition:");
+    expect(list.parentElement?.querySelector("style")?.textContent).toContain(
       ".eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-surface",
     );
     finishShadeCollapse();

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2027,10 +2027,10 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     ]
       .map((match) => match[1])
       .find((rule) => rule.includes("opacity:"));
-    expect(settledSurfaceRule).toContain("opacity:");
-    expect(settledSurfaceRule).toContain("!important");
-    expect(settledSurfaceRule).toContain("transition:");
-    expect(list.parentElement?.querySelector("style")?.textContent).toContain(
+    expect(settledSurfaceRule).toBeUndefined();
+    expect(
+      list.parentElement?.querySelector("style")?.textContent,
+    ).not.toContain(
       ".eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-surface",
     );
     finishShadeCollapse();

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -436,12 +436,15 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   background-color: rgb(28 28 30);
   background-image: none;
 }
-/* The card surface owns the group fade so its fill, copy, and rim move as one
-   physical object. A row-specific variable is reserved for disposable stack
-   rows; falling back to the group variable here would multiply the surface
-   fade and make direct manipulation feel nonlinear. */
+/* The content layer owns the group fade because it now carries both fill and
+   copy. The enclosing surface stays opaque so its specular rim does not dim
+   through inherited compositing. Disposable rows override the group value
+   with their already-combined row visibility. */
 .eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-content {
-  opacity: var(--eliza-notif-row-content-visibility, 1);
+  opacity: var(
+    --eliza-notif-row-content-visibility,
+    var(--eliza-notif-group-content-visibility, 1)
+  );
 }
 .eliza-notif-scroll[data-shade-dragging] [data-notification-group-content] .eliza-notif-row-content {
   transition: none;
@@ -452,26 +455,10 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   transition:
     opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING};
 }
-/* The row button owns the copy, but the glass surface is the visible card.
-   Fade that surface with the content during a close gesture; otherwise the
-   copy disappears into an opaque rounded shell and the card reads as solid.
-   The important override is deliberate because NotificationRow keeps its
-   gesture surface at inline opacity 1 while it owns horizontal dismissing. */
-.eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-surface {
-  opacity: var(--eliza-notif-group-content-visibility, 1) !important;
-  transition: opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING};
-}
-.eliza-notif-scroll[data-shade-dragging] [data-notification-group-content] .eliza-notif-row-surface {
-  transition: none;
-}
 /* A cancelled pull reverses the information fade on the same presentation
    clock while the unchanged glass shell stays in place. */
 [data-notification-shade-cancelling] .eliza-notif-row-content {
   opacity: 1;
-  transition: opacity var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms) ${SHADE_EASING};
-}
-[data-notification-shade-cancelling] .eliza-notif-row-surface {
-  opacity: 1 !important;
   transition: opacity var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms) ${SHADE_EASING};
 }
 /* Bulk clear keeps its right edge aligned with each producer's X. Touch-first

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -436,15 +436,12 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   background-color: rgb(28 28 30);
   background-image: none;
 }
-/* The content layer owns the group fade because it now carries both fill and
-   copy. The enclosing surface stays opaque so its specular rim does not dim
-   through inherited compositing. Disposable rows override the group value
-   with their already-combined row visibility. */
+/* The card surface owns the group fade so its fill, copy, and rim move as one
+   physical object. A row-specific variable is reserved for disposable stack
+   rows; falling back to the group variable here would multiply the surface
+   fade and make direct manipulation feel nonlinear. */
 .eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-content {
-  opacity: var(
-    --eliza-notif-row-content-visibility,
-    var(--eliza-notif-group-content-visibility, 1)
-  );
+  opacity: var(--eliza-notif-row-content-visibility, 1);
 }
 .eliza-notif-scroll[data-shade-dragging] [data-notification-group-content] .eliza-notif-row-content {
   transition: none;
@@ -455,10 +452,26 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   transition:
     opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING};
 }
+/* The row button owns the copy, but the glass surface is the visible card.
+   Fade that surface with the content during a close gesture; otherwise the
+   copy disappears into an opaque rounded shell and the card reads as solid.
+   The important override is deliberate because NotificationRow keeps its
+   gesture surface at inline opacity 1 while it owns horizontal dismissing. */
+.eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-surface {
+  opacity: var(--eliza-notif-group-content-visibility, 1) !important;
+  transition: opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING};
+}
+.eliza-notif-scroll[data-shade-dragging] [data-notification-group-content] .eliza-notif-row-surface {
+  transition: none;
+}
 /* A cancelled pull reverses the information fade on the same presentation
    clock while the unchanged glass shell stays in place. */
 [data-notification-shade-cancelling] .eliza-notif-row-content {
   opacity: 1;
+  transition: opacity var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms) ${SHADE_EASING};
+}
+[data-notification-shade-cancelling] .eliza-notif-row-surface {
+  opacity: 1 !important;
   transition: opacity var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms) ${SHADE_EASING};
 }
 /* Bulk clear keeps its right edge aligned with each producer's X. Touch-first

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -416,22 +416,62 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
 .eliza-notif-scroll[data-shade-dragging] .eliza-notif-count-transition {
   transition: none;
 }
-/* Direct manipulation keeps each glass card as one stable physical surface.
-   Only its information fades toward the committed resting projection; fading
-   an ancestor would dim the specular rim and make the border flicker. */
+/* Keep the rim on the gesture surface, but move its fill to the full-size
+   content layer. This is the demo-era layering that lets the card visibly
+   fade under the finger without changing the rim's material or brightness. */
+.eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) .eliza-notif-row-surface,
+[data-notification-shade-cancelling] .eliza-notif-row-surface {
+  background-color: transparent;
+  background-image: none;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+.eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) .eliza-notif-row-content,
+[data-notification-shade-cancelling] .eliza-notif-row-content {
+  background-color: rgb(22 22 25);
+  background-image: ${LIQUID_GLASS_SHEEN};
+}
+.eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) :is([data-notification-stack-material], [data-notification-stacked]) .eliza-notif-row-content,
+[data-notification-shade-cancelling] :is([data-notification-stack-material], [data-notification-stacked]) .eliza-notif-row-content {
+  background-color: rgb(28 28 30);
+  background-image: none;
+}
+/* The card surface owns the group fade so its fill, copy, and rim move as one
+   physical object. A row-specific variable is reserved for disposable stack
+   rows; falling back to the group variable here would multiply the surface
+   fade and make direct manipulation feel nonlinear. */
 .eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-content {
-  opacity: var(
-    --eliza-notif-row-content-visibility,
-    var(--eliza-notif-group-content-visibility, 1)
-  );
+  opacity: var(--eliza-notif-row-content-visibility, 1);
 }
 .eliza-notif-scroll[data-shade-dragging] [data-notification-group-content] .eliza-notif-row-content {
+  transition: none;
+}
+/* A committed pull keeps the surface and its geometry on one settle clock;
+   disposable stack rows may still use their row-specific visibility. */
+.eliza-notif-scroll[data-shade-settling] [data-notification-group-content] .eliza-notif-row-content {
+  transition:
+    opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING};
+}
+/* The row button owns the copy, but the glass surface is the visible card.
+   Fade that surface with the content during a close gesture; otherwise the
+   copy disappears into an opaque rounded shell and the card reads as solid.
+   The important override is deliberate because NotificationRow keeps its
+   gesture surface at inline opacity 1 while it owns horizontal dismissing. */
+.eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-surface {
+  opacity: var(--eliza-notif-group-content-visibility, 1) !important;
+  transition: opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING};
+}
+.eliza-notif-scroll[data-shade-dragging] [data-notification-group-content] .eliza-notif-row-surface {
   transition: none;
 }
 /* A cancelled pull reverses the information fade on the same presentation
    clock while the unchanged glass shell stays in place. */
 [data-notification-shade-cancelling] .eliza-notif-row-content {
   opacity: 1;
+  transition: opacity var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms) ${SHADE_EASING};
+}
+[data-notification-shade-cancelling] .eliza-notif-row-surface {
+  opacity: 1 !important;
   transition: opacity var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms) ${SHADE_EASING};
 }
 /* Bulk clear keeps its right edge aligned with each producer's X. Touch-first
@@ -2844,9 +2884,11 @@ export function NotificationsHomeCenter({
             shadeExpanded,
             shadeClosing,
           );
+          const preservingCardMaterial =
+            shadeExpanded && (pullDirection === "collapse" || shadeClosing);
           const groupContentVisibility = pullRevealed
             ? revealProgress
-            : groupWasRested
+            : groupWasRested && !preservingCardMaterial
               ? 1
               : groupVisibility;
           // A card follows the finger as one physical surface. Fading its
@@ -2854,10 +2896,9 @@ export function NotificationsHomeCenter({
           // which makes the outline flicker between bright and dull while the
           // user reverses a swipe. The committed/cancelled settle may fade the
           // group after release; the in-hand material stays visually stable.
-          const groupPresentationVisibility =
-            shadeExpanded && pullDirection === "collapse"
-              ? 1
-              : groupContentVisibility;
+          const groupPresentationVisibility = preservingCardMaterial
+            ? 1
+            : groupContentVisibility;
           const groupContentPullOffset = pullRevealed
             ? (1 - revealProgress) * -8
             : groupWasRested
@@ -2923,14 +2964,21 @@ export function NotificationsHomeCenter({
             : groupWasRested
               ? "static"
               : "disposable";
-          const stackPeekVisibility = fanned
-            ? Math.max(
-                groupWasRested ? shadeCloseProgress : 0,
-                1 - stackFanProgress,
-              )
-            : stackPeekMode === "disposable"
+          // A rested stack peek is still a physical card in the expanded
+          // shade. Keep it in the same collapse crossfade as the front card;
+          // promoting it to full opacity at pointer-up made one card appear
+          // stuck while every other surface faded away.
+          const stackPeekVisibility =
+            pullDirection === "collapse" || shadeClosing
               ? pullContentVisibility
-              : 1;
+              : fanned
+                ? Math.max(
+                    groupWasRested ? shadeCloseProgress : 0,
+                    1 - stackFanProgress,
+                  )
+                : stackPeekMode === "disposable"
+                  ? pullContentVisibility
+                  : 1;
           const stackPeekExpansionProgress = fanned
             ? Math.min(stackFanProgress, 1 - shadeCloseProgress)
             : 0;

--- a/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
@@ -531,12 +531,10 @@ for (const [name, width, height] of [
     };
   });
   check(
-    "direct collapse fades every visible glass surface while keeping one rim material",
+    "direct collapse fades every visible card fill while keeping its glass shell and rim opaque",
     directCollapseFrame.groupOpacities.length > 0 &&
       directCollapseFrame.groupOpacities.every((opacity) => opacity === 1) &&
-      directCollapseFrame.surfaceOpacities.some(
-        (opacity) => opacity > 0 && opacity < 1,
-      ) &&
+      directCollapseFrame.surfaceOpacities.every((opacity) => opacity === 1) &&
       directCollapseFrame.rimOpacities.every((opacity) => opacity === 1),
     JSON.stringify(directCollapseFrame),
   );

--- a/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
@@ -531,10 +531,12 @@ for (const [name, width, height] of [
     };
   });
   check(
-    "direct collapse fades every visible card fill while keeping its glass shell and rim opaque",
+    "direct collapse fades every visible glass surface while keeping one rim material",
     directCollapseFrame.groupOpacities.length > 0 &&
       directCollapseFrame.groupOpacities.every((opacity) => opacity === 1) &&
-      directCollapseFrame.surfaceOpacities.every((opacity) => opacity === 1) &&
+      directCollapseFrame.surfaceOpacities.some(
+        (opacity) => opacity > 0 && opacity < 1,
+      ) &&
       directCollapseFrame.rimOpacities.every((opacity) => opacity === 1),
     JSON.stringify(directCollapseFrame),
   );

--- a/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
@@ -531,10 +531,12 @@ for (const [name, width, height] of [
     };
   });
   check(
-    "direct collapse keeps every visible glass card and rim fully opaque",
+    "direct collapse fades every visible glass surface while keeping one rim material",
     directCollapseFrame.groupOpacities.length > 0 &&
       directCollapseFrame.groupOpacities.every((opacity) => opacity === 1) &&
-      directCollapseFrame.surfaceOpacities.every((opacity) => opacity === 1) &&
+      directCollapseFrame.surfaceOpacities.some(
+        (opacity) => opacity > 0 && opacity < 1,
+      ) &&
       directCollapseFrame.rimOpacities.every((opacity) => opacity === 1),
     JSON.stringify(directCollapseFrame),
   );

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -267,8 +267,18 @@ export function applyNotificationPullPresentation(
     const content = group.querySelector<HTMLElement>(
       ":scope > [data-notification-group-content]",
     );
-    const contentVisibility = pullRevealed || !rested ? groupVisibility : 1;
-    const preservesCardMaterial = shadeExpanded && pullPx < 0 && !shadeClosing;
+    const preservesCardMaterialDuringDrag =
+      shadeExpanded && pullPx < 0 && !shadeClosing;
+    // A committed close must keep every visible card's shell in place while
+    // its information fades on the shared settle clock. The DOM does not
+    // reliably mark every currently visible group as rested (notably after a
+    // direct Collapse click), so basing this on `rested` leaves those cards to
+    // disappear as whole ancestors instead of fading their contents.
+    const preservesCommittedCloseMaterial = shadeExpanded && shadeClosing;
+    const preservesCardMaterial =
+      preservesCardMaterialDuringDrag || preservesCommittedCloseMaterial;
+    const contentVisibility =
+      pullRevealed || !rested || preservesCardMaterial ? groupVisibility : 1;
     if (content) {
       const contentPullOffset = pullRevealed
         ? (1 - groupVisibility) * -8
@@ -322,9 +332,11 @@ export function applyNotificationPullPresentation(
       "[data-notification-disposable-row]",
     )) {
       row.style.opacity = String(
-        preservesCardMaterial ? 1 : presentation.disposableContentVisibility,
+        preservesCardMaterialDuringDrag
+          ? 1
+          : presentation.disposableContentVisibility,
       );
-      if (preservesCardMaterial) {
+      if (preservesCardMaterialDuringDrag) {
         row.style.setProperty(
           "--eliza-notif-row-content-visibility",
           String(contentVisibility * presentation.disposableContentVisibility),
@@ -345,11 +357,11 @@ export function applyNotificationPullPresentation(
           : mode === "disposable"
             ? presentation.pullContentVisibility
             : 1;
-      peek.style.opacity = String(
-        preservesCardMaterial && mode === "disposable"
-          ? baseOpacity
-          : baseOpacity * visibility,
-      );
+      const collapseVisibility =
+        preservesCardMaterial && (mode === "static" || mode === "close")
+          ? presentation.pullContentVisibility
+          : visibility;
+      peek.style.opacity = String(baseOpacity * collapseVisibility);
     }
   }
 }


### PR DESCRIPTION
# Relates to

Closes #17328.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      root-audit blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Based directly on current `origin/develop@4deff40c3dba6465b571d6488ec2006812a9a25a`; zero conflicts and one scoped commit ahead.
- [x] `bun run verify` completed all 579/579 typecheck/lint tasks, then stopped
      on the unrelated current-develop orphan-script findings listed below.

# Risks

Low. This changes only notification-shade presentation math, its focused tests,
and the deterministic browser capture. It does not change notification data,
dismissal semantics, APIs, persistence, routing, authentication, or deployment.

# Background

## What does this PR do?

Makes notification-card material fade symmetrically while the shade collapses.
The existing content fade remains intact, while each card surface now follows the
same per-row collapse progress instead of snapping from fully lit to dark. The
rim stays stable during direct collapse and re-grab so the stack does not flicker.

The regression coverage exercises direct collapse, cancel/re-grab, fold/unfold,
stack swipe, and explicit collapse at desktop and mobile viewports.

## What kind of change is this?

Bug fix (non-breaking UI presentation fix).

# Documentation changes needed?

No product documentation change is required; behavior is demonstrated by the
inline visual evidence and encoded by focused tests.

# Testing

## Where should a reviewer start?

Start with `notification-shade-presentation.ts`, then review the focused
expectations in `NotificationsHomeCenter.test.tsx` and the desktop/mobile capture.

## Detailed testing steps

1. Open Home with the notification stack expanded.
2. Drag upward far enough to enter direct collapse.
3. Verify the card material, glow, and text fade together without a dark snap.
4. Reverse/re-grab the gesture and verify the rim stays stable with no flash.
5. Repeat at desktop and mobile widths.

Automated proof:

- `bun run --cwd packages/ui test -- src/components/shell/NotificationsHomeCenter.test.tsx src/components/shell/NotificationsHomeCenter.render-count.test.tsx` — 102/102 passed.
- `bun run --cwd packages/ui typecheck` — passed.
- `bun run --cwd packages/ui lint:check` — 2,796 files checked, passed.
- `bun run audit:ui-determinism` — passed.
- `bun packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs` — desktop and mobile gesture matrix passed with zero page errors.
- `ELIZA_MVP_OCR_ENGINE=packaged bun run --cwd packages/app audit:ocr` — 252 views, 96 verified, 0 broken.
- `git diff --check origin/develop...HEAD` — passed.
- Direct diff error-policy audit — no added empty catch or server `console.*`; this base does not expose `audit:error-policy-ratchet`.
- `bun run verify` — 579/579 typecheck/lint tasks passed; the later root
  `audit:scripts` step stopped on five unrelated orphan-script findings.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/17518-notification-collapse-before-contact-sheet.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/17518-notification-collapse-after-contact-sheet.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/17518-notification-collapse-before-after-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - presentation-only browser gesture; no backend code path changes
<!-- evidence-row:frontend-logs -->
- [x] [17518-notification-collapse-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/17518-notification-collapse-frontend.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain state changes

# Evidence Details

## Real LLM-call trajectory

N/A — no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

Backend: N/A — presentation-only browser gesture; no backend code path changes.

Frontend: attached above. The deterministic desktop/mobile capture reports zero
page errors and loopback-only network traffic.

## Screenshots (before / after) + video walkthrough

The before and after contact sheets include desktop and mobile direct-collapse
frames. The MP4 walks the complete before/after sequence at both viewports.

## Audio / voice walkthrough

N/A — no voice, transcript, TTS, STT, or omnivoice behavior changes.

## Known gaps / failures

`bun run --cwd packages/app audit:app` captured all app views, but the computed
report retains two unrelated baseline `needs-work` findings for mobile Views and
Rolodex overlay clearance. This four-file patch does not touch either surface or
shared layout; the notification-specific desktop/mobile capture and OCR proof are
green. There are no known notification-collapse gaps.

Root `bun run verify` reached 579/579 successful typecheck/lint tasks, then the
current-develop `audit:scripts` gate failed on five untouched orphan test scripts:
`ci-workflow-invariants.test.mjs`, `develop-pr-aggregate.test.mjs`,
`local-inference-attest.test.mjs`, `local-inference-performance-check.test.mjs`,
and `script-test-isolation.test.mjs`. This PR changes none of those files or their
callers. The scoped UI typecheck, Biome, diff, error-policy, determinism, browser,
and OCR gates all pass.

<!-- evidence-row:ocr-review -->
- [x] [17518-notification-collapse-ocr-visual-review.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/17518-notification-collapse-ocr-visual-review.md)

