### PR TITLE
fix(ci): add dependabot/uv/* to trusted PR normalization allowlist

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -160,7 +160,7 @@ jobs:
             exit 1
           fi
           case "$HEAD_REF" in
-            dependabot/npm_and_yarn/*|dependabot/github_actions/*|dependabot/pip/*) ;;
+            dependabot/npm_and_yarn/*|dependabot/github_actions/*|dependabot/pip/*|dependabot/uv/*) ;;
             *)
               echo "::error::unexpected Dependabot ecosystem ref: $HEAD_REF"
               exit 1


### PR DESCRIPTION
## Summary

Adds `dependabot/uv/*` to the trusted Dependabot branch prefix allowlist in the `normalize-dependabot-body` job case statement.

## Problem

The `pr.yaml` workflow `normalize-dependabot-body` job verifies Dependabot PR identity. The case statement only accepts `dependabot/npm_and_yarn/*`, `dependabot/github_actions/*`, and `dependabot/pip/*` but rejects `dependabot/uv/*` — a valid pip-ecosystem prefix. This causes uv-group PRs to fail normalization and blocks the Develop PR Gate.

## Fix

Add `dependabot/uv/*` to the case statement allowlist.

## Evidence Gate

<!-- evidence-head:placeholder -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - CI configuration change; no UI touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI configuration change; no application runtime affected.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - CI configuration change; no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - CI configuration change; no backend path executed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - CI configuration change; no frontend behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - CI configuration change; no LLM invoked.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - CI configuration change; no domain artifacts.

## Contribution provenance

<!-- attribution-row:provider -->
- AI provider/model: Anthropic / claude-mycode
<!-- attribution-row:client -->
- Client / agent tooling: Claude Agent SDK
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

— [harshith8gowda]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-mycode","client":"Claude Agent SDK","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->