### PR TITLE
docs: mark retired audit:test-integrity commands in migration table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,11 +101,11 @@ locking and linear probing so active lanes do not collide. See
 | `bun run smartglasses:simulator` | `bun run --cwd packages/examples/smartglasses simulator` |
 | `bun run smartglasses:smoke:simulator` | `bun run --cwd packages/examples/smartglasses smoke:simulator` |
 | `bun run test:ci:live` | `bun run test:live` |
-| `bun run test:lint` | `bun run audit:test-integrity:all` |
+| `bun run test:lint` | Retired — the underlying `audit:test-integrity` tooling was removed; no replacement |
 | `bun run test:lint:no-vi-mocks` | `bun run audit:test-integrity:no-vi-mocks` |
-| `bun run test:lint:lane-coverage` | `bun run audit:test-integrity:lane-coverage` |
-| `bun run test:lint:test-integrity` | `bun run audit:test-integrity` |
-| `bun run test:lint:test-integrity:self-test` | `bun run audit:test-integrity:self-test` |
+| `bun run test:lint:lane-coverage` | Retired — the underlying `audit:test-integrity:lane-coverage` tooling was removed; no replacement |
+| `bun run test:lint:test-integrity` | Retired — the underlying `audit:test-integrity` tooling was removed; no replacement |
+| `bun run test:lint:test-integrity:self-test` | Retired — the underlying `audit:test-integrity:self-test` tooling was removed; no replacement |
 | `bun run verify:smartglasses-software` | `bun run audit:smartglasses-software` |
 | `bun run personality:judge` | `bun run bench:personality` |
 | `bun run personality:bench:calibrate` | `bun run bench:personality:calibrate` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,11 +101,11 @@ locking and linear probing so active lanes do not collide. See
 | `bun run smartglasses:simulator` | `bun run --cwd packages/examples/smartglasses simulator` |
 | `bun run smartglasses:smoke:simulator` | `bun run --cwd packages/examples/smartglasses smoke:simulator` |
 | `bun run test:ci:live` | `bun run test:live` |
-| `bun run test:lint` | `bun run audit:test-integrity:all` |
+| `bun run test:lint` | Retired — the underlying `audit:test-integrity` tooling was removed; no replacement |
 | `bun run test:lint:no-vi-mocks` | `bun run audit:test-integrity:no-vi-mocks` |
-| `bun run test:lint:lane-coverage` | `bun run audit:test-integrity:lane-coverage` |
-| `bun run test:lint:test-integrity` | `bun run audit:test-integrity` |
-| `bun run test:lint:test-integrity:self-test` | `bun run audit:test-integrity:self-test` |
+| `bun run test:lint:lane-coverage` | Retired — the underlying `audit:test-integrity:lane-coverage` tooling was removed; no replacement |
+| `bun run test:lint:test-integrity` | Retired — the underlying `audit:test-integrity` tooling was removed; no replacement |
+| `bun run test:lint:test-integrity:self-test` | Retired — the underlying `audit:test-integrity:self-test` tooling was removed; no replacement |
 | `bun run verify:smartglasses-software` | `bun run audit:smartglasses-software` |
 | `bun run personality:judge` | `bun run bench:personality` |
 | `bun run personality:bench:calibrate` | `bun run bench:personality:calibrate` |


### PR DESCRIPTION
## Scope

The "Removed Root Command Migrations" table in root `CLAUDE.md` / `AGENTS.md` sends readers to four commands that do not exist. Following the guide produces `error: Script not found`.

Verified against `origin/develop` by checking every documented replacement against `package.json`:

| Documented replacement | Exists at root? |
| --- | --- |
| `bun run audit:test-integrity:all` | **no** |
| `bun run audit:test-integrity:lane-coverage` | **no** |
| `bun run audit:test-integrity` | **no** |
| `bun run audit:test-integrity:self-test` | **no** |
| `bun run audit:test-integrity:no-vi-mocks` | yes |

The underlying tooling is gone too, so these are not simply unregistered scripts: `packages/scripts/` contains `lint-no-vi-mocks.mjs` and no `test-integrity` or `lane-coverage` counterpart.

## Changes

Updated the four broken rows in both `CLAUDE.md` and `AGENTS.md` to state plainly that the check was retired with its tooling and no replacement exists. Kept the one working mapping (`test:lint:no-vi-mocks` -> `audit:test-integrity:no-vi-mocks`).

## Acceptance criteria

- [x] The `test:lint*` rows in root `CLAUDE.md` name only commands that exist, or state plainly that the check was retired with its tooling and no replacement exists.
- [x] `AGENTS.md` receives the identical edit — the repo convention is that the two files are byte-identical, and `bun run check:agents-claude` enforces it.
- [x] Every remaining replacement in the table still resolves: root targets against root `package.json`, `--cwd <dir>` targets against that package's manifest.
- [x] No change to any script or tooling — this is documentation matching reality.

## Evidence

- Screenshots / video: N/A - documentation change with no rendered surface.
- Logs: before/after resolution of every documented replacement, pasted inline.
- Real-LLM trajectories: N/A - no model, prompt, action, or provider behavior changes.
- Domain artifacts: N/A - the resolution check output is the artifact.
- Commands: `bun run check:agents-claude`, plus the per-row resolution check above.

AI provider/model: Anthropic / claude-mycode
Client / agent tooling: Claude Agent SDK
Contribution skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [harshith8gowda]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-mycode","client":"Claude Agent SDK","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->