### PR TITLE
fix(cloud): scope durable onboarding admissions

### DIFF
--- a/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
@@ -3,9 +3,24 @@
  * owner, including concurrent turn ordering and transport replay.
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import type { OnboardingChatResult } from "@/lib/services/eliza-app/onboarding-chat";
-import { OnboardingSessionCoordinator } from "../src/onboarding-session-coordinator";
+import type { OnboardingSessionCoordinator } from "../src/onboarding-session-coordinator";
+
+const noProvisioning = {
+  status: "none" as const,
+  agentId: null,
+  bridgeUrl: null,
+  sandbox: null,
+};
+
+mock.module("../../shared/src/lib/services/eliza-app/provisioning", () => ({
+  ensureElizaAppProvisioning: mock(async () => noProvisioning),
+  getElizaAppProvisioningStatus: mock(async () => noProvisioning),
+}));
+
+const { OnboardingSessionCoordinator: OnboardingSessionCoordinatorValue } =
+  await import("../src/onboarding-session-coordinator");
 
 class TestStorage {
   private readonly values = new Map<string, unknown>();
@@ -15,22 +30,46 @@ class TestStorage {
     return value === undefined ? undefined : (structuredClone(value) as T);
   }
 
-  async put(key: string, value: unknown): Promise<void> {
-    this.values.set(key, structuredClone(value));
+  async put(
+    key: string | Record<string, unknown>,
+    value?: unknown,
+  ): Promise<void> {
+    if (typeof key === "string") {
+      this.values.set(key, structuredClone(value));
+      return;
+    }
+    for (const [entryKey, entryValue] of Object.entries(key)) {
+      this.values.set(entryKey, structuredClone(entryValue));
+    }
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.values.delete(key);
   }
 }
+
+let harnessNumber = 0;
 
 function createCoordinatorHarness(): {
   coordinator: OnboardingSessionCoordinator;
   objectByName(name: string): OnboardingSessionCoordinator;
+  restart(name: string): OnboardingSessionCoordinator;
+  sessionId: string;
+  storageFor(name: string): TestStorage;
 } {
   const objects = new Map<string, OnboardingSessionCoordinator>();
+  const storageByName = new Map<string, TestStorage>();
   const env: Record<string, unknown> = {};
   const objectByName = (name: string): OnboardingSessionCoordinator => {
     let object = objects.get(name);
     if (!object) {
-      object = new OnboardingSessionCoordinator(
-        { storage: new TestStorage() } as unknown as DurableObjectState,
+      let storage = storageByName.get(name);
+      if (!storage) {
+        storage = new TestStorage();
+        storageByName.set(name, storage);
+      }
+      object = new OnboardingSessionCoordinatorValue(
+        { storage } as unknown as DurableObjectState,
         env as never,
       );
       objects.set(name, object);
@@ -43,30 +82,44 @@ function createCoordinatorHarness(): {
         objectByName(name).fetch(new Request(input, init)),
     }),
   };
+  const sessionId = `platform:discord:user-${++harnessNumber}`;
   return {
-    coordinator: objectByName("platform:discord:user-1"),
+    coordinator: objectByName(sessionId),
     objectByName,
+    restart(name: string) {
+      objects.delete(name);
+      return objectByName(name);
+    },
+    storageFor(name: string) {
+      const storage = storageByName.get(name);
+      if (!storage) throw new Error(`missing test storage for ${name}`);
+      return storage;
+    },
+    sessionId,
   };
 }
 
 function turn(
   coordinator: OnboardingSessionCoordinator,
+  sessionId: string,
   message: string,
   idempotencyKey: string,
+  authenticatedUser?: { userId: string; organizationId: string },
 ): Promise<Response> {
   return coordinator.fetch(
     new Request("https://onboarding.test/turn", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        sessionId: "platform:discord:user-1",
+        sessionId,
         input: {
-          sessionId: "platform:discord:user-1",
+          sessionId,
           message,
           platform: "discord",
-          platformUserId: "user-1",
+          platformUserId: sessionId.slice("platform:discord:".length),
           trustedPlatformIdentity: true,
           idempotencyKey,
+          authenticatedUser,
         },
       }),
     }),
@@ -78,12 +131,141 @@ async function readResult(response: Response): Promise<OnboardingChatResult> {
 }
 
 describe("OnboardingSessionCoordinator", () => {
+  test("retains an accepted delivery beyond the former replay window", async () => {
+    const { coordinator, sessionId, storageFor } = createCoordinatorHarness();
+    let first: OnboardingChatResult | undefined;
+
+    for (let index = 0; index < 65; index += 1) {
+      const response = await turn(
+        coordinator,
+        sessionId,
+        `turn ${index}`,
+        `discord:message-${index}`,
+      );
+      expect(response.status).toBe(200);
+      if (index === 0) first = await readResult(response);
+    }
+
+    if (!first) throw new Error("first delivery was not recorded");
+    const scope = `platform:${encodeURIComponent(sessionId)}`;
+    const storedSession = await storageFor(sessionId).get<{
+      historyChunkCount: number;
+    }>(`session:${scope}`);
+    expect(storedSession?.historyChunkCount).toBe(13);
+    expect(
+      await storageFor(sessionId).get<unknown[]>(`history:${scope}:0`),
+    ).toHaveLength(10);
+    const replay = await readResult(
+      await turn(
+        coordinator,
+        sessionId,
+        "must not execute",
+        "discord:message-0",
+      ),
+    );
+    expect(replay.reply).toBe(first.reply);
+    expect(replay.session).toEqual(first.session);
+  });
+
+  test("replays a delivery after the Durable Object restarts", async () => {
+    const harness = createCoordinatorHarness();
+    const first = await readResult(
+      await turn(
+        harness.coordinator,
+        harness.sessionId,
+        "My name is Sam",
+        "discord:message-1",
+      ),
+    );
+
+    const restarted = harness.restart(harness.sessionId);
+    const replay = await readResult(
+      await turn(
+        restarted,
+        harness.sessionId,
+        "must not execute",
+        "discord:message-1",
+      ),
+    );
+
+    expect(replay.reply).toBe(first.reply);
+    expect(replay.session).toEqual(first.session);
+  });
+
+  test("executes a duplicate again after its explicit replay expiry", async () => {
+    const harness = createCoordinatorHarness();
+    await turn(
+      harness.coordinator,
+      harness.sessionId,
+      "My name is Sam",
+      "discord:message-1",
+    );
+    const scope = `platform:${encodeURIComponent(harness.sessionId)}`;
+    const replayKey = `replay:${scope}:${encodeURIComponent("discord:message-1")}`;
+    const storage = harness.storageFor(harness.sessionId);
+    const stored = await storage.get<{ expiresAt: number }>(replayKey);
+    if (!stored) throw new Error("replay entry was not stored");
+    await storage.put(replayKey, { ...stored, expiresAt: Date.now() - 1 });
+
+    const retried = await readResult(
+      await turn(
+        harness.coordinator,
+        harness.sessionId,
+        "Tell me more",
+        "discord:message-1",
+      ),
+    );
+
+    expect(retried.session.history.map((message) => message.content)).toEqual(
+      expect.arrayContaining(["My name is Sam", "Tell me more"]),
+    );
+  });
+
+  test("keeps identical delivery ids isolated by authenticated account", async () => {
+    const harness = createCoordinatorHarness();
+    const first = await readResult(
+      await turn(
+        harness.coordinator,
+        harness.sessionId,
+        "Hello from account A",
+        "discord:message-1",
+        { userId: "user-a", organizationId: "org-a" },
+      ),
+    );
+    const second = await readResult(
+      await turn(
+        harness.coordinator,
+        harness.sessionId,
+        "Hello from account B",
+        "discord:message-1",
+        { userId: "user-b", organizationId: "org-b" },
+      ),
+    );
+
+    expect(second.session.userId).toBe("user-b");
+    expect(second.session.organizationId).toBe("org-b");
+    expect(
+      second.session.history.map((message) => message.content),
+    ).not.toContain("Hello from account A");
+
+    const replay = await readResult(
+      await turn(
+        harness.coordinator,
+        harness.sessionId,
+        "must not execute",
+        "discord:message-1",
+        { userId: "user-a", organizationId: "org-a" },
+      ),
+    );
+    expect(replay).toEqual(first);
+  });
+
   test("serializes concurrent turns and replays a delivery exactly once", async () => {
     const harness = createCoordinatorHarness();
-    const { coordinator } = harness;
+    const { coordinator, sessionId } = harness;
     const [firstResponse, secondResponse] = await Promise.all([
-      turn(coordinator, "My name is Sam", "discord:message-1"),
-      turn(coordinator, "Tell me more", "discord:message-2"),
+      turn(coordinator, sessionId, "My name is Sam", "discord:message-1"),
+      turn(coordinator, sessionId, "Tell me more", "discord:message-2"),
     ]);
     expect(firstResponse.status).toBe(200);
     expect(secondResponse.status).toBe(200);
@@ -105,11 +287,12 @@ describe("OnboardingSessionCoordinator", () => {
         new Request("https://onboarding.test/resolve", { method: "POST" }),
       );
     expect((await continuation.json()) as unknown).toEqual({
-      sessionId: "platform:discord:user-1",
+      sessionId,
     });
 
     const replayResponse = await turn(
       coordinator,
+      sessionId,
       "this changed payload must not execute",
       "discord:message-1",
     );
@@ -120,6 +303,7 @@ describe("OnboardingSessionCoordinator", () => {
 
     const thirdResponse = await turn(
       coordinator,
+      sessionId,
       "Third turn",
       "discord:message-3",
     );

--- a/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
@@ -59,10 +59,21 @@ class TestStorage {
     return keys.map((entry) => this.values.delete(entry)).some(Boolean);
   }
 
-  async list<T>({ prefix }: { prefix: string }): Promise<Map<string, T>> {
+  async list<T>({
+    prefix,
+    startAfter,
+    limit,
+  }: {
+    prefix: string;
+    startAfter?: string;
+    limit?: number;
+  }): Promise<Map<string, T>> {
     return new Map(
       [...this.values.entries()]
         .filter(([key]) => key.startsWith(prefix))
+        .filter(([key]) => !startAfter || key > startAfter)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .slice(0, limit)
         .map(([key, value]) => [key, structuredClone(value) as T]),
     );
   }
@@ -318,6 +329,43 @@ describe("OnboardingSessionCoordinator", () => {
 
     expect(await storage.get(replayKey)).toBeUndefined();
     expect(await storage.getAlarm()).toBeNull();
+  });
+
+  test("sweeps replay expiry in bounded resumable batches", async () => {
+    const harness = createCoordinatorHarness();
+    const storage = harness.storageFor(harness.sessionId);
+    const now = Date.now();
+    const futureExpiry = now + 60_000;
+
+    for (let index = 0; index < 129; index += 1) {
+      await storage.put(
+        `replay:platform:test:expired-${String(index).padStart(3, "0")}`,
+        {
+          expiresAt: now - 1,
+        },
+      );
+    }
+    await storage.put("replay:platform:test:future", {
+      expiresAt: futureExpiry,
+    });
+
+    await harness.coordinator.alarm();
+
+    expect(
+      await storage.list({ prefix: "replay:platform:test:" }),
+    ).toHaveLength(2);
+    expect(await storage.getAlarm()).toBeGreaterThanOrEqual(now);
+    expect(
+      await storage.get<{ startAfter: string }>("replay-cleanup-state"),
+    ).toEqual(expect.objectContaining({ startAfter: expect.any(String) }));
+
+    await harness.coordinator.alarm();
+
+    expect(await storage.list({ prefix: "replay:platform:test:" })).toEqual(
+      new Map([["replay:platform:test:future", { expiresAt: futureExpiry }]]),
+    );
+    expect(await storage.get("replay-cleanup-state")).toBeUndefined();
+    expect(await storage.getAlarm()).toBe(futureExpiry);
   });
 
   test("fails instead of silently dropping a missing history chunk", async () => {

--- a/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
@@ -13,6 +13,16 @@ const noProvisioning = {
   bridgeUrl: null,
   sandbox: null,
 };
+let mirrorFailure: Error | undefined;
+
+mock.module("../../shared/src/lib/cache/client", () => ({
+  cache: {
+    get: mock(async () => null),
+    set: mock(async () => {
+      if (mirrorFailure) throw mirrorFailure;
+    }),
+  },
+}));
 
 mock.module("../../shared/src/lib/services/eliza-app/provisioning", () => ({
   ensureElizaAppProvisioning: mock(async () => noProvisioning),
@@ -24,6 +34,7 @@ const { OnboardingSessionCoordinator: OnboardingSessionCoordinatorValue } =
 
 class TestStorage {
   private readonly values = new Map<string, unknown>();
+  private alarm: number | null = null;
 
   async get<T>(key: string): Promise<T | undefined> {
     const value = this.values.get(key);
@@ -43,8 +54,35 @@ class TestStorage {
     }
   }
 
-  async delete(key: string): Promise<boolean> {
-    return this.values.delete(key);
+  async delete(key: string | string[]): Promise<boolean> {
+    const keys = typeof key === "string" ? [key] : key;
+    return keys.map((entry) => this.values.delete(entry)).some(Boolean);
+  }
+
+  async list<T>({ prefix }: { prefix: string }): Promise<Map<string, T>> {
+    return new Map(
+      [...this.values.entries()]
+        .filter(([key]) => key.startsWith(prefix))
+        .map(([key, value]) => [key, structuredClone(value) as T]),
+    );
+  }
+
+  async getAlarm(): Promise<number | null> {
+    return this.alarm;
+  }
+
+  async setAlarm(timestamp: number): Promise<void> {
+    this.alarm = timestamp;
+  }
+
+  async deleteAlarm(): Promise<void> {
+    this.alarm = null;
+  }
+
+  async transaction<T>(
+    operation: (transaction: TestStorage) => Promise<T>,
+  ): Promise<T> {
+    return operation(this);
   }
 }
 
@@ -131,6 +169,46 @@ async function readResult(response: Response): Promise<OnboardingChatResult> {
 }
 
 describe("OnboardingSessionCoordinator", () => {
+  test("keeps a trusted platform session after a rejected account adoption", async () => {
+    const harness = createCoordinatorHarness();
+    await turn(
+      harness.coordinator,
+      harness.sessionId,
+      "My name is Sam",
+      "discord:message-1",
+    );
+    const scope = `platform:${encodeURIComponent(harness.sessionId)}`;
+    const storage = harness.storageFor(harness.sessionId);
+    const storedSession = await storage.get<Record<string, unknown>>(
+      `session:${scope}`,
+    );
+    if (!storedSession) throw new Error("platform session was not stored");
+    await storage.put(`session:${scope}`, {
+      ...storedSession,
+      userId: "user-a",
+      organizationId: "org-a",
+    });
+    await turn(
+      harness.coordinator,
+      harness.sessionId,
+      "Account B",
+      "discord:message-2",
+      { userId: "user-b", organizationId: "org-b" },
+    );
+
+    const resumed = await readResult(
+      await turn(
+        harness.coordinator,
+        harness.sessionId,
+        "Still here",
+        "discord:message-3",
+      ),
+    );
+    expect(resumed.session.history.map((message) => message.content)).toEqual(
+      expect.arrayContaining(["My name is Sam", "Still here"]),
+    );
+  });
+
   test("retains an accepted delivery beyond the former replay window", async () => {
     const { coordinator, sessionId, storageFor } = createCoordinatorHarness();
     let first: OnboardingChatResult | undefined;
@@ -221,6 +299,77 @@ describe("OnboardingSessionCoordinator", () => {
     );
   });
 
+  test("removes expired replay entries when its alarm fires", async () => {
+    const harness = createCoordinatorHarness();
+    await turn(
+      harness.coordinator,
+      harness.sessionId,
+      "My name is Sam",
+      "discord:message-1",
+    );
+    const scope = `platform:${encodeURIComponent(harness.sessionId)}`;
+    const replayKey = `replay:${scope}:${encodeURIComponent("discord:message-1")}`;
+    const storage = harness.storageFor(harness.sessionId);
+    const stored = await storage.get<{ expiresAt: number }>(replayKey);
+    if (!stored) throw new Error("replay entry was not stored");
+    await storage.put(replayKey, { ...stored, expiresAt: Date.now() - 1 });
+
+    await harness.coordinator.alarm();
+
+    expect(await storage.get(replayKey)).toBeUndefined();
+    expect(await storage.getAlarm()).toBeNull();
+  });
+
+  test("fails instead of silently dropping a missing history chunk", async () => {
+    const harness = createCoordinatorHarness();
+    for (let index = 0; index < 6; index += 1) {
+      await turn(
+        harness.coordinator,
+        harness.sessionId,
+        `turn ${index}`,
+        `discord:message-${index}`,
+      );
+    }
+    const scope = `platform:${encodeURIComponent(harness.sessionId)}`;
+    await harness.storageFor(harness.sessionId).delete(`history:${scope}:1`);
+
+    const response = await turn(
+      harness.coordinator,
+      harness.sessionId,
+      "must fail",
+      "discord:message-missing-history",
+    );
+
+    expect(response.status).toBe(500);
+    expect((await response.json()) as unknown).toEqual({
+      error: `onboarding session history is incomplete for ${scope}`,
+    });
+  });
+
+  test("returns the persisted result when cache mirroring fails", async () => {
+    const harness = createCoordinatorHarness();
+    mirrorFailure = new Error("cache unavailable");
+    try {
+      const response = await turn(
+        harness.coordinator,
+        harness.sessionId,
+        "My name is Sam",
+        "discord:message-1",
+      );
+      expect(response.status).toBe(200);
+      const restarted = harness.restart(harness.sessionId);
+      const replay = await turn(
+        restarted,
+        harness.sessionId,
+        "must not execute",
+        "discord:message-1",
+      );
+      expect(replay.status).toBe(200);
+    } finally {
+      mirrorFailure = undefined;
+    }
+  });
+
   test("keeps identical delivery ids isolated by authenticated account", async () => {
     const harness = createCoordinatorHarness();
     const first = await readResult(
@@ -247,6 +396,21 @@ describe("OnboardingSessionCoordinator", () => {
     expect(
       second.session.history.map((message) => message.content),
     ).not.toContain("Hello from account A");
+    const storage = harness.storageFor(harness.sessionId);
+    const accountAScope = "account:org-a:user-a";
+    const accountBScope = "account:org-b:user-b";
+    expect(
+      await storage.get<{ userId: string }>(`session:${accountAScope}`),
+    ).toMatchObject({ userId: "user-a" });
+    expect(
+      await storage.get<{ userId: string }>(`session:${accountBScope}`),
+    ).toMatchObject({ userId: "user-b" });
+    expect(
+      await storage.get(`replay:${accountAScope}:discord%3Amessage-1`),
+    ).toBeDefined();
+    expect(
+      await storage.get(`replay:${accountBScope}:discord%3Amessage-1`),
+    ).toBeDefined();
 
     const replay = await readResult(
       await turn(

--- a/packages/cloud/api/scripts/onboarding-latency-report.ts
+++ b/packages/cloud/api/scripts/onboarding-latency-report.ts
@@ -14,8 +14,44 @@ class BenchmarkStorage {
     return value === undefined ? undefined : (structuredClone(value) as T);
   }
 
-  async put(key: string, value: unknown): Promise<void> {
-    this.values.set(key, structuredClone(value));
+  async put(
+    key: string | Record<string, unknown>,
+    value?: unknown,
+  ): Promise<void> {
+    if (typeof key === "string") {
+      this.values.set(key, structuredClone(value));
+      return;
+    }
+    for (const [entryKey, entryValue] of Object.entries(key)) {
+      this.values.set(entryKey, structuredClone(entryValue));
+    }
+  }
+
+  async delete(key: string | string[]): Promise<boolean> {
+    const keys = typeof key === "string" ? [key] : key;
+    return keys.map((entry) => this.values.delete(entry)).some(Boolean);
+  }
+
+  async list<T>({ prefix }: { prefix: string }): Promise<Map<string, T>> {
+    return new Map(
+      [...this.values.entries()]
+        .filter(([key]) => key.startsWith(prefix))
+        .map(([key, value]) => [key, structuredClone(value) as T]),
+    );
+  }
+
+  async getAlarm(): Promise<number | null> {
+    return null;
+  }
+
+  async setAlarm(_timestamp: number): Promise<void> {}
+
+  async deleteAlarm(): Promise<void> {}
+
+  async transaction<T>(
+    operation: (transaction: BenchmarkStorage) => Promise<T>,
+  ): Promise<T> {
+    return operation(this);
   }
 }
 

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -82,8 +82,15 @@ async function loadStoredSession(
       storage.get<OnboardingChatMessage[]>(historyStorageKey(scope, index)),
     ),
   );
+  const history: OnboardingChatMessage[] = [];
+  for (const chunk of chunks) {
+    if (!chunk) {
+      throw new Error(`onboarding session history is incomplete for ${scope}`);
+    }
+    history.push(...chunk);
+  }
   const { historyChunkCount: _, ...session } = stored;
-  return { ...session, history: chunks.flatMap((chunk) => chunk ?? []) };
+  return { ...session, history };
 }
 
 function storedSessionEntries(
@@ -111,6 +118,16 @@ function storedSessionEntries(
   return entries;
 }
 
+async function historyStorageKeys(
+  storage: DurableObjectStorage,
+  scope: string,
+): Promise<string[]> {
+  const entries = await storage.list({
+    prefix: `${HISTORY_KEY_PREFIX}${scope}:`,
+  });
+  return [...entries.keys()];
+}
+
 function legacySessionFor(
   ledger: LegacyCoordinatorLedger | undefined,
   input: OnboardingChatInput,
@@ -119,7 +136,9 @@ function legacySessionFor(
   if (!session) return undefined;
 
   const authenticated = input.authenticatedUser;
-  if (!authenticated) return session;
+  if (!authenticated) {
+    return session.userId || session.organizationId ? undefined : session;
+  }
   if (!session.userId && !session.organizationId) return session;
   return session.userId === authenticated.userId &&
     session.organizationId === authenticated.organizationId
@@ -225,20 +244,23 @@ export class OnboardingSessionCoordinator {
     }
   }
 
-  private mirrorSessionBestEffort(session: OnboardingSession): void {
+  private async mirrorSessionBestEffort(
+    session: OnboardingSession,
+  ): Promise<void> {
     // error-policy:J7 cache mirroring is diagnostic/compatibility state. The
     // Durable Object has already persisted the accepted turn, so a mirror
     // outage must not report a successful admission as a failed delivery.
-    void import("@/lib/services/eliza-app/onboarding-chat")
-      .then(({ mirrorOnboardingSessionToCache }) =>
-        mirrorOnboardingSessionToCache(session),
-      )
-      .catch((error: unknown) => {
-        logger.warn("[OnboardingSessionCoordinator] cache mirror failed", {
-          sessionId: session.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
+    try {
+      const { mirrorOnboardingSessionToCache } = await import(
+        "@/lib/services/eliza-app/onboarding-chat"
+      );
+      await mirrorOnboardingSessionToCache(session);
+    } catch (error) {
+      logger.warn("[OnboardingSessionCoordinator] cache mirror failed", {
+        sessionId: session.id,
+        error: error instanceof Error ? error.message : String(error),
       });
+    }
   }
 
   private async runTurn(
@@ -250,7 +272,6 @@ export class OnboardingSessionCoordinator {
     const { loadCachedOnboardingSession, runOnboardingChatWithStore } =
       await import("@/lib/services/eliza-app/onboarding-chat");
     const scope = scopeFor(request.input, request.sessionId);
-    const sessionKey = sessionStorageKey(scope);
     const platformScope = `platform:${storageComponent(request.sessionId)}`;
     const platformSessionKey = sessionStorageKey(platformScope);
     const legacy =
@@ -265,7 +286,7 @@ export class OnboardingSessionCoordinator {
           const session = await loadStoredSession(this.state.storage, scope);
           if (session) {
             await this.bindContinuation(session);
-            this.mirrorSessionBestEffort(session);
+            await this.mirrorSessionBestEffort(session);
             return replayResult(replay, session);
           }
         }
@@ -276,14 +297,16 @@ export class OnboardingSessionCoordinator {
     // An authenticated continuation may be the first turn after a trusted
     // platform conversation. Read that platform record once, then persist the
     // resulting account-owned session under its tenant scope below.
-    const storedSession =
-      (await loadStoredSession(this.state.storage, scope)) ??
-      (scope !== platformScope
+    const scopedSession = await loadStoredSession(this.state.storage, scope);
+    const platformSession =
+      !scopedSession && scope !== platformScope
         ? await loadStoredSession(this.state.storage, platformScope)
-        : undefined);
+        : undefined;
+    const storedSession = scopedSession ?? platformSession;
+    const legacySession = legacySessionFor(legacy, request.input);
     let nextSession =
       storedSession ??
-      legacySessionFor(legacy, request.input) ??
+      legacySession ??
       (await loadCachedOnboardingSession(request.sessionId));
     const result = await runOnboardingChatWithStore(
       request.input,
@@ -297,20 +320,58 @@ export class OnboardingSessionCoordinator {
     );
 
     const writes = storedSessionEntries(scope, result.session);
-    if (request.input.idempotencyKey) {
-      writes[replayStorageKey(scope, request.input.idempotencyKey)] =
-        storedReplay(request.input.idempotencyKey, result);
+    const replay = request.input.idempotencyKey
+      ? storedReplay(request.input.idempotencyKey, result)
+      : undefined;
+    if (replay) {
+      writes[replayStorageKey(scope, replay.key)] = replay;
     }
-    await this.state.storage.put(writes);
-    if (legacy) {
-      await this.state.storage.delete(LEGACY_LEDGER_KEY);
-    }
-    if (sessionKey !== platformSessionKey) {
-      await this.state.storage.delete(platformSessionKey);
-    }
+    const platformHistoryKeys =
+      platformSession && result.session.id === request.sessionId
+        ? await historyStorageKeys(this.state.storage, platformScope)
+        : [];
+    const currentAlarm = await this.state.storage.getAlarm();
+    await this.state.storage.transaction(async (transaction) => {
+      await transaction.put(writes);
+      if (legacySession) await transaction.delete(LEGACY_LEDGER_KEY);
+      if (platformSession && result.session.id === request.sessionId) {
+        await transaction.delete(platformSessionKey);
+        for (const key of platformHistoryKeys) await transaction.delete(key);
+      }
+      if (
+        replay &&
+        (currentAlarm === null || replay.expiresAt < currentAlarm)
+      ) {
+        await transaction.setAlarm(replay.expiresAt);
+      }
+    });
     await this.bindContinuation(result.session);
-    this.mirrorSessionBestEffort(result.session);
+    await this.mirrorSessionBestEffort(result.session);
     return result;
+  }
+
+  async alarm(): Promise<void> {
+    await this.serialize(async () => {
+      const now = Date.now();
+      const replays = await this.state.storage.list<ReplayEntry>({
+        prefix: REPLAY_KEY_PREFIX,
+      });
+      const expired = [...replays.entries()]
+        .filter(([, replay]) => replay.expiresAt <= now)
+        .map(([key]) => key);
+      const nextExpiry = [...replays.values()]
+        .filter((replay) => replay.expiresAt > now)
+        .reduce<number | undefined>(
+          (earliest, replay) =>
+            Math.min(earliest ?? replay.expiresAt, replay.expiresAt),
+          undefined,
+        );
+      await this.state.storage.transaction(async (transaction) => {
+        for (const key of expired) await transaction.delete(key);
+        if (nextExpiry) await transaction.setAlarm(nextExpiry);
+        else await transaction.deleteAlarm();
+      });
+    });
   }
 
   async fetch(request: Request): Promise<Response> {

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -28,6 +28,11 @@ interface ReplayEntry {
   expiresAt: number;
 }
 
+interface ReplayCleanupState {
+  startAfter?: string;
+  nextExpiry?: number;
+}
+
 interface LegacyCoordinatorLedger {
   session: OnboardingSession;
 }
@@ -39,10 +44,14 @@ interface StoredSession extends Omit<OnboardingSession, "history"> {
 const SESSION_KEY_PREFIX = "session:";
 const HISTORY_KEY_PREFIX = "history:";
 const REPLAY_KEY_PREFIX = "replay:";
+const REPLAY_CLEANUP_STATE_KEY = "replay-cleanup-state";
 const LEGACY_LEDGER_KEY = "ledger";
 const REDIRECT_KEY = "continuation-session-id";
 const HISTORY_CHUNK_SIZE = 10;
 const REPLAY_RETENTION_MS = 14 * 24 * 60 * 60 * 1000;
+// Durable Object storage batches are capped at 128 keys. Keep each alarm
+// invocation at that limit and retain a cursor for the next invocation.
+const REPLAY_CLEANUP_BATCH_SIZE = 128;
 
 function storageComponent(value: string): string {
   return encodeURIComponent(value);
@@ -353,22 +362,41 @@ export class OnboardingSessionCoordinator {
   async alarm(): Promise<void> {
     await this.serialize(async () => {
       const now = Date.now();
+      const cleanup = await this.state.storage.get<ReplayCleanupState>(
+        REPLAY_CLEANUP_STATE_KEY,
+      );
       const replays = await this.state.storage.list<ReplayEntry>({
         prefix: REPLAY_KEY_PREFIX,
+        startAfter: cleanup?.startAfter,
+        limit: REPLAY_CLEANUP_BATCH_SIZE,
       });
-      const expired = [...replays.entries()]
+      const entries = [...replays.entries()];
+      const expired = entries
         .filter(([, replay]) => replay.expiresAt <= now)
         .map(([key]) => key);
-      const nextExpiry = [...replays.values()]
-        .filter((replay) => replay.expiresAt > now)
+      const nextExpiry = entries
+        .filter(([, replay]) => replay.expiresAt > now)
         .reduce<number | undefined>(
-          (earliest, replay) =>
+          (earliest, [, replay]) =>
             Math.min(earliest ?? replay.expiresAt, replay.expiresAt),
-          undefined,
+          cleanup?.nextExpiry,
         );
+      const hasMore = entries.length === REPLAY_CLEANUP_BATCH_SIZE;
+      const lastKey = entries.at(-1)?.[0];
       await this.state.storage.transaction(async (transaction) => {
-        for (const key of expired) await transaction.delete(key);
-        if (nextExpiry) await transaction.setAlarm(nextExpiry);
+        if (expired.length > 0) await transaction.delete(expired);
+        if (hasMore && lastKey) {
+          await transaction.put(REPLAY_CLEANUP_STATE_KEY, {
+            startAfter: lastKey,
+            nextExpiry,
+          } satisfies ReplayCleanupState);
+          // Continue in a fresh alarm turn so the full replay namespace is
+          // never materialized or deleted in one Durable Object invocation.
+          await transaction.setAlarm(now + 1);
+          return;
+        }
+        await transaction.delete(REPLAY_CLEANUP_STATE_KEY);
+        if (nextExpiry !== undefined) await transaction.setAlarm(nextExpiry);
         else await transaction.deleteAlarm();
       });
     });

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -7,9 +7,11 @@
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
 import type {
   OnboardingChatInput,
+  OnboardingChatMessage,
   OnboardingChatResult,
   OnboardingSession,
 } from "@/lib/services/eliza-app/onboarding-chat";
+import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 interface CoordinatorRequest {
@@ -23,16 +25,107 @@ interface ReplayEntry {
   session: Omit<OnboardingSession, "history">;
   historyEndMessageId: string;
   historyTail: OnboardingSession["history"];
+  expiresAt: number;
 }
 
-interface CoordinatorLedger {
+interface LegacyCoordinatorLedger {
   session: OnboardingSession;
-  results: ReplayEntry[];
 }
 
-const LEDGER_KEY = "ledger";
+interface StoredSession extends Omit<OnboardingSession, "history"> {
+  historyChunkCount: number;
+}
+
+const SESSION_KEY_PREFIX = "session:";
+const HISTORY_KEY_PREFIX = "history:";
+const REPLAY_KEY_PREFIX = "replay:";
+const LEGACY_LEDGER_KEY = "ledger";
 const REDIRECT_KEY = "continuation-session-id";
-const MAX_REPLAY_RESULTS = 64;
+const HISTORY_CHUNK_SIZE = 10;
+const REPLAY_RETENTION_MS = 14 * 24 * 60 * 60 * 1000;
+
+function storageComponent(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function scopeFor(input: OnboardingChatInput, sessionId: string): string {
+  const authenticated = input.authenticatedUser;
+  return authenticated
+    ? `account:${storageComponent(authenticated.organizationId)}:${storageComponent(authenticated.userId)}`
+    : `platform:${storageComponent(sessionId)}`;
+}
+
+function sessionStorageKey(scope: string): string {
+  return `${SESSION_KEY_PREFIX}${scope}`;
+}
+
+function historyStorageKey(scope: string, index: number): string {
+  return `${HISTORY_KEY_PREFIX}${scope}:${index}`;
+}
+
+function replayStorageKey(scope: string, idempotencyKey: string): string {
+  return `${REPLAY_KEY_PREFIX}${scope}:${storageComponent(idempotencyKey)}`;
+}
+
+async function loadStoredSession(
+  storage: DurableObjectStorage,
+  scope: string,
+): Promise<OnboardingSession | undefined> {
+  const stored = await storage.get<StoredSession | OnboardingSession>(
+    sessionStorageKey(scope),
+  );
+  if (!stored) return undefined;
+  if (!("historyChunkCount" in stored)) return stored;
+
+  const chunks = await Promise.all(
+    Array.from({ length: stored.historyChunkCount }, (_, index) =>
+      storage.get<OnboardingChatMessage[]>(historyStorageKey(scope, index)),
+    ),
+  );
+  const { historyChunkCount: _, ...session } = stored;
+  return { ...session, history: chunks.flatMap((chunk) => chunk ?? []) };
+}
+
+function storedSessionEntries(
+  scope: string,
+  session: OnboardingSession,
+): Record<string, unknown> {
+  const { history, ...metadata } = session;
+  const chunks = Array.from(
+    { length: Math.ceil(history.length / HISTORY_CHUNK_SIZE) },
+    (_, index) =>
+      history.slice(
+        index * HISTORY_CHUNK_SIZE,
+        (index + 1) * HISTORY_CHUNK_SIZE,
+      ),
+  );
+  const entries: Record<string, unknown> = {
+    [sessionStorageKey(scope)]: {
+      ...metadata,
+      historyChunkCount: chunks.length,
+    } satisfies StoredSession,
+  };
+  for (const [index, chunk] of chunks.entries()) {
+    entries[historyStorageKey(scope, index)] = chunk;
+  }
+  return entries;
+}
+
+function legacySessionFor(
+  ledger: LegacyCoordinatorLedger | undefined,
+  input: OnboardingChatInput,
+): OnboardingSession | undefined {
+  const session = ledger?.session;
+  if (!session) return undefined;
+
+  const authenticated = input.authenticatedUser;
+  if (!authenticated) return session;
+  if (!session.userId && !session.organizationId) return session;
+  return session.userId === authenticated.userId &&
+    session.organizationId === authenticated.organizationId
+    ? session
+    : undefined;
+}
 
 function storedReplay(key: string, result: OnboardingChatResult): ReplayEntry {
   const { session, ...stored } = result;
@@ -47,6 +140,7 @@ function storedReplay(key: string, result: OnboardingChatResult): ReplayEntry {
     session: sessionMetadata,
     historyEndMessageId,
     historyTail: history.slice(-2),
+    expiresAt: Date.now() + REPLAY_RETENTION_MS,
   };
 }
 
@@ -108,7 +202,7 @@ export class OnboardingSessionCoordinator {
     }
   }
 
-  private async publishSession(session: OnboardingSession): Promise<void> {
+  private async bindContinuation(session: OnboardingSession): Promise<void> {
     if (session.continuationToken && session.id.startsWith("platform:")) {
       const namespace = this.env.ONBOARDING_SESSIONS;
       if (!namespace) {
@@ -129,10 +223,22 @@ export class OnboardingSessionCoordinator {
         );
       }
     }
-    const { mirrorOnboardingSessionToCache } = await import(
-      "@/lib/services/eliza-app/onboarding-chat"
-    );
-    await mirrorOnboardingSessionToCache(session);
+  }
+
+  private mirrorSessionBestEffort(session: OnboardingSession): void {
+    // error-policy:J7 cache mirroring is diagnostic/compatibility state. The
+    // Durable Object has already persisted the accepted turn, so a mirror
+    // outage must not report a successful admission as a failed delivery.
+    void import("@/lib/services/eliza-app/onboarding-chat")
+      .then(({ mirrorOnboardingSessionToCache }) =>
+        mirrorOnboardingSessionToCache(session),
+      )
+      .catch((error: unknown) => {
+        logger.warn("[OnboardingSessionCoordinator] cache mirror failed", {
+          sessionId: session.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
   }
 
   private async runTurn(
@@ -143,19 +249,42 @@ export class OnboardingSessionCoordinator {
     // bootstrap boundary used by the main Hono application.
     const { loadCachedOnboardingSession, runOnboardingChatWithStore } =
       await import("@/lib/services/eliza-app/onboarding-chat");
-    const ledger = await this.state.storage.get<CoordinatorLedger>(LEDGER_KEY);
-    if (ledger && request.input.idempotencyKey) {
-      const replay = ledger.results.find(
-        (entry) => entry.key === request.input.idempotencyKey,
-      );
+    const scope = scopeFor(request.input, request.sessionId);
+    const sessionKey = sessionStorageKey(scope);
+    const platformScope = `platform:${storageComponent(request.sessionId)}`;
+    const platformSessionKey = sessionStorageKey(platformScope);
+    const legacy =
+      await this.state.storage.get<LegacyCoordinatorLedger>(LEGACY_LEDGER_KEY);
+    const replayKey = request.input.idempotencyKey
+      ? replayStorageKey(scope, request.input.idempotencyKey)
+      : undefined;
+    if (replayKey) {
+      const replay = await this.state.storage.get<ReplayEntry>(replayKey);
       if (replay) {
-        await this.publishSession(ledger.session);
-        return replayResult(replay, ledger.session);
+        if (replay.expiresAt > Date.now()) {
+          const session = await loadStoredSession(this.state.storage, scope);
+          if (session) {
+            await this.bindContinuation(session);
+            this.mirrorSessionBestEffort(session);
+            return replayResult(replay, session);
+          }
+        }
+        await this.state.storage.delete(replayKey);
       }
     }
 
+    // An authenticated continuation may be the first turn after a trusted
+    // platform conversation. Read that platform record once, then persist the
+    // resulting account-owned session under its tenant scope below.
+    const storedSession =
+      (await loadStoredSession(this.state.storage, scope)) ??
+      (scope !== platformScope
+        ? await loadStoredSession(this.state.storage, platformScope)
+        : undefined);
     let nextSession =
-      ledger?.session ?? (await loadCachedOnboardingSession(request.sessionId));
+      storedSession ??
+      legacySessionFor(legacy, request.input) ??
+      (await loadCachedOnboardingSession(request.sessionId));
     const result = await runOnboardingChatWithStore(
       request.input,
       request.sessionId,
@@ -167,16 +296,20 @@ export class OnboardingSessionCoordinator {
       },
     );
 
-    const results = ledger?.results ? [...ledger.results] : [];
+    const writes = storedSessionEntries(scope, result.session);
     if (request.input.idempotencyKey) {
-      results.push(storedReplay(request.input.idempotencyKey, result));
-      if (results.length > MAX_REPLAY_RESULTS) {
-        results.splice(0, results.length - MAX_REPLAY_RESULTS);
-      }
+      writes[replayStorageKey(scope, request.input.idempotencyKey)] =
+        storedReplay(request.input.idempotencyKey, result);
     }
-    const stored: CoordinatorLedger = { session: result.session, results };
-    await this.state.storage.put(LEDGER_KEY, stored);
-    await this.publishSession(result.session);
+    await this.state.storage.put(writes);
+    if (legacy) {
+      await this.state.storage.delete(LEGACY_LEDGER_KEY);
+    }
+    if (sessionKey !== platformSessionKey) {
+      await this.state.storage.delete(platformSessionKey);
+    }
+    await this.bindContinuation(result.session);
+    this.mirrorSessionBestEffort(result.session);
     return result;
   }
 

--- a/packages/test/cloud-e2e/tests/onboarding-tenant-isolation.spec.ts
+++ b/packages/test/cloud-e2e/tests/onboarding-tenant-isolation.spec.ts
@@ -1,0 +1,106 @@
+/** Proves onboarding transcript isolation through the real local cloud Worker. */
+import { randomUUID } from "node:crypto";
+import { seedTestUser } from "../src/fixtures/seed";
+import { expect, test } from "../src/helpers/test-fixtures";
+
+process.env.ELIZA_APP_JWT_SECRET ??= "cloud-e2e-onboarding-session-secret";
+
+test.use({ stackOptions: { frontend: false } });
+test.setTimeout(300_000);
+
+interface OnboardingResponse {
+  success: boolean;
+  data: {
+    messages: Array<{ role: "user" | "assistant"; content: string }>;
+  };
+}
+
+async function createSessionToken(userId: string, organizationId: string) {
+  const { elizaAppSessionService } = await import(
+    "@elizaos/cloud-shared/lib/services/eliza-app/session-service"
+  );
+  return (await elizaAppSessionService.createSession(userId, organizationId))
+    .token;
+}
+
+async function sendTurn(
+  apiUrl: string,
+  token: string,
+  sessionId: string,
+  message: string,
+): Promise<{ status: number; body: OnboardingResponse }> {
+  const response = await fetch(`${apiUrl}/api/eliza-app/onboarding/chat`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ sessionId, message }),
+  });
+  return {
+    status: response.status,
+    body: (await response.json()) as OnboardingResponse,
+  };
+}
+
+test.describe("onboarding tenant isolation", () => {
+  test("keeps a durable transcript scoped to the authenticated account", async ({
+    stack,
+    seededUser: owner,
+  }, testInfo) => {
+    const other = await seedTestUser({
+      slug: `onboarding-other-${randomUUID().slice(0, 8)}`,
+    });
+    const [ownerToken, otherToken] = await Promise.all([
+      createSessionToken(owner.userId, owner.organizationId),
+      createSessionToken(other.userId, other.organizationId),
+    ]);
+    const sessionId = `onboarding-${randomUUID()}`;
+
+    const admitted = await sendTurn(
+      stack.urls.api,
+      ownerToken,
+      sessionId,
+      "owner-private-message",
+    );
+    expect(admitted.status).toBe(200);
+    expect(admitted.body.success).toBe(true);
+
+    const denied = await sendTurn(
+      stack.urls.api,
+      otherToken,
+      sessionId,
+      "other-account-message",
+    );
+    expect(denied.status).toBe(200);
+    expect(denied.body.success).toBe(true);
+    expect(
+      denied.body.data.messages.map((message) => message.content),
+    ).not.toContain("owner-private-message");
+
+    const durableState = await sendTurn(
+      stack.urls.api,
+      ownerToken,
+      sessionId,
+      "owner-resumes-session",
+    );
+    expect(durableState.status).toBe(200);
+    expect(durableState.body.success).toBe(true);
+    expect(
+      durableState.body.data.messages.map((message) => message.content),
+    ).toEqual(
+      expect.arrayContaining([
+        "owner-private-message",
+        "owner-resumes-session",
+      ]),
+    );
+    expect(
+      durableState.body.data.messages.map((message) => message.content),
+    ).not.toContain("other-account-message");
+
+    await testInfo.attach("onboarding-tenant-isolation-trace", {
+      body: JSON.stringify({ admitted, denied, durableState }, null, 2),
+      contentType: "application/json",
+    });
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #17463.

Definition of Done:
- [x] Targets develop and is rebased onto current upstream/develop (abb37c1d2).
- [ ] Full bun run verify was not run; targeted coordinator tests and Cloud API typecheck are recorded below.
- [x] Durable-state behavior is covered by the targeted coordinator harness.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5
<!-- attribution-row:client -->
- Client / agent tooling: Codex
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

# Sync with develop

- [x] Rebasing completed on abb37c1d2 with zero conflicts.
- [x] Cloud API typecheck passed before the rebase; targeted coordinator tests were rerun on the rebased head.

# Risks

Medium: durable onboarding persistence and replay cleanup. The change fails closed on incomplete history chunks, preserves platform state after rejected account adoption, and keeps cache failure non-fatal.

# Background

## What does this PR do?

Scopes session and replay records by account or trusted platform identity; stores session history in bounded chunks; expires replay records through a Durable Object alarm; and preserves ordering while treating the KV compatibility mirror as best-effort.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is required.

# Testing

## Where should a reviewer start?

packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts

## Detailed testing steps

Run bun test packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts. The nine cases cover platform/account collision, 65-message capacity, restart replay, explicit expiry/alarm cleanup, missing chunk failure, mirror failure, tenant-scoped replay keys, and concurrent ordering.

Run bun run --cwd packages/cloud/api typecheck for TypeScript and Worker dry-run validation.

# Evidence Gate

<!-- evidence-head:46bbcf3ce3aa601ab1309968e4c41cffff45e74d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend Durable Object change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend Durable Object change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no browser or user-exercisable visual flow.
<!-- evidence-row:backend-logs -->
- [x] Targeted coordinator suite and Cloud API typecheck executed at head 46bbcf3ce in a clean worktree (maintainer verification).

  <details><summary>bun test packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts @ 46bbcf3ce</summary>

  ```text
  bun test v1.3.14 (0d9b296a)

  __tests__/onboarding-session-coordinator.test.ts:
  [eliza-app onboarding] session bound to a different user; starting fresh session {
    sessionId: "platform:discord:user-1",
    boundUserId: "user-a",
    callerUserId: "user-b",
  }
  [OnboardingSessionCoordinator] cache mirror failed {
    sessionId: "platform:discord:user-8",
    error: "cache unavailable",
  }
  [OnboardingSessionCoordinator] cache mirror failed {
    sessionId: "platform:discord:user-8",
    error: "cache unavailable",
  }

   10 pass
   0 fail
   105 expect() calls
  Ran 10 tests across 1 file. [3.00s]
  ```

  `bun run --cwd packages/cloud/api typecheck` completes through the wrangler `--dry-run` exit with no type errors at the same head.

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - onboarding behavior remains deterministic and performs no model call.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no production DB, memory, task, or external domain record is changed; durable-state assertions are in the coordinator suite.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Known gaps / failures

Exact-head CI has since executed at 46bbcf3ce: quality, security, lint, typecheck, unit/integration/e2e lanes are green; the only prior failure was the stale evidence-head marker, refreshed above. The submitted evidence is the in-process Durable Object harness plus Cloud API typecheck, re-run at head in a clean worktree.

Review follow-up addressed in 900789bdc: preserve the platform record on rejected account adoption; await-and-swallow ordered cache mirroring; alarm-based replay cleanup; fail closed on missing history chunks; benchmark storage API parity; and adversarial tests for each path.
