### PR TITLE
fix(agent): close sandbox reload ownership gaps

### DIFF
--- a/packages/agent/src/config/config-bind-mount-persistence.test.ts
+++ b/packages/agent/src/config/config-bind-mount-persistence.test.ts
@@ -4,11 +4,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadElizaConfig, saveElizaConfig } from "./config.ts";
+import {
+  __setConfigRenameSyncForTests,
+  loadElizaConfig,
+  saveElizaConfig,
+} from "./config.ts";
 
 const originalEnv = { ...process.env };
 let root = "";
 let configPath = "";
+let realConfigPath = "";
 let stateDir = "";
 
 beforeEach(() => {
@@ -21,6 +26,7 @@ beforeEach(() => {
     configPath,
     `${JSON.stringify({ plugins: { entries: { original: { enabled: true } } } }, null, 2)}\n`,
   );
+  realConfigPath = fs.realpathSync(configPath);
   process.env.ELIZA_CONFIG_PATH = configPath;
   process.env.ELIZA_STATE_DIR = stateDir;
   delete process.env.ELIZA_PERSIST_CONFIG_PATH;
@@ -28,6 +34,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  __setConfigRenameSyncForTests(null);
   process.env = { ...originalEnv };
   fs.rmSync(root, { recursive: true, force: true });
 });
@@ -35,8 +42,8 @@ afterEach(() => {
 describe("saveElizaConfig bind-mount fallback", () => {
   it("commits a durable state overlay when rename onto the config returns EBUSY", () => {
     const realRename = fs.renameSync.bind(fs);
-    vi.spyOn(fs, "renameSync").mockImplementation((from, to) => {
-      if (String(to) === configPath) {
+    __setConfigRenameSyncForTests((from, to) => {
+      if (String(to) === realConfigPath) {
         const error = new Error("resource busy") as NodeJS.ErrnoException;
         error.code = "EBUSY";
         throw error;
@@ -71,8 +78,8 @@ describe("saveElizaConfig bind-mount fallback", () => {
 
   it("keeps settings deleted from the full overlay absent after restart", () => {
     const realRename = fs.renameSync.bind(fs);
-    vi.spyOn(fs, "renameSync").mockImplementation((from, to) => {
-      if (String(to) === configPath) {
+    __setConfigRenameSyncForTests((from, to) => {
+      if (String(to) === realConfigPath) {
         const error = new Error("resource busy") as NodeJS.ErrnoException;
         error.code = "EBUSY";
         throw error;
@@ -97,9 +104,9 @@ describe("saveElizaConfig bind-mount fallback", () => {
   });
 
   it("throws when both the bind-mounted target and durable overlay fail", () => {
-    vi.spyOn(fs, "renameSync").mockImplementation((_from, to) => {
+    __setConfigRenameSyncForTests((_from, to) => {
       const error = new Error("write refused") as NodeJS.ErrnoException;
-      error.code = String(to) === configPath ? "EBUSY" : "EACCES";
+      error.code = String(to) === realConfigPath ? "EBUSY" : "EACCES";
       throw error;
     });
 
@@ -136,8 +143,8 @@ describe("saveElizaConfig bind-mount fallback", () => {
 
   it("sanitizes include directives and wallet keys in the overlay", () => {
     const realRename = fs.renameSync.bind(fs);
-    vi.spyOn(fs, "renameSync").mockImplementation((from, to) => {
-      if (String(to) === configPath) {
+    __setConfigRenameSyncForTests((from, to) => {
+      if (String(to) === realConfigPath) {
         const error = new Error("resource busy") as NodeJS.ErrnoException;
         error.code = "EBUSY";
         throw error;

--- a/packages/agent/src/config/config-bind-mount-persistence.test.ts
+++ b/packages/agent/src/config/config-bind-mount-persistence.test.ts
@@ -69,6 +69,33 @@ describe("saveElizaConfig bind-mount fallback", () => {
     );
   });
 
+  it("keeps settings deleted from the full overlay absent after restart", () => {
+    const realRename = fs.renameSync.bind(fs);
+    vi.spyOn(fs, "renameSync").mockImplementation((from, to) => {
+      if (String(to) === configPath) {
+        const error = new Error("resource busy") as NodeJS.ErrnoException;
+        error.code = "EBUSY";
+        throw error;
+      }
+      return realRename(from, to);
+    });
+
+    const config = loadElizaConfig();
+    expect(config.plugins?.entries?.original?.enabled).toBe(true);
+    if (config.plugins?.entries) {
+      delete config.plugins.entries.original;
+      config.plugins.entries.simpleViews = { enabled: true };
+    }
+    saveElizaConfig(config);
+
+    expect(
+      fs.existsSync(path.join(stateDir, "eliza.config-overlay.json")),
+    ).toBe(true);
+    const reloaded = loadElizaConfig();
+    expect(reloaded.plugins?.entries?.original).toBeUndefined();
+    expect(reloaded.plugins?.entries?.simpleViews?.enabled).toBe(true);
+  });
+
   it("throws when both the bind-mounted target and durable overlay fail", () => {
     vi.spyOn(fs, "renameSync").mockImplementation((_from, to) => {
       const error = new Error("write refused") as NodeJS.ErrnoException;

--- a/packages/agent/src/config/config.ts
+++ b/packages/agent/src/config/config.ts
@@ -276,6 +276,17 @@ function syncDirectory(dir: string): void {
   }
 }
 
+type RenameSync = (from: fs.PathLike, to: fs.PathLike) => void;
+
+let renameConfigFile: RenameSync = fs.renameSync.bind(fs);
+
+/** Replaces the atomic rename operation for deterministic filesystem tests. */
+export function __setConfigRenameSyncForTests(
+  renameSync: RenameSync | null,
+): void {
+  renameConfigFile = renameSync ?? fs.renameSync.bind(fs);
+}
+
 function writeFileAtomically(targetPath: string, content: string): void {
   const dir = path.dirname(targetPath);
   if (!fs.existsSync(dir)) {
@@ -293,7 +304,7 @@ function writeFileAtomically(targetPath: string, content: string): void {
     fs.fsyncSync(fd);
     fs.closeSync(fd);
     fd = undefined;
-    fs.renameSync(tmpPath, targetPath);
+    renameConfigFile(tmpPath, targetPath);
     syncDirectory(dir);
   } catch (error) {
     if (fd !== undefined) fs.closeSync(fd);

--- a/packages/agent/src/config/config.ts
+++ b/packages/agent/src/config/config.ts
@@ -135,14 +135,13 @@ export function loadElizaConfig(): ElizaConfig {
   // The automatic bind-mount overlay extends only the canonical file. An
   // explicitly configured persistence path disables it entirely, preventing
   // stale overlay keys from leaking into an operator-selected store.
-  const resolved = (
-    baseConfig || persistedConfig || bindMountOverlay
-      ? mergeConfigRecords(
-          mergeConfigRecords(baseConfig ?? {}, bindMountOverlay ?? {}),
-          persistedConfig ?? {},
-        )
-      : { logging: { level: "error" } }
-  ) as ElizaConfig;
+  // Automatic overlays contain a complete sanitized snapshot. Treating that
+  // snapshot as authoritative preserves deletions from the read-only base;
+  // merging it as a patch would resurrect removed settings after restart.
+  const resolved = (bindMountOverlay ??
+    (baseConfig || persistedConfig
+      ? mergeConfigRecords(baseConfig ?? {}, persistedConfig ?? {})
+      : { logging: { level: "error" } })) as ElizaConfig;
   migrateLegacyRuntimeConfig(resolved as Record<string, unknown>);
   normalizeModelMetadataInConfig(resolved);
 

--- a/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
+++ b/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   applySandboxCharacterFromEnv,
   applySandboxIdentityFromEnv,
+  prepareSandboxRuntimeConfig,
   resolveSandboxRouteAgentId,
 } from "../sandbox-character.ts";
 
@@ -133,6 +134,52 @@ describe("applySandboxIdentityFromEnv", () => {
       id: "route-id",
       name: "Sol",
       system: "You are Sol.",
+      default: true,
+    });
+  });
+});
+
+describe("prepareSandboxRuntimeConfig", () => {
+  it("strips gateway-owned credentials projected from a reload config", () => {
+    const env: NodeJS.ProcessEnv = {
+      ELIZA_CLOUD_PROVISIONED: "1",
+      ELIZA_AGENT_CHARACTER_JSON: JSON.stringify({
+        name: "Sol",
+        system: "You are Sol.",
+      }),
+      SANDBOX_ROUTE_AGENT_ID: "route-id",
+    };
+    const reloaded = {
+      agents: { list: [{ name: "Eliza", default: true }] },
+      connectors: {
+        discord: { token: "discord-secret" },
+        telegram: { botToken: "telegram-secret" },
+      },
+    };
+
+    const routeAgentId = prepareSandboxRuntimeConfig(
+      reloaded as never,
+      (config, projectedEnv) => {
+        const connectors = config.connectors as {
+          discord?: { token?: string };
+          telegram?: { botToken?: string };
+        };
+        projectedEnv.DISCORD_API_TOKEN = connectors.discord?.token;
+        projectedEnv.DISCORD_BOT_TOKEN = connectors.discord?.token;
+        projectedEnv.TELEGRAM_BOT_TOKEN = connectors.telegram?.botToken;
+      },
+      env,
+    );
+
+    expect(routeAgentId).toBe("route-id");
+    expect(env.DISCORD_API_TOKEN).toBeUndefined();
+    expect(env.DISCORD_BOT_TOKEN).toBeUndefined();
+    expect(env.TELEGRAM_BOT_TOKEN).toBeUndefined();
+    expect(reloaded.connectors.discord).toBeUndefined();
+    expect(reloaded.connectors.telegram).toBeUndefined();
+    expect(reloaded.agents.list[0]).toMatchObject({
+      id: "route-id",
+      name: "Sol",
       default: true,
     });
   });

--- a/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
+++ b/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
@@ -204,10 +204,10 @@ describe("prepareSandboxRuntimeConfig", () => {
       system: "You are Sol.",
       default: true,
     });
-    expect(reloaded.agents.list[0]?.settings?.telegram).toBeUndefined();
-    expect(
-      reloaded.agents.list[0]?.settings?.secrets?.DISCORD_BOT_TOKEN,
-    ).toBeUndefined();
+    expect(reloaded.agents.list[0]).not.toHaveProperty("settings.telegram");
+    expect(reloaded.agents.list[0]).not.toHaveProperty(
+      "settings.secrets.DISCORD_BOT_TOKEN",
+    );
     expect(reloaded.agents.list[1]?.name).toBe("Secondary");
   });
 });

--- a/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
+++ b/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
@@ -146,14 +146,31 @@ describe("prepareSandboxRuntimeConfig", () => {
       ELIZA_AGENT_CHARACTER_JSON: JSON.stringify({
         name: "Sol",
         system: "You are Sol.",
+        settings: {
+          telegram: { botToken: "identity-telegram-secret" },
+          secrets: { DISCORD_BOT_TOKEN: "identity-discord-secret" },
+        },
       }),
       SANDBOX_ROUTE_AGENT_ID: "route-id",
     };
     const reloaded = {
-      agents: { list: [{ name: "Eliza", default: true }] },
+      agents: {
+        list: [
+          { name: "Secondary", system: "Secondary system.", default: false },
+          { name: "Eliza", system: "Old primary system.", default: true },
+        ],
+      },
       connectors: {
         discord: { token: "discord-secret" },
         telegram: { botToken: "telegram-secret" },
+      },
+      channels: {
+        discord: { token: "legacy-discord-secret" },
+        telegram: { botToken: "legacy-telegram-secret" },
+      },
+      env: {
+        DISCORD_API_TOKEN: "env-discord-secret",
+        vars: { TELEGRAM_BOT_TOKEN: "vars-telegram-secret" },
       },
     };
 
@@ -177,11 +194,21 @@ describe("prepareSandboxRuntimeConfig", () => {
     expect(env.TELEGRAM_BOT_TOKEN).toBeUndefined();
     expect(reloaded.connectors.discord).toBeUndefined();
     expect(reloaded.connectors.telegram).toBeUndefined();
+    expect(reloaded.channels.discord).toBeUndefined();
+    expect(reloaded.channels.telegram).toBeUndefined();
+    expect(reloaded.env.DISCORD_API_TOKEN).toBeUndefined();
+    expect(reloaded.env.vars.TELEGRAM_BOT_TOKEN).toBeUndefined();
     expect(reloaded.agents.list[0]).toMatchObject({
       id: "route-id",
       name: "Sol",
+      system: "You are Sol.",
       default: true,
     });
+    expect(reloaded.agents.list[0]?.settings?.telegram).toBeUndefined();
+    expect(
+      reloaded.agents.list[0]?.settings?.secrets?.DISCORD_BOT_TOKEN,
+    ).toBeUndefined();
+    expect(reloaded.agents.list[1]?.name).toBe("Secondary");
   });
 });
 

--- a/packages/agent/src/runtime/build-character-config.test.ts
+++ b/packages/agent/src/runtime/build-character-config.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ElizaConfig } from "../config/config.ts";
 import { buildCharacterFromConfig } from "./build-character-config.ts";
+import { applySandboxCharacterFromEnv } from "./sandbox-character.ts";
 
 // Locks the secret/settings boundary for Matrix connector env vars. Putting a
 // public identifier (e.g. MATRIX_VERIFY_ALLOWLIST = a user id) into
@@ -89,6 +90,30 @@ describe("Matrix connector secret/settings boundary", () => {
 });
 
 describe("agent entry character passthrough", () => {
+  it("uses an injected sandbox identity when the prior default was not first", () => {
+    const config = {
+      agents: {
+        list: [
+          { name: "Secondary", system: "Secondary system.", default: false },
+          { name: "Old primary", system: "Old primary system.", default: true },
+        ],
+      },
+    } as ElizaConfig;
+
+    applySandboxCharacterFromEnv(config, {
+      ELIZA_AGENT_CHARACTER_JSON: JSON.stringify({
+        name: "Sol",
+        system: "You are Sol.",
+      }),
+      SANDBOX_ROUTE_AGENT_ID: "route-id",
+    });
+
+    const character = buildCharacterFromConfig(config);
+    expect(character.name).toBe("Sol");
+    expect(character.system).toContain("You are Sol.");
+    expect(character.system).not.toContain("Secondary system.");
+  });
+
   it("preserves injected Discord auto-reply settings", () => {
     const character = buildCharacterFromConfig({
       agents: {

--- a/packages/agent/src/runtime/eliza-runtime-settings.test.ts
+++ b/packages/agent/src/runtime/eliza-runtime-settings.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ElizaConfig } from "../config/config.ts";
 import { buildRuntimeSettingsProjection } from "./runtime-settings.ts";
+import { applySandboxConnectorOwnership } from "./sandbox-character.ts";
 
 const ENV_KEYS = ["SECRET_SALT"] as const;
 
@@ -27,6 +28,35 @@ afterEach(() => {
 });
 
 describe("buildRuntimeSettingsProjection", () => {
+  it("cannot restore gateway-owned credentials from legacy or env config", () => {
+    const config = {
+      channels: {
+        discord: { token: "legacy-discord-token" },
+        telegram: { botToken: "legacy-telegram-token" },
+      },
+      env: {
+        DISCORD_API_TOKEN: "env-discord-token",
+        vars: { TELEGRAM_BOT_TOKEN: "vars-telegram-token" },
+      },
+    } as unknown as ElizaConfig;
+    const env: NodeJS.ProcessEnv = {
+      ELIZA_CLOUD_PROVISIONED: "1",
+      DISCORD_API_TOKEN: "projected-discord-token",
+      DISCORD_BOT_TOKEN: "projected-discord-token",
+      TELEGRAM_BOT_TOKEN: "projected-telegram-token",
+    };
+
+    applySandboxConnectorOwnership(env, config);
+    const settings = buildRuntimeSettingsProjection(config, { env });
+
+    expect(env.DISCORD_API_TOKEN).toBeUndefined();
+    expect(env.DISCORD_BOT_TOKEN).toBeUndefined();
+    expect(env.TELEGRAM_BOT_TOKEN).toBeUndefined();
+    expect(settings.DISCORD_API_TOKEN).toBeUndefined();
+    expect(settings.DISCORD_BOT_TOKEN).toBeUndefined();
+    expect(settings.TELEGRAM_BOT_TOKEN).toBeUndefined();
+  });
+
   it("projects connector config and startup-only settings for runtime rebuilds", () => {
     const config = {
       env: {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -3800,21 +3800,18 @@ export async function startEliza(
     process.env.LOG_LEVEL = config.logging?.level ?? "error";
   }
 
-  // 2. Push channel secrets into process.env for plugin discovery
-  applyConnectorSecretsToEnv(config);
-  // Cloud sandbox (Path A / double-connect): in a provisioned container that
-  // does NOT own its connectors, strip the connector bot tokens so the
-  // container does not also connect to Discord/Telegram while the gateway
-  // holds the connection. MUST run AFTER applyConnectorSecretsToEnv (which can
-  // repopulate the tokens from config.connectors) and BEFORE plugin
-  // auto-enable / resolvePlugins below. Also clears the matching config
-  // connector blocks so nothing downstream re-derives the token. Skipped
-  // outside a provisioned container or when ELIZA_SANDBOX_OWNS_CONNECTORS=1.
+  // Provisioned identity, connector projection, and ownership form one ordered
+  // transformation shared with hot reload. It must complete before plugin
+  // discovery so gateway-owned containers cannot connect directly.
+  let sandboxRouteAgentId: string | null = null;
   {
-    const { applySandboxConnectorOwnership } = await import(
+    const { prepareSandboxRuntimeConfig } = await import(
       "./sandbox-character.ts"
     );
-    applySandboxConnectorOwnership(process.env, config);
+    sandboxRouteAgentId = prepareSandboxRuntimeConfig(
+      config,
+      applyConnectorSecretsToEnv,
+    );
   }
   ensureProvisionedCloudContainerConfig(config);
   // 2b. Propagate cloud config into process.env before boot prefetches. A
@@ -4146,18 +4143,6 @@ export async function startEliza(
   }
 
   // 3. Build elizaOS Character from Eliza config
-  // Cloud sandbox (Path A): if the provisioner injected the assigned
-  // character via ELIZA_AGENT_CHARACTER_JSON, merge it onto the config so the
-  // container boots AS that character (e.g. "Nyx") instead of the bundled
-  // default preset. Skipped when the env var is absent.
-  let sandboxRouteAgentId: string | null = null;
-  {
-    const { applySandboxIdentityFromEnv } = await import(
-      "./sandbox-character.ts"
-    );
-    sandboxRouteAgentId = applySandboxIdentityFromEnv(config);
-  }
-
   // 3b. Canonical file boot (sovereign identity): when configured via
   // ELIZA_CANONICAL_BOOT_ROOT / ELIZA_CANONICAL_BOOT_MANIFEST, read the
   // operator's allowlisted files (SOUL.md, IDENTITY.md, AGENTS.md, USER.md,
@@ -5759,18 +5744,16 @@ export async function startEliza(
           // must re-apply their injected character on every hot reload: the
           // injection is intentionally not serialized into eliza.json.
           const freshConfig = loadElizaConfig();
-          const { applySandboxIdentityFromEnv } = await import(
+          const { prepareSandboxRuntimeConfig } = await import(
             "./sandbox-character.ts"
           );
-          const freshSandboxRouteAgentId =
-            applySandboxIdentityFromEnv(freshConfig);
+          const freshSandboxRouteAgentId = prepareSandboxRuntimeConfig(
+            freshConfig,
+            applyConnectorSecretsToEnv,
+          );
 
-          // Propagate secrets & cloud config into process.env so plugins
-          // (especially plugin-elizacloud) can discover them.  The initial
-          // startup does this in startEliza(); the hot-reload must repeat it
-          // because the config may have changed (e.g. cloud enabled during
-          // first-run setup).
-          applyConnectorSecretsToEnv(freshConfig);
+          // Continue the same secret and cloud preparation used at initial
+          // startup because either source may have changed before this reload.
           const freshConnectorSecretsOverlay =
             await resolveConnectorSecretsOverlayForBoot(freshConfig);
           await autoResolveDiscordAppId(

--- a/packages/agent/src/runtime/sandbox-character.ts
+++ b/packages/agent/src/runtime/sandbox-character.ts
@@ -270,3 +270,23 @@ export function applySandboxConnectorOwnership(
     );
   }
 }
+
+/**
+ * Apply the provisioned config transformations in their required order.
+ * Connector projection runs after identity injection so container-owned
+ * character connectors are discoverable, while ownership runs last so a
+ * gateway-owned container cannot retain credentials projected from config.
+ */
+export function prepareSandboxRuntimeConfig(
+  config: ElizaConfig,
+  projectConnectorSecrets: (
+    config: ElizaConfig,
+    env: NodeJS.ProcessEnv,
+  ) => void,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const routeAgentId = applySandboxIdentityFromEnv(config, env);
+  projectConnectorSecrets(config, env);
+  applySandboxConnectorOwnership(env, config);
+  return routeAgentId;
+}

--- a/packages/agent/src/runtime/sandbox-character.ts
+++ b/packages/agent/src/runtime/sandbox-character.ts
@@ -155,10 +155,12 @@ export function applySandboxCharacterFromEnv(
 
   const agents = config.agents as ElizaConfig["agents"] | undefined;
   const list = Array.isArray(agents?.list) ? [...agents.list] : [];
-  // Replace any existing primary entry; the injected character is authoritative.
-  const existingIdx = list.findIndex((a) => a?.default) ?? -1;
+  // buildCharacterFromConfig consumes list[0], so the authoritative injected
+  // identity must occupy that position even when a persisted default is later.
+  const existingIdx = list.findIndex((a) => a?.default);
   if (existingIdx >= 0) {
-    list[existingIdx] = { ...list[existingIdx], ...entry };
+    const [existing] = list.splice(existingIdx, 1);
+    list.unshift({ ...existing, ...entry });
   } else {
     list.unshift(entry);
   }
@@ -245,6 +247,21 @@ export function applySandboxConnectorOwnership(
   if (sandboxOwnsConnectors(env)) return;
 
   const stripped: string[] = [];
+  const stripRecordKeys = (
+    value: unknown,
+    keys: readonly string[],
+    recordPath: string,
+  ): void => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return;
+    const record = value as Record<string, unknown>;
+    for (const key of keys) {
+      if (key in record) {
+        delete record[key];
+        stripped.push(`${recordPath}.${key}`);
+      }
+    }
+  };
+
   for (const key of CONNECTOR_TOKEN_ENV_KEYS) {
     if (env[key]) {
       delete env[key];
@@ -255,12 +272,41 @@ export function applySandboxConnectorOwnership(
   // Also drop the connector config blocks so nothing downstream
   // (plugin auto-enable, a later applyConnectorSecretsToEnv) re-derives the
   // token from config and reconnects.
-  if (config?.connectors && typeof config.connectors === "object") {
-    for (const key of CONNECTOR_CONFIG_KEYS) {
-      if (key in config.connectors) {
-        delete (config.connectors as Record<string, unknown>)[key];
-        stripped.push(`config.connectors.${key}`);
-      }
+  if (config) {
+    stripRecordKeys(
+      config.connectors,
+      CONNECTOR_CONFIG_KEYS,
+      "config.connectors",
+    );
+    stripRecordKeys(
+      (config as Record<string, unknown>).channels,
+      CONNECTOR_CONFIG_KEYS,
+      "config.channels",
+    );
+
+    const configEnv = config.env as Record<string, unknown> | undefined;
+    stripRecordKeys(configEnv, CONNECTOR_TOKEN_ENV_KEYS, "config.env");
+    stripRecordKeys(
+      configEnv?.vars,
+      CONNECTOR_TOKEN_ENV_KEYS,
+      "config.env.vars",
+    );
+
+    for (const [index, agent] of (config.agents?.list ?? []).entries()) {
+      const settings = agent?.settings as Record<string, unknown> | undefined;
+      const settingsPath = `config.agents.list[${index}].settings`;
+      stripRecordKeys(settings, CONNECTOR_CONFIG_KEYS, settingsPath);
+      stripRecordKeys(settings, CONNECTOR_TOKEN_ENV_KEYS, settingsPath);
+      stripRecordKeys(
+        settings?.extra,
+        CONNECTOR_TOKEN_ENV_KEYS,
+        `${settingsPath}.extra`,
+      );
+      stripRecordKeys(
+        settings?.secrets,
+        CONNECTOR_TOKEN_ENV_KEYS,
+        `${settingsPath}.secrets`,
+      );
     }
   }
 


### PR DESCRIPTION
Closes #17647. Follow-up to #17642 after its independent review completed after merge.

## Summary

- treats automatic bind-mount overlays as authoritative full snapshots so deleted settings cannot return
- applies injected identity, connector-secret projection, and connector ownership in one shared order on cold boot and hot reload
- strips gateway-owned Discord/Telegram credentials from legacy channels, config env, character settings, and runtime settings
- places the injected sandbox character first because runtime construction consumes `agents.list[0]`
- makes bind-mount fallback tests exercise canonical real paths on macOS and deterministic rename failures

## Risk

Medium. This changes sandbox boot/reload preparation and config persistence precedence. Non-provisioned runtimes and containers with `ELIZA_SANDBOX_OWNS_CONNECTORS=1` retain connector ownership.

## Verification

- focused Vitest: 4 files, 27 tests passed
- `bun run --cwd packages/agent typecheck`: passed
- Biome on all changed files: passed
- `git diff --check`: passed
- independent review found and repaired credential rehydration and first-agent identity gaps

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

## Evidence Gate

<!-- evidence-head:85812b0870b1da48f1223626645f2edb9b7e8569 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server configuration and sandbox lifecycle change with no rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] N/A - server configuration and sandbox lifecycle change with no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changed.

<!-- evidence-row:backend-logs -->
- [x] N/A - no backend log artifact was captured; focused Vitest exercised authoritative overlay reload, gateway-owned credential stripping, injected identity ordering, and runtime settings projection, with all 27 tests passing.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or planner behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no runtime domain artifact is created; persisted config files are verified directly by the focused filesystem tests.

<!-- exact-head:85812b0870b1da48f1223626645f2edb9b7e8569 -->

