### PR TITLE
fix(agent): declare pngjs image typings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -164,6 +164,7 @@
         "@types/jsdom": "^28.0.0",
         "@types/node": "^25.2.0",
         "@types/pg": "^8.15.2",
+        "@types/pngjs": "^6.0.5",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/ws": "^8.18.1",
@@ -5849,6 +5850,8 @@
     "@types/nprogress": ["@types/nprogress@0.2.3", "", {}, "sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA=="],
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
+
+    "@types/pngjs": ["@types/pngjs@6.0.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ=="],
 
     "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -386,6 +386,7 @@
     "@types/jsdom": "^28.0.0",
     "@types/node": "^25.2.0",
     "@types/pg": "^8.15.2",
+    "@types/pngjs": "^6.0.5",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/ws": "^8.18.1",


### PR DESCRIPTION
Fixes #17729

## Summary

- declare the maintained `@types/pngjs` package in the Agent workspace
- lock the exact resolved type package so clean Agent typechecks do not depend on ambient declarations
- keep the runtime dependency graph unchanged

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/agent` — 54/54 tasks
- `bun test packages/agent/src/api/media-thumbnail.test.ts` — 3/3
- `bunx @biomejs/biome check packages/agent/package.json`
- `git diff --check`

## Evidence matrix

| Evidence | Status |
|---|---|
| Before/after pixels | N/A - dependency metadata only |
| Video | N/A - no user-facing UI |
| Backend logs | N/A - compile-time dependency declaration only |
| Frontend logs | N/A - no frontend behavior |
| Live LLM trajectory | N/A - no model/action behavior |
| Domain artifact | Turbo clean-runner Agent typecheck: 54/54 tasks; real PNG thumbnail test: 3/3 |

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: `04ff8982861e7aa5045c0a065fb7e1d8750e6e6b:packages/skills/skills/contribute-to-eliza`  
Attribution status: self-reported  
— [codex/restack-demo-0804]

<!-- eliza-computer-attribution:v1 {"agent":"codex","provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"04ff8982861e7aa5045c0a065fb7e1d8750e6e6b:packages/skills/skills/contribute-to-eliza","status":"self-reported","marker":"codex/restack-demo-0804"} -->