### PR TITLE
fix(ci): use runtime-native Windows contract entrypoint

### DIFF
--- a/packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts
+++ b/packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts
@@ -2,14 +2,15 @@
  * Pins the Windows command-coverage contract (#13402) against synthetic
  * workflow and inventory trees. Dropping an inventoried command from the matrix
  * throws (RED), keeping all present passes (GREEN), adding a new command is
- * allowed, and the shipped repo satisfies its own inventory. Static only: no
- * workflow is executed.
+ * allowed, and the shipped repo satisfies its own inventory. Subprocess checks
+ * also pin direct-versus-imported entrypoint behavior in both supported runtimes.
  */
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const {
   parseWindowsCommands,
@@ -21,6 +22,16 @@ const {
 );
 
 const REAL_REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const CONTRACT_SCRIPT = fileURLToPath(
+  new URL("../ci-windows-command-coverage-contract.mjs", import.meta.url),
+);
+
+function runRuntime(command: string, args: string[]) {
+  return spawnSync(command, args, {
+    cwd: REAL_REPO_ROOT,
+    encoding: "utf8",
+  });
+}
 
 // Two lanes with two commands each is enough to exercise both the multi-lane
 // flatten and the per-lane list boundary. Indentation matches windows-ci.yml
@@ -161,4 +172,31 @@ describe("ci-windows-command-coverage-contract", () => {
     expect(result.inventoryCount).toBeGreaterThan(0);
     expect(result.commandCount).toBeGreaterThanOrEqual(result.inventoryCount);
   });
+
+  for (const [runtime, command] of [
+    ["Node", "node"],
+    ["Bun", process.execPath],
+  ] as const) {
+    test(`${runtime}: direct invocation executes the contract`, () => {
+      const result = runRuntime(command, [CONTRACT_SCRIPT]);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toContain(
+        "ci windows command coverage contract passed",
+      );
+    });
+
+    test(`${runtime}: importing the module does not execute the contract`, () => {
+      const moduleUrl = pathToFileURL(CONTRACT_SCRIPT).href;
+      const result = runRuntime(command, [
+        "--eval",
+        `await import(${JSON.stringify(moduleUrl)}); console.log("imported-only")`,
+      ]);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout.trim()).toBe("imported-only");
+    });
+  }
 });

--- a/packages/scripts/ci-windows-command-coverage-contract.mjs
+++ b/packages/scripts/ci-windows-command-coverage-contract.mjs
@@ -153,7 +153,7 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
   return { commandCount: present.length, inventoryCount: inventory.length };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.main) {
   try {
     const { commandCount, inventoryCount } = runContract();
     console.log(


### PR DESCRIPTION
Supersedes #17522 with a runtime-native entrypoint check and executable regression coverage.

## What changed

- uses `import.meta.main`, supported by the repository's Node 24 and Bun runtimes, instead of reconstructing and comparing filesystem URLs
- verifies direct invocation executes the Windows command-coverage contract under Node and Bun
- verifies importing the module stays side-effect free under Node and Bun
- preserves any pre-existing nonzero process exit state instead of assigning `process.exitCode = 0`

This avoids platform-specific drive-letter, slash, URL-encoding, casing, and symlink behavior entirely.

## Verification

Exact head: `deab263861d281d8ecdf410512b969425a6d1d9a`

- `bun test packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts`: 10 passed, 0 failed
- `bunx biome check --write --config-path biome.json` on both changed files: passed
- `git diff --check origin/develop...HEAD`: passed

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI contract and tests only; no rendered surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI contract and tests only; no rendered surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no production user flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend process or transport changes; focused subprocess test output is summarized above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - frontend runtime source and networking do not change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, model, action, provider, or evaluator behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no application data or generated artifacts change.
