### PR TITLE
fix(orchestrator): fail closed when Landlock unavailable without operator override

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -10,7 +10,7 @@
  * lease routes the sub-agent's inference through the parent (revoked when the
  * session ends), credential-proxy and model-gateway env is injected while
  * denied environment keys are stripped, and Codex runs get sandbox/approval
- * configuration with a Landlock-availability fallback. A single process-wide
+ * configuration with a Landlock-availability fallback (fail-closed when no operator override). A single process-wide
  * SIGTERM/SIGINT handler fans out to every live instance so multi-tenant hosts,
  * test runners, and hot-reload cycles don't leak per-instance listeners.
  */
@@ -2637,7 +2637,25 @@ export class AcpService extends Service {
         supported: ["read-only", "workspace-write", "danger-full-access"],
       });
     }
-    return mode ?? CODEX_NO_LANDLOCK_SANDBOX_MODE;
+    // Fail closed: when no operator-owned override is configured, do not
+    // silently widen a workspace-scoped task to host-wide filesystem access.
+    // Operators in container/VM-sandboxed deployments must explicitly set
+    // ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE (e.g. "danger-full-access")
+    // to permit this escalation.
+    if (!raw?.trim() || !mode) {
+      throw new ElizaError(
+        "Landlock unavailable and no operator-configured ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE fallback",
+        {
+          code: "CODEX_NO_LANDLOCK_NO_FALLBACK",
+          context: {
+            required:
+              "Set ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE to one of: read-only, workspace-write, danger-full-access",
+          },
+          severity: "fatal",
+        },
+      );
+    }
+    return mode;
   }
 
   private validateManagedCodexAcpModeConfiguration(): void {
@@ -2888,8 +2906,17 @@ export class AcpService extends Service {
       ) {
         throw new Error(message);
       }
-      const fallbackSandboxMode = this.codexNoLandlockSandboxMode();
-      const fallbackMode = this.managedCodexAcpInitialAgentMode(true);
+      let fallbackSandboxMode: CodexSandboxMode;
+      let fallbackMode: CodexAcpInitialAgentMode | undefined;
+      try {
+        fallbackSandboxMode = this.codexNoLandlockSandboxMode();
+        fallbackMode = this.managedCodexAcpInitialAgentMode(true);
+      } catch (fallbackErr) {
+        // error-policy:J6 no operator-configured no-Landlock fallback → fail
+        // closed by surfacing the original attach error, not the missing-config
+        // error, so operators see the actionable Landlock-availability message.
+        throw new Error(message);
+      }
       this.log(
         "warn",
         "Codex ACP Landlock unavailable; retrying with sandbox fallback",


### PR DESCRIPTION
## Problem

The managed Codex ACP path auto-detects Linux Landlock. When Landlock is unavailable, the production spawn path currently falls back implicitly to `danger-full-access` with approval policy `never`.

A coding task started from chat is presented as workspace-scoped, so silently widening it to host-wide filesystem access violates that authorization boundary. This is especially risky for long-running issue-to-PR work on shared hosts.

## Solution

- No implicit transition from `workspace-write` semantics to `danger-full-access`.
- Fail closed when Landlock is unavailable and no operator-owned fallback is configured.
- Permit an explicit fallback only for deployments where an independent container or VM sandbox enforces the workspace boundary.
- Cover the real `AcpService.spawnSession` path, not only a pure policy helper.

## Changes

1. `codexNoLandlockSandboxMode()` now throws `ElizaError` with code `CODEX_NO_LANDLOCK_NO_FALLBACK` when no operator override is configured via `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE`.
2. The retry logic in `spawnNativeSession` catches this error and re-throws the original Landlock attach failure instead of proceeding with an implicit fallback.
3. Operators in container/VM-sandboxed deployments must explicitly set `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` (e.g. to `"danger-full-access"`) to permit the escalation.

## Evidence Gate

| Gate | Status |
|------|--------|
| Unit tests (existing) | N/A (requires bun install) |
| Integration tests | N/A |
| Manual verification | N/A (review for logic correctness) |
| Build passes | N/A |
| Lint passes | N/A |
| No regressions | N/A |
| Docs updated | N/A (code is self-documenting) |

## Provider/Model Footer

```
AI provider/model: Anthropic / claude-mycode
Client / agent tooling: Claude Agent SDK
Contribution skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [harshith8gowda]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-mycode","client":"Claude Agent SDK","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->
```