### PR TITLE
test(ci): post-#17695 validator baseline mop-up

### DIFF
--- a/scripts/check-ai-workflow-security.test.mjs
+++ b/scripts/check-ai-workflow-security.test.mjs
@@ -8,6 +8,8 @@ import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 
 const SKILL_REVIEW_PATH = ".github/workflows/skill-review.yml";
+const SKILL_REVIEW_REQUIREMENTS_PATH =
+  "packages/skills/skills/skill-creator/requirements.txt";
 const CLAUDE_PATH = ".github/workflows/claude.yml";
 const DOCS_CI_PATH = ".github/workflows/docs-ci.yml";
 

--- a/scripts/check-pr-agent-attribution.test.mjs
+++ b/scripts/check-pr-agent-attribution.test.mjs
@@ -93,7 +93,7 @@ function generatedPrWorkflowPaths() {
     .filter((name) => /\.ya?ml$/.test(name))
     .map((name) => `.github/workflows/${name}`)
     .filter((workflowPath) =>
-      /\bgh\s+pr\s+create\b|peter-evans\/create-pull-request@/.test(
+      /^\s+gh\s+pr\s+create\b|peter-evans\/create-pull-request@/m.test(
         workflowSource(workflowPath),
       ),
     )
@@ -527,7 +527,6 @@ describe("PR agent attribution", () => {
     const ecosystemRefs = {
       npm: "dependabot/npm_and_yarn/*",
       "github-actions": "dependabot/github_actions/*",
-      pip: "dependabot/pip/*",
     };
     assert.deepEqual(
       [...new Set(configuredEcosystems)].sort(),
@@ -586,9 +585,10 @@ describe("PR agent attribution", () => {
 
   it("discovers and validates every workflow-generated PR body", async () => {
     const workflowPaths = generatedPrWorkflowPaths();
-    assert.ok(
-      workflowPaths.length >= 4,
-      "expected all repository PR-creation workflows to be discovered",
+    assert.deepEqual(
+      workflowPaths,
+      [".github/workflows/docs-ci.yml"],
+      "the generated-PR workflow inventory must stay explicit",
     );
     for (const workflowPath of workflowPaths) {
       const source = workflowSource(workflowPath);


### PR DESCRIPTION
# Relates to

Post-#17695 mop-up for the trusted validator baseline broken by the refactor merge.

- [x] This PR targets `develop` at `d04deb98f9f` with zero conflicts.
- [ ] Full `bun run verify` is blocked by the broader develop failures documented on #17695.
- [x] The focused bidirectional proof is included below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Based directly on merge head `d04deb98f9f24021129118af93b5856d2b299127`; zero conflicts.
- [ ] Full verify is blocked by broader post-refactor module-resolution, typecheck, and E2E failures.

# Risks

Low. Test-only repair. The generated-PR workflow inventory remains fail-closed and explicit, and now ignores `gh pr create` prose inside a Claude prompt rather than misclassifying it as executable workflow shell.

# Background

## What does this PR do?

Repairs three deterministic trusted-validator defects introduced in #17695:

1. Restores the deleted `SKILL_REVIEW_REQUIREMENTS_PATH` constant while retaining its live assertion.
2. Removes the deleted Dependabot `pip` ecosystem from the exact allowlist expectation.
3. Tightens generated-PR discovery to executable shell lines and asserts the remaining workflow inventory exactly, avoiding the `gh pr create` prose false-positive in `claude-ci-autoheal.yml`.

## What kind of change is this?

Post-#17695 test/CI mop-up. No workflow files or product code changed.

# Documentation changes needed?

No documentation change is needed.

# Testing

## Where should a reviewer start?

`scripts/check-ai-workflow-security.test.mjs` and `scripts/check-pr-agent-attribution.test.mjs`.

## Detailed testing steps

Parent `d04deb98f9f`:

```text
node --test scripts/check-ai-workflow-security.test.mjs scripts/check-pr-agent-attribution.test.mjs
19 pass, 3 fail
ReferenceError: SKILL_REVIEW_REQUIREMENTS_PATH is not defined
expected ecosystems: github-actions,npm,pip; actual: github-actions,npm
expected all repository PR-creation workflows to be discovered
```

Head `41eaa2afb2a`:

```text
node --test scripts/check-ai-workflow-security.test.mjs scripts/check-pr-agent-attribution.test.mjs
22 pass, 0 fail
```

`git diff --check` also passes.

# Evidence Gate

<!-- evidence-head:41eaa2afb2a8c59d9fe3e200a200be2f9f165454 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or UI changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime path changed; focused test output is included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, task, wallet, file-generation, or audio behavior changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Known gaps / failures

The full develop lane remains red from broader #17695 refactor regressions. This PR intentionally fixes only the three mechanical trusted-validator defects that block evidence gates on unrelated PRs. No workflow, check threshold, timeout, or assertion was weakened.