### PR TITLE
fix(ci): protect runner control directories from workspace pruning

### DIFF
--- a/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
@@ -85,7 +85,10 @@ describe("parseRunnerWorkspacePruneArgs", () => {
     ).toThrow("Unknown flag --min-age");
 
     expect(() =>
-      parseRunnerWorkspacePruneArgs(["--root", "/var/runners", "--nope", "1"], {}),
+      parseRunnerWorkspacePruneArgs(
+        ["--root", "/var/runners", "--nope", "1"],
+        {},
+      ),
     ).toThrow("Unknown flag --nope");
   });
 
@@ -135,5 +138,44 @@ describe("buildRunnerWorkspacePrunePlan", () => {
     expect(plan.entries.map((entry) => entry.path)).toEqual([stale]);
     expect(plan.skippedFresh).toBe(1);
     expect(plan.totalBytes).toBeGreaterThan(0);
+  });
+
+  it("never includes runner-owned control directories (_temp, _actions, _tool, _update, _PipelineMapping) even when stale", () => {
+    const root = tempRoot();
+    const work = join(root, "runner-1", "_work");
+    const protectedDirs = [
+      "_temp",
+      "_actions",
+      "_tool",
+      "_update",
+      "_PipelineMapping",
+    ];
+    const staleRepo = join(work, "stale-user-repo");
+
+    mkdirSync(staleRepo, { recursive: true });
+    for (const name of protectedDirs) {
+      mkdirSync(join(work, name), { recursive: true });
+      writeFileSync(join(work, name, "data.txt"), "control-data");
+    }
+    writeFileSync(join(staleRepo, "code.ts"), "export const x = 1;");
+
+    const now = Date.now();
+    const oldDate = new Date(now - 48 * 60 * 60_000);
+    utimesSync(staleRepo, oldDate, oldDate);
+    for (const name of protectedDirs) {
+      utimesSync(join(work, name), oldDate, oldDate);
+    }
+
+    const plan = buildRunnerWorkspacePrunePlan({
+      root,
+      now,
+      minAgeHours: 6,
+    });
+
+    const plannedPaths = plan.entries.map((e) => e.path);
+    expect(plannedPaths).toEqual([staleRepo]);
+    for (const name of protectedDirs) {
+      expect(plannedPaths).not.toContain(join(work, name));
+    }
   });
 });

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.ts
@@ -44,6 +44,19 @@ const MIN_AGE_HOURS_FLOOR = 1;
 /** Flags that take a value. Anything else is rejected rather than ignored. */
 const VALUE_FLAGS = new Set(["root", "min-age-hours"]);
 
+/**
+ * Direct children of `_work` owned by GitHub Actions runner execution machinery.
+ * Pruning these destroys active runner file command pipes, action steps, toolsets,
+ * and pipeline mappings.
+ */
+export const PROTECTED_RUNNER_CONTROL_DIRS = new Set([
+  "_temp",
+  "_actions",
+  "_tool",
+  "_update",
+  "_PipelineMapping",
+]);
+
 export function parseRunnerWorkspacePruneArgs(
   argv: string[],
   env: NodeJS.ProcessEnv,
@@ -194,6 +207,7 @@ export function buildRunnerWorkspacePrunePlan(input: {
     }
 
     for (const child of children) {
+      if (PROTECTED_RUNNER_CONTROL_DIRS.has(child.name)) continue;
       const childPath = path.join(workDir, child.name);
       if (!realPathInsideRoot(childPath, input.root)) continue;
       let stat: Stats;


### PR DESCRIPTION
## Problem
The self-hosted runner workspace pruner (`packages/scripts/cloud/admin/prune-runner-workspaces.ts`) treats every direct child of `_work` as a disposable repository checkout. GitHub Actions also owns persistent control directories there, including `_temp`, `_actions`, `_tool`, `_update`, and `_PipelineMapping`.

This deletes `_work/_temp/_runner_file_commands/save_state_*` while steps run, causing unrelated workflow steps to fail after checkout.

## Solution
- Defined `PROTECTED_RUNNER_CONTROL_DIRS` containing `_temp`, `_actions`, `_tool`, `_update`, and `_PipelineMapping` in `packages/scripts/cloud/admin/prune-runner-workspaces.ts`.
- Updated `buildRunnerWorkspacePrunePlan` to skip runner control directories when discovering prune targets under `_work`.
- Added unit test coverage in `packages/scripts/cloud/admin/prune-runner-workspaces.test.ts` verifying all protected control directories are preserved while stale repository checkouts remain eligible.

Closes #17534

<!-- eliza.army attribution -->
This pull request was prepared with assist from the eliza.army contributor network.