### PR TITLE
test(ci): accept stricter visual diff ceilings

### DIFF
--- a/packages/scripts/__tests__/quality-fork-browser-contract.test.ts
+++ b/packages/scripts/__tests__/quality-fork-browser-contract.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Guards fork-safe homepage browser CI and its reviewed visual-diff ceilings.
+ */
 import { describe, expect, test } from "bun:test";
 import {
   mkdirSync,
@@ -15,6 +18,7 @@ const { runContract } = await import(
 );
 
 const REAL_REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const NUMBER_LITERAL = String.raw`(0(?:\.\d+)?)`;
 const VALID_WORKFLOW = `name: Quality (Fork)
 jobs:
   build:
@@ -123,7 +127,7 @@ describe("quality-fork-browser-contract", () => {
     }
   });
 
-  test("bounds only the measured mobile visual renderer variance", () => {
+  test("keeps visual diff tolerances within reviewed renderer ceilings", () => {
     const config = readFileSync(
       join(REAL_REPO_ROOT, "packages", "homepage", "playwright.config.ts"),
       "utf8",
@@ -139,10 +143,34 @@ describe("quality-fork-browser-contract", () => {
       ),
       "utf8",
     );
-    expect(config).toMatch(/maxDiffPixelRatio:\s*0\.05/);
-    expect(visual).toMatch(
-      /maxDiffPixelRatio:\s*viewport\.name === ["']mobile["'] \? 0\.08 : 0\.05/,
+    const configMatch = config.match(
+      new RegExp(`maxDiffPixelRatio:\\s*${NUMBER_LITERAL}`),
     );
+    if (!configMatch) {
+      throw new Error("Homepage Playwright config must set maxDiffPixelRatio");
+    }
+
+    const globalTolerance = Number(configMatch[1]);
+    expect(globalTolerance).toBeLessThanOrEqual(0.05);
+
+    const viewportMatch = visual.match(
+      new RegExp(
+        `maxDiffPixelRatio:\\s*viewport\\.name === ["']mobile["']\\s*\\?\\s*${NUMBER_LITERAL}\\s*:\\s*${NUMBER_LITERAL}`,
+      ),
+    );
+    if (viewportMatch) {
+      expect(Number(viewportMatch[1])).toBeLessThanOrEqual(0.08);
+      expect(Number(viewportMatch[2])).toBeLessThanOrEqual(globalTolerance);
+      return;
+    }
+
+    const uniformMatch = visual.match(
+      new RegExp(`maxDiffPixelRatio:\\s*${NUMBER_LITERAL}`),
+    );
+    if (!uniformMatch) {
+      throw new Error("Homepage visual suite must set maxDiffPixelRatio");
+    }
+    expect(Number(uniformMatch[1])).toBeLessThanOrEqual(globalTolerance);
   });
 
   test("the checked-in Quality (Fork) workflow satisfies the contract", () => {


### PR DESCRIPTION
## Summary

- repair the script contract broken when #17608 tightened both homepage visual tolerances to `0.02`
- enforce semantic upper bounds instead of requiring the older `0.08` mobile / `0.05` desktop expression
- retain all fork-safety checks for single-worker execution and reviewed failure-artifact upload

This is the shared root cause of `Script Tests (Linux)` failing on current `develop` and the Scenario runs for #17617 and #17638.

## Verification

Exact head: `ea6a8223ff2356b3fda23268b98552b1e092a95c`, parent `a48e5cf28823154d70c3d2df829fedd9cfdd52b9`.

- exact-head focused Bun test: 8 passed, 0 failed
- controlled `0.09` tolerance mutation: rejected
- Biome: passed
- `git diff --check`: passed

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only contract repair; rendered UI is unchanged

<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only contract repair; rendered UI is unchanged

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-operated flow changed

<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic source-contract test with no backend runtime

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime code changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or routing behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] N/A - test-only change creates no domain artifact

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

<!-- evidence-head:ea6a8223ff2356b3fda23268b98552b1e092a95c -->