### PR TITLE
fix(evidence): trust fork text uploads on the user-attachments files path

### DIFF
--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -167,6 +167,15 @@ const LEGACY_REPO_ASSET_PATH_RE = new RegExp(
 );
 const PR_EVIDENCE_RELEASE_PATH_RE =
   /^\/elizaOS\/eliza\/releases\/download\/pr-evidence(?:-[1-9][0-9]*)?\/([^/]+)$/i;
+// GitHub's uploader mints `/user-attachments/assets/<uuid>` for media and
+// `/user-attachments/files/<id>/<name>` for text formats (.log/.txt/.json/…).
+// Fork contributors cannot upload to the pr-evidence release (push access
+// required), so the files path is the only first-party route for attaching a
+// document artifact (#17600). Unlike the opaque assets path, the filename here
+// carries a real extension, so acceptance is gated on the evidence-file
+// allowlist below — archives and binaries stay untrusted.
+const USER_ATTACHMENT_FILE_PATH_RE =
+  /^\/user-attachments\/files\/[0-9]+\/[^/]+$/i;
 const LEGACY_USER_IMAGE_PATH_RE = /^\/[0-9]+\/[^/].+$/;
 
 function extensionFromPath(pathname) {
@@ -247,6 +256,18 @@ function trustedArtifact(reference) {
       return {
         extension,
         kind: "opaque-upload",
+        ...normalizedReference,
+      };
+    }
+    // A distinct kind, NOT opaque-upload: visual rows treat linked opaque
+    // uploads as media, and a .log file must never satisfy a video row.
+    if (
+      USER_ATTACHMENT_FILE_PATH_RE.test(url.pathname) &&
+      EVIDENCE_FILE_EXTENSIONS.has(extension)
+    ) {
+      return {
+        extension,
+        kind: "file-upload",
         ...normalizedReference,
       };
     }
@@ -2382,7 +2403,7 @@ function buildFixtureBody(overrides = {}) {
     "walkthrough-video":
       "- [x] A video walkthrough: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000000",
     "backend-logs":
-      "- [ ] Backend logs: [backend.txt](https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001)",
+      "- [ ] Backend logs: [backend.txt](https://github.com/user-attachments/files/10000001/backend.txt)",
     "frontend-logs": "- [ ] Frontend logs `N/A - no frontend change`.",
     "llm-trajectory":
       "- [ ] Real-LLM trajectory: [report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/fixture-trajectory.json)",

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -764,6 +764,44 @@ describe("check-pr-evidence row primitives", () => {
     assert.equal(hasEvidenceFileReference(`[archive](${zip})`), false);
   });
 
+  it("accepts fork text uploads on the user-attachments files path (#17600)", () => {
+    // GitHub mints /user-attachments/files/<id>/<name> for text uploads —
+    // the only first-party attachment route a fork contributor has for
+    // document evidence, since release uploads require push access.
+    const log =
+      "https://github.com/user-attachments/files/30640882/17599-verification.log";
+    assert.equal(hasArtifactReference(`[transcript](${log})`), true);
+    assert.equal(hasEvidenceFileReference(`[transcript](${log})`), true);
+    assert.equal(
+      isRowSatisfied(`- [x] Backend logs: [transcript](${log})`),
+      true,
+    );
+  });
+
+  it("keeps non-evidence extensions and malformed files paths untrusted", () => {
+    for (const rejected of [
+      // extension not in the evidence-file allowlist
+      "https://github.com/user-attachments/files/30640882/payload.zip",
+      "https://github.com/user-attachments/files/30640882/tool.exe",
+      // no extension at all
+      "https://github.com/user-attachments/files/30640882/README",
+      // non-numeric id segment
+      "https://github.com/user-attachments/files/abc/notes.log",
+      // nested path
+      "https://github.com/user-attachments/files/30640882/a/b.log",
+    ]) {
+      assert.equal(hasArtifactReference(`[x](${rejected})`), false, rejected);
+    }
+  });
+
+  it("never lets a files-path document satisfy a visual row", () => {
+    const log =
+      "https://github.com/user-attachments/files/30640882/17599-verification.log";
+    assert.equal(hasVisualArtifactReference(`[t](${log})`, "image"), false);
+    assert.equal(hasVisualArtifactReference(`[t](${log})`, "video"), false);
+    assert.equal(hasVisualArtifactReference(log, "video"), false);
+  });
+
   it("detects linked OCR evidence without accepting keyword-only prose", () => {
     const rows = new Map([
       [


### PR DESCRIPTION
Closes #17600

A fork contributor's real text evidence upload (`.log`/`.json`/`.jsonl`/…) mints `https://github.com/user-attachments/files/<id>/<name>` — a shape `trustedArtifact()` did not recognize, so the row reported **`blank`** exactly as if nothing were attached. The two document-capable shapes the gate did trust are both unreachable from a fork: the `pr-evidence` release path requires push access (`pr-evidence.mjs attach` 404s for non-collaborators), and `/user-attachments/assets/<uuid>` is only minted for media. The self-test fixture masked this by asserting `backend.txt` at an `/assets/` UUID — a shape GitHub never mints for text.

## The fix

- `trustedArtifact()` now recognizes `^/user-attachments/files/[0-9]+/[^/]+$` as a distinct **`file-upload`** kind, accepted **only** when the filename's extension is in `EVIDENCE_FILE_EXTENSIONS`. The files path carries a real extension (unlike the opaque assets path), so validation here is *stricter*: `.zip`, extension-less names, non-numeric ids, and nested paths stay untrusted (all covered red in tests).
- Deliberately **not** `opaque-upload`: visual rows treat linked opaque uploads as media, and a `.log` must never satisfy a walkthrough-video row — guarded by a new test.
- The existing byte-level document checks are unchanged and still run on fetch (readable text, placeholder markers, size floors). No new origin is trusted — `/user-attachments/files/` is the same authenticated GitHub upload surface as `/assets/`, with server-assigned immutable ids.
- Self-test fixture corrected to the `/files/` shape GitHub actually mints for `backend.txt`.

This composes with the pasted-transcript path (#17588): pasting covers short logs, but PR bodies cap at 65,536 characters and complete artifacts (full logs, real-LLM trajectory JSONL) routinely exceed inline limits — attachment is the only route at exactly the sizes where evidence matters most.

## Proof

**Live end-to-end, against the real fork-minted URL** (uploaded through the #17599 comment box, published in the #17600 repro comment):

<details><summary>before/after REPL transcript + live fetch verdict (verbatim)</summary>

```
$ node --input-type=module -e "…row = '- [x] Backend logs: [transcript](https://github.com/user-attachments/files/30640882/17599-verification.log)'…"
BEFORE (origin/develop):
  hasArtifactReference: false
  isRowSatisfied: false
AFTER (fix/evidence-trust-file-uploads):
  hasArtifactReference: true
  isRowSatisfied: true

$ node --input-type=module -e "…verifyReferencedArtifacts(body, [{ id: 'backend-logs', … }])…"
LIVE-FETCH AFTER PUBLISH: {"ok":true,"findings":[{"id":"backend-logs","label":"Backend logs",
"url":"https://github.com/user-attachments/files/30640882/17599-verification.log",
"artifactKind":"file-upload","status":"ok",
"contentSha256":"13a01ee7a90029019e8d778207e04d788419c3459952c826062eed60fd70ab40"}]}
```

(Operational note surfaced by this repro: a draft-minted attachment serves HTTP 404 to unauthenticated fetchers until its containing comment/body is actually posted — the gate's `artifact-http-error` on freshly minted URLs is that, not a bad upload.)
</details>

<details><summary>self-test + full suite (verbatim)</summary>

```
$ node scripts/check-pr-evidence.mjs --self-test
check-pr-evidence self-test passed (14 cases).

$ node --test scripts/check-pr-evidence.test.mjs
# tests 90
# suites 9
# pass 90
# fail 0
```
</details>

<details><summary>biome</summary>

```
$ bunx biome check scripts/check-pr-evidence.mjs scripts/check-pr-evidence.test.mjs
Checked 2 files in 83ms. No fixes applied.
```
</details>

Note for reviewers: this PR's own CI evidence check runs the **base** validator (trusted-from-base by design in `pr.yaml`), so the rows below use the pasted-transcript path the base gate accepts; the `/files/` URL above becomes gate-satisfying only after this lands.

Final maintainer replay: rebased without conflict onto `origin/develop@2bd728312ba1c528b5420bed74bcb8119dbab5ea`; exact head `938f24009d5ea355ac2e06f9fd71e5c937001b79`. Self-test 14/14, full evidence suite 92/92, Biome, and diff hygiene pass. The live fork-minted URL independently re-fetched with `artifactKind=file-upload`, status `ok`, and the same SHA-256 shown above.

## Evidence

- Screenshots/video: N/A — validator policy change, no UI surface.
- Real-LLM trajectories: N/A — no model behavior touched.
- Backend logs: pasted verbatim above (REPL + test transcripts).
- Domain artifact: the live verdict flip on a real fork-minted URL, with content sha256, above; published repro comment: https://github.com/elizaOS/eliza/issues/17600#issuecomment-5161143545

## Contribution Provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Anthropic/claude-fable-5; OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code; Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

---

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:938f24009d5ea355ac2e06f9fd71e5c937001b79 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - validator policy change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - validator policy change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-exercisable flow; evidence-gate script change

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior touched

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered views changed

<!-- evidence-row:backend-logs --> - [x] Backend logs: verbatim REPL and test transcripts pasted below
<details><summary>gate verdict flip + test runs (verbatim)</summary>

```
BEFORE (origin/develop):
  hasArtifactReference: false
  isRowSatisfied: false
AFTER (fix/evidence-trust-file-uploads):
  hasArtifactReference: true
  isRowSatisfied: true
$ node scripts/check-pr-evidence.mjs --self-test
check-pr-evidence self-test passed (14 cases).
$ node --test scripts/check-pr-evidence.test.mjs
# tests 90
# pass 90
# fail 0
```

</details>
- [ ] N/A - placeholder, replaced with pasted transcript in next edit

<!-- evidence-row:domain-artifacts --> - [x] Domain artifacts: live gate verdict on the real fork-minted URL, pasted below; published repro comment on #17600
<details><summary>live-fetch verdict with content sha256 (verbatim)</summary>

```
LIVE-FETCH AFTER PUBLISH: {"ok":true,"findings":[{"id":"backend-logs","label":"Backend logs",
"url":"https://github.com/user-attachments/files/30640882/17599-verification.log",
"artifactKind":"file-upload","status":"ok",
"contentSha256":"13a01ee7a90029019e8d778207e04d788419c3459952c826062eed60fd70ab40"}]}
```

</details>
- [ ] N/A - placeholder, replaced with pasted transcript in next edit
