### PR TITLE
test(ci): validate fork quality exact head 17523

### DIFF
--- a/.github/actions/cloud-setup-test-env/action.yml
+++ b/.github/actions/cloud-setup-test-env/action.yml
@@ -40,6 +40,8 @@ runs:
         node-version: "22"
 
     - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      env:
+        HOME: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
       with:
         bun-version: ${{ inputs.bun-version }}
 

--- a/.github/actions/cloud-setup-test-env/action.yml
+++ b/.github/actions/cloud-setup-test-env/action.yml
@@ -41,7 +41,8 @@ runs:
 
     - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       env:
-        HOME: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
+        HOME: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index || 0 }}
+        USERPROFILE: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index || 0 }}
       with:
         bun-version: ${{ inputs.bun-version }}
 

--- a/.github/actions/cloud-setup-test-env/action.yml
+++ b/.github/actions/cloud-setup-test-env/action.yml
@@ -45,6 +45,7 @@ runs:
         USERPROFILE: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index || 0 }}
       with:
         bun-version: ${{ inputs.bun-version }}
+        no-cache: true
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -299,11 +299,12 @@ runs:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       env:
-        # setup-bun installs via os.homedir(), so a per-job HOME prevents
-        # concurrent executable replacement on the shared ~/.bun/bin/bun.
+        # setup-bun installs via os.homedir(), so per-matrix homes prevent
+        # concurrent executable replacement on a shared runner.
         # runner.name is human-readable and may contain spaces, which setup-bun's
-        # executable probe cannot safely consume as part of HOME.
-        HOME: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
+        # executable probe cannot safely consume as part of the home path.
+        HOME: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index || 0 }}
+        USERPROFILE: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index || 0 }}
       with:
         bun-version: ${{ inputs.bun-version }}
 

--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -307,6 +307,7 @@ runs:
         USERPROFILE: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index || 0 }}
       with:
         bun-version: ${{ inputs.bun-version }}
+        no-cache: true
 
     - name: Cache Bun install
       # Cache the Bun install store on every OS, Linux included (#12338). Long

--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -298,6 +298,12 @@ runs:
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
+      env:
+        # setup-bun installs via os.homedir(), so a per-job HOME prevents
+        # concurrent executable replacement on the shared ~/.bun/bin/bun.
+        # runner.name is human-readable and may contain spaces, which setup-bun's
+        # executable probe cannot safely consume as part of HOME.
+        HOME: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
       with:
         bun-version: ${{ inputs.bun-version }}
 

--- a/.github/workflows/quality-fork.yml
+++ b/.github/workflows/quality-fork.yml
@@ -10,7 +10,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: quality-fork-${{ github.ref }}
+  # PR metadata changes may enqueue a skipped pull_request run while a manual
+  # exact-head proof is waiting. Event-scoped groups keep that skipped run from
+  # cancelling the manual proof before a hosted runner is assigned.
+  group: quality-fork-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -236,7 +239,8 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         env:
-          HOME: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
+          HOME: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index || 0 }}
+          USERPROFILE: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index || 0 }}
         with:
           bun-version: ${{ env.BUN_VERSION }}
 

--- a/.github/workflows/quality-fork.yml
+++ b/.github/workflows/quality-fork.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUN_VERSION: "canary"
+  BUN_VERSION: "1.4.0"
   NODE_VERSION: "24.15.0"
 
 # Default to least privilege. Override per-job where needed.
@@ -25,7 +25,7 @@ jobs:
   lint:
     name: Lint
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ubuntu-24.04
     # Fresh Turbo-cold attempt 5 was still linting successfully when the old
     # 10m ceiling canceled it at 10m26s. Allow a finite 15m cold window; attempt
     # 4 completed the same lane in 8m30s.
@@ -91,7 +91,7 @@ jobs:
   typecheck:
     name: Type Check
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ubuntu-24.04
     # Fresh attempt #16657 measured 4m15s of setup (including a wasteful 2m50s
     # stale 1.6 GiB Bun-cache fallback restore) plus 13m28s of still-running
     # full-graph typecheck. Skip that stale restore below and retain a finite
@@ -133,7 +133,7 @@ jobs:
   build:
     name: Build
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ubuntu-24.04
     # A cold workspace build alone has taken 13m and the two-worker homepage
     # suite 25m38s total; the old 32m ceiling cancelled real runs mid-suite
     # whenever both were cold (observed on #17157 and #17256). 45m covers the
@@ -221,7 +221,7 @@ jobs:
   elizaos-cli-global-smoke:
     name: elizaos CLI global-install smoke (#8000)
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -235,6 +235,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        env:
+          HOME: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
         with:
           bun-version: ${{ env.BUN_VERSION }}
 

--- a/.github/workflows/quality-fork.yml
+++ b/.github/workflows/quality-fork.yml
@@ -243,6 +243,7 @@ jobs:
           USERPROFILE: ${{ runner.temp }}/bun-home-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index || 0 }}
         with:
           bun-version: ${{ env.BUN_VERSION }}
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --ignore-scripts --no-frozen-lockfile

--- a/.github/workflows/quality-fork.yml
+++ b/.github/workflows/quality-fork.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUN_VERSION: "1.4.0"
+  BUN_VERSION: "1.3.14"
   NODE_VERSION: "24.15.0"
 
 # Default to least privilege. Override per-job where needed.

--- a/packages/scripts/__tests__/ci-turbo-cache-contract.test.ts
+++ b/packages/scripts/__tests__/ci-turbo-cache-contract.test.ts
@@ -20,6 +20,9 @@ const { runContract } = await import(
 );
 
 const REAL_REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const CI_BUN_VERSION = JSON.parse(
+  readFileSync(join(REAL_REPO_ROOT, ".github", "ci-bun-version.json"), "utf8"),
+).version;
 
 const SHIM_YAML = `name: "GitHub-native Turbo cache"
 description: "test shim"
@@ -54,7 +57,7 @@ runs:
       env:
         HOME: \${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}
       with:
-        bun-version: 1.4.0
+        bun-version: 1.3.14
 `;
 
 const CLEAN_ADOPTER = `name: Clean adopter
@@ -242,7 +245,7 @@ describe("ci-turbo-cache-contract", () => {
       expect(lintJob).toContain(command);
     }
     expect(lintJob).not.toMatch(/continue-on-error/);
-    expect(workflow).toMatch(/BUN_VERSION:\s*["']1\.4\.0["']/);
+    expect(workflow).toContain(`BUN_VERSION: "${CI_BUN_VERSION}"`);
     expect(workflow).toMatch(
       /name:\s*Setup Bun[\s\S]*?HOME:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}\s*[\r\n]+/,
     );

--- a/packages/scripts/__tests__/ci-turbo-cache-contract.test.ts
+++ b/packages/scripts/__tests__/ci-turbo-cache-contract.test.ts
@@ -59,6 +59,7 @@ runs:
         USERPROFILE: \${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}-\${{ strategy.job-index || 0 }}
       with:
         bun-version: 1.3.14
+        no-cache: true
 `;
 
 const CLEAN_ADOPTER = `name: Clean adopter
@@ -220,7 +221,7 @@ describe("ci-turbo-cache-contract", () => {
     const root = buildRepo({ workspaceSetup: unsafeHomeSetup });
     try {
       expect(() => runContract(root)).toThrow(
-        /without space-bearing runner metadata/,
+        /space-bearing runner metadata/,
       );
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -236,6 +237,21 @@ describe("ci-turbo-cache-contract", () => {
     try {
       expect(() => runContract(root)).toThrow(
         /setup-bun home must be isolated by run, attempt, job, matrix entry, and OS/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails when setup-bun caches an ephemeral executable path", () => {
+    const cachedEphemeralHomeSetup = WORKSPACE_SETUP_YAML.replace(
+      "        no-cache: true\n",
+      "",
+    );
+    const root = buildRepo({ workspaceSetup: cachedEphemeralHomeSetup });
+    try {
+      expect(() => runContract(root)).toThrow(
+        /without caching the ephemeral executable path/,
       );
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/packages/scripts/__tests__/ci-turbo-cache-contract.test.ts
+++ b/packages/scripts/__tests__/ci-turbo-cache-contract.test.ts
@@ -49,6 +49,12 @@ runs:
         restore-keys: |
           turbo-\${{ runner.os }}-\${{ steps.turbo-key.outputs.turbo_cache_key }}-
           turbo-\${{ runner.os }}-
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      env:
+        HOME: \${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}
+      with:
+        bun-version: 1.4.0
 `;
 
 const CLEAN_ADOPTER = `name: Clean adopter
@@ -187,6 +193,36 @@ describe("ci-turbo-cache-contract", () => {
     }
   });
 
+  test("fails when setup-bun shares a host HOME across concurrent jobs", () => {
+    const sharedHomeSetup = WORKSPACE_SETUP_YAML.replace(
+      / {6}env:\n {8}HOME:.*\n/,
+      "",
+    );
+    const root = buildRepo({ workspaceSetup: sharedHomeSetup });
+    try {
+      expect(() => runContract(root)).toThrow(
+        /setup-bun HOME must be isolated by run, attempt, and job/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails when setup-bun HOME includes human-readable runner metadata", () => {
+    const unsafeHomeSetup = WORKSPACE_SETUP_YAML.replace(
+      `HOME: \${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}\n`,
+      `HOME: \${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}-\${{ runner.name }}\n`,
+    );
+    const root = buildRepo({ workspaceSetup: unsafeHomeSetup });
+    try {
+      expect(() => runContract(root)).toThrow(
+        /without space-bearing runner metadata/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("the fork lint lane keeps required gates with a bounded cold allowance", () => {
     const workflow = readFileSync(
       join(REAL_REPO_ROOT, ".github", "workflows", "quality-fork.yml"),
@@ -206,6 +242,10 @@ describe("ci-turbo-cache-contract", () => {
       expect(lintJob).toContain(command);
     }
     expect(lintJob).not.toMatch(/continue-on-error/);
+    expect(workflow).toMatch(/BUN_VERSION:\s*["']1\.4\.0["']/);
+    expect(workflow).toMatch(
+      /name:\s*Setup Bun[\s\S]*?HOME:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}\s*[\r\n]+/,
+    );
   });
 
   test("the fork typecheck keeps full coverage with a bounded cold-cache allowance", () => {
@@ -237,7 +277,7 @@ describe("ci-turbo-cache-contract", () => {
     )?.[0];
     expect(typecheckJob).toMatch(/cache-bun-install:\s*["']false["']/);
     expect(buildJob).toMatch(/cache-bun-install:\s*["']false["']/);
-    expect(buildJob).toMatch(/timeout-minutes:\s*32/);
+    expect(buildJob).toMatch(/timeout-minutes:\s*45/);
     expect(buildJob).toMatch(/run:\s*bun run build/);
     expect(buildJob).toMatch(/run:\s*bun run test:e2e --workers=2/);
     expect(buildJob).not.toMatch(/continue-on-error|\|\| true/);

--- a/packages/scripts/__tests__/ci-turbo-cache-contract.test.ts
+++ b/packages/scripts/__tests__/ci-turbo-cache-contract.test.ts
@@ -55,7 +55,8 @@ runs:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       env:
-        HOME: \${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}
+        HOME: \${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}-\${{ strategy.job-index || 0 }}
+        USERPROFILE: \${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}-\${{ strategy.job-index || 0 }}
       with:
         bun-version: 1.3.14
 `;
@@ -198,13 +199,13 @@ describe("ci-turbo-cache-contract", () => {
 
   test("fails when setup-bun shares a host HOME across concurrent jobs", () => {
     const sharedHomeSetup = WORKSPACE_SETUP_YAML.replace(
-      / {6}env:\n {8}HOME:.*\n/,
+      / {8}USERPROFILE:.*\n/,
       "",
     );
     const root = buildRepo({ workspaceSetup: sharedHomeSetup });
     try {
       expect(() => runContract(root)).toThrow(
-        /setup-bun HOME must be isolated by run, attempt, and job/,
+        /setup-bun home must be isolated by run, attempt, job, matrix entry, and OS/,
       );
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -213,13 +214,28 @@ describe("ci-turbo-cache-contract", () => {
 
   test("fails when setup-bun HOME includes human-readable runner metadata", () => {
     const unsafeHomeSetup = WORKSPACE_SETUP_YAML.replace(
-      `HOME: \${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}\n`,
-      `HOME: \${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}-\${{ runner.name }}\n`,
+      `\${{ strategy.job-index || 0 }}`,
+      `\${{ runner.name }}`,
     );
     const root = buildRepo({ workspaceSetup: unsafeHomeSetup });
     try {
       expect(() => runContract(root)).toThrow(
         /without space-bearing runner metadata/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails when setup-bun shares a home across matrix entries", () => {
+    const sharedMatrixHomeSetup = WORKSPACE_SETUP_YAML.replaceAll(
+      `-\${{ strategy.job-index || 0 }}`,
+      "",
+    );
+    const root = buildRepo({ workspaceSetup: sharedMatrixHomeSetup });
+    try {
+      expect(() => runContract(root)).toThrow(
+        /setup-bun home must be isolated by run, attempt, job, matrix entry, and OS/,
       );
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -247,7 +263,7 @@ describe("ci-turbo-cache-contract", () => {
     expect(lintJob).not.toMatch(/continue-on-error/);
     expect(workflow).toContain(`BUN_VERSION: "${CI_BUN_VERSION}"`);
     expect(workflow).toMatch(
-      /name:\s*Setup Bun[\s\S]*?HOME:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}\s*[\r\n]+/,
+      /name:\s*Setup Bun[\s\S]*?HOME:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}-\$\{\{\s*strategy\.job-index\s*\|\|\s*0\s*\}\}\s*[\r\n]+[\s\S]*?USERPROFILE:/,
     );
   });
 

--- a/packages/scripts/ci-turbo-cache-contract.mjs
+++ b/packages/scripts/ci-turbo-cache-contract.mjs
@@ -114,6 +114,12 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
     ),
     `${SETUP_WORKSPACE_PATH}: must retain the deterministic cross-lane restore prefix`,
   );
+  assert(
+    /name:\s*Setup Bun[\s\S]*?HOME:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}\s*[\r\n]+[\s\S]*?bun-version:/.test(
+      workspaceSetup,
+    ),
+    `${SETUP_WORKSPACE_PATH}: setup-bun HOME must be isolated by run, attempt, and job without space-bearing runner metadata`,
+  );
 
   // --- Invariant 2: no adopting workflow also wires the SaaS remote cache. ---
   const workflowFiles = readdirSync(resolve(repoRoot, WORKFLOW_DIR)).filter(

--- a/packages/scripts/ci-turbo-cache-contract.mjs
+++ b/packages/scripts/ci-turbo-cache-contract.mjs
@@ -115,10 +115,10 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
     `${SETUP_WORKSPACE_PATH}: must retain the deterministic cross-lane restore prefix`,
   );
   assert(
-    /name:\s*Setup Bun[\s\S]*?HOME:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}\s*[\r\n]+[\s\S]*?bun-version:/.test(
+    /name:\s*Setup Bun[\s\S]*?HOME:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}-\$\{\{\s*strategy\.job-index\s*\|\|\s*0\s*\}\}\s*[\r\n]+[\s\S]*?USERPROFILE:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}-\$\{\{\s*strategy\.job-index\s*\|\|\s*0\s*\}\}\s*[\r\n]+[\s\S]*?bun-version:/.test(
       workspaceSetup,
     ),
-    `${SETUP_WORKSPACE_PATH}: setup-bun HOME must be isolated by run, attempt, and job without space-bearing runner metadata`,
+    `${SETUP_WORKSPACE_PATH}: setup-bun home must be isolated by run, attempt, job, matrix entry, and OS without space-bearing runner metadata`,
   );
 
   // --- Invariant 2: no adopting workflow also wires the SaaS remote cache. ---

--- a/packages/scripts/ci-turbo-cache-contract.mjs
+++ b/packages/scripts/ci-turbo-cache-contract.mjs
@@ -115,10 +115,10 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
     `${SETUP_WORKSPACE_PATH}: must retain the deterministic cross-lane restore prefix`,
   );
   assert(
-    /name:\s*Setup Bun[\s\S]*?HOME:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}-\$\{\{\s*strategy\.job-index\s*\|\|\s*0\s*\}\}\s*[\r\n]+[\s\S]*?USERPROFILE:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}-\$\{\{\s*strategy\.job-index\s*\|\|\s*0\s*\}\}\s*[\r\n]+[\s\S]*?bun-version:/.test(
+    /name:\s*Setup Bun[\s\S]*?HOME:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}-\$\{\{\s*strategy\.job-index\s*\|\|\s*0\s*\}\}\s*[\r\n]+[\s\S]*?USERPROFILE:\s*\$\{\{\s*runner\.temp\s*\}\}\/bun-home-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}-\$\{\{\s*github\.job\s*\}\}-\$\{\{\s*strategy\.job-index\s*\|\|\s*0\s*\}\}\s*[\r\n]+[\s\S]*?bun-version:[\s\S]*?no-cache:\s*true/.test(
       workspaceSetup,
     ),
-    `${SETUP_WORKSPACE_PATH}: setup-bun home must be isolated by run, attempt, job, matrix entry, and OS without space-bearing runner metadata`,
+    `${SETUP_WORKSPACE_PATH}: setup-bun home must be isolated by run, attempt, job, matrix entry, and OS without caching the ephemeral executable path or using space-bearing runner metadata`,
   );
 
   // --- Invariant 2: no adopting workflow also wires the SaaS remote cache. ---

--- a/packages/scripts/ci-workflow-invariants.mjs
+++ b/packages/scripts/ci-workflow-invariants.mjs
@@ -30,6 +30,8 @@ const WORKFLOW_PATHS = Object.freeze({
   tests: ".github/workflows/test.yml",
 });
 const ISOLATED_BUN_HOME = `\${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}`;
+const FORK_JOB_GUARD =
+  "github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)";
 
 function invariant(condition, message) {
   if (!condition) throw new Error(message);
@@ -243,9 +245,8 @@ export function validateWorkflowSources(sources) {
       `${WORKFLOW_PATHS.qualityFork}: jobs.${jobName} must use the isolated ubuntu-24.04 hosted runner`,
     );
     invariant(
-      typeof job.if === "string" &&
-        job.if.includes("github.event_name == 'workflow_dispatch'"),
-      `${WORKFLOW_PATHS.qualityFork}: jobs.${jobName} must remain executable by workflow_dispatch`,
+      job.if === FORK_JOB_GUARD,
+      `${WORKFLOW_PATHS.qualityFork}: jobs.${jobName} must run only for workflow_dispatch or fork pull requests`,
     );
   }
   const forkCliSetupBun = qualityFork.jobs[

--- a/packages/scripts/ci-workflow-invariants.mjs
+++ b/packages/scripts/ci-workflow-invariants.mjs
@@ -199,8 +199,9 @@ export function validateWorkflowSources(sources) {
   );
   invariant(
     cloudSetupBun?.env?.HOME === ISOLATED_BUN_HOME &&
-      cloudSetupBun?.env?.USERPROFILE === ISOLATED_BUN_HOME,
-    `${WORKFLOW_PATHS.cloudSetup}: setup-bun home must be isolated by run, attempt, job, matrix entry, and OS`,
+      cloudSetupBun?.env?.USERPROFILE === ISOLATED_BUN_HOME &&
+      cloudSetupBun?.with?.["no-cache"] === true,
+    `${WORKFLOW_PATHS.cloudSetup}: setup-bun home must be isolated by run, attempt, job, matrix entry, and OS without caching the ephemeral executable path`,
   );
   const postgresStart = cloudSetupSteps.find(
     (step) =>
@@ -261,8 +262,9 @@ export function validateWorkflowSources(sources) {
   ].steps.find((step) => step?.uses?.startsWith("oven-sh/setup-bun@"));
   invariant(
     forkCliSetupBun?.env?.HOME === ISOLATED_BUN_HOME &&
-      forkCliSetupBun?.env?.USERPROFILE === ISOLATED_BUN_HOME,
-    `${WORKFLOW_PATHS.qualityFork}: CLI setup-bun home must be isolated by run, attempt, job, matrix entry, and OS`,
+      forkCliSetupBun?.env?.USERPROFILE === ISOLATED_BUN_HOME &&
+      forkCliSetupBun?.with?.["no-cache"] === true,
+    `${WORKFLOW_PATHS.qualityFork}: CLI setup-bun home must be isolated by run, attempt, job, matrix entry, and OS without caching the ephemeral executable path`,
   );
   invariant(
     setupWorkspace.runs?.using === "composite" &&
@@ -274,8 +276,9 @@ export function validateWorkflowSources(sources) {
   );
   invariant(
     workspaceSetupBun?.env?.HOME === ISOLATED_BUN_HOME &&
-      workspaceSetupBun?.env?.USERPROFILE === ISOLATED_BUN_HOME,
-    `${WORKFLOW_PATHS.setupWorkspace}: setup-bun home must be isolated on the setup-bun step for every matrix entry and OS`,
+      workspaceSetupBun?.env?.USERPROFILE === ISOLATED_BUN_HOME &&
+      workspaceSetupBun?.with?.["no-cache"] === true,
+    `${WORKFLOW_PATHS.setupWorkspace}: setup-bun home must be isolated on the setup-bun step for every matrix entry and OS without caching the ephemeral executable path`,
   );
 
   const lint = requireJob(develop, WORKFLOW_PATHS.develop, "lint");

--- a/packages/scripts/ci-workflow-invariants.mjs
+++ b/packages/scripts/ci-workflow-invariants.mjs
@@ -29,9 +29,11 @@ const WORKFLOW_PATHS = Object.freeze({
   setupWorkspace: ".github/actions/setup-bun-workspace/action.yml",
   tests: ".github/workflows/test.yml",
 });
-const ISOLATED_BUN_HOME = `\${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}`;
+const ISOLATED_BUN_HOME = `\${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}-\${{ strategy.job-index || 0 }}`;
 const FORK_JOB_GUARD =
   "github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)";
+const FORK_CONCURRENCY_GROUP =
+  "quality-fork-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}";
 
 function invariant(condition, message) {
   if (!condition) throw new Error(message);
@@ -196,8 +198,9 @@ export function validateWorkflowSources(sources) {
     step?.uses?.startsWith("oven-sh/setup-bun@"),
   );
   invariant(
-    cloudSetupBun?.env?.HOME === ISOLATED_BUN_HOME,
-    `${WORKFLOW_PATHS.cloudSetup}: setup-bun HOME must be isolated by run, attempt, and job without space-bearing runner metadata`,
+    cloudSetupBun?.env?.HOME === ISOLATED_BUN_HOME &&
+      cloudSetupBun?.env?.USERPROFILE === ISOLATED_BUN_HOME,
+    `${WORKFLOW_PATHS.cloudSetup}: setup-bun home must be isolated by run, attempt, job, matrix entry, and OS`,
   );
   const postgresStart = cloudSetupSteps.find(
     (step) =>
@@ -235,6 +238,10 @@ export function validateWorkflowSources(sources) {
       Object.hasOwn(qualityFork.on, "workflow_dispatch"),
     `${WORKFLOW_PATHS.qualityFork}: workflow_dispatch must remain available for exact-head proof`,
   );
+  invariant(
+    qualityFork.concurrency?.group === FORK_CONCURRENCY_GROUP,
+    `${WORKFLOW_PATHS.qualityFork}: manual exact-head proof must not share a concurrency group with pull request events`,
+  );
   for (const [jobName, job] of Object.entries(qualityFork.jobs)) {
     invariant(
       job && typeof job === "object",
@@ -253,8 +260,9 @@ export function validateWorkflowSources(sources) {
     "elizaos-cli-global-smoke"
   ].steps.find((step) => step?.uses?.startsWith("oven-sh/setup-bun@"));
   invariant(
-    forkCliSetupBun?.env?.HOME === ISOLATED_BUN_HOME,
-    `${WORKFLOW_PATHS.qualityFork}: CLI setup-bun HOME must be isolated by run, attempt, and job`,
+    forkCliSetupBun?.env?.HOME === ISOLATED_BUN_HOME &&
+      forkCliSetupBun?.env?.USERPROFILE === ISOLATED_BUN_HOME,
+    `${WORKFLOW_PATHS.qualityFork}: CLI setup-bun home must be isolated by run, attempt, job, matrix entry, and OS`,
   );
   invariant(
     setupWorkspace.runs?.using === "composite" &&
@@ -265,8 +273,9 @@ export function validateWorkflowSources(sources) {
     step?.uses?.startsWith("oven-sh/setup-bun@"),
   );
   invariant(
-    workspaceSetupBun?.env?.HOME === ISOLATED_BUN_HOME,
-    `${WORKFLOW_PATHS.setupWorkspace}: setup-bun HOME must be isolated on the setup-bun step`,
+    workspaceSetupBun?.env?.HOME === ISOLATED_BUN_HOME &&
+      workspaceSetupBun?.env?.USERPROFILE === ISOLATED_BUN_HOME,
+    `${WORKFLOW_PATHS.setupWorkspace}: setup-bun home must be isolated on the setup-bun step for every matrix entry and OS`,
   );
 
   const lint = requireJob(develop, WORKFLOW_PATHS.develop, "lint");

--- a/packages/scripts/ci-workflow-invariants.mjs
+++ b/packages/scripts/ci-workflow-invariants.mjs
@@ -24,8 +24,12 @@ const WORKFLOW_PATHS = Object.freeze({
   cloudTests: ".github/workflows/cloud-tests.yml",
   develop: ".github/workflows/develop-pr.yml",
   gitleaks: ".github/workflows/gitleaks.yml",
+  packageJson: "package.json",
+  qualityFork: ".github/workflows/quality-fork.yml",
+  setupWorkspace: ".github/actions/setup-bun-workspace/action.yml",
   tests: ".github/workflows/test.yml",
 });
+const ISOLATED_BUN_HOME = `\${{ runner.temp }}/bun-home-\${{ github.run_id }}-\${{ github.run_attempt }}-\${{ github.job }}`;
 
 function invariant(condition, message) {
   if (!condition) throw new Error(message);
@@ -117,7 +121,16 @@ export function validateWorkflowSources(sources) {
   );
   const develop = parseWorkflow(WORKFLOW_PATHS.develop, sources.develop);
   const gitleaks = parseWorkflow(WORKFLOW_PATHS.gitleaks, sources.gitleaks);
+  const qualityFork = parseWorkflow(
+    WORKFLOW_PATHS.qualityFork,
+    sources.qualityFork,
+  );
+  const setupWorkspace = parseYamlMapping(
+    WORKFLOW_PATHS.setupWorkspace,
+    sources.setupWorkspace,
+  );
   const tests = parseWorkflow(WORKFLOW_PATHS.tests, sources.tests);
+  const packageJson = JSON.parse(sources.packageJson);
 
   const cloudE2e = requireJob(
     cloudTests,
@@ -177,6 +190,13 @@ export function validateWorkflowSources(sources) {
     !cloudSetupSteps.some((step) => step?.uses?.startsWith("actions/cache@")),
     `${WORKFLOW_PATHS.cloudSetup}: multi-gigabyte Bun install archives are prohibited`,
   );
+  const cloudSetupBun = cloudSetupSteps.find((step) =>
+    step?.uses?.startsWith("oven-sh/setup-bun@"),
+  );
+  invariant(
+    cloudSetupBun?.env?.HOME === ISOLATED_BUN_HOME,
+    `${WORKFLOW_PATHS.cloudSetup}: setup-bun HOME must be isolated by run, attempt, and job without space-bearing runner metadata`,
+  );
   const postgresStart = cloudSetupSteps.find(
     (step) =>
       typeof step?.run === "string" &&
@@ -196,6 +216,57 @@ export function validateWorkflowSources(sources) {
     migrations?.if === "inputs.setup-db == 'true'" &&
       migrations["continue-on-error"] !== true,
     `${WORKFLOW_PATHS.cloudSetup}: database migrations must remain fail-closed for setup-db`,
+  );
+
+  invariant(
+    typeof packageJson.packageManager === "string" &&
+      packageJson.packageManager.startsWith("bun@"),
+    `${WORKFLOW_PATHS.packageJson}: packageManager must pin Bun`,
+  );
+  const repositoryBunVersion = packageJson.packageManager.slice("bun@".length);
+  invariant(
+    qualityFork.env?.BUN_VERSION === repositoryBunVersion,
+    `${WORKFLOW_PATHS.qualityFork}: fork validation must use the repository Bun version`,
+  );
+  invariant(
+    qualityFork.on &&
+      typeof qualityFork.on === "object" &&
+      Object.hasOwn(qualityFork.on, "workflow_dispatch"),
+    `${WORKFLOW_PATHS.qualityFork}: workflow_dispatch must remain available for exact-head proof`,
+  );
+  for (const [jobName, job] of Object.entries(qualityFork.jobs)) {
+    invariant(
+      job && typeof job === "object",
+      `${WORKFLOW_PATHS.qualityFork}: jobs.${jobName} must be a mapping`,
+    );
+    invariant(
+      job["runs-on"] === "ubuntu-24.04",
+      `${WORKFLOW_PATHS.qualityFork}: jobs.${jobName} must use the isolated ubuntu-24.04 hosted runner`,
+    );
+    invariant(
+      typeof job.if === "string" &&
+        job.if.includes("github.event_name == 'workflow_dispatch'"),
+      `${WORKFLOW_PATHS.qualityFork}: jobs.${jobName} must remain executable by workflow_dispatch`,
+    );
+  }
+  const forkCliSetupBun = qualityFork.jobs[
+    "elizaos-cli-global-smoke"
+  ].steps.find((step) => step?.uses?.startsWith("oven-sh/setup-bun@"));
+  invariant(
+    forkCliSetupBun?.env?.HOME === ISOLATED_BUN_HOME,
+    `${WORKFLOW_PATHS.qualityFork}: CLI setup-bun HOME must be isolated by run, attempt, and job`,
+  );
+  invariant(
+    setupWorkspace.runs?.using === "composite" &&
+      Array.isArray(setupWorkspace.runs.steps),
+    `${WORKFLOW_PATHS.setupWorkspace}: runs.steps must be a composite step list`,
+  );
+  const workspaceSetupBun = setupWorkspace.runs.steps.find((step) =>
+    step?.uses?.startsWith("oven-sh/setup-bun@"),
+  );
+  invariant(
+    workspaceSetupBun?.env?.HOME === ISOLATED_BUN_HOME,
+    `${WORKFLOW_PATHS.setupWorkspace}: setup-bun HOME must be isolated on the setup-bun step`,
   );
 
   const lint = requireJob(develop, WORKFLOW_PATHS.develop, "lint");
@@ -277,6 +348,18 @@ export function run(repoRoot = REPO_ROOT) {
     develop: readFileSync(path.join(repoRoot, WORKFLOW_PATHS.develop), "utf8"),
     gitleaks: readFileSync(
       path.join(repoRoot, WORKFLOW_PATHS.gitleaks),
+      "utf8",
+    ),
+    packageJson: readFileSync(
+      path.join(repoRoot, WORKFLOW_PATHS.packageJson),
+      "utf8",
+    ),
+    qualityFork: readFileSync(
+      path.join(repoRoot, WORKFLOW_PATHS.qualityFork),
+      "utf8",
+    ),
+    setupWorkspace: readFileSync(
+      path.join(repoRoot, WORKFLOW_PATHS.setupWorkspace),
       "utf8",
     ),
     tests: readFileSync(path.join(repoRoot, WORKFLOW_PATHS.tests), "utf8"),

--- a/packages/scripts/ci-workflow-invariants.mjs
+++ b/packages/scripts/ci-workflow-invariants.mjs
@@ -20,11 +20,11 @@ const { parseDocument } = require("yaml");
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
 const WORKFLOW_PATHS = Object.freeze({
+  ciBunVersion: ".github/ci-bun-version.json",
   cloudSetup: ".github/actions/cloud-setup-test-env/action.yml",
   cloudTests: ".github/workflows/cloud-tests.yml",
   develop: ".github/workflows/develop-pr.yml",
   gitleaks: ".github/workflows/gitleaks.yml",
-  packageJson: "package.json",
   qualityFork: ".github/workflows/quality-fork.yml",
   setupWorkspace: ".github/actions/setup-bun-workspace/action.yml",
   tests: ".github/workflows/test.yml",
@@ -111,6 +111,7 @@ function normalizedNeeds(job) {
 }
 
 export function validateWorkflowSources(sources) {
+  const ciBunVersion = JSON.parse(sources.ciBunVersion);
   const cloudSetup = parseYamlMapping(
     WORKFLOW_PATHS.cloudSetup,
     sources.cloudSetup,
@@ -130,7 +131,6 @@ export function validateWorkflowSources(sources) {
     sources.setupWorkspace,
   );
   const tests = parseWorkflow(WORKFLOW_PATHS.tests, sources.tests);
-  const packageJson = JSON.parse(sources.packageJson);
 
   const cloudE2e = requireJob(
     cloudTests,
@@ -219,14 +219,13 @@ export function validateWorkflowSources(sources) {
   );
 
   invariant(
-    typeof packageJson.packageManager === "string" &&
-      packageJson.packageManager.startsWith("bun@"),
-    `${WORKFLOW_PATHS.packageJson}: packageManager must pin Bun`,
+    typeof ciBunVersion.version === "string" &&
+      /^\d+\.\d+\.\d+$/.test(ciBunVersion.version),
+    `${WORKFLOW_PATHS.ciBunVersion}: version must be a concrete Bun release`,
   );
-  const repositoryBunVersion = packageJson.packageManager.slice("bun@".length);
   invariant(
-    qualityFork.env?.BUN_VERSION === repositoryBunVersion,
-    `${WORKFLOW_PATHS.qualityFork}: fork validation must use the repository Bun version`,
+    qualityFork.env?.BUN_VERSION === ciBunVersion.version,
+    `${WORKFLOW_PATHS.qualityFork}: fork validation must use the canonical CI Bun version`,
   );
   invariant(
     qualityFork.on &&
@@ -337,6 +336,10 @@ export function validateWorkflowSources(sources) {
 
 export function run(repoRoot = REPO_ROOT) {
   return validateWorkflowSources({
+    ciBunVersion: readFileSync(
+      path.join(repoRoot, WORKFLOW_PATHS.ciBunVersion),
+      "utf8",
+    ),
     cloudSetup: readFileSync(
       path.join(repoRoot, WORKFLOW_PATHS.cloudSetup),
       "utf8",
@@ -348,10 +351,6 @@ export function run(repoRoot = REPO_ROOT) {
     develop: readFileSync(path.join(repoRoot, WORKFLOW_PATHS.develop), "utf8"),
     gitleaks: readFileSync(
       path.join(repoRoot, WORKFLOW_PATHS.gitleaks),
-      "utf8",
-    ),
-    packageJson: readFileSync(
-      path.join(repoRoot, WORKFLOW_PATHS.packageJson),
       "utf8",
     ),
     qualityFork: readFileSync(

--- a/packages/scripts/ci-workflow-invariants.test.mjs
+++ b/packages/scripts/ci-workflow-invariants.test.mjs
@@ -26,6 +26,15 @@ const sources = {
     path.join(root, ".github/workflows/gitleaks.yml"),
     "utf8",
   ),
+  packageJson: readFileSync(path.join(root, "package.json"), "utf8"),
+  qualityFork: readFileSync(
+    path.join(root, ".github/workflows/quality-fork.yml"),
+    "utf8",
+  ),
+  setupWorkspace: readFileSync(
+    path.join(root, ".github/actions/setup-bun-workspace/action.yml"),
+    "utf8",
+  ),
   tests: readFileSync(path.join(root, ".github/workflows/test.yml"), "utf8"),
 };
 
@@ -65,6 +74,22 @@ for (const fixture of [
     pattern: /multi-gigabyte Bun install archives are prohibited/,
   },
   {
+    name: "shared Bun executable installation",
+    key: "cloudSetup",
+    mutate: (source) => source.replace(/ {6}env:\n {8}HOME:.*\n/, ""),
+    pattern: /setup-bun HOME must be isolated by run, attempt, and job/,
+  },
+  {
+    name: "space-bearing runner name in Bun HOME",
+    key: "cloudSetup",
+    mutate: (source) =>
+      source.replace(
+        `-\${{ github.job }}\n`,
+        `-\${{ github.job }}-\${{ runner.name }}\n`,
+      ),
+    pattern: /without space-bearing runner metadata/,
+  },
+  {
     name: "degraded Cloud e2e database backend",
     key: "cloudTests",
     mutate: (source) =>
@@ -83,6 +108,60 @@ for (const fixture of [
         "    - name: Run database migrations\n      if: false\n",
       ),
     pattern: /database migrations must remain fail-closed/,
+  },
+  {
+    name: "persistent runner admission for fork validation",
+    key: "qualityFork",
+    mutate: (source) =>
+      `${source}\n  future-fork-job:\n    if: github.event_name == 'workflow_dispatch'\n    runs-on: self-hosted\n    steps:\n      - run: true\n`,
+    pattern:
+      /jobs.future-fork-job must use the isolated ubuntu-24.04 hosted runner/,
+  },
+  {
+    name: "unpinned Bun version for fork validation",
+    key: "packageJson",
+    mutate: (source) =>
+      source.replace(
+        '"packageManager": "bun@1.4.0"',
+        '"packageManager": "bun@1.4.1"',
+      ),
+    pattern: /fork validation must use the repository Bun version/,
+  },
+  {
+    name: "missing manual fork proof trigger",
+    key: "qualityFork",
+    mutate: (source) => source.replace("  workflow_dispatch:\n", ""),
+    pattern: /workflow_dispatch must remain available for exact-head proof/,
+  },
+  {
+    name: "fork job excluded from manual exact-head proof",
+    key: "qualityFork",
+    mutate: (source) =>
+      source.replace(
+        "    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)\n",
+        "    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true\n",
+      ),
+    pattern: /jobs.lint must remain executable by workflow_dispatch/,
+  },
+  {
+    name: "shared CLI Bun executable installation",
+    key: "qualityFork",
+    mutate: (source) =>
+      source.replace(
+        /      - name: Setup Bun\n([\s\S]*?) {8}env:\n {10}HOME:.*\n/,
+        "      - name: Setup Bun\n$1",
+      ),
+    pattern: /CLI setup-bun HOME must be isolated by run, attempt, and job/,
+  },
+  {
+    name: "misplaced workspace setup-bun HOME",
+    key: "setupWorkspace",
+    mutate: (source) =>
+      source.replace(
+        / {6}env:\n {8}# setup-bun installs[\s\S]*? {8}HOME:.*\n/,
+        "",
+      ),
+    pattern: /setup-bun HOME must be isolated on the setup-bun step/,
   },
   {
     name: "conditional lint",

--- a/packages/scripts/ci-workflow-invariants.test.mjs
+++ b/packages/scripts/ci-workflow-invariants.test.mjs
@@ -141,7 +141,19 @@ for (const fixture of [
         "    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)\n",
         "    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true\n",
       ),
-    pattern: /jobs.lint must remain executable by workflow_dispatch/,
+    pattern:
+      /jobs.lint must run only for workflow_dispatch or fork pull requests/,
+  },
+  {
+    name: "same-repository pull request admitted to fork validation",
+    key: "qualityFork",
+    mutate: (source) =>
+      source.replace(
+        "github.event.pull_request.head.repo.fork == true",
+        "github.event_name == 'pull_request'",
+      ),
+    pattern:
+      /jobs.lint must run only for workflow_dispatch or fork pull requests/,
   },
   {
     name: "shared CLI Bun executable installation",

--- a/packages/scripts/ci-workflow-invariants.test.mjs
+++ b/packages/scripts/ci-workflow-invariants.test.mjs
@@ -79,18 +79,25 @@ for (const fixture of [
   {
     name: "shared Bun executable installation",
     key: "cloudSetup",
-    mutate: (source) => source.replace(/ {6}env:\n {8}HOME:.*\n/, ""),
-    pattern: /setup-bun HOME must be isolated by run, attempt, and job/,
+    mutate: (source) => source.replace(/ {8}USERPROFILE:.*\n/, ""),
+    pattern: /setup-bun home must be isolated by run, attempt, job, matrix entry, and OS/,
   },
   {
     name: "space-bearing runner name in Bun HOME",
     key: "cloudSetup",
     mutate: (source) =>
       source.replace(
-        `-\${{ github.job }}\n`,
-        `-\${{ github.job }}-\${{ runner.name }}\n`,
+        `\${{ strategy.job-index || 0 }}`,
+        `\${{ runner.name }}`,
       ),
-    pattern: /without space-bearing runner metadata/,
+    pattern: /setup-bun home must be isolated by run, attempt, job, matrix entry, and OS/,
+  },
+  {
+    name: "matrix jobs share a Bun home",
+    key: "cloudSetup",
+    mutate: (source) =>
+      source.replaceAll(`-\${{ strategy.job-index || 0 }}`, ""),
+    pattern: /setup-bun home must be isolated by run, attempt, job, matrix entry, and OS/,
   },
   {
     name: "degraded Cloud e2e database backend",
@@ -134,6 +141,17 @@ for (const fixture of [
     pattern: /workflow_dispatch must remain available for exact-head proof/,
   },
   {
+    name: "manual proof shares pull request concurrency",
+    key: "qualityFork",
+    mutate: (source) =>
+      source.replace(
+        "quality-fork-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}",
+        "quality-fork-${{ github.ref }}",
+      ),
+    pattern:
+      /manual exact-head proof must not share a concurrency group with pull request events/,
+  },
+  {
     name: "fork job excluded from manual exact-head proof",
     key: "qualityFork",
     mutate: (source) =>
@@ -159,21 +177,15 @@ for (const fixture of [
     name: "shared CLI Bun executable installation",
     key: "qualityFork",
     mutate: (source) =>
-      source.replace(
-        /      - name: Setup Bun\n([\s\S]*?) {8}env:\n {10}HOME:.*\n/,
-        "      - name: Setup Bun\n$1",
-      ),
-    pattern: /CLI setup-bun HOME must be isolated by run, attempt, and job/,
+      source.replace(/ {10}USERPROFILE:.*\n/, ""),
+    pattern: /CLI setup-bun home must be isolated by run, attempt, job, matrix entry, and OS/,
   },
   {
     name: "misplaced workspace setup-bun HOME",
     key: "setupWorkspace",
-    mutate: (source) =>
-      source.replace(
-        / {6}env:\n {8}# setup-bun installs[\s\S]*? {8}HOME:.*\n/,
-        "",
-      ),
-    pattern: /setup-bun HOME must be isolated on the setup-bun step/,
+    mutate: (source) => source.replace(/ {8}USERPROFILE:.*\n/, ""),
+    pattern:
+      /setup-bun home must be isolated on the setup-bun step for every matrix entry and OS/,
   },
   {
     name: "conditional lint",

--- a/packages/scripts/ci-workflow-invariants.test.mjs
+++ b/packages/scripts/ci-workflow-invariants.test.mjs
@@ -100,6 +100,12 @@ for (const fixture of [
     pattern: /setup-bun home must be isolated by run, attempt, job, matrix entry, and OS/,
   },
   {
+    name: "ephemeral cloud Bun executable path is cached",
+    key: "cloudSetup",
+    mutate: (source) => source.replace("        no-cache: true\n", ""),
+    pattern: /without caching the ephemeral executable path/,
+  },
+  {
     name: "degraded Cloud e2e database backend",
     key: "cloudTests",
     mutate: (source) =>
@@ -181,11 +187,23 @@ for (const fixture of [
     pattern: /CLI setup-bun home must be isolated by run, attempt, job, matrix entry, and OS/,
   },
   {
+    name: "ephemeral CLI Bun executable path is cached",
+    key: "qualityFork",
+    mutate: (source) => source.replace("          no-cache: true\n", ""),
+    pattern: /without caching the ephemeral executable path/,
+  },
+  {
     name: "misplaced workspace setup-bun HOME",
     key: "setupWorkspace",
     mutate: (source) => source.replace(/ {8}USERPROFILE:.*\n/, ""),
     pattern:
       /setup-bun home must be isolated on the setup-bun step for every matrix entry and OS/,
+  },
+  {
+    name: "ephemeral workspace Bun executable path is cached",
+    key: "setupWorkspace",
+    mutate: (source) => source.replace("        no-cache: true\n", ""),
+    pattern: /without caching the ephemeral executable path/,
   },
   {
     name: "conditional lint",

--- a/packages/scripts/ci-workflow-invariants.test.mjs
+++ b/packages/scripts/ci-workflow-invariants.test.mjs
@@ -10,6 +10,10 @@ import { validateWorkflowSources } from "./ci-workflow-invariants.mjs";
 
 const root = path.resolve(import.meta.dirname, "../..");
 const sources = {
+  ciBunVersion: readFileSync(
+    path.join(root, ".github/ci-bun-version.json"),
+    "utf8",
+  ),
   cloudSetup: readFileSync(
     path.join(root, ".github/actions/cloud-setup-test-env/action.yml"),
     "utf8",
@@ -26,7 +30,6 @@ const sources = {
     path.join(root, ".github/workflows/gitleaks.yml"),
     "utf8",
   ),
-  packageJson: readFileSync(path.join(root, "package.json"), "utf8"),
   qualityFork: readFileSync(
     path.join(root, ".github/workflows/quality-fork.yml"),
     "utf8",
@@ -118,14 +121,11 @@ for (const fixture of [
       /jobs.future-fork-job must use the isolated ubuntu-24.04 hosted runner/,
   },
   {
-    name: "unpinned Bun version for fork validation",
-    key: "packageJson",
+    name: "divergent Bun version for fork validation",
+    key: "ciBunVersion",
     mutate: (source) =>
-      source.replace(
-        '"packageManager": "bun@1.4.0"',
-        '"packageManager": "bun@1.4.1"',
-      ),
-    pattern: /fork validation must use the repository Bun version/,
+      source.replace(/"version":\s*"\d+\.\d+\.\d+"/, '"version": "0.0.0"'),
+    pattern: /fork validation must use the canonical CI Bun version/,
   },
   {
     name: "missing manual fork proof trigger",


### PR DESCRIPTION
Temporary draft used only to exercise the fork-origin `pull_request` path introduced by #17523 at exact commit `5033d2b61c46585bfb942ad292368b85a9a1a885`.

This PR will be closed after the Quality (Fork) workflow completes. Production review and merge remain on #17523.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only fork admission proof.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only fork admission proof.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] The linked Quality (Fork) run is the execution evidence for this draft.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] The fork-origin workflow run is the sole domain artifact.
