### PR TITLE
test(agent): exclude view LLM evaluation test from standard vitest co…

### DIFF
--- a/packages/agent/src/__tests__/view-llm-eval.live.test.ts
+++ b/packages/agent/src/__tests__/view-llm-eval.live.test.ts
@@ -12,11 +12,10 @@
  * Override the model via VIEW_EVAL_MODEL env var.
  *
  * Running the full suite:
- *   CEREBRAS_API_KEY=... bun test packages/agent/src/__tests__/view-llm-eval.test.ts
+ *   CEREBRAS_API_KEY=... bun test packages/agent/src/__tests__/view-llm-eval.live.test.ts
  *
  * This test file is excluded from the standard CI run by the vitest config's
- * `exclude` patterns (*.live.test.ts, *.real.test.ts). Rename with those
- * suffixes to exclude from CI, or run directly when credentials are available.
+ * `exclude` patterns (*.live.test.ts, *.real.test.ts).
  */
 
 import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/core";

--- a/packages/agent/src/__tests__/view-user-journeys.ts
+++ b/packages/agent/src/__tests__/view-user-journeys.ts
@@ -4,7 +4,7 @@
  * A curated collection of realistic user intents for the views system.
  * These scenarios are used for:
  *   1. Manual exploratory testing against a running agent.
- *   2. LLM-in-the-loop automated evaluation (see view-llm-eval.test.ts).
+ *   2. LLM-in-the-loop automated evaluation (see view-llm-eval.live.test.ts).
  *   3. Documentation of expected agent behaviors.
  *
  * Each entry is self-contained: it describes the user message, the expected


### PR DESCRIPTION
# Relates to

- Fixes #17537

# Definition of Done

- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.

# Description

Renames `packages/agent/src/__tests__/view-llm-eval.test.ts` to `packages/agent/src/__tests__/view-llm-eval.live.test.ts` to align with Vitest's live-test exclusion pattern (`*.live.test.ts`).

- Prevents live LLM judge test suite from being incorrectly collected during standard Vitest CI runs.
- Updates header comments and documentation references in `view-user-journeys.ts`.

# Evidence Gate

| Evidence Category | Required | Provided | Details |
| --- | --- | --- | --- |
| Rebased on latest `origin/develop`, zero conflicts | yes | yes | Clean branch off `develop` |
| `bun install` + `bun run verify` post-sync | yes | yes | Clean rename and documentation update |
| Backend logs | N/A | N/A - test configuration only | N/A |
| Frontend logs | N/A | N/A - no user-facing UI | N/A |
| Screenshots / video | N/A | N/A - no user-facing UI | N/A |
| Real-LLM trajectory | N/A | N/A - test file naming convention | N/A |
| Domain artifact | yes | yes | Renamed file matches `*.live.test.ts` exclusion pattern |
| Native / platform capture | N/A | N/A | N/A |
| Manual review | yes | yes | Verified file structure and imports |

evidence-head: a31ff40f

<!-- eliza.army attribution -->
This pull request was prepared with assist from the eliza.army contributor network.