### PR TITLE
docs(agents): point retired test:lint rows at commands that exist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,11 +101,11 @@ locking and linear probing so active lanes do not collide. See
 | `bun run smartglasses:simulator` | `bun run --cwd packages/examples/smartglasses simulator` |
 | `bun run smartglasses:smoke:simulator` | `bun run --cwd packages/examples/smartglasses smoke:simulator` |
 | `bun run test:ci:live` | `bun run test:live` |
-| `bun run test:lint` | `bun run audit:test-integrity:all` |
+| `bun run test:lint` | retired with its aggregate tooling; no direct replacement |
 | `bun run test:lint:no-vi-mocks` | `bun run audit:test-integrity:no-vi-mocks` |
-| `bun run test:lint:lane-coverage` | `bun run audit:test-integrity:lane-coverage` |
-| `bun run test:lint:test-integrity` | `bun run audit:test-integrity` |
-| `bun run test:lint:test-integrity:self-test` | `bun run audit:test-integrity:self-test` |
+| `bun run test:lint:lane-coverage` | retired with its tooling; no replacement |
+| `bun run test:lint:test-integrity` | retired with its tooling; no replacement |
+| `bun run test:lint:test-integrity:self-test` | retired with its tooling; no replacement |
 | `bun run verify:smartglasses-software` | `bun run audit:smartglasses-software` |
 | `bun run personality:judge` | `bun run bench:personality` |
 | `bun run personality:bench:calibrate` | `bun run bench:personality:calibrate` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,11 +101,11 @@ locking and linear probing so active lanes do not collide. See
 | `bun run smartglasses:simulator` | `bun run --cwd packages/examples/smartglasses simulator` |
 | `bun run smartglasses:smoke:simulator` | `bun run --cwd packages/examples/smartglasses smoke:simulator` |
 | `bun run test:ci:live` | `bun run test:live` |
-| `bun run test:lint` | `bun run audit:test-integrity:all` |
+| `bun run test:lint` | retired with its aggregate tooling; no direct replacement |
 | `bun run test:lint:no-vi-mocks` | `bun run audit:test-integrity:no-vi-mocks` |
-| `bun run test:lint:lane-coverage` | `bun run audit:test-integrity:lane-coverage` |
-| `bun run test:lint:test-integrity` | `bun run audit:test-integrity` |
-| `bun run test:lint:test-integrity:self-test` | `bun run audit:test-integrity:self-test` |
+| `bun run test:lint:lane-coverage` | retired with its tooling; no replacement |
+| `bun run test:lint:test-integrity` | retired with its tooling; no replacement |
+| `bun run test:lint:test-integrity:self-test` | retired with its tooling; no replacement |
 | `bun run verify:smartglasses-software` | `bun run audit:smartglasses-software` |
 | `bun run personality:judge` | `bun run bench:personality` |
 | `bun run personality:bench:calibrate` | `bun run bench:personality:calibrate` |


### PR DESCRIPTION
# Relates to

Closes #17590.

# Risk

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with its exact command and output
- [x] A reviewer can confirm the change works without reading the code, from the evidence below

# Sync with develop

- [x] Rebased onto `origin/develop@c08d27fed96f274909f191ce2543c3515e559b0f`; zero conflicts.
- [x] Checks run post-sync are recorded under "Checks run" below.

# Background

## What does this PR do?

Four of the five `test:lint*` rows in the "Removed Root Command Migrations" table pointed at commands that do not exist. Following the table produced `error: Script not found`. This makes the rows accurate:

| Old command | Was | Now |
| --- | --- | --- |
| `test:lint` | `audit:test-integrity:all` (absent) | retired with its aggregate tooling; no direct replacement |
| `test:lint:no-vi-mocks` | `audit:test-integrity:no-vi-mocks` | unchanged — this one existed |
| `test:lint:lane-coverage` | `audit:test-integrity:lane-coverage` (absent) | retired with its tooling; no replacement |
| `test:lint:test-integrity` | `audit:test-integrity` (absent) | retired with its tooling; no replacement |
| `test:lint:test-integrity:self-test` | `audit:test-integrity:self-test` (absent) | retired with its tooling; no replacement |

`AGENTS.md` receives the byte-identical edit, per the repo convention enforced by `check:agents-claude`.

## What kind of change is this?

Documentation only. No script, tooling, or behavior change.

## Why are we doing this? Any context or related work?

These are not unregistered scripts — the tooling is gone: commit `84bc78ea51d` deliberately removed the aggregate and three of its four components under “remove policy ratchets and changed-file gates.” `packages/scripts/` contains only the narrower `lint-no-vi-mocks.mjs`. So the honest fix is to retire the aggregate and the deleted components rather than present that surviving narrow audit as an equivalent replacement.

The audience is what makes it worth a PR. This file is the repository guide **for agents**, and the migration table is the first thing consulted when a remembered command disappears. An agent that runs `bun run audit:test-integrity`, gets `Script not found`, and has no working alternative either substitutes something unverified or reports a blocked task — both worse than an accurate table. `CLAUDE.md` sets the same bar for itself: "A wrong header is worse than no header."

# Documentation changes needed?

This is the documentation change.

# Testing

## Where should a reviewer start?

The five `test:lint*` rows, then the resolution check below.

## Detailed testing steps

Every documented replacement in the table was resolved against the manifest that would actually run it — root targets against root `package.json`, `--cwd <dir>` targets against that package's own manifest, `node <path>` targets against the filesystem:

<details><summary>resolution check, after this change</summary>

```
rows=37 command-targets=33 retired=4
resolved 33/33 documented command targets; 4 retired rows explicit
```

</details>

Before this change the same check reported four unresolved rows, all in the `test:lint*` family. Worth noting for scope: the `--cwd` rows (`packages/app` `test:e2e`, `packages/browser-extension` `test`, `packages/app-core` `voice:duet`, `packages/examples/smartglasses` `hardware:doctor`, …) all resolve correctly and are untouched.

# Evidence Gate

<!-- evidence-head:030d855a130cecdd03058f09b9c7d6a0674a6d0f -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - documentation change with no rendered surface`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - documentation change with no rendered surface`.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no user-facing flow; the artifact is the command output below`.

<!-- evidence-row:backend-logs -->
- [x] Row resolution before and after, plus the repo's twin-file gate:
<details><summary>resolution check and check:agents-claude</summary>

```
BEFORE (origin/develop c08d27fe)
$ bun run audit:test-integrity
error: Script not found "audit:test-integrity"

AFTER (this branch)
rows=37 command-targets=33 retired=4
resolved 33/33 documented command targets; 4 retired rows explicit

$ bun run check:agents-claude
[assert-agents-claude-identical] PASS: 303 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path is exercised

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no model, prompt, action, or provider behavior changes`.

<!-- evidence-row:domain-artifacts -->
- [x] The corrected table, rendered:
<details><summary>test:lint rows after this change</summary>

```
| bun run test:lint                        | retired with its aggregate tooling; no direct replacement |
| bun run test:lint:no-vi-mocks            | bun run audit:test-integrity:no-vi-mocks       |
| bun run test:lint:lane-coverage          | retired with its tooling; no replacement        |
| bun run test:lint:test-integrity         | retired with its tooling; no replacement        |
| bun run test:lint:test-integrity:self-test | retired with its tooling; no replacement      |
```

</details>

# Checks run

Run on the final rebased head `030d855a130cecdd03058f09b9c7d6a0674a6d0f`:

- per-row resolution of every documented command target → **33/33 resolve**, with 4 retirements explicitly identified
- `bun run check:agents-claude` → PASS, 303 pairs byte-identical
- `bun run audit:test-integrity:no-vi-mocks` → the script executes correctly (see below)
- final maintainer replay → all 303 twin pairs byte-identical, surviving manifest target and script resolve, and diff hygiene passes

`bun run verify` was **not** run in full: this changes two Markdown files and no TypeScript. Stating that rather than implying a green I did not produce.

# Two observations, explicitly out of scope

**1. The evidence gate formerly rejected a real transcript that names this command.** The marker matcher treated the word in `audit:test-integrity:no-vi-mocks` as a fabrication disclosure even inside a command identifier. #17595 corrects that boundary behavior, so the real command is now preserved above and accepted by the gate.

**2. The surviving audit is currently informational.**

`audit:test-integrity:no-vi-mocks` — now the only surviving row in this family — **exits non-zero on `develop`**, reporting ~19,600 `vi.fn()` / `vi.spyOn()` occurrences across the test suite. The script itself works; the codebase simply has that much to report, so the check is effectively unenforced today.

I have deliberately not touched this here: this PR is about the table being accurate, and deciding whether that lint should be enforced, scoped, or retired like its siblings is a maintainer call. Flagging it because a reader following the corrected row will hit it immediately, and it seemed worse to leave that undiscovered.

# Contribution Provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- AI provider/model: Anthropic / claude-opus-5; maintainer replay: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Claude Agent SDK)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code (Claude Agent SDK)
Contribution skill revision: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [greatcodeeer-agent]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code (Claude Agent SDK)","skill_revision":"elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza"} -->
