### PR TITLE
fix(ci): fail fast on unapproved fork workflows

### DIFF
--- a/.github/workflows/security-advisory-gate.yml
+++ b/.github/workflows/security-advisory-gate.yml
@@ -21,6 +21,7 @@ concurrency:
 permissions:
   contents: read
   checks: read
+  actions: read
   pull-requests: read
 
 jobs:

--- a/packages/scripts/develop-pr-aggregate.mjs
+++ b/packages/scripts/develop-pr-aggregate.mjs
@@ -7,6 +7,10 @@
  */
 import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
+import {
+  awaitingApprovalMessage,
+  loadActionRequiredWorkflowPaths,
+} from "./github-actions-approval.mjs";
 
 export const GITHUB_ACTIONS_APP_ID = 15368;
 export const DEFAULT_PULL_REQUEST_ACTIONS = [
@@ -159,12 +163,21 @@ export function evaluateAggregate({
   nowMs,
   deadlineReached = false,
   terminalSettleMs = DEFAULT_TERMINAL_SETTLE_MS,
+  actionRequiredWorkflowPaths = [],
 }) {
   const eventUpdatedMs = parseTimestamp(eventUpdatedAt);
   const freshAfterMs =
     eventUpdatedMs === null ? null : eventUpdatedMs - FRESHNESS_SKEW_MS;
 
   const results = REQUIRED_CHECKS.map((required) => {
+    if (actionRequiredWorkflowPaths.includes(required.workflowPath)) {
+      return failedResult(
+        required,
+        "awaiting-approval",
+        awaitingApprovalMessage([required.workflowPath]),
+      );
+    }
+
     const candidates = checkRuns.filter(
       (run) =>
         run.name === required.context &&
@@ -549,6 +562,11 @@ async function runProduction(env) {
       token: env.GITHUB_TOKEN,
       workflowRunCache,
     });
+    const actionRequiredWorkflowPaths = await loadActionRequiredWorkflowPaths({
+      repository: env.GITHUB_REPOSITORY,
+      headSha: env.HEAD_SHA,
+      requestJson: (url) => requestJson(url, env.GITHUB_TOKEN),
+    });
     const deadlineReached = nowMs >= deadlineMs;
     const evaluation = evaluateAggregate({
       checkRuns,
@@ -557,6 +575,7 @@ async function runProduction(env) {
       eventUpdatedAt: env.PR_UPDATED_AT,
       nowMs,
       deadlineReached,
+      actionRequiredWorkflowPaths,
     });
     const summary = renderSummary(evaluation, {
       headSha: env.HEAD_SHA,

--- a/packages/scripts/develop-pr-aggregate.self-test.mjs
+++ b/packages/scripts/develop-pr-aggregate.self-test.mjs
@@ -22,6 +22,11 @@ import {
   TRUSTED_BASE_REF_LINE,
   validateAggregateWorkflow,
 } from "./develop-pr-aggregate-workflow-contract.mjs";
+import {
+  actionRequiredWorkflowPaths,
+  awaitingApprovalMessage,
+  loadActionRequiredWorkflowPaths,
+} from "./github-actions-approval.mjs";
 
 const NOW_MS = Date.parse("2026-07-14T01:00:00Z");
 const HEAD_SHA = "a".repeat(40);
@@ -73,6 +78,104 @@ const pendingAtDeadline = evaluate(
 );
 assert.equal(pendingAtDeadline.verdict, "failure");
 assert.equal(resultFor(pendingAtDeadline, "gitleaks").code, "pending-timeout");
+
+const heldWorkflowPath = ".github/workflows/gitleaks.yml";
+const heldBeforeDeadline = evaluate(buildCanaryCheckRuns("missing", NOW_MS), {
+  actionRequiredWorkflowPaths: [heldWorkflowPath],
+});
+assert.equal(heldBeforeDeadline.verdict, "failure");
+assert.equal(
+  resultFor(heldBeforeDeadline, "gitleaks").code,
+  "awaiting-approval",
+);
+assert.match(
+  resultFor(heldBeforeDeadline, "gitleaks").detail,
+  /required workflows awaiting maintainer approval: \.github\/workflows\/gitleaks\.yml/,
+);
+
+assert.deepEqual(
+  actionRequiredWorkflowPaths(
+    [
+      {
+        id: 10,
+        path: heldWorkflowPath,
+        event: "pull_request",
+        head_sha: HEAD_SHA,
+        status: "completed",
+        conclusion: "action_required",
+      },
+      {
+        id: 11,
+        path: ".github/workflows/wrong-head.yml",
+        event: "pull_request",
+        head_sha: "b".repeat(40),
+        conclusion: "action_required",
+      },
+      {
+        id: 12,
+        path: ".github/workflows/wrong-event.yml",
+        event: "workflow_dispatch",
+        head_sha: HEAD_SHA,
+        conclusion: "action_required",
+      },
+    ],
+    HEAD_SHA,
+  ),
+  [heldWorkflowPath],
+);
+
+assert.deepEqual(
+  actionRequiredWorkflowPaths(
+    [
+      {
+        id: 20,
+        path: heldWorkflowPath,
+        event: "pull_request",
+        head_sha: HEAD_SHA,
+        conclusion: "action_required",
+      },
+      {
+        id: 21,
+        path: heldWorkflowPath,
+        event: "pull_request",
+        head_sha: HEAD_SHA,
+        status: "completed",
+        conclusion: "success",
+      },
+    ],
+    HEAD_SHA,
+  ),
+  [],
+);
+assert.equal(
+  awaitingApprovalMessage([heldWorkflowPath]),
+  `required workflows awaiting maintainer approval: ${heldWorkflowPath}`,
+);
+
+const approvalPages = [];
+const pagedHeldPaths = await loadActionRequiredWorkflowPaths({
+  repository: "elizaOS/eliza",
+  headSha: HEAD_SHA,
+  requestJson: async (url) => {
+    approvalPages.push(url);
+    return {
+      workflow_runs:
+        approvalPages.length === 1
+          ? [
+              {
+                id: 30,
+                path: heldWorkflowPath,
+                event: "pull_request",
+                head_sha: HEAD_SHA,
+                conclusion: "action_required",
+              },
+            ]
+          : [],
+    };
+  },
+});
+assert.deepEqual(pagedHeldPaths, [heldWorkflowPath]);
+assert.equal(approvalPages.length, 1);
 
 for (const [scenario, code] of [
   ["cancelled", "terminal-cancelled"],

--- a/packages/scripts/develop-pr-aggregate.self-test.mjs
+++ b/packages/scripts/develop-pr-aggregate.self-test.mjs
@@ -185,6 +185,38 @@ assert.equal(approvalPages.length, 2);
 assert.match(approvalPages[0], /[?&]page=1$/);
 assert.match(approvalPages[1], /[?&]page=2$/);
 
+for (const [label, payload] of [
+  ["non-object payload", null],
+  ["missing workflow_runs", {}],
+  ["null workflow_runs", { workflow_runs: null }],
+  ["non-array workflow_runs", { workflow_runs: {} }],
+]) {
+  await assert.rejects(
+    loadActionRequiredWorkflowPaths({
+      repository: "elizaOS/eliza",
+      headSha: HEAD_SHA,
+      requestJson: async () => payload,
+    }),
+    (error) => {
+      assert.match(
+        error.message,
+        /invalid GitHub Actions workflow-runs response/,
+      );
+      assert.match(error.message, /page 1/);
+      assert.match(
+        error.message,
+        /https:\/\/api\.github\.com\/repos\/elizaOS\/eliza\/actions\/runs/,
+      );
+      assert.match(
+        error.message,
+        /expected an object with a workflow_runs array/,
+      );
+      return true;
+    },
+    label,
+  );
+}
+
 for (const [scenario, code] of [
   ["cancelled", "terminal-cancelled"],
   ["timed-out", "terminal-timed_out"],

--- a/packages/scripts/develop-pr-aggregate.self-test.mjs
+++ b/packages/scripts/develop-pr-aggregate.self-test.mjs
@@ -90,7 +90,7 @@ assert.equal(
 );
 assert.match(
   resultFor(heldBeforeDeadline, "gitleaks").detail,
-  /required workflows awaiting maintainer approval: \.github\/workflows\/gitleaks\.yml/,
+  /required workflows awaiting maintainer approval: \.github\/workflows\/gitleaks\.yml; approve the listed workflows, then rerun this gate/,
 );
 
 assert.deepEqual(
@@ -149,7 +149,7 @@ assert.deepEqual(
 );
 assert.equal(
   awaitingApprovalMessage([heldWorkflowPath]),
-  `required workflows awaiting maintainer approval: ${heldWorkflowPath}`,
+  `required workflows awaiting maintainer approval: ${heldWorkflowPath}; approve the listed workflows, then rerun this gate`,
 );
 
 const approvalPages = [];
@@ -161,21 +161,29 @@ const pagedHeldPaths = await loadActionRequiredWorkflowPaths({
     return {
       workflow_runs:
         approvalPages.length === 1
-          ? [
+          ? Array.from({ length: 100 }, (_, index) => ({
+              id: 30 + index,
+              path: `.github/workflows/completed-${index}.yml`,
+              event: "pull_request",
+              head_sha: HEAD_SHA,
+              conclusion: "success",
+            }))
+          : [
               {
-                id: 30,
+                id: 130,
                 path: heldWorkflowPath,
                 event: "pull_request",
                 head_sha: HEAD_SHA,
                 conclusion: "action_required",
               },
-            ]
-          : [],
+            ],
     };
   },
 });
 assert.deepEqual(pagedHeldPaths, [heldWorkflowPath]);
-assert.equal(approvalPages.length, 1);
+assert.equal(approvalPages.length, 2);
+assert.match(approvalPages[0], /[?&]page=1$/);
+assert.match(approvalPages[1], /[?&]page=2$/);
 
 for (const [scenario, code] of [
   ["cancelled", "terminal-cancelled"],

--- a/packages/scripts/github-actions-approval.mjs
+++ b/packages/scripts/github-actions-approval.mjs
@@ -1,12 +1,27 @@
 /**
  * Resolves fork workflows that GitHub has held for maintainer approval. Both
  * base-trusted aggregate gates consume this exact-head view before deciding
- * whether absent check runs are genuinely pending.
+ * whether absent check runs are genuinely pending. Malformed API pages fail
+ * before an adapter error can be mistaken for an empty workflow inventory.
  */
 
 const ACTION_REQUIRED = "action_required";
 const PAGE_SIZE = 100;
 const MAX_PAGES = 10;
+
+function workflowRunsFromPage(payload, page, url) {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    Array.isArray(payload) ||
+    !Array.isArray(payload.workflow_runs)
+  ) {
+    throw new Error(
+      `invalid GitHub Actions workflow-runs response at page ${page} (${url}): expected an object with a workflow_runs array`,
+    );
+  }
+  return payload.workflow_runs;
+}
 
 export function actionRequiredWorkflowPaths(workflowRuns, headSha) {
   const newestByPath = new Map();
@@ -49,9 +64,7 @@ export async function loadActionRequiredWorkflowPaths({
       `?event=pull_request&head_sha=${encodeURIComponent(headSha)}` +
       `&per_page=${PAGE_SIZE}&page=${page}`;
     const payload = await requestJson(url);
-    const pageRuns = Array.isArray(payload.workflow_runs)
-      ? payload.workflow_runs
-      : [];
+    const pageRuns = workflowRunsFromPage(payload, page, url);
     workflowRuns.push(...pageRuns);
     if (pageRuns.length < PAGE_SIZE) break;
   }

--- a/packages/scripts/github-actions-approval.mjs
+++ b/packages/scripts/github-actions-approval.mjs
@@ -60,5 +60,8 @@ export async function loadActionRequiredWorkflowPaths({
 }
 
 export function awaitingApprovalMessage(paths) {
-  return `required workflows awaiting maintainer approval: ${[...paths].sort().join(", ")}`;
+  return (
+    `required workflows awaiting maintainer approval: ${[...paths].sort().join(", ")}; ` +
+    "approve the listed workflows, then rerun this gate"
+  );
 }

--- a/packages/scripts/github-actions-approval.mjs
+++ b/packages/scripts/github-actions-approval.mjs
@@ -1,0 +1,64 @@
+/**
+ * Resolves fork workflows that GitHub has held for maintainer approval. Both
+ * base-trusted aggregate gates consume this exact-head view before deciding
+ * whether absent check runs are genuinely pending.
+ */
+
+const ACTION_REQUIRED = "action_required";
+const PAGE_SIZE = 100;
+const MAX_PAGES = 10;
+
+export function actionRequiredWorkflowPaths(workflowRuns, headSha) {
+  const newestByPath = new Map();
+
+  for (const run of workflowRuns) {
+    if (
+      run.head_sha !== headSha ||
+      run.event !== "pull_request" ||
+      typeof run.path !== "string" ||
+      run.path.length === 0
+    ) {
+      continue;
+    }
+
+    const existing = newestByPath.get(run.path);
+    if (existing === undefined || Number(run.id) > Number(existing.id)) {
+      newestByPath.set(run.path, run);
+    }
+  }
+
+  return [...newestByPath.values()]
+    .filter(
+      (run) =>
+        run.conclusion === ACTION_REQUIRED || run.status === ACTION_REQUIRED,
+    )
+    .map((run) => run.path)
+    .sort();
+}
+
+export async function loadActionRequiredWorkflowPaths({
+  repository,
+  headSha,
+  requestJson,
+}) {
+  const workflowRuns = [];
+
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const url =
+      `https://api.github.com/repos/${repository}/actions/runs` +
+      `?event=pull_request&head_sha=${encodeURIComponent(headSha)}` +
+      `&per_page=${PAGE_SIZE}&page=${page}`;
+    const payload = await requestJson(url);
+    const pageRuns = Array.isArray(payload.workflow_runs)
+      ? payload.workflow_runs
+      : [];
+    workflowRuns.push(...pageRuns);
+    if (pageRuns.length < PAGE_SIZE) break;
+  }
+
+  return actionRequiredWorkflowPaths(workflowRuns, headSha);
+}
+
+export function awaitingApprovalMessage(paths) {
+  return `required workflows awaiting maintainer approval: ${[...paths].sort().join(", ")}`;
+}

--- a/scripts/security/security-advisory-gate.mjs
+++ b/scripts/security/security-advisory-gate.mjs
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+import {
+  awaitingApprovalMessage,
+  loadActionRequiredWorkflowPaths,
+} from "../../packages/scripts/github-actions-approval.mjs";
+
 const LABELS = new Set([
   "security",
   "security issue",
@@ -15,6 +20,7 @@ const PATHS = [
   /(^|\/)(contracts?|migrations)(\/|$)/i,
 ];
 const REQUIRED_CHECKS = ["gitleaks"];
+const REQUIRED_WORKFLOW_PATHS = [".github/workflows/gitleaks.yml"];
 const SUCCESS = new Set(["success"]);
 const TERMINAL = new Set([
   "success",
@@ -116,6 +122,7 @@ function requiredChecksCompletedBy(checks, deadline) {
 
 export async function waitForRequiredChecks({
   loadChecks,
+  loadActionRequiredPaths = async () => [],
   timeoutMs,
   completionGraceMs,
   intervalMs,
@@ -128,6 +135,14 @@ export async function waitForRequiredChecks({
   let completionGraceUsed = false;
 
   for (;;) {
+    const actionRequiredPaths = await loadActionRequiredPaths();
+    const heldRequiredPaths = REQUIRED_WORKFLOW_PATHS.filter((path) =>
+      actionRequiredPaths.includes(path),
+    );
+    if (heldRequiredPaths.length > 0) {
+      throw new Error(awaitingApprovalMessage(heldRequiredPaths));
+    }
+
     const checks = await loadChecks();
     const state = evaluate(checks);
     if (state.failed.length) {
@@ -233,6 +248,15 @@ async function live() {
       }
       return checkRuns;
     },
+    loadActionRequiredPaths: () =>
+      loadActionRequiredWorkflowPaths({
+        repository: `${owner}/${repo}`,
+        headSha: pull.head.sha,
+        requestJson: (url) => {
+          const parsed = new URL(url);
+          return api(`${parsed.pathname}${parsed.search}`, token);
+        },
+      }),
   });
   console.log("deterministic security checks completed successfully");
 }

--- a/scripts/security/security-advisory-gate.test.mjs
+++ b/scripts/security/security-advisory-gate.test.mjs
@@ -181,6 +181,33 @@ describe("delayed fork-workflow approval", () => {
     });
   });
 
+  it("fails immediately with the held workflow path when approval is required", async () => {
+    const clock = fakeClock();
+    let checkLoads = 0;
+    let sleeps = 0;
+
+    await assert.rejects(
+      waitForRequiredChecks({
+        loadChecks: async () => {
+          checkLoads += 1;
+          return [];
+        },
+        loadActionRequiredPaths: async () => [".github/workflows/gitleaks.yml"],
+        timeoutMs: 1_200_000,
+        completionGraceMs: 240_000,
+        intervalMs: 30_000,
+        now: clock.now,
+        sleep: async () => {
+          sleeps += 1;
+        },
+      }),
+      /required workflows awaiting maintainer approval: \.github\/workflows\/gitleaks\.yml/,
+    );
+
+    assert.equal(checkLoads, 0);
+    assert.equal(sleeps, 0);
+  });
+
   it("does not extend the deadline for a missing or unapproved check", async () => {
     const clock = fakeClock();
     await assert.rejects(

--- a/scripts/security/security-advisory-gate.test.mjs
+++ b/scripts/security/security-advisory-gate.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 import {
   canary,
@@ -6,6 +7,29 @@ import {
   evaluate,
   waitForRequiredChecks,
 } from "./security-advisory-gate.mjs";
+
+describe("base-trusted workflow contract", () => {
+  it("grants the read-only Actions authority required by the production query", () => {
+    const workflow = readFileSync(
+      new URL(
+        "../../.github/workflows/security-advisory-gate.yml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const permissions = workflow.match(
+      /^permissions:\r?\n((?:^ {2}[a-z-]+: [^\r\n]+\r?\n)+)/m,
+    )?.[1];
+
+    assert(permissions, "workflow must declare an explicit permissions block");
+    assert.match(permissions, /^ {2}actions: read$/m);
+    assert.doesNotMatch(permissions, /:\s*write\s*$/m);
+    assert.match(
+      workflow,
+      /ref: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.sha \}\}/,
+    );
+  });
+});
 
 describe("security advisory classification", () => {
   it("protects a sensitive previous_filename on rename", () => {
@@ -201,7 +225,7 @@ describe("delayed fork-workflow approval", () => {
           sleeps += 1;
         },
       }),
-      /required workflows awaiting maintainer approval: \.github\/workflows\/gitleaks\.yml/,
+      /required workflows awaiting maintainer approval: \.github\/workflows\/gitleaks\.yml; approve the listed workflows, then rerun this gate/,
     );
 
     assert.equal(checkLoads, 0);


### PR DESCRIPTION
# Relates to

Closes #17551

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] The focused Node tests and Biome checks were run after sync; the unavailable
      repository Bun toolchain and full verification gap are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      deterministic tests and live exact-head workflow-run evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@f1f47e73f`; zero conflicts.
- [ ] `bun run verify` was not available; the exact toolchain blocker and focused
      replacement checks are documented in **Known gaps / failures** below.

# Risks

Low. The change adds one read-only GitHub Actions API query per polling cycle.
It only changes a gate outcome when the newest exact-head `pull_request`
workflow run for a required workflow path is explicitly `action_required`.

# Background

## What does this PR do?

- Loads exact-head `pull_request` workflow-run metadata for both aggregate gates.
- Detects required workflow paths held at GitHub's `action_required` state.
- Fails immediately with an explicit `awaiting-approval` result instead of
  polling until timeout.
- Tells maintainers to approve the listed workflows and rerun the failed gate.
- Grants the base-trusted security gate the read-only `actions: read`
  permission its workflow-run query requires, with a workflow contract test.
- Preserves the existing bounded completion grace once an approved check starts.
- Ignores other heads/events and lets a newer approved run supersede an older
  held run for the same workflow path.
- Exercises real two-page workflow-run pagination.
- Rejects non-object pages and missing, null, or non-array `workflow_runs`
  fields with an error containing the page number and request URL.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing documentation change is needed. The behavior and failure message
are covered by deterministic self-tests.

# Testing

## Where should a reviewer start?

1. `packages/scripts/github-actions-approval.mjs`
2. `packages/scripts/develop-pr-aggregate.mjs`
3. `scripts/security/security-advisory-gate.mjs`

## Detailed testing steps

```text
Node 24 packages/scripts/develop-pr-aggregate.self-test.mjs
=> develop-pr aggregate self-test passed
=> malformed response coverage: non-object, missing, null, and non-array

Node 24 --test scripts/security/security-advisory-gate.test.mjs
=> tests 17, pass 17, fail 0
=> includes the base-trusted workflow permission contract

Biome check on the five changed files
=> Checked 5 files; no errors (8 pre-existing warnings in security-advisory-gate.mjs)

git diff --check
=> passed
```

# Evidence Gate

<!-- evidence-head:079e3aa73ed74e1540fc871ce83df6c538215980 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CI/backend-only change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CI/backend-only change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - there is no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no deployed backend service changed; focused CI
      script output is recorded in Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no database, wallet, generated-file, or other
      domain state is produced by this CI gate change.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

Against the exact head of PR #17577
(`079e3aa73ed74e1540fc871ce83df6c538215980`), the new helper returned:

```text
.github/workflows/android-device-e2e.yml
.github/workflows/certification-verify.yml
.github/workflows/claude-code-review.yml
.github/workflows/claude-security-review.yml
.github/workflows/develop-pr.yml
.github/workflows/feed-env-audit.yml
.github/workflows/gitleaks.yml
.github/workflows/pr.yaml
.github/workflows/quality-fork.yml
.github/workflows/stale-base-guard.yml
```

All listed runs were exact-head `pull_request` runs whose newest workflow-path
run was `completed/action_required`. This includes the required
`.github/workflows/develop-pr.yml` and `.github/workflows/gitleaks.yml` paths.

Frontend logs: N/A - no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - CI/backend-only change.

## Audio / voice walkthrough

N/A - no audio, voice, TTS, or STT change.

## Known gaps / failures

- The repository-required Bun 1.4.0 toolchain is not installed in this Windows
  contributor workspace (`bun` is not on PATH), so `bun install` and the broad
  `bun run verify` command were not run.
- This is not a functional blocker for these pure Node `.mjs` changes: the exact
  Node 24 runtime was used for both focused test suites, all 17 security tests
  passed, the aggregate self-test passed, Biome passed on all changed files, and
  the helper was exercised against live GitHub workflow-run metadata.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [m7mdd77-codex-fork-approval]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->

