### PR TITLE
test(app): reject terminal loading frames in aesthetic audit

### DIFF
--- a/packages/app/test/audit/ocr-content-rules.test.ts
+++ b/packages/app/test/audit/ocr-content-rules.test.ts
@@ -269,4 +269,29 @@ describe("evaluateOcrContent", () => {
     );
     expect(f.verdict).toBe("broken");
   });
+
+  it.each([
+    ["ready", "Finances\nBalance\n$2,765.50\nTransactions (2)"],
+    ["empty", "Finances\nNone\nConnect"],
+    ["error", "Finances\nCould not load finances\nRetry"],
+  ])("verifies a healthy Finances %s render", (_state, text) => {
+    const f = evaluateOcrContent({
+      ocr: ocr(text),
+      expectation: VIEW_EXPECTATIONS["plugin-finances-gui"],
+    });
+    expect(f.verdict).toBe("verified");
+    expect(f.missingRequired).toHaveLength(0);
+  });
+
+  it("breaks a terminal Finances loading frame", () => {
+    const f = evaluateOcrContent({
+      ocr: ocr("Finances\nLoading"),
+      expectation: VIEW_EXPECTATIONS["plugin-finances-gui"],
+    });
+    expect(f.forbiddenPresent).toContain("Loading");
+    expect(f.missingRequired).toContain(
+      "Balance | None | Could not load finances",
+    );
+    expect(f.verdict).toBe("broken");
+  });
 });

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -55,6 +55,10 @@ const { strict: AUDIT_STRICT, needsWorkStrict: AUDIT_STRICT_NEEDS_WORK } =
 // scrollWidth/innerWidth rounding can differ by ~1px on a healthy layout. A real
 // un-contained overflow (WS5) blows past this comfortably.
 const HORIZONTAL_OVERFLOW_TOLERANCE_PX = 2;
+const VIEW_READINESS_POLL_ATTEMPTS = 12;
+const VIEW_READINESS_POLL_INTERVAL_MS = 1_000;
+const VIEW_READINESS_WINDOW_MS =
+  VIEW_READINESS_POLL_ATTEMPTS * VIEW_READINESS_POLL_INTERVAL_MS;
 // Key: `${slug}-${viewport}`. Value: the worst verdict currently tolerated for
 // that view. Empty = zero debt (the INTERACTION_DEBT={}/MAX=0 convention). The
 // CI lane runs the gate default-on against an empty allowlist and passes, so the
@@ -370,17 +374,75 @@ interface ViewFinding {
 interface ViewPaintState {
   readableChars: number;
   overlayPresent: boolean;
-  loadingViewPresent: boolean;
+  loadingStatePresent: boolean;
+  loadingStateLabels: string[];
 }
 
 async function readViewPaint(
   viewRoot: Locator,
   overlay: Locator,
-  loadingView: Locator,
 ): Promise<ViewPaintState> {
-  const readableChars = await viewRoot.evaluate(
-    (root) =>
-      (root as HTMLElement).innerText.trim().replace(/\s+/g, " ").length,
+  const { readableChars, visibleLoadingLabels } = await viewRoot.evaluate(
+    (root) => {
+      const rootElement = root as HTMLElement;
+      const isVisibleInViewport = (element: Element): boolean => {
+        if (!element.isConnected || element.getClientRects().length === 0) {
+          return false;
+        }
+        for (
+          let current: Element | null = element;
+          current;
+          current = current.parentElement
+        ) {
+          const style = getComputedStyle(current);
+          if (
+            (current instanceof HTMLElement && current.hidden) ||
+            style.display === "none" ||
+            style.visibility === "hidden" ||
+            style.visibility === "collapse" ||
+            style.contentVisibility === "hidden" ||
+            Number(style.opacity || "1") === 0
+          ) {
+            return false;
+          }
+        }
+        const rect = element.getBoundingClientRect();
+        return (
+          rect.width > 0 &&
+          rect.height > 0 &&
+          rect.right > 0 &&
+          rect.bottom > 0 &&
+          rect.left < window.innerWidth &&
+          rect.top < window.innerHeight
+        );
+      };
+      const exactLoadingLabel = /^loading(?:\s+view)?(?:\s*(?:…|\.{1,3}))?$/i;
+      const labels = new Set<string>();
+      const elements: Element[] = [
+        rootElement,
+        ...rootElement.querySelectorAll("*"),
+      ];
+      for (const element of elements) {
+        if (!isVisibleInViewport(element)) continue;
+        const text = (
+          element instanceof HTMLElement
+            ? element.innerText
+            : (element.textContent ?? "")
+        )
+          .trim()
+          .replace(/\s+/g, " ");
+        if (
+          element.getAttribute("data-view-status") === "loading" ||
+          exactLoadingLabel.test(text)
+        ) {
+          labels.add(text || '[data-view-status="loading"]');
+        }
+      }
+      return {
+        readableChars: rootElement.innerText.trim().replace(/\s+/g, " ").length,
+        visibleLoadingLabels: [...labels],
+      };
+    },
   );
   const overlayPresent = await overlay.evaluateAll((nodes) =>
     nodes.some((node) => {
@@ -396,8 +458,50 @@ async function readViewPaint(
       );
     }),
   );
-  const loadingViewPresent = await loadingView.isVisible();
-  return { readableChars, overlayPresent, loadingViewPresent };
+  const loadingStateLabels = [...new Set(visibleLoadingLabels)];
+  return {
+    readableChars,
+    overlayPresent,
+    loadingStatePresent: loadingStateLabels.length > 0,
+    loadingStateLabels,
+  };
+}
+
+async function waitForViewPaint(
+  page: Page,
+  readPaint: () => Promise<ViewPaintState>,
+  overlayRequired: boolean,
+  options: {
+    attempts?: number;
+    intervalMs?: number;
+  } = {},
+): Promise<ViewPaintState> {
+  const attempts = options.attempts ?? VIEW_READINESS_POLL_ATTEMPTS;
+  const intervalMs = options.intervalMs ?? VIEW_READINESS_POLL_INTERVAL_MS;
+  let paint = await readPaint();
+  for (
+    let attempt = 0;
+    attempt < attempts &&
+    (paint.readableChars < 10 ||
+      (overlayRequired && !paint.overlayPresent) ||
+      paint.loadingStatePresent);
+    attempt += 1
+  ) {
+    await page.waitForTimeout(intervalMs);
+    paint = await readPaint();
+  }
+  return paint;
+}
+
+function loadingRenderStateIssues(
+  paint: ViewPaintState,
+  readinessWindowMs = VIEW_READINESS_WINDOW_MS,
+): string[] {
+  if (!paint.loadingStatePresent) return [];
+  const labels = paint.loadingStateLabels.join(", ");
+  return [
+    `visible loading state remained after ${readinessWindowMs} ms${labels ? `: ${labels}` : ""}`,
+  ];
 }
 
 /**
@@ -1302,14 +1406,14 @@ test.describe("all-views aesthetic audit (#8796)", () => {
       <div data-test-overlay>Composer</div>
     `);
     const overlay = page.locator("[data-test-overlay]");
-    const loadingView = page.locator('[data-view-status="loading"]');
 
     await expect(
-      readViewPaint(page.locator("[data-test-root]"), overlay, loadingView),
+      readViewPaint(page.locator("[data-test-root]"), overlay),
     ).resolves.toEqual({
       readableChars: "Loaded production view".length,
       overlayPresent: true,
-      loadingViewPresent: false,
+      loadingStatePresent: false,
+      loadingStateLabels: [],
     });
 
     await page.locator("main").evaluate((root) => {
@@ -1319,13 +1423,67 @@ test.describe("all-views aesthetic audit (#8796)", () => {
       );
     });
     await expect(
-      readViewPaint(page.locator("[data-test-root]"), overlay, loadingView),
-    ).resolves.toMatchObject({ loadingViewPresent: true });
+      readViewPaint(page.locator("[data-test-root]"), overlay),
+    ).resolves.toMatchObject({
+      loadingStatePresent: true,
+      loadingStateLabels: ["Loading view"],
+    });
+
+    await page.setContent(`
+      <main data-test-root>
+        <h1>Finances</h1>
+        <div data-domain-state>Loading</div>
+      </main>
+      <div data-test-overlay>Composer</div>
+    `);
+    const readDomainPaint = () =>
+      readViewPaint(page.locator("[data-test-root]"), overlay);
+    const persisted = await waitForViewPaint(page, readDomainPaint, false, {
+      attempts: 2,
+      intervalMs: 5,
+    });
+    expect(persisted).toMatchObject({
+      loadingStatePresent: true,
+      loadingStateLabels: ["Loading"],
+    });
+    expect(loadingRenderStateIssues(persisted, 10)).toEqual([
+      "visible loading state remained after 10 ms: Loading",
+    ]);
+
+    await page.locator("[data-domain-state]").evaluate((state) => {
+      setTimeout(() => {
+        state.textContent = "Balance";
+      }, 10);
+    });
+    const settled = await waitForViewPaint(page, readDomainPaint, false, {
+      attempts: 5,
+      intervalMs: 10,
+    });
+    expect(settled).toMatchObject({
+      loadingStatePresent: false,
+      loadingStateLabels: [],
+    });
+
+    await page.setContent(`
+      <main data-test-root>
+        <h1>Loaded production view</h1>
+        <div hidden data-view-status="loading">Loading view</div>
+        <div style="display: none">Loading</div>
+        <div style="position: fixed; left: -10000px">Loading…</div>
+      </main>
+      <div data-test-overlay>Composer</div>
+    `);
+    await expect(
+      readViewPaint(page.locator("[data-test-root]"), overlay),
+    ).resolves.toMatchObject({
+      loadingStatePresent: false,
+      loadingStateLabels: [],
+    });
 
     await page.setContent("<main>first</main><main>second</main>");
-    await expect(
-      readViewPaint(page.locator("main"), overlay, loadingView),
-    ).rejects.toThrow(/strict mode violation/);
+    await expect(readViewPaint(page.locator("main"), overlay)).rejects.toThrow(
+      /strict mode violation/,
+    );
   });
 
   for (const view of buildAuditCases()) {
@@ -1397,23 +1555,8 @@ test.describe("all-views aesthetic audit (#8796)", () => {
           "[data-testid='chat-composer-textarea']",
         ].join(", ");
         const readPaint = () =>
-          readViewPaint(
-            viewRoot,
-            page.locator(overlaySelector),
-            page.locator('[data-view-status="loading"]'),
-          );
-        let paint = await readPaint();
-        for (
-          let attempt = 0;
-          attempt < 12 &&
-          (paint.readableChars < 10 ||
-            (overlayRequired && !paint.overlayPresent) ||
-            paint.loadingViewPresent);
-          attempt += 1
-        ) {
-          await page.waitForTimeout(1000);
-          paint = await readPaint();
-        }
+          readViewPaint(viewRoot, page.locator(overlaySelector));
+        let paint = await waitForViewPaint(page, readPaint, overlayRequired);
         if (view.slug === "plugin-calendar-gui") {
           const manageSources = page.getByRole("button", {
             name: "Manage calendar sources",
@@ -1426,9 +1569,7 @@ test.describe("all-views aesthetic audit (#8796)", () => {
         }
         const { readableChars, overlayPresent } = paint;
         const renderStateIssues = [
-          ...(paint.loadingViewPresent
-            ? ["dynamic view remained in its loading state after 12 seconds"]
-            : []),
+          ...loadingRenderStateIssues(paint),
           ...(await collectSpatialOverlapIssues(page)),
           ...(await collectSpatialSizingIssues(page)),
           ...(await collectComposerLegibilityIssues(page)),

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -407,14 +407,45 @@ async function readViewPaint(
           }
         }
         const rect = element.getBoundingClientRect();
-        return (
-          rect.width > 0 &&
-          rect.height > 0 &&
-          rect.right > 0 &&
-          rect.bottom > 0 &&
-          rect.left < window.innerWidth &&
-          rect.top < window.innerHeight
-        );
+        let visibleLeft = Math.max(rect.left, 0);
+        let visibleTop = Math.max(rect.top, 0);
+        let visibleRight = Math.min(rect.right, window.innerWidth);
+        let visibleBottom = Math.min(rect.bottom, window.innerHeight);
+        if (
+          rect.width <= 0 ||
+          rect.height <= 0 ||
+          visibleRight <= visibleLeft ||
+          visibleBottom <= visibleTop
+        ) {
+          return false;
+        }
+
+        // A loading label can retain a nonzero viewport rect while a collapsed
+        // grid/rail ancestor clips it completely. Treat it as visible only when
+        // some painted area survives every scroll or clipping container.
+        for (
+          let current = element.parentElement;
+          current;
+          current = current.parentElement
+        ) {
+          const style = getComputedStyle(current);
+          const clipsX = /^(auto|clip|hidden|scroll)$/.test(style.overflowX);
+          const clipsY = /^(auto|clip|hidden|scroll)$/.test(style.overflowY);
+          if (!clipsX && !clipsY) continue;
+          const clip = current.getBoundingClientRect();
+          if (clipsX) {
+            visibleLeft = Math.max(visibleLeft, clip.left);
+            visibleRight = Math.min(visibleRight, clip.right);
+          }
+          if (clipsY) {
+            visibleTop = Math.max(visibleTop, clip.top);
+            visibleBottom = Math.min(visibleBottom, clip.bottom);
+          }
+          if (visibleRight <= visibleLeft || visibleBottom <= visibleTop) {
+            return false;
+          }
+        }
+        return true;
       };
       const exactLoadingLabel = /^loading(?:\s+view)?(?:\s*(?:…|\.{1,3}))?$/i;
       const labels = new Set<string>();
@@ -424,18 +455,28 @@ async function readViewPaint(
       ];
       for (const element of elements) {
         if (!isVisibleInViewport(element)) continue;
-        const text = (
+        const renderedText = (
           element instanceof HTMLElement
             ? element.innerText
             : (element.textContent ?? "")
         )
           .trim()
           .replace(/\s+/g, " ");
+        const directText = [...element.childNodes]
+          .filter((child) => child.nodeType === Node.TEXT_NODE)
+          .map((child) => child.textContent ?? "")
+          .join(" ")
+          .trim()
+          .replace(/\s+/g, " ");
+        const loadingLabel =
+          directText || (element.childElementCount === 0 ? renderedText : "");
         if (
           element.getAttribute("data-view-status") === "loading" ||
-          exactLoadingLabel.test(text)
+          exactLoadingLabel.test(loadingLabel)
         ) {
-          labels.add(text || '[data-view-status="loading"]');
+          labels.add(
+            loadingLabel || renderedText || '[data-view-status="loading"]',
+          );
         }
       }
       return {
@@ -1470,6 +1511,9 @@ test.describe("all-views aesthetic audit (#8796)", () => {
         <div hidden data-view-status="loading">Loading view</div>
         <div style="display: none">Loading</div>
         <div style="position: fixed; left: -10000px">Loading…</div>
+        <div style="position: relative; overflow: hidden; width: 100px; height: 1px">
+          <div style="position: absolute; top: 20px">Loading</div>
+        </div>
       </main>
       <div data-test-overlay>Composer</div>
     `);

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -10,9 +10,9 @@
  * is only checked for the universal defects (blank pixels, developer-string leak,
  * placeholder text); presence lets a matched render earn a positive `verified`.
  *
- * Keyed by the capture slug (filename without extension). Third-party `plugin-*`
- * views are intentionally absent — they own their content and are checked only for
- * the universal defects.
+ * Keyed by the capture slug (filename without extension). Plugin views without
+ * stable first-party chrome stay absent — they own their content and are checked
+ * only for the universal defects.
  */
 import type { OcrExpectation } from "./ocr-content-rules";
 
@@ -194,6 +194,14 @@ export const VIEW_EXPECTATIONS: Record<string, OcrExpectation> = {
       "Electrobun desktop runtime",
       "Electrobun desktop runtim",
     ],
+  },
+  // The finance view's plain `Loading` caption does not carry the dynamic-view
+  // marker the DOM audit historically watched. Requiring one terminal-state
+  // label makes an OCR-visible loading frame broken even if the DOM probe ever
+  // regresses independently; empty and designed error states remain valid.
+  "plugin-finances-gui": {
+    requireAny: ["Balance", "None", "Could not load finances"],
+    forbid: ["Loading"],
   },
   // First-party MVP plugin view (#15781). Unlike third-party plugin surfaces it
   // ships stable, OCR-legible chrome we positively verify. The audit auto-selects


### PR DESCRIPTION
# Relates to

Fixes #17132.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`27332fa4015e72a406e3153ebe616bfea84ffa40`).
- [x] `bun install` and `bun run verify` were run after sync; the exact
      unrelated `audit:scripts` blocker is recorded below.
- [x] A reviewer can confirm the changed audit behavior from the regression
      tests, four-viewport findings, OCR report, and manually reviewed captures.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` completed all 579 Turbo typecheck/lint tasks, then hit
      the unrelated five-file `audit:scripts` orphan gate documented below.

# Risks

Low. This is test/audit code only; production finance rendering and requests are
unchanged. Exact visible `Loading` / `Loading view` labels now hold capture
readiness, with a 12-second bound so a broken view cannot hang the lane.

# Background

## What does this PR do?

- Detects visible exact domain-loading labels inside the audited view, in
  addition to `[data-view-status="loading"]`.
- Polls within the existing bounded readiness window and records a render-state
  failure when loading does not settle.
- Preserves hidden, display-none, and offscreen stale-marker behavior.
- Adds a first-party finance OCR contract that requires a ready, empty, or
  designed-error label and independently forbids terminal `Loading`.
- Adds focused regressions for loaded, persistent-loading, settled, hidden, and
  strict-locator states plus finance OCR ready/empty/error/loading states.

## What kind of change is this?

Bug fix (non-breaking audit-harness correction).

# Documentation changes needed?

N/A - the external behavior and contributor commands are unchanged; the audit
contract and rationale are documented beside the implementation.

# Testing

## Where should a reviewer start?

`packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts`, followed by
`packages/app/test/ui-smoke/ocr-view-expectations.ts` and the OCR unit cases.

## Detailed testing steps

- `bun install` — clean post-rebase install, 4,715 installs checked.
- OCR unit test — 34/34 passed.
- Focused Playwright readiness regression — 1/1 passed.
- App typecheck, app lint, and exact Biome check on all three touched files —
  passed.
- Strict real-bundle finance audit — 4/4 viewports `good`, zero render-state,
  console, quality, overflow, or overlay findings.
- Packaged OCR over those four captures — 4/4 `verified`, 0 broken,
  0 needs-eyeball, and `Balance` read in every viewport.
- Manual original-resolution review — all four viewports show the populated
  balance/transaction/recurring fixture; mobile landscape is not terminal
  loading.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes audit code only, not production UI
      pixels; issue #17132 records the rejected before frame as
      `Finances / Loading`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots:
      ![mobile portrait](https://github.com/aandreakis/eliza/releases/download/pr-17533-evidence/finance-mobile-portrait.jpg)
      ![mobile landscape](https://github.com/aandreakis/eliza/releases/download/pr-17533-evidence/finance-mobile-landscape.jpg)
      ![desktop landscape](https://github.com/aandreakis/eliza/releases/download/pr-17533-evidence/finance-desktop-landscape.jpg)
      ![iPad portrait](https://github.com/aandreakis/eliza/releases/download/pr-17533-evidence/finance-ipad-portrait.jpg).
      All four are post-rebase, full-viewport, and manually reviewed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - there is no changed user interaction or rendered
      UI flow; the affected surface is an automated screenshot-readiness gate.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend, API, database, worker, or service code
      changed.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no production request/response or
      client state path changed; the real-dist audit report records zero console
      errors for all four captures.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model
      behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts:
      [real-dist aesthetic report](https://github.com/aandreakis/eliza/releases/download/pr-17533-evidence/finance-aesthetic-report.json)
      and
      [packaged OCR report](https://github.com/aandreakis/eliza/releases/download/pr-17533-evidence/finance-ocr-triage.json).
      The former records 4/4 `good`; the latter records 4/4 `verified`.

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review:
      [packaged OCR report](https://github.com/aandreakis/eliza/releases/download/pr-17533-evidence/finance-ocr-triage.json)
      reads `Balance` in all four captures and reports 0 broken,
      0 needs-eyeball, and 0 regressions.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

N/A - this is a deterministic audit-harness change. The generated audit report
is the relevant observable artifact and records `bundleProvenance: real-dist`,
zero console errors, and zero render-state issues for every finance viewport.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no production pixels changed; issue #17132 preserves the before failure
description and isolated-bundle provenance.

### After

- [Mobile portrait](https://github.com/aandreakis/eliza/releases/download/pr-17533-evidence/finance-mobile-portrait.jpg)
- [Mobile landscape](https://github.com/aandreakis/eliza/releases/download/pr-17533-evidence/finance-mobile-landscape.jpg)
- [Desktop landscape](https://github.com/aandreakis/eliza/releases/download/pr-17533-evidence/finance-desktop-landscape.jpg)
- [iPad portrait](https://github.com/aandreakis/eliza/releases/download/pr-17533-evidence/finance-ipad-portrait.jpg)

All four were opened at original resolution after the final rebase. Each shows
the populated `$2,765.50` balance, Latte transaction, Netflix recurring charge,
and unobstructed composer; no frame contains terminal `Loading`.

### Walkthrough video

N/A - no user flow changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- Root `bun run verify` passed all 579 Turbo typecheck/lint tasks, build-model
  consistency, Turbo dependency, and secret-leak audits, then failed the
  unrelated `audit:scripts` gate on five existing orphan files:
  `ci-workflow-invariants.test.mjs`, `develop-pr-aggregate.test.mjs`,
  `local-inference-attest.test.mjs`,
  `local-inference-performance-check.test.mjs`, and
  `script-test-isolation.test.mjs`. This branch changes only the three app
  audit files listed above.
- The unfiltered 254-case app walk produced 252 findings with 0 broken views,
  including all four finance captures as `good`, then the strict after-hook
  rejected two unrelated mobile overlay-clearance findings in `builtin-views`
  and `builtin-rolodex`. Both had empty `renderStateIssues`; the scoped
  four-viewport finance strict gate passed 4/4.
- GitHub marks the untrusted-fork workflows `action_required`; a repository
  maintainer must approve them before the aggregate `Develop PR Gate` can
  finish. The external contributor token cannot perform that approval.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [aandreakis-codex-terminal-loading]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->
