### PR TITLE
fix(lifeops): keep internal rooms off connector dispatch

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
@@ -62,10 +62,30 @@ export async function bindScheduledTaskToInboundChat(
     return null;
   }
 
+  // Canonical owner-only audience attestation is shared by connector DMs and
+  // first-party/API turns. A first-party request can target a room whose
+  // canonical source names the owner's preferred connector, so classify the
+  // inbound envelope before consulting that room. Otherwise internal scenario
+  // and API turns are rewritten into unavailable outbound connector sends and
+  // planner idempotency keys leak a synthetic room suffix.
+  const inboundSource =
+    stringField(message.metadata?.source) ??
+    stringField(message.content.source);
+  if (inboundSource === "api" || inboundSource === "client_chat") {
+    return null;
+  }
+
   const room = await runtime.getRoom(message.roomId);
   const source = stringField(room?.source);
   const channelId = stringField(room?.channelId);
   if (!room || !source || !channelId || room.id !== audience.roomId) {
+    return null;
+  }
+  if (
+    source === "api" ||
+    source === "client_chat" ||
+    channelId === room.id
+  ) {
     return null;
   }
 

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
@@ -81,11 +81,7 @@ export async function bindScheduledTaskToInboundChat(
   if (!room || !source || !channelId || room.id !== audience.roomId) {
     return null;
   }
-  if (
-    source === "api" ||
-    source === "client_chat" ||
-    channelId === room.id
-  ) {
+  if (source === "api" || source === "client_chat" || channelId === room.id) {
     return null;
   }
 

--- a/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
@@ -484,6 +484,50 @@ describe("SCHEDULED_TASK action", () => {
       roomId: secondRoomId,
     });
 
+    // Owner-only first-party/API rooms use the same audience attestation as a
+    // connector DM, but must retain their in-app output and public planner key.
+    const apiRoomId = crypto.randomUUID() as UUID;
+    await runtime.createRoom({
+      id: apiRoomId,
+      source: "telegram",
+      // First-party/scenario rooms can inherit the preferred connector source
+      // while retaining the internal room id as their synthetic channel id.
+      channelId: apiRoomId,
+      type: ChannelType.DM,
+      worldId: runtime.agentId,
+    } as Room);
+    await runtime.addParticipant(ownerId, apiRoomId);
+    await runtime.addParticipant(runtime.agentId, apiRoomId);
+    const apiMessage = {
+      ...message,
+      id: crypto.randomUUID() as UUID,
+      roomId: apiRoomId,
+      content: { text: "schedule an internal check", source: "telegram" },
+    } as Memory;
+    await attestDeliveryAudienceFromCanonicalRoom(runtime, apiMessage);
+    const apiIdempotencyKey = `api-${crypto.randomUUID()}`;
+    const apiCreate = await executePlannedToolCall(
+      runtime,
+      { message: apiMessage, userRoles: ["OWNER"], activeContexts: ["tasks"] },
+      {
+        name: "SCHEDULED_TASKS",
+        params: {
+          action: "create",
+          kind: "custom",
+          promptInstructions: "Run the internal check.",
+          trigger: { kind: "manual" },
+          output: { destination: "in_app" },
+          idempotencyKey: apiIdempotencyKey,
+        },
+      },
+    );
+    expect(apiCreate.success).toBe(true);
+    const apiTask = (apiCreate.data as { task?: ScheduledTask } | undefined)
+      ?.task;
+    expect(apiTask?.idempotencyKey).toBe(apiIdempotencyKey);
+    expect(apiTask?.output?.target).toMatch(/^in_app:/);
+    expect(apiTask?.metadata?.chatDeliveryBinding).toBeUndefined();
+
     const before = (await runner.list()).length;
     const deniedMessage = { ...message, id: crypto.randomUUID() as UUID };
     await attestDeliveryAudienceFromCanonicalRoom(runtime, deniedMessage);


### PR DESCRIPTION
## Summary

- prevent owner-only first-party/API rooms from being mistaken for durable external connector DMs
- preserve internal delivery routing and planner idempotency keys when a synthetic room inherits a connector source
- retain account/room-bound delivery for real connector rooms

## Root cause

#17646 correctly bound real connector DMs, but canonical owner-audience attestation is also present on first-party scenario/API rooms. Those synthetic rooms can inherit `source: telegram` while using their internal room UUID as `channelId`, so the new binder rewrote internal scheduled tasks to an unavailable Telegram destination and scoped their public idempotency keys.

## Verification

- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts`
- focused integration: `authorizes before storage and binds a connector task to the attested chat destination` passed
- focused deterministic scenario lane: `deterministic-lifeops-multiday-journey` passed
- focused deterministic scenario lane: `deterministic-lifeops-scheduled-tasks` passed

<!-- evidence-head:edb1ba1e93683987fc8475e3e7e6beec27159c2a -->


<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only scheduler routing fix with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only scheduler routing fix with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic production-path scenarios exercise the behavior; no visual flow changed

<!-- evidence-row:backend-logs -->
- [x] N/A - no production backend deployment was performed; exact-head focused integration and deterministic scenario receipts are listed in Verification

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser network path changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no planner prompt or live-LLM behavior changed; deterministic proxy scenarios test the scheduler seam

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact applies; focused integration and deterministic scenarios cover the affected scheduler routing

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed

## Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported
