### PR TITLE
fix: turn-delivery observability, verify-retry busy-session tolerance, honest trigger replay

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -44,7 +44,8 @@
       "!plugins/plugin-personal-assistant/docs/audit",
       "!packages/elizaos/templates",
       "!packages/app-core/test/contracts/lib/openzeppelin-contracts",
-      "!packages/app-core/src/styles"
+      "!packages/app-core/src/styles",
+      "!packages/homepage/waitlist"
     ]
   },
   "linter": {

--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -5,7 +5,11 @@
  * kind:"prompt", prompt triggers are creatable with the autonomy loop off and
  * land in the originating room — against a minimal in-memory runtime.
  * Also covers the update / delete / toggle lifecycle ops (happy paths and
- * structured not-found failures).
+ * structured not-found failures) and the effect-receipt contract: mutating
+ * ops bind their canonical ack text to committed receipts — an applied
+ * receipt for fresh mutations, a replayed no-op for the idempotent
+ * already-exists path — so the planned-reply egress verifier can ground a
+ * truthful completion claim, while failures stay receipt-less.
  */
 
 import type {
@@ -18,6 +22,7 @@ import type {
 } from "@elizaos/core";
 import {
   AUTONOMY_SERVICE_TYPE,
+  hasAppliedUserFacingEffectProof,
   stringToUuid,
   TRIGGER_SCHEMA_VERSION,
 } from "@elizaos/core";
@@ -520,5 +525,138 @@ describe("TRIGGER update / delete / toggle — lifecycle ops (#16863)", () => {
     expect(result?.data?.enabled).toBe(true);
     expect(updates).toHaveLength(1);
     expect(updates[0].patch.metadata?.trigger?.enabled).toBe(true);
+  });
+});
+
+describe("TRIGGER effect receipts — completion-claim grounding", () => {
+  it("binds a fresh create to an applied receipt with the canonical ack text", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {
+      instructions: "take vitamins",
+      triggerType: "cron",
+      cronExpression: "0 8 * * *",
+    });
+    if (!result) throw new Error("expected a result");
+    expect(result.success).toBe(true);
+    expect(result.verifiedUserFacing).toBe(true);
+    expect(result.userFacingText).toBe(result.text);
+    const receipt = result.effectReceipts?.[0];
+    expect(receipt).toMatchObject({
+      operation: "trigger.create",
+      outcome: "applied",
+      resource: { kind: "trigger.task", id: String(result.data?.taskId) },
+      idempotency: { key: result.data?.dedupeKey, replayed: false },
+    });
+    expect(result.userFacingEffectReceiptIds).toEqual([receipt?.receiptId]);
+    expect(hasAppliedUserFacingEffectProof(result)).toBe(true);
+    expect(createdTasks).toHaveLength(1);
+  });
+
+  it("grounds the already-exists dedupe as a replayed no-op — success, not a lie", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const first = await create(runtime, {
+      instructions: "drink water",
+      delaySeconds: 90,
+    });
+    expect(first?.success).toBe(true);
+    const firstTrigger = createdTasks[0].metadata.trigger;
+    (
+      runtime.getTasks as unknown as { mockResolvedValue: (v: Task[]) => void }
+    ).mockResolvedValue([
+      {
+        id: stringToUuid("existing-task"),
+        name: "TRIGGER_DISPATCH",
+        tags: ["queue", "repeat", "trigger"],
+        metadata: { updatedAt: Date.now(), trigger: firstTrigger },
+      } as unknown as Task,
+    ]);
+    const second = await create(runtime, {
+      instructions: "drink water",
+      delaySeconds: 90,
+    });
+    if (!second) throw new Error("expected a result");
+    expect(second.success).toBe(true);
+    expect(second.verifiedUserFacing).toBe(true);
+    expect(second.userFacingText).toBe("An equivalent trigger already exists.");
+    expect(second.effectReceipts?.[0]).toMatchObject({
+      operation: "trigger.create",
+      outcome: "noop",
+      resource: {
+        kind: "trigger.task",
+        id: String(second.data?.duplicateTaskId),
+      },
+      idempotency: { key: second.data?.dedupeKey, replayed: true },
+    });
+    // The replayed no-op is committed desired-state proof: the truthful
+    // "already covered" ack passes the planned-reply egress verifier instead
+    // of being swapped for the unverified-effect fallback.
+    expect(hasAppliedUserFacingEffectProof(second)).toBe(true);
+    expect(createdTasks).toHaveLength(1);
+  });
+
+  it("refuses to claim success for a failed create — no receipts, no verified text", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {
+      instructions: "take vitamins",
+      triggerType: "cron",
+      cronExpression: "not a cron",
+    });
+    if (!result) throw new Error("expected a result");
+    expect(result.success).toBe(false);
+    expect(result.effectReceipts).toBeUndefined();
+    expect(result.verifiedUserFacing).toBeUndefined();
+    expect(hasAppliedUserFacingEffectProof(result)).toBe(false);
+    expect(createdTasks).toHaveLength(0);
+  });
+
+  it("binds delete to an applied receipt for the removed task", async () => {
+    const taskId = stringToUuid("receipt-delete-task");
+    const task = {
+      id: taskId,
+      name: "TRIGGER_DISPATCH",
+      description: "Trigger: water the plants",
+      roomId: CHAT_ROOM_ID,
+      tags: ["queue", "repeat", "trigger"],
+      metadata: {
+        updatedAt: Date.now(),
+        trigger: {
+          version: TRIGGER_SCHEMA_VERSION,
+          triggerId: stringToUuid("receipt-delete-config"),
+          displayName: "Trigger: water the plants",
+          instructions: "water the plants",
+          triggerType: "interval",
+          enabled: true,
+          wakeMode: "inject_now",
+          createdBy: String(USER_ID),
+          runCount: 0,
+          intervalMs: 3_600_000,
+          kind: "prompt",
+        },
+      },
+    } as unknown as Task;
+    const runtime = {
+      agentId: AGENT_ID,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      getSetting: () => undefined,
+      getService: () => null,
+      getTask: async (id: UUID) => (id === taskId ? task : null),
+      getTasks: async () => [task],
+      deleteTask: vi.fn(async () => undefined),
+    } as unknown as IAgentRuntime;
+    const result = await triggerAction.handler(
+      runtime,
+      makeMessage("delete the plants trigger"),
+      undefined,
+      { parameters: { action: "delete", taskId } },
+    );
+    if (!result) throw new Error("expected a result");
+    expect(result.success).toBe(true);
+    expect(result.userFacingText).toBe(result.text);
+    expect(result.effectReceipts?.[0]).toMatchObject({
+      operation: "trigger.delete",
+      outcome: "applied",
+      resource: { kind: "trigger.task", id: String(taskId) },
+    });
+    expect(hasAppliedUserFacingEffectProof(result)).toBe(true);
   });
 });

--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -577,7 +577,7 @@ describe("TRIGGER effect receipts — completion-claim grounding", () => {
     if (!second) throw new Error("expected a result");
     expect(second.success).toBe(true);
     expect(second.verifiedUserFacing).toBe(true);
-    expect(second.userFacingText).toBe("An equivalent trigger already exists.");
+    expect(second.userFacingText).toBe("Already set — you're covered.");
     expect(second.effectReceipts?.[0]).toMatchObject({
       operation: "trigger.create",
       outcome: "noop",

--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -74,12 +74,15 @@ function makeRuntime(opts: { enableAutonomy: boolean }): {
   return { runtime, createdTasks };
 }
 
-function makeMessage(text: string): Memory {
+function makeMessage(
+  text: string,
+  from?: { entityId?: UUID; roomId?: UUID },
+): Memory {
   return {
     id: stringToUuid(`msg-${text.slice(0, 24)}`),
-    entityId: USER_ID,
+    entityId: from?.entityId ?? USER_ID,
     agentId: AGENT_ID,
-    roomId: CHAT_ROOM_ID,
+    roomId: from?.roomId ?? CHAT_ROOM_ID,
     content: { text },
     createdAt: Date.now(),
   } as Memory;
@@ -89,8 +92,9 @@ async function create(
   runtime: IAgentRuntime,
   parameters: Record<string, unknown>,
   text = "remind me to drink water",
+  from?: { entityId?: UUID; roomId?: UUID },
 ) {
-  return triggerAction.handler(runtime, makeMessage(text), undefined, {
+  return triggerAction.handler(runtime, makeMessage(text, from), undefined, {
     parameters: { action: "create", ...parameters },
   });
 }
@@ -702,5 +706,184 @@ describe("TRIGGER effect receipts — completion-claim grounding", () => {
       resource: { kind: "trigger.task", id: String(taskId) },
     });
     expect(hasAppliedUserFacingEffectProof(result)).toBe(true);
+  });
+});
+
+describe("TRIGGER dedupe — replay key is the complete delivery identity", () => {
+  const OTHER_USER_ID = stringToUuid("trigger-create-other-user");
+  const OTHER_ROOM_ID = stringToUuid("trigger-create-other-room");
+
+  function storeTasks(
+    runtime: IAgentRuntime,
+    triggers: Array<Record<string, unknown> | undefined>,
+  ): void {
+    (
+      runtime.getTasks as unknown as { mockResolvedValue: (v: Task[]) => void }
+    ).mockResolvedValue(
+      triggers.map(
+        (trigger, i) =>
+          ({
+            id: stringToUuid(`stored-task-${i}`),
+            name: "TRIGGER_DISPATCH",
+            tags: ["queue", "repeat", "trigger"],
+            metadata: { updatedAt: Date.now(), trigger },
+          }) as unknown as Task,
+      ),
+    );
+  }
+
+  it("a second recipient sharing the same request still gets their own delivery", async () => {
+    // Two users in the SAME channel ask for the same reminder. Recipient A's
+    // stored trigger must not suppress recipient B: B's reminder would never
+    // fire for B, yet B would be told "you're covered" with a verified
+    // receipt minted from A's row.
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const first = await create(runtime, {
+      instructions: "drink water",
+      delaySeconds: 90,
+    });
+    expect(first?.success).toBe(true);
+    storeTasks(runtime, [
+      createdTasks[0].metadata.trigger as unknown as Record<string, unknown>,
+    ]);
+    const second = await create(
+      runtime,
+      { instructions: "drink water", delaySeconds: 90 },
+      "remind me to drink water",
+      { entityId: OTHER_USER_ID },
+    );
+    if (!second) throw new Error("expected a result");
+    expect(second.success).toBe(true);
+    expect(second.data?.duplicateTaskId).toBeUndefined();
+    expect(second.effectReceipts?.[0]).toMatchObject({
+      outcome: "applied",
+      idempotency: { replayed: false },
+    });
+    expect(createdTasks).toHaveLength(2);
+    expect(createdTasks[1].metadata.trigger?.createdBy).toBe(
+      String(OTHER_USER_ID),
+    );
+    // Distinct recipients produce distinct replay keys for the same request.
+    expect(createdTasks[1].metadata.trigger?.dedupeKey).not.toBe(
+      createdTasks[0].metadata.trigger?.dedupeKey,
+    );
+  });
+
+  it("the same recipient asking in a different room gets a delivery there too", async () => {
+    // A reminder delivers into the room it was created in; the same wording
+    // requested from a different room is a different delivery, not a replay.
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const first = await create(runtime, {
+      instructions: "drink water",
+      delaySeconds: 90,
+    });
+    expect(first?.success).toBe(true);
+    storeTasks(runtime, [
+      createdTasks[0].metadata.trigger as unknown as Record<string, unknown>,
+    ]);
+    const second = await create(
+      runtime,
+      { instructions: "drink water", delaySeconds: 90 },
+      "remind me to drink water",
+      { roomId: OTHER_ROOM_ID },
+    );
+    if (!second) throw new Error("expected a result");
+    expect(second.success).toBe(true);
+    expect(second.data?.duplicateTaskId).toBeUndefined();
+    expect(createdTasks).toHaveLength(2);
+    expect(createdTasks[1].roomId).toBe(OTHER_ROOM_ID);
+  });
+
+  it("the same recipient replaying the same delivery is suppressed as a replayed no-op", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const first = await create(runtime, {
+      instructions: "drink water",
+      delaySeconds: 90,
+    });
+    expect(first?.success).toBe(true);
+    storeTasks(runtime, [
+      createdTasks[0].metadata.trigger as unknown as Record<string, unknown>,
+    ]);
+    const replay = await create(runtime, {
+      instructions: "drink water",
+      delaySeconds: 90,
+    });
+    if (!replay) throw new Error("expected a result");
+    expect(replay.success).toBe(true);
+    expect(replay.effectReceipts?.[0]).toMatchObject({
+      outcome: "noop",
+      idempotency: { replayed: true },
+    });
+    expect(createdTasks).toHaveLength(1);
+  });
+
+  it("a dedupe-key collision can never cross recipients — createdBy is structurally required", async () => {
+    // dedupeHash is a 32-bit djb2, so two different identities CAN collide.
+    // Simulate the collision adversarially: store recipient A's row carrying
+    // the exact key recipient B's ask will compute. B must still get their
+    // own trigger — key equality alone is never proof across creators.
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const probe = await create(
+      runtime,
+      { instructions: "drink water", delaySeconds: 90 },
+      "remind me to drink water",
+      { entityId: OTHER_USER_ID },
+    );
+    expect(probe?.success).toBe(true);
+    const collidingKey = createdTasks[0].metadata.trigger?.dedupeKey;
+    const attackerRow = {
+      ...(createdTasks[0].metadata.trigger as unknown as Record<
+        string,
+        unknown
+      >),
+      createdBy: String(USER_ID),
+      dedupeKey: collidingKey,
+    };
+    createdTasks.length = 0;
+    storeTasks(runtime, [attackerRow]);
+    const second = await create(
+      runtime,
+      { instructions: "drink water", delaySeconds: 90 },
+      "remind me to drink water",
+      { entityId: OTHER_USER_ID },
+    );
+    if (!second) throw new Error("expected a result");
+    expect(second.success).toBe(true);
+    expect(second.data?.duplicateTaskId).toBeUndefined();
+    expect(createdTasks).toHaveLength(1);
+  });
+
+  it("another user's legacy (pre-key) row is not near-duplicate advice for a new recipient", async () => {
+    // The fuzzy tier matches instructions+type on rows without a dedupeKey.
+    // Scoped to the creator: telling recipient B "a similar trigger exists,
+    // delete it first" about A's row suppresses B's own delivery.
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const first = await create(runtime, {
+      instructions: "drink water",
+      delaySeconds: 90,
+    });
+    expect(first?.success).toBe(true);
+    const legacyRow = {
+      ...(createdTasks[0].metadata.trigger as unknown as Record<
+        string,
+        unknown
+      >),
+      dedupeKey: undefined,
+    };
+    createdTasks.length = 0;
+    storeTasks(runtime, [legacyRow]);
+    const second = await create(
+      runtime,
+      { instructions: "drink water", delaySeconds: 90 },
+      "remind me to drink water",
+      { entityId: OTHER_USER_ID },
+    );
+    if (!second) throw new Error("expected a result");
+    expect(second.success).toBe(true);
+    expect(second.data?.legacyFuzzyMatch).toBeUndefined();
+    expect(createdTasks).toHaveLength(1);
+    expect(createdTasks[0].metadata.trigger?.createdBy).toBe(
+      String(OTHER_USER_ID),
+    );
   });
 });

--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -594,6 +594,50 @@ describe("TRIGGER effect receipts — completion-claim grounding", () => {
     expect(createdTasks).toHaveLength(1);
   });
 
+  it("legacy fuzzy match (instructions+type, schedule unknown) reports the near-duplicate WITHOUT a replayed receipt", async () => {
+    // A stored row with no dedupeKey matches on instructions+type only — it
+    // cannot prove the SCHEDULE matches (an 8am row "matches" a 9am ask), so
+    // it must not mint verified already-covered proof.
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    // Build a real trigger config via the action, then strip its dedupeKey
+    // and change its schedule — the legacy row shape: same instructions and
+    // type, different timing, no key to prove equivalence.
+    const first = await create(runtime, {
+      instructions: "drink water",
+      delaySeconds: 30,
+    });
+    expect(first?.success).toBe(true);
+    const legacyTrigger = {
+      ...(createdTasks[0].metadata.trigger as unknown as Record<
+        string,
+        unknown
+      >),
+      dedupeKey: undefined,
+    };
+    createdTasks.length = 0;
+    (
+      runtime.getTasks as unknown as { mockResolvedValue: (v: Task[]) => void }
+    ).mockResolvedValue([
+      {
+        id: stringToUuid("legacy-task"),
+        name: "TRIGGER_DISPATCH",
+        tags: ["queue", "repeat", "trigger"],
+        metadata: { updatedAt: Date.now(), trigger: legacyTrigger },
+      } as unknown as Task,
+    ]);
+    const result = await create(runtime, {
+      instructions: "drink water",
+      delaySeconds: 90,
+    });
+    if (!result) throw new Error("expected a result");
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("similar");
+    expect(result.effectReceipts).toBeUndefined();
+    expect(result.verifiedUserFacing).toBeUndefined();
+    expect(result.data?.legacyFuzzyMatch).toBe(true);
+    expect(createdTasks).toHaveLength(0);
+  });
+
   it("refuses to claim success for a failed create — no receipts, no verified text", async () => {
     const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
     const result = await create(runtime, {

--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -4,8 +4,9 @@
  *
  * Ops:
  *   create — create a trigger (interval / once / cron) with instructions and
- *            wakeMode. Enforces a per-creator limit and dedupes on
- *            (type, instructions, schedule).
+ *            wakeMode. Enforces a per-creator limit and dedupes on the full
+ *            delivery identity (type, instructions, schedule, workflow,
+ *            creator, delivery room).
  *   update — patch displayName / instructions / schedule / wakeMode / maxRuns.
  *   delete — remove a trigger task.
  *   run    — fire a trigger immediately (manual run, force=true).
@@ -461,8 +462,26 @@ async function opCreate(
   const scheduleKey = usedDelay ? `+${delayMs}` : (scheduledAtIso ?? "");
   const workflowId = readString(params.workflowId);
   const dedupeWorkflowId = workflowId === undefined ? "" : workflowId;
+  // Workflow triggers run autonomously, so they land in the autonomy room. A
+  // prompt trigger (reminder) must fire back where the user asked for it — the
+  // originating chat room — so the reminder is actually delivered to them.
+  // Resolved before the dedupe key because the delivery room is part of the
+  // trigger's identity.
+  const service = runtime.getService(AUTONOMY_SERVICE_TYPE);
+  const autonomyService = isAutonomyRoomService(service) ? service : null;
+  const deliveryRoomId = workflowId
+    ? (autonomyService?.getAutonomousRoomId?.() ?? message.roomId)
+    : message.roomId;
+  // The dedupe key is the COMPLETE delivery identity: what fires (type,
+  // instructions, schedule, workflow) plus who it fires FOR (creator) and
+  // WHERE it fires (delivery room). Task lookup is agent-wide, so a key
+  // hashing only the request let one user's stored reminder suppress a
+  // different user's identical ask — the second recipient got a verified
+  // "you're covered" while the only existing trigger delivered to someone
+  // else's room. Only the same recipient re-asking for the same delivery is
+  // a replay.
   const dedupeKey = dedupeHash(
-    `${triggerType}|${instructions.toLowerCase()}|${intervalMs}|${scheduleKey}|${cronExpression ?? ""}|${dedupeWorkflowId}`,
+    `${triggerType}|${instructions.toLowerCase()}|${intervalMs}|${scheduleKey}|${cronExpression ?? ""}|${dedupeWorkflowId}|${creatorId}|${deliveryRoomId}`,
   );
 
   const existingTasks = await runtime.getTasks({
@@ -487,9 +506,18 @@ async function opCreate(
   // receipt. The legacy fallback matches instructions+type only — it ignores
   // the schedule, so a stored 8am reminder "matches" a new 9am request; that
   // is a hint, never proof, and must not become a verified "you're covered".
+  // The createdBy equality is load-bearing even though the key already hashes
+  // the creator: dedupeHash is a 32-bit djb2, so a collision across users is
+  // possible — and a cross-recipient false match here silently swallows a
+  // distinct recipient's delivery. The structural guard makes that class of
+  // suppression impossible regardless of hash width.
   const exactDuplicate = existingTasks.find((t) => {
     const cfg = readTriggerConfig(t);
-    return Boolean(cfg?.enabled && cfg.dedupeKey === dedupeKey);
+    return Boolean(
+      cfg?.enabled &&
+        cfg.createdBy === creatorId &&
+        cfg.dedupeKey === dedupeKey,
+    );
   });
   if (exactDuplicate?.id) {
     // Idempotent success: the desired state (an equivalent enabled trigger)
@@ -511,6 +539,10 @@ async function opCreate(
   const legacyDuplicate = existingTasks.find((t) => {
     const cfg = readTriggerConfig(t);
     if (!cfg?.enabled || cfg.dedupeKey) return false;
+    // Same recipient only: another user's identical wording is a different
+    // delivery, not a near-duplicate — steering them to "delete it first"
+    // would suppress their own reminder in favor of someone else's.
+    if (cfg.createdBy !== creatorId) return false;
     return (
       cfg.instructions.trim().toLowerCase() === instructions.toLowerCase() &&
       cfg.triggerType === triggerType
@@ -565,20 +597,12 @@ async function opCreate(
     );
   }
 
-  // Workflow triggers run autonomously, so they land in the autonomy room. A
-  // prompt trigger (reminder) must fire back where the user asked for it — the
-  // originating chat room — so the reminder is actually delivered to them.
-  const service = runtime.getService(AUTONOMY_SERVICE_TYPE);
-  const autonomyService = isAutonomyRoomService(service) ? service : null;
-  const roomId =
-    triggerConfig.kind === "prompt"
-      ? message.roomId
-      : (autonomyService?.getAutonomousRoomId?.() ?? message.roomId);
-
   const taskId = await runtime.createTask({
     name: TRIGGER_TASK_NAME,
     description: displayName,
-    roomId,
+    // The room hashed into the dedupe key above — the task must land exactly
+    // where its identity says it delivers.
+    roomId: deliveryRoomId,
     tags: [...TRIGGER_TASK_TAGS],
     metadata,
   });

--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -496,7 +496,10 @@ async function opCreate(
     // "you're already covered" ack pass egress verification.
     return okCommitted(
       "create",
-      "An equivalent trigger already exists.",
+      // Human phrasing: the user's goal is already true, so say that plainly
+      // rather than narrating the dedupe machinery ("an equivalent trigger
+      // exists" reads as an internal record, not an answer).
+      "Already set — you're covered.",
       triggerReceipt("create", String(duplicate.id), {
         key: dedupeKey,
         replayed: true,

--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -21,6 +21,7 @@ import {
   type ActionExample,
   type ActionResult,
   AUTONOMY_SERVICE_TYPE,
+  type EffectReceipt,
   type HandlerCallback,
   type HandlerOptions,
   type IAgentRuntime,
@@ -175,6 +176,69 @@ function ok(
     text,
     values: { op, ...(values ?? {}) },
     data: { actionName: TRIGGER_ACTION, op, ...(data ?? {}) },
+  };
+}
+
+// TRIGGER never emits a mid-turn callback (see the handler note below), so the
+// planner's final message is the only user-facing ack — and the planned-reply
+// egress gate refuses any completion claim not bound to a committed effect
+// receipt with exact action-owned text. Every mutating op therefore returns
+// the full receipt contract; a bare {success,text} result made even a genuine
+// "reminder is set" ack structurally unverifiable, so it was replaced with the
+// unverified-effect fallback at egress.
+//
+// The receiptId carries a random component: the planner can re-dispatch the
+// identical create within one turn (both invocations landing on the dedupe
+// path), and the turn-wide receipt merge rejects a reused ID whose observed
+// timestamp differs.
+function triggerReceipt(
+  op: "create" | "update" | "delete" | "toggle",
+  taskId: string,
+  idempotency: { key: string | null; replayed?: boolean },
+): EffectReceipt {
+  const observedAt = new Date().toISOString();
+  const base = {
+    receiptId: `trigger-${op}:${taskId}:${crypto.randomUUID()}`,
+    operation: `trigger.${op}`,
+    resource: { kind: "trigger.task", id: taskId },
+    artifacts: [],
+    idempotency: {
+      key: idempotency.key,
+      replayed: idempotency.replayed === true,
+    },
+    observedAt,
+  } as const;
+  // A replay means the handler verified an equivalent committed trigger row
+  // already exists — the documented replayed-noop semantics — rather than a
+  // fresh commit of a new row.
+  return idempotency.replayed
+    ? {
+        ...base,
+        outcome: "noop",
+        reason: "An equivalent enabled trigger already exists.",
+      }
+    : {
+        ...base,
+        outcome: "applied",
+        commit: { kind: "durable", id: taskId, committedAt: observedAt },
+      };
+}
+
+// Committed-mutation result: binds the canonical text to its receipt so the
+// egress verifier can ground a completion claim on it.
+function okCommitted(
+  op: TriggerOp,
+  text: string,
+  receipt: EffectReceipt,
+  data?: Record<string, unknown>,
+  values?: Record<string, unknown>,
+): ActionResult {
+  return {
+    ...ok(op, text, data, values),
+    userFacingText: text,
+    verifiedUserFacing: true,
+    effectReceipts: [receipt],
+    userFacingEffectReceiptIds: [receipt.receiptId],
   };
 }
 
@@ -427,10 +491,18 @@ async function opCreate(
     );
   });
   if (duplicate?.id) {
-    return ok("create", "An equivalent trigger already exists.", {
-      duplicateTaskId: duplicate.id,
-      dedupeKey,
-    });
+    // Idempotent success: the desired state (an equivalent enabled trigger)
+    // is already committed. The replayed no-op receipt lets a truthful
+    // "you're already covered" ack pass egress verification.
+    return okCommitted(
+      "create",
+      "An equivalent trigger already exists.",
+      triggerReceipt("create", String(duplicate.id), {
+        key: dedupeKey,
+        replayed: true,
+      }),
+      { duplicateTaskId: duplicate.id, dedupeKey },
+    );
   }
 
   // A trigger with a workflowId dispatches that workflow; without one it is a
@@ -490,9 +562,10 @@ async function opCreate(
     metadata,
   });
 
-  return ok(
+  return okCommitted(
     "create",
     `Created trigger "${displayName}" (${describeSchedule(triggerConfig)}).`,
+    triggerReceipt("create", String(taskId), { key: dedupeKey }),
     {
       triggerId,
       taskId,
@@ -571,10 +644,12 @@ async function opUpdate(
     description: next.displayName,
     metadata,
   });
-  return ok("update", `Updated trigger "${next.displayName}".`, {
-    taskId: String(task.id),
-    triggerId: next.triggerId,
-  });
+  return okCommitted(
+    "update",
+    `Updated trigger "${next.displayName}".`,
+    triggerReceipt("update", String(task.id), { key: null }),
+    { taskId: String(task.id), triggerId: next.triggerId },
+  );
 }
 
 async function opDelete(
@@ -586,9 +661,12 @@ async function opDelete(
   if (!loaded.task.id)
     return failed("delete", "Task missing id.", "TASK_NOT_FOUND");
   await runtime.deleteTask(loaded.task.id);
-  return ok("delete", `Deleted trigger "${loaded.trigger.displayName}".`, {
-    taskId: String(loaded.task.id),
-  });
+  return okCommitted(
+    "delete",
+    `Deleted trigger "${loaded.trigger.displayName}".`,
+    triggerReceipt("delete", String(loaded.task.id), { key: null }),
+    { taskId: String(loaded.task.id) },
+  );
 }
 
 async function opRun(
@@ -641,9 +719,10 @@ async function opToggle(
     );
   }
   await runtime.updateTask(task.id, { metadata });
-  return ok(
+  return okCommitted(
     "toggle",
     `${enabled ? "Enabled" : "Disabled"} trigger "${trigger.displayName}".`,
+    triggerReceipt("toggle", String(task.id), { key: null }),
     { taskId: String(task.id), triggerId: trigger.triggerId, enabled },
   );
 }

--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -481,16 +481,17 @@ async function opCreate(
     );
   }
 
-  const duplicate = existingTasks.find((t) => {
+  // Two duplicate tiers with different evidentiary strength. A dedupeKey
+  // match hashes the FULL request (type, instructions, schedule, workflow),
+  // so it proves the desired state is already true and may mint a replayed
+  // receipt. The legacy fallback matches instructions+type only — it ignores
+  // the schedule, so a stored 8am reminder "matches" a new 9am request; that
+  // is a hint, never proof, and must not become a verified "you're covered".
+  const exactDuplicate = existingTasks.find((t) => {
     const cfg = readTriggerConfig(t);
-    if (!cfg?.enabled) return false;
-    if (cfg.dedupeKey) return cfg.dedupeKey === dedupeKey;
-    return (
-      cfg.instructions.trim().toLowerCase() === instructions.toLowerCase() &&
-      cfg.triggerType === triggerType
-    );
+    return Boolean(cfg?.enabled && cfg.dedupeKey === dedupeKey);
   });
-  if (duplicate?.id) {
+  if (exactDuplicate?.id) {
     // Idempotent success: the desired state (an equivalent enabled trigger)
     // is already committed. The replayed no-op receipt lets a truthful
     // "you're already covered" ack pass egress verification.
@@ -500,11 +501,28 @@ async function opCreate(
       // rather than narrating the dedupe machinery ("an equivalent trigger
       // exists" reads as an internal record, not an answer).
       "Already set — you're covered.",
-      triggerReceipt("create", String(duplicate.id), {
+      triggerReceipt("create", String(exactDuplicate.id), {
         key: dedupeKey,
         replayed: true,
       }),
-      { duplicateTaskId: duplicate.id, dedupeKey },
+      { duplicateTaskId: exactDuplicate.id, dedupeKey },
+    );
+  }
+  const legacyDuplicate = existingTasks.find((t) => {
+    const cfg = readTriggerConfig(t);
+    if (!cfg?.enabled || cfg.dedupeKey) return false;
+    return (
+      cfg.instructions.trim().toLowerCase() === instructions.toLowerCase() &&
+      cfg.triggerType === triggerType
+    );
+  });
+  if (legacyDuplicate?.id) {
+    // Un-receipted: the fuzzy match cannot prove the schedule matches, so
+    // this reports the near-duplicate without claiming verified success.
+    return ok(
+      "create",
+      `A similar ${triggerType} trigger already exists ("${readTriggerConfig(legacyDuplicate)?.instructions ?? "unknown"}"). Confirm whether that covers this, or delete it first to create the new one.`,
+      { duplicateTaskId: legacyDuplicate.id, legacyFuzzyMatch: true },
     );
   }
 

--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -10,6 +10,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TRACE_ENV } from "../trace-correlation";
+// The real canonical parser, imported by path on purpose: the round-trip test
+// must fail if the recorder's terminal shape and the validator's accepted
+// vocabulary ever drift apart.
+import { validateTrajectory } from "../../../../scripts/lib/trajectory-validate";
 import {
 	applyTrajectoryFieldCap,
 	captureSkillInvocationIO,
@@ -684,12 +688,14 @@ describe("JsonFileTrajectoryRecorder", () => {
 		expect(trajectory?.metrics.finalDecision).toBe("error");
 	});
 
-	it("stamps a distinct terminal sentinel on a finished trajectory with no evaluation stage", async () => {
+	it("stamps the canonical clean terminal on a finished trajectory with no evaluation stage", async () => {
 		// Non-evaluated terminal paths (Stage-1 direct reply, deterministic
 		// fallback, structured failure reply) end a turn without any evaluation
 		// stage. The recorder must still stamp the clean terminal — an absent
 		// finalDecision on a finished trajectory previously read as "died after
-		// planner" and made delivered turns indistinguishable from drops.
+		// planner" and made delivered turns indistinguishable from drops. The
+		// stamp must be a member of the canonical validator's closed
+		// finalDecision vocabulary, not an invented sentinel.
 		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
 		const id = recorder.startTrajectory({
 			agentId: "agent-direct-reply",
@@ -710,7 +716,39 @@ describe("JsonFileTrajectoryRecorder", () => {
 		await recorder.endTrajectory(id, "finished");
 		const trajectory = await recorder.load(id);
 		expect(trajectory?.status).toBe("finished");
-		expect(trajectory?.metrics.finalDecision).toBe("terminal:finished");
+		expect(trajectory?.metrics.finalDecision).toBe("FINISH");
+	});
+
+	it("round-trips the stamped clean terminal through the real canonical validator", async () => {
+		// The canonical parser (packages/scripts/lib/trajectory-validate.ts)
+		// accepts only FINISH / CONTINUE / max_iterations / error for
+		// finalDecision — any invented terminal sentinel fails validation for
+		// every recorded trajectory. This drives the REAL validator, not a
+		// re-declared vocabulary, so recorder and parser cannot drift apart.
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({
+			agentId: "agent-validator-roundtrip",
+			rootMessage: { id: "msg", text: "whats my favorite color?" },
+		});
+		await recorder.recordStage(id, {
+			stageId: "stage-msghandler-1",
+			kind: "messageHandler",
+			startedAt: 1_000,
+			endedAt: 1_200,
+			latencyMs: 200,
+			model: {
+				modelType: "RESPONSE_HANDLER",
+				provider: "test",
+				response: "crimson.",
+			},
+		});
+		await recorder.endTrajectory(id, "finished");
+		const trajectory = await recorder.load(id);
+		const result = validateTrajectory(trajectory);
+		const finalDecisionIssues = result.issues.filter(
+			(issue) => issue.path === "$.metrics.finalDecision",
+		);
+		expect(finalDecisionIssues).toEqual([]);
 	});
 
 	it("does not overwrite an evaluation-derived finalDecision at finish", async () => {

--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -684,7 +684,7 @@ describe("JsonFileTrajectoryRecorder", () => {
 		expect(trajectory?.metrics.finalDecision).toBe("error");
 	});
 
-	it("stamps finalDecision=FINISH on a finished trajectory with no evaluation stage", async () => {
+	it("stamps a distinct terminal sentinel on a finished trajectory with no evaluation stage", async () => {
 		// Non-evaluated terminal paths (Stage-1 direct reply, deterministic
 		// fallback, structured failure reply) end a turn without any evaluation
 		// stage. The recorder must still stamp the clean terminal — an absent
@@ -710,7 +710,7 @@ describe("JsonFileTrajectoryRecorder", () => {
 		await recorder.endTrajectory(id, "finished");
 		const trajectory = await recorder.load(id);
 		expect(trajectory?.status).toBe("finished");
-		expect(trajectory?.metrics.finalDecision).toBe("FINISH");
+		expect(trajectory?.metrics.finalDecision).toBe("terminal:finished");
 	});
 
 	it("does not overwrite an evaluation-derived finalDecision at finish", async () => {

--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -684,6 +684,55 @@ describe("JsonFileTrajectoryRecorder", () => {
 		expect(trajectory?.metrics.finalDecision).toBe("error");
 	});
 
+	it("stamps finalDecision=FINISH on a finished trajectory with no evaluation stage", async () => {
+		// Non-evaluated terminal paths (Stage-1 direct reply, deterministic
+		// fallback, structured failure reply) end a turn without any evaluation
+		// stage. The recorder must still stamp the clean terminal — an absent
+		// finalDecision on a finished trajectory previously read as "died after
+		// planner" and made delivered turns indistinguishable from drops.
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({
+			agentId: "agent-direct-reply",
+			rootMessage: { id: "msg", text: "whats my favorite color?" },
+		});
+		await recorder.recordStage(id, {
+			stageId: "stage-msghandler-1",
+			kind: "messageHandler",
+			startedAt: 1_000,
+			endedAt: 1_200,
+			latencyMs: 200,
+			model: {
+				modelType: "RESPONSE_HANDLER",
+				provider: "test",
+				response: "crimson.",
+			},
+		});
+		await recorder.endTrajectory(id, "finished");
+		const trajectory = await recorder.load(id);
+		expect(trajectory?.status).toBe("finished");
+		expect(trajectory?.metrics.finalDecision).toBe("FINISH");
+	});
+
+	it("does not overwrite an evaluation-derived finalDecision at finish", async () => {
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({
+			agentId: "agent-eval-continue",
+			rootMessage: { id: "msg", text: "x" },
+		});
+		await recorder.recordStage(id, {
+			stageId: "stage-eval-iter-1",
+			kind: "evaluation",
+			iteration: 1,
+			startedAt: 1_000,
+			endedAt: 1_100,
+			latencyMs: 100,
+			evaluation: { success: true, decision: "CONTINUE", thought: "more" },
+		});
+		await recorder.endTrajectory(id, "finished");
+		const trajectory = await recorder.load(id);
+		expect(trajectory?.metrics.finalDecision).toBe("CONTINUE");
+	});
+
 	it("list returns trajectories sorted by startedAt desc and respects filters", async () => {
 		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
 		const a = recorder.startTrajectory({

--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -9,11 +9,11 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { TRACE_ENV } from "../trace-correlation";
 // The real canonical parser, imported by path on purpose: the round-trip test
 // must fail if the recorder's terminal shape and the validator's accepted
 // vocabulary ever drift apart.
 import { validateTrajectory } from "../../../../scripts/lib/trajectory-validate";
+import { TRACE_ENV } from "../trace-correlation";
 import {
 	applyTrajectoryFieldCap,
 	captureSkillInvocationIO,

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -311,7 +311,12 @@ export interface RecordedTrajectoryMetrics {
 	toolCallFailures: number;
 	toolSearchCount: number;
 	evaluatorFailures: number;
-	finalDecision?: "FINISH" | "CONTINUE" | "max_iterations" | "error";
+	finalDecision?:
+		| "FINISH"
+		| "CONTINUE"
+		| "max_iterations"
+		| "error"
+		| "terminal:finished";
 }
 
 export interface RecordedTrajectory {
@@ -1321,9 +1326,12 @@ class JsonFileTrajectoryRecorder implements TrajectoryRecorder {
 		// evaluation stage, so nothing above ever set finalDecision. Stamp the
 		// clean terminal here — an absent finalDecision on a finished
 		// trajectory reads as "died mid-turn" and made delivered turns look
-		// like drops.
+		// like drops. Distinct sentinel (not "FINISH"): non-turn trajectories
+		// (goal verifier, discarded turns) must not acquire a fabricated
+		// planner decision — analytics can still distinguish "an evaluator
+		// decided FINISH" from "the run ended cleanly without an evaluator".
 		if (status === "finished" && !trajectory.metrics.finalDecision) {
-			trajectory.metrics.finalDecision = "FINISH";
+			trajectory.metrics.finalDecision = "terminal:finished";
 		}
 
 		try {

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -1316,6 +1316,15 @@ class JsonFileTrajectoryRecorder implements TrajectoryRecorder {
 		if (status === "errored" && !trajectory.metrics.finalDecision) {
 			trajectory.metrics.finalDecision = "error";
 		}
+		// Non-evaluated terminal paths (Stage-1 direct reply, deterministic
+		// fallback, structured failure reply) finish a turn without any
+		// evaluation stage, so nothing above ever set finalDecision. Stamp the
+		// clean terminal here — an absent finalDecision on a finished
+		// trajectory reads as "died mid-turn" and made delivered turns look
+		// like drops.
+		if (status === "finished" && !trajectory.metrics.finalDecision) {
+			trajectory.metrics.finalDecision = "FINISH";
+		}
 
 		try {
 			await this.queueFlushTrajectory(trajectory);

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -311,12 +311,7 @@ export interface RecordedTrajectoryMetrics {
 	toolCallFailures: number;
 	toolSearchCount: number;
 	evaluatorFailures: number;
-	finalDecision?:
-		| "FINISH"
-		| "CONTINUE"
-		| "max_iterations"
-		| "error"
-		| "terminal:finished";
+	finalDecision?: "FINISH" | "CONTINUE" | "max_iterations" | "error";
 }
 
 export interface RecordedTrajectory {
@@ -1326,12 +1321,15 @@ class JsonFileTrajectoryRecorder implements TrajectoryRecorder {
 		// evaluation stage, so nothing above ever set finalDecision. Stamp the
 		// clean terminal here — an absent finalDecision on a finished
 		// trajectory reads as "died mid-turn" and made delivered turns look
-		// like drops. Distinct sentinel (not "FINISH"): non-turn trajectories
-		// (goal verifier, discarded turns) must not acquire a fabricated
-		// planner decision — analytics can still distinguish "an evaluator
-		// decided FINISH" from "the run ended cleanly without an evaluator".
+		// like drops. The value must be a member of the canonical validator's
+		// closed vocabulary (packages/scripts/lib/trajectory-validate.ts) —
+		// every recorded trajectory round-trips through it, and an invented
+		// sentinel is rejected as an invalid finalDecision. "FINISH" is the
+		// accepted shape for a cleanly finished run; whether an evaluator
+		// produced it remains distinguishable from the trajectory itself (an
+		// evaluator-decided FINISH always has an evaluation stage).
 		if (status === "finished" && !trajectory.metrics.finalDecision) {
-			trajectory.metrics.finalDecision = "terminal:finished";
+			trajectory.metrics.finalDecision = "FINISH";
 		}
 
 		try {

--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -652,6 +652,34 @@ describe("evaluatePlannedReplyEgress", () => {
 		).toEqual({ verdict: "allow" });
 	});
 
+	it("allows a completion claim grounded by a replayed no-op (already exists)", () => {
+		// The idempotent-duplicate outcome: the handler verified this turn that
+		// an equivalent committed item already satisfies the request. A truthful
+		// "already covered" ack must pass, while the non-replayed no-op case in
+		// the table below stays rejected.
+		const replayedNoop: EffectReceipt = {
+			...effectBase,
+			idempotency: { key: "request-1", replayed: true },
+			outcome: "noop",
+			reason: "an equivalent reminder already exists",
+		};
+		const deduped: ActionResult = {
+			success: true,
+			userFacingText: FABRICATED_ALL_SET_REPLY,
+			verifiedUserFacing: true,
+			effectReceipts: [replayedNoop],
+			userFacingEffectReceiptIds: [replayedNoop.receiptId],
+			data: { actionName: "OWNER_REMINDERS", action: "create" },
+		};
+		expect(
+			evaluatePlannedReplyEgress({
+				reply: FABRICATED_ALL_SET_REPLY,
+				actionResults: [deduped],
+				actions: [reminderSurface],
+			}),
+		).toEqual({ verdict: "allow" });
+	});
+
 	it.each([
 		{
 			name: "bare success",

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -11572,6 +11572,11 @@ export class DefaultMessageService implements IMessageService {
 									return value;
 								})
 							: Promise.resolve(undefined);
+						// Memories owed a MESSAGE_SENT claim once — and only if — the
+						// delivery boundary succeeds. Collected during the persist pass
+						// (which runs concurrently with the callback), committed below
+						// strictly after both operations settle.
+						const deliveredClaimMemories: Memory[] = [];
 						const persistTask = (async () => {
 							for (const responseMemory of responseMessages) {
 								if (
@@ -11603,13 +11608,29 @@ export class DefaultMessageService implements IMessageService {
 										persistedResponseMessageIds.add(responseMemory.id);
 									}
 								}
-
-								// MESSAGE_SENT signals delivery, not persistence. It fires
-								// for transient/doNotPersist replies too (structured failure
-								// replies skip the memory write above): the delivery callback
-								// already ran for them, and suppressing the event made those
-								// delivered turns indistinguishable from dropped ones in
-								// logs, activity streams, and trajectory closure.
+								deliveredClaimMemories.push(responseMemory);
+							}
+						})();
+						const [deliveryOutcome, persistOutcome] = await Promise.allSettled([
+							deliveryTask,
+							persistTask,
+						]);
+						// MESSAGE_SENT signals delivery, not persistence — and delivery
+						// is only a fact once the callback boundary has resolved.
+						// Claiming from inside the persist pass raced the callback and
+						// recorded a durable sent-claim for deliveries that then failed,
+						// turning a dropped reply into recorded success. The claim
+						// commits here, strictly after the boundary succeeded: a
+						// rejected callback produces no claim, and the error rethrown
+						// below reaches the caller with the turn still unclaimed, so a
+						// later retry that delivers can claim exactly once. It still
+						// fires for transient/doNotPersist replies (structured failure
+						// replies skip the memory write above): their delivery is just
+						// as real, and suppressing the event made those delivered turns
+						// indistinguishable from drops in logs, activity streams, and
+						// trajectory closure.
+						if (deliveryOutcome.status === "fulfilled") {
+							for (const responseMemory of deliveredClaimMemories) {
 								detachPostDeliverySideEffect(runtime, "MESSAGE_SENT", () =>
 									this.emitMessageSent(
 										runtime,
@@ -11618,11 +11639,7 @@ export class DefaultMessageService implements IMessageService {
 									),
 								);
 							}
-						})();
-						const [deliveryOutcome, persistOutcome] = await Promise.allSettled([
-							deliveryTask,
-							persistTask,
-						]);
+						}
 						if (persistOutcome.status === "rejected") {
 							// The persist failure (data loss) outranks the delivery
 							// failure for propagation; the held delivery failure is

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3226,9 +3226,10 @@ function appliedEffectReceiptIdsForReply(
 /**
  * An action result grounds only the capability it actually proves.
  * Empty tracked-work claims require a `resource:tracked-work` read action.
- * Completion claims require exact action-owned text bound to an active applied
- * receipt from this turn; bare success, previews, no-ops, failures, and
- * rolled-back effects cannot ground them.
+ * Completion claims require exact action-owned text bound to an active
+ * committed receipt from this turn — applied, or a replayed no-op proving the
+ * desired state was already committed; bare success, previews, non-replayed
+ * no-ops, failures, and rolled-back effects cannot ground them.
  */
 export function plannedReplyHasClaimGroundingReceipt(args: {
 	kind: PlannedReplyClaimKind;
@@ -8948,6 +8949,30 @@ function hasExplicitReplyIntent(
  * the planner produced no real action AND no explicit REPLY — i.e. when
  * we genuinely have nothing to say.
  */
+/**
+ * Race-keep policy for a finished response that a newer same-room message
+ * superseded mid-generation. Returns the human-readable keep reason, or null
+ * when the response should be discarded. Kept when the planner deliberately
+ * chose to converse (explicit REPLY/RESPOND) — the long-standing exception —
+ * or when the turn deterministically addressed the agent even without a REPLY
+ * action (action-mode turns finish without REPLY in their actions list; on a
+ * slow backend an addressed turn that overlaps the next inbound message must
+ * not be silently dropped). `isAddressedTurn` is a thunk so the deterministic
+ * shouldRespond evaluation only runs when the REPLY fast-path did not decide.
+ */
+export function resolveSupersededResponseKeepReason(
+	responseContent: Pick<Content, "actions"> | null | undefined,
+	isAddressedTurn: () => boolean,
+): string | null {
+	if (hasExplicitReplyIntent(responseContent)) {
+		return "explicit REPLY for an addressed message";
+	}
+	if (responseContent && isAddressedTurn()) {
+		return "deterministically addressed turn";
+	}
+	return null;
+}
+
 export function shouldRunMetadataActionRescue(
 	responseContent: Pick<Content, "actions"> | null | undefined,
 ): boolean {
@@ -11184,19 +11209,15 @@ export class DefaultMessageService implements IMessageService {
 				// source, name+tag address), the turn is autonomous, or an early
 				// ack already went out (the user saw the bot engage). Everything
 				// else stays silent, matching the IGNORE it would have gotten.
-				const failureGate = this.shouldRespond(
+				const failureGate = this.isDeterministicallyAddressedTurn({
 					runtime,
 					message,
-					room ?? undefined,
+					room,
 					mentionContext,
-				);
-				const addressedForFailureReply =
-					failureGate.shouldRespond ||
-					mentionContext?.isMention === true ||
-					mentionContext?.isReply === true ||
-					isAutonomous ||
-					earlyReplyMessages.length > 0;
-				if (addressedForFailureReply) {
+					isAutonomous,
+					hasDeliveredEarlyReply: earlyReplyMessages.length > 0,
+				});
+				if (failureGate.addressed) {
 					shouldRespondToMessage = true;
 					terminalDecision = null;
 					strategyResult = await this.buildStructuredFailureReply(
@@ -11373,23 +11394,43 @@ export class DefaultMessageService implements IMessageService {
 			// generating a response, the default behavior is to drop the older
 			// response so the bot only replies to the freshest input.
 			//
-			// Exception: keep the response when the planner picked an explicit
-			// REPLY/RESPOND action. That's a deliberate conversational signal
-			// (often a direct @-mention) and dropping it leaves the user looking
-			// at silence on a tagged message, which the character contract
-			// treats as a bug. The newer message will get its own turn through
-			// the normal pipeline; sending the older REPLY first does not
-			// duplicate either response.
+			// Exceptions — keep the response when:
+			// 1. The planner picked an explicit REPLY/RESPOND action. That's a
+			//    deliberate conversational signal (often a direct @-mention) and
+			//    dropping it leaves the user looking at silence on a tagged
+			//    message, which the character contract treats as a bug.
+			// 2. The turn deterministically addressed the agent (DM, platform
+			//    mention/reply, autonomous, delivered early ack) even without an
+			//    explicit REPLY action. Action-mode turns finish without REPLY in
+			//    their actions list, so on a slow backend any addressed turn that
+			//    overlapped the next inbound message was silently dropped — and
+			//    connectors treat the resulting non-delivery as a deliberate
+			//    IGNORE, making the silence terminal and unobservable.
+			// Either way the newer message still gets its own turn through the
+			// normal pipeline, so each inbound message is answered at most once —
+			// keeping the older response never double-replies to either message.
 			const currentResponseId = agentResponses.get(message.roomId);
 			if (currentResponseId !== responseId && !opts.keepExistingResponses) {
-				if (hasExplicitReplyIntent(responseContent)) {
+				const keepReason = resolveSupersededResponseKeepReason(
+					responseContent,
+					() =>
+						this.isDeterministicallyAddressedTurn({
+							runtime,
+							message,
+							room,
+							mentionContext,
+							isAutonomous,
+							hasDeliveredEarlyReply: earlyReplyMessages.length > 0,
+						}).addressed,
+				);
+				if (keepReason) {
 					runtime.logger.info(
 						{
 							src: "service:message",
 							agentId: runtime.agentId,
 							roomId: message.roomId,
 						},
-						"Race detected but keeping response (explicit REPLY for an addressed message)",
+						`Race detected but keeping response (${keepReason})`,
 					);
 				} else {
 					runtime.logger.info(
@@ -11399,6 +11440,16 @@ export class DefaultMessageService implements IMessageService {
 							roomId: message.roomId,
 						},
 						"Response discarded - newer message being processed",
+					);
+					// Mirror the ignore-path sibling below: a superseded turn ends
+					// its run as "replaced" so the discard is an observable terminal
+					// outcome instead of an unrecorded nothing.
+					await this.emitRunEnded(
+						runtime,
+						runId,
+						message,
+						startTime,
+						"replaced",
 					);
 					return {
 						didRespond: false,
@@ -11557,19 +11608,25 @@ export class DefaultMessageService implements IMessageService {
 										{ src: "service:message", memoryId: responseMemory.id },
 										"Skipping transient response memory persistence",
 									);
-									continue;
-								}
-								runtime.logger.debug(
-									{ src: "service:message", memoryId: responseMemory.id },
-									"Saving response to memory",
-								);
-								await timeInferenceSpan("message:delivery:persistence", () =>
-									runtime.createMemory(responseMemory, "messages"),
-								);
-								if (responseMemory.id) {
-									persistedResponseMessageIds.add(responseMemory.id);
+								} else {
+									runtime.logger.debug(
+										{ src: "service:message", memoryId: responseMemory.id },
+										"Saving response to memory",
+									);
+									await timeInferenceSpan("message:delivery:persistence", () =>
+										runtime.createMemory(responseMemory, "messages"),
+									);
+									if (responseMemory.id) {
+										persistedResponseMessageIds.add(responseMemory.id);
+									}
 								}
 
+								// MESSAGE_SENT signals delivery, not persistence. It fires
+								// for transient/doNotPersist replies too (structured failure
+								// replies skip the memory write above): the delivery callback
+								// already ran for them, and suppressing the event made those
+								// delivered turns indistinguishable from dropped ones in
+								// logs, activity streams, and trajectory closure.
 								detachPostDeliverySideEffect(runtime, "MESSAGE_SENT", () =>
 									this.emitMessageSent(
 										runtime,
@@ -11856,6 +11913,41 @@ export class DefaultMessageService implements IMessageService {
 			...(actionResults ? { actionResults } : {}),
 			state,
 			mode,
+		};
+	}
+
+	/**
+	 * Deterministic "this turn addressed the agent" predicate shared by the
+	 * Stage-1 failure catch (failure-reply gating) and the race-discard check.
+	 * Both are silent-exit gates: when they misjudge an addressed turn the user
+	 * sees terminal, unobservable silence — so they must agree on exactly which
+	 * turns owe the user a delivery. Addressed means: a deterministic
+	 * shouldRespond hit (DM/API/SELF channel, whitelisted source), a platform
+	 * mention or reply, an autonomous turn, or a turn where an early ack
+	 * already went out (the user watched the agent engage).
+	 */
+	private isDeterministicallyAddressedTurn(args: {
+		runtime: IAgentRuntime;
+		message: Memory;
+		room: Room | null | undefined;
+		mentionContext: MentionContext | undefined;
+		isAutonomous: boolean;
+		hasDeliveredEarlyReply: boolean;
+	}): { addressed: boolean; reason: string | undefined } {
+		const gate = this.shouldRespond(
+			args.runtime,
+			args.message,
+			args.room ?? undefined,
+			args.mentionContext,
+		);
+		return {
+			addressed:
+				gate.shouldRespond ||
+				args.mentionContext?.isMention === true ||
+				args.mentionContext?.isReply === true ||
+				args.isAutonomous ||
+				args.hasDeliveredEarlyReply,
+			reason: gate.reason,
 		};
 	}
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8944,35 +8944,29 @@ function hasExplicitReplyIntent(
 }
 
 /**
+ * Race-keep policy for a finished response that a newer same-room message
+ * superseded mid-generation. Returns the human-readable keep reason, or null
+ * when the response should be discarded. Kept only when the planner
+ * deliberately chose to converse (explicit REPLY/RESPOND): every deliverable
+ * response constructor in this pipeline sets `actions:["REPLY"]`, so this is
+ * the complete keep set — a discard is always a non-deliverable shape, and it
+ * ends the run with the observable "replaced" terminal instead of vanishing.
+ */
+export function resolveSupersededResponseKeepReason(
+	responseContent: Pick<Content, "actions"> | null | undefined,
+): string | null {
+	if (hasExplicitReplyIntent(responseContent)) {
+		return "explicit REPLY for an addressed message";
+	}
+	return null;
+}
+
+/**
  * Gate for the metadata-rescue path that promotes a passive (REPLY/NONE)
  * response to a privileged action based on keyword overlap. Run only when
  * the planner produced no real action AND no explicit REPLY — i.e. when
  * we genuinely have nothing to say.
  */
-/**
- * Race-keep policy for a finished response that a newer same-room message
- * superseded mid-generation. Returns the human-readable keep reason, or null
- * when the response should be discarded. Kept when the planner deliberately
- * chose to converse (explicit REPLY/RESPOND) — the long-standing exception —
- * or when the turn deterministically addressed the agent even without a REPLY
- * action (action-mode turns finish without REPLY in their actions list; on a
- * slow backend an addressed turn that overlaps the next inbound message must
- * not be silently dropped). `isAddressedTurn` is a thunk so the deterministic
- * shouldRespond evaluation only runs when the REPLY fast-path did not decide.
- */
-export function resolveSupersededResponseKeepReason(
-	responseContent: Pick<Content, "actions"> | null | undefined,
-	isAddressedTurn: () => boolean,
-): string | null {
-	if (hasExplicitReplyIntent(responseContent)) {
-		return "explicit REPLY for an addressed message";
-	}
-	if (responseContent && isAddressedTurn()) {
-		return "deterministically addressed turn";
-	}
-	return null;
-}
-
 export function shouldRunMetadataActionRescue(
 	responseContent: Pick<Content, "actions"> | null | undefined,
 ): boolean {
@@ -11411,18 +11405,7 @@ export class DefaultMessageService implements IMessageService {
 			// keeping the older response never double-replies to either message.
 			const currentResponseId = agentResponses.get(message.roomId);
 			if (currentResponseId !== responseId && !opts.keepExistingResponses) {
-				const keepReason = resolveSupersededResponseKeepReason(
-					responseContent,
-					() =>
-						this.isDeterministicallyAddressedTurn({
-							runtime,
-							message,
-							room,
-							mentionContext,
-							isAutonomous,
-							hasDeliveredEarlyReply: earlyReplyMessages.length > 0,
-						}).addressed,
-				);
+				const keepReason = resolveSupersededResponseKeepReason(responseContent);
 				if (keepReason) {
 					runtime.logger.info(
 						{

--- a/packages/core/src/services/message.turn-delivery-floor.test.ts
+++ b/packages/core/src/services/message.turn-delivery-floor.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Turn-delivery floor: an addressed turn must never end with zero user-facing
+ * delivery, and every delivery must be observable. Pins the two silent-exit
+ * classes found in the dropped-turn incident:
+ *
+ *   1. Race discard — a finished response superseded by a newer same-room
+ *      message is kept (not silently dropped) whenever the turn addressed the
+ *      agent, while unaddressed responses still discard. Keeping never
+ *      double-replies: each inbound message gets at most one reply.
+ *   2. Delivery observability — a transient/doNotPersist structured failure
+ *      reply skips the memory write but still emits MESSAGE_SENT, so a
+ *      delivered fallback is distinguishable from a drop in logs, activity
+ *      streams, and trajectory closure.
+ *
+ * Drives the real `DefaultMessageService.handleMessage` pipeline end to end —
+ * Stage 1 dispatch, the failure catch, the race check, and delivery — with
+ * only the runtime I/O surface mocked (no live model, no network). Stage-1
+ * outcomes are deterministic HANDLE_RESPONSE envelopes or provider errors.
+ */
+
+import { v4 } from "uuid";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
+import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
+import { TurnControllerRegistry } from "../runtime/turn-controller";
+import { createMockRuntime } from "../testing/mock-runtime";
+import type { Room } from "../types/environment";
+import type { Memory } from "../types/memory";
+import {
+	asUUID,
+	ChannelType,
+	type Content,
+	type UUID,
+} from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+import type { State } from "../types/state";
+import {
+	DefaultMessageService,
+	resolveSupersededResponseKeepReason,
+} from "./message";
+import { drainPostDeliveryTasks } from "./post-delivery-task-tracker";
+
+const RATE_LIMIT_ERROR = new Error(
+	"[cli-inference:sdk] subscription rate limit reached: You've hit your session limit",
+);
+
+function stage1DirectReply(replyText: string) {
+	return {
+		text: "",
+		toolCalls: [
+			{
+				id: "handle-response-1",
+				name: "HANDLE_RESPONSE",
+				arguments: {
+					shouldRespond: "RESPOND",
+					thought: "Direct answer.",
+					contexts: ["general"],
+					intents: [],
+					candidateActionNames: [],
+					replyText,
+					facts: [],
+					relationships: [],
+					addressedTo: [],
+				},
+			},
+		],
+		finishReason: "tool_calls",
+	};
+}
+
+interface Harness {
+	runtime: IAgentRuntime;
+	service: DefaultMessageService;
+	agentId: UUID;
+	roomId: UUID;
+	entityId: UUID;
+	runId: UUID;
+	makeMessage: (text: string) => Memory;
+	emittedEvents: () => Array<{ event: string; payload: unknown }>;
+	persistedTexts: () => string[];
+}
+
+/**
+ * Real DefaultMessageService over a mock runtime with a caller-provided
+ * Stage-1 `useModel`. Fresh agent/room UUIDs per harness so the module-level
+ * response-id race bookkeeping never bleeds between tests.
+ */
+function createHarness(
+	useModelImpl: (
+		harness: () => Harness,
+		modelType: string,
+		callIndex: number,
+	) => Promise<unknown>,
+): Harness {
+	const agentId = asUUID(v4());
+	const entityId = asUUID(v4());
+	const roomId = asUUID(v4());
+	const runId = asUUID(v4());
+	const room: Room = {
+		id: roomId,
+		source: "discord",
+		type: ChannelType.DM,
+	} as Room;
+
+	const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
+	for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
+		responseHandlerFieldRegistry.register(evaluator);
+	}
+
+	const emitted: Array<{ event: string; payload: unknown }> = [];
+	const persisted: Memory[] = [];
+	let useModelCalls = 0;
+
+	const runtime = createMockRuntime({
+		agentId,
+		character: { name: "Remilio", bio: "test agent" },
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			trace: vi.fn(),
+		} as unknown as IAgentRuntime["logger"],
+		getSetting: vi.fn(() => undefined),
+		getService: vi.fn(() => null),
+		getModel: vi.fn(() => async () => {
+			throw RATE_LIMIT_ERROR;
+		}),
+		useModel: vi.fn(async (modelType: unknown) => {
+			useModelCalls += 1;
+			return useModelImpl(() => harness, String(modelType), useModelCalls);
+		}),
+		composeState: vi.fn(
+			async (): Promise<State> => ({ values: {}, data: {}, text: "" }),
+		),
+		runActionsByMode: vi.fn(async () => undefined),
+		applyPipelineHooks: vi.fn(async () => undefined),
+		emitEvent: vi.fn(async (event: unknown, payload: unknown) => {
+			emitted.push({ event: String(event), payload });
+		}),
+		reportError: vi.fn(),
+		startRun: vi.fn(() => runId),
+		getCurrentRunId: vi.fn(() => runId),
+		endRun: vi.fn(),
+		getMemoryById: vi.fn(async () => null),
+		createMemory: vi.fn(async (memory: Memory) => {
+			persisted.push(memory);
+			return asUUID(v4());
+		}),
+		updateMemory: vi.fn(async () => true),
+		queueEmbeddingGeneration: vi.fn(async () => undefined),
+		getParticipantUserState: vi.fn(async () => null),
+		getRoom: vi.fn(async () => room),
+		getRoomsByIds: vi.fn(async () => [room]),
+		getMemories: vi.fn(async () => []),
+		isCheckShouldRespondEnabled: vi.fn(() => true),
+		turnControllers: new TurnControllerRegistry(),
+		responseHandlerFieldRegistry,
+		responseHandlerFieldEvaluators: [
+			...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+		],
+	} as never);
+
+	const harness: Harness = {
+		runtime,
+		service: new DefaultMessageService(),
+		agentId,
+		roomId,
+		entityId,
+		runId,
+		makeMessage: (text: string): Memory => ({
+			id: asUUID(v4()),
+			entityId,
+			agentId,
+			roomId,
+			content: {
+				text,
+				source: "discord",
+				channelType: ChannelType.DM,
+			},
+			createdAt: Date.now(),
+		}),
+		emittedEvents: () => emitted,
+		persistedTexts: () =>
+			persisted
+				.map((memory) =>
+					typeof memory.content?.text === "string" ? memory.content.text : "",
+				)
+				.filter((text) => text.length > 0),
+	};
+	return harness;
+}
+
+function visibleTexts(deliveries: Content[]): string[] {
+	return deliveries
+		.map((content) => (typeof content.text === "string" ? content.text : ""))
+		.filter((text) => text.trim().length > 0);
+}
+
+function messageSentTexts(harness: Harness): string[] {
+	return harness
+		.emittedEvents()
+		.filter(({ event }) => event === "MESSAGE_SENT")
+		.map(({ payload }) => {
+			const message = (payload as { message?: Memory }).message;
+			return typeof message?.content?.text === "string"
+				? message.content.text
+				: "";
+		})
+		.filter((text) => text.length > 0);
+}
+
+describe("delivery observability floor for transient failure replies", () => {
+	beforeEach(() => {
+		vi.stubEnv("ELIZA_TRAJECTORY_RECORDING", "0");
+	});
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("delivers an honest reply AND emits MESSAGE_SENT when the planner phase ends without a delivered message", async () => {
+		// The incident shape: Stage 1 (and every fallback model call) dies, so
+		// the turn produces no planned reply. The addressed DM must still get
+		// an honest structured failure reply, and — although the reply is
+		// transient/doNotPersist and skips the memory write — its delivery must
+		// be observable through MESSAGE_SENT. Before the floor, the event was
+		// only emitted inside the persistence loop, so this delivered turn was
+		// indistinguishable from a drop.
+		const h = createHarness(async () => {
+			throw RATE_LIMIT_ERROR;
+		});
+		const deliveries: Content[] = [];
+
+		const result = await h.service.handleMessage(
+			h.runtime,
+			h.makeMessage("whats my favorite color?"),
+			async (content) => {
+				deliveries.push(content);
+				return [];
+			},
+		);
+		await drainPostDeliveryTasks(h.runtime);
+
+		expect(result.didRespond).toBe(true);
+		const delivered = visibleTexts(deliveries);
+		expect(delivered).toHaveLength(1);
+
+		// Delivery is observable: MESSAGE_SENT carries the delivered text.
+		expect(messageSentTexts(h)).toContain(delivered[0]);
+		// The reply stays transient: no memory row was written for it.
+		expect(h.persistedTexts()).not.toContain(delivered[0]);
+	});
+
+	it("keeps MESSAGE_SENT and persistence for a normal delivered reply (single event, single row)", async () => {
+		const replyText = `crimson. probe-${v4()}`;
+		const h = createHarness(async (_h, modelType) => {
+			if (modelType === "RESPONSE_HANDLER") return stage1DirectReply(replyText);
+			throw RATE_LIMIT_ERROR;
+		});
+		const deliveries: Content[] = [];
+
+		const result = await h.service.handleMessage(
+			h.runtime,
+			h.makeMessage("whats my favorite color?"),
+			async (content) => {
+				deliveries.push(content);
+				return [];
+			},
+		);
+		await drainPostDeliveryTasks(h.runtime);
+
+		expect(result.didRespond).toBe(true);
+		expect(visibleTexts(deliveries)).toEqual([replyText]);
+		// Exactly one MESSAGE_SENT and exactly one persisted row — the floor
+		// must not double-emit or double-persist the normal path.
+		expect(
+			messageSentTexts(h).filter((text) => text === replyText),
+		).toHaveLength(1);
+		expect(
+			h.persistedTexts().filter((text) => text === replyText),
+		).toHaveLength(1);
+	});
+});
+
+describe("race-superseded turns keep addressed responses", () => {
+	beforeEach(() => {
+		vi.stubEnv("ELIZA_TRAJECTORY_RECORDING", "0");
+	});
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("delivers both replies exactly once when a newer message supersedes an in-flight addressed turn", async () => {
+		// Turn 2 arrives and fully completes while turn 1's Stage-1 model call
+		// is still in flight, so turn 1 finishes superseded. The addressed turn
+		// keeps its reply — the user sent two messages and gets exactly one
+		// reply to each; keeping the older response never double-replies.
+		const firstReply = `first answer. probe-${v4()}`;
+		const secondReply = `second answer. probe-${v4()}`;
+		const firstDeliveries: Content[] = [];
+		const secondDeliveries: Content[] = [];
+		let secondTurn: Promise<unknown> | null = null;
+
+		let stage1Calls = 0;
+		const h = createHarness(async (getHarness, modelType) => {
+			if (modelType !== "RESPONSE_HANDLER") throw RATE_LIMIT_ERROR;
+			stage1Calls += 1;
+			if (stage1Calls === 1) {
+				// A newer same-room message arrives and runs to completion while
+				// this Stage-1 call is still in flight.
+				const inner = getHarness();
+				secondTurn = inner.service.handleMessage(
+					inner.runtime,
+					inner.makeMessage("wait, actually a different question"),
+					async (content) => {
+						secondDeliveries.push(content);
+						return [];
+					},
+				);
+				await secondTurn;
+				return stage1DirectReply(firstReply);
+			}
+			return stage1DirectReply(secondReply);
+		});
+
+		const result = await h.service.handleMessage(
+			h.runtime,
+			h.makeMessage("whats my favorite color?"),
+			async (content) => {
+				firstDeliveries.push(content);
+				return [];
+			},
+		);
+		await drainPostDeliveryTasks(h.runtime);
+
+		expect(secondTurn).not.toBeNull();
+		// Each inbound message got exactly one reply — no drop, no double.
+		expect(visibleTexts(firstDeliveries)).toEqual([firstReply]);
+		expect(visibleTexts(secondDeliveries)).toEqual([secondReply]);
+		expect(result.didRespond).toBe(true);
+	});
+
+	it("still delivers the honest failure reply when the failing turn was superseded mid-generation", async () => {
+		// The dropped-turn incident on a slow backend: turn 1's model call dies
+		// AND a newer message already superseded the turn. The failure reply
+		// must survive the race check — the user watched the agent engage a DM
+		// and silence is not an acceptable terminal state.
+		const secondReply = `second answer. probe-${v4()}`;
+		const firstDeliveries: Content[] = [];
+		const secondDeliveries: Content[] = [];
+		let secondTurn: Promise<unknown> | null = null;
+		let firstStage1Seen = false;
+
+		const h = createHarness(async (getHarness, modelType, _callIndex) => {
+			if (modelType === "RESPONSE_HANDLER" && !firstStage1Seen) {
+				firstStage1Seen = true;
+				const inner = getHarness();
+				secondTurn = inner.service.handleMessage(
+					inner.runtime,
+					inner.makeMessage("also, are you there?"),
+					async (content) => {
+						secondDeliveries.push(content);
+						return [];
+					},
+				);
+				await secondTurn;
+				throw RATE_LIMIT_ERROR;
+			}
+			if (modelType === "RESPONSE_HANDLER") {
+				return stage1DirectReply(secondReply);
+			}
+			throw RATE_LIMIT_ERROR;
+		});
+
+		const result = await h.service.handleMessage(
+			h.runtime,
+			h.makeMessage("whats my favorite color?"),
+			async (content) => {
+				firstDeliveries.push(content);
+				return [];
+			},
+		);
+		await drainPostDeliveryTasks(h.runtime);
+
+		expect(secondTurn).not.toBeNull();
+		expect(visibleTexts(secondDeliveries)).toEqual([secondReply]);
+		// The superseded failing turn still delivered exactly one honest reply.
+		expect(result.didRespond).toBe(true);
+		expect(visibleTexts(firstDeliveries)).toHaveLength(1);
+		// And its delivery is observable even though the reply is transient.
+		expect(messageSentTexts(h)).toContain(visibleTexts(firstDeliveries)[0]);
+	});
+});
+
+describe("resolveSupersededResponseKeepReason policy", () => {
+	it("keeps an explicit REPLY without evaluating the addressed predicate", () => {
+		const addressed = vi.fn(() => false);
+		expect(
+			resolveSupersededResponseKeepReason({ actions: ["REPLY"] }, addressed),
+		).toBe("explicit REPLY for an addressed message");
+		expect(addressed).not.toHaveBeenCalled();
+	});
+
+	it("keeps RESPOND (the REPLY alias)", () => {
+		expect(
+			resolveSupersededResponseKeepReason(
+				{ actions: ["RESPOND"] },
+				() => false,
+			),
+		).toBe("explicit REPLY for an addressed message");
+	});
+
+	it("keeps an addressed action-mode response without REPLY in its actions (the incident class)", () => {
+		expect(
+			resolveSupersededResponseKeepReason({ actions: ["TASKS"] }, () => true),
+		).toBe("deterministically addressed turn");
+	});
+
+	it("discards an unaddressed non-REPLY response (group-noise silence preserved)", () => {
+		expect(
+			resolveSupersededResponseKeepReason({ actions: ["TASKS"] }, () => false),
+		).toBeNull();
+	});
+
+	it("discards when there is no response content to keep", () => {
+		expect(resolveSupersededResponseKeepReason(null, () => true)).toBeNull();
+		expect(
+			resolveSupersededResponseKeepReason(undefined, () => true),
+		).toBeNull();
+	});
+});

--- a/packages/core/src/services/message.turn-delivery-floor.test.ts
+++ b/packages/core/src/services/message.turn-delivery-floor.test.ts
@@ -113,7 +113,7 @@ function createHarness(
 
 	const runtime = createMockRuntime({
 		agentId,
-		character: { name: "Remilio", bio: "test agent" },
+		character: { name: "TestAgent", bio: "test agent" },
 		logger: {
 			debug: vi.fn(),
 			info: vi.fn(),
@@ -393,39 +393,26 @@ describe("race-superseded turns keep addressed responses", () => {
 });
 
 describe("resolveSupersededResponseKeepReason policy", () => {
-	it("keeps an explicit REPLY without evaluating the addressed predicate", () => {
-		const addressed = vi.fn(() => false);
-		expect(
-			resolveSupersededResponseKeepReason({ actions: ["REPLY"] }, addressed),
-		).toBe("explicit REPLY for an addressed message");
-		expect(addressed).not.toHaveBeenCalled();
+	it("keeps an explicit REPLY", () => {
+		expect(resolveSupersededResponseKeepReason({ actions: ["REPLY"] })).toBe(
+			"explicit REPLY for an addressed message",
+		);
 	});
 
 	it("keeps RESPOND (the REPLY alias)", () => {
-		expect(
-			resolveSupersededResponseKeepReason(
-				{ actions: ["RESPOND"] },
-				() => false,
-			),
-		).toBe("explicit REPLY for an addressed message");
+		expect(resolveSupersededResponseKeepReason({ actions: ["RESPOND"] })).toBe(
+			"explicit REPLY for an addressed message",
+		);
 	});
 
-	it("keeps an addressed action-mode response without REPLY in its actions (the incident class)", () => {
+	it("discards non-reply shapes — every deliverable constructor sets REPLY", () => {
 		expect(
-			resolveSupersededResponseKeepReason({ actions: ["TASKS"] }, () => true),
-		).toBe("deterministically addressed turn");
-	});
-
-	it("discards an unaddressed non-REPLY response (group-noise silence preserved)", () => {
-		expect(
-			resolveSupersededResponseKeepReason({ actions: ["TASKS"] }, () => false),
+			resolveSupersededResponseKeepReason({ actions: ["TASKS"] }),
 		).toBeNull();
 	});
 
 	it("discards when there is no response content to keep", () => {
-		expect(resolveSupersededResponseKeepReason(null, () => true)).toBeNull();
-		expect(
-			resolveSupersededResponseKeepReason(undefined, () => true),
-		).toBeNull();
+		expect(resolveSupersededResponseKeepReason(null)).toBeNull();
+		expect(resolveSupersededResponseKeepReason(undefined)).toBeNull();
 	});
 });

--- a/packages/core/src/services/message.turn-delivery-floor.test.ts
+++ b/packages/core/src/services/message.turn-delivery-floor.test.ts
@@ -282,6 +282,86 @@ describe("delivery observability floor for transient failure replies", () => {
 	});
 });
 
+describe("MESSAGE_SENT commits only after the delivery boundary succeeds", () => {
+	beforeEach(() => {
+		vi.stubEnv("ELIZA_TRAJECTORY_RECORDING", "0");
+	});
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("a rejected delivery callback produces no durable sent-claim", async () => {
+		// The side-effect ordering bug: MESSAGE_SENT fired from the persist
+		// pass, which runs concurrently with the delivery callback — a failed
+		// delivery still produced a durable sent-claim, so downstream
+		// consumers (activity streams, follow-up seeding, trajectory closure)
+		// recorded a reply the user never received.
+		const replyText = `crimson. probe-${v4()}`;
+		const h = createHarness(async (_h, modelType) => {
+			if (modelType === "RESPONSE_HANDLER") return stage1DirectReply(replyText);
+			throw RATE_LIMIT_ERROR;
+		});
+
+		await expect(
+			h.service.handleMessage(
+				h.runtime,
+				h.makeMessage("whats my favorite color?"),
+				async () => {
+					throw new Error("connector send failed");
+				},
+			),
+		).rejects.toThrow("connector send failed");
+		await drainPostDeliveryTasks(h.runtime);
+
+		expect(messageSentTexts(h)).not.toContain(replyText);
+		// The delivery failure does not skip persistence — the reply row is
+		// stored so the retry path can observe and reconcile it.
+		expect(h.persistedTexts()).toContain(replyText);
+	});
+
+	it("the retry that delivers claims exactly once", async () => {
+		// The failed first attempt must leave the turn unclaimed, and the
+		// successful retry must produce exactly one durable claim — never zero
+		// (delivery invisible) and never two (double-claimed turn).
+		const replyText = `crimson. probe-${v4()}`;
+		const h = createHarness(async (_h, modelType) => {
+			if (modelType === "RESPONSE_HANDLER") return stage1DirectReply(replyText);
+			throw RATE_LIMIT_ERROR;
+		});
+
+		await expect(
+			h.service.handleMessage(
+				h.runtime,
+				h.makeMessage("whats my favorite color?"),
+				async () => {
+					throw new Error("connector send failed");
+				},
+			),
+		).rejects.toThrow("connector send failed");
+		await drainPostDeliveryTasks(h.runtime);
+		expect(
+			messageSentTexts(h).filter((text) => text === replyText),
+		).toHaveLength(0);
+
+		const deliveries: Content[] = [];
+		const retry = await h.service.handleMessage(
+			h.runtime,
+			h.makeMessage("whats my favorite color?"),
+			async (content) => {
+				deliveries.push(content);
+				return [];
+			},
+		);
+		await drainPostDeliveryTasks(h.runtime);
+
+		expect(retry.didRespond).toBe(true);
+		expect(visibleTexts(deliveries)).toEqual([replyText]);
+		expect(
+			messageSentTexts(h).filter((text) => text === replyText),
+		).toHaveLength(1);
+	});
+});
+
 describe("race-superseded turns keep addressed responses", () => {
 	beforeEach(() => {
 		vi.stubEnv("ELIZA_TRAJECTORY_RECORDING", "0");

--- a/packages/core/src/types/effects.test.ts
+++ b/packages/core/src/types/effects.test.ts
@@ -226,4 +226,75 @@ describe("effect receipt proof resolution", () => {
 			).toBe(false);
 		}
 	});
+
+	it("accepts a replayed no-op as committed desired-state proof", () => {
+		const replayedNoop = {
+			...appliedReceipt(),
+			outcome: "noop",
+			commit: undefined,
+			reason: "an equivalent reminder already exists",
+			idempotency: { key: "request-1", replayed: true },
+		} as EffectReceipt;
+		const result = {
+			verifiedUserFacing: true,
+			userFacingText: "An equivalent reminder already exists.",
+			effectReceipts: [replayedNoop],
+			userFacingEffectReceiptIds: [replayedNoop.receiptId],
+		};
+
+		expect(hasAppliedUserFacingEffectProof(result)).toBe(true);
+		expect(resolveAppliedUserFacingEffectReceipts(result)?.[0]).toMatchObject({
+			receiptId: "receipt-1",
+			outcome: "noop",
+			idempotency: { key: "request-1", replayed: true },
+		});
+		// A non-replayed no-op still proves nothing: "nothing changed" without a
+		// verified earlier commit is not desired-state evidence.
+		expect(
+			hasAppliedUserFacingEffectProof({
+				...result,
+				effectReceipts: [
+					{
+						...replayedNoop,
+						idempotency: { key: "request-1", replayed: false },
+					} as EffectReceipt,
+				],
+			}),
+		).toBe(false);
+	});
+
+	it("rejects a replayed no-op whose observed commit was reverted this turn", () => {
+		const replayedNoop = {
+			...appliedReceipt(),
+			outcome: "noop",
+			commit: undefined,
+			reason: "an equivalent reminder already exists",
+			idempotency: { key: "request-1", replayed: true },
+		} as EffectReceipt;
+		const rollback: EffectReceipt = {
+			...appliedReceipt(),
+			receiptId: "receipt-rollback",
+			operation: "lifeops.reminder.rollback",
+			outcome: "rolled_back",
+			commit: undefined,
+			rollback: {
+				receiptId: "rollback-transaction-1",
+				revertedReceiptIds: [replayedNoop.receiptId],
+				rolledBackAt: "2026-07-27T18:01:00.000Z",
+			},
+		} as EffectReceipt;
+		const result = {
+			verifiedUserFacing: true,
+			userFacingText: "An equivalent reminder already exists.",
+			effectReceipts: [replayedNoop],
+			userFacingEffectReceiptIds: [replayedNoop.receiptId],
+		};
+
+		expect(
+			resolveAppliedUserFacingEffectReceipts(
+				result,
+				mergeEffectReceipts([replayedNoop], [rollback]),
+			),
+		).toBeNull();
+	});
 });

--- a/packages/core/src/types/effects.ts
+++ b/packages/core/src/types/effects.ts
@@ -2,8 +2,10 @@
  * Canonical proof records for externally visible mutations. Action handlers
  * return these after persistence or provider acceptance; the message runtime
  * binds user-facing confirmation text to their stable IDs and never treats a
- * generic action success, preview, no-op, failure, or rollback as proof that a
- * requested change was applied.
+ * generic action success, preview, failure, or rollback as proof that a
+ * requested change was applied. A no-op counts only when it is replayed —
+ * the handler verified this turn that an earlier committed result already
+ * satisfies the request (the idempotent "already exists" outcome).
  */
 
 import { ElizaError } from "../errors";
@@ -101,6 +103,25 @@ export type EffectReceipt =
 	| NoopEffectReceipt
 	| FailedEffectReceipt
 	| RolledBackEffectReceipt;
+
+/**
+ * A no-op that verified and reused an earlier committed result this turn.
+ * Normalization rejects `replayed: true` with a null idempotency key, so a
+ * replayed no-op always names the operation identity whose committed effect it
+ * re-observed — which is why it can serve as desired-state proof below.
+ */
+export type ReplayedNoopEffectReceipt = NoopEffectReceipt & {
+	idempotency: EffectIdempotency & { replayed: true };
+};
+
+/**
+ * Receipts proving the desired state is durably committed: a fresh applied
+ * commit, or a replayed no-op re-observing one (idempotent "already exists").
+ * Previews, failures, rollbacks, and non-replayed no-ops never qualify.
+ */
+export type CommittedEffectReceipt =
+	| AppliedEffectReceipt
+	| ReplayedNoopEffectReceipt;
 
 /**
  * Minimal result shape used by grounding helpers without importing ActionResult
@@ -605,14 +626,29 @@ export function resolveUserFacingEffectReceipts(
 	return Object.freeze(resolved);
 }
 
+// A replayed no-op is proof the desired state is durably committed: the
+// handler verified this turn that an earlier committed result already covers
+// the request. Non-replayed no-ops stay rejected — "nothing changed" without a
+// verified prior commit proves nothing.
+function isCommittedEffectReceipt(
+	receipt: EffectReceipt,
+): receipt is CommittedEffectReceipt {
+	return (
+		receipt.outcome === "applied" ||
+		(receipt.outcome === "noop" && receipt.idempotency.replayed)
+	);
+}
+
 /**
  * Resolve the receipts bound to exact action-owned user-facing text. Every ID
- * must exist, be applied, and remain active after any same-turn rollback.
+ * must exist, prove committed desired state (applied, or a replayed no-op
+ * re-observing an earlier commit), and remain active after any same-turn
+ * rollback.
  */
 export function resolveAppliedUserFacingEffectReceipts(
 	result: EffectBearingResult,
 	allTurnReceipts: readonly EffectReceipt[] = result.effectReceipts ?? [],
-): readonly AppliedEffectReceipt[] | null {
+): readonly CommittedEffectReceipt[] | null {
 	const resolved = resolveUserFacingEffectReceipts(result, allTurnReceipts);
 	if (!resolved) return null;
 	const normalizedReceipts = normalizeEffectReceipts(allTurnReceipts);
@@ -620,15 +656,15 @@ export function resolveAppliedUserFacingEffectReceipts(
 	if (
 		resolved.some(
 			(receipt) =>
-				receipt.outcome !== "applied" || reverted.has(receipt.receiptId),
+				!isCommittedEffectReceipt(receipt) || reverted.has(receipt.receiptId),
 		)
 	) {
 		return null;
 	}
-	return Object.freeze(resolved as AppliedEffectReceipt[]);
+	return Object.freeze(resolved as CommittedEffectReceipt[]);
 }
 
-/** True only when exact verified text is bound to active applied receipts. */
+/** True only when exact verified text is bound to active committed receipts. */
 export function hasAppliedUserFacingEffectProof(
 	result: EffectBearingResult,
 	allTurnReceipts?: readonly EffectReceipt[],

--- a/plugins/plugin-agent-orchestrator/src/__tests__/verify-retry-busy-session.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/verify-retry-busy-session.test.ts
@@ -52,7 +52,6 @@ function makeHarness(opts: HarnessOptions): {
   emit: (sessionId: string, event: string, data: unknown) => void;
   completions: Array<{ status: string; completionSummary: string }>;
   swarmEvents: string[];
-  sendPromptCalls: number;
   counters: { sendPromptCalls: () => number };
   metadataPatches: Array<Record<string, unknown>>;
   stopSessionCalls: string[];
@@ -134,7 +133,6 @@ function makeHarness(opts: HarnessOptions): {
     emit,
     completions,
     swarmEvents,
-    sendPromptCalls,
     counters: { sendPromptCalls: () => sendPromptCalls },
     metadataPatches,
     stopSessionCalls,
@@ -204,7 +202,7 @@ describe("verify-retry delivery tolerates a transient busy session", () => {
 
     h.emit(SESSION, "task_complete", retryTaskCompleteData());
     await flushMicrotasks();
-    // Ride out the whole busy deadline (120s of 1s polls).
+    // Ride out the whole busy deadline.
     await vi.advanceTimersByTimeAsync(305_000);
     await flushMicrotasks();
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/verify-retry-busy-session.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/verify-retry-busy-session.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Verify-retry delivery into a busy session, and fail-verdict chat truthfulness.
+ *
+ * Incident shape (color-pop, Aug 1 + Aug 2): a create-app `task_complete` fans
+ * out to several independent consumers. While the app verifier ran (~3s), the
+ * interruption-decider inbox flush delivered a user follow-up that had been
+ * queued mid-build into the now-idle session, starting a new turn. The
+ * verifier's FAIL retry then hit the transport's transient "ACP session is
+ * already busy" claim, and the old one-shot `sendPrompt` treated it as
+ * terminal: escalation dispatched, session stopped (killing the user's
+ * follow-up turn), and — because `escalation` mapped to no completion status —
+ * origin chat got only the teardown's false "<label> stopped before
+ * completion" for an app that was registered and live.
+ *
+ * These tests pin the two structural fixes:
+ *  1. the retry prompt waits out a transient occupant turn (bounded poll on
+ *     the busy classification only, same pattern as parent-agent-dispatch's
+ *     deliverReplyToChild), and a busy-deadline failure un-records the
+ *     retryCount bump for the retry turn that never ran;
+ *  2. a dispatched FAIL verdict (escalation) synthesizes an `errored`
+ *     completion to origin chat carrying the real verdict + deliverable, and
+ *     its dedupe-slot claim suppresses the trailing teardown `stopped` — the
+ *     fail-side analog of the validator-pass suppression.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+import { isSessionBusyError } from "../services/parent-agent-dispatch.js";
+import { SwarmCoordinatorService } from "../services/swarm-coordinator-service.js";
+
+const SESSION = "sess-validator";
+
+function flushMicrotasks(rounds = 6): Promise<void> {
+  let p: Promise<void> = Promise.resolve();
+  for (let i = 0; i < rounds; i++) {
+    p = p.then(() => new Promise((resolve) => setImmediate(resolve)));
+  }
+  return p;
+}
+
+interface HarnessOptions {
+  /** Per-call behavior for acp.sendPrompt; throw to simulate transport errors. */
+  sendPrompt: (call: number) => Promise<{ stopReason: string }>;
+  /** Verdict payload the app-verification service returns. */
+  verdict: Record<string, unknown>;
+  sessionMetadata?: Record<string, unknown>;
+}
+
+function makeHarness(opts: HarnessOptions): {
+  service: SwarmCoordinatorService;
+  emit: (sessionId: string, event: string, data: unknown) => void;
+  completions: Array<{ status: string; completionSummary: string }>;
+  swarmEvents: string[];
+  sendPromptCalls: number;
+  counters: { sendPromptCalls: () => number };
+  metadataPatches: Array<Record<string, unknown>>;
+  stopSessionCalls: string[];
+} {
+  const handlers: Array<
+    (sessionId: string, event: string, data: unknown) => void
+  > = [];
+  const emit = (sessionId: string, event: string, data: unknown): void => {
+    for (const h of [...handlers]) h(sessionId, event, data);
+  };
+  let sendPromptCalls = 0;
+  const metadataPatches: Array<Record<string, unknown>> = [];
+  const stopSessionCalls: string[] = [];
+  const sessionMetadata = opts.sessionMetadata ?? {};
+  const acp = {
+    onSessionEvent(
+      handler: (sessionId: string, event: string, data: unknown) => void,
+    ) {
+      handlers.push(handler);
+      return () => {};
+    },
+    getSession: async (sessionId: string) =>
+      sessionId === SESSION
+        ? {
+            id: SESSION,
+            agentType: "codex",
+            workdir: "/tmp/verify-retry-busy-test",
+            status: "ready",
+            metadata: sessionMetadata,
+          }
+        : undefined,
+    sendPrompt: async () => {
+      sendPromptCalls += 1;
+      return opts.sendPrompt(sendPromptCalls);
+    },
+    updateSessionMetadata: async (
+      _sessionId: string,
+      patch: Record<string, unknown>,
+    ) => {
+      metadataPatches.push(patch);
+      Object.assign(sessionMetadata, patch);
+    },
+    stopSession: async (sessionId: string) => {
+      stopSessionCalls.push(sessionId);
+      // Real teardown emits the session's terminal `stopped` through the same
+      // event stream (closeSession in AcpService) — the event whose synthesis
+      // produced the false "stopped before completion".
+      emit(sessionId, "stopped", {});
+    },
+  };
+  const verification = {
+    verifyApp: async () => opts.verdict,
+  };
+  const runtime = {
+    getService: (type: string) => {
+      if (type === AcpService.serviceType) return acp;
+      if (type === "app-verification") return verification;
+      return null;
+    },
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime;
+  const service = new SwarmCoordinatorService(runtime);
+  (service as unknown as { bindToAcp: () => void }).bindToAcp();
+  const completions: Array<{ status: string; completionSummary: string }> = [];
+  service.setSwarmCompleteCallback(async (payload) => {
+    for (const task of payload.tasks) {
+      completions.push({
+        status: task.status,
+        completionSummary: task.completionSummary,
+      });
+    }
+  });
+  const swarmEvents: string[] = [];
+  service.subscribe((event) => {
+    swarmEvents.push(event.type);
+  });
+  return {
+    service,
+    emit,
+    completions,
+    swarmEvents,
+    sendPromptCalls,
+    counters: { sendPromptCalls: () => sendPromptCalls },
+    metadataPatches,
+    stopSessionCalls,
+  };
+}
+
+const FAIL_VERDICT = {
+  verdict: "fail",
+  checks: [{ label: "lint", passed: false }],
+};
+
+function retryTaskCompleteData(): Record<string, unknown> {
+  return {
+    label: "create-app:color-pop",
+    response: "Deployed and live at https://example.org/apps/color-pop/",
+    validator: { service: "app-verification", method: "verifyApp", params: {} },
+    onVerificationFail: "retry",
+    maxRetries: 1,
+    retryCount: 0,
+  };
+}
+
+const busyError = () => new Error(`ACP session is already busy: ${SESSION}`);
+
+describe("verify-retry delivery tolerates a transient busy session", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits out an occupant turn and delivers the retry instead of escalating", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    const h = makeHarness({
+      // First attempt lands while the flushed user follow-up turn holds the
+      // slot; the second attempt (after one poll) finds the session idle.
+      sendPrompt: async (call) => {
+        if (call === 1) throw busyError();
+        return { stopReason: "end_turn" };
+      },
+      verdict: FAIL_VERDICT,
+    });
+
+    h.emit(SESSION, "task_complete", retryTaskCompleteData());
+    await flushMicrotasks();
+    expect(h.counters.sendPromptCalls()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1_100);
+    await flushMicrotasks();
+
+    // The retry was delivered: no escalation, no teardown, retry recorded.
+    expect(h.counters.sendPromptCalls()).toBe(2);
+    expect(h.stopSessionCalls).toEqual([]);
+    expect(h.completions).toEqual([]);
+    expect(h.swarmEvents).not.toContain("escalation");
+    expect(h.metadataPatches).toEqual([{ retryCount: 1 }]);
+
+    await h.service.stop();
+  });
+
+  it("escalates after the busy deadline, un-records the never-ran retry, and posts the fail verdict once", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    const h = makeHarness({
+      sendPrompt: async () => {
+        throw busyError();
+      },
+      verdict: FAIL_VERDICT,
+    });
+
+    h.emit(SESSION, "task_complete", retryTaskCompleteData());
+    await flushMicrotasks();
+    // Ride out the whole busy deadline (120s of 1s polls).
+    await vi.advanceTimersByTimeAsync(305_000);
+    await flushMicrotasks();
+
+    // The bump was reverted: metadata never claims a retry that never ran.
+    expect(h.metadataPatches).toEqual([{ retryCount: 1 }, { retryCount: 0 }]);
+    // The fail verdict reached origin chat as ONE errored completion carrying
+    // the verdict + the live deliverable — and the teardown `stopped` that
+    // followed did not add a false "stopped before completion".
+    expect(h.stopSessionCalls).toEqual([SESSION]);
+    expect(h.completions).toHaveLength(1);
+    expect(h.completions[0]?.status).toBe("errored");
+    expect(h.completions[0]?.completionSummary).toContain(
+      "App verification failed: lint",
+    );
+    expect(h.completions[0]?.completionSummary).toContain(
+      "https://example.org/apps/color-pop/",
+    );
+    expect(h.swarmEvents).toContain("escalation");
+
+    await h.service.stop();
+  });
+
+  it("still treats a non-busy transport error as terminal (no poll loop)", async () => {
+    const h = makeHarness({
+      sendPrompt: async () => {
+        throw new Error(
+          "Sub-agent state was lost (process exited without persisting). No automatic action taken.",
+        );
+      },
+      verdict: FAIL_VERDICT,
+    });
+
+    h.emit(SESSION, "task_complete", retryTaskCompleteData());
+    await flushMicrotasks();
+
+    // One attempt, straight to escalation; the bump is NOT reverted for a
+    // non-busy failure (the classification is busy-specific).
+    expect(h.counters.sendPromptCalls()).toBe(1);
+    expect(h.completions).toHaveLength(1);
+    expect(h.completions[0]?.status).toBe("errored");
+    expect(h.stopSessionCalls).toEqual([SESSION]);
+
+    await h.service.stop();
+  });
+});
+
+describe("dispatched FAIL verdict owns the session's user-facing terminal", () => {
+  it("posts errored to origin chat and suppresses the teardown stopped (no-retry fail)", async () => {
+    const h = makeHarness({
+      sendPrompt: async () => ({ stopReason: "end_turn" }),
+      verdict: FAIL_VERDICT,
+    });
+
+    // No onVerificationFail: the FAIL dispatches escalation immediately.
+    h.emit(SESSION, "task_complete", {
+      label: "create-app:color-pop",
+      response: "Deployed and live at https://example.org/apps/color-pop/",
+      validator: {
+        service: "app-verification",
+        method: "verifyApp",
+        params: {},
+      },
+    });
+    await flushMicrotasks();
+
+    expect(h.completions).toHaveLength(1);
+    expect(h.completions[0]?.status).toBe("errored");
+    expect(h.completions[0]?.completionSummary).toContain(
+      "App verification failed: lint",
+    );
+    // The pre-fix bug: this array ended as [{ status: "stopped", ... }] — the
+    // generic "stopped before completion" — with the fail verdict dropped.
+    expect(h.completions.some((c) => c.status === "stopped")).toBe(false);
+
+    await h.service.stop();
+  });
+
+  it("a genuine stop with no dispatched verdict still synthesizes (fail-open)", async () => {
+    const h = makeHarness({
+      sendPrompt: async () => ({ stopReason: "end_turn" }),
+      verdict: FAIL_VERDICT,
+    });
+
+    h.emit(SESSION, "stopped", { label: "create-app:color-pop" });
+    await flushMicrotasks();
+
+    expect(h.completions).toHaveLength(1);
+    expect(h.completions[0]?.status).toBe("stopped");
+
+    await h.service.stop();
+  });
+});
+
+describe("isSessionBusyError classification", () => {
+  it("matches the transport's busy rejection and nothing else", () => {
+    expect(isSessionBusyError(busyError())).toBe(true);
+    expect(isSessionBusyError(new Error("session not found"))).toBe(false);
+    expect(isSessionBusyError("ACP session is already busy")).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/verify-retry-stop-race.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/verify-retry-stop-race.test.ts
@@ -10,14 +10,18 @@
  * false "<task> — stopped before completion." into the origin room — while
  * the retry went on to verify and PASS.
  *
- * These tests pin the two structural fixes plus the trigger:
+ * These tests pin the structural fixes plus the trigger:
  *  1. the router stamps a pending-handoff marker on the original session
  *     before awaiting the spawn, and resolves it on settlement (successor
  *     stamp on success, cleared on spawn failure);
- *  2. the coordinator treats a `stopped` carrying the pending marker as
- *     handoff plumbing (no synthesis, no dedupe-slot claim) while a genuine
- *     stop with no marker still synthesizes;
- *  3. trailing sentence punctuation is trimmed at the URL token boundary so a
+ *  2. the coordinator treats a `stopped` carrying the CURRENT-generation
+ *     pending marker as handoff plumbing (no synthesis, no dedupe-slot
+ *     claim), while a genuine stop with no marker still synthesizes;
+ *  3. suppression is generation-scoped: a persisted marker that outlived its
+ *     handoff (prior process generation, or a settle whose metadata clear was
+ *     swallowed) never suppresses a legitimate later stop — it is ignored and
+ *     explicitly cleared;
+ *  4. trailing sentence punctuation is trimmed at the URL token boundary so a
  *     live app is never probed at a punctuation path and declared dead.
  */
 
@@ -26,6 +30,10 @@ import type { AddressInfo } from "node:net";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpService } from "../services/acp-service.js";
+import {
+  beginPendingHandoff,
+  settlePendingHandoff,
+} from "../services/handoff-pending.js";
 import {
   annotateUnverifiedUrls,
   SubAgentRouter,
@@ -190,10 +198,13 @@ describe("coordinator: teardown `stopped` during an in-flight handoff is plumbin
     service: SwarmCoordinatorService;
     emit: (sessionId: string, event: string, data: unknown) => void;
     completions: Array<{ status: string; sessionId: string }>;
+    metadataPatches: Array<{ sessionId: string; patch: MetadataPatch }>;
   } {
     const handlers: Array<
       (sessionId: string, event: string, data: unknown) => void
     > = [];
+    const metadataPatches: Array<{ sessionId: string; patch: MetadataPatch }> =
+      [];
     const acp = {
       onSessionEvent(
         handler: (sessionId: string, event: string, data: unknown) => void,
@@ -202,6 +213,17 @@ describe("coordinator: teardown `stopped` during an in-flight handoff is plumbin
         return () => {};
       },
       getSession: async (sessionId: string) => sessions.get(sessionId),
+      updateSessionMetadata: vi.fn(
+        async (sessionId: string, patch: MetadataPatch) => {
+          metadataPatches.push({ sessionId, patch });
+          const session = sessions.get(sessionId) as
+            | { metadata?: Record<string, unknown> }
+            | undefined;
+          if (session) {
+            session.metadata = { ...session.metadata, ...patch };
+          }
+        },
+      ),
     };
     const runtime = {
       getService: (type: string) =>
@@ -222,6 +244,7 @@ describe("coordinator: teardown `stopped` during an in-flight handoff is plumbin
         for (const h of [...handlers]) h(sessionId, event, data);
       },
       completions,
+      metadataPatches,
     };
   }
 
@@ -238,28 +261,89 @@ describe("coordinator: teardown `stopped` during an in-flight handoff is plumbin
     };
   }
 
-  it("does not synthesize a stop that carries the pending marker — and does not claim the dedupe slot", async () => {
+  it("does not synthesize a stop carrying the CURRENT-generation pending marker — and does not claim the dedupe slot", async () => {
+    // The in-flight window: the router minted this generation's token and the
+    // successor spawn has not settled, so the token is still registered.
+    const token = beginPendingHandoff("sess-orig");
     const sessions = new Map<string, unknown>([
       [
         "sess-orig",
-        storedSession("sess-orig", {
-          [HANDOFF_PENDING_META_KEY]: new Date().toISOString(),
-        }),
+        storedSession("sess-orig", { [HANDOFF_PENDING_META_KEY]: token }),
       ],
     ]);
     const { service, emit, completions } = makeCoordinatorHarness(sessions);
 
-    // The incident: teardown stop races ahead of the successor stamp.
-    emit("sess-orig", "stopped", {});
-    await flushMicrotasks();
-    expect(completions).toEqual([]);
+    try {
+      // The incident: teardown stop races ahead of the successor stamp.
+      emit("sess-orig", "stopped", {});
+      await flushMicrotasks();
+      expect(completions).toEqual([]);
 
-    // The skip must NOT claim the synthesis slot: the lineage's validated
-    // completion (dispatched later against the same session) still posts.
-    emit("sess-orig", "task_complete", { response: "verified live" });
+      // The skip must NOT claim the synthesis slot: the lineage's validated
+      // completion (dispatched later against the same session) still posts.
+      emit("sess-orig", "task_complete", { response: "verified live" });
+      await flushMicrotasks();
+      expect(completions).toEqual([
+        { status: "completed", sessionId: "sess-orig" },
+      ]);
+    } finally {
+      settlePendingHandoff("sess-orig", token);
+      await service.stop();
+    }
+  });
+
+  it("a stale persisted marker from a prior generation does not suppress a legitimate later stop — and is cleared", async () => {
+    // The leak the generation scoping exists for: a marker persisted by a
+    // prior process generation (crash between stamp and settle) survives in
+    // the store, but no handoff is in flight in THIS process. The stop must
+    // synthesize, and the leaked marker must be removed so it cannot shadow
+    // any future terminal either.
+    const sessions = new Map<string, unknown>([
+      [
+        "sess-stale",
+        storedSession("sess-stale", {
+          [HANDOFF_PENDING_META_KEY]:
+            "2026-08-01T00:00:00.000Z/00000000-0000-4000-8000-00000000dead",
+        }),
+      ],
+    ]);
+    const { service, emit, completions, metadataPatches } =
+      makeCoordinatorHarness(sessions);
+
+    emit("sess-stale", "stopped", {});
     await flushMicrotasks();
     expect(completions).toEqual([
-      { status: "completed", sessionId: "sess-orig" },
+      { status: "stopped", sessionId: "sess-stale" },
+    ]);
+    expect(
+      metadataPatches.some(
+        (p) =>
+          p.sessionId === "sess-stale" &&
+          p.patch[HANDOFF_PENDING_META_KEY] === null,
+      ),
+    ).toBe(true);
+
+    await service.stop();
+  });
+
+  it("a marker that outlived its settled handoff (swallowed clear) does not suppress the next genuine stop", async () => {
+    // Settlement retired the token from the registry, but the best-effort
+    // metadata clear was swallowed, so the marker string is still persisted.
+    // Presence alone must not be authority: the stop synthesizes.
+    const token = beginPendingHandoff("sess-settled");
+    settlePendingHandoff("sess-settled", token);
+    const sessions = new Map<string, unknown>([
+      [
+        "sess-settled",
+        storedSession("sess-settled", { [HANDOFF_PENDING_META_KEY]: token }),
+      ],
+    ]);
+    const { service, emit, completions } = makeCoordinatorHarness(sessions);
+
+    emit("sess-settled", "stopped", {});
+    await flushMicrotasks();
+    expect(completions).toEqual([
+      { status: "stopped", sessionId: "sess-settled" },
     ]);
 
     await service.stop();
@@ -275,6 +359,74 @@ describe("coordinator: teardown `stopped` during an in-flight handoff is plumbin
     await flushMicrotasks();
     expect(completions).toEqual([
       { status: "stopped", sessionId: "sess-plain" },
+    ]);
+
+    await service.stop();
+  });
+
+  it("router and coordinator agree end to end: suppressed while the spawn is in flight, synthesizing after the failed spawn clears it", async () => {
+    // Full loop through the REAL token: the router stamps the shared store,
+    // the coordinator reads the same store. Mid-flight the stop is plumbing;
+    // once the spawn fails and the router clears the marker, the next genuine
+    // stop synthesizes exactly once.
+    const sessions = new Map<string, unknown>([
+      ["sess-orig", storedSession("sess-orig", { roomId: ROOM })],
+    ]);
+    const spawn = makeDeferred<{ sessionId: string }>();
+    const routerAcp = {
+      onSessionEvent: () => () => {},
+      getSession: vi.fn(async () => undefined),
+      getSessions: vi.fn(async () => []),
+      spawnSession: vi.fn(() => spawn.promise),
+      updateSessionMetadata: vi.fn(
+        async (sessionId: string, patch: MetadataPatch) => {
+          const session = sessions.get(sessionId) as
+            | { metadata?: Record<string, unknown> }
+            | undefined;
+          if (session) {
+            session.metadata = { ...session.metadata, ...patch };
+          }
+        },
+      ),
+    };
+    const routerRuntime = {
+      agentId: AGENT_ID,
+      character: { name: "Tester" },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getSetting: () => undefined,
+      getService: (type: string) =>
+        type === "ACP_SERVICE" || type === "ACP_SUBPROCESS_SERVICE"
+          ? routerAcp
+          : undefined,
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const router = new SubAgentRouter(routerRuntime);
+    const internals = router as unknown as {
+      retryIncompleteBuild(
+        session: Record<string, unknown>,
+        dead: Array<{ url: string; status: string }>,
+      ): Promise<boolean>;
+    };
+    const { service, emit, completions } = makeCoordinatorHarness(sessions);
+
+    const pending = internals.retryIncompleteBuild(originSession("sess-orig"), [
+      { url: "https://example.com/apps/color-pop/", status: "HTTP 404" },
+    ]);
+    await flushMicrotasks();
+
+    // Mid-flight: the persisted marker carries the registered token.
+    emit("sess-orig", "stopped", {});
+    await flushMicrotasks();
+    expect(completions).toEqual([]);
+
+    spawn.reject(new Error("spawn exploded"));
+    await expect(pending).resolves.toBe(false);
+
+    // After the failed spawn the decision is cleared; a genuine stop posts.
+    emit("sess-orig", "stopped", {});
+    await flushMicrotasks();
+    expect(completions).toEqual([
+      { status: "stopped", sessionId: "sess-orig" },
     ]);
 
     await service.stop();

--- a/plugins/plugin-agent-orchestrator/src/__tests__/verify-retry-stop-race.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/verify-retry-stop-race.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Verify-retry handoff must be observable BEFORE the successor spawn settles.
+ *
+ * Incident shape (color-pop): a task_complete's claimed URL probed dead (the
+ * extractor had pulled trailing prose punctuation into the URL), so the router
+ * dispatched a verify-retry. The retry subprocess took seconds to become
+ * ready, and the ORIGINAL session's teardown `stopped` was processed inside
+ * that window. The handed-off successor stamp only lands AFTER spawnSession
+ * resolves, so every coordinator guard read pre-stamp state and synthesized a
+ * false "<task> — stopped before completion." into the origin room — while
+ * the retry went on to verify and PASS.
+ *
+ * These tests pin the two structural fixes plus the trigger:
+ *  1. the router stamps a pending-handoff marker on the original session
+ *     before awaiting the spawn, and resolves it on settlement (successor
+ *     stamp on success, cleared on spawn failure);
+ *  2. the coordinator treats a `stopped` carrying the pending marker as
+ *     handoff plumbing (no synthesis, no dedupe-slot claim) while a genuine
+ *     stop with no marker still synthesizes;
+ *  3. trailing sentence punctuation is trimmed at the URL token boundary so a
+ *     live app is never probed at a punctuation path and declared dead.
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+import {
+  annotateUnverifiedUrls,
+  SubAgentRouter,
+} from "../services/sub-agent-router.ts";
+import { SwarmCoordinatorService } from "../services/swarm-coordinator-service.js";
+
+const ROOM = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const AGENT_ID = "00000000-0000-4000-8000-000000000001";
+const HANDOFF_PENDING_META_KEY = "routerHandoffPendingAt";
+const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
+
+type MetadataPatch = Record<string, unknown>;
+
+function makeDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: Error) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function makeRouterHarness(spawn: {
+  promise: Promise<{ sessionId: string }>;
+}): {
+  router: SubAgentRouter;
+  internals: {
+    retryIncompleteBuild(
+      session: Record<string, unknown>,
+      dead: Array<{ url: string; status: string }>,
+    ): Promise<boolean>;
+  };
+  metadataPatches: Array<{ sessionId: string; patch: MetadataPatch }>;
+} {
+  const metadataPatches: Array<{ sessionId: string; patch: MetadataPatch }> =
+    [];
+  const acp = {
+    onSessionEvent: () => () => {},
+    getSession: vi.fn(async () => undefined),
+    getSessions: vi.fn(async () => []),
+    spawnSession: vi.fn(() => spawn.promise),
+    updateSessionMetadata: vi.fn(
+      async (sessionId: string, patch: MetadataPatch) => {
+        metadataPatches.push({ sessionId, patch });
+      },
+    ),
+  };
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Tester" },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: () => undefined,
+    getService: (type: string) =>
+      type === "ACP_SERVICE" || type === "ACP_SUBPROCESS_SERVICE"
+        ? acp
+        : undefined,
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime;
+  const router = new SubAgentRouter(runtime);
+  return {
+    router,
+    internals: router as unknown as {
+      retryIncompleteBuild(
+        session: Record<string, unknown>,
+        dead: Array<{ url: string; status: string }>,
+      ): Promise<boolean>;
+    },
+    metadataPatches,
+  };
+}
+
+function originSession(id: string): Record<string, unknown> {
+  return {
+    id,
+    agentType: "codex",
+    workdir: "/tmp/orchestrator-stop-race-test",
+    status: "ready",
+    createdAt: new Date(0),
+    lastActivityAt: new Date(0),
+    metadata: {
+      roomId: ROOM,
+      label: "build color-pop",
+      initialTask: "Build the app and give me the live url",
+    },
+  };
+}
+
+describe("router pre-stamps the handoff decision before the spawn settles", () => {
+  it("writes the pending marker BEFORE spawnSession resolves, then supersedes it with the successor stamp", async () => {
+    const spawn = makeDeferred<{ sessionId: string }>();
+    const { internals, metadataPatches } = makeRouterHarness(spawn);
+
+    const pending = internals.retryIncompleteBuild(originSession("sess-orig"), [
+      { url: "https://example.com/apps/color-pop/!", status: "HTTP 404" },
+    ]);
+    await flushMicrotasks();
+
+    // The incident window: spawn is still in flight. The decision must
+    // already be observable on the ORIGINAL session's metadata.
+    const preSpawn = metadataPatches.filter(
+      (p) =>
+        p.sessionId === "sess-orig" &&
+        typeof p.patch[HANDOFF_PENDING_META_KEY] === "string",
+    );
+    expect(preSpawn.length).toBe(1);
+    expect(
+      metadataPatches.some(
+        (p) => typeof p.patch[HANDED_OFF_SUCCESSOR_META_KEY] === "string",
+      ),
+    ).toBe(false);
+
+    spawn.resolve({ sessionId: "sess-retry" });
+    await expect(pending).resolves.toBe(true);
+
+    // Settlement: one update carries the real successor id AND retires the
+    // pending marker (no window where both are absent).
+    const settled = metadataPatches.at(-1);
+    expect(settled?.sessionId).toBe("sess-orig");
+    expect(settled?.patch[HANDED_OFF_SUCCESSOR_META_KEY]).toBe("sess-retry");
+    expect(settled?.patch[HANDOFF_PENDING_META_KEY]).toBeNull();
+  });
+
+  it("clears the pending marker when the retry spawn fails, so the honest failure path stays live", async () => {
+    const spawn = makeDeferred<{ sessionId: string }>();
+    const { internals, metadataPatches } = makeRouterHarness(spawn);
+
+    const pending = internals.retryIncompleteBuild(originSession("sess-orig"), [
+      { url: "https://example.com/apps/color-pop/", status: "HTTP 404" },
+    ]);
+    await flushMicrotasks();
+    expect(
+      metadataPatches.some(
+        (p) => typeof p.patch[HANDOFF_PENDING_META_KEY] === "string",
+      ),
+    ).toBe(true);
+
+    spawn.reject(new Error("spawn exploded"));
+    await expect(pending).resolves.toBe(false);
+
+    const settled = metadataPatches.at(-1);
+    expect(settled?.sessionId).toBe("sess-orig");
+    expect(settled?.patch[HANDOFF_PENDING_META_KEY]).toBeNull();
+    expect(
+      metadataPatches.some(
+        (p) => typeof p.patch[HANDED_OFF_SUCCESSOR_META_KEY] === "string",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("coordinator: teardown `stopped` during an in-flight handoff is plumbing", () => {
+  function makeCoordinatorHarness(sessions: Map<string, unknown>): {
+    service: SwarmCoordinatorService;
+    emit: (sessionId: string, event: string, data: unknown) => void;
+    completions: Array<{ status: string; sessionId: string }>;
+  } {
+    const handlers: Array<
+      (sessionId: string, event: string, data: unknown) => void
+    > = [];
+    const acp = {
+      onSessionEvent(
+        handler: (sessionId: string, event: string, data: unknown) => void,
+      ) {
+        handlers.push(handler);
+        return () => {};
+      },
+      getSession: async (sessionId: string) => sessions.get(sessionId),
+    };
+    const runtime = {
+      getService: (type: string) =>
+        type === AcpService.serviceType ? acp : null,
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const service = new SwarmCoordinatorService(runtime);
+    (service as unknown as { bindToAcp: () => void }).bindToAcp();
+    const completions: Array<{ status: string; sessionId: string }> = [];
+    service.setSwarmCompleteCallback(async (payload) => {
+      for (const task of payload.tasks) {
+        completions.push({ status: task.status, sessionId: task.sessionId });
+      }
+    });
+    return {
+      service,
+      emit: (sessionId, event, data) => {
+        for (const h of [...handlers]) h(sessionId, event, data);
+      },
+      completions,
+    };
+  }
+
+  function storedSession(
+    id: string,
+    metadata: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {
+      id,
+      agentType: "codex",
+      workdir: "/tmp/orchestrator-stop-race-test",
+      status: "stopped",
+      metadata,
+    };
+  }
+
+  it("does not synthesize a stop that carries the pending marker — and does not claim the dedupe slot", async () => {
+    const sessions = new Map<string, unknown>([
+      [
+        "sess-orig",
+        storedSession("sess-orig", {
+          [HANDOFF_PENDING_META_KEY]: new Date().toISOString(),
+        }),
+      ],
+    ]);
+    const { service, emit, completions } = makeCoordinatorHarness(sessions);
+
+    // The incident: teardown stop races ahead of the successor stamp.
+    emit("sess-orig", "stopped", {});
+    await flushMicrotasks();
+    expect(completions).toEqual([]);
+
+    // The skip must NOT claim the synthesis slot: the lineage's validated
+    // completion (dispatched later against the same session) still posts.
+    emit("sess-orig", "task_complete", { response: "verified live" });
+    await flushMicrotasks();
+    expect(completions).toEqual([
+      { status: "completed", sessionId: "sess-orig" },
+    ]);
+
+    await service.stop();
+  });
+
+  it("still synthesizes a genuine stop with no marker (fail-open)", async () => {
+    const sessions = new Map<string, unknown>([
+      ["sess-plain", storedSession("sess-plain", {})],
+    ]);
+    const { service, emit, completions } = makeCoordinatorHarness(sessions);
+
+    emit("sess-plain", "stopped", {});
+    await flushMicrotasks();
+    expect(completions).toEqual([
+      { status: "stopped", sessionId: "sess-plain" },
+    ]);
+
+    await service.stop();
+  });
+});
+
+describe("URL extraction trims trailing sentence punctuation (the cascade trigger)", () => {
+  let savedSettle: string | undefined;
+  let host: Server;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    savedSettle = process.env.ELIZA_URL_VERIFY_SETTLE_MS;
+    process.env.ELIZA_URL_VERIFY_SETTLE_MS = "0";
+    host = createServer((req, res) => {
+      if (req.url === "/apps/color-pop/") {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("app");
+        return;
+      }
+      res.writeHead(404, { "content-type": "text/plain" });
+      res.end("not found");
+    });
+    await new Promise<void>((resolve) => host.listen(0, "127.0.0.1", resolve));
+    const { port } = host.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}/apps/color-pop/`;
+  });
+
+  afterEach(async () => {
+    if (savedSettle === undefined)
+      delete process.env.ELIZA_URL_VERIFY_SETTLE_MS;
+    else process.env.ELIZA_URL_VERIFY_SETTLE_MS = savedSettle;
+    await new Promise<void>((resolve) => host.close(() => resolve()));
+  });
+
+  it("does not probe the trailing '!' as part of a live URL", async () => {
+    // The sub-agent's prose ends the sentence with "!": the live app must be
+    // verified at its real path, not declared dead at the punctuation path.
+    const verified = await annotateUnverifiedUrls(
+      `The app is deployed and live at ${baseUrl}!`,
+      undefined,
+      "Build the app and give me the live url",
+    );
+    expect(verified.dead).toEqual([]);
+    expect(verified.verifiedUrls).toContain(baseUrl);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/handoff-pending.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/handoff-pending.ts
@@ -1,0 +1,62 @@
+/**
+ * In-process generation registry for the router's pending-handoff marker
+ * (`routerHandoffPendingAt`). The router persists that marker on the ORIGINAL
+ * session's metadata the moment it decides on a handoff (verify-retry or
+ * failover respawn), BEFORE the successor spawn settles, so the swarm
+ * coordinator can recognize the session's teardown `stopped` as handoff
+ * plumbing. But a persisted marker can outlive its handoff — a crash between
+ * stamp and settle, or a swallowed best-effort metadata clear, leaves it in
+ * the store where it would suppress every later legitimate stop for that
+ * session, forever.
+ *
+ * This registry scopes suppression to the handoff's generation: each decision
+ * mints a unique token that is both written into the metadata marker and held
+ * here while — and only while — the spawn is in flight. The coordinator
+ * honors a marker only when its exact value is the current in-flight token;
+ * any other persisted value (prior process, prior generation, already
+ * settled) is stale and must be ignored and cleared. A process restart
+ * empties the registry, which is exactly the wanted semantics: no handoff can
+ * be in flight in a process that just booted.
+ *
+ * Router (writer) and coordinator (reader) run in the same runtime process,
+ * so module state is the narrowest shared channel — no store schema, and no
+ * import cycle between the two services.
+ */
+
+import { randomUUID } from "node:crypto";
+
+const inFlightHandoffTokens = new Map<string, string>();
+
+/**
+ * Mint and register the current-generation token for a session's in-flight
+ * handoff. The ISO prefix is traceability only; the whole value is the token.
+ * Call BEFORE the successor spawn is awaited, and persist the returned value
+ * as the metadata marker so reader and registry compare the same string.
+ */
+export function beginPendingHandoff(sessionId: string): string {
+  const token = `${new Date().toISOString()}/${randomUUID()}`;
+  inFlightHandoffTokens.set(sessionId, token);
+  return token;
+}
+
+/**
+ * Retire a generation token once its spawn settled (success or failure).
+ * Token-matched so a stale settle can never retire a newer handoff's token.
+ */
+export function settlePendingHandoff(sessionId: string, token: string): void {
+  if (inFlightHandoffTokens.get(sessionId) === token) {
+    inFlightHandoffTokens.delete(sessionId);
+  }
+}
+
+/**
+ * True only while the marker value read from session metadata is the current
+ * in-flight generation for that session. A persisted marker that fails this
+ * check is stale and must not suppress a terminal.
+ */
+export function isPendingHandoffCurrent(
+  sessionId: string,
+  markerValue: string,
+): boolean {
+  return inFlightHandoffTokens.get(sessionId) === markerValue;
+}

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-dispatch.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-dispatch.ts
@@ -46,8 +46,10 @@ const delay = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 /** The transport's transient "a turn is in flight" rejection (vs. a terminal
- * failure like a lost/closed session, which must not be retried). */
-function isSessionBusyError(err: unknown): boolean {
+ * failure like a lost/closed session, which must not be retried). Exported so
+ * every consumer that prompts a possibly-mid-turn session (this dispatcher,
+ * the swarm coordinator's verify-retry) classifies the error identically. */
+export function isSessionBusyError(err: unknown): boolean {
   return err instanceof Error && /already busy/i.test(err.message);
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -103,6 +103,20 @@ const SHARED_SUB_AGENT_ENTITY_NAME = "sub-agents";
 // the successor's sessionId (for traceability); presence is what matters. Kept
 // as a matching local literal in swarm-coordinator-service.ts (no cross-import).
 const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
+// Metadata marker stamped on a session at the MOMENT the router decides to
+// hand its work to a successor (verify-retry or state-lost/failover respawn),
+// BEFORE the successor spawn is awaited. The successor stamp above only lands
+// after spawnSession resolves — seconds later when the subprocess is slow to
+// boot — and the original session's teardown `stopped` can be processed inside
+// that window, where every swarm-coordinator guard reads pre-stamp state and
+// synthesizes a false "stopped before completion" into the origin room. This
+// marker makes the in-flight decision observable. It exists ONLY between the
+// handoff decision and spawn settlement: markSessionHandedOff replaces it with
+// the successor stamp on success, and the spawn-failure catch clears it so the
+// surfaced failure and any later genuine stop still synthesize. Value is an
+// ISO timestamp (traceability); presence is what matters. Matching local
+// literal in swarm-coordinator-service.ts (no cross-import).
+const HANDOFF_PENDING_META_KEY = "routerHandoffPendingAt";
 // Metadata marker the router stamps on a successor session (verify-retry,
 // state-lost respawn, account failover) when it re-points the forwarded
 // `roomId` away from the origin session's raw value. Presence tells downstream
@@ -163,7 +177,12 @@ function collectVerifiableUrlCandidates(
     // the template stem as if the sub-agent claimed that directory is live.
     if (suffix.startsWith("<") || suffix.startsWith("&lt;")) continue;
 
-    const url = raw.replace(/[.,;:]+$/, "");
+    // Trailing sentence punctuation is prose delimiting, not part of the URL
+    // ("live at https://host/app/!" probed the literal `/!` path, got a 404,
+    // and declared a live app dead — triggering a pointless verify-retry).
+    // Trimmed only at end-of-token; interior `!`/`?` (query strings, bang
+    // routes) are untouched.
+    const url = raw.replace(/[.,;:!?]+$/, "");
     // Raw `curl -i` output includes CDN reporting endpoints in `report-to`
     // headers. They are not part of the built app, and letting them into the
     // bounded verifier list crowds out real page/assets.
@@ -2013,6 +2032,10 @@ export class SubAgentRouter extends Service {
     const resumeMeta = resumeContext
       ? { [RESUME_CONTEXT_METADATA_KEY]: resumeContext }
       : {};
+    // Pre-stamp the respawn decision BEFORE awaiting the spawn — same race as
+    // the verify-retry path: the dead session's teardown `stopped` can be
+    // processed while the replacement spawn is still in flight.
+    await this.markHandoffPending(session.id);
     try {
       const result = await service.spawnSession({
         agentType: session.agentType,
@@ -2074,6 +2097,9 @@ export class SubAgentRouter extends Service {
       await this.markSessionHandedOff(session.id, result.sessionId);
       return true;
     } catch (err) {
+      // Clear the pending marker: no successor exists, so the honest failure
+      // path (and any later genuine stop) must synthesize normally.
+      await this.clearHandoffPending(session.id);
       this.log(
         "warn",
         `${reason} respawn spawn failed; surfacing the failure instead`,
@@ -2175,14 +2201,49 @@ export class SubAgentRouter extends Service {
     oldSessionId: string,
     successorSessionId: string,
   ): Promise<void> {
+    await this.patchHandoffMetadata(oldSessionId, {
+      [HANDED_OFF_SUCCESSOR_META_KEY]: successorSessionId,
+      // Same update: the pending decision marker is superseded by the real
+      // successor stamp, so no window exists where both are absent.
+      [HANDOFF_PENDING_META_KEY]: null,
+    });
+  }
+
+  /**
+   * Stamp the pending-handoff marker on a session whose successor spawn is
+   * about to be awaited, so its teardown `stopped` — which can be processed
+   * while the spawn is still in flight — is recognized by swarm-synthesis as
+   * handoff plumbing rather than a genuine terminal. Must be called BEFORE
+   * `spawnSession` is awaited; pair with {@link clearHandoffPending} in the
+   * spawn-failure path. Best-effort, same contract as markSessionHandedOff.
+   */
+  private async markHandoffPending(sessionId: string): Promise<void> {
+    await this.patchHandoffMetadata(sessionId, {
+      [HANDOFF_PENDING_META_KEY]: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Remove the pending-handoff marker after a FAILED successor spawn, so the
+   * caller's surfaced-failure post and any later genuine stop synthesize
+   * exactly as before the decision was made.
+   */
+  private async clearHandoffPending(sessionId: string): Promise<void> {
+    await this.patchHandoffMetadata(sessionId, {
+      [HANDOFF_PENDING_META_KEY]: null,
+    });
+  }
+
+  private async patchHandoffMetadata(
+    sessionId: string,
+    patch: Record<string, unknown>,
+  ): Promise<void> {
     const service =
       this.acp ??
       (this.runtime.getService("ACP_SUBPROCESS_SERVICE") as AcpService | null);
     if (typeof service?.updateSessionMetadata !== "function") return;
     try {
-      await service.updateSessionMetadata(oldSessionId, {
-        [HANDED_OFF_SUCCESSOR_META_KEY]: successorSessionId,
-      });
+      await service.updateSessionMetadata(sessionId, patch);
     } catch {
       // error-policy:J6 best-effort handoff marker; a missed stamp only risks the
       // prior duplicate-post, never a dropped terminal.
@@ -2270,6 +2331,12 @@ ${originalTask}
 
 Do not report done until every referenced URL in the final page resolves without verification errors.`;
 
+    // Pre-stamp the retry decision BEFORE awaiting the spawn: the retry
+    // subprocess can take seconds to become ready, and the original session's
+    // teardown `stopped` fires inside that window — a post-spawn-only stamp
+    // (the prior shape) let synthesis post a false "stopped before
+    // completion" for a build whose retry was already in flight.
+    await this.markHandoffPending(session.id);
     try {
       const result = await service.spawnSession({
         agentType: session.agentType,
@@ -2299,13 +2366,17 @@ Do not report done until every referenced URL in the final page resolves without
         maxRetries,
         deadCount: dead.length,
       });
-      // Mark the old session as handed off BEFORE its teardown `stopped` fires
-      // so synthesis treats that stop as plumbing, not a second completion
-      // (#11711). Best-effort: a missed stamp only risks the prior duplicate
-      // post, never a dropped genuine terminal.
+      // Record the real successor id (#11711) — lineage-continuation readers
+      // consume it. The teardown-`stopped` race itself is closed by the
+      // pending marker stamped before the spawn, not by this call: the stop
+      // can land while spawnSession is still in flight.
       await this.markSessionHandedOff(session.id, result.sessionId);
       return true;
     } catch (err) {
+      // The decision did not survive: clear the pending marker BEFORE
+      // returning so the caller's surfaced verification failure and any later
+      // genuine stop synthesize normally.
+      await this.clearHandoffPending(session.id);
       this.log(
         "warn",
         "verify-retry spawn failed; surfacing the failure instead",

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -42,6 +42,10 @@ import {
   reportCodingAccountFailure,
 } from "./coding-account-selection.js";
 import {
+  beginPendingHandoff,
+  settlePendingHandoff,
+} from "./handoff-pending.js";
+import {
   readSessionRetryCount,
   resolveStateLostRespawnCap,
   SESSION_RETRY_METADATA_KEY,
@@ -110,12 +114,17 @@ const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
 // boot — and the original session's teardown `stopped` can be processed inside
 // that window, where every swarm-coordinator guard reads pre-stamp state and
 // synthesizes a false "stopped before completion" into the origin room. This
-// marker makes the in-flight decision observable. It exists ONLY between the
-// handoff decision and spawn settlement: markSessionHandedOff replaces it with
-// the successor stamp on success, and the spawn-failure catch clears it so the
-// surfaced failure and any later genuine stop still synthesize. Value is an
-// ISO timestamp (traceability); presence is what matters. Matching local
-// literal in swarm-coordinator-service.ts (no cross-import).
+// marker makes the in-flight decision observable. It is meant to exist ONLY
+// between the handoff decision and spawn settlement: markSessionHandedOff
+// replaces it with the successor stamp on success, and the spawn-failure catch
+// clears it so the surfaced failure and any later genuine stop still
+// synthesize. Because the persisted value can nonetheless outlive the handoff
+// (crash between stamp and settle, swallowed best-effort clear), presence
+// alone is NOT authority: the value is the handoff's generation token
+// (handoff-pending.ts), and the coordinator honors it only while that exact
+// token is registered in-flight — stale persisted markers are ignored and
+// cleared, so they can never suppress a later legitimate stop. Matching local
+// key literal in swarm-coordinator-service.ts (no cross-import).
 const HANDOFF_PENDING_META_KEY = "routerHandoffPendingAt";
 // Metadata marker the router stamps on a successor session (verify-retry,
 // state-lost respawn, account failover) when it re-points the forwarded
@@ -2035,7 +2044,7 @@ export class SubAgentRouter extends Service {
     // Pre-stamp the respawn decision BEFORE awaiting the spawn — same race as
     // the verify-retry path: the dead session's teardown `stopped` can be
     // processed while the replacement spawn is still in flight.
-    await this.markHandoffPending(session.id);
+    const pendingToken = await this.markHandoffPending(session.id);
     try {
       const result = await service.spawnSession({
         agentType: session.agentType,
@@ -2094,12 +2103,16 @@ export class SubAgentRouter extends Service {
       }
       // Same handoff stamp as verify-retry (#11711): the old session's teardown
       // `stopped` is plumbing, not a user-facing completion — the respawn posts.
-      await this.markSessionHandedOff(session.id, result.sessionId);
+      await this.markSessionHandedOff(
+        session.id,
+        result.sessionId,
+        pendingToken,
+      );
       return true;
     } catch (err) {
       // Clear the pending marker: no successor exists, so the honest failure
       // path (and any later genuine stop) must synthesize normally.
-      await this.clearHandoffPending(session.id);
+      await this.clearHandoffPending(session.id, pendingToken);
       this.log(
         "warn",
         `${reason} respawn spawn failed; surfacing the failure instead`,
@@ -2200,6 +2213,7 @@ export class SubAgentRouter extends Service {
   private async markSessionHandedOff(
     oldSessionId: string,
     successorSessionId: string,
+    pendingToken: string,
   ): Promise<void> {
     await this.patchHandoffMetadata(oldSessionId, {
       [HANDED_OFF_SUCCESSOR_META_KEY]: successorSessionId,
@@ -2207,6 +2221,12 @@ export class SubAgentRouter extends Service {
       // successor stamp, so no window exists where both are absent.
       [HANDOFF_PENDING_META_KEY]: null,
     });
+    // Registry retire AFTER the successor stamp lands: a stop processed in
+    // between reads the successor stamp, so no window opens where the marker
+    // is current-but-unstamped. If the patch was swallowed, the persisted
+    // marker is now stale (registry retired) and the coordinator ignores and
+    // clears it — failing toward the prior duplicate-post, never suppression.
+    settlePendingHandoff(oldSessionId, pendingToken);
   }
 
   /**
@@ -2214,21 +2234,34 @@ export class SubAgentRouter extends Service {
    * about to be awaited, so its teardown `stopped` — which can be processed
    * while the spawn is still in flight — is recognized by swarm-synthesis as
    * handoff plumbing rather than a genuine terminal. Must be called BEFORE
-   * `spawnSession` is awaited; pair with {@link clearHandoffPending} in the
-   * spawn-failure path. Best-effort, same contract as markSessionHandedOff.
+   * `spawnSession` is awaited. Returns the generation token that scopes the
+   * marker to THIS handoff: the coordinator only honors the marker while the
+   * token is registered in-flight, so a persisted marker that outlives its
+   * handoff (crash, swallowed clear) can never suppress a later legitimate
+   * stop. Pair with {@link clearHandoffPending} in the spawn-failure path and
+   * pass the token to {@link markSessionHandedOff} on success. Best-effort on
+   * the metadata write, same contract as markSessionHandedOff.
    */
-  private async markHandoffPending(sessionId: string): Promise<void> {
+  private async markHandoffPending(sessionId: string): Promise<string> {
+    const token = beginPendingHandoff(sessionId);
     await this.patchHandoffMetadata(sessionId, {
-      [HANDOFF_PENDING_META_KEY]: new Date().toISOString(),
+      [HANDOFF_PENDING_META_KEY]: token,
     });
+    return token;
   }
 
   /**
    * Remove the pending-handoff marker after a FAILED successor spawn, so the
    * caller's surfaced-failure post and any later genuine stop synthesize
-   * exactly as before the decision was made.
+   * exactly as before the decision was made. The registry retire comes first
+   * and is unconditional: even when the metadata clear is swallowed, the
+   * persisted marker is no longer current and cannot suppress anything.
    */
-  private async clearHandoffPending(sessionId: string): Promise<void> {
+  private async clearHandoffPending(
+    sessionId: string,
+    pendingToken: string,
+  ): Promise<void> {
+    settlePendingHandoff(sessionId, pendingToken);
     await this.patchHandoffMetadata(sessionId, {
       [HANDOFF_PENDING_META_KEY]: null,
     });
@@ -2336,7 +2369,7 @@ Do not report done until every referenced URL in the final page resolves without
     // teardown `stopped` fires inside that window — a post-spawn-only stamp
     // (the prior shape) let synthesis post a false "stopped before
     // completion" for a build whose retry was already in flight.
-    await this.markHandoffPending(session.id);
+    const pendingToken = await this.markHandoffPending(session.id);
     try {
       const result = await service.spawnSession({
         agentType: session.agentType,
@@ -2370,13 +2403,17 @@ Do not report done until every referenced URL in the final page resolves without
       // consume it. The teardown-`stopped` race itself is closed by the
       // pending marker stamped before the spawn, not by this call: the stop
       // can land while spawnSession is still in flight.
-      await this.markSessionHandedOff(session.id, result.sessionId);
+      await this.markSessionHandedOff(
+        session.id,
+        result.sessionId,
+        pendingToken,
+      );
       return true;
     } catch (err) {
       // The decision did not survive: clear the pending marker BEFORE
       // returning so the caller's surfaced verification failure and any later
       // genuine stop synthesize normally.
-      await this.clearHandoffPending(session.id);
+      await this.clearHandoffPending(session.id, pendingToken);
       this.log(
         "warn",
         "verify-retry spawn failed; surfacing the failure instead",

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -25,11 +25,12 @@ import {
 } from "@elizaos/core";
 import { AcpService } from "./acp-service.js";
 import { OrchestratorTaskService } from "./orchestrator-task-service.js";
+import { isSessionBusyError } from "./parent-agent-dispatch.js";
 import {
   DEFAULT_MAX_RELAY_CHARS,
   sanitizeCompletionRelay,
 } from "./transcript-sanitizer.js";
-import { TERMINAL_SESSION_STATUSES } from "./types.js";
+import { type PromptResult, TERMINAL_SESSION_STATUSES } from "./types.js";
 
 export { SWARM_COORDINATOR_SERVICE_TYPE } from "@elizaos/core";
 
@@ -95,6 +96,27 @@ const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
 const HANDOFF_PENDING_META_KEY = "routerHandoffPendingAt";
 
 const LEGACY_TASK_EVICTION_GRACE_MS = 60_000;
+
+// Bounded wait-for-idle for the verify-retry prompt. A `task_complete` fans
+// out to several independent consumers of the same event: while the app
+// verifier runs (seconds of lint/typecheck/probe work), another consumer —
+// e.g. the interruption-decider inbox flush delivering a user follow-up that
+// was queued mid-build — can legitimately start a new turn on the now-idle
+// session. The retry prompt then finds the session's single turn slot taken
+// ("ACP session is already busy", a transient claim the transport releases
+// when the occupant turn settles). Delivery therefore polls until idle with a
+// deadline — the same pattern parent-agent-dispatch uses to deliver broker
+// replies — retrying ONLY on the busy classification; every other error is
+// terminal. The deadline must be long enough for a full occupant turn to
+// finish but no shorter than the bound the cited pattern already uses
+// (parent-agent-dispatch's REPLY_DELIVERY_TIMEOUT_MS, 300s): the occupant
+// can run a full prompt turn, and both consumers of isSessionBusyError
+// should wait out the same worst case before declaring the session wedged.
+const RETRY_PROMPT_BUSY_DEADLINE_MS = 300_000;
+const RETRY_PROMPT_BUSY_POLL_MS = 1_000;
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -1200,6 +1222,20 @@ export class SwarmCoordinatorService
     if (event === "task_complete") return "completed";
     if (event === "stopped") return "stopped";
     if (event === "error") return "errored";
+    // A custom-validator FAIL is dispatched as `escalation` (only
+    // dispatchCustomValidatorResult produces this event) and carries the
+    // actionable verdict ("App verification failed: lint") plus the enriched
+    // deliverable. Dropping it here meant origin chat never saw the fail
+    // verdict — only the verification room did (plugin-app-control's
+    // VerificationRoomBridgeService writes its verdict as a room memory, not
+    // a connector send, so origin CHAT still had nothing) — and the teardown
+    // `stopped` then synthesized a false "<label> stopped before completion"
+    // for a task whose deliverable may be registered and live. Treating the
+    // escalation as an errored terminal posts the verdict to origin chat, and
+    // its dedupe-slot claim marks the terminal as delivered — the fail-side
+    // analog of validatorPassSessions — so the trailing teardown `stopped` is
+    // recognized as plumbing and suppressed.
+    if (event === "escalation") return "errored";
     return null;
   }
 
@@ -1606,10 +1642,15 @@ export class SwarmCoordinatorService
     const feedback = JSON.stringify(result, null, 2).slice(0, 12_000);
     try {
       if (typeof acp.updateSessionMetadata === "function") {
+        // The bump must land BEFORE the retry turn starts: the retried turn's
+        // own task_complete re-enters the validator path and reads retryCount
+        // from session metadata, so bumping after the turn would let a
+        // still-failing build retry without bound.
         await acp.updateSessionMetadata(sessionId, { retryCount: nextRetry });
         this.enrichmentMetadataCache.delete(sessionId);
       }
-      const promptResult = await acp.sendPrompt(
+      const promptResult = await this.sendRetryPromptWhenIdle(
+        acp,
         sessionId,
         [
           `Verification failed (retry ${nextRetry}/${maxRetries}).`,
@@ -1638,6 +1679,26 @@ export class SwarmCoordinatorService
     } catch (err) {
       // error-policy:J7 a retry transport failure must not hide the original
       // verification failure; warn and let the caller dispatch escalation.
+      if (
+        isSessionBusyError(err) &&
+        typeof acp.updateSessionMetadata === "function"
+      ) {
+        // Busy through the whole deadline ⇒ the retry turn never started.
+        // Un-record the bump so the session's metadata does not claim a retry
+        // attempt that never ran.
+        try {
+          await acp.updateSessionMetadata(sessionId, { retryCount });
+          this.enrichmentMetadataCache.delete(sessionId);
+        } catch (revertErr) {
+          // error-policy:J6 bookkeeping revert on a session headed for
+          // escalation + teardown; the escalation dispatch is unaffected.
+          logger.warn(
+            `[SwarmCoordinator] failed to revert retryCount after undeliverable retry: ${
+              revertErr instanceof Error ? revertErr.message : String(revertErr)
+            }`,
+          );
+        }
+      }
       logger.warn(
         `[SwarmCoordinator] custom validator retry failed: ${
           err instanceof Error ? err.message : String(err)
@@ -1649,6 +1710,32 @@ export class SwarmCoordinatorService
         maxRetries,
       });
       return false;
+    }
+  }
+
+  /**
+   * Deliver the verify-retry prompt into the session, waiting out a transient
+   * occupant turn (see RETRY_PROMPT_BUSY_DEADLINE_MS). Retries ONLY on the
+   * transport's "already busy" rejection; a deadline expiry re-throws the last
+   * busy error and every other error propagates immediately, so the caller's
+   * escalation path always runs on a terminal failure.
+   */
+  private async sendRetryPromptWhenIdle(
+    acp: AcpService,
+    sessionId: string,
+    prompt: string,
+  ): Promise<PromptResult> {
+    const deadline = Date.now() + RETRY_PROMPT_BUSY_DEADLINE_MS;
+    for (;;) {
+      try {
+        return await acp.sendPrompt(sessionId, prompt);
+      } catch (err) {
+        if (isSessionBusyError(err) && Date.now() < deadline) {
+          await delay(RETRY_PROMPT_BUSY_POLL_MS);
+          continue;
+        }
+        throw err;
+      }
     }
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -1730,6 +1730,10 @@ export class SwarmCoordinatorService
       try {
         return await acp.sendPrompt(sessionId, prompt);
       } catch (err) {
+        // error-policy:J2 context-preserving retry boundary — only the
+        // transient busy classification retries within the deadline; every
+        // other error (and deadline expiry) rethrows unchanged into the
+        // caller's escalation path, which is the designed J1 boundary.
         if (isSessionBusyError(err) && Date.now() < deadline) {
           await delay(RETRY_PROMPT_BUSY_POLL_MS);
           continue;

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -24,6 +24,7 @@ import {
   SWARM_COORDINATOR_SERVICE_TYPE,
 } from "@elizaos/core";
 import { AcpService } from "./acp-service.js";
+import { isPendingHandoffCurrent } from "./handoff-pending.js";
 import { OrchestratorTaskService } from "./orchestrator-task-service.js";
 import { isSessionBusyError } from "./parent-agent-dispatch.js";
 import {
@@ -84,15 +85,19 @@ const ROUTER_OWNED_TERMINAL_EVENTS = new Set(["task_complete", "error"]);
 // synthesis must not post the old one (#11711). Matching local literal (no
 // import from sub-agent-router — see the ROUTER_ORIGIN_UUID_RE note).
 const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
-// Pending-handoff marker (matching local literal — see sub-agent-router.ts):
-// the router stamps it on the ORIGINAL session at the moment it decides on a
-// verify-retry / respawn, BEFORE the successor spawn resolves. The successor
-// stamp above only lands after the spawn settles — seconds later on a slow
-// subprocess boot — and a teardown `stopped` processed inside that window
-// reads pre-stamp state on every guard, synthesizing a false "stopped before
-// completion". Presence ⇒ the stop is handoff plumbing. The router clears the
-// marker when the spawn settles (successor stamp on success, removal on
-// failure), so a stop with no handoff in flight synthesizes exactly as before.
+// Pending-handoff marker (matching local key literal — see
+// sub-agent-router.ts): the router stamps it on the ORIGINAL session at the
+// moment it decides on a verify-retry / respawn, BEFORE the successor spawn
+// resolves. The successor stamp above only lands after the spawn settles —
+// seconds later on a slow subprocess boot — and a teardown `stopped`
+// processed inside that window reads pre-stamp state on every guard,
+// synthesizing a false "stopped before completion". Presence alone is NOT
+// authority: the persisted marker can outlive its handoff (crash between
+// stamp and settle, swallowed best-effort clear), and honoring a stale one
+// would suppress every later legitimate stop for the session. The value is
+// the handoff's generation token, honored only while handoff-pending.ts
+// still registers it in-flight; a stale marker is ignored AND cleared so the
+// stop synthesizes exactly as if the marker had never leaked.
 const HANDOFF_PENDING_META_KEY = "routerHandoffPendingAt";
 
 const LEGACY_TASK_EVICTION_GRACE_MS = 60_000;
@@ -992,13 +997,21 @@ export class SwarmCoordinatorService
       if (readString(fresh, HANDED_OFF_SUCCESSOR_META_KEY)) {
         return;
       }
-      // Handoff decided but successor spawn not yet settled (the pending
-      // marker exists only inside that window): the stop is teardown
-      // plumbing racing ahead of the successor stamp. Same semantics as the
-      // stamped skip above — do NOT claim the dedupe slot, so the successor's
-      // (or the validator's) completion for this lineage still posts.
-      if (readString(fresh, HANDOFF_PENDING_META_KEY)) {
-        return;
+      // Handoff decided but successor spawn not yet settled: the stop is
+      // teardown plumbing racing ahead of the successor stamp. Same semantics
+      // as the stamped skip above — do NOT claim the dedupe slot, so the
+      // successor's (or the validator's) completion for this lineage still
+      // posts. Suppression is generation-scoped: the marker only counts while
+      // its exact token is the registered in-flight handoff. A persisted
+      // marker that outlived its handoff (prior process generation, crash
+      // between stamp and settle, swallowed clear) must not silence a
+      // legitimate stop — it is cleared here and the stop synthesizes.
+      const pendingMarker = readString(fresh, HANDOFF_PENDING_META_KEY);
+      if (pendingMarker) {
+        if (isPendingHandoffCurrent(sessionId, pendingMarker)) {
+          return;
+        }
+        await this.clearStalePendingHandoffMarker(sessionId);
       }
       // A verify-retry session reports its outcome under the ORIGINAL
       // session's validated completion (dispatchCustomValidatorResult runs on
@@ -1358,6 +1371,30 @@ export class SwarmCoordinatorService
       // fall through to empty — fail open (treat unknown as not-superseded)
     }
     return {};
+  }
+
+  /**
+   * Remove a pending-handoff marker whose generation token is no longer the
+   * registered in-flight handoff. Clearing keeps the leak from shadowing any
+   * future terminal for this session; the calling stop still synthesizes this
+   * turn regardless of whether the clear lands.
+   */
+  private async clearStalePendingHandoffMarker(
+    sessionId: string,
+  ): Promise<void> {
+    const acp = this.acp();
+    if (typeof acp?.updateSessionMetadata !== "function") return;
+    try {
+      await acp.updateSessionMetadata(sessionId, {
+        [HANDOFF_PENDING_META_KEY]: null,
+      });
+      this.enrichmentMetadataCache.delete(sessionId);
+    } catch {
+      // error-policy:J6 best-effort marker cleanup on a session already being
+      // torn down; a missed clear re-runs on the next stop and never
+      // suppresses a terminal (staleness is decided by the registry, not the
+      // store).
+    }
   }
 
   private async getEnrichmentMetadata(

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -83,6 +83,16 @@ const ROUTER_OWNED_TERMINAL_EVENTS = new Set(["task_complete", "error"]);
 // synthesis must not post the old one (#11711). Matching local literal (no
 // import from sub-agent-router — see the ROUTER_ORIGIN_UUID_RE note).
 const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
+// Pending-handoff marker (matching local literal — see sub-agent-router.ts):
+// the router stamps it on the ORIGINAL session at the moment it decides on a
+// verify-retry / respawn, BEFORE the successor spawn resolves. The successor
+// stamp above only lands after the spawn settles — seconds later on a slow
+// subprocess boot — and a teardown `stopped` processed inside that window
+// reads pre-stamp state on every guard, synthesizing a false "stopped before
+// completion". Presence ⇒ the stop is handoff plumbing. The router clears the
+// marker when the spawn settles (successor stamp on success, removal on
+// failure), so a stop with no handoff in flight synthesizes exactly as before.
+const HANDOFF_PENDING_META_KEY = "routerHandoffPendingAt";
 
 const LEGACY_TASK_EVICTION_GRACE_MS = 60_000;
 
@@ -950,31 +960,33 @@ export class SwarmCoordinatorService
       return;
     }
 
-    if (
-      event === "stopped" &&
-      readString(
-        await this.getFreshSessionMetadata(sessionId),
-        HANDED_OFF_SUCCESSOR_META_KEY,
-      )
-    ) {
-      return;
-    }
-
-    // A verify-retry session reports its outcome under the ORIGINAL session's
-    // validated completion (dispatchCustomValidatorResult runs on the lineage
-    // root, which claims the synthesis slot). The retry session's own teardown
-    // `stopped` is plumbing — synthesizing it posts a false
-    // "<label> — stopped before completion." into a room that already received
-    // the pass verdict. A retry that genuinely dies without ANY lineage
-    // completion still synthesizes: the root never claimed the slot.
     if (event === "stopped") {
       if (this.validatorPassSessions.has(sessionId)) {
         return;
       }
-      const retryOf = readString(
-        await this.getFreshSessionMetadata(sessionId),
-        "retryOfSessionId",
-      );
+      // One store re-read serves every stopped-guard below (the fresh read
+      // also refreshes the enrichment cache for downstream reads this turn).
+      const fresh = await this.getFreshSessionMetadata(sessionId);
+      if (readString(fresh, HANDED_OFF_SUCCESSOR_META_KEY)) {
+        return;
+      }
+      // Handoff decided but successor spawn not yet settled (the pending
+      // marker exists only inside that window): the stop is teardown
+      // plumbing racing ahead of the successor stamp. Same semantics as the
+      // stamped skip above — do NOT claim the dedupe slot, so the successor's
+      // (or the validator's) completion for this lineage still posts.
+      if (readString(fresh, HANDOFF_PENDING_META_KEY)) {
+        return;
+      }
+      // A verify-retry session reports its outcome under the ORIGINAL
+      // session's validated completion (dispatchCustomValidatorResult runs on
+      // the lineage root, which claims the synthesis slot). The retry
+      // session's own teardown `stopped` is plumbing — synthesizing it posts
+      // a false "<label> — stopped before completion." into a room that
+      // already received the pass verdict. A retry that genuinely dies
+      // without ANY lineage completion still synthesizes: the root never
+      // claimed the slot.
+      const retryOf = readString(fresh, "retryOfSessionId");
       if (
         retryOf &&
         (this.synthesizedCompletionSessions.has(retryOf) ||

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -1194,5 +1194,54 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 		});
 	} // end if (isAuditLogEnabled)
 
+	// ── gateway shard lifecycle ────────────────────────────────────────
+	// Observability only. A live incident (2026-08-02 04:01 UTC) lost a
+	// MESSAGE_CREATE dispatch with zero process-side evidence: no ingress
+	// log, no memory, no trajectory — the connection was delivering events
+	// 39s before and 31s after. Without these handlers a silent zombie
+	// resume/re-identify that drops a dispatch is unattributable; with them,
+	// any recurrence carries a shard-lifecycle timestamp to correlate.
+	// Deliberately no recovery/backfill here — replaying missed history has
+	// duplicate-delivery risk and stays gated on an attributed recurrence.
+	service.client.on("shardDisconnect", (event, shardId) => {
+		service.runtime.logger.warn(
+			{
+				src: "plugin:discord",
+				agentId: service.runtime.agentId,
+				shardId,
+				code: event?.code,
+			},
+			"Gateway shard disconnected",
+		);
+	});
+	service.client.on("shardResume", (shardId, replayedEvents) => {
+		service.runtime.logger.warn(
+			{
+				src: "plugin:discord",
+				agentId: service.runtime.agentId,
+				shardId,
+				replayedEvents,
+			},
+			"Gateway shard resumed",
+		);
+	});
+	service.client.on("shardError", (error, shardId) => {
+		service.runtime.logger.warn(
+			{
+				src: "plugin:discord",
+				agentId: service.runtime.agentId,
+				shardId,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Gateway shard error",
+		);
+	});
+	service.client.on("invalidated", () => {
+		service.runtime.logger.error(
+			{ src: "plugin:discord", agentId: service.runtime.agentId },
+			"Gateway session invalidated — client will not auto-reconnect",
+		);
+	});
+
 	return { channelDebouncer };
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/unanswered-question-followup.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/unanswered-question-followup.ts
@@ -198,6 +198,10 @@ export async function registerQuestionFollowupForAgentMessage(
   options: { now?: Date } = {},
 ): Promise<QuestionFollowupRegistration | null> {
   if (message.entityId !== runtime.agentId) return null;
+  // Synthetic failure fallbacks (rate-limit / transient-error apologies) now
+  // emit MESSAGE_SENT like every delivered reply; a template that happens to
+  // end in "?" must not seed a follow-up about its own apology.
+  if (message.content?.elizaSyntheticFailure === true) return null;
   const roomId = typeof message.roomId === "string" ? message.roomId : null;
   if (!roomId || !message.id) return null;
   const question = extractTrailingQuestion(messageText(message));

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -633,6 +633,22 @@ export default defineConfig({
           "index.js",
         ),
       },
+      // The scenario corpus imports shared assertion helpers through
+      // `@elizaos/scenario-runner/scenario-assertions` — the same
+      // package-exports subpath shape as `/schema` above, which this lane
+      // cannot resolve (the `./*` exports wildcard points at a `./dist/*.js`
+      // that plugin-tests never builds). Anchor it to source; its only
+      // package import is `/schema`, covered by the alias above.
+      {
+        find: /^@elizaos\/scenario-runner\/scenario-assertions$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages",
+          "scenario-runner",
+          "src",
+          "scenario-assertions.ts",
+        ),
+      },
       {
         find: /^react\/jsx-dev-runtime$/,
         replacement: path.join(reactRoot, "jsx-dev-runtime.js"),

--- a/plugins/plugin-sql/src/__tests__/pg-manager.test.ts
+++ b/plugins/plugin-sql/src/__tests__/pg-manager.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit coverage for PostgresConnectionManager: pool wiring (env-tunable
+ * sizing, RLS application_name), the per-connection
+ * `hnsw.iterative_scan = strict_order` init (set on connect, degrades to a
+ * debug log when the GUC is missing), shutdown gating, connection testing,
+ * and idempotent close. The `pg` Pool is mocked — no live Postgres; the real
+ * query path is covered by the real-PGlite integration suites.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const poolMocks = vi.hoisted(() => {
+  const instances: Array<{
+    config: Record<string, unknown>;
+    handlers: Map<string, (arg: unknown) => void>;
+    connect: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+    ending: boolean;
+    ended: boolean;
+  }> = [];
+  return { instances };
+});
+
+vi.mock("pg", () => ({
+  Pool: class MockPool {
+    config: Record<string, unknown>;
+    handlers = new Map<string, (arg: unknown) => void>();
+    connect = vi.fn();
+    end = vi.fn(async () => {
+      this.ended = true;
+    });
+    ending = false;
+    ended = false;
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+      poolMocks.instances.push(this as never);
+    }
+    on(event: string, handler: (arg: unknown) => void) {
+      this.handlers.set(event, handler);
+      return this;
+    }
+  },
+}));
+
+import { PostgresConnectionManager } from "../pg/manager";
+
+const CONN = "postgres://user:pass@db.example:5432/eliza";
+
+function lastPool() {
+  return poolMocks.instances[poolMocks.instances.length - 1];
+}
+
+describe("PostgresConnectionManager", () => {
+  beforeEach(() => {
+    poolMocks.instances.length = 0;
+  });
+
+  afterEach(() => {
+    delete process.env.POSTGRES_POOL_MAX;
+    delete process.env.POSTGRES_POOL_MIN;
+  });
+
+  it("builds the pool with default sizing and exposes pool + drizzle handles", () => {
+    const manager = new PostgresConnectionManager(CONN);
+    const pool = lastPool();
+
+    expect(pool.config.max).toBe(20);
+    expect(pool.config.min).toBe(2);
+    expect(manager.getConnection()).toBe(pool as never);
+    expect(manager.getDatabase()).toBeDefined();
+    expect(manager.isShuttingDown()).toBe(false);
+  });
+
+  it("honors env pool sizing and stamps the RLS server id as application_name", () => {
+    process.env.POSTGRES_POOL_MAX = "5";
+    process.env.POSTGRES_POOL_MIN = "0";
+    new PostgresConnectionManager(CONN, "0123456789abcdef");
+    const pool = lastPool();
+
+    expect(pool.config.max).toBe(5);
+    expect(pool.config.min).toBe(0);
+    expect(pool.config.application_name).toBe("0123456789abcdef");
+  });
+
+  it("sets hnsw.iterative_scan = strict_order on every new connection", async () => {
+    new PostgresConnectionManager(CONN);
+    const pool = lastPool();
+    const client = { query: vi.fn(async () => ({})) };
+
+    pool.handlers.get("connect")?.(client);
+
+    expect(client.query).toHaveBeenCalledWith("SET hnsw.iterative_scan = 'strict_order'");
+  });
+
+  it("degrades quietly when the iterative_scan GUC does not exist (pgvector < 0.8)", async () => {
+    new PostgresConnectionManager(CONN);
+    const pool = lastPool();
+    const client = {
+      query: vi.fn(async () => {
+        throw new Error('unrecognized configuration parameter "hnsw.iterative_scan"');
+      }),
+    };
+
+    // Must not throw or produce an unhandled rejection.
+    pool.handlers.get("connect")?.(client);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(client.query).toHaveBeenCalledOnce();
+  });
+
+  it("rejects client acquisition while shutting down and closes idempotently", async () => {
+    const manager = new PostgresConnectionManager(CONN);
+    const pool = lastPool();
+
+    const closed = manager.close();
+    const closedAgain = manager.close();
+    await Promise.all([closed, closedAgain]);
+
+    expect(pool.end).toHaveBeenCalledTimes(1);
+    expect(manager.isShuttingDown()).toBe(true);
+    await expect(manager.getClient()).rejects.toThrow(/shutting down/);
+  });
+
+  it("testConnection returns true on a live SELECT 1 and false on failure", async () => {
+    const manager = new PostgresConnectionManager(CONN);
+    const pool = lastPool();
+    const client = { query: vi.fn(async () => ({})), release: vi.fn() };
+    pool.connect.mockResolvedValueOnce(client);
+
+    await expect(manager.testConnection()).resolves.toBe(true);
+    expect(client.query).toHaveBeenCalledWith("SELECT 1");
+    expect(client.release).toHaveBeenCalled();
+
+    pool.connect.mockRejectedValueOnce(new Error("connection refused"));
+    await expect(manager.testConnection()).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
Batch of turn-delivery and sub-agent verify fixes from live operation, sliced to what is not yet on develop:

- **turn delivery floor**: a finished turn always delivers something — deliberate silence is recorded as the chosen terminal, idempotent side effects count as done, `MESSAGE_SENT` fires on actual delivery, and discarded superseded responses record a "replaced" terminal instead of vanishing. New `message.turn-delivery-floor` suite (418 lines) plus side-effect-claim and effects coverage.
- **verify-retry busy-session tolerance**: a verify-retry landing on a busy session no longer false-fails; fail verdicts reach chat instead of dying in the coordinator; Discord gateway loss is observable (session teardown on gateway drop is recorded, not silent). New `verify-retry-busy-session` suite (305 lines).
- **verify-retry stop race**: the router pre-stamps the handoff decision before the successor spawn is awaited, so the original session's teardown `stopped` processed inside the spawn window cannot synthesize a false "stopped before completion" into a room that already got the pass verdict. New `verify-retry-stop-race` suite (324 lines). Superseded parts of the source commit (app-control texts, stage-1 time-in-context) were dropped — develop already carries newer variants.
- **honest trigger replay**: replayed-noop receipts are minted only for dedupeKey-proven duplicates; a legacy instructions+type fuzzy match reports the near-duplicate without claiming verified success; already-exists reminder acks read in voice instead of dedupe-machinery prose; the trajectory terminal stamp uses a distinct `terminal:finished` sentinel so non-turn trajectories never acquire a fabricated planner FINISH; synthetic failure replies cannot seed unanswered-question follow-ups.
- **adjacent test coverage**: pg-manager unit suite for plugin-sql pool wiring / hnsw init / shutdown gating (mocked `pg`, no live Postgres) — coverage that predates this batch and was never upstreamed.

Suites green: core message/effects/trajectory-recorder (137), agent trigger (27), orchestrator verify-retry + task-supervisor (29), discord events (27), pg-manager (6). Typecheck clean on all touched packages (remaining worktree-env failures reproduce identically at develop baseline — unbuilt optional-plugin dists only).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:ba8a50949a6cef41eed492894eb3b3589913fb3f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change with no user flow to record on screen.

<!-- evidence-row:backend-logs -->
- [x] Backend logs — live deployment: the gateway-loss observability added here firing in production (`Gateway shard resumed` warns from this PR's discord-events change), and a finished turn recording its terminal through the delivery floor instead of vanishing.

<details><summary>Backend logs — gateway observability + turn-delivery floor live</summary>

```text
 Warn   #agent:remilio nubilio  [PLUGIN:DISCORD] Gateway shard resumed (shardId=0, replayedEvents=2)
 Warn   #agent:remilio nubilio  [PLUGIN:DISCORD] Gateway shard resumed (shardId=0, replayedEvents=1)
 Debug  #agent:remilio nubilio  [SERVICE:MESSAGE] Agent decided not to respond
 Debug  #agent:remilio nubilio  [BASIC-CAPABILITIES] Message sent (text=)
 Debug  #agent:remilio nubilio  [SERVICE:MESSAGE] Saved terminal response to memory (memoryId=ec1cab2d-e1a2-4ac5-b9ee-fb4f0e213e47)
 Debug  [InferenceTiming] message-turn provider=openai total=878ms ttft=681ms message:planner=713ms model:RESPONSE_HANDLER=647.59ms
 Debug  [BASIC-CAPABILITIES] Logged RUN_ENDED event (runId=5d262b5c-5bc8-464f-b7a6-7a5c430060eb, status=completed)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the affected code path.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - this batch changes delivery, verify-retry, and replay plumbing whose contracts are pinned by the 1,100+ lines of new deterministic suites listed above; no single live-model trajectory isolates these paths.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - the outcomes are terminal and receipt records in the agent database; representative ids appear in the backend log excerpt.

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface exists for this change.

## Known gaps / failures

- Initial `check-pr-evidence` runs failed inside the base-branch validator self-test (skill-review PyYAML pin moved on develop in `e9d64249f08` while its test followed later in `0f8699cebd6`); the PR base snapshot was refreshed to pick up the repaired validators.
- Live backend log lines are excerpted with channel/user context withheld; full logs remain on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




