### PR TITLE
fix(scripts): replace rg with git ls-files in packageJsonPaths

### DIFF
--- a/packages/scripts/check-live-test-artifact-coverage.mjs
+++ b/packages/scripts/check-live-test-artifact-coverage.mjs
@@ -147,11 +147,18 @@ function parseArgs(argv) {
 }
 
 function packageJsonPaths() {
-  const completed = spawnSync("rg", ["--files", "-g", "package.json"], {
+  const completed = spawnSync("git", ["ls-files", "*package.json"], {
     cwd: REPO_ROOT,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
+  if (completed.error) {
+    throw new Error(
+      completed.error.code === "ENOENT"
+        ? "git is required but was not found on PATH"
+        : `failed to list package.json files: ${completed.error.message}`,
+    );
+  }
   if (completed.status !== 0) {
     throw new Error(completed.stderr || "failed to list package.json files");
   }

--- a/packages/scripts/check-live-test-artifact-coverage.mjs
+++ b/packages/scripts/check-live-test-artifact-coverage.mjs
@@ -147,6 +147,9 @@ function parseArgs(argv) {
 }
 
 function packageJsonPaths() {
+  // `*package.json` is a suffix match in git's pathspec, so it would also pick
+  // up a stray `foo-package.json`. The basename filter below keeps the result
+  // identical to the `rg -g package.json` this replaces.
   const completed = spawnSync("git", ["ls-files", "*package.json"], {
     cwd: REPO_ROOT,
     encoding: "utf8",
@@ -166,6 +169,7 @@ function packageJsonPaths() {
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean)
+    .filter((file) => path.posix.basename(file) === "package.json")
     .filter(
       (file) =>
         !file.includes("/node_modules/") &&


### PR DESCRIPTION
## Summary

Replaces undeclared `rg` (ripgrep) dependency with `git ls-files` in `check-live-test-artifact-coverage.mjs`. The script was shelling out to `rg` without declaring it as a dependency, and masked the actual error when `rg` was missing (reported generic "failed to list package.json files" instead of naming the missing binary).

## Problem

`packages/scripts/check-live-test-artifact-coverage.mjs:149-157` used `spawnSync("rg", ["--files", "-g", "package.json"])` which:
- `rg` is an undeclared dependency (only `spawnSync("rg")` in packages/scripts)
- When `rg` absent, `status` is `null` (not nonzero), `stderr` is `undefined`, `error.code` is `ENOENT` — all masked by `completed.stderr || "failed to list package.json files"`
- Other repo checkers declare ripgrep as provisioned dependency or use git

## Fix

Replace `rg --files -g package.json` with `git ls-files *package.json`:
- git is a hard requirement everywhere this runs
- `ls-files` respects tracking (not .gitignore heuristics)
- Added proper ENOENT handling to name missing git binary

## Evidence Gate

<!-- evidence-head:d4cd9f29ee5fd7481513b30716f717e8aa2b17b6 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - Script logic change; no UI/frontend touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Script logic change; no application runtime affected.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - Script logic change; no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Real run of the touched script at PR head d4cd9f29ee5fd7481513b30716f717e8aa2b17b6 (worktree of `pull/17686/head`), on a machine where `rg` is NOT installed — the exact environment the old code failed in:

<details>
<summary>Transcript: script runs end to end on the new git ls-files path; old rg path reproduced for contrast</summary>

```
$ node packages/scripts/check-live-test-artifact-coverage.mjs
live/e2e script inventory 222 scripts; 204 without artifact evidence
exit=0

# OLD code path reproduced on the same machine (rg absent):
$ node -e 'spawnSync("rg", ["--files","-g","package.json"], ...)'
OLD: rg spawnSync -> status: null error.code: ENOENT stderr: undefined
OLD thrown message would be: "failed to list package.json files"   # binary name masked

# New listing path, at PR head:
$ git ls-files '*package.json' | <basename filter>  -> 313 files
# The basename filter is load-bearing: git's suffix pathspec also matches
suffix-only matches filtered out by the basename check: 2
packages/benchmarks/solana/solana-gym-env/voyager/environments/basic_package.json
packages/benchmarks/solana/solana-gym-env/voyager/environments/swap_package.json
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - Script logic change; no frontend behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - Script logic change; no LLM invoked.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - Script logic change; no domain artifacts produced.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-mycode
<!-- attribution-row:client -->
- Client / agent tooling: Claude Agent SDK
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

— [harshith8gowda]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-mycode","client":"Claude Agent SDK","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->

