### PR TITLE
fix(telegram): enforce typed activation policy

### DIFF
--- a/packages/agent/src/runtime/build-character-config.test.ts
+++ b/packages/agent/src/runtime/build-character-config.test.ts
@@ -8,8 +8,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ElizaConfig } from "../config/config.ts";
 import { buildCharacterFromConfig } from "./build-character-config.ts";
-import { applySandboxCharacterFromEnv } from "./sandbox-character.ts";
 import { buildRuntimeSettingsProjection } from "./runtime-settings.ts";
+import { applySandboxCharacterFromEnv } from "./sandbox-character.ts";
 
 // Locks the secret/settings boundary for Matrix connector env vars. Putting a
 // public identifier (e.g. MATRIX_VERIFY_ALLOWLIST = a user id) into
@@ -119,6 +119,9 @@ describe("agent entry character passthrough", () => {
     const telegram = {
       botToken: "telegram-token",
       webhookSecret: "webhook-secret",
+      webhookUrl: "https://telegram.example/hook?token=secret",
+      proxy: "http://proxy-user:proxy-password@proxy.example",
+      apiRoot: "http://127.0.0.1:8081",
       dmPolicy: "allowlist",
       allowFrom: ["42"],
       groupPolicy: "allowlist",
@@ -132,6 +135,8 @@ describe("agent entry character passthrough", () => {
       accounts: {
         ops: {
           botToken: "ops-token",
+          apiRoot: "http://127.0.0.1:8082",
+          proxy: "http://ops:secret@proxy.example",
           groupPolicy: "disabled",
         },
       },
@@ -150,17 +155,29 @@ describe("agent entry character passthrough", () => {
     );
     expect(character.settings?.telegram).toEqual({
       dmPolicy: "allowlist",
+      apiRoot: "http://127.0.0.1:8081",
       allowFrom: ["42"],
       groupPolicy: "allowlist",
       groupAllowFrom: ["42"],
       groups: telegram.groups,
-      accounts: { ops: { groupPolicy: "disabled" } },
+      accounts: {
+        ops: {
+          apiRoot: "http://127.0.0.1:8082",
+          groupPolicy: "disabled",
+        },
+      },
     });
     expect(JSON.stringify(character.settings?.telegram)).not.toContain(
       "telegram-token",
     );
     expect(JSON.stringify(character.settings?.telegram)).not.toContain(
       "ops-token",
+    );
+    expect(JSON.stringify(character.settings?.telegram)).not.toContain(
+      "proxy-password",
+    );
+    expect(JSON.stringify(character.settings?.telegram)).not.toContain(
+      "webhook-secret",
     );
   });
 
@@ -176,14 +193,38 @@ describe("agent entry character passthrough", () => {
             name: "Nyx",
             system: "You are Nyx.",
             settings: {
-              telegram: { botToken: "agent-token", groupPolicy: "open" },
+              telegram: {
+                botToken: "agent-token",
+                groupPolicy: "open",
+                allowedChats: ["-1001"],
+                autoReply: true,
+              },
             },
           },
         ],
       },
     } as ElizaConfig);
 
-    expect(character.settings?.telegram).toEqual({ groupPolicy: "disabled" });
+    expect(character.settings?.telegram).toEqual({
+      groupPolicy: "disabled",
+      allowedChats: ["-1001"],
+      autoReply: true,
+    });
+  });
+
+  it("drops credential-bearing and invalid Telegram API roots", () => {
+    for (const apiRoot of [
+      "https://user:password@telegram.example",
+      "file:///tmp/telegram-api",
+      "not a URL",
+    ]) {
+      const character = buildCharacterFromConfig({
+        connectors: { telegram: { botToken: "token", apiRoot } },
+        agents: { list: [{ name: "Nyx", system: "You are Nyx." }] },
+      } as unknown as ElizaConfig);
+
+      expect(character.settings?.telegram).toEqual({});
+    }
   });
 
   it("preserves injected Discord auto-reply settings", () => {

--- a/packages/agent/src/runtime/build-character-config.test.ts
+++ b/packages/agent/src/runtime/build-character-config.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ElizaConfig } from "../config/config.ts";
 import { buildCharacterFromConfig } from "./build-character-config.ts";
 import { applySandboxCharacterFromEnv } from "./sandbox-character.ts";
+import { buildRuntimeSettingsProjection } from "./runtime-settings.ts";
 
 // Locks the secret/settings boundary for Matrix connector env vars. Putting a
 // public identifier (e.g. MATRIX_VERIFY_ALLOWLIST = a user id) into
@@ -112,6 +113,77 @@ describe("agent entry character passthrough", () => {
     expect(character.name).toBe("Sol");
     expect(character.system).toContain("You are Sol.");
     expect(character.system).not.toContain("Secondary system.");
+  });
+
+  it("projects standard Telegram policy without copying connector secrets", () => {
+    const telegram = {
+      botToken: "telegram-token",
+      webhookSecret: "webhook-secret",
+      dmPolicy: "allowlist",
+      allowFrom: ["42"],
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["42"],
+      groups: {
+        "-1001": {
+          requireMention: true,
+          topics: { "77": { requireMention: true } },
+        },
+      },
+      accounts: {
+        ops: {
+          botToken: "ops-token",
+          groupPolicy: "disabled",
+        },
+      },
+    };
+
+    const config = {
+      connectors: { telegram },
+      agents: { list: [{ id: "nyx", name: "Nyx", system: "You are Nyx." }] },
+    } as ElizaConfig;
+    const character = buildCharacterFromConfig(config);
+    const runtimeSettings = buildRuntimeSettingsProjection(config, { env: {} });
+
+    expect(runtimeSettings.TELEGRAM_BOT_TOKEN).toBe("telegram-token");
+    expect(runtimeSettings.TELEGRAM_ACCOUNT_TOKENS_JSON).toBe(
+      JSON.stringify({ ops: "ops-token" }),
+    );
+    expect(character.settings?.telegram).toEqual({
+      dmPolicy: "allowlist",
+      allowFrom: ["42"],
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["42"],
+      groups: telegram.groups,
+      accounts: { ops: { groupPolicy: "disabled" } },
+    });
+    expect(JSON.stringify(character.settings?.telegram)).not.toContain(
+      "telegram-token",
+    );
+    expect(JSON.stringify(character.settings?.telegram)).not.toContain(
+      "ops-token",
+    );
+  });
+
+  it("keeps the standard connector policy authoritative over stale agent settings", () => {
+    const character = buildCharacterFromConfig({
+      connectors: {
+        telegram: { botToken: "connector-token", groupPolicy: "disabled" },
+      },
+      agents: {
+        list: [
+          {
+            id: "nyx",
+            name: "Nyx",
+            system: "You are Nyx.",
+            settings: {
+              telegram: { botToken: "agent-token", groupPolicy: "open" },
+            },
+          },
+        ],
+      },
+    } as ElizaConfig);
+
+    expect(character.settings?.telegram).toEqual({ groupPolicy: "disabled" });
   });
 
   it("preserves injected Discord auto-reply settings", () => {

--- a/packages/agent/src/runtime/build-character-config.ts
+++ b/packages/agent/src/runtime/build-character-config.ts
@@ -29,40 +29,121 @@ import {
   resolveAdvancedCapabilitiesEnabled,
 } from "./advanced-capabilities-config.ts";
 
+const TELEGRAM_PUBLIC_POLICY_KEYS = [
+  "name",
+  "enabled",
+  "apiRoot",
+  "dmPolicy",
+  "groupPolicy",
+  "allowFrom",
+  "groupAllowFrom",
+  "replyToMode",
+  "groups",
+] as const;
+const TELEGRAM_LEGACY_PUBLIC_KEYS = [
+  ...TELEGRAM_PUBLIC_POLICY_KEYS,
+  "allowedChats",
+  "autoReply",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function projectTelegramKeys(
+  value: unknown,
+  keys: readonly string[],
+): Record<string, JsonValue> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const projected: Record<string, JsonValue> = {};
+  for (const key of keys) {
+    const entry = value[key];
+    if (entry !== undefined) {
+      projected[key] = entry as JsonValue;
+    }
+  }
+  return projected;
+}
+
+function projectTelegramPolicy(value: unknown): Record<string, JsonValue> {
+  const projected = projectTelegramKeys(value, TELEGRAM_PUBLIC_POLICY_KEYS);
+  if (typeof projected.apiRoot === "string") {
+    try {
+      const parsed = new URL(projected.apiRoot);
+      if (
+        (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+        parsed.username ||
+        parsed.password
+      ) {
+        delete projected.apiRoot;
+      }
+    } catch {
+      // error-policy:J3 invalid connector URLs are omitted from runtime config.
+      delete projected.apiRoot;
+    }
+  }
+  return projected;
+}
+
 function projectTelegramConnectorSettings(
   connector: unknown,
+  existingSettings: CharacterSettings | undefined,
 ): CharacterSettings {
   if (!connector || typeof connector !== "object" || Array.isArray(connector)) {
     return {};
   }
 
-  const {
-    botToken: _botToken,
-    tokenFile: _tokenFile,
-    webhookSecret: _webhookSecret,
-    accounts,
-    ...safeConnector
-  } = connector as Record<string, unknown>;
-  const safeAccounts: Record<string, unknown> = {};
+  const connectorRecord = connector as Record<string, unknown>;
+  const rawExistingTelegram = isRecord(existingSettings?.telegram)
+    ? existingSettings.telegram
+    : {};
+  const existingTelegram = projectTelegramKeys(
+    rawExistingTelegram,
+    TELEGRAM_LEGACY_PUBLIC_KEYS,
+  );
+  const projectedAccounts: Record<string, JsonValue> = {};
+  const existingAccounts = isRecord(rawExistingTelegram.accounts)
+    ? Object.fromEntries(
+        Object.entries(rawExistingTelegram.accounts).map(
+          ([accountId, account]) => [
+            accountId,
+            projectTelegramKeys(account, TELEGRAM_LEGACY_PUBLIC_KEYS),
+          ],
+        ),
+      )
+    : {};
 
-  if (accounts && typeof accounts === "object" && !Array.isArray(accounts)) {
-    for (const [accountId, account] of Object.entries(accounts)) {
-      if (!account || typeof account !== "object" || Array.isArray(account)) {
-        continue;
-      }
-      const {
-        botToken: _accountBotToken,
-        tokenFile: _accountTokenFile,
-        webhookSecret: _accountWebhookSecret,
-        ...safeAccount
-      } = account as Record<string, unknown>;
-      safeAccounts[accountId] = safeAccount;
+  if (isRecord(connectorRecord.accounts)) {
+    for (const [accountId, account] of Object.entries(
+      connectorRecord.accounts,
+    )) {
+      const projected = projectTelegramPolicy(account);
+      const existingAccount = projectTelegramKeys(
+        existingAccounts[accountId],
+        TELEGRAM_LEGACY_PUBLIC_KEYS,
+      );
+      projectedAccounts[accountId] = {
+        ...existingAccount,
+        ...projected,
+      } as JsonValue;
     }
   }
 
   const telegram = {
-    ...safeConnector,
-    ...(Object.keys(safeAccounts).length > 0 ? { accounts: safeAccounts } : {}),
+    ...existingTelegram,
+    ...projectTelegramPolicy(connectorRecord),
+    ...(Object.keys(existingAccounts).length > 0 ||
+    Object.keys(projectedAccounts).length > 0
+      ? {
+          accounts: {
+            ...existingAccounts,
+            ...projectedAccounts,
+          },
+        }
+      : {}),
   } as JsonValue;
   return { telegram };
 }
@@ -311,6 +392,7 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
       : systemPrompt;
   const connectorSettings = projectTelegramConnectorSettings(
     config.connectors?.telegram,
+    agentEntry?.settings,
   );
   const mergedSettings = {
     ...(agentEntry?.settings ?? {}),

--- a/packages/agent/src/runtime/build-character-config.ts
+++ b/packages/agent/src/runtime/build-character-config.ts
@@ -11,7 +11,9 @@
 import {
   type Character,
   type CharacterInput,
+  type CharacterSettings,
   defaultCharacterSystemTemplate,
+  type JsonValue,
   mergeCharacterDefaults,
 } from "@elizaos/core";
 import {
@@ -26,6 +28,44 @@ import {
   applyAdvancedCapabilitySettings,
   resolveAdvancedCapabilitiesEnabled,
 } from "./advanced-capabilities-config.ts";
+
+function projectTelegramConnectorSettings(
+  connector: unknown,
+): CharacterSettings {
+  if (!connector || typeof connector !== "object" || Array.isArray(connector)) {
+    return {};
+  }
+
+  const {
+    botToken: _botToken,
+    tokenFile: _tokenFile,
+    webhookSecret: _webhookSecret,
+    accounts,
+    ...safeConnector
+  } = connector as Record<string, unknown>;
+  const safeAccounts: Record<string, unknown> = {};
+
+  if (accounts && typeof accounts === "object" && !Array.isArray(accounts)) {
+    for (const [accountId, account] of Object.entries(accounts)) {
+      if (!account || typeof account !== "object" || Array.isArray(account)) {
+        continue;
+      }
+      const {
+        botToken: _accountBotToken,
+        tokenFile: _accountTokenFile,
+        webhookSecret: _accountWebhookSecret,
+        ...safeAccount
+      } = account as Record<string, unknown>;
+      safeAccounts[accountId] = safeAccount;
+    }
+  }
+
+  const telegram = {
+    ...safeConnector,
+    ...(Object.keys(safeAccounts).length > 0 ? { accounts: safeAccounts } : {}),
+  } as JsonValue;
+  return { telegram };
+}
 
 /**
  * Build a Character object from the runtime ElizaConfig.
@@ -269,8 +309,12 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
     capabilityHints.length > 0
       ? `${systemPrompt}\n\n${capabilityHints.join("\n")}`
       : systemPrompt;
+  const connectorSettings = projectTelegramConnectorSettings(
+    config.connectors?.telegram,
+  );
   const mergedSettings = {
     ...(agentEntry?.settings ?? {}),
+    ...connectorSettings,
     ...settings,
   };
 

--- a/packages/agent/src/runtime/connector-vault-refs.test.ts
+++ b/packages/agent/src/runtime/connector-vault-refs.test.ts
@@ -26,7 +26,10 @@ import {
   resolveConnectorSecretSettings,
   type VaultLike,
 } from "./operations/vault-bridge.ts";
-import { buildRuntimeSettingsProjection } from "./runtime-settings.ts";
+import {
+  buildRuntimeSettingsProjection,
+  resolveTelegramAccountTokenVaultSettings,
+} from "./runtime-settings.ts";
 
 const SECRET = "mfa.discord-bot-token-plaintext-1234567890";
 const VAULT_KEY = "connectors.discord.token";
@@ -232,6 +235,65 @@ describe("buildRuntimeSettingsProjection with connector refs", () => {
     // Unresolved ref → fail-closed: neither the sentinel literal nor any
     // partial value reaches a plugin.
     expect(settings.TELEGRAM_BOT_TOKEN).toBeUndefined();
+  });
+
+  it("merges vault-resolved and plain Telegram account tokens in settings only", async () => {
+    const accountSecret = "telegram-account-vault-secret";
+    const config = {
+      connectors: {
+        telegram: {
+          accounts: {
+            ops: { botToken: "plain-ops-token" },
+            alerts: {
+              botToken: formatVaultRef("connectors.telegram.alerts.token"),
+            },
+          },
+        },
+      },
+    } as unknown as ElizaConfig;
+
+    applyConnectorSecretsToEnv(config);
+    const { resolved, failures } =
+      await resolveTelegramAccountTokenVaultSettings(
+        config,
+        fakeVault({
+          "connectors.telegram.alerts.token": accountSecret,
+        }),
+      );
+    const settings = buildRuntimeSettingsProjection(config, {
+      env: {} as NodeJS.ProcessEnv,
+      connectorSecretsOverlay: resolved,
+    });
+
+    expect(failures).toEqual([]);
+    expect(JSON.parse(settings.TELEGRAM_ACCOUNT_TOKENS_JSON)).toEqual({
+      ops: "plain-ops-token",
+      alerts: accountSecret,
+    });
+    expect(process.env.TELEGRAM_BOT_TOKEN).toBeUndefined();
+    expect(Object.values(process.env)).not.toContain(accountSecret);
+  });
+
+  it("fails closed for a missing Telegram account vault ref", async () => {
+    const config = {
+      connectors: {
+        telegram: {
+          accounts: {
+            alerts: {
+              botToken: formatVaultRef("connectors.telegram.alerts.missing"),
+            },
+          },
+        },
+      },
+    } as unknown as ElizaConfig;
+
+    const { resolved, failures } =
+      await resolveTelegramAccountTokenVaultSettings(config, fakeVault({}));
+
+    expect(resolved).toEqual({});
+    expect(failures).toEqual([
+      'TELEGRAM_ACCOUNT_TOKENS_JSON["alerts"] (vault://connectors.telegram.alerts.missing)',
+    ]);
   });
 
   it("keeps plain connector values in settings unchanged (backward compat)", () => {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -68,7 +68,9 @@ import { shouldLoadRemoteCodingRunnerForBoot } from "./remote-coding-runner-gate
 import { runRuntimeStartupMaintenance } from "./runtime-maintenance.ts";
 import {
   buildRuntimeSettingsProjection,
+  collectTelegramAccountTokenVaultRefs,
   type RuntimeSettingsProjectionOptions,
+  resolveTelegramAccountTokenVaultSettings,
 } from "./runtime-settings.ts";
 
 export { deduplicatePluginActions } from "./plugin-action-dedupe.ts";
@@ -2076,9 +2078,14 @@ export async function resolveConnectorSecretsOverlayForBoot(
   config: ElizaConfig,
 ): Promise<Record<string, string>> {
   const connectorEnvVars = collectConnectorEnvVars(config);
-  const refKeys = Object.entries(connectorEnvVars)
+  const connectorRefKeys = Object.entries(connectorEnvVars)
     .filter(([, value]) => isVaultRef(value))
     .map(([key]) => key);
+  const accountRefKeys = collectTelegramAccountTokenVaultRefs(config).map(
+    ({ accountId }) =>
+      `TELEGRAM_ACCOUNT_TOKENS_JSON[${JSON.stringify(accountId)}]`,
+  );
+  const refKeys = [...connectorRefKeys, ...accountRefKeys];
   if (refKeys.length === 0) return {};
 
   if (isMobilePlatform() || readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1") {
@@ -2089,17 +2096,23 @@ export async function resolveConnectorSecretsOverlayForBoot(
   }
 
   const { sharedVault } = importAppCoreRuntime();
-  const { resolved, failures } = await resolveConnectorSecretSettings(
+  const vault = sharedVault();
+  const connectorResult = await resolveConnectorSecretSettings(
     connectorEnvVars,
-    sharedVault(),
+    vault,
   );
+  const accountResult = await resolveTelegramAccountTokenVaultSettings(
+    config,
+    vault,
+  );
+  const failures = [...connectorResult.failures, ...accountResult.failures];
   if (failures.length > 0) {
     // Key names only — never values, never the underlying vault error.
     logger.error(
       `[vault-bootstrap] connector vault ref(s) failed to resolve (fail-closed): ${failures.join(", ")}`,
     );
   }
-  return resolved;
+  return { ...connectorResult.resolved, ...accountResult.resolved };
 }
 
 /**

--- a/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
@@ -159,6 +159,30 @@ describe("collectPluginNames runtime mode provider policy", () => {
     expect(names.has("@elizaos/plugin-telegram-standalone")).toBe(false);
   });
 
+  it("keeps additive plugin sources from restoring a second Telegram poller", () => {
+    process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
+
+    const names = collectPluginNames({
+      connectors: {
+        telegram: { botToken: "telegram-token", groupPolicy: "disabled" },
+      },
+      plugins: {
+        allow: ["@elizaos/plugin-telegram-standalone"],
+        entries: { "telegram-standalone": { enabled: true } },
+        installs: {
+          "@elizaos/plugin-telegram-standalone": {
+            source: "npm",
+            spec: "latest",
+          },
+        },
+      },
+    } as ElizaConfig);
+
+    expect(names.has("@elizaos/plugin-telegram")).toBe(true);
+    expect(names.has("@elizaos/plugin-telegram-standalone")).toBe(false);
+  });
+
   it("uses standalone Telegram as the sole owner for legacy env-only mode", () => {
     process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
     process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";

--- a/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
@@ -21,6 +21,8 @@ const ENV_KEYS = [
   "ELIZA_BUILD_VARIANT",
   "ELIZA_AGENT_ORCHESTRATOR",
   "ELIZA_PLUGIN_SET",
+  "ELIZA_LIFEOPS_PASSIVE_CONNECTORS",
+  "ELIZA_TELEGRAM_STANDALONE_BOT",
   "ELIZA_DEFAULT_AGENT_TYPE",
   "ELIZA_ACP_DEFAULT_AGENT",
   "ELIZA_AGENT_SELECTION_STRATEGY",
@@ -137,6 +139,34 @@ describe("collectPluginNames runtime mode provider policy", () => {
     expect(names.has("@elizaos/plugin-local-inference")).toBe(true);
     expect(names.has("@elizaos/plugin-ollama")).toBe(true);
     expect(names.has("@elizaos/plugin-elizacloud")).toBe(false);
+  });
+
+  it("keeps the typed Telegram connector as the sole owner when the standalone flag is stale", () => {
+    process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
+
+    const names = collectPluginNames({
+      connectors: {
+        telegram: {
+          botToken: "telegram-token",
+          groupPolicy: "allowlist",
+          groups: { "-1001": { requireMention: true } },
+        },
+      },
+    } as ElizaConfig);
+
+    expect(names.has("@elizaos/plugin-telegram")).toBe(true);
+    expect(names.has("@elizaos/plugin-telegram-standalone")).toBe(false);
+  });
+
+  it("uses standalone Telegram as the sole owner for legacy env-only mode", () => {
+    process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
+
+    const names = collectPluginNames({} as ElizaConfig);
+
+    expect(names.has("@elizaos/plugin-telegram-standalone")).toBe(true);
+    expect(names.has("@elizaos/plugin-telegram")).toBe(false);
   });
 
   it("keeps plugin-local-inference when only local embeddings are disabled", () => {

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -853,7 +853,9 @@ export function collectPluginNames(
     }
   }
 
-  if (useTelegramStandalone) {
+  if (hasStandardTelegramConnector) {
+    pluginsToLoad.delete("@elizaos/plugin-telegram-standalone");
+  } else if (useTelegramStandalone) {
     pluginsToLoad.delete("@elizaos/plugin-telegram");
   }
 

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -410,6 +410,24 @@ export function collectPluginNames(
     | undefined;
   const pluginEntries = (config.plugins as Record<string, unknown> | undefined)
     ?.entries as Record<string, { enabled?: boolean }> | undefined;
+  const telegramConnector =
+    config.connectors?.telegram ??
+    (
+      (config as Record<string, unknown>).channels as
+        | Record<string, unknown>
+        | undefined
+    )?.telegram;
+  const hasStandardTelegramConnector = Boolean(
+    telegramConnector &&
+      typeof telegramConnector === "object" &&
+      !Array.isArray(telegramConnector) &&
+      (telegramConnector as Record<string, unknown>).enabled !== false,
+  );
+  // A persisted connector config is authoritative because only the full plugin
+  // consumes its typed DM/group/topic policy. The legacy standalone flag is a
+  // fallback for env-only deployments, never a second polling owner.
+  const useTelegramStandalone =
+    telegramStandaloneRequested() && !hasStandardTelegramConnector;
 
   const isPluginExplicitlyDisabled = (pluginPackageName: string): boolean => {
     const marker = "/plugin-";
@@ -562,11 +580,11 @@ export function collectPluginNames(
   // Opt-in standalone Telegram polling bot. Loaded only when passive connectors
   // are disabled and ELIZA_TELEGRAM_STANDALONE_BOT is set; its service owns the
   // Telegraf long-poll lifecycle (previously inlined in the app-core boot tail).
-  if (telegramStandaloneRequested()) {
+  if (useTelegramStandalone) {
     pluginsToLoad.add("@elizaos/plugin-telegram-standalone");
     track(
       "@elizaos/plugin-telegram-standalone",
-      "telegram standalone bot (gate ELIZA_TELEGRAM_STANDALONE_BOT)",
+      "telegram standalone bot (env-only fallback owner)",
     );
   }
   // Allow list is additive — extra plugins on top of auto-detection,
@@ -606,6 +624,9 @@ export function collectPluginNames(
     }
     const pluginName = CHANNEL_PLUGIN_MAP[channelName];
     if (pluginName) {
+      if (useTelegramStandalone && pluginName === "@elizaos/plugin-telegram") {
+        continue;
+      }
       pluginsToLoad.add(pluginName);
       track(pluginName, `connectors.${channelName}`);
     }
@@ -830,6 +851,10 @@ export function collectPluginNames(
       }
       pluginsToLoad.delete(name);
     }
+  }
+
+  if (useTelegramStandalone) {
+    pluginsToLoad.delete("@elizaos/plugin-telegram");
   }
 
   return pluginsToLoad;

--- a/packages/agent/src/runtime/runtime-settings.ts
+++ b/packages/agent/src/runtime/runtime-settings.ts
@@ -8,7 +8,11 @@ import {
   collectConfigEnvVars,
   collectConnectorEnvVars,
 } from "../config/env-vars.ts";
-import { isVaultRef } from "./operations/vault-bridge.ts";
+import {
+  isVaultRef,
+  resolveConnectorSecretSettings,
+  type VaultLike,
+} from "./operations/vault-bridge.ts";
 
 export interface RuntimeSettingsProjectionOptions {
   preferredProviderId?: string;
@@ -62,7 +66,7 @@ export function isEnvKeyAllowedForForwarding(key: string): boolean {
   return true;
 }
 
-function collectTelegramAccountTokenSettings(
+export function collectTelegramAccountTokenSettings(
   config: ElizaConfig,
 ): Record<string, string> {
   const connector = config.connectors?.telegram as
@@ -75,16 +79,104 @@ function collectTelegramAccountTokenSettings(
   )) {
     const token = account?.botToken;
     const normalizedToken = typeof token === "string" ? token.trim() : "";
-    if (
-      normalizedToken.length > 0 &&
-      !normalizedToken.toLowerCase().startsWith("vault://")
-    ) {
+    if (normalizedToken.length > 0 && !isVaultRef(normalizedToken)) {
       accountTokens[accountId] = normalizedToken;
     }
   }
 
   return Object.keys(accountTokens).length > 0
     ? { TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify(accountTokens) }
+    : {};
+}
+
+export function collectTelegramAccountTokenVaultRefs(
+  config: ElizaConfig,
+): Array<{ accountId: string; ref: string }> {
+  const connector = config.connectors?.telegram as
+    | { accounts?: Record<string, { botToken?: unknown } | undefined> }
+    | undefined;
+
+  return Object.entries(connector?.accounts ?? {}).flatMap(
+    ([accountId, account]) => {
+      const token = account?.botToken;
+      const normalizedToken = typeof token === "string" ? token.trim() : "";
+      return isVaultRef(normalizedToken)
+        ? [{ accountId, ref: normalizedToken }]
+        : [];
+    },
+  );
+}
+
+export async function resolveTelegramAccountTokenVaultSettings(
+  config: ElizaConfig,
+  vault: VaultLike,
+): Promise<{ resolved: Record<string, string>; failures: string[] }> {
+  const keyToAccountId = new Map<string, string>();
+  const refs: Record<string, string> = {};
+  for (const { accountId, ref } of collectTelegramAccountTokenVaultRefs(
+    config,
+  )) {
+    const key = `TELEGRAM_ACCOUNT_TOKENS_JSON[${JSON.stringify(accountId)}]`;
+    refs[key] = ref;
+    keyToAccountId.set(key, accountId);
+  }
+  const { resolved, failures } = await resolveConnectorSecretSettings(
+    refs,
+    vault,
+  );
+  const accountTokens: Record<string, string> = {};
+  for (const [key, accountId] of keyToAccountId) {
+    const token = resolved[key];
+    if (token) {
+      accountTokens[accountId] = token;
+    }
+  }
+  return {
+    resolved:
+      Object.keys(accountTokens).length > 0
+        ? { TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify(accountTokens) }
+        : {},
+    failures,
+  };
+}
+
+function parseTelegramAccountTokenSetting(
+  value: string | undefined,
+): Record<string, string> {
+  if (!value) {
+    return {};
+  }
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new TypeError("TELEGRAM_ACCOUNT_TOKENS_JSON must be a JSON object");
+  }
+  return Object.fromEntries(
+    Object.entries(parsed as Record<string, unknown>).map(
+      ([accountId, token]) => {
+        if (typeof token !== "string" || token.trim().length === 0) {
+          throw new TypeError(
+            `TELEGRAM_ACCOUNT_TOKENS_JSON contains an invalid token for account ${JSON.stringify(accountId)}`,
+          );
+        }
+        return [accountId, token.trim()];
+      },
+    ),
+  );
+}
+
+function mergeTelegramAccountTokenSettings(
+  config: ElizaConfig,
+  connectorSecretsOverlay: Record<string, string> | undefined,
+): Record<string, string> {
+  const plain = parseTelegramAccountTokenSetting(
+    collectTelegramAccountTokenSettings(config).TELEGRAM_ACCOUNT_TOKENS_JSON,
+  );
+  const resolved = parseTelegramAccountTokenSetting(
+    connectorSecretsOverlay?.TELEGRAM_ACCOUNT_TOKENS_JSON,
+  );
+  const merged = { ...plain, ...resolved };
+  return Object.keys(merged).length > 0
+    ? { TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify(merged) }
     : {};
 }
 
@@ -110,7 +202,10 @@ export function buildRuntimeSettingsProjection(
       ),
     ),
     ...(options.connectorSecretsOverlay ?? {}),
-    ...collectTelegramAccountTokenSettings(config),
+    ...mergeTelegramAccountTokenSettings(
+      config,
+      options.connectorSecretsOverlay,
+    ),
     ...(options.preferredProviderId
       ? { MODEL_PROVIDER: options.preferredProviderId }
       : {}),

--- a/packages/agent/src/runtime/runtime-settings.ts
+++ b/packages/agent/src/runtime/runtime-settings.ts
@@ -62,6 +62,32 @@ export function isEnvKeyAllowedForForwarding(key: string): boolean {
   return true;
 }
 
+function collectTelegramAccountTokenSettings(
+  config: ElizaConfig,
+): Record<string, string> {
+  const connector = config.connectors?.telegram as
+    | { accounts?: Record<string, { botToken?: unknown } | undefined> }
+    | undefined;
+  const accountTokens: Record<string, string> = {};
+
+  for (const [accountId, account] of Object.entries(
+    connector?.accounts ?? {},
+  )) {
+    const token = account?.botToken;
+    const normalizedToken = typeof token === "string" ? token.trim() : "";
+    if (
+      normalizedToken.length > 0 &&
+      !normalizedToken.toLowerCase().startsWith("vault://")
+    ) {
+      accountTokens[accountId] = normalizedToken;
+    }
+  }
+
+  return Object.keys(accountTokens).length > 0
+    ? { TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify(accountTokens) }
+    : {};
+}
+
 export function buildRuntimeSettingsProjection(
   config: ElizaConfig,
   options: RuntimeSettingsProjectionOptions = {},
@@ -84,6 +110,7 @@ export function buildRuntimeSettingsProjection(
       ),
     ),
     ...(options.connectorSecretsOverlay ?? {}),
+    ...collectTelegramAccountTokenSettings(config),
     ...(options.preferredProviderId
       ? { MODEL_PROVIDER: options.preferredProviderId }
       : {}),

--- a/plugins/plugin-telegram/__tests__/core-test-mock.ts
+++ b/plugins/plugin-telegram/__tests__/core-test-mock.ts
@@ -15,6 +15,7 @@ vi.mock("@elizaos/core", async () => {
   const interactions = await import(
     "../../../packages/core/src/messaging/interactions/index"
   );
+  const { ElizaError } = await import("../../../packages/core/src/errors");
 
   // The message-triage adapter base + service are equally pure (only `logger`
   // and type imports), so the mock delegates to the real submodules rather than
@@ -120,6 +121,7 @@ vi.mock("@elizaos/core", async () => {
     BaseMessageAdapter,
     ChannelType,
     CommandRegistryService,
+    ElizaError,
     EventType,
     getDefaultTriageService,
     ModelType,

--- a/plugins/plugin-telegram/src/accounts.test.ts
+++ b/plugins/plugin-telegram/src/accounts.test.ts
@@ -1,0 +1,35 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { resolveTelegramAccount } from "./accounts";
+
+describe("Telegram standard account config resolution", () => {
+  it("combines projected account policy with its runtime-only bot token", () => {
+    const runtime = {
+      character: {
+        settings: {
+          telegram: {
+            accounts: {
+              ops: {
+                groupPolicy: "allowlist",
+                groups: { "-1001": { requireMention: true } },
+              },
+            },
+          },
+        },
+      },
+      getSetting: vi.fn((key: string) =>
+        key === "TELEGRAM_ACCOUNT_TOKENS_JSON"
+          ? JSON.stringify({ ops: "ops-token" })
+          : undefined,
+      ),
+    } as unknown as IAgentRuntime;
+
+    const account = resolveTelegramAccount(runtime, "ops");
+
+    expect(account.botToken).toBe("ops-token");
+    expect(account.config).toMatchObject({
+      groupPolicy: "allowlist",
+      groups: { "-1001": { requireMention: true } },
+    });
+  });
+});

--- a/plugins/plugin-telegram/src/accounts.test.ts
+++ b/plugins/plugin-telegram/src/accounts.test.ts
@@ -1,6 +1,9 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-import { resolveTelegramAccount } from "./accounts";
+import {
+  listEnabledTelegramAccounts,
+  resolveTelegramAccount,
+} from "./accounts";
 
 describe("Telegram standard account config resolution", () => {
   it("combines projected account policy with its runtime-only bot token", () => {
@@ -31,5 +34,31 @@ describe("Telegram standard account config resolution", () => {
       groupPolicy: "allowlist",
       groups: { "-1001": { requireMention: true } },
     });
+  });
+
+  it("fails closed when projected account-token JSON is malformed", () => {
+    const runtime = {
+      character: {
+        settings: { telegram: { accounts: { ops: { enabled: true } } } },
+      },
+      getSetting: vi.fn(() => "{not-json"),
+    } as unknown as IAgentRuntime;
+
+    expect(() => listEnabledTelegramAccounts(runtime)).toThrowError(
+      expect.objectContaining({ code: "TELEGRAM_ACCOUNT_TOKENS_INVALID" }),
+    );
+  });
+
+  it("fails closed when any projected account token is empty", () => {
+    const runtime = {
+      character: {
+        settings: { telegram: { accounts: { ops: { enabled: true } } } },
+      },
+      getSetting: vi.fn(() => JSON.stringify({ ops: "" })),
+    } as unknown as IAgentRuntime;
+
+    expect(() => listEnabledTelegramAccounts(runtime)).toThrowError(
+      expect.objectContaining({ code: "TELEGRAM_ACCOUNT_TOKEN_MISSING" }),
+    );
   });
 });

--- a/plugins/plugin-telegram/src/accounts.ts
+++ b/plugins/plugin-telegram/src/accounts.ts
@@ -16,6 +16,29 @@ export interface TelegramAccountConfig {
   apiRoot?: string;
   allowedChats?: string[];
   autoReply?: boolean;
+  dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
+  groupPolicy?: "open" | "disabled" | "allowlist";
+  allowFrom?: Array<string | number>;
+  groupAllowFrom?: Array<string | number>;
+  replyToMode?: "off" | "first" | "all";
+  groups?: Record<
+    string,
+    | {
+        requireMention?: boolean;
+        enabled?: boolean;
+        allowFrom?: Array<string | number>;
+        topics?: Record<
+          string,
+          | {
+              requireMention?: boolean;
+              enabled?: boolean;
+              allowFrom?: Array<string | number>;
+            }
+          | undefined
+        >;
+      }
+    | undefined
+  >;
   personal?: {
     phone?: string;
     appId?: string;
@@ -29,6 +52,12 @@ export interface TelegramMultiAccountConfig {
   enabled?: boolean;
   botToken?: string;
   apiRoot?: string;
+  dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
+  groupPolicy?: "open" | "disabled" | "allowlist";
+  allowFrom?: Array<string | number>;
+  groupAllowFrom?: Array<string | number>;
+  replyToMode?: "off" | "first" | "all";
+  groups?: TelegramAccountConfig["groups"];
   accounts?: Record<string, TelegramAccountConfig>;
 }
 
@@ -45,6 +74,31 @@ function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function getRuntimeAccountTokens(
+  runtime: IAgentRuntime,
+): Record<string, string> {
+  const raw = runtime.getSetting("TELEGRAM_ACCOUNT_TOKENS_JSON");
+  if (typeof raw !== "string" || !raw.trim()) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).flatMap(
+        ([accountId, token]) => {
+          const value = readNonEmptyString(token);
+          return value ? [[accountId, value]] : [];
+        },
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
 export function normalizeTelegramAccountId(accountId?: string | null): string {
   return readNonEmptyString(accountId) ?? DEFAULT_ACCOUNT_ID;
 }
@@ -52,7 +106,7 @@ export function normalizeTelegramAccountId(accountId?: string | null): string {
 export function getTelegramMultiAccountConfig(
   runtime: IAgentRuntime,
 ): TelegramMultiAccountConfig {
-  const characterTelegram = runtime.character.settings?.telegram as
+  const characterTelegram = runtime.character?.settings?.telegram as
     | TelegramMultiAccountConfig
     | undefined;
 
@@ -60,6 +114,12 @@ export function getTelegramMultiAccountConfig(
     enabled: characterTelegram?.enabled,
     botToken: characterTelegram?.botToken,
     apiRoot: characterTelegram?.apiRoot,
+    dmPolicy: characterTelegram?.dmPolicy,
+    groupPolicy: characterTelegram?.groupPolicy,
+    allowFrom: characterTelegram?.allowFrom,
+    groupAllowFrom: characterTelegram?.groupAllowFrom,
+    replyToMode: characterTelegram?.replyToMode,
+    groups: characterTelegram?.groups,
     accounts: characterTelegram?.accounts,
   };
 }
@@ -103,6 +163,12 @@ function resolveTelegramBotToken(
   if (configToken) {
     return configToken;
   }
+  const accountToken = readNonEmptyString(
+    getRuntimeAccountTokens(runtime)[accountId],
+  );
+  if (accountToken) {
+    return accountToken;
+  }
   if (accountId !== DEFAULT_ACCOUNT_ID) {
     return undefined;
   }
@@ -123,6 +189,12 @@ export function resolveTelegramAccount(
     enabled: multi.enabled,
     botToken: multi.botToken,
     apiRoot: multi.apiRoot,
+    dmPolicy: multi.dmPolicy,
+    groupPolicy: multi.groupPolicy,
+    allowFrom: multi.allowFrom,
+    groupAllowFrom: multi.groupAllowFrom,
+    replyToMode: multi.replyToMode,
+    groups: multi.groups,
     ...accountConfig,
   };
   const apiRoot =

--- a/plugins/plugin-telegram/src/accounts.ts
+++ b/plugins/plugin-telegram/src/accounts.ts
@@ -5,7 +5,7 @@
  * `ResolvedTelegramAccount` the service launches a bot for. `default` is the
  * synthetic id for the single-account configuration.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 
 export const DEFAULT_ACCOUNT_ID = "default";
 
@@ -81,22 +81,41 @@ function getRuntimeAccountTokens(
   if (typeof raw !== "string" || !raw.trim()) {
     return {};
   }
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return {};
-    }
-    return Object.fromEntries(
-      Object.entries(parsed as Record<string, unknown>).flatMap(
-        ([accountId, token]) => {
-          const value = readNonEmptyString(token);
-          return value ? [[accountId, value]] : [];
-        },
-      ),
-    );
-  } catch {
-    return {};
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    // error-policy:J2 runtime projection corruption must retain its parse cause.
+    throw new ElizaError("Telegram account token settings are not valid JSON", {
+      code: "TELEGRAM_ACCOUNT_TOKENS_INVALID",
+      cause: error,
+      severity: "fatal",
+    });
   }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ElizaError("Telegram account token settings must be an object", {
+      code: "TELEGRAM_ACCOUNT_TOKENS_INVALID",
+      severity: "fatal",
+    });
+  }
+  return Object.fromEntries(
+    Object.entries(parsed as Record<string, unknown>).map(
+      ([accountId, token]) => {
+        const value = readNonEmptyString(token);
+        if (!value) {
+          throw new ElizaError(
+            `Telegram account token is missing for ${JSON.stringify(accountId)}`,
+            {
+              code: "TELEGRAM_ACCOUNT_TOKEN_MISSING",
+              context: { accountId },
+              severity: "fatal",
+            },
+          );
+        }
+        return [accountId, value];
+      },
+    ),
+  );
 }
 
 export function normalizeTelegramAccountId(accountId?: string | null): string {

--- a/plugins/plugin-telegram/src/command-registration.test.ts
+++ b/plugins/plugin-telegram/src/command-registration.test.ts
@@ -90,6 +90,7 @@ function makeRuntime(settings: Record<string, string> = {}): IAgentRuntime {
       cache.set(key, value);
       return true;
     }),
+    reportError: vi.fn(),
     character: { name: "TestAgent" },
   } as unknown as IAgentRuntime;
 }
@@ -350,15 +351,21 @@ describe("applyTelegramSetMyCommands", () => {
     );
   });
 
-  it("swallows setMyCommands network failures without throwing", async () => {
+  it("reports setMyCommands network failures without stopping polling", async () => {
     const setMyCommands = vi.fn(async () => {
       throw new Error("ETELEGRAM 429: Too Many Requests");
     });
     const bot = { telegram: { setMyCommands } } as never;
+    const runtime = makeRuntime();
 
     await expect(
-      applyTelegramSetMyCommands(bot, makeRuntime(), "default"),
+      applyTelegramSetMyCommands(bot, runtime, "default"),
     ).resolves.toBeUndefined();
     expect(setMyCommands).toHaveBeenCalledTimes(1);
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "telegram:command-menu",
+      expect.any(Error),
+      { accountId: "default" },
+    );
   });
 });

--- a/plugins/plugin-telegram/src/command-registration.ts
+++ b/plugins/plugin-telegram/src/command-registration.ts
@@ -412,19 +412,20 @@ export function registerTelegramCommandHandlers(
       try {
         await handler(ctx);
       } catch (error) {
-        logger.error(
-          {
-            src: "plugin:telegram",
-            agentId: runtime.agentId,
+        // error-policy:J1 command boundary reports and returns an explicit failure.
+        runtime.reportError("telegram:command", error, {
+          accountId,
+          command: descriptor.name,
+        });
+        try {
+          await ctx.reply(`Could not run /${descriptor.name}.`);
+        } catch (replyError) {
+          // error-policy:J7 failed diagnostics must not terminate polling.
+          runtime.reportError("telegram:command-reply", replyError, {
             accountId,
             command: descriptor.name,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "Error handling slash command",
-        );
-        await ctx
-          .reply(`Could not run /${descriptor.name}.`)
-          .catch(() => undefined);
+          });
+        }
       }
     });
   }
@@ -461,14 +462,7 @@ export async function applyTelegramSetMyCommands(
       "Published slash-command menu to Telegram",
     );
   } catch (error) {
-    logger.warn(
-      {
-        src: "plugin:telegram",
-        agentId: runtime.agentId,
-        accountId,
-        error: error instanceof Error ? error.message : String(error),
-      },
-      "setMyCommands failed; slash-command menu not published",
-    );
+    // error-policy:J7 menu publication is diagnostic, not required for polling.
+    runtime.reportError("telegram:command-menu", error, { accountId });
   }
 }

--- a/plugins/plugin-telegram/src/interactions-roundtrip.test.ts
+++ b/plugins/plugin-telegram/src/interactions-roundtrip.test.ts
@@ -15,8 +15,10 @@ function createCallbackManager() {
   const ensureConnection = vi.fn(async () => undefined);
   const runtime = {
     agentId: "agent-1",
+    character: { name: "Agent", settings: {} },
     messageService: { handleMessage },
     ensureConnection,
+    getSetting: vi.fn(() => undefined),
   };
   const bot = { telegram: { sendMessage: vi.fn(), sendChatAction: vi.fn() } };
   return {

--- a/plugins/plugin-telegram/src/messageConnector.test.ts
+++ b/plugins/plugin-telegram/src/messageConnector.test.ts
@@ -176,6 +176,39 @@ describe("Telegram message connector adapter", () => {
     expect(manager.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("does not let TELEGRAM_ALLOWED_CHATS override typed Telegram policy", async () => {
+    const getSetting = vi.fn((key: string) =>
+      key === "TELEGRAM_ALLOWED_CHATS" ? '["-999"]' : undefined,
+    );
+    const runtime = {
+      agentId: "agent-1",
+      character: {
+        settings: {
+          telegram: {
+            botToken: "token",
+            groupPolicy: "open",
+            groups: { "-100123": { requireMention: true } },
+          },
+        },
+      },
+      getSetting,
+    } as unknown as IAgentRuntime;
+    const service = createTelegramService({
+      runtime,
+      defaultAccountId: "default",
+      accountStates: new Map(),
+    }) as unknown as {
+      isGroupAuthorized(ctx: unknown, accountId?: string): Promise<boolean>;
+    };
+
+    await expect(
+      service.isGroupAuthorized({
+        chat: { id: -100123, type: "supergroup" },
+      }),
+    ).resolves.toBe(true);
+    expect(getSetting).not.toHaveBeenCalledWith("TELEGRAM_ALLOWED_CHATS");
+  });
+
   it("resolves known chats into connector targets", async () => {
     const runtime = createRuntime();
     const service = createTelegramService({

--- a/plugins/plugin-telegram/src/messageManager.activation-policy.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.activation-policy.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Production-path coverage for Telegram safe activation: MessageManager handles
+ * Telegraf message contexts with the typed connector policy already present on
+ * `character.settings.telegram`, and only addressed/authorized updates reach
+ * memory or model dispatch.
+ */
+import type {
+  Content,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { MessageManager } from "./messageManager";
+
+const BOT_USER = {
+  id: 9001,
+  is_bot: true,
+  first_name: "Agent",
+  username: "agent_bot",
+};
+
+type RuntimeOptions = {
+  telegram?: Record<string, unknown>;
+  autoReply?: boolean;
+  handleMessage?: (
+    runtime: IAgentRuntime,
+    memory: Memory,
+    callback: HandlerCallback,
+  ) => Promise<void>;
+};
+
+function createHarness(options: RuntimeOptions = {}) {
+  const createMemory = vi.fn(async () => undefined);
+  const ensureConnection = vi.fn(async () => undefined);
+  const sendMessage = vi.fn(async (chatId: string | number, text: string) => ({
+    message_id: 500,
+    date: 1_700_000_010,
+    text,
+    chat: { id: chatId, type: "supergroup" },
+  }));
+  const sendChatAction = vi.fn(async () => undefined);
+  const messageService = {
+    handleMessage: vi.fn(
+      options.handleMessage ??
+        (async () => {
+          return undefined;
+        }),
+    ),
+  };
+  const runtime = {
+    agentId: "agent-1",
+    character: {
+      name: "Agent",
+      settings: {
+        telegram: options.telegram ?? {
+          botToken: "token",
+          dmPolicy: "allowlist",
+          allowFrom: ["42"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["42"],
+          groups: {
+            "-1001": { requireMention: true },
+          },
+        },
+      },
+    },
+    createMemory,
+    ensureConnection,
+    messageService,
+    getSetting: vi.fn((key: string) => {
+      if (key === "TELEGRAM_AUTO_REPLY" && options.autoReply) {
+        return "true";
+      }
+      return undefined;
+    }),
+    getService: vi.fn(() => null),
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime & {
+    createMemory: ReturnType<typeof vi.fn>;
+    ensureConnection: ReturnType<typeof vi.fn>;
+    messageService: { handleMessage: ReturnType<typeof vi.fn> };
+  };
+  const bot = {
+    botInfo: BOT_USER,
+    telegram: {
+      sendMessage,
+      sendChatAction,
+    },
+  };
+
+  return {
+    manager: new MessageManager(bot as never, runtime),
+    runtime,
+    sendMessage,
+  };
+}
+
+function groupContext(overrides: Record<string, unknown> = {}) {
+  return {
+    from: {
+      id: 42,
+      first_name: "Ada",
+      username: "ada",
+      is_bot: false,
+    },
+    chat: { id: -1001, type: "supergroup", title: "Ops" },
+    message: {
+      message_id: 10,
+      date: 1_700_000_000,
+      text: "hello room",
+      chat: { id: -1001, type: "supergroup", title: "Ops" },
+      ...overrides,
+    },
+  };
+}
+
+describe("MessageManager typed Telegram activation policy", () => {
+  it("does not create memory or dispatch for unaddressed ordinary group traffic", async () => {
+    const { manager, runtime } = createHarness();
+
+    await manager.handleMessage(groupContext() as never);
+
+    expect(runtime.ensureConnection).not.toHaveBeenCalled();
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+    expect(runtime.messageService.handleMessage).not.toHaveBeenCalled();
+  });
+
+  it("blocks unauthorized senders and unconfigured groups before memory, even for forced commands", async () => {
+    const { manager, runtime } = createHarness();
+    const mention = {
+      text: "@agent_bot run",
+      entities: [{ type: "mention", offset: 0, length: 10 }],
+    };
+
+    await manager.handleMessage(
+      {
+        ...groupContext(mention),
+        from: {
+          id: 7,
+          first_name: "Eve",
+          username: "eve",
+          is_bot: false,
+        },
+      } as never,
+      { forceReply: true },
+    );
+
+    await manager.handleMessage({
+      ...groupContext({
+        ...mention,
+        chat: { id: -9999, type: "supergroup", title: "Other" },
+      }),
+      chat: { id: -9999, type: "supergroup", title: "Other" },
+    } as never);
+
+    expect(runtime.ensureConnection).not.toHaveBeenCalled();
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+    expect(runtime.messageService.handleMessage).not.toHaveBeenCalled();
+  });
+
+  it("dispatches native mentions and strips only the addressed bot mention", async () => {
+    const { manager, runtime } = createHarness();
+
+    await manager.handleMessage(
+      groupContext({
+        text: "@agent_bot hello @someone_else",
+        entities: [{ type: "mention", offset: 0, length: 10 }],
+      }) as never,
+    );
+
+    expect(runtime.messageService.handleMessage).toHaveBeenCalledTimes(1);
+    const memory = runtime.messageService.handleMessage.mock.calls[0][1];
+    expect(memory.content.text).toBe("hello @someone_else");
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+  });
+
+  it("dispatches replies to the bot without a mention", async () => {
+    const { manager, runtime } = createHarness();
+
+    await manager.handleMessage(
+      groupContext({
+        reply_to_message: {
+          message_id: 9,
+          date: 1_699_999_999,
+          text: "agent reply",
+          chat: { id: -1001, type: "supergroup", title: "Ops" },
+          from: BOT_USER,
+        },
+      }) as never,
+    );
+
+    expect(runtime.messageService.handleMessage).toHaveBeenCalledTimes(1);
+    const memory = runtime.messageService.handleMessage.mock.calls[0][1];
+    expect(memory.content.inReplyTo).toBeDefined();
+  });
+
+  it("obeys typed DM allowlist policy", async () => {
+    const { manager, runtime } = createHarness();
+
+    await manager.handleMessage({
+      from: { id: 42, first_name: "Ada", username: "ada", is_bot: false },
+      chat: { id: 42, type: "private", first_name: "Ada" },
+      message: {
+        message_id: 11,
+        date: 1_700_000_000,
+        text: "hello",
+        chat: { id: 42, type: "private", first_name: "Ada" },
+      },
+    } as never);
+
+    expect(runtime.messageService.handleMessage).toHaveBeenCalledTimes(1);
+
+    await manager.handleMessage({
+      from: { id: 7, first_name: "Eve", username: "eve", is_bot: false },
+      chat: { id: 7, type: "private", first_name: "Eve" },
+      message: {
+        message_id: 12,
+        date: 1_700_000_000,
+        text: "hello",
+        chat: { id: 7, type: "private", first_name: "Eve" },
+      },
+    } as never);
+
+    expect(runtime.messageService.handleMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps topic identity and delivers generated replies to the thread and source message", async () => {
+    const { manager, runtime, sendMessage } = createHarness({
+      telegram: {
+        botToken: "token",
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["42"],
+        replyToMode: "first",
+        groups: {
+          "-1001": {
+            requireMention: true,
+            topics: { "77": { requireMention: true } },
+          },
+        },
+      },
+      handleMessage: async (_runtime, _memory, callback) => {
+        await callback({ text: "thread reply" } as Content);
+      },
+    });
+
+    await manager.handleMessage({
+      ...groupContext({
+        text: "@agent_bot thread",
+        entities: [{ type: "mention", offset: 0, length: 10 }],
+        is_topic_message: true,
+        message_thread_id: 77,
+      }),
+      telegram: {
+        sendMessage,
+        sendChatAction: vi.fn(async () => undefined),
+      },
+    } as never);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      -1001,
+      "thread reply",
+      expect.objectContaining({
+        message_thread_id: 77,
+        reply_parameters: { message_id: 10 },
+      }),
+    );
+    expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+    const responseMemory = runtime.createMemory.mock.calls[0][0];
+    expect(responseMemory.roomId).toBe(
+      runtime.messageService.handleMessage.mock.calls[0][1].roomId,
+    );
+    expect(responseMemory.metadata.telegram).toMatchObject({
+      chatId: -1001,
+      threadId: "77",
+    });
+  });
+
+  it("does not let legacy auto-reply override typed group mention policy", async () => {
+    const { manager, runtime } = createHarness({ autoReply: true });
+
+    await manager.handleMessage(groupContext() as never);
+
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+    expect(runtime.messageService.handleMessage).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-telegram/src/messageManager.activation-policy.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.activation-policy.test.ts
@@ -271,7 +271,7 @@ describe("MessageManager typed Telegram activation policy", () => {
       runtime.messageService.handleMessage.mock.calls[0][1].roomId,
     );
     expect(responseMemory.metadata.telegram).toMatchObject({
-      chatId: -1001,
+      chatId: "-1001",
       threadId: "77",
     });
   });

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -36,11 +36,18 @@ import type {
   Message,
   ReactionType,
   Update,
+  User,
 } from "@telegraf/types";
 import type { Context, NarrowedContext, Telegraf } from "telegraf";
 import { Markup } from "telegraf";
+import {
+  getTelegramMultiAccountConfig,
+  resolveTelegramAccount,
+  type TelegramAccountConfig,
+} from "./accounts";
 import { resolveTelegramSenderAuth } from "./command-registration";
 import { renderTelegramInteractions } from "./interactions";
+import { evaluateTelegramPolicy, hasTypedTelegramPolicyConfig } from "./policy";
 import {
   type TelegramContent,
   TelegramEventTypes,
@@ -89,6 +96,16 @@ function contentTypeForMime(mime?: string): ContentType {
   if (mime?.startsWith("video/")) return "video";
   if (mime?.startsWith("audio/")) return "audio";
   return "document";
+}
+
+function telegramMessagePlainText(message: Message): string | undefined {
+  if ("text" in message && typeof message.text === "string") {
+    return message.text;
+  }
+  if ("caption" in message && typeof message.caption === "string") {
+    return message.caption;
+  }
+  return undefined;
 }
 
 const MAX_MESSAGE_LENGTH = 4096; // Telegram's max message length
@@ -1027,6 +1044,11 @@ export class MessageManager {
       // lookup) and attached to the final chunk only, alongside any other
       // interaction controls.
       const embedLaunchRow = await this.buildEmbedLaunchRow(ctx);
+      const telegramConfig = getTelegramMultiAccountConfig(this.runtime);
+      const replyToMode =
+        telegramConfig.accounts?.[this.accountId]?.replyToMode ??
+        telegramConfig.replyToMode ??
+        "first";
 
       for (let i = 0; i < chunks.length; i++) {
         const chunk = convertMarkdownToTelegram(chunks[i]);
@@ -1054,11 +1076,14 @@ export class MessageManager {
             : undefined;
 
         const chatId = ctx.chat.id;
+        const shouldReplyToSource =
+          replyToMessageId !== undefined &&
+          replyToMode !== "off" &&
+          (replyToMode === "all" || i === 0);
         const sendOptions = {
-          reply_parameters:
-            i === 0 && replyToMessageId
-              ? { message_id: replyToMessageId }
-              : undefined,
+          reply_parameters: shouldReplyToSource
+            ? { message_id: replyToMessageId }
+            : undefined,
           message_thread_id: messageThreadId,
           reply_markup: replyMarkup,
         };
@@ -1295,10 +1320,9 @@ export class MessageManager {
    * Handle incoming messages from Telegram and process them accordingly.
    * @param {Context} ctx - The context object containing information about the message.
    * @param {object} [options] - Handling options.
-   * @param {boolean} [options.forceReply] - When true, always route the message
-   *   through the agent and force a reply, bypassing the TELEGRAM_AUTO_REPLY gate.
-   *   Used for explicit slash-command invocations where the user intent to get a
-   *   response is unambiguous.
+   * @param {boolean} [options.forceReply] - Marks an explicit slash-command
+   *   invocation. It bypasses only the legacy TELEGRAM_AUTO_REPLY gate; typed
+   *   DM/group authorization still applies.
    * @returns {Promise<void>}
    */
   public async handleMessage(
@@ -1343,13 +1367,78 @@ export class MessageManager {
         this.runtime,
         this.scopedTelegramKey(telegramMessageId),
       );
+      const chat = message.chat as Chat;
+
+      const telegramAutoReplyRaw = this.runtime.getSetting(
+        "TELEGRAM_AUTO_REPLY",
+      );
+      const telegramAutoReply =
+        !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
+        (telegramAutoReplyRaw === true || telegramAutoReplyRaw === "true");
+      const accountConfig = resolveTelegramAccount(
+        this.runtime,
+        this.accountId,
+      ).config;
+      const policyDecision = await evaluateTelegramPolicy({
+        runtime: this.runtime,
+        config: accountConfig,
+        message,
+        from: ctx.from,
+        chatType: chat.type,
+        chatId: telegramChatId,
+        threadId,
+        botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
+        forceReply: options?.forceReply,
+        legacyAutoReply: telegramAutoReply,
+      });
+      const typedPolicyConfigured = hasTypedTelegramPolicyConfig(accountConfig);
+      if (!policyDecision.shouldDispatch && typedPolicyConfigured) {
+        if (policyDecision.denialMessage && chat.type === "private") {
+          try {
+            await this.bot.telegram.sendMessage(
+              chat.id,
+              policyDecision.denialMessage,
+            );
+          } catch (error) {
+            logger.warn(
+              {
+                src: "plugin:telegram",
+                agentId: this.runtime.agentId,
+                accountId: this.accountId,
+                chatId: telegramChatId,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              "Failed to send Telegram pairing response",
+            );
+          }
+        }
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            accountId: this.accountId,
+            chatId: telegramChatId,
+            reason: policyDecision.reason,
+          },
+          "Telegram message skipped by typed activation policy",
+        );
+        return;
+      }
 
       // Process message content and attachments
       const { processedContent, attachments } =
         await this.processMessage(message);
 
+      const rawMessageText = telegramMessagePlainText(message);
+      const policyAdjustedContent =
+        policyDecision.textOverride !== undefined && rawMessageText
+          ? processedContent.startsWith(rawMessageText)
+            ? `${policyDecision.textOverride}${processedContent.slice(rawMessageText.length)}`
+            : policyDecision.textOverride
+          : processedContent;
+
       // Clean processedContent and attachments to avoid NULL characters
-      const cleanedContent = cleanText(processedContent);
+      const cleanedContent = cleanText(policyAdjustedContent);
       const cleanedAttachments = attachments.map((att) => ({
         ...att,
         text: cleanText(att.text),
@@ -1362,7 +1451,6 @@ export class MessageManager {
       }
 
       // Get chat type and determine channel type
-      const chat = message.chat as Chat;
       const channelType = getChannelType(chat);
 
       await this.runtime.ensureConnection({
@@ -1484,6 +1572,7 @@ export class MessageManager {
               ctx,
               content,
               message.message_id,
+              threadIdNum,
             );
           }
 
@@ -1519,19 +1608,11 @@ export class MessageManager {
         threadId: threadIdNum,
       });
 
-      // Inbound messages are always persisted to memory above. The agent only
-      // auto-generates a reply when TELEGRAM_AUTO_REPLY is explicitly enabled —
-      // default-off prevents the runtime from speaking on the user's behalf.
-      // A forced reply (explicit slash-command invocation) always routes to the
-      // agent regardless of the auto-reply gate, since the user explicitly asked
-      // for a response by typing a command.
-      const telegramAutoReplyRaw = this.runtime.getSetting(
-        "TELEGRAM_AUTO_REPLY",
-      );
-      const telegramAutoReply =
-        !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
-        (telegramAutoReplyRaw === true || telegramAutoReplyRaw === "true");
-      const shouldReply = options?.forceReply === true || telegramAutoReply;
+      // Without typed Telegram policy, legacy deployments keep their historical
+      // passive ingestion plus TELEGRAM_AUTO_REPLY gate.
+      // A forced reply (explicit slash-command invocation) bypasses the legacy
+      // auto-reply gate, but typed route and sender authorization still applies.
+      const shouldReply = policyDecision.shouldDispatch;
 
       if (!shouldReply) {
         try {
@@ -1584,6 +1665,35 @@ export class MessageManager {
     }
   }
 
+  private async isExplicitUpdateAuthorized(params: {
+    message: Message;
+    from: User;
+    chat: Chat;
+    threadId?: string;
+  }): Promise<boolean> {
+    const telegramConfig = getTelegramMultiAccountConfig(this.runtime);
+    const accountConfig: TelegramAccountConfig = {
+      ...telegramConfig,
+      ...telegramConfig.accounts?.[this.accountId],
+    };
+    if (!hasTypedTelegramPolicyConfig(accountConfig)) {
+      return true;
+    }
+
+    const decision = await evaluateTelegramPolicy({
+      runtime: this.runtime,
+      config: accountConfig,
+      message: params.message,
+      from: params.from,
+      chatType: params.chat.type,
+      chatId: params.chat.id.toString(),
+      threadId: params.threadId,
+      botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
+      forceReply: true,
+    });
+    return decision.shouldDispatch;
+  }
+
   /**
    * Handle an inline-keyboard button tap whose payload was produced by the
    * shared interaction codec (a choice or followup answer). The chosen value is
@@ -1631,6 +1741,21 @@ export class MessageManager {
     const telegramRoomid = threadId
       ? `${telegramChatId}-${threadId}`
       : telegramChatId;
+    if (
+      !(await this.isExplicitUpdateAuthorized({
+        message: sourceMessage as Message,
+        from: ctx.from,
+        chat,
+        threadId,
+      }))
+    ) {
+      try {
+        await ctx.answerCbQuery();
+      } catch {
+        // best-effort: a stale callback may already have expired
+      }
+      return;
+    }
     const roomId = createUniqueUuid(
       this.runtime,
       this.scopedTelegramKey(telegramRoomid),
@@ -1962,6 +2087,15 @@ export class MessageManager {
 
     const firstReaction = reaction.new_reaction[0];
     if (!firstReaction) {
+      return;
+    }
+    if (
+      !(await this.isExplicitUpdateAuthorized({
+        message: syntheticReactionMessage,
+        from: ctx.from,
+        chat: reaction.chat as Chat,
+      }))
+    ) {
       return;
     }
     // Emoji reactions carry the glyph on `.emoji`; non-emoji reactions

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -17,6 +17,7 @@ import {
   type ContentType,
   createUniqueUuid,
   decodeCallback,
+  ElizaError,
   EventType,
   type HandlerCallback,
   type IAgentRuntime,
@@ -43,11 +44,14 @@ import { Markup } from "telegraf";
 import {
   getTelegramMultiAccountConfig,
   resolveTelegramAccount,
-  type TelegramAccountConfig,
 } from "./accounts";
 import { resolveTelegramSenderAuth } from "./command-registration";
 import { renderTelegramInteractions } from "./interactions";
-import { evaluateTelegramPolicy, hasTypedTelegramPolicyConfig } from "./policy";
+import {
+  evaluateTelegramPolicy,
+  hasTypedTelegramPolicyConfig,
+  type TelegramPolicyDecision,
+} from "./policy";
 import {
   type TelegramContent,
   TelegramEventTypes,
@@ -106,6 +110,50 @@ function telegramMessagePlainText(message: Message): string | undefined {
     return message.caption;
   }
   return undefined;
+}
+
+export type TelegramIngressAdmission = {
+  admitted: boolean;
+  typedPolicyConfigured: boolean;
+  decision: TelegramPolicyDecision;
+  sourceMemory?: Memory;
+  threadId?: string;
+};
+
+function telegramMetadata(memory: Memory): Record<string, unknown> | undefined {
+  const metadata = isRecord(memory.metadata) ? memory.metadata : undefined;
+  return metadata && isRecord(metadata.telegram)
+    ? metadata.telegram
+    : undefined;
+}
+
+function telegramThreadId(memory: Memory): string | undefined {
+  const value = telegramMetadata(memory)?.threadId;
+  return typeof value === "string" || typeof value === "number"
+    ? String(value)
+    : undefined;
+}
+
+function isTelegramCommandForBot(
+  message: Message,
+  botUsername: string | undefined,
+): boolean | null {
+  if (!("text" in message) || typeof message.text !== "string") {
+    return null;
+  }
+  const command = message.entities?.find(
+    (entity) => entity.type === "bot_command" && entity.offset === 0,
+  );
+  if (!command) {
+    return null;
+  }
+  const token = message.text.slice(0, command.length);
+  const target = token.split("@", 2)[1];
+  if (!target) {
+    return true;
+  }
+  const normalizedBot = botUsername?.replace(/^@/, "").trim().toLowerCase();
+  return Boolean(normalizedBot && target.toLowerCase() === normalizedBot);
 }
 
 const MAX_MESSAGE_LENGTH = 4096; // Telegram's max message length
@@ -337,6 +385,10 @@ export class MessageManager {
   public bot: Telegraf<Context>;
   protected runtime: IAgentRuntime;
   protected accountId: string;
+  private readonly ingressAdmissions = new WeakMap<
+    object,
+    TelegramIngressAdmission
+  >();
 
   /**
    * Constructor for creating a new instance of a BotAgent.
@@ -356,6 +408,282 @@ export class MessageManager {
 
   private scopedTelegramKey(key: string): string {
     return this.accountId === "default" ? key : `${this.accountId}:${key}`;
+  }
+
+  private telegramMessageKey(
+    chatId: number | string,
+    messageId: number | string,
+  ): string {
+    return this.scopedTelegramKey(`message:${chatId}:${messageId}`);
+  }
+
+  private telegramMessageMemoryId(
+    chatId: number | string,
+    messageId: number | string,
+  ): UUID {
+    return createUniqueUuid(
+      this.runtime,
+      this.telegramMessageKey(chatId, messageId),
+    ) as UUID;
+  }
+
+  private legacyTelegramMessageMemoryId(messageId: number | string): UUID {
+    return createUniqueUuid(
+      this.runtime,
+      this.scopedTelegramKey(String(messageId)),
+    ) as UUID;
+  }
+
+  private memoryMatchesTelegramMessage(
+    memory: Memory,
+    chatId: string,
+    messageId: string,
+  ): boolean {
+    const metadata = isRecord(memory.metadata) ? memory.metadata : {};
+    const telegram = telegramMetadata(memory);
+    const memoryAccountId =
+      typeof metadata.accountId === "string" ? metadata.accountId : "default";
+    return (
+      metadata.source === "telegram" &&
+      memoryAccountId === this.accountId &&
+      String(telegram?.chatId ?? "") === chatId &&
+      String(telegram?.messageId ?? metadata.messageIdFull ?? "") === messageId
+    );
+  }
+
+  private async resolveReactionSourceMemory(
+    chatId: string,
+    messageId: string,
+  ): Promise<Memory | null> {
+    const current = await this.runtime.getMemoryById(
+      this.telegramMessageMemoryId(chatId, messageId),
+    );
+    if (
+      current &&
+      this.memoryMatchesTelegramMessage(current, chatId, messageId)
+    ) {
+      return current;
+    }
+
+    const legacy = await this.runtime.getMemoryById(
+      this.legacyTelegramMessageMemoryId(messageId),
+    );
+    return legacy &&
+      this.memoryMatchesTelegramMessage(legacy, chatId, messageId)
+      ? legacy
+      : null;
+  }
+
+  private telegramAutoReplyEnabled(): boolean {
+    const raw = this.runtime.getSetting("TELEGRAM_AUTO_REPLY");
+    return (
+      !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
+      (raw === true || raw === "true")
+    );
+  }
+
+  private async evaluateMessageAdmission(
+    ctx: Context,
+    forceReply?: boolean,
+  ): Promise<TelegramIngressAdmission> {
+    if (!ctx.message || !ctx.from || !ctx.chat) {
+      return {
+        admitted: false,
+        typedPolicyConfigured: false,
+        decision: { shouldDispatch: false, reason: "blocked" },
+      };
+    }
+    const message = ctx.message as Message;
+    const accountConfig = resolveTelegramAccount(
+      this.runtime,
+      this.accountId,
+    ).config;
+    const typedPolicyConfigured = hasTypedTelegramPolicyConfig(accountConfig);
+    const commandForBot = isTelegramCommandForBot(
+      message,
+      (this.bot as unknown as { botInfo?: User }).botInfo?.username,
+    );
+    if (commandForBot === false) {
+      return {
+        admitted: false,
+        typedPolicyConfigured,
+        decision: { shouldDispatch: false, reason: "blocked" },
+      };
+    }
+    const threadId =
+      "is_topic_message" in message && message.is_topic_message
+        ? message.message_thread_id?.toString()
+        : undefined;
+    const decision = await evaluateTelegramPolicy({
+      runtime: this.runtime,
+      config: accountConfig,
+      message,
+      from: ctx.from,
+      chatType: ctx.chat.type,
+      chatId: ctx.chat.id.toString(),
+      threadId,
+      botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
+      forceReply: forceReply ?? commandForBot === true,
+      legacyAutoReply: this.telegramAutoReplyEnabled(),
+    });
+    return {
+      admitted: !typedPolicyConfigured || decision.shouldDispatch,
+      typedPolicyConfigured,
+      decision,
+      threadId,
+    };
+  }
+
+  private async evaluateCallbackAdmission(
+    ctx: Context,
+  ): Promise<TelegramIngressAdmission> {
+    const query = ctx.callbackQuery;
+    if (!query?.message || !ctx.from) {
+      return {
+        admitted: false,
+        typedPolicyConfigured: false,
+        decision: { shouldDispatch: false, reason: "blocked" },
+      };
+    }
+    return this.evaluateExplicitAdmission(
+      query.message as Message,
+      ctx.from,
+      query.message.chat as Chat,
+    );
+  }
+
+  private async evaluateReactionAdmission(
+    ctx: Context,
+  ): Promise<TelegramIngressAdmission> {
+    const reaction =
+      "message_reaction" in ctx.update
+        ? ctx.update.message_reaction
+        : undefined;
+    if (!reaction || !ctx.from) {
+      return {
+        admitted: false,
+        typedPolicyConfigured: false,
+        decision: { shouldDispatch: false, reason: "blocked" },
+      };
+    }
+    const chatId = reaction.chat.id.toString();
+    const messageId = reaction.message_id.toString();
+    const accountConfig = resolveTelegramAccount(
+      this.runtime,
+      this.accountId,
+    ).config;
+    const typedPolicyConfigured = hasTypedTelegramPolicyConfig(accountConfig);
+    const topicPolicyConfigured = Boolean(
+      accountConfig.groups?.[chatId]?.topics &&
+        Object.keys(accountConfig.groups[chatId]?.topics ?? {}).length > 0,
+    );
+    const sourceMemory = await this.resolveReactionSourceMemory(
+      chatId,
+      messageId,
+    );
+    const threadId = sourceMemory ? telegramThreadId(sourceMemory) : undefined;
+    if (
+      typedPolicyConfigured &&
+      topicPolicyConfigured &&
+      (!sourceMemory || !threadId)
+    ) {
+      return {
+        admitted: false,
+        typedPolicyConfigured,
+        decision: { shouldDispatch: false, reason: "blocked" },
+      };
+    }
+    const syntheticMessage = {
+      message_id: reaction.message_id,
+      chat: reaction.chat,
+      from: ctx.from,
+      date: reaction.date,
+    } as Message;
+    const decision = await evaluateTelegramPolicy({
+      runtime: this.runtime,
+      config: accountConfig,
+      message: syntheticMessage,
+      from: ctx.from,
+      chatType: reaction.chat.type,
+      chatId,
+      threadId,
+      botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
+      forceReply: true,
+    });
+    return {
+      admitted: !typedPolicyConfigured || decision.shouldDispatch,
+      typedPolicyConfigured,
+      decision,
+      sourceMemory: sourceMemory ?? undefined,
+      threadId,
+    };
+  }
+
+  private async evaluateExplicitAdmission(
+    message: Message,
+    from: User,
+    chat: Chat,
+  ): Promise<TelegramIngressAdmission> {
+    const accountConfig = resolveTelegramAccount(
+      this.runtime,
+      this.accountId,
+    ).config;
+    const typedPolicyConfigured = hasTypedTelegramPolicyConfig(accountConfig);
+    const threadId =
+      "is_topic_message" in message && message.is_topic_message
+        ? message.message_thread_id?.toString()
+        : undefined;
+    const decision = await evaluateTelegramPolicy({
+      runtime: this.runtime,
+      config: accountConfig,
+      message,
+      from,
+      chatType: chat.type,
+      chatId: chat.id.toString(),
+      threadId,
+      botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
+      forceReply: true,
+    });
+    return {
+      admitted: !typedPolicyConfigured || decision.shouldDispatch,
+      typedPolicyConfigured,
+      decision,
+      threadId,
+    };
+  }
+
+  public async admitIngress(ctx: Context): Promise<TelegramIngressAdmission> {
+    const cached = this.ingressAdmissions.get(ctx);
+    if (cached) {
+      return cached;
+    }
+    let admission: TelegramIngressAdmission;
+    if ("message_reaction" in ctx.update) {
+      admission = await this.evaluateReactionAdmission(ctx);
+    } else if (ctx.callbackQuery) {
+      admission = await this.evaluateCallbackAdmission(ctx);
+    } else {
+      admission = await this.evaluateMessageAdmission(ctx);
+    }
+    this.ingressAdmissions.set(ctx, admission);
+    return admission;
+  }
+
+  public async sendIngressDenial(
+    ctx: Context,
+    admission: TelegramIngressAdmission,
+  ): Promise<void> {
+    if (
+      !admission.decision.denialMessage ||
+      ctx.chat?.type !== "private" ||
+      !ctx.chat
+    ) {
+      return;
+    }
+    await this.bot.telegram.sendMessage(
+      ctx.chat.id,
+      admission.decision.denialMessage,
+    );
   }
 
   /**
@@ -1120,9 +1448,9 @@ export class MessageManager {
     const memories: Memory[] = [];
     for (const sentMessage of args.sentMessages) {
       const responseMemory: Memory = {
-        id: createUniqueUuid(
-          this.runtime,
-          this.scopedTelegramKey(sentMessage.message_id.toString()),
+        id: this.telegramMessageMemoryId(
+          sentMessage.chat.id,
+          sentMessage.message_id,
         ),
         entityId: this.runtime.agentId,
         agentId: this.runtime.agentId,
@@ -1150,8 +1478,12 @@ export class MessageManager {
           sourceId: this.runtime.agentId,
           chatType: args.chatType,
           messageIdFull: sentMessage.message_id.toString(),
+          telegramMessageKey: this.telegramMessageKey(
+            sentMessage.chat.id,
+            sentMessage.message_id,
+          ),
           telegram: {
-            chatId: sentMessage.chat.id,
+            chatId: sentMessage.chat.id.toString(),
             messageId: sentMessage.message_id.toString(),
             threadId: args.threadId,
           },
@@ -1334,6 +1666,7 @@ export class MessageManager {
     }
 
     const message = ctx.message as Message.TextMessage;
+    const sender = ctx.from;
 
     try {
       const telegramUserId = ctx.from.id.toString();
@@ -1363,55 +1696,18 @@ export class MessageManager {
       const roomId = createUniqueUuid(this.runtime, scopedRoomKey) as UUID;
       const worldId = createUniqueUuid(this.runtime, scopedChatKey) as UUID;
       const telegramMessageId = message.message_id.toString();
-      const messageId = createUniqueUuid(
-        this.runtime,
-        this.scopedTelegramKey(telegramMessageId),
+      const messageId = this.telegramMessageMemoryId(
+        telegramChatId,
+        telegramMessageId,
       );
       const chat = message.chat as Chat;
 
-      const telegramAutoReplyRaw = this.runtime.getSetting(
-        "TELEGRAM_AUTO_REPLY",
-      );
-      const telegramAutoReply =
-        !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
-        (telegramAutoReplyRaw === true || telegramAutoReplyRaw === "true");
-      const accountConfig = resolveTelegramAccount(
-        this.runtime,
-        this.accountId,
-      ).config;
-      const policyDecision = await evaluateTelegramPolicy({
-        runtime: this.runtime,
-        config: accountConfig,
-        message,
-        from: ctx.from,
-        chatType: chat.type,
-        chatId: telegramChatId,
-        threadId,
-        botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
-        forceReply: options?.forceReply,
-        legacyAutoReply: telegramAutoReply,
-      });
-      const typedPolicyConfigured = hasTypedTelegramPolicyConfig(accountConfig);
-      if (!policyDecision.shouldDispatch && typedPolicyConfigured) {
-        if (policyDecision.denialMessage && chat.type === "private") {
-          try {
-            await this.bot.telegram.sendMessage(
-              chat.id,
-              policyDecision.denialMessage,
-            );
-          } catch (error) {
-            logger.warn(
-              {
-                src: "plugin:telegram",
-                agentId: this.runtime.agentId,
-                accountId: this.accountId,
-                chatId: telegramChatId,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              "Failed to send Telegram pairing response",
-            );
-          }
-        }
+      const admission =
+        this.ingressAdmissions.get(ctx) ??
+        (await this.evaluateMessageAdmission(ctx, options?.forceReply));
+      const policyDecision = admission.decision;
+      if (!admission.admitted) {
+        await this.sendIngressDenial(ctx, admission);
         logger.debug(
           {
             src: "plugin:telegram",
@@ -1489,11 +1785,9 @@ export class MessageManager {
           channelType,
           inReplyTo:
             "reply_to_message" in message && message.reply_to_message
-              ? createUniqueUuid(
-                  this.runtime,
-                  this.scopedTelegramKey(
-                    message.reply_to_message.message_id.toString(),
-                  ),
+              ? this.telegramMessageMemoryId(
+                  telegramChatId,
+                  message.reply_to_message.message_id,
                 )
               : undefined,
         },
@@ -1514,6 +1808,10 @@ export class MessageManager {
           sourceId: entityId,
           chatType: chat.type,
           messageIdFull: telegramMessageId,
+          telegramMessageKey: this.telegramMessageKey(
+            telegramChatId,
+            telegramMessageId,
+          ),
           sender: {
             id: telegramUserId,
             name: ctx.from.first_name,
@@ -1541,65 +1839,37 @@ export class MessageManager {
           : undefined;
 
       // Create callback for handling responses
-      const baseCallback: HandlerCallback = async (
-        content: Content,
-        _actionName?: string,
-      ) => {
-        try {
-          // If response is from reasoning do not send it.
-          if (!content.text) {
-            return [];
-          }
-
-          let sentMessages: boolean | Message.TextMessage[] = false;
-          // channelType target === 'telegram'
-          if (content.channelType === "DM") {
-            // Route through sendMessageInChunks so DM replies get the same
-            // markdown conversion + inline interactions as group replies. Target
-            // ctx.from.id (the user's private chat) via a ctx shim, since a DM
-            // response to a group message must not go to ctx.chat.id.
-            sentMessages = ctx.from
-              ? await this.sendMessageInChunks(
-                  {
-                    chat: { id: ctx.from.id },
-                    telegram: this.bot.telegram,
-                  } as Context,
-                  content,
-                )
-              : [];
-          } else {
-            sentMessages = await this.sendMessageInChunks(
-              ctx,
-              content,
-              message.message_id,
-              threadIdNum,
-            );
-          }
-
-          if (!Array.isArray(sentMessages)) {
-            return [];
-          }
-
-          return this.persistSentMessageMemories({
-            sentMessages,
-            content,
-            roomId,
-            channelType,
-            chatType: chat.type,
-            threadId,
-            inReplyTo: messageId,
-          });
-        } catch (error) {
-          logger.error(
-            {
-              src: "plugin:telegram",
-              agentId: this.runtime.agentId,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            "Error in message callback",
-          );
+      const baseCallback: HandlerCallback = async (content: Content) => {
+        // A model response with no user-facing text is a legitimate no-op.
+        if (!content.text) {
           return [];
         }
+
+        const sentMessages =
+          content.channelType === "DM"
+            ? await this.sendMessageInChunks(
+                {
+                  chat: { id: sender.id },
+                  telegram: this.bot.telegram,
+                } as Context,
+                content,
+              )
+            : await this.sendMessageInChunks(
+                ctx,
+                content,
+                message.message_id,
+                threadIdNum,
+              );
+
+        return this.persistSentMessageMemories({
+          sentMessages,
+          content,
+          roomId,
+          channelType,
+          chatType: chat.type,
+          threadId,
+          inReplyTo: messageId,
+        });
       };
       const callback = createTelegramCompactProgressCallback({
         baseCallback,
@@ -1615,21 +1885,7 @@ export class MessageManager {
       const shouldReply = policyDecision.shouldDispatch;
 
       if (!shouldReply) {
-        try {
-          await this.runtime.createMemory(memory, "messages");
-        } catch (persistError) {
-          logger.warn(
-            {
-              src: "plugin:telegram",
-              agentId: this.runtime.agentId,
-              error:
-                persistError instanceof Error
-                  ? persistError.message
-                  : String(persistError),
-            },
-            "Failed to persist inbound memory while auto-reply is disabled",
-          );
-        }
+        await this.runtime.createMemory(memory, "messages");
         logger.debug(
           { src: "plugin:telegram", agentId: this.runtime.agentId },
           "Auto-reply disabled (TELEGRAM_AUTO_REPLY=false); message ingested without response",
@@ -1650,48 +1906,17 @@ export class MessageManager {
         );
       }
     } catch (error) {
-      logger.error(
-        {
-          src: "plugin:telegram",
-          agentId: this.runtime.agentId,
+      // error-policy:J2 retain connector identity on the propagated failure.
+      throw new ElizaError("Telegram message handling failed", {
+        code: "TELEGRAM_MESSAGE_HANDLING_FAILED",
+        context: {
+          accountId: this.accountId,
           chatId: ctx.chat?.id,
           messageId: ctx.message.message_id,
-          from: ctx.from.username || ctx.from.id,
-          error: error instanceof Error ? error.message : String(error),
         },
-        "Error handling Telegram message",
-      );
-      throw error;
+        cause: error,
+      });
     }
-  }
-
-  private async isExplicitUpdateAuthorized(params: {
-    message: Message;
-    from: User;
-    chat: Chat;
-    threadId?: string;
-  }): Promise<boolean> {
-    const telegramConfig = getTelegramMultiAccountConfig(this.runtime);
-    const accountConfig: TelegramAccountConfig = {
-      ...telegramConfig,
-      ...telegramConfig.accounts?.[this.accountId],
-    };
-    if (!hasTypedTelegramPolicyConfig(accountConfig)) {
-      return true;
-    }
-
-    const decision = await evaluateTelegramPolicy({
-      runtime: this.runtime,
-      config: accountConfig,
-      message: params.message,
-      from: params.from,
-      chatType: params.chat.type,
-      chatId: params.chat.id.toString(),
-      threadId: params.threadId,
-      botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
-      forceReply: true,
-    });
-    return decision.shouldDispatch;
   }
 
   /**
@@ -1741,19 +1966,10 @@ export class MessageManager {
     const telegramRoomid = threadId
       ? `${telegramChatId}-${threadId}`
       : telegramChatId;
-    if (
-      !(await this.isExplicitUpdateAuthorized({
-        message: sourceMessage as Message,
-        from: ctx.from,
-        chat,
-        threadId,
-      }))
-    ) {
-      try {
-        await ctx.answerCbQuery();
-      } catch {
-        // best-effort: a stale callback may already have expired
-      }
+    const admission =
+      this.ingressAdmissions.get(ctx) ??
+      (await this.evaluateCallbackAdmission(ctx));
+    if (!admission.admitted) {
       return;
     }
     const roomId = createUniqueUuid(
@@ -2078,26 +2294,28 @@ export class MessageManager {
     const reaction = ctx.update.message_reaction;
     const reactedToMessageId = reaction.message_id;
 
-    const syntheticReactionMessage = {
-      message_id: reactedToMessageId,
-      chat: reaction.chat,
-      from: ctx.from,
-      date: Math.floor(Date.now() / 1000),
-    } as Message;
-
     const firstReaction = reaction.new_reaction[0];
     if (!firstReaction) {
       return;
     }
-    if (
-      !(await this.isExplicitUpdateAuthorized({
-        message: syntheticReactionMessage,
-        from: ctx.from,
-        chat: reaction.chat as Chat,
-      }))
-    ) {
+    const admission =
+      this.ingressAdmissions.get(ctx) ??
+      (await this.evaluateReactionAdmission(ctx));
+    if (!admission.admitted) {
       return;
     }
+    const syntheticReactionMessage = {
+      message_id: reactedToMessageId,
+      chat: reaction.chat,
+      from: ctx.from,
+      date: reaction.date,
+      ...(admission.threadId
+        ? {
+            is_topic_message: true,
+            message_thread_id: Number(admission.threadId),
+          }
+        : {}),
+    } as Message;
     // Emoji reactions carry the glyph on `.emoji`; non-emoji reactions
     // (custom_emoji / paid) are identified by `.type`.
     const reactionLabel =
@@ -2108,10 +2326,12 @@ export class MessageManager {
         this.runtime,
         this.scopedTelegramKey(ctx.from.id.toString()),
       ) as UUID;
-      const roomId = createUniqueUuid(
-        this.runtime,
-        this.scopedTelegramKey(ctx.chat.id.toString()),
-      );
+      const roomId =
+        admission.sourceMemory?.roomId ??
+        createUniqueUuid(
+          this.runtime,
+          this.scopedTelegramKey(ctx.chat.id.toString()),
+        );
 
       const reactionId = createUniqueUuid(
         this.runtime,
@@ -2130,10 +2350,9 @@ export class MessageManager {
           channelType: getChannelType(reaction.chat as Chat),
           text: `Reacted with: ${reactionLabel}`,
           source: "telegram",
-          inReplyTo: createUniqueUuid(
-            this.runtime,
-            this.scopedTelegramKey(reaction.message_id.toString()),
-          ),
+          inReplyTo:
+            admission.sourceMemory?.id ??
+            this.telegramMessageMemoryId(reaction.chat.id, reaction.message_id),
           metadata: { accountId: this.accountId },
         },
         metadata: {
@@ -2160,6 +2379,7 @@ export class MessageManager {
             ),
             chatId: reaction.chat.id.toString(),
             messageId: reaction.message_id.toString(),
+            threadId: admission.threadId,
           },
           telegramUserId: ctx.from.id.toString(),
           telegramChatId: reaction.chat.id.toString(),
@@ -2169,43 +2389,28 @@ export class MessageManager {
 
       // Create callback for handling reaction responses
       const callback: HandlerCallback = async (content: Content) => {
-        try {
-          // Add null check for content.text
-          const replyText = content.text ?? "";
-          const sentMessage = await ctx.reply(replyText);
-          const responseMemory: Memory = {
-            id: createUniqueUuid(
-              this.runtime,
-              this.scopedTelegramKey(sentMessage.message_id.toString()),
-            ),
-            entityId: this.runtime.agentId,
-            agentId: this.runtime.agentId,
-            roomId,
-            content: {
-              ...content,
-              inReplyTo: reactionId,
-              metadata: { accountId: this.accountId },
-            },
-            metadata: {
-              type: "message",
-              source: "telegram",
-              accountId: this.accountId,
-              provider: "telegram",
-            } satisfies Memory["metadata"],
-            createdAt: sentMessage.date * 1000,
-          };
-          return [responseMemory];
-        } catch (error) {
-          logger.error(
-            {
-              src: "plugin:telegram",
-              agentId: this.runtime.agentId,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            "Error in reaction callback",
-          );
-          return [];
-        }
+        const threadId = admission.threadId
+          ? Number(admission.threadId)
+          : undefined;
+        const sentMessages = await this.sendMessageInChunks(
+          {
+            chat: reaction.chat,
+            from: ctx.from,
+            telegram: this.bot.telegram,
+          } as Context,
+          content,
+          reaction.message_id,
+          threadId,
+        );
+        return this.persistSentMessageMemories({
+          sentMessages,
+          content,
+          roomId,
+          channelType: getChannelType(reaction.chat as Chat),
+          chatType: reaction.chat.type,
+          threadId: admission.threadId,
+          inReplyTo: reactionId,
+        });
       };
 
       // Let the bootstrap plugin handle the reaction
@@ -2236,14 +2441,16 @@ export class MessageManager {
         originalReaction: firstReaction as ReactionType,
       } as TelegramReactionReceivedPayload);
     } catch (error) {
-      logger.error(
-        {
-          src: "plugin:telegram",
-          agentId: this.runtime.agentId,
-          error: error instanceof Error ? error.message : String(error),
+      // error-policy:J2 retain connector identity on the propagated failure.
+      throw new ElizaError("Telegram reaction handling failed", {
+        code: "TELEGRAM_REACTION_HANDLING_FAILED",
+        context: {
+          accountId: this.accountId,
+          chatId: reaction.chat.id,
+          messageId: reaction.message_id,
         },
-        "Error handling reaction",
-      );
+        cause: error,
+      });
     }
   }
 
@@ -2372,9 +2579,9 @@ export class MessageManager {
           : {};
       for (const sentMessage of sentMessages) {
         const memory: Memory = {
-          id: createUniqueUuid(
-            this.runtime,
-            this.scopedTelegramKey(sentMessage.message_id.toString()),
+          id: this.telegramMessageMemoryId(
+            sentMessage.chat.id,
+            sentMessage.message_id,
           ),
           entityId: this.runtime.agentId,
           agentId: this.runtime.agentId,
@@ -2410,6 +2617,10 @@ export class MessageManager {
             fromId: this.runtime.agentId,
             sourceId: this.runtime.agentId,
             messageIdFull: sentMessage.message_id.toString(),
+            telegramMessageKey: this.telegramMessageKey(
+              sentMessage.chat.id,
+              sentMessage.message_id,
+            ),
             telegram: {
               chatId: sentMessage.chat.id.toString(),
               messageId: sentMessage.message_id.toString(),

--- a/plugins/plugin-telegram/src/policy.ts
+++ b/plugins/plugin-telegram/src/policy.ts
@@ -1,0 +1,323 @@
+/**
+ * Telegram inbound activation policy for the bot runtime. It interprets the
+ * typed `connectors.telegram` account/group/topic config after startup has
+ * copied that object into `character.settings.telegram`, and returns a single
+ * decision before the message manager creates memory or dispatches a model turn.
+ */
+import { checkPairingAllowed, type IAgentRuntime } from "@elizaos/core";
+import type { Message, User } from "@telegraf/types";
+import type { TelegramAccountConfig } from "./accounts";
+
+type TelegramGroupConfig = NonNullable<TelegramAccountConfig["groups"]>[string];
+type TelegramTopicConfig = NonNullable<
+  NonNullable<TelegramGroupConfig>["topics"]
+>[string];
+
+type TelegramPolicyConfig = Pick<
+  TelegramAccountConfig,
+  | "dmPolicy"
+  | "groupPolicy"
+  | "allowFrom"
+  | "groupAllowFrom"
+  | "replyToMode"
+  | "groups"
+>;
+
+export type TelegramPolicyDecision = {
+  shouldDispatch: boolean;
+  textOverride?: string;
+  denialMessage?: string;
+  reason:
+    | "forced"
+    | "legacy-auto-reply"
+    | "dm"
+    | "mention"
+    | "reply-to-bot"
+    | "blocked";
+};
+
+function normalizeList(values: Array<string | number> | undefined): string[] {
+  return (values ?? [])
+    .map((value) => String(value).trim())
+    .filter((value) => value.length > 0);
+}
+
+function matchesAllowList(
+  values: Array<string | number> | undefined,
+  identifiers: string[],
+): boolean {
+  const normalized = normalizeList(values);
+  if (normalized.includes("*")) {
+    return true;
+  }
+  return identifiers.some((identifier) => normalized.includes(identifier));
+}
+
+function hasEntries(values: Array<string | number> | undefined): boolean {
+  return normalizeList(values).length > 0;
+}
+
+function senderIdentifiers(from: User): string[] {
+  return [
+    String(from.id),
+    from.username ? `@${from.username}` : "",
+    from.username ?? "",
+  ].filter(Boolean);
+}
+
+export function hasTypedTelegramPolicyConfig(
+  config: TelegramPolicyConfig,
+): boolean {
+  return Boolean(
+    config.dmPolicy ||
+      config.groupPolicy ||
+      config.replyToMode ||
+      hasEntries(config.allowFrom) ||
+      hasEntries(config.groupAllowFrom) ||
+      (config.groups && Object.keys(config.groups).length > 0),
+  );
+}
+
+function resolveGroupConfig(
+  config: TelegramPolicyConfig,
+  chatId: string,
+): TelegramGroupConfig {
+  return config.groups?.[chatId];
+}
+
+function resolveTopicConfig(
+  groupConfig: TelegramGroupConfig,
+  threadId?: string,
+): TelegramTopicConfig {
+  return threadId ? groupConfig?.topics?.[threadId] : undefined;
+}
+
+function messageText(message: Message): string {
+  if ("text" in message && typeof message.text === "string") {
+    return message.text;
+  }
+  if ("caption" in message && typeof message.caption === "string") {
+    return message.caption;
+  }
+  return "";
+}
+
+function messageEntities(
+  message: Message,
+): Array<{ type: string; offset: number; length: number }> {
+  if ("entities" in message && Array.isArray(message.entities)) {
+    return message.entities;
+  }
+  if (
+    "caption_entities" in message &&
+    Array.isArray(message.caption_entities)
+  ) {
+    return message.caption_entities;
+  }
+  return [];
+}
+
+function detectAddressedMention(
+  message: Message,
+  botUsername: string | undefined,
+): { mentioned: boolean; text: string } {
+  const text = messageText(message);
+  const normalizedBot = botUsername?.replace(/^@/, "").trim().toLowerCase();
+  if (!text || !normalizedBot) {
+    return { mentioned: false, text };
+  }
+
+  for (const entity of messageEntities(message)) {
+    if (entity.type !== "mention") {
+      continue;
+    }
+    const mention = text.slice(entity.offset, entity.offset + entity.length);
+    if (mention.replace(/^@/, "").toLowerCase() !== normalizedBot) {
+      continue;
+    }
+    return {
+      mentioned: true,
+      text: `${text.slice(0, entity.offset)}${text.slice(
+        entity.offset + entity.length,
+      )}`.trim(),
+    };
+  }
+
+  return { mentioned: false, text };
+}
+
+function isReplyToBot(message: Message, botInfo?: User): boolean {
+  if (!("reply_to_message" in message) || !message.reply_to_message) {
+    return false;
+  }
+  const repliedMessage = message.reply_to_message;
+  const repliedFrom =
+    "from" in repliedMessage && repliedMessage.from
+      ? repliedMessage.from
+      : undefined;
+  if (!repliedFrom?.is_bot) {
+    return false;
+  }
+  if (botInfo?.id !== undefined) {
+    return repliedFrom.id === botInfo.id;
+  }
+  return false;
+}
+
+async function resolveDmAccess(params: {
+  runtime: IAgentRuntime;
+  config: TelegramPolicyConfig;
+  identifiers: string[];
+  from: User;
+}): Promise<{ allowed: boolean; denialMessage?: string }> {
+  const policy = params.config.dmPolicy ?? "pairing";
+  if (policy === "disabled") {
+    return { allowed: false };
+  }
+  if (policy === "open") {
+    return { allowed: true };
+  }
+  if (policy === "allowlist") {
+    return {
+      allowed: matchesAllowList(params.config.allowFrom, params.identifiers),
+    };
+  }
+
+  const metadata: Record<string, string> = {};
+  if (params.from.username) {
+    metadata.username = params.from.username;
+  }
+  if (params.from.first_name) {
+    metadata.name = params.from.first_name;
+  }
+  const result = await checkPairingAllowed(params.runtime, {
+    channel: "telegram",
+    senderId: String(params.from.id),
+    metadata,
+  });
+  return { allowed: result.allowed, denialMessage: result.replyMessage };
+}
+
+function groupSelected(params: {
+  policy: "open" | "disabled" | "allowlist";
+  groupConfig: TelegramGroupConfig;
+  topicConfig: TelegramTopicConfig;
+}): boolean {
+  if (params.policy === "disabled") {
+    return false;
+  }
+  if (
+    params.groupConfig?.enabled === false ||
+    params.topicConfig?.enabled === false
+  ) {
+    return false;
+  }
+  if (params.policy === "open") {
+    return true;
+  }
+  return Boolean(params.groupConfig);
+}
+
+function groupSenderAllowed(params: {
+  config: TelegramPolicyConfig;
+  groupConfig: TelegramGroupConfig;
+  topicConfig: TelegramTopicConfig;
+  identifiers: string[];
+}): boolean {
+  if (hasEntries(params.topicConfig?.allowFrom)) {
+    return matchesAllowList(params.topicConfig?.allowFrom, params.identifiers);
+  }
+  if (hasEntries(params.groupConfig?.allowFrom)) {
+    return matchesAllowList(params.groupConfig?.allowFrom, params.identifiers);
+  }
+  if (hasEntries(params.config.groupAllowFrom)) {
+    return matchesAllowList(params.config.groupAllowFrom, params.identifiers);
+  }
+  return true;
+}
+
+export async function evaluateTelegramPolicy(params: {
+  runtime: IAgentRuntime;
+  config: TelegramPolicyConfig;
+  message: Message;
+  from: User;
+  chatType: string;
+  chatId: string;
+  threadId?: string;
+  botInfo?: User;
+  forceReply?: boolean;
+  legacyAutoReply?: boolean;
+}): Promise<TelegramPolicyDecision> {
+  if (!hasTypedTelegramPolicyConfig(params.config)) {
+    if (params.forceReply) {
+      return { shouldDispatch: true, reason: "forced" };
+    }
+    return params.legacyAutoReply
+      ? { shouldDispatch: true, reason: "legacy-auto-reply" }
+      : { shouldDispatch: false, reason: "blocked" };
+  }
+
+  const identifiers = senderIdentifiers(params.from);
+  const mention = detectAddressedMention(
+    params.message,
+    params.botInfo?.username,
+  );
+
+  if (params.chatType === "private") {
+    const access = await resolveDmAccess({
+      runtime: params.runtime,
+      config: params.config,
+      identifiers,
+      from: params.from,
+    });
+    return access.allowed
+      ? {
+          shouldDispatch: true,
+          reason: params.forceReply ? "forced" : "dm",
+        }
+      : {
+          shouldDispatch: false,
+          reason: "blocked",
+          denialMessage: access.denialMessage,
+        };
+  }
+
+  const policy = params.config.groupPolicy ?? "allowlist";
+  const groupConfig = resolveGroupConfig(params.config, params.chatId);
+  const topicConfig = resolveTopicConfig(groupConfig, params.threadId);
+  if (!groupSelected({ policy, groupConfig, topicConfig })) {
+    return { shouldDispatch: false, reason: "blocked" };
+  }
+  if (
+    !groupSenderAllowed({
+      config: params.config,
+      groupConfig,
+      topicConfig,
+      identifiers,
+    })
+  ) {
+    return { shouldDispatch: false, reason: "blocked" };
+  }
+
+  if (params.forceReply) {
+    return { shouldDispatch: true, reason: "forced" };
+  }
+
+  const replyToBot = isReplyToBot(params.message, params.botInfo);
+  const requireMention =
+    topicConfig?.requireMention ?? groupConfig?.requireMention ?? true;
+  if (mention.mentioned) {
+    return {
+      shouldDispatch: true,
+      reason: "mention",
+      textOverride: mention.text,
+    };
+  }
+  if (replyToBot) {
+    return { shouldDispatch: true, reason: "reply-to-bot" };
+  }
+  if (!requireMention) {
+    return { shouldDispatch: true, reason: "mention" };
+  }
+  return { shouldDispatch: false, reason: "blocked" };
+}

--- a/plugins/plugin-telegram/src/service.launch-supervision.test.ts
+++ b/plugins/plugin-telegram/src/service.launch-supervision.test.ts
@@ -167,4 +167,33 @@ describe("TelegramService.launchPollerSupervised", () => {
     expect(first.bot.launch).toHaveBeenCalledTimes(1);
     expect(second.bot.launch).toHaveBeenCalledTimes(1);
   });
+
+  it("does not relaunch a poller after its service is stopped", async () => {
+    const { bot, calls } = makeBot();
+    const { service } = makeService();
+    Object.assign(service as unknown as Record<string, unknown>, {
+      accountStates: new Map([
+        [
+          "acct",
+          {
+            accountId: "acct",
+            account: { accountId: "acct", botToken: "tok-stop" },
+            bot,
+          },
+        ],
+      ]),
+    });
+
+    const launched = callLaunch(service, bot, "tok-stop", "acct");
+    calls[0].onLaunch();
+    await launched;
+
+    await service.stop();
+    calls[0].reject(new Error(CONFLICT));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(bot.stop).toHaveBeenCalledWith("service-stop");
+    expect(bot.launch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/plugins/plugin-telegram/src/service.local-bot-api.integration.test.ts
+++ b/plugins/plugin-telegram/src/service.local-bot-api.integration.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Exercises Telegram ingress through real Telegraf long polling against a local
+ * Bot API server. The harness captures serialized HTTP calls while production
+ * middleware, policy, topic recovery, commands, and multi-account ownership run
+ * unchanged; only api.telegram.org itself is replaced.
+ */
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  createUniqueUuid,
+  type HandlerCallback,
+  type IAgentRuntime,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TelegramService } from "./service";
+
+const AGENT_ID = "00000000-0000-4000-8000-000000000001" as UUID;
+const DEFAULT_TOKEN = "100000001:local_default_token";
+
+interface CapturedCall {
+  token: string;
+  method: string;
+  body: Record<string, unknown>;
+  rawBody: string;
+}
+
+class LocalBotApi {
+  readonly calls: CapturedCall[] = [];
+  readonly deliveredUpdateIds = new Set<number>();
+  readonly maxConcurrentPolls = new Map<string, number>();
+  private readonly queuedUpdates = new Map<string, unknown[]>();
+  private readonly activePolls = new Map<string, number>();
+  private server: Server | undefined;
+  private nextMessageId = 700;
+
+  async start(): Promise<string> {
+    this.server = createServer((req, res) => this.handle(req, res));
+    await new Promise<void>((resolve) =>
+      this.server?.listen(0, "127.0.0.1", resolve),
+    );
+    const address = this.server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Local Telegram Bot API did not bind a TCP port");
+    }
+    return `http://127.0.0.1:${(address satisfies AddressInfo).port}`;
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    await new Promise<void>((resolve, reject) =>
+      this.server?.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+
+  enqueue(token: string, update: Record<string, unknown>): void {
+    const queued = this.queuedUpdates.get(token) ?? [];
+    queued.push(update);
+    this.queuedUpdates.set(token, queued);
+  }
+
+  callsFor(method: string, token?: string): CapturedCall[] {
+    return this.calls.filter(
+      (call) => call.method === method && (!token || call.token === token),
+    );
+  }
+
+  private handle(req: IncomingMessage, res: ServerResponse): void {
+    const match = req.url?.match(/^\/bot([^/]+)\/([^?]+)/);
+    if (!match) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    const [, token, method] = match;
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      const rawBody = Buffer.concat(chunks).toString("utf8");
+      let body: Record<string, unknown> = {};
+      try {
+        body = rawBody ? (JSON.parse(rawBody) as Record<string, unknown>) : {};
+      } catch {
+        // error-policy:J3 malformed client input remains visible in rawBody.
+      }
+      this.calls.push({ token, method, body, rawBody });
+      this.respond(token, method, body, res);
+    });
+  }
+
+  private respond(
+    token: string,
+    method: string,
+    body: Record<string, unknown>,
+    res: ServerResponse,
+  ): void {
+    res.setHeader("content-type", "application/json");
+    if (method === "getUpdates") {
+      const active = (this.activePolls.get(token) ?? 0) + 1;
+      this.activePolls.set(token, active);
+      this.maxConcurrentPolls.set(
+        token,
+        Math.max(active, this.maxConcurrentPolls.get(token) ?? 0),
+      );
+      setTimeout(() => {
+        const queued = this.queuedUpdates.get(token) ?? [];
+        const result = body.offset === -1 ? [] : queued.splice(0);
+        for (const update of result as Array<{ update_id?: unknown }>) {
+          if (typeof update.update_id === "number") {
+            this.deliveredUpdateIds.add(update.update_id);
+          }
+        }
+        this.activePolls.set(token, active - 1);
+        res.end(JSON.stringify({ ok: true, result }));
+      }, 20);
+      return;
+    }
+
+    if (method === "getMe") {
+      res.end(
+        JSON.stringify({
+          ok: true,
+          result: {
+            id: Number(token.split(":")[0]),
+            is_bot: true,
+            first_name: "Local Agent",
+            username: `local_${token.split(":")[0]}_bot`,
+          },
+        }),
+      );
+      return;
+    }
+
+    if (method === "sendMessage") {
+      res.end(
+        JSON.stringify({
+          ok: true,
+          result: {
+            message_id: this.nextMessageId++,
+            date: 1_700_000_100,
+            text: body.text ?? "",
+            chat: { id: body.chat_id, type: "supergroup", title: "Ops" },
+            ...(body.message_thread_id
+              ? {
+                  is_topic_message: true,
+                  message_thread_id: body.message_thread_id,
+                }
+              : {}),
+          },
+        }),
+      );
+      return;
+    }
+
+    res.end(JSON.stringify({ ok: true, result: true }));
+  }
+}
+
+type RuntimeHarness = IAgentRuntime & {
+  createMemory: ReturnType<typeof vi.fn>;
+  emitEvent: ReturnType<typeof vi.fn>;
+  ensureConnection: ReturnType<typeof vi.fn>;
+  ensureRoomExists: ReturnType<typeof vi.fn>;
+  ensureWorldExists: ReturnType<typeof vi.fn>;
+  messageService: { handleMessage: ReturnType<typeof vi.fn> };
+};
+
+function createRuntime(args: {
+  apiRoot: string;
+  telegram: Record<string, unknown>;
+  settings: Record<string, string>;
+  memories?: Map<UUID, Memory>;
+}): RuntimeHarness {
+  const memories = args.memories ?? new Map<UUID, Memory>();
+  return {
+    agentId: AGENT_ID,
+    character: {
+      name: "Local Agent",
+      settings: { telegram: args.telegram },
+    },
+    actions: [],
+    getSetting: vi.fn((key: string) => args.settings[key]),
+    getService: vi.fn(() => null),
+    getMemoryById: vi.fn(async (id: UUID) => memories.get(id) ?? null),
+    createMemory: vi.fn(async (memory: Memory) => {
+      if (memory.id) memories.set(memory.id, memory);
+    }),
+    updateMemory: vi.fn(async () => undefined),
+    ensureConnection: vi.fn(async () => undefined),
+    ensureRoomExists: vi.fn(async () => undefined),
+    ensureWorldExists: vi.fn(async () => undefined),
+    emitEvent: vi.fn(),
+    reportError: vi.fn(),
+    messageService: { handleMessage: vi.fn(async () => undefined) },
+  } as unknown as RuntimeHarness;
+}
+
+function sourceMemory(
+  runtime: IAgentRuntime,
+  messageId: number,
+  threadId?: number,
+): Memory {
+  const chatId = "-1001";
+  return {
+    id: createUniqueUuid(runtime, `message:${chatId}:${messageId}`) as UUID,
+    agentId: runtime.agentId,
+    entityId: AGENT_ID,
+    roomId: createUniqueUuid(
+      runtime,
+      threadId === undefined ? chatId : `${chatId}-${threadId}`,
+    ) as UUID,
+    content: { text: "source", source: "telegram" },
+    metadata: {
+      source: "telegram",
+      accountId: "default",
+      messageIdFull: String(messageId),
+      telegramMessageKey: `message:${chatId}:${messageId}`,
+      telegram: {
+        chatId,
+        messageId: String(messageId),
+        ...(threadId === undefined ? {} : { threadId: String(threadId) }),
+      },
+    },
+  };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  description: string,
+  timeoutMs = 3_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function assertNoIngressSideEffects(runtime: RuntimeHarness): void {
+  expect(runtime.ensureConnection).not.toHaveBeenCalled();
+  expect(runtime.ensureRoomExists).not.toHaveBeenCalled();
+  expect(runtime.ensureWorldExists).not.toHaveBeenCalled();
+  expect(runtime.createMemory).not.toHaveBeenCalled();
+  expect(runtime.messageService.handleMessage).not.toHaveBeenCalled();
+  expect(runtime.emitEvent).not.toHaveBeenCalled();
+}
+
+describe("TelegramService local Bot API integration", () => {
+  let api: LocalBotApi;
+  let apiRoot: string;
+  const services: TelegramService[] = [];
+
+  beforeEach(async () => {
+    api = new LocalBotApi();
+    apiRoot = await api.start();
+  });
+
+  afterEach(async () => {
+    for (const service of services.splice(0)) {
+      await service.stop();
+    }
+    await api.stop();
+  });
+
+  it("denies commands, callbacks, and owned-topic reactions before side effects", async () => {
+    const memories = new Map<UUID, Memory>();
+    const runtime = createRuntime({
+      apiRoot,
+      memories,
+      telegram: {
+        apiRoot,
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["42"],
+        groups: {
+          "-1001": {
+            requireMention: false,
+            topics: { "77": { enabled: false, allowFrom: ["42"] } },
+          },
+        },
+      },
+      settings: { TELEGRAM_BOT_TOKEN: DEFAULT_TOKEN },
+    });
+    const source = sourceMemory(runtime, 10, 77);
+    memories.set(source.id as UUID, source);
+    const unownedTopicSource = sourceMemory(runtime, 12);
+    memories.set(unownedTopicSource.id as UUID, unownedTopicSource);
+    const service = await TelegramService.start(runtime);
+    services.push(service);
+    await waitFor(
+      () => api.callsFor("getUpdates", DEFAULT_TOKEN).length > 0,
+      "initial polling",
+    );
+
+    api.enqueue(DEFAULT_TOKEN, {
+      update_id: 1,
+      message: {
+        message_id: 20,
+        date: 1_700_000_000,
+        text: "/tasks",
+        entities: [{ type: "bot_command", offset: 0, length: 6 }],
+        from: { id: 42, is_bot: false, first_name: "Ada" },
+        chat: { id: -9999, type: "supergroup", title: "Other" },
+      },
+    });
+    api.enqueue(DEFAULT_TOKEN, {
+      update_id: 2,
+      callback_query: {
+        id: "callback-2",
+        from: { id: 42, is_bot: false, first_name: "Ada" },
+        chat_instance: "local",
+        data: "foreign",
+        message: {
+          message_id: 21,
+          date: 1_700_000_001,
+          text: "button",
+          chat: { id: -9999, type: "supergroup", title: "Other" },
+        },
+      },
+    });
+    api.enqueue(DEFAULT_TOKEN, {
+      update_id: 3,
+      message_reaction: {
+        chat: {
+          id: -1001,
+          type: "supergroup",
+          title: "Ops",
+          is_forum: true,
+        },
+        message_id: 10,
+        user: { id: 42, is_bot: false, first_name: "Ada" },
+        date: 1_700_000_002,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "👍" }],
+      },
+    });
+    api.enqueue(DEFAULT_TOKEN, {
+      update_id: 4,
+      message_reaction: {
+        chat: {
+          id: -1001,
+          type: "supergroup",
+          title: "Ops",
+          is_forum: true,
+        },
+        message_id: 12,
+        user: { id: 42, is_bot: false, first_name: "Ada" },
+        date: 1_700_000_003,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "?" }],
+      },
+    });
+
+    await waitFor(
+      () => api.deliveredUpdateIds.has(4),
+      "denied updates to cross the polling boundary",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    assertNoIngressSideEffects(runtime);
+    expect(api.callsFor("sendMessage")).toHaveLength(0);
+    expect(api.callsFor("answerCallbackQuery")).toHaveLength(0);
+    expect(api.callsFor("pinChatMessage")).toHaveLength(0);
+  });
+
+  it("recovers reaction topic ownership and replies in the stored topic", async () => {
+    const memories = new Map<UUID, Memory>();
+    const runtime = createRuntime({
+      apiRoot,
+      memories,
+      telegram: {
+        apiRoot,
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["42"],
+        groups: {
+          "-1001": {
+            requireMention: true,
+            topics: { "88": { enabled: true, allowFrom: ["42"] } },
+          },
+        },
+      },
+      settings: { TELEGRAM_BOT_TOKEN: DEFAULT_TOKEN },
+    });
+    const source = sourceMemory(runtime, 11, 88);
+    memories.set(source.id as UUID, source);
+    const service = await TelegramService.start(runtime);
+    services.push(service);
+
+    api.enqueue(DEFAULT_TOKEN, {
+      update_id: 11,
+      message_reaction: {
+        chat: {
+          id: -1001,
+          type: "supergroup",
+          title: "Ops",
+          is_forum: true,
+        },
+        message_id: 11,
+        user: { id: 42, is_bot: false, first_name: "Ada" },
+        date: 1_700_000_011,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "✅" }],
+      },
+    });
+
+    await waitFor(
+      () => runtime.emitEvent.mock.calls.length === 2,
+      "reaction events",
+    );
+    const payload = runtime.emitEvent.mock.calls[0][1] as {
+      message: Memory;
+      callback: HandlerCallback;
+    };
+    expect(payload.message.roomId).toBe(source.roomId);
+    expect(payload.message.content.inReplyTo).toBe(source.id);
+    expect(payload.message.metadata?.telegram).toMatchObject({
+      chatId: "-1001",
+      threadId: "88",
+    });
+
+    await payload.callback({ text: "reaction received" });
+    const send = api.callsFor("sendMessage")[0];
+    expect(send.body).toMatchObject({
+      chat_id: -1001,
+      message_thread_id: 88,
+      reply_parameters: { message_id: 11 },
+    });
+    expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+    expect(runtime.createMemory.mock.calls[0][0].roomId).toBe(source.roomId);
+  });
+
+  it("runs one live poll per distinct account token and rejects shared tokens before HTTP", async () => {
+    const accountTokens = {
+      alerts: "100000002:local_alerts_token",
+      ops: "100000003:local_ops_token",
+    };
+    const runtime = createRuntime({
+      apiRoot,
+      telegram: {
+        accounts: {
+          alerts: { apiRoot, groupPolicy: "disabled" },
+          ops: { apiRoot, groupPolicy: "disabled" },
+        },
+      },
+      settings: {
+        TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify(accountTokens),
+      },
+    });
+    const service = await TelegramService.start(runtime);
+    services.push(service);
+
+    await waitFor(
+      () =>
+        Object.values(accountTokens).every(
+          (token) => api.callsFor("getUpdates", token).length > 0,
+        ),
+      "both account pollers",
+    );
+    expect(service.getBots()).toHaveLength(2);
+    for (const token of Object.values(accountTokens)) {
+      expect(api.maxConcurrentPolls.get(token)).toBe(1);
+    }
+
+    const duplicateRuntime = createRuntime({
+      apiRoot,
+      telegram: {
+        accounts: {
+          first: { apiRoot, groupPolicy: "disabled" },
+          second: { apiRoot, groupPolicy: "disabled" },
+        },
+      },
+      settings: {
+        TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify({
+          first: "100000004:shared_token",
+          second: "100000004:shared_token",
+        }),
+      },
+    });
+    const callsBeforeDuplicate = api.calls.length;
+
+    await expect(TelegramService.start(duplicateRuntime)).rejects.toMatchObject(
+      {
+        code: "TELEGRAM_DUPLICATE_BOT_TOKEN",
+      },
+    );
+    expect(api.calls).toHaveLength(callsBeforeDuplicate);
+  });
+});

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -57,6 +57,7 @@ import {
 } from "./command-registration";
 import { TELEGRAM_SERVICE_NAME } from "./constants";
 import { MessageManager } from "./messageManager";
+import { hasTypedTelegramPolicyConfig } from "./policy";
 import { registerTelegramTaskBoardCommand } from "./task-board";
 import {
   type TelegramEntityPayload,
@@ -1178,6 +1179,14 @@ export class TelegramService extends Service {
       this.getAccountState(accountId)?.account.config.allowedChats;
     if (accountAllowedChats?.length) {
       return accountAllowedChats.includes(chatId);
+    }
+
+    const accountConfig = resolveTelegramAccount(
+      this.runtime,
+      accountId,
+    ).config;
+    if (hasTypedTelegramPolicyConfig(accountConfig)) {
+      return true;
     }
 
     const allowedChats = this.runtime.getSetting("TELEGRAM_ALLOWED_CHATS");

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -14,6 +14,7 @@ import {
   ChannelType,
   type Content,
   createUniqueUuid,
+  ElizaError,
   type Entity,
   EventType,
   type IAgentRuntime,
@@ -168,6 +169,27 @@ type TelegramAccountRuntime = {
 };
 
 const ACTIVE_TELEGRAM_POLLERS = new Map<string, ActiveTelegramPoller>();
+const RETIRED_TELEGRAM_POLLERS = new WeakSet<Telegraf<Context>>();
+
+function assertUniqueTelegramAccountTokens(
+  accounts: ResolvedTelegramAccount[],
+): void {
+  const owners = new Map<string, string>();
+  for (const account of accounts) {
+    if (!account.botToken) {
+      continue;
+    }
+    const existing = owners.get(account.botToken);
+    if (existing) {
+      throw new ElizaError("Telegram accounts must not share a bot token", {
+        code: "TELEGRAM_DUPLICATE_BOT_TOKEN",
+        context: { accountIds: [existing, account.accountId] },
+        severity: "fatal",
+      });
+    }
+    owners.set(account.botToken, account.accountId);
+  }
+}
 
 function getCanonicalOwnerId(runtime: IAgentRuntime): UUID | null {
   for (const key of CANONICAL_OWNER_SETTING_KEYS) {
@@ -298,6 +320,7 @@ export class TelegramService extends Service {
   private botToken: string | null;
   private defaultAccountId = DEFAULT_ACCOUNT_ID;
   private accountStates: Map<string, TelegramAccountRuntime> = new Map();
+  private configuredBots = new WeakSet<Telegraf<Context>>();
 
   /**
    * Constructor for TelegramService class.
@@ -333,29 +356,16 @@ export class TelegramService extends Service {
       return;
     }
 
-    try {
-      const state = this.createAccountRuntime(account);
-      this.setDefaultAccountState(state);
-      logger.debug(
-        {
-          src: "plugin:telegram",
-          agentId: runtime.agentId,
-          accountId: account.accountId,
-        },
-        "TelegramService constructor completed",
-      );
-    } catch (error) {
-      logger.error(
-        {
-          src: "plugin:telegram",
-          agentId: runtime.agentId,
-          error: error instanceof Error ? error.message : String(error),
-        },
-        "Failed to initialize Telegram bot",
-      );
-      this.bot = null;
-      this.messageManager = null;
-    }
+    const state = this.createAccountRuntime(account);
+    this.setDefaultAccountState(state);
+    logger.debug(
+      {
+        src: "plugin:telegram",
+        agentId: runtime.agentId,
+        accountId: account.accountId,
+      },
+      "TelegramService constructor completed",
+    );
   }
 
   private createAccountRuntime(
@@ -518,9 +528,11 @@ export class TelegramService extends Service {
    * @returns {Promise<TelegramService>} A promise that resolves with the initialized TelegramService.
    */
   static async start(runtime: IAgentRuntime): Promise<TelegramService> {
+    const enabledAccounts = listEnabledTelegramAccounts(runtime);
+    assertUniqueTelegramAccountTokens(enabledAccounts);
     const service = new TelegramService(runtime);
 
-    for (const account of listEnabledTelegramAccounts(runtime)) {
+    for (const account of enabledAccounts) {
       if (!service.getAccountState(account.accountId)) {
         service.setDefaultAccountState(service.createAccountRuntime(account));
       }
@@ -539,6 +551,7 @@ export class TelegramService extends Service {
     for (const state of service.accountStates.values()) {
       let retryCount = 0;
       let lastError: Error | null = null;
+      let initialized = false;
 
       while (retryCount < maxRetries) {
         try {
@@ -552,8 +565,6 @@ export class TelegramService extends Service {
             "Starting Telegram bot",
           );
           await service.initializeBot(state);
-          service.setupMiddlewares(state);
-          service.setupMessageHandlers(state);
           await state.bot.telegram.getMe();
 
           logger.success(
@@ -565,6 +576,7 @@ export class TelegramService extends Service {
             },
             "Telegram bot started successfully",
           );
+          initialized = true;
           break;
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error));
@@ -613,17 +625,18 @@ export class TelegramService extends Service {
         }
       }
 
-      if (retryCount >= maxRetries) {
-        logger.error(
-          {
-            src: "plugin:telegram",
-            agentId: runtime.agentId,
+      if (!initialized) {
+        await service.stop();
+        throw new ElizaError("Telegram account failed to initialize", {
+          code: "TELEGRAM_ACCOUNT_INITIALIZATION_FAILED",
+          context: {
             accountId: state.accountId,
+            attempts: retryCount,
             maxRetries,
-            error: lastError?.message,
           },
-          "Initialization failed after all attempts",
-        );
+          cause: lastError ?? undefined,
+          severity: "fatal",
+        });
       }
     }
 
@@ -653,7 +666,21 @@ export class TelegramService extends Service {
         : [];
     if (states.length > 0) {
       for (const state of states) {
-        state.bot.stop("service-stop");
+        RETIRED_TELEGRAM_POLLERS.add(state.bot);
+        try {
+          state.bot.stop("service-stop");
+        } catch (error) {
+          // error-policy:J6 best-effort teardown must continue across accounts.
+          logger.debug(
+            {
+              src: "plugin:telegram",
+              agentId: this.runtime.agentId,
+              accountId: state.accountId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            "Telegram bot was already stopped",
+          );
+        }
         const token = state.account.botToken;
         if (token) {
           const active = ACTIVE_TELEGRAM_POLLERS.get(token);
@@ -667,7 +694,20 @@ export class TelegramService extends Service {
 
     const bot = this.bot;
     if (bot) {
-      bot.stop("service-stop");
+      RETIRED_TELEGRAM_POLLERS.add(bot);
+      try {
+        bot.stop("service-stop");
+      } catch (error) {
+        // error-policy:J6 best-effort teardown for an already-stopped bot.
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Telegram bot was already stopped",
+        );
+      }
       if (this.botToken) {
         const active = ACTIVE_TELEGRAM_POLLERS.get(this.botToken);
         if (active?.bot === bot) {
@@ -702,6 +742,7 @@ export class TelegramService extends Service {
           },
           "Stopping existing Telegram poller before launching a new one",
         );
+        RETIRED_TELEGRAM_POLLERS.add(active.bot);
         try {
           active.bot.stop("replaced-by-new-runtime");
         } catch (error) {
@@ -721,50 +762,52 @@ export class TelegramService extends Service {
       }
     }
 
-    bot.start((ctx) => {
-      const slashStartPayload = {
-        ctx,
-        runtime: this.runtime,
-        source: "telegram",
-        accountId,
-        metadata: { accountId },
-      };
-      this.runtime.emitEvent(
-        TelegramEventTypes.SLASH_START as string,
-        slashStartPayload,
-      );
-    });
+    if (!this.configuredBots.has(bot)) {
+      this.setupMiddlewares(activeState ?? undefined);
 
-    // Register universal slash-command handlers BEFORE launch. Telegraf accepts
-    // command registration any time before launch(), and a matched command
-    // handler that never calls next() terminates the middleware chain — so the
-    // catch-all message handler in setupMessageHandlers does not also process
-    // command messages (no double-processing).
-    const commandMessageManager =
-      activeState?.messageManager ?? this.messageManager ?? undefined;
-    if (commandMessageManager) {
-      const registered = registerTelegramCommandHandlers(
-        bot,
-        this.runtime,
-        commandMessageManager,
-        accountId,
-      );
-      logger.debug(
-        {
-          src: "plugin:telegram",
-          agentId: this.runtime.agentId,
+      bot.start((ctx) => {
+        const slashStartPayload = {
+          ctx,
+          runtime: this.runtime,
+          source: "telegram",
           accountId,
-          commandCount: registered.length,
-        },
-        "Registered universal slash-command handlers",
-      );
-      // #8902: the live, edited-in-place orchestrator task board (`/tasks`).
-      registerTelegramTaskBoardCommand(
-        bot,
-        this.runtime,
-        commandMessageManager,
-        accountId,
-      );
+          metadata: { accountId },
+        };
+        this.runtime.emitEvent(
+          TelegramEventTypes.SLASH_START as string,
+          slashStartPayload,
+        );
+      });
+
+      // Commands sit after policy/discovery middleware and before the catch-all
+      // message handler, so every command is admitted first and handled once.
+      const commandMessageManager =
+        activeState?.messageManager ?? this.messageManager ?? undefined;
+      if (commandMessageManager) {
+        const registered = registerTelegramCommandHandlers(
+          bot,
+          this.runtime,
+          commandMessageManager,
+          accountId,
+        );
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            accountId,
+            commandCount: registered.length,
+          },
+          "Registered universal slash-command handlers",
+        );
+        registerTelegramTaskBoardCommand(
+          bot,
+          this.runtime,
+          commandMessageManager,
+          accountId,
+        );
+      }
+      this.setupMessageHandlers(activeState ?? undefined);
+      this.configuredBots.add(bot);
     }
 
     // Telegraf v4's `bot.launch()` resolves only when polling STOPS — it awaits
@@ -796,6 +839,7 @@ export class TelegramService extends Service {
     // 409s against the lingering one. bot.stop() throws if already stopped, so
     // teardown is best-effort.
     const stopBot = (reason: string): void => {
+      RETIRED_TELEGRAM_POLLERS.add(bot);
       try {
         bot.stop(reason);
       } catch {
@@ -836,6 +880,9 @@ export class TelegramService extends Service {
     const stableRunMs = 60_000;
 
     const ownsToken = (): boolean => {
+      if (RETIRED_TELEGRAM_POLLERS.has(bot)) {
+        return false;
+      }
       if (!botToken) {
         return true;
       }
@@ -978,12 +1025,49 @@ export class TelegramService extends Service {
    */
   private setupMiddlewares(state?: TelegramAccountRuntime): void {
     const bot = state?.bot ?? this.bot;
+    const messageManager = state?.messageManager ?? this.messageManager;
     const accountId = state?.accountId ?? this.defaultAccountId;
-    // Register the authorization middleware
     bot?.use((ctx, next) => this.authorizationMiddleware(ctx, next, accountId));
-
-    // Register the chat and entity management middleware
+    bot?.use((ctx, next) =>
+      this.activationPolicyMiddleware(
+        ctx,
+        next,
+        messageManager ?? undefined,
+        accountId,
+      ),
+    );
     bot?.use((ctx, next) => this.chatAndEntityMiddleware(ctx, next, accountId));
+  }
+
+  private async activationPolicyMiddleware(
+    ctx: Context,
+    next: MiddlewareNext,
+    messageManager: MessageManager | undefined,
+    accountId: string,
+  ): Promise<void> {
+    if (!messageManager) {
+      throw new ElizaError("Telegram message manager is not initialized", {
+        code: "TELEGRAM_MESSAGE_MANAGER_MISSING",
+        context: { accountId },
+        severity: "fatal",
+      });
+    }
+    const admission = await messageManager.admitIngress(ctx);
+    if (!admission.admitted) {
+      await messageManager.sendIngressDenial(ctx, admission);
+      logger.debug(
+        {
+          src: "plugin:telegram",
+          agentId: this.runtime.agentId,
+          accountId,
+          chatId: ctx.chat?.id,
+          reason: admission.decision.reason,
+        },
+        "Telegram update denied before side effects",
+      );
+      return;
+    }
+    await next();
   }
 
   /**
@@ -1031,7 +1115,7 @@ export class TelegramService extends Service {
     next: MiddlewareNext,
     accountId = this.defaultAccountId,
   ): Promise<void> {
-    if (!ctx.chat) {
+    if (!ctx.chat || !ctx.message) {
       return next();
     }
 
@@ -1113,15 +1197,8 @@ export class TelegramService extends Service {
         // Preprocessing runs in the middleware chain; this only dispatches.
         await messageManager?.handleMessage(ctx);
       } catch (error) {
-        logger.error(
-          {
-            src: "plugin:telegram",
-            agentId: this.runtime.agentId,
-            accountId,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "Error handling message",
-        );
+        // error-policy:J7 Telegram's update loop must survive after reporting.
+        this.runtime.reportError("telegram:message", error, { accountId });
       }
     });
 
@@ -1130,15 +1207,8 @@ export class TelegramService extends Service {
       try {
         await messageManager?.handleReaction(ctx);
       } catch (error) {
-        logger.error(
-          {
-            src: "plugin:telegram",
-            agentId: this.runtime.agentId,
-            accountId,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "Error handling reaction",
-        );
+        // error-policy:J7 Telegram's update loop must survive after reporting.
+        this.runtime.reportError("telegram:reaction", error, { accountId });
       }
     });
 
@@ -1148,15 +1218,8 @@ export class TelegramService extends Service {
       try {
         await messageManager?.handleCallbackQuery(ctx);
       } catch (error) {
-        logger.error(
-          {
-            src: "plugin:telegram",
-            agentId: this.runtime.agentId,
-            accountId,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "Error handling callback query",
-        );
+        // error-policy:J7 Telegram's update loop must survive after reporting.
+        this.runtime.reportError("telegram:callback", error, { accountId });
       }
     });
   }


### PR DESCRIPTION
## Maintainer repair review\n\nExact-head review repaired policy-denied side effects, untrusted reaction topic routing, duplicate/restarted Telegram pollers, non-atomic multi-account startup, duplicate tokens, vault-backed account token resolution, public-config redaction, and swallowed ingress failures. Admission now happens before discovery, writes, acknowledgements, or replies; reaction ownership derives from persisted source memory; and startup is atomic. The repair passed 40 agent tests, 144 Telegram tests across 21 files, Telegram lint/typecheck, a real local Bot API HTTP polling harness, and the full root verify.\n\nMerge remains held until live \x60api.telegram.org\x60 evidence covers forum reactions, multi-account poll/reconnect including 401/409/429, and an allowed-message live-model trajectory.\n\n<!-- exact-head:5e9e6424e6f9ea96be1028db3869385ed224874d -->\n\n## Summary

- project the typed `connectors.telegram` policy into the production runtime without copying bot credentials into public character settings
- resolve root and account-set bot tokens through runtime-only settings, while preserving DM/group/topic policy per account
- apply authorization and address activation before inbound memory creation or model dispatch for messages, slash-command turns, callbacks, and reactions
- trigger groups only for native `@bot` mentions, replies to this bot, or explicit `requireMention: false`; preserve topic room identity, `message_thread_id`, source reply target, and `replyToMode`
- make typed policy authoritative over legacy `TELEGRAM_AUTO_REPLY` / `TELEGRAM_ALLOWED_CHATS`
- keep the full Telegram plugin as the sole owner when a standard connector is configured; standalone remains an env-only fallback owner

## Validation

- `bun run --cwd plugins/plugin-telegram test`
  - 20 files passed, 138 tests passed
- `bun run --cwd plugins/plugin-telegram typecheck`
  - passed
- `bun run --cwd plugins/plugin-telegram lint:check`
  - passed, 50 files checked
- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/runtime/build-character-config.test.ts packages/agent/src/runtime/plugin-collector-mode-policy.test.ts`
  - 2 files passed, 22 tests passed
- `bun run --cwd packages/agent lint:check`
  - passed, 804 files checked

## Bidirectional proof

The exact focused tests were copied onto unpatched develop at `f1f47e73f61de6e593ebaf1ac536161864219746`:

- Telegram production-path command: 3 files failed, 9 tests failed, 11 passed on base; 3 files passed, 20 tests passed here
- Agent config/collector command: 2 files failed, 3 tests failed, 19 passed on base; 2 files passed, 22 tests passed here

Base failures cover standard-config projection, account token resolution, duplicate full + standalone ownership, unaddressed group suppression, native mention dispatch/stripping, reply-to-bot dispatch, typed DM allowlist, unauthorized/unconfigured routes, topic delivery, and legacy precedence.

No deployment or workflow files changed.

## Evidence Gate

<!-- evidence-head:5e9e6424e6f9ea96be1028db3869385ed224874d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend Telegram connector/runtime policy change with no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend Telegram connector/runtime policy change with no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual user flow or rendered UI changed; production-path connector tests exercise the complete route.

<!-- evidence-row:backend-logs -->
- [x] <details><summary>Production-path test transcript</summary>

```text
$ bun run --cwd plugins/plugin-telegram test -- src/accounts.test.ts src/messageManager.activation-policy.test.ts src/messageConnector.test.ts
Test Files  3 passed (3)
Tests       20 passed (20)
$ bun run --cwd plugins/plugin-telegram test
Test Files  20 passed (20)
Tests       138 passed (138)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, network, or rendered source changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - this changes pre-dispatch connector authorization only; no model, prompt, provider, action, or generated response behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - focused tests intentionally assert denied updates create no memory or domain artifact; no database, task, wallet, audio, or generated-file behavior changed.

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or visual text changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`, `openai-codex/gpt-5.5-codex-mini`
<!-- attribution-row:client -->
- Client / agent tooling: OpenClaw and Codex CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no repository contribution skill was used; generic coding-agent orchestration only
<!-- attribution-row:status -->
- Attribution status: self-reported
