### PR TITLE
Fix/windows ci timing and copy assertions

### DIFF
--- a/plugins/plugin-app-control/src/actions/app.test.ts
+++ b/plugins/plugin-app-control/src/actions/app.test.ts
@@ -40,7 +40,7 @@ describe("APP action role policy", () => {
 		expect(result).toEqual(
 			expect.objectContaining({
 				success: false,
-				text: expect.stringContaining("only the owner"),
+				text: expect.stringContaining("only my owner"),
 			}),
 		);
 		expect(client.listInstalledApps).not.toHaveBeenCalled();


### PR DESCRIPTION
# Relates to

- Fixes #17495

# Definition of Done

- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.

# Description

Narrows PR #17543 to the `plugin-app-control` owner denial string assertion fix, dropping the heartbeat timing refactor to avoid duplication with PR #17529.

- Updates `plugins/plugin-app-control/src/actions/app.test.ts` line 43 to assert `text: expect.stringContaining("only my owner")`, matching the actual shipped denial message in `app.ts` line 325 ("Sorry — only my owner can manage apps.").

# Evidence Gate

| Evidence Category | Required | Provided | Details |
| --- | --- | --- | --- |
| Rebased on latest `origin/develop`, zero conflicts | yes | yes | Rebased on `origin/develop` |
| `bun install` + `bun run verify` post-sync | yes | yes | Tested string assertion match |
| Backend logs | N/A | N/A - test assertion update | N/A |
| Frontend logs | N/A | N/A - no user-facing UI | N/A |
| Screenshots / video | N/A | N/A - no user-facing UI | N/A |
| Real-LLM trajectory | N/A | N/A - test assertion update | N/A |
| Domain artifact | yes | yes | String matches `app.ts` line 325 |
| Native / platform capture | N/A | N/A | N/A |
| Manual review | yes | yes | Verified string against `app.ts:325` |

evidence-head: 1dcf7b075e7a918aeae9b61d36bb97e55a7aebe1

<!-- eliza.army attribution -->
This pull request was prepared with assist from the eliza.army contributor network.