### PR TITLE
fix(ci): protect runner control directories from pruning

### DIFF
--- a/packages/deploy/runner-workspace-cleanup/smoke-test.sh
+++ b/packages/deploy/runner-workspace-cleanup/smoke-test.sh
@@ -115,18 +115,25 @@ for script in "$SCRIPT_DIR/install.sh" "$SCRIPT_DIR/smoke-test.sh" \
   bash -n "$script" || fail "bash syntax error in $script"
 done
 
-# 8. BEHAVIORAL: the prune reclaims a stale checkout and spares a fresh one,
-#    driven through the real tool against a temporary runner tree.
-mkdir -p "$RUNNER_ROOT/runner-1/_work/stale-repo" "$RUNNER_ROOT/runner-1/_work/fresh-repo"
+# 8. BEHAVIORAL: the prune reclaims a stale checkout, spares a fresh one, and
+#    preserves live runner command pipes even when their parent mtime is stale.
+#    This is driven through the real tool against a temporary runner tree.
+mkdir -p "$RUNNER_ROOT/runner-1/_work/stale-repo" \
+         "$RUNNER_ROOT/runner-1/_work/fresh-repo" \
+         "$RUNNER_ROOT/runner-1/_work/_temp/_runner_file_commands"
 echo payload > "$RUNNER_ROOT/runner-1/_work/stale-repo/file"
 echo payload > "$RUNNER_ROOT/runner-1/_work/fresh-repo/file"
+echo state > "$RUNNER_ROOT/runner-1/_work/_temp/_runner_file_commands/save_state_smoke"
 # Age it through node: `touch -d "48 hours ago"` is GNU-only and the BSD `-A`
 # form counts HHMMSS, so both silently mis-age this directory on macOS.
 node -e '
   const fs = require("node:fs");
   const when = new Date(Date.now() - 48 * 3600 * 1000);
-  fs.utimesSync(process.argv[1], when, when);
-' "$RUNNER_ROOT/runner-1/_work/stale-repo"
+  for (const target of process.argv.slice(1)) {
+    fs.utimesSync(target, when, when);
+  }
+' "$RUNNER_ROOT/runner-1/_work/stale-repo" \
+  "$RUNNER_ROOT/runner-1/_work/_temp"
 
 # `--allow-active` only because this assertion runs INSIDE a CI job, which is
 # itself a live `Runner.Worker` the tool's host-global guard would refuse on —
@@ -138,6 +145,8 @@ node -e '
 
 test ! -e "$RUNNER_ROOT/runner-1/_work/stale-repo" || fail "stale checkout was not reclaimed"
 test -e "$RUNNER_ROOT/runner-1/_work/fresh-repo" || fail "fresh checkout must be preserved"
+test -e "$RUNNER_ROOT/runner-1/_work/_temp/_runner_file_commands/save_state_smoke" \
+  || fail "runner file-command state must be preserved"
 
 # 9. If systemd-analyze is available, verify rendered units whose paths point
 #    at a temp staging of the REAL shipped files. The normal rendering above

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
@@ -17,6 +17,7 @@ import {
   buildRunnerWorkspacePrunePlan,
   findRunnerWorkDirs,
   parseRunnerWorkspacePruneArgs,
+  RUNNER_MANAGED_WORK_ENTRIES,
 } from "./prune-runner-workspaces";
 
 const roots: string[] = [];
@@ -123,6 +124,9 @@ describe("buildRunnerWorkspacePrunePlan", () => {
       "_tool",
       "_update",
     ];
+    expect([...RUNNER_MANAGED_WORK_ENTRIES].sort()).toEqual(
+      [...runnerManaged].sort(),
+    );
     mkdirSync(staleWorkspace, { recursive: true });
     for (const name of runnerManaged) {
       const controlDir = join(work, name);
@@ -146,6 +150,7 @@ describe("buildRunnerWorkspacePrunePlan", () => {
 
     expect(plan.entries.map((entry) => entry.path)).toEqual([staleWorkspace]);
     expect(plan.skippedFresh).toBe(0);
+    expect(plan.skippedProtected).toBe(runnerManaged.length);
   });
 
   it("selects only stale children of _work directories", () => {
@@ -173,6 +178,7 @@ describe("buildRunnerWorkspacePrunePlan", () => {
     expect(plan.workDirs).toEqual([work]);
     expect(plan.entries.map((entry) => entry.path)).toEqual([stale]);
     expect(plan.skippedFresh).toBe(1);
+    expect(plan.skippedProtected).toBe(0);
     expect(plan.totalBytes).toBeGreaterThan(0);
   });
 });

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
@@ -109,6 +109,42 @@ describe("findRunnerWorkDirs", () => {
 });
 
 describe("buildRunnerWorkspacePrunePlan", () => {
+  it("never selects runner-owned control directories", () => {
+    const root = tempRoot();
+    const work = join(root, "runner-1", "_work");
+    const staleWorkspace = join(work, "repo-old");
+    const runnerManaged = [
+      "_actions",
+      "_PipelineMapping",
+      "_temp",
+      "_tool",
+      "_update",
+    ];
+    mkdirSync(staleWorkspace, { recursive: true });
+    for (const name of runnerManaged) {
+      const controlDir = join(work, name);
+      mkdirSync(controlDir, { recursive: true });
+      writeFileSync(join(controlDir, "runner-state"), name);
+    }
+
+    const now = Date.now();
+    const oldDate = new Date(now - 8 * 60 * 60_000);
+    utimesSync(staleWorkspace, oldDate, oldDate);
+    for (const name of runnerManaged) {
+      const controlDir = join(work, name);
+      utimesSync(controlDir, oldDate, oldDate);
+    }
+
+    const plan = buildRunnerWorkspacePrunePlan({
+      root,
+      now,
+      minAgeHours: 6,
+    });
+
+    expect(plan.entries.map((entry) => entry.path)).toEqual([staleWorkspace]);
+    expect(plan.skippedFresh).toBe(0);
+  });
+
   it("selects only stale children of _work directories", () => {
     const root = tempRoot();
     const work = join(root, "runner-1", "_work");

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
@@ -85,7 +85,10 @@ describe("parseRunnerWorkspacePruneArgs", () => {
     ).toThrow("Unknown flag --min-age");
 
     expect(() =>
-      parseRunnerWorkspacePruneArgs(["--root", "/var/runners", "--nope", "1"], {}),
+      parseRunnerWorkspacePruneArgs(
+        ["--root", "/var/runners", "--nope", "1"],
+        {},
+      ),
     ).toThrow("Unknown flag --nope");
   });
 

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.ts
@@ -43,6 +43,16 @@ const DEFAULT_MIN_AGE_HOURS = 6;
 const MIN_AGE_HOURS_FLOOR = 1;
 /** Flags that take a value. Anything else is rejected rather than ignored. */
 const VALUE_FLAGS = new Set(["root", "min-age-hours"]);
+// These directories belong to the runner process, not to a completed job.
+// Deleting them can remove command files while an action is still publishing
+// state, even when this script's process guard observes no Runner.Worker.
+const RUNNER_MANAGED_WORK_ENTRIES = new Set([
+  "_actions",
+  "_PipelineMapping",
+  "_temp",
+  "_tool",
+  "_update",
+]);
 
 export function parseRunnerWorkspacePruneArgs(
   argv: string[],
@@ -194,6 +204,12 @@ export function buildRunnerWorkspacePrunePlan(input: {
     }
 
     for (const child of children) {
+      if (
+        !child.isDirectory() ||
+        RUNNER_MANAGED_WORK_ENTRIES.has(child.name)
+      ) {
+        continue;
+      }
       const childPath = path.join(workDir, child.name);
       if (!realPathInsideRoot(childPath, input.root)) continue;
       let stat: Stats;

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.ts
@@ -204,10 +204,7 @@ export function buildRunnerWorkspacePrunePlan(input: {
     }
 
     for (const child of children) {
-      if (
-        !child.isDirectory() ||
-        RUNNER_MANAGED_WORK_ENTRIES.has(child.name)
-      ) {
+      if (!child.isDirectory() || RUNNER_MANAGED_WORK_ENTRIES.has(child.name)) {
         continue;
       }
       const childPath = path.join(workDir, child.name);

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.ts
@@ -35,6 +35,7 @@ export interface WorkspacePlan {
   workDirs: string[];
   entries: WorkspaceEntry[];
   skippedFresh: number;
+  skippedProtected: number;
   totalBytes: number;
 }
 
@@ -43,10 +44,12 @@ const DEFAULT_MIN_AGE_HOURS = 6;
 const MIN_AGE_HOURS_FLOOR = 1;
 /** Flags that take a value. Anything else is rejected rather than ignored. */
 const VALUE_FLAGS = new Set(["root", "min-age-hours"]);
-// These directories belong to the runner process, not to a completed job.
-// Deleting them can remove command files while an action is still publishing
-// state, even when this script's process guard observes no Runner.Worker.
-const RUNNER_MANAGED_WORK_ENTRIES = new Set([
+/**
+ * Direct `_work` children owned by the runner rather than a completed job.
+ * Deleting them can remove command files while an action is publishing state,
+ * even when the process guard observes no Runner.Worker.
+ */
+export const RUNNER_MANAGED_WORK_ENTRIES = new Set([
   "_actions",
   "_PipelineMapping",
   "_temp",
@@ -193,6 +196,7 @@ export function buildRunnerWorkspacePrunePlan(input: {
   const workDirs = findRunnerWorkDirs(input.root);
   const entries: WorkspaceEntry[] = [];
   let skippedFresh = 0;
+  let skippedProtected = 0;
 
   for (const workDir of workDirs) {
     let children: ReturnType<typeof readdirSync>;
@@ -204,7 +208,9 @@ export function buildRunnerWorkspacePrunePlan(input: {
     }
 
     for (const child of children) {
-      if (!child.isDirectory() || RUNNER_MANAGED_WORK_ENTRIES.has(child.name)) {
+      if (!child.isDirectory()) continue;
+      if (RUNNER_MANAGED_WORK_ENTRIES.has(child.name)) {
+        skippedProtected += 1;
         continue;
       }
       const childPath = path.join(workDir, child.name);
@@ -233,6 +239,7 @@ export function buildRunnerWorkspacePrunePlan(input: {
     workDirs,
     entries,
     skippedFresh,
+    skippedProtected,
     totalBytes: entries.reduce((sum, entry) => sum + entry.bytes, 0),
   };
 }
@@ -280,6 +287,9 @@ async function main(): Promise<void> {
   );
   console.log(
     `[prune-runner-workspaces] skipped fresh entries: ${plan.skippedFresh}`,
+  );
+  console.log(
+    `[prune-runner-workspaces] skipped runner control entries: ${plan.skippedProtected}`,
   );
   console.log(
     `[prune-runner-workspaces] reclaimable: ${formatBytes(plan.totalBytes)}`,


### PR DESCRIPTION
Closes #17534.

## Summary

- exclude GitHub Actions runner-owned control directories from workspace prune plans
- keep stale ordinary repository workspaces eligible for deletion
- add regression coverage for every protected directory

The pruner previously treated every direct child of `_work` as a repository checkout. On self-hosted runners that includes `_temp`, where Actions keeps live `save_state_*` command files, plus action and tool caches. Runs 30692175805 and 30691649390 both failed after those files disappeared on `eliza-robot-6`.

## Validation

- `bun test packages/scripts/cloud/admin/prune-runner-workspaces.test.ts`: 8 passed, 14 assertions
- mutation proof: removing the protection fails the new test with all five runner-owned directories selected
- `bunx biome check packages/scripts/cloud/admin/prune-runner-workspaces.ts packages/scripts/cloud/admin/prune-runner-workspaces.test.ts`: passed
- `git diff --check origin/develop 2267292685f931014636f23a5e602a91a5e4cff7`: passed

## Evidence

- Backend logs: [run 30692175805](https://github.com/elizaOS/eliza/actions/runs/30692175805) and [run 30691649390](https://github.com/elizaOS/eliza/actions/runs/30691649390) show `save_state_*` disappearing immediately after checkout.
- Frontend logs: N/A - runner administration only.
- Before/after screenshots and video: N/A - no user-facing UI.
- Real-LLM trajectory: N/A - no agent, prompt, action, or model behavior.
- Domain artifacts: regression test plan selects only the stale ordinary workspace; mutation selects all five protected entries and fails.
- Native/platform capture: N/A - Linux runner filesystem behavior, exercised in temp filesystem tests.
- Manual review: exact commit `2267292685f931014636f23a5e602a91a5e4cff7` inspected against current `develop`.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no user-facing UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no user-facing UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - runner administration only

<!-- evidence-row:backend-logs -->
- [ ] N/A - this filesystem planning change has no backend service execution path

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, action, or model behavior

<!-- evidence-row:domain-artifacts -->
- [x] [17535-pr-17535-runner-pruner-validation.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17535-pr-17535-runner-pruner-validation.log)

<!-- evidence-head:7282567e74a57a8c565ff1277dc27bb0c907f622 -->

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-terra`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: self-reported