### PR TITLE
fix(ci): add dependabot/uv/* prefix to trusted PR normalization allowlist

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -160,7 +160,7 @@ jobs:
             exit 1
           fi
           case "$HEAD_REF" in
-            dependabot/npm_and_yarn/*|dependabot/github_actions/*|dependabot/pip/*) ;;
+            dependabot/npm_and_yarn/*|dependabot/github_actions/*|dependabot/pip/*|dependabot/uv/*) ;;
             *)
               echo "::error::unexpected Dependabot ecosystem ref: $HEAD_REF"
               exit 1

--- a/scripts/check-pr-agent-attribution.test.mjs
+++ b/scripts/check-pr-agent-attribution.test.mjs
@@ -597,7 +597,7 @@ describe("PR agent attribution", () => {
     const ecosystemRefs = {
       npm: "dependabot/npm_and_yarn/*",
       "github-actions": "dependabot/github_actions/*",
-      pip: "dependabot/pip/*",
+      pip: ["dependabot/pip/*", "dependabot/uv/*"],
     };
     assert.deepEqual(
       [...new Set(configuredEcosystems)].sort(),
@@ -605,11 +605,16 @@ describe("PR agent attribution", () => {
       "the trusted ref allowlist must be updated for every configured ecosystem",
     );
     for (const ecosystem of configuredEcosystems) {
-      assert.match(
-        normalizer,
-        new RegExp(ecosystemRefs[ecosystem].replaceAll("*", "\\*")),
-        `${ecosystem} Dependabot refs must be explicitly allowed`,
-      );
+      const refs = Array.isArray(ecosystemRefs[ecosystem])
+        ? ecosystemRefs[ecosystem]
+        : [ecosystemRefs[ecosystem]];
+      for (const ref of refs) {
+        assert.match(
+          normalizer,
+          new RegExp(ref.replaceAll("*", "\\*")),
+          `${ecosystem} Dependabot ref ${ref} must be explicitly allowed`,
+        );
+      }
     }
 
     const policyBlock = [


### PR DESCRIPTION
## Problem

The PR normalization workflow in `.github/workflows/pr.yaml` accepts Dependabot npm, GitHub Actions, and pip branch prefixes but rejects the `dependabot/uv/*` prefix generated by the configured pip ecosystem. When Dependabot targets a project using uv lock files under the pip ecosystem, it creates branches prefixed `dependabot/uv/*` instead of `dependabot/pip/*`. The `case` statement in the normalizer rejects these PRs with `::error::unexpected Dependabot ecosystem ref`, blocking them before evidence validation and the Develop PR Gate.

## Fix

1. **`.github/workflows/pr.yaml`** — added `dependabot/uv/*` to the `case` statement allowlist alongside the existing `npm_and_yarn`, `github_actions`, and `pip` prefixes.
2. **`scripts/check-pr-agent-attribution.test.mjs`** — updated the `ecosystemRefs` mapping so `pip` maps to both `dependabot/pip/*` and `dependabot/uv/*`. Updated the assertion loop to handle array-valued ref mappings so both prefixes are verified against the workflow normalizer.

## Evidence

| Row | Status |
|-----|--------|
| Screenshots / video | N/A — CI workflow change, no rendered surface |
| Logs | Verified `pr.yaml` case statement includes `dependabot/uv/*` prefix |
| Real-LLM trajectories | N/A — no model, prompt, or agent behavior changes |
| Domain artifacts | N/A |
| Commands | `grep dependabot/uv .github/workflows/pr.yaml` confirms allowlist entry; test updated to validate both pip and uv refs |
| Tests | `check-pr-agent-attribution.test.mjs` updated — ecosystemRefs now maps pip to both pip/* and uv/*, loop handles array values |
| Typecheck | N/A — no TypeScript changes |

AI provider/model: Anthropic / claude-mycode
Client / agent tooling: Claude Agent SDK
Contribution skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [harshith8gowda]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-mycode","client":"Claude Agent SDK","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->
