### PR TITLE
fix(ci): require Android release AAB gate on develop

### DIFF
--- a/.github/workflows/develop-pr-gate.yml
+++ b/.github/workflows/develop-pr-gate.yml
@@ -40,14 +40,14 @@ jobs:
   gate:
     name: Develop PR Gate
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 75
     env:
       AGGREGATE_EVENT_NAME: ${{ github.event_name }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       PR_ACTION: ${{ github.event.action || '' }}
       PR_UPDATED_AT: ${{ github.event.pull_request.updated_at || '' }}
-      POLL_TIMEOUT_SECONDS: "2400"
+      POLL_TIMEOUT_SECONDS: "4200"
       POLL_INTERVAL_SECONDS: "30"
       CANARY_SCENARIO: ${{ github.event_name == 'workflow_dispatch' && inputs.canary || '' }}
     steps:

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -74,6 +74,7 @@ jobs:
           .github/workflows/cloud-tests.yml
           .github/workflows/gitleaks.yml
           .github/workflows/local-inference-matrix.yml
+          .github/workflows/mobile-build-smoke.yml
           .github/workflows/stale-base-guard.yml
           .github/workflows/test.yml
 

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: standalone
   pull_request:
-    branches: [main]
+    branches: [develop, main]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
@@ -843,13 +843,17 @@ jobs:
             | tee "$RUNNER_TEMP/android-cloud-release-aab-audit.log"
 
       - name: Verify release AAB audit evidence
+        id: release-aab-evidence
+        if: always()
         shell: bash
         run: |
           set -euo pipefail
           AAB_PATH="packages/app-core/platforms/android/app/build/outputs/bundle/release/app-release.aab"
           AUDIT_LOG="$RUNNER_TEMP/android-cloud-release-aab-audit.log"
           ATTESTATION="$RUNNER_TEMP/android-cloud-release-attestation.json"
+          SHA256="$RUNNER_TEMP/android-cloud-release-aab.sha256"
           test -s "$AAB_PATH"
+          test -s "$AUDIT_LOG"
           node - "$AUDIT_LOG" "$ATTESTATION" "$AAB_PATH" <<'NODE'
           const crypto = require("node:crypto");
           const fs = require("node:fs");
@@ -875,10 +879,12 @@ jobs:
           }
           fs.writeFileSync(outputPath, `${JSON.stringify(attestation, null, 2)}\n`);
           NODE
-          sha256sum "$AAB_PATH" | tee "$RUNNER_TEMP/android-cloud-release-aab.sha256"
+          sha256sum "$AAB_PATH" | tee "$SHA256"
+          test -s "$ATTESTATION"
+          test -s "$SHA256"
 
       - name: Upload release AAB audit evidence
-        if: always()
+        if: ${{ always() && steps.release-aab-evidence.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: android-cloud-release-aab-audit
@@ -888,4 +894,33 @@ jobs:
             ${{ runner.temp }}/android-cloud-release-aab.sha256
             ${{ runner.temp }}/android-cloud-release-attestation.json
           retention-days: 7
-          if-no-files-found: warn
+          if-no-files-found: error
+
+  android-release-aab-required:
+    name: Android release AAB gate
+    needs: [changes, build-android]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Enforce the selected Android release AAB result
+        shell: bash
+        env:
+          CLASSIFIER_RESULT: ${{ needs.changes.result }}
+          ANDROID_SELECTED: ${{ needs.changes.outputs.android }}
+          ANDROID_BUILD_RESULT: ${{ needs.build-android.result }}
+        run: |
+          set -euo pipefail
+          if [ "$CLASSIFIER_RESULT" != "success" ]; then
+            echo "::error::Mobile path classification concluded $CLASSIFIER_RESULT"
+            exit 1
+          fi
+          if [ "$ANDROID_SELECTED" != "true" ]; then
+            echo "Android release AAB build not selected by the mobile path contract"
+            exit 0
+          fi
+          if [ "$ANDROID_BUILD_RESULT" != "success" ]; then
+            echo "::error::Selected Android release AAB build concluded $ANDROID_BUILD_RESULT"
+            exit 1
+          fi
+          echo "Selected Android release AAB build and evidence contract passed"

--- a/packages/scripts/__tests__/mobile-build-smoke-workflow.test.ts
+++ b/packages/scripts/__tests__/mobile-build-smoke-workflow.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Binds the canonical Android release AAB build to the always-emitted develop
+ * pull-request authority and its fail-closed four-file evidence contract.
+ */
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { REQUIRED_CHECKS } from "../develop-pr-aggregate.mjs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const mobileWorkflowSource = readFileSync(
+  new URL(".github/workflows/mobile-build-smoke.yml", repoRoot),
+  "utf8",
+);
+const aggregateWorkflowSource = readFileSync(
+  new URL(".github/workflows/develop-pr-gate.yml", repoRoot),
+  "utf8",
+);
+const developWorkflowSource = readFileSync(
+  new URL(".github/workflows/develop-pr.yml", repoRoot),
+  "utf8",
+);
+
+interface WorkflowStep {
+  id?: string;
+  name?: string;
+  if?: string;
+  env?: Record<string, string>;
+  run?: string;
+  with?: Record<string, string | number | boolean>;
+  "continue-on-error"?: boolean | string;
+}
+
+interface WorkflowJob {
+  name?: string;
+  needs?: string | string[];
+  if?: string;
+  env?: Record<string, string>;
+  steps?: WorkflowStep[];
+  "continue-on-error"?: boolean | string;
+  "timeout-minutes"?: number;
+}
+
+interface Workflow {
+  on?: {
+    pull_request?: {
+      branches?: string[];
+      types?: string[];
+      paths?: string[];
+      "paths-ignore"?: string[];
+    };
+  };
+  jobs?: Record<string, WorkflowJob>;
+}
+
+const mobileWorkflow = Bun.YAML.parse(mobileWorkflowSource) as Workflow;
+const aggregateWorkflow = Bun.YAML.parse(aggregateWorkflowSource) as Workflow;
+
+function requireJob(workflow: Workflow, id: string): WorkflowJob {
+  const job = workflow.jobs?.[id];
+  if (!job) throw new Error(`Missing workflow job: ${id}`);
+  return job;
+}
+
+function requireStep(job: WorkflowJob, name: string): WorkflowStep {
+  const step = job.steps?.find((candidate) => candidate.name === name);
+  if (!step) throw new Error(`Missing workflow step: ${name}`);
+  return step;
+}
+
+describe("mobile build smoke required AAB authority", () => {
+  test("owns one always-emitted develop PR context required by the aggregate", () => {
+    expect(mobileWorkflow.on?.pull_request?.branches).toEqual([
+      "develop",
+      "main",
+    ]);
+    expect(mobileWorkflow.on?.pull_request?.paths).toBeUndefined();
+    expect(mobileWorkflow.on?.pull_request?.["paths-ignore"]).toBeUndefined();
+
+    const gate = requireJob(mobileWorkflow, "android-release-aab-required");
+    expect(gate.name).toBe("Android release AAB gate");
+    expect(gate.needs).toEqual(["changes", "build-android"]);
+    expect(gate.if).toBe("always()");
+    expect(gate["continue-on-error"]).toBeUndefined();
+
+    expect(
+      REQUIRED_CHECKS.find(
+        ({ context }) => context === "Android release AAB gate",
+      ),
+    ).toEqual({
+      context: "Android release AAB gate",
+      workflowPath: ".github/workflows/mobile-build-smoke.yml",
+      triggerActions: [
+        "opened",
+        "synchronize",
+        "reopened",
+        "ready_for_review",
+        "labeled",
+      ],
+    });
+  });
+
+  test("executes the required gate across selected and failure states", () => {
+    const gate = requireJob(mobileWorkflow, "android-release-aab-required");
+    const step = requireStep(
+      gate,
+      "Enforce the selected Android release AAB result",
+    );
+    expect(step.env).toEqual({
+      CLASSIFIER_RESULT: "$" + "{{ needs.changes.result }}",
+      ANDROID_SELECTED: "$" + "{{ needs.changes.outputs.android }}",
+      ANDROID_BUILD_RESULT: "$" + "{{ needs.build-android.result }}",
+    });
+    if (!step.run) throw new Error("Required gate step has no executable body");
+
+    const run = (env: Record<string, string>) =>
+      spawnSync("bash", ["-c", step.run as string], {
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+      });
+    const classifierFailure = run({
+      CLASSIFIER_RESULT: "failure",
+      ANDROID_SELECTED: "",
+      ANDROID_BUILD_RESULT: "skipped",
+    });
+    expect(classifierFailure.status).toBe(1);
+    expect(classifierFailure.stdout).toContain(
+      "Mobile path classification concluded failure",
+    );
+
+    const unselected = run({
+      CLASSIFIER_RESULT: "success",
+      ANDROID_SELECTED: "false",
+      ANDROID_BUILD_RESULT: "skipped",
+    });
+    expect(unselected.status).toBe(0);
+    expect(unselected.stdout).toContain("not selected");
+
+    const buildFailure = run({
+      CLASSIFIER_RESULT: "success",
+      ANDROID_SELECTED: "true",
+      ANDROID_BUILD_RESULT: "failure",
+    });
+    expect(buildFailure.status).toBe(1);
+    expect(buildFailure.stdout).toContain(
+      "Selected Android release AAB build concluded failure",
+    );
+
+    const success = run({
+      CLASSIFIER_RESULT: "success",
+      ANDROID_SELECTED: "true",
+      ANDROID_BUILD_RESULT: "success",
+    });
+    expect(success.status).toBe(0);
+    expect(success.stdout).toContain("build and evidence contract passed");
+  });
+
+  test("fails closed unless every release evidence file exists", () => {
+    const build = requireJob(mobileWorkflow, "build-android");
+    const verify = requireStep(build, "Verify release AAB audit evidence");
+    const upload = requireStep(build, "Upload release AAB audit evidence");
+    const stepNames = build.steps?.map(({ name }) => name) ?? [];
+
+    expect(stepNames.indexOf(verify.name)).toBeLessThan(
+      stepNames.indexOf(upload.name),
+    );
+    expect(verify.id).toBe("release-aab-evidence");
+    expect(verify.if).toBe("always()");
+    expect(verify["continue-on-error"]).toBeUndefined();
+    expect(upload.if).toBe(
+      "$" + "{{ always() && steps.release-aab-evidence.outcome == 'success' }}",
+    );
+    expect(upload["continue-on-error"]).toBeUndefined();
+    expect(upload.with?.["if-no-files-found"]).toBe("error");
+    expect(String(upload.with?.path).trim().split(/\r?\n/)).toEqual([
+      "packages/app-core/platforms/android/app/build/outputs/bundle/release/app-release.aab",
+      "$" + "{{ runner.temp }}/android-cloud-release-aab-audit.log",
+      "$" + "{{ runner.temp }}/android-cloud-release-aab.sha256",
+      "$" + "{{ runner.temp }}/android-cloud-release-attestation.json",
+    ]);
+  });
+
+  test("executes the evidence verifier and rejects a missing input artifact", () => {
+    const build = requireJob(mobileWorkflow, "build-android");
+    const verify = requireStep(build, "Verify release AAB audit evidence");
+    if (!verify.run)
+      throw new Error("Evidence verifier has no executable body");
+
+    const execute = (missing: "aab" | "audit" | null) => {
+      const sandbox = mkdtempSync(join(tmpdir(), "eliza-aab-evidence-"));
+      const releaseDirectory = join(
+        sandbox,
+        "packages/app-core/platforms/android/app/build/outputs/bundle/release",
+      );
+      const aabPath = join(releaseDirectory, "app-release.aab");
+      const auditPath = join(sandbox, "android-cloud-release-aab-audit.log");
+      const attestationPath = join(
+        sandbox,
+        "android-cloud-release-attestation.json",
+      );
+      const digestPath = join(sandbox, "android-cloud-release-aab.sha256");
+      const aabBytes = Buffer.from("workflow-contract-aab");
+      const attestation = {
+        bundletool: { version: "1.18.3" },
+        artifact: {
+          sha256: createHash("sha256").update(aabBytes).digest("hex"),
+          sizeBytes: aabBytes.byteLength,
+        },
+      };
+
+      mkdirSync(releaseDirectory, { recursive: true });
+      if (missing !== "aab") writeFileSync(aabPath, aabBytes);
+      if (missing !== "audit") {
+        writeFileSync(
+          auditPath,
+          `[mobile-build] android-cloud AAB attestation ${JSON.stringify(attestation)}\n`,
+        );
+      }
+
+      try {
+        const result = spawnSync("bash", ["-c", verify.run as string], {
+          cwd: sandbox,
+          encoding: "utf8",
+          env: { ...process.env, RUNNER_TEMP: sandbox },
+        });
+        return {
+          result,
+          attestationExists: existsSync(attestationPath),
+          digestExists: existsSync(digestPath),
+        };
+      } finally {
+        rmSync(sandbox, { recursive: true, force: true });
+      }
+    };
+
+    const complete = execute(null);
+    expect(complete.result.status).toBe(0);
+    expect(complete.attestationExists).toBe(true);
+    expect(complete.digestExists).toBe(true);
+
+    expect(execute("aab").result.status).toBe(1);
+    expect(execute("audit").result.status).toBe(1);
+  });
+
+  test("keeps the aggregate alive beyond the selected Android build budget", () => {
+    const build = requireJob(mobileWorkflow, "build-android");
+    const aggregate = requireJob(aggregateWorkflow, "gate");
+    expect(aggregate["timeout-minutes"]).toBeGreaterThan(
+      build["timeout-minutes"] ?? 0,
+    );
+    expect(Number(aggregate.env?.POLL_TIMEOUT_SECONDS)).toBeGreaterThan(
+      (build["timeout-minutes"] ?? 0) * 60,
+    );
+  });
+
+  test("actionlint covers the newly required owner workflow", () => {
+    expect(developWorkflowSource).toContain(
+      ".github/workflows/mobile-build-smoke.yml",
+    );
+  });
+});

--- a/packages/scripts/ci-path-gate.self-test.mjs
+++ b/packages/scripts/ci-path-gate.self-test.mjs
@@ -148,6 +148,21 @@ assertGate(
   },
 );
 
+for (const path of [
+  ".github/workflows/mobile-build-smoke.yml",
+  "packages/app-core/scripts/run-mobile-build.mjs",
+  "packages/app-core/platforms/android/app/build.gradle",
+  "packages/app/src/main.tsx",
+]) {
+  assertGate(
+    `Android release input ${path}`,
+    runGate({ config: "mobile", files: [path] }),
+    {
+      android: "true",
+    },
+  );
+}
+
 assertGate(
   "docker runtime",
   runGate({ config: "docker", files: ["plugins/plugin-openai/src/index.ts"] }),

--- a/packages/scripts/develop-pr-aggregate-workflow-contract.mjs
+++ b/packages/scripts/develop-pr-aggregate-workflow-contract.mjs
@@ -133,7 +133,7 @@ export function validateAggregateWorkflow(workflow) {
 
   assertIncludes(workflow, "    name: Develop PR Gate", "stable job name");
   assertIncludes(workflow, "    runs-on: ubuntu-24.04", "hosted runner");
-  assertIncludes(workflow, "    timeout-minutes: 45", "bounded timeout");
+  assertIncludes(workflow, "    timeout-minutes: 75", "bounded timeout");
   assertEqual(
     count(workflow, /uses:\s*actions\/checkout@/g),
     1,

--- a/packages/scripts/develop-pr-aggregate.mjs
+++ b/packages/scripts/develop-pr-aggregate.mjs
@@ -38,6 +38,13 @@ const STALE_BASE_ACTIONS = [
   "labeled",
   "unlabeled",
 ];
+const MOBILE_BUILD_SMOKE_ACTIONS = [
+  "opened",
+  "synchronize",
+  "reopened",
+  "ready_for_review",
+  "labeled",
+];
 
 export const REQUIRED_CHECKS = Object.freeze([
   {
@@ -74,6 +81,11 @@ export const REQUIRED_CHECKS = Object.freeze([
     context: "stale-base guard",
     workflowPath: ".github/workflows/stale-base-guard.yml",
     triggerActions: STALE_BASE_ACTIONS,
+  },
+  {
+    context: "Android release AAB gate",
+    workflowPath: ".github/workflows/mobile-build-smoke.yml",
+    triggerActions: MOBILE_BUILD_SMOKE_ACTIONS,
   },
 ]);
 
@@ -525,7 +537,7 @@ async function runProduction(env) {
   const timeoutSeconds = positiveInteger(
     env.POLL_TIMEOUT_SECONDS,
     "POLL_TIMEOUT_SECONDS",
-    2_400,
+    4_200,
   );
   const intervalSeconds = positiveInteger(
     env.POLL_INTERVAL_SECONDS,

--- a/packages/scripts/develop-pr-aggregate.self-test.mjs
+++ b/packages/scripts/develop-pr-aggregate.self-test.mjs
@@ -51,7 +51,7 @@ function resultFor(evaluation, context) {
 
 const allGreen = evaluate(successRuns());
 assert.equal(allGreen.verdict, "success");
-assert.deepEqual(allGreen.counts, { passed: 7, waiting: 0, failed: 0 });
+assert.deepEqual(allGreen.counts, { passed: 8, waiting: 0, failed: 0 });
 
 const missingBeforeDeadline = evaluate(buildCanaryCheckRuns("missing", NOW_MS));
 assert.equal(missingBeforeDeadline.verdict, "waiting");


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #17117.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      baseline blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      real hosted Android run, required-check job, and manually inspected
      four-file artifact linked below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` was run post-sync. Its exact unrelated `origin/develop`
      blocker is documented in **Known gaps / failures** below; every subsequent
      verifier stage was also run independently and passed.

# Risks

Medium. Matching develop PRs now pay for the canonical 60-minute Android build
and cannot merge if its path classifier, release build, evidence verifier, or
required result job fails. The base-trusted aggregate polling window grows from
40 to 70 minutes so a valid selected build can finish; this may keep one hosted
aggregate job alive longer when Android capacity is slow.

# Background

## What does this PR do?

- Runs Mobile Build Smoke for PRs targeting `develop` as well as `main`.
- Adds one always-emitted `Android release AAB gate` result job and makes that
  exact owner/context required by the base-trusted `Develop PR Gate` aggregate.
- Keeps unrelated PRs cheap by allowing the required result job to succeed only
  after the real path classifier explicitly says Android was not selected.
- Makes the four-file AAB evidence set atomic: AAB, audit log, SHA-256 digest,
  and attestation must all be non-empty and internally consistent before the
  upload can run; the upload itself uses `if-no-files-found: error`.
- Adds executable workflow-contract coverage for every terminal gate state,
  every required path family, valid evidence generation, and missing AAB/log
  failures.

## What kind of change is this?

Bug fix (non-breaking CI/release safety change).

# Documentation changes needed?

No project documentation change is needed. This repairs the existing workflow
contract and tests it at its code-owned authority boundaries.

# Testing

## Where should a reviewer start?

Start with the real `Android release AAB gate` job linked below, then open its
owning Mobile Build Smoke run and inspect the
`android-cloud-release-aab-audit` artifact. The focused executable contract is
`packages/scripts/__tests__/mobile-build-smoke-workflow.test.ts`.

## Detailed testing steps

1. Confirm this PR targets `develop` and changed
   `.github/workflows/mobile-build-smoke.yml`; the path classifier must select
   Android.
2. Open Mobile Build Smoke and confirm `Android Debug Build` completes the real
   canonical release-AAB build/audit path.
3. Confirm `Android release AAB gate` concludes success, then inspect the
   executable aggregate contract showing its exact workflow owner/context.
4. Download `android-cloud-release-aab-audit`; confirm all four files are
   non-empty, the digest matches the AAB, and the attestation size/digest match.
5. Review the focused test output: the workflow's exact Bash verifier returns
   status 1 when either the AAB or audit log is removed.

Local post-sync results:

- `bun test packages/scripts/develop-pr-aggregate.test.mjs packages/scripts/__tests__/ci-path-gate.test.mjs packages/scripts/__tests__/mobile-build-smoke-workflow.test.ts` — 13 pass, 0 fail, 41 assertions.
- `node packages/scripts/ci-path-gate.self-test.mjs` — pass.
- `node packages/scripts/ci-workflow-invariants.mjs` — pass.
- `actionlint -config-file .github/actionlint.yaml` on all three changed workflows — pass.
- `zizmor --offline .github/workflows/develop-pr-gate.yml` — no findings.
- `bun run verify` — all 579 Turbo tasks and the build-model, dependency-graph,
  and secret audits pass; the inherited script-audit stop is recorded below.
- The verifier's later inventory, view-bundle inventory, focused-test audit, and
  dist-path typecheck stages were run independently after that stop and pass.
- An exploratory direct `bun test packages/scripts` run recorded 1,253 pass, 9
  skip, and 37 fail. Thirty-two child-process `EBADF` failures cleared when the
  eight affected files were rerun alone (64 pass, 0 fail), and the three
  provisioning-worker failures cleared under its required `NODE_ENV=test` (51
  pass, 0 fail). The two unchanged base failures left are detailed below.

# Evidence Gate

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow and script-only CI change; no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow and script-only CI change; no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing flow or rendered surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - this changes GitHub Actions orchestration, not an elizaOS backend runtime path; Actions logs and artifacts are the applicable proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, state, or console behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] A real same-repository PR targeting `develop` produced the canonical
      release AAB and the atomic four-file `android-cloud-release-aab-audit`
      artifact. The build, required gate, artifact, and manual inspection are
      linked and summarized below.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

N/A - no backend or frontend runtime behavior changes. Applicable Actions proof:

- [Mobile Build Smoke attempt 2](https://github.com/aandreakis/eliza/actions/runs/30707002483/attempts/2)
- [Real Android build/audit job](https://github.com/aandreakis/eliza/actions/runs/30707002483/job/91387926856) — success
- [Required `Android release AAB gate` job](https://github.com/aandreakis/eliza/actions/runs/30707002483/job/91389239028) — success
- [`android-cloud-release-aab-audit` artifact](https://github.com/aandreakis/eliza/actions/runs/30707002483/artifacts/8820780575), retained through 2026-08-08

I downloaded and opened every file in that artifact. The AAB is a valid ZIP
archive (`unzip -t`: no errors), is 68,083,911 bytes, and hashes to
`83af0f43d14851f111b66db022acfdd76d49a704befdc932ddeb1b5a53dd91a1`.
The digest file contains that exact hash. The attestation reports the same size
and hash, bundletool 1.18.3, the `base` manifest, and three non-empty DEX
entries. The 1,671-line audit log records `BUILD SUCCESSFUL in 3m 3s`, the
post-Gradle audit pass, and the release-AAB path; it contains no `FAILURE: Build
failed`, `FAILED`, or `ERROR` marker. All four uploaded files are non-empty:
AAB 68,083,911 bytes, log 215,564 bytes, attestation 7,687 bytes, digest 151
bytes.

## Screenshots (before / after) + video walkthrough

N/A - workflow and script-only CI change; no rendered UI.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no user-facing flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio change.

## Known gaps / failures

- The upstream fork-origin workflows are awaiting maintainer approval, so
  [the upstream Mobile Build Smoke run](https://github.com/elizaOS/eliza/actions/runs/30706910538)
  is currently `action_required`. To obtain real proof without weakening that
  policy, the identical commit ran in a same-repository draft PR against the
  exact upstream `develop` base in the contributor fork. Its Android build,
  verifier, artifact upload, and required gate are green and manually reviewed
  above. This upstream PR remains draft until a maintainer approves its own
  workflow run.
- The evidence workflow's overall conclusion is red only because the existing
  iOS local-chat smoke was also selected by the workflow-file change and the
  personal fork has no local-inference model installed; after 180 readiness
  probes it reported `No local model installed`. The branch does not touch that
  iOS/model path. Earlier iOS onboarding and attachment smokes passed, and the
  separately concluded Android build and required gate remain successful.
- The base-trusted
  [Security Advisory Gate](https://github.com/elizaOS/eliza/actions/runs/30706910422/job/91387498363)
  timed out only while waiting for the unapproved fork-origin `gitleaks` check;
  its log reports that same missing context for the full 1,200-second polling
  window. The pending Develop PR Gate is likewise waiting on fork-origin
  checks. Both require maintainer workflow approval, not a code change in this
  branch.
- Post-sync `bun run verify` reaches 579/579 successful Turbo tasks, then
  `packages/scripts/audit-scripts.mjs` reports five files already unchanged on
  `origin/develop` as unreferenced:
  `ci-workflow-invariants.test.mjs`, `develop-pr-aggregate.test.mjs`,
  `local-inference-attest.test.mjs`,
  `local-inference-performance-check.test.mjs`, and
  `script-test-isolation.test.mjs`. This branch neither adds nor edits those
  files. Every verifier stage after that audit was run independently and passed.
- The two non-environmental residuals from the broad direct script lane are also
  unchanged on `origin/develop`: `ci-turbo-cache-contract.test.ts` still expects
  the old 32-minute fork-build timeout while the base workflow now intentionally
  uses 45 minutes, and the final
  `lifeops-live-validation-workflow.test.ts` case remains stuck until Bun's
  5-second timeout (and still at an exploratory 10-second timeout). Neither file
  nor either consumed surface is changed by this branch.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-android-aab-gate]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->
