### PR TITLE
fix(ci): add Video build dependency to Calendar typecheck

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -251,7 +251,7 @@
       "outputs": []
     },
     "@elizaos/plugin-calendar#typecheck": {
-      "dependsOn": [],
+      "dependsOn": ["@elizaos/plugin-video#build"],
       "outputs": []
     },
     "@elizaos/plugin-personal-assistant#typecheck": {


### PR DESCRIPTION
## Summary

Adds `@elizaos/plugin-video#build` as a dependency of `@elizaos/plugin-calendar#typecheck` in turbo.json. This prevents nondeterministic TS7016 failures when Calendar typecheck starts before Video has emitted its declaration files.

## Problem

Calendar typecheck traverses `@elizaos/agent` source, whose generated optional-plugin map imports Video. When Video build has emitted `dist/index.js` but not `dist/index.d.ts`, Calendar typecheck fails nondeterministically.

## Fix

Add `"@elizaos/plugin-video#build"` to the `dependsOn` array of `@elizaos/plugin-calendar#typecheck` in turbo.json.

## Evidence Gate

<!-- evidence-head:placeholder -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - CI pipeline change; no UI touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI pipeline change; no application runtime affected.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - CI pipeline change; no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - CI pipeline change; no backend path executed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - CI pipeline change; no frontend behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - CI pipeline change; no LLM invoked.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - CI pipeline change; no domain artifacts produced.

## Contribution provenance

<!-- attribution-row:provider -->
- AI provider/model: Anthropic / claude-mycode
<!-- attribution-row:client -->
- Client / agent tooling: Claude Agent SDK
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

-- [harshith8gowda]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-mycode","client":"Claude Agent SDK","skill_revision":"elizaOS/eliza@4b0bad53a7fd5cc0c1f0c507c849f27ebb53b1d3:packages/skills/skills/contribute-to-eliza"} -->