### PR TITLE
fix(training): restore solvable uv dependency contract

### DIFF
--- a/packages/training/Dockerfile
+++ b/packages/training/Dockerfile
@@ -76,7 +76,7 @@ COPY uv.lock ./
 # image.
 RUN uv venv --python 3.12 /workspace/.venv \
  && . /workspace/.venv/bin/activate \
- && uv sync --extra train --frozen --no-install-project
+ && uv sync --extra train --locked --no-install-project
 
 ENV VIRTUAL_ENV=/workspace/.venv \
     PATH=/workspace/.venv/bin:$PATH \

--- a/packages/training/Dockerfile.cpu
+++ b/packages/training/Dockerfile.cpu
@@ -50,7 +50,7 @@ COPY uv.lock ./
 # pin only matters for the GPU image.
 RUN uv venv --python 3.12 /workspace/.venv \
  && . /workspace/.venv/bin/activate \
- && uv sync --extra train --frozen --no-install-project
+ && uv sync --extra train --locked --no-install-project
 
 ENV VIRTUAL_ENV=/workspace/.venv \
     PATH=/root/.bun/bin:/workspace/.venv/bin:$PATH \

--- a/packages/training/pyproject.toml
+++ b/packages/training/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "argostranslate>=1.11.0",
   # Argos Translate 1.11.0 requires this exact Stanza release. Declaring the
   # transitive pin keeps uv/Dependabot from proposing an unsatisfiable upgrade.
-  "stanza==1.12.2",
+  "stanza==1.10.1",
   "httpx>=0.27.0",
   # PolarQuant's Lloyd-Max centroid generation imports scipy.stats.norm
   # directly; keep it in the base training environment so smoke tests and
@@ -41,7 +41,7 @@ train = [
   # resolves to (torch 2.11+cu130 in practice) when --extra serve is
   # also selected (smoke), and 2.10+cu126 when train is alone (Vast
   # SFT path). Both wheels run on Vast Blackwell driver 570.x.
-  "torch>=2.5.0,<2.14",
+  "torch>=2.5.0,<2.13",
   "transformers>=4.46.0",
   "accelerate>=1.1.0",
   "peft>=0.14.0",
@@ -112,7 +112,7 @@ rl = [
   # GRPO trainer needs vLLM for rollouts; pin separately so users running RL
   # without serving don't have to install the full `serve` extra (which has
   # an incompatible torch ABI). vllm>=0.6 is what verl 0.5+ requires.
-  "vllm>=0.6.0,<0.26.0",
+  "vllm>=0.6.0,<0.8.0",
   # Atropos — continuous RL environment server. Drives the GRPO loop in
   # scripts/rl/atropos_trainer.py against eliza-native trajectory JSONL
   # exports under $ELIZA_STATE_DIR/trajectories. Config:
@@ -153,7 +153,7 @@ serve = [
   # Pin a minor floor that captures all of these. See
   # scripts/inference/serve_vllm.py for the canonical flag set per model +
   # GPU target.
-  "vllm>=0.20.0,<0.26.0",
+  "vllm>=0.20.0,<0.21.0",
   # `vllm-flash-attn` is bundled with vLLM 0.20+; add explicitly so the
   # constraint solver doesn't pull a stale wheel from a transitive dep.
   "transformers>=4.46.0",


### PR DESCRIPTION
Closes #17661.

## Summary

- restore the four training dependency bounds represented by the validated `uv.lock`
- pin Stanza to the exact version required by Argos Translate
- replace Docker `uv sync --frozen` with `uv sync --locked` so metadata drift fails closed

## Root cause

Merged Dependabot PR #16531 changed four project constraints without updating the training lockfile. One change is unsatisfiable: `argostranslate==1.11.0` requires `stanza==1.10.1`, while the manifest requested 1.12.2. The wider Torch and vLLM bounds also no longer described the authenticated lock.

The Dockerfiles used `--frozen`, which skips freshness validation. `--locked` preserves reproducible installation while rejecting any future manifest and lock divergence.

## Verification

- reproduced the original unsatisfiable resolver failure
- `uv lock --check`: 319 packages resolved
- locked base sync dry run: 90 packages selected
- locked `train` export: complete 319-package graph
- `git diff --check`: passed
- Docker builds: unavailable locally because the Docker daemon is offline; hosted workflows must pass before merge

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

## Evidence Gate

<!-- evidence-head:7b255e3287cac5d69075ad0878429ea99e173c2e -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend process, request, persistence, or service runtime changed; this is dependency metadata and image-install validation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - dependency metadata and image installation policy create no persisted product artifact.
<!-- exact-head:7b255e3287cac5d69075ad0878429ea99e173c2e -->
