### PR TITLE
fix(lp3): preserve paired LAN transport and settle streams

### DIFF
--- a/packages/app/vite.config.test.ts
+++ b/packages/app/vite.config.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { runInNewContext } from "node:vm";
-import { appDevWsBasePlugin } from "./vite.config";
+import { appDevWsBasePlugin, resolveLocalCspSources } from "./vite.config";
 
 describe("appDevWsBasePlugin", () => {
   test("injects same-origin ws/wss bases without a machine-local address", () => {
@@ -40,5 +40,29 @@ describe("appDevWsBasePlugin", () => {
       expect(window.__ELIZAOS_WS_BASE__).toBe(expected);
       expect(window.__ELIZA_WS_BASE__).toBe(expected);
     }
+  });
+});
+
+describe("resolveLocalCspSources", () => {
+  test("permits paired Android transports whose private-LAN host is selected at runtime", () => {
+    expect(resolveLocalCspSources("android", false)).toEqual({
+      localHttpSources: " http://localhost:* http://127.0.0.1:*",
+      localConnectSources: " http: ws:",
+    });
+  });
+
+  test("keeps non-Android cleartext access limited to loopback", () => {
+    expect(resolveLocalCspSources("ios", false)).toEqual({
+      localHttpSources: " http://localhost:* http://127.0.0.1:*",
+      localConnectSources:
+        " http://localhost:* ws://localhost:* wss://localhost:* http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:*",
+    });
+  });
+
+  test("keeps iOS store builds free of all cleartext sources", () => {
+    expect(resolveLocalCspSources("ios", true)).toEqual({
+      localHttpSources: "",
+      localConnectSources: "",
+    });
   });
 });

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -968,12 +968,10 @@ function appShellMetadataPlugin(): Plugin {
     CAPACITOR_BUILD_TARGET === "ios" &&
     (process.env.ELIZA_BUILD_VARIANT === "store" ||
       process.env.ELIZA_RELEASE_AUTHORITY === "apple-app-store");
-  const localHttpSources = isIosStoreBuild
-    ? ""
-    : " http://localhost:* http://127.0.0.1:*";
-  const localConnectSources = isIosStoreBuild
-    ? ""
-    : " http://localhost:* ws://localhost:* wss://localhost:* http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:*";
+  const { localHttpSources, localConnectSources } = resolveLocalCspSources(
+    CAPACITOR_BUILD_TARGET,
+    isIosStoreBuild,
+  );
   const manifest = `${JSON.stringify(
     {
       name: APP_SHELL_METADATA.appName,
@@ -1039,6 +1037,30 @@ function appShellMetadataPlugin(): Plugin {
         source: manifest,
       });
     },
+  };
+}
+
+export function resolveLocalCspSources(
+  capacitorBuildTarget: string,
+  isIosStoreBuild: boolean,
+): { localHttpSources: string; localConnectSources: string } {
+  if (isIosStoreBuild) {
+    return { localHttpSources: "", localConnectSources: "" };
+  }
+
+  const localHttpSources = " http://localhost:* http://127.0.0.1:*";
+  if (capacitorBuildTarget === "android") {
+    // Paired Android shells discover the host at runtime, so its private-LAN
+    // address cannot be enumerated at build time. API-base validation still
+    // limits accepted cleartext hosts to loopback/private addresses, while the
+    // CSP must permit the resulting REST/EventSource and WebSocket transports.
+    return { localHttpSources, localConnectSources: " http: ws:" };
+  }
+
+  return {
+    localHttpSources,
+    localConnectSources:
+      " http://localhost:* ws://localhost:* wss://localhost:* http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:*",
   };
 }
 

--- a/packages/ui/src/api/client-agent-stream.test.ts
+++ b/packages/ui/src/api/client-agent-stream.test.ts
@@ -614,4 +614,31 @@ describe("ElizaClient chat-turn status SSE (#8813)", () => {
     expect(result.text).toContain("par");
     expect(cancel).toHaveBeenCalledWith("elizaos-sse-read-failed");
   });
+
+  it("does not fabricate an assistant error when an empty stream ends before its terminal frame", async () => {
+    const read = vi.fn().mockRejectedValueOnce(new Error("socket reset"));
+    const cancel = vi.fn(async () => {});
+    const request = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          body: { getReader: () => ({ read, cancel }) },
+        }) as unknown as Response,
+    );
+    const client = new ElizaClient("http://agent.example:31337", "token");
+    client.setRequestTransport({ request });
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/conversation-id/messages/stream",
+      "go home",
+      vi.fn(),
+    );
+
+    expect(result).toMatchObject({
+      text: "",
+      completed: false,
+    });
+    expect(cancel).toHaveBeenCalledWith("elizaos-sse-read-failed");
+  });
 });

--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -7,6 +7,7 @@
  * network-status-change event it emits. WebSocket stubbed, no live server.
  */
 
+import { Capacitor } from "@capacitor/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { NETWORK_STATUS_CHANGE_EVENT } from "../events";
 import { __resetNetworkStatusForTests, ElizaClient } from "./client-base";
@@ -83,6 +84,7 @@ function stubWindowProtocol(protocol: string): void {
 
 describe("ElizaClient websocket connection policy", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
     __resetNetworkStatusForTests();
   });
@@ -164,6 +166,39 @@ describe("ElizaClient websocket connection policy", () => {
       maxReconnectAttempts: 15,
       disconnectedAt: null,
     });
+  });
+
+  it("opens loopback ws from a local Android sideload renderer", () => {
+    const createdUrls = stubWebSocket();
+    vi.spyOn(Capacitor, "getPlatform").mockReturnValue("android");
+    const client = new ElizaClient("http://127.0.0.1:31338", "agent-token");
+
+    client.connectWs();
+
+    expect(window.location.protocol).toBe("https:");
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("ws://127.0.0.1:31338/ws?");
+  });
+
+  it("opens trusted private-LAN ws from a local Android sideload renderer", () => {
+    const createdUrls = stubWebSocket();
+    vi.spyOn(Capacitor, "getPlatform").mockReturnValue("android");
+    const client = new ElizaClient("http://192.168.1.10:31338", "agent-token");
+
+    client.connectWs();
+
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("ws://192.168.1.10:31338/ws?");
+  });
+
+  it("still blocks public cleartext ws from a local Android sideload renderer", () => {
+    const createdUrls = stubWebSocket();
+    vi.spyOn(Capacitor, "getPlatform").mockReturnValue("android");
+    const client = new ElizaClient("http://203.0.113.10:31338", "agent-token");
+
+    client.connectWs();
+
+    expect(createdUrls).toEqual([]);
   });
 
   it("still opens cleartext ws from an HTTP page", () => {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -17,6 +17,8 @@ import {
 } from "../events";
 import { hydrateAndroidLocalAgentTokenForUrl } from "../first-run/local-agent-token";
 import { isMobileLocalAgentIpcUrl } from "../first-run/mobile-runtime-mode";
+import { isAndroidLocalSideloadBuild } from "../platform/android-runtime";
+import { isTrustedRestoreApiBaseUrl } from "../state/runtime-url-trust";
 import { shellLocalStorage } from "../surface-realm-channel";
 import {
   clearElizaApiBase,
@@ -497,11 +499,24 @@ function getInjectedWsBase(): string | undefined {
 
 function shouldUseRestOnlyForInsecureWebSocket(
   wsProtocol: "ws:" | "wss:",
+  host: string,
 ): boolean {
   if (wsProtocol !== "ws:") return false;
   if (typeof window === "undefined") return false;
   const rendererProtocol = window.location?.protocol;
-  return rendererProtocol === "https:" || rendererProtocol === "capacitor:";
+  if (rendererProtocol !== "https:" && rendererProtocol !== "capacitor:") {
+    return false;
+  }
+
+  // Direct Android builds enable mixed content so their packaged
+  // https://localhost renderer can keep the paired runtime's backchannel
+  // alive. The same trust gate that protects persisted API bases restricts
+  // this exception to loopback/private-LAN hosts; store and public cleartext
+  // endpoints retain the browser's stricter boundary.
+  const isTrustedPairedHost = isTrustedRestoreApiBaseUrl(`http://${host}`);
+  if (isTrustedPairedHost && isAndroidLocalSideloadBuild()) return false;
+
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -1419,7 +1434,7 @@ export class ElizaClient {
     // renderer also cannot use that cleartext WebView socket even though its
     // native HTTP bridge keeps REST healthy. Both origins therefore use the
     // same REST-only state instead of reporting a dead backend (#16843).
-    if (shouldUseRestOnlyForInsecureWebSocket(wsProtocol)) {
+    if (shouldUseRestOnlyForInsecureWebSocket(wsProtocol, host)) {
       this.backoffMs = 500;
       this.reconnectAttempt = 0;
       this.disconnectedAt = null;
@@ -2018,12 +2033,12 @@ export class ElizaClient {
       }
     }
 
+    const rawReplyText = streamState.doneText ?? streamState.fullText;
     const resolvedText =
-      streamState.doneNoResponseReason === "ignored"
+      streamState.doneNoResponseReason === "ignored" ||
+      (!streamState.receivedDone && rawReplyText.trim().length === 0)
         ? ""
-        : this.normalizeAssistantText(
-            streamState.doneText ?? streamState.fullText,
-          );
+        : this.normalizeAssistantText(rawReplyText);
     return {
       text: resolvedText,
       agentName: streamState.doneAgentName ?? "Eliza",


### PR DESCRIPTION
> Latest publication sync (2026-08-06): exact head `3bd520d18fa54d13809248acae52452e2694b866`; cumulative top `3bd520d18fa54d13809248acae52452e2694b866`; 0 behind `origin/develop@35f6345511c8bc5ad00fc4cd01da40e4fb11c203`. The 107-commit replay is patch-identical; the only final-tree delta is develop's already-merged CI browser-runner provisioning.

## Summary

Preserves the paired Mac-runtime transport after an Android/LP3 client leaves USB and connects over its private-LAN or hotspot endpoint. It also keeps interrupted-stream settlement from fabricating a stale generic failure beneath a later successful reply.

This remains a narrow client transport/settlement change: it does not bypass the model, add deterministic action shortcuts, or broaden non-Android cleartext policy.

## Exact stack provenance

- Exact head: `8b653b6b84a18f85e3c118391555d9e9c4dc2185`
- Exact tree: `34610a3fe6b6f5dcfe4c055dc577d3119212fef0`
- Exact stacked base: `#17688@3472dc829305ef246bd81a23f7f9ce917bec7658`
- Stack root: `origin/develop@255b67adda9d32aab34f8879d17cce1ddcf963a1`
- The rewritten commit has the same stable patch ID as the prior PR head (`fa9c30e41d20eb0bc316a009bb3df70e85e863af`).

## What changed

- Allow the Android runtime to select its paired private-LAN HTTP/WebSocket host while keeping iOS and non-Android cleartext access loopback-only.
- Normalize paired runtime WebSocket targets without losing the selected host.
- Preserve authoritative structured stream completion/failure state and avoid emitting a stale generic error after reconnection.

## Validation

- [x] Frozen workspace install completed without changing the lockfile.
- [x] `bun test vite.config.test.ts` in `packages/app`: 4/4 passed.
- [x] UI stream/WebSocket suites: 36/36 passed.
- [x] `bun run build`: 121/121 packages and 19/19 view bundles passed.
- [x] `bun run verify`: 342/342 tasks and all repository audits passed.
- [x] Worktree is clean; `git diff --check` passed.

## Review entry points

- `packages/ui/src/api/client-base.ts`
- `packages/ui/src/api/client-agent-stream.test.ts`
- `packages/ui/src/api/client-base-websocket.test.ts`
- `packages/app/vite.config.ts`
- `packages/app/vite.config.test.ts`

## Evidence gate

<!-- evidence-head:3bd520d18fa54d13809248acae52452e2694b866 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no exact-head physical LP3 capture exists yet; this draft cannot be promoted until the before-state artifact replaces this row.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no exact-head physical LP3 capture exists yet; this draft cannot be promoted until the after-state artifact replaces this row.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no exact-head unplugged LP3 recording exists yet; this draft cannot be promoted until the MP4 replaces this row.
<!-- evidence-row:backend-logs -->
- [x] N/A - no exact-head unplugged Mac-runtime log exists yet; this draft cannot be promoted until the log replaces this row.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no exact-head LP3 network/console log exists yet; this draft cannot be promoted until the log replaces this row.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this PR changes transport and client settlement, not prompting or model/provider selection. A live action trajectory will accompany the required physical LP3 flow proof.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - paired endpoint, APK hash/signature, empty `adb reverse` list, and request/transcript correlation remain unavailable until the physical LP3 run; this draft cannot be promoted without them.
<!-- evidence-row:ocr-review -->
- [x] N/A - there is no final transcript image to review until the physical LP3 capture; this draft cannot be promoted without OCR/manual review.

## Known gate

The code and repository gates are green, but this PR intentionally remains a draft until the exact-head APK is installed and the unplugged LP3 flow is captured and manually reviewed. No device result is claimed from desktop-only tests.

Closes #17684. Closes #17685.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - the installed Codex GitHub publication skill is versioned as a local plugin package, not an owner/repo commit`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

