### PR TITLE
fix(ci): trust Dependabot uv branches

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -160,7 +160,7 @@ jobs:
             exit 1
           fi
           case "$HEAD_REF" in
-            dependabot/npm_and_yarn/*|dependabot/github_actions/*|dependabot/pip/*) ;;
+            dependabot/npm_and_yarn/*|dependabot/github_actions/*|dependabot/pip/*|dependabot/uv/*) ;;
             *)
               echo "::error::unexpected Dependabot ecosystem ref: $HEAD_REF"
               exit 1

--- a/scripts/check-pr-agent-attribution.test.mjs
+++ b/scripts/check-pr-agent-attribution.test.mjs
@@ -595,9 +595,9 @@ describe("PR agent attribution", () => {
       ),
     ].map((match) => match[1]);
     const ecosystemRefs = {
-      npm: "dependabot/npm_and_yarn/*",
-      "github-actions": "dependabot/github_actions/*",
-      pip: "dependabot/pip/*",
+      npm: ["dependabot/npm_and_yarn/*"],
+      "github-actions": ["dependabot/github_actions/*"],
+      pip: ["dependabot/pip/*", "dependabot/uv/*"],
     };
     assert.deepEqual(
       [...new Set(configuredEcosystems)].sort(),
@@ -605,11 +605,13 @@ describe("PR agent attribution", () => {
       "the trusted ref allowlist must be updated for every configured ecosystem",
     );
     for (const ecosystem of configuredEcosystems) {
-      assert.match(
-        normalizer,
-        new RegExp(ecosystemRefs[ecosystem].replaceAll("*", "\\*")),
-        `${ecosystem} Dependabot refs must be explicitly allowed`,
-      );
+      for (const ecosystemRef of ecosystemRefs[ecosystem]) {
+        assert.match(
+          normalizer,
+          new RegExp(ecosystemRef.replaceAll("*", "\\*")),
+          `${ecosystem} Dependabot ref ${ecosystemRef} must be explicitly allowed`,
+        );
+      }
     }
 
     const policyBlock = [


### PR DESCRIPTION
Closes #17664.

## Summary

- allow the exact first-party `dependabot/uv/*` branch prefix in trusted body normalization
- keep actor, repository, and visible-policy validation unchanged
- enforce both pip and uv branch forms for the configured pip ecosystem

## Root cause

The repository configures Dependabot for uv-backed Python groups, but the trusted pull-request normalizer recognizes only `dependabot/pip/*`. A valid uv dependency PR therefore fails before evidence normalization and makes the aggregate Develop PR Gate fail. Because normalization runs from the trusted base through `pull_request_target`, the prerequisite must land independently of the blocked dependency PR.

## Verification

- PR attribution and workflow policy: 18 tests passed
- Biome and `git diff --check`: passed

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

## Evidence Gate

<!-- evidence-head:9ac0b89a4a7b4310281c99ed8745fb47e0a7fe92 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend process, request, persistence, or service runtime changed; this is trusted CI policy.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this workflow allowlist creates no persisted product artifact.
<!-- exact-head:9ac0b89a4a7b4310281c99ed8745fb47e0a7fe92 -->
