### PR TITLE
fix(lifeops): bind scheduled chat delivery

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
@@ -49,6 +49,10 @@ import {
 import { messageText } from "../lifeops/google/format-helpers.js";
 import { resolvePendingPromptsStore } from "../lifeops/pending-prompts/store.js";
 import { LifeOpsRepository } from "../lifeops/repository.js";
+import {
+  bindScheduledTaskToInboundChat,
+  SCHEDULED_TASK_DELIVERY_BINDING_KEY,
+} from "../lifeops/scheduled-task/delivery-binding.js";
 import type {
   ScheduledTask,
   ScheduledTaskFilter,
@@ -1107,6 +1111,7 @@ async function handleGet(
 async function handleCreate(
   scope: RunnerScope,
   params: ScheduledTaskParams,
+  message: Memory,
 ): Promise<ActionResult> {
   const promptInstructions =
     typeof params.promptInstructions === "string"
@@ -1206,11 +1211,26 @@ async function handleCreate(
       },
     };
   }
-  const output = normalizeOutputInput(scope, params.output);
+  const chatDeliveryBinding = await bindScheduledTaskToInboundChat(
+    scope.runtime,
+    message,
+  );
+  // A verified connector DM is bound to its canonical external channel. The
+  // model cannot redirect a future reminder by inventing output.target. Other
+  // turn kinds retain the in-app/default normalization above.
+  const output = chatDeliveryBinding
+    ? {
+        destination: "channel" as const,
+        target: `${chatDeliveryBinding.source}:${chatDeliveryBinding.channelId}`,
+      }
+    : normalizeOutputInput(scope, params.output);
   const completionCheck = normalizeCompletionCheckInput(params.completionCheck);
   const metadata = {
     ...(params.metadata ?? {}),
     ...(requestedTaskId ? { plannerTaskId: requestedTaskId } : {}),
+    ...(chatDeliveryBinding
+      ? { [SCHEDULED_TASK_DELIVERY_BINDING_KEY]: chatDeliveryBinding }
+      : {}),
     ...(scope.roomId && params.completionCheck
       ? { pendingPromptRoomId: scope.roomId }
       : {}),
@@ -1938,7 +1958,7 @@ export const scheduledTaskAction: Action & {
         result = await handleGet(scope, params);
         break;
       case "create":
-        result = await handleCreate(scope, params);
+        result = await handleCreate(scope, params, message);
         break;
       case "update":
         result = await handleUpdate(scope, params);

--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
@@ -51,6 +51,7 @@ import { resolvePendingPromptsStore } from "../lifeops/pending-prompts/store.js"
 import { LifeOpsRepository } from "../lifeops/repository.js";
 import {
   bindScheduledTaskToInboundChat,
+  readScheduledTaskChatDeliveryBinding,
   SCHEDULED_TASK_DELIVERY_BINDING_KEY,
 } from "../lifeops/scheduled-task/delivery-binding.js";
 import type {
@@ -1157,6 +1158,41 @@ async function handleCreate(
     normalizeSubjectKind(params.subjectKind),
     params.subjectId,
   );
+  // Capture the server-attested destination BEFORE duplicate resolution. A
+  // schedule is not equivalent across connector accounts/rooms: collapsing
+  // two identical reminder texts before reading their bindings silently sends
+  // only the first room's copy.
+  const chatDeliveryBinding = await bindScheduledTaskToInboundChat(
+    scope.runtime,
+    message,
+  );
+  const sameDeliveryBinding = (candidate: ScheduledTask): boolean => {
+    const candidateBinding = readScheduledTaskChatDeliveryBinding(
+      candidate.metadata,
+    );
+    if (!chatDeliveryBinding) {
+      return !Object.hasOwn(
+        candidate.metadata ?? {},
+        SCHEDULED_TASK_DELIVERY_BINDING_KEY,
+      );
+    }
+    return (
+      candidateBinding?.source === chatDeliveryBinding.source &&
+      candidateBinding.roomId === chatDeliveryBinding.roomId &&
+      candidateBinding.channelId === chatDeliveryBinding.channelId &&
+      candidateBinding.accountId === chatDeliveryBinding.accountId
+    );
+  };
+  // Scope planner idempotency to the canonical delivery binding. The runner's
+  // idempotency index is global to the agent, so leaving a model-supplied key
+  // unscoped can alias otherwise-distinct reminders created in two DMs.
+  const requestedIdempotencyKey = params.idempotencyKey?.trim() || undefined;
+  const effectiveIdempotencyKey = requestedIdempotencyKey
+    ? chatDeliveryBinding
+      ? `${requestedIdempotencyKey}:${chatDeliveryBinding.source}:${chatDeliveryBinding.accountId ?? "default"}:${chatDeliveryBinding.roomId}`
+      : requestedIdempotencyKey
+    : undefined;
+
   // Content-level duplicate guard. `idempotencyKey` already dedupes exact
   // retries, but a planner re-asked across turns tends to mint a NEW key for
   // the same intent (observed live: two identical brush-teeth cron reminders
@@ -1179,22 +1215,22 @@ async function handleCreate(
   );
   const normalizedInstructions = promptInstructions.toLowerCase();
   const triggerKey = stableTriggerKey(trigger);
-  const idempotencyDuplicate =
-    typeof params.idempotencyKey === "string" &&
-    params.idempotencyKey.trim().length > 0
-      ? allTasks.find(
-          (candidate) =>
-            candidate.idempotencyKey === params.idempotencyKey?.trim(),
-        )
-      : undefined;
+  const idempotencyDuplicate = effectiveIdempotencyKey
+    ? allTasks.find(
+        (candidate) =>
+          candidate.idempotencyKey === effectiveIdempotencyKey &&
+          sameDeliveryBinding(candidate),
+      )
+    : undefined;
   const contentDuplicate = activeSiblings.find(
     (candidate) =>
-      (candidate.promptInstructions.trim().toLowerCase() ===
+      sameDeliveryBinding(candidate) &&
+      ((candidate.promptInstructions.trim().toLowerCase() ===
         normalizedInstructions &&
         stableTriggerKey(candidate.trigger) === triggerKey) ||
-      (requestedTaskId !== undefined &&
-        (candidate.taskId === requestedTaskId ||
-          candidate.metadata?.plannerTaskId === requestedTaskId)),
+        (requestedTaskId !== undefined &&
+          (candidate.taskId === requestedTaskId ||
+            candidate.metadata?.plannerTaskId === requestedTaskId))),
   );
   const duplicate = idempotencyDuplicate ?? contentDuplicate;
   if (duplicate) {
@@ -1211,10 +1247,6 @@ async function handleCreate(
       },
     };
   }
-  const chatDeliveryBinding = await bindScheduledTaskToInboundChat(
-    scope.runtime,
-    message,
-  );
   // A verified connector DM is bound to its canonical external channel. The
   // model cannot redirect a future reminder by inventing output.target. Other
   // turn kinds retain the in-app/default normalization above.
@@ -1255,8 +1287,8 @@ async function handleCreate(
       ...(output ? { output } : {}),
       ...(nonEmptyRecord(params.pipeline) ? { pipeline: params.pipeline } : {}),
       ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
-      ...(params.idempotencyKey
-        ? { idempotencyKey: params.idempotencyKey }
+      ...(effectiveIdempotencyKey
+        ? { idempotencyKey: effectiveIdempotencyKey }
         : {}),
       respectsGlobalPause: params.respectsGlobalPause ?? true,
       source: params.source ?? "user_chat",
@@ -1339,7 +1371,24 @@ async function handleUpdate(
       data: { subaction: "update", task: existing, unchanged: true },
     };
   }
-  const updated = await scope.runner.apply(taskId, "edit", params.patch);
+  const existingBinding = readScheduledTaskChatDeliveryBinding(
+    existing.metadata,
+  );
+  // Delivery identity is server-attested state, never model-editable state.
+  // Preserve both the canonical output and binding while still allowing the
+  // owner to reschedule or rewrite the reminder itself.
+  const safePatch = existingBinding
+    ? {
+        ...params.patch,
+        output: existing.output,
+        metadata: {
+          ...(existing.metadata ?? {}),
+          ...(params.patch.metadata ?? {}),
+          [SCHEDULED_TASK_DELIVERY_BINDING_KEY]: existingBinding,
+        },
+      }
+    : params.patch;
+  const updated = await scope.runner.apply(taskId, "edit", safePatch);
   return {
     success: true,
     text: "Updated that scheduled item.",

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
@@ -1,0 +1,180 @@
+import {
+  evaluateOwnerExclusiveDisclosure,
+  getTrustedDeliveryAudience,
+  type IAgentRuntime,
+  type Memory,
+} from "@elizaos/core";
+import type { ScheduledTaskDispatchRecord } from "./index.js";
+
+export const SCHEDULED_TASK_DELIVERY_BINDING_KEY = "chatDeliveryBinding";
+
+export interface ScheduledTaskChatDeliveryBinding {
+  version: 1;
+  source: string;
+  roomId: string;
+  channelId: string;
+  accountId?: string;
+  audience: {
+    kind: "direct" | "voice_private";
+    provenance: "canonical_room";
+    ownerEntityId: string;
+    agentEntityId: string;
+    participantEntityIds: string[];
+    membershipVersion: string;
+  };
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function canonicalParticipants(values: readonly string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort((a, b) =>
+    a.localeCompare(b),
+  );
+}
+
+function membershipVersion(values: readonly string[]): string {
+  return canonicalParticipants(values).join("\u0000");
+}
+
+/**
+ * Capture the connector destination from server-attested canonical room state.
+ * Model parameters and message metadata are deliberately not consulted for the
+ * destination. Unattested/internal/API turns keep the existing in-app path.
+ */
+export async function bindScheduledTaskToInboundChat(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<ScheduledTaskChatDeliveryBinding | null> {
+  const decision = evaluateOwnerExclusiveDisclosure(message);
+  const audience = getTrustedDeliveryAudience(message);
+  if (
+    !decision.allowed ||
+    decision.basis !== "owner_private_destination" ||
+    !audience ||
+    audience.provenance !== "canonical_room" ||
+    (audience.kind !== "direct" && audience.kind !== "voice_private") ||
+    !audience.canonicalOwnerEntityId
+  ) {
+    return null;
+  }
+
+  const room = await runtime.getRoom(message.roomId);
+  const source = stringField(room?.source);
+  const channelId = stringField(room?.channelId);
+  if (!room || !source || !channelId || room.id !== audience.roomId) {
+    return null;
+  }
+
+  const roomMetadata =
+    room.metadata && typeof room.metadata === "object"
+      ? (room.metadata as Record<string, unknown>)
+      : undefined;
+  const accountId = stringField(roomMetadata?.accountId);
+  return {
+    version: 1,
+    source,
+    roomId: room.id,
+    channelId,
+    ...(accountId ? { accountId } : {}),
+    audience: {
+      kind: audience.kind,
+      provenance: "canonical_room",
+      ownerEntityId: audience.canonicalOwnerEntityId,
+      agentEntityId: audience.agentEntityId,
+      participantEntityIds: [...audience.participantEntityIds],
+      membershipVersion: audience.membershipVersion,
+    },
+  };
+}
+
+function hasScheduledTaskChatDeliveryBinding(
+  metadata: ScheduledTaskDispatchRecord["metadata"],
+): boolean {
+  return Boolean(
+    metadata && Object.hasOwn(metadata, SCHEDULED_TASK_DELIVERY_BINDING_KEY),
+  );
+}
+
+export function readScheduledTaskChatDeliveryBinding(
+  metadata: ScheduledTaskDispatchRecord["metadata"],
+): ScheduledTaskChatDeliveryBinding | null {
+  const value = metadata?.[SCHEDULED_TASK_DELIVERY_BINDING_KEY];
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const binding = value as Partial<ScheduledTaskChatDeliveryBinding>;
+  const audience = binding.audience;
+  if (
+    binding.version !== 1 ||
+    !stringField(binding.source) ||
+    !stringField(binding.roomId) ||
+    !stringField(binding.channelId) ||
+    !audience ||
+    audience.provenance !== "canonical_room" ||
+    (audience.kind !== "direct" && audience.kind !== "voice_private") ||
+    !stringField(audience.ownerEntityId) ||
+    !stringField(audience.agentEntityId) ||
+    !Array.isArray(audience.participantEntityIds) ||
+    !stringField(audience.membershipVersion)
+  ) {
+    return null;
+  }
+  return binding as ScheduledTaskChatDeliveryBinding;
+}
+
+/** Re-read canonical room state immediately before visible connector egress. */
+export async function revalidateScheduledTaskChatDeliveryBinding(
+  runtime: IAgentRuntime,
+  record: ScheduledTaskDispatchRecord,
+): Promise<
+  | { ok: true; binding: ScheduledTaskChatDeliveryBinding }
+  | { ok: false; reason: string }
+  | null
+> {
+  const binding = readScheduledTaskChatDeliveryBinding(record.metadata);
+  if (!binding) {
+    return hasScheduledTaskChatDeliveryBinding(record.metadata)
+      ? { ok: false, reason: "delivery_binding_invalid" }
+      : null;
+  }
+  if (
+    record.channelKey !== binding.source ||
+    record.output?.destination !== "channel" ||
+    record.output.target !== `${binding.source}:${binding.channelId}`
+  ) {
+    return { ok: false, reason: "delivery_channel_changed" };
+  }
+  try {
+    const [room, participants] = await Promise.all([
+      runtime.getRoom(binding.roomId as never),
+      runtime.getParticipantsForRoom(binding.roomId as never),
+    ]);
+    const current = canonicalParticipants(participants);
+    const expected = canonicalParticipants(
+      binding.audience.participantEntityIds,
+    );
+    if (
+      !room ||
+      room.source !== binding.source ||
+      room.channelId !== binding.channelId ||
+      binding.audience.agentEntityId !== runtime.agentId ||
+      current.length !== expected.length ||
+      current.some((value, index) => value !== expected[index]) ||
+      membershipVersion(current) !== binding.audience.membershipVersion ||
+      current.length !== 2 ||
+      !current.includes(binding.audience.ownerEntityId) ||
+      !current.includes(binding.audience.agentEntityId)
+    ) {
+      return { ok: false, reason: "delivery_audience_changed" };
+    }
+    return { ok: true, binding };
+  } catch (error) {
+    runtime.reportError("lifeops:scheduled-task:delivery-binding", error, {
+      taskId: record.taskId,
+      roomId: binding.roomId,
+    });
+    return { ok: false, reason: "delivery_audience_lookup_failed" };
+  }
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
@@ -155,10 +155,16 @@ export async function revalidateScheduledTaskChatDeliveryBinding(
     const expected = canonicalParticipants(
       binding.audience.participantEntityIds,
     );
+    const roomMetadata =
+      room?.metadata && typeof room.metadata === "object"
+        ? (room.metadata as Record<string, unknown>)
+        : undefined;
+    const currentAccountId = stringField(roomMetadata?.accountId);
     if (
       !room ||
       room.source !== binding.source ||
       room.channelId !== binding.channelId ||
+      currentAccountId !== binding.accountId ||
       binding.audience.agentEntityId !== runtime.agentId ||
       current.length !== expected.length ||
       current.some((value, index) => value !== expected[index]) ||

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -18,7 +18,12 @@ import {
   resolveOwnerEntityId,
 } from "@elizaos/agent";
 import { getHostExecutionCapabilities } from "@elizaos/app-core/services/task-host-capabilities";
-import { type IAgentRuntime, logger, ServiceType } from "@elizaos/core";
+import {
+  type IAgentRuntime,
+  inspectSendHandlerResult,
+  logger,
+  ServiceType,
+} from "@elizaos/core";
 import type {
   ActivitySignalBusView,
   GlobalPauseView,
@@ -458,6 +463,12 @@ function applyDispatchPolicy(result: DispatchResult): DispatchResult {
 
 export function createProductionScheduledTaskDispatcher(opts: {
   runtime: IAgentRuntime;
+  /** Test seam; production persists through LifeOpsRepository. */
+  persistDispatchAttempt?: (
+    record: ScheduledTaskDispatchRecord,
+    message: string,
+    idempotencyKey: string,
+  ) => Promise<void>;
 }): ScheduledTaskDispatcher {
   return {
     async dispatch(
@@ -523,11 +534,14 @@ export function createProductionScheduledTaskDispatcher(opts: {
       // raw-instruction fallback, because delivering instruction-voice text
       // verbatim to the owner was the bug this step exists to fix.
       let message: string;
+      const preparedMessage = record.metadata?.dispatchPreparedMessage;
       try {
-        message = await composeOwnerFacingScheduledTaskText(
-          opts.runtime,
-          record,
-        );
+        message =
+          deliveryBindingDecision?.ok &&
+          typeof preparedMessage === "string" &&
+          preparedMessage.trim().length > 0
+            ? preparedMessage
+            : await composeOwnerFacingScheduledTaskText(opts.runtime, record);
       } catch (error) {
         // error-policy:J1 boundary translation — dispatch outcomes are the
         // runner's typed contract; the failure also reaches RECENT_ERRORS and
@@ -538,6 +552,57 @@ export function createProductionScheduledTaskDispatcher(opts: {
           { taskId: record.taskId, channelKey: record.channelKey },
         );
         return renderFailureDispatchResult(error);
+      }
+
+      if (deliveryBindingDecision?.ok && preparedMessage !== message) {
+        // Persist the exact rendered payload BEFORE provider egress. Recovery
+        // must replay byte-for-byte content because connector-level durable
+        // dedupe includes message text; rerendering after a crash could produce
+        // different prose and defeat exactly-once delivery.
+        const existingDispatchKey = record.metadata?.dispatchIdempotencyKey;
+        const dispatchIdempotencyKey =
+          typeof existingDispatchKey === "string" &&
+          existingDispatchKey.trim().length > 0
+            ? existingDispatchKey.trim()
+            : `${record.taskId}:${record.firedAtIso}`;
+        if (opts.persistDispatchAttempt) {
+          await opts.persistDispatchAttempt(
+            record,
+            message,
+            dispatchIdempotencyKey,
+          );
+        } else {
+          const repository = new LifeOpsRepository(opts.runtime);
+          const current = await repository.getScheduledTask(
+            opts.runtime.agentId,
+            record.taskId,
+          );
+          if (!current) {
+            return applyDispatchPolicy({
+              ok: false,
+              reason: "transport_error",
+              acceptance: "not_accepted",
+              userActionable: false,
+              message:
+                "Scheduled task disappeared before dispatch preparation.",
+            });
+          }
+          const attemptMetadata = {
+            dispatchPreparedMessage: message,
+            dispatchIdempotencyKey,
+            dispatchAttempt: {
+              status: "prepared",
+              preparedAtIso: new Date().toISOString(),
+              firedAtIso: record.firedAtIso,
+            },
+          };
+          current.metadata = {
+            ...(current.metadata ?? {}),
+            ...attemptMetadata,
+          };
+          await repository.upsertScheduledTask(opts.runtime.agentId, current);
+          if (record.metadata) Object.assign(record.metadata, attemptMetadata);
+        }
       }
 
       if (!channel?.send) {
@@ -712,7 +777,113 @@ export function createProductionScheduledTaskDispatcher(opts: {
         }
       }
 
-      const result = await channel.send(payload);
+      let result: DispatchResult;
+      const persistedDispatchKey = record.metadata?.dispatchIdempotencyKey;
+      const dispatchIdempotencyKey =
+        typeof persistedDispatchKey === "string" &&
+        persistedDispatchKey.trim().length > 0
+          ? persistedDispatchKey.trim()
+          : `${record.taskId}:${record.firedAtIso}`;
+      if (chatDeliveryBinding) {
+        // Bound chat delivery must use the runtime's account-aware connector
+        // transport, not the legacy LifeOps mixin (which selects an implicit
+        // owner/default account). The connector transport also returns the
+        // provider receipt used by its durable duplicate-suppression path.
+        try {
+          const disposition = inspectSendHandlerResult(
+            await opts.runtime.sendMessageToTarget(
+              {
+                source: chatDeliveryBinding.source,
+                accountId: chatDeliveryBinding.accountId,
+                channelId: chatDeliveryBinding.channelId,
+                roomId: chatDeliveryBinding.roomId as never,
+              },
+              {
+                text: message,
+                agentVoiced: true,
+                metadata: {
+                  taskId: record.taskId,
+                  firedAtIso: record.firedAtIso,
+                  accountId: chatDeliveryBinding.accountId,
+                  scheduledDispatchKey: dispatchIdempotencyKey,
+                },
+              },
+            ),
+          );
+          if (disposition.kind === "delivered") {
+            const providerMessageId = disposition.providerMessageId;
+            result = {
+              ok: true,
+              ...(providerMessageId ? { messageId: providerMessageId } : {}),
+              ...(providerMessageId
+                ? {
+                    receipt: {
+                      provider: chatDeliveryBinding.source,
+                      providerMessageId,
+                      idempotencyKey: dispatchIdempotencyKey,
+                      acceptedAt: new Date(
+                        disposition.receipt?.acceptedAt ?? Date.now(),
+                      ).toISOString(),
+                      metadata: {
+                        replayed: disposition.replayed,
+                        accountId: chatDeliveryBinding.accountId,
+                        persistence:
+                          disposition.receipt?.persistence.status ?? "legacy",
+                      },
+                    },
+                  }
+                : {}),
+            };
+            if (
+              disposition.receipt?.persistence.status === "partial" ||
+              disposition.receipt?.persistence.status === "failed"
+            ) {
+              // Provider acceptance is authoritative: never retry and duplicate
+              // the visible message merely because local evidence degraded.
+              opts.runtime.reportError(
+                "lifeops:scheduled-task:delivery-evidence",
+                new Error(
+                  `Provider accepted scheduled dispatch but local persistence is ${disposition.receipt.persistence.status}`,
+                ),
+                { taskId: record.taskId, providerMessageId },
+              );
+            }
+          } else {
+            result = {
+              ok: false,
+              reason:
+                disposition.kind === "not_delivered"
+                  ? "disconnected"
+                  : "transport_error",
+              acceptance:
+                disposition.kind === "not_delivered"
+                  ? "not_accepted"
+                  : "unknown",
+              userActionable: disposition.kind === "not_delivered",
+              message: disposition.message,
+            };
+          }
+        } catch (error) {
+          opts.runtime.reportError(
+            "lifeops:scheduled-task:bound-chat-send",
+            error,
+            {
+              taskId: record.taskId,
+              source: chatDeliveryBinding.source,
+              accountId: chatDeliveryBinding.accountId,
+            },
+          );
+          result = {
+            ok: false,
+            reason: "transport_error",
+            acceptance: "unknown",
+            userActionable: false,
+            message: error instanceof Error ? error.message : String(error),
+          };
+        }
+      } else {
+        result = await channel.send(payload);
+      }
       if (result.ok) {
         return applyDispatchPolicy({
           ...result,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -78,6 +78,10 @@ import {
   readActivityProfile,
   registerActivityProfileGates,
 } from "./activity-gates.js";
+import {
+  readScheduledTaskChatDeliveryBinding,
+  revalidateScheduledTaskChatDeliveryBinding,
+} from "./delivery-binding.js";
 import { registerModelMomentCheckGate } from "./moment-judge.js";
 import { createLifeOpsSubjectStoreView } from "./subject-store.js";
 
@@ -459,6 +463,21 @@ export function createProductionScheduledTaskDispatcher(opts: {
     async dispatch(
       record: ScheduledTaskDispatchRecord,
     ): Promise<DispatchResult> {
+      // Connector reminders created from chat carry a durable binding minted
+      // from canonical room state. Re-read that state before any composition or
+      // send so restart cannot turn stale owner-only data into a shared-room
+      // disclosure.
+      const deliveryBindingDecision =
+        await revalidateScheduledTaskChatDeliveryBinding(opts.runtime, record);
+      if (deliveryBindingDecision && !deliveryBindingDecision.ok) {
+        return applyDispatchPolicy({
+          ok: false,
+          reason: "auth_expired",
+          userActionable: true,
+          message: deliveryBindingDecision.reason,
+        });
+      }
+
       if (isLocalAgentBackupDispatch(record)) {
         const backup = await createLocalAgentBackup(
           opts.runtime,
@@ -630,12 +649,28 @@ export function createProductionScheduledTaskDispatcher(opts: {
         });
       }
 
+      const chatDeliveryBinding = readScheduledTaskChatDeliveryBinding(
+        record.metadata,
+      );
       const payload = {
         target,
         message,
         metadata: {
           taskId: record.taskId,
           firedAtIso: record.firedAtIso,
+          ...(chatDeliveryBinding
+            ? {
+                accountId: chatDeliveryBinding.accountId,
+                roomId: chatDeliveryBinding.roomId,
+                audience: {
+                  kind: chatDeliveryBinding.audience.kind,
+                  provenance: chatDeliveryBinding.audience.provenance,
+                  membershipVersion:
+                    chatDeliveryBinding.audience.membershipVersion,
+                  ownerOnly: true,
+                },
+              }
+            : {}),
           ...(record.intensity ? { intensity: record.intensity } : {}),
           ...(record.contextRequest
             ? { contextRequest: record.contextRequest }

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -693,6 +693,25 @@ export function createProductionScheduledTaskDispatcher(opts: {
         if (denied) return applyDispatchPolicy(denied);
       }
 
+      // Composition and send-policy evaluation may perform async work after the
+      // first audience check. Close that TOCTOU window by reading canonical room
+      // membership again at the last possible point before connector egress.
+      if (chatDeliveryBinding) {
+        const finalBindingDecision =
+          await revalidateScheduledTaskChatDeliveryBinding(
+            opts.runtime,
+            record,
+          );
+        if (!finalBindingDecision?.ok) {
+          return applyDispatchPolicy({
+            ok: false,
+            reason: "auth_expired",
+            userActionable: true,
+            message: finalBindingDecision?.reason ?? "delivery_binding_missing",
+          });
+        }
+      }
+
       const result = await channel.send(payload);
       if (result.ok) {
         return applyDispatchPolicy({

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
@@ -14,7 +14,14 @@
  * mobile `/api/background/run-due-tasks` route both call.
  */
 
-import { EventType, logger, type Memory, type UUID } from "@elizaos/core";
+import {
+  ChannelType,
+  EventType,
+  logger,
+  type Memory,
+  type Room,
+  type UUID,
+} from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createLifeOpsTestRuntime,
@@ -32,8 +39,10 @@ import { registerLifeOpsScheduledTaskSubjectStore } from "./runtime-wiring.ts";
 import { processDueScheduledTasks } from "./scheduler.ts";
 import { getScheduledTaskRunner } from "./service.ts";
 
-interface ScheduledTaskSeed
-  extends Omit<ScheduledTask, "taskId" | "state" | "createdBy"> {
+interface ScheduledTaskSeed extends Omit<
+  ScheduledTask,
+  "taskId" | "state" | "createdBy"
+> {
   taskId?: string;
   createdBy?: string;
   state?: ScheduledTask["state"];
@@ -127,6 +136,127 @@ describe("processDueScheduledTasks — production wiring", () => {
     const transitions = log.map((entry) => entry.transition);
     expect(transitions).toContain("fired");
   });
+
+  it("reconciles a stale bound fire after restart by replaying its provider receipt", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const ownerId = "00000000-0000-0000-0000-0000000000aa" as UUID;
+    const roomId = "00000000-0000-0000-0000-0000000000cc" as UUID;
+    await runtime.createEntity({
+      id: ownerId,
+      names: ["Owner"],
+      agentId: runtime.agentId,
+    });
+    await runtime.createRoom({
+      id: roomId,
+      source: "telegram",
+      channelId: "owner-chat-42",
+      type: ChannelType.DM,
+      worldId: runtime.agentId,
+      metadata: { accountId: "personal" },
+    } as Room);
+    await runtime.addParticipant(ownerId, roomId);
+    await runtime.addParticipant(runtime.agentId, roomId);
+
+    vi.spyOn(runtime, "useModel").mockResolvedValue(
+      "Your scheduled check is ready.",
+    );
+    const acceptedAt = Date.parse("2026-05-09T12:00:02.000Z");
+    const send = vi.spyOn(runtime, "sendMessageToTarget").mockResolvedValue({
+      kind: "duplicate",
+      priorDelivery: "delivered",
+      receipt: {
+        providerMessageIds: ["telegram-provider-1"],
+        acceptedAt,
+        persistence: { status: "persisted", memoryIds: [] },
+      },
+    } as never);
+
+    const firedAt = "2026-05-09T12:00:00.000Z";
+    const seed = await seedScheduledTask(runtime, {
+      kind: "reminder",
+      promptInstructions: "Run the private check.",
+      trigger: { kind: "once", atIso: firedAt },
+      priority: "medium",
+      respectsGlobalPause: true,
+      source: "user_chat",
+      ownerVisible: true,
+      output: {
+        destination: "channel",
+        target: "telegram:owner-chat-42",
+      },
+      state: { status: "fired", firedAt, followupCount: 0 },
+      metadata: {
+        chatDeliveryBinding: {
+          version: 1,
+          source: "telegram",
+          roomId,
+          channelId: "owner-chat-42",
+          audience: {
+            kind: "direct",
+            provenance: "canonical_room",
+            ownerEntityId: ownerId,
+            agentEntityId: runtime.agentId,
+            participantEntityIds: [ownerId, runtime.agentId].sort(),
+            membershipVersion: [ownerId, runtime.agentId].sort().join("\u0000"),
+          },
+        },
+      },
+    });
+
+    const [firstTick, secondTick] = await Promise.all([
+      processDueScheduledTasks({
+        runtime,
+        agentId: runtime.agentId,
+        now: new Date("2026-05-09T12:06:00.000Z"),
+        limit: 5,
+      }),
+      processDueScheduledTasks({
+        runtime,
+        agentId: runtime.agentId,
+        now: new Date("2026-05-09T12:06:00.000Z"),
+        limit: 5,
+      }),
+    ]);
+    const errors = [...firstTick.errors, ...secondTick.errors];
+    const fires = [...firstTick.fires, ...secondTick.fires];
+
+    expect(errors).toEqual([]);
+    expect(fires).toHaveLength(1);
+    expect(fires[0]).toMatchObject({
+      taskId: seed.taskId,
+      status: "fired",
+      reason: "stale bound dispatch recovery",
+    });
+    expect(send).toHaveBeenCalledOnce();
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "telegram",
+        channelId: "owner-chat-42",
+      }),
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          scheduledDispatchKey: `${seed.taskId}:${firedAt}`,
+        }),
+      }),
+    );
+    const persisted = await new LifeOpsRepository(runtime).getScheduledTask(
+      runtime.agentId,
+      seed.taskId,
+    );
+    expect(persisted?.metadata).toMatchObject({
+      dispatchPreparedMessage: "Your scheduled check is ready.",
+      dispatchIdempotencyKey: `${seed.taskId}:${firedAt}`,
+    });
+    expect(persisted?.metadata?.lastDispatchResult).toMatchObject({
+      ok: true,
+      messageId: "telegram-provider-1",
+      receipt: {
+        providerMessageId: "telegram-provider-1",
+        metadata: expect.objectContaining({ replayed: true }),
+      },
+    });
+  }, 120_000);
 
   it("respectsGlobalPause via the real GlobalPauseStore: paused tasks skip, then fire after clear()", async () => {
     runtimeResult = await createLifeOpsTestRuntime();

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
@@ -39,10 +39,8 @@ import { registerLifeOpsScheduledTaskSubjectStore } from "./runtime-wiring.ts";
 import { processDueScheduledTasks } from "./scheduler.ts";
 import { getScheduledTaskRunner } from "./service.ts";
 
-interface ScheduledTaskSeed extends Omit<
-  ScheduledTask,
-  "taskId" | "state" | "createdBy"
-> {
+interface ScheduledTaskSeed
+  extends Omit<ScheduledTask, "taskId" | "state" | "createdBy"> {
   taskId?: string;
   createdBy?: string;
   state?: ScheduledTask["state"];

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -57,6 +57,7 @@ import {
   applyReminderIntensityToNoReplyPolicy,
   softenReminderIntensityForQuietStreak,
 } from "./no-reply-intensity.js";
+import { readScheduledTaskChatDeliveryBinding } from "./delivery-binding.js";
 import { getScheduledTaskRunner } from "./service.js";
 
 type NoReplyTerminalStatus = "skipped" | "expired" | "failed";
@@ -467,6 +468,27 @@ async function recordPendingPromptIfNeeded(args: {
   return recorded;
 }
 
+const STALE_BOUND_DISPATCH_MS = 5 * 60_000;
+
+/**
+ * A bound connector fire can crash after the atomic claim, including after the
+ * provider accepted the message but before `lastDispatchResult` persisted.
+ * Only these receipt-capable, connector-bound sends are recoverable: replaying
+ * the same deterministic `(taskId,firedAt)` key through the runtime connector
+ * returns its committed receipt instead of posting a second message. Legacy
+ * channel sends remain parked because their acceptance is unknowable.
+ */
+function isRecoverableBoundDispatch(task: ScheduledTask, now: Date): boolean {
+  if (task.state.status !== "fired") return false;
+  if (task.metadata?.lastDispatchResult !== undefined) return false;
+  if (!readScheduledTaskChatDeliveryBinding(task.metadata)) return false;
+  const firedAt = task.state.firedAt ? Date.parse(task.state.firedAt) : NaN;
+  return (
+    Number.isFinite(firedAt) &&
+    now.getTime() - firedAt >= STALE_BOUND_DISPATCH_MS
+  );
+}
+
 export async function processDueScheduledTasks(
   request: ProcessDueScheduledTasksRequest,
 ): Promise<ProcessDueScheduledTasksResult> {
@@ -544,8 +566,45 @@ export async function processDueScheduledTasks(
   });
   const completedTaskIds = new Set<string>();
   const timeoutTaskIds = new Set<string>();
+  const recoveredTaskIds = new Set<string>();
+
+  // Restart reconciliation runs before completion-timeout handling. Otherwise
+  // a claimed-but-undelivered reminder could age into its no-reply policy even
+  // though the owner never received the original prompt.
+  for (const task of liveCandidates) {
+    if (result.fires.length >= limit) break;
+    if (!isRecoverableBoundDispatch(task, request.now)) continue;
+    try {
+      // A single CAS claims the exact fired occurrence observed by this tick.
+      // There is deliberately no reopen write: reopen-then-claim lets two
+      // workers claim one another's reopen and double-dispatch.
+      const fireResult = await runner.fireWithResult(task.taskId, {
+        recoverFiredAtIso: task.state.firedAt,
+      } as never);
+      const recovered = await handleFireResult({
+        request,
+        repo,
+        fireResult,
+        decision: {
+          due: true,
+          reason: "stale bound dispatch recovery",
+          occurrenceAtIso: task.state.firedAt,
+        },
+        dueContext,
+        result,
+      });
+      if (recovered) recoveredTaskIds.add(task.taskId);
+    } catch (error) {
+      const message = errorMessage(error);
+      logger.warn(
+        `[lifeops-scheduled-task] dispatch recovery failed for ${task.taskId}: ${message}`,
+      );
+      result.errors.push({ taskId: task.taskId, phase: "fire", message });
+    }
+  }
 
   for (const task of timeoutCandidates) {
+    if (recoveredTaskIds.has(task.taskId)) continue;
     if (result.completions.length >= limit) {
       break;
     }
@@ -582,6 +641,7 @@ export async function processDueScheduledTasks(
   // cheap indexed DB ops in a pathological burst and guarantee the due-fire
   // pass always gets its full `limit`.
   for (const task of timeoutCandidates) {
+    if (recoveredTaskIds.has(task.taskId)) continue;
     if (completedTaskIds.has(task.taskId)) continue;
     if (result.completionTimeouts.length >= limit) {
       break;
@@ -630,6 +690,7 @@ export async function processDueScheduledTasks(
   }
 
   for (const task of dueCandidates) {
+    if (recoveredTaskIds.has(task.taskId)) continue;
     if (completedTaskIds.has(task.taskId)) continue;
     if (timeoutTaskIds.has(task.taskId)) continue;
     if (result.fires.length >= limit) {

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -53,11 +53,11 @@ import {
   resolvePendingPromptsStore,
 } from "../pending-prompts/store.js";
 import { LifeOpsRepository } from "../repository.js";
+import { readScheduledTaskChatDeliveryBinding } from "./delivery-binding.js";
 import {
   applyReminderIntensityToNoReplyPolicy,
   softenReminderIntensityForQuietStreak,
 } from "./no-reply-intensity.js";
-import { readScheduledTaskChatDeliveryBinding } from "./delivery-binding.js";
 import { getScheduledTaskRunner } from "./service.js";
 
 type NoReplyTerminalStatus = "skipped" | "expired" | "failed";

--- a/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
@@ -13,15 +13,18 @@ import type {
   EffectReceipt,
   HandlerCallback,
   Memory,
+  Room,
   UUID,
 } from "@elizaos/core";
 import {
   attestDeliveryAudienceFromCanonicalRoom,
+  ChannelType,
   executePlannedToolCall,
 } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { scheduledTaskAction } from "../src/actions/scheduled-task.ts";
 import type { ScheduledTask } from "../src/lifeops/scheduled-task/index.ts";
+import { getScheduledTaskRunner } from "../src/lifeops/scheduled-task/service.ts";
 import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
@@ -330,6 +333,106 @@ describe("SCHEDULED_TASK action", () => {
       outcome: "noop",
       operation: "lifeops.scheduled_task.cancel",
     });
+  }, 120_000);
+
+  it("authorizes before storage and binds a connector task to the attested chat destination", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const ownerId = crypto.randomUUID() as UUID;
+    const roomId = crypto.randomUUID() as UUID;
+    runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", ownerId);
+    await runtime.createEntity({
+      id: ownerId,
+      names: ["Owner"],
+      agentId: runtime.agentId,
+    });
+    await runtime.createRoom({
+      id: roomId,
+      source: "telegram",
+      channelId: "owner-chat-42",
+      type: ChannelType.DM,
+      worldId: runtime.agentId,
+      metadata: { accountId: "personal" },
+    } as Room);
+    await runtime.addParticipant(ownerId, roomId);
+    await runtime.addParticipant(runtime.agentId, roomId);
+
+    const message = {
+      id: crypto.randomUUID() as UUID,
+      entityId: ownerId,
+      roomId,
+      agentId: runtime.agentId,
+      content: { text: "run my private check later", source: "telegram" },
+      createdAt: Date.now(),
+    } as Memory;
+    await attestDeliveryAudienceFromCanonicalRoom(runtime, message);
+    const result = await executePlannedToolCall(
+      runtime,
+      { message, userRoles: ["OWNER"], activeContexts: ["tasks"] },
+      {
+        name: "SCHEDULED_TASKS",
+        params: {
+          action: "create",
+          kind: "custom",
+          promptInstructions: "Run the private check and report the result.",
+          trigger: { kind: "manual" },
+          output: { destination: "channel", target: "discord:public-room" },
+          idempotencyKey: `bound-${crypto.randomUUID()}`,
+        },
+      },
+    );
+    expect(result.success).toBe(true);
+    const task = (result.data as { task?: ScheduledTask } | undefined)?.task;
+    expect(task?.output).toEqual({
+      destination: "channel",
+      target: "telegram:owner-chat-42",
+    });
+    expect(task?.metadata?.chatDeliveryBinding).toMatchObject({
+      version: 1,
+      source: "telegram",
+      roomId,
+      channelId: "owner-chat-42",
+      audience: {
+        kind: "direct",
+        provenance: "canonical_room",
+        ownerEntityId: ownerId,
+        agentEntityId: runtime.agentId,
+      },
+    });
+
+    const runner = getScheduledTaskRunner(runtime, {
+      agentId: runtime.agentId,
+    });
+    const before = (await runner.list()).length;
+    const deniedMessage = { ...message, id: crypto.randomUUID() as UUID };
+    await attestDeliveryAudienceFromCanonicalRoom(runtime, deniedMessage);
+    const guestId = crypto.randomUUID() as UUID;
+    await runtime.createEntity({
+      id: guestId,
+      names: ["Guest"],
+      agentId: runtime.agentId,
+    });
+    await runtime.addParticipant(guestId, roomId);
+    const denied = await executePlannedToolCall(
+      runtime,
+      {
+        message: deniedMessage,
+        userRoles: ["OWNER"],
+        activeContexts: ["tasks"],
+      },
+      {
+        name: "SCHEDULED_TASKS",
+        params: {
+          action: "create",
+          kind: "custom",
+          promptInstructions: "Must not persist.",
+          trigger: { kind: "manual" },
+          idempotencyKey: `denied-${crypto.randomUUID()}`,
+        },
+      },
+    );
+    expect(denied.success).toBe(false);
+    expect((await runner.list()).length).toBe(before);
   }, 120_000);
 
   it("binds one callback to the validated receipt through the canonical executor", async () => {

--- a/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
@@ -366,6 +366,7 @@ describe("SCHEDULED_TASK action", () => {
       createdAt: Date.now(),
     } as Memory;
     await attestDeliveryAudienceFromCanonicalRoom(runtime, message);
+    const bindingIdempotencyKey = `bound-${crypto.randomUUID()}`;
     const result = await executePlannedToolCall(
       runtime,
       { message, userRoles: ["OWNER"], activeContexts: ["tasks"] },
@@ -377,7 +378,7 @@ describe("SCHEDULED_TASK action", () => {
           promptInstructions: "Run the private check and report the result.",
           trigger: { kind: "manual" },
           output: { destination: "channel", target: "discord:public-room" },
-          idempotencyKey: `bound-${crypto.randomUUID()}`,
+          idempotencyKey: bindingIdempotencyKey,
         },
       },
     );
@@ -403,6 +404,86 @@ describe("SCHEDULED_TASK action", () => {
     const runner = getScheduledTaskRunner(runtime, {
       agentId: runtime.agentId,
     });
+
+    const poisonedUpdate = await executePlannedToolCall(
+      runtime,
+      { message, userRoles: ["OWNER"], activeContexts: ["tasks"] },
+      {
+        name: "SCHEDULED_TASKS",
+        params: {
+          action: "update",
+          taskId: task?.taskId,
+          patch: {
+            promptInstructions: "Run the updated private check.",
+            output: { destination: "channel", target: "discord:public-room" },
+            metadata: { chatDeliveryBinding: { version: 999 } },
+          },
+        },
+      },
+    );
+    expect(poisonedUpdate.success).toBe(true);
+    const protectedTask = (await runner.list()).find(
+      (candidate) => candidate.taskId === task?.taskId,
+    );
+    expect(protectedTask?.promptInstructions).toBe(
+      "Run the updated private check.",
+    );
+    expect(protectedTask?.output).toEqual({
+      destination: "channel",
+      target: "telegram:owner-chat-42",
+    });
+    expect(protectedTask?.metadata?.chatDeliveryBinding).toMatchObject({
+      version: 1,
+      roomId,
+    });
+
+    // The same content and planner idempotency key in a second account/room is
+    // a distinct delivery, not a duplicate of the first DM.
+    const secondRoomId = crypto.randomUUID() as UUID;
+    await runtime.createRoom({
+      id: secondRoomId,
+      source: "telegram",
+      channelId: "owner-chat-99",
+      type: ChannelType.DM,
+      worldId: runtime.agentId,
+      metadata: { accountId: "work" },
+    } as Room);
+    await runtime.addParticipant(ownerId, secondRoomId);
+    await runtime.addParticipant(runtime.agentId, secondRoomId);
+    const secondMessage = {
+      ...message,
+      id: crypto.randomUUID() as UUID,
+      roomId: secondRoomId,
+    } as Memory;
+    await attestDeliveryAudienceFromCanonicalRoom(runtime, secondMessage);
+    const secondCreate = await executePlannedToolCall(
+      runtime,
+      {
+        message: secondMessage,
+        userRoles: ["OWNER"],
+        activeContexts: ["tasks"],
+      },
+      {
+        name: "SCHEDULED_TASKS",
+        params: {
+          action: "create",
+          kind: "custom",
+          promptInstructions: "Run the private check and report the result.",
+          trigger: { kind: "manual" },
+          idempotencyKey: bindingIdempotencyKey,
+        },
+      },
+    );
+    expect(secondCreate.success).toBe(true);
+    const secondTask = (
+      secondCreate.data as { task?: ScheduledTask } | undefined
+    )?.task;
+    expect(secondTask?.taskId).not.toBe(task?.taskId);
+    expect(secondTask?.output?.target).toBe("telegram:owner-chat-99");
+    expect(secondTask?.metadata?.chatDeliveryBinding).toMatchObject({
+      roomId: secondRoomId,
+    });
+
     const before = (await runner.list()).length;
     const deniedMessage = { ...message, id: crypto.randomUUID() as UUID };
     await attestDeliveryAudienceFromCanonicalRoom(runtime, deniedMessage);
@@ -627,8 +708,7 @@ describe("SCHEDULED_TASK action", () => {
     expect(history?.success).toBe(true);
     const entries = (
       history?.data as
-        | { entries?: Array<{ taskId: string; eventType?: string }> }
-        | undefined
+        { entries?: Array<{ taskId: string; eventType?: string }> } | undefined
     )?.entries;
     if (!entries) throw new Error("history did not return entries");
     // Entries from BOTH tasks are present — the read spans the whole ledger.

--- a/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
@@ -708,7 +708,8 @@ describe("SCHEDULED_TASK action", () => {
     expect(history?.success).toBe(true);
     const entries = (
       history?.data as
-        { entries?: Array<{ taskId: string; eventType?: string }> } | undefined
+        | { entries?: Array<{ taskId: string; eventType?: string }> }
+        | undefined
     )?.entries;
     if (!entries) throw new Error("history did not return entries");
     // Entries from BOTH tasks are present — the read spans the whole ledger.

--- a/plugins/plugin-personal-assistant/test/scheduled-task-dispatcher.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-dispatcher.test.ts
@@ -30,6 +30,7 @@ import {
   registerChannelRegistry,
 } from "../src/lifeops/channels/index.js";
 import type { DispatchResult } from "../src/lifeops/connectors/contract.js";
+import { SCHEDULED_TASK_DELIVERY_BINDING_KEY } from "../src/lifeops/scheduled-task/delivery-binding.js";
 import { createProductionScheduledTaskDispatcher } from "../src/lifeops/scheduled-task/runtime-wiring.js";
 import {
   createSendPolicyRegistry,
@@ -357,6 +358,101 @@ describe("scheduled task production dispatcher", () => {
       ok: false,
       reason: "auth_expired",
       userActionable: true,
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("revalidates a persisted chat destination and preserves privacy metadata on egress", async () => {
+    let participants = [
+      "00000000-0000-0000-0000-0000000000aa",
+      "00000000-0000-0000-0000-0000000000bb",
+    ];
+    const runtime = {
+      ...(makeDispatchRuntime() as unknown as Record<string, unknown>),
+      getRoom: vi.fn(async () => ({
+        id: "00000000-0000-0000-0000-0000000000cc",
+        source: "telegram",
+        channelId: "owner-chat-42",
+      })),
+      getParticipantsForRoom: vi.fn(async () => participants),
+    } as unknown as IAgentRuntime;
+    const send = vi.fn(async () => ({
+      ok: true as const,
+      messageId: "telegram-provider-1",
+    }));
+    const registry = createChannelRegistry();
+    registry.register(sendCapableChannel(send));
+    registerChannelRegistry(runtime, registry);
+    const metadata = {
+      [SCHEDULED_TASK_DELIVERY_BINDING_KEY]: {
+        version: 1,
+        source: "telegram",
+        roomId: "00000000-0000-0000-0000-0000000000cc",
+        channelId: "owner-chat-42",
+        accountId: "personal",
+        audience: {
+          kind: "direct",
+          provenance: "canonical_room",
+          ownerEntityId: "00000000-0000-0000-0000-0000000000aa",
+          agentEntityId: "00000000-0000-0000-0000-0000000000bb",
+          participantEntityIds: participants,
+          membershipVersion: participants.join("\u0000"),
+        },
+      },
+    };
+    const dispatcher = createProductionScheduledTaskDispatcher({ runtime });
+    const record = {
+      taskId: "task_bound",
+      firedAtIso: "2026-05-10T12:00:00.000Z",
+      channelKey: "telegram",
+      promptInstructions: "private request",
+      contextRequest: undefined,
+      output: {
+        destination: "channel" as const,
+        target: "telegram:owner-chat-42",
+      },
+      metadata,
+    };
+
+    await expect(dispatcher.dispatch(record)).resolves.toMatchObject({
+      ok: true,
+      channelKey: "telegram",
+      target: "owner-chat-42",
+    });
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: "owner-chat-42",
+        metadata: expect.objectContaining({
+          accountId: "personal",
+          roomId: "00000000-0000-0000-0000-0000000000cc",
+          audience: {
+            kind: "direct",
+            provenance: "canonical_room",
+            membershipVersion: participants.join("\u0000"),
+            ownerOnly: true,
+          },
+        }),
+      }),
+    );
+
+    send.mockClear();
+    await expect(
+      dispatcher.dispatch({
+        ...record,
+        output: { destination: "channel", target: "telegram:other-chat" },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: "auth_expired",
+      message: "delivery_channel_changed",
+    });
+    expect(send).not.toHaveBeenCalled();
+
+    participants = [...participants, "00000000-0000-0000-0000-0000000000dd"];
+    await expect(dispatcher.dispatch(record)).resolves.toMatchObject({
+      ok: false,
+      reason: "auth_expired",
+      message: "delivery_audience_changed",
     });
     expect(send).not.toHaveBeenCalled();
   });

--- a/plugins/plugin-personal-assistant/test/scheduled-task-dispatcher.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-dispatcher.test.ts
@@ -373,12 +373,33 @@ describe("scheduled task production dispatcher", () => {
         id: "00000000-0000-0000-0000-0000000000cc",
         source: "telegram",
         channelId: "owner-chat-42",
+        metadata: { accountId: "personal" },
       })),
       getParticipantsForRoom: vi.fn(async () => participants),
+      sendMessageToTarget: vi
+        .fn()
+        .mockResolvedValueOnce({
+          kind: "delivered" as const,
+          receipt: {
+            providerMessageIds: ["telegram-provider-1"],
+            acceptedAt: Date.parse("2026-05-10T12:00:01.000Z"),
+            persistence: { status: "persisted" as const, memoryIds: [] },
+          },
+          memories: [],
+        })
+        .mockResolvedValueOnce({
+          kind: "duplicate" as const,
+          priorDelivery: "delivered" as const,
+          receipt: {
+            providerMessageIds: ["telegram-provider-1"],
+            acceptedAt: Date.parse("2026-05-10T12:00:01.000Z"),
+            persistence: { status: "persisted" as const, memoryIds: [] },
+          },
+        }),
     } as unknown as IAgentRuntime;
     const send = vi.fn(async () => ({
       ok: true as const,
-      messageId: "telegram-provider-1",
+      messageId: "legacy-should-not-send",
     }));
     const registry = createChannelRegistry();
     registry.register(sendCapableChannel(send));
@@ -400,7 +421,15 @@ describe("scheduled task production dispatcher", () => {
         },
       },
     };
-    const dispatcher = createProductionScheduledTaskDispatcher({ runtime });
+    const dispatcher = createProductionScheduledTaskDispatcher({
+      runtime,
+      persistDispatchAttempt: async (dispatchRecord, message, key) => {
+        Object.assign(dispatchRecord.metadata ?? {}, {
+          dispatchPreparedMessage: message,
+          dispatchIdempotencyKey: key,
+        });
+      },
+    });
     const record = {
       taskId: "task_bound",
       firedAtIso: "2026-05-10T12:00:00.000Z",
@@ -419,23 +448,34 @@ describe("scheduled task production dispatcher", () => {
       channelKey: "telegram",
       target: "owner-chat-42",
     });
-    expect(send).toHaveBeenCalledWith(
+    expect(runtime.sendMessageToTarget).toHaveBeenCalledWith(
       expect.objectContaining({
-        target: "owner-chat-42",
+        source: "telegram",
+        accountId: "personal",
+        channelId: "owner-chat-42",
+        roomId: "00000000-0000-0000-0000-0000000000cc",
+      }),
+      expect.objectContaining({
+        text: RENDERED_MESSAGE,
+        agentVoiced: true,
         metadata: expect.objectContaining({
-          accountId: "personal",
-          roomId: "00000000-0000-0000-0000-0000000000cc",
-          audience: {
-            kind: "direct",
-            provenance: "canonical_room",
-            membershipVersion: participants.join("\u0000"),
-            ownerOnly: true,
-          },
+          scheduledDispatchKey: "task_bound:2026-05-10T12:00:00.000Z",
         }),
       }),
     );
+    expect(send).not.toHaveBeenCalled();
+    expect(await dispatcher.dispatch(record)).toMatchObject({
+      ok: true,
+      messageId: "telegram-provider-1",
+      receipt: {
+        provider: "telegram",
+        providerMessageId: "telegram-provider-1",
+        idempotencyKey: "task_bound:2026-05-10T12:00:00.000Z",
+        metadata: expect.objectContaining({ replayed: true }),
+      },
+    });
 
-    send.mockClear();
+    vi.mocked(runtime.sendMessageToTarget).mockClear();
     await expect(
       dispatcher.dispatch({
         ...record,

--- a/plugins/plugin-personal-assistant/test/scheduled-task-dispatcher.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-dispatcher.test.ts
@@ -455,6 +455,29 @@ describe("scheduled task production dispatcher", () => {
       message: "delivery_audience_changed",
     });
     expect(send).not.toHaveBeenCalled();
+
+    // The audience can change while composition or an async send policy runs.
+    // The final canonical read must catch that race before connector egress.
+    participants = metadata.chatDeliveryBinding.audience.participantEntityIds;
+    const policies = createSendPolicyRegistry();
+    policies.register({
+      kind: "audience_changes_during_policy",
+      describe: { label: "Audience changes during policy" },
+      evaluate: async () => {
+        participants = [
+          ...participants,
+          "00000000-0000-0000-0000-0000000000ee",
+        ];
+        return { kind: "allow" as const };
+      },
+    });
+    registerSendPolicyRegistry(runtime, policies);
+    await expect(dispatcher.dispatch(record)).resolves.toMatchObject({
+      ok: false,
+      reason: "auth_expired",
+      message: "delivery_audience_changed",
+    });
+    expect(send).not.toHaveBeenCalled();
   });
 
   it("fires a ScheduledTask through a fake channel sender", async () => {

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -508,7 +508,11 @@ export interface ScheduledTaskRunnerExtras {
    */
   fire(
     taskId: string,
-    args?: { eventPayload?: unknown; allowTerminalRefire?: boolean },
+    args?: {
+      eventPayload?: unknown;
+      allowTerminalRefire?: boolean;
+      recoverFiredAtIso?: string;
+    },
   ): Promise<ScheduledTask>;
   /**
    * Strict fire-attempt. Returns the {@link ScheduledTaskFireResult}
@@ -519,7 +523,11 @@ export interface ScheduledTaskRunnerExtras {
    */
   fireWithResult(
     taskId: string,
-    args?: { eventPayload?: unknown; allowTerminalRefire?: boolean },
+    args?: {
+      eventPayload?: unknown;
+      allowTerminalRefire?: boolean;
+      recoverFiredAtIso?: string;
+    },
   ): Promise<ScheduledTaskFireResult>;
   /**
    * Re-evaluate completion for a fired task (e.g. user_replied_within
@@ -1150,7 +1158,11 @@ export function createScheduledTaskRunner(
 
   async function fire(
     taskId: string,
-    args?: { eventPayload?: unknown; allowTerminalRefire?: boolean },
+    args?: {
+      eventPayload?: unknown;
+      allowTerminalRefire?: boolean;
+      recoverFiredAtIso?: string;
+    },
   ): Promise<ScheduledTask> {
     const result = await fireWithResult(taskId, args);
     switch (result.kind) {
@@ -1218,7 +1230,11 @@ export function createScheduledTaskRunner(
 
   async function fireWithResult(
     taskId: string,
-    args?: { eventPayload?: unknown; allowTerminalRefire?: boolean },
+    args?: {
+      eventPayload?: unknown;
+      allowTerminalRefire?: boolean;
+      recoverFiredAtIso?: string;
+    },
   ): Promise<ScheduledTaskFireResult> {
     const task = await deps.store.get(taskId);
     if (!task) throw new Error(`fire: task ${taskId} not found`);
@@ -1237,6 +1253,14 @@ export function createScheduledTaskRunner(
     // (see {@link ScheduledTaskClaimExpectation}); the winner rewrites
     // `firedAt`, which invalidates the loser's expectation even when both
     // observed the same status.
+    const recoveryClaim = args?.recoverFiredAtIso !== undefined;
+    if (
+      recoveryClaim &&
+      (task.state.status !== "fired" ||
+        task.state.firedAt !== args.recoverFiredAtIso)
+    ) {
+      return { kind: "raced", taskId: task.taskId };
+    }
     const refireClaim =
       args?.allowTerminalRefire === true &&
       task.state.status !== "scheduled" &&
@@ -1355,7 +1379,7 @@ export function createScheduledTaskRunner(
     const claim = await deps.store.claimForFire({
       taskId: task.taskId,
       firedAtIso: fireAtIso,
-      ...(refireClaim
+      ...(refireClaim || recoveryClaim
         ? {
             expected: {
               status: task.state.status,
@@ -1368,6 +1392,22 @@ export function createScheduledTaskRunner(
       return { kind: "raced", taskId: task.taskId };
     }
     const claimed = claim.task;
+    if (recoveryClaim && args?.recoverFiredAtIso) {
+      const persistedDispatchKey = claimed.metadata?.dispatchIdempotencyKey;
+      const dispatchIdempotencyKey =
+        typeof persistedDispatchKey === "string" &&
+        persistedDispatchKey.trim().length > 0
+          ? persistedDispatchKey.trim()
+          : `${claimed.taskId}:${args.recoverFiredAtIso}`;
+      claimed.metadata = {
+        ...(claimed.metadata ?? {}),
+        dispatchIdempotencyKey,
+        recoveredDispatchAtIso: fireAtIso,
+      };
+      await logger.log(claimed.taskId, "reopened", {
+        reason: "stale bound dispatch recovery",
+      });
+    }
     if (refireClaim) {
       // Fresh occurrence: drop the previous occurrence's response state and
       // any dispatch continuation — the new occurrence starts at the initial

--- a/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
@@ -79,6 +79,8 @@ async function startService(
   return service;
 }
 
+const SQL_PERSISTENCE_TEST_TIMEOUT_MS = 15_000;
+
 describe("scheduling SQL persistence", () => {
   const harnesses: RuntimeHarness[] = [];
 
@@ -157,7 +159,7 @@ describe("scheduling SQL persistence", () => {
       "SELECT id FROM app_lifeops.life_scheduled_tasks",
     );
     expect(source.rows).toEqual([{ id: "legacy-watcher" }]);
-  });
+  }, SQL_PERSISTENCE_TEST_TIMEOUT_MS);
 
   it("keeps a due watcher through runner service re-init and fires it", async () => {
     const harness = await createRuntimeHarness();
@@ -220,5 +222,5 @@ describe("scheduling SQL persistence", () => {
         WHERE id = '${scheduled.taskId}'`,
     );
     expect(rows.rows[0]?.status).toBe("fired");
-  });
+  }, SQL_PERSISTENCE_TEST_TIMEOUT_MS);
 });

--- a/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
@@ -94,20 +94,22 @@ describe("scheduling SQL persistence", () => {
     await expect(service.stop()).resolves.toBeUndefined();
   });
 
-  it("copies legacy app_lifeops scheduled-task rows non-destructively", async () => {
-    const harness = await createRuntimeHarness();
-    harnesses.push(harness);
-    await harness.pg.query("CREATE SCHEMA IF NOT EXISTS app_lifeops");
-    await harness.pg.query(
-      `CREATE TABLE app_lifeops.life_scheduled_tasks
+  it(
+    "copies legacy app_lifeops scheduled-task rows non-destructively",
+    async () => {
+      const harness = await createRuntimeHarness();
+      harnesses.push(harness);
+      await harness.pg.query("CREATE SCHEMA IF NOT EXISTS app_lifeops");
+      await harness.pg.query(
+        `CREATE TABLE app_lifeops.life_scheduled_tasks
         (LIKE app_scheduling.life_scheduled_tasks INCLUDING DEFAULTS INCLUDING CONSTRAINTS)`,
-    );
-    await harness.pg.query(
-      `CREATE TABLE app_lifeops.life_scheduled_task_log
+      );
+      await harness.pg.query(
+        `CREATE TABLE app_lifeops.life_scheduled_task_log
         (LIKE app_scheduling.life_scheduled_task_log INCLUDING DEFAULTS INCLUDING CONSTRAINTS)`,
-    );
-    await harness.pg.query(
-      `INSERT INTO app_scheduling.life_scheduled_tasks (
+      );
+      await harness.pg.query(
+        `INSERT INTO app_scheduling.life_scheduled_tasks (
         id, agent_id, kind, prompt_instructions, trigger_json, priority,
         respects_global_pause, state_json, source, created_by, owner_visible,
         metadata_json, created_at, updated_at
@@ -117,9 +119,9 @@ describe("scheduling SQL persistence", () => {
         '{"status":"scheduled","followupCount":0}', 'plugin', 'current', TRUE,
         '{}', '2026-07-17T00:00:00.000Z', '2026-07-17T00:00:00.000Z'
       )`,
-    );
-    await harness.pg.query(
-      `INSERT INTO app_lifeops.life_scheduled_tasks (
+      );
+      await harness.pg.query(
+        `INSERT INTO app_lifeops.life_scheduled_tasks (
         id, agent_id, kind, prompt_instructions, trigger_json, priority,
         respects_global_pause, state_json, source, created_by, owner_visible,
         metadata_json, created_at, updated_at
@@ -129,98 +131,107 @@ describe("scheduling SQL persistence", () => {
         '{"status":"scheduled","followupCount":0}', 'plugin', 'legacy', TRUE,
         '{}', '2026-07-17T00:00:00.000Z', '2026-07-17T00:00:00.000Z'
       )`,
-    );
-    await harness.pg.query(
-      `INSERT INTO app_lifeops.life_scheduled_task_log (
+      );
+      await harness.pg.query(
+        `INSERT INTO app_lifeops.life_scheduled_task_log (
         id, agent_id, task_id, occurred_at, transition, rolled_up
       ) VALUES (
         'legacy-log', 'agent-sql-persist', 'legacy-watcher',
         '2026-07-17T00:00:00.000Z', 'scheduled', FALSE
       )`,
-    );
+      );
 
-    const results = await migrateSchedulingTables(async (sql) => {
-      const result = await harness.pg.query<Record<string, unknown>>(sql);
-      return result.rows;
-    });
+      const results = await migrateSchedulingTables(async (sql) => {
+        const result = await harness.pg.query<Record<string, unknown>>(sql);
+        return result.rows;
+      });
 
-    expect(results.map((result) => result.outcome)).toEqual([
-      "copied",
-      "copied",
-    ]);
-    const target = await harness.pg.query(
-      "SELECT id, kind FROM app_scheduling.life_scheduled_tasks ORDER BY id",
-    );
-    expect(target.rows).toEqual([
-      { id: "current-task", kind: "reminder" },
-      { id: "legacy-watcher", kind: "watcher" },
-    ]);
-    const source = await harness.pg.query(
-      "SELECT id FROM app_lifeops.life_scheduled_tasks",
-    );
-    expect(source.rows).toEqual([{ id: "legacy-watcher" }]);
-  }, SQL_PERSISTENCE_TEST_TIMEOUT_MS);
+      expect(results.map((result) => result.outcome)).toEqual([
+        "copied",
+        "copied",
+      ]);
+      const target = await harness.pg.query(
+        "SELECT id, kind FROM app_scheduling.life_scheduled_tasks ORDER BY id",
+      );
+      expect(target.rows).toEqual([
+        { id: "current-task", kind: "reminder" },
+        { id: "legacy-watcher", kind: "watcher" },
+      ]);
+      const source = await harness.pg.query(
+        "SELECT id FROM app_lifeops.life_scheduled_tasks",
+      );
+      expect(source.rows).toEqual([{ id: "legacy-watcher" }]);
+    },
+    SQL_PERSISTENCE_TEST_TIMEOUT_MS,
+  );
 
-  it("keeps a due watcher through runner service re-init and fires it", async () => {
-    const harness = await createRuntimeHarness();
-    harnesses.push(harness);
-    const dispatches: string[] = [];
-    const dispatcher: ScheduledTaskDispatcher = {
-      async dispatch(record): Promise<DispatchResult> {
-        dispatches.push(record.taskId);
-        return { ok: true, messageId: `msg:${record.taskId}` };
-      },
-    };
-    registerScheduledTaskRunnerDeps(harness.runtime, (runtime, agentId) => ({
-      store: createSchedulingSqlScheduledTaskStore({ runtime, agentId }),
-      logStore: createSchedulingSqlScheduledTaskLogStore({ runtime, agentId }),
-      dispatcher,
-      ownerFacts: () => ({ timezone: "UTC" }),
-      globalPause: { current: async () => ({ active: false }) },
-      activity: { hasSignalSince: () => false },
-      subjectStore: { wasUpdatedSince: () => false },
-    }));
-    const firstService = await startService(harness);
-    const firstRunner = getScheduledTaskRunner(harness.runtime, {
-      agentId: harness.runtime.agentId,
-      now: () => new Date("2026-07-17T09:00:00.000Z"),
-    });
-    const scheduled = await firstRunner.schedule({
-      kind: "watcher",
-      promptInstructions: "Check the persisted watcher.",
-      trigger: { kind: "once", atIso: "2026-07-17T09:00:00.000Z" },
-      priority: "medium",
-      respectsGlobalPause: true,
-      source: "plugin",
-      createdBy: "test",
-      ownerVisible: true,
-      executionProfile: "bg-heavy-fgs",
-    });
+  it(
+    "keeps a due watcher through runner service re-init and fires it",
+    async () => {
+      const harness = await createRuntimeHarness();
+      harnesses.push(harness);
+      const dispatches: string[] = [];
+      const dispatcher: ScheduledTaskDispatcher = {
+        async dispatch(record): Promise<DispatchResult> {
+          dispatches.push(record.taskId);
+          return { ok: true, messageId: `msg:${record.taskId}` };
+        },
+      };
+      registerScheduledTaskRunnerDeps(harness.runtime, (runtime, agentId) => ({
+        store: createSchedulingSqlScheduledTaskStore({ runtime, agentId }),
+        logStore: createSchedulingSqlScheduledTaskLogStore({
+          runtime,
+          agentId,
+        }),
+        dispatcher,
+        ownerFacts: () => ({ timezone: "UTC" }),
+        globalPause: { current: async () => ({ active: false }) },
+        activity: { hasSignalSince: () => false },
+        subjectStore: { wasUpdatedSince: () => false },
+      }));
+      const firstService = await startService(harness);
+      const firstRunner = getScheduledTaskRunner(harness.runtime, {
+        agentId: harness.runtime.agentId,
+        now: () => new Date("2026-07-17T09:00:00.000Z"),
+      });
+      const scheduled = await firstRunner.schedule({
+        kind: "watcher",
+        promptInstructions: "Check the persisted watcher.",
+        trigger: { kind: "once", atIso: "2026-07-17T09:00:00.000Z" },
+        priority: "medium",
+        respectsGlobalPause: true,
+        source: "plugin",
+        createdBy: "test",
+        ownerVisible: true,
+        executionProfile: "bg-heavy-fgs",
+      });
 
-    await firstService.stop();
-    harness.setService(null);
-    await startService(harness);
-    const restartedRunner = getScheduledTaskRunner(harness.runtime, {
-      agentId: harness.runtime.agentId,
-      now: () => new Date("2026-07-17T09:01:00.000Z"),
-    });
+      await firstService.stop();
+      harness.setService(null);
+      await startService(harness);
+      const restartedRunner = getScheduledTaskRunner(harness.runtime, {
+        agentId: harness.runtime.agentId,
+        now: () => new Date("2026-07-17T09:01:00.000Z"),
+      });
 
-    const restored = await restartedRunner.list({
-      kind: "watcher",
-      status: "scheduled",
-    });
-    expect(restored.map((task) => task.taskId)).toEqual([scheduled.taskId]);
-    expect(restored[0]?.executionProfile).toBe("bg-heavy-fgs");
+      const restored = await restartedRunner.list({
+        kind: "watcher",
+        status: "scheduled",
+      });
+      expect(restored.map((task) => task.taskId)).toEqual([scheduled.taskId]);
+      expect(restored[0]?.executionProfile).toBe("bg-heavy-fgs");
 
-    const fired = await restartedRunner.fire(scheduled.taskId);
+      const fired = await restartedRunner.fire(scheduled.taskId);
 
-    expect(fired.state.status).toBe("fired");
-    expect(dispatches).toEqual([scheduled.taskId]);
-    const rows = await harness.pg.query<{ status: string }>(
-      `SELECT state_json::jsonb ->> 'status' AS status
+      expect(fired.state.status).toBe("fired");
+      expect(dispatches).toEqual([scheduled.taskId]);
+      const rows = await harness.pg.query<{ status: string }>(
+        `SELECT state_json::jsonb ->> 'status' AS status
          FROM app_scheduling.life_scheduled_tasks
         WHERE id = '${scheduled.taskId}'`,
-    );
-    expect(rows.rows[0]?.status).toBe("fired");
-  }, SQL_PERSISTENCE_TEST_TIMEOUT_MS);
+      );
+      expect(rows.rows[0]?.status).toBe("fired");
+    },
+    SQL_PERSISTENCE_TEST_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary
- bind chat-created scheduled tasks to the server-attested connector room, account, and owner-only audience
- scope content/idempotency dedupe to that binding, so identical reminders in two DMs/accounts remain distinct
- preserve the attested output and binding across model-controlled reschedules/updates
- route bound sends through `runtime.sendMessageToTarget` with the captured `accountId`, retaining provider receipts and Telegram message IDs
- persist the exact rendered payload and deterministic dispatch key before egress, then reconcile stale claimed fires after restart through a single CAS
- fail visibly on unknown/partial transport outcomes instead of silently dropping or blind-retrying

## Production gap
The scheduler and canonical audience guard existed independently but were not joined. Chat-created tasks could dedupe across rooms, lose their bound destination during update, select an implicit connector account, and strand a one-shot as `fired` after a crash. A crash after provider acceptance also lacked a stable payload/key to reconcile without duplicate delivery.

## Exact-head proof
Head: `e3d650fff1017d47c7248a1b0e63373cdb40ca80`

- real runtime + PGlite action test proves create/list/update/cancel persistence, cross-room dedupe isolation, and binding preservation against redirect/metadata poisoning
- real production tick + PGlite restart reconciliation test drives two concurrent workers against one stale `fired` row: one CAS winner, one provider receipt replay, one persisted result
- production dispatcher test proves account-aware target routing, deterministic dispatch key, committed duplicate receipt replay, audience revalidation, and no legacy channel-mixin send
- #17209 timezone/DST primitives remain the sole schedule implementation; no duplicate timezone parser or clock was added

## Tests
- `bun run --cwd plugins/plugin-scheduling typecheck`
- `bun run --cwd plugins/plugin-personal-assistant typecheck`
- `bun run --cwd plugins/plugin-personal-assistant test -- --run test/scheduled-task-dispatcher.test.ts` (9/9)
- `bun x vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts -t "authorizes before storage"` (1/1)
- `bun x vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts -t "reconciles a stale bound fire"` (1/1, concurrent PGlite)
- prior exact-head suites remain green: persistent connector integration 6/6, DST boundaries 31/31

<!-- evidence-head:e3d650fff1017d47c7248a1b0e63373cdb40ca80 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic production-path tests exercise the behavior; no visual flow changed

<!-- evidence-row:backend-logs -->
- [x] N/A - no production backend deployment was performed; exact-head focused suite results are listed above

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser network path changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no planner prompt changed; deterministic persistence/transport seams are tested directly

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact applies; PGlite assertions cover persisted task binding, prepared payload/key, dispatch result, state log, and concurrent recovery

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed

## Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported