### PR TITLE
chore(ui): stop tracking generated agent-surface E2E output

### DIFF
--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -235,6 +235,10 @@ interaction geometry**, **safe-area clearance**, and **tap-target minimums**
 
 This package mostly reads config injected by the host, not raw env vars:
 
+- `E2E_RECORD=1` with `E2E_RECORDING_DIR=<absolute path>` — sends isolated
+  browser-runner artifacts to the canonical repository recording tree. Direct
+  runner invocations without the explicit destination keep their fixture-local
+  output directory.
 - `__ELIZA_BUILD_VARIANT__` — Vite `define` consumed by `build-variant.ts`
   (`"store"` | `"direct"`, default `"direct"`).
 - Eliza API base/token are runtime values managed via the api client helpers

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -235,6 +235,10 @@ interaction geometry**, **safe-area clearance**, and **tap-target minimums**
 
 This package mostly reads config injected by the host, not raw env vars:
 
+- `E2E_RECORD=1` with `E2E_RECORDING_DIR=<absolute path>` — sends isolated
+  browser-runner artifacts to the canonical repository recording tree. Direct
+  runner invocations without the explicit destination keep their fixture-local
+  output directory.
 - `__ELIZA_BUILD_VARIANT__` — Vite `define` consumed by `build-variant.ts`
   (`"store"` | `"direct"`, default `"direct"`).
 - Eliza API base/token are runtime values managed via the api client helpers

--- a/packages/ui/src/agent-surface/__e2e__/MANUAL_REVIEW.md
+++ b/packages/ui/src/agent-surface/__e2e__/MANUAL_REVIEW.md
@@ -1,7 +1,8 @@
 # Agent-surface e2e — manual review
 
 Run: `bun run --cwd packages/ui test:agent-surface-e2e` (real headless chromium,
-no app server). Screenshots land in `output/`.
+no app server). Direct-run screenshots land in `output/`; the repository-wide
+recorder writes them to its suite-specific `e2e-recordings/` destination.
 
 ## Verdict: **good**
 

--- a/packages/ui/src/agent-surface/__e2e__/output-path.mjs
+++ b/packages/ui/src/agent-surface/__e2e__/output-path.mjs
@@ -1,0 +1,26 @@
+/**
+ * Resolves agent-surface browser artifacts to the canonical recorder's
+ * explicit destination while retaining fixture-local output for direct runs.
+ */
+
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export const DIRECT_AGENT_SURFACE_OUTPUT_DIR = join(here, "output");
+
+export const AGENT_SURFACE_ARTIFACT_NAMES = [
+  "fixture.html",
+  "real-view.html",
+  "agent-surface-rest.png",
+  "agent-surface-highlight.png",
+  "agent-surface-real-view.png",
+];
+
+export function resolveAgentSurfaceOutputDir(env = process.env) {
+  if (env.E2E_RECORD === "1" && env.E2E_RECORDING_DIR) {
+    return resolve(env.E2E_RECORDING_DIR);
+  }
+  return DIRECT_AGENT_SURFACE_OUTPUT_DIR;
+}

--- a/packages/ui/src/agent-surface/__e2e__/run-e2e.mjs
+++ b/packages/ui/src/agent-surface/__e2e__/run-e2e.mjs
@@ -15,21 +15,37 @@
  *      discovers and drives real plugin source — list-elements → agent-click /
  *      agent-fill → state change — exactly as DynamicViewLoader does in-app.
  *
+ * Direct runs write to ./output. The canonical recorder sets E2E_RECORD=1 and
+ * E2E_RECORDING_DIR to collect these artifacts under the repository-wide
+ * e2e-recordings tree.
+ *
  * Run: bun run packages/ui/src/agent-surface/__e2e__/run-e2e.mjs
  * Exits non-zero on any failed assertion.
  */
 
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { chromium } from "playwright";
+import {
+  AGENT_SURFACE_ARTIFACT_NAMES,
+  resolveAgentSurfaceOutputDir,
+} from "./output-path.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const uiSrc = resolve(here, "..");
 const repoRoot = resolve(here, "../../../../..");
-const outDir = join(here, "output");
+const outDir = resolveAgentSurfaceOutputDir();
 await mkdir(outDir, { recursive: true });
+
+// A previous successful run must never satisfy the current run's evidence
+// contract. Remove only the runner-owned files before launching Chromium.
+await Promise.all(
+  AGENT_SURFACE_ARTIFACT_NAMES.map((name) =>
+    rm(join(outDir, name), { force: true }),
+  ),
+);
 
 function assert(cond, msg) {
   if (!cond) {
@@ -219,10 +235,19 @@ async function driveRealView(browser) {
   }
 }
 
+async function assertArtifactsWritten() {
+  for (const artifactName of AGENT_SURFACE_ARTIFACT_NAMES) {
+    const artifactPath = join(outDir, artifactName);
+    const artifact = await stat(artifactPath);
+    assert(artifact.size > 0, `${artifactName} was written to ${outDir}`);
+  }
+}
+
 const browser = await chromium.launch();
 try {
   await driveSyntheticFixture(browser);
   await driveRealView(browser);
+  await assertArtifactsWritten();
   console.log(`\nScreenshots written to ${outDir}`);
 } finally {
   await browser.close();

--- a/scripts/e2e-recordings/agent-surface-recording-contract.test.mjs
+++ b/scripts/e2e-recordings/agent-surface-recording-contract.test.mjs
@@ -1,0 +1,47 @@
+/**
+ * Locks the canonical recorder and direct agent-surface runner to one explicit
+ * recording destination while preserving fixture-local direct-run output.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  DIRECT_AGENT_SURFACE_OUTPUT_DIR,
+  resolveAgentSurfaceOutputDir,
+} from "../../packages/ui/src/agent-surface/__e2e__/output-path.mjs";
+import {
+  recordingEnvironment,
+  recordingOutputDirForSuite,
+} from "./run-all.mjs";
+import { suiteByName } from "./suites.mjs";
+
+const suite = suiteByName("ui-agent-surface");
+if (!suite)
+  throw new Error("ui-agent-surface recording suite is not registered");
+
+describe("agent-surface recording destination", () => {
+  it("keeps fixture-local output as the direct-run default", () => {
+    expect(resolveAgentSurfaceOutputDir({})).toBe(
+      DIRECT_AGENT_SURFACE_OUTPUT_DIR,
+    );
+    expect(resolveAgentSurfaceOutputDir({ E2E_RECORD: "1" })).toBe(
+      DIRECT_AGENT_SURFACE_OUTPUT_DIR,
+    );
+  });
+
+  it("agrees with the canonical recorder's explicit destination", () => {
+    const outputDir = recordingOutputDirForSuite(suite);
+    const environment = recordingEnvironment(suite, outputDir, {});
+    expect(resolveAgentSurfaceOutputDir(environment)).toBe(outputDir);
+  });
+
+  it("keeps recorder-owned destination keys authoritative", () => {
+    const outputDir = recordingOutputDirForSuite(suite);
+    const environment = recordingEnvironment(
+      { ...suite, recordEnv: { E2E_RECORD: "0", E2E_RECORDING_DIR: "/wrong" } },
+      outputDir,
+      {},
+    );
+    expect(environment.E2E_RECORD).toBe("1");
+    expect(environment.E2E_RECORDING_DIR).toBe(outputDir);
+  });
+});

--- a/scripts/e2e-recordings/run-all.mjs
+++ b/scripts/e2e-recordings/run-all.mjs
@@ -33,6 +33,24 @@ const SKIP_EXIT_CODE = 77;
 const SCRIPTS_DIR = __dirname;
 const PACKAGES = UI_E2E_SUITES;
 
+/** Returns the canonical artifact destination advertised for a suite. */
+export function recordingOutputDirForSuite(pkg) {
+  return path.join(RECORDINGS_DIR, pkg.name, "test-results");
+}
+
+/**
+ * Builds record-mode environment with recorder-owned keys applied last so a
+ * suite cannot redirect evidence away from the contact-sheet input tree.
+ */
+export function recordingEnvironment(pkg, outputDir, baseEnv = process.env) {
+  return {
+    ...baseEnv,
+    ...(pkg.recordEnv ?? {}),
+    E2E_RECORD: "1",
+    E2E_RECORDING_DIR: outputDir,
+  };
+}
+
 // ─── CLI argument parsing ────────────────────────────────────────────────────
 export function parseRunAllArgs(argv) {
   const flagMap = new Map();
@@ -165,7 +183,7 @@ function runCommandSuite(pkg) {
     }
   }
 
-  const outputDir = path.join(RECORDINGS_DIR, pkg.name, "test-results");
+  const outputDir = recordingOutputDirForSuite(pkg);
   fs.mkdirSync(outputDir, { recursive: true });
   console.log(`  Running: ${formatCommand(pkg.command)}`);
   console.log(`  Output:  e2e-recordings/${pkg.name}/test-results/`);
@@ -174,11 +192,7 @@ function runCommandSuite(pkg) {
   const result = spawnSync(bin, args, {
     cwd: REPO_ROOT,
     stdio: "inherit",
-    env: {
-      ...process.env,
-      E2E_RECORD: "1",
-      ...(pkg.recordEnv ?? {}),
-    },
+    env: recordingEnvironment(pkg, outputDir),
   });
 
   const exitCode = result.status ?? 1;
@@ -255,7 +269,7 @@ function runPackageTests(pkg) {
   }
 
   // Ensure the recording output directory exists so Playwright has somewhere to write
-  const recordingOut = path.join(RECORDINGS_DIR, pkg.name, "test-results");
+  const recordingOut = recordingOutputDirForSuite(pkg);
   fs.mkdirSync(recordingOut, { recursive: true });
 
   console.log(`  Running: bun run --cwd ${pkg.configDir} ${pkg.script}`);
@@ -264,14 +278,9 @@ function runPackageTests(pkg) {
   const result = spawnSync("bun", ["run", "--cwd", pkg.configDir, pkg.script], {
     cwd: REPO_ROOT,
     stdio: "inherit",
-    env: {
-      ...process.env,
-      // Signal to Playwright config that we want full recording.
-      // The config itself computes outputDir from import.meta.dirname + E2E_RECORD.
-      E2E_RECORD: "1",
-      // Per-package extra env (e.g. ELIZA_UI_SMOKE_FORCE_STUB for the app package).
-      ...(pkg.recordEnv ?? {}),
-    },
+    // Custom runners consume the explicit destination; Playwright configs can
+    // continue deriving their package destination from E2E_RECORD.
+    env: recordingEnvironment(pkg, recordingOut),
   });
 
   const exitCode = result.status ?? 1;


### PR DESCRIPTION
## Summary

Removes five generated agent-surface browser outputs from source control and routes future repository-wide evidence recordings to the canonical `e2e-recordings/ui-agent-surface/test-results` destination. Direct runner invocations retain their fixture-local output directory.

This repairs the deeper recorder/runner contract rather than only ignoring generated files: the canonical orchestrator now passes an explicit destination, the runner validates all five outputs, and focused contract coverage locks both modes. No production runtime or rendered product behavior changes.

## Changes

- Delete the five checked-in generated HTML/PNG outputs and ignore only their exact fixture-local directory.
- Pass `E2E_RECORDING_DIR` from the canonical recorder to custom and package runners.
- Resolve the agent-surface destination explicitly while preserving direct-run compatibility.
- Remove the five runner-owned outputs before launch, then fail when the current run does not recreate every artifact as a nonempty file.
- Document the recording contract in the mirrored package guidance.

## Exact-head verification

Head: `4eee4297900394ad0dacca578c56e0d355769a89`

- `bun test scripts/e2e-recordings/agent-surface-recording-contract.test.mjs scripts/e2e-recordings/run-all-require-evidence.test.mjs`: 10 passed, 0 failed.
- `bun run --cwd packages/ui test:agent-surface-e2e`: passed; direct mode produced five nonempty artifacts.
- `node scripts/e2e-recordings/run-all.mjs --packages=ui-agent-surface --skip-sheets --skip-viewer`: passed; canonical mode produced five nonempty artifacts under the repository recorder tree.
- Canonical output inventory: 1,562,357 bytes total across two HTML fixtures and three PNG screenshots.
- Biome and `git diff --check`: passed.
- Exact repair checkout was clean after verification; generated evidence remained ignored.
- All three screenshots were manually reviewed and were nonblank.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - this test/evidence-tooling repair does not alter a rendered product view.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - product pixels are unchanged; the generated runner screenshots were manually reviewed as nonblank.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no interactive product flow changes.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no backend runtime path changes.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no production frontend code changes; both Chromium runner modes completed successfully.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no runtime domain data is created; the generated evidence artifacts were verified separately above.`

## Maintainer repair

The submitted cleanup correctly removed generated files, but canonical evidence collection still scanned a different directory. This exact-head aggregate repairs the destination contract and adds nonempty-artifact validation while retaining the original proposal.

Original proposal: @0xSolace.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: Codex CLI 0.145.0
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

— [codex-shawwalters]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex CLI 0.145.0","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:4eee4297900394ad0dacca578c56e0d355769a89 -->
