### PR TITLE
fix(ui): preserve notification material through repeated shade gestures

### DIFF
--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -62,7 +62,6 @@ import {
 import { NOTIFICATION_ROW_SETTLE_MS } from "./notification-shade-content";
 import {
   notificationPullOvershootOffset,
-  notificationPullPresentation,
   PULL_TRAVEL_PX,
 } from "./notification-shade-presentation";
 
@@ -610,28 +609,6 @@ describe("dampenPull", () => {
     expect(notificationPullOvershootOffset(PULL_TRAVEL_PX)).toBe(0);
     expect(notificationPullOvershootOffset(overpull)).toBeCloseTo(9.8, 1);
     expect(notificationPullOvershootOffset(-overpull)).toBeCloseTo(-9.8, 1);
-  });
-
-  it("fades the count before upward overpull reaches its clipping boundary", () => {
-    const atCloseDetent = notificationPullPresentation(
-      -PULL_TRAVEL_PX,
-      true,
-      false,
-    );
-    const midwayThroughBoundaryFade = notificationPullPresentation(
-      -(PULL_TRAVEL_PX + 4),
-      true,
-      false,
-    );
-    const pastBoundaryFade = notificationPullPresentation(
-      -(PULL_TRAVEL_PX + 8),
-      true,
-      false,
-    );
-
-    expect(atCloseDetent.notificationCountVisibility).toBe(1);
-    expect(midwayThroughBoundaryFade.notificationCountVisibility).toBe(0.5);
-    expect(pastBoundaryFade.notificationCountVisibility).toBe(0);
   });
 });
 
@@ -1750,7 +1727,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.queryByText("Files updated")).toBeNull();
   });
 
-  it("fades expanded cards while retaining the resting priority stack", () => {
+  it("closes every card while retaining priority shells for stable geometry", () => {
     seedTriage();
     renderRestedNotifications();
     const list = screen.getByTestId("home-notification-list");
@@ -1830,6 +1807,18 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     finishShadeCollapse();
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getByTestId("notification-row")).toBe(priorityRow);
+    expect(priorityGroupContent?.style.opacity).toBe("0");
+    expect(priorityGroupContent?.style.transition).toBe("none");
+    expect(
+      priorityGroupContent
+        ?.closest("[data-notification-group]")
+        ?.getAttribute("aria-hidden"),
+    ).toBe("true");
+    expect(
+      priorityGroupContent
+        ?.closest("[data-notification-group]")
+        ?.hasAttribute("inert"),
+    ).toBe(true);
   });
 
   it("keeps the same card material through a reversible upward drag", () => {
@@ -1870,6 +1859,10 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     const agentSurface = screen
       .getByText("Agent summary")
       .closest<HTMLElement>('[data-testid="notification-row-swipe"]');
+    const mailGroup = screen
+      .getByText("Urgent mail")
+      .closest("[data-notification-group]")
+      ?.querySelector<HTMLElement>("[data-notification-group-content]");
     const filesContent = filesSurface?.querySelector<HTMLElement>(
       ".eliza-notif-row-content",
     );
@@ -1893,6 +1886,9 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     });
 
     expect(list.hasAttribute("data-shade-dragging")).toBe(true);
+    // Count and clear controls own no layout space, so gesture presentation
+    // must never move an already-visible priority stack to compensate for them.
+    expect(mailGroup?.style.transform).toBe("translate3d(0, 0px, 0)");
     const css = list.parentElement?.querySelector("style")?.textContent ?? "";
     const activeDragRule = css.match(
       /\.eliza-notif-scroll\[data-shade-dragging\]\s*\{([^}]*)\}/,
@@ -2702,7 +2698,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     const previewGroups = Array.from(
       list.querySelectorAll<HTMLElement>("[data-notification-pull-reveal]"),
     );
-    expect(previewGroups).toHaveLength(2);
+    expect(previewGroups).toHaveLength(3);
     expect(screen.queryByTestId("notifications-collapse")).toBeNull();
     fireEvent.pointerUp(list, {
       pointerType: "mouse",
@@ -2746,7 +2742,15 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
       false,
     );
-    expect(previewGroups.every((group) => !group.isConnected)).toBe(true);
+    const retainedGroups = previewGroups.filter((group) => group.isConnected);
+    expect(retainedGroups).toHaveLength(1);
+    expect(retainedGroups[0]?.getAttribute("aria-hidden")).toBe("true");
+    expect(retainedGroups[0]?.hasAttribute("inert")).toBe(true);
+    expect(
+      retainedGroups[0]?.querySelector<HTMLElement>(
+        "[data-notification-group-content]",
+      )?.style.opacity,
+    ).toBe("0");
     expect(screen.queryByTestId("notifications-collapse")).toBeNull();
     expect(screen.queryAllByTestId("notification-row")).toHaveLength(1);
   });

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1818,20 +1818,14 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(settledContentRule).not.toContain(
       "--eliza-notif-group-content-visibility",
     );
-    const settledSurfaceRule = [
-      ...(list.parentElement
-        ?.querySelector("style")
-        ?.textContent?.matchAll(
-          /\.eliza-notif-scroll:is\(\[data-shade-dragging\], \[data-shade-settling\]\)[^{}]*\.eliza-notif-row-surface\s*\{([^}]*)\}/g,
-        ) ?? []),
-    ]
-      .map((match) => match[1])
-      .find((rule) => rule.includes("opacity:"));
-    expect(settledSurfaceRule).toContain("opacity:");
-    expect(settledSurfaceRule).toContain("!important");
-    expect(settledSurfaceRule).toContain("transition:");
+    const settledMaterialRule = list.parentElement
+      ?.querySelector("style")
+      ?.textContent?.match(
+        /\.eliza-notif-scroll\[data-shade-mode="expanded"\]\[data-shade-settling\][^{}]*\.eliza-notif-glass::after\s*\{([^}]*)\}/,
+      )?.[1];
+    expect(settledMaterialRule).toContain("transition: opacity");
     expect(list.parentElement?.querySelector("style")?.textContent).toContain(
-      ".eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-surface",
+      '.eliza-notif-scroll[data-shade-mode="expanded"]:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-glass',
     );
     finishShadeCollapse();
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
@@ -1942,6 +1936,12 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(filesContentOpacity).toBeGreaterThan(0);
     expect(filesContentOpacity).toBeLessThan(1);
     expect(agentContentOpacity).toBeLessThan(filesContentOpacity);
+    const filesSurfaceOpacity = Number.parseFloat(
+      filesGroup?.style.getPropertyValue(
+        "--eliza-notif-group-surface-visibility",
+      ) ?? "0",
+    );
+    expect(filesSurfaceOpacity).toBeCloseTo(filesContentOpacity, 6);
     expect(screen.queryByTestId("notifications-count")).toBeNull();
     expect(screen.queryByTestId("notifications-collapse-footer")).toBeNull();
 
@@ -1983,6 +1983,11 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(
       filesGroup?.style.getPropertyValue(
         "--eliza-notif-group-content-visibility",
+      ),
+    ).toBe("");
+    expect(
+      filesGroup?.style.getPropertyValue(
+        "--eliza-notif-group-surface-visibility",
       ),
     ).toBe("");
     expect(
@@ -2142,8 +2147,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
         title: "Agent summary",
       }),
     );
-    renderRestedNotifications();
-    const list = expandShade();
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
     const priorityRow = screen
       .getByText("Urgent mail")
       .closest<HTMLElement>('[data-testid="notification-row"]');
@@ -2154,6 +2159,12 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     const prioritySurface = priorityRow.closest<HTMLElement>(
       '[data-testid="notification-row-swipe"]',
     );
+    const initialMaterial = {
+      groupOpacity: priorityGroup?.style.opacity,
+      groupTransform: priorityGroup?.style.transform,
+      surfaceOpacity: prioritySurface?.style.opacity,
+      surfaceTransform: prioritySurface?.style.transform,
+    };
 
     fireEvent.pointerDown(list, {
       pointerType: "mouse",
@@ -2184,24 +2195,53 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       ),
     ).toBe("");
     expect(
+      priorityGroup?.style.getPropertyValue(
+        "--eliza-notif-group-surface-visibility",
+      ),
+    ).toBe("");
+    expect(
       priorityGroup
         ?.querySelector<HTMLElement>("[data-notification-disposable-row]")
         ?.style.getPropertyValue("--eliza-notif-row-content-visibility") ?? "",
     ).toBe("");
 
-    expandShade();
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 88,
+      clientX: 12,
+      clientY: 20,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 88,
+      clientX: 12,
+      clientY: 160,
+    });
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 88,
+      clientX: 12,
+      clientY: 160,
+    });
+    act(() => vi.advanceTimersByTime(500));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(
       priorityGroup?.style.getPropertyValue(
         "--eliza-notif-group-content-visibility",
       ),
     ).toBe("");
-    expect(prioritySurface?.style.opacity).toBe("1");
+    expect({
+      groupOpacity: priorityGroup?.style.opacity,
+      groupTransform: priorityGroup?.style.transform,
+      surfaceOpacity: prioritySurface?.style.opacity,
+      surfaceTransform: prioritySurface?.style.transform,
+    }).toEqual(initialMaterial);
 
     fireEvent.pointerDown(list, {
       pointerType: "mouse",
       isPrimary: true,
-      pointerId: 88,
+      pointerId: 89,
       clientX: 12,
       clientY: 160,
     });
@@ -2211,11 +2251,16 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
         "--eliza-notif-group-content-visibility",
       ),
     ).toBe("");
-    expect(prioritySurface?.style.opacity).toBe("1");
+    expect({
+      groupOpacity: priorityGroup?.style.opacity,
+      groupTransform: priorityGroup?.style.transform,
+      surfaceOpacity: prioritySurface?.style.opacity,
+      surfaceTransform: prioritySurface?.style.transform,
+    }).toEqual(initialMaterial);
 
     fireEvent.pointerMove(list, {
       pointerType: "mouse",
-      pointerId: 88,
+      pointerId: 89,
       clientX: 12,
       clientY: 116,
     });

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1876,6 +1876,9 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     const agentSurface = screen
       .getByText("Agent summary")
       .closest<HTMLElement>('[data-testid="notification-row-swipe"]');
+    const filesContent = filesSurface?.querySelector<HTMLElement>(
+      ".eliza-notif-row-content",
+    );
 
     fireEvent.pointerDown(list, {
       pointerType: "mouse",
@@ -1884,6 +1887,10 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientX: 12,
       clientY: 160,
     });
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    expect(filesSurface?.style.transform).toBe("");
+    expect(filesContent?.style.transform).toBe("");
+    expect(filesContent?.className).not.toContain("active:scale");
     fireEvent.pointerMove(list, {
       pointerType: "mouse",
       pointerId: 83,
@@ -1896,8 +1903,11 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     const activeDragRule = css.match(
       /\.eliza-notif-scroll\[data-shade-dragging\]\s*\{([^}]*)\}/,
     )?.[1];
-    expect(activeDragRule).toContain("-webkit-mask-image: none");
-    expect(activeDragRule).toContain("mask-image: none");
+    expect(activeDragRule).not.toContain("mask-image");
+    const releaseSettleRule = css.match(
+      /\.eliza-notif-scroll\[data-shade-release-settling\]\s*\{([^}]*)\}/,
+    )?.[1];
+    expect(releaseSettleRule).not.toContain("mask-image");
     // A pull may animate compositor properties, but changing which element
     // paints the fill produces a visible first-frame color/rim discontinuity.
     const gestureMaterialRules = [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
@@ -1910,7 +1920,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       .map((match) => match[2] ?? "")
       .join("\n");
     expect(gestureMaterialRules).not.toMatch(
-      /background-(?:color|image)|backdrop-filter/,
+      /background-(?:color|image)|backdrop-filter|mask-image/,
     );
 
     let filesOpacity = Number.parseFloat(filesGroup?.style.opacity ?? "1");

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1838,7 +1838,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.getByTestId("notification-row")).toBe(priorityRow);
   });
 
-  it("keeps card material fully opaque through a reversible upward drag", () => {
+  it("keeps the same card material through a reversible upward drag", () => {
     __ingestNotificationForTests(
       makeNotification({
         priority: "urgent",
@@ -1898,6 +1898,20 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     )?.[1];
     expect(activeDragRule).toContain("-webkit-mask-image: none");
     expect(activeDragRule).toContain("mask-image: none");
+    // A pull may animate compositor properties, but changing which element
+    // paints the fill produces a visible first-frame color/rim discontinuity.
+    const gestureMaterialRules = [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
+      .filter(
+        (match) =>
+          match[1]?.includes("data-shade-dragging") ||
+          match[1]?.includes("data-shade-settling") ||
+          match[1]?.includes("data-notification-shade-cancelling"),
+      )
+      .map((match) => match[2] ?? "")
+      .join("\n");
+    expect(gestureMaterialRules).not.toMatch(
+      /background-(?:color|image)|backdrop-filter/,
+    );
 
     let filesOpacity = Number.parseFloat(filesGroup?.style.opacity ?? "1");
     let agentOpacity = Number.parseFloat(agentGroup?.style.opacity ?? "1");

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2120,6 +2120,116 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
   });
 
+  it("clears gesture-owned visibility before a reopened shade starts its next close", () => {
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "urgent",
+        source: "mail",
+        title: "Urgent mail",
+      }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "normal",
+        source: "files",
+        title: "Files updated",
+      }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "low",
+        source: "agent",
+        title: "Agent summary",
+      }),
+    );
+    renderRestedNotifications();
+    const list = expandShade();
+    const priorityRow = screen
+      .getByText("Urgent mail")
+      .closest<HTMLElement>('[data-testid="notification-row"]');
+    if (!priorityRow) throw new Error("Expected the urgent notification row");
+    const priorityGroup = priorityRow.closest<HTMLElement>(
+      "[data-notification-group-content]",
+    );
+    const prioritySurface = priorityRow.closest<HTMLElement>(
+      '[data-testid="notification-row-swipe"]',
+    );
+
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 87,
+      clientX: 12,
+      clientY: 160,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 87,
+      clientX: 12,
+      clientY: 20,
+    });
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 87,
+      clientX: 12,
+      clientY: 20,
+    });
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+    finishShadeCollapse();
+
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(
+      priorityGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ),
+    ).toBe("");
+    expect(
+      priorityGroup
+        ?.querySelector<HTMLElement>("[data-notification-disposable-row]")
+        ?.style.getPropertyValue("--eliza-notif-row-content-visibility") ?? "",
+    ).toBe("");
+
+    expandShade();
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(
+      priorityGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ),
+    ).toBe("");
+    expect(prioritySurface?.style.opacity).toBe("1");
+
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 88,
+      clientX: 12,
+      clientY: 160,
+    });
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    expect(
+      priorityGroup?.style.getPropertyValue(
+        "--eliza-notif-group-content-visibility",
+      ),
+    ).toBe("");
+    expect(prioritySurface?.style.opacity).toBe("1");
+
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 88,
+      clientX: 12,
+      clientY: 116,
+    });
+    expect(list.hasAttribute("data-shade-dragging")).toBe(true);
+    expect(prioritySurface?.style.opacity).toBe("1");
+    expect(
+      Number.parseFloat(
+        priorityGroup?.style.getPropertyValue(
+          "--eliza-notif-group-content-visibility",
+        ) ?? "0",
+      ),
+    ).toBeGreaterThan(0);
+  });
+
   it("fades fanned contents without dimming their card material", () => {
     __ingestNotificationForTests(
       makeNotification({

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -414,17 +414,13 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   overflow-anchor: none;
 }
 .eliza-notif-scroll[data-shade-dragging] {
-  -webkit-mask-image: none;
-  mask-image: none;
   transition: none;
 }
-/* The retained overshoot padding is the release runway. Keep the edge mask off
-   until the cards finish crossing it; otherwise the mask darkens the lowest
-   physical stack layers and then brightens them as they settle upward. */
+/* The scroll-edge mask is part of the settled material. Keeping it mounted
+   through direct manipulation lets cards fade continuously as they cross the
+   edge instead of changing every card's compositing on the first drag frame. */
 .eliza-notif-scroll[data-shade-release-settling] {
   animation: none;
-  -webkit-mask-image: none;
-  mask-image: none;
 }
 .eliza-notif-scroll [data-notification-group] {
   position: relative;

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -327,30 +327,12 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
 .eliza-notif-scroll[data-shade-dragging] .eliza-notif-shade-transition {
   transition: none;
 }
-/* Keep the rim on the gesture surface, but move its fill to the full-size
-   content layer. This is the demo-era layering that lets the card visibly
-   fade under the finger without changing the rim's material or brightness. */
-.eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) .eliza-notif-row-surface,
-[data-notification-shade-cancelling] .eliza-notif-row-surface {
-  background-color: transparent;
-  background-image: none;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-}
-.eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) .eliza-notif-row-content,
-[data-notification-shade-cancelling] .eliza-notif-row-content {
-  background-color: rgb(22 22 25);
-  background-image: ${LIQUID_GLASS_SHEEN};
-}
-.eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) :is([data-notification-stack-material], [data-notification-stacked]) .eliza-notif-row-content,
-[data-notification-shade-cancelling] :is([data-notification-stack-material], [data-notification-stacked]) .eliza-notif-row-content {
-  background-color: rgb(28 28 30);
-  background-image: none;
-}
-/* The card surface owns the group fade so its fill, copy, and rim move as one
-   physical object. A row-specific variable is reserved for disposable stack
-   rows; falling back to the group variable here would multiply the surface
-   fade and make direct manipulation feel nonlinear. */
+/* The settled card surface keeps ownership of its fill, sheen, and rim through
+   drag and settle. Moving those layers to the inner button on the first drag
+   frame changes their compositing before any meaningful travel and reads as a
+   color jump. Opacity and transform provide the continuous close instead. A
+   row-specific variable is reserved for disposable stack rows; falling back to
+   the group variable here would multiply the fade. */
 .eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-content {
   opacity: var(--eliza-notif-row-content-visibility, 1);
 }

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -227,24 +227,40 @@ const NOTIF_SCROLL_CSS = `
   .eliza-notif-meta { font-size: clamp(.6875rem, calc(.5rem + .75cqi), .8125rem); }
 }
 .eliza-notif-glass {
-  background-color: rgb(12 12 14 / 34%);
-  background-image: ${LIQUID_GLASS_SHEEN};
-  box-shadow: ${LIQUID_GLASS_EDGE_SHADOW};
-  -webkit-backdrop-filter: ${LIQUID_GLASS_BLUR};
-  backdrop-filter: ${LIQUID_GLASS_BLUR};
-  transition: background-color 150ms linear;
+  --eliza-notif-glass-fill: rgb(12 12 14 / 34%);
+  --eliza-notif-glass-sheen: ${LIQUID_GLASS_SHEEN};
+  --eliza-notif-glass-backdrop: ${LIQUID_GLASS_BLUR};
+  --eliza-notif-glass-visibility: 1;
+  isolation: isolate;
+  background-color: transparent;
+  background-image: none;
+  box-shadow: none;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
 }
-/* The global focus reset removes box shadows, but this inset edge is part of
-   the glass material rather than a focus ring and must survive card focus. */
-.eliza-notif-glass:focus-within {
-  box-shadow: ${LIQUID_GLASS_EDGE_SHADOW} !important;
+/* The fill and edge depth live on a permanent layer beneath card content. The
+   mask-composite rim remains the permanent ::before layer below, so neither
+   layer changes ownership when a shade gesture begins. */
+.eliza-notif-glass::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background-color: var(--eliza-notif-glass-fill);
+  background-image: var(--eliza-notif-glass-sheen);
+  box-shadow: ${LIQUID_GLASS_EDGE_SHADOW};
+  -webkit-backdrop-filter: var(--eliza-notif-glass-backdrop);
+  backdrop-filter: var(--eliza-notif-glass-backdrop);
+  opacity: var(--eliza-notif-glass-visibility);
+  pointer-events: none;
+  transition: background-color 150ms linear;
 }
 /* Chromium honors url(#…) on backdrop-filter → refract the background at the
    rim (the "liquid" cue). WebKit can't, so it keeps the frosted blur above. */
 @supports (backdrop-filter: url(#x)) or (-webkit-backdrop-filter: url(#x)) {
   .eliza-notif-glass {
-    -webkit-backdrop-filter: ${LIQUID_GLASS_REFRACTION};
-    backdrop-filter: ${LIQUID_GLASS_REFRACTION};
+    --eliza-notif-glass-backdrop: ${LIQUID_GLASS_REFRACTION};
   }
 }
 /* A dense expanded inbox cannot afford one live backdrop-refraction graph per
@@ -253,17 +269,15 @@ const NOTIF_SCROLL_CSS = `
    and scroll stay compositor-cheap even at the 100-row render cap. */
 .eliza-notif-scroll[data-shade-preview] .eliza-notif-glass,
 .eliza-notif-scroll[data-shade-mode="expanded"] .eliza-notif-glass {
-  background-color: rgb(22 22 25);
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
+  --eliza-notif-glass-fill: rgb(22 22 25);
+  --eliza-notif-glass-backdrop: none;
 }
 /* Backdrop refraction has to resample the fixed wallpaper while the complete
    home pane translates. Keep the same opaque material during a horizontal rail
    drag/settle, then restore refraction when the pager reaches rest. */
 [data-rail-gesture-active] .eliza-notif-glass {
-  background-color: rgb(22 22 25 / 88%);
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
+  --eliza-notif-glass-fill: rgb(22 22 25 / 88%);
+  --eliza-notif-glass-backdrop: none;
 }
 /* A collapsed stack is a set of physical cards, not translucent glass panes.
    Keep its front card and peeks solid through every shade/pager material
@@ -271,14 +285,16 @@ const NOTIF_SCROLL_CSS = `
 .eliza-notif-scroll [data-notification-stack-material] .eliza-notif-glass,
 .eliza-notif-scroll [data-notification-stacked] .eliza-notif-glass,
 .eliza-notif-scroll .eliza-notif-glass.eliza-notif-stack-peek {
-  background-color: rgb(28 28 30);
-  background-image: none;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
+  --eliza-notif-glass-fill: rgb(28 28 30);
+  --eliza-notif-glass-sheen: none;
+  --eliza-notif-glass-backdrop: none;
 }
 /* Directional specular rim tracing every rounded corner (mask-composite ring)
    — replaces the old one-sided inset hairline that read as a vertical line. */
 ${liquidGlassRimCss(".eliza-notif-glass")}
+.eliza-notif-glass::before {
+  opacity: var(--eliza-notif-glass-visibility);
+}
 /* Touch browsers can leave :hover latched on the release target until React's
    settled projection replaces it. Only precise pointers get a hover material,
    so every physical card keeps one fill throughout a touch release. */
@@ -286,10 +302,10 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   .eliza-notif-scroll [data-notification-stack-material] .eliza-notif-glass:hover,
   .eliza-notif-scroll [data-notification-stacked] .eliza-notif-glass:hover,
   .eliza-notif-scroll .eliza-notif-glass.eliza-notif-stack-peek:hover {
-    background-color: rgb(38 38 42);
+    --eliza-notif-glass-fill: rgb(38 38 42);
   }
   .eliza-notif-glass:hover {
-    background-color: rgb(38 38 42 / 42%);
+    --eliza-notif-glass-fill: rgb(38 38 42 / 42%);
   }
 }
 .eliza-notif-pull-reveal {
@@ -335,7 +351,10 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
    row-specific variable is reserved for disposable stack rows; falling back to
    the group variable here would multiply the fade. */
 .eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-content {
-  opacity: var(--eliza-notif-row-content-visibility, 1);
+  opacity: var(
+    --eliza-notif-row-content-visibility,
+    var(--eliza-notif-group-content-visibility, 1)
+  );
 }
 .eliza-notif-scroll[data-shade-dragging] [data-notification-group-content] .eliza-notif-row-content {
   transition: none;
@@ -346,17 +365,22 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   transition:
     opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING};
 }
-/* The row button owns the copy, but the glass surface is the visible card.
-   Fade that surface with the content during a close gesture; otherwise the
-   copy disappears into an opaque rounded shell and the card reads as solid.
-   The important override is deliberate because NotificationRow keeps its
-   gesture surface at inline opacity 1 while it owns horizontal dismissing. */
-.eliza-notif-scroll:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-row-surface {
-  opacity: var(--eliza-notif-group-content-visibility, 1) !important;
-  transition: opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING};
+/* Collapse opacity belongs to the permanent fill and rim layers, never their
+   parent element. This avoids recompositing the faint right edge while still
+   fading the complete physical card at the same rate as its information. The
+   element-level override also neutralizes stack-peek inline opacity so it
+   cannot multiply the shared fade. */
+.eliza-notif-scroll[data-shade-mode="expanded"]:is([data-shade-dragging], [data-shade-settling]) [data-notification-group-content] .eliza-notif-glass {
+  --eliza-notif-glass-visibility: var(--eliza-notif-group-surface-visibility, 1);
+  opacity: 1 !important;
 }
-.eliza-notif-scroll[data-shade-dragging] [data-notification-group-content] .eliza-notif-row-surface {
+.eliza-notif-scroll[data-shade-mode="expanded"][data-shade-dragging] [data-notification-group-content] .eliza-notif-glass::before,
+.eliza-notif-scroll[data-shade-mode="expanded"][data-shade-dragging] [data-notification-group-content] .eliza-notif-glass::after {
   transition: none;
+}
+.eliza-notif-scroll[data-shade-mode="expanded"][data-shade-settling] [data-notification-group-content] .eliza-notif-glass::before,
+.eliza-notif-scroll[data-shade-mode="expanded"][data-shade-settling] [data-notification-group-content] .eliza-notif-glass::after {
+  transition: opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING};
 }
 /* A cancelled pull reverses the information fade on the same presentation
    clock while the unchanged glass shell stays in place. */
@@ -364,8 +388,12 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   opacity: 1;
   transition: opacity var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms) ${SHADE_EASING};
 }
-[data-notification-shade-cancelling] .eliza-notif-row-surface {
+[data-notification-shade-cancelling] .eliza-notif-glass {
+  --eliza-notif-glass-visibility: 1;
   opacity: 1 !important;
+}
+[data-notification-shade-cancelling] .eliza-notif-glass::before,
+[data-notification-shade-cancelling] .eliza-notif-glass::after {
   transition: opacity var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms) ${SHADE_EASING};
 }
 /* Bulk clear keeps its right edge aligned with each producer's X. Touch-first

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -131,6 +131,7 @@ import {
 } from "./liquid-glass";
 import {
   applyNotificationPullPresentation,
+  clearNotificationPullVisibilityOverrides,
   dampenPull,
   notificationGroupContainerOffset,
   notificationGroupPullOffset,
@@ -1264,6 +1265,12 @@ export function NotificationsHomeCenter({
         // targeting zero so padding and card transforms share one transition.
         if (pullReleaseSettling) list.getBoundingClientRect();
         list.style.setProperty("--eliza-notif-pull-overshoot", "0px");
+      }
+      // A cancelled pull retains its last visibility while it reverses. Once
+      // every gesture-owned settle is over, remove the imperative variables so
+      // persistent keyed rows begin the next close from React's settled state.
+      if (!pullCancellingDirection && !pullReleaseSettling) {
+        clearNotificationPullVisibilityOverrides(centerRef.current);
       }
       return;
     }

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -16,9 +16,9 @@
  *
  * Two shade modes:
  *
- *  - RESTED is triage: interrupt-tier (`high`/`urgent`) producer stacks remain
- *    visible above the interactive total while quieter notifications stay folded
- *    behind the same producer's visible stack depth.
+ *  - RESTED is closed: no notification card remains visible or interactive.
+ *    Interrupt-tier producer shells stay mounted only to preserve identity and
+ *    geometry across the close/reopen transition.
  *  - EXPANDED shows every priority and preserves each producer stack until the
  *    user fans that group out in place; the list is height-capped and scrolls
  *    internally.
@@ -133,7 +133,6 @@ import {
   applyNotificationPullPresentation,
   clearNotificationPullVisibilityOverrides,
   dampenPull,
-  notificationGroupContainerOffset,
   notificationGroupPullOffset,
   notificationGroupPullVisibility,
   notificationPullOvershootOffset,
@@ -2478,6 +2477,7 @@ export function NotificationsHomeCenter({
   const previewingExpansion =
     canExpand &&
     (pullDirection === "expand" || pullCancellingDirection === "expand");
+  const shadeAtRest = !shadeExpanded && !previewingExpansion;
   const groups = shadeExpanded
     ? expandedGroups
     : previewingExpansion
@@ -2657,7 +2657,8 @@ export function NotificationsHomeCenter({
         {groups.map((group, groupIndex) => {
           const allGroupRows = allGroupRowsByKey.get(group.key) ?? group.rows;
           const groupWasRested = restedGroupKeys.has(group.key);
-          const pullRevealed = previewingExpansion && !groupWasRested;
+          const pullRevealed = previewingExpansion;
+          const groupAtRest = shadeAtRest && groupWasRested;
           const revealProgress = pullRevealed
             ? notificationGroupPullVisibility(
                 pullPx,
@@ -2680,17 +2681,14 @@ export function NotificationsHomeCenter({
             closeVisibility,
             shadeOpenVisibility,
           );
-          const groupContainerOffset = notificationGroupContainerOffset(
-            pullPx,
-            shadeExpanded,
-            shadeClosing,
-          );
           const preservingCardMaterial =
             shadeExpanded && (pullDirection === "collapse" || shadeClosing);
           const groupContentVisibility = pullRevealed
             ? revealProgress
             : groupWasRested && !preservingCardMaterial
-              ? 1
+              ? groupAtRest
+                ? 0
+                : 1
               : groupVisibility;
           // A card follows the finger as one physical surface. Fading its
           // ancestor during direct manipulation also fades the glass rim,
@@ -2703,19 +2701,16 @@ export function NotificationsHomeCenter({
           const groupContentPullOffset = pullRevealed
             ? (1 - revealProgress) * -8
             : groupWasRested
-              ? 0
-              : notificationGroupPullOffset(
-                  pullPx,
-                  shadeExpanded,
-                  shadeClosing,
-                  groupVisibility,
-                );
+              ? groupAtRest
+                ? -8
+                : 0
+              : notificationGroupPullOffset(groupVisibility);
           // Framer Motion owns the outer group's layout transform. Keeping the
           // finger-tracked transform on this stable child lets a committed
           // preview continue into its CSS settle without either system
           // replacing the other's transform at pointer-up.
           const groupContentOffset =
-            groupContainerOffset + groupContentPullOffset + pullOvershootOffset;
+            groupContentPullOffset + pullOvershootOffset;
           const stackExpanded = expandedStacks.has(group.key);
           // Every presentation shares one shell, so the top NotificationRow
           // stays under the same parent/key while a fanned stack closes.
@@ -2807,7 +2802,8 @@ export function NotificationsHomeCenter({
               data-notification-stack-closing={stackClosing ? "" : undefined}
               data-rested-notification-group={groupWasRested ? "" : undefined}
               data-notification-pull-reveal={pullRevealed ? "" : undefined}
-              inert={pullRevealed ? true : undefined}
+              aria-hidden={groupAtRest ? true : undefined}
+              inert={pullRevealed || groupAtRest ? true : undefined}
               className={cn(
                 "relative flex flex-col",
                 pullRevealed &&
@@ -2833,7 +2829,7 @@ export function NotificationsHomeCenter({
                       : 0,
                   opacity: groupPresentationVisibility,
                   transform: `translate3d(0, ${groupContentOffset}px, 0)`,
-                  transition: isPulling ? "none" : undefined,
+                  transition: isPulling || groupAtRest ? "none" : undefined,
                 }}
               >
                 {fanned ? (

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -27,6 +27,7 @@ import {
   summarizeStability,
 } from "../../../testing/layout-stability.ts";
 import {
+  touchDragHold,
   touchLongPress,
   touchSwipe,
   touchTap,

--- a/packages/ui/src/components/shell/notification-shade-content.tsx
+++ b/packages/ui/src/components/shell/notification-shade-content.tsx
@@ -559,7 +559,7 @@ export const NotificationRow = memo(function NotificationRow({
               onExpandStack(stackKey, event.detail === 0);
             } else onOpen(notification);
           }}
-          className="eliza-notif-row-content flex min-h-touch min-w-0 items-center gap-3 rounded-2xl px-3 py-2 text-left active:scale-[0.99] motion-reduce:active:scale-100"
+          className="eliza-notif-row-content flex min-h-touch min-w-0 items-center gap-3 rounded-2xl px-3 py-2 text-left"
         >
           <NotificationSourceIcon
             source={notification.source}

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -298,8 +298,13 @@ export function applyNotificationPullPresentation(
           "--eliza-notif-group-content-visibility",
           String(contentVisibility),
         );
+        content.style.setProperty(
+          "--eliza-notif-group-surface-visibility",
+          String(contentVisibility),
+        );
       } else if (!shadeClosing) {
         content.style.removeProperty("--eliza-notif-group-content-visibility");
+        content.style.removeProperty("--eliza-notif-group-surface-visibility");
       }
       content.style.transform = `translate3d(0, ${
         containerOffset + contentPullOffset + presentation.pullOvershootOffset
@@ -380,6 +385,7 @@ export function clearNotificationPullVisibilityOverrides(
     "[data-notification-group-content]",
   )) {
     content.style.removeProperty("--eliza-notif-group-content-visibility");
+    content.style.removeProperty("--eliza-notif-group-surface-visibility");
   }
   for (const row of root.querySelectorAll<HTMLElement>(
     "[data-notification-disposable-row]",

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -366,6 +366,28 @@ export function applyNotificationPullPresentation(
   }
 }
 
+/**
+ * Release gesture-only visibility overrides when React resumes ownership of a
+ * settled shade. These custom properties are written outside React during a
+ * pull, so leaving them on persistent keyed rows lets a later drag reactivate
+ * the previous cycle's terminal opacity before its first presentation frame.
+ */
+export function clearNotificationPullVisibilityOverrides(
+  root: HTMLElement | null,
+): void {
+  if (!root) return;
+  for (const content of root.querySelectorAll<HTMLElement>(
+    "[data-notification-group-content]",
+  )) {
+    content.style.removeProperty("--eliza-notif-group-content-visibility");
+  }
+  for (const row of root.querySelectorAll<HTMLElement>(
+    "[data-notification-disposable-row]",
+  )) {
+    row.style.removeProperty("--eliza-notif-row-content-visibility");
+  }
+}
+
 /** Limit direct manipulation to groups near the scrollport. */
 export function visibleNotificationGroups(
   root: HTMLElement | null,

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -72,93 +72,20 @@ export function notificationPullPresentation(
     ? disposableContentVisibility
     : pullRevealProgress;
   const pullOvershootOffset = notificationPullOvershootOffset(pullPx);
-  const countCloseOvershootProgress = Math.min(
-    1,
-    Math.max(0, -pullOvershootOffset / (PULL_MAX_OVERSHOOT_PX / 4)),
-  );
-  const countCloseBoundaryVisibility =
-    1 -
-    countCloseOvershootProgress ** 2 * (3 - 2 * countCloseOvershootProgress);
-  // The count follows the same continuous travel as the cards but stays much
-  // dimmer while their surfaces overlap. This reads as a fade beneath the
-  // stack without either legible text through glass or a hard clipping edge.
-  // Once upward elastic travel carries it toward the scrollport boundary, a
-  // smooth end fade completes before the final quarter of resisted movement.
-  const notificationCountVisibility =
-    (shadeExpanded ? shadeCloseProgress ** 3 : (1 - pullRevealProgress) ** 3) *
-    countCloseBoundaryVisibility;
-  const clearControlVisibility = shadeExpanded
-    ? disposableContentVisibility
-    : pullPx > 0
-      ? pullRevealProgress
-      : 0;
-  // The clear-control slot reserves its full row as soon as a drag starts so
-  // notification groups can mount without reflowing under the finger. The
-  // count follows that slot in document flow, so it needs the same inverse
-  // offset as the groups or its first drag frame jumps by the full 40px row.
-  const notificationCountOffset = notificationGroupContainerOffset(
-    pullPx,
-    shadeExpanded,
-    shadeClosing,
-  );
   return {
     shadeCloseProgress,
     committedCloseProgress,
     disposableContentVisibility,
     pullContentVisibility,
-    notificationCountVisibility,
-    notificationCountOffset,
     pullOvershootOffset,
-    collapseControlOvershootOffset: Math.min(0, pullOvershootOffset),
-    notificationCountLayoutVisibility:
-      shadeExpanded && pullPx < 0 && !shadeClosing
-        ? 1
-        : shadeExpanded
-          ? shadeCloseProgress
-          : 1 - pullRevealProgress,
     emptyStateVisibility: shadeExpanded
       ? disposableContentVisibility
       : notificationPullRevealProgress(pullPx, 0),
-    collapseControlVisibility: shadeExpanded
-      ? disposableContentVisibility
-      : pullRevealProgress,
-    clearControlVisibility,
-    clearControlLayoutVisibility: shadeExpanded
-      ? shadeClosing || pullPx < 0
-        ? 0
-        : 1
-      : pullPx > 0
-        ? 1
-        : 0,
   };
 }
 
-export function notificationGroupContainerOffset(
-  pullPx: number,
-  shadeExpanded: boolean,
-  shadeClosing: boolean,
-): number {
-  if (shadeClosing) return 0;
-  if (shadeExpanded && pullPx < 0) {
-    return (1 - notificationPullRevealProgress(-pullPx, 0)) * 40;
-  }
-  if (!shadeExpanded && pullPx > 0) {
-    return (1 - notificationPullRevealProgress(pullPx, 0)) * -40;
-  }
-  return 0;
-}
-
-export function notificationGroupPullOffset(
-  pullPx: number,
-  shadeExpanded: boolean,
-  shadeClosing: boolean,
-  groupVisibility: number,
-): number {
-  const countSlotCompensation =
-    shadeExpanded && pullPx < 0 && !shadeClosing
-      ? (1 - notificationPullRevealProgress(-pullPx, 0)) * -40
-      : 0;
-  return countSlotCompensation + (1 - groupVisibility) * -8;
+export function notificationGroupPullOffset(groupVisibility: number): number {
+  return (1 - groupVisibility) * -8;
 }
 
 export function notificationGroupPullVisibility(
@@ -189,9 +116,6 @@ export function applyNotificationPullPresentation(
   shadeClosing: boolean,
   visibleGroups?: readonly HTMLElement[],
 ): void {
-  const count = root?.querySelector<HTMLElement>(
-    "[data-notification-count-slot]",
-  );
   if (!root) return;
   const presentation = notificationPullPresentation(
     pullPx,
@@ -205,26 +129,6 @@ export function applyNotificationPullPresentation(
     "--eliza-notif-pull-overshoot",
     `${Math.max(0, presentation.pullOvershootOffset)}px`,
   );
-  if (count) {
-    count.style.height = `${presentation.notificationCountLayoutVisibility * 32}px`;
-    count.style.marginBottom = `${(presentation.notificationCountLayoutVisibility - 1) * 8}px`;
-    count.style.opacity = String(presentation.notificationCountVisibility);
-    count.style.transform = `translate3d(0, ${
-      presentation.notificationCountOffset + presentation.pullOvershootOffset
-    }px, 0)`;
-  }
-  const clearSlot = root.querySelector<HTMLElement>(
-    "[data-notification-clear-slot]",
-  );
-  if (clearSlot) {
-    clearSlot.style.height = `${presentation.clearControlLayoutVisibility * 32}px`;
-    clearSlot.style.marginBottom = `${(presentation.clearControlLayoutVisibility - 1) * 8}px`;
-    clearSlot.style.opacity = String(presentation.clearControlVisibility);
-    clearSlot.style.transform = `translate3d(0, ${
-      (1 - presentation.clearControlVisibility) * -8 +
-      presentation.pullOvershootOffset
-    }px, 0)`;
-  }
   const empty = root.querySelector<HTMLElement>("[data-notification-empty]");
   if (empty) {
     Object.assign(
@@ -234,16 +138,6 @@ export function applyNotificationPullPresentation(
         presentation.pullOvershootOffset,
       ),
     );
-  }
-  const collapse = root.querySelector<HTMLElement>(
-    "[data-notification-collapse-footer]",
-  );
-  if (collapse) {
-    collapse.style.opacity = String(presentation.collapseControlVisibility);
-    collapse.style.transform = `translateY(${
-      (1 - presentation.collapseControlVisibility) * 4 +
-      presentation.collapseControlOvershootOffset
-    }px)`;
   }
   const groups =
     visibleGroups ??
@@ -257,11 +151,6 @@ export function applyNotificationPullPresentation(
       shadeExpanded,
       shadeClosing,
       pullRevealed,
-    );
-    const containerOffset = notificationGroupContainerOffset(
-      pullPx,
-      shadeExpanded,
-      shadeClosing,
     );
     const rested = group.hasAttribute("data-rested-notification-group");
     const content = group.querySelector<HTMLElement>(
@@ -284,12 +173,7 @@ export function applyNotificationPullPresentation(
         ? (1 - groupVisibility) * -8
         : rested
           ? 0
-          : notificationGroupPullOffset(
-              pullPx,
-              shadeExpanded,
-              shadeClosing,
-              groupVisibility,
-            );
+          : notificationGroupPullOffset(groupVisibility);
       content.style.opacity = String(
         preservesCardMaterial ? 1 : contentVisibility,
       );
@@ -306,9 +190,7 @@ export function applyNotificationPullPresentation(
         content.style.removeProperty("--eliza-notif-group-content-visibility");
         content.style.removeProperty("--eliza-notif-group-surface-visibility");
       }
-      content.style.transform = `translate3d(0, ${
-        containerOffset + contentPullOffset + presentation.pullOvershootOffset
-      }px, 0)`;
+      content.style.transform = `translate3d(0, ${contentPullOffset + presentation.pullOvershootOffset}px, 0)`;
     }
     if (!shadeExpanded && pullPx > 0) {
       if (content?.hasAttribute("data-notification-stacked")) {

--- a/packages/ui/src/hooks/useHorizontalPager.test.tsx
+++ b/packages/ui/src/hooks/useHorizontalPager.test.tsx
@@ -566,21 +566,27 @@ describe("useHorizontalPager — drag-scoped GPU promotion (#swipe-smoothness)",
     });
   }
 
-  it("promotes the rail at pointerdown, holds through the drag, drops on settle end", () => {
+  it("keeps pending input inert, then promotes on horizontal commit through settle", () => {
     const { getByTestId } = render(<Harness />);
     const rail = getByTestId("rail");
     act(() => {
       clock = 1000;
       fireEvent.pointerDown(rail, { ...touch, clientX: 800 });
-      // Armed at pointerdown — the compositor gets the whole slop window to
-      // build the layer before the first tracked frame — and the rail-gesture
-      // signal opens with it.
-      expect(rail.style.willChange).toBe("transform");
-      expect(rail.hasAttribute("data-rail-gesture-active")).toBe(true);
-      expect(isRailGestureActive()).toBe(true);
+      expect(rail.style.willChange).toBe("");
+      expect(rail.hasAttribute("data-rail-gesture-active")).toBe(false);
+      expect(isRailGestureActive()).toBe(false);
+      fireEvent.pointerMove(rail, {
+        ...touch,
+        clientX: 792,
+        clientY: 308,
+      });
+      expect(rail.style.willChange).toBe("");
+      expect(isRailGestureActive()).toBe(false);
       fireEvent.pointerMove(rail, { ...touch, clientX: 770 });
     });
     expect(rail.style.willChange).toBe("transform");
+    expect(rail.hasAttribute("data-rail-gesture-active")).toBe(true);
+    expect(isRailGestureActive()).toBe(true);
     // Held through the drag frames + the release settle.
     act(() => {
       fireEvent.pointerMove(rail, { ...touch, clientX: 400 });
@@ -597,17 +603,16 @@ describe("useHorizontalPager — drag-scoped GPU promotion (#swipe-smoothness)",
     expect(isRailGestureActive()).toBe(false);
   });
 
-  it("drops the pointerdown promotion the moment a gesture commits VERTICAL", () => {
+  it("never promotes a pointerdown or vertical gesture", () => {
     const { getByTestId } = render(<Harness />);
     const rail = getByTestId("rail");
     act(() => {
       clock = 1000;
       fireEvent.pointerDown(rail, { ...touch, clientX: 500 });
-      expect(rail.style.willChange).toBe("transform");
-      expect(isRailGestureActive()).toBe(true);
-      // Vertical-dominant move: axis commits to Y — this is the widget list
-      // scrolling, not a rail pan, so the promotion (and the signal) must
-      // release immediately, not linger through the scroll.
+      expect(rail.style.willChange).toBe("");
+      expect(isRailGestureActive()).toBe(false);
+      // Vertical-dominant movement belongs to the shade/list and must stay
+      // visually inert from contact through release.
       fireEvent.pointerMove(rail, { ...touch, clientX: 505, clientY: 400 });
       expect(rail.style.willChange).toBe("");
       expect(rail.hasAttribute("data-rail-gesture-active")).toBe(false);
@@ -638,7 +643,7 @@ describe("useHorizontalPager — drag-scoped GPU promotion (#swipe-smoothness)",
         clientX: 792,
         clientY: 308,
       });
-      expect(isRailGestureActive()).toBe(true);
+      expect(isRailGestureActive()).toBe(false);
 
       clock = 1500;
       fireEvent.pointerMove(rail, {
@@ -646,6 +651,7 @@ describe("useHorizontalPager — drag-scoped GPU promotion (#swipe-smoothness)",
         clientX: 430,
         clientY: 312,
       });
+      expect(isRailGestureActive()).toBe(true);
       clock = 2200;
       fireEvent.pointerUp(rail, {
         ...touch,
@@ -656,19 +662,42 @@ describe("useHorizontalPager — drag-scoped GPU promotion (#swipe-smoothness)",
     expect(onChange).toHaveBeenCalledWith(1);
   });
 
-  it("drops the pointerdown promotion after a plain tap (zero-delta settle, no transitionend)", () => {
+  it("keeps a plain tap visually inert", () => {
     const { getByTestId } = render(<Harness />);
     const rail = getByTestId("rail");
     act(() => {
       clock = 1000;
       fireEvent.pointerDown(rail, { ...touch, clientX: 500 });
-      expect(rail.style.willChange).toBe("transform");
+      expect(rail.style.willChange).toBe("");
+      expect(rail.hasAttribute("data-rail-gesture-active")).toBe(false);
+      expect(isRailGestureActive()).toBe(false);
       clock = 1050;
-      // No movement: the settle writes the same transform back, so no
-      // transitionend will ever fire — finish() must drop the promotion (and
-      // release the signal) itself or it would leak until the next gesture.
       fireEvent.pointerUp(rail, { ...touch, clientX: 500 });
     });
+    expect(rail.style.willChange).toBe("");
+    expect(isRailGestureActive()).toBe(false);
+  });
+
+  it("arms a coalesced down→up horizontal flick before its release settle", () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(<Harness onPageChange={onChange} />);
+    const rail = getByTestId("rail");
+    act(() => {
+      clock = 1000;
+      fireEvent.pointerDown(rail, { ...touch, clientX: 800 });
+      expect(isRailGestureActive()).toBe(false);
+      clock = 1080;
+      fireEvent.pointerUp(rail, {
+        ...touch,
+        clientX: 680,
+        clientY: 302,
+      });
+    });
+    expect(onChange).toHaveBeenCalledWith(1);
+    expect(rail.style.willChange).toBe("transform");
+    expect(rail.hasAttribute("data-rail-gesture-active")).toBe(true);
+    expect(isRailGestureActive()).toBe(true);
+    endTransform(rail);
     expect(rail.style.willChange).toBe("");
     expect(isRailGestureActive()).toBe(false);
   });

--- a/packages/ui/src/hooks/useHorizontalPager.ts
+++ b/packages/ui/src/hooks/useHorizontalPager.ts
@@ -299,14 +299,12 @@ export function useHorizontalPager<
   // Center). Without a promotion hint WebKit/iOS Safari rasterizes the rail into
   // its parent layer, so every frame of a horizontal pan re-rasterizes the
   // blurred/masked subtree as it translates (the installed-PWA left↔right
-  // micro-stutter). Hinting `will-change: transform` on the rail up front lets
-  // the compositor promote the whole surface to its own layer and translate it
-  // without a per-frame repaint. Deliberately NOT permanent — a resident hint
-  // keeps a promoted layer (and its GPU memory) alive at rest for no benefit, so
-  // it is dropped the instant the settle transition ends (see `armRailPromotion`
-  // / `dropRailPromotion` below). Written imperatively on the same element as
-  // the transform (the pager already bypasses React for the per-frame drag), so
-  // it never triggers a re-render.
+  // micro-stutter). Hinting `will-change: transform` once horizontal intent is
+  // established lets the compositor promote the surface before the first
+  // rAF-scheduled translate without perturbing a tap or vertical gesture. The
+  // hint is deliberately NOT permanent — a resident layer costs GPU memory at
+  // rest — so it is dropped when the settle transition ends. Written
+  // imperatively on the transform owner, it never triggers a React render.
   const railPromotedRef = React.useRef(false);
   const dropRailPromotion = React.useCallback(() => {
     const rail = railRef.current;
@@ -333,9 +331,8 @@ export function useHorizontalPager<
   }, []);
 
   // Offset of the most recent transform write. Lets the settle paths detect a
-  // ZERO-DELTA write (a tap, or an abandoned drag that never moved): such a
-  // write changes nothing, so no `transitionend` will ever fire to drop the
-  // pointerdown-armed rail promotion — the caller must drop it directly.
+  // ZERO-DELTA write after horizontal intent was armed: such a write changes
+  // nothing, so no `transitionend` will fire to drop the promotion.
   const lastWrittenOffsetRef = React.useRef(0);
   const writeOffset = React.useCallback(
     (offset: number, transitionMs: number | null) => {
@@ -422,9 +419,9 @@ export function useHorizontalPager<
     const target = pageOffset(state.page, measureWidth());
     const noMove = Math.abs(target - lastWrittenOffsetRef.current) < 1;
     writeOffset(target, SETTLE_MS);
-    // A no-move abandon (press, then the button released off-surface before any
-    // travel) writes the same transform back — no settle transition runs, so no
-    // `transitionend` will drop the pointerdown-armed promotion. Drop it here.
+    // A horizontal drag can return to its resting offset before the button is
+    // released off-surface. No transition runs in that case, so drop the
+    // already-armed promotion directly.
     if (noMove) dropRailPromotion();
   }, [
     cancelScheduledOffset,
@@ -532,6 +529,10 @@ export function useHorizontalPager<
       // intentionally discard that queued value and return from the last frame
       // that was actually shown.
       if (!cancelled && releaseAxis === "horizontal") {
+        // Some touch stacks coalesce down→up without a move event. The axis
+        // resolves here in that case, so arm before the release-driven settle
+        // just as the move path arms before its first scheduled translate.
+        armRailPromotion();
         flushScheduledOffset();
         commitRailDragFrame(railRef.current);
       } else {
@@ -626,6 +627,7 @@ export function useHorizontalPager<
       }
     },
     [
+      armRailPromotion,
       canMove,
       cancelScheduledOffset,
       clickSuppression,
@@ -698,16 +700,8 @@ export function useHorizontalPager<
         hadButtons: event.pointerType !== "touch" && event.buttons > 0,
       };
       writeOffset(baseOffset, null);
-      // Promote the rail NOW, not on the first horizontal-committed move frame:
-      // arming at pointerdown gives the compositor the whole slop window to
-      // build the layer before the first tracked translate, so the opening
-      // frames of a swipe composite instead of paying the promotion raster
-      // right when the finger starts moving. A gesture that commits VERTICAL
-      // drops the promotion immediately (see onPointerMove); a plain tap drops
-      // it in finish()'s zero-delta path.
-      armRailPromotion();
     },
-    [armRailPromotion, cancelScheduledOffset, measureWidth, writeOffset],
+    [cancelScheduledOffset, measureWidth, writeOffset],
   );
 
   const onPointerMove = React.useCallback(
@@ -740,13 +734,10 @@ export function useHorizontalPager<
         // cancelled otherwise-valid swipes after only a few pixels of jitter.
         state.axis = resolveGestureAxis(dx, dy);
         if (state.axis === "pending") return;
-        // The promotion was armed at pointerdown (so the compositor had the
-        // slop window to build the layer before the first tracked frame). A
-        // gesture that commits VERTICAL is the home widget list scrolling, not
-        // a rail pan — the rail will not move, so drop the layer (and release
-        // the rail-gesture signal) immediately instead of holding GPU memory
-        // and parked widget flushes through a scroll.
-        if (state.axis === "vertical") dropRailPromotion();
+        // Pending input is visually inert: a tap or vertical shade/list gesture
+        // must not change the rail layer or any descendant glass material. Arm
+        // only after horizontal intent is proven, before the first rAF write.
+        if (state.axis === "horizontal") armRailPromotion();
       }
       if (state.axis !== "horizontal") return;
 
@@ -782,7 +773,7 @@ export function useHorizontalPager<
       }
       scheduleOffset(state.baseOffset + visualDragOffset(state, dx));
     },
-    [abandonDrag, dropRailPromotion, scheduleOffset, visualDragOffset],
+    [abandonDrag, armRailPromotion, scheduleOffset, visualDragOffset],
   );
 
   const onPointerUp = React.useCallback(

--- a/packages/ui/src/state/rail-gesture-store.ts
+++ b/packages/ui/src/state/rail-gesture-store.ts
@@ -3,11 +3,11 @@
  * would re-rasterize the promoted rail layer (e.g. live-widget flushes from
  * useActivityEvents) can park until the swipe settles.
  *
- * The window is exactly the pager's rail-promotion window: armed at
- * pointerdown (useHorizontalPager.armRailPromotion), released when the settle
- * transition ends / the gesture commits to the vertical axis / the surface
- * unmounts (dropRailPromotion). Reduced motion keeps a restrained spatial
- * settle, so it uses the same bounded promotion window.
+ * The window is exactly the pager's rail-promotion window: armed only after
+ * horizontal intent commits (or a coalesced down→up release resolves
+ * horizontal), then released when the settle transition ends or the surface
+ * unmounts. Pending taps and vertical gestures never enter this store. Reduced
+ * motion keeps a restrained spatial settle, so it uses the same bounded window.
  *
  * Module-level store shared via globalThis (survives HMR + reachable from the
  * pager's imperative gesture handlers outside any React subtree) +


### PR DESCRIPTION
> Latest publication sync (2026-08-06): exact head `e8420a2577fa55a47cf71195921c001499434e65`; cumulative top `3bd520d18fa54d13809248acae52452e2694b866`; 0 behind `origin/develop@35f6345511c8bc5ad00fc4cd01da40e4fb11c203`. The 107-commit replay is patch-identical; the only final-tree delta is develop's already-merged CI browser-runner provisioning.

# Relates to

Closes #17726.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/gpt-5.6-sol
<!-- attribution-row:client -->
- Client / agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@04ff8982861e7aa5045c0a065fb7e1d8750e6e6b:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

# Sync with the stacked base

- [x] Base PR: #17517, exact base `84a4c872919ce3693f7375cf352b21207f29c819`.
- [x] Base PR itself is stacked on current `develop@255b67adda9d32aab34f8879d17cce1ddcf963a1`.
- [x] Exact head: `0b742fcb1f213f16ce0bdcfb69d43801979b34d5`.
- [x] Exact tree: `39b1730eb0be840a6c693641e0ce6267643a0784`.
- [x] Frozen install passed without tracked changes.

# What this PR does

Preserves one continuous notification-card material while the home notification shade is pulled, cancelled, closed, reopened, and closed again. The fix removes gesture-state material handoffs, keeps the scroll fade stable, clears per-group pull state after settlement, and defers the horizontal rail's compositor promotion until horizontal intent is established. It also keeps the full shade closeable through repeated cycles without a first-contact rim/glow jump.

This is a seven-commit, eight-path UI packet. Seven production/test paths are byte-identical to the product code the user approved in the cumulative `2138` preview (`5e01384371ce2397fac37f44083409c30ef592ce`); the eighth path is a one-line E2E harness import needed to execute the held-touch proof on a clean runner.

# Testing

- `bun install --frozen-lockfile --ignore-scripts` — PASS, tracked tree unchanged.
- Focused supported Vitest matrix (`NotificationsHomeCenter`, `HomeScreen`, pager, rail store) — 130/130 PASS; the suite's pre-existing React `act(...)` warning remains non-fatal.
- `bun run --cwd packages/ui typecheck` — PASS.
- Targeted Biome — PASS.
- `node --check packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs` — PASS.
- `bun run --cwd packages/ui test:home-screen-e2e` — PASS on the exact head:
  - partial pull moves continuously and cancelled pull settles to `0.00px`;
  - down-open/up-close works without duplicate rows;
  - repeated mobile gestures and desktop directional gestures preserve the single row;
  - three 120 Hz rail windows: median p95 `9.2ms`, `0%` dropped frames;
  - zero page errors;
  - 11 screenshots and an MP4-compatible walkthrough artifact.
- Full root build — PASS, 121/121 tasks plus all 19 view bundles.
- Full `bun run verify` — PASS on the exact head.
- `git diff --check` — PASS; worktree clean.

# Evidence gate

<!-- evidence-head:e8420a2577fa55a47cf71195921c001499434e65 -->
<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17727-base-4e77-before-first8s-contact.jpg)
<!-- evidence-row:after-screenshots -->
- [x] Exact-head rendered pixels: [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17727-2229709-mobile-after.jpg) and [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17727-2229709-desktop-after.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] Exact-head H.264 MP4: [mobile notification/launcher walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17727-2229709-notification-walkthrough.mp4), 25.76 seconds, 402×874, manually reviewed end-to-end.
<!-- evidence-row:backend-logs -->
- [ ] N/A - notification gesture renderer/state-machine slice; no backend code path changes
<!-- evidence-row:frontend-logs -->
- [x] [Exact-head real-browser log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17727-2229709-frontend-e2e.log) records the gesture assertions, frame samples, screenshots, and zero page errors.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - notification gesture slice does not change agent, action, prompt, provider, or model behavior
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - notification gesture slice produces no persistent domain artifact
<!-- evidence-row:ocr-review -->
- [x] [17727-0b742fcb-notification-ocr.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17727-0b742fcb-notification-ocr.json)

# Risk and rollout

The main risk is a gesture-axis or repeated-cycle regression. The focused state-machine tests, real held-touch browser path, repeated down-open/up-close sequence, desktop pointer coverage, and rail frame-budget gate cover those boundaries. The PR remains draft while stacked-parent CI and review complete; it should merge only after the lower stack lands and GitHub recomputes this exact head against the landed base.

-- [codex/restack-pr17727-0806]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@04ff8982861e7aa5045c0a065fb7e1d8750e6e6b:packages/skills/skills/contribute-to-eliza"} -->

