### PR TITLE
fix(ui): stop reserving hidden 48px touch action lane below every chat message

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
@@ -136,8 +136,12 @@ describe("ChatMessage desktop hover chrome", () => {
     const content = actions.parentElement;
     const restingContentClass = content?.className;
     expect(message.className).toContain("mb-0");
+    // Fine-pointer hover keeps its compact lane permanently reserved, so a
+    // hover/focus reveal never reflows mid-thread. The 48px touch lane is now a
+    // coarse-pointer, revealed-only state rather than static responsive CSS.
     expect(content?.className).toContain("pb-6");
-    expect(content?.className).toContain("pointer-coarse:pb-12");
+    expect(content?.className).not.toContain("pb-12");
+    expect(content?.className).not.toContain("pointer-coarse:pb-12");
     expect(actions.className).toContain("bottom-0");
     expect(actions.className).toContain("absolute");
     expect(actions.getAttribute("aria-hidden")).toBe("true");

--- a/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
@@ -125,13 +125,27 @@ describe("ChatMessage tap-to-reveal vs transcript scroll", () => {
       name: "Show message actions",
     });
     const rail = screen.getByTestId("thread-line-actions");
+    const rowContent = rail.parentElement;
+
+    // The hidden 48px touch action lane must not be reserved below EVERY
+    // message on a coarse-pointer phone. On the LP3 (414px viewport) the old
+    // pointer-coarse:pb-12 consumed ~12% of the screen per message.
+    expect(rowContent?.className).not.toContain("pb-12");
 
     // Mobile browsers focus the bubble before dispatching their synthesized
     // click. Focus alone must not pre-toggle the rail or that click hides it.
     act(() => bubble.focus());
     expect(rail.getAttribute("aria-hidden")).toBe("true");
+    expect(rowContent?.className).not.toContain("pb-12");
     fireEvent.click(bubble);
     expect(rail.getAttribute("aria-hidden")).toBe("false");
+    // Once the user explicitly reveals the touch controls, expand the lane so
+    // the absolute rail does not cover the message bubble.
+    expect(rowContent?.className).toContain("pb-12");
+
+    fireEvent.click(bubble);
+    expect(rail.getAttribute("aria-hidden")).toBe("true");
+    expect(rowContent?.className).not.toContain("pb-12");
   });
 
   it("a scroll-like touch (travel past the slop) does NOT toggle the rail", () => {

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -1135,11 +1135,20 @@ export const ChatMessage = memo(function ChatMessage({
         <MessageRowContent
           className={cn(
             "relative flex flex-col",
-            // Reserve the action lane before reveal so hover, focus, and touch
-            // never reflow nearby messages. The extra four pixels keep the rail
-            // visibly outside outlined bubbles without letting it protrude past
-            // the row and get clipped by the transcript viewport.
-            hasActionLane && "pb-6 pointer-coarse:pb-12",
+            // Fine pointers reserve the compact action lane before hover/focus,
+            // preserving the no-reflow desktop interaction contract. Coarse
+            // pointers must NOT reserve the 48px touch lane while it is hidden:
+            // on the LP3's 414px-tall WebView that consumed ~12% of the screen
+            // below every message and read as a giant blank gap. Expand the
+            // touch lane only for the explicitly revealed accessory, then
+            // collapse it again when dismissed. Padding transitions so the
+            // intentional tap-driven reflow is legible rather than a jump.
+            hasActionLane &&
+              (supportsHover
+                ? "pb-6"
+                : accessoryVisible
+                  ? "pb-12 transition-[padding-bottom] duration-200"
+                  : "transition-[padding-bottom] duration-200"),
             isFirstRun
               ? "max-w-[22rem] items-start"
               : isUser


### PR DESCRIPTION
## Summary

Removes the large static blank lane below every chat bubble on coarse-pointer devices while preserving stable no-reflow action controls on desktop.

## Root cause, proven on the actual LP3

WebView devtools measurement on the Light Phone 3 (`360 × 414` CSS viewport):

- visible bubble height: `54px`
- `MessageRowContent` height: `102px`
- computed `padding-bottom`: `48px`

The 48px was not keyboard/detent inset. It came from the production chat row in `packages/ui/src/components/composites/chat/chat-message.tsx`:

```tsx
hasActionLane && "pb-6 pointer-coarse:pb-12"
```

That statically reserved a full 48px touch action lane under **every message**, even while the action rail was hidden. On the LP3's 414px viewport, one hidden lane is ~12% of the visible screen and reads as the reported dead space below bubbles.

## Fix

- Fine/hover pointers keep a permanent compact `pb-6` lane, preserving the no-reflow hover/focus contract for mid-thread actions.
- Coarse/touch pointers reserve **zero hidden lane**.
- After the user explicitly taps a bubble to reveal actions, the row transitions to `pb-12`, keeping the absolute touch rail clear of message content. It collapses again on dismiss.
- No negative margins, detent hacks, or hard-coded device offsets.

## Bidirectional proof

Focused tests:

```sh
bun run --cwd packages/ui vitest run \
  src/components/composites/chat/chat-message.tap-reveal.test.tsx \
  src/components/composites/chat/chat-message.hover-reveal.test.tsx
```

- `develop` implementation + new assertions: **2 test files failed, 2 assertions failed**
  - touch row incorrectly contains the static `pb-12` reserve before reveal
  - desktop row still carries the old `pointer-coarse:pb-12` responsive class
- this branch: **2 files passed, 11/11 tests passed**
- Opposite-direction assertions:
  - touch: no `pb-12` hidden → `pb-12` after explicit reveal → no `pb-12` after dismiss
  - desktop: permanent `pb-6` remains, so hover/focus reveal does not reflow

### Device before evidence

`~/.moltbot/projects/eliza-fleet/lp3-shots/lp3-pad-20260802.png` records the reported LP3 state. The devtools numbers above identify the exact 48px lane in that production DOM.

## Production path

The patch is in `@elizaos/ui`, not a fixture. `packages/app/src/main.tsx` imports `@elizaos/ui/App`; `packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug` resolves `packages/app` as the renderer and runs its Vite build before Capacitor sync/Gradle packaging. Therefore this `ChatMessage` implementation is the Android-cloud WebView code path.

Production renderer verification on this commit (`dfc2e8b94fd`):

```sh
ELIZA_CAPACITOR_BUILD_TARGET=android \
ELIZA_BUILD_VARIANT=direct \
ELIZA_RELEASE_AUTHORITY=developer-debug \
VITE_ELIZA_ANDROID_RUNTIME_MODE=cloud \
ELIZA_RUNTIME_MODE=cloud RUNTIME_MODE=cloud LOCAL_RUNTIME_MODE=cloud \
VITE_ELIZA_RUNTIME_MODE=cloud \
bun run --cwd packages/app build:web
```

Result: **10,100 modules transformed, production Vite build passed**, renderer manifest build `2b751c643f89`, service-worker build rev `dfc2e8b94fdc`. The exact mobile orchestrator was also invoked; on this Linux host it stopped at the native preflight because no Android SDK is installed, before Gradle packaging. The renderer phase it would run is the successful `packages/app` build above.

## Evidence Gate

<!-- evidence-head:dfc2e8b94fdc54182c9a8863de03079446e48bee -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17574-lp3-pad-20260802.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17574-after.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17574-action-lane-walkthrough.webm

<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend-only layout change with no backend request path

<!-- evidence-row:frontend-logs -->
- [ ] N/A - local render-only class state; no request, response, console, or network path changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent behavior change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduler, wallet, or generated-domain artifact

<!-- evidence-row:ocr-review -->
- [x] [17574-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17574-ocr-review.txt)

## Contribution Attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`