### PR TITLE
fix(discord): avoid readiness diagnostic secret false positive

### DIFF
--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -23,6 +23,7 @@ import {
 	type User,
 } from "discord.js";
 import { isDiscordUserAddressed } from "./addressing";
+import { DISCORD_SERVICE_NAME } from "./constants";
 import { type ChannelDebouncer, createChannelDebouncer } from "./debouncer";
 import {
 	getDiscordMessageCoalesceConfig,
@@ -671,7 +672,7 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 			await waitForDiscordIngressReadiness(service.clientReadyPromise);
 		} catch (error) {
 			service.runtime.reportError(
-				["discord", "gateway-interaction-before-ready"].join(":"),
+				`${DISCORD_SERVICE_NAME}:gateway-interaction-before-ready`,
 				error,
 				{
 					accountId,


### PR DESCRIPTION
## Summary
- reuse `DISCORD_SERVICE_NAME` when composing the interaction-readiness diagnostic key
- avoid the `discord-client-secret` false positive triggered when #17645 became a merge commit
- keep secret scanning fully enabled and unchanged

## Verification
- `bunx biome check plugins/plugin-discord/discord-events.ts`
- `gitleaks detect --config .gitleaks.toml --source . --verbose --no-banner --log-opts '-1 HEAD'` (no leaks)
- exact-head CI gitleaks: passed
- plugin typecheck could not run locally because this clean worktree has no installed `tsc`; CI is authoritative

## Incident
Post-merge develop `196a4d3022c7bc59adae914d91b8ee3df74f28ce` failed `Merge Queue Quality Gate` because gitleaks attributed the diagnostic string assembly to the merge commit. This is the immediate mop-up; the cutover queue stays frozen pending this PR and a green post-merge develop verdict.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend diagnostic composition only; no UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend diagnostic composition only; no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - exact-head gitleaks CI and local scanner output directly verify this static diagnostic composition fix.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - gitleaks scan result is the relevant artifact and passed on the exact head.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

<!-- evidence-head:ec75f6e984bdfffd4b6a50c13cb627c14de14fd4 -->