### PR TITLE
fix(telegram): harden identity and restart delivery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5507,6 +5507,7 @@
       "name": "@elizaos/plugin-telegram-standalone",
       "version": "2.0.3-beta.7",
       "dependencies": {
+        "@elizaos/plugin-telegram": "workspace:*",
         "telegraf": "4.16.3",
       },
       "devDependencies": {

--- a/packages/agent/src/api/connector-health.test.ts
+++ b/packages/agent/src/api/connector-health.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit coverage for connector health probing. Telegram exposes poller liveness,
+ * so a registered service object is not enough to report the connector healthy.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { ConnectorHealthMonitor } from "./connector-health";
+
+function createMonitor(service: unknown): ConnectorHealthMonitor {
+  return new ConnectorHealthMonitor({
+    runtime: {
+      getService: vi.fn(() => service),
+    } as never,
+    config: {
+      connectors: {
+        telegram: { enabled: true },
+      },
+    },
+    broadcastWs: vi.fn(),
+    intervalMs: 60_000,
+  });
+}
+
+describe("ConnectorHealthMonitor", () => {
+  it("reports Telegram missing when the service exists but the poller is not live", async () => {
+    const monitor = createMonitor({
+      getPollerHealth: () => ({
+        ok: false,
+        connected: false,
+        lastError: "poller stopped",
+      }),
+    });
+
+    await monitor.check();
+
+    expect(monitor.getConnectorStatuses()).toEqual({ telegram: "missing" });
+  });
+
+  it("reports Telegram ok only when poller health is connected", async () => {
+    const monitor = createMonitor({
+      getPollerHealth: () => ({
+        ok: true,
+        connected: true,
+      }),
+    });
+
+    await monitor.check();
+
+    expect(monitor.getConnectorStatuses()).toEqual({ telegram: "ok" });
+  });
+});

--- a/packages/agent/src/api/connector-health.ts
+++ b/packages/agent/src/api/connector-health.ts
@@ -10,6 +10,12 @@ import type { AgentRuntime } from "@elizaos/core";
 
 export type ConnectorStatus = "ok" | "missing" | "unknown";
 
+type PollerHealthProbe = {
+  getPollerHealth: () =>
+    | { ok?: boolean; connected?: boolean; lastError?: string }
+    | Promise<{ ok?: boolean; connected?: boolean; lastError?: string }>;
+};
+
 export interface ConnectorHealthMonitorOptions {
   runtime: AgentRuntime;
   config: { connectors?: Record<string, unknown> };
@@ -55,6 +61,14 @@ const CONNECTOR_PLUGIN_MAP_NORMALIZED = Object.fromEntries(
     pluginName,
   ]),
 );
+
+function hasPollerHealthProbe(service: unknown): service is PollerHealthProbe {
+  return (
+    typeof service === "object" &&
+    service !== null &&
+    typeof (service as PollerHealthProbe).getPollerHealth === "function"
+  );
+}
 
 export class ConnectorHealthMonitor {
   private runtime: AgentRuntime;
@@ -124,7 +138,15 @@ export class ConnectorHealthMonitor {
     if (!pluginName) return "unknown";
 
     const service = this.runtime.getService(pluginName);
-    if (service) return "ok";
+    if (service) {
+      if (hasPollerHealthProbe(service)) {
+        const health = await service.getPollerHealth();
+        return health.ok === true && health.connected === true
+          ? "ok"
+          : "missing";
+      }
+      return "ok";
+    }
 
     // Also check runtime.clients if available
     const clients = (

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -444,8 +444,8 @@ describe("gateway webhook handler e2e routing", () => {
           key.includes("webhook:telegram") && !key.endsWith(":processing"),
       ),
     ).toEqual([
-      "webhook:telegram:project:eliza-app:bot:218da20172ac4d99:message:123",
-      "webhook:telegram:project:eliza-app:bot:9c352facd71adf06:message:123",
+      "webhook:telegram:project:eliza-app:account:bot:218da20172ac4d99:message:123",
+      "webhook:telegram:project:eliza-app:account:bot:9c352facd71adf06:message:123",
     ]);
   });
 

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -1,5 +1,6 @@
 // Exercises the gateway-webhook webhook handler.e2e path with deterministic cloud service fixtures.
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { telegramAdapter } from "../src/adapters/telegram";
 import type {
   ChatEvent,
   PlatformAdapter,
@@ -31,6 +32,10 @@ class MemoryRedis implements GatewayRedis {
     if (options.nx && this.store.has(key)) return null;
     this.store.set(key, value);
     return "OK";
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.store.delete(key) ? 1 : 0;
   }
 
   async lpush(): Promise<unknown> {
@@ -98,6 +103,8 @@ const envKeys = [
   "ELIZA_APP_TWILIO_ACCOUNT_SID",
   "ELIZA_APP_TWILIO_AUTH_TOKEN",
   "ELIZA_APP_TWILIO_PHONE_NUMBER",
+  "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+  "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
 ] as const;
 const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
 
@@ -106,6 +113,27 @@ function configureEnv(): void {
   process.env.ELIZA_APP_TWILIO_ACCOUNT_SID = "AC_test";
   process.env.ELIZA_APP_TWILIO_AUTH_TOKEN = "twilio-secret";
   process.env.ELIZA_APP_TWILIO_PHONE_NUMBER = "+15550000000";
+}
+
+function createTelegramAdapter(
+  event: ChatEvent,
+): PlatformAdapter & { replies: string[]; typingCount: number } {
+  const adapter: PlatformAdapter & { replies: string[]; typingCount: number } =
+    {
+      platform: "telegram",
+      replies: [],
+      typingCount: 0,
+      getDedupeScope: telegramAdapter.getDedupeScope,
+      verifyWebhook: mock(async () => true),
+      extractEvent: mock(async () => event),
+      sendReply: mock(async (_config, _event, text) => {
+        adapter.replies.push(text);
+      }),
+      sendTypingIndicator: mock(async () => {
+        adapter.typingCount += 1;
+      }),
+    };
+  return adapter;
 }
 
 async function waitFor(assertion: () => boolean, label: string): Promise<void> {
@@ -334,4 +362,168 @@ describe("gateway webhook handler e2e routing", () => {
     await new Promise((resolve) => setTimeout(resolve, 200));
     expect(adapter.replies).toEqual([]);
   });
+
+  test("scopes Telegram webhook dedupe by project and bot account", async () => {
+    configureEnv();
+    const redis = new MemoryRedis();
+    redis.store.set("agent:agent-1:server", "server-1");
+    redis.store.set("server:server-1:url", "http://agent-server.local");
+    const event: ChatEvent = {
+      platform: "telegram",
+      messageId: "123",
+      chatId: "42",
+      senderId: "42",
+      senderName: "Ada",
+      text: "same update id",
+      rawPayload: {},
+    };
+    const botA = createTelegramAdapter(event);
+    const botB = createTelegramAdapter(event);
+
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        request.url ===
+        "https://api.elizacloud.ai/api/internal/identity/resolve"
+      ) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              user: { id: "user-1", organizationId: "org-1" },
+              agent: { id: "agent-1" },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (request.url === "http://agent-server.local/agents/agent-1/message") {
+        return new Response(JSON.stringify({ response: "ok" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "bot-token-a";
+    await handleWebhook(
+      new Request("https://gateway.example/webhook/eliza-app/telegram", {
+        method: "POST",
+        body: "{}",
+      }),
+      botA,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "bot-token-b";
+    await handleWebhook(
+      new Request("https://gateway.example/webhook/eliza-app/telegram", {
+        method: "POST",
+        body: "{}",
+      }),
+      botB,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+
+    expect(botA.replies).toEqual(["ok"]);
+    expect(botB.replies).toEqual(["ok"]);
+    expect(
+      [...redis.store.keys()].filter(
+        (key) =>
+          key.includes("webhook:telegram") && !key.endsWith(":processing"),
+      ),
+    ).toEqual([
+      "webhook:telegram:project:eliza-app:bot:218da20172ac4d99:message:123",
+      "webhook:telegram:project:eliza-app:bot:9c352facd71adf06:message:123",
+    ]);
+  });
+
+  test("fails visibly instead of replaying after Telegram egress starts", async () => {
+    configureEnv();
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "bot-token-a";
+    const redis = new MemoryRedis();
+    redis.store.set("agent:agent-1:server", "server-1");
+    redis.store.set("server:server-1:url", "http://agent-server.local");
+    const event: ChatEvent = {
+      platform: "telegram",
+      messageId: "uncertain-1",
+      chatId: "42",
+      senderId: "42",
+      senderName: "Ada",
+      text: "send exactly once",
+      rawPayload: {},
+    };
+    const adapter = createTelegramAdapter(event);
+    let forwardAttempts = 0;
+    let sendAttempts = 0;
+    adapter.sendReply = mock(async () => {
+      sendAttempts += 1;
+      throw new Error("Telegram acknowledgement unavailable");
+    });
+
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        request.url ===
+        "https://api.elizacloud.ai/api/internal/identity/resolve"
+      ) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              user: { id: "user-1", organizationId: "org-1" },
+              agent: { id: "agent-1" },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (request.url === "http://agent-server.local/agents/agent-1/message") {
+        forwardAttempts += 1;
+        return new Response(JSON.stringify({ response: "one response" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    const request = () =>
+      new Request("https://gateway.example/webhook/eliza-app/telegram", {
+        method: "POST",
+        body: "{}",
+      });
+    const deps = {
+      redis,
+      cloudBaseUrl: "https://api.elizacloud.ai",
+      getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+    };
+
+    await expect(
+      handleWebhook(request(), adapter, deps, "eliza-app"),
+    ).rejects.toThrow("Telegram acknowledgement unavailable");
+
+    const retry = await handleWebhook(request(), adapter, deps, "eliza-app");
+    expect(retry.status).toBe(503);
+    expect(await retry.json()).toEqual({ error: "delivery outcome uncertain" });
+    expect(sendAttempts).toBe(1);
+    expect(forwardAttempts).toBe(1);
+    expect(
+      [...redis.store.entries()].some(
+        ([key, value]) =>
+          key.includes("uncertain-1") && value === "egress_started",
+      ),
+    ).toBe(true);
+  }, 30_000);
 });

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
@@ -6,6 +6,15 @@ import type { ChatEvent, PlatformAdapter, WebhookConfig } from "./types";
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const MAX_MESSAGE_LENGTH = 4096;
 
+function fingerprintBotToken(botToken: string | undefined): string {
+  if (!botToken) return "missing";
+  return crypto
+    .createHash("sha256")
+    .update(botToken)
+    .digest("hex")
+    .slice(0, 16);
+}
+
 async function telegramApi<T>(
   botToken: string,
   method: string,
@@ -76,6 +85,14 @@ interface TelegramUpdate {
 
 export const telegramAdapter: PlatformAdapter = {
   platform: "telegram",
+
+  getDedupeScope(
+    config: WebhookConfig,
+    _event: ChatEvent,
+    project: string,
+  ): string {
+    return `project:${project}:bot:${fingerprintBotToken(config.botToken)}`;
+  },
 
   async verifyWebhook(
     request: Request,

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
@@ -1,19 +1,11 @@
 // Handles webhook gateway telegram behavior for authenticated connector fan-in.
 import crypto from "node:crypto";
+import { resolveConnectorAccountId } from "../connector-account";
 import { logger } from "../logger";
 import type { ChatEvent, PlatformAdapter, WebhookConfig } from "./types";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const MAX_MESSAGE_LENGTH = 4096;
-
-function fingerprintBotToken(botToken: string | undefined): string {
-  if (!botToken) return "missing";
-  return crypto
-    .createHash("sha256")
-    .update(botToken)
-    .digest("hex")
-    .slice(0, 16);
-}
 
 async function telegramApi<T>(
   botToken: string,
@@ -91,7 +83,8 @@ export const telegramAdapter: PlatformAdapter = {
     _event: ChatEvent,
     project: string,
   ): string {
-    return `project:${project}:bot:${fingerprintBotToken(config.botToken)}`;
+    const accountId = resolveConnectorAccountId("telegram", config);
+    return `project:${project}:account:${accountId ?? "bot:missing"}`;
   },
 
   async verifyWebhook(

--- a/packages/cloud/services/gateway-webhook/src/adapters/types.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/types.ts
@@ -15,6 +15,12 @@ export interface ChatEvent {
 
 export interface PlatformAdapter {
   platform: Platform;
+  getDedupeScope?(
+    config: WebhookConfig,
+    event: ChatEvent,
+    project: string,
+    agentId?: string,
+  ): string;
   verifyWebhook(
     request: Request,
     rawBody: string,

--- a/packages/cloud/services/gateway-webhook/src/connector-account.ts
+++ b/packages/cloud/services/gateway-webhook/src/connector-account.ts
@@ -1,0 +1,30 @@
+// Stable connector-account identity shared by delivery dedupe and provenance forwarding.
+import { createHash } from "node:crypto";
+import type { Platform, WebhookConfig } from "./adapters/types";
+
+export function credentialFingerprint(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+/**
+ * Return a stable, non-secret account id for the connector configuration.
+ * Telegram tokens are credentials, so only their fingerprint may cross the
+ * gateway boundary or enter Redis keys and stored provenance.
+ */
+export function resolveConnectorAccountId(
+  platform: Platform,
+  config: WebhookConfig,
+): string | undefined {
+  switch (platform) {
+    case "telegram":
+      return config.botToken
+        ? `bot:${credentialFingerprint(config.botToken)}`
+        : undefined;
+    case "whatsapp":
+      return config.phoneNumberId ?? config.businessPhone;
+    case "twilio":
+      return config.phoneNumber ?? config.accountSid;
+    case "blooio":
+      return config.fromNumber;
+  }
+}

--- a/packages/cloud/services/gateway-webhook/src/redis.ts
+++ b/packages/cloud/services/gateway-webhook/src/redis.ts
@@ -27,6 +27,7 @@ interface SetOptions {
 export interface GatewayRedis {
   get<T = unknown>(key: string): Promise<T | null>;
   set(key: string, value: string, options?: SetOptions): Promise<unknown>;
+  del(key: string): Promise<unknown>;
   lpush(key: string, value: string): Promise<unknown>;
   ltrim(key: string, start: number, stop: number): Promise<unknown>;
   expire(key: string, seconds: number): Promise<unknown>;
@@ -62,6 +63,10 @@ class NativeRedisAdapter implements GatewayRedis {
       return this.client.set(key, value, "NX");
     }
     return this.client.set(key, value);
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.client.del(key);
   }
 
   async lpush(key: string, value: string): Promise<unknown> {
@@ -117,6 +122,10 @@ class MemoryRedisAdapter implements GatewayRedis {
       return this.client.set(key, value, "NX");
     }
     return this.client.set(key, value);
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.client.del(key);
   }
 
   async lpush(key: string, value: string): Promise<unknown> {

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -16,6 +16,10 @@ import {
 import { resolveWebhookConfig } from "./webhook-config";
 
 const DEDUP_TTL_SECONDS = 300;
+const PROCESSING_TTL_SECONDS = 60;
+const TELEGRAM_DELIVERY_TTL_SECONDS = 30 * 24 * 60 * 60;
+const TELEGRAM_EGRESS_STARTED = "egress_started";
+const TELEGRAM_DELIVERED = "delivered";
 
 interface HandlerDeps {
   redis: GatewayRedis;
@@ -73,7 +77,82 @@ export async function handleWebhook(
     return ackResponse(adapter.platform);
   }
 
-  const dedupKey = `webhook:${adapter.platform}:${event.messageId}`;
+  const dedupKey = buildWebhookDedupeKey(
+    adapter,
+    config,
+    event,
+    project,
+    agentId,
+  );
+  const priorDeliveryState = await redis.get<string>(dedupKey);
+  if (priorDeliveryState) {
+    if (
+      adapter.platform === "telegram" &&
+      priorDeliveryState === TELEGRAM_EGRESS_STARTED
+    ) {
+      logger.error(
+        "Telegram webhook delivery outcome is uncertain; refusing replay",
+        {
+          platform: adapter.platform,
+          messageId: event.messageId,
+          dedupKey,
+        },
+      );
+      return new Response(
+        JSON.stringify({ error: "delivery outcome uncertain" }),
+        {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+    logger.debug("Duplicate webhook skipped", {
+      platform: adapter.platform,
+      messageId: event.messageId,
+      dedupKey,
+    });
+    return ackResponse(adapter.platform);
+  }
+
+  if (adapter.platform === "telegram") {
+    const processingKey = `${dedupKey}:processing`;
+    const claimed = await redis.set(processingKey, "1", {
+      nx: true,
+      ex: PROCESSING_TTL_SECONDS,
+    });
+    if (!claimed) {
+      return new Response(JSON.stringify({ error: "update in progress" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    try {
+      await processMessage(
+        adapter,
+        config,
+        event,
+        deps,
+        project,
+        agentId,
+        async () => {
+          // Write the no-replay barrier before the Bot API call. A crash or
+          // ambiguous network failure after this point must fail visibly on a
+          // Telegram retry instead of sending the same response twice.
+          await redis.set(dedupKey, TELEGRAM_EGRESS_STARTED, {
+            ex: TELEGRAM_DELIVERY_TTL_SECONDS,
+          });
+        },
+      );
+      await redis.set(dedupKey, TELEGRAM_DELIVERED, {
+        ex: TELEGRAM_DELIVERY_TTL_SECONDS,
+      });
+      return ackResponse(adapter.platform);
+    } finally {
+      await redis.del(processingKey);
+    }
+  }
+
   const isNew = await redis.set(dedupKey, "1", {
     nx: true,
     ex: DEDUP_TTL_SECONDS,
@@ -82,6 +161,7 @@ export async function handleWebhook(
     logger.debug("Duplicate webhook skipped", {
       platform: adapter.platform,
       messageId: event.messageId,
+      dedupKey,
     });
     return ackResponse(adapter.platform);
   }
@@ -102,6 +182,19 @@ export async function handleWebhook(
   return ackResponse(adapter.platform);
 }
 
+function buildWebhookDedupeKey(
+  adapter: PlatformAdapter,
+  config: WebhookConfig,
+  event: ChatEvent,
+  project: string,
+  agentId?: string,
+): string {
+  const scope = adapter.getDedupeScope?.(config, event, project, agentId);
+  return scope
+    ? `webhook:${adapter.platform}:${scope}:message:${event.messageId}`
+    : `webhook:${adapter.platform}:${event.messageId}`;
+}
+
 async function processMessage(
   adapter: PlatformAdapter,
   config: WebhookConfig,
@@ -109,6 +202,7 @@ async function processMessage(
   deps: HandlerDeps,
   project: string,
   explicitAgentId?: string,
+  beforeEgress?: () => Promise<void>,
 ): Promise<void> {
   const { redis, cloudBaseUrl, getAuthHeader } = deps;
   const authHeader = getAuthHeader();
@@ -128,7 +222,7 @@ async function processMessage(
       platform: adapter.platform,
       senderId: event.senderId,
     });
-    await sendOnboardingReply(adapter, config, event, deps);
+    await sendOnboardingReply(adapter, config, event, deps, beforeEgress);
     return;
   }
 
@@ -137,7 +231,7 @@ async function processMessage(
   const server = await resolveAgentServer(redis, agentId);
   if (!server) {
     logger.error("No server found for agent", { project, agentId });
-    return;
+    throw new Error(`No server found for agent ${agentId}`);
   }
 
   adapter.sendTypingIndicator(config, event).catch((err) => {
@@ -174,7 +268,7 @@ async function processMessage(
       platform: adapter.platform,
       agentId,
     });
-    return;
+    throw err;
   }
 
   // An empty responseText is a deliberate no-response from the agent (mute /
@@ -192,12 +286,14 @@ async function processMessage(
   }
 
   try {
+    await beforeEgress?.();
     await adapter.sendReply(config, event, responseText);
   } catch (err) {
     logger.error("Failed to send reply", {
       error: err instanceof Error ? err.message : String(err),
       platform: adapter.platform,
     });
+    throw err;
   }
 }
 
@@ -206,51 +302,46 @@ async function sendOnboardingReply(
   config: WebhookConfig,
   event: ChatEvent,
   deps: HandlerDeps,
+  beforeEgress?: () => Promise<void>,
 ): Promise<void> {
   const { cloudBaseUrl, getAuthHeader } = deps;
 
-  try {
-    const response = await fetch(
-      `${cloudBaseUrl}/api/eliza-app/onboarding/chat`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...getAuthHeader(),
-        },
-        body: JSON.stringify({
-          sessionId: `platform:${adapter.platform}:${event.senderId}`,
-          message: event.text,
-          platform: adapter.platform,
-          platformUserId: event.senderId,
-          platformDisplayName: event.senderName,
-        }),
-        signal: AbortSignal.timeout(30_000),
+  const response = await fetch(
+    `${cloudBaseUrl}/api/eliza-app/onboarding/chat`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...getAuthHeader(),
       },
+      body: JSON.stringify({
+        sessionId: `platform:${adapter.platform}:${event.senderId}`,
+        message: event.text,
+        platform: adapter.platform,
+        platformUserId: event.senderId,
+        platformDisplayName: event.senderName,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `onboarding chat failed (${response.status}) ${body.slice(0, 200)}`,
     );
-
-    if (!response.ok) {
-      const body = await response.text().catch(() => "");
-      throw new Error(
-        `onboarding chat failed (${response.status}) ${body.slice(0, 200)}`,
-      );
-    }
-
-    const body = (await response.json()) as {
-      data?: {
-        reply?: string;
-      };
-    };
-    const reply =
-      body.data?.reply ??
-      "I can get your Eliza Cloud agent set up. Open https://app.elizacloud.ai/get-started to continue.";
-    await adapter.sendReply(config, event, reply);
-  } catch (err) {
-    logger.error("Failed to send onboarding reply", {
-      platform: adapter.platform,
-      error: err instanceof Error ? err.message : String(err),
-    });
   }
+
+  const body = (await response.json()) as {
+    data?: {
+      reply?: string;
+    };
+  };
+  const reply =
+    body.data?.reply ??
+    "I can get your Eliza Cloud agent set up. Open https://app.elizacloud.ai/get-started to continue.";
+  await beforeEgress?.();
+  await adapter.sendReply(config, event, reply);
 }
 
 function ackResponse(platform: Platform): Response {

--- a/plugins/plugin-telegram-standalone/package.json
+++ b/plugins/plugin-telegram-standalone/package.json
@@ -55,6 +55,7 @@
     }
   },
   "dependencies": {
+    "@elizaos/plugin-telegram": "workspace:*",
     "telegraf": "4.16.3"
   },
   "peerDependencies": {

--- a/plugins/plugin-telegram-standalone/src/handler.test.ts
+++ b/plugins/plugin-telegram-standalone/src/handler.test.ts
@@ -1,0 +1,68 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleTelegramStandaloneMessage } from "./handler";
+
+function makeRuntime() {
+  const cache = new Map<string, unknown>();
+  const createMemory = vi.fn(async () => undefined);
+  const handleMessage = vi.fn(async () => undefined);
+  const runtime = {
+    agentId: "agent-1",
+    getSetting: vi.fn(() => undefined),
+    getCache: vi.fn(async (key: string) => cache.get(key)),
+    setCache: vi.fn(async (key: string, value: unknown) => {
+      cache.set(key, value);
+      return true;
+    }),
+    ensureConnection: vi.fn(async () => undefined),
+    createMemory,
+    messageService: { handleMessage },
+  } as unknown as IAgentRuntime;
+  return { runtime, cache, createMemory, handleMessage };
+}
+
+function context(chatId: number, messageId = 7) {
+  const chat = { id: chatId, type: "private", first_name: "Ada" };
+  const from = { id: 42, first_name: "Ada", username: "ada", is_bot: false };
+  return {
+    chat,
+    from,
+    message: {
+      message_id: messageId,
+      date: 1_700_000_000,
+      text: `hello from ${chatId}`,
+      chat,
+      from,
+    },
+    reply: vi.fn(async () => ({ message_id: 8, date: 1_700_000_001, chat })),
+  } as never;
+}
+
+describe("standalone Telegram durable identity", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("scopes inbound memory identity by account, chat, and message id", async () => {
+    const { runtime, handleMessage } = makeRuntime();
+
+    await handleTelegramStandaloneMessage(runtime, context(111));
+    await handleTelegramStandaloneMessage(runtime, context(222));
+
+    expect(handleMessage).toHaveBeenCalledTimes(2);
+    const ids = handleMessage.mock.calls.map((call) => call[1].id);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it("deduplicates a successfully processed redelivery", async () => {
+    const { runtime, handleMessage } = makeRuntime();
+    const update = context(111);
+
+    await handleTelegramStandaloneMessage(runtime, update);
+    await handleTelegramStandaloneMessage(runtime, update);
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(runtime.setCache).toHaveBeenCalledWith(
+      "telegram-standalone:processed:default:111:7",
+      expect.any(Object)
+    );
+  });
+});

--- a/plugins/plugin-telegram-standalone/src/handler.test.ts
+++ b/plugins/plugin-telegram-standalone/src/handler.test.ts
@@ -1,6 +1,8 @@
 import type { IAgentRuntime } from "@elizaos/core";
+import { resolveTelegramRuntimeEntityId } from "@elizaos/plugin-telegram";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleTelegramStandaloneMessage } from "./handler";
+import { resolveStandaloneTelegramEntityId } from "./identity";
 
 function makeRuntime() {
   const cache = new Map<string, unknown>();
@@ -63,6 +65,14 @@ describe("standalone Telegram durable identity", () => {
     expect(runtime.setCache).toHaveBeenCalledWith(
       "telegram-standalone:processed:default:111:7",
       expect.any(Object)
+    );
+  });
+
+  it("uses the same unmatched user entity id as the plugin connector", async () => {
+    const { runtime } = makeRuntime();
+
+    await expect(resolveStandaloneTelegramEntityId(runtime, "default", "555001")).resolves.toBe(
+      await resolveTelegramRuntimeEntityId(runtime, "default", "555001")
     );
   });
 });

--- a/plugins/plugin-telegram-standalone/src/handler.ts
+++ b/plugins/plugin-telegram-standalone/src/handler.ts
@@ -8,6 +8,7 @@ import {
   type Memory,
   type UUID,
 } from "@elizaos/core";
+import { resolveStandaloneTelegramEntityId } from "./identity";
 
 function formatError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -96,6 +97,14 @@ function splitTelegramText(text: string): string[] {
   return chunks;
 }
 
+function telegramStandaloneMemoryKey(accountId: string, chatId: string, messageId: string): string {
+  return `telegram:${accountId}:message:${chatId}:${messageId}`;
+}
+
+function telegramStandaloneDedupeKey(accountId: string, chatId: string, messageId: string): string {
+  return `telegram-standalone:processed:${accountId}:${chatId}:${messageId}`;
+}
+
 export async function handleTelegramStandaloneMessage(
   runtime: IAgentRuntime,
   ctx: TelegramStandaloneContext
@@ -110,6 +119,7 @@ export async function handleTelegramStandaloneMessage(
     const from = ctx.from ?? message.from;
     const telegramUserId = String(from?.id ?? `chat-${chatId}`);
     const username = from?.username ?? from?.first_name ?? `telegram-${telegramUserId}`;
+    const accountId = "default";
     const threadId =
       message.message_thread_id !== undefined ? String(message.message_thread_id) : undefined;
     const telegramRoomId = threadId ? `${chatId}-${threadId}` : chatId;
@@ -131,12 +141,34 @@ export async function handleTelegramStandaloneMessage(
       return;
     }
 
-    const entityId = createUniqueUuid(runtime, `telegram-user:${telegramUserId}`) as UUID;
+    const telegramMessageId =
+      message.message_id !== undefined ? String(message.message_id) : `${chatId}:${Date.now()}`;
+    const dedupeKey = telegramStandaloneDedupeKey(accountId, chatId, telegramMessageId);
+    const deliveryMarker = await runtime.getCache<{ state?: "delivery_started" | "processed" }>(
+      dedupeKey
+    );
+    if (deliveryMarker !== undefined) {
+      if (deliveryMarker.state === "delivery_started") {
+        runtime.reportError(
+          "telegram-standalone:delivery-uncertain",
+          new Error(
+            `Telegram delivery outcome is uncertain for ${accountId}/${chatId}/${telegramMessageId}; refusing duplicate egress`
+          ),
+          { accountId, chatId, messageId: telegramMessageId }
+        );
+      }
+      logger.debug(
+        `[telegram-standalone] duplicate Telegram message skipped chat=${chatId} message=${telegramMessageId}`
+      );
+      return;
+    }
+
+    const entityId = await resolveStandaloneTelegramEntityId(runtime, accountId, telegramUserId);
     const roomId = createUniqueUuid(runtime, `telegram-room:${telegramRoomId}`) as UUID;
     const worldId = createUniqueUuid(runtime, `telegram-world:${chatId}`) as UUID;
     const messageId = createUniqueUuid(
       runtime,
-      `telegram-message:${message.message_id ?? `${chatId}:${Date.now()}`}`
+      telegramStandaloneMemoryKey(accountId, chatId, telegramMessageId)
     ) as UUID;
     const channelType = getTelegramChannelType(chat.type);
     const createdAt = typeof message.date === "number" ? message.date * 1000 : Date.now();
@@ -168,7 +200,11 @@ export async function handleTelegramStandaloneMessage(
           message.reply_to_message?.message_id !== undefined
             ? (createUniqueUuid(
                 runtime,
-                `telegram-message:${message.reply_to_message.message_id}`
+                telegramStandaloneMemoryKey(
+                  accountId,
+                  chatId,
+                  String(message.reply_to_message.message_id)
+                )
               ) as UUID)
             : undefined,
       },
@@ -176,6 +212,8 @@ export async function handleTelegramStandaloneMessage(
         type: "message",
         source: "telegram",
         provider: "telegram",
+        accountId,
+        scope: "room",
         timestamp: createdAt,
         entityName: from?.first_name,
         entityUserName: from?.username,
@@ -190,6 +228,8 @@ export async function handleTelegramStandaloneMessage(
           username: from?.username,
         },
         telegram: {
+          id: telegramUserId,
+          userId: telegramUserId,
           chatId,
           messageId: String(message.message_id ?? ""),
           threadId,
@@ -204,6 +244,14 @@ export async function handleTelegramStandaloneMessage(
       if (!content.text) {
         return [];
       }
+
+      await runtime.setCache(dedupeKey, {
+        state: "delivery_started",
+        processedAt: Date.now(),
+        accountId,
+        chatId,
+        messageId: telegramMessageId,
+      });
 
       const sentMemories: Memory[] = [];
       const chunks = splitTelegramText(content.text);
@@ -220,7 +268,10 @@ export async function handleTelegramStandaloneMessage(
         const sentMessageId =
           sent?.message_id !== undefined ? String(sent.message_id) : `local-${Date.now()}-${index}`;
         const responseMemory: Memory = {
-          id: createUniqueUuid(runtime, `telegram-message:${sentMessageId}`) as UUID,
+          id: createUniqueUuid(
+            runtime,
+            telegramStandaloneMemoryKey(accountId, String(sent?.chat?.id ?? chatId), sentMessageId)
+          ) as UUID,
           entityId: runtime.agentId,
           agentId: runtime.agentId,
           roomId,
@@ -235,6 +286,8 @@ export async function handleTelegramStandaloneMessage(
             type: "message",
             source: "telegram",
             provider: "telegram",
+            accountId,
+            scope: "room",
             timestamp: typeof sent?.date === "number" ? sent.date * 1000 : Date.now(),
             fromBot: true,
             fromId: runtime.agentId,
@@ -259,10 +312,19 @@ export async function handleTelegramStandaloneMessage(
     await runtime.messageService.handleMessage(runtime, memory, callback, {
       continueAfterActions: true,
     });
+    await runtime.setCache(dedupeKey, {
+      state: "processed",
+      processedAt: Date.now(),
+      accountId,
+      chatId,
+      messageId: telegramMessageId,
+    });
   } catch (outerErr) {
+    runtime.reportError("telegram-standalone:delivery", outerErr);
     logger.warn(`[telegram-standalone] Telegram handler error: ${formatError(outerErr)}`);
     // error-policy:J6 best-effort user-facing error notice; the underlying
     // failure is already logged above, so a failed reply has nowhere left to go.
     await ctx.reply("Sorry, I encountered an error processing your message.").catch(() => {});
+    throw outerErr;
   }
 }

--- a/plugins/plugin-telegram-standalone/src/identity.ts
+++ b/plugins/plugin-telegram-standalone/src/identity.ts
@@ -1,47 +1,11 @@
 /** Durable Telegram sender resolution for the standalone production connector. */
-import {
-  createUniqueUuid,
-  ElizaError,
-  type Entity,
-  getConfiguredOwnerEntityIds,
-  type IAgentRuntime,
-  type UUID,
-} from "@elizaos/core";
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { resolveTelegramRuntimeEntityId } from "@elizaos/plugin-telegram";
 
 export async function resolveStandaloneTelegramEntityId(
   runtime: IAgentRuntime,
   accountId: string,
   telegramUserId: string
 ): Promise<UUID> {
-  const ownerIds = getConfiguredOwnerEntityIds(runtime);
-  if (ownerIds.length === 0) {
-    return createUniqueUuid(runtime, `telegram:${accountId}:user:${telegramUserId}`) as UUID;
-  }
-  if (typeof runtime.getEntityById !== "function") {
-    throw new ElizaError("Telegram identity store is not ready", {
-      code: "TELEGRAM_IDENTITY_NOT_READY",
-      context: { accountId, telegramUserId },
-    });
-  }
-
-  for (const ownerId of ownerIds) {
-    const owner = (await runtime.getEntityById(ownerId as UUID)) as Entity | null;
-    const telegram = asRecord(asRecord(owner?.metadata)?.telegram);
-    const boundId = telegram?.userId ?? telegram?.id;
-    const boundAccount = telegram?.accountId;
-    if (
-      String(boundId ?? "") === telegramUserId &&
-      (boundAccount === undefined || String(boundAccount) === accountId)
-    ) {
-      return ownerId as UUID;
-    }
-  }
-
-  return createUniqueUuid(runtime, `telegram:${accountId}:user:${telegramUserId}`) as UUID;
+  return resolveTelegramRuntimeEntityId(runtime, accountId, telegramUserId);
 }

--- a/plugins/plugin-telegram-standalone/src/identity.ts
+++ b/plugins/plugin-telegram-standalone/src/identity.ts
@@ -1,0 +1,47 @@
+/** Durable Telegram sender resolution for the standalone production connector. */
+import {
+  createUniqueUuid,
+  ElizaError,
+  type Entity,
+  getConfiguredOwnerEntityIds,
+  type IAgentRuntime,
+  type UUID,
+} from "@elizaos/core";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export async function resolveStandaloneTelegramEntityId(
+  runtime: IAgentRuntime,
+  accountId: string,
+  telegramUserId: string
+): Promise<UUID> {
+  const ownerIds = getConfiguredOwnerEntityIds(runtime);
+  if (ownerIds.length === 0) {
+    return createUniqueUuid(runtime, `telegram:${accountId}:user:${telegramUserId}`) as UUID;
+  }
+  if (typeof runtime.getEntityById !== "function") {
+    throw new ElizaError("Telegram identity store is not ready", {
+      code: "TELEGRAM_IDENTITY_NOT_READY",
+      context: { accountId, telegramUserId },
+    });
+  }
+
+  for (const ownerId of ownerIds) {
+    const owner = (await runtime.getEntityById(ownerId as UUID)) as Entity | null;
+    const telegram = asRecord(asRecord(owner?.metadata)?.telegram);
+    const boundId = telegram?.userId ?? telegram?.id;
+    const boundAccount = telegram?.accountId;
+    if (
+      String(boundId ?? "") === telegramUserId &&
+      (boundAccount === undefined || String(boundAccount) === accountId)
+    ) {
+      return ownerId as UUID;
+    }
+  }
+
+  return createUniqueUuid(runtime, `telegram:${accountId}:user:${telegramUserId}`) as UUID;
+}

--- a/plugins/plugin-telegram-standalone/src/poller-lock.ts
+++ b/plugins/plugin-telegram-standalone/src/poller-lock.ts
@@ -1,101 +1,15 @@
-/**
- * Process-local Telegram bot token ownership and liveness state shared by the
- * full and standalone Telegram pollers. Telegram allows only one long-polling
- * `getUpdates` consumer per bot token, so every production poller must claim
- * the token before launching and expose whether that claim is actually polling.
- */
-import type { Context, Telegraf } from "telegraf";
-
-export type TelegramPollerMode = "full" | "standalone";
-
-export type TelegramPollerHealth = {
-  ok: boolean;
-  mode: TelegramPollerMode;
-  accountId: string;
-  ownerId: string;
-  connected: boolean;
-  lastUpdateAt?: number;
-  lastError?: string;
-};
-
-export type TelegramPollerClaim = TelegramPollerHealth & {
-  bot: Telegraf<Context>;
-};
-
-const LOCKS_KEY = "__elizaosTelegramPollerLocks";
-
-function getLocks(): Map<string, TelegramPollerClaim> {
-  const globalState = globalThis as typeof globalThis & {
-    __elizaosTelegramPollerLocks?: Map<string, TelegramPollerClaim>;
-  };
-  if (!globalState[LOCKS_KEY]) {
-    globalState[LOCKS_KEY] = new Map<string, TelegramPollerClaim>();
-  }
-  return globalState[LOCKS_KEY];
-}
-
-export function claimTelegramPollerToken(
-  token: string,
-  claim: Omit<TelegramPollerClaim, "connected" | "ok" | "lastUpdateAt">
-): TelegramPollerClaim {
-  const locks = getLocks();
-  const active = locks.get(token);
-  if (active && active.bot !== claim.bot) {
-    throw new Error(
-      `Telegram bot token already has an active ${active.mode} poller for ${active.ownerId}/${active.accountId}`
-    );
-  }
-  const next: TelegramPollerClaim = {
-    ...claim,
-    ok: false,
-    connected: false,
-  };
-  locks.set(token, next);
-  return next;
-}
-
-export function getTelegramPollerClaim(token: string): TelegramPollerClaim | undefined {
-  return getLocks().get(token);
-}
-
-export function releaseTelegramPollerToken(token: string, bot: Telegraf<Context>): void {
-  const locks = getLocks();
-  if (locks.get(token)?.bot === bot) {
-    locks.delete(token);
-  }
-}
-
-export function markTelegramPollerConnected(token: string, bot: Telegraf<Context>): void {
-  const claim = getLocks().get(token);
-  if (claim?.bot === bot) {
-    claim.connected = true;
-    claim.ok = true;
-    claim.lastError = undefined;
-  }
-}
-
-export function markTelegramPollerUpdate(token: string, bot: Telegraf<Context>): void {
-  const claim = getLocks().get(token);
-  if (claim?.bot === bot) {
-    claim.lastUpdateAt = Date.now();
-  }
-}
-
-export function markTelegramPollerError(
-  token: string,
-  bot: Telegraf<Context>,
-  error: unknown
-): void {
-  const claim = getLocks().get(token);
-  if (claim?.bot === bot) {
-    claim.connected = false;
-    claim.ok = false;
-    claim.lastError = error instanceof Error ? error.message : String(error);
-  }
-}
-
-export function listTelegramPollerHealth(mode?: TelegramPollerMode): TelegramPollerHealth[] {
-  return Array.from(getLocks().values())
-    .filter((claim) => !mode || claim.mode === mode)
-    .map(({ bot: _bot, ...health }) => ({ ...health }));
-}
+/** Shared Telegram poller ownership exports from the full Telegram plugin. */
+export {
+  claimTelegramPollerToken,
+  ensureTelegramPollerTokenAvailable,
+  getTelegramPollerClaim,
+  listTelegramPollerHealth,
+  markTelegramPollerConnected,
+  markTelegramPollerError,
+  markTelegramPollerTerminated,
+  markTelegramPollerUpdate,
+  releaseTelegramPollerToken,
+  type TelegramPollerClaim,
+  type TelegramPollerHealth,
+  type TelegramPollerMode,
+} from "@elizaos/plugin-telegram";

--- a/plugins/plugin-telegram-standalone/src/poller-lock.ts
+++ b/plugins/plugin-telegram-standalone/src/poller-lock.ts
@@ -1,0 +1,101 @@
+/**
+ * Process-local Telegram bot token ownership and liveness state shared by the
+ * full and standalone Telegram pollers. Telegram allows only one long-polling
+ * `getUpdates` consumer per bot token, so every production poller must claim
+ * the token before launching and expose whether that claim is actually polling.
+ */
+import type { Context, Telegraf } from "telegraf";
+
+export type TelegramPollerMode = "full" | "standalone";
+
+export type TelegramPollerHealth = {
+  ok: boolean;
+  mode: TelegramPollerMode;
+  accountId: string;
+  ownerId: string;
+  connected: boolean;
+  lastUpdateAt?: number;
+  lastError?: string;
+};
+
+export type TelegramPollerClaim = TelegramPollerHealth & {
+  bot: Telegraf<Context>;
+};
+
+const LOCKS_KEY = "__elizaosTelegramPollerLocks";
+
+function getLocks(): Map<string, TelegramPollerClaim> {
+  const globalState = globalThis as typeof globalThis & {
+    __elizaosTelegramPollerLocks?: Map<string, TelegramPollerClaim>;
+  };
+  if (!globalState[LOCKS_KEY]) {
+    globalState[LOCKS_KEY] = new Map<string, TelegramPollerClaim>();
+  }
+  return globalState[LOCKS_KEY];
+}
+
+export function claimTelegramPollerToken(
+  token: string,
+  claim: Omit<TelegramPollerClaim, "connected" | "ok" | "lastUpdateAt">
+): TelegramPollerClaim {
+  const locks = getLocks();
+  const active = locks.get(token);
+  if (active && active.bot !== claim.bot) {
+    throw new Error(
+      `Telegram bot token already has an active ${active.mode} poller for ${active.ownerId}/${active.accountId}`
+    );
+  }
+  const next: TelegramPollerClaim = {
+    ...claim,
+    ok: false,
+    connected: false,
+  };
+  locks.set(token, next);
+  return next;
+}
+
+export function getTelegramPollerClaim(token: string): TelegramPollerClaim | undefined {
+  return getLocks().get(token);
+}
+
+export function releaseTelegramPollerToken(token: string, bot: Telegraf<Context>): void {
+  const locks = getLocks();
+  if (locks.get(token)?.bot === bot) {
+    locks.delete(token);
+  }
+}
+
+export function markTelegramPollerConnected(token: string, bot: Telegraf<Context>): void {
+  const claim = getLocks().get(token);
+  if (claim?.bot === bot) {
+    claim.connected = true;
+    claim.ok = true;
+    claim.lastError = undefined;
+  }
+}
+
+export function markTelegramPollerUpdate(token: string, bot: Telegraf<Context>): void {
+  const claim = getLocks().get(token);
+  if (claim?.bot === bot) {
+    claim.lastUpdateAt = Date.now();
+  }
+}
+
+export function markTelegramPollerError(
+  token: string,
+  bot: Telegraf<Context>,
+  error: unknown
+): void {
+  const claim = getLocks().get(token);
+  if (claim?.bot === bot) {
+    claim.connected = false;
+    claim.ok = false;
+    claim.lastError = error instanceof Error ? error.message : String(error);
+  }
+}
+
+export function listTelegramPollerHealth(mode?: TelegramPollerMode): TelegramPollerHealth[] {
+  return Array.from(getLocks().values())
+    .filter((claim) => !mode || claim.mode === mode)
+    .map(({ bot: _bot, ...health }) => ({ ...health }));
+}

--- a/plugins/plugin-telegram-standalone/src/service.test.ts
+++ b/plugins/plugin-telegram-standalone/src/service.test.ts
@@ -22,6 +22,10 @@ const { FakeTelegraf, launchMock, stopMock, constructed } = vi.hoisted(() => {
 vi.mock("telegraf", () => ({ Telegraf: FakeTelegraf }));
 
 import { shouldStartTelegramStandaloneBot, TelegramStandaloneService } from "./index";
+import {
+  claimTelegramPollerToken as claimFullTelegramPollerToken,
+  releaseTelegramPollerToken as releaseFullTelegramPollerToken,
+} from "@elizaos/plugin-telegram";
 import { claimTelegramPollerToken, releaseTelegramPollerToken } from "./poller-lock";
 
 // Minimal runtime — the service only touches getService() at stop time.
@@ -120,6 +124,25 @@ describe("TelegramStandaloneService lifecycle", () => {
     );
     expect(launchMock).not.toHaveBeenCalled();
     releaseTelegramPollerToken("test-token", activeBot);
+  });
+
+  it("observes full-mode poller ownership through the shared lock implementation", async () => {
+    process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "1";
+    process.env.TELEGRAM_BOT_TOKEN = "test-shared-token";
+    const activeBot = { stop: vi.fn() } as never;
+    claimFullTelegramPollerToken("test-shared-token", {
+      bot: activeBot,
+      mode: "full",
+      ownerId: "agent-full",
+      accountId: "default",
+    });
+
+    await expect(TelegramStandaloneService.start(fakeRuntime())).rejects.toThrow(
+      /already has an active full poller/i
+    );
+    expect(launchMock).not.toHaveBeenCalled();
+    releaseFullTelegramPollerToken("test-shared-token", activeBot);
   });
 
   it("stands down under the gate when no bot token is configured", async () => {

--- a/plugins/plugin-telegram-standalone/src/service.test.ts
+++ b/plugins/plugin-telegram-standalone/src/service.test.ts
@@ -21,11 +21,11 @@ const { FakeTelegraf, launchMock, stopMock, constructed } = vi.hoisted(() => {
 
 vi.mock("telegraf", () => ({ Telegraf: FakeTelegraf }));
 
-import { shouldStartTelegramStandaloneBot, TelegramStandaloneService } from "./index";
 import {
   claimTelegramPollerToken as claimFullTelegramPollerToken,
   releaseTelegramPollerToken as releaseFullTelegramPollerToken,
 } from "@elizaos/plugin-telegram";
+import { shouldStartTelegramStandaloneBot, TelegramStandaloneService } from "./index";
 import { claimTelegramPollerToken, releaseTelegramPollerToken } from "./poller-lock";
 
 // Minimal runtime — the service only touches getService() at stop time.

--- a/plugins/plugin-telegram-standalone/src/service.test.ts
+++ b/plugins/plugin-telegram-standalone/src/service.test.ts
@@ -22,10 +22,12 @@ const { FakeTelegraf, launchMock, stopMock, constructed } = vi.hoisted(() => {
 vi.mock("telegraf", () => ({ Telegraf: FakeTelegraf }));
 
 import { shouldStartTelegramStandaloneBot, TelegramStandaloneService } from "./index";
+import { claimTelegramPollerToken, releaseTelegramPollerToken } from "./poller-lock";
 
 // Minimal runtime — the service only touches getService() at stop time.
 function fakeRuntime(): Parameters<typeof TelegramStandaloneService.start>[0] {
   return {
+    agentId: "agent-standalone",
     getService: vi.fn(() => null),
   } as unknown as Parameters<typeof TelegramStandaloneService.start>[0];
 }
@@ -92,9 +94,32 @@ describe("TelegramStandaloneService lifecycle", () => {
 
     expect(constructed).toEqual([{ token: "test-token" }]);
     expect(launchMock).toHaveBeenCalledOnce();
+    expect(launchMock.mock.calls[0][0]).toMatchObject({
+      dropPendingUpdates: false,
+      allowedUpdates: ["message", "message_reaction"],
+    });
 
     await service.stop();
     expect(stopMock).toHaveBeenCalledWith("service-stop");
+  });
+
+  it("fails instead of launching when another Telegram poller owns the token", async () => {
+    process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "1";
+    process.env.TELEGRAM_BOT_TOKEN = "test-token";
+    const activeBot = { stop: vi.fn() } as never;
+    claimTelegramPollerToken("test-token", {
+      bot: activeBot,
+      mode: "full",
+      ownerId: "agent-full",
+      accountId: "default",
+    });
+
+    await expect(TelegramStandaloneService.start(fakeRuntime())).rejects.toThrow(
+      /already has an active full poller/i
+    );
+    expect(launchMock).not.toHaveBeenCalled();
+    releaseTelegramPollerToken("test-token", activeBot);
   });
 
   it("stands down under the gate when no bot token is configured", async () => {

--- a/plugins/plugin-telegram-standalone/src/service.ts
+++ b/plugins/plugin-telegram-standalone/src/service.ts
@@ -6,7 +6,7 @@ import {
   claimTelegramPollerToken,
   getTelegramPollerClaim,
   markTelegramPollerConnected,
-  markTelegramPollerError,
+  markTelegramPollerTerminated,
   markTelegramPollerUpdate,
   releaseTelegramPollerToken,
   type TelegramPollerHealth,
@@ -18,9 +18,9 @@ function formatError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-// Module-level reference so a hot runtime restart can stop the previous poller
-// before the next one launches — two long-polls on one bot token would fight
-// over ownership and Telegram would 409 one of them.
+// Module-level reference lets this service stop its own previous standalone
+// poller during hot restart. Cross-mode ownership is enforced by the shared
+// poller lock, which preserves a hard failure for a live full-service owner.
 let activeStandaloneBot: Telegraf<Context> | null = null;
 let activeStandaloneToken: string | null = null;
 
@@ -119,7 +119,7 @@ export class TelegramStandaloneService extends Service {
           }
         )
         .catch((err: unknown) => {
-          markTelegramPollerError(botToken, bot, err);
+          markTelegramPollerTerminated(botToken, bot, err);
           logger.warn(`[telegram-standalone] Telegram bot launch error: ${formatError(err)}`);
         });
 

--- a/plugins/plugin-telegram-standalone/src/service.ts
+++ b/plugins/plugin-telegram-standalone/src/service.ts
@@ -2,6 +2,15 @@ import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import { type Context, Telegraf } from "telegraf";
 import { handleTelegramStandaloneMessage } from "./handler";
 import { shouldStartTelegramStandaloneBot } from "./policy";
+import {
+  claimTelegramPollerToken,
+  getTelegramPollerClaim,
+  markTelegramPollerConnected,
+  markTelegramPollerError,
+  markTelegramPollerUpdate,
+  releaseTelegramPollerToken,
+  type TelegramPollerHealth,
+} from "./poller-lock";
 
 export const TELEGRAM_STANDALONE_SERVICE_NAME = "telegram-standalone";
 
@@ -13,17 +22,24 @@ function formatError(err: unknown): string {
 // before the next one launches — two long-polls on one bot token would fight
 // over ownership and Telegram would 409 one of them.
 let activeStandaloneBot: Telegraf<Context> | null = null;
+let activeStandaloneToken: string | null = null;
 
 function stopActiveStandaloneBot(reason: string): void {
   if (!activeStandaloneBot) {
     return;
   }
+  const bot = activeStandaloneBot;
+  const token = activeStandaloneToken;
   try {
-    activeStandaloneBot.stop(reason);
+    bot.stop(reason);
   } catch {
     /* ignore */
   }
+  if (token) {
+    releaseTelegramPollerToken(token, bot);
+  }
   activeStandaloneBot = null;
+  activeStandaloneToken = null;
 }
 
 /**
@@ -42,6 +58,7 @@ export class TelegramStandaloneService extends Service {
     "Opt-in standalone Telegram polling bot (gate ELIZA_TELEGRAM_STANDALONE_BOT).";
 
   private bot: Telegraf<Context> | null = null;
+  private botToken: string | null = null;
 
   static async start(runtime: IAgentRuntime): Promise<TelegramStandaloneService> {
     const service = new TelegramStandaloneService(runtime);
@@ -72,8 +89,17 @@ export class TelegramStandaloneService extends Service {
     try {
       const apiRoot = process.env.TELEGRAM_API_ROOT || "https://api.telegram.org";
       const bot = new Telegraf(botToken, { telegram: { apiRoot } });
+      this.bot = bot;
+      this.botToken = botToken;
+      claimTelegramPollerToken(botToken, {
+        bot,
+        mode: "standalone",
+        ownerId: String(this.runtime.agentId),
+        accountId: "default",
+      });
 
       bot.on("message", async (ctx) => {
+        markTelegramPollerUpdate(botToken, bot);
         await handleTelegramStandaloneMessage(this.runtime, ctx);
       });
 
@@ -83,16 +109,22 @@ export class TelegramStandaloneService extends Service {
 
       // Fire-and-forget — bot.launch() only resolves on stop().
       bot
-        .launch({
-          dropPendingUpdates: true,
-          allowedUpdates: ["message", "message_reaction"],
-        })
-        .catch((err: unknown) =>
-          logger.warn(`[telegram-standalone] Telegram bot launch error: ${formatError(err)}`)
-        );
+        .launch(
+          {
+            dropPendingUpdates: false,
+            allowedUpdates: ["message", "message_reaction"],
+          },
+          () => {
+            markTelegramPollerConnected(botToken, bot);
+          }
+        )
+        .catch((err: unknown) => {
+          markTelegramPollerError(botToken, bot, err);
+          logger.warn(`[telegram-standalone] Telegram bot launch error: ${formatError(err)}`);
+        });
 
-      this.bot = bot;
       activeStandaloneBot = bot;
+      activeStandaloneToken = botToken;
 
       // Stop the poller on process signals in addition to the runtime's
       // service-stop path, matching the previous inline connector's SIGINT
@@ -103,8 +135,40 @@ export class TelegramStandaloneService extends Service {
       await new Promise((r) => setTimeout(r, 500));
       logger.info("[telegram-standalone] Telegram bot polling started");
     } catch (err) {
+      if (botToken && this.bot) {
+        releaseTelegramPollerToken(botToken, this.bot);
+      }
+      this.bot = null;
+      this.botToken = null;
       logger.warn(`[telegram-standalone] Telegram bot setup failed: ${formatError(err)}`);
+      throw err;
     }
+  }
+
+  public getPollerHealth(): TelegramPollerHealth {
+    if (!this.botToken || !this.bot) {
+      return {
+        ok: false,
+        mode: "standalone",
+        accountId: "default",
+        ownerId: String(this.runtime.agentId),
+        connected: false,
+        lastError: "Telegram standalone poller is not launched",
+      };
+    }
+    const claim = getTelegramPollerClaim(this.botToken);
+    if (claim?.bot === this.bot) {
+      const { bot: _bot, ...health } = claim;
+      return health;
+    }
+    return {
+      ok: false,
+      mode: "standalone",
+      accountId: "default",
+      ownerId: String(this.runtime.agentId),
+      connected: false,
+      lastError: "Telegram standalone poller lock is not active",
+    };
   }
 
   async stop(): Promise<void> {
@@ -117,6 +181,10 @@ export class TelegramStandaloneService extends Service {
         /* ignore */
       }
     }
+    if (this.botToken && this.bot) {
+      releaseTelegramPollerToken(this.botToken, this.bot);
+    }
     this.bot = null;
+    this.botToken = null;
   }
 }

--- a/plugins/plugin-telegram/AGENTS.md
+++ b/plugins/plugin-telegram/AGENTS.md
@@ -120,7 +120,7 @@ Account resolution order (for the `default` account): `character.settings.telegr
 
 ## Conventions / gotchas
 
-- **One bot token per Telegram long-poll session.** If two agent instances share the same token they will 409-conflict. The plugin tracks active pollers in `ACTIVE_TELEGRAM_POLLERS` (module-level `Map`) and stops the previous poller before launching a new one.
+- **One bot token per Telegram long-poll session.** If two live agent instances share the same token they will 409-conflict. Full and standalone pollers use the shared process-local lock in `src/poller-lock.ts`: global records are keyed by a token fingerprint, never the plaintext token, and they do not store live `Telegraf` objects. A claim is reclaimed only after its poller reaches an explicit terminal state; starting, retrying, or quiet-but-live owners remain a hard launch failure.
 - **`TelegramService` must start before `TelegramOwnerPairingServiceImpl`** — the pairing service's `start` looks up the live Telegraf `bot` instance from the already-running `TelegramService`.
 - **Message sending**: use `MessageManager` (available as `TelegramService.messageManager`). Markdown is converted to Telegram MarkdownV2 via `convertMarkdownToTelegram` in `utils.ts`. Messages longer than 4096 characters are split.
 - **Forum topics**: each thread becomes a separate `Room` with `channelId` of the form `<chatId>-<threadId>`. Room metadata includes `isForumTopic: true`.

--- a/plugins/plugin-telegram/CLAUDE.md
+++ b/plugins/plugin-telegram/CLAUDE.md
@@ -120,7 +120,7 @@ Account resolution order (for the `default` account): `character.settings.telegr
 
 ## Conventions / gotchas
 
-- **One bot token per Telegram long-poll session.** If two agent instances share the same token they will 409-conflict. The plugin tracks active pollers in `ACTIVE_TELEGRAM_POLLERS` (module-level `Map`) and stops the previous poller before launching a new one.
+- **One bot token per Telegram long-poll session.** If two live agent instances share the same token they will 409-conflict. Full and standalone pollers use the shared process-local lock in `src/poller-lock.ts`: global records are keyed by a token fingerprint, never the plaintext token, and they do not store live `Telegraf` objects. A claim is reclaimed only after its poller reaches an explicit terminal state; starting, retrying, or quiet-but-live owners remain a hard launch failure.
 - **`TelegramService` must start before `TelegramOwnerPairingServiceImpl`** — the pairing service's `start` looks up the live Telegraf `bot` instance from the already-running `TelegramService`.
 - **Message sending**: use `MessageManager` (available as `TelegramService.messageManager`). Markdown is converted to Telegram MarkdownV2 via `convertMarkdownToTelegram` in `utils.ts`. Messages longer than 4096 characters are split.
 - **Forum topics**: each thread becomes a separate `Room` with `channelId` of the form `<chatId>-<threadId>`. Room metadata includes `isForumTopic: true`.

--- a/plugins/plugin-telegram/__tests__/core-test-mock.ts
+++ b/plugins/plugin-telegram/__tests__/core-test-mock.ts
@@ -121,6 +121,7 @@ vi.mock("@elizaos/core", async () => {
     ChannelType,
     CommandRegistryService,
     EventType,
+    getConfiguredOwnerEntityIds: () => [],
     getDefaultTriageService,
     ModelType,
     Role,

--- a/plugins/plugin-telegram/__tests__/keyless-harness.harness.test.ts
+++ b/plugins/plugin-telegram/__tests__/keyless-harness.harness.test.ts
@@ -15,10 +15,21 @@
  * api.telegram.org, no network, NO API keys: the outbound seam is captured.
  */
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  attestDeliveryAudienceFromCanonicalRoom,
+  authorizeOwnerExclusiveDisclosure,
+  createUniqueUuid,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
 import { type MockLlmRuntime, withMockLlmRuntime } from "@elizaos/test-harness";
 import type { Context } from "telegraf";
 import { Telegraf } from "telegraf";
 import { afterEach, describe, expect, it } from "vitest";
+import { resolveTelegramRuntimeEntityId } from "../src/identity.ts";
 import { MessageManager } from "../src/index.ts";
 
 const cleanups: Array<() => Promise<void>> = [];
@@ -36,6 +47,165 @@ function track(harness: MockLlmRuntime): MockLlmRuntime {
 }
 
 describe("telegram connector loop (keyless harness)", () => {
+  it("fails closed when a configured owner cannot be read from the identity store", async () => {
+    const notReadyRuntime = {
+      agentId: "992093a1-27d3-0543-846c-0dafe6e68065",
+      getSetting: (key: string) =>
+        key === "ELIZA_ADMIN_ENTITY_ID"
+          ? "11111111-1111-4111-8111-111111111111"
+          : undefined,
+    };
+
+    await expect(
+      resolveTelegramRuntimeEntityId(
+        notReadyRuntime as never,
+        "default",
+        "555001",
+      ),
+    ).rejects.toMatchObject({ code: "TELEGRAM_IDENTITY_NOT_READY" });
+  });
+
+  it("keeps canonical owner identity and completed-delivery dedupe across a PGlite restart", async () => {
+    const pgliteDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "telegram-durable-"),
+    );
+    const ownerId = "11111111-1111-4111-8111-111111111111" as UUID;
+    const telegramUserId = "555001";
+    const chatId = 555001;
+    const messageId = 100;
+    let first: MockLlmRuntime | undefined;
+    let second: MockLlmRuntime | undefined;
+
+    const createContext = (
+      delivered: Array<{ chatId: number | string; text: string }>,
+    ): Context => {
+      const sendMessage = async (
+        target: number | string,
+        text: string,
+      ): Promise<unknown> => {
+        delivered.push({ chatId: target, text });
+        return {
+          message_id: delivered.length,
+          chat: { id: target, type: "private" },
+          date: Math.floor(Date.now() / 1000),
+          text,
+        };
+      };
+      const chat = { id: chatId, type: "private", first_name: "Ada" };
+      const from = {
+        id: Number(telegramUserId),
+        is_bot: false,
+        first_name: "Ada",
+        username: "ada",
+      };
+      return {
+        from,
+        chat,
+        message: {
+          message_id: messageId,
+          date: Math.floor(Date.now() / 1000),
+          text: "Remember my launch phrase is solar key and reply once.",
+          chat,
+          from,
+        },
+        telegram: {
+          sendChatAction: async () => true,
+          sendMessage,
+        },
+      } as unknown as Context;
+    };
+
+    try {
+      first = await withMockLlmRuntime({ strict: false, pgliteDir });
+      first.runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", ownerId);
+      await first.runtime.createEntity({
+        id: ownerId,
+        agentId: first.runtime.agentId,
+        names: ["Ada"],
+        metadata: {
+          telegram: {
+            id: telegramUserId,
+            userId: telegramUserId,
+            accountId: "default",
+          },
+        },
+      });
+
+      const firstDelivered: Array<{ chatId: number | string; text: string }> =
+        [];
+      const firstBot = new Telegraf("123456:TEST_TOKEN", {
+        telegram: { apiRoot: "http://127.0.0.1:0/" },
+      });
+      Object.assign(firstBot.telegram, createContext(firstDelivered).telegram);
+      const firstManager = new MessageManager(
+        firstBot,
+        first.runtime,
+        "default",
+      );
+      await firstManager.handleMessage(createContext(firstDelivered), {
+        forceReply: true,
+      });
+      expect(firstDelivered).toHaveLength(1);
+
+      const roomId = createUniqueUuid(first.runtime, String(chatId)) as UUID;
+      const memories = await first.runtime.getMemories({
+        roomId,
+        tableName: "messages",
+        count: 20,
+      });
+      const inbound = memories.find((memory) => memory.entityId === ownerId);
+      expect(inbound?.content.text).toContain("solar key");
+      if (!inbound) throw new Error("canonical Telegram owner memory missing");
+      expect(
+        new Set(await first.runtime.getParticipantsForRoom(roomId)),
+      ).toEqual(new Set([ownerId, first.runtime.agentId]));
+      await attestDeliveryAudienceFromCanonicalRoom(first.runtime, inbound);
+      expect(
+        (await authorizeOwnerExclusiveDisclosure(first.runtime, inbound))
+          .allowed,
+      ).toBe(true);
+
+      await first.cleanup();
+      first = undefined;
+
+      second = await withMockLlmRuntime({ strict: false, pgliteDir });
+      second.runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", ownerId);
+      expect((await second.runtime.getEntityById(ownerId))?.id).toBe(ownerId);
+
+      const replayDelivered: Array<{ chatId: number | string; text: string }> =
+        [];
+      const secondBot = new Telegraf("123456:TEST_TOKEN", {
+        telegram: { apiRoot: "http://127.0.0.1:0/" },
+      });
+      Object.assign(
+        secondBot.telegram,
+        createContext(replayDelivered).telegram,
+      );
+      const secondManager = new MessageManager(
+        secondBot,
+        second.runtime,
+        "default",
+      );
+      await secondManager.handleMessage(createContext(replayDelivered), {
+        forceReply: true,
+      });
+      expect(replayDelivered).toHaveLength(0);
+
+      const persisted = (await second.runtime.getMemories({
+        roomId: createUniqueUuid(second.runtime, String(chatId)) as UUID,
+        tableName: "messages",
+        count: 20,
+      })) as Memory[];
+      expect(
+        persisted.filter((memory) => memory.entityId === ownerId),
+      ).toHaveLength(1);
+    } finally {
+      await second?.cleanup();
+      await first?.cleanup();
+      fs.rmSync(pgliteDir, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it("drives a synthetic Telegram message through the mock LLM to a delivered reply", async () => {
     // Heuristic (non-strict) proxy: the reply turn makes several model calls;
     // let the proxy answer them deterministically without hand fixtures.

--- a/plugins/plugin-telegram/src/identity.ts
+++ b/plugins/plugin-telegram/src/identity.ts
@@ -1,0 +1,92 @@
+/**
+ * Telegram sender identity resolution against the canonical owner entity.
+ * Owner pairing writes the verified Telegram id into the owner entity metadata;
+ * inbound production paths read that durable row before deriving a connector
+ * entity so a restart cannot split the owner into a fresh platform UUID.
+ */
+import {
+  createUniqueUuid,
+  ElizaError,
+  type Entity,
+  getConfiguredOwnerEntityIds,
+  type IAgentRuntime,
+  type UUID,
+} from "@elizaos/core";
+
+export function telegramIdentityMetadata(
+  telegramUserId: string,
+  name?: string,
+  username?: string,
+  accountId?: string,
+): Record<string, string> {
+  return {
+    userId: telegramUserId,
+    id: telegramUserId,
+    ...(name ? { name } : {}),
+    ...(username ? { username } : {}),
+    ...(accountId ? { accountId } : {}),
+  };
+}
+
+function metadataRecord(
+  entity: Entity | null | undefined,
+): Record<string, unknown> | null {
+  const metadata = entity?.metadata;
+  return metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? (metadata as Record<string, unknown>)
+    : null;
+}
+
+function connectorRecord(
+  entity: Entity | null | undefined,
+): Record<string, unknown> | null {
+  const telegram = metadataRecord(entity)?.telegram;
+  return telegram && typeof telegram === "object" && !Array.isArray(telegram)
+    ? (telegram as Record<string, unknown>)
+    : null;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function telegramOwnerMatches(
+  entity: Entity | null | undefined,
+  telegramUserId: string,
+  accountId: string,
+): boolean {
+  const telegram = connectorRecord(entity);
+  if (!telegram) return false;
+  const id = stringField(telegram.userId) ?? stringField(telegram.id);
+  if (id !== telegramUserId) return false;
+  const boundAccountId = stringField(telegram.accountId);
+  return !boundAccountId || boundAccountId === accountId;
+}
+
+export async function resolveTelegramRuntimeEntityId(
+  runtime: IAgentRuntime,
+  accountId: string,
+  telegramUserId: string,
+): Promise<UUID> {
+  const ownerIds = getConfiguredOwnerEntityIds(runtime);
+  if (ownerIds.length === 0) {
+    return createUniqueUuid(runtime, `${accountId}:${telegramUserId}`) as UUID;
+  }
+  if (typeof runtime.getEntityById !== "function") {
+    throw new ElizaError("Telegram identity store is not ready", {
+      code: "TELEGRAM_IDENTITY_NOT_READY",
+      context: { accountId, telegramUserId },
+    });
+  }
+
+  for (const ownerId of ownerIds) {
+    const owner = await runtime.getEntityById(ownerId as UUID);
+    if (telegramOwnerMatches(owner, telegramUserId, accountId)) {
+      return ownerId as UUID;
+    }
+  }
+
+  return createUniqueUuid(runtime, `${accountId}:${telegramUserId}`) as UUID;
+}

--- a/plugins/plugin-telegram/src/identity.ts
+++ b/plugins/plugin-telegram/src/identity.ts
@@ -62,6 +62,9 @@ function telegramOwnerMatches(
   const id = stringField(telegram.userId) ?? stringField(telegram.id);
   if (id !== telegramUserId) return false;
   const boundAccountId = stringField(telegram.accountId);
+  // Older owner-pairing rows predate account-scoped metadata. The Telegram
+  // user id is server-attested, so those rows remain valid for the runtime's
+  // owner while newly written rows bind to the specific bot account.
   return !boundAccountId || boundAccountId === accountId;
 }
 
@@ -88,5 +91,8 @@ export async function resolveTelegramRuntimeEntityId(
     }
   }
 
+  // `getEntityById` throws on storage failure; a null owner here means the
+  // configured owner is not paired to this Telegram user yet, not that the row
+  // failed to load.
   return createUniqueUuid(runtime, `${accountId}:${telegramUserId}`) as UUID;
 }

--- a/plugins/plugin-telegram/src/index.ts
+++ b/plugins/plugin-telegram/src/index.ts
@@ -89,6 +89,7 @@ export * from "./accounts";
 export * from "./connector-account-provider";
 export * from "./identity";
 export * from "./local-client";
+export * from "./poller-lock";
 export {
   MessageManager,
   stopTelegramAccountAuthSession,

--- a/plugins/plugin-telegram/src/index.ts
+++ b/plugins/plugin-telegram/src/index.ts
@@ -87,6 +87,7 @@ const telegramPlugin: Plugin = {
 export * from "./account-auth-service";
 export * from "./accounts";
 export * from "./connector-account-provider";
+export * from "./identity";
 export * from "./local-client";
 export {
   MessageManager,

--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -421,10 +421,16 @@ describe("MessageManager malformed payload handling", () => {
   it("persists hostile text input after stripping null characters", async () => {
     const ensureConnection = vi.fn(async () => undefined);
     const createMemory = vi.fn(async () => undefined);
+    const cache = new Map<string, unknown>();
     const runtime = {
       agentId: "agent-1",
       ensureConnection,
       createMemory,
+      getCache: vi.fn(async (key: string) => cache.get(key)),
+      setCache: vi.fn(async (key: string, value: unknown) => {
+        cache.set(key, value);
+        return true;
+      }),
       getSetting: vi.fn(() => undefined),
     } as unknown as IAgentRuntime;
     const manager = new MessageManager({ telegram: {} } as never, runtime);
@@ -463,6 +469,94 @@ describe("MessageManager malformed payload handling", () => {
       chatId: "123",
       messageId: "99",
     });
+  });
+
+  it("scopes inbound memory ids by account, chat, and Telegram message id", async () => {
+    const cache = new Map<string, unknown>();
+    const createMemory = vi.fn(async () => undefined);
+    const runtime = {
+      agentId: "agent-1",
+      ensureConnection: vi.fn(async () => undefined),
+      createMemory,
+      getCache: vi.fn(async (key: string) => cache.get(key)),
+      setCache: vi.fn(async (key: string, value: unknown) => {
+        cache.set(key, value);
+        return true;
+      }),
+      getSetting: vi.fn(() => undefined),
+    } as unknown as IAgentRuntime;
+    const manager = new MessageManager(
+      { telegram: {} } as never,
+      runtime,
+      "acct-a",
+    );
+
+    for (const chatId of [111, 222]) {
+      await manager.handleMessage({
+        from: {
+          id: 42,
+          first_name: "Ada",
+          username: "ada",
+          is_bot: false,
+        },
+        chat: { id: chatId, type: "private", first_name: "Ada" },
+        message: {
+          message_id: 99,
+          date: 1_700_000_000,
+          text: `hello from ${chatId}`,
+          chat: { id: chatId, type: "private", first_name: "Ada" },
+        },
+      } as never);
+    }
+
+    expect(createMemory).toHaveBeenCalledTimes(2);
+    const ids = createMemory.mock.calls.map((call) => call[0].id);
+    expect(new Set(ids).size).toBe(2);
+    expect(runtime.setCache).toHaveBeenCalledWith(
+      "telegram:processed:acct-a:111:99",
+      expect.any(Object),
+    );
+    expect(runtime.setCache).toHaveBeenCalledWith(
+      "telegram:processed:acct-a:222:99",
+      expect.any(Object),
+    );
+  });
+
+  it("skips duplicate Telegram messages already marked in durable cache", async () => {
+    const cache = new Map<string, unknown>([
+      ["telegram:processed:acct-a:111:99", { processedAt: Date.now() }],
+    ]);
+    const createMemory = vi.fn(async () => undefined);
+    const runtime = {
+      agentId: "agent-1",
+      ensureConnection: vi.fn(async () => undefined),
+      createMemory,
+      getCache: vi.fn(async (key: string) => cache.get(key)),
+      setCache: vi.fn(async (key: string, value: unknown) => {
+        cache.set(key, value);
+        return true;
+      }),
+      getSetting: vi.fn(() => undefined),
+    } as unknown as IAgentRuntime;
+    const manager = new MessageManager(
+      { telegram: {} } as never,
+      runtime,
+      "acct-a",
+    );
+
+    await manager.handleMessage({
+      from: { id: 42, first_name: "Ada", username: "ada", is_bot: false },
+      chat: { id: 111, type: "private", first_name: "Ada" },
+      message: {
+        message_id: 99,
+        date: 1_700_000_000,
+        text: "duplicate",
+        chat: { id: 111, type: "private", first_name: "Ada" },
+      },
+    } as never);
+
+    expect(createMemory).not.toHaveBeenCalled();
+    expect(runtime.setCache).not.toHaveBeenCalled();
   });
 });
 

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -40,6 +40,10 @@ import type {
 import type { Context, NarrowedContext, Telegraf } from "telegraf";
 import { Markup } from "telegraf";
 import { resolveTelegramSenderAuth } from "./command-registration";
+import {
+  resolveTelegramRuntimeEntityId,
+  telegramIdentityMetadata,
+} from "./identity";
 import { renderTelegramInteractions } from "./interactions";
 import {
   type TelegramContent,
@@ -131,19 +135,6 @@ type ComputerUseApprovalResolver = {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
-}
-
-function telegramIdentityMetadata(
-  telegramUserId: string,
-  name?: string,
-  username?: string,
-): Record<string, string> {
-  return {
-    userId: telegramUserId,
-    id: telegramUserId,
-    ...(name ? { name } : {}),
-    ...(username ? { username } : {}),
-  };
 }
 
 function isCompactProgressContent(
@@ -339,6 +330,54 @@ export class MessageManager {
 
   private scopedTelegramKey(key: string): string {
     return this.accountId === "default" ? key : `${this.accountId}:${key}`;
+  }
+
+  private telegramMessageMemoryKey(
+    chatId: number | string,
+    messageId: number | string,
+  ): string {
+    return `telegram:${this.accountId}:message:${chatId}:${messageId}`;
+  }
+
+  private telegramUpdateDedupeKey(
+    chatId: number | string,
+    messageId: number | string,
+  ): string {
+    return `telegram:processed:${this.accountId}:${chatId}:${messageId}`;
+  }
+
+  private async getTelegramMessageDeliveryState(
+    chatId: number | string,
+    messageId: number | string,
+  ): Promise<"delivery_started" | "processed" | undefined> {
+    const marker = await this.runtime.getCache<{
+      processedAt: number;
+      accountId: string;
+      chatId: string;
+      messageId: string;
+      state?: "delivery_started" | "processed";
+    }>(this.telegramUpdateDedupeKey(chatId, messageId));
+    if (!marker) return undefined;
+    // Markers written before delivery-state tracking landed represent turns
+    // that completed successfully.
+    return marker.state ?? "processed";
+  }
+
+  private async markTelegramMessageDeliveryState(
+    chatId: number | string,
+    messageId: number | string,
+    state: "delivery_started" | "processed",
+  ): Promise<void> {
+    await this.runtime.setCache(
+      this.telegramUpdateDedupeKey(chatId, messageId),
+      {
+        processedAt: Date.now(),
+        accountId: this.accountId,
+        chatId: String(chatId),
+        messageId: String(messageId),
+        state,
+      },
+    );
   }
 
   /**
@@ -1097,7 +1136,10 @@ export class MessageManager {
       const responseMemory: Memory = {
         id: createUniqueUuid(
           this.runtime,
-          this.scopedTelegramKey(sentMessage.message_id.toString()),
+          this.telegramMessageMemoryKey(
+            sentMessage.chat.id,
+            sentMessage.message_id,
+          ),
         ),
         entityId: this.runtime.agentId,
         agentId: this.runtime.agentId,
@@ -1313,10 +1355,11 @@ export class MessageManager {
 
     try {
       const telegramUserId = ctx.from.id.toString();
-      const entityId = createUniqueUuid(
+      const entityId = await resolveTelegramRuntimeEntityId(
         this.runtime,
-        this.scopedTelegramKey(telegramUserId),
-      ) as UUID;
+        this.accountId,
+        telegramUserId,
+      );
 
       const threadId =
         "is_topic_message" in message && message.is_topic_message
@@ -1341,8 +1384,46 @@ export class MessageManager {
       const telegramMessageId = message.message_id.toString();
       const messageId = createUniqueUuid(
         this.runtime,
-        this.scopedTelegramKey(telegramMessageId),
+        this.telegramMessageMemoryKey(telegramChatId, telegramMessageId),
       );
+
+      const deliveryState = await this.getTelegramMessageDeliveryState(
+        telegramChatId,
+        telegramMessageId,
+      );
+      if (deliveryState) {
+        if (deliveryState === "delivery_started") {
+          const error = new Error(
+            `Telegram delivery outcome is uncertain for ${this.accountId}/${telegramChatId}/${telegramMessageId}; refusing duplicate egress`,
+          );
+          this.runtime.reportError("telegram:delivery-uncertain", error, {
+            accountId: this.accountId,
+            chatId: telegramChatId,
+            messageId: telegramMessageId,
+          });
+          logger.error(
+            {
+              src: "plugin:telegram",
+              agentId: this.runtime.agentId,
+              accountId: this.accountId,
+              chatId: telegramChatId,
+              messageId: telegramMessageId,
+            },
+            "Refusing to replay a Telegram turn after delivery started",
+          );
+        }
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            accountId: this.accountId,
+            chatId: telegramChatId,
+            messageId: telegramMessageId,
+          },
+          "Skipping duplicate Telegram message update",
+        );
+        return;
+      }
 
       // Process message content and attachments
       const { processedContent, attachments } =
@@ -1403,8 +1484,9 @@ export class MessageManager {
             "reply_to_message" in message && message.reply_to_message
               ? createUniqueUuid(
                   this.runtime,
-                  this.scopedTelegramKey(
-                    message.reply_to_message.message_id.toString(),
+                  this.telegramMessageMemoryKey(
+                    telegramChatId,
+                    message.reply_to_message.message_id,
                   ),
                 )
               : undefined,
@@ -1436,6 +1518,7 @@ export class MessageManager {
               telegramUserId,
               ctx.from.first_name,
               ctx.from.username,
+              this.accountId,
             ),
             chatId: telegramChatId,
             messageId: telegramMessageId,
@@ -1462,6 +1545,16 @@ export class MessageManager {
           if (!content.text) {
             return [];
           }
+
+          // Persist the no-replay barrier before touching Telegram. If the
+          // process dies after this point, a redelivered update fails visibly
+          // instead of risking a duplicate message whose first send may have
+          // reached Telegram without returning an acknowledgement.
+          await this.markTelegramMessageDeliveryState(
+            telegramChatId,
+            telegramMessageId,
+            "delivery_started",
+          );
 
           let sentMessages: boolean | Message.TextMessage[] = false;
           // channelType target === 'telegram'
@@ -1501,6 +1594,11 @@ export class MessageManager {
             inReplyTo: messageId,
           });
         } catch (error) {
+          this.runtime.reportError("telegram:delivery", error, {
+            accountId: this.accountId,
+            chatId: telegramChatId,
+            messageId: telegramMessageId,
+          });
           logger.error(
             {
               src: "plugin:telegram",
@@ -1509,7 +1607,7 @@ export class MessageManager {
             },
             "Error in message callback",
           );
-          return [];
+          throw error;
         }
       };
       const callback = createTelegramCompactProgressCallback({
@@ -1536,6 +1634,11 @@ export class MessageManager {
       if (!shouldReply) {
         try {
           await this.runtime.createMemory(memory, "messages");
+          await this.markTelegramMessageDeliveryState(
+            telegramChatId,
+            telegramMessageId,
+            "processed",
+          );
         } catch (persistError) {
           logger.warn(
             {
@@ -1558,6 +1661,11 @@ export class MessageManager {
           this.runtime,
           memory,
           callback,
+        );
+        await this.markTelegramMessageDeliveryState(
+          telegramChatId,
+          telegramMessageId,
+          "processed",
         );
       } else {
         logger.error(
@@ -1644,7 +1752,7 @@ export class MessageManager {
     const callbackKey = `cbq-${query.id}`;
     const messageId = createUniqueUuid(
       this.runtime,
-      this.scopedTelegramKey(callbackKey),
+      this.telegramMessageMemoryKey(telegramChatId, callbackKey),
     );
     const channelType = getChannelType(chat);
     const computerUseApproval = parseComputerUseApprovalCallback(decoded.value);
@@ -1777,7 +1885,7 @@ export class MessageManager {
     const memory: Memory = {
       id: createUniqueUuid(
         this.runtime,
-        this.scopedTelegramKey(`cua-${queryId}`),
+        this.telegramMessageMemoryKey(args.chat.id, `cua-${queryId}`),
       ),
       entityId: args.entityId,
       agentId: this.runtime.agentId,
@@ -1982,7 +2090,7 @@ export class MessageManager {
       const reactionId = createUniqueUuid(
         this.runtime,
         this.scopedTelegramKey(
-          `${reaction.message_id}-${ctx.from.id}-${Date.now()}`,
+          `reaction:${reaction.chat.id}:${reaction.message_id}:${ctx.from.id}:${Date.now()}`,
         ),
       );
 
@@ -1998,7 +2106,10 @@ export class MessageManager {
           source: "telegram",
           inReplyTo: createUniqueUuid(
             this.runtime,
-            this.scopedTelegramKey(reaction.message_id.toString()),
+            this.telegramMessageMemoryKey(
+              reaction.chat.id,
+              reaction.message_id,
+            ),
           ),
           metadata: { accountId: this.accountId },
         },
@@ -2042,7 +2153,10 @@ export class MessageManager {
           const responseMemory: Memory = {
             id: createUniqueUuid(
               this.runtime,
-              this.scopedTelegramKey(sentMessage.message_id.toString()),
+              this.telegramMessageMemoryKey(
+                sentMessage.chat.id,
+                sentMessage.message_id,
+              ),
             ),
             entityId: this.runtime.agentId,
             agentId: this.runtime.agentId,
@@ -2240,7 +2354,10 @@ export class MessageManager {
         const memory: Memory = {
           id: createUniqueUuid(
             this.runtime,
-            this.scopedTelegramKey(sentMessage.message_id.toString()),
+            this.telegramMessageMemoryKey(
+              sentMessage.chat.id,
+              sentMessage.message_id,
+            ),
           ),
           entityId: this.runtime.agentId,
           agentId: this.runtime.agentId,

--- a/plugins/plugin-telegram/src/poller-lock.test.ts
+++ b/plugins/plugin-telegram/src/poller-lock.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit coverage for Telegram poller ownership. The lock crosses plugin modes
+ * through process-global state, so these tests pin the privacy invariant
+ * (fingerprinted keys, no bot instances in global records) and the reclaim
+ * boundary between dead/stale claims and live incumbents.
+ */
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  claimTelegramPollerToken,
+  getTelegramPollerClaim,
+  listTelegramPollerHealth,
+  markTelegramPollerConnected,
+  markTelegramPollerError,
+  markTelegramPollerTerminated,
+  markTelegramPollerUpdate,
+  releaseTelegramPollerToken,
+} from "./poller-lock";
+
+const LOCKS_KEY = Symbol.for("elizaos.telegram.pollerLocks");
+const LEGACY_LOCKS_KEY = "__elizaosTelegramPollerLocks";
+
+function makeBot() {
+  return { stop: vi.fn() } as never;
+}
+
+function fingerprint(token: string): string {
+  return `bot:${createHash("sha256").update(token).digest("hex").slice(0, 16)}`;
+}
+
+function globalLocks(): Map<string, unknown> {
+  return (globalThis as Record<PropertyKey, unknown>)[LOCKS_KEY] as Map<
+    string,
+    unknown
+  >;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  globalLocks()?.clear();
+  delete (globalThis as Record<string, unknown>)[LEGACY_LOCKS_KEY];
+});
+
+describe("Telegram poller lock privacy", () => {
+  it("stores claims under credential fingerprints without plaintext tokens or bot instances", () => {
+    const token = "123456:plaintext-secret";
+    const bot = makeBot();
+
+    claimTelegramPollerToken(token, {
+      bot,
+      mode: "full",
+      ownerId: "agent-a",
+      accountId: "default",
+    });
+
+    const locks = globalLocks();
+    expect(Array.from(locks.keys())).toEqual([fingerprint(token)]);
+    expect(Array.from(locks.keys()).join(" ")).not.toContain(token);
+    expect(JSON.stringify(Array.from(locks.values()))).not.toContain(token);
+    expect(Array.from(locks.values())).not.toContain(bot);
+
+    const claim = getTelegramPollerClaim(token);
+    expect(claim?.bot).toBe(bot);
+    expect(listTelegramPollerHealth()).toEqual([
+      expect.not.objectContaining({ bot }),
+    ]);
+  });
+
+  it("redacts the bot token before persisting poller errors", () => {
+    const token = "123456:plaintext-secret";
+    const bot = makeBot();
+    claimTelegramPollerToken(token, {
+      bot,
+      mode: "full",
+      ownerId: "agent-a",
+      accountId: "default",
+    });
+
+    markTelegramPollerError(
+      token,
+      bot,
+      new Error(
+        `request failed for https://api.telegram.org/bot${token}/getUpdates with token ${token}`,
+      ),
+    );
+
+    expect(getTelegramPollerClaim(token)?.lastError).toBe(
+      "request failed for https://api.telegram.org/bot[REDACTED]/getUpdates with token [REDACTED]",
+    );
+  });
+
+  it("deletes the legacy plaintext-token global map when the shared lock initializes", () => {
+    (globalThis as Record<string, unknown>)[LEGACY_LOCKS_KEY] = new Map([
+      ["123456:plaintext-secret", { leaked: true }],
+    ]);
+
+    claimTelegramPollerToken("123456:plaintext-secret", {
+      bot: makeBot(),
+      mode: "full",
+      ownerId: "agent-a",
+      accountId: "default",
+    });
+
+    expect(
+      (globalThis as Record<string, unknown>)[LEGACY_LOCKS_KEY],
+    ).toBeUndefined();
+  });
+});
+
+describe("Telegram poller lock reclaim", () => {
+  it("preserves a known disconnected owner as a hard failure", () => {
+    const token = "200000:starting-owner";
+    const oldBot = makeBot();
+    const newBot = makeBot();
+    claimTelegramPollerToken(token, {
+      bot: oldBot,
+      mode: "full",
+      ownerId: "agent-old",
+      accountId: "default",
+    });
+    markTelegramPollerError(token, oldBot, new Error("poller stopped"));
+
+    expect(() =>
+      claimTelegramPollerToken(token, {
+        bot: newBot,
+        mode: "standalone",
+        ownerId: "agent-new",
+        accountId: "default",
+      }),
+    ).toThrow(/already has an active full poller/i);
+  });
+
+  it("reclaims a claim only after an explicit terminal transition", () => {
+    const token = "200000:terminal-owner";
+    const oldBot = makeBot();
+    const newBot = makeBot();
+    claimTelegramPollerToken(token, {
+      bot: oldBot,
+      mode: "full",
+      ownerId: "agent-old",
+      accountId: "default",
+    });
+    markTelegramPollerConnected(token, oldBot);
+    markTelegramPollerTerminated(token, oldBot, new Error("poller gave up"));
+
+    claimTelegramPollerToken(token, {
+      bot: newBot,
+      mode: "standalone",
+      ownerId: "agent-new",
+      accountId: "default",
+    });
+
+    expect(getTelegramPollerClaim(token)).toEqual(
+      expect.objectContaining({
+        bot: newBot,
+        mode: "standalone",
+        ownerId: "agent-new",
+      }),
+    );
+  });
+
+  it("keeps a connected owner live even when no updates arrive", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const token = "200000:live-owner";
+    const oldBot = makeBot();
+    const newBot = makeBot();
+    claimTelegramPollerToken(token, {
+      bot: oldBot,
+      mode: "full",
+      ownerId: "agent-old",
+      accountId: "default",
+    });
+    markTelegramPollerConnected(token, oldBot);
+
+    vi.setSystemTime(1_000_000 + 24 * 60 * 60 * 1000);
+    markTelegramPollerUpdate(token, oldBot);
+    vi.setSystemTime(1_000_000 + 48 * 60 * 60 * 1000);
+
+    expect(() =>
+      claimTelegramPollerToken(token, {
+        bot: newBot,
+        mode: "standalone",
+        ownerId: "agent-new",
+        accountId: "default",
+      }),
+    ).toThrow(/already has an active full poller/i);
+
+    releaseTelegramPollerToken(token, oldBot);
+  });
+});

--- a/plugins/plugin-telegram/src/poller-lock.test.ts
+++ b/plugins/plugin-telegram/src/poller-lock.test.ts
@@ -25,7 +25,7 @@ function makeBot() {
 }
 
 function fingerprint(token: string): string {
-  return `bot:${createHash("sha256").update(token).digest("hex").slice(0, 16)}`;
+  return `bot:${createHash("sha256").update(token).digest("hex")}`;
 }
 
 function globalLocks(): Map<string, unknown> {

--- a/plugins/plugin-telegram/src/poller-lock.ts
+++ b/plugins/plugin-telegram/src/poller-lock.ts
@@ -43,7 +43,7 @@ const botOwnerKeys = new WeakMap<Telegraf<Context>, symbol>();
 const botByOwnerKey = new Map<symbol, Telegraf<Context>>();
 
 function credentialFingerprint(value: string): string {
-  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+  return createHash("sha256").update(value).digest("hex");
 }
 
 function lockKeyForToken(token: string): string {

--- a/plugins/plugin-telegram/src/poller-lock.ts
+++ b/plugins/plugin-telegram/src/poller-lock.ts
@@ -1,0 +1,114 @@
+/**
+ * Process-local Telegram bot token ownership and liveness state shared by the
+ * full and standalone Telegram pollers. Telegram allows only one long-polling
+ * `getUpdates` consumer per bot token, so every production poller must claim
+ * the token before launching and expose whether that claim is actually polling.
+ */
+import type { Context, Telegraf } from "telegraf";
+
+export type TelegramPollerMode = "full" | "standalone";
+
+export type TelegramPollerHealth = {
+  ok: boolean;
+  mode: TelegramPollerMode;
+  accountId: string;
+  ownerId: string;
+  connected: boolean;
+  lastUpdateAt?: number;
+  lastError?: string;
+};
+
+export type TelegramPollerClaim = TelegramPollerHealth & {
+  bot: Telegraf<Context>;
+};
+
+const LOCKS_KEY = "__elizaosTelegramPollerLocks";
+
+function getLocks(): Map<string, TelegramPollerClaim> {
+  const globalState = globalThis as typeof globalThis & {
+    __elizaosTelegramPollerLocks?: Map<string, TelegramPollerClaim>;
+  };
+  if (!globalState[LOCKS_KEY]) {
+    globalState[LOCKS_KEY] = new Map<string, TelegramPollerClaim>();
+  }
+  return globalState[LOCKS_KEY];
+}
+
+export function claimTelegramPollerToken(
+  token: string,
+  claim: Omit<TelegramPollerClaim, "connected" | "ok" | "lastUpdateAt">,
+): TelegramPollerClaim {
+  const locks = getLocks();
+  const active = locks.get(token);
+  if (active && active.bot !== claim.bot) {
+    throw new Error(
+      `Telegram bot token already has an active ${active.mode} poller for ${active.ownerId}/${active.accountId}`,
+    );
+  }
+  const next: TelegramPollerClaim = {
+    ...claim,
+    ok: false,
+    connected: false,
+  };
+  locks.set(token, next);
+  return next;
+}
+
+export function getTelegramPollerClaim(
+  token: string,
+): TelegramPollerClaim | undefined {
+  return getLocks().get(token);
+}
+
+export function releaseTelegramPollerToken(
+  token: string,
+  bot: Telegraf<Context>,
+): void {
+  const locks = getLocks();
+  if (locks.get(token)?.bot === bot) {
+    locks.delete(token);
+  }
+}
+
+export function markTelegramPollerConnected(
+  token: string,
+  bot: Telegraf<Context>,
+): void {
+  const claim = getLocks().get(token);
+  if (claim?.bot === bot) {
+    claim.connected = true;
+    claim.ok = true;
+    claim.lastError = undefined;
+  }
+}
+
+export function markTelegramPollerUpdate(
+  token: string,
+  bot: Telegraf<Context>,
+): void {
+  const claim = getLocks().get(token);
+  if (claim?.bot === bot) {
+    claim.lastUpdateAt = Date.now();
+  }
+}
+
+export function markTelegramPollerError(
+  token: string,
+  bot: Telegraf<Context>,
+  error: unknown,
+): void {
+  const claim = getLocks().get(token);
+  if (claim?.bot === bot) {
+    claim.connected = false;
+    claim.ok = false;
+    claim.lastError = error instanceof Error ? error.message : String(error);
+  }
+}
+
+export function listTelegramPollerHealth(
+  mode?: TelegramPollerMode,
+): TelegramPollerHealth[] {
+  return Array.from(getLocks().values())
+    .filter((claim) => !mode || claim.mode === mode)
+    .map(({ bot: _bot, ...health }) => ({ ...health }));
+}

--- a/plugins/plugin-telegram/src/poller-lock.ts
+++ b/plugins/plugin-telegram/src/poller-lock.ts
@@ -3,7 +3,10 @@
  * full and standalone Telegram pollers. Telegram allows only one long-polling
  * `getUpdates` consumer per bot token, so every production poller must claim
  * the token before launching and expose whether that claim is actually polling.
+ * Global records are fingerprinted and bot-free because this map is visible to
+ * every tenant sharing the process.
  */
+import { createHash } from "node:crypto";
 import type { Context, Telegraf } from "telegraf";
 
 export type TelegramPollerMode = "full" | "standalone";
@@ -19,45 +22,135 @@ export type TelegramPollerHealth = {
 };
 
 export type TelegramPollerClaim = TelegramPollerHealth & {
+  bot?: Telegraf<Context>;
+};
+
+type TelegramPollerClaimInput = Omit<
+  TelegramPollerHealth,
+  "connected" | "ok" | "lastUpdateAt"
+> & {
   bot: Telegraf<Context>;
 };
 
-const LOCKS_KEY = "__elizaosTelegramPollerLocks";
+type StoredTelegramPollerClaim = TelegramPollerHealth & {
+  ownerKey: symbol;
+  reclaimable: boolean;
+};
 
-function getLocks(): Map<string, TelegramPollerClaim> {
+const LOCKS_KEY = Symbol.for("elizaos.telegram.pollerLocks");
+const LEGACY_LOCKS_KEY = "__elizaosTelegramPollerLocks";
+const botOwnerKeys = new WeakMap<Telegraf<Context>, symbol>();
+const botByOwnerKey = new Map<symbol, Telegraf<Context>>();
+
+function credentialFingerprint(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+function lockKeyForToken(token: string): string {
+  return `bot:${credentialFingerprint(token)}`;
+}
+
+function getLocks(): Map<string, StoredTelegramPollerClaim> {
   const globalState = globalThis as typeof globalThis & {
-    __elizaosTelegramPollerLocks?: Map<string, TelegramPollerClaim>;
+    [LOCKS_KEY]?: Map<string, StoredTelegramPollerClaim>;
+    [LEGACY_LOCKS_KEY]?: unknown;
   };
+  delete globalState[LEGACY_LOCKS_KEY];
   if (!globalState[LOCKS_KEY]) {
-    globalState[LOCKS_KEY] = new Map<string, TelegramPollerClaim>();
+    globalState[LOCKS_KEY] = new Map<string, StoredTelegramPollerClaim>();
   }
   return globalState[LOCKS_KEY];
 }
 
+function ownerKeyForBot(bot: Telegraf<Context>): symbol {
+  const existing = botOwnerKeys.get(bot);
+  if (existing) {
+    return existing;
+  }
+  const ownerKey = Symbol("telegram-poller-owner");
+  botOwnerKeys.set(bot, ownerKey);
+  botByOwnerKey.set(ownerKey, bot);
+  return ownerKey;
+}
+
+function attachBot(claim: StoredTelegramPollerClaim): TelegramPollerClaim {
+  const { ownerKey, reclaimable: _reclaimable, ...health } = claim;
+  return {
+    ...health,
+    bot: botByOwnerKey.get(ownerKey),
+  };
+}
+
+function isReclaimable(claim: StoredTelegramPollerClaim): boolean {
+  // `connected` and `lastUpdateAt` are health observations, not leases. A new
+  // poller is briefly disconnected, and a healthy bot can receive no updates
+  // for hours, so neither state proves that ownership is dead. Only an explicit
+  // terminal transition makes a claim safe to replace.
+  return claim.reclaimable;
+}
+
+function redactErrorMessage(token: string, error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return raw
+    .replace(new RegExp(`/bot${escaped}`, "g"), "/bot[REDACTED]")
+    .replace(new RegExp(escaped, "g"), "[REDACTED]");
+}
+
+export function ensureTelegramPollerTokenAvailable(
+  token: string,
+  bot: Telegraf<Context>,
+): void {
+  const locks = getLocks();
+  const key = lockKeyForToken(token);
+  const active = locks.get(key);
+  if (!active || botByOwnerKey.get(active.ownerKey) === bot) {
+    return;
+  }
+  if (isReclaimable(active)) {
+    botByOwnerKey.delete(active.ownerKey);
+    locks.delete(key);
+    return;
+  }
+  throw new Error(
+    `Telegram bot token already has an active ${active.mode} poller for ${active.ownerId}/${active.accountId}`,
+  );
+}
+
 export function claimTelegramPollerToken(
   token: string,
-  claim: Omit<TelegramPollerClaim, "connected" | "ok" | "lastUpdateAt">,
+  claim: TelegramPollerClaimInput,
 ): TelegramPollerClaim {
   const locks = getLocks();
-  const active = locks.get(token);
-  if (active && active.bot !== claim.bot) {
-    throw new Error(
-      `Telegram bot token already has an active ${active.mode} poller for ${active.ownerId}/${active.accountId}`,
-    );
+  const key = lockKeyForToken(token);
+  const ownerKey = ownerKeyForBot(claim.bot);
+  const active = locks.get(key);
+  if (active && active.ownerKey !== ownerKey) {
+    if (!isReclaimable(active)) {
+      throw new Error(
+        `Telegram bot token already has an active ${active.mode} poller for ${active.ownerId}/${active.accountId}`,
+      );
+    }
+    botByOwnerKey.delete(active.ownerKey);
   }
-  const next: TelegramPollerClaim = {
-    ...claim,
+  const { bot, ...health } = claim;
+  const next: StoredTelegramPollerClaim = {
+    ...health,
+    ownerKey,
+    reclaimable: false,
     ok: false,
     connected: false,
   };
-  locks.set(token, next);
-  return next;
+  botByOwnerKey.set(ownerKey, bot);
+  locks.set(key, next);
+  return attachBot(next);
 }
 
 export function getTelegramPollerClaim(
   token: string,
 ): TelegramPollerClaim | undefined {
-  return getLocks().get(token);
+  const claim = getLocks().get(lockKeyForToken(token));
+  return claim ? attachBot(claim) : undefined;
 }
 
 export function releaseTelegramPollerToken(
@@ -65,8 +158,12 @@ export function releaseTelegramPollerToken(
   bot: Telegraf<Context>,
 ): void {
   const locks = getLocks();
-  if (locks.get(token)?.bot === bot) {
-    locks.delete(token);
+  const key = lockKeyForToken(token);
+  const claim = locks.get(key);
+  const ownerKey = botOwnerKeys.get(bot);
+  if (claim && ownerKey && claim.ownerKey === ownerKey) {
+    locks.delete(key);
+    botByOwnerKey.delete(ownerKey);
   }
 }
 
@@ -74,10 +171,11 @@ export function markTelegramPollerConnected(
   token: string,
   bot: Telegraf<Context>,
 ): void {
-  const claim = getLocks().get(token);
-  if (claim?.bot === bot) {
+  const claim = getLocks().get(lockKeyForToken(token));
+  if (claim && claim.ownerKey === botOwnerKeys.get(bot)) {
     claim.connected = true;
     claim.ok = true;
+    claim.lastUpdateAt = Date.now();
     claim.lastError = undefined;
   }
 }
@@ -86,9 +184,24 @@ export function markTelegramPollerUpdate(
   token: string,
   bot: Telegraf<Context>,
 ): void {
-  const claim = getLocks().get(token);
-  if (claim?.bot === bot) {
+  const claim = getLocks().get(lockKeyForToken(token));
+  if (claim && claim.ownerKey === botOwnerKeys.get(bot)) {
     claim.lastUpdateAt = Date.now();
+  }
+}
+
+export function markTelegramPollerTerminated(
+  token: string,
+  bot: Telegraf<Context>,
+  error: unknown,
+): void {
+  const claim = getLocks().get(lockKeyForToken(token));
+  if (claim && claim.ownerKey === botOwnerKeys.get(bot)) {
+    claim.connected = false;
+    claim.ok = false;
+    claim.lastError = redactErrorMessage(token, error);
+    claim.reclaimable = true;
+    botByOwnerKey.delete(claim.ownerKey);
   }
 }
 
@@ -97,11 +210,11 @@ export function markTelegramPollerError(
   bot: Telegraf<Context>,
   error: unknown,
 ): void {
-  const claim = getLocks().get(token);
-  if (claim?.bot === bot) {
+  const claim = getLocks().get(lockKeyForToken(token));
+  if (claim && claim.ownerKey === botOwnerKeys.get(bot)) {
     claim.connected = false;
     claim.ok = false;
-    claim.lastError = error instanceof Error ? error.message : String(error);
+    claim.lastError = redactErrorMessage(token, error);
   }
 }
 
@@ -110,5 +223,7 @@ export function listTelegramPollerHealth(
 ): TelegramPollerHealth[] {
   return Array.from(getLocks().values())
     .filter((claim) => !mode || claim.mode === mode)
-    .map(({ bot: _bot, ...health }) => ({ ...health }));
+    .map(({ ownerKey: _ownerKey, reclaimable: _reclaimable, ...health }) => ({
+      ...health,
+    }));
 }

--- a/plugins/plugin-telegram/src/service.launch-supervision.test.ts
+++ b/plugins/plugin-telegram/src/service.launch-supervision.test.ts
@@ -10,7 +10,6 @@
  * runtime taking over the token cancels the loser's relaunch. Runtime, timers,
  * and `@elizaos/core` (logger/Service) are mocked.
  */
-import { logger } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TelegramService } from "./service";
 
@@ -88,7 +87,7 @@ describe("TelegramService.launchPollerSupervised", () => {
     // must proceed off the connect callback, not off loop completion.
     expect(bot.launch).toHaveBeenCalledTimes(1);
     expect(calls[0].config).toEqual({
-      dropPendingUpdates: true,
+      dropPendingUpdates: false,
       allowedUpdates: ["message", "message_reaction", "callback_query"],
     });
 
@@ -123,17 +122,12 @@ describe("TelegramService.launchPollerSupervised", () => {
     // Sixth failure exceeds the relaunch budget: give up, do not relaunch.
     calls[5].reject(new Error(CONFLICT));
     await flushMicrotasks();
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({ maxPollRelaunches: 5 }),
-      expect.stringContaining("gave up"),
-    );
-
     await vi.advanceTimersByTimeAsync(60_000);
     expect(bot.launch).toHaveBeenCalledTimes(6);
     expect(runtime.reportError).toHaveBeenCalledTimes(6);
   });
 
-  it("does not relaunch after a newer runtime takes over the bot token", async () => {
+  it("fails loudly instead of replacing a poller that already owns the token", async () => {
     const first = makeBot();
     const second = makeBot();
     const { service } = makeService();
@@ -147,24 +141,11 @@ describe("TelegramService.launchPollerSupervised", () => {
     first.calls[0].onLaunch();
     await firstLaunched;
 
-    // A newer runtime launches on the same token and connects: its connect
-    // registers it as the active poller, superseding the first.
-    const secondLaunched = callLaunch(
-      service,
-      second.bot,
-      "tok-takeover",
-      "acct",
-    );
-    second.calls[0].onLaunch();
-    await secondLaunched;
+    await expect(
+      callLaunch(service, second.bot, "tok-takeover", "acct"),
+    ).rejects.toThrow(/already has an active/i);
 
-    // The first poller's loop now dies. Because it no longer owns the token,
-    // the failure is surfaced but no relaunch is scheduled.
-    first.calls[0].reject(new Error(CONFLICT));
-    await flushMicrotasks();
-    await vi.advanceTimersByTimeAsync(60_000);
-
-    expect(first.bot.launch).toHaveBeenCalledTimes(1);
-    expect(second.bot.launch).toHaveBeenCalledTimes(1);
+    expect(first.bot.stop).not.toHaveBeenCalled();
+    expect(second.bot.launch).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-telegram/src/service.launch-supervision.test.ts
+++ b/plugins/plugin-telegram/src/service.launch-supervision.test.ts
@@ -10,6 +10,7 @@
  * runtime taking over the token cancels the loser's relaunch. Runtime, timers,
  * and `@elizaos/core` (logger/Service) are mocked.
  */
+import { logger } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TelegramService } from "./service";
 
@@ -98,6 +99,7 @@ describe("TelegramService.launchPollerSupervised", () => {
   it("self-heals a post-connect poll failure with a bounded, backed-off relaunch and then gives up", async () => {
     const { bot, calls } = makeBot();
     const { service, runtime } = makeService();
+    const loggerError = vi.spyOn(logger, "error").mockImplementation(() => {});
 
     const launched = callLaunch(service, bot, "tok-heal", "acct");
     calls[0].onLaunch();
@@ -125,6 +127,10 @@ describe("TelegramService.launchPollerSupervised", () => {
     await vi.advanceTimersByTimeAsync(60_000);
     expect(bot.launch).toHaveBeenCalledTimes(6);
     expect(runtime.reportError).toHaveBeenCalledTimes(6);
+    expect(loggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ maxPollRelaunches: 5 }),
+      expect.stringContaining("gave up"),
+    );
   });
 
   it("fails loudly instead of replacing a poller that already owns the token", async () => {

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -6,8 +6,8 @@
  * reactions, and threads route back out through Telegram.
  *
  * Forum topics become distinct Rooms keyed `<chatId>-<threadId>`. Active pollers
- * are tracked in a module-level map so a token is never long-polled twice
- * (Telegram 409s on concurrent getUpdates). Must start before
+ * are tracked in the shared process-local poller lock so a token is never
+ * long-polled twice (Telegram 409s on concurrent getUpdates). Must start before
  * `TelegramOwnerPairingServiceImpl`, which looks up the live bot instance here.
  */
 import {
@@ -60,10 +60,12 @@ import { resolveTelegramRuntimeEntityId } from "./identity";
 import { MessageManager } from "./messageManager";
 import {
   claimTelegramPollerToken,
+  ensureTelegramPollerTokenAvailable,
   getTelegramPollerClaim,
   listTelegramPollerHealth,
   markTelegramPollerConnected,
   markTelegramPollerError,
+  markTelegramPollerTerminated,
   markTelegramPollerUpdate,
   releaseTelegramPollerToken,
   type TelegramPollerHealth,
@@ -711,22 +713,22 @@ export class TelegramService extends Service {
     const accountId = activeState?.accountId ?? this.defaultAccountId;
 
     if (botToken) {
-      const active = getTelegramPollerClaim(botToken);
-      if (active && active.bot !== bot) {
+      try {
+        ensureTelegramPollerTokenAvailable(botToken, bot);
+      } catch (error) {
+        const active = getTelegramPollerClaim(botToken);
         logger.error(
           {
             src: "plugin:telegram",
             agentId: this.runtime.agentId,
             accountId,
-            activeMode: active.mode,
-            activeOwnerId: active.ownerId,
-            activeAccountId: active.accountId,
+            activeMode: active?.mode,
+            activeOwnerId: active?.ownerId,
+            activeAccountId: active?.accountId,
           },
           "Telegram bot token is already owned by another poller",
         );
-        throw new Error(
-          `Telegram bot token already owned by ${active.mode} poller ${active.ownerId}/${active.accountId}`,
-        );
+        throw error;
       }
     }
 
@@ -888,7 +890,15 @@ export class TelegramService extends Service {
             },
             "Telegram poller gave up after repeated conflicts — verify only one instance holds this bot token",
           );
-          clearActive();
+          if (botToken) {
+            markTelegramPollerTerminated(
+              botToken,
+              bot,
+              new Error("Telegram poller exhausted its relaunch budget"),
+            );
+          } else {
+            clearActive();
+          }
           return;
         }
         relaunches++;

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -56,7 +56,18 @@ import {
   registerTelegramCommandHandlers,
 } from "./command-registration";
 import { TELEGRAM_SERVICE_NAME } from "./constants";
+import { resolveTelegramRuntimeEntityId } from "./identity";
 import { MessageManager } from "./messageManager";
+import {
+  claimTelegramPollerToken,
+  getTelegramPollerClaim,
+  listTelegramPollerHealth,
+  markTelegramPollerConnected,
+  markTelegramPollerError,
+  markTelegramPollerUpdate,
+  releaseTelegramPollerToken,
+  type TelegramPollerHealth,
+} from "./poller-lock";
 import { registerTelegramTaskBoardCommand } from "./task-board";
 import {
   type TelegramEntityPayload,
@@ -153,20 +164,12 @@ function filterMemoriesByQuery(
 
 type MiddlewareNext = () => Promise<void>;
 
-type ActiveTelegramPoller = {
-  bot: Telegraf<Context>;
-  agentId: UUID;
-  accountId: string;
-};
-
 type TelegramAccountRuntime = {
   accountId: string;
   account: ResolvedTelegramAccount;
   bot: Telegraf<Context>;
   messageManager: MessageManager;
 };
-
-const ACTIVE_TELEGRAM_POLLERS = new Map<string, ActiveTelegramPoller>();
 
 function getCanonicalOwnerId(runtime: IAgentRuntime): UUID | null {
   for (const key of CANONICAL_OWNER_SETTING_KEYS) {
@@ -441,6 +444,30 @@ export class TelegramService extends Service {
     return this.getDefaultAccountState()?.bot ?? this.bot ?? null;
   }
 
+  public getPollerHealth(): TelegramPollerHealth {
+    const health = this.getPollerHealthByAccount();
+    return (
+      health.find((entry) => entry.accountId === this.defaultAccountId) ??
+      health[0] ?? {
+        ok: false,
+        mode: "full",
+        accountId: this.defaultAccountId,
+        ownerId: String(this.runtime.agentId),
+        connected: false,
+        lastError: "Telegram poller is not launched",
+      }
+    );
+  }
+
+  public getPollerHealthByAccount(): TelegramPollerHealth[] {
+    const accountIds = new Set(this.getAccountIds());
+    return listTelegramPollerHealth("full").filter(
+      (entry) =>
+        entry.ownerId === String(this.runtime.agentId) &&
+        accountIds.has(entry.accountId),
+    );
+  }
+
   private resolveAccountIdFromContext(
     context?: MessageConnectorQueryContext | null,
     target?: TargetInfo | null,
@@ -655,10 +682,7 @@ export class TelegramService extends Service {
         state.bot.stop("service-stop");
         const token = state.account.botToken;
         if (token) {
-          const active = ACTIVE_TELEGRAM_POLLERS.get(token);
-          if (active?.bot === state.bot) {
-            ACTIVE_TELEGRAM_POLLERS.delete(token);
-          }
+          releaseTelegramPollerToken(token, state.bot);
         }
       }
       return;
@@ -668,10 +692,7 @@ export class TelegramService extends Service {
     if (bot) {
       bot.stop("service-stop");
       if (this.botToken) {
-        const active = ACTIVE_TELEGRAM_POLLERS.get(this.botToken);
-        if (active?.bot === bot) {
-          ACTIVE_TELEGRAM_POLLERS.delete(this.botToken);
-        }
+        releaseTelegramPollerToken(this.botToken, bot);
       }
     }
   }
@@ -690,33 +711,22 @@ export class TelegramService extends Service {
     const accountId = activeState?.accountId ?? this.defaultAccountId;
 
     if (botToken) {
-      const active = ACTIVE_TELEGRAM_POLLERS.get(botToken);
+      const active = getTelegramPollerClaim(botToken);
       if (active && active.bot !== bot) {
-        logger.warn(
+        logger.error(
           {
             src: "plugin:telegram",
             agentId: this.runtime.agentId,
             accountId,
-            previousAgentId: active.agentId,
+            activeMode: active.mode,
+            activeOwnerId: active.ownerId,
+            activeAccountId: active.accountId,
           },
-          "Stopping existing Telegram poller before launching a new one",
+          "Telegram bot token is already owned by another poller",
         );
-        try {
-          active.bot.stop("replaced-by-new-runtime");
-        } catch (error) {
-          logger.warn(
-            {
-              src: "plugin:telegram",
-              agentId: this.runtime.agentId,
-              accountId,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            "Failed to stop previous Telegram poller cleanly",
-          );
-        }
-        ACTIVE_TELEGRAM_POLLERS.delete(botToken);
-        // Give Telegram a brief moment to release long-poll ownership.
-        await new Promise((resolve) => setTimeout(resolve, 300));
+        throw new Error(
+          `Telegram bot token already owned by ${active.mode} poller ${active.ownerId}/${active.accountId}`,
+        );
       }
     }
 
@@ -838,14 +848,15 @@ export class TelegramService extends Service {
       if (!botToken) {
         return true;
       }
-      const active = ACTIVE_TELEGRAM_POLLERS.get(botToken);
+      const active = getTelegramPollerClaim(botToken);
       return active === undefined || active.bot === bot;
     };
     const markActive = (): void => {
       if (botToken) {
-        ACTIVE_TELEGRAM_POLLERS.set(botToken, {
+        claimTelegramPollerToken(botToken, {
           bot,
-          agentId: this.runtime.agentId,
+          mode: "full",
+          ownerId: String(this.runtime.agentId),
           accountId,
         });
       }
@@ -854,10 +865,7 @@ export class TelegramService extends Service {
       if (!botToken) {
         return;
       }
-      const active = ACTIVE_TELEGRAM_POLLERS.get(botToken);
-      if (active?.bot === bot) {
-        ACTIVE_TELEGRAM_POLLERS.delete(botToken);
-      }
+      releaseTelegramPollerToken(botToken, bot);
     };
 
     let relaunches = 0;
@@ -906,15 +914,29 @@ export class TelegramService extends Service {
 
       const runLaunch = (): void => {
         let connectedAt = 0;
+        try {
+          markActive();
+        } catch (error) {
+          if (!connectedOnce) {
+            reject(error);
+          } else {
+            if (botToken) {
+              markTelegramPollerError(botToken, bot, error);
+            }
+          }
+          return;
+        }
         bot
           .launch(
             {
-              dropPendingUpdates: true,
+              dropPendingUpdates: false,
               allowedUpdates: ["message", "message_reaction", "callback_query"],
             },
             () => {
               connectedAt = Date.now();
-              markActive();
+              if (botToken) {
+                markTelegramPollerConnected(botToken, bot);
+              }
               if (!connectedOnce) {
                 connectedOnce = true;
                 resolve();
@@ -940,6 +962,9 @@ export class TelegramService extends Service {
                 clearActive();
                 reject(error);
                 return;
+              }
+              if (botToken) {
+                markTelegramPollerError(botToken, bot, error);
               }
               // error-policy:J7 poll-loop failure after connecting (or on a
               // relaunch) — start() has already returned, so surface it
@@ -1109,6 +1134,10 @@ export class TelegramService extends Service {
     // Regular message handler
     bot?.on("message", async (ctx) => {
       try {
+        const token = state?.account.botToken ?? this.botToken;
+        if (token) {
+          markTelegramPollerUpdate(token, bot);
+        }
         // Preprocessing runs in the middleware chain; this only dispatches.
         await messageManager?.handleMessage(ctx);
       } catch (error) {
@@ -1127,6 +1156,10 @@ export class TelegramService extends Service {
     // Reaction handler
     bot?.on("message_reaction", async (ctx) => {
       try {
+        const token = state?.account.botToken ?? this.botToken;
+        if (token) {
+          markTelegramPollerUpdate(token, bot);
+        }
         await messageManager?.handleReaction(ctx);
       } catch (error) {
         logger.error(
@@ -1145,6 +1178,10 @@ export class TelegramService extends Service {
     // interaction protocol). Foreign callbacks are acknowledged and ignored.
     bot?.on("callback_query", async (ctx) => {
       try {
+        const token = state?.account.botToken ?? this.botToken;
+        if (token) {
+          markTelegramPollerUpdate(token, bot);
+        }
         await messageManager?.handleCallbackQuery(ctx);
       } catch (error) {
         logger.error(
@@ -1279,10 +1316,11 @@ export class TelegramService extends Service {
   ): Promise<void> {
     if (ctx.from) {
       const telegramId = ctx.from.id.toString();
-      const entityId = createUniqueUuid(
+      const entityId = await resolveTelegramRuntimeEntityId(
         this.runtime,
-        this.scopedTelegramKey(telegramId, accountId),
-      ) as UUID;
+        accountId,
+        telegramId,
+      );
 
       if (this.syncedEntityIds.has(entityId)) {
         return;
@@ -1327,10 +1365,11 @@ export class TelegramService extends Service {
     if (ctx.message && "new_chat_members" in ctx.message) {
       for (const newMember of ctx.message.new_chat_members) {
         const telegramId = newMember.id.toString();
-        const entityId = createUniqueUuid(
+        const entityId = await resolveTelegramRuntimeEntityId(
           this.runtime,
-          this.scopedTelegramKey(telegramId, accountId),
-        ) as UUID;
+          accountId,
+          telegramId,
+        );
 
         if (this.syncedEntityIds.has(entityId)) {
           continue;


### PR DESCRIPTION
## Summary

Telegram's production poller and hosted webhook paths could lose queued updates on restart, collide platform message IDs across chats/bots, split a paired owner back into a connector-derived entity, silently swallow wire failures, or replay an outbound response after an ambiguous send.

This PR makes the vertical restart-safe:

- resolves Telegram senders against the durable canonical owner entity before any room, memory, model, or delivery side effect, and fails closed when the configured identity store is unavailable;
- centralizes owner lookup and unmatched-user fallback identity in one exported Telegram policy consumed by both full and standalone connectors, preventing cutover drift;
- keys message identity by account + chat + Telegram message ID and persists delivery state before wire egress;
- refuses replay after egress begins, reporting an explicit uncertain-delivery failure rather than risking a duplicate;
- stops dropping pending long-poll updates and enforces one process-local poller per bot token across full/standalone modes;
- scopes hosted webhook dedupe by project + bot fingerprint and writes an `egress_started` Redis barrier before Bot API delivery;
- makes connector health depend on actual poller liveness rather than service-object existence.

## Production paths

- Standard connector: `plugin-collector.ts` -> `plugin-telegram/src/index.ts` -> `service.ts` polling/supervision -> `messageManager.ts` identity, canonical ingress, audience-attested core message service, and Telegram egress.
- Standalone opt-in: `plugin-telegram-standalone/src/service.ts` -> `handler.ts`.
- Hosted webhook: `gateway-webhook/src/adapters/telegram.ts` -> `webhook-handler.ts` -> agent-server -> Bot API reply.

No media/rich-text behavior, workflow, check, deployment, or production configuration changed.

## Bidirectional proof

A production-entrypoint harness boots real `AgentRuntime` + plugin-sql/PGlite, creates a durably Telegram-bound canonical owner, drives `MessageManager.handleMessage`, verifies owner-only DM authorization and exactly one wire send, closes the runtime/database, reopens the same PGlite directory, and replays the same Telegram update. The owner row and canonical memory survive while the replay produces zero sends.

The same test copied unchanged (apart from removing the new helper-only readiness assertion/import) onto exact `origin/develop` fails because the inbound memory uses a connector-derived entity instead of the canonical owner (`inbound` is undefined).

## Verification

- Telegram real AgentRuntime/PGlite harness: 3/3 passed
- Telegram focused unit suites: 24/24 passed
- Cross-connector unmatched-user identity regression: passed in the standalone handler suite (both connectors return the same entity ID)
- Exact-head focused recheck: full connector message manager 21/21; standalone handler 3/3; both package typechecks passed
- Telegram full unit package: 120/120 tests passed; one unrelated suite could not import unbuilt `@elizaos/plugin-x402` in this borrowed dependency tree
- Standalone: 9/9 passed + typecheck passed
- Gateway webhook: 37/37 passed + typecheck passed
- Connector health: 2/2 passed
- Full Telegram plugin typecheck passed
- Biome on all changed files passed
- `git diff --check` passed
- Agent package typecheck was attempted; borrowed dependencies lack several optional plugin builds and also emit unchanged orchestrator target diagnostics. No changed health file emitted a diagnostic.

## Safety semantics

Telegram does not accept a caller idempotency key for `sendMessage`. Therefore an ambiguous network outcome cannot be safely retried. The connector writes a durable no-replay barrier immediately before egress. Success becomes `processed`/`delivered`; a crash or error after the barrier remains visible through `runtime.reportError`, logs, or webhook HTTP 503 and is never resent automatically.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend connector identity/delivery change; no UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend connector identity/delivery change; no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic production-entrypoint/PGlite restart proof; no visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - exact-head focused outputs are summarized above; CI remains authoritative.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic model proxy only; no prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - PGlite owner/entity/memory persistence, audience authorization, restart replay, and wire-send assertions are the artifact.

<!-- evidence-head:a81f0106c47ce12e48501171e91065485a64bfa1 -->

