### PR TITLE
fix(native-browser): attach through nested Android hosts

### DIFF
--- a/plugins/plugin-native-browser-surface/android/src/androidTest/java/ai/eliza/plugins/browsersurface/BrowserSurfaceIsolationInstrumentedTest.kt
+++ b/plugins/plugin-native-browser-surface/android/src/androidTest/java/ai/eliza/plugins/browsersurface/BrowserSurfaceIsolationInstrumentedTest.kt
@@ -1,6 +1,10 @@
 package ai.eliza.plugins.browsersurface
 
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.LinearLayout
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.webkit.Profile
 import androidx.webkit.ProfileStore
 import androidx.webkit.WebViewFeature
@@ -75,5 +79,18 @@ class BrowserSurfaceIsolationInstrumentedTest {
         // A second read of the default profile sees the shared write.
         val again = store.getOrCreateProfile(Profile.DEFAULT_PROFILE_NAME).cookieManager
         assertEquals(true, again.getCookie(urlShared)?.contains("shared=value"))
+    }
+
+    @Test
+    fun attachmentHostResolvesNearestFrameLayoutAncestorThroughNestedParents() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val root = FrameLayout(context)
+        val intermediate = LinearLayout(context)
+        val hostWebView = View(context)
+
+        root.addView(intermediate)
+        intermediate.addView(hostWebView)
+
+        assertEquals(root, findNearestFrameLayoutAncestor(hostWebView))
     }
 }

--- a/plugins/plugin-native-browser-surface/android/src/main/java/ai/eliza/plugins/browsersurface/BrowserSurfacePlugin.kt
+++ b/plugins/plugin-native-browser-surface/android/src/main/java/ai/eliza/plugins/browsersurface/BrowserSurfacePlugin.kt
@@ -64,8 +64,8 @@ class ElizaSurfaceManagerPlugin : Plugin() {
                 call.resolve()
                 return@runOnUiThread
             }
-            val host = bridge.webView.parent as? FrameLayout ?: run {
-                call.reject("host webview has no FrameLayout parent to attach the surface to")
+            val host = findNearestFrameLayoutAncestor(bridge.webView) ?: run {
+                call.reject("host webview has no FrameLayout ancestor to attach the surface to")
                 return@runOnUiThread
             }
 
@@ -242,4 +242,13 @@ class ElizaSurfaceManagerPlugin : Plugin() {
             call.resolve(result)
         }
     }
+}
+
+internal fun findNearestFrameLayoutAncestor(view: View): FrameLayout? {
+    var current = view.parent
+    while (current is View) {
+        if (current is FrameLayout) return current
+        current = current.parent
+    }
+    return null
 }


### PR DESCRIPTION
# Relates to

No linked issue. This fixes the Android attachment failure reproduced on LP3:

```text
host webview has no FrameLayout parent to attach the surface to
```

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on latest `origin/develop` (`59b6f8b89ea03cf266c81e94aebb4817857e36c7`) with zero conflicts.
- [x] Source-format checks pass. Android compile/instrumentation limitations of this host are recorded below.
- [x] A reviewer can confirm the structural change and focused nested-parent test without relying on the temporary LP3 hot patch.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`, `openai/gpt-5.5`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`, `Codex CLI 0.124.0`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - the installed OpenClaw coding-agent skill is not a Git checkout with an available revision SHA`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Based directly on `59b6f8b89ea03cf266c81e94aebb4817857e36c7`; zero conflicts.
- [x] Full Android compilation cannot run on this host because no JDK is installed. Exact command and failure are documented below.

# Risks

Low. The attachment host changes from an immediate-parent cast to a nearest-ancestor walk. Existing surface lifecycle and isolation checks are untouched. `WebViewFeature.MULTI_PROFILE` remains mandatory and fail-closed.

# Background

## What does this PR do?

Capacitor's host WebView can sit inside an intermediate swipe/detent `ViewGroup`, while the valid attachment `FrameLayout` is higher in the parent chain. The plugin previously rejected unless the immediate parent itself was a `FrameLayout`.

This PR:

- walks upward from `bridge.webView.parent` to the nearest `FrameLayout` ancestor;
- retains rejection when no `FrameLayout` ancestor exists;
- adds an Android instrumented regression test with `FrameLayout -> LinearLayout -> host View` and asserts the root frame is selected;
- does not alter multi-profile storage isolation or any other fail-closed gate.

## What kind of change is this?

Bug fix, non-breaking.

# Documentation changes needed?

No. The behavior is internal to the native surface attachment implementation and is covered by a focused test.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-native-browser-surface/android/src/main/java/ai/eliza/plugins/browsersurface/BrowserSurfacePlugin.kt`
2. `plugins/plugin-native-browser-surface/android/src/androidTest/java/ai/eliza/plugins/browsersurface/BrowserSurfaceIsolationInstrumentedTest.kt`

## Detailed testing steps

With a JDK and Android SDK available:

```bash
cd packages/app-core/platforms/android
./gradlew \
  :elizaos-capacitor-browser-surface:compileDebugKotlin \
  :elizaos-capacitor-browser-surface:compileDebugAndroidTestKotlin \
  --no-daemon

# On an emulator/device:
./gradlew \
  :elizaos-capacitor-browser-surface:connectedDebugAndroidTest \
  --no-daemon
```

Checks run on this host:

```bash
git diff --check
# passed
```

# Evidence Gate

<!-- evidence-head:5f929781a7c9de306a20ced418bedb1b7643ff16 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a native attachment-host fix, not a rendered layout/style change; the reproduced before-state is the exact plugin rejection above.
<!-- evidence-row:after-screenshots -->
- [x] N/A - after reaching the ancestor, the same LP3 device correctly proceeds to the next existing fail-closed gate (`MULTI_PROFILE` unsupported), so it cannot render third-party content on that system WebView.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no source-built Android artifact could be produced on this host because Java/JDK is unavailable.
<!-- evidence-row:backend-logs -->
- [x] N/A - this code runs inside the Capacitor Android host, not the backend.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no source-built Android artifact could run on this no-JDK host. The live reproduced native rejection is included below only as diagnosis; the focused source-level instrumented test is the regression proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, wallet, generated file, or external side effect.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or layout changed.

# Evidence Details

## Real LLM-call trajectory

N/A. No model path is involved.

## Backend + frontend logs

Live LP3 before-state:

```text
host webview has no FrameLayout parent to attach the surface to
```

The immediate parent was an intermediate swipe/detent `ViewGroup`; a valid `FrameLayout` existed above it. The added test recreates that hierarchy directly.

## Screenshots (before / after) + video walkthrough

N/A. This is native host plumbing, and the device cannot progress past the intentionally retained WebView isolation requirement.

## Audio / voice walkthrough

N/A.

## Known gaps / failures

- Android compilation was attempted with:

  ```bash
  cd packages/app-core/platforms/android
  ./gradlew :elizaos-capacitor-browser-surface:compileDebugKotlin :elizaos-capacitor-browser-surface:compileDebugAndroidTestKotlin --no-daemon
  ```

  It could not start because this host has no Java installation and `JAVA_HOME` is unset:

  ```text
  ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
  ```

- LP3's system WebView 113 does not support `WebViewFeature.MULTI_PROFILE`. The browser surface therefore still rejects isolated storage on that device, as designed. This PR does not weaken isolation, switch to shared storage, or downgrade the gate.
- The current Browser UI logs native surface creation failures and can leave an empty native frame. Surfacing the unsupported-WebView error in the Browser UI remains a follow-up; it is intentionally not bundled into this focused native attachment PR.
- The live temporary hot patch used during diagnosis is not included and is not treated as upstream/source evidence.
- No production deployment or merge is part of this PR.
