### PR TITLE
fix(cloud): release a deleted agent's node slot exactly once

### DIFF
--- a/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
+++ b/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
@@ -17,6 +17,7 @@ async function runEnsureAgentSandboxSchema(): Promise<void> {
       ADD COLUMN IF NOT EXISTS "lifecycle_revision" bigint NOT NULL DEFAULT 0,
       ADD COLUMN IF NOT EXISTS "deletion_attempt_id" uuid,
       ADD COLUMN IF NOT EXISTS "deletion_started_at" timestamptz,
+      ADD COLUMN IF NOT EXISTS "deletion_allocation_counted" boolean,
       ADD COLUMN IF NOT EXISTS "warm_claim_credential_state" text,
       ADD COLUMN IF NOT EXISTS "warm_claim_source_pool_id" uuid,
       ADD COLUMN IF NOT EXISTS "warm_claim_key_fingerprint" text,

--- a/packages/cloud/shared/src/db/migrations/0189_agent_sandbox_deletion_allocation_ownership.sql
+++ b/packages/cloud/shared/src/db/migrations/0189_agent_sandbox_deletion_allocation_ownership.sql
@@ -1,0 +1,41 @@
+-- Records whether a deletion generation still owns one counted slot in
+-- `docker_nodes.allocated_count`, so a managed agent's node slot is released
+-- exactly once however many times its teardown runs.
+--
+-- Remote teardown is retryable and treats "No such container" as success, but
+-- the local counter is not idempotent: the sandbox row keeps its node/container
+-- locator until the row itself is deleted, so a retry after any post-stop
+-- failure (credential revocation, the row-delete CAS, job-status persistence)
+-- decrements the same slot again. `GREATEST(count - 1, 0)` hides the underflow
+-- instead of preventing it, and the freed slot can belong to a LIVE sibling on
+-- that node. Suspend has the same shape: it stops and decrements while keeping
+-- the locator, so a later delete repeats the decrement with no retry involved.
+--
+-- Nullable with no default and no backfill. NULL is a real third state, not
+-- "unknown-so-assume-false": rows that already carried a deletion intent when
+-- this shipped have no recorded answer, and both guesses are wrong — `true`
+-- double-frees a live sibling's capacity, `false` leaks the slot until the node
+-- drains. A NULL is instead left for `syncAllocatedCounts` to resolve: it
+-- recomputes `allocated_count` from the surviving rows once the deletion
+-- finishes, so a deletion in flight at deploy time self-heals on the next
+-- sweep. Until it does, that node reads one slot fuller than it is — the safe
+-- direction, since schedulers gate on `allocated_count < capacity`, so the
+-- error can only under-pack a node, never over-pack one.
+--
+-- No CHECK constraint pairing this with `deletion_attempt_id`: ADD CONSTRAINT
+-- full-scans `agent_sandboxes` under ACCESS EXCLUSIVE. Same trade-off migration
+-- 0185 documents for `jobs.execution_interruptions`.
+--
+-- The pairing is structural, but only in one direction, and the exact shape
+-- matters to anyone later auditing whether it could be enforced: every writer
+-- that ESTABLISHES a deletion generation sets both columns together. A recovery
+-- re-enqueue deliberately updates `deletion_attempt_id` while leaving this
+-- column alone, because re-deriving ownership from a row already in
+-- `deletion_pending` would read as "still counted" and free a live sibling's
+-- slot on every sweep. So a constraint requiring both to be written together
+-- would reject a legitimate continuation.
+--
+-- ADD COLUMN of a nullable column with no default is metadata-only on PG11+,
+-- so this is safe on a hot table.
+ALTER TABLE "agent_sandboxes"
+  ADD COLUMN IF NOT EXISTS "deletion_allocation_counted" boolean;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1317,6 +1317,13 @@
       "when": 1785960000000,
       "tag": "0188_sso_bridge_store",
       "breakpoints": true
+    },
+    {
+      "idx": 188,
+      "version": "7",
+      "when": 1786046400000,
+      "tag": "0189_agent_sandbox_deletion_allocation_ownership",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -2194,9 +2194,11 @@ export class AgentSandboxesRepository {
    * so an unexpected underflow leaves the counter untouched and visible instead
    * of being silently absorbed.
    *
-   * @returns true if THIS call actually decremented the node. False covers both
-   * "ownership was not ours to spend" and "ownership was spent but the counter
-   * did not move" (already 0, or no `docker_nodes` row) — the latter warns.
+   * @returns which of the three {@link DeletionAllocationRelease} outcomes
+   * occurred. `counter-unchanged` also warns: ownership was ours to spend, but
+   * the node counter did not move — either it was already 0 or the
+   * `docker_nodes` row is gone, and in both cases there is no slot left to give
+   * back, so committing the flip is correct.
    */
   private async spendDeletionAllocation(
     nodeId: string,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -2204,6 +2204,11 @@ export class AgentSandboxesRepository {
     nodeId: string,
     claimWhere: SQL,
   ): Promise<DeletionAllocationRelease> {
+    // Memoized per database URL, so this is a settled-promise await after the
+    // first call in an isolate rather than DDL on every teardown. It stays on
+    // this path because the deletion writers can reach the column before the
+    // migration has run — `deploy-eliza-provisioning-worker.yml` has no
+    // `migrate-db` gate.
     await ensureAgentSandboxSchema();
     return dbWrite.transaction(async (tx) => {
       const [claimed] = await tx
@@ -2222,6 +2227,12 @@ export class AgentSandboxesRepository {
         .where(and(eq(dockerNodes.node_id, nodeId), gt(dockerNodes.allocated_count, 0)))
         .returning({ nodeId: dockerNodes.node_id });
       if (decremented.length === 0) {
+        // Committing the flip is still correct. Either the counter was already
+        // 0, or the `docker_nodes` row is gone — and when the row goes its
+        // `allocated_count` goes with it, so there is no counter left to leak
+        // into. A transiently-absent node self-heals anyway: `syncAllocatedCounts`
+        // recomputes from surviving rows, and the error direction only ever
+        // under-packs a node, never over-packs one.
         logger.warn(
           `[agent-sandboxes] Deletion allocation ownership consumed for node ${nodeId} but allocated_count was not decremented — counter already at 0 or node row missing`,
         );
@@ -2272,6 +2283,13 @@ export class AgentSandboxesRepository {
    * absence directly, which supersedes whichever deletion attempt was in
    * flight. The node is still matched, so a row since re-placed elsewhere
    * cannot have the wrong node's capacity released.
+   *
+   * The missing `organization_id` predicate is deliberate and not a weaker
+   * fence: `agent_sandboxes.id` is the primary key, so scoping by org selects
+   * the same row or none. `tryReleaseDeletionAllocation` carries it because its
+   * caller holds an org-scoped request context and passing it through keeps the
+   * tenant boundary explicit at that entry point; the reaper has no such
+   * context, having started from a container name on a node.
    */
   async releaseDeletionAllocationOnReap(
     agentId: string,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -311,6 +311,17 @@ export async function prepareAgentBackupInsertData(
   };
 }
 
+/**
+ * Outcome of spending a deletion generation's allocation ownership.
+ *
+ * Three-valued on purpose. A boolean conflates the benign expected case
+ * (`not-owned` — the retry path this feature exists to make safe) with a real
+ * accounting bug (`counter-unchanged` — ownership was ours, but the node
+ * counter did not move), and an operator reading `released: false` could not
+ * tell which they were looking at.
+ */
+export type DeletionAllocationRelease = "released" | "not-owned" | "counter-unchanged";
+
 export class AgentSandboxesRepository {
   // Reads
 
@@ -2187,7 +2198,10 @@ export class AgentSandboxesRepository {
    * "ownership was not ours to spend" and "ownership was spent but the counter
    * did not move" (already 0, or no `docker_nodes` row) — the latter warns.
    */
-  private async spendDeletionAllocation(nodeId: string, claimWhere: SQL): Promise<boolean> {
+  private async spendDeletionAllocation(
+    nodeId: string,
+    claimWhere: SQL,
+  ): Promise<DeletionAllocationRelease> {
     await ensureAgentSandboxSchema();
     return dbWrite.transaction(async (tx) => {
       const [claimed] = await tx
@@ -2195,7 +2209,7 @@ export class AgentSandboxesRepository {
         .set({ deletion_allocation_counted: false, updated_at: new Date() })
         .where(and(claimWhere, eq(agentSandboxes.deletion_allocation_counted, true)))
         .returning({ id: agentSandboxes.id });
-      if (!claimed) return false;
+      if (!claimed) return "not-owned";
 
       const decremented = await tx
         .update(dockerNodes)
@@ -2209,8 +2223,9 @@ export class AgentSandboxesRepository {
         logger.warn(
           `[agent-sandboxes] Deletion allocation ownership consumed for node ${nodeId} but allocated_count was not decremented — counter already at 0 or node row missing`,
         );
+        return "counter-unchanged";
       }
-      return decremented.length > 0;
+      return "released";
     });
   }
 
@@ -2228,7 +2243,7 @@ export class AgentSandboxesRepository {
     orgId: string,
     deletionAttemptId: string,
     nodeId: string,
-  ): Promise<boolean> {
+  ): Promise<DeletionAllocationRelease> {
     return this.spendDeletionAllocation(
       nodeId,
       and(
@@ -2256,7 +2271,10 @@ export class AgentSandboxesRepository {
    * flight. The node is still matched, so a row since re-placed elsewhere
    * cannot have the wrong node's capacity released.
    */
-  async releaseDeletionAllocationOnReap(agentId: string, nodeId: string): Promise<boolean> {
+  async releaseDeletionAllocationOnReap(
+    agentId: string,
+    nodeId: string,
+  ): Promise<DeletionAllocationRelease> {
     return this.spendDeletionAllocation(
       nodeId,
       and(eq(agentSandboxes.id, agentId), eq(agentSandboxes.node_id, nodeId)) as SQL,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -14,6 +14,7 @@ import {
   asc,
   desc,
   eq,
+  gt,
   gte,
   inArray,
   isNotNull,
@@ -67,6 +68,7 @@ import {
   WARM_POOL_ORG_ID,
   WARM_POOL_USER_ID,
 } from "../schemas/agent-sandboxes";
+import { dockerNodes } from "../schemas/docker-nodes";
 import { jobs } from "../schemas/jobs";
 import { imageRepo, imageRepoSql } from "../utils/docker-image-ref";
 
@@ -2166,6 +2168,99 @@ export class AgentSandboxesRepository {
       }
     }
     return state;
+  }
+
+  /**
+   * Spend recorded allocation ownership and give the node its slot back, in one
+   * transaction (#17185).
+   *
+   * The flag flip and the decrement commit together so they can never disagree:
+   * whoever wins the row lock consumes the ownership, and every later caller
+   * matches no row and decrements nothing. Callers differ only in `claimWhere`,
+   * which is the fence deciding WHO is entitled to spend it.
+   *
+   * `allocated_count > 0` is a guard rather than `GREATEST(... , 0)` clamping,
+   * so an unexpected underflow leaves the counter untouched and visible instead
+   * of being silently absorbed.
+   *
+   * @returns true if THIS call actually decremented the node. False covers both
+   * "ownership was not ours to spend" and "ownership was spent but the counter
+   * did not move" (already 0, or no `docker_nodes` row) — the latter warns.
+   */
+  private async spendDeletionAllocation(nodeId: string, claimWhere: SQL): Promise<boolean> {
+    await ensureAgentSandboxSchema();
+    return dbWrite.transaction(async (tx) => {
+      const [claimed] = await tx
+        .update(agentSandboxes)
+        .set({ deletion_allocation_counted: false, updated_at: new Date() })
+        .where(and(claimWhere, eq(agentSandboxes.deletion_allocation_counted, true)))
+        .returning({ id: agentSandboxes.id });
+      if (!claimed) return false;
+
+      const decremented = await tx
+        .update(dockerNodes)
+        .set({
+          allocated_count: sql`${dockerNodes.allocated_count} - 1`,
+          updated_at: new Date(),
+        })
+        .where(and(eq(dockerNodes.node_id, nodeId), gt(dockerNodes.allocated_count, 0)))
+        .returning({ nodeId: dockerNodes.node_id });
+      if (decremented.length === 0) {
+        logger.warn(
+          `[agent-sandboxes] Deletion allocation ownership consumed for node ${nodeId} but allocated_count was not decremented — counter already at 0 or node row missing`,
+        );
+      }
+      return decremented.length > 0;
+    });
+  }
+
+  /**
+   * Release the slot held by ONE deletion generation, at most once.
+   *
+   * Fenced on the whole locator, not just the row id: a superseded generation,
+   * another organization, or a row that has since moved nodes must not release
+   * the current node's capacity. This is what makes a re-claimed delete job
+   * (crash-retry, or a post-stop credential/row-delete/job-status failure) a
+   * no-op instead of a second decrement freeing a live sibling's slot.
+   */
+  async tryReleaseDeletionAllocation(
+    agentId: string,
+    orgId: string,
+    deletionAttemptId: string,
+    nodeId: string,
+  ): Promise<boolean> {
+    return this.spendDeletionAllocation(
+      nodeId,
+      and(
+        eq(agentSandboxes.id, agentId),
+        eq(agentSandboxes.organization_id, orgId),
+        eq(agentSandboxes.deletion_attempt_id, deletionAttemptId),
+        eq(agentSandboxes.node_id, nodeId),
+      ) as SQL,
+    );
+  }
+
+  /**
+   * Release a held slot once the orphan reconciler has PROVEN the container is
+   * gone.
+   *
+   * The delete path deliberately keeps ownership when it cannot prove absence —
+   * a bounded timeout abandons a container that may still be running, and a
+   * `deletion_failed` row's container is by definition still out there. Without
+   * this the slot would stay counted forever once `reEnqueueFailedDeletions`
+   * hits its circuit breaker, permanently shrinking the node and inflating the
+   * autoscaler's view of demand (the #15378 regression).
+   *
+   * Unfenced by generation on purpose: the reaper observed the container's
+   * absence directly, which supersedes whichever deletion attempt was in
+   * flight. The node is still matched, so a row since re-placed elsewhere
+   * cannot have the wrong node's capacity released.
+   */
+  async releaseDeletionAllocationOnReap(agentId: string, nodeId: string): Promise<boolean> {
+    return this.spendDeletionAllocation(
+      nodeId,
+      and(eq(agentSandboxes.id, agentId), eq(agentSandboxes.node_id, nodeId)) as SQL,
+    );
   }
 }
 

--- a/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
@@ -110,6 +110,31 @@ export const agentSandboxes = pgTable(
     deletion_attempt_id: uuid("deletion_attempt_id"),
     deletion_started_at: timestamp("deletion_started_at", { withTimezone: true }),
     /**
+     * Whether THIS deletion generation still owns one counted slot in
+     * `docker_nodes.allocated_count`, so the slot is released exactly once no
+     * matter how many times the teardown runs.
+     *
+     * Remote teardown is retryable and idempotent-ish ("No such container" is a
+     * success), but the local counter is not: the row keeps its node/container
+     * locator until the row is deleted, so a retry after a post-stop failure
+     * (credential revocation, row-delete CAS, job-status persistence) would
+     * re-decrement the same slot and free a LIVE sibling's capacity —
+     * `GREATEST(count - 1, 0)` hides the underflow rather than preventing it.
+     *
+     * `true` — this generation holds a counted slot; the release CAS may run.
+     * `false` — it never held one (suspended/sleeping rows already released at
+     * suspend time), or this generation already released it.
+     * `null` — no deletion intent, or a pre-migration intent whose ownership was
+     * never recorded; reconciliation resolves those explicitly rather than
+     * guessing, because guessing either leaks capacity or double-frees it.
+     *
+     * "Ownership never outlives its generation" is structural, not a CHECK
+     * constraint: the only writers set this together with `deletion_attempt_id`
+     * in a single UPDATE, and `ADD CONSTRAINT` would full-scan `agent_sandboxes`
+     * under ACCESS EXCLUSIVE — the same trade-off migration 0185 documents.
+     */
+    deletion_allocation_counted: boolean("deletion_allocation_counted"),
+    /**
      * Execution tier (see AgentExecutionTier). New agents default to "shared"
      * (container-free); only a real need escalates to a dedicated container.
      * The migration backfills pre-existing container rows to "dedicated-lazy".

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
@@ -214,7 +214,7 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
           deletionAttemptId,
           nodeId,
         ),
-      ).toBe(true);
+      ).toBe("released");
       expect(await allocatedCount(nodeId)).toBe(1);
       expect(await ownership(agentId)).toBe(false);
 
@@ -228,7 +228,7 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
           deletionAttemptId,
           nodeId,
         ),
-      ).toBe(false);
+      ).toBe("not-owned");
       expect(await allocatedCount(nodeId)).toBe(1);
 
       // A third recovery sweep is still a no-op.
@@ -239,7 +239,7 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
           deletionAttemptId,
           nodeId,
         ),
-      ).toBe(false);
+      ).toBe("not-owned");
       expect(await allocatedCount(nodeId)).toBe(1);
     },
     PGLITE_TIMEOUT,
@@ -268,7 +268,12 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
         ),
       ]);
 
-      expect(results.filter(Boolean)).toHaveLength(1);
+      // Exactly one caller wins the row lock and spends the ownership; the other
+      // re-evaluates against the committed row and finds nothing to claim. Assert
+      // the outcomes by name — every outcome is a truthy string, so a
+      // truthiness count would pass no matter which two came back.
+      expect(results.filter((r) => r === "released")).toHaveLength(1);
+      expect(results.filter((r) => r === "not-owned")).toHaveLength(1);
       expect(await allocatedCount(nodeId)).toBe(1);
     },
     PGLITE_TIMEOUT,
@@ -291,7 +296,7 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
           deletionAttemptId,
           nodeId,
         ),
-      ).toBe(false);
+      ).toBe("not-owned");
       expect(await allocatedCount(nodeId)).toBe(2);
     },
     PGLITE_TIMEOUT,
@@ -312,7 +317,7 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
           crypto.randomUUID(), // a superseded attempt id
           nodeId,
         ),
-      ).toBe(false);
+      ).toBe("not-owned");
       expect(await allocatedCount(nodeId)).toBe(2);
       expect(await ownership(agentId)).toBe(true);
     },
@@ -340,7 +345,7 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
           deletionAttemptId,
           otherNodeId,
         ),
-      ).toBe(false);
+      ).toBe("not-owned");
       expect(await allocatedCount(otherNodeId)).toBe(2);
       expect(await allocatedCount(nodeId)).toBe(2);
     },
@@ -362,7 +367,7 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
           deletionAttemptId,
           nodeId,
         ),
-      ).toBe(false);
+      ).toBe("not-owned");
       expect(await allocatedCount(nodeId)).toBe(2);
     },
     PGLITE_TIMEOUT,
@@ -380,9 +385,9 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
         .set({ allocated_count: 0 })
         .where(eq(dockerNodes.node_id, nodeId));
 
-      // Ownership is still consumed — the claim was real — but the guard blocks
-      // the underflow, and the return value reports that the counter did NOT
-      // move so no caller logs a decrement that never happened.
+      // Ownership IS consumed — the claim was real — but the guard blocks the
+      // underflow. The outcome must say so: `counter-unchanged` is an accounting
+      // mismatch worth a warn, distinct from the benign `not-owned` retry.
       expect(
         await agentSandboxesRepository.tryReleaseDeletionAllocation(
           agentId,
@@ -390,7 +395,7 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
           deletionAttemptId,
           nodeId,
         ),
-      ).toBe(false);
+      ).toBe("counter-unchanged");
       expect(await allocatedCount(nodeId)).toBe(0);
       expect(await ownership(agentId)).toBe(false);
     },
@@ -443,7 +448,7 @@ describe("a deletion continuation never re-derives ownership from its own state"
           attemptId,
           nodeId,
         ),
-      ).toBe(false);
+      ).toBe("not-owned");
       expect(await allocatedCount(nodeId)).toBe(2);
     },
     PGLITE_TIMEOUT,
@@ -481,7 +486,7 @@ describe("releaseDeletionAllocationOnReap — absence proven by the orphan reape
       expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, nodeId)).toBe(1);
 
       expect(await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, nodeId)).toBe(
-        true,
+        "released",
       );
       expect(await allocatedCount(nodeId)).toBe(1);
       expect(await ownership(agentId)).toBe(false);
@@ -501,7 +506,7 @@ describe("releaseDeletionAllocationOnReap — absence proven by the orphan reape
 
       await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, nodeId);
       expect(await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, nodeId)).toBe(
-        false,
+        "not-owned",
       );
       expect(await allocatedCount(nodeId)).toBe(1);
     },
@@ -525,7 +530,7 @@ describe("releaseDeletionAllocationOnReap — absence proven by the orphan reape
 
       expect(
         await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, otherNodeId),
-      ).toBe(false);
+      ).toBe("not-owned");
       expect(await allocatedCount(otherNodeId)).toBe(2);
       expect(await allocatedCount(nodeId)).toBe(2);
     },
@@ -542,7 +547,7 @@ describe("releaseDeletionAllocationOnReap — absence proven by the orphan reape
       });
 
       expect(await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, nodeId)).toBe(
-        false,
+        "not-owned",
       );
       expect(await allocatedCount(nodeId)).toBe(2);
     },

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
@@ -1,0 +1,691 @@
+/**
+ * Durable deletion-allocation ownership (#17185): one logical managed Docker
+ * allocation gives back exactly one `docker_nodes.allocated_count` slot, however
+ * many times its teardown runs.
+ *
+ * The defect these pin is a double-free, not a leak. Remote teardown is
+ * retryable and treats "No such container" as success, but the sandbox row keeps
+ * its node locator until the row is deleted — so a retry after any post-stop
+ * failure used to decrement the same node again and free a LIVE sibling's slot,
+ * with `GREATEST(count - 1, 0)` hiding the underflow. Ownership makes the second
+ * release a no-op instead.
+ *
+ * Drives the REAL repository CAS and the REAL workload-reconciliation query
+ * against in-process PGlite (real Drizzle schema via pushSchema) with NOTHING
+ * mocked, so the actual SQL — the cross-table transaction, the locator
+ * predicate, the `allocated_count > 0` guard — executes. Fails LOUDLY if
+ * PGlite/pushSchema is unavailable; it never silently passes.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { apiKeys } from "../../../db/schemas/api-keys";
+import { containers } from "../../../db/schemas/containers";
+import { dockerNodes } from "../../../db/schemas/docker-nodes";
+import { generations } from "../../../db/schemas/generations";
+import { jobs } from "../../../db/schemas/jobs";
+import { organizations } from "../../../db/schemas/organizations";
+import { usageRecords } from "../../../db/schemas/usage-records";
+import { userCharacters } from "../../../db/schemas/user-characters";
+import { users } from "../../../db/schemas/users";
+import { holdsCountedNodeSlot, TERMINAL_SANDBOX_STATUSES } from "../docker-node-workload-queries";
+
+const PGLITE_TIMEOUT = 60_000;
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let agentSandboxesRepository: typeof import("../../../db/repositories/agent-sandboxes").agentSandboxesRepository;
+let countAllocatedWorkloadsOnNodeWithDatabase: typeof import("../docker-node-workload-queries").countAllocatedWorkloadsOnNodeWithDatabase;
+let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
+let ProvisioningJobService: typeof import("../provisioning-jobs").ProvisioningJobService;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.error("[deletion-allocation-ownership.test] non-PGlite DATABASE_URL; failing.");
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ agentSandboxesRepository } = await import("../../../db/repositories/agent-sandboxes"));
+    ({ countAllocatedWorkloadsOnNodeWithDatabase } = await import(
+      "../docker-node-workload-queries"
+    ));
+    ({ ElizaSandboxService } = await import("../eliza-sandbox"));
+    ({ ProvisioningJobService } = await import("../provisioning-jobs"));
+
+    const schema = {
+      organizations,
+      users,
+      userCharacters,
+      agentSandboxes,
+      apiKeys,
+      generations,
+      usageRecords,
+      jobs,
+      dockerNodes,
+      containers,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[deletion-allocation-ownership.test] PGlite/pushSchema unavailable — failing.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+/**
+ * A node carrying two allocations: the row under test plus a live sibling. The
+ * sibling is the thing a double-free actually harms, so every release assertion
+ * below is really "did the sibling keep its slot".
+ */
+async function seedNodeWithTargetAndSibling(options: {
+  allocationCounted: boolean | null;
+  status?: "running" | "stopped" | "sleeping" | "deletion_pending" | "deletion_failed";
+  withDeletionIntent?: boolean;
+}): Promise<{ agentId: string; orgId: string; nodeId: string; deletionAttemptId: string }> {
+  const nodeId = uniq("node");
+  const deletionAttemptId = crypto.randomUUID();
+
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "5.000000" })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+
+  await dbWrite
+    .insert(dockerNodes)
+    .values({ node_id: nodeId, hostname: `${nodeId}.test.invalid`, allocated_count: 2 });
+
+  const withIntent = options.withDeletionIntent ?? true;
+  const [agent] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: org.id,
+      user_id: user.id,
+      agent_name: uniq("agent"),
+      status: options.status ?? "deletion_pending",
+      node_id: nodeId,
+      container_name: uniq("container"),
+      ...(withIntent
+        ? { deletion_attempt_id: deletionAttemptId, deletion_started_at: new Date() }
+        : {}),
+      deletion_allocation_counted: options.allocationCounted,
+    })
+    .returning();
+
+  return { agentId: agent.id, orgId: org.id, nodeId, deletionAttemptId };
+}
+
+async function allocatedCount(nodeId: string): Promise<number> {
+  const [row] = await dbWrite
+    .select({ n: dockerNodes.allocated_count })
+    .from(dockerNodes)
+    .where(eq(dockerNodes.node_id, nodeId));
+  return Number(row.n);
+}
+
+/** A real agent row created through the service, so the delete path sees a genuine one. */
+async function seedAgentViaService(): Promise<{
+  agentId: string;
+  orgId: string;
+  userId: string;
+}> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "5.000000" })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  const res = await new ElizaSandboxService().createAgent({
+    organizationId: org.id,
+    userId: user.id,
+    agentName: uniq("agent"),
+    executionTier: "dedicated-always",
+    maxNonTerminalAgents: 10,
+  });
+  return { agentId: res.agent.id, orgId: org.id, userId: user.id };
+}
+
+async function deletionAttemptId(agentId: string): Promise<string> {
+  const [row] = await dbWrite
+    .select({ id: agentSandboxes.deletion_attempt_id })
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, agentId));
+  if (!row.id) throw new Error("expected a deletion attempt id to be stamped");
+  return row.id;
+}
+
+async function ownership(agentId: string): Promise<boolean | null> {
+  const [row] = await dbWrite
+    .select({ owned: agentSandboxes.deletion_allocation_counted })
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, agentId));
+  return row.owned;
+}
+
+describe("tryReleaseDeletionAllocation — releases exactly once", () => {
+  test(
+    "retry after a post-stop failure does not free the live sibling's slot",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, orgId, nodeId, deletionAttemptId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+      });
+
+      // First pass: teardown succeeded, slot handed back. 2 -> 1.
+      expect(
+        await agentSandboxesRepository.tryReleaseDeletionAllocation(
+          agentId,
+          orgId,
+          deletionAttemptId,
+          nodeId,
+        ),
+      ).toBe(true);
+      expect(await allocatedCount(nodeId)).toBe(1);
+      expect(await ownership(agentId)).toBe(false);
+
+      // Credential revocation / row-delete / job-status failed downstream, so the
+      // whole delete re-runs and the remote stop reports "No such container".
+      // The sibling's slot must survive.
+      expect(
+        await agentSandboxesRepository.tryReleaseDeletionAllocation(
+          agentId,
+          orgId,
+          deletionAttemptId,
+          nodeId,
+        ),
+      ).toBe(false);
+      expect(await allocatedCount(nodeId)).toBe(1);
+
+      // A third recovery sweep is still a no-op.
+      expect(
+        await agentSandboxesRepository.tryReleaseDeletionAllocation(
+          agentId,
+          orgId,
+          deletionAttemptId,
+          nodeId,
+        ),
+      ).toBe(false);
+      expect(await allocatedCount(nodeId)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "concurrent releases of one generation decrement once",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, orgId, nodeId, deletionAttemptId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+      });
+
+      const results = await Promise.all([
+        agentSandboxesRepository.tryReleaseDeletionAllocation(
+          agentId,
+          orgId,
+          deletionAttemptId,
+          nodeId,
+        ),
+        agentSandboxesRepository.tryReleaseDeletionAllocation(
+          agentId,
+          orgId,
+          deletionAttemptId,
+          nodeId,
+        ),
+      ]);
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+      expect(await allocatedCount(nodeId)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a suspended row that never owned a slot never decrements one",
+    async () => {
+      if (!pgliteReady) return;
+      // Suspend already handed the slot back while keeping the locator — the
+      // exact shape that let a later delete decrement a second time.
+      const { agentId, orgId, nodeId, deletionAttemptId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: false,
+      });
+
+      expect(
+        await agentSandboxesRepository.tryReleaseDeletionAllocation(
+          agentId,
+          orgId,
+          deletionAttemptId,
+          nodeId,
+        ),
+      ).toBe(false);
+      expect(await allocatedCount(nodeId)).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a stale deletion generation cannot release the current one's slot",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, orgId, nodeId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+      });
+
+      expect(
+        await agentSandboxesRepository.tryReleaseDeletionAllocation(
+          agentId,
+          orgId,
+          crypto.randomUUID(), // a superseded attempt id
+          nodeId,
+        ),
+      ).toBe(false);
+      expect(await allocatedCount(nodeId)).toBe(2);
+      expect(await ownership(agentId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a stale node locator cannot release a different node's capacity",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, orgId, nodeId, deletionAttemptId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+      });
+      const otherNodeId = uniq("node");
+      await dbWrite.insert(dockerNodes).values({
+        node_id: otherNodeId,
+        hostname: `${otherNodeId}.test.invalid`,
+        allocated_count: 2,
+      });
+
+      expect(
+        await agentSandboxesRepository.tryReleaseDeletionAllocation(
+          agentId,
+          orgId,
+          deletionAttemptId,
+          otherNodeId,
+        ),
+      ).toBe(false);
+      expect(await allocatedCount(otherNodeId)).toBe(2);
+      expect(await allocatedCount(nodeId)).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "another organization cannot release this row's slot",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, nodeId, deletionAttemptId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+      });
+
+      expect(
+        await agentSandboxesRepository.tryReleaseDeletionAllocation(
+          agentId,
+          crypto.randomUUID(),
+          deletionAttemptId,
+          nodeId,
+        ),
+      ).toBe(false);
+      expect(await allocatedCount(nodeId)).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "an already-zero counter is left alone rather than driven negative",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, orgId, nodeId, deletionAttemptId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+      });
+      await dbWrite
+        .update(dockerNodes)
+        .set({ allocated_count: 0 })
+        .where(eq(dockerNodes.node_id, nodeId));
+
+      // Ownership is still consumed — the claim was real — but the guard blocks
+      // the underflow, and the return value reports that the counter did NOT
+      // move so no caller logs a decrement that never happened.
+      expect(
+        await agentSandboxesRepository.tryReleaseDeletionAllocation(
+          agentId,
+          orgId,
+          deletionAttemptId,
+          nodeId,
+        ),
+      ).toBe(false);
+      expect(await allocatedCount(nodeId)).toBe(0);
+      expect(await ownership(agentId)).toBe(false);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("releaseDeletionAllocationOnReap — absence proven by the orphan reaper", () => {
+  test(
+    "an abandoned deletion stops counting once its container is reaped",
+    async () => {
+      if (!pgliteReady) return;
+      // The delete could not prove absence (bounded timeout, or the row went
+      // deletion_failed), so it kept ownership and the slot stayed counted.
+      // Without this release the slot would be held forever once
+      // reEnqueueFailedDeletions hits its circuit breaker — the #15378 shape.
+      const { agentId, nodeId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+        status: "deletion_failed",
+      });
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, nodeId)).toBe(1);
+
+      expect(await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, nodeId)).toBe(
+        true,
+      );
+      expect(await allocatedCount(nodeId)).toBe(1);
+      expect(await ownership(agentId)).toBe(false);
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, nodeId)).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a second reap of the same agent does not free the live sibling's slot",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, nodeId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+        status: "deletion_failed",
+      });
+
+      await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, nodeId);
+      expect(await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, nodeId)).toBe(
+        false,
+      );
+      expect(await allocatedCount(nodeId)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "reaping cannot release capacity on a node the row has since left",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, nodeId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+        status: "deletion_failed",
+      });
+      const otherNodeId = uniq("node");
+      await dbWrite.insert(dockerNodes).values({
+        node_id: otherNodeId,
+        hostname: `${otherNodeId}.test.invalid`,
+        allocated_count: 2,
+      });
+
+      expect(
+        await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, otherNodeId),
+      ).toBe(false);
+      expect(await allocatedCount(otherNodeId)).toBe(2);
+      expect(await allocatedCount(nodeId)).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a row that never owned a slot is untouched by a reap",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, nodeId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: false,
+        status: "deletion_failed",
+      });
+
+      expect(await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, nodeId)).toBe(
+        false,
+      );
+      expect(await allocatedCount(nodeId)).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("holdsCountedNodeSlot — ownership initialization from pre-delete state", () => {
+  test("a placed, running row owns its slot", () => {
+    expect(holdsCountedNodeSlot({ status: "running", node_id: "node-1" })).toBe(true);
+  });
+
+  test("suspended and sleeping rows already gave the slot back", () => {
+    expect(holdsCountedNodeSlot({ status: "stopped", node_id: "node-1" })).toBe(false);
+    expect(holdsCountedNodeSlot({ status: "sleeping", node_id: "node-1" })).toBe(false);
+  });
+
+  test("an unplaced row never had a slot", () => {
+    expect(holdsCountedNodeSlot({ status: "running", node_id: null })).toBe(false);
+    expect(holdsCountedNodeSlot({ status: "pending", node_id: null })).toBe(false);
+  });
+
+  test("a disconnected container still occupies its node", () => {
+    expect(holdsCountedNodeSlot({ status: "disconnected", node_id: "node-1" })).toBe(true);
+  });
+
+  test("statuses the capacity recount treats as free are never owned here", () => {
+    // `syncAllocatedCounts` recomputes allocated_count from
+    // TERMINAL_SANDBOX_STATUSES. Any status it drops has already had its slot
+    // reclaimed, so stamping ownership for one would release it a second time —
+    // the double-free this issue closes. Derivation keeps the two in lockstep.
+    for (const status of TERMINAL_SANDBOX_STATUSES) {
+      expect(holdsCountedNodeSlot({ status, node_id: "node-1" })).toBe(false);
+    }
+  });
+});
+
+describe("workload reconciliation counts a deletion row exactly while it owns a slot", () => {
+  test(
+    "deletion_pending counts before release and stops counting after",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, orgId, nodeId, deletionAttemptId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+        status: "deletion_pending",
+      });
+
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, nodeId)).toBe(1);
+
+      await agentSandboxesRepository.tryReleaseDeletionAllocation(
+        agentId,
+        orgId,
+        deletionAttemptId,
+        nodeId,
+      );
+
+      // The row lingers in deletion_pending until the row delete commits, but it
+      // no longer consumes capacity — a status-only rule kept counting it here.
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, nodeId)).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "deletion_failed still counts while it owns a slot",
+    async () => {
+      if (!pgliteReady) return;
+      const { nodeId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+        status: "deletion_failed",
+      });
+
+      // deletion_failed is a TERMINAL_SANDBOX_STATUS, so the status-only rule
+      // reported this node as free while its container was still placed.
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, nodeId)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "pre-migration NULL ownership keeps the original status-only behaviour",
+    async () => {
+      if (!pgliteReady) return;
+      const pending = await seedNodeWithTargetAndSibling({
+        allocationCounted: null,
+        status: "deletion_pending",
+      });
+      const failed = await seedNodeWithTargetAndSibling({
+        allocationCounted: null,
+        status: "deletion_failed",
+      });
+
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, pending.nodeId)).toBe(1);
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, failed.nodeId)).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a live row with no deletion intent is unaffected",
+    async () => {
+      if (!pgliteReady) return;
+      const { nodeId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: null,
+        status: "running",
+        withDeletionIntent: false,
+      });
+
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, nodeId)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("enqueueAgentDeleteOnce initializes ownership from the pre-delete state", () => {
+  test(
+    "a placed, running agent starts its deletion owning one slot; a re-enqueue keeps that answer",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, orgId, userId } = await seedAgentViaService();
+      const nodeId = uniq("node");
+      await dbWrite
+        .insert(dockerNodes)
+        .values({ node_id: nodeId, hostname: `${nodeId}.test.invalid`, allocated_count: 2 });
+      await dbWrite
+        .update(agentSandboxes)
+        .set({ status: "running", node_id: nodeId, container_name: uniq("container") })
+        .where(eq(agentSandboxes.id, agentId));
+
+      await new ProvisioningJobService().enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+      });
+      expect(await ownership(agentId)).toBe(true);
+
+      // Release, then let a recovery sweep re-enqueue. Re-deriving ownership here
+      // would read the row's own `deletion_pending` status as "still counted" and
+      // free a slot on every sweep; inheriting keeps the released answer.
+      const attemptId = await deletionAttemptId(agentId);
+      await agentSandboxesRepository.tryReleaseDeletionAllocation(
+        agentId,
+        orgId,
+        attemptId,
+        nodeId,
+      );
+      expect(await allocatedCount(nodeId)).toBe(1);
+
+      await new ProvisioningJobService().enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+      });
+      expect(await ownership(agentId)).toBe(false);
+      expect(await allocatedCount(nodeId)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a suspended agent starts its deletion owning nothing",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, orgId, userId } = await seedAgentViaService();
+      const nodeId = uniq("node");
+      await dbWrite
+        .insert(dockerNodes)
+        .values({ node_id: nodeId, hostname: `${nodeId}.test.invalid`, allocated_count: 2 });
+      // Suspend already gave the slot back while keeping the locator.
+      await dbWrite
+        .update(agentSandboxes)
+        .set({ status: "stopped", node_id: nodeId, container_name: uniq("container") })
+        .where(eq(agentSandboxes.id, agentId));
+
+      await new ProvisioningJobService().enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+      });
+
+      expect(await ownership(agentId)).toBe(false);
+      const attemptId = await deletionAttemptId(agentId);
+      await agentSandboxesRepository.tryReleaseDeletionAllocation(
+        agentId,
+        orgId,
+        attemptId,
+        nodeId,
+      );
+      expect(await allocatedCount(nodeId)).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "an unplaced (shared-tier) agent starts its deletion owning nothing",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, orgId, userId } = await seedAgentViaService();
+
+      await new ProvisioningJobService().enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+      });
+
+      expect(await ownership(agentId)).toBe(false);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// Without this a pushSchema failure would early-return every case above and a
+// capacity-safety proof would masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
@@ -38,7 +38,11 @@ import { organizations } from "../../../db/schemas/organizations";
 import { usageRecords } from "../../../db/schemas/usage-records";
 import { userCharacters } from "../../../db/schemas/user-characters";
 import { users } from "../../../db/schemas/users";
-import { holdsCountedNodeSlot, TERMINAL_SANDBOX_STATUSES } from "../docker-node-workload-queries";
+import {
+  holdsCountedNodeSlot,
+  isDeletionContinuation,
+  TERMINAL_SANDBOX_STATUSES,
+} from "../docker-node-workload-queries";
 
 const PGLITE_TIMEOUT = 60_000;
 
@@ -392,6 +396,73 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
     },
     PGLITE_TIMEOUT,
   );
+});
+
+describe("a deletion continuation never re-derives ownership from its own state", () => {
+  test(
+    "a deletion_pending row with NULL intent columns is not armed by a re-enqueue",
+    async () => {
+      if (!pgliteReady) return;
+      // The #17249 shape: the row is already in a deletion state but carries no
+      // intent columns. Under the narrow `deletion_started_at === null` test this
+      // reads as a FRESH deletion, so ownership is re-derived from the row's own
+      // `deletion_pending` status — which scores as still-counted — arming a
+      // release for a slot the pre-ownership provider already decremented.
+      const { agentId, orgId, userId } = await seedAgentViaService();
+      const nodeId = uniq("node");
+      await dbWrite
+        .insert(dockerNodes)
+        .values({ node_id: nodeId, hostname: `${nodeId}.test.invalid`, allocated_count: 2 });
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          status: "deletion_pending",
+          node_id: nodeId,
+          container_name: uniq("container"),
+          deletion_attempt_id: null,
+          deletion_started_at: null,
+          deletion_allocation_counted: null,
+        })
+        .where(eq(agentSandboxes.id, agentId));
+
+      await new ProvisioningJobService().enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+      });
+
+      // Ownership must stay unrecorded: this generation cannot prove it owns a
+      // slot, and guessing "true" is the double-free.
+      expect(await ownership(agentId)).toBeNull();
+
+      const attemptId = await deletionAttemptId(agentId);
+      expect(
+        await agentSandboxesRepository.tryReleaseDeletionAllocation(
+          agentId,
+          orgId,
+          attemptId,
+          nodeId,
+        ),
+      ).toBe(false);
+      expect(await allocatedCount(nodeId)).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test("isDeletionContinuation covers the shapes the narrow test misses", () => {
+    const fresh = { status: "running", deletion_attempt_id: null, deletion_started_at: null };
+    expect(isDeletionContinuation(fresh)).toBe(false);
+
+    // Each of these is a continuation the `deletion_started_at` test alone misses.
+    for (const row of [
+      { status: "deletion_pending", deletion_attempt_id: null, deletion_started_at: null },
+      { status: "deletion_failed", deletion_attempt_id: null, deletion_started_at: null },
+      { status: "running", deletion_attempt_id: crypto.randomUUID(), deletion_started_at: null },
+      { status: "running", deletion_attempt_id: null, deletion_started_at: new Date() },
+    ]) {
+      expect(isDeletionContinuation(row)).toBe(true);
+    }
+  });
 });
 
 describe("releaseDeletionAllocationOnReap — absence proven by the orphan reaper", () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
@@ -246,7 +246,7 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
   );
 
   test(
-    "concurrent releases of one generation decrement once",
+    "a second release of an already-spent generation is a no-op",
     async () => {
       if (!pgliteReady) return;
       const { agentId, orgId, nodeId, deletionAttemptId } = await seedNodeWithTargetAndSibling({
@@ -268,10 +268,22 @@ describe("tryReleaseDeletionAllocation — releases exactly once", () => {
         ),
       ]);
 
-      // Exactly one caller wins the row lock and spends the ownership; the other
-      // re-evaluates against the committed row and finds nothing to claim. Assert
-      // the outcomes by name — every outcome is a truthy string, so a
-      // truthiness count would pass no matter which two came back.
+      // This harness cannot demonstrate a race, and the test does not claim to.
+      // PGlite is a single WASM backend behind one connection, so these two
+      // transactions cannot interleave — the second queues and begins after the
+      // first commits. What is pinned is the property the retry path actually
+      // relies on: releasing an already-spent generation returns `not-owned` and
+      // does not decrement twice.
+      //
+      // NOT covered here: real row-lock contention, where a second transaction
+      // blocks on the UPDATE and then re-evaluates its WHERE against the updated
+      // row under READ COMMITTED. That needs two independent PostgreSQL
+      // connections, and the isolation level matters — under REPEATABLE READ the
+      // loser raises a serialization failure instead of returning `not-owned`,
+      // and no caller here catches that.
+      //
+      // Assert the outcomes by name: every outcome is a truthy string, so a
+      // truthiness count would pass whichever two came back.
       expect(results.filter((r) => r === "released")).toHaveLength(1);
       expect(results.filter((r) => r === "not-owned")).toHaveLength(1);
       expect(await allocatedCount(nodeId)).toBe(1);

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-release-proven-absence.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-release-proven-absence.test.ts
@@ -22,7 +22,7 @@
  * branch a future refactor could silently drop.
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
 
 const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
 const CAN_USE_ISOLATED_PGLITE =
@@ -36,6 +36,7 @@ import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
 import { dockerNodes } from "../../../db/schemas/docker-nodes";
 import { organizations } from "../../../db/schemas/organizations";
 import { users } from "../../../db/schemas/users";
+import { apiKeysService } from "../api-keys";
 import { PROVISIONING_JOB_TEST_TABLES } from "./tier-upgrade-pglite-schema";
 
 const PGLITE_TIMEOUT = 60_000;
@@ -214,6 +215,41 @@ describe("deleteAgent releases the node slot only on proven absence", () => {
       await service.deleteAgent(agentId, orgId);
 
       expect(await nodeCount(nodeId)).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a failure after the release, then a full-path retry, still decrements once",
+    async () => {
+      if (!pgliteReady) return;
+      // The issue's headline scenario, driven end to end rather than by calling
+      // the CAS twice by hand: the teardown succeeds and the slot is released,
+      // then a downstream step fails, so the whole delete re-runs. The retry
+      // must find ownership already spent and leave the live sibling's slot
+      // alone. Credential revocation is the first thing after the release that
+      // can fail, so it is the honest place to inject it.
+      const { service, agentId, orgId, nodeId } = await seedPlacedAgent();
+      scriptProvider(service, async () => {});
+
+      const revoke = spyOn(apiKeysService, "revokeForAgent").mockRejectedValueOnce(
+        new Error("credential revocation failed"),
+      );
+      try {
+        await expect(service.deleteAgent(agentId, orgId)).rejects.toThrow(
+          /credential revocation failed/,
+        );
+        // The release already committed before the failure — that is the design.
+        expect(await nodeCount(nodeId)).toBe(1);
+        expect(await ownership(agentId)).toBe(false);
+
+        // Retry the whole path. Revocation now succeeds, the delete completes,
+        // and the release CAS is a no-op because ownership is spent.
+        await service.deleteAgent(agentId, orgId);
+        expect(await nodeCount(nodeId)).toBe(1);
+      } finally {
+        revoke.mockRestore();
+      }
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-release-proven-absence.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-release-proven-absence.test.ts
@@ -1,0 +1,226 @@
+/**
+ * A deletion generation releases its node slot only on PROVEN absence (#17185).
+ *
+ * The exactly-once CAS is covered elsewhere; what these pin is the policy that
+ * decides whether the CAS is reached at all. Two paths must NOT release: a
+ * reachable stop failure (the container is still there and the teardown will be
+ * retried) and a bounded-timeout abandon (the container may still be running).
+ * Releasing on either hands a live container's slot back to the scheduler, which
+ * then packs a new container onto a node still running the old one — a worse
+ * failure than the double-free this feature closes, because it is invisible
+ * until the node is oversubscribed.
+ *
+ * Drives the real `ElizaSandboxService.deleteAgent` against in-process PGlite
+ * with the real repositories and a scripted `SandboxProvider` injected at the
+ * `_provider` seam.
+ *
+ * The abandon case overrides `runBoundedSandboxStop` rather than stalling a real
+ * stop past `SANDBOX_DELETE_STOP_TIMEOUT_MS` (120s, not env-tunable): that would
+ * make the suite two minutes slower and timing-dependent for no added coverage.
+ * The timer itself is exercised by the provider suites; what is under test here
+ * is what `deleteAgent` DOES with a `timedOut` verdict, which is exactly the
+ * branch a future refactor could silently drop.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { eq } from "drizzle-orm";
+import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { dockerNodes } from "../../../db/schemas/docker-nodes";
+import { organizations } from "../../../db/schemas/organizations";
+import { users } from "../../../db/schemas/users";
+import { PROVISIONING_JOB_TEST_TABLES } from "./tier-upgrade-pglite-schema";
+
+const PGLITE_TIMEOUT = 60_000;
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.error("[deletion-release-proven-absence] non-PGlite DATABASE_URL; failing.");
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ ElizaSandboxService } = await import("../eliza-sandbox"));
+    // Plain DDL rather than drizzle-kit pushSchema: the generated path spends
+    // minutes on "Pulling schema from database" here and blows the hook budget.
+    // This is the same helper the other provisioning-job PGlite suites use.
+    for (const ddl of PROVISIONING_JOB_TEST_TABLES) {
+      await dbWrite.execute(ddl);
+    }
+    await dbWrite.execute(`CREATE TABLE IF NOT EXISTS "docker_nodes" (
+      "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+      "node_id" text NOT NULL,
+      "hostname" text NOT NULL,
+      "ssh_port" integer NOT NULL DEFAULT 22,
+      "capacity" integer NOT NULL DEFAULT 8,
+      "enabled" boolean NOT NULL DEFAULT true,
+      "status" text NOT NULL DEFAULT 'unknown'::text,
+      "allocated_count" integer NOT NULL DEFAULT 0,
+      "last_health_check" timestamptz,
+      "ssh_user" text NOT NULL DEFAULT 'root'::text,
+      "host_key_fingerprint" text,
+      "metadata" jsonb NOT NULL DEFAULT '{}'::jsonb,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "updated_at" timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY ("id"),
+      UNIQUE ("node_id")
+    )`);
+  } catch (error) {
+    pgliteReady = false;
+    console.error("[deletion-release-proven-absence] PGlite/pushSchema unavailable.", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+/** A placed, running agent owning one of its node's two slots (the other is a live sibling). */
+async function seedPlacedAgent(): Promise<{
+  service: InstanceType<typeof ElizaSandboxService>;
+  agentId: string;
+  orgId: string;
+  nodeId: string;
+}> {
+  const service = new ElizaSandboxService();
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "5.000000" })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  const created = await service.createAgent({
+    organizationId: org.id,
+    userId: user.id,
+    agentName: uniq("agent"),
+    executionTier: "dedicated-always",
+    maxNonTerminalAgents: 10,
+  });
+  const nodeId = uniq("node");
+  await dbWrite
+    .insert(dockerNodes)
+    .values({ node_id: nodeId, hostname: `${nodeId}.test.invalid`, allocated_count: 2 });
+  await dbWrite
+    .update(agentSandboxes)
+    .set({
+      status: "running",
+      node_id: nodeId,
+      container_name: uniq("container"),
+      sandbox_id: uniq("sandbox"),
+    })
+    .where(eq(agentSandboxes.id, created.agent.id));
+  return { service, agentId: created.agent.id, orgId: org.id, nodeId };
+}
+
+/** Injects a provider whose stop behaves as scripted; everything else is real. */
+function scriptProvider(
+  service: InstanceType<typeof ElizaSandboxService>,
+  stop: () => Promise<void>,
+): void {
+  (service as unknown as { _provider: unknown })._provider = {
+    stop,
+    stopForReplacement: stop,
+  };
+}
+
+async function nodeCount(nodeId: string): Promise<number> {
+  const [row] = await dbWrite
+    .select({ n: dockerNodes.allocated_count })
+    .from(dockerNodes)
+    .where(eq(dockerNodes.node_id, nodeId));
+  return Number(row.n);
+}
+
+async function ownership(agentId: string): Promise<boolean | null> {
+  const [row] = await dbWrite
+    .select({ owned: agentSandboxes.deletion_allocation_counted })
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, agentId));
+  return row?.owned ?? null;
+}
+
+describe("deleteAgent releases the node slot only on proven absence", () => {
+  test(
+    "a clean teardown releases exactly one slot",
+    async () => {
+      if (!pgliteReady) return;
+      const { service, agentId, orgId, nodeId } = await seedPlacedAgent();
+      scriptProvider(service, async () => {});
+
+      await service.deleteAgent(agentId, orgId);
+
+      expect(await nodeCount(nodeId)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a reachable stop failure keeps ownership and the slot",
+    async () => {
+      if (!pgliteReady) return;
+      const { service, agentId, orgId, nodeId } = await seedPlacedAgent();
+      // A reachable node that refuses: the container is still running, so the
+      // teardown must be retried and the slot must stay counted until it works.
+      scriptProvider(service, async () => {
+        throw new Error("Cannot connect to the Docker daemon");
+      });
+
+      const result = await service.deleteAgent(agentId, orgId);
+
+      expect(result.success).toBe(false);
+      expect(await nodeCount(nodeId)).toBe(2);
+      expect(await ownership(agentId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a bounded-timeout abandon keeps ownership and the slot",
+    async () => {
+      if (!pgliteReady) return;
+      const { service, agentId, orgId, nodeId } = await seedPlacedAgent();
+      scriptProvider(service, async () => {});
+      // The verdict `runBoundedSandboxStop` produces when the teardown blows its
+      // hard cap: the delete completes but the container is ABANDONED and may
+      // still be running, so its slot is not ours to hand back.
+      (
+        service as unknown as { runBoundedSandboxStop: () => Promise<unknown> }
+      ).runBoundedSandboxStop = async () => ({
+        error: new Error("agent-delete stop timed out"),
+        timedOut: true as const,
+      });
+
+      await service.deleteAgent(agentId, orgId);
+
+      expect(await nodeCount(nodeId)).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+// Loud guard: PGlite is in-process, so this must be true or every case above
+// early-returns and a safety proof becomes a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-stop-no-capacity-mutation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-stop-no-capacity-mutation.test.ts
@@ -1,0 +1,143 @@
+/**
+ * `DockerSandboxProvider` stop is remote-teardown-only (#17185).
+ *
+ * The provider used to decrement `docker_nodes.allocated_count` at the end of
+ * every stop. That made local capacity arithmetic a side effect of a RETRYABLE
+ * remote operation which treats "already gone" as success — so each retry after
+ * a post-stop failure freed another slot, and the slot it freed belonged to a
+ * live sibling on that node. Ownership of the counter moved to the caller's
+ * deletion generation; the provider must now never touch it, on ANY outcome.
+ *
+ * Drives the real `DockerSandboxProvider` with only the SSH transport scripted
+ * (the seam the issue names) and the container meta pre-seeded in memory, so the
+ * real classification logic — already-absent, unreachable-abandon, genuine
+ * failure — decides each path. `decrementAllocated` is spied, never stubbed out
+ * of existence: the assertion is that the real method is never reached.
+ */
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+// Scripted SSH transport. Registered BEFORE the provider import so the provider
+// binds to it. `exec` is caller-controlled per test, which is what lets one
+// harness cover success, already-absent, unreachable, and hard-failure paths.
+let execBehavior: (command: string) => Promise<string> = async () => "";
+mock.module("../docker-ssh", () => ({
+  DockerSSHClient: {
+    getClient: () => ({
+      exec: async (command: string) => execBehavior(command),
+    }),
+  },
+}));
+
+import { dockerNodesRepository } from "../../../db/repositories/docker-nodes";
+import { DockerSandboxProvider } from "../docker-sandbox-provider";
+
+const SANDBOX_ID = "agent-capacity-ownership-test";
+const NODE_ID = "node-1";
+
+type ContainerMetaSeed = {
+  nodeId: string;
+  hostname: string;
+  containerName: string;
+  bridgePort: number;
+  webUiPort: number;
+  agentId: string;
+  sshPort: number;
+  sshUser: string;
+};
+
+function seedContainer(provider: DockerSandboxProvider): void {
+  // resolveContainer() returns straight from the private in-memory map, so
+  // seeding it keeps the DB out of the stop path entirely.
+  (provider as unknown as { containers: Map<string, ContainerMetaSeed> }).containers.set(
+    SANDBOX_ID,
+    {
+      nodeId: NODE_ID,
+      hostname: "138.201.80.125",
+      containerName: SANDBOX_ID,
+      bridgePort: 3001,
+      webUiPort: 3002,
+      agentId: SANDBOX_ID,
+      sshPort: 22,
+      sshUser: "root",
+    },
+  );
+}
+
+let decrementSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  // Headscale deletion is skipped when unconfigured.
+  delete process.env.HEADSCALE_API_KEY;
+  decrementSpy = spyOn(dockerNodesRepository, "decrementAllocated");
+});
+
+afterEach(() => {
+  decrementSpy.mockRestore();
+});
+
+describe("provider stop never mutates node capacity", () => {
+  test("a clean stop + rm leaves allocated_count to the caller", async () => {
+    execBehavior = async () => "";
+    const provider = new DockerSandboxProvider();
+    seedContainer(provider);
+
+    await expect(provider.stop(SANDBOX_ID)).resolves.toBeUndefined();
+    expect(decrementSpy).not.toHaveBeenCalled();
+  });
+
+  test("an already-absent container does not release a slot a second time", async () => {
+    // The retry shape from the issue: the first attempt tore the container down,
+    // a downstream step failed, and the re-run finds it gone. Accepting that as
+    // success is correct; decrementing again is what freed a live sibling's slot.
+    execBehavior = async () => {
+      throw new Error("Error response from daemon: No such container: agent-x");
+    };
+    const provider = new DockerSandboxProvider();
+    seedContainer(provider);
+
+    await expect(provider.stop(SANDBOX_ID)).resolves.toBeUndefined();
+    expect(decrementSpy).not.toHaveBeenCalled();
+  });
+
+  test("an abandoned container on an unreachable node leaks on the box, not in the counter", async () => {
+    execBehavior = async () => {
+      throw new Error("[docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms");
+    };
+    const provider = new DockerSandboxProvider();
+    seedContainer(provider);
+
+    await expect(provider.stop(SANDBOX_ID)).resolves.toBeUndefined();
+    expect(decrementSpy).not.toHaveBeenCalled();
+  });
+
+  test("a reachable stop failure rejects, so the caller never reaches its release", async () => {
+    // This is how ownership survives a genuine failure: the provider throws, the
+    // delete path returns before the release CAS, and the retry that finally
+    // completes the teardown is the one that hands the slot back.
+    execBehavior = async () => {
+      throw new Error("Cannot connect to the Docker daemon");
+    };
+    const provider = new DockerSandboxProvider();
+    seedContainer(provider);
+
+    await expect(provider.stop(SANDBOX_ID)).rejects.toThrow(/Failed to stop container/);
+    expect(decrementSpy).not.toHaveBeenCalled();
+  });
+
+  test("replacement teardown DOES still release, because nothing else owns its slot", async () => {
+    // The counter-free rule is scoped to deletion, not to the provider. Suspend,
+    // shutdown, sleep, warm-claim retire and ghost cleanup all reach the same
+    // stop path through `stopForReplacement`, stop exactly once under a fence,
+    // and have no durable generation to hand the release to — so the provider
+    // stays their capacity owner. `holdsCountedNodeSlot` treating a suspended
+    // row as already-released depends on this decrement still happening.
+    execBehavior = async () => "";
+    const provider = new DockerSandboxProvider();
+    seedContainer(provider);
+    decrementSpy.mockResolvedValue(undefined);
+
+    await expect(provider.stopForReplacement(SANDBOX_ID)).resolves.toBeUndefined();
+    expect(decrementSpy).toHaveBeenCalledTimes(1);
+    expect(decrementSpy).toHaveBeenCalledWith(NODE_ID);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-unreachable-terminal.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-unreachable-terminal.test.ts
@@ -23,9 +23,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // Fake SSH client: getClient() returns an object whose exec() rejects with a
 // caller-controlled error. Registered BEFORE importing the provider so the
 // provider binds to this mock. This is the only thing we need to stub — the
-// container meta is pre-seeded in memory (no DB lookup) and the post-stop
-// decrementAllocated is best-effort (its DB call fails gracefully via .catch
-// in the provider, which itself exercises the fall-through path).
+// container meta is pre-seeded in memory (no DB lookup), and the provider no
+// longer touches `allocated_count` at all, so no database is involved in the
+// stop path (#17185).
 let nextExecError: Error = new Error("unset");
 mock.module("../docker-ssh", () => ({
   DockerSSHClient: {

--- a/packages/cloud/shared/src/lib/services/__tests__/orphan-reap-releases-deletion-slot.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/orphan-reap-releases-deletion-slot.test.ts
@@ -1,0 +1,170 @@
+/**
+ * The orphan reaper hands back the node slot of the deletion it just proved
+ * absent (#17185).
+ *
+ * A delete that cannot prove the container is gone — a bounded-timeout abandon,
+ * or a `deletion_failed` row — deliberately keeps its slot counted. Reaping is
+ * the only step that supplies that proof, so it is where the slot is released.
+ * Without it, an abandoned deletion holds a slot forever once
+ * `reEnqueueFailedDeletions` trips its circuit breaker, permanently shrinking
+ * the node and inflating the autoscaler's demand signal (#15378).
+ *
+ * The load-bearing assumption is an identity spanning two modules: the reaper's
+ * `orphan.key` must be an `agent_sandboxes.id`, because `onReaped` feeds it to a
+ * CAS keyed on that column. If `keyOf` ever returned a container name or a
+ * prefixed id, the CAS would match no row, return false, and the leak would come
+ * back silently — the warn only fires *after* a successful claim, so nothing
+ * would go red.
+ *
+ * Drives the REAL `AGENT_ORPHAN_RECONCILER_CONFIG` through the REAL
+ * `reconcileOrphanContainers` with a scripted node, so the production `keyOf`
+ * and `onReaped` are the ones under test. The repository call is spied rather
+ * than hit: what is being pinned is the identity handed across the seam, and the
+ * CAS itself already has database coverage in
+ * `deletion-allocation-ownership.test.ts`.
+ */
+
+import { afterAll, describe, expect, spyOn, test } from "bun:test";
+
+const PRIOR_SKIP_ENSURE = process.env.SKIP_AGENT_SANDBOX_ENSURE;
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+import { agentSandboxesRepository } from "../../../db/repositories/agent-sandboxes";
+import { AGENT_ORPHAN_RECONCILER_CONFIG } from "../docker-node-workloads";
+import {
+  type NodeContainerRef,
+  type OrphanReconcilerNode,
+  reconcileOrphanContainers,
+} from "../orphan-container-reconciler";
+
+const NODE_ID = "node-reap-1";
+/**
+ * Old enough to clear the rowless grace window. A container whose age is unknown
+ * or recent is deliberately never reaped: mid-provision it exists before its row
+ * commits, so reaping it would kill live work.
+ */
+const OLD_ENOUGH_MS = 1;
+/** A uuid, so a container-name/prefix leak is unmistakable in the assertion. */
+const AGENT_ID = "3f1c6b2e-9a44-4d21-8b77-0e5a91c4d2f8";
+
+function nodeWith(containers: NodeContainerRef[]): OrphanReconcilerNode & { removed: string[] } {
+  const removed: string[] = [];
+  return {
+    node_id: NODE_ID,
+    hostname: "reap.test.invalid",
+    status: "healthy",
+    listContainers: async () => containers,
+    removeContainer: async (id: string) => {
+      removed.push(id);
+    },
+    removed,
+  };
+}
+
+describe("orphan reap releases the deletion generation's slot", () => {
+  test("keyOf yields the agent id the release CAS is keyed on", () => {
+    // The whole seam in one line: whatever the reaper derives from a container
+    // name is what reaches a CAS matching `agent_sandboxes.id`.
+    expect(AGENT_ORPHAN_RECONCILER_CONFIG.keyOf(`agent-${AGENT_ID}`)).toBe(AGENT_ID);
+    expect(AGENT_ORPHAN_RECONCILER_CONFIG.keyOf("unrelated-container")).toBeNull();
+  });
+
+  test("a reaped orphan releases exactly that agent's slot on that node", async () => {
+    const release = spyOn(agentSandboxesRepository, "releaseDeletionAllocationOnReap")
+      // The DB-level behaviour is covered elsewhere; here we assert the call.
+      .mockResolvedValue(true);
+    try {
+      // No live row for this key, so the container is a genuine orphan.
+      const node = nodeWith([
+        { id: "container-abc", name: `agent-${AGENT_ID}`, createdAtMs: OLD_ENOUGH_MS },
+      ]);
+
+      const result = await reconcileOrphanContainers([node], {
+        ...AGENT_ORPHAN_RECONCILER_CONFIG,
+        loadStatuses: async () => [],
+        // The rowless grace window protects the create-before-row-commit race;
+        // zero it so the sweep reaps on this pass instead of deferring.
+        rowlessGraceMs: 0,
+      });
+
+      expect(result.reaped).toBe(1);
+      expect(node.removed).toEqual(["container-abc"]);
+      expect(release).toHaveBeenCalledTimes(1);
+      expect(release).toHaveBeenCalledWith(AGENT_ID, NODE_ID);
+    } finally {
+      release.mockRestore();
+    }
+  });
+
+  test("a retained container never releases a slot the deletion still owns", async () => {
+    const release = spyOn(
+      agentSandboxesRepository,
+      "releaseDeletionAllocationOnReap",
+    ).mockResolvedValue(true);
+    try {
+      // A live row on this node: the reaper must retain, so the deletion keeps
+      // its slot and the release must not fire.
+      const node = nodeWith([
+        { id: "container-abc", name: `agent-${AGENT_ID}`, createdAtMs: OLD_ENOUGH_MS },
+      ]);
+
+      const result = await reconcileOrphanContainers([node], {
+        ...AGENT_ORPHAN_RECONCILER_CONFIG,
+        loadStatuses: async () => [
+          {
+            key: AGENT_ID,
+            containerName: `agent-${AGENT_ID}`,
+            status: "running",
+            nodeId: NODE_ID,
+            updatedAt: new Date(),
+          },
+        ],
+        rowlessGraceMs: 0,
+      });
+
+      expect(result.reaped).toBe(0);
+      expect(node.removed).toEqual([]);
+      expect(release).not.toHaveBeenCalled();
+    } finally {
+      release.mockRestore();
+    }
+  });
+
+  test("a failed release never aborts the sweep", async () => {
+    const release = spyOn(
+      agentSandboxesRepository,
+      "releaseDeletionAllocationOnReap",
+    ).mockRejectedValue(new Error("transient database failure"));
+    try {
+      const node = nodeWith([
+        { id: "container-abc", name: `agent-${AGENT_ID}`, createdAtMs: OLD_ENOUGH_MS },
+        {
+          id: "container-def",
+          name: "agent-11111111-2222-4333-8444-555555555555",
+          createdAtMs: OLD_ENOUGH_MS,
+        },
+      ]);
+
+      const result = await reconcileOrphanContainers([node], {
+        ...AGENT_ORPHAN_RECONCILER_CONFIG,
+        loadStatuses: async () => [],
+        rowlessGraceMs: 0,
+      });
+
+      // Both containers are still reaped: the bookkeeping is best-effort by
+      // contract, and the next sweep retries it against an idempotent CAS.
+      expect(result.reaped).toBe(2);
+      expect(node.removed).toEqual(["container-abc", "container-def"]);
+    } finally {
+      release.mockRestore();
+    }
+  });
+});
+
+// bun shares one process across files without --isolate, so an unrestored env
+// override here would silently disable the ensure guard for whatever suite runs
+// next. Restore exactly what was there before.
+afterAll(() => {
+  if (PRIOR_SKIP_ENSURE === undefined) delete process.env.SKIP_AGENT_SANDBOX_ENSURE;
+  else process.env.SKIP_AGENT_SANDBOX_ENSURE = PRIOR_SKIP_ENSURE;
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
@@ -157,6 +157,7 @@ export const PROVISIONING_JOB_TEST_TABLES: readonly string[] = [
   "lifecycle_execution_generation" uuid,
   "deletion_attempt_id" uuid,
   "deletion_started_at" timestamptz,
+  "deletion_allocation_counted" boolean,
   "execution_tier" text NOT NULL DEFAULT 'shared'::text,
   "bridge_url" text,
   "health_url" text,

--- a/packages/cloud/shared/src/lib/services/docker-node-workload-queries.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workload-queries.ts
@@ -16,6 +16,57 @@ export const TERMINAL_SANDBOX_STATUSES = [
   "deletion_failed",
 ] as const;
 
+export const TERMINAL_SANDBOX_STATUS_SET: ReadonlySet<string> = new Set(TERMINAL_SANDBOX_STATUSES);
+
+/**
+ * Whether a row still holds one counted slot in `docker_nodes.allocated_count`.
+ *
+ * Seeds `agent_sandboxes.deletion_allocation_counted` when a deletion generation
+ * starts, so it must be evaluated against the PRE-delete lifecycle state, before
+ * the row moves to `deletion_pending`.
+ *
+ * Derived from `TERMINAL_SANDBOX_STATUSES` rather than listing statuses again,
+ * because the two rules must not drift: `syncAllocatedCounts` periodically
+ * RECOMPUTES `allocated_count` from that same set, so any status this treated as
+ * still-counted while the recount treated it as free would be released twice —
+ * once by the recount, once by the deletion CAS — which is the exact double-free
+ * #17185 exists to close. A row with no `node_id` was never placed at all.
+ */
+/**
+ * Whether a row is ALREADY inside a deletion generation, so a new delete request
+ * continues it rather than establishing a fresh one.
+ *
+ * Deliberately broader than `deletion_started_at !== null`. Nothing ties the
+ * intent columns to `status`, so a row can sit in `deletion_pending` with both
+ * intent columns NULL — the shape the #17249 incident left behind, and the shape
+ * of any row that entered `deletion_pending` before those columns existed. Under
+ * the narrow test such a row reads as "fresh", and ownership gets re-derived from
+ * its own `deletion_pending` status, which `holdsCountedNodeSlot` scores as still
+ * counted. That arms a release for a slot the pre-ownership provider already
+ * decremented, and the next teardown frees a live sibling's slot — the exact
+ * double-free `deletion_allocation_counted` exists to prevent (#17185).
+ *
+ * Both deletion-intent writers must use this; they disagreed once and that
+ * disagreement was the defect.
+ */
+export function isDeletionContinuation(row: {
+  status: string;
+  deletion_attempt_id: string | null;
+  deletion_started_at: Date | string | null;
+}): boolean {
+  return (
+    Boolean(row.deletion_attempt_id) ||
+    row.deletion_started_at !== null ||
+    row.status === "deletion_pending" ||
+    row.status === "deletion_failed"
+  );
+}
+
+export function holdsCountedNodeSlot(row: { status: string; node_id: string | null }): boolean {
+  if (!row.node_id) return false;
+  return !TERMINAL_SANDBOX_STATUS_SET.has(row.status);
+}
+
 type WorkloadCountDatabase = Pick<typeof dbRead, "select">;
 
 /** Counts live app and agent rows assigned to one Docker node. */
@@ -39,10 +90,27 @@ export async function countAllocatedWorkloadsOnNodeWithDatabase(
       .where(
         and(
           eq(agentSandboxes.node_id, nodeId),
-          sql`${agentSandboxes.status} not in (${sql.join(
-            TERMINAL_SANDBOX_STATUSES.map((status) => sql`${status}`),
-            sql`, `,
-          )})`,
+          // Recorded allocation ownership outranks status. Once a deletion
+          // generation has handed its slot back the row stops consuming
+          // capacity immediately, even though it lingers in `deletion_pending`
+          // until the row delete commits; conversely a `deletion_failed` row
+          // that still owns its slot genuinely occupies one, which a
+          // status-only rule counted as free (#17185).
+          //
+          // NULL keeps the pre-ownership behaviour byte for byte: rows with no
+          // deletion intent never had ownership recorded, and neither did
+          // deletion intents that predate the column — both fall through to the
+          // terminal-status rule rather than being guessed either way.
+          sql`(
+            ${agentSandboxes.deletion_allocation_counted} IS TRUE
+            OR (
+              ${agentSandboxes.deletion_allocation_counted} IS NULL
+              AND ${agentSandboxes.status} not in (${sql.join(
+                TERMINAL_SANDBOX_STATUSES.map((status) => sql`${status}`),
+                sql`, `,
+              )})
+            )
+          )`,
         ),
       ),
     database

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
@@ -6,9 +6,10 @@
 // These suites mock `db/helpers` with a partial `dbWrite` (no `execute`), so the
 // self-healing DDL guard cannot run here. Skipping it is the house pattern for
 // mocked-database suites; the guard itself is covered by the PGlite tests.
+const PRIOR_SKIP_ENSURE = process.env.SKIP_AGENT_SANDBOX_ENSURE;
 process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 
@@ -86,4 +87,12 @@ describe("countAllocatedWorkloadsOnNode — live-slot accounting (#15378)", () =
     expect(rendered.filter((params) => params.includes("replacement-node"))).toHaveLength(3);
     expect(rendered.some((params) => params.includes("true"))).toBe(true);
   });
+});
+
+// bun shares one process across files without --isolate, so an unrestored env
+// override here would silently disable the ensure guard for whatever suite runs
+// next. Restore exactly what was there before.
+afterAll(() => {
+  if (PRIOR_SKIP_ENSURE === undefined) delete process.env.SKIP_AGENT_SANDBOX_ENSURE;
+  else process.env.SKIP_AGENT_SANDBOX_ENSURE = PRIOR_SKIP_ENSURE;
 });

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
@@ -3,6 +3,11 @@
  * agent sandbox rows must not inflate allocated_count, or the autoscaler reads
  * bare-metal robots as full and bills new Hetzner-cloud nodes instead (#15378).
  */
+// These suites mock `db/helpers` with a partial `dbWrite` (no `execute`), so the
+// self-healing DDL guard cannot run here. Skipping it is the house pattern for
+// mocked-database suites; the guard itself is covered by the PGlite tests.
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -204,7 +204,13 @@ export async function loadSandboxStatusesByIds(
  * moved the workload (#15228). Apps deliberately fan one name across rows and
  * are NOT node-aware.
  */
-const AGENT_ORPHAN_RECONCILER_CONFIG: OrphanReconcilerConfig = {
+/**
+ * Exported so a test can drive the REAL wiring rather than a copy: the contract
+ * that `keyOf` yields an `agent_sandboxes.id` — which `onReaped` then feeds to a
+ * CAS keyed on that column — is an assumption spanning two modules, and a copy
+ * of the config in a test would assert nothing about the one production uses.
+ */
+export const AGENT_ORPHAN_RECONCILER_CONFIG: OrphanReconcilerConfig = {
   prefix: AGENT_CONTAINER_NAME_PREFIX,
   keyOf: agentIdFromContainerName,
   terminalStatuses: TERMINAL_SANDBOX_STATUS_SET,

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -6,11 +6,14 @@
  */
 import { ElizaError } from "@elizaos/core";
 import { and, eq, inArray, or, sql } from "drizzle-orm";
+import { ensureAgentSandboxSchema } from "../../db/ensure-agent-sandbox-schema";
 import { dbRead, dbWrite } from "../../db/helpers";
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
 import {
   countAllocatedWorkloadsOnNodeWithDatabase,
+  TERMINAL_SANDBOX_STATUS_SET,
   TERMINAL_SANDBOX_STATUSES,
 } from "./docker-node-workload-queries";
 import { AGENT_CONTAINER_NAME_PREFIX } from "./docker-sandbox-utils";
@@ -47,7 +50,6 @@ async function countRows(query: Promise<Array<{ count: number }>>): Promise<numb
  * agent_delete job is actively in flight and owns the teardown; reaping under
  * it would race the worker.
  */
-const TERMINAL_SANDBOX_STATUS_SET = new Set<string>(TERMINAL_SANDBOX_STATUSES);
 
 /**
  * Active compute slots on a Docker node.
@@ -58,13 +60,27 @@ const TERMINAL_SANDBOX_STATUS_SET = new Set<string>(TERMINAL_SANDBOX_STATUSES);
  *
  * The agent side excludes the same {@link TERMINAL_SANDBOX_STATUSES} the orphan
  * reconciler uses to decide a container "should NOT be running" — a row in one
- * of those states holds no live slot. Including `sleeping` or
- * `deletion_failed` would inflate `allocated_count`, make bare-metal nodes
- * appear full, and trigger unnecessary Hetzner capacity (#15378).
+ * of those states holds no live slot — EXCEPT where a deletion generation still
+ * records ownership of one. A `deletion_failed` row exists precisely because
+ * teardown did not succeed, so while its container is still out there it does
+ * occupy a slot, and counting it is what stops a delete that cannot prove
+ * absence from freeing a live sibling's capacity (#17185). That does not
+ * reintroduce the inflation of #15378, because ownership is not open-ended: the
+ * orphan reaper releases it in the same sweep that removes the container, so an
+ * abandoned deletion stops counting the moment its container is proven gone.
  * `disconnected` is deliberately NOT excluded: it is non-terminal (the
  * container is up but unreachable) and still occupies the slot.
  */
 export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<number> {
+  // This is the placement hot path (`getAvailableNode`, the autoscaler,
+  // `syncAllocatedCounts`), and the query reads ownership columns added after
+  // the base table. The provisioning worker deploys without a `migrate-db`
+  // gate, so on a pre-migration rollout an unguarded read fails closed and NO
+  // agent can be placed. Ensure is memoized per database URL, so the DDL runs
+  // once per isolate; the residual per-call cost is the env lookup, not I/O.
+  // Deliberately on this wrapper rather than the injected-database variant,
+  // which stays hermetic for tests.
+  await ensureAgentSandboxSchema();
   return countAllocatedWorkloadsOnNodeWithDatabase(dbRead, nodeId);
 }
 
@@ -197,6 +213,12 @@ const AGENT_ORPHAN_RECONCILER_CONFIG: OrphanReconcilerConfig = {
   nodeAware: true,
   rowlessGraceMs: DEFAULT_ROWLESS_GRACE_MS,
   nodeMoveGraceMs: DEFAULT_NODE_MOVE_GRACE_MS,
+  // Reaping is the only step that PROVES an agent container is gone, so it is
+  // where a deletion generation that could not prove absence finally hands its
+  // node slot back (#17185).
+  onReaped: async (agentId, nodeId) => {
+    await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, nodeId);
+  },
 };
 
 /**

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -11,6 +11,7 @@ import { dbRead, dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
+import { logger } from "../utils/logger";
 import {
   countAllocatedWorkloadsOnNodeWithDatabase,
   TERMINAL_SANDBOX_STATUS_SET,
@@ -71,17 +72,47 @@ async function countRows(query: Promise<Array<{ count: number }>>): Promise<numb
  * `disconnected` is deliberately NOT excluded: it is non-terminal (the
  * container is up but unreachable) and still occupies the slot.
  */
+/** Postgres `undefined_column` — the shape a pre-migration read takes. */
+const UNDEFINED_COLUMN = "42703";
+
+function isUndefinedColumn(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === UNDEFINED_COLUMN
+  );
+}
+
 export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<number> {
-  // This is the placement hot path (`getAvailableNode`, the autoscaler,
-  // `syncAllocatedCounts`), and the query reads ownership columns added after
-  // the base table. The provisioning worker deploys without a `migrate-db`
-  // gate, so on a pre-migration rollout an unguarded read fails closed and NO
-  // agent can be placed. Ensure is memoized per database URL, so the DDL runs
-  // once per isolate; the residual per-call cost is the env lookup, not I/O.
-  // Deliberately on this wrapper rather than the injected-database variant,
-  // which stays hermetic for tests.
-  await ensureAgentSandboxSchema();
-  return countAllocatedWorkloadsOnNodeWithDatabase(dbRead, nodeId);
+  // Repair-on-failure rather than prophylactic DDL. This is the placement hot
+  // path (`getAvailableNode`, the autoscaler, `syncAllocatedCounts`, each once
+  // per node per sweep) and it reads ownership columns added after the base
+  // table, which the provisioning worker can reach before its migration has run
+  // — its deploy has no `migrate-db` gate.
+  //
+  // Calling ensure up front would guard that, but at a cost the guard does not
+  // justify: it puts a ~15-statement ALTER/CREATE block on every placement, and
+  // `ensureAgentSandboxSchema` rethrows AND drops its memo on failure, so one
+  // transient DDL failure would fail placement for every agent — a strictly
+  // wider blast radius than the missing column it protects against.
+  //
+  // Instead the query runs unguarded, and only an actual `undefined_column`
+  // triggers the self-heal and one retry. The happy path pays nothing, the
+  // pre-migration path still recovers, and a DDL failure surfaces on a request
+  // that was already failing rather than taking down placement wholesale.
+  try {
+    return await countAllocatedWorkloadsOnNodeWithDatabase(dbRead, nodeId);
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — the retry is the handling; any
+    // other failure, and any failure of the retry itself, propagates with cause.
+    if (!isUndefinedColumn(error)) throw error;
+    logger.warn(
+      "[docker-node-workloads] Workload count hit a missing column; applying agent-sandbox schema ensure and retrying once",
+      { nodeId },
+    );
+    await ensureAgentSandboxSchema();
+    return countAllocatedWorkloadsOnNodeWithDatabase(dbRead, nodeId);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -2271,7 +2271,11 @@ export class DockerSandboxProvider implements SandboxProvider {
   }
 
   async stop(sandboxId: string): Promise<void> {
-    await this.stopWithPolicy(sandboxId, true);
+    // Deletion is the one teardown whose capacity is owned elsewhere: the
+    // caller's deletion generation releases the slot exactly once via
+    // `tryReleaseDeletionAllocation`, because this path is retryable and
+    // treats "already gone" as success (#17185).
+    await this.stopWithPolicy(sandboxId, true, false);
   }
 
   /**
@@ -2280,10 +2284,19 @@ export class DockerSandboxProvider implements SandboxProvider {
    * an unresolved stop must retain the database fence and block replacement.
    */
   async stopForReplacement(sandboxId: string): Promise<void> {
-    await this.stopWithPolicy(sandboxId, false);
+    // Suspend, shutdown, sleep, warm-claim retire and ghost cleanup all route
+    // here. None has a durable generation to own the slot, and each stops
+    // exactly once under a fence, so the provider still releases capacity for
+    // them — the same per-operation ownership `stopOnSpecificNodeWithPolicy`
+    // already declares.
+    await this.stopWithPolicy(sandboxId, false, true);
   }
 
-  private async stopWithPolicy(sandboxId: string, allowUnreachableAbandon: boolean): Promise<void> {
+  private async stopWithPolicy(
+    sandboxId: string,
+    allowUnreachableAbandon: boolean,
+    releaseCapacity: boolean,
+  ): Promise<void> {
     const meta = await this.resolveContainer(sandboxId);
 
     logger.info(
@@ -2354,8 +2367,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       // (and its headscale registration, if deletion was skipped) can leak until
       // such a sweeper is built or it is reclaimed by hand. We accept that leak
       // to keep the work cycle bounded; the lifecycle/capacity owner should add
-      // a node-reconcile sweep (and revisit the allocated_count decrement below)
-      // when one lands. Do NOT claim a reconciler already reclaims it.
+      // a node-reconcile sweep when one lands. Do NOT claim a reconciler already
+      // reclaims it. The abandoned container's node slot is still released once
+      // by the caller's deletion generation — an abandoned container leaks on
+      // the box, not in `allocated_count`.
       const unreachable = isNodeUnreachableMessage(stopMsg) && isNodeUnreachableMessage(rmMsg);
       if (!stopIsGone && !rmIsGone && (!unreachable || !allowUnreachableAbandon)) {
         throw new Error(
@@ -2378,12 +2393,18 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
     }
 
-    // Decrement allocated_count on the node
-    await dockerNodesRepository.decrementAllocated(meta.nodeId).catch((err) => {
-      logger.warn(
-        `[docker-sandbox] Failed to decrement allocated_count for node ${meta.nodeId}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    });
+    // Capacity release is per-operation, not unconditional. A teardown whose
+    // caller owns a durable generation passes `releaseCapacity: false` and
+    // hands the slot back itself, because this path is retryable and treats
+    // "already absent" as success — so decrementing here would run several
+    // times for one allocation and free a live sibling's slot (#17185).
+    if (releaseCapacity) {
+      await dockerNodesRepository.decrementAllocated(meta.nodeId).catch((err) => {
+        logger.warn(
+          `[docker-sandbox] Failed to decrement allocated_count for node ${meta.nodeId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    }
 
     // Deletes Headscale VPN registration only for containers that were
     // actually enrolled. Fallback-mode containers can run with HEADSCALE_API_KEY

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -13,6 +13,7 @@ import {
 } from "@elizaos/shared/agent-backup-limits";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
+import { ensureAgentSandboxSchema } from "../../db/ensure-agent-sandbox-schema";
 import { type Database, dbWrite } from "../../db/helpers";
 import { agentBillingRepository } from "../../db/repositories/agent-billing";
 import {
@@ -76,6 +77,10 @@ import { aiBillingRecordsService } from "./ai-billing-records";
 import { apiKeysService } from "./api-keys";
 import { imageRequiresDigestPin, isCodingContainerImageAllowed } from "./coding-containers";
 import type { CreditReconciliationResult, CreditReservation } from "./credits";
+import {
+  holdsCountedNodeSlot,
+  isDeletionContinuation,
+} from "./docker-node-workload-queries";
 import type { DockerSandboxMetadata } from "./docker-sandbox-provider";
 import { shellQuote } from "./docker-sandbox-utils";
 import { DockerSSHClient } from "./docker-ssh";
@@ -1758,6 +1763,12 @@ export class ElizaSandboxService {
     // genuine hang. A real stop failure on a REACHABLE node still escalates
     // (returns failure / retry), since the container may still be running; an
     // "already gone" failure is ignorable and we proceed.
+    // Whether the container is PROVEN gone. A bounded timeout completes the
+    // delete but abandons a container that may still be running, so it is not
+    // proof — releasing its slot would let the scheduler pack new containers
+    // onto a box still running the old ones.
+    let containerProvenGone = true;
+
     if (precheck.sandboxId) {
       const sandboxId = precheck.sandboxId;
       const stop = await this.runBoundedSandboxStop(sandboxId);
@@ -1765,6 +1776,10 @@ export class ElizaSandboxService {
       if (stop) {
         const errorMessage = stop.error instanceof Error ? stop.error.message : String(stop.error);
         if ("timedOut" in stop) {
+          // The container may still be running, so this generation keeps its
+          // node slot. The orphan reconciler releases it once it proves the
+          // container is actually absent (#17185).
+          containerProvenGone = false;
           // HONEST LIMITATION: there is currently NO automatic reclaimer — no
           // orphan-sweep / node-reconcile job that lists actual containers on a
           // node and removes ones with no DB row (see docker-sandbox-provider's
@@ -1794,6 +1809,32 @@ export class ElizaSandboxService {
           return { success: false, error: "Failed to delete sandbox" };
         }
       }
+    }
+
+    // The container is proven gone, so this generation hands its node slot back
+    // — and does so BEFORE the steps that can still fail below (credential
+    // revocation, the row-delete CAS, job-status persistence). Those failures
+    // re-run this whole path; the CAS is what makes the second run a no-op
+    // instead of a second decrement that frees a live sibling's slot (#17185).
+    //
+    // Two paths deliberately skip the release and keep ownership: a reachable
+    // stop FAILURE returns above without reaching here, and a bounded timeout
+    // abandons a container that may still be running. Both leave the slot
+    // counted until something proves absence — the retry that completes the
+    // teardown, or the orphan reconciler that reaps the container.
+    if (containerProvenGone && precheck.nodeId) {
+      const released = await agentSandboxesRepository.tryReleaseDeletionAllocation(
+        agentId,
+        orgId,
+        precheck.deletionAttemptId,
+        precheck.nodeId,
+      );
+      logger.info("[agent-sandbox] Deletion node-slot release", {
+        released,
+        agentId,
+        nodeId: precheck.nodeId,
+        deletionAttemptId: precheck.deletionAttemptId,
+      });
     }
 
     // Revoke both credential owners before deleting the row. The source-pool
@@ -1849,6 +1890,7 @@ export class ElizaSandboxService {
     | {
         ok: true;
         sandboxId: string | null;
+        nodeId: string | null;
         status: AgentSandbox["status"];
         sourcePoolId: string | null;
         environmentRevision: number;
@@ -1857,6 +1899,11 @@ export class ElizaSandboxService {
       }
     | { ok: false; error: string }
   > {
+    // The deletion intent this stamps includes `deletion_allocation_counted`,
+    // which the provisioning worker can reach before its migration has run
+    // (its deploy does not gate on migrate-db). Ensure is memoized, so the DDL
+    // runs once per isolate rather than once per delete.
+    await ensureAgentSandboxSchema();
     return dbWrite.transaction(async (tx) => {
       await this.lockLifecycle(tx, agentId, orgId);
 
@@ -1877,12 +1924,21 @@ export class ElizaSandboxService {
       const deletionAttemptId = rec.deletion_attempt_id ?? crypto.randomUUID();
       // A retry preserves the original audit timestamp while taking a fresh
       // database generation for the new teardown attempt.
+      //
+      // Allocation ownership rides the same rule, for the same reason: a
+      // continuation must inherit the original generation's recorded answer, not
+      // re-derive it from a row this deletion has already moved to
+      // `deletion_pending` — which would read as "still counted" forever and free
+      // a live sibling's slot on every retry (#17185).
       const [owned] = await tx
         .update(agentSandboxes)
         .set({
           status: "deletion_pending",
           deletion_attempt_id: deletionAttemptId,
           ...(rec.deletion_started_at === null ? { deletion_started_at: new Date() } : {}),
+          ...(isDeletionContinuation(rec)
+            ? {}
+            : { deletion_allocation_counted: holdsCountedNodeSlot(rec) }),
           updated_at: new Date(),
         })
         .where(
@@ -1908,6 +1964,7 @@ export class ElizaSandboxService {
       return {
         ok: true as const,
         sandboxId: rec.sandbox_id,
+        nodeId: rec.node_id,
         status: rec.status,
         sourcePoolId: rec.warm_claim_source_pool_id,
         environmentRevision: rec.environment_revision,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1820,18 +1820,26 @@ export class ElizaSandboxService {
     // counted until something proves absence — the retry that completes the
     // teardown, or the orphan reconciler that reaps the container.
     if (containerProvenGone && precheck.nodeId) {
-      const released = await agentSandboxesRepository.tryReleaseDeletionAllocation(
+      const outcome = await agentSandboxesRepository.tryReleaseDeletionAllocation(
         agentId,
         orgId,
         precheck.deletionAttemptId,
         precheck.nodeId,
       );
-      logger.info("[agent-sandbox] Deletion node-slot release", {
-        released,
+      // `not-owned` is the expected retry outcome and stays at info; only a
+      // counter that failed to move while ownership WAS ours is an accounting
+      // problem worth an operator's attention.
+      const context = {
+        outcome,
         agentId,
         nodeId: precheck.nodeId,
         deletionAttemptId: precheck.deletionAttemptId,
-      });
+      };
+      if (outcome === "counter-unchanged") {
+        logger.warn("[agent-sandbox] Deletion node-slot release did not move the counter", context);
+      } else {
+        logger.info("[agent-sandbox] Deletion node-slot release", context);
+      }
     }
 
     // Revoke both credential owners before deleting the row. The source-pool

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -77,10 +77,7 @@ import { aiBillingRecordsService } from "./ai-billing-records";
 import { apiKeysService } from "./api-keys";
 import { imageRequiresDigestPin, isCodingContainerImageAllowed } from "./coding-containers";
 import type { CreditReconciliationResult, CreditReservation } from "./credits";
-import {
-  holdsCountedNodeSlot,
-  isDeletionContinuation,
-} from "./docker-node-workload-queries";
+import { holdsCountedNodeSlot, isDeletionContinuation } from "./docker-node-workload-queries";
 import type { DockerSandboxMetadata } from "./docker-sandbox-provider";
 import { shellQuote } from "./docker-sandbox-utils";
 import { DockerSSHClient } from "./docker-ssh";

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
@@ -176,6 +176,16 @@ export interface OrphanReconcilerConfig {
    * Defaults to `DEFAULT_NODE_MOVE_GRACE_MS` when node-aware and unset.
    */
   nodeMoveGraceMs?: number;
+
+  /**
+   * Invoked after a container is successfully reaped, with the decision key and
+   * the node it was reaped from. The reap is the only place that PROVES a
+   * container is absent, so this is where a caller can hand back durable state
+   * that was deliberately held until absence was proven — e.g. an agent
+   * deletion generation's node slot (#17185). Best-effort by contract: a
+   * failure here is logged and never aborts the sweep.
+   */
+  onReaped?(key: string, nodeId: string): Promise<void>;
 }
 
 /**
@@ -558,6 +568,18 @@ export async function reconcileOrphanContainers(
         // whichever container holds it NOW, i.e. the new live one) — DO NOT.
         await node.removeContainer(orphan.id);
         result.reaped += 1;
+        if (config.onReaped) {
+          // error-policy:J7 the reap itself succeeded and is already counted;
+          // a bookkeeping failure must not abort the remaining reaps. The next
+          // sweep retries it, and the CAS behind it is idempotent.
+          await config.onReaped(orphan.key, node.node_id).catch((error: unknown) => {
+            logger.warn(`[${config.logScope}] Post-reap bookkeeping failed`, {
+              nodeId: node.node_id,
+              key: orphan.key,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
+        }
         logger.info(`[${config.logScope}] Reaped orphan container`, {
           nodeId: node.node_id,
           hostname: node.hostname,

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
@@ -569,9 +569,13 @@ export async function reconcileOrphanContainers(
         await node.removeContainer(orphan.id);
         result.reaped += 1;
         if (config.onReaped) {
-          // error-policy:J7 the reap itself succeeded and is already counted;
-          // a bookkeeping failure must not abort the remaining reaps. The next
-          // sweep retries it, and the CAS behind it is idempotent.
+          // error-policy:J6 best-effort teardown bookkeeping. Not J7: this is not
+          // diagnostics — a swallowed failure holds a real node slot. It is
+          // survivable only because the retry contract is explicit: the reap is
+          // already counted, the remaining reaps must still run, and the next
+          // sweep re-attempts the release against a CAS that is idempotent by
+          // construction, so a missed release costs one sweep interval of
+          // capacity rather than leaking it permanently.
           await config.onReaped(orphan.key, node.node_id).catch((error: unknown) => {
             logger.warn(`[${config.logScope}] Post-reap bookkeeping failed`, {
               nodeId: node.node_id,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -15,6 +15,7 @@
 // These suites mock `db/helpers` with a partial `dbWrite` (no `execute`), so the
 // self-healing DDL guard cannot run here. Skipping it is the house pattern for
 // mocked-database suites; the guard itself is covered by the PGlite tests.
+const PRIOR_SKIP_ENSURE = process.env.SKIP_AGENT_SANDBOX_ENSURE;
 process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
 import { afterAll, afterEach, describe, expect, mock, spyOn, test } from "bun:test";
@@ -325,4 +326,12 @@ describe("reEnqueueFailedDeletions — recover stuck deletion_failed rows", () =
       enqueueSpy.mockRestore();
     }
   });
+});
+
+// bun shares one process across files without --isolate, so an unrestored env
+// override here would silently disable the ensure guard for whatever suite runs
+// next. Restore exactly what was there before.
+afterAll(() => {
+  if (PRIOR_SKIP_ENSURE === undefined) delete process.env.SKIP_AGENT_SANDBOX_ENSURE;
+  else process.env.SKIP_AGENT_SANDBOX_ENSURE = PRIOR_SKIP_ENSURE;
 });

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -12,6 +12,11 @@
  * helpers module with chainable query builders that capture the generated SQL.
  */
 
+// These suites mock `db/helpers` with a partial `dbWrite` (no `execute`), so the
+// self-healing DDL guard cannot run here. Skipping it is the house pattern for
+// mocked-database suites; the guard itself is covered by the PGlite tests.
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
 import { afterAll, afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -73,10 +73,7 @@ import { appsService } from "./apps";
 import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-service";
 import { readContainerProvisionJobData } from "./container-jobs-data";
 import { dispatchContainerStopJob } from "./container-stop-job-service";
-import {
-  holdsCountedNodeSlot,
-  isDeletionContinuation,
-} from "./docker-node-workload-queries";
+import { holdsCountedNodeSlot, isDeletionContinuation } from "./docker-node-workload-queries";
 import {
   configureElizaLifecycleTransaction,
   elizaAdminCanaryRolloutAdvisoryLockSql,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -28,6 +28,7 @@ import {
   sql,
 } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
+import { ensureAgentSandboxSchema } from "../../db/ensure-agent-sandbox-schema";
 import { dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import {
@@ -41,6 +42,7 @@ import {
 } from "../../db/repositories/jobs";
 import {
   type AgentExecutionTier,
+  type AgentSandboxStatus,
   agentSandboxes,
   UPGRADE_FAILURE_TARGET_MARKER_PREFIX,
 } from "../../db/schemas/agent-sandboxes";
@@ -71,6 +73,10 @@ import { appsService } from "./apps";
 import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-service";
 import { readContainerProvisionJobData } from "./container-jobs-data";
 import { dispatchContainerStopJob } from "./container-stop-job-service";
+import {
+  holdsCountedNodeSlot,
+  isDeletionContinuation,
+} from "./docker-node-workload-queries";
 import {
   configureElizaLifecycleTransaction,
   elizaAdminCanaryRolloutAdvisoryLockSql,
@@ -735,7 +741,7 @@ interface LifecycleSandboxRow {
   agent_name: string | null;
   created_at: Date;
   execution_tier: AgentExecutionTier;
-  status: string;
+  status: AgentSandboxStatus;
   updated_at: Date | null;
   claimed_at: Date | null;
   warm_claim_credential_state: "pending" | "attested" | "ready" | "failed" | null;
@@ -1411,6 +1417,10 @@ export class ProvisioningJobService {
       executionTier: AgentExecutionTier;
     };
   }): Promise<EnqueueAgentDeleteResult> {
+    // Stamps `deletion_allocation_counted`, and this runs inside the
+    // provisioning worker, whose deploy does not gate on migrate-db. Ensure is
+    // memoized, so the DDL runs once per isolate rather than once per enqueue.
+    await ensureAgentSandboxSchema();
     const expectedIdentity = params.expectedIdentity;
     const expectedCreatedAt = expectedIdentity ? new Date(expectedIdentity.createdAt) : null;
     if (expectedCreatedAt && !Number.isFinite(expectedCreatedAt.getTime())) {
@@ -1560,6 +1570,16 @@ export class ProvisioningJobService {
             status: "deletion_pending" as const,
             deletion_attempt_id: deletionAttemptId,
             ...(continuesEarlierDeletion ? {} : { deletion_started_at: new Date() }),
+            // Gated on the BROADER continuation signal than the start time is.
+            // `continuesEarlierDeletion` only checks `deletion_started_at`, and
+            // nothing ties that column to `status`, so a row already sitting in
+            // deletion_pending with null intent columns would take the "fresh"
+            // branch and re-derive ownership from its OWN deletion status —
+            // reading as "still counted" and freeing a slot on every recovery
+            // sweep, the exact double-free this column exists to stop (#17185).
+            ...(isDeletionContinuation(sandbox)
+              ? {}
+              : { deletion_allocation_counted: holdsCountedNodeSlot(sandbox) }),
             billing_status: "suspended" as const,
             scheduled_shutdown_at: null,
             shutdown_warning_sent_at: null,


### PR DESCRIPTION
# Relates to

Closes #17185.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
      One conflict, in the migration journal, resolved by renumbering — see
      **Sync with develop**.
- [x] `bun install` was re-run after sync. `bun run verify` was run but could
      not be carried to completion locally — see **Known gaps** for exactly what
      did and did not run.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `c43d283cf`; zero commits behind.
- [x] **Migration renumbered `0188` -> `0189`.** `0188_sso_bridge_store` landed on
      develop while this branch was open and took both the file number and journal
      idx 187. The rebase conflicted on `_journal.json`; develop's entry is
      preserved untouched at idx 187 and this branch's migration is now
      `0189_agent_sandbox_deletion_allocation_ownership` at idx 188. The journal
      diff against develop is a 7-line addition and nothing else.
- [x] `bun install` re-run after the rebase; `bun.lock` unchanged by this branch.
- [ ] `bun run verify` post-sync: partial. Detailed in **Known gaps**.

# Risks

**Medium.** Multi-tenant node capacity accounting, with a schema addition.

- The column is nullable with no default and no backfill; `ADD COLUMN` of a
  nullable column is metadata-only on PG11+, so the migration does not lock
  `agent_sandboxes`.
- `NULL` preserves the pre-change behaviour exactly, so a deployment mid-flight
  behaves as it does today until each row's next deletion generation.
- The direction of error is deliberate: a node reads one slot **fuller** than it
  is until `syncAllocatedCounts` next runs. Schedulers gate on
  `allocated_count < capacity`, so the error can only under-pack a node, never
  over-pack one.
- The provider no longer decrements on the deletion path. Every other teardown
  (suspend, shutdown, sleep, warm-claim retire, ghost cleanup) routes through
  `stopForReplacement`, which is unchanged.

# Background

## What does this PR do?

One logical managed Docker allocation now releases exactly one
`docker_nodes.allocated_count` slot, across retries, crashes, already-absent
responses, suspend/delete sequences, and late provider completion.

`DockerSandboxProvider.stopWithPolicy` decremented the node counter at the end
of every teardown. Remote teardown is retryable and treats "No such container"
as success, but the sandbox row keeps its node locator until the row itself is
deleted — so a retry after any post-stop failure (credential revocation, the
row-delete CAS, job-status persistence) decremented the same slot again, and the
slot it freed belonged to a **live sibling** on that node.
`GREATEST(count - 1, 0)` hid the underflow rather than preventing it. Suspend had
the same shape: it stops and decrements while keeping the locator, so a later
delete repeated the decrement with no retry involved.

Capacity ownership is now declared per operation, reusing the seam
`stopOnSpecificNodeWithPolicy` already had:

- `agent_sandboxes.deletion_allocation_counted` (migration 0189) records whether
  a deletion generation still owns a counted slot, mirroring the
  `replacement_cleanup_allocation_counted` mechanism this table already uses.
- `stop()` passes `releaseCapacity: false`; the generation hands the slot back
  itself through a CAS that flips ownership and decrements the node in one
  transaction. `stopForReplacement()` passes `true`.
- The release runs only on **proven** absence. A reachable stop failure and a
  bounded-timeout abandon both keep ownership, so a container that may still be
  running never has its slot handed to the scheduler.
- The orphan reconciler releases the slot in the same sweep that reaps the
  container — the one place absence is proven. That prevents an abandoned
  deletion holding a slot forever once `reEnqueueFailedDeletions` trips its
  circuit breaker (#15378).
- Workload reconciliation counts a deletion row exactly while it owns a slot;
  `NULL` falls through to the previous status rule.

Both deletion-intent writers share `isDeletionContinuation`, so a row already in
`deletion_pending` with NULL intent columns — the shape #17249 left behind —
cannot re-derive ownership from its own deletion status.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The rationale
lives in the migration prose and the column doc, per the repo comment doctrine.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/db/repositories/agent-sandboxes.ts` —
`spendDeletionAllocation` is the whole invariant in one transaction. Then
`docker-sandbox-provider.ts` for the `releaseCapacity` split, and
`eliza-sandbox.ts` for the proven-absence policy.

## Detailed testing steps

None: automated tests are acceptable. Four suites, all real-path:

- `deletion-allocation-ownership.test.ts` — the CAS and reconciliation against
  in-process PGlite with the real Drizzle schema, nothing mocked.
- `deletion-release-proven-absence.test.ts` — the real `deleteAgent` with a
  scripted provider: clean teardown releases once; a reachable stop failure and
  a bounded-timeout abandon both keep ownership and the slot.
- `orphan-reap-releases-deletion-slot.test.ts` — the real
  `AGENT_ORPHAN_RECONCILER_CONFIG` through the real reconciler, pinning that
  `keyOf` yields the `agent_sandboxes.id` the release CAS is keyed on.
- `docker-sandbox-stop-no-capacity-mutation.test.ts` — the real provider with
  only the SSH transport scripted, proving it never reaches the counter.

Mutation-checked: restoring the old unconditional decrement fails 4 of the 5
provider cases.

# Evidence Gate

<!-- evidence-head:70a97ec2e8ae83bd8f6d5a85084dad97c84f5508 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered surface. The diff is node capacity accounting in
      `packages/cloud/shared` and touches no `.tsx`/`.css`/`.svg`/`.html` under
      `packages/app`, `packages/ui` or `apps/app`.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered surface, as above.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-exercisable flow; the behaviour is a database CAS on a
      provisioning-worker path with no UI entry point.
<!-- evidence-row:backend-logs -->
- [x] Real `[docker-sandbox]` output from the provider suite, driving every
      classification branch. Also mirrored at
      https://gist.github.com/Zorba-the-buddhah/b70f29ac88a300e08688970b5ce2c74d

<details>
<summary>Backend logs — provider teardown output (all four branches)</summary>

```
[docker-sandbox] docker stop failed for agent-capacity-ownership-test: Error response from daemon: No such container: agent-x
[docker-sandbox] docker rm failed for agent-capacity-ownership-test: Error response from daemon: No such container: agent-x
[docker-sandbox] docker stop failed for agent-capacity-ownership-test: [docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms
[docker-sandbox] docker rm failed for agent-capacity-ownership-test: [docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms
[docker-sandbox] Node 138.201.80.125 unreachable during stop of agent-capacity-ownership-test; completing delete and ABANDONING the container — it will LEAK until reclaimed (no automatic orphan-sweep / node-reconcile job exists yet) — docker stop -> [docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms; docker rm -f -> [docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms {
[docker-sandbox] docker stop failed for agent-capacity-ownership-test: Cannot connect to the Docker daemon
[docker-sandbox] docker rm failed for agent-capacity-ownership-test: Cannot connect to the Docker daemon
[⣷] Pulling schema from database...
[agent-sandboxes] Deletion allocation ownership consumed for node node-32-4if4wl but allocated_count was not decremented — counter already at 0 or node row missing
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code path is reachable from this change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt or model behaviour changes; this
      is capacity arithmetic on the provisioning path.
<!-- evidence-row:domain-artifacts -->
- [x] Real PGlite rows through the real repository CAS. A node at
      `allocated_count = 2` carries the agent under deletion plus a LIVE sibling.
      Release #1 takes it to 1 and spends ownership; releases #2 and #3 (the
      post-stop-failure retry and a recovery sweep) return `not-owned` and leave
      it at 1. Before this change the third read 0 — the sibling's slot. Also
      mirrored at
      https://gist.github.com/Zorba-the-buddhah/ab231e3f5509d3f9f3e27ebc950e3be8

<details>
<summary>Domain artifacts — agent_sandboxes / docker_nodes output before and after each release</summary>

```
^[[2K^[[1G[⣟] Pulling schema from database...
^[[2K^[[1G[⡿] Pulling schema from database...
^[[2K^[[1G[⢿] Pulling schema from database...
^[[2K^[[1G[✓] Pulling schema from database...
target agent: e8a5ae5a-fb8f-48d5-ac60-e3261dbbaa2e
live sibling: d1ebde3f-6345-41ff-84f4-5ea1b9003c5a
node: node-evidence-1

=== BEFORE — deletion generation owns one of the node's two slots ===
┌───┬────────────────┬──────────────────┬─────────────────────────────┬─────────────────┐
│   │ agent_name     │ status           │ deletion_allocation_counted │ allocated_count │
├───┼────────────────┼──────────────────┼─────────────────────────────┼─────────────────┤
│ 0 │ deleting-agent │ deletion_pending │ true                        │ 2               │
│ 1 │ live-sibling   │ running          │ null                        │ 2               │
└───┴────────────────┴──────────────────┴─────────────────────────────┴─────────────────┘

release #1 (teardown proven, first pass) -> true

=== AFTER release #1 — slot handed back, ownership spent (2 -> 1) ===
┌───┬────────────────┬──────────────────┬─────────────────────────────┬─────────────────┐
│   │ agent_name     │ status           │ deletion_allocation_counted │ allocated_count │
├───┼────────────────┼──────────────────┼─────────────────────────────┼─────────────────┤
│ 0 │ deleting-agent │ deletion_pending │ false                       │ 1               │
│ 1 │ live-sibling   │ running          │ null                        │ 1               │
└───┴────────────────┴──────────────────┴─────────────────────────────┴─────────────────┘

release #2 (post-stop failure forced a retry) -> false

=== AFTER release #2 — NO second decrement; the live sibling keeps its slot ===
┌───┬────────────────┬──────────────────┬─────────────────────────────┬─────────────────┐
│   │ agent_name     │ status           │ deletion_allocation_counted │ allocated_count │
├───┼────────────────┼──────────────────┼─────────────────────────────┼─────────────────┤
│ 0 │ deleting-agent │ deletion_pending │ false                       │ 1               │
│ 1 │ live-sibling   │ running          │ null                        │ 1               │
└───┴────────────────┴──────────────────┴─────────────────────────────┴─────────────────┘

release #3 (recovery sweep) -> false

=== AFTER release #3 — still 1. Before #17185 this read 0, freeing the sibling's slot ===
┌───┬────────────────┬──────────────────┬─────────────────────────────┬─────────────────┐
│   │ agent_name     │ status           │ deletion_allocation_counted │ allocated_count │
├───┼────────────────┼──────────────────┼─────────────────────────────┼─────────────────┤
│ 0 │ deleting-agent │ deletion_pending │ false                       │ 1               │
│ 1 │ live-sibling   │ running          │ null                        │ 1               │
└───┴────────────────┴──────────────────┴─────────────────────────────┴─────────────────┘
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - the change has no rendered visual surface, so there is no visual text
      to OCR.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt or model behaviour changes.`

## Backend + frontend logs

Backend:
https://gist.github.com/Zorba-the-buddhah/b70f29ac88a300e08688970b5ce2c74d —
structured `[docker-sandbox]` output captured from the real provider driving
every classification branch (clean stop, already-absent, unreachable-abandon,
reachable failure).

Frontend: `N/A - no frontend code path is reachable from this change.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered surface; the diff touches no UI files.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS or STT surface is touched.`

## Domain artifacts

https://gist.github.com/Zorba-the-buddhah/ab231e3f5509d3f9f3e27ebc950e3be8 —
real PGlite rows through the real repository CAS. A node at
`allocated_count = 2` carries the agent under deletion plus a **live sibling**.
Release #1 takes it to 1 and spends ownership; releases #2 and #3 (the
post-stop-failure retry and a recovery sweep) return `not-owned` and leave it at
1. Before this change the third read 0 — the sibling's slot.

## Known gaps / failures

- **`bun run verify` did not complete locally, and I am not claiming it passes.**
  A full run on the pre-review head finished at `518 successful, 578 total` with
  a single failure — `@elizaos/eliza-computer#typecheck`, missing `graphql` and
  `@testing-library/jest-dom` types — which was a stale `node_modules` predating
  #17424 landing on develop, not this diff. Re-running `bun install` fixed that
  package (`tsc -b` clean). Subsequent full runs on the final head were killed by
  my own environment before reaching the summary; the furthest reached 578 turbo
  tasks with zero errors but no post-turbo audits. What IS verified on
  `70a97ec2e` (this head, post-rebase): `bun run --cwd packages/cloud/shared
  typecheck` and `lint:check` both exit 0, and all seven touched suites pass —
  57 tests, 0 failures: ownership/CAS 26, proven-absence 5, provider
  no-capacity-mutation 5, unreachable-terminal 7, orphan-reap 4,
  workloads-count 3, delete-enqueue 7. Each PGlite-backed suite was run in its
  own process, which is the isolation `scripts/run-bun-tests.mjs` applies for
  full-package runs; batching them into one Bun process makes the second PGlite
  suite fail on a spent write connection, and this branch's
  `pglite schema applied — never a silent skip` guard reports that rather than
  passing vacuously. Treat the
  repo-wide gate as unproven from my side and let CI be the authority once the
  workflows can run.

- **No CI signal on the previous head.** All `pull_request` workflows were held
  at `action_required` pending first-time-contributor approval, so both
  aggregate gates polled for check runs that never appeared and reported
  timeouts. Filed as #17551; a fix is in #17577. Not a code failure — details in
  the comments below.
- **Concurrency is argued, not observed under load.** The exactly-once property
  is proven by the transaction structure and by a two-caller PGlite race, not by
  a production-scale concurrent delete. That remains a residual human check.
- **Production `NULL` population is unknown to me.** Whether any live
  `agent_sandboxes` row currently sits in `deletion_pending`/`deletion_failed`
  with NULL intent columns decides whether the continuation fix is urgent or
  theoretical. I cannot query production; flagging it for someone who can.

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-zorba]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->

