### PR TITLE
fix(agent): persist bind-mounted config and preserve reload identity

### DIFF
--- a/packages/agent/src/config/config-bind-mount-persistence.test.ts
+++ b/packages/agent/src/config/config-bind-mount-persistence.test.ts
@@ -1,0 +1,86 @@
+/** Regression coverage for config persistence when eliza.json is a file bind mount. */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadElizaConfig, saveElizaConfig } from "./config.ts";
+
+const originalEnv = { ...process.env };
+let root = "";
+let configPath = "";
+let stateDir = "";
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-config-bind-"));
+  configPath = path.join(root, "cfg", "eliza.json");
+  stateDir = path.join(root, "state");
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(
+    configPath,
+    `${JSON.stringify({ plugins: { entries: { original: { enabled: true } } } }, null, 2)}\n`,
+  );
+  process.env.ELIZA_CONFIG_PATH = configPath;
+  process.env.ELIZA_STATE_DIR = stateDir;
+  delete process.env.ELIZA_PERSIST_CONFIG_PATH;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.env = { ...originalEnv };
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("saveElizaConfig bind-mount fallback", () => {
+  it("commits a durable state overlay when rename onto the config returns EBUSY", () => {
+    const realRename = fs.renameSync.bind(fs);
+    vi.spyOn(fs, "renameSync").mockImplementation((from, to) => {
+      if (String(to) === configPath) {
+        const error = new Error("resource busy") as NodeJS.ErrnoException;
+        error.code = "EBUSY";
+        throw error;
+      }
+      return realRename(from, to);
+    });
+
+    saveElizaConfig({
+      plugins: {
+        entries: {
+          original: { enabled: true },
+          simpleViews: { enabled: true },
+        },
+      },
+    } as never);
+
+    const overlayPath = path.join(stateDir, "eliza.config-overlay.json");
+    expect(fs.existsSync(overlayPath)).toBe(true);
+    expect(fs.statSync(overlayPath).mode & 0o777).toBe(0o600);
+    expect(fs.readFileSync(configPath, "utf8")).not.toContain("simpleViews");
+    expect(loadElizaConfig().plugins?.entries?.simpleViews?.enabled).toBe(true);
+
+    // Once selected, the overlay remains the write target. A stale overlay can
+    // never override a later canonical write after restart.
+    saveElizaConfig({
+      plugins: { entries: { simpleViews: { enabled: false } } },
+    } as never);
+    expect(loadElizaConfig().plugins?.entries?.simpleViews?.enabled).toBe(
+      false,
+    );
+  });
+
+  it("throws when both the bind-mounted target and durable overlay fail", () => {
+    vi.spyOn(fs, "renameSync").mockImplementation((_from, to) => {
+      const error = new Error("write refused") as NodeJS.ErrnoException;
+      error.code = String(to) === configPath ? "EBUSY" : "EACCES";
+      throw error;
+    });
+
+    expect(() =>
+      saveElizaConfig({ plugins: { entries: {} } } as never),
+    ).toThrow("state overlay persistence failed");
+    expect(
+      fs.existsSync(path.join(stateDir, "eliza.config-overlay.json")),
+    ).toBe(false);
+  });
+});

--- a/packages/agent/src/config/config-bind-mount-persistence.test.ts
+++ b/packages/agent/src/config/config-bind-mount-persistence.test.ts
@@ -83,4 +83,56 @@ describe("saveElizaConfig bind-mount fallback", () => {
       fs.existsSync(path.join(stateDir, "eliza.config-overlay.json")),
     ).toBe(false);
   });
+
+  it("keeps an explicit persistence path authoritative over a stale overlay", () => {
+    const overlayPath = path.join(stateDir, "eliza.config-overlay.json");
+    const persistPath = path.join(root, "persist", "eliza.json");
+    fs.writeFileSync(
+      overlayPath,
+      `${JSON.stringify({ plugins: { entries: { stale: { enabled: true } } } })}\n`,
+      { mode: 0o600 },
+    );
+    process.env.ELIZA_PERSIST_CONFIG_PATH = persistPath;
+
+    saveElizaConfig({
+      plugins: { entries: { current: { enabled: true } } },
+    } as never);
+
+    expect(fs.existsSync(persistPath)).toBe(true);
+    expect(fs.statSync(persistPath).mode & 0o777).toBe(0o600);
+    expect(loadElizaConfig().plugins?.entries).toEqual({
+      original: { enabled: true },
+      current: { enabled: true },
+    });
+    expect(fs.readFileSync(overlayPath, "utf8")).toContain('"stale"');
+  });
+
+  it("sanitizes include directives and wallet keys in the overlay", () => {
+    const realRename = fs.renameSync.bind(fs);
+    vi.spyOn(fs, "renameSync").mockImplementation((from, to) => {
+      if (String(to) === configPath) {
+        const error = new Error("resource busy") as NodeJS.ErrnoException;
+        error.code = "EBUSY";
+        throw error;
+      }
+      return realRename(from, to);
+    });
+
+    saveElizaConfig({
+      $include: "secrets.json",
+      env: {
+        ELIZA_WALLET_OS_STORE: "true",
+        EVM_PRIVATE_KEY: "secret",
+        SOLANA_PRIVATE_KEY: "secret",
+      },
+    } as never);
+
+    const persisted = fs.readFileSync(
+      path.join(stateDir, "eliza.config-overlay.json"),
+      "utf8",
+    );
+    expect(persisted).not.toContain("$include");
+    expect(persisted).not.toContain("PRIVATE_KEY");
+    expect(persisted).not.toContain("secret");
+  });
 });

--- a/packages/agent/src/config/config.ts
+++ b/packages/agent/src/config/config.ts
@@ -9,6 +9,7 @@
  * keystore is enabled — wallet private keys, then writes atomically via a temp
  * file + rename with 0600 permissions.
  */
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { logger } from "@elizaos/core";
@@ -266,6 +267,7 @@ function syncDirectory(dir: string): void {
       process.platform !== "win32" &&
       code !== "EINVAL" &&
       code !== "ENOTSUP" &&
+      code !== "EOPNOTSUPP" &&
       code !== "EISDIR"
     ) {
       throw error;
@@ -280,10 +282,14 @@ function writeFileAtomically(targetPath: string, content: string): void {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  const tmpPath = `${targetPath}.tmp.${process.pid}`;
+  const tmpPath = `${targetPath}.tmp.${process.pid}.${randomUUID()}`;
   let fd: number | undefined;
   try {
-    fd = fs.openSync(tmpPath, "w", 0o600);
+    fd = fs.openSync(
+      tmpPath,
+      fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL,
+      0o600,
+    );
     fs.writeFileSync(fd, content, "utf-8");
     fs.fsyncSync(fd);
     fs.closeSync(fd);

--- a/packages/agent/src/config/config.ts
+++ b/packages/agent/src/config/config.ts
@@ -128,14 +128,17 @@ export function loadElizaConfig(): ElizaConfig {
   const persistedConfig =
     persistPath !== configPath ? readConfigFile(persistPath) : null;
   const bindMountOverlay =
-    bindMountOverlayPath !== configPath && bindMountOverlayPath !== persistPath
+    persistPath === configPath && bindMountOverlayPath !== configPath
       ? readConfigFile(bindMountOverlayPath)
       : null;
+  // The automatic bind-mount overlay extends only the canonical file. An
+  // explicitly configured persistence path disables it entirely, preventing
+  // stale overlay keys from leaking into an operator-selected store.
   const resolved = (
     baseConfig || persistedConfig || bindMountOverlay
       ? mergeConfigRecords(
-          mergeConfigRecords(baseConfig ?? {}, persistedConfig ?? {}),
-          bindMountOverlay ?? {},
+          mergeConfigRecords(baseConfig ?? {}, bindMountOverlay ?? {}),
+          persistedConfig ?? {},
         )
       : { logging: { level: "error" } }
   ) as ElizaConfig;
@@ -255,8 +258,18 @@ function syncDirectory(dir: string): void {
   try {
     fd = fs.openSync(dir, "r");
     fs.fsyncSync(fd);
-  } catch {
-    // Directory fsync is unsupported on some platforms (notably Windows).
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    // Directory fsync is unsupported on Windows and on a small set of
+    // filesystems. Real I/O failures must remain observable to the caller.
+    if (
+      process.platform !== "win32" &&
+      code !== "EINVAL" &&
+      code !== "ENOTSUP" &&
+      code !== "EISDIR"
+    ) {
+      throw error;
+    }
   } finally {
     if (fd !== undefined) fs.closeSync(fd);
   }
@@ -344,6 +357,7 @@ function stripWalletPrivateKeysFromConfig(config: ElizaConfig): void {
 
 export function saveElizaConfig(config: ElizaConfig): void {
   const configPath = resolveConfigWritePath();
+  const canonicalConfigPath = resolveConfigPath();
   const dir = path.dirname(configPath);
 
   if (!fs.existsSync(dir)) {
@@ -379,6 +393,7 @@ export function saveElizaConfig(config: ElizaConfig): void {
     ? fs.realpathSync(configPath)
     : configPath;
   const bindMountOverlayPath = resolveBindMountOverlayPath();
+  const mayUseBindMountOverlay = configPath === canonicalConfigPath;
   let writtenPath = realConfigPath;
 
   // A file bind mount cannot be replaced with rename(2): Linux returns EBUSY.
@@ -386,7 +401,7 @@ export function saveElizaConfig(config: ElizaConfig): void {
   // directory. The overlay is temp+fsync+rename committed and loaded last on
   // every subsequent boot. Keep using an existing overlay so stale state can
   // never override a later write to the read-only base file.
-  if (fs.existsSync(bindMountOverlayPath)) {
+  if (mayUseBindMountOverlay && fs.existsSync(bindMountOverlayPath)) {
     writeFileAtomically(bindMountOverlayPath, content);
     writtenPath = bindMountOverlayPath;
   } else {
@@ -394,7 +409,7 @@ export function saveElizaConfig(config: ElizaConfig): void {
       writeFileAtomically(realConfigPath, content);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
-      if (code !== "EBUSY") throw error;
+      if (code !== "EBUSY" || !mayUseBindMountOverlay) throw error;
       try {
         writeFileAtomically(bindMountOverlayPath, content);
         writtenPath = bindMountOverlayPath;
@@ -415,8 +430,10 @@ export function saveElizaConfig(config: ElizaConfig): void {
   // (potentially world-readable) permissions.
   try {
     fs.chmodSync(writtenPath, 0o600);
-  } catch {
-    // chmodSync may fail on some platforms (e.g. Windows). Non-fatal.
+  } catch (error) {
+    // Windows does not implement POSIX permission bits. On POSIX, failure to
+    // enforce the config's secret-bearing 0600 contract is a real write error.
+    if (process.platform !== "win32") throw error;
   }
 
   if (!fs.existsSync(writtenPath)) {
@@ -454,5 +471,11 @@ export function configFileExists(): boolean {
   }
 
   const persistPath = resolveConfigWritePath();
-  return persistPath !== configPath && fs.existsSync(persistPath);
+  if (persistPath !== configPath && fs.existsSync(persistPath)) {
+    return true;
+  }
+
+  return (
+    persistPath === configPath && fs.existsSync(resolveBindMountOverlayPath())
+  );
 }

--- a/packages/agent/src/config/config.ts
+++ b/packages/agent/src/config/config.ts
@@ -27,6 +27,7 @@ import { collectConfigEnvVars, collectConnectorEnvVars } from "./env-vars.ts";
 import { resolveConfigIncludes } from "./includes.ts";
 import { normalizeModelMetadataInConfig } from "./model-metadata.ts";
 import {
+  getElizaNamespace,
   resolveConfigPath,
   resolveStateDir,
   resolveUserPath,
@@ -41,6 +42,15 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 function resolveConfigWritePath(env: NodeJS.ProcessEnv = process.env): string {
   const persistPath = env.ELIZA_PERSIST_CONFIG_PATH?.trim();
   return persistPath ? resolveUserPath(persistPath) : resolveConfigPath();
+}
+
+function resolveBindMountOverlayPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return path.join(
+    resolveStateDir(env),
+    `${getElizaNamespace(env)}.config-overlay.json`,
+  );
 }
 
 function applyConfigEnvToProcessEnv(entries: Record<string, string>): void {
@@ -112,13 +122,21 @@ function readConfigFile(configPath: string): ElizaConfig | null {
 export function loadElizaConfig(): ElizaConfig {
   const configPath = resolveConfigPath();
   const persistPath = resolveConfigWritePath();
+  const bindMountOverlayPath = resolveBindMountOverlayPath();
 
   const baseConfig = readConfigFile(configPath);
   const persistedConfig =
     persistPath !== configPath ? readConfigFile(persistPath) : null;
+  const bindMountOverlay =
+    bindMountOverlayPath !== configPath && bindMountOverlayPath !== persistPath
+      ? readConfigFile(bindMountOverlayPath)
+      : null;
   const resolved = (
-    baseConfig || persistedConfig
-      ? mergeConfigRecords(baseConfig ?? {}, persistedConfig ?? {})
+    baseConfig || persistedConfig || bindMountOverlay
+      ? mergeConfigRecords(
+          mergeConfigRecords(baseConfig ?? {}, persistedConfig ?? {}),
+          bindMountOverlay ?? {},
+        )
       : { logging: { level: "error" } }
   ) as ElizaConfig;
   migrateLegacyRuntimeConfig(resolved as Record<string, unknown>);
@@ -213,6 +231,9 @@ export function loadElizaConfig(): ElizaConfig {
       {
         path: configPath,
         persistPath: persistPath !== configPath ? persistPath : undefined,
+        bindMountOverlayPath: bindMountOverlay
+          ? bindMountOverlayPath
+          : undefined,
         topLevelKeys: Object.keys(resolved as Record<string, unknown>).sort(),
         cloud: settingsDebugCloudSummary(cloud),
         envVarKeysHydrated: Object.keys({
@@ -227,6 +248,44 @@ export function loadElizaConfig(): ElizaConfig {
   }
 
   return resolved;
+}
+
+function syncDirectory(dir: string): void {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(dir, "r");
+    fs.fsyncSync(fd);
+  } catch {
+    // Directory fsync is unsupported on some platforms (notably Windows).
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}
+
+function writeFileAtomically(targetPath: string, content: string): void {
+  const dir = path.dirname(targetPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  const tmpPath = `${targetPath}.tmp.${process.pid}`;
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(tmpPath, "w", 0o600);
+    fs.writeFileSync(fd, content, "utf-8");
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = undefined;
+    fs.renameSync(tmpPath, targetPath);
+    syncDirectory(dir);
+  } catch (error) {
+    if (fd !== undefined) fs.closeSync(fd);
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // Preserve the original write error. A stale uniquely named temp is safe.
+    }
+    throw error;
+  }
 }
 
 function stripIncludeDirectives(value: unknown): unknown {
@@ -319,31 +378,56 @@ export function saveElizaConfig(config: ElizaConfig): void {
   const realConfigPath = fs.existsSync(configPath)
     ? fs.realpathSync(configPath)
     : configPath;
-  const tmpPath = `${realConfigPath}.tmp.${process.pid}`;
-  fs.writeFileSync(tmpPath, content, {
-    encoding: "utf-8",
-    mode: 0o600,
-  });
-  fs.renameSync(tmpPath, realConfigPath);
+  const bindMountOverlayPath = resolveBindMountOverlayPath();
+  let writtenPath = realConfigPath;
+
+  // A file bind mount cannot be replaced with rename(2): Linux returns EBUSY.
+  // Once observed, persist the complete sanitized config in the writable state
+  // directory. The overlay is temp+fsync+rename committed and loaded last on
+  // every subsequent boot. Keep using an existing overlay so stale state can
+  // never override a later write to the read-only base file.
+  if (fs.existsSync(bindMountOverlayPath)) {
+    writeFileAtomically(bindMountOverlayPath, content);
+    writtenPath = bindMountOverlayPath;
+  } else {
+    try {
+      writeFileAtomically(realConfigPath, content);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EBUSY") throw error;
+      try {
+        writeFileAtomically(bindMountOverlayPath, content);
+        writtenPath = bindMountOverlayPath;
+        logger.warn(
+          `[eliza-config] ${realConfigPath} is not replaceable (EBUSY); persisted config atomically to ${bindMountOverlayPath}`,
+        );
+      } catch (fallbackError) {
+        throw new Error(
+          `[eliza-config] Bind-mounted config could not be replaced and state overlay persistence failed: ${String(fallbackError)}`,
+          { cause: error },
+        );
+      }
+    }
+  }
 
   // Enforce 600 on every write — writeFileSync's mode only applies on
   // creation, so files created by older versions retain their original
   // (potentially world-readable) permissions.
   try {
-    fs.chmodSync(configPath, 0o600);
+    fs.chmodSync(writtenPath, 0o600);
   } catch {
     // chmodSync may fail on some platforms (e.g. Windows). Non-fatal.
   }
 
-  if (!fs.existsSync(configPath)) {
+  if (!fs.existsSync(writtenPath)) {
     throw new Error(
-      `[eliza-config] Config file missing after write: ${configPath}`,
+      `[eliza-config] Config file missing after write: ${writtenPath}`,
     );
   }
-  const stat = fs.statSync(configPath);
+  const stat = fs.statSync(writtenPath);
   if (stat.size === 0) {
     throw new Error(
-      `[eliza-config] Config file is empty after write: ${configPath}`,
+      `[eliza-config] Config file is empty after write: ${writtenPath}`,
     );
   }
 
@@ -352,7 +436,7 @@ export function saveElizaConfig(config: ElizaConfig): void {
     const cloud = c.cloud as Record<string, unknown> | undefined;
     logger.debug(
       {
-        path: configPath,
+        path: writtenPath,
         bytes: stat.size,
         topLevelKeys: Object.keys(c).sort(),
         cloud: settingsDebugCloudSummary(cloud),

--- a/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
+++ b/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   applySandboxCharacterFromEnv,
+  applySandboxIdentityFromEnv,
   resolveSandboxRouteAgentId,
 } from "../sandbox-character.ts";
 
@@ -104,6 +105,36 @@ describe("applySandboxCharacterFromEnv", () => {
     const entry = (out as { agents: { list: Array<Record<string, unknown>> } })
       .agents.list[0];
     expect(entry.name).toBe("Nyx");
+  });
+});
+
+describe("applySandboxIdentityFromEnv", () => {
+  it("re-applies the injected character and routing id to a fresh reload config", () => {
+    const env = {
+      ELIZA_AGENT_CHARACTER_JSON: JSON.stringify({
+        id: "embedded-id",
+        name: "Sol",
+        system: "You are Sol.",
+      }),
+      SANDBOX_ROUTE_AGENT_ID: "route-id",
+    };
+
+    const initial = {} as never;
+    const reloaded = {
+      agents: { list: [{ name: "Eliza", default: true }] },
+    } as never;
+    expect(applySandboxIdentityFromEnv(initial, env)).toBe("route-id");
+    expect(applySandboxIdentityFromEnv(reloaded, env)).toBe("route-id");
+
+    const reloadedPrimary = (
+      reloaded as { agents: { list: Array<Record<string, unknown>> } }
+    ).agents.list[0];
+    expect(reloadedPrimary).toMatchObject({
+      id: "route-id",
+      name: "Sol",
+      system: "You are Sol.",
+      default: true,
+    });
   });
 });
 

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4152,10 +4152,10 @@ export async function startEliza(
   // default preset. Skipped when the env var is absent.
   let sandboxRouteAgentId: string | null = null;
   {
-    const { applySandboxCharacterFromEnv, resolveSandboxRouteAgentId } =
-      await import("./sandbox-character.ts");
-    applySandboxCharacterFromEnv(config);
-    sandboxRouteAgentId = resolveSandboxRouteAgentId();
+    const { applySandboxIdentityFromEnv } = await import(
+      "./sandbox-character.ts"
+    );
+    sandboxRouteAgentId = applySandboxIdentityFromEnv(config);
   }
 
   // 3b. Canonical file boot (sovereign identity): when configured via
@@ -5755,8 +5755,15 @@ export async function startEliza(
             fast: true,
           });
 
-          // Reload config from disk (updated by API)
+          // Reload config from disk (updated by API). Provisioned containers
+          // must re-apply their injected character on every hot reload: the
+          // injection is intentionally not serialized into eliza.json.
           const freshConfig = loadElizaConfig();
+          const { applySandboxIdentityFromEnv } = await import(
+            "./sandbox-character.ts"
+          );
+          const freshSandboxRouteAgentId =
+            applySandboxIdentityFromEnv(freshConfig);
 
           // Propagate secrets & cloud config into process.env so plugins
           // (especially plugin-elizacloud) can discover them.  The initial
@@ -5818,6 +5825,9 @@ export async function startEliza(
           // Rebuild character from the fresh config so first-run changes
           // (name, bio, style, etc.) are picked up on restart.
           const freshCharacter = buildCharacterFromConfig(freshConfig);
+          if (freshSandboxRouteAgentId) {
+            freshCharacter.id = freshSandboxRouteAgentId as UUID;
+          }
 
           const freshWorkspaceDir =
             freshConfig.agents?.defaults?.workspace ?? workspaceDir;

--- a/packages/agent/src/runtime/sandbox-character.ts
+++ b/packages/agent/src/runtime/sandbox-character.ts
@@ -199,6 +199,15 @@ export function applySandboxCharacterFromEnv(
   return config;
 }
 
+/** Apply the complete provisioned identity contract for initial boot or reload. */
+export function applySandboxIdentityFromEnv(
+  config: ElizaConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  applySandboxCharacterFromEnv(config, env);
+  return resolveSandboxRouteAgentId(env);
+}
+
 /** Connector bot-token env vars that trigger a direct platform connection. */
 const CONNECTOR_TOKEN_ENV_KEYS = [
   "DISCORD_API_TOKEN",


### PR DESCRIPTION
# Relates to

LP3 plugin enablement persistence and provisioned-agent restart identity regression.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Risks

Medium. Config persistence is startup-critical. The fallback is limited to Linux-style `EBUSY` replacement failures, writes a complete sanitized overlay using an exclusive randomized 0600 temp file + file fsync + rename + directory fsync, and throws if that commit also fails. Existing overlays remain the write target for canonical config saves so stale state cannot override a later base write. An explicit `ELIZA_PERSIST_CONFIG_PATH` disables the automatic overlay entirely and remains authoritative.

# Background

## What does this PR do?

Fixes two failures exposed while enabling first-party views in a container:

1. `saveElizaConfig()` always replaced `eliza.json` with `rename(2)`. A single-file Docker bind mount cannot be replaced and returns `EBUSY`, so plugin enablement appeared live but disappeared after restart. On exactly that error, the agent now atomically commits the full sanitized config to `<state-dir>/<namespace>.config-overlay.json`; `loadElizaConfig()` merges it last on canonical-config boots. An explicit persistence path bypasses the automatic overlay so stale keys cannot leak across deployment modes. Any fallback failure is surfaced, never ignored.
2. Initial startup applies `ELIZA_AGENT_CHARACTER_JSON` and pins `SANDBOX_ROUTE_AGENT_ID`, but the hot-reload closure rebuilt directly from disk config. A plugin-triggered restart could therefore replace the injected Sol character with default Eliza and a name-derived UUID. Initial boot and hot reload now share `applySandboxIdentityFromEnv`, and reload re-pins the routing id.

## What kind of change is this?

Bug fix, non-breaking.

# Testing

## Develop-red proof

- Bind-mount regression against the develop implementation throws `EBUSY` at `renameSync(tmp, /cfg/eliza.json)` and creates no durable overlay.
- Develop's hot-reload path calls `loadElizaConfig()` followed directly by `buildCharacterFromConfig(freshConfig)`; it never reapplies `ELIZA_AGENT_CHARACTER_JSON` or `SANDBOX_ROUTE_AGENT_ID`.

## Head-green proof

- `config-bind-mount-persistence.test.ts`: simulates canonical rename `EBUSY`, verifies a 0600 durable overlay, unchanged base mount, restart load, second write, fail-closed dual-write failure, explicit-persist precedence over stale overlays, and include/wallet-key sanitization.
- `sandbox-character.test.ts`: applies the same injected Sol identity to initial and fresh reload configs and verifies the stable route id.
- Focused result: **2 files, 18 tests passed**.
- Biome on all five changed files: clean.
- `git diff --check`: clean.
- Package typecheck reaches only unrelated missing optional workspace declarations in the isolated worktree; the prior exact-head CI typecheck passed and the new exact-head CI run is authoritative.

# Evidence Gate

<!-- evidence-head:505d21ce1cb64a218e866da0447b6d081bf6923a -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend persistence and runtime identity only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no visual surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic filesystem/runtime regressions cover the changed boundaries.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused test output is documented above; no production container was mutated.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend source changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no user domain records changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text changed.

# Known gaps / failures

Physical LP3/container confirmation remains downstream deployment proof. No workflow files changed and no checks were weakened.

