### PR TITLE
fix(bench): inherit personal-assistant test resolution

### DIFF
--- a/packages/lifeops-bench/vitest.config.ts
+++ b/packages/lifeops-bench/vitest.config.ts
@@ -1,9 +1,11 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
+import personalAssistantConfig from "../../plugins/plugin-personal-assistant/vitest.config";
 
 const fileDir = path.dirname(fileURLToPath(import.meta.url));
 const monorepoRoot = path.resolve(fileDir, "../..");
+const appCoreSrc = path.join(monorepoRoot, "packages/app-core/src");
 const coreSrc = path.join(monorepoRoot, "packages/core/src");
 const loggerSrc = path.join(monorepoRoot, "packages/logger/src");
 const sharedSrc = path.join(monorepoRoot, "packages/shared/src");
@@ -11,6 +13,7 @@ const cloudRoutingSrc = path.join(monorepoRoot, "packages/cloud/routing/src");
 const cloudSdkSrc = path.join(monorepoRoot, "packages/cloud/sdk/src");
 
 export default defineConfig({
+  plugins: personalAssistantConfig.plugins,
   test: {
     testTimeout: 120_000,
     hookTimeout: 120_000,
@@ -18,6 +21,11 @@ export default defineConfig({
   },
   resolve: {
     alias: [
+      ...(personalAssistantConfig.resolve?.alias ?? []),
+      {
+        find: /^@elizaos\/app-core\/(.+)$/,
+        replacement: path.join(appCoreSrc, "$1"),
+      },
       {
         find: /^@elizaos\/core$/,
         replacement: path.join(coreSrc, "index.node.ts"),


### PR DESCRIPTION
## Summary
- make the LifeOps benchmark Vitest config inherit the personal-assistant test resolver/plugins it already depends on through its real-runtime helper
- add the missing `@elizaos/app-core/*` source alias needed by that inherited runtime path
- keep the benchmark lane source-based, with no workflow or check changes

## Root cause
The benchmark command runs from a clean checkout without `packages/agent/dist`. Three LifeOps tests added in #17499 import `plugins/plugin-personal-assistant/test/helpers/runtime.ts`, but the benchmark config did not inherit that helper's owning package resolver. Vite therefore followed `@elizaos/agent` to the package's valid production `dist/index.js` export and failed because no build step had produced it. This is a benchmark-harness resolution assumption, not a broken published export and not caused by #17497.

## Proof
- Before: exact CI command fails at import collection with `Failed to resolve entry for package "@elizaos/agent"`.
- After, with `packages/agent/dist`, `plugins/plugin-personal-assistant/dist`, `plugins/plugin-scheduling/dist`, and `plugins/plugin-elizacloud/dist` deliberately absent: exact CI command passes 18 files / 179 tests.
- `bunx biome check packages/lifeops-bench/vitest.config.ts`
- `git diff --check`

## Evidence rows
<!-- evidence-head:688a688d115742ec333384e54558193a00506e8c -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - test-resolution-only change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-resolution-only change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or rendered UI changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime behavior changed; the exact CI command passed 18 files and 179 tests locally with relevant dist directories absent.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, provider, model, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled task, wallet, file, or media artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

## Contribution attribution
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`
