### PR TITLE
ci(evidence): document the pasted-transcript path the gate accepts

### DIFF
--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -382,6 +382,56 @@ export function hasInlineTranscriptEvidence(text) {
   });
 }
 
+/**
+ * Explain a pasted transcript that just missed the floor.
+ *
+ * A row holding a real code block is a different author mistake from an empty
+ * one: they followed CONTRIBUTING.md § Evidence and landed under a threshold.
+ * Reporting a bare `blank` there sends them to upload an artifact instead of
+ * pasting four more lines. Returns null when no block is present, so a genuinely
+ * empty row keeps its plain `blank`.
+ */
+export function describeInlineTranscriptShortfall(text) {
+  const source = String(text ?? "");
+  const blocks = [
+    ...source.matchAll(/<details[\s\S]*?<\/details>/gi),
+    ...source.matchAll(/<pre[\s\S]*?<\/pre>/gi),
+    ...source.matchAll(/```[\s\S]*?```/g),
+  ].map((match) => match[0]);
+  if (blocks.length === 0) return null;
+
+  let best = null;
+  for (const block of blocks) {
+    const content = block
+      .replace(/<summary[\s\S]*?<\/summary>/gi, " ")
+      .replace(/<[^>]*>/g, " ")
+      .replace(/```/g, " ");
+    if (NON_REAL_EVIDENCE_RE.test(content)) continue;
+    const lines = content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    const chars = lines.join("").length;
+    // Report the closest attempt rather than the first.
+    if (best === null || lines.length + chars > best.lines + best.chars) {
+      best = { lines: lines.length, chars };
+    }
+  }
+  if (best === null) return null;
+
+  const missed = [];
+  if (best.lines < INLINE_TRANSCRIPT_MIN_LINES) {
+    missed.push(`${best.lines} line(s), needs ${INLINE_TRANSCRIPT_MIN_LINES}`);
+  }
+  if (best.chars < INLINE_TRANSCRIPT_MIN_CHARS) {
+    missed.push(
+      `${best.chars} character(s), needs ${INLINE_TRANSCRIPT_MIN_CHARS}`,
+    );
+  }
+  if (missed.length === 0) return null;
+  return `pasted transcript is under the floor (${missed.join("; ")})`;
+}
+
 function substantiveTrajectoryValue(value, minimumLength) {
   const serialized =
     typeof value === "string" ? value.trim() : JSON.stringify(value);
@@ -709,14 +759,13 @@ export function evaluatePrEvidence(
     ) {
       return { id, label, status: "artifact-required" };
     }
-    return {
-      id,
-      label,
-      status:
-        artifactRequired || isEvidenceRowSatisfied(id, rowText)
-          ? "ok"
-          : "blank",
-    };
+    if (artifactRequired || isEvidenceRowSatisfied(id, rowText)) {
+      return { id, label, status: "ok" };
+    }
+    const shortfall = describeInlineTranscriptShortfall(rowText);
+    return shortfall
+      ? { id, label, status: "blank", detail: shortfall }
+      : { id, label, status: "blank" };
   });
   if (surfaceArtifactsRequired) {
     const { id, label } = SURFACE_OCR_EVIDENCE_ROW;
@@ -2323,6 +2372,83 @@ export function runSelfTest() {
     if (blank?.status !== "blank") {
       failures.push("blank row should be reported blank");
     }
+    if (blank?.detail) {
+      failures.push("an empty row must not claim a transcript shortfall");
+    }
+  }
+
+  {
+    // Pins the documented forms to the implemented ones: the failure help
+    // advertises a pasted transcript, so a compliant one must satisfy the gate.
+    // Without this, the help and `hasInlineTranscriptEvidence` can drift apart
+    // and outside contributors — who cannot upload release assets — are told
+    // their only options are a link or `N/A`.
+    const transcript = [
+      "- [x] Backend logs:",
+      "```",
+      "[develop-pr-gate] poll 1: passed=0 waiting=3 failed=0",
+      "[develop-pr-gate] poll 2: passed=2 waiting=1 failed=0",
+      "[develop-pr-gate] poll 3: passed=3 waiting=0 failed=0",
+      "[develop-pr-gate] all required checks green after 92s",
+      "```",
+    ].join("\n");
+    const { ok, findings } = evaluatePrEvidence(
+      buildFixtureBody({ "backend-logs": transcript }),
+    );
+    const row = findings.find((finding) => finding.id === "backend-logs");
+    if (!ok || row?.status !== "ok") {
+      failures.push(
+        "a pasted transcript meeting the documented floor should satisfy the gate",
+      );
+    }
+  }
+
+  {
+    // The help tells authors to prefer <details> because it is the only form
+    // that survives a blank line. Pin that promise.
+    const withBlankLines = [
+      "- [x] Backend logs:",
+      "",
+      "<details><summary>gate output</summary>",
+      "",
+      "```",
+      "[develop-pr-gate] poll 1: passed=0 waiting=3 failed=0",
+      "",
+      "[develop-pr-gate] poll 2: passed=2 waiting=1 failed=0",
+      "[develop-pr-gate] all required checks green after 92s",
+      "```",
+      "",
+      "</details>",
+    ].join("\n");
+    const { findings } = evaluatePrEvidence(
+      buildFixtureBody({ "backend-logs": withBlankLines }),
+    );
+    const row = findings.find((finding) => finding.id === "backend-logs");
+    if (row?.status !== "ok") {
+      failures.push(
+        "a <details> transcript containing blank lines should satisfy the gate",
+      );
+    }
+  }
+
+  {
+    // A transcript that just misses the floor is a different mistake from an
+    // empty row, and must say which threshold it missed.
+    const short = ["- [x] Backend logs:", "```", "poll 1: ok", "```"].join(
+      "\n",
+    );
+    const { findings } = evaluatePrEvidence(
+      buildFixtureBody({ "backend-logs": short }),
+    );
+    const row = findings.find((finding) => finding.id === "backend-logs");
+    if (row?.status !== "blank") {
+      failures.push("an under-floor transcript should still fail");
+    }
+    if (!row?.detail?.includes("under the floor")) {
+      failures.push(
+        "an under-floor transcript should report which threshold it missed",
+      );
+    }
   }
 
   {
@@ -2671,8 +2797,17 @@ How to fix (fastest path):
      (uploads to the pr-evidence release and verifies this gate locally)
 
 Rules: visual rows on UI-touching PRs need REAL media (an uploaded image/video,
-not a link to the PR or /checks page); every other row needs an artifact link
-or 'N/A - <reason>'. A wholly-new surface may N/A the before-screenshots row.
+not a link to the PR or /checks page); every other row needs an artifact link,
+a pasted transcript, or 'N/A - <reason>'. A wholly-new surface may N/A the
+before-screenshots row.
+
+Pasted transcripts must be at least ${INLINE_TRANSCRIPT_MIN_LINES} lines and ${INLINE_TRANSCRIPT_MIN_CHARS} characters, and must stay
+inside the row block. Prefer a <details> block — CONTRIBUTING.md § Evidence
+prescribes it, and it is the only form that survives blank lines: the row ends
+at the first blank line unless a <details> is open. A bare \`\`\` fence therefore
+works only when it starts directly after the row line AND contains no blank
+line; the row is cut at that blank line and the rest of the transcript is
+never seen.
 Worked example: https://github.com/elizaOS/eliza/pull/15171
 Full standard: CONTRIBUTING.md § Evidence.`,
     );

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -349,7 +349,7 @@ function inlineTranscriptMeasurements(text) {
   const blocks = [
     ...source.matchAll(/<details[\s\S]*?<\/details>/gi),
     ...source.matchAll(/<pre[\s\S]*?<\/pre>/gi),
-    ...source.matchAll(/```[\s\S]*?```/g),
+    ...source.matchAll(/(?:```[\s\S]*?```|~~~[\s\S]*?~~~)/g),
   ].map((match) => match[0]);
 
   return blocks.flatMap((block) => {
@@ -357,7 +357,7 @@ function inlineTranscriptMeasurements(text) {
       // A <summary> is a caption, not evidence — it must not carry the block.
       .replace(/<summary[\s\S]*?<\/summary>/gi, " ")
       .replace(/<[^>]*>/g, " ")
-      .replace(/```/g, " ");
+      .replace(/^\s*(?:`{3,}|~{3,})[^\r\n]*$/gm, " ");
     if (NON_REAL_EVIDENCE_RE.test(content)) return [];
     const lines = content
       .split(/\r?\n/)
@@ -423,6 +423,26 @@ export function describeInlineTranscriptShortfall(text) {
   }
   if (missed.length === 0) return null;
   return `pasted transcript is under the floor (${missed.join("; ")})`;
+}
+
+function fencedBlockDelimiter(line) {
+  const match = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
+  if (!match) return null;
+  return {
+    character: match[1][0],
+    length: match[1].length,
+    remainder: match[2],
+  };
+}
+
+function closesFencedBlock(line, fence) {
+  const delimiter = fencedBlockDelimiter(line);
+  return (
+    delimiter !== null &&
+    delimiter.character === fence.character &&
+    delimiter.length >= fence.length &&
+    delimiter.remainder.trim() === ""
+  );
 }
 
 function substantiveTrajectoryValue(value, minimumLength) {
@@ -588,39 +608,71 @@ export function boundRowBlock(block) {
   const out = [];
   let started = false;
   let detailsDepth = 0;
+  let fence = null;
+  let fenceStart = -1;
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
     if (!started) {
       if (line.trim() === "") continue;
       started = true;
       out.push(line);
+      const delimiter = fencedBlockDelimiter(line);
+      if (delimiter) {
+        fence = delimiter;
+        fenceStart = out.length - 1;
+      }
       continue;
     }
 
     const trimmed = line.trim();
     if (trimmed === "") {
-      if (detailsDepth > 0) {
+      if (detailsDepth > 0 || fence !== null) {
         out.push(line);
         continue;
       }
       const next = lines.slice(index + 1).find((candidate) => candidate.trim());
-      if (next && /^<details\b/i.test(next.trim())) {
+      if (
+        next &&
+        (/^<details\b/i.test(next.trim()) ||
+          fencedBlockDelimiter(next) !== null)
+      ) {
         out.push(line);
         continue;
       }
       break;
     }
-    if (detailsDepth === 0 && /^#/.test(trimmed)) break;
-    if (/<!--\s*evidence-row:/i.test(trimmed)) break;
-    if (detailsDepth === 0 && /^[-*]\s/.test(line) && !/^\s/.test(line)) {
+    if (fence === null && detailsDepth === 0 && /^#/.test(trimmed)) break;
+    if (fence === null && /<!--\s*evidence-row:/i.test(trimmed)) break;
+    if (
+      fence === null &&
+      detailsDepth === 0 &&
+      /^[-*]\s/.test(line) &&
+      !/^\s/.test(line)
+    ) {
       break;
     }
     out.push(line);
+    if (fence !== null) {
+      if (closesFencedBlock(line, fence)) {
+        fence = null;
+        fenceStart = -1;
+      }
+      continue;
+    }
+    const delimiter = fencedBlockDelimiter(line);
+    if (delimiter) {
+      fence = delimiter;
+      fenceStart = out.length - 1;
+      continue;
+    }
     detailsDepth += (line.match(/<details\b/gi) ?? []).length;
     detailsDepth -= (line.match(/<\/details>/gi) ?? []).length;
     detailsDepth = Math.max(0, detailsDepth);
   }
-  return out.join("\n").trim();
+  // An unterminated fence must not absorb headings or links below the row and
+  // accidentally turn unrelated prose into evidence.
+  const bounded = fence === null ? out : out.slice(0, fenceStart);
+  return bounded.join("\n").trim();
 }
 
 export function extractEvidenceRows(body) {
@@ -2795,12 +2847,10 @@ a pasted transcript, or 'N/A - <reason>'. A wholly-new surface may N/A the
 before-screenshots row.
 
 Pasted transcripts must be at least ${INLINE_TRANSCRIPT_MIN_LINES} lines and ${INLINE_TRANSCRIPT_MIN_CHARS} characters, and must stay
-inside the row block. Prefer a <details> block — CONTRIBUTING.md § Evidence
-prescribes it, and it is the only form that survives blank lines: the row ends
-at the first blank line unless a <details> is open. A bare \`\`\` fence therefore
-works only when it starts directly after the row line AND contains no blank
-line; the row is cut at that blank line and the rest of the transcript is
-never seen.
+inside the row block. CONTRIBUTING.md § Evidence prefers a <details> block;
+complete backtick or tilde fences are also supported, including a blank line
+before the fence and blank lines inside it. Unclosed containers fail closed so
+they cannot absorb unrelated prose below the evidence row.
 Worked example: https://github.com/elizaOS/eliza/pull/15171
 Full standard: CONTRIBUTING.md § Evidence.`,
     );

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -344,6 +344,35 @@ function hasSubstantiveInlineLog(text) {
 const INLINE_TRANSCRIPT_MIN_LINES = 3;
 const INLINE_TRANSCRIPT_MIN_CHARS = 120;
 
+function inlineTranscriptMeasurements(text) {
+  const source = String(text ?? "");
+  const blocks = [
+    ...source.matchAll(/<details[\s\S]*?<\/details>/gi),
+    ...source.matchAll(/<pre[\s\S]*?<\/pre>/gi),
+    ...source.matchAll(/```[\s\S]*?```/g),
+  ].map((match) => match[0]);
+
+  return blocks.flatMap((block) => {
+    const content = block
+      // A <summary> is a caption, not evidence — it must not carry the block.
+      .replace(/<summary[\s\S]*?<\/summary>/gi, " ")
+      .replace(/<[^>]*>/g, " ")
+      .replace(/```/g, " ");
+    if (NON_REAL_EVIDENCE_RE.test(content)) return [];
+    const lines = content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    return [{ lines: lines.length, chars: lines.join("").length }];
+  });
+}
+
+function inlineTranscriptMeetsFloor({ lines, chars }) {
+  return (
+    lines >= INLINE_TRANSCRIPT_MIN_LINES && chars >= INLINE_TRANSCRIPT_MIN_CHARS
+  );
+}
+
 /**
  * True when the row carries a pasted log/transcript body rather than a link to
  * one. CONTRIBUTING.md § Evidence and the root AGENTS.md both prescribe "long
@@ -358,28 +387,7 @@ const INLINE_TRANSCRIPT_MIN_CHARS = 120;
  * before this is consulted, so screenshots and video still demand real media.
  */
 export function hasInlineTranscriptEvidence(text) {
-  const source = String(text ?? "");
-  const blocks = [
-    ...source.matchAll(/<details[\s\S]*?<\/details>/gi),
-    ...source.matchAll(/<pre[\s\S]*?<\/pre>/gi),
-    ...source.matchAll(/```[\s\S]*?```/g),
-  ].map((match) => match[0]);
-  return blocks.some((block) => {
-    const content = block
-      // A <summary> is a caption, not evidence — it must not carry the block.
-      .replace(/<summary[\s\S]*?<\/summary>/gi, " ")
-      .replace(/<[^>]*>/g, " ")
-      .replace(/```/g, " ");
-    const lines = content
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
-    return (
-      lines.length >= INLINE_TRANSCRIPT_MIN_LINES &&
-      lines.join("").length >= INLINE_TRANSCRIPT_MIN_CHARS &&
-      !NON_REAL_EVIDENCE_RE.test(content)
-    );
-  });
+  return inlineTranscriptMeasurements(text).some(inlineTranscriptMeetsFloor);
 }
 
 /**
@@ -392,32 +400,17 @@ export function hasInlineTranscriptEvidence(text) {
  * empty row keeps its plain `blank`.
  */
 export function describeInlineTranscriptShortfall(text) {
-  const source = String(text ?? "");
-  const blocks = [
-    ...source.matchAll(/<details[\s\S]*?<\/details>/gi),
-    ...source.matchAll(/<pre[\s\S]*?<\/pre>/gi),
-    ...source.matchAll(/```[\s\S]*?```/g),
-  ].map((match) => match[0]);
-  if (blocks.length === 0) return null;
-
   let best = null;
-  for (const block of blocks) {
-    const content = block
-      .replace(/<summary[\s\S]*?<\/summary>/gi, " ")
-      .replace(/<[^>]*>/g, " ")
-      .replace(/```/g, " ");
-    if (NON_REAL_EVIDENCE_RE.test(content)) continue;
-    const lines = content
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
-    const chars = lines.join("").length;
-    // Report the closest attempt rather than the first.
-    if (best === null || lines.length + chars > best.lines + best.chars) {
-      best = { lines: lines.length, chars };
+  for (const measurement of inlineTranscriptMeasurements(text)) {
+    // Report the closest attempt rather than whichever block appears first.
+    if (
+      best === null ||
+      measurement.lines + measurement.chars > best.lines + best.chars
+    ) {
+      best = measurement;
     }
   }
-  if (best === null) return null;
+  if (best === null || inlineTranscriptMeetsFloor(best)) return null;
 
   const missed = [];
   if (best.lines < INLINE_TRANSCRIPT_MIN_LINES) {

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -17,6 +17,7 @@ import {
   findRetiredRepoEvidenceFiles,
   hasArtifactReference,
   hasEvidenceFileReference,
+  hasInlineTranscriptEvidence,
   hasMatchingEvidenceHead,
   hasNaWithReason,
   hasOcrEvidenceReference,
@@ -1346,6 +1347,55 @@ describe("check-pr-evidence marker extraction", () => {
     const bounded = boundRowBlock(block);
     assert.ok(bounded.includes("continued indented line"));
     assert.ok(!bounded.includes("example.com"));
+  });
+
+  it("keeps complete fenced transcripts intact across blank lines", () => {
+    const transcript = [
+      "- [x] Backend logs from the exact run:",
+      "",
+      "```text",
+      "INFO request POST /api/agents returned statusCode=201 with the expected agent identifier",
+      "",
+      "INFO database transaction committed the agent and owner rows without warnings",
+      "INFO response body matched the persisted record and the request correlation identifier",
+      "```",
+      "",
+      "# not part of the row",
+      "https://example.com/should-not-be-captured",
+    ].join("\n");
+    const bounded = boundRowBlock(transcript);
+    assert.match(bounded, /database transaction committed/);
+    assert.ok(!bounded.includes("example.com"));
+
+    const body = buildBody({ "backend-logs": transcript });
+    const finding = evaluatePrEvidence(body).findings.find(
+      (entry) => entry.id === "backend-logs",
+    );
+    assert.equal(finding?.status, "ok");
+  });
+
+  it("supports tilde fences and rejects an unterminated fence without bleed", () => {
+    const complete = [
+      "- [x] Backend logs:",
+      "~~~log",
+      "INFO first request completed with statusCode=200 and a stable correlation identifier",
+      "WARN retry path was exercised once before the upstream connection recovered successfully",
+      "INFO final response matched the durable database record and emitted no error event",
+      "~~~",
+    ].join("\n");
+    assert.equal(hasInlineTranscriptEvidence(boundRowBlock(complete)), true);
+
+    const unterminated = [
+      "- [x] Backend logs:",
+      "```text",
+      "short line",
+      "",
+      "# unrelated evidence",
+      "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000006",
+    ].join("\n");
+    const bounded = boundRowBlock(unterminated);
+    assert.equal(bounded, "- [x] Backend logs:");
+    assert.ok(!bounded.includes("user-attachments"));
   });
 });
 


### PR DESCRIPTION
# Relates to

Closes #17588.

# Risk

- [x] This PR targets `develop` and is rebased onto `origin/develop@581e9dadb17f16006990c98e5984607ea78be0c9` with zero conflicts.
- [x] A reviewer can confirm the parser behavior and its failure mode from the executable tests and mutation record below.

# Background

`check-pr-evidence.mjs` accepts pasted transcripts for non-visual evidence rows, but its help advertised only links and `N/A`. More importantly, `boundRowBlock` stopped at a blank line inside a fenced transcript. The most natural Markdown form therefore looked valid to an author while the gate silently saw only the checkbox line.

# Implementation

- The failure help now documents all supported evidence forms and the actual `3` line / `120` character transcript floor.
- Transcript measurement and shortfall diagnostics share one parsing path, so help cannot drift from acceptance.
- Evidence rows now preserve complete backtick and tilde fences across a blank line before the fence and blank lines inside it.
- Fence closing follows Markdown semantics: the delimiter character must match and the closer must be at least as long as the opener.
- Unterminated fences fail closed and are truncated before the opener, preventing unrelated headings or links below a row from becoming accidental evidence.
- Regression cases cover complete backtick fences, tilde fences, blank lines, threshold diagnostics, and unterminated-fence bleed.

This is the implementation-level repair. The earlier draft merely documented the fenced-block limitation; that would have left a standard Markdown transcript broken.

# Verification

Exact repaired head: `355c58a98194945d319845f4ed34faf21230cae7`
<!-- evidence-head:355c58a98194945d319845f4ed34faf21230cae7 -->

- `node scripts/check-pr-evidence.mjs --self-test`: 14/14 cases passed.
- `node --test scripts/check-pr-evidence.test.mjs`: 89/89 tests passed.
- scoped Biome and `git diff --check`: passed.
- mutation proof: removing fenced-block blank-line preservation makes `keeps complete fenced transcripts intact across blank lines` fail because only the checkbox remains; restoring it returns the case and full suite to green.
- Final maintainer replay after the hosted-runner merge: self-test 14/14, full suite 89/89, Biome, and diff hygiene pass at exact rebased head `355c58a9819`.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - CLI parser and help-text change; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CLI parser and help-text change; no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-operated UI flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head parser verification. The PR-event gate intentionally executes the base-branch validator, so this row uses the pre-repair no-blank fenced form; the exact-head regression and mutation tests above prove the repaired blank-line form:
```text
$ node scripts/check-pr-evidence.mjs --self-test
check-pr-evidence self-test passed (14 cases).
$ node --test scripts/check-pr-evidence.test.mjs
tests 89; pass 89; fail 0; duration 102.542708 ms
$ bunx biome check scripts/check-pr-evidence.mjs scripts/check-pr-evidence.test.mjs
Checked 2 files. No fixes applied.
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, evaluator, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Rendered failure help after the repair:
```text
Pasted transcripts must be at least 3 lines and 120 characters, and must stay
inside the row block. CONTRIBUTING.md § Evidence prefers a <details> block;
complete backtick or tilde fences are also supported, including a blank line
before the fence and blank lines inside it. Unclosed containers fail closed so
they cannot absorb unrelated prose below the evidence row.
```

# Contribution Provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Anthropic/claude-opus-5; OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code (Claude Agent SDK); Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

AI provider/model: Anthropic / claude-opus-5; OpenAI / gpt-5.6-sol
Client / agent tooling: Claude Code (Claude Agent SDK); Codex desktop
Contribution skill revision: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [greatcodeeer-agent + codex-shaw]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code (Claude Agent SDK); Codex desktop","skill_revision":"elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza"} -->
