### PR TITLE
feat(pendant): add canonical ambient listening surface

### DIFF
--- a/packages/agent/src/api/pendant-session-routes.test.ts
+++ b/packages/agent/src/api/pendant-session-routes.test.ts
@@ -51,6 +51,18 @@ const {
 
 class TestRuntime {
   readonly agentId: UUID;
+  readonly character = { name: "Test Agent" };
+  readonly memories = new Map<string, Record<string, unknown>>();
+  readonly createMemory = vi.fn(
+    async (memory: Record<string, unknown>, tableName: string) => {
+      this.memories.set(String(memory.id), memory);
+      expect(tableName).toBe("messages");
+      return memory.id;
+    },
+  );
+  readonly updateMemory = vi.fn(async (memory: Record<string, unknown>) => {
+    this.memories.set(String(memory.id), memory);
+  });
 
   constructor(agentId: UUID) {
     this.agentId = agentId;
@@ -62,20 +74,8 @@ class TestRuntime {
     );
   }
 
-  async getMemoryById(): Promise<never> {
-    throw new Error("Pendant session routes must not read Memory records");
-  }
-
-  async createMemory(): Promise<never> {
-    throw new Error("Pendant session routes must not create Memory records");
-  }
-
-  async updateMemory(): Promise<never> {
-    throw new Error("Pendant session routes must not update Memory records");
-  }
-
-  async deleteMemory(): Promise<never> {
-    throw new Error("Pendant session routes must not delete Memory records");
+  async getMemoryById(id: string): Promise<Record<string, unknown> | null> {
+    return this.memories.get(id) ?? null;
   }
 }
 
@@ -367,6 +367,63 @@ describe("handlePendantSessionRoutes", () => {
     }
   });
 
+  it("writes one owner-private canonical Memory with pendant provenance", async () => {
+    const ownerId = uuid();
+    const h = makeHarness(ownerId);
+    await h.request("POST", "/api/pendant/sessions", {
+      sessionId: "sess-memory",
+    });
+    const lease = okBody<{ leaseToken: string }>(
+      await h.request("POST", "/api/pendant/sessions/sess-memory/lease", {
+        holder: "capturer",
+      }),
+    );
+
+    const mutation = await h.request(
+      "POST",
+      "/api/pendant/sessions/sess-memory/segments",
+      {
+        leaseToken: lease.leaseToken,
+        segment: segment("sess-memory", 0, 0, "private pendant fact"),
+      },
+    );
+    expect(mutation.status).toBe(200);
+    expect(h.runtime.memories).toHaveLength(1);
+    const [memory] = [...h.runtime.memories.values()];
+    expect(memory).toMatchObject({
+      entityId: ownerId,
+      agentId: h.runtime.agentId,
+      content: {
+        text: "private pendant fact",
+        source: "pendant",
+        channelType: "VOICE_DM",
+      },
+      metadata: {
+        provider: "pendant",
+        scope: "owner-private",
+        scopedToEntityId: ownerId,
+        base: { source: "pendant", scope: "owner-private" },
+        pendant: {
+          userId: ownerId,
+          sessionId: "sess-memory",
+          segmentId: "sess-memory:segment:0",
+        },
+      },
+    });
+    expect(h.runtime.createMemory).toHaveBeenCalledWith(
+      expect.objectContaining({ id: memory?.id }),
+      "messages",
+      true,
+    );
+
+    await h.request("POST", "/api/pendant/sessions/sess-memory/segments", {
+      leaseToken: lease.leaseToken,
+      segment: segment("sess-memory", 0, 0, "private pendant fact"),
+    });
+    expect(h.runtime.memories).toHaveLength(1);
+    expect(h.runtime.createMemory).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps exact duplicate replay idempotent and conflicts altered same-revision content", async () => {
     const h = makeHarness();
     await h.request("POST", "/api/pendant/sessions", { sessionId: "sess-b" });
@@ -613,16 +670,38 @@ describe("handlePendantSessionRoutes", () => {
     );
     expect(second.leaseToken).not.toBe(first.leaseToken);
 
+    await h.request("POST", "/api/pendant/sessions/sess-c/segments", {
+      leaseToken: second.leaseToken,
+      segment: {
+        ...segment("sess-c", 0),
+        status: "pending",
+        text: "",
+        endedAt: null,
+      },
+    });
     await h.request("POST", "/api/pendant/sessions/sess-c/pause", {});
     const blocked = await h.request(
       "POST",
       "/api/pendant/sessions/sess-c/segments",
       {
         leaseToken: second.leaseToken,
-        segment: segment("sess-c", 0),
+        segment: segment("sess-c", 1),
       },
     );
     expect(blocked.status).toBe(409);
+    const lateAsr = await h.request(
+      "PATCH",
+      "/api/pendant/sessions/sess-c/segments/sess-c%3Asegment%3A0",
+      {
+        leaseToken: second.leaseToken,
+        revision: 1,
+        status: "resolved",
+        text: "must not land after pause",
+        endedAt: "2026-07-09T00:00:01.000Z",
+      },
+    );
+    expect(lateAsr.status).toBe(409);
+    expect(h.runtime.memories).toHaveLength(0);
   });
 
   it("converges polling, deletes from memory, and enforces owner and agent isolation", async () => {

--- a/packages/agent/src/api/pendant-session-routes.ts
+++ b/packages/agent/src/api/pendant-session-routes.ts
@@ -14,6 +14,7 @@ import {
   sendJson as httpSendJson,
   type LegacyRouteHandler,
   logger,
+  type Memory,
   type Route,
   resolveCanonicalOwnerId,
   stringToUuid,
@@ -355,6 +356,65 @@ async function notifyCommittedSegment(
       );
     }
   }
+}
+
+function canonicalPendantMemoryId(event: PendantCommittedSegmentEvent): UUID {
+  return stringToUuid(
+    `pendant:${event.snapshot.session.agentId}:${event.snapshot.session.id}:${event.segment.id}`,
+  );
+}
+
+/** Persist the resolved transcript as the one recallable pendant record. */
+async function persistCanonicalPendantMemory(
+  runtime: AgentRuntime,
+  event: PendantCommittedSegmentEvent,
+): Promise<void> {
+  const text = event.segment.text.trim();
+  if (event.segment.status !== "resolved" || !text) return;
+
+  const { session } = event.snapshot;
+  const id = canonicalPendantMemoryId(event);
+  const roomId = stringToUuid(
+    `${runtime.character?.name?.trim() || "Eliza"}-web-chat-room`,
+  );
+  const timestamp = Date.parse(
+    event.segment.endedAt ?? event.segment.updatedAt,
+  );
+  const memory: Memory = {
+    id,
+    entityId: session.ownerId as UUID,
+    agentId: session.agentId as UUID,
+    roomId,
+    createdAt: Number.isFinite(timestamp) ? timestamp : Date.now(),
+    content: { text, source: "pendant", channelType: "VOICE_DM" },
+    metadata: {
+      provider: "pendant",
+      accountId: session.agentId,
+      platformMessageId: event.segment.id,
+      sourceId: event.segment.id,
+      chatType: "dm",
+      scope: "owner-private",
+      scopedToEntityId: session.ownerId,
+      addedBy: session.ownerId,
+      addedByRole: "OWNER",
+      base: { source: "pendant", scope: "owner-private" },
+      pendant: {
+        userId: session.ownerId,
+        accountId: session.agentId,
+        messageId: event.segment.id,
+        sessionId: session.id,
+        segmentId: event.segment.id,
+        segmentRevision: event.segment.revision,
+      },
+    },
+  };
+
+  const existing = await runtime.getMemoryById(id);
+  if (existing) {
+    await runtime.updateMemory({ ...existing, ...memory });
+    return;
+  }
+  await runtime.createMemory(memory, "messages", true);
 }
 
 function broadcastMutation(
@@ -741,8 +801,12 @@ export async function handlePendantSessionRoutes(
         };
       });
       if (event.committed) {
+        await persistCanonicalPendantMemory(identity.runtime, event);
         await notifyCommittedSegment(event);
         broadcastMutation(ctx, event.snapshot);
+      } else {
+        // Repair a prior attempt where the projection committed but Memory did not.
+        await persistCanonicalPendantMemory(identity.runtime, event);
       }
       json(
         res,
@@ -769,9 +833,8 @@ export async function handlePendantSessionRoutes(
       const segmentId = tail[1];
       const event = await withSessionLock(lockKey, async () => {
         const stored = await loadStored({ repository, ...identity, sessionId });
-        // Pausing prevents new capture segments, but already-durable pending
-        // segments must still accept late ASR/diarization revisions.
-        assertNotEnded(stored);
+        // Pause severs late ASR/diarization writes from the prior generation.
+        assertCanAppend(stored);
         assertLease(stored, parsed.data.leaseToken);
         const existingIndex = stored.segments.findIndex(
           (segment) => segment.id === segmentId,
@@ -821,8 +884,11 @@ export async function handlePendantSessionRoutes(
         };
       });
       if (event.committed) {
+        await persistCanonicalPendantMemory(identity.runtime, event);
         await notifyCommittedSegment(event);
         broadcastMutation(ctx, event.snapshot);
+      } else {
+        await persistCanonicalPendantMemory(identity.runtime, event);
       }
       json(
         res,

--- a/packages/ui/src/components/pages/PendantTranscriptView.test.tsx
+++ b/packages/ui/src/components/pages/PendantTranscriptView.test.tsx
@@ -1,20 +1,21 @@
 /**
  * Pendant transcript view states are rendered against mocked pendant transport
- * and scrolling hooks so the component contract stays deterministic in jsdom.
+ * and canonical session sync so the ambient route contract stays deterministic.
  */
 
 // @vitest-environment jsdom
 
+import type { PendantSessionSnapshot } from "@elizaos/shared/contracts";
 import {
   act,
   cleanup,
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { PENDANT_TRANSCRIPT_STORAGE_KEY } from "../../pendant/pendant-transcript-session";
 import type {
   UsePendantOptions,
   UsePendantResult,
@@ -26,6 +27,14 @@ const pendantMock = vi.hoisted(() => ({
   onSegment: undefined as UsePendantOptions["onSegment"] | undefined,
 }));
 
+const syncMock = vi.hoisted(() => ({
+  clients: [] as Array<ReturnType<typeof createMockSyncClient>>,
+  createClient: vi.fn(
+    (onSnapshot?: (snapshot: PendantSessionSnapshot) => void) =>
+      createMockSyncClient(onSnapshot),
+  ),
+}));
+
 vi.mock("../../pendant/usePendant", () => ({
   usePendant: (options?: UsePendantOptions) => {
     pendantMock.onSegment = options?.onSegment;
@@ -33,6 +42,17 @@ vi.mock("../../pendant/usePendant", () => ({
       throw new Error("usePendant mock result was not configured");
     }
     return pendantMock.result;
+  },
+}));
+
+vi.mock("../../pendant/session-sync-client", () => ({
+  createPendantSessionSyncClient: (options?: {
+    onSnapshot?: (snapshot: PendantSessionSnapshot) => void;
+    onError?: (error: Error) => void;
+  }) => {
+    const client = syncMock.createClient(options?.onSnapshot);
+    syncMock.clients.push(client);
+    return client;
   },
 }));
 
@@ -52,6 +72,113 @@ const connect = vi.fn();
 const disconnect = vi.fn();
 const pause = vi.fn();
 const resume = vi.fn();
+
+function createMockSyncClient(
+  onSnapshot?: (snapshot: PendantSessionSnapshot) => void,
+) {
+  return {
+    unsyncedQueue: [],
+    createSession: vi.fn(async () => {
+      const snapshot = sessionSnapshot();
+      onSnapshot?.(snapshot);
+      return snapshot;
+    }),
+    acquireLease: vi.fn(async () => ({
+      ok: true as const,
+      session: sessionSnapshot().session,
+      leaseToken: "lease-token",
+    })),
+    appendSegment: vi.fn(async () => {
+      const snapshot = sessionSnapshot({
+        segments: [segmentSnapshot({ status: "pending", text: "" })],
+        revision: 2,
+      });
+      onSnapshot?.(snapshot);
+      return snapshot;
+    }),
+    patchSegment: vi.fn(async () => {
+      const snapshot = sessionSnapshot({
+        segments: [
+          segmentSnapshot({ status: "resolved", text: "hello pendant" }),
+        ],
+        revision: 3,
+      });
+      onSnapshot?.(snapshot);
+      return snapshot;
+    }),
+    pause: vi.fn(async () => {
+      const snapshot = sessionSnapshot({
+        state: "paused",
+        segments: [
+          segmentSnapshot({
+            status: "resolved",
+            text: "late tail after pause",
+          }),
+        ],
+        revision: 4,
+      });
+      onSnapshot?.(snapshot);
+      return snapshot;
+    }),
+    resume: vi.fn(async () => sessionSnapshot({ revision: 5 })),
+    startPolling: vi.fn(),
+    stopPolling: vi.fn(),
+    discardUnsyncedMutation: vi.fn(),
+  };
+}
+
+function sessionSnapshot({
+  segments = [],
+  state = "active",
+  revision = 1,
+}: {
+  segments?: PendantSessionSnapshot["segments"];
+  state?: PendantSessionSnapshot["session"]["state"];
+  revision?: number;
+} = {}): PendantSessionSnapshot {
+  return {
+    schemaVersion: 1,
+    session: {
+      id: "session-1",
+      ownerId: "owner",
+      agentId: "agent",
+      startedAt: "2026-08-04T00:00:00.000Z",
+      endedAt: null,
+      state,
+      captureLease: null,
+      processingLocation: "cloud",
+      revision,
+    },
+    segments,
+    insightRefs: [],
+  };
+}
+
+function segmentSnapshot({
+  status,
+  text,
+}: {
+  status: "pending" | "resolved" | "asr-error";
+  text: string;
+}): PendantSessionSnapshot["segments"][number] {
+  return {
+    id: "session-1:segment:0",
+    sessionId: "session-1",
+    ordinal: 0,
+    status,
+    text,
+    words: [],
+    speakerCluster: null,
+    speakerAlias: null,
+    confidence: null,
+    error: status === "asr-error" ? "ASR failed" : null,
+    createdAt: "2026-08-04T00:00:00.000Z",
+    updatedAt: "2026-08-04T00:00:01.000Z",
+    startedAt: "2026-08-04T00:00:00.000Z",
+    endedAt: status === "pending" ? null : "2026-08-04T00:00:01.000Z",
+    revision: status === "pending" ? 0 : 1,
+  };
+}
 
 function setPendantState(
   overrides: Partial<UsePendantResult["state"]> = {},
@@ -81,14 +208,14 @@ function setPendantState(
 
 describe("PendantTranscriptView", () => {
   beforeEach(() => {
-    localStorage.clear();
     vi.clearAllMocks();
+    syncMock.clients = [];
+    syncMock.createClient.mockClear();
     setPendantState();
   });
 
   afterEach(() => {
     cleanup();
-    localStorage.clear();
   });
 
   it("keeps unsupported distinct from idle", () => {
@@ -103,7 +230,7 @@ describe("PendantTranscriptView", () => {
     ).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Connect/ })).toBeNull();
     expect(screen.getByTestId("pendant-recording-indicator").textContent).toBe(
-      "Idle",
+      "Off",
     );
   });
 
@@ -130,258 +257,131 @@ describe("PendantTranscriptView", () => {
     ).toBe(false);
   });
 
-  it("renders cache corruption as error instead of a healthy empty feed", () => {
-    localStorage.setItem(PENDANT_TRANSCRIPT_STORAGE_KEY, "{not json");
-
+  it("connects through the canonical session controller before BLE capture", async () => {
     render(<PendantTranscriptView />);
 
-    expect(screen.getByTestId("pendant-transcript-cache-error")).toBeTruthy();
-    expect(screen.getByText("Transcript cache unavailable")).toBeTruthy();
-    expect(screen.queryByText("No transcript segments yet")).toBeNull();
-    expect(
-      screen.getByRole("button", { name: /Clear local view\/cache/ }),
-    ).toBeTruthy();
-  });
+    fireEvent.click(screen.getByRole("button", { name: /^Connect$/ }));
 
-  it("shows pause while connected and calls pause", () => {
-    setPendantState({
-      status: "connected",
-      paused: false,
-      deviceName: "omi devkit",
+    await waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+    const client = syncMock.clients[0];
+    expect(client?.createSession).toHaveBeenCalledWith({
+      processingLocation: "cloud",
     });
-
-    render(<PendantTranscriptView />);
-    fireEvent.click(screen.getByRole("button", { name: /Pause/ }));
-
-    expect(pause).toHaveBeenCalledTimes(1);
-    expect(resume).not.toHaveBeenCalled();
-  });
-
-  it("shows resume while paused and calls resume", () => {
-    setPendantState({
-      status: "paused",
-      paused: true,
+    expect(client?.acquireLease).toHaveBeenCalledWith("session-1", {
+      holder: expect.any(String),
+      leaseMs: 300_000,
     });
-
-    render(<PendantTranscriptView />);
-    fireEvent.click(screen.getByRole("button", { name: /Resume/ }));
-
-    expect(resume).toHaveBeenCalledTimes(1);
-    expect(pause).not.toHaveBeenCalled();
-  });
-
-  it("renders persisted resolved transcript text with timings hidden by default", () => {
-    const startedAt = Date.UTC(2026, 0, 1, 13, 14, 15);
-    localStorage.setItem(
-      PENDANT_TRANSCRIPT_STORAGE_KEY,
-      JSON.stringify({
-        segments: [
-          {
-            id: "segment-1",
-            status: "resolved",
-            text: "hello world",
-            startedAt,
-            endedAt: startedAt + 1_250,
-            durationMs: 1_250,
-            words: [
-              { text: "hello", startMs: 0, endMs: 500 },
-              { text: "world", startMs: 550, endMs: 1_200 },
-            ],
-            warning: null,
-          },
-        ],
-        updatedAt: startedAt + 1_250,
-        clearedThrough: null,
-      }),
-    );
-
-    render(<PendantTranscriptView />);
-
-    expect(screen.getByText("hello world")).toBeTruthy();
-    expect(
-      screen.getByText("Local offline cache · this device only"),
-    ).toBeTruthy();
-    expect(screen.queryByTitle("0-500ms")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: /Show timings/ }));
-    expect(screen.getByText("hello").getAttribute("title")).toBe("0-500ms");
-    expect(screen.getByText("world").getAttribute("title")).toBe("550-1200ms");
-    fireEvent.click(screen.getByRole("button", { name: /Hide timings/ }));
-    expect(screen.queryByTitle("0-500ms")).toBeNull();
+    expect(client?.startPolling).toHaveBeenCalledWith("session-1");
     expect(
       screen.getByText(
-        new Intl.DateTimeFormat("en-US", {
-          hour: "2-digit",
-          minute: "2-digit",
-          second: "2-digit",
-          hour12: false,
-        }).format(startedAt),
+        "Canonical private session · synced across owner devices",
       ),
     ).toBeTruthy();
   });
 
-  it("clear suppresses late old completions but allows new pending segments", () => {
-    localStorage.setItem(
-      PENDANT_TRANSCRIPT_STORAGE_KEY,
-      JSON.stringify({
-        segments: [
-          {
-            id: "segment-before-clear",
-            status: "pending",
-            text: "",
-            startedAt: 1_000,
-            endedAt: 1_500,
-            durationMs: 500,
-            words: [],
-            warning: null,
-          },
-        ],
-        updatedAt: 1_500,
-        clearedThrough: null,
-      }),
-    );
-    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(2_000);
+  it("renders status and transcript from canonical session snapshots", async () => {
+    const { rerender } = render(<PendantTranscriptView />);
+    fireEvent.click(screen.getByRole("button", { name: /^Connect$/ }));
+    await waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+    setPendantState({
+      status: "listening",
+      paused: false,
+      deviceName: "omi devkit",
+      batteryPercent: 91,
+    });
+    rerender(<PendantTranscriptView />);
 
-    try {
-      render(<PendantTranscriptView />);
-      expect(screen.getByText("Transcribing...")).toBeTruthy();
-
-      fireEvent.click(
-        screen.getByRole("button", { name: /Clear local view\/cache/ }),
-      );
-      expect(screen.getByText("No transcript segments yet")).toBeTruthy();
-
-      act(() => {
-        pendantMock.onSegment?.({
-          id: "segment-before-clear",
-          status: "resolved",
-          text: "late stale text",
-          startedAt: 1_000,
-          endedAt: 1_500,
-          durationMs: 500,
-          words: [],
-        });
-      });
-      expect(screen.queryByText("late stale text")).toBeNull();
-      expect(screen.getByText("No transcript segments yet")).toBeTruthy();
-
-      act(() => {
-        pendantMock.onSegment?.({
-          id: "segment-after-clear",
-          status: "pending",
-          startedAt: 2_100,
-          endedAt: 2_500,
-          durationMs: 400,
-        });
-      });
-      expect(screen.getByText("Transcribing...")).toBeTruthy();
-    } finally {
-      nowSpy.mockRestore();
-    }
-  });
-
-  it("renders ASR failures as quiet visible rows while silence discard stays invisible", () => {
-    render(<PendantTranscriptView />);
-
-    act(() => {
+    await act(async () => {
       pendantMock.onSegment?.({
-        id: "silent",
+        id: "local-1",
         status: "pending",
-        startedAt: 1_000,
-        endedAt: 1_500,
-        durationMs: 500,
+        startedAt: Date.parse("2026-08-04T00:00:00.000Z"),
+        endedAt: Date.parse("2026-08-04T00:00:01.000Z"),
+        durationMs: 1000,
       });
+      await Promise.resolve();
+      await Promise.resolve();
     });
-    expect(screen.getByText("Transcribing...")).toBeTruthy();
-
-    act(() => {
-      pendantMock.onSegment?.({
-        id: "silent",
-        status: "discarded",
-        discardReason: "silence",
-        startedAt: 1_000,
-        endedAt: 1_500,
-        durationMs: 500,
-      });
-    });
-    expect(screen.queryByText("Transcribing...")).toBeNull();
-    expect(screen.queryByTestId("pendant-segment-discarded")).toBeNull();
-
-    act(() => {
-      pendantMock.onSegment?.({
-        id: "failed",
-        status: "failed",
-        failureReason: "asr-failed",
-        warning: "Could not transcribe this segment.",
-        startedAt: 2_000,
-        endedAt: 2_500,
-        durationMs: 500,
-      });
-    });
-    expect(screen.getByTestId("pendant-segment-failed")).toBeTruthy();
-    expect(screen.getByText("Could not transcribe this segment.")).toBeTruthy();
-  });
-
-  it("marks prior disconnected feed as frozen read-only", () => {
-    localStorage.setItem(
-      PENDANT_TRANSCRIPT_STORAGE_KEY,
-      JSON.stringify({
-        segments: [
-          {
-            id: "segment-1",
-            status: "resolved",
-            text: "old transcript",
-            startedAt: 1_000,
-            endedAt: 1_500,
-            durationMs: 500,
-            words: [],
-            warning: null,
-          },
-        ],
-        updatedAt: 1_500,
-        clearedThrough: null,
-      }),
-    );
-    setPendantState({ status: "idle" });
-
-    render(<PendantTranscriptView />);
-
-    expect(screen.getByText("old transcript")).toBeTruthy();
-    expect(screen.getByTestId("pendant-transcript-frozen").textContent).toBe(
-      "Feed frozen - reconnect the pendant to resume live capture.",
-    );
-  });
-
-  it("shows reconnecting without live pause controls", () => {
-    localStorage.setItem(
-      PENDANT_TRANSCRIPT_STORAGE_KEY,
-      JSON.stringify({
-        segments: [
-          {
-            id: "segment-1",
-            status: "resolved",
-            text: "preserved transcript",
-            startedAt: 1_000,
-            endedAt: 1_500,
-            durationMs: 500,
-            words: [],
-            warning: null,
-          },
-        ],
-        updatedAt: 1_500,
-        clearedThrough: null,
-      }),
-    );
-    setPendantState({ status: "reconnecting" });
-
-    render(<PendantTranscriptView />);
 
     expect(screen.getByTestId("pendant-recording-indicator").textContent).toBe(
-      "Reconnecting",
+      "Listeningcloud",
     );
-    expect(screen.getByRole("button", { name: /Reconnecting/ })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /Pause/ })).toBeNull();
-    expect(screen.getByTestId("pendant-transcript-frozen").textContent).toBe(
-      "Feed frozen - reconnect the pendant to resume live capture.",
-    );
+    expect(screen.getByText("Transcribing...")).toBeTruthy();
+
+    await act(async () => {
+      pendantMock.onSegment?.({
+        id: "local-1",
+        status: "resolved",
+        text: "hello pendant",
+        startedAt: Date.parse("2026-08-04T00:00:00.000Z"),
+        endedAt: Date.parse("2026-08-04T00:00:01.000Z"),
+        durationMs: 1000,
+        words: [],
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("hello pendant")).toBeTruthy();
+    expect(screen.getByText("1 resolved · 0 pending")).toBeTruthy();
+  });
+
+  it("severs canonical capture on pause and suppresses in-flight transcript tails", async () => {
+    const { rerender } = render(<PendantTranscriptView />);
+    fireEvent.click(screen.getByRole("button", { name: /^Connect$/ }));
+    await waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+    setPendantState({ status: "listening", paused: false });
+    rerender(<PendantTranscriptView />);
+
+    await act(async () => {
+      pendantMock.onSegment?.({
+        id: "local-tail",
+        status: "pending",
+        startedAt: Date.parse("2026-08-04T00:00:00.000Z"),
+        endedAt: Date.parse("2026-08-04T00:00:01.000Z"),
+        durationMs: 1000,
+      });
+      fireEvent.click(screen.getByRole("button", { name: /Pause Listening/ }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const client = syncMock.clients[0];
+    expect(pause).toHaveBeenCalledTimes(1);
+    expect(client?.stopPolling).toHaveBeenCalled();
+    expect(client?.pause).toHaveBeenCalledWith("session-1");
+    expect(screen.queryByText("late tail after pause")).toBeNull();
+    expect(screen.queryByText("Transcribing...")).toBeNull();
+  });
+
+  it("resumes the severed canonical session before BLE capture", async () => {
+    const { rerender } = render(<PendantTranscriptView />);
+    fireEvent.click(screen.getByRole("button", { name: /^Connect$/ }));
+    await waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+
+    setPendantState({ status: "listening", paused: false });
+    rerender(<PendantTranscriptView />);
+    fireEvent.click(screen.getByRole("button", { name: /Pause Listening/ }));
+    setPendantState({ status: "paused", paused: true });
+    rerender(<PendantTranscriptView />);
+    fireEvent.click(screen.getByRole("button", { name: /Resume Listening/ }));
+
+    await waitFor(() => expect(resume).toHaveBeenCalledTimes(1));
+    const client = syncMock.clients[0];
+    expect(client?.createSession).toHaveBeenCalledTimes(1);
+    expect(client?.resume).toHaveBeenCalledWith("session-1");
+    expect(client?.startPolling).toHaveBeenLastCalledWith("session-1");
+  });
+
+  it("does not read or write browser storage as transcript authority", () => {
+    const getItem = vi.spyOn(Storage.prototype, "getItem");
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    const removeItem = vi.spyOn(Storage.prototype, "removeItem");
+
+    render(<PendantTranscriptView />);
+
+    expect(getItem).not.toHaveBeenCalled();
+    expect(setItem).not.toHaveBeenCalled();
+    expect(removeItem).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/pages/PendantTranscriptView.tsx
+++ b/packages/ui/src/components/pages/PendantTranscriptView.tsx
@@ -6,6 +6,7 @@
  * ambient capture without disconnecting the pendant or stopping battery updates.
  */
 
+import type { PendantSessionSnapshot } from "@elizaos/shared/contracts";
 import {
   ArrowDown,
   BatteryLow,
@@ -17,20 +18,20 @@ import {
   Pause,
   Play,
   Timer,
-  Trash2,
 } from "lucide-react";
 import * as React from "react";
 import { useThreadAutoScroll } from "../../hooks/useThreadAutoScroll";
 import { cn } from "../../lib/utils";
+import { CanonicalPendantSessionController } from "../../pendant/canonical-session-controller";
 import {
   isPendantLiveStatus,
   pendantStatusLabel,
 } from "../../pendant/pendant-status";
-import {
-  createLocalOptimisticPendantTranscriptSessionAdapter,
-  type PendantTranscriptSegment,
-  pendantTranscriptSessionReducer,
+import type {
+  PendantTranscriptSegment,
+  PendantTranscriptSessionState,
 } from "../../pendant/pendant-transcript-session";
+import { createPendantSessionSyncClient } from "../../pendant/session-sync-client";
 import { usePendant } from "../../pendant/usePendant";
 import { Button } from "../ui/button";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
@@ -109,34 +110,56 @@ function BatteryDisplay({
 }
 
 export function PendantTranscriptView(): React.ReactElement {
-  const sessionAdapter = React.useMemo(
-    () => createLocalOptimisticPendantTranscriptSessionAdapter(),
+  const [session, setSession] = React.useState<PendantTranscriptSessionState>({
+    segments: [],
+    updatedAt: null,
+    clearedThrough: null,
+  });
+  const [cacheError, setCacheError] = React.useState<string | null>(null);
+  const [showTimings, setShowTimings] = React.useState(false);
+  const acceptSnapshot = React.useCallback(
+    (snapshot: PendantSessionSnapshot) => {
+      const segments = snapshot.segments.map((segment) => ({
+        id: segment.id,
+        status:
+          segment.status === "asr-error" ? ("failed" as const) : segment.status,
+        text: segment.text,
+        startedAt: Date.parse(segment.startedAt),
+        endedAt: Date.parse(segment.endedAt ?? segment.updatedAt),
+        durationMs: Math.max(
+          0,
+          Date.parse(segment.endedAt ?? segment.updatedAt) -
+            Date.parse(segment.startedAt),
+        ),
+        words: segment.words.map((word) => ({
+          text: word.word,
+          startMs: word.startMs,
+          endMs: word.endMs,
+        })),
+        warning: segment.error,
+      }));
+      setSession({
+        segments,
+        updatedAt:
+          segments.at(-1)?.endedAt ?? Date.parse(snapshot.session.startedAt),
+        clearedThrough: null,
+      });
+      setCacheError(null);
+    },
     [],
   );
-  const initialCache = React.useMemo(() => {
-    try {
-      return { session: sessionAdapter.load(), error: null as string | null };
-    } catch (error) {
-      // error-policy:J4 A blocked or corrupt cache renders an explicit unavailable state.
-      return {
-        session: {
-          segments: [],
-          updatedAt: null,
-          clearedThrough: null,
-        },
-        error:
-          error instanceof Error
-            ? error.message
-            : "Pendant transcript cache is unavailable.",
-      };
-    }
-  }, [sessionAdapter]);
-  const [session, dispatchSession] = React.useReducer(
-    pendantTranscriptSessionReducer,
-    initialCache.session,
-  );
-  const [cacheError, setCacheError] = React.useState(initialCache.error);
-  const [showTimings, setShowTimings] = React.useState(false);
+  const controller = React.useMemo(() => {
+    const client = createPendantSessionSyncClient({
+      onSnapshot: acceptSnapshot,
+      onError: (error) => setCacheError(error.message),
+    });
+    return new CanonicalPendantSessionController({
+      client,
+      holder: crypto.randomUUID(),
+      onSnapshot: acceptSnapshot,
+      onError: (error) => setCacheError(error.message),
+    });
+  }, [acceptSnapshot]);
   const { scrollRef, atBottom, jumpToLatest } =
     useThreadAutoScroll<HTMLDivElement>({
       growthKey: `${session.segments.length}:${
@@ -145,24 +168,35 @@ export function PendantTranscriptView(): React.ReactElement {
     });
 
   const { state, supported, connect, disconnect, pause, resume } = usePendant({
-    onSegment: React.useCallback((detail) => {
-      dispatchSession({ type: "segment", detail });
-    }, []),
+    dispatchResolvedTranscript: false,
+    onSegment: React.useCallback(
+      (detail) => controller.handleSegment(detail),
+      [controller],
+    ),
   });
 
-  React.useEffect(() => {
-    if (cacheError) return;
-    try {
-      sessionAdapter.save(session);
-    } catch (error) {
-      // error-policy:J4 Persistence failures stay visible instead of reading as saved.
-      setCacheError(
-        error instanceof Error
-          ? error.message
-          : "Pendant transcript cache could not be saved.",
-      );
-    }
-  }, [cacheError, session, sessionAdapter]);
+  React.useEffect(() => () => controller.stop(), [controller]);
+
+  const connectCanonical = React.useCallback(() => {
+    void controller
+      .start()
+      .then(connect)
+      .catch((error) => {
+        setCacheError(error instanceof Error ? error.message : String(error));
+      });
+  }, [connect, controller]);
+  const pauseCanonical = React.useCallback(() => {
+    pause();
+    controller.pause();
+  }, [controller, pause]);
+  const resumeCanonical = React.useCallback(() => {
+    void controller
+      .resume()
+      .then(resume)
+      .catch((error) => {
+        setCacheError(error instanceof Error ? error.message : String(error));
+      });
+  }, [controller, resume]);
 
   const live = isPendantLiveStatus(state.status);
   const frozen = !live && session.segments.length > 0;
@@ -251,7 +285,7 @@ export function PendantTranscriptView(): React.ReactElement {
                   <Button
                     variant="surfaceAccent"
                     size="sm"
-                    onClick={resume}
+                    onClick={resumeCanonical}
                     data-testid="pendant-transcript-resume"
                   >
                     <Play className="size-4" aria-hidden />
@@ -261,7 +295,7 @@ export function PendantTranscriptView(): React.ReactElement {
                   <Button
                     variant="surface"
                     size="sm"
-                    onClick={pause}
+                    onClick={pauseCanonical}
                     data-testid="pendant-transcript-pause"
                   >
                     <Pause className="size-4" aria-hidden />
@@ -273,7 +307,7 @@ export function PendantTranscriptView(): React.ReactElement {
               <Button
                 variant="surfaceAccent"
                 size="sm"
-                onClick={connect}
+                onClick={connectCanonical}
                 disabled={busy}
                 data-testid="pendant-transcript-connect"
               >
@@ -285,30 +319,6 @@ export function PendantTranscriptView(): React.ReactElement {
                 {busy ? pendantStatusLabel(state.status) : "Connect"}
               </Button>
             )}
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                const at = Date.now();
-                try {
-                  sessionAdapter.clear(at);
-                  dispatchSession({ type: "clear", at });
-                  setCacheError(null);
-                } catch (error) {
-                  // error-policy:J4 Clear failures preserve the visible cache/error state.
-                  setCacheError(
-                    error instanceof Error
-                      ? error.message
-                      : "Pendant transcript cache could not be cleared.",
-                  );
-                }
-              }}
-              disabled={session.segments.length === 0 && !cacheError}
-              data-testid="pendant-transcript-clear"
-            >
-              <Trash2 className="size-4" aria-hidden />
-              Clear local view/cache
-            </Button>
             {hasTimings ? (
               <Button
                 variant="ghost"
@@ -324,7 +334,7 @@ export function PendantTranscriptView(): React.ReactElement {
               {resolvedCount} resolved · {pendingCount} pending
             </span>
             <span className="text-xs text-muted">
-              Local offline cache · this device only
+              Canonical private session · synced across owner devices
             </span>
           </div>
           {frozen ? (
@@ -366,10 +376,10 @@ export function PendantTranscriptView(): React.ReactElement {
               <div className="flex h-full items-center justify-center px-6 text-center">
                 <div className="max-w-md">
                   <p className="text-sm font-medium text-danger">
-                    Transcript cache unavailable
+                    Canonical transcript unavailable
                   </p>
                   <p className="mt-2 text-sm leading-6 text-muted">
-                    Reset the local cache to retry storage access.
+                    Reconnect to the private agent session to retry sync.
                   </p>
                 </div>
               </div>

--- a/packages/ui/src/components/pages/PendantTranscriptView.tsx
+++ b/packages/ui/src/components/pages/PendantTranscriptView.tsx
@@ -1,9 +1,9 @@
 /**
- * Realtime local transcript surface for the omi pendant.
+ * Canonical ambient transcript surface for the omi pendant.
  *
- * It owns a Phase 1 browser-local optimistic cache: connect BLE, show pending,
- * resolved, and failed ASR segments, persist them across refresh, and pause
- * ambient capture without disconnecting the pendant or stopping battery updates.
+ * It presents the server-authoritative pendant session established by the
+ * canonical session controller while keeping BLE capture default-off until the
+ * user connects the pendant from this route.
  */
 
 import type { PendantSessionSnapshot } from "@elizaos/shared/contracts";
@@ -13,10 +13,12 @@ import {
   BatteryMedium,
   Bluetooth,
   BluetoothConnected,
+  CircleDot,
   Loader2,
-  Mic,
   Pause,
   Play,
+  Radio,
+  Square,
   Timer,
 } from "lucide-react";
 import * as React from "react";
@@ -109,14 +111,74 @@ function BatteryDisplay({
   );
 }
 
+function PendantRecordingIndicator({
+  live,
+  paused,
+  status,
+  processingLocation,
+}: {
+  live: boolean;
+  paused: boolean;
+  status: string;
+  processingLocation: string | null;
+}): React.ReactElement {
+  const listening = live && !paused;
+  const label = paused
+    ? "Paused"
+    : status === "reconnecting"
+      ? "Reconnecting"
+      : listening
+        ? "Listening"
+        : "Off";
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "inline-flex items-center gap-2 rounded-sm border px-3 py-2 text-sm font-medium",
+        listening
+          ? "border-accent bg-accent-subtle text-txt-strong"
+          : paused
+            ? "border-border bg-card text-muted-strong"
+            : "border-border bg-card text-muted",
+      )}
+      data-testid="pendant-recording-indicator"
+      data-listening={listening ? "true" : "false"}
+    >
+      {listening ? (
+        <Square
+          className="size-3.5 fill-accent text-accent animate-pulse motion-reduce:animate-none"
+          aria-hidden
+        />
+      ) : paused ? (
+        <Radio className="size-3.5 text-muted-strong" aria-hidden />
+      ) : (
+        <CircleDot className="size-3.5 text-muted" aria-hidden />
+      )}
+      <span>{label}</span>
+      {live && processingLocation ? (
+        <span className="border-l border-border pl-2 text-2xs uppercase tracking-wide text-muted">
+          {processingLocation}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
 export function PendantTranscriptView(): React.ReactElement {
   const [session, setSession] = React.useState<PendantTranscriptSessionState>({
     segments: [],
     updatedAt: null,
     clearedThrough: null,
   });
-  const [cacheError, setCacheError] = React.useState<string | null>(null);
+  const [syncError, setSyncError] = React.useState<string | null>(null);
   const [showTimings, setShowTimings] = React.useState(false);
+  const [processingLocation, setProcessingLocation] = React.useState<
+    PendantSessionSnapshot["session"]["processingLocation"] | null
+  >(null);
+  const controllerRef = React.useRef<CanonicalPendantSessionController | null>(
+    null,
+  );
   const acceptSnapshot = React.useCallback(
     (snapshot: PendantSessionSnapshot) => {
       const segments = snapshot.segments.map((segment) => ({
@@ -144,21 +206,28 @@ export function PendantTranscriptView(): React.ReactElement {
           segments.at(-1)?.endedAt ?? Date.parse(snapshot.session.startedAt),
         clearedThrough: null,
       });
-      setCacheError(null);
+      setProcessingLocation(snapshot.session.processingLocation);
+      setSyncError(null);
     },
     [],
   );
   const controller = React.useMemo(() => {
     const client = createPendantSessionSyncClient({
-      onSnapshot: acceptSnapshot,
-      onError: (error) => setCacheError(error.message),
+      onSnapshot: (snapshot) => {
+        if (controllerRef.current?.acceptsSnapshot(snapshot)) {
+          acceptSnapshot(snapshot);
+        }
+      },
+      onError: (error) => setSyncError(error.message),
     });
-    return new CanonicalPendantSessionController({
+    const nextController = new CanonicalPendantSessionController({
       client,
       holder: crypto.randomUUID(),
       onSnapshot: acceptSnapshot,
-      onError: (error) => setCacheError(error.message),
+      onError: (error) => setSyncError(error.message),
     });
+    controllerRef.current = nextController;
+    return nextController;
   }, [acceptSnapshot]);
   const { scrollRef, atBottom, jumpToLatest } =
     useThreadAutoScroll<HTMLDivElement>({
@@ -182,7 +251,7 @@ export function PendantTranscriptView(): React.ReactElement {
       .start()
       .then(connect)
       .catch((error) => {
-        setCacheError(error instanceof Error ? error.message : String(error));
+        setSyncError(error instanceof Error ? error.message : String(error));
       });
   }, [connect, controller]);
   const pauseCanonical = React.useCallback(() => {
@@ -194,7 +263,7 @@ export function PendantTranscriptView(): React.ReactElement {
       .resume()
       .then(resume)
       .catch((error) => {
-        setCacheError(error instanceof Error ? error.message : String(error));
+        setSyncError(error instanceof Error ? error.message : String(error));
       });
   }, [controller, resume]);
 
@@ -234,82 +303,64 @@ export function PendantTranscriptView(): React.ReactElement {
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <span
-                className={cn(
-                  "inline-flex items-center gap-1.5 rounded-sm border border-border px-2.5 py-1.5 text-xs",
-                  live && !state.paused && "border-accent text-accent",
-                  state.paused && "text-muted",
-                )}
-                data-testid="pendant-recording-indicator"
-              >
-                {live ? (
-                  <Mic
-                    className={cn(
-                      "size-4",
-                      !state.paused &&
-                        "animate-pulse motion-reduce:animate-none",
-                    )}
-                    aria-hidden
-                  />
-                ) : (
-                  <Bluetooth className="size-4" aria-hidden />
-                )}
-                {state.paused
-                  ? "Paused"
-                  : state.status === "reconnecting"
-                    ? "Reconnecting"
-                    : live
-                      ? "Recording"
-                      : "Idle"}
-              </span>
+              <PendantRecordingIndicator
+                live={live}
+                paused={state.paused}
+                status={state.status}
+                processingLocation={processingLocation}
+              />
               <BatteryDisplay percent={state.batteryPercent} />
             </div>
           </div>
-          <div className="mt-4 flex flex-wrap items-center gap-2">
+          <div className="mt-4 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
             {!supported ? (
               <span className="text-sm text-muted">
                 Bluetooth pendant is not available in this environment.
               </span>
             ) : live ? (
-              <>
-                <Button
-                  variant="surface"
-                  size="sm"
-                  onClick={disconnect}
-                  data-testid="pendant-transcript-disconnect"
-                >
-                  <BluetoothConnected className="size-4" aria-hidden />
-                  Disconnect
-                </Button>
+              <div className="grid gap-2 sm:grid-cols-2">
                 {state.paused ? (
                   <Button
                     variant="surfaceAccent"
-                    size="sm"
+                    size="lg"
                     onClick={resumeCanonical}
                     data-testid="pendant-transcript-resume"
+                    className="w-full"
                   >
                     <Play className="size-4" aria-hidden />
-                    Resume
+                    Resume Listening
                   </Button>
                 ) : (
                   <Button
                     variant="surface"
-                    size="sm"
+                    size="lg"
                     onClick={pauseCanonical}
                     data-testid="pendant-transcript-pause"
+                    className="w-full"
                   >
                     <Pause className="size-4" aria-hidden />
-                    Pause
+                    Pause Listening
                   </Button>
                 )}
-              </>
+                <Button
+                  variant="surface"
+                  size="lg"
+                  onClick={disconnect}
+                  data-testid="pendant-transcript-disconnect"
+                  className="w-full"
+                >
+                  <BluetoothConnected className="size-4" aria-hidden />
+                  Disconnect
+                </Button>
+              </div>
             ) : (
               <Button
                 variant="surfaceAccent"
-                size="sm"
+                size="lg"
                 onClick={connectCanonical}
                 disabled={busy}
                 data-testid="pendant-transcript-connect"
+                className="w-full sm:w-auto"
               >
                 {busy ? (
                   <Loader2 className="size-4 animate-spin" aria-hidden />
@@ -319,6 +370,16 @@ export function PendantTranscriptView(): React.ReactElement {
                 {busy ? pendantStatusLabel(state.status) : "Connect"}
               </Button>
             )}
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted">
+              <span>
+                {resolvedCount} resolved · {pendingCount} pending
+              </span>
+              <span>
+                Canonical private session · synced across owner devices
+              </span>
+            </div>
+          </div>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
             {hasTimings ? (
               <Button
                 variant="ghost"
@@ -330,12 +391,6 @@ export function PendantTranscriptView(): React.ReactElement {
                 {showTimings ? "Hide timings" : "Show timings"}
               </Button>
             ) : null}
-            <span className="text-xs text-muted">
-              {resolvedCount} resolved · {pendingCount} pending
-            </span>
-            <span className="text-xs text-muted">
-              Canonical private session · synced across owner devices
-            </span>
           </div>
           {frozen ? (
             <div
@@ -354,13 +409,13 @@ export function PendantTranscriptView(): React.ReactElement {
               {errorMessage}
             </div>
           ) : null}
-          {cacheError ? (
+          {syncError ? (
             <div
               role="alert"
               className="mt-3 border-l-2 border-danger bg-danger/10 px-3 py-2 text-sm text-danger"
-              data-testid="pendant-transcript-cache-error"
+              data-testid="pendant-transcript-sync-error"
             >
-              {cacheError}
+              {syncError}
             </div>
           ) : null}
         </header>
@@ -372,7 +427,7 @@ export function PendantTranscriptView(): React.ReactElement {
             aria-live="polite"
             data-testid="pendant-transcript-feed"
           >
-            {cacheError && session.segments.length === 0 ? (
+            {syncError && session.segments.length === 0 ? (
               <div className="flex h-full items-center justify-center px-6 text-center">
                 <div className="max-w-md">
                   <p className="text-sm font-medium text-danger">

--- a/packages/ui/src/pendant/canonical-session-controller.test.ts
+++ b/packages/ui/src/pendant/canonical-session-controller.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { CanonicalPendantSessionController } from "./canonical-session-controller";
+import type { PendantTranscriptSegmentDetail } from "./transcript-segment-event";
+
+function snapshot(revision = 0) {
+  return {
+    schemaVersion: 1 as const,
+    session: {
+      id: "session-1",
+      ownerId: "owner",
+      agentId: "agent",
+      startedAt: "2026-08-04T00:00:00.000Z",
+      endedAt: null,
+      state: "active" as const,
+      captureLease: null,
+      processingLocation: "cloud" as const,
+      revision,
+    },
+    segments: [],
+    insightRefs: [],
+  };
+}
+
+function detail(
+  status: "pending" | "resolved",
+): PendantTranscriptSegmentDetail {
+  return {
+    id: "local-1",
+    status,
+    text: status === "resolved" ? "canonical words" : undefined,
+    startedAt: Date.parse("2026-08-04T00:00:00.000Z"),
+    endedAt: Date.parse("2026-08-04T00:00:01.000Z"),
+    durationMs: 1000,
+    words: [],
+  };
+}
+
+function harness() {
+  const order: string[] = [];
+  const client = {
+    unsyncedQueue: [],
+    createSession: vi.fn(async () => snapshot()),
+    acquireLease: vi.fn(async () => ({
+      ok: true as const,
+      session: snapshot().session,
+      leaseToken: "lease",
+    })),
+    appendSegment: vi.fn(async () => {
+      order.push("append");
+      return snapshot(2);
+    }),
+    patchSegment: vi.fn(async () => {
+      order.push("patch");
+      return snapshot(3);
+    }),
+    pause: vi.fn(async () => snapshot(4)),
+    resume: vi.fn(async () => snapshot(5)),
+    startPolling: vi.fn(),
+    stopPolling: vi.fn(),
+    discardUnsyncedMutation: vi.fn(),
+  };
+  const controller = new CanonicalPendantSessionController({
+    client: client as never,
+    holder: "device",
+    onSnapshot: vi.fn(),
+    onError: (error) => {
+      throw error;
+    },
+  });
+  return { client, controller, order };
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("CanonicalPendantSessionController", () => {
+  it("emits VOICE_DM only after the canonical resolved patch commits", async () => {
+    const h = harness();
+    window.addEventListener("eliza:pendant:voice-transcript", () =>
+      h.order.push("voice"),
+    );
+    await h.controller.start();
+    h.controller.handleSegment(detail("pending"));
+    h.controller.handleSegment(detail("resolved"));
+    await settle();
+
+    expect(h.order).toEqual(["append", "patch", "voice"]);
+    expect(h.client.appendSegment).toHaveBeenCalledTimes(1);
+    expect(h.client.patchSegment).toHaveBeenCalledWith(
+      "session-1",
+      "session-1:segment:0",
+      expect.objectContaining({ status: "resolved", text: "canonical words" }),
+    );
+  });
+
+  it("drops queued capture writes when pause advances the generation", async () => {
+    const h = harness();
+    await h.controller.start();
+    h.controller.handleSegment(detail("pending"));
+    h.controller.handleSegment(detail("resolved"));
+    h.controller.pause();
+    await settle();
+
+    expect(h.client.pause).toHaveBeenCalledWith("session-1");
+    expect(h.client.appendSegment).not.toHaveBeenCalled();
+    expect(h.client.patchSegment).not.toHaveBeenCalled();
+    expect(h.order).toEqual([]);
+  });
+});

--- a/packages/ui/src/pendant/canonical-session-controller.test.ts
+++ b/packages/ui/src/pendant/canonical-session-controller.test.ts
@@ -110,4 +110,54 @@ describe("CanonicalPendantSessionController", () => {
     expect(h.client.patchSegment).not.toHaveBeenCalled();
     expect(h.order).toEqual([]);
   });
+
+  it("does not publish an append snapshot that resolves after pause", async () => {
+    const h = harness();
+    let resolveAppend:
+      | ((pendingSnapshot: ReturnType<typeof snapshot>) => void)
+      | undefined;
+    h.client.appendSegment.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveAppend = resolve;
+        }),
+    );
+    const onSnapshot = vi.fn();
+    const controller = new CanonicalPendantSessionController({
+      client: h.client as never,
+      holder: "device",
+      onSnapshot,
+      onError: (error) => {
+        throw error;
+      },
+    });
+
+    await controller.start();
+    onSnapshot.mockClear();
+    controller.handleSegment(detail("pending"));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    controller.pause();
+    if (!resolveAppend) throw new Error("append did not start");
+    resolveAppend(snapshot(2));
+    await settle();
+
+    expect(h.client.pause).toHaveBeenCalledWith("session-1");
+    expect(onSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("severs snapshot delivery while paused and resumes the canonical session", async () => {
+    const h = harness();
+    await h.controller.start();
+
+    h.controller.pause();
+    expect(h.controller.acceptsSnapshot(snapshot(4))).toBe(false);
+    await h.controller.resume();
+
+    expect(h.client.createSession).toHaveBeenCalledTimes(1);
+    expect(h.client.resume).toHaveBeenCalledWith("session-1");
+    expect(h.client.startPolling).toHaveBeenLastCalledWith("session-1");
+    expect(h.controller.acceptsSnapshot(snapshot(6))).toBe(true);
+  });
 });

--- a/packages/ui/src/pendant/canonical-session-controller.ts
+++ b/packages/ui/src/pendant/canonical-session-controller.ts
@@ -1,0 +1,181 @@
+import type {
+  PendantSegment,
+  PendantSessionSnapshot,
+} from "@elizaos/shared/contracts";
+import { dispatchPendantVoiceTranscript } from "./pendant-connection";
+import type { PendantSessionSyncClient } from "./session-sync-client";
+import type { PendantTranscriptSegmentDetail } from "./transcript-segment-event";
+
+export interface CanonicalPendantSessionControllerOptions {
+  client: PendantSessionSyncClient;
+  holder: string;
+  onSnapshot: (snapshot: PendantSessionSnapshot) => void;
+  onError: (error: Error) => void;
+}
+
+/** Serializes capture mutations and exposes only server-committed snapshots. */
+export class CanonicalPendantSessionController {
+  private sessionId: string | null = null;
+  private leaseToken: string | null = null;
+  private nextOrdinal = 0;
+  private readonly ordinals = new Map<string, number>();
+  private chain: Promise<void> = Promise.resolve();
+  private generation = 0;
+
+  constructor(
+    private readonly options: CanonicalPendantSessionControllerOptions,
+  ) {}
+
+  start(): Promise<void> {
+    return this.enqueue(async () => {
+      if (this.sessionId && this.leaseToken) return;
+      const snapshot = await this.options.client.createSession({
+        processingLocation: "cloud",
+      });
+      const lease = await this.options.client.acquireLease(
+        snapshot.session.id,
+        {
+          holder: this.options.holder,
+          leaseMs: 5 * 60_000,
+        },
+      );
+      this.sessionId = snapshot.session.id;
+      this.leaseToken = lease.leaseToken;
+      this.options.onSnapshot(snapshot);
+      this.options.client.startPolling(snapshot.session.id);
+    });
+  }
+
+  handleSegment(detail: PendantTranscriptSegmentDetail): void {
+    const generation = this.generation;
+    void this.enqueue(async () => {
+      if (generation !== this.generation || detail.status === "discarded")
+        return;
+      await this.ensureStarted();
+      if (generation !== this.generation) return;
+      const sessionId = this.sessionId;
+      const leaseToken = this.leaseToken;
+      if (!sessionId || !leaseToken)
+        throw new Error("Pendant session is unavailable");
+
+      let ordinal = this.ordinals.get(detail.id);
+      if (ordinal === undefined) {
+        ordinal = this.nextOrdinal++;
+        this.ordinals.set(detail.id, ordinal);
+        const pending = await this.options.client.appendSegment(sessionId, {
+          leaseToken,
+          segment: toWireSegment(detail, ordinal, "pending", 0),
+        });
+        this.options.onSnapshot(pending);
+      }
+      if (detail.status === "pending") return;
+      if (generation !== this.generation) return;
+
+      const committed = await this.options.client.patchSegment(
+        sessionId,
+        `${sessionId}:segment:${ordinal}`,
+        {
+          leaseToken,
+          revision: 1,
+          status: detail.status === "resolved" ? "resolved" : "asr-error",
+          text: detail.text?.trim() ?? "",
+          words: (detail.words ?? []).map((word) => ({
+            word: word.text,
+            startMs: word.startMs,
+            endMs: word.endMs,
+          })),
+          error:
+            detail.status === "failed"
+              ? (detail.warning ?? "ASR failed")
+              : null,
+          endedAt: new Date(detail.endedAt).toISOString(),
+        },
+      );
+      if (generation !== this.generation) return;
+      this.options.onSnapshot(committed);
+      if (detail.status === "resolved" && detail.text?.trim()) {
+        dispatchPendantVoiceTranscript(detail.text);
+      }
+    });
+  }
+
+  pause(): void {
+    this.generation += 1;
+    this.options.client.stopPolling();
+    for (const mutation of [...this.options.client.unsyncedQueue]) {
+      this.options.client.discardUnsyncedMutation(mutation.id);
+    }
+    const sessionId = this.sessionId;
+    if (!sessionId) return;
+    void this.options.client
+      .pause(sessionId)
+      .catch((error) => this.options.onError(asError(error)));
+  }
+
+  resume(): Promise<void> {
+    return this.enqueue(async () => {
+      if (!this.sessionId) return;
+      const snapshot = await this.options.client.resume(this.sessionId);
+      this.options.onSnapshot(snapshot);
+      this.options.client.startPolling(this.sessionId);
+    });
+  }
+
+  stop(): void {
+    this.generation += 1;
+    this.options.client.stopPolling();
+  }
+
+  private async ensureStarted(): Promise<void> {
+    if (this.sessionId && this.leaseToken) return;
+    const snapshot = await this.options.client.createSession({
+      processingLocation: "cloud",
+    });
+    const lease = await this.options.client.acquireLease(snapshot.session.id, {
+      holder: this.options.holder,
+      leaseMs: 5 * 60_000,
+    });
+    this.sessionId = snapshot.session.id;
+    this.leaseToken = lease.leaseToken;
+    this.options.onSnapshot(snapshot);
+    this.options.client.startPolling(snapshot.session.id);
+  }
+
+  private enqueue(work: () => Promise<void>): Promise<void> {
+    const result = this.chain.then(work);
+    this.chain = result.catch((error) => {
+      this.options.onError(asError(error));
+    });
+    return result;
+  }
+}
+
+function toWireSegment(
+  detail: PendantTranscriptSegmentDetail,
+  ordinal: number,
+  status: PendantSegment["status"],
+  revision: number,
+): Omit<PendantSegment, "id" | "sessionId" | "createdAt" | "updatedAt"> {
+  return {
+    ordinal,
+    status,
+    text: status === "resolved" ? (detail.text?.trim() ?? "") : "",
+    words: (detail.words ?? []).map((word) => ({
+      word: word.text,
+      startMs: word.startMs,
+      endMs: word.endMs,
+    })),
+    speakerCluster: null,
+    speakerAlias: null,
+    confidence: null,
+    error: null,
+    startedAt: new Date(detail.startedAt).toISOString(),
+    endedAt:
+      status === "pending" ? null : new Date(detail.endedAt).toISOString(),
+    revision,
+  };
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/ui/src/pendant/canonical-session-controller.ts
+++ b/packages/ui/src/pendant/canonical-session-controller.ts
@@ -21,6 +21,7 @@ export class CanonicalPendantSessionController {
   private readonly ordinals = new Map<string, number>();
   private chain: Promise<void> = Promise.resolve();
   private generation = 0;
+  private acceptingSnapshots = false;
 
   constructor(
     private readonly options: CanonicalPendantSessionControllerOptions,
@@ -41,6 +42,7 @@ export class CanonicalPendantSessionController {
       );
       this.sessionId = snapshot.session.id;
       this.leaseToken = lease.leaseToken;
+      this.acceptingSnapshots = true;
       this.options.onSnapshot(snapshot);
       this.options.client.startPolling(snapshot.session.id);
     });
@@ -66,6 +68,7 @@ export class CanonicalPendantSessionController {
           leaseToken,
           segment: toWireSegment(detail, ordinal, "pending", 0),
         });
+        if (generation !== this.generation) return;
         this.options.onSnapshot(pending);
       }
       if (detail.status === "pending") return;
@@ -105,6 +108,7 @@ export class CanonicalPendantSessionController {
     for (const mutation of [...this.options.client.unsyncedQueue]) {
       this.options.client.discardUnsyncedMutation(mutation.id);
     }
+    this.acceptingSnapshots = false;
     const sessionId = this.sessionId;
     if (!sessionId) return;
     void this.options.client
@@ -115,6 +119,7 @@ export class CanonicalPendantSessionController {
   resume(): Promise<void> {
     return this.enqueue(async () => {
       if (!this.sessionId) return;
+      this.acceptingSnapshots = true;
       const snapshot = await this.options.client.resume(this.sessionId);
       this.options.onSnapshot(snapshot);
       this.options.client.startPolling(this.sessionId);
@@ -124,6 +129,15 @@ export class CanonicalPendantSessionController {
   stop(): void {
     this.generation += 1;
     this.options.client.stopPolling();
+    this.acceptingSnapshots = false;
+    this.sessionId = null;
+    this.leaseToken = null;
+    this.nextOrdinal = 0;
+    this.ordinals.clear();
+  }
+
+  acceptsSnapshot(snapshot: PendantSessionSnapshot): boolean {
+    return this.acceptingSnapshots && this.sessionId === snapshot.session.id;
   }
 
   private async ensureStarted(): Promise<void> {
@@ -137,6 +151,7 @@ export class CanonicalPendantSessionController {
     });
     this.sessionId = snapshot.session.id;
     this.leaseToken = lease.leaseToken;
+    this.acceptingSnapshots = true;
     this.options.onSnapshot(snapshot);
     this.options.client.startPolling(snapshot.session.id);
   }

--- a/packages/ui/src/pendant/pendant-connection.test.ts
+++ b/packages/ui/src/pendant/pendant-connection.test.ts
@@ -524,6 +524,43 @@ describe("PendantConnection connect orchestration", () => {
     expect(conn.getState().paused).toBe(false);
   });
 
+  it("invalidates in-flight and queued ASR generations when paused", async () => {
+    asrControl.mode = "deferred";
+    const transport = new FakeTransport({});
+    const segments: PendantTranscriptSegmentDetail[] = [];
+    const voice = vi.fn();
+    window.addEventListener("eliza:pendant:voice-transcript", voice);
+    const conn = new PendantConnection({
+      onState: collectStates().onState,
+      createTransport: () => transport,
+      onSegment: (detail) => segments.push(detail),
+    });
+    await conn.connect();
+
+    emitStoppedUtterance(transport, 0);
+    await flushMicrotasks();
+    emitStoppedUtterance(transport, 2);
+    expect(asrControl.calls).toBe(1);
+    expect(segments.map((item) => item.status)).toEqual(["pending", "pending"]);
+
+    conn.pause();
+    asrControl.resolvers.shift()?.({
+      text: "must not commit",
+      words: [{ text: "must", startMs: 0, endMs: 80 }],
+    });
+    await flushMicrotasks();
+
+    expect(asrControl.calls).toBe(1);
+    expect(segments.filter((item) => item.status === "resolved")).toHaveLength(
+      0,
+    );
+    expect(segments.filter((item) => item.status === "discarded")).toHaveLength(
+      2,
+    );
+    expect(voice).not.toHaveBeenCalled();
+    window.removeEventListener("eliza:pendant:voice-transcript", voice);
+  });
+
   it("does not emit a frame buffered before or during pause into VAD after resume", async () => {
     const transport = new FakeTransport({});
     const { onState } = collectStates();

--- a/packages/ui/src/pendant/pendant-connection.ts
+++ b/packages/ui/src/pendant/pendant-connection.ts
@@ -118,6 +118,11 @@ export interface PendantConnectionOptions {
    * Bluetooth elsewhere.
    */
   createTransport?: () => PendantTransport | null;
+  /**
+   * Dispatch resolved text directly to VOICE_DM. Canonical session owners set
+   * this false and dispatch only after the server commits the segment.
+   */
+  dispatchResolvedTranscript?: boolean;
   /** Maximum spontaneous mid-session reconnect attempts. */
   reconnectMaxAttempts?: number;
   /** Delay between spontaneous mid-session reconnect attempts. */
@@ -194,6 +199,9 @@ export class PendantConnection {
 
   /** True while an utterance is being transcribed — serializes finalizations. */
   private finalizing: Promise<void> = Promise.resolve();
+  /** Invalidates queued/in-flight ASR when capture is paused or disconnected. */
+  private captureGeneration = 0;
+  private transcriptionAbort: AbortController | null = null;
 
   private readonly onAudioPayload = (payload: Uint8Array): void => {
     this.handleNotification(payload);
@@ -252,8 +260,10 @@ export class PendantConnection {
     if (detail.status !== "resolved") return;
     const text = detail.text?.trim() ?? "";
     if (!text) return;
-    dispatchPendantVoiceTranscript(text);
-    this.opts.onTranscript?.(text);
+    if (this.opts.dispatchResolvedTranscript !== false) {
+      dispatchPendantVoiceTranscript(text);
+      this.opts.onTranscript?.(text);
+    }
   }
 
   private resetDetector(): void {
@@ -635,8 +645,9 @@ export class PendantConnection {
       if (segment) this.emitSegment(segment);
       this.resetDetector();
       if (segment) {
+        const generation = this.captureGeneration;
         this.finalizing = this.finalizing.then(() =>
-          this.finalizeUtterance(chunks, total, segment),
+          this.finalizeUtterance(chunks, total, segment, generation),
         );
       }
     }
@@ -664,8 +675,16 @@ export class PendantConnection {
     chunks: Float32Array[],
     total: number,
     segment: PendantTranscriptSegmentDetail,
+    generation: number,
   ): Promise<void> {
-    if (total === 0) return;
+    if (total === 0 || generation !== this.captureGeneration || this.paused) {
+      this.emitSegment({
+        ...segment,
+        status: "discarded",
+        discardReason: "paused",
+      });
+      return;
+    }
     const pcm = new Float32Array(total);
     let off = 0;
     for (const c of chunks) {
@@ -684,8 +703,20 @@ export class PendantConnection {
     const wav = encodeMonoPcm16Wav(pcm, OMI_OPUS_SAMPLE_RATE_HZ);
     const wasStatus = this.state.status;
     this.patch({ status: "transcribing" });
+    const abort = new AbortController();
+    this.transcriptionAbort = abort;
     try {
-      const { text, words } = await transcribeLocalInferenceWav(wav);
+      const { text, words } = await transcribeLocalInferenceWav(wav, {
+        signal: abort.signal,
+      });
+      if (generation !== this.captureGeneration || this.paused) {
+        this.emitSegment({
+          ...segment,
+          status: "discarded",
+          discardReason: "paused",
+        });
+        return;
+      }
       const resolvedSegment: PendantTranscriptSegmentDetail = {
         ...segment,
         status: "resolved",
@@ -695,6 +726,18 @@ export class PendantConnection {
       this.patch({ lastTranscript: text, error: null, typedError: null });
       this.commitSegment(resolvedSegment);
     } catch (error) {
+      if (
+        abort.signal.aborted ||
+        generation !== this.captureGeneration ||
+        this.paused
+      ) {
+        this.emitSegment({
+          ...segment,
+          status: "discarded",
+          discardReason: "paused",
+        });
+        return;
+      }
       // error-policy:J4 Failed ASR becomes an explicit failed transcript segment.
       // ASR failure is non-fatal for ambient capture, but it must stay visible
       // so the transcript surface does not look healthy while segments drop.
@@ -708,6 +751,7 @@ export class PendantConnection {
         warning: typedError.message,
       });
     } finally {
+      if (this.transcriptionAbort === abort) this.transcriptionAbort = null;
       // Return to the ambient listening state (or hearing if speech already
       // resumed while we were transcribing).
       const next =
@@ -727,6 +771,9 @@ export class PendantConnection {
     if (this.paused) return;
     if (!this.transport || !this.decoder || !this.isPauseableStatus()) return;
     this.paused = true;
+    this.captureGeneration += 1;
+    this.transcriptionAbort?.abort();
+    this.transcriptionAbort = null;
     this.reassembler.reset();
     this.accountedDroppedPackets = 0;
     this.resetDetector();

--- a/packages/ui/src/pendant/transcript-segment-event.ts
+++ b/packages/ui/src/pendant/transcript-segment-event.ts
@@ -16,7 +16,7 @@ export type PendantSegmentStatus =
   | "discarded"
   | "failed";
 
-export type PendantSegmentDiscardReason = "silence";
+export type PendantSegmentDiscardReason = "silence" | "paused";
 export type PendantSegmentFailureReason = "asr-failed";
 
 export interface PendantAsrWord {

--- a/packages/ui/src/pendant/usePendant.ts
+++ b/packages/ui/src/pendant/usePendant.ts
@@ -24,6 +24,7 @@ export interface UsePendantOptions {
   vadSpeechRmsThreshold?: number;
   onTranscript?: (text: string) => void;
   onSegment?: (detail: PendantTranscriptSegmentDetail) => void;
+  dispatchResolvedTranscript?: boolean;
 }
 
 export interface UsePendantResult {
@@ -80,6 +81,7 @@ export function usePendant(options: UsePendantOptions = {}): UsePendantResult {
       onState: setPendantState,
       onTranscript: optionsRef.current.onTranscript,
       onSegment: optionsRef.current.onSegment,
+      dispatchResolvedTranscript: optionsRef.current.dispatchResolvedTranscript,
       vadSilenceMs: optionsRef.current.vadSilenceMs,
       vadSpeechRmsThreshold: optionsRef.current.vadSpeechRmsThreshold,
     };


### PR DESCRIPTION
## Summary
- fold ambient always-listening UX into the canonical `PendantTranscriptView` route
- show persistent listening/paused/off status, server-backed live transcript rows, battery/processing status, and large pause/resume controls
- suppress polling and in-flight append snapshots while paused, then resume the same canonical session using PR #17724's sever semantics
- keep capture default-off and remove browser storage authority from the route tests

## Dependency
This is intentionally stacked on **#17724** (`bd5e1730c65`) because that canonical session-sync route is still open. Review only `bd5e1730c65..efcacec1528`; after #17724 merges, this PR should reduce to the four UI/controller files in this commit.

## Prior-art credit
The status, live-feed, and prominent capture-control UX was mined from closed-unmerged **#16014**. This PR reuses only those UI ideas and wires them exclusively to #17724's canonical server-authoritative path. It does not revive #16014's local persistence or introduce another capture/write owner.

## Block 0
Checked open PRs and active reconnect lanes first. No open ambient pendant PR overlaps this lane, and this PR deliberately does not duplicate #17724's route, persistence, privacy, or server API scope.

## Bidirectional proof
- positive: canonical snapshots render listening status, pending/resolved transcript rows, processing location, and resume sequencing
- negative: pause stops polling, invalidates in-flight appends, drops late snapshot tails, and browser storage methods are never called

## Verification
- `bunx vitest run src/pendant/pendant-connection.test.ts src/pendant/session-sync-client.test.ts src/pendant/canonical-session-controller.test.ts src/components/pages/PendantTranscriptView.test.tsx` (38/38)
- `bunx biome check` on all four changed files
- `git diff --check`
- UI typecheck reaches only the pre-existing missing `@elizaos/cloud-routing` workspace package errors; no touched-file diagnostics
