### PR TITLE
fix(scripts): use pathToFileURL for Windows-safe CLI entrypoint check

### DIFF
--- a/packages/scripts/ci-windows-command-coverage-contract.mjs
+++ b/packages/scripts/ci-windows-command-coverage-contract.mjs
@@ -23,7 +23,7 @@
  */
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const DEFAULT_REPO_ROOT = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -153,13 +153,17 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
   return { commandCount: present.length, inventoryCount: inventory.length };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
   try {
     const { commandCount, inventoryCount } = runContract();
     console.log(
       `ci windows command coverage contract passed ` +
         `(${commandCount} lane command(s); ${inventoryCount} inventoried command(s) all present)`,
     );
+    process.exitCode = 0;
   } catch (error) {
     console.error(
       `[ci-windows-command-coverage-contract] FAIL ${error.message}`,
@@ -167,3 +171,5 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     process.exit(1);
   }
 }
+
+


### PR DESCRIPTION
# Relates to

Windows CI regression: importing the command-coverage contract under Bun could be misclassified as direct execution because a hand-built `file://` URL did not match Windows drive-letter paths.

# Sync with develop

- [x] Targets `develop` and includes current `develop` at exact head `7c186c1bc18937601c8f5ebd96e6e414837ec0c7`.
- [x] Merge state is clean.

# Risks

Low. One CLI entrypoint guard changes from manual URL concatenation to Node’s platform-aware `pathToFileURL(resolve(...))`; exported contract behavior is unchanged.

# Background

On Windows, `import.meta.url` is a normalized `file:///C:/...` URL while ``file://${process.argv[1]}`` contains backslashes and the wrong slash count. The old guard therefore ran the CLI body during test imports. The replacement uses Node’s URL conversion and handles a missing argv entry.

# Testing

- `bun test --config=/dev/null packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts` — 6/6 pass.
- Direct Node and Bun invocations produce the expected success line.
- The Windows CI lane is the platform proof for drive-letter semantics.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - command-line script only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - command-line script only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] The contract test/direct invocation output is the executable proof surface; no backend service is involved.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, provider, prompt, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent artifact is produced.

# Known gaps / failures

None.