### PR TITLE
ci(develop-pr): gate changed plugin packages with their own unit tests

### DIFF
--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -1,12 +1,11 @@
 name: Develop PR
 
-# Lightweight gate for pull requests targeting `develop`: lint, typecheck, and
-# build only. The full test/e2e/scenario/benchmark surface runs post-merge on
-# push to `develop` (and nightly/on-demand), not on every PR — so PR feedback
-# stays fast and hosted-runner capacity is spent on the ~200 daily PRs' fast
-# signal rather than the whole integration matrix. `main` PRs keep the heavy
-# gates via `ci.yaml`, `test.yml`'s peers, and `quality.yml`. Steps mirror
-# `ci.yaml` so PR and post-merge lanes stay in agreement.
+# Lightweight gate for pull requests targeting `develop`: lint, typecheck,
+# build, and the unit suites owned by changed plugin packages. The broader
+# test/e2e/scenario/benchmark surface runs post-merge on push to `develop` (and
+# nightly/on-demand), keeping pre-merge feedback scoped to affected code.
+# `main` PRs retain the heavy gates through `ci.yaml`, `test.yml`'s peers, and
+# `quality.yml`. Steps mirror their post-merge counterparts where applicable.
 
 on:
   pull_request:
@@ -167,10 +166,12 @@ jobs:
   # Scoped to plugin packages the PR actually changes: the full plugin sweep is
   # a sharded post-merge lane and is far too slow for a per-PR gate.
   plugin-tests:
+    name: plugin-tests
     runs-on: ubuntu-latest
-    # 20 not 10: `build:core` alone is ~1.5 min, and the cap only binds when a
-    # PR touches an unusual number of plugin packages at once.
-    timeout-minutes: 20
+    # Rust-backed plugin suites can compile their native test harness on a cold
+    # hosted runner. The cache keeps normal runs short; the cap prevents a
+    # changed plugin from consuming an unbounded gate slot.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -194,41 +195,81 @@ jobs:
           skip-avatar-clone: "true"
           no-vision-deps: "true"
 
-      # Emits a `(plugins/<pkg>)`-anchored regex — the same label surface
-      # `TEST_PACKAGE_FILTER` already matches in `test:plugins`. Only directories
-      # that are real packages with a `test` script are included, so a PR
-      # touching, say, `plugins/dist/**` does not select a task-less filter.
+      # Both sides of a rename are treated as changes so moving a file between
+      # plugins cannot leave the source package's tests out of the gate.
+      # Direct plugin workspaces are the only plugin shape declared by the root
+      # workspace manifest; nested package.json files are implementation data.
       - name: Resolve changed plugin packages
         id: changed
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
-          selected=""
-          for pkg in $(git diff --name-only "$BASE_SHA"...HEAD -- plugins \
-            | awk -F/ 'NF > 2 && $1 == "plugins" { print $2 }' | sort -u); do
-            if [ -f "plugins/$pkg/package.json" ] \
-              && node -e "process.exit(require('./plugins/$pkg/package.json').scripts?.test ? 0 : 1)"; then
-              selected="${selected:+$selected|}$pkg"
+          selected=()
+          changed_paths_file=$(mktemp)
+          sorted_packages_file=$(mktemp)
+          trap 'rm -f "$changed_paths_file" "$sorted_packages_file"' EXIT
+          git diff --no-renames --name-only -z "$BASE_SHA"...HEAD -- plugins > "$changed_paths_file"
+          while IFS= read -r -d '' changed_path; do
+            pkg="${changed_path#plugins/}"
+            pkg="${pkg%%/*}"
+            if [[ ! "$pkg" =~ ^plugin-[a-z0-9-]+$ ]]; then
+              echo "Unsupported plugin workspace path: $changed_path" >&2
+              exit 1
             fi
-          done
-          if [ -z "$selected" ]; then
-            echo "filter=" >> "$GITHUB_OUTPUT"
-            echo "No changed plugin package has a test script; nothing to gate."
-          else
-            echo "filter=\\(plugins/($selected)\\)" >> "$GITHUB_OUTPUT"
-            echo "Gating plugin packages: $selected"
+            manifest="plugins/$pkg/package.json"
+            if [ -f "$manifest" ] && node -e '
+              const { readFileSync } = require("node:fs");
+              const manifest = JSON.parse(readFileSync(process.argv[1], "utf8"));
+              process.exit(typeof manifest.scripts?.test === "string" ? 0 : 1);
+            ' "$manifest"; then
+              selected+=("$pkg")
+            fi
+          done < "$changed_paths_file"
+
+          if [ "${#selected[@]}" -gt 0 ]; then
+            printf '%s\n' "${selected[@]}" | sort -u > "$sorted_packages_file"
+            selected=()
+            while IFS= read -r pkg; do
+              selected+=("$pkg")
+            done < "$sorted_packages_file"
           fi
 
-      # Same runner the post-merge lane uses for these packages: each package's
-      # own `test` script (`vitest run`) via run-all-tests.mjs. `--min-tasks=1`
-      # fails closed if the filter selects nothing, so a silently empty gate
-      # cannot report green.
+          if [ "${#selected[@]}" -eq 0 ]; then
+            echo "filter=" >> "$GITHUB_OUTPUT"
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "No changed plugin package has a test script; nothing to gate."
+          else
+            joined=$(IFS='|'; echo "${selected[*]}")
+            echo "filter=\\(plugins/($joined)\\)" >> "$GITHUB_OUTPUT"
+            echo "count=${#selected[@]}" >> "$GITHUB_OUTPUT"
+            echo "Gating ${#selected[@]} plugin package(s): $joined"
+          fi
+
+      - name: Cache cargo registry and shared target dir
+        if: steps.changed.outputs.filter != ''
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/.cargo-shared-target
+          key: ${{ runner.os }}-cargo-develop-plugin-tests-${{ hashFiles('plugins/*/rust/Cargo.lock', 'plugins/*/rust/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-develop-plugin-tests-
+
+      # The post-merge plugin lane builds the core dependency graph and view
+      # bundles before invoking package-owned test scripts. Matching those
+      # prerequisites prevents a clean hosted runner from failing on absent
+      # generated artifacts instead of the changed plugin's behavior.
       - name: Run unit tests for changed plugins
         if: steps.changed.outputs.filter != ''
         env:
+          CARGO_INCREMENTAL: "0"
+          CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-shared-target
           TEST_PACKAGE_FILTER: ${{ steps.changed.outputs.filter }}
           TEST_SCRIPT_FILTER: "^test$"
         run: |
           bun run build:core
-          node packages/scripts/run-all-tests.mjs --only=test --no-cloud --concurrency=3 --min-tasks=1
+          bun run build:views
+          node packages/scripts/run-all-tests.mjs --only=test --no-cloud --concurrency=3 --min-tasks=${{ steps.changed.outputs.count }}

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -156,3 +156,79 @@ jobs:
 
       - name: Build packages
         run: bun run build:core
+
+  # Plugin specs did not run pre-merge for `develop` PRs: `test.yml` has no
+  # `pull_request` trigger, and `windows-ci.yml`'s PR trigger is scoped to
+  # `main` — so a regression only a plugin spec can catch was discovered after
+  # merge (#17550). This job closes that gap on the develop PR gate only; it
+  # does not touch post-merge coverage in `test.yml`, and it does not duplicate
+  # the Windows lane, which owns `plugin-app-control` on Windows specifically.
+  #
+  # Scoped to plugin packages the PR actually changes: the full plugin sweep is
+  # a sharded post-merge lane and is far too slow for a per-PR gate.
+  plugin-tests:
+    runs-on: ubuntu-latest
+    # 20 not 10: `build:core` alone is ~1.5 min, and the cap only binds when a
+    # PR touches an unusual number of plugin packages at once.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          # Full history so the changed-package diff can resolve the PR base;
+          # a shallow clone cannot see the merge base.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14" # pinned: floating canary writes lockfileVersion 2 and breaks --frozen-lockfile (#11184/#9454)
+          install-command: bun install
+          install-native-deps: "false"
+          install-protoc: "false"
+          setup-python: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      # Emits a `(plugins/<pkg>)`-anchored regex — the same label surface
+      # `TEST_PACKAGE_FILTER` already matches in `test:plugins`. Only directories
+      # that are real packages with a `test` script are included, so a PR
+      # touching, say, `plugins/dist/**` does not select a task-less filter.
+      - name: Resolve changed plugin packages
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          selected=""
+          for pkg in $(git diff --name-only "$BASE_SHA"...HEAD -- plugins \
+            | awk -F/ 'NF > 2 && $1 == "plugins" { print $2 }' | sort -u); do
+            if [ -f "plugins/$pkg/package.json" ] \
+              && node -e "process.exit(require('./plugins/$pkg/package.json').scripts?.test ? 0 : 1)"; then
+              selected="${selected:+$selected|}$pkg"
+            fi
+          done
+          if [ -z "$selected" ]; then
+            echo "filter=" >> "$GITHUB_OUTPUT"
+            echo "No changed plugin package has a test script; nothing to gate."
+          else
+            echo "filter=\\(plugins/($selected)\\)" >> "$GITHUB_OUTPUT"
+            echo "Gating plugin packages: $selected"
+          fi
+
+      # Same runner the post-merge lane uses for these packages: each package's
+      # own `test` script (`vitest run`) via run-all-tests.mjs. `--min-tasks=1`
+      # fails closed if the filter selects nothing, so a silently empty gate
+      # cannot report green.
+      - name: Run unit tests for changed plugins
+        if: steps.changed.outputs.filter != ''
+        env:
+          TEST_PACKAGE_FILTER: ${{ steps.changed.outputs.filter }}
+          TEST_SCRIPT_FILTER: "^test$"
+        run: |
+          bun run build:core
+          node packages/scripts/run-all-tests.mjs --only=test --no-cloud --concurrency=3 --min-tasks=1

--- a/packages/scripts/ci-workflow-invariants.mjs
+++ b/packages/scripts/ci-workflow-invariants.mjs
@@ -210,6 +210,35 @@ export function validateWorkflowSources(sources) {
     "run typecheck",
   );
 
+  const pluginTests = requireJob(
+    develop,
+    WORKFLOW_PATHS.develop,
+    "plugin-tests",
+  );
+  const changedPlugins = pluginTests.steps.find(
+    (step) => step?.id === "changed" && typeof step.run === "string",
+  );
+  invariant(
+    changedPlugins?.run.includes("git diff --no-renames --name-only -z") &&
+      changedPlugins.run.includes('echo "count=$' + '{#selected[@]}"'),
+    `${WORKFLOW_PATHS.develop}: jobs.plugin-tests must select both sides of renames and emit an exact task floor`,
+  );
+  const runPluginTests = pluginTests.steps.find(
+    (step) =>
+      typeof step?.run === "string" &&
+      step.run.includes("packages/scripts/run-all-tests.mjs"),
+  );
+  invariant(
+    runPluginTests?.if === "steps.changed.outputs.filter != ''" &&
+      runPluginTests["continue-on-error"] !== true &&
+      runPluginTests.run.includes("bun run build:core") &&
+      runPluginTests.run.includes("bun run build:views") &&
+      runPluginTests.run.includes(
+        "--min-tasks=$" + "{{ steps.changed.outputs.count }}",
+      ),
+    `${WORKFLOW_PATHS.develop}: jobs.plugin-tests must run the package-owned tests with clean-run prerequisites and an exact task floor`,
+  );
+
   const secrets = requireJob(gitleaks, WORKFLOW_PATHS.gitleaks, "gitleaks");
   requireCommand(
     secrets,

--- a/packages/scripts/develop-pr-aggregate.mjs
+++ b/packages/scripts/develop-pr-aggregate.mjs
@@ -56,6 +56,11 @@ export const REQUIRED_CHECKS = Object.freeze([
     triggerActions: DEVELOP_PR_ACTIONS,
   },
   {
+    context: "plugin-tests",
+    workflowPath: ".github/workflows/develop-pr.yml",
+    triggerActions: DEVELOP_PR_ACTIONS,
+  },
+  {
     context: "gitleaks",
     workflowPath: ".github/workflows/gitleaks.yml",
     triggerActions: DEFAULT_PULL_REQUEST_ACTIONS,

--- a/packages/scripts/develop-pr-aggregate.self-test.mjs
+++ b/packages/scripts/develop-pr-aggregate.self-test.mjs
@@ -51,7 +51,7 @@ function resultFor(evaluation, context) {
 
 const allGreen = evaluate(successRuns());
 assert.equal(allGreen.verdict, "success");
-assert.deepEqual(allGreen.counts, { passed: 7, waiting: 0, failed: 0 });
+assert.deepEqual(allGreen.counts, { passed: 8, waiting: 0, failed: 0 });
 
 const missingBeforeDeadline = evaluate(buildCanaryCheckRuns("missing", NOW_MS));
 assert.equal(missingBeforeDeadline.verdict, "waiting");


### PR DESCRIPTION
Closes #17550.

## Summary

Changed plugin packages now run their own unit suites before a pull request can
merge into `develop`. The `plugin-tests` context is always emitted and is a
required input to the repository's `Develop PR Gate`; PRs with no test-bearing
plugin change terminate green without installing extra build prerequisites.

## Root cause and reviewed implementation

The pre-merge `develop` workflow ran lint, typecheck, and build, but package-owned
plugin tests only ran after merge. The original version of this PR added a test
job, yet four gaps left regressions able to pass:

- the aggregate merge gate did not require `plugin-tests`;
- Git rename detection could report only the destination and omit the source
  package;
- a fixed `--min-tasks=1` under-protected changes spanning multiple plugins;
- a clean hosted runner lacked the core and view artifacts used by real plugin
  suites.

The final implementation registers the named job in the aggregate contract,
uses a fail-closed no-renames NUL-delimited diff so both sides of moves are
classified, validates direct plugin workspace names, computes the exact unique
package count, and passes that count to `--min-tasks`. Test-bearing changes build
core and all authoritative plugin views before invoking the existing test
orchestrator. Rust-backed plugins share a bounded Cargo cache and a 45-minute
job cap.

## Validation

Exact implementation head `8e52fb57f58f64cae64a36d36ca7d05e61209792`,
rebased on `origin/develop` at
`898d75aadc2f303e32320a88116a2b7743171110`:

- `actionlint .github/workflows/develop-pr.yml`: passed;
- aggregate self-test: passed with all 8 required contexts;
- merge-critical workflow invariant audit: passed;
- real historical multi-plugin diff: resolver selected 4 packages and the
  planner scheduled exactly 4 package-owned test tasks;
- no-plugin diff: emitted an empty filter and count 0;
- clean `build:core` and `build:views`: passed;
- real `plugin-app-control` gate: 48 files, 1,643 tests, all passed;
- `bun run verify`: all 581 Turbo tasks and repository audits passed.

The red proof used temporary commit
`ede8bc9ec13eb710f2c75adaec0ad0c70e8adce8`, which changed the expected
`plugin-app-control` role from `OWNER` to `ADMIN`. The new
[`plugin-tests` job failed](https://github.com/elizaOS/eliza/actions/runs/30757868532/job/91523113930)
while lint and build remained green. That mutation is absent from this final
head; the exact same job must return green before merge.

## Evidence

<!-- evidence-head:8e52fb57f58f64cae64a36d36ca7d05e61209792 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI-only change with no rendered product surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI-only change with no rendered product surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the executable artifact is the red/green Actions result.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head builds, package tests, aggregate contracts, and full verify](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17552-exact-head-validation.log); [deliberate red gate](https://github.com/elizaOS/eliza/actions/runs/30757868532/job/91523113930).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or evaluator behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Deliberate red and restored-green gate record](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17552-plugin-tests-red-green.txt).

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code; Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: self-reported
