### PR TITLE
test(app-control): align owner denial copy

### DIFF
--- a/plugins/plugin-app-control/src/actions/app.test.ts
+++ b/plugins/plugin-app-control/src/actions/app.test.ts
@@ -40,7 +40,7 @@ describe("APP action role policy", () => {
 		expect(result).toEqual(
 			expect.objectContaining({
 				success: false,
-				text: expect.stringContaining("only the owner"),
+				text: expect.stringContaining("only my owner"),
 			}),
 		);
 		expect(client.listInstalledApps).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Align the APP owner-gate test with the deterministic production denial copy introduced by #17478.

The current Windows plugins lane fails because the handler returns `Sorry - only my owner can manage apps.` while the test still searches for `only the owner`. The gate behavior itself is correct: the result is unsuccessful and no app-control client request is made.

Failure evidence: https://github.com/elizaOS/eliza/actions/runs/30688453745/job/91338745983

## Verification

- exact failing Windows run: 1 failed, 1618 passed, 6 skipped; this assertion is the sole failure
- identical failure reproduced on four consecutive develop SHAs beginning with the copy change
- `git diff --check`: passed
- full plugin test and Windows rerun: pending GitHub checks on this exact head

## Evidence

- Backend logs: linked Windows job above
- Frontend console/network logs: N/A - test-only copy alignment
- Screenshots/video: N/A - no production UI change
- Real-LLM trajectories: N/A - no agent runtime behavior change
- Domain artifacts: N/A - no application data mutation
