### PR TITLE
fix(ci): generate shared i18n keyword data in Dockerfile.ci

### DIFF
--- a/packages/app-core/deploy/Dockerfile.ci
+++ b/packages/app-core/deploy/Dockerfile.ci
@@ -101,6 +101,10 @@ RUN node "${APP_CORE_DIR}/scripts/link-docker-local-app-packages.mjs"
 
 RUN node "${APP_CORE_DIR}/scripts/ensure-generated-core-proto-js.mjs"
 
+# Shared i18n keyword data is gitignored; app/shared builds import the generated
+# JS module, so the Docker pruner stage must materialize it (same as run-repo-setup).
+RUN node "${APP_CORE_DIR}/scripts/ensure-shared-i18n-data.mjs"
+
 # Patch plugin-agent-skills getCatalogStats crash (alpha.11 vs alpha.66 interface mismatch)
 RUN sed -i 's/const stats = service.getCatalogStats();/const stats = typeof service.getCatalogStats === "function" ? service.getCatalogStats() : { loaded: 0, total: 0, storageType: "unknown" };/g' node_modules/@elizaos/plugin-agent-skills/dist/index.js 2>/dev/null || true
 ARG VERSION_CLEAN


### PR DESCRIPTION
# Relates to

Closes #17468.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused validation of the generation script was run after the Dockerfile
      edit; full `bun run verify` was not re-run for this one-line Dockerfile
      change (recorded under Known gaps).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xAI/grok-4.5`
<!-- attribution-row:client -->
- Client / agent tooling: `Grok Build TUI`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@64942cd44461ecc24b3ca1421de74900906e9506:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Based on the latest `origin/develop` (`64942cd44461ecc24b3ca1421de74900906e9506`); zero conflicts; one commit ahead.
- [x] Focused generation command recorded below; unrelated monorepo `bun run verify` not re-run for this Dockerfile-only change.

# Risks

Low. Adds one build-time generation step in the Docker pruner stage using an existing idempotent script already invoked by repo setup. Main risk is a missing script path or generator failure failing the image build early (fail-closed), which is preferred over a missing import at app build time.

# Background

## What does this PR do?

- Runs `packages/app-core/scripts/ensure-shared-i18n-data.mjs` in the `Dockerfile.ci` pruner stage immediately after `ensure-generated-core-proto-js.mjs`.
- Materializes gitignored shared/core `validation-keyword-data` TS/JS outputs so CI Docker builds can resolve `@elizaos/shared` keyword imports.

## What kind of change is this?

Bug fix (CI / Docker build infrastructure, non-breaking).

## Relation to #17640

Open PR #17640 claims the same intent but its head **empties** `Dockerfile.ci` (0 additions / 246 deletions). This PR keeps the full Dockerfile and adds only the generation step.

# Documentation changes needed?

No product documentation change. Dockerfile comment documents why the step exists.

# Testing

## Where should a reviewer start?

1. `packages/app-core/deploy/Dockerfile.ci` — the single new `RUN` after the proto ensure step.
2. Confirm `packages/app-core/scripts/ensure-shared-i18n-data.mjs` exists and invokes `packages/shared/scripts/generate-keywords.mjs`.

## Detailed testing steps

```text
# From a checkout at this head:
node --input-type=module -e "import { runKeywordGenerator } from './packages/app-core/scripts/ensure-shared-i18n-data.mjs'; console.log(runKeywordGenerator());"

# Observed (excerpt):
Generating keyword code from JSON...
Total: 241 entries, 6 locales
TypeScript (shared): packages/shared/src/i18n/generated/validation-keyword-data.ts
JavaScript (shared): packages/shared/src/i18n/generated/validation-keyword-data.js
TypeScript (core):   packages/core/src/i18n/generated/validation-keyword-data.ts
Done!
{ skipped: false }
```

`git diff --stat origin/develop...HEAD` → `1 file changed, 4 insertions(+)`.

# Evidence Gate

<!-- evidence-head:404e852b82f8d015c91deef36feba21481585bc1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Dockerfile/build-time change only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Dockerfile/build-time change only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changed.
<!-- evidence-row:backend-logs -->
- [x] Generation log from the same ensure script the Dockerfile invokes (see Evidence Details).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - generated keyword files are gitignored build products; sizes confirmed after generation (shared JS ~466KB, shared TS ~466KB).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path changed.

## Backend + frontend logs

```text
Generating keyword code from JSON...
  Loaded action-search.generated.keywords.json: 114 entries
  Loaded context-search.keywords.json: 38 entries
  Loaded shared.keywords.json: 73 entries
  Loaded typescript.keywords.json: 16 entries
  Loaded validate.keywords.json: 2 entries
Total: 241 entries, 6 locales
  TypeScript (shared): packages/shared/src/i18n/generated/validation-keyword-data.ts
  JavaScript (shared): packages/shared/src/i18n/generated/validation-keyword-data.js
  TypeScript (core):   packages/core/src/i18n/generated/validation-keyword-data.ts
Done!
{ skipped: false }
```

Frontend logs: N/A.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Known gaps / failures

- Full `bun run verify` was not re-run; change is one Dockerfile `RUN` plus an existing script already used by repo setup.
- Full multi-stage `docker build` of `Dockerfile.ci` was not executed in this session (host resource/time); the pruner step invokes the same Node script proven above.
- Direct `node packages/app-core/scripts/ensure-shared-i18n-data.mjs` as a bare CLI entry is a no-op on Windows path `import.meta.url` matching; Docker Linux `RUN node path` matches the script's entry guard. Generation was proven via the exported `runKeywordGenerator()` API the module provides.

AI provider/model: xAI / grok-4.5
Client / agent tooling: Grok Build TUI
Contribution skill revision: elizaOS/eliza@64942cd44461ecc24b3ca1421de74900906e9506:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-krutftw]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"Grok Build TUI","skill_revision":"elizaOS/eliza@64942cd44461ecc24b3ca1421de74900906e9506:packages/skills/skills/contribute-to-eliza"} -->
