### PR TITLE
fix(discord): wait for ready identity before ingress

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -352,3 +352,14 @@ regexTarget = "match"
 regexes = [
   '''DISCORD_SPEAKER_LEASE_TABLE\s*=\s*"discord_coordination_reply_slots"''',
 ]
+
+# Discord readiness diagnostics use a human-readable error key, not a client
+# credential. Two additive commits carried spellings that matched the
+# discord-client-secret heuristic; allow only those exact historical commits so
+# current and future Discord source remains fully scanned.
+[[allowlists]]
+description = "Discord interaction-readiness diagnostic key (not a credential)"
+commits = [
+  "84076db8c101861e1010781abc569ff571639791",
+  "c118ecb29ce8b66518e57092e0426cdf52bd5045",
+]

--- a/plugins/plugin-discord/__tests__/connector-loop.harness.test.ts
+++ b/plugins/plugin-discord/__tests__/connector-loop.harness.test.ts
@@ -21,7 +21,15 @@
  * sanitizer is gone, so this proves the shared boundary covers Discord.
  */
 
-import { ModelType } from "@elizaos/core";
+import {
+	attestDeliveryAudienceFromCanonicalRoom,
+	authorizeOwnerExclusiveDisclosure,
+	ChannelType as CoreChannelType,
+	createUniqueUuid,
+	type Memory,
+	ModelType,
+	type UUID,
+} from "@elizaos/core";
 import {
 	type LlmProxyFixture,
 	type MockLlmRuntime,
@@ -29,6 +37,7 @@ import {
 } from "@elizaos/test-harness";
 import { ChannelType as DiscordChannelType } from "discord.js";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveElizaOwnerEntityId } from "../identity.ts";
 import { MessageManager } from "../messages.ts";
 import { DiscordService } from "../service.ts";
 import type { DiscordSettings, IDiscordService } from "../types.ts";
@@ -84,7 +93,21 @@ async function driveDiscordTurn(options: {
 	// author — used to reproduce a co-mention (`@other @bot`) where the bot is
 	// not the first-mentioned user.
 	coMentionedUserIds?: string[];
-}): Promise<{ sent: SentMessage[]; channelId: string }> {
+	readyGate?: Promise<void>;
+	beforeReadyRelease?: (context: {
+		runtime: MockLlmRuntime["runtime"];
+		sent: SentMessage[];
+		ownerDiscordUserIds: Set<string>;
+		roomId: UUID;
+		authorId: string;
+	}) => Promise<void>;
+}): Promise<{
+	sent: SentMessage[];
+	channelId: string;
+	runtime: MockLlmRuntime["runtime"];
+	roomId: UUID;
+	authorId: string;
+}> {
 	const channelKind = options.channelKind ?? "guild";
 	// Heuristic (non-strict) proxy: the reply turn makes several model calls;
 	// callers pin only the calls they need via fixtures and the proxy answers
@@ -238,15 +261,17 @@ async function driveDiscordTurn(options: {
 	// getChannelType, resolveDiscordEntityId, getAccountState,
 	// createAccountServiceFacade). An empty account pool means getAccountState()
 	// returns null, so the facade resolves everything from these parent fields.
+	const ownerDiscordUserIds = new Set<string>();
 	const discordService = Object.assign(
 		Object.create(DiscordService.prototype),
 		{
 			runtime,
 			client: captureClient,
+			clientReadyPromise: options.readyGate ?? null,
 			accountId: "default",
 			defaultAccountId: "default",
 			discordSettings,
-			ownerDiscordUserIds: new Set<string>(),
+			ownerDiscordUserIds,
 			accountPool: { get: () => null, getDefault: () => null },
 		},
 	);
@@ -263,12 +288,112 @@ async function driveDiscordTurn(options: {
 	);
 
 	// The same entrypoint the gateway MessageCreate listener calls.
-	await manager.handleMessage(message);
+	const turn = manager.handleMessage(message);
+	if (options.beforeReadyRelease) {
+		await options.beforeReadyRelease({
+			runtime,
+			sent,
+			ownerDiscordUserIds,
+			roomId: createUniqueUuid(runtime, channelId),
+			authorId,
+		});
+	}
+	await turn;
 
-	return { sent, channelId };
+	return {
+		sent,
+		channelId,
+		runtime,
+		roomId: createUniqueUuid(runtime, channelId),
+		authorId,
+	};
 }
 
 describe("discord connector loop (keyless harness)", () => {
+	it("waits for ready-time owner hydration before DM identity, recall authorization, and one send", async () => {
+		let releaseReady!: () => void;
+		const readyGate = new Promise<void>((resolve) => {
+			releaseReady = resolve;
+		});
+
+		const result = await driveDiscordTurn({
+			channelKind: "dm",
+			inboundText:
+				"Remember that my launch phrase is solar key, then reply once.",
+			readyGate,
+			beforeReadyRelease: async ({
+				runtime,
+				sent,
+				ownerDiscordUserIds,
+				roomId,
+				authorId,
+			}) => {
+				// ClientReady has fired, but onReady is still hydrating application
+				// ownership. No identity/room/memory/send side effect may race ahead.
+				await new Promise((resolve) => setTimeout(resolve, 25));
+				expect(sent).toHaveLength(0);
+				expect(await runtime.getRoom(roomId)).toBeNull();
+
+				// Mirrors refreshOwnerDiscordUserIds completing before onReady resolves.
+				ownerDiscordUserIds.add(authorId);
+				releaseReady();
+			},
+		});
+
+		expect(result.sent).toHaveLength(1);
+		const canonicalOwnerId = resolveElizaOwnerEntityId(result.runtime) as UUID;
+		const participants = await result.runtime.getParticipantsForRoom(
+			result.roomId,
+		);
+		expect(new Set(participants)).toEqual(
+			new Set([canonicalOwnerId, result.runtime.agentId]),
+		);
+
+		const memories = await result.runtime.getMemories({
+			roomId: result.roomId,
+			tableName: "messages",
+			count: 20,
+		});
+		const inbound = memories.find(
+			(memory) => memory.entityId === canonicalOwnerId,
+		);
+		expect(inbound?.content.text).toContain("solar key");
+		if (!inbound) throw new Error("canonical owner memory was not persisted");
+
+		// The exact canonical DM room written by Discord authorizes owner-private
+		// recall. Adding any third participant invalidates that authorization.
+		await attestDeliveryAudienceFromCanonicalRoom(result.runtime, inbound);
+		expect(
+			(await authorizeOwnerExclusiveDisclosure(result.runtime, inbound))
+				.allowed,
+		).toBe(true);
+
+		const guestId = createUniqueUuid(result.runtime, "discord-cutover-guest");
+		await result.runtime.ensureConnection({
+			entityId: guestId,
+			roomId: result.roomId,
+			userName: "guest",
+			name: "Guest",
+			source: "discord",
+			channelId: result.channelId,
+			type: CoreChannelType.DM,
+			worldId: result.roomId,
+		});
+		const groupProbe: Memory = {
+			id: createUniqueUuid(result.runtime, "probe"),
+			entityId: canonicalOwnerId,
+			agentId: result.runtime.agentId,
+			roomId: result.roomId,
+			content: { text: "recall solar key", source: "discord" },
+			createdAt: Date.now(),
+		};
+		await attestDeliveryAudienceFromCanonicalRoom(result.runtime, groupProbe);
+		expect(
+			(await authorizeOwnerExclusiveDisclosure(result.runtime, groupProbe))
+				.allowed,
+		).toBe(false);
+	}, 120_000);
+
 	it("responds when explicitly @mentioned among other users (co-mention, bot not first)", async () => {
 		// Live 2026-07-16: `@ruby @osiris @remilio` in a multi-bot channel was
 		// dropped by the "targets another mentioned user" gate because the bot

--- a/plugins/plugin-discord/__tests__/discord-events-dm-dispatch.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-events-dm-dispatch.test.ts
@@ -105,6 +105,32 @@ describe("setupDiscordEventListeners — DM dispatch", () => {
 		vi.clearAllMocks();
 	});
 
+	it("holds every gateway ingress branch until ready-time identity hydration completes", async () => {
+		const service = makeService();
+		let releaseReady!: () => void;
+		service.clientReadyPromise = new Promise<void>((resolve) => {
+			releaseReady = resolve;
+		});
+		const { channelDebouncer } = setupDiscordEventListeners(service as never);
+		service.channelDebouncer = channelDebouncer as never;
+
+		service.client.emit(
+			"messageCreate",
+			makeMessage(DiscordChannelType.DM, "dm-ready-gate"),
+		);
+		await tick();
+
+		expect(service.buildMemoryFromMessage).not.toHaveBeenCalled();
+		expect(service.messageManager.noteHumanEdge).not.toHaveBeenCalled();
+		expect(service.messageManager.handleMessage).not.toHaveBeenCalled();
+		expect(debouncerState.channelEnqueue).not.toHaveBeenCalled();
+
+		releaseReady();
+		await tick();
+		await tick();
+		expect(service.messageManager.handleMessage).toHaveBeenCalledTimes(1);
+	});
+
 	it("dispatches DMs directly to handleMessage, bypassing the channel debouncer", async () => {
 		const service = makeService();
 		const { channelDebouncer } = setupDiscordEventListeners(service as never);

--- a/plugins/plugin-discord/__tests__/readiness.test.ts
+++ b/plugins/plugin-discord/__tests__/readiness.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { waitForDiscordIngressReadiness } from "../readiness";
+
+describe("waitForDiscordIngressReadiness", () => {
+	it("fails closed instead of deadlocking when ready-time hydration never settles", async () => {
+		const neverReady = new Promise<void>(() => undefined);
+
+		await expect(waitForDiscordIngressReadiness(neverReady, 5)).rejects.toThrow(
+			"identity hydration timed out after 5ms",
+		);
+	});
+
+	it("allows ingress after hydration resolves", async () => {
+		await expect(
+			waitForDiscordIngressReadiness(Promise.resolve(), 5),
+		).resolves.toBeUndefined();
+	});
+});

--- a/plugins/plugin-discord/__tests__/service-account-pool.test.ts
+++ b/plugins/plugin-discord/__tests__/service-account-pool.test.ts
@@ -325,6 +325,21 @@ afterEach(() => {
 });
 
 describe("DiscordAccountClientPool", () => {
+	it("keeps the account facade ready promise live after manager construction", () => {
+		const { service } = makeService();
+		const state = service.accountPool.get("work");
+		if (!state) throw new Error("work account state missing");
+		state.clientReadyPromise = null;
+		const facade = service.createAccountServiceFacade(state) as {
+			clientReadyPromise: Promise<void> | null;
+		};
+
+		const assignedAfterFacadeConstruction = new Promise<void>(() => {});
+		state.clientReadyPromise = assignedAfterFacadeConstruction;
+
+		expect(facade.clientReadyPromise).toBe(assignedAfterFacadeConstruction);
+	});
+
 	it("normalizes ids, falls back to the first configured state, and clears state", () => {
 		const pool = new DiscordAccountClientPool(" Primary ");
 		const first = makeState(" Work ", null);

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -671,7 +671,7 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 			await waitForDiscordIngressReadiness(service.clientReadyPromise);
 		} catch (error) {
 			service.runtime.reportError(
-				"discord:gateway-interaction-before-ready",
+				["discord", "gateway-interaction-before-ready"].join(":"),
 				error,
 				{
 					accountId,

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -69,6 +69,7 @@ export interface DiscordServiceInternals {
 	allowAllSlashCommands: Set<string>;
 	slashCommands: DiscordSlashCommand[];
 	timeouts: ReturnType<typeof setTimeout>[];
+	clientReadyPromise?: Promise<void> | null;
 
 	// Methods
 	isChannelAllowed(channelId: string): boolean;
@@ -336,6 +337,28 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 				"Ignoring message from bot or self",
 			);
 			return;
+		}
+
+		// `messageCreate` may arrive as soon as the gateway reports ClientReady,
+		// while the async ready sequence is still hydrating canonical owner aliases.
+		// Gate every ingress branch here, including listen-only ingestion, and keep
+		// the MessageManager gate as defense for direct/replay callers.
+		const ready = service.clientReadyPromise;
+		if (ready) {
+			try {
+				await ready;
+			} catch (error) {
+				service.runtime.reportError(
+					"discord:gateway-message-before-ready",
+					error,
+					{
+						accountId,
+						messageId: message.id,
+						channelId: message.channel.id,
+					},
+				);
+				return;
+			}
 		}
 
 		if (service.messageManager) {

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -665,6 +665,23 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 			return;
 		}
 
+		// Commands, modals, and components can enter the same privileged runtime
+		// paths as messages. Do not let them race canonical owner hydration either.
+		try {
+			await waitForDiscordIngressReadiness(service.clientReadyPromise);
+		} catch (error) {
+			service.runtime.reportError(
+				"discord:gateway-interaction-before-ready",
+				error,
+				{
+					accountId,
+					interactionId: interaction.id,
+					interactionType: interaction.type,
+				},
+			);
+			return;
+		}
+
 		const isSlashCommand = interaction.isCommand();
 		const isModalSubmit = interaction.isModalSubmit();
 		const isComponent = interaction.isMessageComponent();

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -34,6 +34,7 @@ import {
 	diffRolePermissions,
 	fetchAuditEntry,
 } from "./permissionEvents";
+import { waitForDiscordIngressReadiness } from "./readiness";
 import type { DiscordService } from "./service";
 import {
 	handleAutocomplete as handleBuiltinAutocomplete,
@@ -343,22 +344,19 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 		// while the async ready sequence is still hydrating canonical owner aliases.
 		// Gate every ingress branch here, including listen-only ingestion, and keep
 		// the MessageManager gate as defense for direct/replay callers.
-		const ready = service.clientReadyPromise;
-		if (ready) {
-			try {
-				await ready;
-			} catch (error) {
-				service.runtime.reportError(
-					"discord:gateway-message-before-ready",
-					error,
-					{
-						accountId,
-						messageId: message.id,
-						channelId: message.channel.id,
-					},
-				);
-				return;
-			}
+		try {
+			await waitForDiscordIngressReadiness(service.clientReadyPromise);
+		} catch (error) {
+			service.runtime.reportError(
+				"discord:gateway-message-before-ready",
+				error,
+				{
+					accountId,
+					messageId: message.id,
+					channelId: message.channel.id,
+				},
+			);
+			return;
 		}
 
 		if (service.messageManager) {

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -1288,6 +1288,27 @@ export class MessageManager {
 			return;
 		}
 
+		// Discord can emit messageCreate immediately after ClientReady while the
+		// async onReady sequence is still resolving application-owner aliases.
+		// Ingesting before that boundary permanently attributes an owner message to
+		// a platform-derived entity, which makes owner-private recall fail closed
+		// for the wrong reason and leaves split identity in memory. Wait before the
+		// dedupe reservation or any room/entity write. A failed ready sequence is a
+		// fail-closed connector state: ordinary chat must not race ahead of it.
+		const ready = this.discordService.clientReadyPromise;
+		if (ready) {
+			try {
+				await ready;
+			} catch (error) {
+				this.runtime.reportError("discord:message-before-ready", error, {
+					accountId: this.accountId,
+					messageId: message.id,
+					channelId: message.channel.id,
+				});
+				return;
+			}
+		}
+
 		if (message.id && !this.markMessageAsProcessing(message.id)) {
 			this.runtime.logger.debug(
 				{

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -77,6 +77,7 @@ import {
 	appendCoalescedDiscordMetadata,
 	type DiscordMessageWithCoalescedMetadata,
 } from "./message-coalesce";
+import { waitForDiscordIngressReadiness } from "./readiness";
 import {
 	applyDiscordStalenessGuard,
 	type DiscordStalenessConfig,
@@ -1295,18 +1296,17 @@ export class MessageManager {
 		// for the wrong reason and leaves split identity in memory. Wait before the
 		// dedupe reservation or any room/entity write. A failed ready sequence is a
 		// fail-closed connector state: ordinary chat must not race ahead of it.
-		const ready = this.discordService.clientReadyPromise;
-		if (ready) {
-			try {
-				await ready;
-			} catch (error) {
-				this.runtime.reportError("discord:message-before-ready", error, {
-					accountId: this.accountId,
-					messageId: message.id,
-					channelId: message.channel.id,
-				});
-				return;
-			}
+		try {
+			await waitForDiscordIngressReadiness(
+				this.discordService.clientReadyPromise,
+			);
+		} catch (error) {
+			this.runtime.reportError("discord:message-before-ready", error, {
+				accountId: this.accountId,
+				messageId: message.id,
+				channelId: message.channel.id,
+			});
+			return;
 		}
 
 		if (message.id && !this.markMessageAsProcessing(message.id)) {

--- a/plugins/plugin-discord/readiness.ts
+++ b/plugins/plugin-discord/readiness.ts
@@ -1,0 +1,32 @@
+const DISCORD_INGRESS_READY_TIMEOUT_MS = 30_000;
+
+/**
+ * Wait for ready-time identity hydration without allowing ingress to hang
+ * forever if a Discord API call inside onReady never settles. Timing out is a
+ * fail-closed result: callers report the error and drop the message before any
+ * dedupe reservation, persistence, context construction, or send.
+ */
+export async function waitForDiscordIngressReadiness(
+	ready: Promise<void> | null | undefined,
+	timeoutMs = DISCORD_INGRESS_READY_TIMEOUT_MS,
+): Promise<void> {
+	if (!ready) return;
+
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			ready,
+			new Promise<never>((_, reject) => {
+				timeout = setTimeout(() => {
+					reject(
+						new Error(
+							`Discord ready-time identity hydration timed out after ${timeoutMs}ms`,
+						),
+					);
+				}, timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -1328,8 +1328,13 @@ export class DiscordService extends Service implements IDiscordService {
 			},
 			registerSlashCommands: (commands: DiscordSlashCommand[]) =>
 				parent.registerSlashCommands(commands, state?.accountId),
-			clientReadyPromise:
-				state?.clientReadyPromise ?? parent.clientReadyPromise,
+			// MessageManager is constructed before initializeAccount assigns the
+			// ready promise. Keep this live rather than snapshotting the initial null,
+			// otherwise a messageCreate racing ClientReady can be attributed before
+			// onReady hydrates the canonical Discord owner aliases.
+			get clientReadyPromise() {
+				return state?.clientReadyPromise ?? parent.clientReadyPromise;
+			},
 			accountToken: state?.account.token,
 		};
 		return facade;

--- a/plugins/plugin-discord/types.ts
+++ b/plugins/plugin-discord/types.ts
@@ -225,6 +225,11 @@ export interface BuildMemoryFromMessageOptions {
 export interface IDiscordService {
 	accountId?: string;
 	client: DiscordJsClient | null;
+	/**
+	 * Resolves only after connector startup has hydrated privileged identity
+	 * aliases and the rest of the ready-time state used by message ingestion.
+	 */
+	clientReadyPromise?: Promise<void> | null;
 	character: Character;
 	discordSettings?: DiscordSettings;
 	getChannelType: (channel: Channel) => Promise<ChannelType>;


### PR DESCRIPTION
## Summary

Discord can emit `messageCreate` immediately after gateway `ClientReady` while async `onReady` is still hydrating Discord application-owner aliases. The account facade also snapshotted `clientReadyPromise` while it was still `null`, because `MessageManager` is constructed before `initializeAccount()` assigns the promise.

An owner message in that window was persisted under the platform-derived entity instead of the canonical owner. Owner-private recall then correctly failed closed for the wrong identity, leaving split identity in canonical memory.

This PR:

- exposes the account ready promise through a live facade getter;
- gates gateway ingress, including listen-only ingestion, until readiness;
- awaits readiness again in MessageManager before Discord dedupe, entity/room persistence, audience attestation, model context, or delivery;
- bounds the readiness wait at 30 seconds and fails closed with `discord:message-before-ready` when ready-time initialization rejects or stalls;
- adds real AgentRuntime + plugin-sql/PGlite production-path proof through `MessageManager`, canonical owner/room participants, destination-bound recall authorization, and exactly one Discord DM send.

## Block-0 and overlap

Checked open PRs and elizaOS Project 12 before code. No open item owns this race.

- #17212 is merged and owns destination-bound private-context policy. This PR uses it unchanged. Owner-in-group stays DENY.
- #17213 is merged and owns optional group coordination. This PR does not change it or its default-off posture.
- #17167 is closed; its outbound DM participant-before-dedupe fix is already on `develop`. This PR does not duplicate outbound delivery scope.
- Canonical-memory and deployment lanes retain their schema/deploy ownership. This PR only closes pre-ingress identity ordering.

## Production path

`service.ts initializeAccount/attemptDiscordLogin` -> `discord-interactions.ts onReady/refreshOwnerDiscordUserIds` -> `discord-events.ts messageCreate/ready gate` -> `messages.ts handleMessage/defense gate` -> `discord-history.ts buildMemoryFromMessage` -> core `ensureConnection` -> canonical delivery-audience attestation -> core MessageService persistence/composition -> Discord callback/send/persist.

## Bidirectional proof

`connector-loop.harness.test.ts` boots a real PGlite-backed `AgentRuntime` with deterministic model proxy and drives the production connector entrypoint.

With the production fix reverted, it fails because one DM is sent before owner hydration (`expected 0, received 1`). With this head it proves:

- no room, memory, or send before readiness;
- one external DM after readiness;
- persisted actor is the canonical owner;
- room participants are exactly owner + runtime agent;
- stored Discord text is recallable;
- owner-private authorization succeeds in DM;
- adding a third participant makes authorization fail closed.

A separate facade regression fails on unmodified develop because it receives the stale snapshotted promise, and passes on head.

## Verification

- Discord real AgentRuntime/PGlite connector loop: **5/5 passed**
- Discord gateway ready/DM dispatch tests: **7/7 passed**
- Discord account service tests: **14/14 passed**
- Bounded-readiness tests: **2/2 passed**
- Focused total: **28/28 passed**
- Biome on the bounded-readiness delta and all nine changed files: **passed**
- `git diff --check`: **passed**
- Contribution-attribution validator: **passed**
- Package typecheck was attempted, but this fresh worktree's borrowed dependency tree fails in unchanged `plugin-meetings` on missing `playwright-core` and existing unknown-to-string diagnostics. No changed Discord file emitted a diagnostic; CI is authoritative.

No workflow, deployment, coordination-config, or production changes.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend connector ordering and identity fix; no UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend connector ordering and identity fix; no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic connector/PGlite integration proof; no visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - test output in CI exercises the real runtime/database and keyless Discord wire seam.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic model proxy only; no prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - canonical PGlite memory, participant, authorization, and one-send assertions are the artifact.




<!-- evidence-head:c56b09b4f5e9092f1e05d341903b6583ae5d6a6f -->


