### PR TITLE
fix(android): resolve Capacitor packages in isolated installs

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
@@ -1000,6 +1000,7 @@ describe("pinned bundletool provisioning", () => {
       env: {
         ELIZA_MOBILE_AUDIT_SCRIPT: "  /tools/audit.mjs  ",
         NODE_BINARY: "  /tools/node  ",
+        NODE_PATH: "  /workspace/existing-node-modules  ",
         PATH: "/usr/bin",
       },
       javaHome: "/jdk",
@@ -1008,6 +1009,21 @@ describe("pinned bundletool provisioning", () => {
     expect(path.isAbsolute(defaults.NODE_BINARY)).toBe(true);
     expect(defaults.NODE_BINARY).toBe(process.execPath);
     expect(overridden.NODE_BINARY).toBe("/tools/node");
+    expect(defaults.NODE_PATH).toBe(
+      path.join(
+        fileURLToPath(new URL("../../app", import.meta.url)),
+        "node_modules",
+      ),
+    );
+    expect(overridden.NODE_PATH).toBe(
+      [
+        path.join(
+          fileURLToPath(new URL("../../app", import.meta.url)),
+          "node_modules",
+        ),
+        "/workspace/existing-node-modules",
+      ].join(path.delimiter),
+    );
     expect(path.isAbsolute(defaults.ELIZA_MOBILE_AUDIT_SCRIPT)).toBe(true);
     expect(defaults.ELIZA_MOBILE_AUDIT_SCRIPT).toBe(
       fileURLToPath(new URL("./run-mobile-build.mjs", import.meta.url)),

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6915,6 +6915,13 @@ export function createAndroidBuildEnv(
       env.ELIZA_MOBILE_AUDIT_SCRIPT?.trim() || fileURLToPath(import.meta.url),
     JAVA_HOME: javaHome,
     NODE_BINARY: env.NODE_BINARY?.trim() || process.execPath,
+    // Capacitor 8 generates settings.gradle package lookups through a child
+    // `node` process. Bun's isolated linker keeps mobile dependencies under
+    // packages/app/node_modules, which is not an ancestor of app-core's
+    // canonical Android tree, so bare require.resolve() otherwise fails.
+    NODE_PATH: [path.join(appDir, "node_modules"), env.NODE_PATH?.trim()]
+      .filter(Boolean)
+      .join(path.delimiter),
     PATH: prependPath(env, [
       path.join(javaHome, "bin"),
       path.join(androidSdkRoot, "platform-tools"),


### PR DESCRIPTION
## Summary

- export `packages/app/node_modules` through `NODE_PATH` for Gradle child processes
- preserve an existing `NODE_PATH`
- cover default and overridden build environments

## Root cause

Capacitor 8's generated `capacitor.settings.gradle` resolves npm packages by spawning `node` with `require.resolve()`. With Bun's isolated linker, the mobile packages live under `packages/app/node_modules`, while Gradle runs from `packages/app-core/platforms/android`, so the package tree is not an ancestor and fresh Android builds fail before Gradle configuration.

## Bidirectional proof

- Before: fresh `bun install` + `build:android:lp3-cloud:debug` reached `cap sync`, then Gradle failed at `capacitor.settings.gradle:2` because `@capacitor/android/package.json` was not resolvable.
- After: with the build environment's `NODE_PATH`, the canonical Gradle project configured all Capacitor modules and `:capacitor-cordova-android-plugins:writeDebugAarMetadata` completed successfully without an Android-tree `node_modules` symlink.

## Tests

- `vitest ...run-mobile-build-android-aab-audit.test.mjs -t 'passes an absolute JavaScript runtime to Gradle for the AAB finalizer'` (1 passed)
- `vitest ...portable-capacitor-settings.test.mjs` (2 passed)
- real Gradle configuration proof: `BUILD SUCCESSFUL`, metadata task

## Evidence applicability

- Live LLM trajectory: N/A, build orchestration only
- UI screenshots/video: N/A, no UI behavior changed
- Runtime logs/state: N/A, no agent runtime path changed

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Sol (moltbot agent runtime)`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Evidence Gate

<!-- evidence-head:b71fbd5fb8d949e8ff8a5d59755a1b78797c0c1a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - build-toolchain fix with no user-visible surface. The "before" state is a Gradle configuration failure at `capacitor.settings.gradle:2` (`@capacitor/android/package.json` not resolvable), reproduced from a fresh `bun install` and quoted in the Bidirectional proof section above.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no user-visible surface. The "after" state is `BUILD SUCCESSFUL` with `:capacitor-cordova-android-plugins:writeDebugAarMetadata` completing, also quoted above.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - nothing to walk through; the change exports `NODE_PATH` to Gradle child processes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend or runtime code path changes. The diff touches `packages/app-core/scripts/run-mobile-build.mjs` and its test only.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No prompt, model, provider, or agent action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database rows, memories, scheduled tasks, or wallet state change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface introduced.

# Known gaps / failures

- Real Gradle configuration was verified locally (`BUILD SUCCESSFUL`); no hosted Android build runs on this PR.
- No workflow files changed. No checks weakened.



