### PR TITLE
fix(ui): cover deferred cloud-agent refresh settling after teardown with unhandled rejection check

### DIFF
--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -809,6 +809,35 @@ describe("CloudAgentsSection load state (error vs empty)", () => {
     });
   });
 
+  it("consumes a list rejection that settles after unmount", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      let rejectFetch!: (reason?: unknown) => void;
+      const pendingFetch = new Promise<never>((_resolve, reject) => {
+        rejectFetch = reject;
+      });
+      clientMock.getCloudCompatAgents.mockReturnValue(pendingFetch);
+
+      const view = render(<CloudAgentsSection />);
+      await waitFor(() =>
+        expect(clientMock.getCloudCompatAgents).toHaveBeenCalledTimes(1),
+      );
+      view.unmount();
+
+      rejectFetch(new Error("late cloud-agent fetch failure"));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
   it("does not let an older list response overwrite a newer refresh", async () => {
     let resolveInitial:
       | ((value: { success: true; data: [] }) => void)


### PR DESCRIPTION
## Summary

Adds a regression for the production ownership guard that consumes a deferred cloud-agent list rejection after the Settings view has unmounted. The successful late-response discard test remains intact; this new case covers the rejection path through Node/Vitest's actual `unhandledRejection` channel.

This is test-only hardening for behavior already implemented in `CloudAgentsSection`; it does not change production runtime behavior.

## Testing

- `CloudAgentsSection.test.tsx`: 27 passed, 0 failed.
- Mutation check: rethrowing the stale-owner rejection makes the new regression fail with the deferred error.
- `@elizaos/ui` typecheck: passed.
- Biome check: passed.
- `git diff --check`: passed.
- Rebasing the one-file test patch onto `fdfd108789f345332891a9b0ec47a32fb1d39b5b` produced no conflict.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - this test-only change has no rendered product behavior.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - this test-only change has no rendered product behavior.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - there is no interactive flow or production UI change.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no backend runtime path changes.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend runtime code changes.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - this regression test creates no runtime domain artifact.`

## Maintainer repair

The submitted patch contained a duplicated out-of-scope block and listened on the browser channel, while Vitest reports unhandled promise rejection through the process channel. The repaired exact head preserves the existing late-success regression and adds a separate deferred-rejection case with deterministic event-loop settling and guaranteed listener cleanup.

Original proposal: @harshith8gowda.

- Evidence metadata was revalidated after the exact-head fork workflow approval.\n\n<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: Codex CLI 0.145.0
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

— [codex-shawwalters]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex CLI 0.145.0","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:eb4c6122dabf44d31f685739ed3e50959fcbc026 -->