### PR TITLE
fix(eliza-computer): derive leaderboard freshness at read time and unblock scheduled refreshes

### DIFF
--- a/.github/workflows/eliza-computer.yml
+++ b/.github/workflows/eliza-computer.yml
@@ -43,9 +43,15 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: eliza-computer-${{ github.event.pull_request.number || github.ref }}
-  # Quality-only PR supersessions may cancel. A trusted develop release must
-  # finish its deployment and byte verification before a newer run starts.
+  # PR runs supersede one another inside their own pull request. Trusted
+  # develop runs (push, schedule, workflow_dispatch) each use a unique group so
+  # a deploy waiting on the eliza-army-production environment can never
+  # queue-cancel newer scheduled quality runs; that interaction previously held
+  # the published contribution data stale for days while every six-hour
+  # refresh was cancelled behind one unapproved deploy. Production release
+  # ordering is still serialized by the deploy job's dedicated
+  # eliza-computer-production group and its post-approval freshness guard.
+  group: eliza-computer-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
@@ -224,6 +230,41 @@ jobs:
         with:
           name: eliza-computer-pages-${{ github.run_id }}
           path: packages/eliza-computer/dist
+
+      - name: Refuse to regress the published data snapshot
+        run: |
+          set -euo pipefail
+          artifact_ms="$(
+            node -e 'const value = JSON.parse(require("node:fs").readFileSync("packages/eliza-computer/dist/data/leaderboard.json", "utf8")); const parsed = Date.parse(value.generatedAt); if (!Number.isFinite(parsed)) throw new TypeError("artifact leaderboard.generatedAt is invalid"); process.stdout.write(String(parsed));'
+          )"
+          now_ms="$(node -e 'process.stdout.write(Date.now().toString())')"
+          if [ "$(( now_ms - artifact_ms ))" -gt "$(( 8 * 60 * 60 * 1000 ))" ]; then
+            echo "::warning::This release ships a contribution snapshot older than 8 hours. Approve or dispatch the newest run for fresher data."
+          fi
+          live_response="$RUNNER_TEMP/eliza-army-live-leaderboard.json"
+          live_status="$(
+            curl --silent --show-error \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --header "Cache-Control: no-cache" \
+              --output "$live_response" \
+              --write-out "%{http_code}" \
+              "https://eliza.army/data/leaderboard.json?release-guard=$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          )" || live_status="unreachable"
+          if [ "$live_status" != "200" ]; then
+            echo "::notice::The live snapshot is not readable (status $live_status); releasing the verified bundle."
+            exit 0
+          fi
+          if ! live_ms="$(
+            node -e 'const value = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")); const parsed = Date.parse(value.generatedAt); if (!Number.isFinite(parsed)) throw new TypeError("live leaderboard.generatedAt is invalid"); process.stdout.write(String(parsed));' "$live_response"
+          )"; then
+            echo "::notice::The live snapshot is unparseable; releasing the verified bundle."
+            exit 0
+          fi
+          if [ "$live_ms" -gt "$artifact_ms" ]; then
+            echo "::error::The live contribution snapshot is newer than this run's artifact. A superseded release must not regress published data; approve or dispatch the newest run instead."
+            exit 1
+          fi
 
       - name: Require live release-input equivalence
         run: |

--- a/packages/eliza-computer/AGENTS.md
+++ b/packages/eliza-computer/AGENTS.md
@@ -104,7 +104,9 @@ one complete transaction.
 - Cap review/comment awards by actor and artifact.
 - Model disclosure is reported provenance, not proof, and never adds points.
 - Every public snapshot records its repository, window, rule version,
-  generation time, source cutoff, and any staleness.
+  generation time, and source cutoff. Staleness is never persisted in the
+  snapshot; consumers derive it from `generatedAt` at read time because a
+  generation-time flag cannot describe how long a deployed artifact has aged.
 
 ## Work-candidate selection contract
 

--- a/packages/eliza-computer/CLAUDE.md
+++ b/packages/eliza-computer/CLAUDE.md
@@ -104,7 +104,9 @@ one complete transaction.
 - Cap review/comment awards by actor and artifact.
 - Model disclosure is reported provenance, not proof, and never adds points.
 - Every public snapshot records its repository, window, rule version,
-  generation time, source cutoff, and any staleness.
+  generation time, and source cutoff. Staleness is never persisted in the
+  snapshot; consumers derive it from `generatedAt` at read time because a
+  generation-time flag cannot describe how long a deployed artifact has aged.
 
 ## Work-candidate selection contract
 

--- a/packages/eliza-computer/scripts/deployment-contract.test.mjs
+++ b/packages/eliza-computer/scripts/deployment-contract.test.mjs
@@ -90,8 +90,14 @@ describe("eliza.army deployment contract", () => {
     expect(workflow).toContain(
       `cancel-in-progress: ${"$"}{{ github.event_name == 'pull_request' }}`,
     );
+    // Trusted develop runs must never share a workflow-level concurrency
+    // group: a deploy waiting on environment approval would queue-cancel
+    // every newer scheduled quality run and freeze the published data.
+    expect(workflow).toContain(
+      `group: eliza-computer-${"$"}{{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}`,
+    );
     expect(workflow).not.toContain(
-      `group: eliza-computer-${"$"}{{ github.event.pull_request.number || github.ref }}\n  cancel-in-progress: true`,
+      `group: eliza-computer-${"$"}{{ github.event.pull_request.number || github.ref }}`,
     );
     expect(deployJob).toContain(
       "github.event_name == 'push' && github.ref == 'refs/heads/develop'",
@@ -109,6 +115,41 @@ describe("eliza.army deployment contract", () => {
     expect(deployJob).toContain("group: eliza-computer-production");
     expect(deployJob).toContain("cancel-in-progress: false");
     expect(deployJob).toContain("name: eliza-army-production");
+  });
+
+  it("never regresses the published contribution snapshot", () => {
+    // Independent develop runs release in approval order, not run order, so
+    // the deploy must refuse to overwrite newer live data with an older
+    // artifact and must read freshness from generatedAt at release time.
+    const guardStep = deployJob.slice(
+      deployJob.indexOf(
+        "- name: Refuse to regress the published data snapshot",
+      ),
+      deployJob.indexOf("- name: Require live release-input equivalence"),
+    );
+    expect(guardStep).toContain(
+      "packages/eliza-computer/dist/data/leaderboard.json",
+    );
+    expect(guardStep).toContain("https://eliza.army/data/leaderboard.json");
+    expect(guardStep).toContain('--header "Cache-Control: no-cache"');
+    expect(guardStep).toContain(
+      "A superseded release must not regress published data",
+    );
+    expect(guardStep).toContain('if [ "$live_ms" -gt "$artifact_ms" ]; then');
+    // The guard runs after the artifact download and before any Cloudflare
+    // credential is referenced.
+    const downloadIndex = deployJob.indexOf(
+      "- name: Download verified Pages bundle",
+    );
+    const guardIndex = deployJob.indexOf(
+      "- name: Refuse to regress the published data snapshot",
+    );
+    const credentialIndex = deployJob.indexOf(
+      "- name: Require scoped Cloudflare credentials",
+    );
+    expect(downloadIndex).toBeGreaterThan(-1);
+    expect(guardIndex).toBeGreaterThan(downloadIndex);
+    expect(credentialIndex).toBeGreaterThan(guardIndex);
   });
 
   it("has no candidate-controlled production release path", () => {

--- a/packages/eliza-computer/scripts/evidence-contract.mjs
+++ b/packages/eliza-computer/scripts/evidence-contract.mjs
@@ -118,14 +118,16 @@ export function assertLiveLedgerReady(
       : contents,
     "leaderboard",
   );
-  if (snapshot.schemaVersion !== "1") {
-    throw new TypeError("leaderboard.schemaVersion must be 1");
+  if (snapshot.schemaVersion !== "2") {
+    throw new TypeError("leaderboard.schemaVersion must be 2");
   }
   if (snapshot.repository !== "elizaOS/eliza") {
     throw new TypeError("leaderboard.repository must be elizaOS/eliza");
   }
-  if (snapshot.stale !== false) {
-    throw new TypeError("leaderboard.stale must be false");
+  if ("stale" in snapshot) {
+    throw new TypeError(
+      "leaderboard must not persist a staleness claim; freshness is derived from generatedAt",
+    );
   }
   const generatedAt = asTimestamp(
     snapshot.generatedAt,

--- a/packages/eliza-computer/scripts/evidence-contract.test.mjs
+++ b/packages/eliza-computer/scripts/evidence-contract.test.mjs
@@ -22,10 +22,9 @@ const now = Date.parse("2026-07-30T20:00:00.000Z");
 
 function liveLedger(overrides = {}) {
   return {
-    schemaVersion: "1",
+    schemaVersion: "2",
     repository: "elizaOS/eliza",
     generatedAt: "2026-07-30T19:58:00.000Z",
-    stale: false,
     source: {
       provider: "github-graphql",
       fetchedAt: "2026-07-30T19:57:59.000Z",

--- a/packages/eliza-computer/src/App.tsx
+++ b/packages/eliza-computer/src/App.tsx
@@ -866,6 +866,18 @@ export function App() {
       (clock - Date.parse(snapshot.generatedAt)) / (60 * 60 * 1000);
     return ageHours > 8 ? "stale" : "fresh";
   }, [clock, snapshot]);
+  const snapshotAge = useMemo(() => {
+    if (!snapshot) {
+      return undefined;
+    }
+    const ageMs = Math.max(0, clock - Date.parse(snapshot.generatedAt));
+    const ageHours = Math.floor(ageMs / (60 * 60 * 1000));
+    if (ageHours < 24) {
+      return `${ageHours} ${ageHours === 1 ? "hour" : "hours"}`;
+    }
+    const ageDays = Math.floor(ageHours / 24);
+    return `${ageDays} ${ageDays === 1 ? "day" : "days"}`;
+  }, [clock, snapshot]);
 
   return (
     <>
@@ -951,6 +963,9 @@ export function App() {
                 PRs
               </span>
               <span>Updated {formatDate(snapshot.generatedAt, true)}</span>
+              {freshness === "stale" ? (
+                <span>Data is {snapshotAge} old</span>
+              ) : null}
             </>
           ) : dataState.status === "error" ? (
             <>

--- a/packages/eliza-computer/src/lib/leaderboard.test.ts
+++ b/packages/eliza-computer/src/lib/leaderboard.test.ts
@@ -2167,7 +2167,6 @@ describe("deduplication and public schema", () => {
     expect(snapshot).toMatchObject({
       repository: LEADERBOARD_REPOSITORY,
       ruleVersion: SCORE_RULE_VERSION,
-      stale: false,
       source: {
         provider: "github-graphql",
         counts: { openIssues: 1, openPullRequests: 1 },
@@ -2246,6 +2245,24 @@ describe("deduplication and public schema", () => {
 
     expect(() => assertLeaderboardSnapshot(malformed)).toThrow(
       `snapshot.repository must be ${LEADERBOARD_REPOSITORY}`,
+    );
+  });
+
+  it("rejects any persisted staleness claim so freshness stays consumer-derived", () => {
+    // A generation-time stale flag lies as soon as the deployed artifact
+    // outlives its build: the live site served stale:false for days while the
+    // snapshot itself was generated 2026-08-01. Freshness must be derived by
+    // the consumer from generatedAt, never trusted from the producer.
+    const snapshot = createLeaderboardSnapshot(input());
+    expect(snapshot).not.toHaveProperty("stale");
+
+    const claimingFresh: unknown = { ...snapshot, stale: false };
+    expect(() => assertLeaderboardSnapshot(claimingFresh)).toThrow(
+      "must not persist a staleness claim",
+    );
+    const claimingStale: unknown = { ...snapshot, stale: true };
+    expect(() => assertLeaderboardSnapshot(claimingStale)).toThrow(
+      "must not persist a staleness claim",
     );
   });
 

--- a/packages/eliza-computer/src/lib/leaderboard.ts
+++ b/packages/eliza-computer/src/lib/leaderboard.ts
@@ -5,7 +5,7 @@
  */
 
 export const LEADERBOARD_REPOSITORY = "elizaOS/eliza" as const;
-export const LEADERBOARD_SCHEMA_VERSION = "1" as const;
+export const LEADERBOARD_SCHEMA_VERSION = "2" as const;
 export const SCORE_RULE_VERSION = "eliza-computer-v4" as const;
 export const SCORE_WINDOW_DAYS = 30;
 export const VERIFICATION_WINDOW_DAYS = 7;
@@ -396,7 +396,6 @@ export interface LeaderboardSnapshot {
   ruleVersion: typeof SCORE_RULE_VERSION;
   generatedAt: string;
   sourceUpdatedAt: string;
-  stale: false;
   window: {
     days: number;
     from: string;
@@ -2289,7 +2288,6 @@ export function createLeaderboardSnapshot(
     ruleVersion: SCORE_RULE_VERSION,
     generatedAt: input.generatedAt,
     sourceUpdatedAt: latestSourceUpdate(input),
-    stale: false,
     window: {
       days: SCORE_WINDOW_DAYS,
       from: input.windowFrom,
@@ -3296,8 +3294,10 @@ export function assertLeaderboardSnapshot(
   if (snapshot.ruleVersion !== SCORE_RULE_VERSION) {
     throw new Error(`snapshot.ruleVersion must be ${SCORE_RULE_VERSION}`);
   }
-  if (snapshot.stale !== false) {
-    throw new Error("A freshly generated snapshot must set stale=false");
+  if ("stale" in snapshot) {
+    throw new Error(
+      "snapshot must not persist a staleness claim; consumers derive freshness from generatedAt",
+    );
   }
   assertIsoTimestamp(snapshot.generatedAt, "snapshot.generatedAt");
   assertIsoTimestamp(snapshot.sourceUpdatedAt, "snapshot.sourceUpdatedAt");

--- a/packages/eliza-computer/tests/app.test.tsx
+++ b/packages/eliza-computer/tests/app.test.tsx
@@ -365,6 +365,44 @@ describe("App", () => {
     expect(screen.getByText("Snapshot update delayed")).toBeInTheDocument();
   });
 
+  it("renders a days-old snapshot as delayed with its age on first load", async () => {
+    // Regression: the live site served a 2026-08-01 snapshot for days while
+    // its embedded generation-time flag claimed freshness. The browser must
+    // derive staleness from generatedAt relative to now and say how old the
+    // data is, regardless of any producer-side claim.
+    vi.useFakeTimers();
+    const now = new Date("2026-08-04T02:00:00.000Z");
+    vi.setSystemTime(now);
+    const snapshot = snapshotFixture();
+    const generatedAt = "2026-08-01T19:18:35.643Z";
+    snapshot.generatedAt = generatedAt;
+    snapshot.sourceUpdatedAt = generatedAt;
+    snapshot.source.fetchedAt = generatedAt;
+    for (const item of [
+      ...snapshot.workQueue.issues,
+      ...snapshot.workQueue.pullRequests,
+    ]) {
+      item.createdAt = generatedAt;
+      item.updatedAt = generatedAt;
+    }
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => structuredClone(snapshot),
+    } as Response);
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Snapshot update delayed")).toBeInTheDocument();
+    expect(screen.getByText("Data is 2 days old")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Latest GitHub snapshot"),
+    ).not.toBeInTheDocument();
+  });
+
   it("accepts a valid snapshot when the visitor clock is behind", async () => {
     vi.useFakeTimers();
     const snapshot = snapshotFixture();

--- a/packages/eliza-computer/tests/fixtures.ts
+++ b/packages/eliza-computer/tests/fixtures.ts
@@ -16,12 +16,11 @@ export function snapshotFixture(): LeaderboardSnapshot {
     kind: "User",
   };
   return {
-    schemaVersion: "1",
+    schemaVersion: "2",
     repository: "elizaOS/eliza",
     ruleVersion: "eliza-computer-v4",
     generatedAt,
     sourceUpdatedAt: generatedAt,
-    stale: false,
     window: {
       days: 30,
       from: "2026-06-30T00:00:00.000Z",

--- a/packages/skills/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/packages/skills/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -297,23 +297,78 @@ function compareComment(left, right) {
 }
 
 export function parsePaginatedJson(output) {
-  const parsed = JSON.parse(output);
-  if (!Array.isArray(parsed)) {
-    throw new TypeError("gh --slurp output must be an array of pages");
+  // `gh api --paginate` prints each page as its own top-level JSON array,
+  // concatenated back to back. This scanner splits those top-level arrays
+  // without gh's newer `--slurp` flag (added in gh 2.48.0), so the inventory
+  // works on every GitHub CLI that supports `--paginate`, including
+  // distribution-packaged releases such as 2.45.0.
+  const text = output.trim();
+  if (text.length === 0) {
+    return [];
   }
-  return parsed.flatMap((page, index) => {
-    if (!Array.isArray(page)) {
-      throw new TypeError(`gh page ${index + 1} must be an array`);
+  const pages = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        inString = false;
+      }
+      continue;
     }
-    return page;
-  });
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "[" || character === "{") {
+      if (depth === 0) {
+        if (character !== "[") {
+          throw new TypeError(
+            `gh page ${pages.length + 1} must be an array`,
+          );
+        }
+        start = index;
+      }
+      depth += 1;
+      continue;
+    }
+    if (character === "]" || character === "}") {
+      depth -= 1;
+      if (depth < 0) {
+        throw new TypeError("gh api output is not balanced JSON");
+      }
+      if (depth === 0) {
+        const page = JSON.parse(text.slice(start, index + 1));
+        if (!Array.isArray(page)) {
+          throw new TypeError(`gh page ${pages.length + 1} must be an array`);
+        }
+        pages.push(page);
+        start = -1;
+      }
+      continue;
+    }
+    if (depth === 0 && !/\s/.test(character)) {
+      throw new TypeError("gh api output must contain only JSON arrays");
+    }
+  }
+  if (depth !== 0 || inString) {
+    throw new TypeError("gh api output is not balanced JSON");
+  }
+  return pages.flat();
 }
 
 export function readGhPages(endpoint, spawn = spawnSync) {
   if (typeof endpoint !== "string" || endpoint.length === 0) {
     throw new TypeError("GitHub endpoint must be a non-empty string");
   }
-  const args = ["api", "--method", "GET", "--paginate", "--slurp", endpoint];
+  const args = ["api", "--method", "GET", "--paginate", endpoint];
   const result = spawn("gh", args, {
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,

--- a/packages/skills/test/contribute-to-eliza.test.ts
+++ b/packages/skills/test/contribute-to-eliza.test.ts
@@ -328,13 +328,26 @@ describe("live report parsing", () => {
     }
   });
 
-  it("flattens paginated gh output and rejects malformed pages", () => {
+  it("flattens concatenated --paginate output without gh --slurp", () => {
+    // gh api --paginate (without the 2.48.0-only --slurp flag) prints each
+    // page as its own top-level JSON array, back to back.
     assert.deepStrictEqual(
-      parsePaginatedJson('[[{"number":1}],[{"number":2}]]'),
+      parsePaginatedJson('[{"number":1}]\n[{"number":2}]'),
       [{ number: 1 }, { number: 2 }],
     );
-    assert.throws(() => parsePaginatedJson('{"number":1}'), /array of pages/);
-    assert.throws(() => parsePaginatedJson('[[{"number":1}],{}]'), /page 2/);
+    assert.deepStrictEqual(
+      parsePaginatedJson('[{"number":1}][{"number":2},{"number":3}]'),
+      [{ number: 1 }, { number: 2 }, { number: 3 }],
+    );
+    assert.deepStrictEqual(parsePaginatedJson("[]"), []);
+    assert.deepStrictEqual(parsePaginatedJson(""), []);
+    assert.deepStrictEqual(
+      parsePaginatedJson('[{"title":"brackets ][ inside strings"}]'),
+      [{ title: "brackets ][ inside strings" }],
+    );
+    assert.throws(() => parsePaginatedJson('{"number":1}'), /must be an array/);
+    assert.throws(() => parsePaginatedJson('[{"number":1}]{}'), /page 2/);
+    assert.throws(() => parsePaginatedJson('[{"number":1}'), /not balanced/);
   });
 
   it("accepts exact provider/model pairs and rejects placeholders", () => {
@@ -695,7 +708,7 @@ describe("live report behavior", () => {
         invocation = { command, args, options };
         return {
           status: 0,
-          stdout: '[[{"number":1}],[{"number":2}]]',
+          stdout: '[{"number":1}]\n[{"number":2}]',
           stderr: "",
         };
       },
@@ -703,13 +716,15 @@ describe("live report behavior", () => {
 
     assert.deepStrictEqual(pages, [{ number: 1 }, { number: 2 }]);
     assert.strictEqual(invocation?.command, "gh");
-    assert.deepStrictEqual(invocation?.args.slice(0, 5), [
+    assert.deepStrictEqual(invocation?.args.slice(0, 4), [
       "api",
       "--method",
       "GET",
       "--paginate",
-      "--slurp",
     ]);
+    // The 2.48.0-only --slurp flag must stay absent so packaged GitHub CLI
+    // releases (for example Ubuntu's gh 2.45.0) can run the inventory.
+    assert.ok(!invocation?.args.includes("--slurp"));
     assert.ok(
       !invocation?.args.some((argument) => /POST|PATCH|DELETE/.test(argument)),
     );


### PR DESCRIPTION
## Problem

https://eliza.army has served a contribution snapshot generated **2026-08-01T19:18:35Z** for days while its JSON claimed `"stale": false`. Two independent defects:

### Defect A (honesty): staleness was computed at generation time

`createLeaderboardSnapshot` persisted `stale: false` into the artifact. That flag describes the moment of generation, not the age of the deployed file, so the live site's data could (and did) claim freshness indefinitely. Live evidence at audit time (2026-08-04):

```
generatedAt: 2026-08-01T19:18:35.643Z
stale: false        <- days old, still claiming fresh
```

### Defect B (pipeline): scheduled refreshes cancelled each other behind the environment gate

All trusted develop runs shared the workflow-level concurrency group `eliza-computer-${{ github.ref }}`. The deploy job waits on the `eliza-army-production` environment (required reviewer). While one deploy sat waiting for approval, it held the group, and GitHub queue-cancelled every newer scheduled run. Run history (`gh run list -w eliza-computer.yml`):

- 30714323956 push **success** 2026-08-01 (last data that shipped)
- 30726162329 schedule **cancelled** (quality succeeded 08-02 00:57, deploy waited ~2 days, then cancelled)
- 30737242293, 30748233773, 30761486773, 30775659078, 30793594516, 30817368006, 30843325185 schedule **cancelled** (every 6h refresh 08-02 through 08-03)
- 30865642477 push **cancelled** 08-04
- 30867060842 schedule **waiting** on the environment at audit time

Fresh snapshots were generated successfully on every run and then thrown away.

## Fix

**A. Freshness is now consumer-derived, never persisted.**
- `stale` removed from the snapshot schema (bumped to `schemaVersion: "2"`); `assertLeaderboardSnapshot` and the evidence contract now **reject** any persisted staleness claim so it cannot come back.
- The browser already derived `fresh`/`stale` from `generatedAt` vs now; it now also renders the concrete data age ("Data is 2 days old") next to the delayed banner so visitors see how old the numbers are.

**B. Trusted develop runs no longer share a cancellable group.**
- Workflow concurrency: PR runs keep per-PR supersession; push/schedule/dispatch runs get per-run groups so a deploy waiting for environment approval can never queue-cancel newer quality runs.
- Production ordering stays serialized by the deploy job's existing `eliza-computer-production` group (`cancel-in-progress: false`).
- Because independent runs now release in approval order rather than run order, a new pre-credential deploy step compares the artifact's `generatedAt` with the live `/data/leaderboard.json` and **fails the release if it would regress published data** with an older snapshot. It runs before any Cloudflare secret is referenced.

None of the #17424 hardening invariants are weakened: deploys remain develop-only with exact-SHA checkout assertions, frozen lockfile, no candidate promotion, live release-input equivalence checks, and post-deploy byte verification. The deployment contract test locks the new concurrency shape and the regression guard's position before credentials.

**Rolled in: gh CLI compatibility for the skill inventory.**
The skill's first required read-only step failed on packaged GitHub CLIs (`unknown flag: --slurp`, e.g. Ubuntu's gh 2.45.0; `--slurp` only exists since gh 2.48.0). `readGhPages` now uses plain `gh api --paginate` and parses the concatenated top-level JSON arrays itself, with string-aware page splitting. Verified end to end on gh 2.45.0: the previously failing `live-report.mjs` inventory now completes against live elizaOS/eliza (393 open issues / 77 PRs paginated, exit 0).

## Proof

Bidirectional: the new tests fail on the old implementation and pass on the new one (verified by stashing the fix and re-running).

- `rejects any persisted staleness claim so freshness stays consumer-derived` - fails before (snapshot had `stale: false`), passes after
- `renders a days-old snapshot as delayed with its age on first load` - reproduces the exact live failure (generatedAt 2026-08-01, clock 2026-08-04) and asserts the delayed banner + age render
- deployment contract: `keeps every release path restricted to develop` (new concurrency assertions) and `never regresses the published contribution snapshot` - both fail against the old workflow
- skill: pagination tests rewritten for slurp-free output, plus a lock that `--slurp` stays absent

Runs: `packages/eliza-computer` vitest 162/162, typecheck, biome format+lint clean, build, Playwright e2e 28/28 against the built bundle with a freshly generated real snapshot (30 leaders, 121 score events). `packages/skills` contribute-to-eliza suite 18/18. `bun install --frozen-lockfile`.

Live verification of the pipeline fix (first post-merge scheduled run shipping while an older deploy waits) requires an approved production release, which only a maintainer can do.

AI provider/model: Anthropic / claude-fable-5
