### PR TITLE
fix(deploy): stop pruning runners whose state cannot be determined

### DIFF
--- a/packages/deploy/runner-workspace-cleanup/README.md
+++ b/packages/deploy/runner-workspace-cleanup/README.md
@@ -13,9 +13,9 @@ for it. So it never ran: prod-2 (`eliza-prod-robot-2`, a 98 GB root) refilled to
 to reclaim, and an operator had to clear `_work` by hand (again) on 2026-07-15.
 This bundle is the missing recurring call site.
 
-The tool prunes only per-runner `_work` checkouts older than `--min-age-hours`
-and **refuses to delete while a `Runner.Worker` process is active** (its built-in
-guard), so a scheduled run never interrupts a live CI job.
+The tool prunes only per-runner `_work` checkouts older than `--min-age-hours`.
+The timer helper proves the specific runner is inactive before bypassing the
+tool's host-global process guard; ambiguous bindings or unit states fail closed.
 
 ## Why system-level (not the `../systemd/` bundle)
 
@@ -32,12 +32,13 @@ delete. So the work is split by whether the runner can currently accept a job:
 | Runner state | Covered by | Why it is race-free |
 |---|---|---|
 | **Active** (unit running) | its own **job-completed hook** | the runner invokes it *between* jobs, in its own context, scoped to its own `_work` |
-| **Inactive / orphaned** | the **timer** (idle helper) | a stopped unit cannot be handed a job, so nothing can start writing |
+| **Inactive / orphaned** | the **timer** (idle helper) | the exact `.service` binding reports inactive, or no runner configuration remains |
 
-The timer helper skips every runner whose unit is active and says so in its
-output; the hook never touches a sibling runner. The tool's built-in
-`Runner.Worker` guard stays on underneath both (the scheduled path never passes
-`--allow-active`).
+The timer helper reads the authoritative `.service` binding written by GitHub's
+runner installer, skips active or undeterminable runners, and says why in its
+output. The hook never touches a sibling runner. Both paths pass
+`--allow-active` because the tool's process guard is host-global; their
+per-runner lifecycle checks are the safety boundary.
 
 ## Layout
 

--- a/packages/deploy/runner-workspace-cleanup/bin/eliza-prune-idle-runner-workspaces.sh
+++ b/packages/deploy/runner-workspace-cleanup/bin/eliza-prune-idle-runner-workspaces.sh
@@ -15,12 +15,8 @@
 #   RUNNER_WORKSPACE_ROOT   runners' work root
 #   PRUNE_MIN_AGE_HOURS     minimum checkout age to prune
 #   BUN_BIN / PRUNE_TOOL    runtime + tool path
-# NO `set -e`: one runner's failure must not stop the sweep. The orphan case
-# this helper exists for — a deregistered runner whose agentName matches no
-# unit — makes `grep` in the unit-resolution pipeline exit 1, and under
-# `set -euo pipefail` that single miss aborted the whole script before the
-# orphaned→prune branch could run. Errors are isolated per runner instead,
-# counted, and surfaced in the exit code at the end.
+# NO `set -e`: one runner's failure must not stop the sweep. Errors are
+# isolated per runner, counted, and surfaced in the exit code at the end.
 set -uo pipefail
 
 ROOT="${RUNNER_WORKSPACE_ROOT:?RUNNER_WORKSPACE_ROOT is required}"
@@ -40,25 +36,23 @@ for runner_dir in "$ROOT"/*/; do
   [[ -d "${runner_dir}_work" ]] || continue
   name="$(basename "$runner_dir")"
 
-  # Resolve this directory's runner unit. Installations name the unit after the
-  # registered agent (`.runner` -> agentName), which is what systemd knows.
-  #
-  # A miss is tolerated, but "this runner does not exist" and "I could not tell
-  # what this runner is" are NOT the same answer, and only the first one may
-  # reach a delete. `.runner` present-but-unreadable, a truncated write during
-  # registration or self-update, or a schema change to agentName all yield an
-  # empty agent_name; treating that as orphaned prunes a possibly-busy runner
-  # with --allow-active, which is how a live job loses its workspace mid-step.
-  # Absent => orphaned (prunable). Unparseable => undeterminable (never pruned).
-  agent_name=""
+  # GitHub's service installer records the exact generated unit name here.
+  # Deriving it from agentName is unsafe because service-name normalization and
+  # truncation are not reversible, and suffix searches can select a sibling.
+  service_binding="${runner_dir}.service"
+  unit=""
   undeterminable=""
-  if [[ -e "${runner_dir}.runner" ]]; then
-    if [[ -r "${runner_dir}.runner" ]]; then
-      agent_name="$(sed -n 's/.*"agentName"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${runner_dir}.runner" | head -1 || true)"
-      [[ -n "$agent_name" ]] || undeterminable="unparseable .runner (no agentName)"
+  if [[ -e "$service_binding" ]]; then
+    if [[ -f "$service_binding" && -r "$service_binding" ]]; then
+      unit="$(<"$service_binding")"
+      if [[ "$unit" != actions.runner.*.service || "$unit" == *[[:space:]]* ]]; then
+        undeterminable="invalid .service binding"
+      fi
     else
-      undeterminable="unreadable .runner"
+      undeterminable="unreadable .service binding"
     fi
+  elif [[ -e "${runner_dir}.runner" ]]; then
+    undeterminable="configured runner has no .service binding"
   fi
 
   if [[ -n "$undeterminable" ]]; then
@@ -67,29 +61,28 @@ for runner_dir in "$ROOT"/*/; do
     continue
   fi
 
-  # Exact match on the unit suffix. A substring match resolves agent `runner-1`
-  # to unit `...runner-10` (list-units order, head -1), so the is-active check
-  # below would consult the WRONG runner and prune a busy one as idle.
-  unit=""
-  if [[ -n "$agent_name" ]]; then
-    match="$(systemctl list-units 'actions.runner.*' --all --no-legend --plain 2>/dev/null \
-      | awk '{print $1}' | sed -e 's/^actions\.runner\.//' -e 's/\.service$//' \
-      | awk -v want="$agent_name" -F. '$NF == want {print; exit}' || true)"
-    [[ -n "$match" ]] && unit="actions.runner.${match}.service"
-  fi
-
-  if [[ -n "$unit" ]] && systemctl is-active --quiet "$unit" 2>/dev/null; then
-    # Active runner: the hook owns this one. Skipping is the race-free choice.
-    echo "skip $name — runner unit active ($unit); job-completed hook owns it"
-    skipped_active=$((skipped_active + 1))
-    continue
+  if [[ -n "$unit" ]]; then
+    active_state="$(systemctl is-active "$unit" 2>/dev/null || true)"
+    case "$active_state" in
+      active)
+        # Active runner: the hook owns this one. Skipping is the race-free choice.
+        echo "skip $name — runner unit active ($unit); job-completed hook owns it"
+        skipped_active=$((skipped_active + 1))
+        continue
+        ;;
+      inactive) ;;
+      *)
+        echo "skip $name — runner unit state is ${active_state:-unknown} ($unit); refusing to prune"
+        skipped_undeterminable=$((skipped_undeterminable + 1))
+        continue
+        ;;
+    esac
   fi
 
   if [[ -z "$unit" ]]; then
-    # No `.runner` at all, or a registered agent no unit answers to: an
-    # orphaned/removed runner directory. Safe to reclaim — nothing can schedule
-    # work into it.
-    echo "prune $name — no runner unit resolves to it (orphaned)"
+    # No runner or service configuration remains, so this is a directory left
+    # behind by a removed runner rather than a runnable installation.
+    echo "prune $name — no runner configuration remains (orphaned)"
   else
     echo "prune $name — runner unit inactive ($unit)"
   fi

--- a/packages/deploy/runner-workspace-cleanup/bin/eliza-prune-idle-runner-workspaces.sh
+++ b/packages/deploy/runner-workspace-cleanup/bin/eliza-prune-idle-runner-workspaces.sh
@@ -32,6 +32,7 @@ TOOL="${PRUNE_TOOL:?PRUNE_TOOL is required}"
 
 pruned=0
 skipped_active=0
+skipped_undeterminable=0
 failed=0
 
 for runner_dir in "$ROOT"/*/; do
@@ -41,17 +42,40 @@ for runner_dir in "$ROOT"/*/; do
 
   # Resolve this directory's runner unit. Installations name the unit after the
   # registered agent (`.runner` -> agentName), which is what systemd knows.
-  # Every stage tolerates a miss: no match means orphaned, not an error.
+  #
+  # A miss is tolerated, but "this runner does not exist" and "I could not tell
+  # what this runner is" are NOT the same answer, and only the first one may
+  # reach a delete. `.runner` present-but-unreadable, a truncated write during
+  # registration or self-update, or a schema change to agentName all yield an
+  # empty agent_name; treating that as orphaned prunes a possibly-busy runner
+  # with --allow-active, which is how a live job loses its workspace mid-step.
+  # Absent => orphaned (prunable). Unparseable => undeterminable (never pruned).
   agent_name=""
-  if [[ -r "${runner_dir}.runner" ]]; then
-    agent_name="$(sed -n 's/.*"agentName"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${runner_dir}.runner" | head -1 || true)"
+  undeterminable=""
+  if [[ -e "${runner_dir}.runner" ]]; then
+    if [[ -r "${runner_dir}.runner" ]]; then
+      agent_name="$(sed -n 's/.*"agentName"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${runner_dir}.runner" | head -1 || true)"
+      [[ -n "$agent_name" ]] || undeterminable="unparseable .runner (no agentName)"
+    else
+      undeterminable="unreadable .runner"
+    fi
   fi
 
+  if [[ -n "$undeterminable" ]]; then
+    echo "skip $name — $undeterminable; cannot prove this runner is idle, refusing to prune"
+    skipped_undeterminable=$((skipped_undeterminable + 1))
+    continue
+  fi
+
+  # Exact match on the unit suffix. A substring match resolves agent `runner-1`
+  # to unit `...runner-10` (list-units order, head -1), so the is-active check
+  # below would consult the WRONG runner and prune a busy one as idle.
   unit=""
   if [[ -n "$agent_name" ]]; then
     match="$(systemctl list-units 'actions.runner.*' --all --no-legend --plain 2>/dev/null \
-      | awk '{print $1}' | sed 's/^actions\.runner\.//' | grep -F -- "$agent_name" | head -1 || true)"
-    [[ -n "$match" ]] && unit="actions.runner.${match}"
+      | awk '{print $1}' | sed -e 's/^actions\.runner\.//' -e 's/\.service$//' \
+      | awk -v want="$agent_name" -F. '$NF == want {print; exit}' || true)"
+    [[ -n "$match" ]] && unit="actions.runner.${match}.service"
   fi
 
   if [[ -n "$unit" ]] && systemctl is-active --quiet "$unit" 2>/dev/null; then
@@ -62,8 +86,9 @@ for runner_dir in "$ROOT"/*/; do
   fi
 
   if [[ -z "$unit" ]]; then
-    # No resolvable unit: an orphaned/removed runner directory. Safe to reclaim
-    # — nothing can schedule work into it.
+    # No `.runner` at all, or a registered agent no unit answers to: an
+    # orphaned/removed runner directory. Safe to reclaim — nothing can schedule
+    # work into it.
     echo "prune $name — no runner unit resolves to it (orphaned)"
   else
     echo "prune $name — runner unit inactive ($unit)"
@@ -86,7 +111,7 @@ for runner_dir in "$ROOT"/*/; do
   fi
 done
 
-echo "idle-prune done: pruned=$pruned skipped_active=$skipped_active failed=$failed"
+echo "idle-prune done: pruned=$pruned skipped_active=$skipped_active skipped_undeterminable=$skipped_undeterminable failed=$failed"
 # Surface degraded sweeps to systemd without having let one bad runner stop
 # the others.
 [[ "$failed" -eq 0 ]] || exit 1

--- a/packages/deploy/runner-workspace-cleanup/smoke-test.sh
+++ b/packages/deploy/runner-workspace-cleanup/smoke-test.sh
@@ -184,19 +184,20 @@ EOF_ENV
     || fail "systemd-analyze rejected the rendered units"
 fi
 
-# 10. BEHAVIORAL: the idle helper sweeps EVERY orphaned runner — the exact
-#     #15398 case. A deregistered runner's agentName matches no unit, which
-#     under the old `set -e` aborted the sweep at the FIRST orphan (the grep
-#     miss propagated through the command substitution), so a second orphan was
-#     never processed. Driven through the REAL helper + REAL tool with only
-#     systemctl stubbed to "no units exist".
+# 10. BEHAVIORAL: the idle helper sweeps every directory left behind by a
+#     removed runner. Driven through the real helper and prune tool with only
+#     systemctl stubbed.
 STUB_DIR="$TMP_DIR/stub-bin"
 mkdir -p "$STUB_DIR"
 cat > "$STUB_DIR/systemctl" <<'EOF_STUB'
 #!/usr/bin/env bash
 case "${1:-}" in
   list-units) exit 0 ;;   # no actions.runner.* units: every runner is orphaned
-  is-active)  exit 3 ;;   # inactive
+  is-active)
+    case "${2:-}" in
+      actions.runner.acme-org.failed-state.service) echo failed; exit 3 ;;
+      *) exit 1 ;;
+    esac ;;
   *)          exit 0 ;;
 esac
 EOF_STUB
@@ -206,7 +207,6 @@ SWEEP_ROOT="$TMP_DIR/sweep-root"
 for r in runner-a runner-b; do
   mkdir -p "$SWEEP_ROOT/$r/_work/stale-repo"
   echo payload > "$SWEEP_ROOT/$r/_work/stale-repo/file"
-  printf '{"agentName": "%s"}\n' "$r" > "$SWEEP_ROOT/$r/.runner"
   node -e '
     const fs = require("node:fs");
     const when = new Date(Date.now() - 48 * 3600 * 1000);
@@ -229,14 +229,11 @@ test ! -e "$SWEEP_ROOT/runner-b/_work/stale-repo" \
 grep -q "pruned=2" "$TMP_DIR/sweep.log" || fail "sweep did not report pruned=2: $(cat "$TMP_DIR/sweep.log")"
 
 
-# 11. BEHAVIORAL: a runner whose `.runner` exists but cannot be parsed is
-#     UNDETERMINABLE, not orphaned. The helper passes --allow-active on the
-#     prune path, so classifying "I could not tell" as "nothing can be running
-#     here" is what lets a live job lose its workspace mid-step. Absent
-#     `.runner` must still prune (the #15398 orphan case) in the same sweep, so
-#     one run proves both halves.
+# 11. BEHAVIORAL: configured runners without a trustworthy systemd binding are
+#     undeterminable, not orphaned. The helper passes --allow-active only after
+#     this proof, so ambiguity must never reach the destructive branch.
 FAILOPEN_ROOT="$TMP_DIR/failopen-root"
-for r in unreadable-runner unparseable-runner truly-orphaned; do
+for r in missing-binding invalid-binding unknown-state failed-state truly-orphaned; do
   mkdir -p "$FAILOPEN_ROOT/$r/_work/stale-repo"
   echo payload > "$FAILOPEN_ROOT/$r/_work/stale-repo/file"
   node -e '
@@ -245,9 +242,13 @@ for r in unreadable-runner unparseable-runner truly-orphaned; do
     fs.utimesSync(process.argv[1], when, when);
   ' "$FAILOPEN_ROOT/$r/_work/stale-repo"
 done
-printf '{"agentName": "unreadable-runner"}\n' > "$FAILOPEN_ROOT/unreadable-runner/.runner"
-chmod 000 "$FAILOPEN_ROOT/unreadable-runner/.runner"
-printf '{"poolId": 3}\n' > "$FAILOPEN_ROOT/unparseable-runner/.runner"
+printf '{"agentName": "missing-binding"}\n' > "$FAILOPEN_ROOT/missing-binding/.runner"
+printf '{"agentName": "invalid-binding"}\n' > "$FAILOPEN_ROOT/invalid-binding/.runner"
+printf 'not-a-runner-unit\n' > "$FAILOPEN_ROOT/invalid-binding/.service"
+printf '{"agentName": "unknown-state"}\n' > "$FAILOPEN_ROOT/unknown-state/.runner"
+printf 'actions.runner.acme-org.unknown-state.service\n' > "$FAILOPEN_ROOT/unknown-state/.service"
+printf '{"agentName": "failed-state"}\n' > "$FAILOPEN_ROOT/failed-state/.runner"
+printf 'actions.runner.acme-org.failed-state.service\n' > "$FAILOPEN_ROOT/failed-state/.service"
 # truly-orphaned deliberately has no .runner at all.
 
 PATH="$STUB_DIR:$PATH" \
@@ -257,47 +258,46 @@ BUN_BIN="$BUN_BIN" \
 PRUNE_TOOL="$TOOL_SRC" \
   bash "$SCRIPT_DIR/bin/eliza-prune-idle-runner-workspaces.sh" >"$TMP_DIR/failopen.log" 2>&1 \
   || fail "sweep exited nonzero on the undeterminable mix: $(cat "$TMP_DIR/failopen.log")"
-chmod 644 "$FAILOPEN_ROOT/unreadable-runner/.runner"
 
-test -e "$FAILOPEN_ROOT/unreadable-runner/_work/stale-repo" \
-  || fail "unreadable .runner was pruned — the helper cannot prove that runner is idle and must refuse"
-test -e "$FAILOPEN_ROOT/unparseable-runner/_work/stale-repo" \
-  || fail "unparseable .runner (no agentName) was pruned — same fail-open path"
+test -e "$FAILOPEN_ROOT/missing-binding/_work/stale-repo" \
+  || fail "configured runner without .service binding was pruned"
+test -e "$FAILOPEN_ROOT/invalid-binding/_work/stale-repo" \
+  || fail "runner with invalid .service binding was pruned"
+test -e "$FAILOPEN_ROOT/unknown-state/_work/stale-repo" \
+  || fail "runner whose unit state could not be determined was pruned"
+test -e "$FAILOPEN_ROOT/failed-state/_work/stale-repo" \
+  || fail "failed unit was pruned even though its worker may still be shutting down"
 test ! -e "$FAILOPEN_ROOT/truly-orphaned/_work/stale-repo" \
   || fail "runner with no .runner at all was NOT pruned — the #15398 orphan case must still work"
-grep -q "skipped_undeterminable=2" "$TMP_DIR/failopen.log" \
-  || fail "sweep did not report skipped_undeterminable=2: $(cat "$TMP_DIR/failopen.log")"
+grep -q "skipped_undeterminable=4" "$TMP_DIR/failopen.log" \
+  || fail "sweep did not report skipped_undeterminable=4: $(cat "$TMP_DIR/failopen.log")"
 grep -q "pruned=1" "$TMP_DIR/failopen.log" \
   || fail "sweep did not prune exactly the one genuine orphan: $(cat "$TMP_DIR/failopen.log")"
 
-# 12. BEHAVIORAL: unit resolution must match the agent name exactly. With a
-#     substring match, agent `runner-1` resolves to unit `...runner-10` first
-#     (list-units order + head -1), so the is-active probe reads the WRONG
-#     runner: an idle runner-10 makes a BUSY runner-1 look prunable.
+# 12. BEHAVIORAL: the exact unit binding written by GitHub's service installer
+#     is authoritative even when agent names overlap or contain dots.
 COLLIDE_STUB="$TMP_DIR/stub-collide"
 mkdir -p "$COLLIDE_STUB"
 cat > "$COLLIDE_STUB/systemctl" <<'EOF_STUB'
 #!/usr/bin/env bash
 case "${1:-}" in
-  list-units)
-    # runner-10 first on purpose: a substring match takes it for `runner-1`.
-    echo "actions.runner.acme-org.runner-10.service loaded active running"
-    echo "actions.runner.acme-org.runner-1.service loaded active running"
-    exit 0 ;;
   is-active)
-    # Only runner-1 is busy; runner-10 is idle.
-    [[ "${3:-}" == *".runner-1.service" ]] && exit 0
-    exit 3 ;;
+    case "${2:-}" in
+      actions.runner.acme-org.runner.1.service) echo active; exit 0 ;;
+      actions.runner.acme-org.runner-10.service) echo inactive; exit 3 ;;
+      *) echo unknown; exit 4 ;;
+    esac ;;
   *) exit 0 ;;
 esac
 EOF_STUB
 chmod +x "$COLLIDE_STUB/systemctl"
 
 COLLIDE_ROOT="$TMP_DIR/collide-root"
-for r in runner-1 runner-10; do
+for r in runner.1 runner-10; do
   mkdir -p "$COLLIDE_ROOT/$r/_work/stale-repo"
   echo payload > "$COLLIDE_ROOT/$r/_work/stale-repo/file"
   printf '{"agentName": "%s"}\n' "$r" > "$COLLIDE_ROOT/$r/.runner"
+  printf 'actions.runner.acme-org.%s.service\n' "$r" > "$COLLIDE_ROOT/$r/.service"
   node -e '
     const fs = require("node:fs");
     const when = new Date(Date.now() - 48 * 3600 * 1000);
@@ -313,8 +313,8 @@ PRUNE_TOOL="$TOOL_SRC" \
   bash "$SCRIPT_DIR/bin/eliza-prune-idle-runner-workspaces.sh" >"$TMP_DIR/collide.log" 2>&1 \
   || fail "sweep exited nonzero on the prefix-collision pair: $(cat "$TMP_DIR/collide.log")"
 
-test -e "$COLLIDE_ROOT/runner-1/_work/stale-repo" \
-  || fail "BUSY runner-1 was pruned — its unit resolved to the idle runner-10 by substring match"
+test -e "$COLLIDE_ROOT/runner.1/_work/stale-repo" \
+  || fail "busy runner.1 was pruned instead of using its exact .service binding"
 test ! -e "$COLLIDE_ROOT/runner-10/_work/stale-repo" \
   || fail "idle runner-10 was not pruned"
 

--- a/packages/deploy/runner-workspace-cleanup/smoke-test.sh
+++ b/packages/deploy/runner-workspace-cleanup/smoke-test.sh
@@ -228,4 +228,94 @@ test ! -e "$SWEEP_ROOT/runner-b/_work/stale-repo" \
   || fail "second orphaned runner was not pruned — the sweep stopped at the first (set -e regression)"
 grep -q "pruned=2" "$TMP_DIR/sweep.log" || fail "sweep did not report pruned=2: $(cat "$TMP_DIR/sweep.log")"
 
+
+# 11. BEHAVIORAL: a runner whose `.runner` exists but cannot be parsed is
+#     UNDETERMINABLE, not orphaned. The helper passes --allow-active on the
+#     prune path, so classifying "I could not tell" as "nothing can be running
+#     here" is what lets a live job lose its workspace mid-step. Absent
+#     `.runner` must still prune (the #15398 orphan case) in the same sweep, so
+#     one run proves both halves.
+FAILOPEN_ROOT="$TMP_DIR/failopen-root"
+for r in unreadable-runner unparseable-runner truly-orphaned; do
+  mkdir -p "$FAILOPEN_ROOT/$r/_work/stale-repo"
+  echo payload > "$FAILOPEN_ROOT/$r/_work/stale-repo/file"
+  node -e '
+    const fs = require("node:fs");
+    const when = new Date(Date.now() - 48 * 3600 * 1000);
+    fs.utimesSync(process.argv[1], when, when);
+  ' "$FAILOPEN_ROOT/$r/_work/stale-repo"
+done
+printf '{"agentName": "unreadable-runner"}\n' > "$FAILOPEN_ROOT/unreadable-runner/.runner"
+chmod 000 "$FAILOPEN_ROOT/unreadable-runner/.runner"
+printf '{"poolId": 3}\n' > "$FAILOPEN_ROOT/unparseable-runner/.runner"
+# truly-orphaned deliberately has no .runner at all.
+
+PATH="$STUB_DIR:$PATH" \
+RUNNER_WORKSPACE_ROOT="$FAILOPEN_ROOT" \
+PRUNE_MIN_AGE_HOURS=6 \
+BUN_BIN="$BUN_BIN" \
+PRUNE_TOOL="$TOOL_SRC" \
+  bash "$SCRIPT_DIR/bin/eliza-prune-idle-runner-workspaces.sh" >"$TMP_DIR/failopen.log" 2>&1 \
+  || fail "sweep exited nonzero on the undeterminable mix: $(cat "$TMP_DIR/failopen.log")"
+chmod 644 "$FAILOPEN_ROOT/unreadable-runner/.runner"
+
+test -e "$FAILOPEN_ROOT/unreadable-runner/_work/stale-repo" \
+  || fail "unreadable .runner was pruned — the helper cannot prove that runner is idle and must refuse"
+test -e "$FAILOPEN_ROOT/unparseable-runner/_work/stale-repo" \
+  || fail "unparseable .runner (no agentName) was pruned — same fail-open path"
+test ! -e "$FAILOPEN_ROOT/truly-orphaned/_work/stale-repo" \
+  || fail "runner with no .runner at all was NOT pruned — the #15398 orphan case must still work"
+grep -q "skipped_undeterminable=2" "$TMP_DIR/failopen.log" \
+  || fail "sweep did not report skipped_undeterminable=2: $(cat "$TMP_DIR/failopen.log")"
+grep -q "pruned=1" "$TMP_DIR/failopen.log" \
+  || fail "sweep did not prune exactly the one genuine orphan: $(cat "$TMP_DIR/failopen.log")"
+
+# 12. BEHAVIORAL: unit resolution must match the agent name exactly. With a
+#     substring match, agent `runner-1` resolves to unit `...runner-10` first
+#     (list-units order + head -1), so the is-active probe reads the WRONG
+#     runner: an idle runner-10 makes a BUSY runner-1 look prunable.
+COLLIDE_STUB="$TMP_DIR/stub-collide"
+mkdir -p "$COLLIDE_STUB"
+cat > "$COLLIDE_STUB/systemctl" <<'EOF_STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+  list-units)
+    # runner-10 first on purpose: a substring match takes it for `runner-1`.
+    echo "actions.runner.acme-org.runner-10.service loaded active running"
+    echo "actions.runner.acme-org.runner-1.service loaded active running"
+    exit 0 ;;
+  is-active)
+    # Only runner-1 is busy; runner-10 is idle.
+    [[ "${3:-}" == *".runner-1.service" ]] && exit 0
+    exit 3 ;;
+  *) exit 0 ;;
+esac
+EOF_STUB
+chmod +x "$COLLIDE_STUB/systemctl"
+
+COLLIDE_ROOT="$TMP_DIR/collide-root"
+for r in runner-1 runner-10; do
+  mkdir -p "$COLLIDE_ROOT/$r/_work/stale-repo"
+  echo payload > "$COLLIDE_ROOT/$r/_work/stale-repo/file"
+  printf '{"agentName": "%s"}\n' "$r" > "$COLLIDE_ROOT/$r/.runner"
+  node -e '
+    const fs = require("node:fs");
+    const when = new Date(Date.now() - 48 * 3600 * 1000);
+    fs.utimesSync(process.argv[1], when, when);
+  ' "$COLLIDE_ROOT/$r/_work/stale-repo"
+done
+
+PATH="$COLLIDE_STUB:$PATH" \
+RUNNER_WORKSPACE_ROOT="$COLLIDE_ROOT" \
+PRUNE_MIN_AGE_HOURS=6 \
+BUN_BIN="$BUN_BIN" \
+PRUNE_TOOL="$TOOL_SRC" \
+  bash "$SCRIPT_DIR/bin/eliza-prune-idle-runner-workspaces.sh" >"$TMP_DIR/collide.log" 2>&1 \
+  || fail "sweep exited nonzero on the prefix-collision pair: $(cat "$TMP_DIR/collide.log")"
+
+test -e "$COLLIDE_ROOT/runner-1/_work/stale-repo" \
+  || fail "BUSY runner-1 was pruned — its unit resolved to the idle runner-10 by substring match"
+test ! -e "$COLLIDE_ROOT/runner-10/_work/stale-repo" \
+  || fail "idle runner-10 was not pruned"
+
 echo "runner-workspace-cleanup smoke OK (behavioral)"


### PR DESCRIPTION
Closes #17566.

## Summary

The scheduled runner-workspace pruner now deletes only when it can positively establish one of two safe states:

- no runner or service configuration remains, so the directory is orphaned; or
- the exact systemd unit bound to that runner reports `inactive`.

Every ambiguous state fails closed and is counted as `skipped_undeterminable`. This composes with #17535: that merged fix protects GitHub Actions control directories inside `_work`, while this PR prevents an entire live runner workspace from being misclassified as idle.

## Root cause and implementation

The old helper reconstructed a systemd unit by parsing `agentName` from `.runner`, substring-searching `systemctl list-units`, and treating every miss or command failure as an orphan. That approach had three destructive failure modes:

1. a missing, unreadable, or changed `.runner` shape became “no runner”;
2. `runner-1` could resolve to `runner-10`; and
3. a failed `systemctl` query became an empty match and therefore permission to prune.

GitHub’s runner service installer already writes the authoritative generated unit name to `<runner>/.service`. The generated name cannot safely be reconstructed: the runner normalizes spaces and can truncate long names with a random suffix. GitHub’s own troubleshooting documentation recommends reading `.service` to locate the service.

This PR therefore:

- reads and validates the exact `.service` binding instead of guessing from `agentName`;
- skips configured runners with missing, unreadable, or malformed bindings;
- queries that exact unit and prunes only on the literal `inactive` state;
- skips `active`, `failed`, activating/deactivating, unknown, empty, and command-failure states;
- preserves genuine orphan cleanup when neither `.runner` nor `.service` remains; and
- reports active, undeterminable, pruned, and failed counts separately.

Primary references: [GitHub runner service-name generation](https://github.com/actions/runner/blob/main/src/Runner.Listener/Configuration/ServiceControlManager.cs), [systemd service installer](https://github.com/actions/runner/blob/main/src/Misc/layoutbin/systemd.svc.sh.template), and [GitHub’s `.service` guidance](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/monitor-and-troubleshoot).

## Risk

The behavior is asymmetric in the safe direction: uncertainty converts a deletion into retention. A permanently broken binding can consume disk, but the summary exposes `skipped_undeterminable` so operators can repair it. A healthy inactive runner and a configuration-free orphan remain reclaimable.

## Validation

Exact head `115a04ed0fbc43e5bd526fd8fc4878415287b1ad`, rebased directly on merged #17535:

- `bash packages/deploy/runner-workspace-cleanup/smoke-test.sh` — passed against the real prune tool.
- `shellcheck` on the helper and smoke suite — passed.
- `bun run verify` — 581/581 build/typecheck/lint tasks and every repository audit passed.
- Mutation: allowing a configured runner without `.service` to reach the orphan branch fails with `configured runner without .service binding was pruned`.
- Mutation: ignoring the exact binding and selecting `runner-10` fails with `busy runner.1 was pruned instead of using its exact .service binding`.
- Restoring the implementation returns the full smoke suite to green.

The smoke suite also proves #17535’s runner-command-file fixture survives, missing/malformed bindings survive, unknown and failed unit states survive, a dotted active runner is not confused with an idle sibling, and a genuine orphan is reclaimed.

## Evidence

<!-- evidence-head:115a04ed0fbc43e5bd526fd8fc4878415287b1ad -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - host-local shell infrastructure has no rendered user interface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - host-local shell infrastructure has no rendered user interface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no interactive UI flow for this systemd timer helper.
<!-- evidence-row:backend-logs -->
- [x] N/A - the host-local timer does not execute through an application backend service.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or client transport is involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or evaluator behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head smoke, shellcheck, full verify, both red mutations, and restored green run](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17575-pr-17575-runner-state-validation.log)

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code; Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: self-reported

<!-- evidence-refresh:2026-08-02T16:36Z -->

