### PR TITLE
test(app): cover notes controls in mobile landscape

### DIFF
--- a/packages/app/test/ui-smoke/plugin-views-interaction.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-views-interaction.spec.ts
@@ -2,10 +2,13 @@
  * Playwright UI-smoke spec for the Plugin Views Interaction app flow using the
  * real renderer fixture.
  */
+import { writeFile } from "node:fs/promises";
 import { expect, type Locator, test } from "@playwright/test";
 import {
+  expectNoPageDiagnostics,
   hideChatOverlay,
   installDefaultAppRoutes,
+  installPageDiagnosticsGuard,
   openAppPath,
   seedAppStorage,
 } from "./helpers";
@@ -122,6 +125,162 @@ async function fillOrToggleInput(input: Locator, index: number): Promise<void> {
 }
 
 test.describe("plugin view interaction coverage", () => {
+  test("notes mobile landscape — composer color and save stay reachable", async ({
+    page,
+  }, testInfo) => {
+    const consoleEntries: string[] = [];
+    const networkEntries: string[] = [];
+    page.on("console", (message) => {
+      consoleEntries.push(`[${message.type()}] ${message.text()}`);
+    });
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (url.pathname.startsWith("/api/")) {
+        networkEntries.push(`--> ${request.method()} ${url.pathname}`);
+      }
+    });
+    page.on("response", (response) => {
+      const url = new URL(response.url());
+      if (url.pathname.startsWith("/api/")) {
+        networkEntries.push(
+          `<-- ${response.status()} ${response.request().method()} ${url.pathname}`,
+        );
+      }
+    });
+    page.on("requestfailed", (request) => {
+      const failureText = request.failure()?.errorText ?? "unknown";
+      if (failureText.includes("net::ERR_ABORTED")) return;
+      networkEntries.push(
+        `xx> ${request.method()} ${request.url()} ${failureText}`,
+      );
+    });
+
+    installPageDiagnosticsGuard(page);
+    await page.setViewportSize({ width: 844, height: 390 });
+    await seedAppStorage(page);
+    await installDefaultAppRoutes(page);
+    await openAppPath(page, "/notes");
+
+    const notesView = page.getByTestId("simple-notes-view");
+    const composer = notesView.locator("form").first();
+    await expect(notesView).toBeVisible();
+    await expect(composer).toBeVisible();
+    await expect(page.getByTestId("chat-overlay")).toBeVisible();
+    const composerPosition = await composer.evaluate(
+      (element) => getComputedStyle(element).position,
+    );
+
+    const title = "Mobile landscape note";
+    await notesView.locator('[data-agent-id="notes-title"]').fill(title);
+    await notesView
+      .locator('[data-agent-id="notes-body"]')
+      .fill("Created through the real Notes bundle at 844×390.");
+
+    const green = notesView.locator(
+      '[data-agent-id="notes-compose-color-green"]',
+    );
+    await green.scrollIntoViewIfNeeded();
+    await expect(green).toBeVisible();
+    expect(await isPointerReachable(green)).toBe(true);
+    await green.click();
+    await expect(green).toHaveAttribute("data-state", "selected");
+    const selectedColorState = await green.getAttribute("data-state");
+
+    const save = notesView.locator('[data-agent-id="notes-save"]');
+    await save.scrollIntoViewIfNeeded();
+    await expect(save).toBeEnabled();
+    expect(await isPointerReachable(save)).toBe(true);
+    const rootScrollTop = await notesView.evaluate(
+      (element) => element.scrollTop,
+    );
+    expect(rootScrollTop).toBeGreaterThan(0);
+    expect(composerPosition).toBe("static");
+
+    const controlsScreenshotPath = testInfo.outputPath(
+      "notes-mobile-landscape-controls.png",
+    );
+    await page.screenshot({ path: controlsScreenshotPath, fullPage: false });
+    await testInfo.attach("notes-mobile-landscape-controls.png", {
+      path: controlsScreenshotPath,
+      contentType: "image/png",
+    });
+
+    const interactionRequest = page.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        new URL(request.url()).pathname === "/api/views/notes/interact",
+    );
+    const interactionResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname === "/api/views/notes/interact",
+    );
+    await save.click();
+    const request = await interactionRequest;
+    const response = await interactionResponse;
+    const payload = request.postDataJSON();
+
+    expect(payload).toMatchObject({
+      capability: "create-note",
+      params: {
+        title,
+        body: "Created through the real Notes bundle at 844×390.",
+        color: "green",
+      },
+    });
+    expect(response.status()).toBe(200);
+    const createdNote = notesView.getByRole("heading", { name: title });
+    await expect(createdNote).toBeVisible();
+    await createdNote.scrollIntoViewIfNeeded();
+    await expectNoPageDiagnostics(page, "notes mobile landscape interaction");
+
+    const screenshotPath = testInfo.outputPath(
+      "notes-mobile-landscape-after.png",
+    );
+    await page.screenshot({ path: screenshotPath, fullPage: false });
+    await testInfo.attach("notes-mobile-landscape-after.png", {
+      path: screenshotPath,
+      contentType: "image/png",
+    });
+
+    const consolePath = testInfo.outputPath("frontend-console.log");
+    await writeFile(consolePath, consoleEntries.join("\n"));
+    await testInfo.attach("frontend-console.log", {
+      path: consolePath,
+      contentType: "text/plain",
+    });
+
+    const networkPath = testInfo.outputPath("frontend-network.log");
+    await writeFile(networkPath, networkEntries.join("\n"));
+    await testInfo.attach("frontend-network.log", {
+      path: networkPath,
+      contentType: "text/plain",
+    });
+
+    const observationsPath = testInfo.outputPath(
+      "notes-mobile-landscape-observations.json",
+    );
+    await writeFile(
+      observationsPath,
+      JSON.stringify(
+        {
+          viewport: page.viewportSize(),
+          composerPosition,
+          rootScrollTop,
+          selectedColorState,
+          request: payload,
+          responseStatus: response.status(),
+        },
+        null,
+        2,
+      ),
+    );
+    await testInfo.attach("notes-mobile-landscape-observations.json", {
+      path: observationsPath,
+      contentType: "application/json",
+    });
+  });
+
   for (const view of GUI_CASES) {
     test(`${view.id} — exercise every control, no crash`, async ({ page }) => {
       const pageErrors: string[] = [];


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #17114.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. This is a test-only change in one Playwright UI-smoke spec. It adds no production runtime, API, schema, persistence, or dependency changes. The main risk is future fixture drift in the real-bundle test path.

# Background

## What does this PR do?

Adds a focused 844×390 Notes regression that keeps the real chat overlay visible, scrolls through the root Notes flow, selects the green composer color, saves a note, and proves both controls are pointer-reachable. It also asserts the composer remains `position: static`, the root actually scrolls, the `create-note` request payload is correct, the response is 200, the created note renders, and browser diagnostics stay clean.

The production repair is already present on `develop`; this PR supplies the missing interaction regression and reproducible evidence. A red control temporarily restored the historical sticky composer locally and failed on pointer reachability; that temporary production edit was reverted and is not part of this diff.

## What kind of change is this?

Bug-fix regression coverage (non-breaking, test-only).

# Documentation changes needed?

My changes do not require a project documentation update.

# Testing

## Where should a reviewer start?

Start with `packages/app/test/ui-smoke/plugin-views-interaction.spec.ts`, test `notes mobile landscape — composer color and save stay reachable`.

## Detailed testing steps

- PASS — `ELIZA_UI_SMOKE_SKIP_BUILD=1 E2E_RECORD=1 CI=1 bun run --cwd packages/app test:e2e -- --project=chromium test/ui-smoke/plugin-views-interaction.spec.ts --grep "notes mobile landscape"` (1/1, exact committed-head web bundle).
- RED CONTROL — with the historical `position: sticky; top: 12px` composer style temporarily restored, the same interaction failed because the green color control was not pointer-reachable. The temporary edit was then reverted.
- PASS — `bun run --cwd packages/app build:web` (9,374 modules; 404 assets; chunk-safety verification passed; build revision `de5945e7219b`).
- PASS — `bun run --cwd plugins/plugin-simple-views test` (6 files, 39 tests).
- PASS — `bun run --cwd plugins/plugin-simple-views typecheck`.
- PASS — `bun run --cwd plugins/plugin-simple-views lint:check` (30 files).
- PASS — `bun run --cwd packages/app typecheck`.
- PASS — `bun run build` (176/176 tasks; 27/27 authoritative view bundles).
- PARTIAL / unrelated blockers — `CI=1 bun run --cwd packages/app audit:app:verify` completed 254 tests and 252 findings: broken=0, needs-work=2, needs-eyeball=25, good=225, minimalism/hover/density probe failures=0. Notes passed all four audited viewports. The final aggregate check failed only for two current-`develop` mobile-portrait launcher findings listed below.
- PASS — `ELIZA_MVP_OCR_ENGINE=packaged bun run --cwd packages/app audit:ocr` (252 views; verified=96, broken=0, needs-eyeball=156).
- PARTIAL / unrelated blocker — `bun run verify` completed its main graph at 579/579, then current `develop`'s `audit:scripts` reported five orphan-file findings listed below. The remaining audits were run individually and passed: script inventory (123 files, 0 orphan), view-bundle inventory (27 targets, 0 exclusions), focused-test audit (8,838 files, 0 focused tests and 0 orphaned skips), and dist typecheck (201 aliases, 28 consumer configs).

# Evidence Gate

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-before-sticky-controls-unreachable.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-after-controls-reachable.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-after-interaction.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only browser coverage uses deterministic route fixtures; no backend production path changes
<!-- evidence-row:frontend-logs -->
- [x] [17548-17114-frontend-network.log](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-frontend-network.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [x] [17548-17114-observations.json](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-observations.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

Backend: N/A - test-only browser coverage with deterministic route fixtures; no backend production path changes.

Frontend: [console log](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-frontend-console.log) and [network log](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-frontend-network.log). The network trace includes `POST /api/views/notes/interact` → 200; the console has no warnings, errors, or uncaught page diagnostics.

## Screenshots (before / after) + video walkthrough

All files below are direct GitHub release assets from the author fork; no evidence is committed to the source branch.

### Before

[Red-control screenshot](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-before-sticky-controls-unreachable.png) and [red-control MP4](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-before-sticky-controls-unreachable.mp4). They show the historical sticky composer trapping the lower controls at 844×390 with the chat overlay visible.

### After

[Reachable controls](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-after-controls-reachable.png), [created note](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-after-note-created.png), and [full-audit Notes mobile-landscape capture](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-notes-full-audit-mobile-landscape.png). They show the green color selector and enabled Add note control reachable in root scroll flow, followed by the rendered green note.

### Walkthrough video

[Exact-head walkthrough MP4](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-after-interaction.mp4) shows boot, Notes navigation, color selection, save, and the rendered note at 844×390.

Additional machine-readable proof: [interaction observations](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-observations.json), [full app audit report](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-full-app-audit-report.json), and [packaged OCR triage](https://github.com/aandreakis/eliza/releases/download/pr-evidence/17548-17114-ocr-triage.json).

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changes.

## Known gaps / failures

- The strict full-app aggregate is blocked by two unrelated current-`develop` mobile-portrait launcher findings: `builtin-views` and `builtin-rolodex`, where the global chat overlay overlaps the last launcher icons. Notes itself passed desktop landscape, mobile landscape, mobile portrait, and iPad portrait with zero broken/probe/OCR findings.
- Root `bun run verify` reaches 579/579 tasks, then `audit:scripts` flags five untouched current-`develop` files: `packages/scripts/ci-workflow-invariants.test.mjs`, `develop-pr-aggregate.test.mjs`, `local-inference-attest.test.mjs`, `local-inference-performance-check.test.mjs`, and `script-test-isolation.test.mjs`. The immediately rerun canonical script inventory reports 123 files and 0 orphans.
- The extra `mvp:visual-verify -- --strict --require-baseline-states` check is also blocked by stale current-`develop` visual-baseline state: 11 expectation failures, 124 missing required historical states, and 17 screenshots without baselines. This test-only branch does not touch those baselines.
- Backend logs are N/A because the contribution changes only deterministic browser coverage. LLM trajectory and audio are N/A because those paths are untouched.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-notes-mobile-landscape]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->
