### PR TITLE
fix(evidence): stop fabrication markers matching inside identifiers

### DIFF
--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -325,8 +325,14 @@ export function hasEvidenceFileReference(text) {
   return trustedArtifacts(text).some(artifactCanBeEvidenceFile);
 }
 
+// `\b` matches after a hyphen and a slash, so a marker welded into an
+// identifier — `audit:test-integrity:no-vi-mocks`, `fixtures/setup.ts` — used to
+// void an otherwise genuine transcript and push real evidence out of the PR.
+// Requiring the marker to stand alone keeps the intent (evidence produced by a
+// mocked or placeholder run is still rejected) without punishing output that
+// merely names such a command or path.
 const NON_REAL_EVIDENCE_RE =
-  /\b(?:placeholder|example output|logs? here|todo|tbd|fabricated|invented|fake|mocks?|fixtures?|synthetic|dummy)\b/i;
+  /(?<![\w\/-])(?:placeholder|example output|logs? here|todo|tbd|fabricated|invented|fake|mocks?|fixtures?|synthetic|dummy)(?![\w\/-])/i;
 
 function hasSubstantiveInlineLog(text) {
   const source = String(text ?? "");
@@ -2424,6 +2430,46 @@ export function runSelfTest() {
   {
     const { ok } = evaluatePrEvidence(buildFixtureBody());
     if (!ok) failures.push("all-filled fixture should pass");
+  }
+
+  {
+    // Both directions of the fabrication-marker rule. A marker inside an
+    // identifier is not a fabrication claim; a bare one still is. Without the
+    // second half, tightening the boundaries could quietly disarm the check.
+    const naming = [
+      "- [x] Backend logs:",
+      "```",
+      "$ bun run audit:test-integrity:no-vi-mocks",
+      "packages/scripts/lint-no-vi-mocks.mjs:12: const json = vi.fn();",
+      "running fixtures/setup.ts against the real adapter",
+      "exit 0 after 41s",
+      "```",
+    ].join("\n");
+    const named = evaluatePrEvidence(buildFixtureBody({ "backend-logs": naming }));
+    const namedRow = named.findings.find((f) => f.id === "backend-logs");
+    if (namedRow?.status !== "ok") {
+      failures.push(
+        "a transcript naming a marker-bearing command or path should satisfy the gate",
+      );
+    }
+
+    const disclosed = [
+      "- [x] Backend logs:",
+      "```",
+      "this run uses mocks instead of the real service",
+      "TODO: logs here",
+      "the remaining output is a placeholder pending a real capture run",
+      "```",
+    ].join("\n");
+    const fabricated = evaluatePrEvidence(
+      buildFixtureBody({ "backend-logs": disclosed }),
+    );
+    const fabricatedRow = fabricated.findings.find(
+      (f) => f.id === "backend-logs",
+    );
+    if (fabricatedRow?.status === "ok") {
+      failures.push("a disclosed placeholder/mocked run must still be rejected");
+    }
   }
 
   {

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -325,14 +325,12 @@ export function hasEvidenceFileReference(text) {
   return trustedArtifacts(text).some(artifactCanBeEvidenceFile);
 }
 
-// `\b` matches after a hyphen and a slash, so a marker welded into an
-// identifier — `audit:test-integrity:no-vi-mocks`, `fixtures/setup.ts` — used to
-// void an otherwise genuine transcript and push real evidence out of the PR.
-// Requiring the marker to stand alone keeps the intent (evidence produced by a
-// mocked or placeholder run is still rejected) without punishing output that
-// merely names such a command or path.
+// `\b` treats punctuation inside commands, paths, and member names as a word
+// boundary. A marker must therefore be separated from an identifier on both
+// sides; a dot only joins the following token when it actually starts an
+// extension/member, so sentence-ending punctuation remains detectable.
 const NON_REAL_EVIDENCE_RE =
-  /(?<![\w\/-])(?:placeholder|example output|logs? here|todo|tbd|fabricated|invented|fake|mocks?|fixtures?|synthetic|dummy)(?![\w\/-])/i;
+  /(?<![\w/\\@:.-])(?:placeholder|example output|logs? here|todo|tbd|fabricated|invented|fake|mocks?|fixtures?|synthetic|dummy)(?![\w/\\@-]|:[\w-]|\.[\w-])/i;
 
 function hasSubstantiveInlineLog(text) {
   const source = String(text ?? "");
@@ -2442,6 +2440,8 @@ export function runSelfTest() {
       "$ bun run audit:test-integrity:no-vi-mocks",
       "packages/scripts/lint-no-vi-mocks.mjs:12: const json = vi.fn();",
       "running fixtures/setup.ts against the real adapter",
+      "loaded fixture.json through object.mock and test:mocks",
+      String.raw`opened C:\fixtures\setup.ts and todo.md`,
       "exit 0 after 41s",
       "```",
     ].join("\n");
@@ -2459,6 +2459,7 @@ export function runSelfTest() {
       "this run uses mocks instead of the real service",
       "TODO: logs here",
       "the remaining output is a placeholder pending a real capture run",
+      "the artifact is fake.",
       "```",
     ].join("\n");
     const fabricated = evaluatePrEvidence(

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -1021,6 +1021,25 @@ describe("check-pr-evidence row primitives", () => {
     }
   });
 
+  it("does not treat marker words inside command, path, or member identifiers as confessions", () => {
+    const backend = [
+      "- [x] Backend logs:",
+      "<details><summary>Backend logs</summary>",
+      "```text",
+      "$ bun run audit:test-integrity:no-vi-mocks",
+      "packages/fixtures/setup.ts:12 loaded fixture.json through object.mock",
+      String.raw`C:\fixtures\setup.ts completed test:mocks and todo.md`,
+      "2026-07-30T18:01:12Z INFO statusCode=200 count=313 duration_ms=84",
+      "```",
+      "</details>",
+    ].join("\n");
+
+    assert.equal(
+      evaluatePrEvidence(buildBody({ "backend-logs": backend })).ok,
+      true,
+    );
+  });
+
   it("accepts only structured inline trajectories with model, input, and output records", () => {
     const trajectory = [
       "- [x] Real-LLM trajectory:",


### PR DESCRIPTION
# Relates to

Closes #17594.

# Risk

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused and full gate tests, Biome, and diff hygiene were replayed after sync.
- [x] A reviewer can confirm both the false-positive repair and the retained fabrication rejection from the evidence below.

# Sync with develop

- [x] Rebased without conflict onto `origin/develop@a38ea13ca8af98314b8ea3b494b3666a352f248e`.
- [x] Exact head: `6b3276b19525b4057701dce3cf8ceca6b42eaa33`.

# Background

`NON_REAL_EVIDENCE_RE` used `\b` boundaries. JavaScript treats punctuation in commands, paths, filenames, and member names as word boundaries, so a real transcript that merely named one of the gate's marker words could void the entire evidence row.

The boundary now requires a marker to stand apart from identifier punctuation on both sides. A dot is treated as identifier punctuation only when it starts an extension or member; sentence-ending punctuation still leaves a bare marker detectable:

```js
/(?<![\w/\\@:.-])(?:placeholder|…|mocks?|fixtures?|…)(?![\w/\\@-]|:[\w-]|\.[\w-])/i
```

This covers hyphenated commands, POSIX and Windows paths, colon-delimited script names, filenames, and object members. Explicit disclosure that evidence is fake, mocked, a placeholder, or otherwise non-real remains rejected.

## Why this is the implementation fix

The original patch protected only `/` and `-`. Maintainer review extended the rule and tests to cover `\\`, `.`, `:`, and `@`, while preserving sentence-ending punctuation. The full test suite now exercises the production evaluator, not only the embedded self-test.

# Testing

The load-bearing control is unchanged: reverting the boundary makes the marker-bearing identifier case fail. On the final rebased head:

```text
$ bun test scripts/check-pr-evidence.test.mjs
93 pass
0 fail
check-pr-evidence self-test passed (14 cases).

$ bunx biome check scripts/check-pr-evidence.mjs scripts/check-pr-evidence.test.mjs
Checked 2 files. No fixes applied.

$ git diff --check origin/develop...HEAD
(exit 0)
```

The 93 cases include the merged complete-fence parser and fork-file verification suites, plus the new command/path/member boundary case.

# Evidence Gate

<!-- evidence-head:6b3276b19525b4057701dce3cf8ceca6b42eaa33 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - CI evidence parser change with no rendered surface`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - CI evidence parser change with no rendered surface`.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no user-facing flow; the production evaluator transcript is below`.

<!-- evidence-row:backend-logs -->
- [x] Final exact-head production-evaluator replay:
<details><summary>full gate suite</summary>

```text
$ bun test scripts/check-pr-evidence.test.mjs
93 pass
0 fail
Ran 93 tests across 1 file.
check-pr-evidence self-test passed (14 cases).

$ bunx biome check scripts/check-pr-evidence.mjs scripts/check-pr-evidence.test.mjs
Checked 2 files. No fixes applied.
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path is exercised.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no model, prompt, action, provider, or runtime behavior changes`.

<!-- evidence-row:domain-artifacts -->
- [x] Reverted-boundary control:
<details><summary>load-bearing regression result</summary>

```text
check-pr-evidence self-test FAILED:
  - a transcript naming a marker-bearing command or path should satisfy the gate
```

The fixed exact head passes the same case and the full 93-test suite above.

</details>

# Checks run

- `bun test scripts/check-pr-evidence.test.mjs` → 93/93 pass.
- embedded production self-test → 14/14 cases pass.
- `bunx biome check scripts/check-pr-evidence.mjs scripts/check-pr-evidence.test.mjs` → clean.
- `git diff --check origin/develop...HEAD` → clean.

`bun run verify` was not run in full because this changes one CI parser and its test. The repository's exact hosted build/typecheck/security/evidence lanes are the final merge gate.

# Contribution Provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- AI provider/model: Anthropic / claude-opus-5; maintainer replay: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Claude Agent SDK); Codex desktop
<!-- attribution-row:skill-revision -->
- Contribution skill revision: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

AI provider/model: Anthropic / claude-opus-5; OpenAI / GPT-5
Client / agent tooling: Claude Code (Claude Agent SDK); Codex desktop
Contribution skill revision: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported and maintainer-verified
— [greatcodeeer-agent + codex-maintainer-review]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic+openai","model":"claude-opus-5+gpt-5","client":"Claude Code + Codex desktop","skill_revision":"elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza"} -->
