### PR TITLE
test(ci): follow skill review requirements pin

### DIFF
--- a/scripts/check-ai-workflow-security.test.mjs
+++ b/scripts/check-ai-workflow-security.test.mjs
@@ -8,6 +8,8 @@ import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 
 const SKILL_REVIEW_PATH = ".github/workflows/skill-review.yml";
+const SKILL_REVIEW_REQUIREMENTS_PATH =
+  "packages/skills/skills/skill-creator/requirements.txt";
 const ELIZA_COMPUTER_PATH = ".github/workflows/eliza-computer.yml";
 const ELIZA_ARMY_RELEASE_LABEL_PATH =
   ".github/workflows/eliza-army-release-label.yml";
@@ -100,6 +102,7 @@ describe("AI workflow security policy", () => {
 
   it("validates untrusted changed skills without secrets, models, writes, or persistent runners", () => {
     const source = workflow(SKILL_REVIEW_PATH);
+    const requirements = workflow(SKILL_REVIEW_REQUIREMENTS_PATH);
 
     assert.match(source, /^\s*pull_request_target:\s*$/m);
     assert.doesNotMatch(source, /^\s*pull_request:\s*$/m);
@@ -152,7 +155,14 @@ describe("AI workflow security policy", () => {
     assert.match(source, /"--literal-pathspecs",\s*\n\s*"ls-tree"/);
     assert.match(source, /git\("cat-file", "blob", object_id, binary=True\)/);
     assert.match(source, /os\.O_CREAT \| os\.O_EXCL \| os\.O_WRONLY/);
-    assert.match(source, /PyYAML==6\.0\.3 --hash=sha256:[0-9a-f]{64}/);
+    assert.match(
+      source,
+      /--requirement trusted\/packages\/skills\/skills\/skill-creator\/requirements\.txt/,
+    );
+    assert.match(
+      requirements,
+      /PyYAML==6\.0\.3 \\\s+--hash=sha256:[0-9a-f]{64}/,
+    );
     assert.match(source, /--require-hashes/);
   });
 


### PR DESCRIPTION
## Relates to

Closes #17626.

## Summary

The trusted contribution validator still expected the PyYAML hash pin inline in skill-review.yml after develop moved it into the skill-creator requirements file. This updates the contract test to verify both halves of the actual boundary: the workflow installs the trusted requirements file, and that file contains the exact hash-pinned PyYAML dependency.

## Verification

- focused security/contribution/evidence tests: 116 passed
- Biome: clean
- git diff --check: clean

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

## Evidence Gate

<!-- evidence-head:1467f062b4c6748d1ca92a237757e4e17b8cf322 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - validator test only; no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- [x] N/A - validator test only; no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changed.

<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime backend path changed; the focused Node test output reports 116 passing validator cases.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - this change only repairs a trusted CI self-test assertion.

<!-- exact-head:1467f062b4c6748d1ca92a237757e4e17b8cf322 -->