### PR TITLE
test(core): cover sliceToFitBudget, which bounds the actionState prompt budget

### DIFF
--- a/packages/core/src/utils/slice-to-fit-budget.test.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.test.ts
@@ -78,11 +78,12 @@ describe("sliceToFitBudget", () => {
 		});
 
 		it("returns a contiguous suffix, never a gap", () => {
-			// "huge" blocks anything older, so only the tail survives.
-			const items = ["huuuuuuuge", "a", "b"];
-			expect(sliceToFitBudget(items, byLength, 5, { fromEnd: true })).toEqual([
-				"a",
-				"b",
+			// The oversized middle item blocks the older item even though that
+			// item would fit in the remaining budget. Skipping the blocker would
+			// turn a suffix into a gap and make the returned slice exceed budget.
+			const items = ["old", "huuuuuuuge", "tail"];
+			expect(sliceToFitBudget(items, byLength, 7, { fromEnd: true })).toEqual([
+				"tail",
 			]);
 		});
 

--- a/packages/core/src/utils/slice-to-fit-budget.test.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for sliceToFitBudget against real arrays and a real estimator (no
+ * mocks): it bounds prompt size for providers, so the invariant that matters is
+ * that the returned slice never exceeds the budget and never silently drops an
+ * item that would have fit. Both directions are covered because `fromEnd`
+ * selects the newest items — the case a provider uses when recent context
+ * matters more than old.
+ */
+import { describe, expect, it } from "vitest";
+import { sliceToFitBudget } from "./slice-to-fit-budget";
+
+/** Estimator matching the real usage shape: cost derived from the item itself. */
+const byLength = (item: string) => item.length;
+
+describe("sliceToFitBudget", () => {
+	it("returns everything when the whole set fits", () => {
+		const items = ["aaa", "bb", "c"];
+		expect(sliceToFitBudget(items, byLength, 100)).toEqual(items);
+	});
+
+	it("keeps the running total within the budget", () => {
+		const items = ["aaaaa", "bbbbb", "ccccc"];
+		const kept = sliceToFitBudget(items, byLength, 12);
+
+		expect(kept).toEqual(["aaaaa", "bbbbb"]);
+		expect(
+			kept.reduce((sum, item) => sum + item.length, 0),
+		).toBeLessThanOrEqual(12);
+	});
+
+	it("includes an item that exactly exhausts the budget", () => {
+		// Boundary: the comparison is `>`, so a perfect fit must be kept rather
+		// than dropped — otherwise a provider silently loses one item per call.
+		expect(sliceToFitBudget(["aaaaa", "bbbbb"], byLength, 10)).toEqual([
+			"aaaaa",
+			"bbbbb",
+		]);
+	});
+
+	it("returns empty when the first item alone exceeds the budget", () => {
+		expect(sliceToFitBudget(["aaaaaaaaaa"], byLength, 3)).toEqual([]);
+	});
+
+	it("stops at the first item that does not fit rather than skipping it", () => {
+		// The result is a contiguous prefix: a later small item is NOT pulled
+		// forward past a large one, because callers rely on order being preserved.
+		expect(sliceToFitBudget(["aaaaaaaa", "b"], byLength, 5)).toEqual([]);
+	});
+
+	it("returns empty for an empty input", () => {
+		expect(sliceToFitBudget([], byLength, 100)).toEqual([]);
+	});
+
+	it("returns empty for a zero or negative budget", () => {
+		expect(sliceToFitBudget(["a"], byLength, 0)).toEqual([]);
+		expect(sliceToFitBudget(["a"], byLength, -10)).toEqual([]);
+	});
+
+	it("treats a zero budget as no room even for a zero-cost item", () => {
+		// Without the explicit `targetChars <= 0` guard this returns [""],
+		// because 0 + 0 never exceeds 0. A caller asking for zero characters
+		// wants nothing back, so the guard is load-bearing rather than cosmetic.
+		expect(sliceToFitBudget([""], byLength, 0)).toEqual([]);
+		expect(sliceToFitBudget([""], byLength, 0, { fromEnd: true })).toEqual([]);
+	});
+
+	it("keeps zero-cost items when there is any budget at all", () => {
+		expect(sliceToFitBudget(["", "", "a"], byLength, 1)).toEqual(["", "", "a"]);
+	});
+
+	describe("fromEnd", () => {
+		it("keeps the newest items and preserves their original order", () => {
+			const items = ["old", "mid", "new"];
+			expect(sliceToFitBudget(items, byLength, 6, { fromEnd: true })).toEqual([
+				"mid",
+				"new",
+			]);
+		});
+
+		it("returns a contiguous suffix, never a gap", () => {
+			// "huge" blocks anything older, so only the tail survives.
+			const items = ["huuuuuuuge", "a", "b"];
+			expect(sliceToFitBudget(items, byLength, 5, { fromEnd: true })).toEqual([
+				"a",
+				"b",
+			]);
+		});
+
+		it("returns everything when the whole set fits", () => {
+			const items = ["a", "b"];
+			expect(sliceToFitBudget(items, byLength, 100, { fromEnd: true })).toEqual(
+				items,
+			);
+		});
+
+		it("returns empty when the newest item alone exceeds the budget", () => {
+			expect(
+				sliceToFitBudget(["a", "toooooo-long"], byLength, 3, { fromEnd: true }),
+			).toEqual([]);
+		});
+	});
+
+	it("estimates each item exactly once", () => {
+		// The implementation sizes everything upfront specifically to avoid
+		// double estimation; an estimator can be expensive (serialization), so
+		// this pins the stated property rather than trusting the comment.
+		const calls: string[] = [];
+		const counting = (item: string) => {
+			calls.push(item);
+			return item.length;
+		};
+
+		sliceToFitBudget(["aa", "bb", "cc"], counting, 4);
+
+		expect(calls).toEqual(["aa", "bb", "cc"]);
+	});
+
+	it("does not mutate the input array", () => {
+		const items = ["aaa", "bbb", "ccc"];
+		const copy = [...items];
+
+		sliceToFitBudget(items, byLength, 4);
+		sliceToFitBudget(items, byLength, 4, { fromEnd: true });
+
+		expect(items).toEqual(copy);
+	});
+
+	it("works with non-string items via their own estimator", () => {
+		const items = [{ chars: 5 }, { chars: 5 }, { chars: 5 }];
+		expect(sliceToFitBudget(items, (item) => item.chars, 11)).toEqual([
+			{ chars: 5 },
+			{ chars: 5 },
+		]);
+	});
+});


### PR DESCRIPTION
Closes #17597.

Adds a unit test for `sliceToFitBudget`, which had none.

## Why this function

It is the only thing bounding the `actionState` provider's action history before
that history reaches the model
([`actionState.ts:203`](https://github.com/elizaOS/eliza/blob/develop/packages/core/src/features/basic-capabilities/providers/actionState.ts#L203),
its sole caller, on the `fromEnd: true` path). A regression here throws nothing —
it either drops the agent's most recent run from context or lets the prompt slip
past `ACTION_HISTORY_TARGET_CHARS`. Both fail quietly.

## What is covered

16 cases across both directions: exact fit (the `>` vs `>=` boundary), first item
too large, the contiguous-slice guarantee, empty input, zero/negative budget,
zero-cost items, single-estimation, and input immutability.

## Proof the suite is load-bearing

A test file that merely restates the implementation passes forever and catches
nothing, so I mutated the real source and confirmed the suite fails. Each row
below is a separate run against a deliberately broken `slice-to-fit-budget.ts`:

| Mutation applied to the source | Suite result | First case to catch it |
| --- | --- | --- |
| `> targetChars` → `>= targetChars` (exact-fit off-by-one) | 3 failed / 13 passed | `includes an item that exactly exhausts the budget` |
| `break` → `continue` (drops the contiguity guarantee) | 4 failed / 12 passed | `stops at the first item that does not fit rather than skipping it` |
| `targetChars <= 0` → `targetChars < 0` (guard weakened) | 1 failed / 15 passed | `treats a zero budget as no room even for a zero-cost item` |
| `break` → `continue` in the **`fromEnd`** loop | 2 failed / 14 passed | `returns a contiguous suffix, never a gap` (after @lalalune's fix — see below) |
| `if (items.length === 0) return [];` removed | 16 passed — **survived** | none, and correctly so |

The fourth is reported rather than hidden: that guard is a fast path, not a
behavior. With it gone the forward loop still yields `slice(0, 0)` and the
`fromEnd` loop still yields `slice(0)`, so the function is observably identical.
It is an equivalent mutant, and writing a test that pretended to kill it would be
the exact larp this suite exists to avoid.

The third mutation survived my first draft. Rather than leave the hole I added
the zero-cost-item case, which is what now closes it — the table above is the
re-run, not the original.

Source was restored and verified clean (`git diff --quiet`) after every mutation;
only the test file is added in this PR.

## Checks

`bun run --cwd packages/core test -- src/utils/slice-to-fit-budget.test.ts` →
16 passed. `bun run --cwd packages/core typecheck` → clean.
`bunx biome check` → clean.

Final maintainer replay: rebased without conflict onto `origin/develop@c9ebdf0e96e553f6a4c946c3dd3d78edeff4e9a2`; exact head `2a3a60c1fff37369a425f8ec9a744f9c83295674`. The 16-test suite, package typecheck, Biome, and diff hygiene all pass after the rebase.

# Evidence Gate

<!-- evidence-head:2a3a60c1fff37369a425f8ec9a744f9c83295674 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change to a pure function in packages/core; no rendered surface exists to screenshot.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change to a pure function in packages/core; no rendered surface exists to screenshot.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - there is no user flow; the change adds a unit test file and no runtime code path.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end:

<details>
<summary>Backend test output — baseline run, all 16 cases</summary>

```
$ bun run --cwd packages/core test -- src/utils/slice-to-fit-budget.test.ts --reporter=verbose
$ node ../scripts/run-vitest.mjs run src/utils/slice-to-fit-budget.test.ts "--reporter=verbose"
 RUN  v4.1.5 /Users/genkiai/CODE/GenkiAI/projects/ElizaOS/eliza/packages/core
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > returns everything when the whole set fits 3ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > keeps the running total within the budget 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > includes an item that exactly exhausts the budget 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > returns empty when the first item alone exceeds the budget 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > stops at the first item that does not fit rather than skipping it 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > returns empty for an empty input 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > returns empty for a zero or negative budget 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > treats a zero budget as no room even for a zero-cost item 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > keeps zero-cost items when there is any budget at all 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > fromEnd > keeps the newest items and preserves their original order 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > fromEnd > returns a contiguous suffix, never a gap 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > fromEnd > returns everything when the whole set fits 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > fromEnd > returns empty when the newest item alone exceeds the budget 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > estimates each item exactly once 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > does not mutate the input array 0ms
 ✓ src/utils/slice-to-fit-budget.test.ts > sliceToFitBudget > works with non-string items via their own estimator 0ms
 Test Files  1 passed (1)
      Tests  16 passed (16)
   Start at  09:15:07
   Duration  1.07s (transform 383ms, setup 0ms, import 444ms, tests 6ms, environment 0ms)
INFO typecheck: bun run --cwd packages/core typecheck -> Done!
INFO lint: bunx biome check packages/core/src/utils/slice-to-fit-budget.test.ts -> Checked 1 file. No fixes applied.
```
</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend surface, no requests; this is a pure in-process function under packages/core.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model call is involved. sliceToFitBudget is a deterministic array function and this PR adds no agent, action, provider, or prompt behavior.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — for a pure utility the observable artifact is which cases fail when the implementation is broken. Each block below is a separate run against a deliberately broken source, restored afterwards:

<details>
<summary>Mutation run output — each run edits the real source, then restores it</summary>

```
INFO MUT exact-fit boundary (> becomes >=)
      Tests  3 failed | 13 passed (16)
      x includes an item that exactly exhausts the budget
      x keeps zero-cost items when there is any budget at all
      x keeps the newest items and preserves their original order
INFO MUT forward break becomes continue
      Tests  4 failed | 12 passed (16)
      x keeps the running total within the budget
      x returns empty when the first item alone exceeds the budget
      x stops at the first item that does not fit rather than skipping it
      x works with non-string items via their own estimator
INFO MUT zero budget guard (<=0 becomes <0)
      Tests  1 failed | 15 passed (16)
      x treats a zero budget as no room even for a zero-cost item
INFO MUT empty-array guard removed
      Tests  16 passed (16)
      equivalent mutant: slice(0,0) and slice(0) already return [] -- no test should claim to kill this
INFO MUT fromEnd break becomes continue -- against the ORIGINAL test
      Tests  1 failed | 15 passed (16)
      x returns empty when the newest item alone exceeds the budget
      NOTE the contiguity case itself PASSED -- it was not load-bearing
INFO MUT fromEnd break becomes continue -- against the CORRECTED test
      Tests  2 failed | 14 passed (16)
      x returns a contiguous suffix, never a gap
      x returns empty when the newest item alone exceeds the budget
INFO source restored: git diff --quiet -> yes
```
</details>

No DB rows, memories, scheduled tasks, or generated files are produced by this change.

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model call is involved.` `sliceToFitBudget` takes an array and an
estimator and returns a slice; this PR adds only a test file, so no prompt,
provider, or model path is exercised or altered.

## Domain artifacts

The mutation matrix above. A pure function produces no DB rows, memories,
scheduled tasks, or on-chain output; the observable artifact is which cases fail
when the implementation is broken, which is what the matrix records.

## Contribution Provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Anthropic/claude-opus-5; OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code (Claude Agent SDK); Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

---
AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code (Claude Agent SDK)
Contribution skill revision: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [greatcodeeer-agent]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code (Claude Agent SDK)","skill_revision":"elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza"} -->
[17598-mutation-matrix.log](https://github.com/user-attachments/files/30644163/17598-mutation-matrix.log)
[17598-test-run.log](https://github.com/user-attachments/files/30644165/17598-test-run.log)

