### PR TITLE
feat(telegram): preserve media and rich text fidelity

### DIFF
--- a/packages/agent/src/runtime/build-character-config.test.ts
+++ b/packages/agent/src/runtime/build-character-config.test.ts
@@ -8,8 +8,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ElizaConfig } from "../config/config.ts";
 import { buildCharacterFromConfig } from "./build-character-config.ts";
-import { applySandboxCharacterFromEnv } from "./sandbox-character.ts";
 import { buildRuntimeSettingsProjection } from "./runtime-settings.ts";
+import { applySandboxCharacterFromEnv } from "./sandbox-character.ts";
 
 // Locks the secret/settings boundary for Matrix connector env vars. Putting a
 // public identifier (e.g. MATRIX_VERIFY_ALLOWLIST = a user id) into
@@ -119,6 +119,9 @@ describe("agent entry character passthrough", () => {
     const telegram = {
       botToken: "telegram-token",
       webhookSecret: "webhook-secret",
+      webhookUrl: "https://telegram.example/hook?token=secret",
+      proxy: "http://proxy-user:proxy-password@proxy.example",
+      apiRoot: "http://127.0.0.1:8081",
       dmPolicy: "allowlist",
       allowFrom: ["42"],
       groupPolicy: "allowlist",
@@ -132,6 +135,8 @@ describe("agent entry character passthrough", () => {
       accounts: {
         ops: {
           botToken: "ops-token",
+          apiRoot: "http://127.0.0.1:8082",
+          proxy: "http://ops:secret@proxy.example",
           groupPolicy: "disabled",
         },
       },
@@ -150,17 +155,29 @@ describe("agent entry character passthrough", () => {
     );
     expect(character.settings?.telegram).toEqual({
       dmPolicy: "allowlist",
+      apiRoot: "http://127.0.0.1:8081",
       allowFrom: ["42"],
       groupPolicy: "allowlist",
       groupAllowFrom: ["42"],
       groups: telegram.groups,
-      accounts: { ops: { groupPolicy: "disabled" } },
+      accounts: {
+        ops: {
+          apiRoot: "http://127.0.0.1:8082",
+          groupPolicy: "disabled",
+        },
+      },
     });
     expect(JSON.stringify(character.settings?.telegram)).not.toContain(
       "telegram-token",
     );
     expect(JSON.stringify(character.settings?.telegram)).not.toContain(
       "ops-token",
+    );
+    expect(JSON.stringify(character.settings?.telegram)).not.toContain(
+      "proxy-password",
+    );
+    expect(JSON.stringify(character.settings?.telegram)).not.toContain(
+      "webhook-secret",
     );
   });
 
@@ -176,14 +193,38 @@ describe("agent entry character passthrough", () => {
             name: "Nyx",
             system: "You are Nyx.",
             settings: {
-              telegram: { botToken: "agent-token", groupPolicy: "open" },
+              telegram: {
+                botToken: "agent-token",
+                groupPolicy: "open",
+                allowedChats: ["-1001"],
+                autoReply: true,
+              },
             },
           },
         ],
       },
     } as ElizaConfig);
 
-    expect(character.settings?.telegram).toEqual({ groupPolicy: "disabled" });
+    expect(character.settings?.telegram).toEqual({
+      groupPolicy: "disabled",
+      allowedChats: ["-1001"],
+      autoReply: true,
+    });
+  });
+
+  it("drops credential-bearing and invalid Telegram API roots", () => {
+    for (const apiRoot of [
+      "https://user:password@telegram.example",
+      "file:///tmp/telegram-api",
+      "not a URL",
+    ]) {
+      const character = buildCharacterFromConfig({
+        connectors: { telegram: { botToken: "token", apiRoot } },
+        agents: { list: [{ name: "Nyx", system: "You are Nyx." }] },
+      } as unknown as ElizaConfig);
+
+      expect(character.settings?.telegram).toEqual({});
+    }
   });
 
   it("preserves injected Discord auto-reply settings", () => {

--- a/packages/agent/src/runtime/build-character-config.test.ts
+++ b/packages/agent/src/runtime/build-character-config.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ElizaConfig } from "../config/config.ts";
 import { buildCharacterFromConfig } from "./build-character-config.ts";
 import { applySandboxCharacterFromEnv } from "./sandbox-character.ts";
+import { buildRuntimeSettingsProjection } from "./runtime-settings.ts";
 
 // Locks the secret/settings boundary for Matrix connector env vars. Putting a
 // public identifier (e.g. MATRIX_VERIFY_ALLOWLIST = a user id) into
@@ -112,6 +113,77 @@ describe("agent entry character passthrough", () => {
     expect(character.name).toBe("Sol");
     expect(character.system).toContain("You are Sol.");
     expect(character.system).not.toContain("Secondary system.");
+  });
+
+  it("projects standard Telegram policy without copying connector secrets", () => {
+    const telegram = {
+      botToken: "telegram-token",
+      webhookSecret: "webhook-secret",
+      dmPolicy: "allowlist",
+      allowFrom: ["42"],
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["42"],
+      groups: {
+        "-1001": {
+          requireMention: true,
+          topics: { "77": { requireMention: true } },
+        },
+      },
+      accounts: {
+        ops: {
+          botToken: "ops-token",
+          groupPolicy: "disabled",
+        },
+      },
+    };
+
+    const config = {
+      connectors: { telegram },
+      agents: { list: [{ id: "nyx", name: "Nyx", system: "You are Nyx." }] },
+    } as ElizaConfig;
+    const character = buildCharacterFromConfig(config);
+    const runtimeSettings = buildRuntimeSettingsProjection(config, { env: {} });
+
+    expect(runtimeSettings.TELEGRAM_BOT_TOKEN).toBe("telegram-token");
+    expect(runtimeSettings.TELEGRAM_ACCOUNT_TOKENS_JSON).toBe(
+      JSON.stringify({ ops: "ops-token" }),
+    );
+    expect(character.settings?.telegram).toEqual({
+      dmPolicy: "allowlist",
+      allowFrom: ["42"],
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["42"],
+      groups: telegram.groups,
+      accounts: { ops: { groupPolicy: "disabled" } },
+    });
+    expect(JSON.stringify(character.settings?.telegram)).not.toContain(
+      "telegram-token",
+    );
+    expect(JSON.stringify(character.settings?.telegram)).not.toContain(
+      "ops-token",
+    );
+  });
+
+  it("keeps the standard connector policy authoritative over stale agent settings", () => {
+    const character = buildCharacterFromConfig({
+      connectors: {
+        telegram: { botToken: "connector-token", groupPolicy: "disabled" },
+      },
+      agents: {
+        list: [
+          {
+            id: "nyx",
+            name: "Nyx",
+            system: "You are Nyx.",
+            settings: {
+              telegram: { botToken: "agent-token", groupPolicy: "open" },
+            },
+          },
+        ],
+      },
+    } as ElizaConfig);
+
+    expect(character.settings?.telegram).toEqual({ groupPolicy: "disabled" });
   });
 
   it("preserves injected Discord auto-reply settings", () => {

--- a/packages/agent/src/runtime/build-character-config.ts
+++ b/packages/agent/src/runtime/build-character-config.ts
@@ -29,40 +29,121 @@ import {
   resolveAdvancedCapabilitiesEnabled,
 } from "./advanced-capabilities-config.ts";
 
+const TELEGRAM_PUBLIC_POLICY_KEYS = [
+  "name",
+  "enabled",
+  "apiRoot",
+  "dmPolicy",
+  "groupPolicy",
+  "allowFrom",
+  "groupAllowFrom",
+  "replyToMode",
+  "groups",
+] as const;
+const TELEGRAM_LEGACY_PUBLIC_KEYS = [
+  ...TELEGRAM_PUBLIC_POLICY_KEYS,
+  "allowedChats",
+  "autoReply",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function projectTelegramKeys(
+  value: unknown,
+  keys: readonly string[],
+): Record<string, JsonValue> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const projected: Record<string, JsonValue> = {};
+  for (const key of keys) {
+    const entry = value[key];
+    if (entry !== undefined) {
+      projected[key] = entry as JsonValue;
+    }
+  }
+  return projected;
+}
+
+function projectTelegramPolicy(value: unknown): Record<string, JsonValue> {
+  const projected = projectTelegramKeys(value, TELEGRAM_PUBLIC_POLICY_KEYS);
+  if (typeof projected.apiRoot === "string") {
+    try {
+      const parsed = new URL(projected.apiRoot);
+      if (
+        (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+        parsed.username ||
+        parsed.password
+      ) {
+        delete projected.apiRoot;
+      }
+    } catch {
+      // error-policy:J3 invalid connector URLs are omitted from runtime config.
+      delete projected.apiRoot;
+    }
+  }
+  return projected;
+}
+
 function projectTelegramConnectorSettings(
   connector: unknown,
+  existingSettings: CharacterSettings | undefined,
 ): CharacterSettings {
   if (!connector || typeof connector !== "object" || Array.isArray(connector)) {
     return {};
   }
 
-  const {
-    botToken: _botToken,
-    tokenFile: _tokenFile,
-    webhookSecret: _webhookSecret,
-    accounts,
-    ...safeConnector
-  } = connector as Record<string, unknown>;
-  const safeAccounts: Record<string, unknown> = {};
+  const connectorRecord = connector as Record<string, unknown>;
+  const rawExistingTelegram = isRecord(existingSettings?.telegram)
+    ? existingSettings.telegram
+    : {};
+  const existingTelegram = projectTelegramKeys(
+    rawExistingTelegram,
+    TELEGRAM_LEGACY_PUBLIC_KEYS,
+  );
+  const projectedAccounts: Record<string, JsonValue> = {};
+  const existingAccounts = isRecord(rawExistingTelegram.accounts)
+    ? Object.fromEntries(
+        Object.entries(rawExistingTelegram.accounts).map(
+          ([accountId, account]) => [
+            accountId,
+            projectTelegramKeys(account, TELEGRAM_LEGACY_PUBLIC_KEYS),
+          ],
+        ),
+      )
+    : {};
 
-  if (accounts && typeof accounts === "object" && !Array.isArray(accounts)) {
-    for (const [accountId, account] of Object.entries(accounts)) {
-      if (!account || typeof account !== "object" || Array.isArray(account)) {
-        continue;
-      }
-      const {
-        botToken: _accountBotToken,
-        tokenFile: _accountTokenFile,
-        webhookSecret: _accountWebhookSecret,
-        ...safeAccount
-      } = account as Record<string, unknown>;
-      safeAccounts[accountId] = safeAccount;
+  if (isRecord(connectorRecord.accounts)) {
+    for (const [accountId, account] of Object.entries(
+      connectorRecord.accounts,
+    )) {
+      const projected = projectTelegramPolicy(account);
+      const existingAccount = projectTelegramKeys(
+        existingAccounts[accountId],
+        TELEGRAM_LEGACY_PUBLIC_KEYS,
+      );
+      projectedAccounts[accountId] = {
+        ...existingAccount,
+        ...projected,
+      } as JsonValue;
     }
   }
 
   const telegram = {
-    ...safeConnector,
-    ...(Object.keys(safeAccounts).length > 0 ? { accounts: safeAccounts } : {}),
+    ...existingTelegram,
+    ...projectTelegramPolicy(connectorRecord),
+    ...(Object.keys(existingAccounts).length > 0 ||
+    Object.keys(projectedAccounts).length > 0
+      ? {
+          accounts: {
+            ...existingAccounts,
+            ...projectedAccounts,
+          },
+        }
+      : {}),
   } as JsonValue;
   return { telegram };
 }
@@ -311,6 +392,7 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
       : systemPrompt;
   const connectorSettings = projectTelegramConnectorSettings(
     config.connectors?.telegram,
+    agentEntry?.settings,
   );
   const mergedSettings = {
     ...(agentEntry?.settings ?? {}),

--- a/packages/agent/src/runtime/build-character-config.ts
+++ b/packages/agent/src/runtime/build-character-config.ts
@@ -11,7 +11,9 @@
 import {
   type Character,
   type CharacterInput,
+  type CharacterSettings,
   defaultCharacterSystemTemplate,
+  type JsonValue,
   mergeCharacterDefaults,
 } from "@elizaos/core";
 import {
@@ -26,6 +28,44 @@ import {
   applyAdvancedCapabilitySettings,
   resolveAdvancedCapabilitiesEnabled,
 } from "./advanced-capabilities-config.ts";
+
+function projectTelegramConnectorSettings(
+  connector: unknown,
+): CharacterSettings {
+  if (!connector || typeof connector !== "object" || Array.isArray(connector)) {
+    return {};
+  }
+
+  const {
+    botToken: _botToken,
+    tokenFile: _tokenFile,
+    webhookSecret: _webhookSecret,
+    accounts,
+    ...safeConnector
+  } = connector as Record<string, unknown>;
+  const safeAccounts: Record<string, unknown> = {};
+
+  if (accounts && typeof accounts === "object" && !Array.isArray(accounts)) {
+    for (const [accountId, account] of Object.entries(accounts)) {
+      if (!account || typeof account !== "object" || Array.isArray(account)) {
+        continue;
+      }
+      const {
+        botToken: _accountBotToken,
+        tokenFile: _accountTokenFile,
+        webhookSecret: _accountWebhookSecret,
+        ...safeAccount
+      } = account as Record<string, unknown>;
+      safeAccounts[accountId] = safeAccount;
+    }
+  }
+
+  const telegram = {
+    ...safeConnector,
+    ...(Object.keys(safeAccounts).length > 0 ? { accounts: safeAccounts } : {}),
+  } as JsonValue;
+  return { telegram };
+}
 
 /**
  * Build a Character object from the runtime ElizaConfig.
@@ -269,8 +309,12 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
     capabilityHints.length > 0
       ? `${systemPrompt}\n\n${capabilityHints.join("\n")}`
       : systemPrompt;
+  const connectorSettings = projectTelegramConnectorSettings(
+    config.connectors?.telegram,
+  );
   const mergedSettings = {
     ...(agentEntry?.settings ?? {}),
+    ...connectorSettings,
     ...settings,
   };
 

--- a/packages/agent/src/runtime/connector-vault-refs.test.ts
+++ b/packages/agent/src/runtime/connector-vault-refs.test.ts
@@ -26,7 +26,10 @@ import {
   resolveConnectorSecretSettings,
   type VaultLike,
 } from "./operations/vault-bridge.ts";
-import { buildRuntimeSettingsProjection } from "./runtime-settings.ts";
+import {
+  buildRuntimeSettingsProjection,
+  resolveTelegramAccountTokenVaultSettings,
+} from "./runtime-settings.ts";
 
 const SECRET = "mfa.discord-bot-token-plaintext-1234567890";
 const VAULT_KEY = "connectors.discord.token";
@@ -232,6 +235,65 @@ describe("buildRuntimeSettingsProjection with connector refs", () => {
     // Unresolved ref → fail-closed: neither the sentinel literal nor any
     // partial value reaches a plugin.
     expect(settings.TELEGRAM_BOT_TOKEN).toBeUndefined();
+  });
+
+  it("merges vault-resolved and plain Telegram account tokens in settings only", async () => {
+    const accountSecret = "telegram-account-vault-secret";
+    const config = {
+      connectors: {
+        telegram: {
+          accounts: {
+            ops: { botToken: "plain-ops-token" },
+            alerts: {
+              botToken: formatVaultRef("connectors.telegram.alerts.token"),
+            },
+          },
+        },
+      },
+    } as unknown as ElizaConfig;
+
+    applyConnectorSecretsToEnv(config);
+    const { resolved, failures } =
+      await resolveTelegramAccountTokenVaultSettings(
+        config,
+        fakeVault({
+          "connectors.telegram.alerts.token": accountSecret,
+        }),
+      );
+    const settings = buildRuntimeSettingsProjection(config, {
+      env: {} as NodeJS.ProcessEnv,
+      connectorSecretsOverlay: resolved,
+    });
+
+    expect(failures).toEqual([]);
+    expect(JSON.parse(settings.TELEGRAM_ACCOUNT_TOKENS_JSON)).toEqual({
+      ops: "plain-ops-token",
+      alerts: accountSecret,
+    });
+    expect(process.env.TELEGRAM_BOT_TOKEN).toBeUndefined();
+    expect(Object.values(process.env)).not.toContain(accountSecret);
+  });
+
+  it("fails closed for a missing Telegram account vault ref", async () => {
+    const config = {
+      connectors: {
+        telegram: {
+          accounts: {
+            alerts: {
+              botToken: formatVaultRef("connectors.telegram.alerts.missing"),
+            },
+          },
+        },
+      },
+    } as unknown as ElizaConfig;
+
+    const { resolved, failures } =
+      await resolveTelegramAccountTokenVaultSettings(config, fakeVault({}));
+
+    expect(resolved).toEqual({});
+    expect(failures).toEqual([
+      'TELEGRAM_ACCOUNT_TOKENS_JSON["alerts"] (vault://connectors.telegram.alerts.missing)',
+    ]);
   });
 
   it("keeps plain connector values in settings unchanged (backward compat)", () => {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -68,7 +68,9 @@ import { shouldLoadRemoteCodingRunnerForBoot } from "./remote-coding-runner-gate
 import { runRuntimeStartupMaintenance } from "./runtime-maintenance.ts";
 import {
   buildRuntimeSettingsProjection,
+  collectTelegramAccountTokenVaultRefs,
   type RuntimeSettingsProjectionOptions,
+  resolveTelegramAccountTokenVaultSettings,
 } from "./runtime-settings.ts";
 
 export { deduplicatePluginActions } from "./plugin-action-dedupe.ts";
@@ -2076,9 +2078,14 @@ export async function resolveConnectorSecretsOverlayForBoot(
   config: ElizaConfig,
 ): Promise<Record<string, string>> {
   const connectorEnvVars = collectConnectorEnvVars(config);
-  const refKeys = Object.entries(connectorEnvVars)
+  const connectorRefKeys = Object.entries(connectorEnvVars)
     .filter(([, value]) => isVaultRef(value))
     .map(([key]) => key);
+  const accountRefKeys = collectTelegramAccountTokenVaultRefs(config).map(
+    ({ accountId }) =>
+      `TELEGRAM_ACCOUNT_TOKENS_JSON[${JSON.stringify(accountId)}]`,
+  );
+  const refKeys = [...connectorRefKeys, ...accountRefKeys];
   if (refKeys.length === 0) return {};
 
   if (isMobilePlatform() || readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1") {
@@ -2089,17 +2096,23 @@ export async function resolveConnectorSecretsOverlayForBoot(
   }
 
   const { sharedVault } = importAppCoreRuntime();
-  const { resolved, failures } = await resolveConnectorSecretSettings(
+  const vault = sharedVault();
+  const connectorResult = await resolveConnectorSecretSettings(
     connectorEnvVars,
-    sharedVault(),
+    vault,
   );
+  const accountResult = await resolveTelegramAccountTokenVaultSettings(
+    config,
+    vault,
+  );
+  const failures = [...connectorResult.failures, ...accountResult.failures];
   if (failures.length > 0) {
     // Key names only — never values, never the underlying vault error.
     logger.error(
       `[vault-bootstrap] connector vault ref(s) failed to resolve (fail-closed): ${failures.join(", ")}`,
     );
   }
-  return resolved;
+  return { ...connectorResult.resolved, ...accountResult.resolved };
 }
 
 /**

--- a/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
@@ -159,6 +159,30 @@ describe("collectPluginNames runtime mode provider policy", () => {
     expect(names.has("@elizaos/plugin-telegram-standalone")).toBe(false);
   });
 
+  it("keeps additive plugin sources from restoring a second Telegram poller", () => {
+    process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
+
+    const names = collectPluginNames({
+      connectors: {
+        telegram: { botToken: "telegram-token", groupPolicy: "disabled" },
+      },
+      plugins: {
+        allow: ["@elizaos/plugin-telegram-standalone"],
+        entries: { "telegram-standalone": { enabled: true } },
+        installs: {
+          "@elizaos/plugin-telegram-standalone": {
+            source: "npm",
+            spec: "latest",
+          },
+        },
+      },
+    } as ElizaConfig);
+
+    expect(names.has("@elizaos/plugin-telegram")).toBe(true);
+    expect(names.has("@elizaos/plugin-telegram-standalone")).toBe(false);
+  });
+
   it("uses standalone Telegram as the sole owner for legacy env-only mode", () => {
     process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
     process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";

--- a/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
@@ -21,6 +21,8 @@ const ENV_KEYS = [
   "ELIZA_BUILD_VARIANT",
   "ELIZA_AGENT_ORCHESTRATOR",
   "ELIZA_PLUGIN_SET",
+  "ELIZA_LIFEOPS_PASSIVE_CONNECTORS",
+  "ELIZA_TELEGRAM_STANDALONE_BOT",
   "ELIZA_DEFAULT_AGENT_TYPE",
   "ELIZA_ACP_DEFAULT_AGENT",
   "ELIZA_AGENT_SELECTION_STRATEGY",
@@ -137,6 +139,34 @@ describe("collectPluginNames runtime mode provider policy", () => {
     expect(names.has("@elizaos/plugin-local-inference")).toBe(true);
     expect(names.has("@elizaos/plugin-ollama")).toBe(true);
     expect(names.has("@elizaos/plugin-elizacloud")).toBe(false);
+  });
+
+  it("keeps the typed Telegram connector as the sole owner when the standalone flag is stale", () => {
+    process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
+
+    const names = collectPluginNames({
+      connectors: {
+        telegram: {
+          botToken: "telegram-token",
+          groupPolicy: "allowlist",
+          groups: { "-1001": { requireMention: true } },
+        },
+      },
+    } as ElizaConfig);
+
+    expect(names.has("@elizaos/plugin-telegram")).toBe(true);
+    expect(names.has("@elizaos/plugin-telegram-standalone")).toBe(false);
+  });
+
+  it("uses standalone Telegram as the sole owner for legacy env-only mode", () => {
+    process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
+
+    const names = collectPluginNames({} as ElizaConfig);
+
+    expect(names.has("@elizaos/plugin-telegram-standalone")).toBe(true);
+    expect(names.has("@elizaos/plugin-telegram")).toBe(false);
   });
 
   it("keeps plugin-local-inference when only local embeddings are disabled", () => {

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -853,7 +853,9 @@ export function collectPluginNames(
     }
   }
 
-  if (useTelegramStandalone) {
+  if (hasStandardTelegramConnector) {
+    pluginsToLoad.delete("@elizaos/plugin-telegram-standalone");
+  } else if (useTelegramStandalone) {
     pluginsToLoad.delete("@elizaos/plugin-telegram");
   }
 

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -410,6 +410,24 @@ export function collectPluginNames(
     | undefined;
   const pluginEntries = (config.plugins as Record<string, unknown> | undefined)
     ?.entries as Record<string, { enabled?: boolean }> | undefined;
+  const telegramConnector =
+    config.connectors?.telegram ??
+    (
+      (config as Record<string, unknown>).channels as
+        | Record<string, unknown>
+        | undefined
+    )?.telegram;
+  const hasStandardTelegramConnector = Boolean(
+    telegramConnector &&
+      typeof telegramConnector === "object" &&
+      !Array.isArray(telegramConnector) &&
+      (telegramConnector as Record<string, unknown>).enabled !== false,
+  );
+  // A persisted connector config is authoritative because only the full plugin
+  // consumes its typed DM/group/topic policy. The legacy standalone flag is a
+  // fallback for env-only deployments, never a second polling owner.
+  const useTelegramStandalone =
+    telegramStandaloneRequested() && !hasStandardTelegramConnector;
 
   const isPluginExplicitlyDisabled = (pluginPackageName: string): boolean => {
     const marker = "/plugin-";
@@ -562,11 +580,11 @@ export function collectPluginNames(
   // Opt-in standalone Telegram polling bot. Loaded only when passive connectors
   // are disabled and ELIZA_TELEGRAM_STANDALONE_BOT is set; its service owns the
   // Telegraf long-poll lifecycle (previously inlined in the app-core boot tail).
-  if (telegramStandaloneRequested()) {
+  if (useTelegramStandalone) {
     pluginsToLoad.add("@elizaos/plugin-telegram-standalone");
     track(
       "@elizaos/plugin-telegram-standalone",
-      "telegram standalone bot (gate ELIZA_TELEGRAM_STANDALONE_BOT)",
+      "telegram standalone bot (env-only fallback owner)",
     );
   }
   // Allow list is additive — extra plugins on top of auto-detection,
@@ -606,6 +624,9 @@ export function collectPluginNames(
     }
     const pluginName = CHANNEL_PLUGIN_MAP[channelName];
     if (pluginName) {
+      if (useTelegramStandalone && pluginName === "@elizaos/plugin-telegram") {
+        continue;
+      }
       pluginsToLoad.add(pluginName);
       track(pluginName, `connectors.${channelName}`);
     }
@@ -830,6 +851,10 @@ export function collectPluginNames(
       }
       pluginsToLoad.delete(name);
     }
+  }
+
+  if (useTelegramStandalone) {
+    pluginsToLoad.delete("@elizaos/plugin-telegram");
   }
 
   return pluginsToLoad;

--- a/packages/agent/src/runtime/runtime-settings.ts
+++ b/packages/agent/src/runtime/runtime-settings.ts
@@ -8,7 +8,11 @@ import {
   collectConfigEnvVars,
   collectConnectorEnvVars,
 } from "../config/env-vars.ts";
-import { isVaultRef } from "./operations/vault-bridge.ts";
+import {
+  isVaultRef,
+  resolveConnectorSecretSettings,
+  type VaultLike,
+} from "./operations/vault-bridge.ts";
 
 export interface RuntimeSettingsProjectionOptions {
   preferredProviderId?: string;
@@ -62,7 +66,7 @@ export function isEnvKeyAllowedForForwarding(key: string): boolean {
   return true;
 }
 
-function collectTelegramAccountTokenSettings(
+export function collectTelegramAccountTokenSettings(
   config: ElizaConfig,
 ): Record<string, string> {
   const connector = config.connectors?.telegram as
@@ -75,16 +79,104 @@ function collectTelegramAccountTokenSettings(
   )) {
     const token = account?.botToken;
     const normalizedToken = typeof token === "string" ? token.trim() : "";
-    if (
-      normalizedToken.length > 0 &&
-      !normalizedToken.toLowerCase().startsWith("vault://")
-    ) {
+    if (normalizedToken.length > 0 && !isVaultRef(normalizedToken)) {
       accountTokens[accountId] = normalizedToken;
     }
   }
 
   return Object.keys(accountTokens).length > 0
     ? { TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify(accountTokens) }
+    : {};
+}
+
+export function collectTelegramAccountTokenVaultRefs(
+  config: ElizaConfig,
+): Array<{ accountId: string; ref: string }> {
+  const connector = config.connectors?.telegram as
+    | { accounts?: Record<string, { botToken?: unknown } | undefined> }
+    | undefined;
+
+  return Object.entries(connector?.accounts ?? {}).flatMap(
+    ([accountId, account]) => {
+      const token = account?.botToken;
+      const normalizedToken = typeof token === "string" ? token.trim() : "";
+      return isVaultRef(normalizedToken)
+        ? [{ accountId, ref: normalizedToken }]
+        : [];
+    },
+  );
+}
+
+export async function resolveTelegramAccountTokenVaultSettings(
+  config: ElizaConfig,
+  vault: VaultLike,
+): Promise<{ resolved: Record<string, string>; failures: string[] }> {
+  const keyToAccountId = new Map<string, string>();
+  const refs: Record<string, string> = {};
+  for (const { accountId, ref } of collectTelegramAccountTokenVaultRefs(
+    config,
+  )) {
+    const key = `TELEGRAM_ACCOUNT_TOKENS_JSON[${JSON.stringify(accountId)}]`;
+    refs[key] = ref;
+    keyToAccountId.set(key, accountId);
+  }
+  const { resolved, failures } = await resolveConnectorSecretSettings(
+    refs,
+    vault,
+  );
+  const accountTokens: Record<string, string> = {};
+  for (const [key, accountId] of keyToAccountId) {
+    const token = resolved[key];
+    if (token) {
+      accountTokens[accountId] = token;
+    }
+  }
+  return {
+    resolved:
+      Object.keys(accountTokens).length > 0
+        ? { TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify(accountTokens) }
+        : {},
+    failures,
+  };
+}
+
+function parseTelegramAccountTokenSetting(
+  value: string | undefined,
+): Record<string, string> {
+  if (!value) {
+    return {};
+  }
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new TypeError("TELEGRAM_ACCOUNT_TOKENS_JSON must be a JSON object");
+  }
+  return Object.fromEntries(
+    Object.entries(parsed as Record<string, unknown>).map(
+      ([accountId, token]) => {
+        if (typeof token !== "string" || token.trim().length === 0) {
+          throw new TypeError(
+            `TELEGRAM_ACCOUNT_TOKENS_JSON contains an invalid token for account ${JSON.stringify(accountId)}`,
+          );
+        }
+        return [accountId, token.trim()];
+      },
+    ),
+  );
+}
+
+function mergeTelegramAccountTokenSettings(
+  config: ElizaConfig,
+  connectorSecretsOverlay: Record<string, string> | undefined,
+): Record<string, string> {
+  const plain = parseTelegramAccountTokenSetting(
+    collectTelegramAccountTokenSettings(config).TELEGRAM_ACCOUNT_TOKENS_JSON,
+  );
+  const resolved = parseTelegramAccountTokenSetting(
+    connectorSecretsOverlay?.TELEGRAM_ACCOUNT_TOKENS_JSON,
+  );
+  const merged = { ...plain, ...resolved };
+  return Object.keys(merged).length > 0
+    ? { TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify(merged) }
     : {};
 }
 
@@ -110,7 +202,10 @@ export function buildRuntimeSettingsProjection(
       ),
     ),
     ...(options.connectorSecretsOverlay ?? {}),
-    ...collectTelegramAccountTokenSettings(config),
+    ...mergeTelegramAccountTokenSettings(
+      config,
+      options.connectorSecretsOverlay,
+    ),
     ...(options.preferredProviderId
       ? { MODEL_PROVIDER: options.preferredProviderId }
       : {}),

--- a/packages/agent/src/runtime/runtime-settings.ts
+++ b/packages/agent/src/runtime/runtime-settings.ts
@@ -62,6 +62,32 @@ export function isEnvKeyAllowedForForwarding(key: string): boolean {
   return true;
 }
 
+function collectTelegramAccountTokenSettings(
+  config: ElizaConfig,
+): Record<string, string> {
+  const connector = config.connectors?.telegram as
+    | { accounts?: Record<string, { botToken?: unknown } | undefined> }
+    | undefined;
+  const accountTokens: Record<string, string> = {};
+
+  for (const [accountId, account] of Object.entries(
+    connector?.accounts ?? {},
+  )) {
+    const token = account?.botToken;
+    const normalizedToken = typeof token === "string" ? token.trim() : "";
+    if (
+      normalizedToken.length > 0 &&
+      !normalizedToken.toLowerCase().startsWith("vault://")
+    ) {
+      accountTokens[accountId] = normalizedToken;
+    }
+  }
+
+  return Object.keys(accountTokens).length > 0
+    ? { TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify(accountTokens) }
+    : {};
+}
+
 export function buildRuntimeSettingsProjection(
   config: ElizaConfig,
   options: RuntimeSettingsProjectionOptions = {},
@@ -84,6 +110,7 @@ export function buildRuntimeSettingsProjection(
       ),
     ),
     ...(options.connectorSecretsOverlay ?? {}),
+    ...collectTelegramAccountTokenSettings(config),
     ...(options.preferredProviderId
       ? { MODEL_PROVIDER: options.preferredProviderId }
       : {}),

--- a/plugins/plugin-telegram/__tests__/core-test-mock.ts
+++ b/plugins/plugin-telegram/__tests__/core-test-mock.ts
@@ -15,6 +15,7 @@ vi.mock("@elizaos/core", async () => {
   const interactions = await import(
     "../../../packages/core/src/messaging/interactions/index"
   );
+  const { ElizaError } = await import("../../../packages/core/src/errors");
 
   // The message-triage adapter base + service are equally pure (only `logger`
   // and type imports), so the mock delegates to the real submodules rather than
@@ -120,6 +121,7 @@ vi.mock("@elizaos/core", async () => {
     BaseMessageAdapter,
     ChannelType,
     CommandRegistryService,
+    ElizaError,
     EventType,
     getDefaultTriageService,
     ModelType,

--- a/plugins/plugin-telegram/src/accounts.test.ts
+++ b/plugins/plugin-telegram/src/accounts.test.ts
@@ -1,0 +1,35 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { resolveTelegramAccount } from "./accounts";
+
+describe("Telegram standard account config resolution", () => {
+  it("combines projected account policy with its runtime-only bot token", () => {
+    const runtime = {
+      character: {
+        settings: {
+          telegram: {
+            accounts: {
+              ops: {
+                groupPolicy: "allowlist",
+                groups: { "-1001": { requireMention: true } },
+              },
+            },
+          },
+        },
+      },
+      getSetting: vi.fn((key: string) =>
+        key === "TELEGRAM_ACCOUNT_TOKENS_JSON"
+          ? JSON.stringify({ ops: "ops-token" })
+          : undefined,
+      ),
+    } as unknown as IAgentRuntime;
+
+    const account = resolveTelegramAccount(runtime, "ops");
+
+    expect(account.botToken).toBe("ops-token");
+    expect(account.config).toMatchObject({
+      groupPolicy: "allowlist",
+      groups: { "-1001": { requireMention: true } },
+    });
+  });
+});

--- a/plugins/plugin-telegram/src/accounts.test.ts
+++ b/plugins/plugin-telegram/src/accounts.test.ts
@@ -1,6 +1,9 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-import { resolveTelegramAccount } from "./accounts";
+import {
+  listEnabledTelegramAccounts,
+  resolveTelegramAccount,
+} from "./accounts";
 
 describe("Telegram standard account config resolution", () => {
   it("combines projected account policy with its runtime-only bot token", () => {
@@ -31,5 +34,31 @@ describe("Telegram standard account config resolution", () => {
       groupPolicy: "allowlist",
       groups: { "-1001": { requireMention: true } },
     });
+  });
+
+  it("fails closed when projected account-token JSON is malformed", () => {
+    const runtime = {
+      character: {
+        settings: { telegram: { accounts: { ops: { enabled: true } } } },
+      },
+      getSetting: vi.fn(() => "{not-json"),
+    } as unknown as IAgentRuntime;
+
+    expect(() => listEnabledTelegramAccounts(runtime)).toThrowError(
+      expect.objectContaining({ code: "TELEGRAM_ACCOUNT_TOKENS_INVALID" }),
+    );
+  });
+
+  it("fails closed when any projected account token is empty", () => {
+    const runtime = {
+      character: {
+        settings: { telegram: { accounts: { ops: { enabled: true } } } },
+      },
+      getSetting: vi.fn(() => JSON.stringify({ ops: "" })),
+    } as unknown as IAgentRuntime;
+
+    expect(() => listEnabledTelegramAccounts(runtime)).toThrowError(
+      expect.objectContaining({ code: "TELEGRAM_ACCOUNT_TOKEN_MISSING" }),
+    );
   });
 });

--- a/plugins/plugin-telegram/src/accounts.ts
+++ b/plugins/plugin-telegram/src/accounts.ts
@@ -16,6 +16,29 @@ export interface TelegramAccountConfig {
   apiRoot?: string;
   allowedChats?: string[];
   autoReply?: boolean;
+  dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
+  groupPolicy?: "open" | "disabled" | "allowlist";
+  allowFrom?: Array<string | number>;
+  groupAllowFrom?: Array<string | number>;
+  replyToMode?: "off" | "first" | "all";
+  groups?: Record<
+    string,
+    | {
+        requireMention?: boolean;
+        enabled?: boolean;
+        allowFrom?: Array<string | number>;
+        topics?: Record<
+          string,
+          | {
+              requireMention?: boolean;
+              enabled?: boolean;
+              allowFrom?: Array<string | number>;
+            }
+          | undefined
+        >;
+      }
+    | undefined
+  >;
   personal?: {
     phone?: string;
     appId?: string;
@@ -29,6 +52,12 @@ export interface TelegramMultiAccountConfig {
   enabled?: boolean;
   botToken?: string;
   apiRoot?: string;
+  dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
+  groupPolicy?: "open" | "disabled" | "allowlist";
+  allowFrom?: Array<string | number>;
+  groupAllowFrom?: Array<string | number>;
+  replyToMode?: "off" | "first" | "all";
+  groups?: TelegramAccountConfig["groups"];
   accounts?: Record<string, TelegramAccountConfig>;
 }
 
@@ -45,6 +74,31 @@ function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function getRuntimeAccountTokens(
+  runtime: IAgentRuntime,
+): Record<string, string> {
+  const raw = runtime.getSetting("TELEGRAM_ACCOUNT_TOKENS_JSON");
+  if (typeof raw !== "string" || !raw.trim()) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).flatMap(
+        ([accountId, token]) => {
+          const value = readNonEmptyString(token);
+          return value ? [[accountId, value]] : [];
+        },
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
 export function normalizeTelegramAccountId(accountId?: string | null): string {
   return readNonEmptyString(accountId) ?? DEFAULT_ACCOUNT_ID;
 }
@@ -52,7 +106,7 @@ export function normalizeTelegramAccountId(accountId?: string | null): string {
 export function getTelegramMultiAccountConfig(
   runtime: IAgentRuntime,
 ): TelegramMultiAccountConfig {
-  const characterTelegram = runtime.character.settings?.telegram as
+  const characterTelegram = runtime.character?.settings?.telegram as
     | TelegramMultiAccountConfig
     | undefined;
 
@@ -60,6 +114,12 @@ export function getTelegramMultiAccountConfig(
     enabled: characterTelegram?.enabled,
     botToken: characterTelegram?.botToken,
     apiRoot: characterTelegram?.apiRoot,
+    dmPolicy: characterTelegram?.dmPolicy,
+    groupPolicy: characterTelegram?.groupPolicy,
+    allowFrom: characterTelegram?.allowFrom,
+    groupAllowFrom: characterTelegram?.groupAllowFrom,
+    replyToMode: characterTelegram?.replyToMode,
+    groups: characterTelegram?.groups,
     accounts: characterTelegram?.accounts,
   };
 }
@@ -103,6 +163,12 @@ function resolveTelegramBotToken(
   if (configToken) {
     return configToken;
   }
+  const accountToken = readNonEmptyString(
+    getRuntimeAccountTokens(runtime)[accountId],
+  );
+  if (accountToken) {
+    return accountToken;
+  }
   if (accountId !== DEFAULT_ACCOUNT_ID) {
     return undefined;
   }
@@ -123,6 +189,12 @@ export function resolveTelegramAccount(
     enabled: multi.enabled,
     botToken: multi.botToken,
     apiRoot: multi.apiRoot,
+    dmPolicy: multi.dmPolicy,
+    groupPolicy: multi.groupPolicy,
+    allowFrom: multi.allowFrom,
+    groupAllowFrom: multi.groupAllowFrom,
+    replyToMode: multi.replyToMode,
+    groups: multi.groups,
     ...accountConfig,
   };
   const apiRoot =

--- a/plugins/plugin-telegram/src/accounts.ts
+++ b/plugins/plugin-telegram/src/accounts.ts
@@ -5,7 +5,7 @@
  * `ResolvedTelegramAccount` the service launches a bot for. `default` is the
  * synthetic id for the single-account configuration.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 
 export const DEFAULT_ACCOUNT_ID = "default";
 
@@ -81,22 +81,41 @@ function getRuntimeAccountTokens(
   if (typeof raw !== "string" || !raw.trim()) {
     return {};
   }
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return {};
-    }
-    return Object.fromEntries(
-      Object.entries(parsed as Record<string, unknown>).flatMap(
-        ([accountId, token]) => {
-          const value = readNonEmptyString(token);
-          return value ? [[accountId, value]] : [];
-        },
-      ),
-    );
-  } catch {
-    return {};
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    // error-policy:J2 runtime projection corruption must retain its parse cause.
+    throw new ElizaError("Telegram account token settings are not valid JSON", {
+      code: "TELEGRAM_ACCOUNT_TOKENS_INVALID",
+      cause: error,
+      severity: "fatal",
+    });
   }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ElizaError("Telegram account token settings must be an object", {
+      code: "TELEGRAM_ACCOUNT_TOKENS_INVALID",
+      severity: "fatal",
+    });
+  }
+  return Object.fromEntries(
+    Object.entries(parsed as Record<string, unknown>).map(
+      ([accountId, token]) => {
+        const value = readNonEmptyString(token);
+        if (!value) {
+          throw new ElizaError(
+            `Telegram account token is missing for ${JSON.stringify(accountId)}`,
+            {
+              code: "TELEGRAM_ACCOUNT_TOKEN_MISSING",
+              context: { accountId },
+              severity: "fatal",
+            },
+          );
+        }
+        return [accountId, value];
+      },
+    ),
+  );
 }
 
 export function normalizeTelegramAccountId(accountId?: string | null): string {

--- a/plugins/plugin-telegram/src/command-registration.test.ts
+++ b/plugins/plugin-telegram/src/command-registration.test.ts
@@ -90,6 +90,7 @@ function makeRuntime(settings: Record<string, string> = {}): IAgentRuntime {
       cache.set(key, value);
       return true;
     }),
+    reportError: vi.fn(),
     character: { name: "TestAgent" },
   } as unknown as IAgentRuntime;
 }
@@ -350,15 +351,21 @@ describe("applyTelegramSetMyCommands", () => {
     );
   });
 
-  it("swallows setMyCommands network failures without throwing", async () => {
+  it("reports setMyCommands network failures without stopping polling", async () => {
     const setMyCommands = vi.fn(async () => {
       throw new Error("ETELEGRAM 429: Too Many Requests");
     });
     const bot = { telegram: { setMyCommands } } as never;
+    const runtime = makeRuntime();
 
     await expect(
-      applyTelegramSetMyCommands(bot, makeRuntime(), "default"),
+      applyTelegramSetMyCommands(bot, runtime, "default"),
     ).resolves.toBeUndefined();
     expect(setMyCommands).toHaveBeenCalledTimes(1);
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "telegram:command-menu",
+      expect.any(Error),
+      { accountId: "default" },
+    );
   });
 });

--- a/plugins/plugin-telegram/src/command-registration.ts
+++ b/plugins/plugin-telegram/src/command-registration.ts
@@ -412,19 +412,20 @@ export function registerTelegramCommandHandlers(
       try {
         await handler(ctx);
       } catch (error) {
-        logger.error(
-          {
-            src: "plugin:telegram",
-            agentId: runtime.agentId,
+        // error-policy:J1 command boundary reports and returns an explicit failure.
+        runtime.reportError("telegram:command", error, {
+          accountId,
+          command: descriptor.name,
+        });
+        try {
+          await ctx.reply(`Could not run /${descriptor.name}.`);
+        } catch (replyError) {
+          // error-policy:J7 failed diagnostics must not terminate polling.
+          runtime.reportError("telegram:command-reply", replyError, {
             accountId,
             command: descriptor.name,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "Error handling slash command",
-        );
-        await ctx
-          .reply(`Could not run /${descriptor.name}.`)
-          .catch(() => undefined);
+          });
+        }
       }
     });
   }
@@ -461,14 +462,7 @@ export async function applyTelegramSetMyCommands(
       "Published slash-command menu to Telegram",
     );
   } catch (error) {
-    logger.warn(
-      {
-        src: "plugin:telegram",
-        agentId: runtime.agentId,
-        accountId,
-        error: error instanceof Error ? error.message : String(error),
-      },
-      "setMyCommands failed; slash-command menu not published",
-    );
+    // error-policy:J7 menu publication is diagnostic, not required for polling.
+    runtime.reportError("telegram:command-menu", error, { accountId });
   }
 }

--- a/plugins/plugin-telegram/src/interactions-roundtrip.test.ts
+++ b/plugins/plugin-telegram/src/interactions-roundtrip.test.ts
@@ -15,8 +15,10 @@ function createCallbackManager() {
   const ensureConnection = vi.fn(async () => undefined);
   const runtime = {
     agentId: "agent-1",
+    character: { name: "Agent", settings: {} },
     messageService: { handleMessage },
     ensureConnection,
+    getSetting: vi.fn(() => undefined),
   };
   const bot = { telegram: { sendMessage: vi.fn(), sendChatAction: vi.fn() } };
   return {

--- a/plugins/plugin-telegram/src/messageConnector.test.ts
+++ b/plugins/plugin-telegram/src/messageConnector.test.ts
@@ -176,6 +176,39 @@ describe("Telegram message connector adapter", () => {
     expect(manager.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("does not let TELEGRAM_ALLOWED_CHATS override typed Telegram policy", async () => {
+    const getSetting = vi.fn((key: string) =>
+      key === "TELEGRAM_ALLOWED_CHATS" ? '["-999"]' : undefined,
+    );
+    const runtime = {
+      agentId: "agent-1",
+      character: {
+        settings: {
+          telegram: {
+            botToken: "token",
+            groupPolicy: "open",
+            groups: { "-100123": { requireMention: true } },
+          },
+        },
+      },
+      getSetting,
+    } as unknown as IAgentRuntime;
+    const service = createTelegramService({
+      runtime,
+      defaultAccountId: "default",
+      accountStates: new Map(),
+    }) as unknown as {
+      isGroupAuthorized(ctx: unknown, accountId?: string): Promise<boolean>;
+    };
+
+    await expect(
+      service.isGroupAuthorized({
+        chat: { id: -100123, type: "supergroup" },
+      }),
+    ).resolves.toBe(true);
+    expect(getSetting).not.toHaveBeenCalledWith("TELEGRAM_ALLOWED_CHATS");
+  });
+
   it("resolves known chats into connector targets", async () => {
     const runtime = createRuntime();
     const service = createTelegramService({

--- a/plugins/plugin-telegram/src/messageManager.activation-policy.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.activation-policy.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Production-path coverage for Telegram safe activation: MessageManager handles
+ * Telegraf message contexts with the typed connector policy already present on
+ * `character.settings.telegram`, and only addressed/authorized updates reach
+ * memory or model dispatch.
+ */
+import type {
+  Content,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { MessageManager } from "./messageManager";
+
+const BOT_USER = {
+  id: 9001,
+  is_bot: true,
+  first_name: "Agent",
+  username: "agent_bot",
+};
+
+type RuntimeOptions = {
+  telegram?: Record<string, unknown>;
+  autoReply?: boolean;
+  handleMessage?: (
+    runtime: IAgentRuntime,
+    memory: Memory,
+    callback: HandlerCallback,
+  ) => Promise<void>;
+};
+
+function createHarness(options: RuntimeOptions = {}) {
+  const createMemory = vi.fn(async () => undefined);
+  const ensureConnection = vi.fn(async () => undefined);
+  const sendMessage = vi.fn(async (chatId: string | number, text: string) => ({
+    message_id: 500,
+    date: 1_700_000_010,
+    text,
+    chat: { id: chatId, type: "supergroup" },
+  }));
+  const sendChatAction = vi.fn(async () => undefined);
+  const messageService = {
+    handleMessage: vi.fn(
+      options.handleMessage ??
+        (async () => {
+          return undefined;
+        }),
+    ),
+  };
+  const runtime = {
+    agentId: "agent-1",
+    character: {
+      name: "Agent",
+      settings: {
+        telegram: options.telegram ?? {
+          botToken: "token",
+          dmPolicy: "allowlist",
+          allowFrom: ["42"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["42"],
+          groups: {
+            "-1001": { requireMention: true },
+          },
+        },
+      },
+    },
+    createMemory,
+    ensureConnection,
+    messageService,
+    getSetting: vi.fn((key: string) => {
+      if (key === "TELEGRAM_AUTO_REPLY" && options.autoReply) {
+        return "true";
+      }
+      return undefined;
+    }),
+    getService: vi.fn(() => null),
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime & {
+    createMemory: ReturnType<typeof vi.fn>;
+    ensureConnection: ReturnType<typeof vi.fn>;
+    messageService: { handleMessage: ReturnType<typeof vi.fn> };
+  };
+  const bot = {
+    botInfo: BOT_USER,
+    telegram: {
+      sendMessage,
+      sendChatAction,
+    },
+  };
+
+  return {
+    manager: new MessageManager(bot as never, runtime),
+    runtime,
+    sendMessage,
+  };
+}
+
+function groupContext(overrides: Record<string, unknown> = {}) {
+  return {
+    from: {
+      id: 42,
+      first_name: "Ada",
+      username: "ada",
+      is_bot: false,
+    },
+    chat: { id: -1001, type: "supergroup", title: "Ops" },
+    message: {
+      message_id: 10,
+      date: 1_700_000_000,
+      text: "hello room",
+      chat: { id: -1001, type: "supergroup", title: "Ops" },
+      ...overrides,
+    },
+  };
+}
+
+describe("MessageManager typed Telegram activation policy", () => {
+  it("does not create memory or dispatch for unaddressed ordinary group traffic", async () => {
+    const { manager, runtime } = createHarness();
+
+    await manager.handleMessage(groupContext() as never);
+
+    expect(runtime.ensureConnection).not.toHaveBeenCalled();
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+    expect(runtime.messageService.handleMessage).not.toHaveBeenCalled();
+  });
+
+  it("blocks unauthorized senders and unconfigured groups before memory, even for forced commands", async () => {
+    const { manager, runtime } = createHarness();
+    const mention = {
+      text: "@agent_bot run",
+      entities: [{ type: "mention", offset: 0, length: 10 }],
+    };
+
+    await manager.handleMessage(
+      {
+        ...groupContext(mention),
+        from: {
+          id: 7,
+          first_name: "Eve",
+          username: "eve",
+          is_bot: false,
+        },
+      } as never,
+      { forceReply: true },
+    );
+
+    await manager.handleMessage({
+      ...groupContext({
+        ...mention,
+        chat: { id: -9999, type: "supergroup", title: "Other" },
+      }),
+      chat: { id: -9999, type: "supergroup", title: "Other" },
+    } as never);
+
+    expect(runtime.ensureConnection).not.toHaveBeenCalled();
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+    expect(runtime.messageService.handleMessage).not.toHaveBeenCalled();
+  });
+
+  it("dispatches native mentions and strips only the addressed bot mention", async () => {
+    const { manager, runtime } = createHarness();
+
+    await manager.handleMessage(
+      groupContext({
+        text: "@agent_bot hello @someone_else",
+        entities: [{ type: "mention", offset: 0, length: 10 }],
+      }) as never,
+    );
+
+    expect(runtime.messageService.handleMessage).toHaveBeenCalledTimes(1);
+    const memory = runtime.messageService.handleMessage.mock.calls[0][1];
+    expect(memory.content.text).toBe("hello @someone_else");
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+  });
+
+  it("dispatches replies to the bot without a mention", async () => {
+    const { manager, runtime } = createHarness();
+
+    await manager.handleMessage(
+      groupContext({
+        reply_to_message: {
+          message_id: 9,
+          date: 1_699_999_999,
+          text: "agent reply",
+          chat: { id: -1001, type: "supergroup", title: "Ops" },
+          from: BOT_USER,
+        },
+      }) as never,
+    );
+
+    expect(runtime.messageService.handleMessage).toHaveBeenCalledTimes(1);
+    const memory = runtime.messageService.handleMessage.mock.calls[0][1];
+    expect(memory.content.inReplyTo).toBeDefined();
+  });
+
+  it("obeys typed DM allowlist policy", async () => {
+    const { manager, runtime } = createHarness();
+
+    await manager.handleMessage({
+      from: { id: 42, first_name: "Ada", username: "ada", is_bot: false },
+      chat: { id: 42, type: "private", first_name: "Ada" },
+      message: {
+        message_id: 11,
+        date: 1_700_000_000,
+        text: "hello",
+        chat: { id: 42, type: "private", first_name: "Ada" },
+      },
+    } as never);
+
+    expect(runtime.messageService.handleMessage).toHaveBeenCalledTimes(1);
+
+    await manager.handleMessage({
+      from: { id: 7, first_name: "Eve", username: "eve", is_bot: false },
+      chat: { id: 7, type: "private", first_name: "Eve" },
+      message: {
+        message_id: 12,
+        date: 1_700_000_000,
+        text: "hello",
+        chat: { id: 7, type: "private", first_name: "Eve" },
+      },
+    } as never);
+
+    expect(runtime.messageService.handleMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps topic identity and delivers generated replies to the thread and source message", async () => {
+    const { manager, runtime, sendMessage } = createHarness({
+      telegram: {
+        botToken: "token",
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["42"],
+        replyToMode: "first",
+        groups: {
+          "-1001": {
+            requireMention: true,
+            topics: { "77": { requireMention: true } },
+          },
+        },
+      },
+      handleMessage: async (_runtime, _memory, callback) => {
+        await callback({ text: "thread reply" } as Content);
+      },
+    });
+
+    await manager.handleMessage({
+      ...groupContext({
+        text: "@agent_bot thread",
+        entities: [{ type: "mention", offset: 0, length: 10 }],
+        is_topic_message: true,
+        message_thread_id: 77,
+      }),
+      telegram: {
+        sendMessage,
+        sendChatAction: vi.fn(async () => undefined),
+      },
+    } as never);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      -1001,
+      "thread reply",
+      expect.objectContaining({
+        message_thread_id: 77,
+        reply_parameters: { message_id: 10 },
+      }),
+    );
+    expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+    const responseMemory = runtime.createMemory.mock.calls[0][0];
+    expect(responseMemory.roomId).toBe(
+      runtime.messageService.handleMessage.mock.calls[0][1].roomId,
+    );
+    expect(responseMemory.metadata.telegram).toMatchObject({
+      chatId: -1001,
+      threadId: "77",
+    });
+  });
+
+  it("does not let legacy auto-reply override typed group mention policy", async () => {
+    const { manager, runtime } = createHarness({ autoReply: true });
+
+    await manager.handleMessage(groupContext() as never);
+
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+    expect(runtime.messageService.handleMessage).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-telegram/src/messageManager.activation-policy.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.activation-policy.test.ts
@@ -271,7 +271,7 @@ describe("MessageManager typed Telegram activation policy", () => {
       runtime.messageService.handleMessage.mock.calls[0][1].roomId,
     );
     expect(responseMemory.metadata.telegram).toMatchObject({
-      chatId: -1001,
+      chatId: "-1001",
       threadId: "77",
     });
   });

--- a/plugins/plugin-telegram/src/messageManager.outbound-media.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.outbound-media.test.ts
@@ -1,8 +1,9 @@
 /**
  * Unit tests for outbound media dispatch: each `Media` attachment routes to the
  * matching Telegram sender (sendPhoto / sendVideo / sendAudio / sendDocument) by
- * coarse content type, unknown types degrade to a document, and accompanying
- * prose is sent alongside. Telegraf send calls are mocked.
+ * coarse content type, unknown types produce a visible unsupported-media
+ * notice, and accompanying prose is sent alongside. Telegraf send calls are
+ * mocked.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
@@ -28,12 +29,55 @@ function setup() {
     runtime as never,
   );
 
+  const sent = (message_id: number, chatId = 123, caption?: string) => ({
+    message_id,
+    date: 1_700_000_000 + message_id,
+    caption,
+    chat: { id: chatId, type: "private" },
+  });
   const senders = {
-    sendPhoto: vi.fn(async () => ({ message_id: 1 })),
-    sendVideo: vi.fn(async () => ({ message_id: 2 })),
-    sendAudio: vi.fn(async () => ({ message_id: 3 })),
-    sendDocument: vi.fn(async () => ({ message_id: 4 })),
-    sendAnimation: vi.fn(async () => ({ message_id: 5 })),
+    sendPhoto: vi.fn(
+      async (
+        chatId: number | string,
+        _url: string,
+        opts?: { caption?: string },
+      ) => sent(1, Number(chatId), opts?.caption),
+    ),
+    sendVideo: vi.fn(
+      async (
+        chatId: number | string,
+        _url: string,
+        opts?: { caption?: string },
+      ) => sent(2, Number(chatId), opts?.caption),
+    ),
+    sendAudio: vi.fn(
+      async (
+        chatId: number | string,
+        _url: string,
+        opts?: { caption?: string },
+      ) => sent(3, Number(chatId), opts?.caption),
+    ),
+    sendVoice: vi.fn(
+      async (
+        chatId: number | string,
+        _url: string,
+        opts?: { caption?: string },
+      ) => sent(4, Number(chatId), opts?.caption),
+    ),
+    sendDocument: vi.fn(
+      async (
+        chatId: number | string,
+        _url: string,
+        opts?: { caption?: string },
+      ) => sent(5, Number(chatId), opts?.caption),
+    ),
+    sendAnimation: vi.fn(
+      async (
+        chatId: number | string,
+        _url: string,
+        opts?: { caption?: string },
+      ) => sent(6, Number(chatId), opts?.caption),
+    ),
     sendChatAction: vi.fn(async () => undefined),
     sendMessage: vi.fn(async (chatId: number | string, text: string) => ({
       message_id: 9,
@@ -65,7 +109,7 @@ describe("Telegram connector outbound media", () => {
     expect(senders.sendPhoto).toHaveBeenCalledWith(
       123,
       "https://cdn.example.com/cat.png",
-      { caption: "a cat" },
+      expect.objectContaining({ caption: "a cat", parse_mode: "MarkdownV2" }),
     );
     // Attachment-only reply: no trailing empty text message.
     expect(senders.sendMessage).not.toHaveBeenCalled();
@@ -92,16 +136,26 @@ describe("Telegram connector outbound media", () => {
     expect(senders.sendVideo).toHaveBeenCalledWith(
       123,
       "https://cdn.example.com/clip.mp4",
-      { caption: undefined },
+      {
+        caption: undefined,
+        message_thread_id: undefined,
+        parse_mode: undefined,
+        reply_parameters: undefined,
+      },
     );
     expect(senders.sendAudio).toHaveBeenCalledWith(
       123,
       "https://cdn.example.com/clip.mp3",
-      { caption: undefined },
+      {
+        caption: undefined,
+        message_thread_id: undefined,
+        parse_mode: undefined,
+        reply_parameters: undefined,
+      },
     );
   });
 
-  it("sends a document attachment, and degrades an unknown type to a document", async () => {
+  it("sends a document attachment, and visibly reports an unknown type", async () => {
     const { manager, ctx, senders } = setup();
     await manager.sendMessageInChunks(ctx, {
       text: "",
@@ -111,16 +165,25 @@ describe("Telegram connector outbound media", () => {
           url: "https://cdn.example.com/report.pdf",
           contentType: "document",
         },
-        // No contentType → degrades to a document upload (never throws/drops).
         { id: "blob", url: "https://cdn.example.com/data.bin" },
       ],
     } as never);
 
-    expect(senders.sendDocument).toHaveBeenCalledTimes(2);
+    expect(senders.sendDocument).toHaveBeenCalledTimes(1);
     expect(senders.sendDocument).toHaveBeenCalledWith(
       123,
       "https://cdn.example.com/report.pdf",
-      { caption: undefined },
+      {
+        caption: undefined,
+        message_thread_id: undefined,
+        parse_mode: undefined,
+        reply_parameters: undefined,
+      },
+    );
+    expect(senders.sendMessage).toHaveBeenCalledWith(
+      123,
+      expect.stringContaining("could not send"),
+      expect.objectContaining({ parse_mode: "MarkdownV2" }),
     );
   });
 
@@ -139,5 +202,54 @@ describe("Telegram connector outbound media", () => {
 
     expect(senders.sendPhoto).toHaveBeenCalledTimes(1);
     expect(senders.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves thread/reply options, sends sequentially, and uses sendVoice for voice notes", async () => {
+    const { manager, ctx, senders } = setup();
+    const sent = await manager.sendMessageInChunks(
+      ctx,
+      {
+        text: "[[audio_as_voice]]",
+        attachments: [
+          {
+            id: "v1",
+            url: "https://cdn.example.com/voice.ogg",
+            contentType: "audio",
+            source: "Voice Note",
+            description: "voice caption",
+          },
+          {
+            id: "p1",
+            url: "https://cdn.example.com/p.png",
+            contentType: "image",
+          },
+        ],
+      } as never,
+      88,
+      9,
+    );
+
+    expect(senders.sendVoice.mock.invocationCallOrder[0]).toBeLessThan(
+      senders.sendPhoto.mock.invocationCallOrder[0],
+    );
+    expect(senders.sendVoice).toHaveBeenCalledWith(
+      123,
+      "https://cdn.example.com/voice.ogg",
+      expect.objectContaining({
+        caption: "voice caption",
+        message_thread_id: 9,
+        reply_parameters: { message_id: 88 },
+      }),
+    );
+    expect(senders.sendPhoto).toHaveBeenCalledWith(
+      123,
+      "https://cdn.example.com/p.png",
+      expect.objectContaining({
+        message_thread_id: 9,
+        reply_parameters: undefined,
+      }),
+    );
+    expect(senders.sendMessage).not.toHaveBeenCalled();
+    expect(sent.map((message) => message.message_id)).toEqual([4, 1]);
   });
 });

--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -2,11 +2,14 @@
  * Unit tests for `MessageManager` outbound chunking and malformed-payload
  * handling: over-limit messages hard-split at Telegram's size cap (preferring
  * newline boundaries), interaction-only replies still carry fallback text, and
- * unknown attachment types degrade to a document upload. Telegraf is mocked.
+ * unknown attachment types produce a visible unsupported-media notice. Telegraf
+ * is mocked.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { MediaType, MessageManager } from "./messageManager";
+
+const TELEGRAM_LIMIT = 4096;
 
 function createManager() {
   let messageId = 0;
@@ -30,6 +33,21 @@ function createManager() {
     sendChatAction,
     sendMessage,
   };
+}
+
+function expectTelegramChunksValid(chunks: string[]) {
+  expect(chunks.length).toBeGreaterThan(0);
+  for (const chunk of chunks) {
+    expect(chunk.length).toBeGreaterThan(0);
+    expect(chunk.length).toBeLessThanOrEqual(TELEGRAM_LIMIT);
+    expect((chunk.match(/(?<!\\)\*/g) ?? []).length % 2).toBe(0);
+    expect((chunk.match(/(?<!\\)_/g) ?? []).length % 2).toBe(0);
+    expect((chunk.match(/(?<!\\)~/g) ?? []).length % 2).toBe(0);
+    expect((chunk.match(/(?<!\\)`/g) ?? []).length % 2).toBe(0);
+    expect((chunk.match(/(?<!\\)\[/g) ?? []).length).toBe(
+      (chunk.match(/(?<!\\)\]\(/g) ?? []).length,
+    );
+  }
 }
 
 describe("MessageManager long message splitting", () => {
@@ -103,6 +121,117 @@ describe("MessageManager long message splitting", () => {
       `${firstLine}\ny`,
       "z",
     ]);
+  });
+
+  it("keeps MarkdownV2-expanded chunks under Telegram's final limit", async () => {
+    const { manager, sendMessage } = createManager();
+    const text = "escaped punctuation! ".repeat(350);
+
+    await manager.sendMessageInChunks(
+      {
+        chat: { id: 123 },
+        telegram: {
+          sendChatAction: vi.fn(async () => undefined),
+          sendMessage,
+        },
+      } as never,
+      { text },
+    );
+
+    expect(sendMessage.mock.calls.length).toBeGreaterThan(1);
+    expect(
+      sendMessage.mock.calls.every((call) => String(call[1]).length <= 4096),
+    ).toBe(true);
+    expect(sendMessage.mock.calls.map((call) => call[1]).join("")).toContain(
+      "escaped punctuation\\!",
+    );
+  });
+
+  it("rewraps a bold span longer than Telegram's final limit", async () => {
+    const { manager, sendMessage } = createManager();
+    const text = `**${"bold text ".repeat(600)}**`;
+
+    await manager.sendMessageInChunks(
+      {
+        chat: { id: 123 },
+        telegram: {
+          sendChatAction: vi.fn(async () => undefined),
+          sendMessage,
+        },
+      } as never,
+      { text },
+    );
+
+    const chunks = sendMessage.mock.calls.map((call) => String(call[1]));
+    expect(chunks.length).toBeGreaterThan(1);
+    expectTelegramChunksValid(chunks);
+    expect(chunks.every((chunk) => chunk.startsWith("*"))).toBe(true);
+    expect(chunks.every((chunk) => chunk.endsWith("*"))).toBe(true);
+  });
+
+  it("rewraps a fenced code block longer than Telegram's final limit", async () => {
+    const { manager, sendMessage } = createManager();
+    const text = `\`\`\`ts\n${"const value = 1;\n".repeat(420)}\`\`\``;
+
+    await manager.sendMessageInChunks(
+      {
+        chat: { id: 123 },
+        telegram: {
+          sendChatAction: vi.fn(async () => undefined),
+          sendMessage,
+        },
+      } as never,
+      { text },
+    );
+
+    const chunks = sendMessage.mock.calls.map((call) => String(call[1]));
+    expect(chunks.length).toBeGreaterThan(1);
+    expectTelegramChunksValid(chunks);
+    expect(chunks.every((chunk) => chunk.startsWith("```ts\n"))).toBe(true);
+    expect(chunks.every((chunk) => chunk.endsWith("```"))).toBe(true);
+  });
+
+  it("keeps link-adjacent long messages valid after MarkdownV2 conversion", async () => {
+    const { manager, sendMessage } = createManager();
+    const link = "[docs](https://example.test/path-v1)";
+    const text = `${"read this! ".repeat(390)}${link}${" then continue. ".repeat(90)}`;
+
+    await manager.sendMessageInChunks(
+      {
+        chat: { id: 123 },
+        telegram: {
+          sendChatAction: vi.fn(async () => undefined),
+          sendMessage,
+        },
+      } as never,
+      { text },
+    );
+
+    const chunks = sendMessage.mock.calls.map((call) => String(call[1]));
+    expect(chunks.length).toBeGreaterThan(1);
+    expectTelegramChunksValid(chunks);
+    expect(chunks.join("")).toContain("[docs](https://example.test/path-v1)");
+  });
+
+  it("counts emoji using Telegram's UTF-16 message limit", async () => {
+    const { manager, sendMessage } = createManager();
+    const text = `prefix ${"🧪".repeat(2300)} suffix!`;
+
+    await manager.sendMessageInChunks(
+      {
+        chat: { id: 123 },
+        telegram: {
+          sendChatAction: vi.fn(async () => undefined),
+          sendMessage,
+        },
+      } as never,
+      { text },
+    );
+
+    const chunks = sendMessage.mock.calls.map((call) => String(call[1]));
+    expect(chunks.length).toBeGreaterThan(1);
+    expectTelegramChunksValid(chunks);
+    expect(chunks.join("")).toContain("🧪");
   });
 });
 
@@ -194,16 +323,44 @@ describe("MessageManager malformed payload handling", () => {
     }
   });
 
-  it("does not throw when image description or file lookup fails", async () => {
+  it("keeps an inbound photo attachment on the canonical production path", async () => {
     const getFileLink = vi.fn(
       async () => new URL("https://files.test/photo.jpg"),
     );
-    const useModel = vi.fn(async () => {
-      throw new Error("vision failed");
+    const manager = new MessageManager(
+      { telegram: { getFileLink } } as never,
+      { agentId: "agent-1" } as never,
+    );
+
+    const result = await manager.processMessage({
+      message_id: 1,
+      date: 1,
+      chat: { id: 123, type: "private" },
+      photo: [{ file_id: "p1", file_unique_id: "u1", width: 1, height: 1 }],
+    } as never);
+
+    expect(result).toEqual({
+      processedContent: "",
+      attachments: [
+        expect.objectContaining({
+          id: "p1",
+          url: "https://files.test/photo.jpg",
+          contentType: "image",
+        }),
+      ],
+    });
+    const attachment = result.attachments[0];
+    expect(attachment).not.toHaveProperty("text");
+    expect(attachment).not.toHaveProperty("description");
+  });
+
+  it("does not throw when Telegram fails an image file lookup", async () => {
+    const getFileLink = vi.fn(async () => {
+      throw new Error("telegram file expired");
     });
     const manager = new MessageManager(
       { telegram: { getFileLink } } as never,
-      { agentId: "agent-1", useModel } as never,
+      { agentId: "agent-1" } as never,
     );
 
     await expect(
@@ -214,74 +371,52 @@ describe("MessageManager malformed payload handling", () => {
         photo: [{ file_id: "p1", file_unique_id: "u1", width: 1, height: 1 }],
       } as never),
     ).resolves.toEqual({ processedContent: "", attachments: [] });
-    expect(useModel).toHaveBeenCalled();
+    expect(getFileLink).toHaveBeenCalledTimes(1);
   });
 
-  it("does not throw when Telegram fails the second image file lookup", async () => {
-    const getFileLink = vi
-      .fn()
-      .mockResolvedValueOnce(new URL("https://files.test/photo.jpg"))
-      .mockRejectedValueOnce(new Error("telegram file expired"));
-    const useModel = vi.fn(async () => ({
-      title: "Receipt",
-      description: "Total is visible",
-    }));
-    const manager = new MessageManager(
-      { telegram: { getFileLink } } as never,
-      { agentId: "agent-1", useModel } as never,
-    );
-
-    await expect(
-      manager.processMessage({
-        message_id: 1,
-        date: 1,
-        chat: { id: 123, type: "private" },
-        photo: [{ file_id: "p1", file_unique_id: "u1", width: 1, height: 1 }],
-      } as never),
-    ).resolves.toEqual({ processedContent: "", attachments: [] });
-    expect(getFileLink).toHaveBeenCalledTimes(2);
-    expect(useModel).toHaveBeenCalledWith(
-      "IMAGE_DESCRIPTION",
-      "https://files.test/photo.jpg",
-    );
-  });
-
-  it("degrades an unknown attachment content type to a document send (and still awaits failures)", async () => {
+  it("reports unknown attachment content types visibly instead of degrading to a document", async () => {
     const { manager } = createManager();
-    const sendDocument = vi.fn(async () => {
-      throw new Error("telegram unavailable");
-    });
+    const sendMessage = vi.fn(
+      async (chatId: number | string, text: string) => ({
+        message_id: 1,
+        date: 1,
+        text,
+        chat: { id: chatId, type: "private" },
+      }),
+    );
 
-    // Unknown/absent content types degrade to a document upload rather than
-    // throwing synchronously (a sync throw inside Promise.all would abort the
-    // whole reply); the underlying send failure is still awaited and propagated.
-    await expect(
-      manager.sendMessageInChunks(
-        {
-          chat: { id: 123 },
-          telegram: { sendDocument },
-        } as never,
-        {
-          text: "",
-          attachments: [
-            {
-              id: "a1",
-              url: "https://files.test/file.bin",
-              contentType: "application/octet-stream",
-            },
-          ],
-        } as never,
-      ),
-    ).rejects.toThrow("telegram unavailable");
-    expect(sendDocument).toHaveBeenCalled();
+    const sent = await manager.sendMessageInChunks(
+      {
+        chat: { id: 123 },
+        telegram: { sendMessage, sendChatAction: vi.fn() },
+      } as never,
+      {
+        text: "",
+        attachments: [
+          {
+            id: "a1",
+            url: "https://files.test/file.bin",
+            contentType: "application/octet-stream",
+          },
+        ],
+      } as never,
+    );
+    expect(sent).toHaveLength(1);
+    expect(sendMessage.mock.calls[0][1]).toContain(
+      "I could not send this Telegram attachment",
+    );
   });
 
   it("never drops the agent's text when sending an attachment", async () => {
     const { manager } = createManager();
-    const sendPhoto = vi.fn(async () => undefined);
+    const sendPhoto = vi.fn(async (chatId: number | string) => ({
+      message_id: 1,
+      date: 1,
+      chat: { id: chatId, type: "private" },
+    }));
     const sendChatAction = vi.fn(async () => undefined);
     const sendMessage = vi.fn(async (chatId: number, text: string) => ({
-      message_id: 1,
+      message_id: 2,
       date: 1,
       text,
       chat: { id: chatId, type: "private" },
@@ -306,7 +441,7 @@ describe("MessageManager malformed payload handling", () => {
 
     expect(sendPhoto).toHaveBeenCalledTimes(1); // media sent
     expect(sendMessage).toHaveBeenCalledTimes(1); // prose NOT dropped
-    expect(sent).toHaveLength(1);
+    expect(sent).toHaveLength(2);
     expect(String(sendMessage.mock.calls[0][1])).toContain(
       "here is your image",
     );
@@ -314,7 +449,11 @@ describe("MessageManager malformed payload handling", () => {
 
   it("does not post an empty trailing message for an attachment-only reply", async () => {
     const { manager } = createManager();
-    const sendPhoto = vi.fn(async () => undefined);
+    const sendPhoto = vi.fn(async (chatId: number | string) => ({
+      message_id: 1,
+      date: 1,
+      chat: { id: chatId, type: "private" },
+    }));
     const sendMessage = vi.fn();
     const sendChatAction = vi.fn(async () => undefined);
 
@@ -337,7 +476,7 @@ describe("MessageManager malformed payload handling", () => {
 
     expect(sendPhoto).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();
-    expect(sent).toEqual([]);
+    expect(sent).toHaveLength(1);
   });
 
   it("ingests an inbound voice message as an AUDIO attachment", async () => {
@@ -368,6 +507,115 @@ describe("MessageManager malformed payload handling", () => {
         contentType: "audio",
       }),
     ]);
+    expect(result.attachments[0]).not.toHaveProperty("text");
+    expect(result.attachments[0]).not.toHaveProperty("description");
+  });
+
+  it("passes inbound voice to messageService as audio without placeholder text", async () => {
+    const getFileLink = vi.fn(
+      async () => new URL("https://files.test/voice.ogg"),
+    );
+    const handleMessage = vi.fn(async () => undefined);
+    const runtime = {
+      agentId: "agent-1",
+      character: {
+        name: "Agent",
+        settings: {
+          telegram: {
+            botToken: "123456:ABCDEF",
+            dmPolicy: "allowlist",
+            allowFrom: ["42"],
+          },
+        },
+      },
+      getSetting: vi.fn((key: string) =>
+        key === "TELEGRAM_AUTO_REPLY" ? "true" : undefined,
+      ),
+      ensureConnection: vi.fn(async () => undefined),
+      messageService: { handleMessage },
+      getService: vi.fn(() => null),
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const manager = new MessageManager(
+      { telegram: { getFileLink } } as never,
+      runtime,
+    );
+
+    await manager.handleMessage({
+      from: { id: 42, first_name: "Ada", username: "ada", is_bot: false },
+      chat: { id: 123, type: "private", first_name: "Ada" },
+      message: {
+        message_id: 99,
+        date: 1_700_000_000,
+        chat: { id: 123, type: "private", first_name: "Ada" },
+        voice: {
+          file_id: "v1",
+          file_unique_id: "u1",
+          duration: 3,
+          mime_type: "audio/ogg",
+        },
+      },
+    } as never);
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    const memory = handleMessage.mock.calls[0][1];
+    expect(memory.content.attachments).toEqual([
+      expect.objectContaining({
+        id: "v1",
+        url: "https://files.test/voice.ogg",
+        contentType: "audio",
+      }),
+    ]);
+    expect(memory.content.attachments[0]).not.toHaveProperty("text");
+    expect(memory.content.attachments[0]).not.toHaveProperty("description");
+    expect(memory.content.text).not.toContain("transcript");
+    expect(memory.content.text.trim()).toBe("");
+  });
+
+  it("preserves Telegram text entity metadata using UTF-16 offsets", async () => {
+    const createMemory = vi.fn(async () => undefined);
+    const runtime = {
+      agentId: "agent-1",
+      getSetting: vi.fn(() => undefined),
+      ensureConnection: vi.fn(async () => undefined),
+      createMemory,
+    } as unknown as IAgentRuntime;
+    const manager = new MessageManager({ telegram: {} } as never, runtime);
+
+    await manager.handleMessage({
+      from: { id: 42, first_name: "Ada", username: "ada", is_bot: false },
+      chat: { id: 123, type: "private", first_name: "Ada" },
+      message: {
+        message_id: 99,
+        date: 1_700_000_000,
+        text: "Go 🧪bold link",
+        entities: [
+          { type: "bold", offset: 5, length: 6 },
+          {
+            type: "text_link",
+            offset: 12,
+            length: 4,
+            url: "https://example.test",
+          },
+        ],
+        chat: { id: 123, type: "private", first_name: "Ada" },
+      },
+    } as never);
+
+    const memory = createMemory.mock.calls[0][0];
+    expect(memory.content.text).toBe("Go 🧪bold link");
+    expect(memory.content.metadata.telegram.richText).toMatchObject({
+      rawText: "Go 🧪bold link",
+      entities: [
+        { type: "bold", offset: 5, length: 6 },
+        {
+          type: "text_link",
+          offset: 12,
+          length: 4,
+          url: "https://example.test",
+        },
+      ],
+    });
   });
 
   it("ignores reaction updates with empty reaction arrays", async () => {

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -36,11 +36,18 @@ import type {
   Message,
   ReactionType,
   Update,
+  User,
 } from "@telegraf/types";
 import type { Context, NarrowedContext, Telegraf } from "telegraf";
 import { Markup } from "telegraf";
+import {
+  getTelegramMultiAccountConfig,
+  resolveTelegramAccount,
+  type TelegramAccountConfig,
+} from "./accounts";
 import { resolveTelegramSenderAuth } from "./command-registration";
 import { renderTelegramInteractions } from "./interactions";
+import { evaluateTelegramPolicy, hasTypedTelegramPolicyConfig } from "./policy";
 import {
   type TelegramContent,
   TelegramEventTypes,
@@ -89,6 +96,16 @@ function contentTypeForMime(mime?: string): ContentType {
   if (mime?.startsWith("video/")) return "video";
   if (mime?.startsWith("audio/")) return "audio";
   return "document";
+}
+
+function telegramMessagePlainText(message: Message): string | undefined {
+  if ("text" in message && typeof message.text === "string") {
+    return message.text;
+  }
+  if ("caption" in message && typeof message.caption === "string") {
+    return message.caption;
+  }
+  return undefined;
 }
 
 const MAX_MESSAGE_LENGTH = 4096; // Telegram's max message length
@@ -1027,6 +1044,11 @@ export class MessageManager {
       // lookup) and attached to the final chunk only, alongside any other
       // interaction controls.
       const embedLaunchRow = await this.buildEmbedLaunchRow(ctx);
+      const telegramConfig = getTelegramMultiAccountConfig(this.runtime);
+      const replyToMode =
+        telegramConfig.accounts?.[this.accountId]?.replyToMode ??
+        telegramConfig.replyToMode ??
+        "first";
 
       for (let i = 0; i < chunks.length; i++) {
         const chunk = convertMarkdownToTelegram(chunks[i]);
@@ -1054,11 +1076,14 @@ export class MessageManager {
             : undefined;
 
         const chatId = ctx.chat.id;
+        const shouldReplyToSource =
+          replyToMessageId !== undefined &&
+          replyToMode !== "off" &&
+          (replyToMode === "all" || i === 0);
         const sendOptions = {
-          reply_parameters:
-            i === 0 && replyToMessageId
-              ? { message_id: replyToMessageId }
-              : undefined,
+          reply_parameters: shouldReplyToSource
+            ? { message_id: replyToMessageId }
+            : undefined,
           message_thread_id: messageThreadId,
           reply_markup: replyMarkup,
         };
@@ -1295,10 +1320,9 @@ export class MessageManager {
    * Handle incoming messages from Telegram and process them accordingly.
    * @param {Context} ctx - The context object containing information about the message.
    * @param {object} [options] - Handling options.
-   * @param {boolean} [options.forceReply] - When true, always route the message
-   *   through the agent and force a reply, bypassing the TELEGRAM_AUTO_REPLY gate.
-   *   Used for explicit slash-command invocations where the user intent to get a
-   *   response is unambiguous.
+   * @param {boolean} [options.forceReply] - Marks an explicit slash-command
+   *   invocation. It bypasses only the legacy TELEGRAM_AUTO_REPLY gate; typed
+   *   DM/group authorization still applies.
    * @returns {Promise<void>}
    */
   public async handleMessage(
@@ -1343,13 +1367,78 @@ export class MessageManager {
         this.runtime,
         this.scopedTelegramKey(telegramMessageId),
       );
+      const chat = message.chat as Chat;
+
+      const telegramAutoReplyRaw = this.runtime.getSetting(
+        "TELEGRAM_AUTO_REPLY",
+      );
+      const telegramAutoReply =
+        !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
+        (telegramAutoReplyRaw === true || telegramAutoReplyRaw === "true");
+      const accountConfig = resolveTelegramAccount(
+        this.runtime,
+        this.accountId,
+      ).config;
+      const policyDecision = await evaluateTelegramPolicy({
+        runtime: this.runtime,
+        config: accountConfig,
+        message,
+        from: ctx.from,
+        chatType: chat.type,
+        chatId: telegramChatId,
+        threadId,
+        botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
+        forceReply: options?.forceReply,
+        legacyAutoReply: telegramAutoReply,
+      });
+      const typedPolicyConfigured = hasTypedTelegramPolicyConfig(accountConfig);
+      if (!policyDecision.shouldDispatch && typedPolicyConfigured) {
+        if (policyDecision.denialMessage && chat.type === "private") {
+          try {
+            await this.bot.telegram.sendMessage(
+              chat.id,
+              policyDecision.denialMessage,
+            );
+          } catch (error) {
+            logger.warn(
+              {
+                src: "plugin:telegram",
+                agentId: this.runtime.agentId,
+                accountId: this.accountId,
+                chatId: telegramChatId,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              "Failed to send Telegram pairing response",
+            );
+          }
+        }
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            accountId: this.accountId,
+            chatId: telegramChatId,
+            reason: policyDecision.reason,
+          },
+          "Telegram message skipped by typed activation policy",
+        );
+        return;
+      }
 
       // Process message content and attachments
       const { processedContent, attachments } =
         await this.processMessage(message);
 
+      const rawMessageText = telegramMessagePlainText(message);
+      const policyAdjustedContent =
+        policyDecision.textOverride !== undefined && rawMessageText
+          ? processedContent.startsWith(rawMessageText)
+            ? `${policyDecision.textOverride}${processedContent.slice(rawMessageText.length)}`
+            : policyDecision.textOverride
+          : processedContent;
+
       // Clean processedContent and attachments to avoid NULL characters
-      const cleanedContent = cleanText(processedContent);
+      const cleanedContent = cleanText(policyAdjustedContent);
       const cleanedAttachments = attachments.map((att) => ({
         ...att,
         text: cleanText(att.text),
@@ -1362,7 +1451,6 @@ export class MessageManager {
       }
 
       // Get chat type and determine channel type
-      const chat = message.chat as Chat;
       const channelType = getChannelType(chat);
 
       await this.runtime.ensureConnection({
@@ -1484,6 +1572,7 @@ export class MessageManager {
               ctx,
               content,
               message.message_id,
+              threadIdNum,
             );
           }
 
@@ -1519,19 +1608,11 @@ export class MessageManager {
         threadId: threadIdNum,
       });
 
-      // Inbound messages are always persisted to memory above. The agent only
-      // auto-generates a reply when TELEGRAM_AUTO_REPLY is explicitly enabled —
-      // default-off prevents the runtime from speaking on the user's behalf.
-      // A forced reply (explicit slash-command invocation) always routes to the
-      // agent regardless of the auto-reply gate, since the user explicitly asked
-      // for a response by typing a command.
-      const telegramAutoReplyRaw = this.runtime.getSetting(
-        "TELEGRAM_AUTO_REPLY",
-      );
-      const telegramAutoReply =
-        !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
-        (telegramAutoReplyRaw === true || telegramAutoReplyRaw === "true");
-      const shouldReply = options?.forceReply === true || telegramAutoReply;
+      // Without typed Telegram policy, legacy deployments keep their historical
+      // passive ingestion plus TELEGRAM_AUTO_REPLY gate.
+      // A forced reply (explicit slash-command invocation) bypasses the legacy
+      // auto-reply gate, but typed route and sender authorization still applies.
+      const shouldReply = policyDecision.shouldDispatch;
 
       if (!shouldReply) {
         try {
@@ -1584,6 +1665,35 @@ export class MessageManager {
     }
   }
 
+  private async isExplicitUpdateAuthorized(params: {
+    message: Message;
+    from: User;
+    chat: Chat;
+    threadId?: string;
+  }): Promise<boolean> {
+    const telegramConfig = getTelegramMultiAccountConfig(this.runtime);
+    const accountConfig: TelegramAccountConfig = {
+      ...telegramConfig,
+      ...telegramConfig.accounts?.[this.accountId],
+    };
+    if (!hasTypedTelegramPolicyConfig(accountConfig)) {
+      return true;
+    }
+
+    const decision = await evaluateTelegramPolicy({
+      runtime: this.runtime,
+      config: accountConfig,
+      message: params.message,
+      from: params.from,
+      chatType: params.chat.type,
+      chatId: params.chat.id.toString(),
+      threadId: params.threadId,
+      botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
+      forceReply: true,
+    });
+    return decision.shouldDispatch;
+  }
+
   /**
    * Handle an inline-keyboard button tap whose payload was produced by the
    * shared interaction codec (a choice or followup answer). The chosen value is
@@ -1631,6 +1741,21 @@ export class MessageManager {
     const telegramRoomid = threadId
       ? `${telegramChatId}-${threadId}`
       : telegramChatId;
+    if (
+      !(await this.isExplicitUpdateAuthorized({
+        message: sourceMessage as Message,
+        from: ctx.from,
+        chat,
+        threadId,
+      }))
+    ) {
+      try {
+        await ctx.answerCbQuery();
+      } catch {
+        // best-effort: a stale callback may already have expired
+      }
+      return;
+    }
     const roomId = createUniqueUuid(
       this.runtime,
       this.scopedTelegramKey(telegramRoomid),
@@ -1962,6 +2087,15 @@ export class MessageManager {
 
     const firstReaction = reaction.new_reaction[0];
     if (!firstReaction) {
+      return;
+    }
+    if (
+      !(await this.isExplicitUpdateAuthorized({
+        message: syntheticReactionMessage,
+        from: ctx.from,
+        chat: reaction.chat as Chat,
+      }))
+    ) {
       return;
     }
     // Emoji reactions carry the glyph on `.emoji`; non-emoji reactions

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -17,6 +17,7 @@ import {
   type ContentType,
   createUniqueUuid,
   decodeCallback,
+  ElizaError,
   EventType,
   type HandlerCallback,
   type IAgentRuntime,
@@ -43,11 +44,14 @@ import { Markup } from "telegraf";
 import {
   getTelegramMultiAccountConfig,
   resolveTelegramAccount,
-  type TelegramAccountConfig,
 } from "./accounts";
 import { resolveTelegramSenderAuth } from "./command-registration";
 import { renderTelegramInteractions } from "./interactions";
-import { evaluateTelegramPolicy, hasTypedTelegramPolicyConfig } from "./policy";
+import {
+  evaluateTelegramPolicy,
+  hasTypedTelegramPolicyConfig,
+  type TelegramPolicyDecision,
+} from "./policy";
 import {
   type TelegramContent,
   TelegramEventTypes,
@@ -106,6 +110,50 @@ function telegramMessagePlainText(message: Message): string | undefined {
     return message.caption;
   }
   return undefined;
+}
+
+export type TelegramIngressAdmission = {
+  admitted: boolean;
+  typedPolicyConfigured: boolean;
+  decision: TelegramPolicyDecision;
+  sourceMemory?: Memory;
+  threadId?: string;
+};
+
+function telegramMetadata(memory: Memory): Record<string, unknown> | undefined {
+  const metadata = isRecord(memory.metadata) ? memory.metadata : undefined;
+  return metadata && isRecord(metadata.telegram)
+    ? metadata.telegram
+    : undefined;
+}
+
+function telegramThreadId(memory: Memory): string | undefined {
+  const value = telegramMetadata(memory)?.threadId;
+  return typeof value === "string" || typeof value === "number"
+    ? String(value)
+    : undefined;
+}
+
+function isTelegramCommandForBot(
+  message: Message,
+  botUsername: string | undefined,
+): boolean | null {
+  if (!("text" in message) || typeof message.text !== "string") {
+    return null;
+  }
+  const command = message.entities?.find(
+    (entity) => entity.type === "bot_command" && entity.offset === 0,
+  );
+  if (!command) {
+    return null;
+  }
+  const token = message.text.slice(0, command.length);
+  const target = token.split("@", 2)[1];
+  if (!target) {
+    return true;
+  }
+  const normalizedBot = botUsername?.replace(/^@/, "").trim().toLowerCase();
+  return Boolean(normalizedBot && target.toLowerCase() === normalizedBot);
 }
 
 const MAX_MESSAGE_LENGTH = 4096; // Telegram's max message length
@@ -337,6 +385,10 @@ export class MessageManager {
   public bot: Telegraf<Context>;
   protected runtime: IAgentRuntime;
   protected accountId: string;
+  private readonly ingressAdmissions = new WeakMap<
+    object,
+    TelegramIngressAdmission
+  >();
 
   /**
    * Constructor for creating a new instance of a BotAgent.
@@ -356,6 +408,282 @@ export class MessageManager {
 
   private scopedTelegramKey(key: string): string {
     return this.accountId === "default" ? key : `${this.accountId}:${key}`;
+  }
+
+  private telegramMessageKey(
+    chatId: number | string,
+    messageId: number | string,
+  ): string {
+    return this.scopedTelegramKey(`message:${chatId}:${messageId}`);
+  }
+
+  private telegramMessageMemoryId(
+    chatId: number | string,
+    messageId: number | string,
+  ): UUID {
+    return createUniqueUuid(
+      this.runtime,
+      this.telegramMessageKey(chatId, messageId),
+    ) as UUID;
+  }
+
+  private legacyTelegramMessageMemoryId(messageId: number | string): UUID {
+    return createUniqueUuid(
+      this.runtime,
+      this.scopedTelegramKey(String(messageId)),
+    ) as UUID;
+  }
+
+  private memoryMatchesTelegramMessage(
+    memory: Memory,
+    chatId: string,
+    messageId: string,
+  ): boolean {
+    const metadata = isRecord(memory.metadata) ? memory.metadata : {};
+    const telegram = telegramMetadata(memory);
+    const memoryAccountId =
+      typeof metadata.accountId === "string" ? metadata.accountId : "default";
+    return (
+      metadata.source === "telegram" &&
+      memoryAccountId === this.accountId &&
+      String(telegram?.chatId ?? "") === chatId &&
+      String(telegram?.messageId ?? metadata.messageIdFull ?? "") === messageId
+    );
+  }
+
+  private async resolveReactionSourceMemory(
+    chatId: string,
+    messageId: string,
+  ): Promise<Memory | null> {
+    const current = await this.runtime.getMemoryById(
+      this.telegramMessageMemoryId(chatId, messageId),
+    );
+    if (
+      current &&
+      this.memoryMatchesTelegramMessage(current, chatId, messageId)
+    ) {
+      return current;
+    }
+
+    const legacy = await this.runtime.getMemoryById(
+      this.legacyTelegramMessageMemoryId(messageId),
+    );
+    return legacy &&
+      this.memoryMatchesTelegramMessage(legacy, chatId, messageId)
+      ? legacy
+      : null;
+  }
+
+  private telegramAutoReplyEnabled(): boolean {
+    const raw = this.runtime.getSetting("TELEGRAM_AUTO_REPLY");
+    return (
+      !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
+      (raw === true || raw === "true")
+    );
+  }
+
+  private async evaluateMessageAdmission(
+    ctx: Context,
+    forceReply?: boolean,
+  ): Promise<TelegramIngressAdmission> {
+    if (!ctx.message || !ctx.from || !ctx.chat) {
+      return {
+        admitted: false,
+        typedPolicyConfigured: false,
+        decision: { shouldDispatch: false, reason: "blocked" },
+      };
+    }
+    const message = ctx.message as Message;
+    const accountConfig = resolveTelegramAccount(
+      this.runtime,
+      this.accountId,
+    ).config;
+    const typedPolicyConfigured = hasTypedTelegramPolicyConfig(accountConfig);
+    const commandForBot = isTelegramCommandForBot(
+      message,
+      (this.bot as unknown as { botInfo?: User }).botInfo?.username,
+    );
+    if (commandForBot === false) {
+      return {
+        admitted: false,
+        typedPolicyConfigured,
+        decision: { shouldDispatch: false, reason: "blocked" },
+      };
+    }
+    const threadId =
+      "is_topic_message" in message && message.is_topic_message
+        ? message.message_thread_id?.toString()
+        : undefined;
+    const decision = await evaluateTelegramPolicy({
+      runtime: this.runtime,
+      config: accountConfig,
+      message,
+      from: ctx.from,
+      chatType: ctx.chat.type,
+      chatId: ctx.chat.id.toString(),
+      threadId,
+      botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
+      forceReply: forceReply ?? commandForBot === true,
+      legacyAutoReply: this.telegramAutoReplyEnabled(),
+    });
+    return {
+      admitted: !typedPolicyConfigured || decision.shouldDispatch,
+      typedPolicyConfigured,
+      decision,
+      threadId,
+    };
+  }
+
+  private async evaluateCallbackAdmission(
+    ctx: Context,
+  ): Promise<TelegramIngressAdmission> {
+    const query = ctx.callbackQuery;
+    if (!query?.message || !ctx.from) {
+      return {
+        admitted: false,
+        typedPolicyConfigured: false,
+        decision: { shouldDispatch: false, reason: "blocked" },
+      };
+    }
+    return this.evaluateExplicitAdmission(
+      query.message as Message,
+      ctx.from,
+      query.message.chat as Chat,
+    );
+  }
+
+  private async evaluateReactionAdmission(
+    ctx: Context,
+  ): Promise<TelegramIngressAdmission> {
+    const reaction =
+      "message_reaction" in ctx.update
+        ? ctx.update.message_reaction
+        : undefined;
+    if (!reaction || !ctx.from) {
+      return {
+        admitted: false,
+        typedPolicyConfigured: false,
+        decision: { shouldDispatch: false, reason: "blocked" },
+      };
+    }
+    const chatId = reaction.chat.id.toString();
+    const messageId = reaction.message_id.toString();
+    const accountConfig = resolveTelegramAccount(
+      this.runtime,
+      this.accountId,
+    ).config;
+    const typedPolicyConfigured = hasTypedTelegramPolicyConfig(accountConfig);
+    const topicPolicyConfigured = Boolean(
+      accountConfig.groups?.[chatId]?.topics &&
+        Object.keys(accountConfig.groups[chatId]?.topics ?? {}).length > 0,
+    );
+    const sourceMemory = await this.resolveReactionSourceMemory(
+      chatId,
+      messageId,
+    );
+    const threadId = sourceMemory ? telegramThreadId(sourceMemory) : undefined;
+    if (
+      typedPolicyConfigured &&
+      topicPolicyConfigured &&
+      (!sourceMemory || !threadId)
+    ) {
+      return {
+        admitted: false,
+        typedPolicyConfigured,
+        decision: { shouldDispatch: false, reason: "blocked" },
+      };
+    }
+    const syntheticMessage = {
+      message_id: reaction.message_id,
+      chat: reaction.chat,
+      from: ctx.from,
+      date: reaction.date,
+    } as Message;
+    const decision = await evaluateTelegramPolicy({
+      runtime: this.runtime,
+      config: accountConfig,
+      message: syntheticMessage,
+      from: ctx.from,
+      chatType: reaction.chat.type,
+      chatId,
+      threadId,
+      botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
+      forceReply: true,
+    });
+    return {
+      admitted: !typedPolicyConfigured || decision.shouldDispatch,
+      typedPolicyConfigured,
+      decision,
+      sourceMemory: sourceMemory ?? undefined,
+      threadId,
+    };
+  }
+
+  private async evaluateExplicitAdmission(
+    message: Message,
+    from: User,
+    chat: Chat,
+  ): Promise<TelegramIngressAdmission> {
+    const accountConfig = resolveTelegramAccount(
+      this.runtime,
+      this.accountId,
+    ).config;
+    const typedPolicyConfigured = hasTypedTelegramPolicyConfig(accountConfig);
+    const threadId =
+      "is_topic_message" in message && message.is_topic_message
+        ? message.message_thread_id?.toString()
+        : undefined;
+    const decision = await evaluateTelegramPolicy({
+      runtime: this.runtime,
+      config: accountConfig,
+      message,
+      from,
+      chatType: chat.type,
+      chatId: chat.id.toString(),
+      threadId,
+      botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
+      forceReply: true,
+    });
+    return {
+      admitted: !typedPolicyConfigured || decision.shouldDispatch,
+      typedPolicyConfigured,
+      decision,
+      threadId,
+    };
+  }
+
+  public async admitIngress(ctx: Context): Promise<TelegramIngressAdmission> {
+    const cached = this.ingressAdmissions.get(ctx);
+    if (cached) {
+      return cached;
+    }
+    let admission: TelegramIngressAdmission;
+    if ("message_reaction" in ctx.update) {
+      admission = await this.evaluateReactionAdmission(ctx);
+    } else if (ctx.callbackQuery) {
+      admission = await this.evaluateCallbackAdmission(ctx);
+    } else {
+      admission = await this.evaluateMessageAdmission(ctx);
+    }
+    this.ingressAdmissions.set(ctx, admission);
+    return admission;
+  }
+
+  public async sendIngressDenial(
+    ctx: Context,
+    admission: TelegramIngressAdmission,
+  ): Promise<void> {
+    if (
+      !admission.decision.denialMessage ||
+      ctx.chat?.type !== "private" ||
+      !ctx.chat
+    ) {
+      return;
+    }
+    await this.bot.telegram.sendMessage(
+      ctx.chat.id,
+      admission.decision.denialMessage,
+    );
   }
 
   /**
@@ -1120,9 +1448,9 @@ export class MessageManager {
     const memories: Memory[] = [];
     for (const sentMessage of args.sentMessages) {
       const responseMemory: Memory = {
-        id: createUniqueUuid(
-          this.runtime,
-          this.scopedTelegramKey(sentMessage.message_id.toString()),
+        id: this.telegramMessageMemoryId(
+          sentMessage.chat.id,
+          sentMessage.message_id,
         ),
         entityId: this.runtime.agentId,
         agentId: this.runtime.agentId,
@@ -1150,8 +1478,12 @@ export class MessageManager {
           sourceId: this.runtime.agentId,
           chatType: args.chatType,
           messageIdFull: sentMessage.message_id.toString(),
+          telegramMessageKey: this.telegramMessageKey(
+            sentMessage.chat.id,
+            sentMessage.message_id,
+          ),
           telegram: {
-            chatId: sentMessage.chat.id,
+            chatId: sentMessage.chat.id.toString(),
             messageId: sentMessage.message_id.toString(),
             threadId: args.threadId,
           },
@@ -1334,6 +1666,7 @@ export class MessageManager {
     }
 
     const message = ctx.message as Message.TextMessage;
+    const sender = ctx.from;
 
     try {
       const telegramUserId = ctx.from.id.toString();
@@ -1363,55 +1696,18 @@ export class MessageManager {
       const roomId = createUniqueUuid(this.runtime, scopedRoomKey) as UUID;
       const worldId = createUniqueUuid(this.runtime, scopedChatKey) as UUID;
       const telegramMessageId = message.message_id.toString();
-      const messageId = createUniqueUuid(
-        this.runtime,
-        this.scopedTelegramKey(telegramMessageId),
+      const messageId = this.telegramMessageMemoryId(
+        telegramChatId,
+        telegramMessageId,
       );
       const chat = message.chat as Chat;
 
-      const telegramAutoReplyRaw = this.runtime.getSetting(
-        "TELEGRAM_AUTO_REPLY",
-      );
-      const telegramAutoReply =
-        !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
-        (telegramAutoReplyRaw === true || telegramAutoReplyRaw === "true");
-      const accountConfig = resolveTelegramAccount(
-        this.runtime,
-        this.accountId,
-      ).config;
-      const policyDecision = await evaluateTelegramPolicy({
-        runtime: this.runtime,
-        config: accountConfig,
-        message,
-        from: ctx.from,
-        chatType: chat.type,
-        chatId: telegramChatId,
-        threadId,
-        botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
-        forceReply: options?.forceReply,
-        legacyAutoReply: telegramAutoReply,
-      });
-      const typedPolicyConfigured = hasTypedTelegramPolicyConfig(accountConfig);
-      if (!policyDecision.shouldDispatch && typedPolicyConfigured) {
-        if (policyDecision.denialMessage && chat.type === "private") {
-          try {
-            await this.bot.telegram.sendMessage(
-              chat.id,
-              policyDecision.denialMessage,
-            );
-          } catch (error) {
-            logger.warn(
-              {
-                src: "plugin:telegram",
-                agentId: this.runtime.agentId,
-                accountId: this.accountId,
-                chatId: telegramChatId,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              "Failed to send Telegram pairing response",
-            );
-          }
-        }
+      const admission =
+        this.ingressAdmissions.get(ctx) ??
+        (await this.evaluateMessageAdmission(ctx, options?.forceReply));
+      const policyDecision = admission.decision;
+      if (!admission.admitted) {
+        await this.sendIngressDenial(ctx, admission);
         logger.debug(
           {
             src: "plugin:telegram",
@@ -1489,11 +1785,9 @@ export class MessageManager {
           channelType,
           inReplyTo:
             "reply_to_message" in message && message.reply_to_message
-              ? createUniqueUuid(
-                  this.runtime,
-                  this.scopedTelegramKey(
-                    message.reply_to_message.message_id.toString(),
-                  ),
+              ? this.telegramMessageMemoryId(
+                  telegramChatId,
+                  message.reply_to_message.message_id,
                 )
               : undefined,
         },
@@ -1514,6 +1808,10 @@ export class MessageManager {
           sourceId: entityId,
           chatType: chat.type,
           messageIdFull: telegramMessageId,
+          telegramMessageKey: this.telegramMessageKey(
+            telegramChatId,
+            telegramMessageId,
+          ),
           sender: {
             id: telegramUserId,
             name: ctx.from.first_name,
@@ -1541,65 +1839,37 @@ export class MessageManager {
           : undefined;
 
       // Create callback for handling responses
-      const baseCallback: HandlerCallback = async (
-        content: Content,
-        _actionName?: string,
-      ) => {
-        try {
-          // If response is from reasoning do not send it.
-          if (!content.text) {
-            return [];
-          }
-
-          let sentMessages: boolean | Message.TextMessage[] = false;
-          // channelType target === 'telegram'
-          if (content.channelType === "DM") {
-            // Route through sendMessageInChunks so DM replies get the same
-            // markdown conversion + inline interactions as group replies. Target
-            // ctx.from.id (the user's private chat) via a ctx shim, since a DM
-            // response to a group message must not go to ctx.chat.id.
-            sentMessages = ctx.from
-              ? await this.sendMessageInChunks(
-                  {
-                    chat: { id: ctx.from.id },
-                    telegram: this.bot.telegram,
-                  } as Context,
-                  content,
-                )
-              : [];
-          } else {
-            sentMessages = await this.sendMessageInChunks(
-              ctx,
-              content,
-              message.message_id,
-              threadIdNum,
-            );
-          }
-
-          if (!Array.isArray(sentMessages)) {
-            return [];
-          }
-
-          return this.persistSentMessageMemories({
-            sentMessages,
-            content,
-            roomId,
-            channelType,
-            chatType: chat.type,
-            threadId,
-            inReplyTo: messageId,
-          });
-        } catch (error) {
-          logger.error(
-            {
-              src: "plugin:telegram",
-              agentId: this.runtime.agentId,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            "Error in message callback",
-          );
+      const baseCallback: HandlerCallback = async (content: Content) => {
+        // A model response with no user-facing text is a legitimate no-op.
+        if (!content.text) {
           return [];
         }
+
+        const sentMessages =
+          content.channelType === "DM"
+            ? await this.sendMessageInChunks(
+                {
+                  chat: { id: sender.id },
+                  telegram: this.bot.telegram,
+                } as Context,
+                content,
+              )
+            : await this.sendMessageInChunks(
+                ctx,
+                content,
+                message.message_id,
+                threadIdNum,
+              );
+
+        return this.persistSentMessageMemories({
+          sentMessages,
+          content,
+          roomId,
+          channelType,
+          chatType: chat.type,
+          threadId,
+          inReplyTo: messageId,
+        });
       };
       const callback = createTelegramCompactProgressCallback({
         baseCallback,
@@ -1615,21 +1885,7 @@ export class MessageManager {
       const shouldReply = policyDecision.shouldDispatch;
 
       if (!shouldReply) {
-        try {
-          await this.runtime.createMemory(memory, "messages");
-        } catch (persistError) {
-          logger.warn(
-            {
-              src: "plugin:telegram",
-              agentId: this.runtime.agentId,
-              error:
-                persistError instanceof Error
-                  ? persistError.message
-                  : String(persistError),
-            },
-            "Failed to persist inbound memory while auto-reply is disabled",
-          );
-        }
+        await this.runtime.createMemory(memory, "messages");
         logger.debug(
           { src: "plugin:telegram", agentId: this.runtime.agentId },
           "Auto-reply disabled (TELEGRAM_AUTO_REPLY=false); message ingested without response",
@@ -1650,48 +1906,17 @@ export class MessageManager {
         );
       }
     } catch (error) {
-      logger.error(
-        {
-          src: "plugin:telegram",
-          agentId: this.runtime.agentId,
+      // error-policy:J2 retain connector identity on the propagated failure.
+      throw new ElizaError("Telegram message handling failed", {
+        code: "TELEGRAM_MESSAGE_HANDLING_FAILED",
+        context: {
+          accountId: this.accountId,
           chatId: ctx.chat?.id,
           messageId: ctx.message.message_id,
-          from: ctx.from.username || ctx.from.id,
-          error: error instanceof Error ? error.message : String(error),
         },
-        "Error handling Telegram message",
-      );
-      throw error;
+        cause: error,
+      });
     }
-  }
-
-  private async isExplicitUpdateAuthorized(params: {
-    message: Message;
-    from: User;
-    chat: Chat;
-    threadId?: string;
-  }): Promise<boolean> {
-    const telegramConfig = getTelegramMultiAccountConfig(this.runtime);
-    const accountConfig: TelegramAccountConfig = {
-      ...telegramConfig,
-      ...telegramConfig.accounts?.[this.accountId],
-    };
-    if (!hasTypedTelegramPolicyConfig(accountConfig)) {
-      return true;
-    }
-
-    const decision = await evaluateTelegramPolicy({
-      runtime: this.runtime,
-      config: accountConfig,
-      message: params.message,
-      from: params.from,
-      chatType: params.chat.type,
-      chatId: params.chat.id.toString(),
-      threadId: params.threadId,
-      botInfo: (this.bot as unknown as { botInfo?: User }).botInfo,
-      forceReply: true,
-    });
-    return decision.shouldDispatch;
   }
 
   /**
@@ -1741,19 +1966,10 @@ export class MessageManager {
     const telegramRoomid = threadId
       ? `${telegramChatId}-${threadId}`
       : telegramChatId;
-    if (
-      !(await this.isExplicitUpdateAuthorized({
-        message: sourceMessage as Message,
-        from: ctx.from,
-        chat,
-        threadId,
-      }))
-    ) {
-      try {
-        await ctx.answerCbQuery();
-      } catch {
-        // best-effort: a stale callback may already have expired
-      }
+    const admission =
+      this.ingressAdmissions.get(ctx) ??
+      (await this.evaluateCallbackAdmission(ctx));
+    if (!admission.admitted) {
       return;
     }
     const roomId = createUniqueUuid(
@@ -2078,26 +2294,28 @@ export class MessageManager {
     const reaction = ctx.update.message_reaction;
     const reactedToMessageId = reaction.message_id;
 
-    const syntheticReactionMessage = {
-      message_id: reactedToMessageId,
-      chat: reaction.chat,
-      from: ctx.from,
-      date: Math.floor(Date.now() / 1000),
-    } as Message;
-
     const firstReaction = reaction.new_reaction[0];
     if (!firstReaction) {
       return;
     }
-    if (
-      !(await this.isExplicitUpdateAuthorized({
-        message: syntheticReactionMessage,
-        from: ctx.from,
-        chat: reaction.chat as Chat,
-      }))
-    ) {
+    const admission =
+      this.ingressAdmissions.get(ctx) ??
+      (await this.evaluateReactionAdmission(ctx));
+    if (!admission.admitted) {
       return;
     }
+    const syntheticReactionMessage = {
+      message_id: reactedToMessageId,
+      chat: reaction.chat,
+      from: ctx.from,
+      date: reaction.date,
+      ...(admission.threadId
+        ? {
+            is_topic_message: true,
+            message_thread_id: Number(admission.threadId),
+          }
+        : {}),
+    } as Message;
     // Emoji reactions carry the glyph on `.emoji`; non-emoji reactions
     // (custom_emoji / paid) are identified by `.type`.
     const reactionLabel =
@@ -2108,10 +2326,12 @@ export class MessageManager {
         this.runtime,
         this.scopedTelegramKey(ctx.from.id.toString()),
       ) as UUID;
-      const roomId = createUniqueUuid(
-        this.runtime,
-        this.scopedTelegramKey(ctx.chat.id.toString()),
-      );
+      const roomId =
+        admission.sourceMemory?.roomId ??
+        createUniqueUuid(
+          this.runtime,
+          this.scopedTelegramKey(ctx.chat.id.toString()),
+        );
 
       const reactionId = createUniqueUuid(
         this.runtime,
@@ -2130,10 +2350,9 @@ export class MessageManager {
           channelType: getChannelType(reaction.chat as Chat),
           text: `Reacted with: ${reactionLabel}`,
           source: "telegram",
-          inReplyTo: createUniqueUuid(
-            this.runtime,
-            this.scopedTelegramKey(reaction.message_id.toString()),
-          ),
+          inReplyTo:
+            admission.sourceMemory?.id ??
+            this.telegramMessageMemoryId(reaction.chat.id, reaction.message_id),
           metadata: { accountId: this.accountId },
         },
         metadata: {
@@ -2160,6 +2379,7 @@ export class MessageManager {
             ),
             chatId: reaction.chat.id.toString(),
             messageId: reaction.message_id.toString(),
+            threadId: admission.threadId,
           },
           telegramUserId: ctx.from.id.toString(),
           telegramChatId: reaction.chat.id.toString(),
@@ -2169,43 +2389,28 @@ export class MessageManager {
 
       // Create callback for handling reaction responses
       const callback: HandlerCallback = async (content: Content) => {
-        try {
-          // Add null check for content.text
-          const replyText = content.text ?? "";
-          const sentMessage = await ctx.reply(replyText);
-          const responseMemory: Memory = {
-            id: createUniqueUuid(
-              this.runtime,
-              this.scopedTelegramKey(sentMessage.message_id.toString()),
-            ),
-            entityId: this.runtime.agentId,
-            agentId: this.runtime.agentId,
-            roomId,
-            content: {
-              ...content,
-              inReplyTo: reactionId,
-              metadata: { accountId: this.accountId },
-            },
-            metadata: {
-              type: "message",
-              source: "telegram",
-              accountId: this.accountId,
-              provider: "telegram",
-            } satisfies Memory["metadata"],
-            createdAt: sentMessage.date * 1000,
-          };
-          return [responseMemory];
-        } catch (error) {
-          logger.error(
-            {
-              src: "plugin:telegram",
-              agentId: this.runtime.agentId,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            "Error in reaction callback",
-          );
-          return [];
-        }
+        const threadId = admission.threadId
+          ? Number(admission.threadId)
+          : undefined;
+        const sentMessages = await this.sendMessageInChunks(
+          {
+            chat: reaction.chat,
+            from: ctx.from,
+            telegram: this.bot.telegram,
+          } as Context,
+          content,
+          reaction.message_id,
+          threadId,
+        );
+        return this.persistSentMessageMemories({
+          sentMessages,
+          content,
+          roomId,
+          channelType: getChannelType(reaction.chat as Chat),
+          chatType: reaction.chat.type,
+          threadId: admission.threadId,
+          inReplyTo: reactionId,
+        });
       };
 
       // Let the bootstrap plugin handle the reaction
@@ -2236,14 +2441,16 @@ export class MessageManager {
         originalReaction: firstReaction as ReactionType,
       } as TelegramReactionReceivedPayload);
     } catch (error) {
-      logger.error(
-        {
-          src: "plugin:telegram",
-          agentId: this.runtime.agentId,
-          error: error instanceof Error ? error.message : String(error),
+      // error-policy:J2 retain connector identity on the propagated failure.
+      throw new ElizaError("Telegram reaction handling failed", {
+        code: "TELEGRAM_REACTION_HANDLING_FAILED",
+        context: {
+          accountId: this.accountId,
+          chatId: reaction.chat.id,
+          messageId: reaction.message_id,
         },
-        "Error handling reaction",
-      );
+        cause: error,
+      });
     }
   }
 
@@ -2372,9 +2579,9 @@ export class MessageManager {
           : {};
       for (const sentMessage of sentMessages) {
         const memory: Memory = {
-          id: createUniqueUuid(
-            this.runtime,
-            this.scopedTelegramKey(sentMessage.message_id.toString()),
+          id: this.telegramMessageMemoryId(
+            sentMessage.chat.id,
+            sentMessage.message_id,
           ),
           entityId: this.runtime.agentId,
           agentId: this.runtime.agentId,
@@ -2410,6 +2617,10 @@ export class MessageManager {
             fromId: this.runtime.agentId,
             sourceId: this.runtime.agentId,
             messageIdFull: sentMessage.message_id.toString(),
+            telegramMessageKey: this.telegramMessageKey(
+              sentMessage.chat.id,
+              sentMessage.message_id,
+            ),
             telegram: {
               chatId: sentMessage.chat.id.toString(),
               messageId: sentMessage.message_id.toString(),

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -21,6 +21,7 @@ import {
   EventType,
   type HandlerCallback,
   type IAgentRuntime,
+  type JsonValue,
   lifeOpsPassiveConnectorsEnabled,
   logger,
   type Media,
@@ -35,6 +36,7 @@ import type {
   Document,
   InlineKeyboardButton,
   Message,
+  MessageEntity,
   ReactionType,
   Update,
   User,
@@ -62,6 +64,7 @@ import {
   cleanText,
   convertMarkdownToTelegram,
   convertToTelegramButtons,
+  splitMarkdownForTelegram,
 } from "./utils";
 
 /**
@@ -87,8 +90,11 @@ export enum MediaType {
   VIDEO = "video",
   DOCUMENT = "document",
   AUDIO = "audio",
+  VOICE = "voice",
   ANIMATION = "animation",
 }
+
+type TelegramSentMessage = Message;
 
 /**
  * Map a Telegram file's MIME type to the coarse core ContentType. Returns the
@@ -154,6 +160,107 @@ function isTelegramCommandForBot(
   }
   const normalizedBot = botUsername?.replace(/^@/, "").trim().toLowerCase();
   return Boolean(normalizedBot && target.toLowerCase() === normalizedBot);
+}
+
+function telegramMessageEntities(message: Message): MessageEntity[] {
+  if ("entities" in message && Array.isArray(message.entities)) {
+    return message.entities;
+  }
+  if (
+    "caption_entities" in message &&
+    Array.isArray(message.caption_entities)
+  ) {
+    return message.caption_entities;
+  }
+  return [];
+}
+
+function telegramTextWithEntities(message: Message): {
+  rawText: string | undefined;
+  renderedText: string | undefined;
+  entities: MessageEntity[];
+} {
+  const rawText = telegramMessagePlainText(message);
+  const entities = telegramMessageEntities(message);
+  return {
+    rawText,
+    renderedText: rawText,
+    entities,
+  };
+}
+
+function telegramEntityMetadata(entity: MessageEntity): {
+  [key: string]: JsonValue;
+} {
+  const metadata: { [key: string]: JsonValue } = {
+    type: entity.type,
+    offset: entity.offset,
+    length: entity.length,
+  };
+  if ("url" in entity && typeof entity.url === "string") {
+    metadata.url = entity.url;
+  }
+  if ("language" in entity && typeof entity.language === "string") {
+    metadata.language = entity.language;
+  }
+  if (
+    "custom_emoji_id" in entity &&
+    typeof entity.custom_emoji_id === "string"
+  ) {
+    metadata.custom_emoji_id = entity.custom_emoji_id;
+  }
+  if ("user" in entity && entity.user) {
+    metadata.user = {
+      id: entity.user.id,
+      is_bot: entity.user.is_bot,
+      first_name: entity.user.first_name,
+      ...(entity.user.last_name ? { last_name: entity.user.last_name } : {}),
+      ...(entity.user.username ? { username: entity.user.username } : {}),
+    };
+  }
+  return metadata;
+}
+
+function telegramRichTextMetadata(
+  message: Message,
+):
+  | { rawText: string; entities: Array<{ [key: string]: JsonValue }> }
+  | undefined {
+  const { rawText, entities } = telegramTextWithEntities(message);
+  if (!rawText || entities.length === 0) {
+    return undefined;
+  }
+  return {
+    rawText,
+    entities: entities.map(telegramEntityMetadata),
+  };
+}
+
+function addTelegramAttachmentProvenance(
+  attachment: Media,
+  message: Message,
+  accountId: string,
+): Media {
+  const threadId =
+    "message_thread_id" in message && message.message_thread_id !== undefined
+      ? message.message_thread_id.toString()
+      : undefined;
+  return {
+    ...attachment,
+    createdAt: message.date * 1000,
+    metadata: {
+      ...(attachment as Media & { metadata?: Record<string, unknown> })
+        .metadata,
+      source: "telegram",
+      provider: "telegram",
+      accountId,
+      chatId: message.chat.id.toString(),
+      messageId: message.message_id.toString(),
+      threadId,
+      mediaGroupId:
+        "media_group_id" in message ? message.media_group_id : undefined,
+    },
+  } as Media & { metadata: Record<string, unknown> };
 }
 
 const MAX_MESSAGE_LENGTH = 4096; // Telegram's max message length
@@ -312,8 +419,13 @@ function isPdfTextService(service: unknown): service is PdfTextService {
 type TelegramMediaSender = (
   chatId: number | string,
   media: string | { source: fs.ReadStream },
-  extra?: { caption?: string },
-) => Promise<unknown>;
+  extra?: {
+    caption?: string;
+    parse_mode?: "MarkdownV2";
+    reply_parameters?: { message_id: number };
+    message_thread_id?: number;
+  },
+) => Promise<TelegramSentMessage>;
 
 const getChannelType = (chat: Chat): ChannelType => {
   const chatType = chat.type;
@@ -990,11 +1102,9 @@ export class MessageManager {
     let processedContent = "";
     const attachments: Media[] = [];
 
-    // Get message text
-    if ("text" in message && message.text) {
-      processedContent = message.text;
-    } else if ("caption" in message && message.caption) {
-      processedContent = message.caption as string;
+    const rendered = telegramTextWithEntities(message);
+    if (rendered.renderedText) {
+      processedContent = rendered.renderedText;
     }
 
     // Process documents
@@ -1018,17 +1128,26 @@ export class MessageManager {
             processedContent += documentContent;
           }
 
-          attachments.push({
-            id: document.file_id,
-            url: fileLink.toString(),
-            title,
-            source: document.mime_type?.startsWith("application/pdf")
-              ? "PDF"
-              : "Document",
-            contentType: contentTypeForMime(document.mime_type),
-            description: documentInfo.formattedDescription,
-            text: fullText,
-          });
+          attachments.push(
+            addTelegramAttachmentProvenance(
+              {
+                id: document.file_id,
+                url: fileLink.toString(),
+                title,
+                source: document.mime_type?.startsWith("application/pdf")
+                  ? "PDF"
+                  : "Document",
+                contentType: contentTypeForMime(document.mime_type),
+                mimeType: document.mime_type,
+                filename: document.file_name,
+                size: document.file_size,
+                description: documentInfo.formattedDescription,
+                text: fullText,
+              },
+              message,
+              this.accountId,
+            ),
+          );
           logger.debug(
             {
               src: "plugin:telegram",
@@ -1048,54 +1167,76 @@ export class MessageManager {
             "Error processing document",
           );
           // Add a fallback attachment even if processing failed
-          attachments.push({
-            id: document.file_id,
-            url: "",
-            title: `Document: ${documentInfo.fileName}`,
-            source: "Document",
-            description: `Document processing failed: ${documentInfo.fileName}`,
-            text: `Document: ${documentInfo.fileName}\nSize: ${documentInfo.fileSize || 0} bytes\nType: ${documentInfo.mimeType || "unknown"}`,
-          });
+          attachments.push(
+            addTelegramAttachmentProvenance(
+              {
+                id: document.file_id,
+                url: "",
+                title: `Document: ${documentInfo.fileName}`,
+                source: "Document",
+                mimeType: documentInfo.mimeType,
+                filename: documentInfo.fileName,
+                size: documentInfo.fileSize,
+                description: `Document processing failed: ${documentInfo.fileName}`,
+                text: `Document: ${documentInfo.fileName}\nSize: ${documentInfo.fileSize || 0} bytes\nType: ${documentInfo.mimeType || "unknown"}`,
+              },
+              message,
+              this.accountId,
+            ),
+          );
         }
       } else {
-        // Add a basic attachment even if documentInfo is null
-        attachments.push({
-          id: document.file_id,
-          url: "",
-          title: `Document: ${document.file_name || "Unknown Document"}`,
-          source: "Document",
-          description: `Document: ${document.file_name || "Unknown Document"}`,
-          text: `Document: ${document.file_name || "Unknown Document"}\nSize: ${document.file_size || 0} bytes\nType: ${document.mime_type || "unknown"}`,
-        });
+        attachments.push(
+          addTelegramAttachmentProvenance(
+            {
+              id: document.file_id,
+              url: "",
+              title: `Document: ${document.file_name || "Unknown Document"}`,
+              source: "Document",
+              contentType: contentTypeForMime(document.mime_type),
+              mimeType: document.mime_type,
+              filename: document.file_name,
+              size: document.file_size,
+              description: `Document: ${document.file_name || "Unknown Document"}`,
+              text: `Document: ${document.file_name || "Unknown Document"}\nSize: ${document.file_size || 0} bytes\nType: ${document.mime_type || "unknown"}`,
+            },
+            message,
+            this.accountId,
+          ),
+        );
       }
     }
 
     // Process images
     if ("photo" in message && message.photo.length > 0) {
-      const imageInfo = await this.processImage(message);
-      if (imageInfo) {
-        try {
-          const photo = message.photo[message.photo.length - 1];
-          const fileLink = await this.bot.telegram.getFileLink(photo.file_id);
-          attachments.push({
-            id: photo.file_id,
-            url: fileLink.toString(),
-            title: "Image Attachment",
-            source: "Image",
-            contentType: "image",
-            description: imageInfo.description,
-            text: imageInfo.description,
-          });
-        } catch (error) {
-          logger.error(
+      try {
+        const photo = message.photo[message.photo.length - 1];
+        const fileLink = await this.bot.telegram.getFileLink(photo.file_id);
+        attachments.push(
+          addTelegramAttachmentProvenance(
             {
-              src: "plugin:telegram",
-              agentId: this.runtime.agentId,
-              error: error instanceof Error ? error.message : String(error),
+              id: photo.file_id,
+              url: fileLink.toString(),
+              title: "Image Attachment",
+              source: "Image",
+              contentType: "image",
+              size: photo.file_size,
+              width: photo.width,
+              height: photo.height,
             },
-            "Error attaching processed image",
-          );
-        }
+            message,
+            this.accountId,
+          ),
+        );
+      } catch (error) {
+        logger.error(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Error attaching image",
+        );
       }
     }
 
@@ -1110,13 +1251,64 @@ export class MessageManager {
     ): Promise<void> => {
       try {
         const fileLink = await this.bot.telegram.getFileLink(fileId);
-        attachments.push({
-          id: fileId,
-          url: fileLink.toString(),
-          title,
-          source,
-          contentType,
-        });
+        const telegramFile =
+          "voice" in message && message.voice?.file_id === fileId
+            ? message.voice
+            : "audio" in message && message.audio?.file_id === fileId
+              ? message.audio
+              : "video" in message && message.video?.file_id === fileId
+                ? message.video
+                : "animation" in message &&
+                    message.animation?.file_id === fileId
+                  ? message.animation
+                  : undefined;
+        attachments.push(
+          addTelegramAttachmentProvenance(
+            {
+              id: fileId,
+              url: fileLink.toString(),
+              title,
+              source,
+              contentType,
+              mimeType:
+                telegramFile &&
+                "mime_type" in telegramFile &&
+                typeof telegramFile.mime_type === "string"
+                  ? telegramFile.mime_type
+                  : undefined,
+              filename:
+                telegramFile &&
+                "file_name" in telegramFile &&
+                typeof telegramFile.file_name === "string"
+                  ? telegramFile.file_name
+                  : undefined,
+              size:
+                typeof telegramFile?.file_size === "number"
+                  ? telegramFile.file_size
+                  : undefined,
+              duration:
+                telegramFile &&
+                "duration" in telegramFile &&
+                typeof telegramFile.duration === "number"
+                  ? telegramFile.duration
+                  : undefined,
+              width:
+                telegramFile &&
+                "width" in telegramFile &&
+                typeof telegramFile.width === "number"
+                  ? telegramFile.width
+                  : undefined,
+              height:
+                telegramFile &&
+                "height" in telegramFile &&
+                typeof telegramFile.height === "number"
+                  ? telegramFile.height
+                  : undefined,
+            },
+            message,
+            this.accountId,
+          ),
+        );
       } catch (error) {
         logger.error(
           {
@@ -1134,7 +1326,7 @@ export class MessageManager {
         message.voice.file_id,
         "audio",
         "Voice Message",
-        "Voice",
+        "Voice Note",
       );
     }
     if ("audio" in message && message.audio) {
@@ -1254,63 +1446,129 @@ export class MessageManager {
     }
   }
 
+  private async sendUnsupportedMediaNotice(
+    ctx: Context,
+    attachment: Media,
+    replyToMessageId?: number,
+    messageThreadId?: number,
+  ): Promise<Message.TextMessage> {
+    if (!ctx.chat) {
+      throw new Error("sendUnsupportedMediaNotice: ctx.chat is undefined");
+    }
+    const chatId = ctx.chat.id;
+    const title = attachment.title || attachment.filename || attachment.id;
+    const contentType = attachment.contentType || attachment.mimeType;
+    const notice = [
+      "I could not send this Telegram attachment.",
+      title ? `Attachment: ${title}` : undefined,
+      contentType ? `Type: ${contentType}` : undefined,
+    ]
+      .filter(Boolean)
+      .join("\n");
+    const formatted = convertMarkdownToTelegram(notice);
+    const sendOptions = {
+      reply_parameters: replyToMessageId
+        ? { message_id: replyToMessageId }
+        : undefined,
+      message_thread_id: messageThreadId,
+    };
+    return this.sendWithRetry(
+      () =>
+        ctx.telegram.sendMessage(chatId, formatted, {
+          ...sendOptions,
+          parse_mode: "MarkdownV2",
+        }),
+      () => ctx.telegram.sendMessage(chatId, cleanText(notice), sendOptions),
+    );
+  }
+
   /**
-   * Sends a message in chunks, handling attachments and splitting the message if necessary
-   *
-   * @param {Context} ctx - The context object representing the current state of the bot
-   * @param {TelegramContent} content - The content of the message to be sent
-   * @param {number} [replyToMessageId] - The ID of the message to reply to, if any
-   * @returns {Promise<Message.TextMessage[]>} - An array of TextMessage objects representing the messages sent
+   * Sends a message in chunks, handling attachments and splitting the message if necessary.
    */
   async sendMessageInChunks(
     ctx: Context,
     content: TelegramContent,
     replyToMessageId?: number,
     messageThreadId?: number,
-  ): Promise<Message.TextMessage[]> {
+  ): Promise<TelegramSentMessage[]> {
+    const sentMessages: TelegramSentMessage[] = [];
+    const telegramConfig = getTelegramMultiAccountConfig(this.runtime);
+    const replyToMode =
+      telegramConfig.accounts?.[this.accountId]?.replyToMode ??
+      telegramConfig.replyToMode ??
+      "first";
+
     if (content.attachments && content.attachments.length > 0) {
-      await Promise.all(
-        content.attachments.map(async (attachment: Media) => {
-          const typeMap: { [key: string]: MediaType } = {
-            "image/gif": MediaType.ANIMATION,
-            image: MediaType.PHOTO,
-            doc: MediaType.DOCUMENT,
-            video: MediaType.VIDEO,
-            audio: MediaType.AUDIO,
-          };
+      for (const attachment of content.attachments) {
+        const typeMap: { [key: string]: MediaType } = {
+          "image/gif": MediaType.ANIMATION,
+          image: MediaType.PHOTO,
+          doc: MediaType.DOCUMENT,
+          video: MediaType.VIDEO,
+          audio: MediaType.AUDIO,
+        };
 
-          let mediaType: MediaType | undefined;
+        let mediaType: MediaType | undefined;
 
-          for (const prefix in typeMap) {
-            if (attachment.contentType?.startsWith(prefix)) {
-              mediaType = typeMap[prefix];
-              break;
-            }
+        for (const prefix in typeMap) {
+          if (attachment.contentType?.startsWith(prefix)) {
+            mediaType = typeMap[prefix];
+            break;
           }
+        }
 
-          if (!mediaType) {
-            // Degrade unknown/absent content types to a document upload instead
-            // of throwing — a throw inside Promise.all aborts the whole reply
-            // and silently drops the agent's text.
-            logger.warn(
-              {
-                src: "plugin:telegram",
-                agentId: this.runtime.agentId,
-                contentType: attachment.contentType,
-              },
-              "Unknown Telegram attachment content type; sending as document",
-            );
-            mediaType = MediaType.DOCUMENT;
-          }
-
-          await this.sendMedia(
-            ctx,
-            attachment.url,
-            mediaType,
-            attachment.description,
+        if (!mediaType) {
+          logger.warn(
+            {
+              src: "plugin:telegram",
+              agentId: this.runtime.agentId,
+              contentType: attachment.contentType,
+            },
+            "Unknown Telegram attachment content type; sending visible failure",
           );
-        }),
-      );
+          const shouldReplyToSource =
+            replyToMessageId !== undefined &&
+            replyToMode !== "off" &&
+            (replyToMode === "all" || sentMessages.length === 0);
+          sentMessages.push(
+            await this.sendUnsupportedMediaNotice(
+              ctx,
+              attachment,
+              shouldReplyToSource ? replyToMessageId : undefined,
+              messageThreadId,
+            ),
+          );
+          continue;
+        }
+
+        const contentMetadata = isRecord(content.metadata)
+          ? content.metadata
+          : {};
+        const telegramMetadata = isRecord(contentMetadata.telegram)
+          ? contentMetadata.telegram
+          : {};
+        const sendsAudioAsVoice =
+          mediaType === MediaType.AUDIO &&
+          ((typeof content.text === "string" &&
+            content.text.includes("[[audio_as_voice]]")) ||
+            telegramMetadata.audioAsVoice === true ||
+            telegramMetadata.sendAsVoice === true ||
+            attachment.source === "Voice Note");
+        const shouldReplyToSource =
+          replyToMessageId !== undefined &&
+          replyToMode !== "off" &&
+          (replyToMode === "all" || sentMessages.length === 0);
+
+        const sentMedia = await this.sendMedia(
+          ctx,
+          attachment.url,
+          sendsAudioAsVoice ? MediaType.VOICE : mediaType,
+          attachment.description,
+          shouldReplyToSource ? replyToMessageId : undefined,
+          messageThreadId,
+        );
+        sentMessages.push(sentMedia);
+      }
       // Fall through to the text path below so an attachment reply never drops
       // the agent's accompanying prose (sent as a follow-up message).
     }
@@ -1327,8 +1585,6 @@ export class MessageManager {
         content,
         buildInteractionUrlResolver(appBaseUrl),
       );
-      const sentMessages: Message.TextMessage[] = [];
-
       const telegramButtons = convertToTelegramButtons(content.buttons ?? []);
       const hasKeyboardRows =
         rendered.keyboardRows.length > 0 || telegramButtons.length > 0;
@@ -1344,7 +1600,7 @@ export class MessageManager {
         return sentMessages;
       }
 
-      const chunks = this.splitMessage(textToSend);
+      const chunks = splitMarkdownForTelegram(textToSend, MAX_MESSAGE_LENGTH);
 
       if (!ctx.chat) {
         logger.error(
@@ -1372,14 +1628,12 @@ export class MessageManager {
       // lookup) and attached to the final chunk only, alongside any other
       // interaction controls.
       const embedLaunchRow = await this.buildEmbedLaunchRow(ctx);
-      const telegramConfig = getTelegramMultiAccountConfig(this.runtime);
-      const replyToMode =
-        telegramConfig.accounts?.[this.accountId]?.replyToMode ??
-        telegramConfig.replyToMode ??
-        "first";
-
       for (let i = 0; i < chunks.length; i++) {
-        const chunk = convertMarkdownToTelegram(chunks[i]);
+        const rawChunk = chunks[i].replaceAll("[[audio_as_voice]]", "").trim();
+        if (!rawChunk) {
+          continue;
+        }
+        const chunk = convertMarkdownToTelegram(rawChunk);
         if (!ctx.chat) {
           logger.error(
             { src: "plugin:telegram", agentId: this.runtime.agentId },
@@ -1407,7 +1661,7 @@ export class MessageManager {
         const shouldReplyToSource =
           replyToMessageId !== undefined &&
           replyToMode !== "off" &&
-          (replyToMode === "all" || i === 0);
+          (replyToMode === "all" || sentMessages.length === 0);
         const sendOptions = {
           reply_parameters: shouldReplyToSource
             ? { message_id: replyToMessageId }
@@ -1426,7 +1680,7 @@ export class MessageManager {
           // otherwise the user sees literal backslash escapes ("Sure\!"). Mirror
           // the editMessage fallback, which sends cleanText(text).
           () =>
-            ctx.telegram.sendMessage(chatId, cleanText(chunks[i]), sendOptions),
+            ctx.telegram.sendMessage(chatId, cleanText(rawChunk), sendOptions),
         )) as Message.TextMessage;
 
         sentMessages.push(sentMessage);
@@ -1437,7 +1691,7 @@ export class MessageManager {
   }
 
   private async persistSentMessageMemories(args: {
-    sentMessages: Message.TextMessage[];
+    sentMessages: TelegramSentMessage[];
     content: TelegramContent;
     roomId: UUID;
     channelType: ChannelType;
@@ -1458,7 +1712,12 @@ export class MessageManager {
         content: {
           ...args.content,
           source: "telegram",
-          text: sentMessage.text,
+          text:
+            "text" in sentMessage
+              ? sentMessage.text
+              : "caption" in sentMessage && sentMessage.caption
+                ? sentMessage.caption
+                : args.content.text,
           inReplyTo: args.inReplyTo,
           channelType: args.channelType,
           metadata: { accountId: this.accountId },
@@ -1513,7 +1772,9 @@ export class MessageManager {
     mediaPath: string,
     type: MediaType,
     caption?: string,
-  ): Promise<void> {
+    replyToMessageId?: number,
+    messageThreadId?: number,
+  ): Promise<TelegramSentMessage> {
     try {
       const isUrl = /^(http|https):\/\//.test(mediaPath);
       // Look up the raw sender lazily and bind only the one we need. Building
@@ -1525,6 +1786,7 @@ export class MessageManager {
         [MediaType.VIDEO]: ctx.telegram.sendVideo,
         [MediaType.DOCUMENT]: ctx.telegram.sendDocument,
         [MediaType.AUDIO]: ctx.telegram.sendAudio,
+        [MediaType.VOICE]: ctx.telegram.sendVoice,
         [MediaType.ANIMATION]: ctx.telegram.sendAnimation,
       };
 
@@ -1537,12 +1799,45 @@ export class MessageManager {
       if (!ctx.chat) {
         throw new Error("sendMedia: ctx.chat is undefined");
       }
+      const chatId = ctx.chat.id;
 
+      const formattedCaption = caption
+        ? convertMarkdownToTelegram(caption)
+        : undefined;
+      const sendOptions = {
+        caption: formattedCaption,
+        parse_mode: formattedCaption ? ("MarkdownV2" as const) : undefined,
+        reply_parameters: replyToMessageId
+          ? { message_id: replyToMessageId }
+          : undefined,
+        message_thread_id: messageThreadId,
+      };
+      const plainTextFallback = caption
+        ? () => {
+            const fallbackOptions = {
+              ...sendOptions,
+              caption: cleanText(caption),
+              parse_mode: undefined,
+            };
+            if (isUrl) {
+              return sendFunction(chatId, mediaPath, fallbackOptions);
+            }
+            const fallbackStream = fs.createReadStream(mediaPath);
+            return sendFunction(
+              chatId,
+              { source: fallbackStream },
+              fallbackOptions,
+            ).finally(() => fallbackStream.destroy());
+          }
+        : undefined;
+
+      let sentMessage: TelegramSentMessage;
       if (isUrl) {
-        // Handle HTTP URLs
-        await sendFunction(ctx.chat.id, mediaPath, { caption });
+        sentMessage = await this.sendWithRetry(
+          () => sendFunction(chatId, mediaPath, sendOptions),
+          plainTextFallback,
+        );
       } else {
-        // Handle local file paths
         if (!fs.existsSync(mediaPath)) {
           throw new Error(`File not found at path: ${mediaPath}`);
         }
@@ -1550,10 +1845,10 @@ export class MessageManager {
         const fileStream = fs.createReadStream(mediaPath);
 
         try {
-          if (!ctx.chat) {
-            throw new Error("sendMedia (file): ctx.chat is undefined");
-          }
-          await sendFunction(ctx.chat.id, { source: fileStream }, { caption });
+          sentMessage = await this.sendWithRetry(
+            () => sendFunction(chatId, { source: fileStream }, sendOptions),
+            plainTextFallback,
+          );
         } finally {
           fileStream.destroy();
         }
@@ -1568,6 +1863,7 @@ export class MessageManager {
         },
         "Media sent successfully",
       );
+      return sentMessage;
     } catch (error) {
       logger.error(
         {
@@ -1581,71 +1877,6 @@ export class MessageManager {
       );
       throw error;
     }
-  }
-
-  /**
-   * Splits a given text into an array of strings based on the maximum message length.
-   *
-   * @param {string} text - The text to split into chunks.
-   * @returns {string[]} An array of strings with each element representing a chunk of the original text.
-   */
-  private splitMessage(text: string): string[] {
-    const chunks: string[] = [];
-    if (!text) {
-      return chunks;
-    }
-
-    let currentChunk = "";
-
-    const appendSegment = (segment: string) => {
-      let remaining = segment;
-
-      while (remaining.length > 0) {
-        const availableLength = MAX_MESSAGE_LENGTH - currentChunk.length;
-
-        if (remaining.length <= availableLength) {
-          currentChunk += remaining;
-          return;
-        }
-
-        if (availableLength > 0) {
-          currentChunk += remaining.slice(0, availableLength);
-          remaining = remaining.slice(availableLength);
-        }
-
-        if (currentChunk) {
-          chunks.push(currentChunk);
-          currentChunk = "";
-        }
-      }
-    };
-
-    const lines = text.split("\n");
-    for (const line of lines) {
-      let segment = currentChunk ? `\n${line}` : line;
-      if (!segment) {
-        continue;
-      }
-
-      if (
-        currentChunk &&
-        currentChunk.length + segment.length > MAX_MESSAGE_LENGTH
-      ) {
-        chunks.push(currentChunk);
-        currentChunk = "";
-        segment = line;
-        if (!segment) {
-          continue;
-        }
-      }
-
-      appendSegment(segment);
-    }
-
-    if (currentChunk) {
-      chunks.push(currentChunk);
-    }
-    return chunks;
   }
 
   /**
@@ -1735,12 +1966,19 @@ export class MessageManager {
 
       // Clean processedContent and attachments to avoid NULL characters
       const cleanedContent = cleanText(policyAdjustedContent);
-      const cleanedAttachments = attachments.map((att) => ({
-        ...att,
-        text: cleanText(att.text),
-        description: cleanText(att.description),
-        title: cleanText(att.title),
-      }));
+      const cleanedAttachments = attachments.map((att) => {
+        const cleaned = { ...att };
+        if (typeof cleaned.text === "string") {
+          cleaned.text = cleanText(cleaned.text);
+        }
+        if (typeof cleaned.description === "string") {
+          cleaned.description = cleanText(cleaned.description);
+        }
+        if (typeof cleaned.title === "string") {
+          cleaned.title = cleanText(cleaned.title);
+        }
+        return cleaned;
+      });
 
       if (!cleanedContent && cleanedAttachments.length === 0) {
         return;
@@ -1781,7 +2019,12 @@ export class MessageManager {
           text: cleanedContent || " ",
           attachments: cleanedAttachments,
           source: "telegram",
-          metadata: { accountId: this.accountId },
+          metadata: {
+            accountId: this.accountId,
+            telegram: {
+              richText: telegramRichTextMetadata(message),
+            },
+          },
           channelType,
           inReplyTo:
             "reply_to_message" in message && message.reply_to_message
@@ -1840,8 +2083,14 @@ export class MessageManager {
 
       // Create callback for handling responses
       const baseCallback: HandlerCallback = async (content: Content) => {
+        const telegramContent = content as TelegramContent;
         // A model response with no user-facing text is a legitimate no-op.
-        if (!content.text) {
+        if (
+          !content.text &&
+          (!telegramContent.attachments ||
+            telegramContent.attachments.length === 0) &&
+          (!telegramContent.buttons || telegramContent.buttons.length === 0)
+        ) {
           return [];
         }
 
@@ -2534,14 +2783,14 @@ export class MessageManager {
    * @param {number | string} chatId - The Telegram chat ID to send the message to
    * @param {Content} content - The content to send
    * @param {number} [replyToMessageId] - Optional message ID to reply to
-   * @returns {Promise<Message.TextMessage[]>} The sent messages
+   * @returns {Promise<Message[]>} The sent messages
    */
   public async sendMessage(
     chatId: number | string,
     content: Content,
     replyToMessageId?: number,
     messageThreadId?: number,
-  ): Promise<Message.TextMessage[]> {
+  ): Promise<TelegramSentMessage[]> {
     try {
       // Create a context-like object for sending
       const ctx = {
@@ -2588,7 +2837,12 @@ export class MessageManager {
           roomId,
           content: {
             ...content,
-            text: sentMessage.text,
+            text:
+              "text" in sentMessage
+                ? sentMessage.text
+                : "caption" in sentMessage && sentMessage.caption
+                  ? sentMessage.caption
+                  : content.text,
             source: "telegram",
             metadata: { ...contentMetadata, accountId: this.accountId },
             channelType: getChannelType({

--- a/plugins/plugin-telegram/src/policy.ts
+++ b/plugins/plugin-telegram/src/policy.ts
@@ -1,0 +1,323 @@
+/**
+ * Telegram inbound activation policy for the bot runtime. It interprets the
+ * typed `connectors.telegram` account/group/topic config after startup has
+ * copied that object into `character.settings.telegram`, and returns a single
+ * decision before the message manager creates memory or dispatches a model turn.
+ */
+import { checkPairingAllowed, type IAgentRuntime } from "@elizaos/core";
+import type { Message, User } from "@telegraf/types";
+import type { TelegramAccountConfig } from "./accounts";
+
+type TelegramGroupConfig = NonNullable<TelegramAccountConfig["groups"]>[string];
+type TelegramTopicConfig = NonNullable<
+  NonNullable<TelegramGroupConfig>["topics"]
+>[string];
+
+type TelegramPolicyConfig = Pick<
+  TelegramAccountConfig,
+  | "dmPolicy"
+  | "groupPolicy"
+  | "allowFrom"
+  | "groupAllowFrom"
+  | "replyToMode"
+  | "groups"
+>;
+
+export type TelegramPolicyDecision = {
+  shouldDispatch: boolean;
+  textOverride?: string;
+  denialMessage?: string;
+  reason:
+    | "forced"
+    | "legacy-auto-reply"
+    | "dm"
+    | "mention"
+    | "reply-to-bot"
+    | "blocked";
+};
+
+function normalizeList(values: Array<string | number> | undefined): string[] {
+  return (values ?? [])
+    .map((value) => String(value).trim())
+    .filter((value) => value.length > 0);
+}
+
+function matchesAllowList(
+  values: Array<string | number> | undefined,
+  identifiers: string[],
+): boolean {
+  const normalized = normalizeList(values);
+  if (normalized.includes("*")) {
+    return true;
+  }
+  return identifiers.some((identifier) => normalized.includes(identifier));
+}
+
+function hasEntries(values: Array<string | number> | undefined): boolean {
+  return normalizeList(values).length > 0;
+}
+
+function senderIdentifiers(from: User): string[] {
+  return [
+    String(from.id),
+    from.username ? `@${from.username}` : "",
+    from.username ?? "",
+  ].filter(Boolean);
+}
+
+export function hasTypedTelegramPolicyConfig(
+  config: TelegramPolicyConfig,
+): boolean {
+  return Boolean(
+    config.dmPolicy ||
+      config.groupPolicy ||
+      config.replyToMode ||
+      hasEntries(config.allowFrom) ||
+      hasEntries(config.groupAllowFrom) ||
+      (config.groups && Object.keys(config.groups).length > 0),
+  );
+}
+
+function resolveGroupConfig(
+  config: TelegramPolicyConfig,
+  chatId: string,
+): TelegramGroupConfig {
+  return config.groups?.[chatId];
+}
+
+function resolveTopicConfig(
+  groupConfig: TelegramGroupConfig,
+  threadId?: string,
+): TelegramTopicConfig {
+  return threadId ? groupConfig?.topics?.[threadId] : undefined;
+}
+
+function messageText(message: Message): string {
+  if ("text" in message && typeof message.text === "string") {
+    return message.text;
+  }
+  if ("caption" in message && typeof message.caption === "string") {
+    return message.caption;
+  }
+  return "";
+}
+
+function messageEntities(
+  message: Message,
+): Array<{ type: string; offset: number; length: number }> {
+  if ("entities" in message && Array.isArray(message.entities)) {
+    return message.entities;
+  }
+  if (
+    "caption_entities" in message &&
+    Array.isArray(message.caption_entities)
+  ) {
+    return message.caption_entities;
+  }
+  return [];
+}
+
+function detectAddressedMention(
+  message: Message,
+  botUsername: string | undefined,
+): { mentioned: boolean; text: string } {
+  const text = messageText(message);
+  const normalizedBot = botUsername?.replace(/^@/, "").trim().toLowerCase();
+  if (!text || !normalizedBot) {
+    return { mentioned: false, text };
+  }
+
+  for (const entity of messageEntities(message)) {
+    if (entity.type !== "mention") {
+      continue;
+    }
+    const mention = text.slice(entity.offset, entity.offset + entity.length);
+    if (mention.replace(/^@/, "").toLowerCase() !== normalizedBot) {
+      continue;
+    }
+    return {
+      mentioned: true,
+      text: `${text.slice(0, entity.offset)}${text.slice(
+        entity.offset + entity.length,
+      )}`.trim(),
+    };
+  }
+
+  return { mentioned: false, text };
+}
+
+function isReplyToBot(message: Message, botInfo?: User): boolean {
+  if (!("reply_to_message" in message) || !message.reply_to_message) {
+    return false;
+  }
+  const repliedMessage = message.reply_to_message;
+  const repliedFrom =
+    "from" in repliedMessage && repliedMessage.from
+      ? repliedMessage.from
+      : undefined;
+  if (!repliedFrom?.is_bot) {
+    return false;
+  }
+  if (botInfo?.id !== undefined) {
+    return repliedFrom.id === botInfo.id;
+  }
+  return false;
+}
+
+async function resolveDmAccess(params: {
+  runtime: IAgentRuntime;
+  config: TelegramPolicyConfig;
+  identifiers: string[];
+  from: User;
+}): Promise<{ allowed: boolean; denialMessage?: string }> {
+  const policy = params.config.dmPolicy ?? "pairing";
+  if (policy === "disabled") {
+    return { allowed: false };
+  }
+  if (policy === "open") {
+    return { allowed: true };
+  }
+  if (policy === "allowlist") {
+    return {
+      allowed: matchesAllowList(params.config.allowFrom, params.identifiers),
+    };
+  }
+
+  const metadata: Record<string, string> = {};
+  if (params.from.username) {
+    metadata.username = params.from.username;
+  }
+  if (params.from.first_name) {
+    metadata.name = params.from.first_name;
+  }
+  const result = await checkPairingAllowed(params.runtime, {
+    channel: "telegram",
+    senderId: String(params.from.id),
+    metadata,
+  });
+  return { allowed: result.allowed, denialMessage: result.replyMessage };
+}
+
+function groupSelected(params: {
+  policy: "open" | "disabled" | "allowlist";
+  groupConfig: TelegramGroupConfig;
+  topicConfig: TelegramTopicConfig;
+}): boolean {
+  if (params.policy === "disabled") {
+    return false;
+  }
+  if (
+    params.groupConfig?.enabled === false ||
+    params.topicConfig?.enabled === false
+  ) {
+    return false;
+  }
+  if (params.policy === "open") {
+    return true;
+  }
+  return Boolean(params.groupConfig);
+}
+
+function groupSenderAllowed(params: {
+  config: TelegramPolicyConfig;
+  groupConfig: TelegramGroupConfig;
+  topicConfig: TelegramTopicConfig;
+  identifiers: string[];
+}): boolean {
+  if (hasEntries(params.topicConfig?.allowFrom)) {
+    return matchesAllowList(params.topicConfig?.allowFrom, params.identifiers);
+  }
+  if (hasEntries(params.groupConfig?.allowFrom)) {
+    return matchesAllowList(params.groupConfig?.allowFrom, params.identifiers);
+  }
+  if (hasEntries(params.config.groupAllowFrom)) {
+    return matchesAllowList(params.config.groupAllowFrom, params.identifiers);
+  }
+  return true;
+}
+
+export async function evaluateTelegramPolicy(params: {
+  runtime: IAgentRuntime;
+  config: TelegramPolicyConfig;
+  message: Message;
+  from: User;
+  chatType: string;
+  chatId: string;
+  threadId?: string;
+  botInfo?: User;
+  forceReply?: boolean;
+  legacyAutoReply?: boolean;
+}): Promise<TelegramPolicyDecision> {
+  if (!hasTypedTelegramPolicyConfig(params.config)) {
+    if (params.forceReply) {
+      return { shouldDispatch: true, reason: "forced" };
+    }
+    return params.legacyAutoReply
+      ? { shouldDispatch: true, reason: "legacy-auto-reply" }
+      : { shouldDispatch: false, reason: "blocked" };
+  }
+
+  const identifiers = senderIdentifiers(params.from);
+  const mention = detectAddressedMention(
+    params.message,
+    params.botInfo?.username,
+  );
+
+  if (params.chatType === "private") {
+    const access = await resolveDmAccess({
+      runtime: params.runtime,
+      config: params.config,
+      identifiers,
+      from: params.from,
+    });
+    return access.allowed
+      ? {
+          shouldDispatch: true,
+          reason: params.forceReply ? "forced" : "dm",
+        }
+      : {
+          shouldDispatch: false,
+          reason: "blocked",
+          denialMessage: access.denialMessage,
+        };
+  }
+
+  const policy = params.config.groupPolicy ?? "allowlist";
+  const groupConfig = resolveGroupConfig(params.config, params.chatId);
+  const topicConfig = resolveTopicConfig(groupConfig, params.threadId);
+  if (!groupSelected({ policy, groupConfig, topicConfig })) {
+    return { shouldDispatch: false, reason: "blocked" };
+  }
+  if (
+    !groupSenderAllowed({
+      config: params.config,
+      groupConfig,
+      topicConfig,
+      identifiers,
+    })
+  ) {
+    return { shouldDispatch: false, reason: "blocked" };
+  }
+
+  if (params.forceReply) {
+    return { shouldDispatch: true, reason: "forced" };
+  }
+
+  const replyToBot = isReplyToBot(params.message, params.botInfo);
+  const requireMention =
+    topicConfig?.requireMention ?? groupConfig?.requireMention ?? true;
+  if (mention.mentioned) {
+    return {
+      shouldDispatch: true,
+      reason: "mention",
+      textOverride: mention.text,
+    };
+  }
+  if (replyToBot) {
+    return { shouldDispatch: true, reason: "reply-to-bot" };
+  }
+  if (!requireMention) {
+    return { shouldDispatch: true, reason: "mention" };
+  }
+  return { shouldDispatch: false, reason: "blocked" };
+}

--- a/plugins/plugin-telegram/src/service.launch-supervision.test.ts
+++ b/plugins/plugin-telegram/src/service.launch-supervision.test.ts
@@ -167,4 +167,33 @@ describe("TelegramService.launchPollerSupervised", () => {
     expect(first.bot.launch).toHaveBeenCalledTimes(1);
     expect(second.bot.launch).toHaveBeenCalledTimes(1);
   });
+
+  it("does not relaunch a poller after its service is stopped", async () => {
+    const { bot, calls } = makeBot();
+    const { service } = makeService();
+    Object.assign(service as unknown as Record<string, unknown>, {
+      accountStates: new Map([
+        [
+          "acct",
+          {
+            accountId: "acct",
+            account: { accountId: "acct", botToken: "tok-stop" },
+            bot,
+          },
+        ],
+      ]),
+    });
+
+    const launched = callLaunch(service, bot, "tok-stop", "acct");
+    calls[0].onLaunch();
+    await launched;
+
+    await service.stop();
+    calls[0].reject(new Error(CONFLICT));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(bot.stop).toHaveBeenCalledWith("service-stop");
+    expect(bot.launch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/plugins/plugin-telegram/src/service.local-bot-api.integration.test.ts
+++ b/plugins/plugin-telegram/src/service.local-bot-api.integration.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Exercises Telegram ingress through real Telegraf long polling against a local
+ * Bot API server. The harness captures serialized HTTP calls while production
+ * middleware, policy, topic recovery, commands, and multi-account ownership run
+ * unchanged; only api.telegram.org itself is replaced.
+ */
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  createUniqueUuid,
+  type HandlerCallback,
+  type IAgentRuntime,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TelegramService } from "./service";
+
+const AGENT_ID = "00000000-0000-4000-8000-000000000001" as UUID;
+const DEFAULT_TOKEN = "100000001:local_default_token";
+
+interface CapturedCall {
+  token: string;
+  method: string;
+  body: Record<string, unknown>;
+  rawBody: string;
+}
+
+class LocalBotApi {
+  readonly calls: CapturedCall[] = [];
+  readonly deliveredUpdateIds = new Set<number>();
+  readonly maxConcurrentPolls = new Map<string, number>();
+  private readonly queuedUpdates = new Map<string, unknown[]>();
+  private readonly activePolls = new Map<string, number>();
+  private server: Server | undefined;
+  private nextMessageId = 700;
+
+  async start(): Promise<string> {
+    this.server = createServer((req, res) => this.handle(req, res));
+    await new Promise<void>((resolve) =>
+      this.server?.listen(0, "127.0.0.1", resolve),
+    );
+    const address = this.server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Local Telegram Bot API did not bind a TCP port");
+    }
+    return `http://127.0.0.1:${(address satisfies AddressInfo).port}`;
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    await new Promise<void>((resolve, reject) =>
+      this.server?.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+
+  enqueue(token: string, update: Record<string, unknown>): void {
+    const queued = this.queuedUpdates.get(token) ?? [];
+    queued.push(update);
+    this.queuedUpdates.set(token, queued);
+  }
+
+  callsFor(method: string, token?: string): CapturedCall[] {
+    return this.calls.filter(
+      (call) => call.method === method && (!token || call.token === token),
+    );
+  }
+
+  private handle(req: IncomingMessage, res: ServerResponse): void {
+    const match = req.url?.match(/^\/bot([^/]+)\/([^?]+)/);
+    if (!match) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    const [, token, method] = match;
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      const rawBody = Buffer.concat(chunks).toString("utf8");
+      let body: Record<string, unknown> = {};
+      try {
+        body = rawBody ? (JSON.parse(rawBody) as Record<string, unknown>) : {};
+      } catch {
+        // error-policy:J3 malformed client input remains visible in rawBody.
+      }
+      this.calls.push({ token, method, body, rawBody });
+      this.respond(token, method, body, res);
+    });
+  }
+
+  private respond(
+    token: string,
+    method: string,
+    body: Record<string, unknown>,
+    res: ServerResponse,
+  ): void {
+    res.setHeader("content-type", "application/json");
+    if (method === "getUpdates") {
+      const active = (this.activePolls.get(token) ?? 0) + 1;
+      this.activePolls.set(token, active);
+      this.maxConcurrentPolls.set(
+        token,
+        Math.max(active, this.maxConcurrentPolls.get(token) ?? 0),
+      );
+      setTimeout(() => {
+        const queued = this.queuedUpdates.get(token) ?? [];
+        const result = body.offset === -1 ? [] : queued.splice(0);
+        for (const update of result as Array<{ update_id?: unknown }>) {
+          if (typeof update.update_id === "number") {
+            this.deliveredUpdateIds.add(update.update_id);
+          }
+        }
+        this.activePolls.set(token, active - 1);
+        res.end(JSON.stringify({ ok: true, result }));
+      }, 20);
+      return;
+    }
+
+    if (method === "getMe") {
+      res.end(
+        JSON.stringify({
+          ok: true,
+          result: {
+            id: Number(token.split(":")[0]),
+            is_bot: true,
+            first_name: "Local Agent",
+            username: `local_${token.split(":")[0]}_bot`,
+          },
+        }),
+      );
+      return;
+    }
+
+    if (method === "sendMessage") {
+      res.end(
+        JSON.stringify({
+          ok: true,
+          result: {
+            message_id: this.nextMessageId++,
+            date: 1_700_000_100,
+            text: body.text ?? "",
+            chat: { id: body.chat_id, type: "supergroup", title: "Ops" },
+            ...(body.message_thread_id
+              ? {
+                  is_topic_message: true,
+                  message_thread_id: body.message_thread_id,
+                }
+              : {}),
+          },
+        }),
+      );
+      return;
+    }
+
+    res.end(JSON.stringify({ ok: true, result: true }));
+  }
+}
+
+type RuntimeHarness = IAgentRuntime & {
+  createMemory: ReturnType<typeof vi.fn>;
+  emitEvent: ReturnType<typeof vi.fn>;
+  ensureConnection: ReturnType<typeof vi.fn>;
+  ensureRoomExists: ReturnType<typeof vi.fn>;
+  ensureWorldExists: ReturnType<typeof vi.fn>;
+  messageService: { handleMessage: ReturnType<typeof vi.fn> };
+};
+
+function createRuntime(args: {
+  apiRoot: string;
+  telegram: Record<string, unknown>;
+  settings: Record<string, string>;
+  memories?: Map<UUID, Memory>;
+}): RuntimeHarness {
+  const memories = args.memories ?? new Map<UUID, Memory>();
+  return {
+    agentId: AGENT_ID,
+    character: {
+      name: "Local Agent",
+      settings: { telegram: args.telegram },
+    },
+    actions: [],
+    getSetting: vi.fn((key: string) => args.settings[key]),
+    getService: vi.fn(() => null),
+    getMemoryById: vi.fn(async (id: UUID) => memories.get(id) ?? null),
+    createMemory: vi.fn(async (memory: Memory) => {
+      if (memory.id) memories.set(memory.id, memory);
+    }),
+    updateMemory: vi.fn(async () => undefined),
+    ensureConnection: vi.fn(async () => undefined),
+    ensureRoomExists: vi.fn(async () => undefined),
+    ensureWorldExists: vi.fn(async () => undefined),
+    emitEvent: vi.fn(),
+    reportError: vi.fn(),
+    messageService: { handleMessage: vi.fn(async () => undefined) },
+  } as unknown as RuntimeHarness;
+}
+
+function sourceMemory(
+  runtime: IAgentRuntime,
+  messageId: number,
+  threadId?: number,
+): Memory {
+  const chatId = "-1001";
+  return {
+    id: createUniqueUuid(runtime, `message:${chatId}:${messageId}`) as UUID,
+    agentId: runtime.agentId,
+    entityId: AGENT_ID,
+    roomId: createUniqueUuid(
+      runtime,
+      threadId === undefined ? chatId : `${chatId}-${threadId}`,
+    ) as UUID,
+    content: { text: "source", source: "telegram" },
+    metadata: {
+      source: "telegram",
+      accountId: "default",
+      messageIdFull: String(messageId),
+      telegramMessageKey: `message:${chatId}:${messageId}`,
+      telegram: {
+        chatId,
+        messageId: String(messageId),
+        ...(threadId === undefined ? {} : { threadId: String(threadId) }),
+      },
+    },
+  };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  description: string,
+  timeoutMs = 3_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function assertNoIngressSideEffects(runtime: RuntimeHarness): void {
+  expect(runtime.ensureConnection).not.toHaveBeenCalled();
+  expect(runtime.ensureRoomExists).not.toHaveBeenCalled();
+  expect(runtime.ensureWorldExists).not.toHaveBeenCalled();
+  expect(runtime.createMemory).not.toHaveBeenCalled();
+  expect(runtime.messageService.handleMessage).not.toHaveBeenCalled();
+  expect(runtime.emitEvent).not.toHaveBeenCalled();
+}
+
+describe("TelegramService local Bot API integration", () => {
+  let api: LocalBotApi;
+  let apiRoot: string;
+  const services: TelegramService[] = [];
+
+  beforeEach(async () => {
+    api = new LocalBotApi();
+    apiRoot = await api.start();
+  });
+
+  afterEach(async () => {
+    for (const service of services.splice(0)) {
+      await service.stop();
+    }
+    await api.stop();
+  });
+
+  it("denies commands, callbacks, and owned-topic reactions before side effects", async () => {
+    const memories = new Map<UUID, Memory>();
+    const runtime = createRuntime({
+      apiRoot,
+      memories,
+      telegram: {
+        apiRoot,
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["42"],
+        groups: {
+          "-1001": {
+            requireMention: false,
+            topics: { "77": { enabled: false, allowFrom: ["42"] } },
+          },
+        },
+      },
+      settings: { TELEGRAM_BOT_TOKEN: DEFAULT_TOKEN },
+    });
+    const source = sourceMemory(runtime, 10, 77);
+    memories.set(source.id as UUID, source);
+    const unownedTopicSource = sourceMemory(runtime, 12);
+    memories.set(unownedTopicSource.id as UUID, unownedTopicSource);
+    const service = await TelegramService.start(runtime);
+    services.push(service);
+    await waitFor(
+      () => api.callsFor("getUpdates", DEFAULT_TOKEN).length > 0,
+      "initial polling",
+    );
+
+    api.enqueue(DEFAULT_TOKEN, {
+      update_id: 1,
+      message: {
+        message_id: 20,
+        date: 1_700_000_000,
+        text: "/tasks",
+        entities: [{ type: "bot_command", offset: 0, length: 6 }],
+        from: { id: 42, is_bot: false, first_name: "Ada" },
+        chat: { id: -9999, type: "supergroup", title: "Other" },
+      },
+    });
+    api.enqueue(DEFAULT_TOKEN, {
+      update_id: 2,
+      callback_query: {
+        id: "callback-2",
+        from: { id: 42, is_bot: false, first_name: "Ada" },
+        chat_instance: "local",
+        data: "foreign",
+        message: {
+          message_id: 21,
+          date: 1_700_000_001,
+          text: "button",
+          chat: { id: -9999, type: "supergroup", title: "Other" },
+        },
+      },
+    });
+    api.enqueue(DEFAULT_TOKEN, {
+      update_id: 3,
+      message_reaction: {
+        chat: {
+          id: -1001,
+          type: "supergroup",
+          title: "Ops",
+          is_forum: true,
+        },
+        message_id: 10,
+        user: { id: 42, is_bot: false, first_name: "Ada" },
+        date: 1_700_000_002,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "👍" }],
+      },
+    });
+    api.enqueue(DEFAULT_TOKEN, {
+      update_id: 4,
+      message_reaction: {
+        chat: {
+          id: -1001,
+          type: "supergroup",
+          title: "Ops",
+          is_forum: true,
+        },
+        message_id: 12,
+        user: { id: 42, is_bot: false, first_name: "Ada" },
+        date: 1_700_000_003,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "?" }],
+      },
+    });
+
+    await waitFor(
+      () => api.deliveredUpdateIds.has(4),
+      "denied updates to cross the polling boundary",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    assertNoIngressSideEffects(runtime);
+    expect(api.callsFor("sendMessage")).toHaveLength(0);
+    expect(api.callsFor("answerCallbackQuery")).toHaveLength(0);
+    expect(api.callsFor("pinChatMessage")).toHaveLength(0);
+  });
+
+  it("recovers reaction topic ownership and replies in the stored topic", async () => {
+    const memories = new Map<UUID, Memory>();
+    const runtime = createRuntime({
+      apiRoot,
+      memories,
+      telegram: {
+        apiRoot,
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["42"],
+        groups: {
+          "-1001": {
+            requireMention: true,
+            topics: { "88": { enabled: true, allowFrom: ["42"] } },
+          },
+        },
+      },
+      settings: { TELEGRAM_BOT_TOKEN: DEFAULT_TOKEN },
+    });
+    const source = sourceMemory(runtime, 11, 88);
+    memories.set(source.id as UUID, source);
+    const service = await TelegramService.start(runtime);
+    services.push(service);
+
+    api.enqueue(DEFAULT_TOKEN, {
+      update_id: 11,
+      message_reaction: {
+        chat: {
+          id: -1001,
+          type: "supergroup",
+          title: "Ops",
+          is_forum: true,
+        },
+        message_id: 11,
+        user: { id: 42, is_bot: false, first_name: "Ada" },
+        date: 1_700_000_011,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "✅" }],
+      },
+    });
+
+    await waitFor(
+      () => runtime.emitEvent.mock.calls.length === 2,
+      "reaction events",
+    );
+    const payload = runtime.emitEvent.mock.calls[0][1] as {
+      message: Memory;
+      callback: HandlerCallback;
+    };
+    expect(payload.message.roomId).toBe(source.roomId);
+    expect(payload.message.content.inReplyTo).toBe(source.id);
+    expect(payload.message.metadata?.telegram).toMatchObject({
+      chatId: "-1001",
+      threadId: "88",
+    });
+
+    await payload.callback({ text: "reaction received" });
+    const send = api.callsFor("sendMessage")[0];
+    expect(send.body).toMatchObject({
+      chat_id: -1001,
+      message_thread_id: 88,
+      reply_parameters: { message_id: 11 },
+    });
+    expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+    expect(runtime.createMemory.mock.calls[0][0].roomId).toBe(source.roomId);
+  });
+
+  it("runs one live poll per distinct account token and rejects shared tokens before HTTP", async () => {
+    const accountTokens = {
+      alerts: "100000002:local_alerts_token",
+      ops: "100000003:local_ops_token",
+    };
+    const runtime = createRuntime({
+      apiRoot,
+      telegram: {
+        accounts: {
+          alerts: { apiRoot, groupPolicy: "disabled" },
+          ops: { apiRoot, groupPolicy: "disabled" },
+        },
+      },
+      settings: {
+        TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify(accountTokens),
+      },
+    });
+    const service = await TelegramService.start(runtime);
+    services.push(service);
+
+    await waitFor(
+      () =>
+        Object.values(accountTokens).every(
+          (token) => api.callsFor("getUpdates", token).length > 0,
+        ),
+      "both account pollers",
+    );
+    expect(service.getBots()).toHaveLength(2);
+    for (const token of Object.values(accountTokens)) {
+      expect(api.maxConcurrentPolls.get(token)).toBe(1);
+    }
+
+    const duplicateRuntime = createRuntime({
+      apiRoot,
+      telegram: {
+        accounts: {
+          first: { apiRoot, groupPolicy: "disabled" },
+          second: { apiRoot, groupPolicy: "disabled" },
+        },
+      },
+      settings: {
+        TELEGRAM_ACCOUNT_TOKENS_JSON: JSON.stringify({
+          first: "100000004:shared_token",
+          second: "100000004:shared_token",
+        }),
+      },
+    });
+    const callsBeforeDuplicate = api.calls.length;
+
+    await expect(TelegramService.start(duplicateRuntime)).rejects.toMatchObject(
+      {
+        code: "TELEGRAM_DUPLICATE_BOT_TOKEN",
+      },
+    );
+    expect(api.calls).toHaveLength(callsBeforeDuplicate);
+  });
+});

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -57,6 +57,7 @@ import {
 } from "./command-registration";
 import { TELEGRAM_SERVICE_NAME } from "./constants";
 import { MessageManager } from "./messageManager";
+import { hasTypedTelegramPolicyConfig } from "./policy";
 import { registerTelegramTaskBoardCommand } from "./task-board";
 import {
   type TelegramEntityPayload,
@@ -1178,6 +1179,14 @@ export class TelegramService extends Service {
       this.getAccountState(accountId)?.account.config.allowedChats;
     if (accountAllowedChats?.length) {
       return accountAllowedChats.includes(chatId);
+    }
+
+    const accountConfig = resolveTelegramAccount(
+      this.runtime,
+      accountId,
+    ).config;
+    if (hasTypedTelegramPolicyConfig(accountConfig)) {
+      return true;
     }
 
     const allowedChats = this.runtime.getSetting("TELEGRAM_ALLOWED_CHATS");

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -14,6 +14,7 @@ import {
   ChannelType,
   type Content,
   createUniqueUuid,
+  ElizaError,
   type Entity,
   EventType,
   type IAgentRuntime,
@@ -168,6 +169,27 @@ type TelegramAccountRuntime = {
 };
 
 const ACTIVE_TELEGRAM_POLLERS = new Map<string, ActiveTelegramPoller>();
+const RETIRED_TELEGRAM_POLLERS = new WeakSet<Telegraf<Context>>();
+
+function assertUniqueTelegramAccountTokens(
+  accounts: ResolvedTelegramAccount[],
+): void {
+  const owners = new Map<string, string>();
+  for (const account of accounts) {
+    if (!account.botToken) {
+      continue;
+    }
+    const existing = owners.get(account.botToken);
+    if (existing) {
+      throw new ElizaError("Telegram accounts must not share a bot token", {
+        code: "TELEGRAM_DUPLICATE_BOT_TOKEN",
+        context: { accountIds: [existing, account.accountId] },
+        severity: "fatal",
+      });
+    }
+    owners.set(account.botToken, account.accountId);
+  }
+}
 
 function getCanonicalOwnerId(runtime: IAgentRuntime): UUID | null {
   for (const key of CANONICAL_OWNER_SETTING_KEYS) {
@@ -298,6 +320,7 @@ export class TelegramService extends Service {
   private botToken: string | null;
   private defaultAccountId = DEFAULT_ACCOUNT_ID;
   private accountStates: Map<string, TelegramAccountRuntime> = new Map();
+  private configuredBots = new WeakSet<Telegraf<Context>>();
 
   /**
    * Constructor for TelegramService class.
@@ -333,29 +356,16 @@ export class TelegramService extends Service {
       return;
     }
 
-    try {
-      const state = this.createAccountRuntime(account);
-      this.setDefaultAccountState(state);
-      logger.debug(
-        {
-          src: "plugin:telegram",
-          agentId: runtime.agentId,
-          accountId: account.accountId,
-        },
-        "TelegramService constructor completed",
-      );
-    } catch (error) {
-      logger.error(
-        {
-          src: "plugin:telegram",
-          agentId: runtime.agentId,
-          error: error instanceof Error ? error.message : String(error),
-        },
-        "Failed to initialize Telegram bot",
-      );
-      this.bot = null;
-      this.messageManager = null;
-    }
+    const state = this.createAccountRuntime(account);
+    this.setDefaultAccountState(state);
+    logger.debug(
+      {
+        src: "plugin:telegram",
+        agentId: runtime.agentId,
+        accountId: account.accountId,
+      },
+      "TelegramService constructor completed",
+    );
   }
 
   private createAccountRuntime(
@@ -518,9 +528,11 @@ export class TelegramService extends Service {
    * @returns {Promise<TelegramService>} A promise that resolves with the initialized TelegramService.
    */
   static async start(runtime: IAgentRuntime): Promise<TelegramService> {
+    const enabledAccounts = listEnabledTelegramAccounts(runtime);
+    assertUniqueTelegramAccountTokens(enabledAccounts);
     const service = new TelegramService(runtime);
 
-    for (const account of listEnabledTelegramAccounts(runtime)) {
+    for (const account of enabledAccounts) {
       if (!service.getAccountState(account.accountId)) {
         service.setDefaultAccountState(service.createAccountRuntime(account));
       }
@@ -539,6 +551,7 @@ export class TelegramService extends Service {
     for (const state of service.accountStates.values()) {
       let retryCount = 0;
       let lastError: Error | null = null;
+      let initialized = false;
 
       while (retryCount < maxRetries) {
         try {
@@ -552,8 +565,6 @@ export class TelegramService extends Service {
             "Starting Telegram bot",
           );
           await service.initializeBot(state);
-          service.setupMiddlewares(state);
-          service.setupMessageHandlers(state);
           await state.bot.telegram.getMe();
 
           logger.success(
@@ -565,6 +576,7 @@ export class TelegramService extends Service {
             },
             "Telegram bot started successfully",
           );
+          initialized = true;
           break;
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error));
@@ -613,17 +625,18 @@ export class TelegramService extends Service {
         }
       }
 
-      if (retryCount >= maxRetries) {
-        logger.error(
-          {
-            src: "plugin:telegram",
-            agentId: runtime.agentId,
+      if (!initialized) {
+        await service.stop();
+        throw new ElizaError("Telegram account failed to initialize", {
+          code: "TELEGRAM_ACCOUNT_INITIALIZATION_FAILED",
+          context: {
             accountId: state.accountId,
+            attempts: retryCount,
             maxRetries,
-            error: lastError?.message,
           },
-          "Initialization failed after all attempts",
-        );
+          cause: lastError ?? undefined,
+          severity: "fatal",
+        });
       }
     }
 
@@ -653,7 +666,21 @@ export class TelegramService extends Service {
         : [];
     if (states.length > 0) {
       for (const state of states) {
-        state.bot.stop("service-stop");
+        RETIRED_TELEGRAM_POLLERS.add(state.bot);
+        try {
+          state.bot.stop("service-stop");
+        } catch (error) {
+          // error-policy:J6 best-effort teardown must continue across accounts.
+          logger.debug(
+            {
+              src: "plugin:telegram",
+              agentId: this.runtime.agentId,
+              accountId: state.accountId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            "Telegram bot was already stopped",
+          );
+        }
         const token = state.account.botToken;
         if (token) {
           const active = ACTIVE_TELEGRAM_POLLERS.get(token);
@@ -667,7 +694,20 @@ export class TelegramService extends Service {
 
     const bot = this.bot;
     if (bot) {
-      bot.stop("service-stop");
+      RETIRED_TELEGRAM_POLLERS.add(bot);
+      try {
+        bot.stop("service-stop");
+      } catch (error) {
+        // error-policy:J6 best-effort teardown for an already-stopped bot.
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Telegram bot was already stopped",
+        );
+      }
       if (this.botToken) {
         const active = ACTIVE_TELEGRAM_POLLERS.get(this.botToken);
         if (active?.bot === bot) {
@@ -702,6 +742,7 @@ export class TelegramService extends Service {
           },
           "Stopping existing Telegram poller before launching a new one",
         );
+        RETIRED_TELEGRAM_POLLERS.add(active.bot);
         try {
           active.bot.stop("replaced-by-new-runtime");
         } catch (error) {
@@ -721,50 +762,52 @@ export class TelegramService extends Service {
       }
     }
 
-    bot.start((ctx) => {
-      const slashStartPayload = {
-        ctx,
-        runtime: this.runtime,
-        source: "telegram",
-        accountId,
-        metadata: { accountId },
-      };
-      this.runtime.emitEvent(
-        TelegramEventTypes.SLASH_START as string,
-        slashStartPayload,
-      );
-    });
+    if (!this.configuredBots.has(bot)) {
+      this.setupMiddlewares(activeState ?? undefined);
 
-    // Register universal slash-command handlers BEFORE launch. Telegraf accepts
-    // command registration any time before launch(), and a matched command
-    // handler that never calls next() terminates the middleware chain — so the
-    // catch-all message handler in setupMessageHandlers does not also process
-    // command messages (no double-processing).
-    const commandMessageManager =
-      activeState?.messageManager ?? this.messageManager ?? undefined;
-    if (commandMessageManager) {
-      const registered = registerTelegramCommandHandlers(
-        bot,
-        this.runtime,
-        commandMessageManager,
-        accountId,
-      );
-      logger.debug(
-        {
-          src: "plugin:telegram",
-          agentId: this.runtime.agentId,
+      bot.start((ctx) => {
+        const slashStartPayload = {
+          ctx,
+          runtime: this.runtime,
+          source: "telegram",
           accountId,
-          commandCount: registered.length,
-        },
-        "Registered universal slash-command handlers",
-      );
-      // #8902: the live, edited-in-place orchestrator task board (`/tasks`).
-      registerTelegramTaskBoardCommand(
-        bot,
-        this.runtime,
-        commandMessageManager,
-        accountId,
-      );
+          metadata: { accountId },
+        };
+        this.runtime.emitEvent(
+          TelegramEventTypes.SLASH_START as string,
+          slashStartPayload,
+        );
+      });
+
+      // Commands sit after policy/discovery middleware and before the catch-all
+      // message handler, so every command is admitted first and handled once.
+      const commandMessageManager =
+        activeState?.messageManager ?? this.messageManager ?? undefined;
+      if (commandMessageManager) {
+        const registered = registerTelegramCommandHandlers(
+          bot,
+          this.runtime,
+          commandMessageManager,
+          accountId,
+        );
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            accountId,
+            commandCount: registered.length,
+          },
+          "Registered universal slash-command handlers",
+        );
+        registerTelegramTaskBoardCommand(
+          bot,
+          this.runtime,
+          commandMessageManager,
+          accountId,
+        );
+      }
+      this.setupMessageHandlers(activeState ?? undefined);
+      this.configuredBots.add(bot);
     }
 
     // Telegraf v4's `bot.launch()` resolves only when polling STOPS — it awaits
@@ -796,6 +839,7 @@ export class TelegramService extends Service {
     // 409s against the lingering one. bot.stop() throws if already stopped, so
     // teardown is best-effort.
     const stopBot = (reason: string): void => {
+      RETIRED_TELEGRAM_POLLERS.add(bot);
       try {
         bot.stop(reason);
       } catch {
@@ -836,6 +880,9 @@ export class TelegramService extends Service {
     const stableRunMs = 60_000;
 
     const ownsToken = (): boolean => {
+      if (RETIRED_TELEGRAM_POLLERS.has(bot)) {
+        return false;
+      }
       if (!botToken) {
         return true;
       }
@@ -978,12 +1025,49 @@ export class TelegramService extends Service {
    */
   private setupMiddlewares(state?: TelegramAccountRuntime): void {
     const bot = state?.bot ?? this.bot;
+    const messageManager = state?.messageManager ?? this.messageManager;
     const accountId = state?.accountId ?? this.defaultAccountId;
-    // Register the authorization middleware
     bot?.use((ctx, next) => this.authorizationMiddleware(ctx, next, accountId));
-
-    // Register the chat and entity management middleware
+    bot?.use((ctx, next) =>
+      this.activationPolicyMiddleware(
+        ctx,
+        next,
+        messageManager ?? undefined,
+        accountId,
+      ),
+    );
     bot?.use((ctx, next) => this.chatAndEntityMiddleware(ctx, next, accountId));
+  }
+
+  private async activationPolicyMiddleware(
+    ctx: Context,
+    next: MiddlewareNext,
+    messageManager: MessageManager | undefined,
+    accountId: string,
+  ): Promise<void> {
+    if (!messageManager) {
+      throw new ElizaError("Telegram message manager is not initialized", {
+        code: "TELEGRAM_MESSAGE_MANAGER_MISSING",
+        context: { accountId },
+        severity: "fatal",
+      });
+    }
+    const admission = await messageManager.admitIngress(ctx);
+    if (!admission.admitted) {
+      await messageManager.sendIngressDenial(ctx, admission);
+      logger.debug(
+        {
+          src: "plugin:telegram",
+          agentId: this.runtime.agentId,
+          accountId,
+          chatId: ctx.chat?.id,
+          reason: admission.decision.reason,
+        },
+        "Telegram update denied before side effects",
+      );
+      return;
+    }
+    await next();
   }
 
   /**
@@ -1031,7 +1115,7 @@ export class TelegramService extends Service {
     next: MiddlewareNext,
     accountId = this.defaultAccountId,
   ): Promise<void> {
-    if (!ctx.chat) {
+    if (!ctx.chat || !ctx.message) {
       return next();
     }
 
@@ -1113,15 +1197,8 @@ export class TelegramService extends Service {
         // Preprocessing runs in the middleware chain; this only dispatches.
         await messageManager?.handleMessage(ctx);
       } catch (error) {
-        logger.error(
-          {
-            src: "plugin:telegram",
-            agentId: this.runtime.agentId,
-            accountId,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "Error handling message",
-        );
+        // error-policy:J7 Telegram's update loop must survive after reporting.
+        this.runtime.reportError("telegram:message", error, { accountId });
       }
     });
 
@@ -1130,15 +1207,8 @@ export class TelegramService extends Service {
       try {
         await messageManager?.handleReaction(ctx);
       } catch (error) {
-        logger.error(
-          {
-            src: "plugin:telegram",
-            agentId: this.runtime.agentId,
-            accountId,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "Error handling reaction",
-        );
+        // error-policy:J7 Telegram's update loop must survive after reporting.
+        this.runtime.reportError("telegram:reaction", error, { accountId });
       }
     });
 
@@ -1148,15 +1218,8 @@ export class TelegramService extends Service {
       try {
         await messageManager?.handleCallbackQuery(ctx);
       } catch (error) {
-        logger.error(
-          {
-            src: "plugin:telegram",
-            agentId: this.runtime.agentId,
-            accountId,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "Error handling callback query",
-        );
+        // error-policy:J7 Telegram's update loop must survive after reporting.
+        this.runtime.reportError("telegram:callback", error, { accountId });
       }
     });
   }

--- a/plugins/plugin-telegram/src/utils.ts
+++ b/plugins/plugin-telegram/src/utils.ts
@@ -10,6 +10,7 @@ import type { Button } from "./types";
 
 // A list of Telegram MarkdownV2 reserved characters that must be escaped
 const TELEGRAM_RESERVED_REGEX = /([_*[\]()~`>#+\-=|{}.!\\])/g;
+const TELEGRAM_MESSAGE_LIMIT = 4096;
 
 /**
  * Escapes plain text for Telegram MarkdownV2.
@@ -202,6 +203,359 @@ export function convertMarkdownToTelegram(markdown: string): string {
   }
 
   return finalResult;
+}
+
+type MarkdownSplitToken =
+  | { kind: "plain"; raw: string }
+  | { kind: "escaped"; raw: string }
+  | { kind: "bold"; marker: "**"; content: string }
+  | { kind: "italic"; marker: "*" | "_"; content: string }
+  | { kind: "strike"; marker: "~~"; content: string }
+  | { kind: "inlineCode"; content: string }
+  | { kind: "fence"; language: string; content: string }
+  | { kind: "link"; text: string; url: string };
+
+function convertedLength(markdown: string): number {
+  return convertMarkdownToTelegram(markdown).length;
+}
+
+function tokenRaw(token: MarkdownSplitToken): string {
+  switch (token.kind) {
+    case "plain":
+    case "escaped":
+      return token.raw;
+    case "bold":
+      return `${token.marker}${token.content}${token.marker}`;
+    case "italic":
+      return `${token.marker}${token.content}${token.marker}`;
+    case "strike":
+      return `${token.marker}${token.content}${token.marker}`;
+    case "inlineCode":
+      return `\`${token.content}\``;
+    case "fence":
+      return `\`\`\`${token.language}\n${token.content}\`\`\``;
+    case "link":
+      return `[${token.text}](${token.url})`;
+  }
+}
+
+function findUnescaped(text: string, needle: string, start: number): number {
+  let index = text.indexOf(needle, start);
+  while (index !== -1) {
+    let slashCount = 0;
+    for (let i = index - 1; i >= 0 && text[i] === "\\"; i -= 1) {
+      slashCount += 1;
+    }
+    if (slashCount % 2 === 0) {
+      return index;
+    }
+    index = text.indexOf(needle, index + needle.length);
+  }
+  return -1;
+}
+
+function tokenizeMarkdownForTelegram(markdown: string): MarkdownSplitToken[] {
+  const tokens: MarkdownSplitToken[] = [];
+  let plain = "";
+  const flushPlain = () => {
+    if (plain) {
+      tokens.push({ kind: "plain", raw: plain });
+      plain = "";
+    }
+  };
+
+  for (let i = 0; i < markdown.length; ) {
+    if (markdown[i] === "\\" && i + 1 < markdown.length) {
+      flushPlain();
+      tokens.push({ kind: "escaped", raw: markdown.slice(i, i + 2) });
+      i += 2;
+      continue;
+    }
+
+    if (markdown.startsWith("```", i)) {
+      const close = markdown.indexOf("```", i + 3);
+      if (close !== -1) {
+        const openingLineEnd = markdown.indexOf("\n", i + 3);
+        if (openingLineEnd !== -1 && openingLineEnd < close) {
+          flushPlain();
+          tokens.push({
+            kind: "fence",
+            language: markdown.slice(i + 3, openingLineEnd),
+            content: markdown.slice(openingLineEnd + 1, close),
+          });
+          i = close + 3;
+          continue;
+        }
+      }
+    }
+
+    if (markdown[i] === "`") {
+      const close = findUnescaped(markdown, "`", i + 1);
+      if (close !== -1) {
+        flushPlain();
+        tokens.push({
+          kind: "inlineCode",
+          content: markdown.slice(i + 1, close),
+        });
+        i = close + 1;
+        continue;
+      }
+    }
+
+    if (markdown[i] === "[") {
+      const textEnd = findUnescaped(markdown, "](", i + 1);
+      if (textEnd !== -1) {
+        const urlEnd = findUnescaped(markdown, ")", textEnd + 2);
+        if (urlEnd !== -1) {
+          flushPlain();
+          tokens.push({
+            kind: "link",
+            text: markdown.slice(i + 1, textEnd),
+            url: markdown.slice(textEnd + 2, urlEnd),
+          });
+          i = urlEnd + 1;
+          continue;
+        }
+      }
+    }
+
+    if (markdown.startsWith("**", i)) {
+      const close = findUnescaped(markdown, "**", i + 2);
+      if (close !== -1) {
+        flushPlain();
+        tokens.push({
+          kind: "bold",
+          marker: "**",
+          content: markdown.slice(i + 2, close),
+        });
+        i = close + 2;
+        continue;
+      }
+    }
+
+    if (markdown.startsWith("~~", i)) {
+      const close = findUnescaped(markdown, "~~", i + 2);
+      if (close !== -1) {
+        flushPlain();
+        tokens.push({
+          kind: "strike",
+          marker: "~~",
+          content: markdown.slice(i + 2, close),
+        });
+        i = close + 2;
+        continue;
+      }
+    }
+
+    if (markdown[i] === "*" && !markdown.startsWith("**", i)) {
+      const close = findUnescaped(markdown, "*", i + 1);
+      if (close !== -1 && !markdown.startsWith("*", close + 1)) {
+        flushPlain();
+        tokens.push({
+          kind: "italic",
+          marker: "*",
+          content: markdown.slice(i + 1, close),
+        });
+        i = close + 1;
+        continue;
+      }
+    }
+
+    if (markdown[i] === "_") {
+      const close = findUnescaped(markdown, "_", i + 1);
+      if (close !== -1) {
+        flushPlain();
+        tokens.push({
+          kind: "italic",
+          marker: "_",
+          content: markdown.slice(i + 1, close),
+        });
+        i = close + 1;
+        continue;
+      }
+    }
+
+    plain += markdown[i];
+    i += 1;
+  }
+
+  flushPlain();
+  return tokens;
+}
+
+function splitPlainMarkdown(text: string, maxLength: number): string[] {
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    let low = 1;
+    let high = remaining.length;
+    let best = 1;
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      if (convertedLength(remaining.slice(0, mid)) <= maxLength) {
+        best = mid;
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+
+    const preferred = Math.max(
+      remaining.lastIndexOf("\n\n", best),
+      remaining.lastIndexOf("\n", best),
+      remaining.lastIndexOf(" ", best),
+    );
+    const splitAt = preferred > 0 ? preferred : best;
+    const chunk = remaining.slice(0, splitAt).trimEnd();
+    if (chunk) {
+      chunks.push(chunk);
+    }
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+  return chunks;
+}
+
+function splitWrappedMarkdown(
+  content: string,
+  wrap: (chunk: string) => string,
+  maxLength: number,
+): string[] {
+  const chunks: string[] = [];
+  let remaining = content;
+  while (remaining.length > 0) {
+    let low = 1;
+    let high = remaining.length;
+    let best = 1;
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      if (convertedLength(wrap(remaining.slice(0, mid))) <= maxLength) {
+        best = mid;
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+
+    const preferred = Math.max(
+      remaining.lastIndexOf("\n\n", best),
+      remaining.lastIndexOf("\n", best),
+      remaining.lastIndexOf(" ", best),
+    );
+    const splitAt = preferred > 0 ? preferred : best;
+    const inner = remaining.slice(0, splitAt).trimEnd();
+    if (inner) {
+      chunks.push(wrap(inner));
+    }
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+  return chunks;
+}
+
+function splitOversizedToken(
+  token: MarkdownSplitToken,
+  maxLength: number,
+): string[] {
+  switch (token.kind) {
+    case "bold":
+      return splitWrappedMarkdown(
+        token.content,
+        (chunk) => `${token.marker}${chunk}${token.marker}`,
+        maxLength,
+      );
+    case "italic":
+      return splitWrappedMarkdown(
+        token.content,
+        (chunk) => `${token.marker}${chunk}${token.marker}`,
+        maxLength,
+      );
+    case "strike":
+      return splitWrappedMarkdown(
+        token.content,
+        (chunk) => `${token.marker}${chunk}${token.marker}`,
+        maxLength,
+      );
+    case "inlineCode":
+      return splitWrappedMarkdown(
+        token.content,
+        (chunk) => `\`${chunk}\``,
+        maxLength,
+      );
+    case "fence":
+      return splitWrappedMarkdown(
+        token.content,
+        (chunk) => `\`\`\`${token.language}\n${chunk}\`\`\``,
+        maxLength,
+      );
+    case "link": {
+      const wrapped = splitWrappedMarkdown(
+        token.text,
+        (chunk) => `[${chunk}](${token.url})`,
+        maxLength,
+      );
+      if (wrapped.length > 0) {
+        return wrapped;
+      }
+      return splitPlainMarkdown(tokenRaw(token), maxLength);
+    }
+    case "plain":
+    case "escaped":
+      return splitPlainMarkdown(token.raw, maxLength);
+  }
+}
+
+/**
+ * Splits source Markdown only at boundaries that remain valid after Telegram
+ * MarkdownV2 conversion. Oversized formatting spans are reopened in each output
+ * chunk so callers can convert every chunk independently before sending.
+ */
+export function splitMarkdownForTelegram(
+  markdown: string,
+  maxLength = TELEGRAM_MESSAGE_LIMIT,
+): string[] {
+  if (!markdown) {
+    return [];
+  }
+  if (convertedLength(markdown) <= maxLength) {
+    return [markdown];
+  }
+
+  const chunks: string[] = [];
+  let current = "";
+  const flush = () => {
+    const trimmed = current.trim();
+    if (trimmed) {
+      chunks.push(trimmed);
+    }
+    current = "";
+  };
+
+  for (const token of tokenizeMarkdownForTelegram(markdown)) {
+    const raw = tokenRaw(token);
+    if (convertedLength(raw) > maxLength) {
+      flush();
+      for (const piece of splitOversizedToken(token, maxLength)) {
+        if (piece && convertedLength(piece) <= maxLength) {
+          chunks.push(piece);
+        }
+      }
+      continue;
+    }
+
+    const next = current ? `${current}${raw}` : raw;
+    if (convertedLength(next) <= maxLength) {
+      current = next;
+      continue;
+    }
+
+    flush();
+    current = raw;
+  }
+
+  flush();
+
+  return chunks.filter(
+    (chunk) => chunk.length > 0 && convertedLength(chunk) <= maxLength,
+  );
 }
 
 /**


### PR DESCRIPTION
# Relates to

Stacked dependency: #17620

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`, `openai-codex/gpt-5.3-codex`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`, `Codex CLI`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Built on the current #17620 head, whose base is current `develop`; zero conflicts.
- [x] Focused tests, production transcription-path tests, plugin typecheck, lint, formatting, and diff checks pass.

# Risks

Medium. This changes Telegram message normalization, outbound formatting, and media dispatch. Risk is bounded to the Telegram plugin and covered by focused bidirectional tests plus the existing production attachment/transcription suite.

# Background

## What does this PR do?

- Preserves Telegram photos, documents, voice/audio/video, captions, UTF-16 entity provenance, thread IDs, and media-group IDs in canonical inbound memories.
- Routes voice notes into `DefaultMessageService.processAttachments` without connector-local transcript placeholders.
- Sends outbound media sequentially with reply/topic fidelity, MarkdownV2 captions, `sendVoice`, canonical sent-memory persistence, and visible unsupported-media failures.
- Splits long rich text against Telegram's final 4096 UTF-16-unit limit while preserving/reopening supported formatting constructs.

## What kind of change is this?

Feature, non-breaking connector fidelity improvement.

# Documentation changes needed?

No user-facing documentation change is required.

# Testing

## Where should a reviewer start?

`plugins/plugin-telegram/src/messageManager.ts`, `plugins/plugin-telegram/src/utils.ts`, and their focused tests.

## Detailed testing steps

```text
bunx vitest run plugins/plugin-telegram/src/messageManager.test.ts plugins/plugin-telegram/src/messageManager.outbound-media.test.ts
Test Files  2 passed (2)
Tests       31 passed (31)

bunx vitest run packages/core/src/services/message.processAttachments.test.ts
Test Files  1 passed (1)
Tests       13 passed (13)

cd plugins/plugin-telegram && bun run typecheck
$ tsc --noEmit -p tsconfig.json
Process exited with code 0
```

Oxlint on the four changed TS files: 0 warnings, 0 errors. Prettier and `git diff --check`: passed.

# Evidence Gate

<!-- evidence-head:b67d5251af1312c94de8baa6004fe07aa522b674 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - connector backend change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - connector backend change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend flow or visual surface changed.
<!-- evidence-row:backend-logs -->
- [x] Focused runtime-path transcript:

<details><summary>Connector and production transcription test output</summary>

```text
plugins/plugin-telegram/src/messageManager.test.ts: 26 tests passed
plugins/plugin-telegram/src/messageManager.outbound-media.test.ts: 5 tests passed
packages/core/src/services/message.processAttachments.test.ts: 13 tests passed, including TRANSCRIPTION model routing
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model selection, action, or provider behavior changed; the connector hands audio to the existing production TRANSCRIPTION model path.
<!-- evidence-row:domain-artifacts -->
- [x] Canonical-memory and Telegram send/persist assertions:

<details><summary>Domain artifact assertion coverage</summary>

```text
Inbound artifact: audio attachment has Telegram account/chat/message/thread provenance and leaves transcript enrichment to core.
Outbound artifact: returned Telegram media messages are sent sequentially with reply/topic fidelity and persisted as canonical memories.
Formatting artifact: every converted MarkdownV2 chunk is non-empty, entity-balanced, and at most 4096 UTF-16 code units.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI or visual text changed.

# Evidence Details

## Audio / voice walkthrough

N/A - no live Telegram bot token or production chat was used from this isolated development lane. The connector-to-runtime boundary test proves voice arrives as an audio attachment without placeholder text, and the existing production core suite proves that exact shape invokes `runtime.useModel(ModelType.TRANSCRIPTION)`.

## Known gaps / failures

- The repository-wide Telegram suite contains local Bot API server tests that cannot bind in this isolated sandbox; focused connector tests and the exact core production transcription suite are green.
- PR is intentionally stacked on #17620. The extra files visible in the develop comparison belong to that dependency. This commit itself changes only four Telegram plugin files.
- No identity-binding, restart delivery/dedupe, workflow, check-policy, production, or auto-merge changes.
