### PR TITLE
fix(agent): surface connector discovery failure instead of dashboard fallback

### DIFF
--- a/packages/agent/src/services/client-chat-sender.test.ts
+++ b/packages/agent/src/services/client-chat-sender.test.ts
@@ -344,3 +344,67 @@ describe("registerClientChatSendHandler — cross-conversation safety", () => {
     expect(broadcastWs).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("registerClientChatSendHandler — connector discovery failure is observable", () => {
+  it("surfaces a missing connector-discovery API instead of falling back to the dashboard", async () => {
+    // A runtime whose registry is broken: getMessageConnectors is absent, so
+    // the fallback cannot prove whether `my_custom_source` is a registered
+    // connector. Falling back would hijack a possibly-registered connector's
+    // delivery; the failure must surface instead.
+    const { runtime, created } = makeRuntime();
+    delete (runtime as { getMessageConnectors?: unknown }).getMessageConnectors;
+    const { state, broadcastWs } = makeState([conv("c1", "room-1")]);
+    registerClientChatSendHandler(runtime as unknown as IAgentRuntime, state);
+
+    await expect(
+      runtime.sendMessageToTarget(
+        { source: "my_custom_source", roomId: "room-1" as UUID },
+        { text: "relayed result" },
+      ),
+    ).rejects.toThrow(/connector discovery unavailable/);
+
+    // Nothing was delivered to the dashboard, and no WS event fired: a broken
+    // registry must not look like a healthy unregistered source.
+    expect(created).toHaveLength(0);
+    expect(broadcastWs).not.toHaveBeenCalled();
+  });
+
+  it("propagates a throwing connector-discovery API instead of rerouting to the dashboard", async () => {
+    const { runtime, created } = makeRuntime();
+    (runtime as { getMessageConnectors?: unknown }).getMessageConnectors =
+      () => {
+        throw new Error("registry exploded");
+      };
+    const { state, broadcastWs } = makeState([conv("c1", "room-1")]);
+    registerClientChatSendHandler(runtime as unknown as IAgentRuntime, state);
+
+    await expect(
+      runtime.sendMessageToTarget(
+        { source: "my_custom_source", roomId: "room-1" as UUID },
+        { text: "relayed result" },
+      ),
+    ).rejects.toThrow(/registry exploded/);
+
+    expect(created).toHaveLength(0);
+    expect(broadcastWs).not.toHaveBeenCalled();
+  });
+
+  it("still delivers explicit dashboard relay sources when discovery is broken", async () => {
+    // The relay seam (registerInternalSendHandler) is independent of connector
+    // discovery: client_chat must remain addressable even when the registry is
+    // broken, per the first acceptance criterion.
+    const { runtime, created } = makeRuntime();
+    delete (runtime as { getMessageConnectors?: unknown }).getMessageConnectors;
+    const { state, broadcastWs } = makeState([conv("c1", "room-1")]);
+    registerClientChatSendHandler(runtime as unknown as IAgentRuntime, state);
+
+    await runtime.sendMessageToTarget(
+      { source: "client_chat", roomId: "room-1" as UUID },
+      { text: "relayed result" },
+    );
+
+    expect(created).toHaveLength(1);
+    expect(created[0]?.roomId).toBe("room-1");
+    expect(broadcastWs).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent/src/services/client-chat-sender.test.ts
+++ b/packages/agent/src/services/client-chat-sender.test.ts
@@ -347,24 +347,23 @@ describe("registerClientChatSendHandler — cross-conversation safety", () => {
 
 describe("registerClientChatSendHandler — connector discovery failure is observable", () => {
   it("surfaces a missing connector-discovery API instead of falling back to the dashboard", async () => {
-    // A runtime whose registry is broken: getMessageConnectors is absent, so
-    // the fallback cannot prove whether `my_custom_source` is a registered
-    // connector. Falling back would hijack a possibly-registered connector's
-    // delivery; the failure must surface instead.
     const { runtime, created } = makeRuntime();
     delete (runtime as { getMessageConnectors?: unknown }).getMessageConnectors;
     const { state, broadcastWs } = makeState([conv("c1", "room-1")]);
     registerClientChatSendHandler(runtime as unknown as IAgentRuntime, state);
 
-    await expect(
-      runtime.sendMessageToTarget(
-        { source: "my_custom_source", roomId: "room-1" as UUID },
-        { text: "relayed result" },
-      ),
-    ).rejects.toThrow(/connector discovery unavailable/);
+    const result = runtime.sendMessageToTarget(
+      { source: "my_custom_source", roomId: "room-1" as UUID },
+      { text: "relayed result" },
+    );
+    await expect(result).rejects.toMatchObject({
+      name: "ElizaError",
+      message: expect.stringMatching(/connector discovery unavailable/),
+      code: "CONNECTOR_DISCOVERY_UNAVAILABLE",
+      context: { source: "my_custom_source" },
+      severity: "fatal",
+    });
 
-    // Nothing was delivered to the dashboard, and no WS event fired: a broken
-    // registry must not look like a healthy unregistered source.
     expect(created).toHaveLength(0);
     expect(broadcastWs).not.toHaveBeenCalled();
   });

--- a/packages/agent/src/services/client-chat-sender.ts
+++ b/packages/agent/src/services/client-chat-sender.ts
@@ -219,7 +219,16 @@ function installDashboardFallbackSend(
 
   const originalSend = runtime.sendMessageToTarget.bind(runtime);
   const hasRegisteredHandler = (source: string): boolean => {
-    if (typeof runtime.getMessageConnectors !== "function") return false;
+    if (typeof runtime.getMessageConnectors !== "function") {
+      // Connector discovery is unavailable: we cannot tell whether `source` is
+      // a registered connector. Treating it as unregistered and falling back
+      // to the dashboard would hijack delivery for a connector we cannot see —
+      // a broken registry looks like a healthy unregistered source and delivery
+      // is rerouted to the dashboard. Surface the failure instead of guessing.
+      throw new Error(
+        `connector discovery unavailable; refusing dashboard fallback for source: ${source}`,
+      );
+    }
     return runtime
       .getMessageConnectors()
       .some((connector) => connector.source === source);

--- a/packages/agent/src/services/client-chat-sender.ts
+++ b/packages/agent/src/services/client-chat-sender.ts
@@ -12,6 +12,7 @@ import crypto from "node:crypto";
 import {
   type Content,
   createMessageMemory,
+  ElizaError,
   type IAgentRuntime,
   MESSAGE_SOURCE_CLIENT_CHAT,
   type Memory,
@@ -220,13 +221,15 @@ function installDashboardFallbackSend(
   const originalSend = runtime.sendMessageToTarget.bind(runtime);
   const hasRegisteredHandler = (source: string): boolean => {
     if (typeof runtime.getMessageConnectors !== "function") {
-      // Connector discovery is unavailable: we cannot tell whether `source` is
-      // a registered connector. Treating it as unregistered and falling back
-      // to the dashboard would hijack delivery for a connector we cannot see —
-      // a broken registry looks like a healthy unregistered source and delivery
-      // is rerouted to the dashboard. Surface the failure instead of guessing.
-      throw new Error(
+      // Failing closed preserves transport ownership when a runtime violates
+      // the connector-discovery contract.
+      throw new ElizaError(
         `connector discovery unavailable; refusing dashboard fallback for source: ${source}`,
+        {
+          code: "CONNECTOR_DISCOVERY_UNAVAILABLE",
+          context: { source },
+          severity: "fatal",
+        },
       );
     }
     return runtime


### PR DESCRIPTION
Relates to #17035.

## Summary

The dashboard fallback now refuses to claim transport ownership when connector
discovery is unavailable. A runtime contract violation surfaces as a structured
`ElizaError` instead of being translated into “no connector registered” and
silently rerouted into an unrelated dashboard conversation.

Explicit internal relay sources (`client_chat`, `agent_message_api`,
`compat_openai`, and `compat_anthropic`) remain independent of connector
discovery and continue through their registered internal send handlers.

## Root cause and implementation

`installDashboardFallbackSend` distinguishes an unknown dashboard-origin source
from a source owned by a connector. Its guard previously returned `false` when
the required `runtime.getMessageConnectors` method was absent. That answer is
indistinguishable from a healthy registry that contains no matching connector,
so the wrapper persisted and broadcast the message through the dashboard.

The guard now throws `ElizaError` with:

- code `CONNECTOR_DISCOVERY_UNAVAILABLE`;
- the affected source in `context`;
- fatal severity, because the runtime no longer satisfies its required
  transport contract.

A connector-discovery implementation that throws still propagates its original
failure. Neither failure path persists a dashboard message or emits its WS
event.

## Scope

This PR satisfies the connector-discovery failure-observability criterion of
#17035. It does not claim to close that issue: its broader exact-head live-model,
database, SSE/WS, and client-recording acceptance items remain open and should
be verified on the successful delivery paths separately.

## Validation

Exact head `3b425294449624eddf9b886611703def8fd05097`, rebased on
`origin/develop` at `1d722d2e6ed38fbb2ae2fed67f17a1d7bfd096dc`:

- three related transport suites: 45/45 tests passed;
- focused sender suite: 13/13 tests passed;
- Biome on both changed files: passed;
- `bun run verify`: 581/581 Turbo tasks and every repository audit passed;
- mutation restoring the old `return false` behavior: the regression test fails
  because the promise resolves with a persisted dashboard message;
- restored exact head: the focused suite returns to 13/13 green.

## Evidence

<!-- evidence-head:3b425294449624eddf9b886611703def8fd05097 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side transport guard with no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side transport guard with no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changes.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head focused tests, full verify, red mutation, and restored green run](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17580-exact-head-validation-3b425.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changes; the regression asserts that no dashboard WS event is emitted.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the failure occurs at the transport ownership guard; no model, prompt, provider, action, or evaluator changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the required result is absence of a fabricated dashboard memory; the focused test asserts zero persistence.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `custom/ds-deepseek-v4-pro-max`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Hermes; Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: self-reported
