### PR TITLE
fix(ui): route gateway LAN discovery through the desktop bridge

### DIFF
--- a/packages/ui/src/bridge/gateway-discovery.test.ts
+++ b/packages/ui/src/bridge/gateway-discovery.test.ts
@@ -11,7 +11,7 @@ const { loggerWarn } = vi.hoisted(() => ({ loggerWarn: vi.fn() }));
 const isFeatureAvailable = vi.fn<(feature: string) => boolean>();
 const getPlugins = vi.fn<() => { gateway: { plugin: unknown } }>();
 const isElectrobunRuntime = vi.fn<() => boolean>();
-const invokeDesktopBridgeRequest =
+const invokeDesktopBridgeRequestWithTimeout =
   vi.fn<
     (options: { rpcMethod: string; params?: unknown }) => Promise<unknown>
   >();
@@ -26,10 +26,10 @@ vi.mock("./electrobun-runtime", () => ({
 }));
 
 vi.mock("./electrobun-rpc", () => ({
-  invokeDesktopBridgeRequest: (options: {
+  invokeDesktopBridgeRequestWithTimeout: (options: {
     rpcMethod: string;
     params?: unknown;
-  }) => invokeDesktopBridgeRequest(options),
+  }) => invokeDesktopBridgeRequestWithTimeout(options),
 }));
 
 vi.mock("@elizaos/logger", () => ({
@@ -50,6 +50,7 @@ const ENDPOINT = {
   tlsEnabled: false,
   isLocal: true,
 };
+const ok = <T>(value: T) => ({ status: "ok" as const, value });
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -62,8 +63,20 @@ describe("discoverGatewayEndpoints — capability gate", () => {
   it("returns nothing without scanning when discovery is unsupported", async () => {
     isFeatureAvailable.mockReturnValue(false);
 
-    await expect(discoverGatewayEndpoints()).resolves.toEqual([]);
-    expect(invokeDesktopBridgeRequest).not.toHaveBeenCalled();
+    await expect(discoverGatewayEndpoints()).resolves.toEqual({
+      status: "unsupported",
+      gateways: [],
+      detail: "Gateway discovery is unsupported on this platform",
+    });
+    expect(invokeDesktopBridgeRequestWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("reports an unavailable native plugin distinctly from an empty scan", async () => {
+    await expect(discoverGatewayEndpoints()).resolves.toEqual({
+      status: "unavailable",
+      gateways: [],
+      detail: "Native gateway discovery plugin is unavailable",
+    });
   });
 });
 
@@ -75,13 +88,14 @@ describe("discoverGatewayEndpoints — Capacitor native transport", () => {
       gateway: { plugin: { startDiscovery, stopDiscovery } },
     });
 
-    await expect(discoverGatewayEndpoints({ timeoutMs: 25 })).resolves.toEqual([
-      ENDPOINT,
-    ]);
+    await expect(discoverGatewayEndpoints({ timeoutMs: 25 })).resolves.toEqual({
+      status: "ok",
+      gateways: [ENDPOINT],
+    });
     expect(startDiscovery).toHaveBeenCalledWith({ timeout: 25 });
     expect(stopDiscovery).toHaveBeenCalledTimes(1);
     // Native must not be routed through the desktop bridge.
-    expect(invokeDesktopBridgeRequest).not.toHaveBeenCalled();
+    expect(invokeDesktopBridgeRequestWithTimeout).not.toHaveBeenCalled();
   });
 
   it("degrades to an empty scan when the native plugin throws", async () => {
@@ -91,9 +105,11 @@ describe("discoverGatewayEndpoints — Capacitor native transport", () => {
       gateway: { plugin: { startDiscovery, stopDiscovery } },
     });
 
-    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual(
-      [],
-    );
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual({
+      status: "failed",
+      gateways: [],
+      detail: "Native gateway discovery failed",
+    });
     expect(stopDiscovery).toHaveBeenCalledTimes(1);
   });
 
@@ -109,9 +125,33 @@ describe("discoverGatewayEndpoints — Capacitor native transport", () => {
       },
     });
 
-    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual([
-      ENDPOINT,
-    ]);
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual({
+      status: "ok",
+      gateways: [ENDPOINT],
+    });
+  });
+
+  it("reports a best-effort native stop failure without rejecting the scan", async () => {
+    const stopDiscovery = vi.fn().mockRejectedValue(new Error("stop failed"));
+    getPlugins.mockReturnValue({
+      gateway: {
+        plugin: {
+          startDiscovery: vi.fn().mockResolvedValue({ gateways: [ENDPOINT] }),
+          stopDiscovery,
+        },
+      },
+    });
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual({
+      status: "ok",
+      gateways: [ENDPOINT],
+    });
+    await vi.waitFor(() => {
+      expect(loggerWarn).toHaveBeenCalledWith(
+        { error: expect.any(Error) },
+        "[gateway-discovery] Failed to stop native discovery",
+      );
+    });
   });
 });
 
@@ -121,23 +161,26 @@ describe("discoverGatewayEndpoints — Electrobun desktop transport", () => {
   });
 
   it("collects gateways that arrive after the scan window, not the empty start payload", async () => {
-    invokeDesktopBridgeRequest.mockImplementation(async ({ rpcMethod }) => {
-      // The desktop backend arms the browser and returns its cold cache.
-      if (rpcMethod === "gatewayStartDiscovery") {
-        return { gateways: [], status: "Discovery started" };
-      }
-      // Responses land on the browser's `up` events during the window.
-      if (rpcMethod === "gatewayGetDiscoveredGateways") {
-        return { gateways: [ENDPOINT] };
-      }
-      return undefined;
+    invokeDesktopBridgeRequestWithTimeout.mockImplementation(
+      async ({ rpcMethod }) => {
+        // The desktop backend arms the browser and returns its cold cache.
+        if (rpcMethod === "gatewayStartDiscovery") {
+          return ok({ gateways: [], status: "Discovery started" });
+        }
+        // Responses land on the browser's `up` events during the window.
+        if (rpcMethod === "gatewayGetDiscoveredGateways") {
+          return ok({ gateways: [ENDPOINT] });
+        }
+        return ok(undefined);
+      },
+    );
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 10 })).resolves.toEqual({
+      status: "ok",
+      gateways: [ENDPOINT],
     });
 
-    await expect(discoverGatewayEndpoints({ timeoutMs: 10 })).resolves.toEqual([
-      ENDPOINT,
-    ]);
-
-    const methods = invokeDesktopBridgeRequest.mock.calls.map(
+    const methods = invokeDesktopBridgeRequestWithTimeout.mock.calls.map(
       ([options]) => options.rpcMethod,
     );
     expect(methods).toContain("gatewayStartDiscovery");
@@ -145,77 +188,126 @@ describe("discoverGatewayEndpoints — Electrobun desktop transport", () => {
     expect(methods).toContain("gatewayStopDiscovery");
   });
 
-  it("does not arm the backend stop timer, so the collect read stays in-session", async () => {
-    invokeDesktopBridgeRequest.mockResolvedValue({ gateways: [] });
+  it("arms a backend backstop after the UI collection window", async () => {
+    invokeDesktopBridgeRequestWithTimeout.mockResolvedValue(
+      ok({ gateways: [], status: "Discovery started" }),
+    );
 
     await discoverGatewayEndpoints({ timeoutMs: 5 });
 
-    const start = invokeDesktopBridgeRequest.mock.calls.find(
+    const start = invokeDesktopBridgeRequestWithTimeout.mock.calls.find(
       ([options]) => options.rpcMethod === "gatewayStartDiscovery",
     );
-    expect(start?.[0].params).toEqual({});
+    expect(start?.[0].params).toEqual({ timeout: 505 });
   });
 
-  it("falls back to the start payload's warm cache when the collect read is empty", async () => {
-    invokeDesktopBridgeRequest.mockImplementation(async ({ rpcMethod }) => {
-      if (rpcMethod === "gatewayStartDiscovery") {
-        return { gateways: [ENDPOINT], status: "Already discovering" };
-      }
-      return null;
-    });
-
-    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual([
-      ENDPOINT,
-    ]);
-  });
-
-  it("returns empty and skips collection when no desktop bridge is present", async () => {
-    invokeDesktopBridgeRequest.mockResolvedValue(null);
-
-    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual(
-      [],
+  it("falls back to the start payload's warm cache when collection is unavailable", async () => {
+    invokeDesktopBridgeRequestWithTimeout.mockImplementation(
+      async ({ rpcMethod }) => {
+        if (rpcMethod === "gatewayStartDiscovery") {
+          return ok({ gateways: [ENDPOINT], status: "Already discovering" });
+        }
+        if (rpcMethod === "gatewayGetDiscoveredGateways") {
+          return { status: "missing" };
+        }
+        return ok(undefined);
+      },
     );
 
-    const methods = invokeDesktopBridgeRequest.mock.calls.map(
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual({
+      status: "ok",
+      gateways: [ENDPOINT],
+    });
+  });
+
+  it("reports unavailable and skips collection when no desktop bridge is present", async () => {
+    invokeDesktopBridgeRequestWithTimeout.mockResolvedValue({
+      status: "missing",
+    });
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual({
+      status: "unavailable",
+      gateways: [],
+      detail: "Desktop gateway discovery bridge is unavailable",
+    });
+
+    const methods = invokeDesktopBridgeRequestWithTimeout.mock.calls.map(
       ([options]) => options.rpcMethod,
     );
     expect(methods).not.toContain("gatewayGetDiscoveredGateways");
   });
 
-  it("degrades to an empty scan and still stops discovery when the bridge throws", async () => {
-    invokeDesktopBridgeRequest.mockImplementation(async ({ rpcMethod }) => {
-      if (rpcMethod === "gatewayStartDiscovery") {
-        throw new Error("bridge closed");
-      }
-      return undefined;
-    });
-
-    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual(
-      [],
+  it("reports a failed start without fabricating a healthy empty scan", async () => {
+    invokeDesktopBridgeRequestWithTimeout.mockImplementation(
+      async ({ rpcMethod }) => {
+        if (rpcMethod === "gatewayStartDiscovery") {
+          return { status: "rejected", error: new Error("bridge closed") };
+        }
+        return ok(undefined);
+      },
     );
-    const methods = invokeDesktopBridgeRequest.mock.calls.map(
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual({
+      status: "failed",
+      gateways: [],
+      detail: "Desktop gateway discovery failed to start",
+    });
+    const methods = invokeDesktopBridgeRequestWithTimeout.mock.calls.map(
       ([options]) => options.rpcMethod,
     );
-    expect(methods).toContain("gatewayStopDiscovery");
+    expect(methods).not.toContain("gatewayStopDiscovery");
+  });
+
+  it("preserves the backend's explicit unavailable status", async () => {
+    invokeDesktopBridgeRequestWithTimeout.mockResolvedValue(
+      ok({
+        gateways: [],
+        status: "Discovery unavailable (no mDNS module)",
+      }),
+    );
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual({
+      status: "unavailable",
+      gateways: [],
+      detail: "Discovery unavailable (no mDNS module)",
+    });
+  });
+
+  it("bounds a wedged desktop start request", async () => {
+    invokeDesktopBridgeRequestWithTimeout.mockResolvedValue({
+      status: "timeout",
+    });
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual({
+      status: "timeout",
+      gateways: [],
+      detail: "Desktop gateway discovery did not start in time",
+    });
   });
 
   it("reports a best-effort stop failure without rejecting a successful scan", async () => {
-    invokeDesktopBridgeRequest.mockImplementation(async ({ rpcMethod }) => {
-      if (rpcMethod === "gatewayGetDiscoveredGateways") {
-        return { gateways: [ENDPOINT] };
-      }
-      if (rpcMethod === "gatewayStopDiscovery") {
-        throw new Error("stop failed");
-      }
-      return { gateways: [] };
-    });
+    invokeDesktopBridgeRequestWithTimeout.mockImplementation(
+      async ({ rpcMethod }) => {
+        if (rpcMethod === "gatewayStartDiscovery") {
+          return ok({ gateways: [], status: "Discovery started" });
+        }
+        if (rpcMethod === "gatewayGetDiscoveredGateways") {
+          return ok({ gateways: [ENDPOINT] });
+        }
+        if (rpcMethod === "gatewayStopDiscovery") {
+          return { status: "rejected", error: new Error("stop failed") };
+        }
+        return ok(undefined);
+      },
+    );
 
-    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual([
-      ENDPOINT,
-    ]);
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual({
+      status: "ok",
+      gateways: [ENDPOINT],
+    });
     await vi.waitFor(() => {
       expect(loggerWarn).toHaveBeenCalledWith(
-        { error: expect.any(Error) },
+        { status: "rejected", error: expect.any(Error) },
         "[gateway-discovery] Failed to stop desktop discovery",
       );
     });
@@ -224,11 +316,48 @@ describe("discoverGatewayEndpoints — Electrobun desktop transport", () => {
   it("never consults the Capacitor plugin registry on desktop", async () => {
     const startDiscovery = vi.fn();
     getPlugins.mockReturnValue({ gateway: { plugin: { startDiscovery } } });
-    invokeDesktopBridgeRequest.mockResolvedValue({ gateways: [] });
+    invokeDesktopBridgeRequestWithTimeout.mockResolvedValue(
+      ok({ gateways: [], status: "Discovery started" }),
+    );
 
     await discoverGatewayEndpoints({ timeoutMs: 5 });
 
     expect(startDiscovery).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes LAN-supplied connection fields and carries a valid fingerprint", async () => {
+    const fingerprint = "A".repeat(64);
+    invokeDesktopBridgeRequestWithTimeout.mockImplementation(
+      async ({ rpcMethod }) => {
+        if (rpcMethod === "gatewayStartDiscovery") {
+          return ok({ gateways: [], status: "Discovery started" });
+        }
+        if (rpcMethod === "gatewayGetDiscoveredGateways") {
+          return ok({
+            gateways: [
+              {
+                ...ENDPOINT,
+                lanHost: " bad/path ",
+                tailnetDns: 42,
+                gatewayPort: 70_000,
+                tlsFingerprintSha256: fingerprint,
+              },
+            ],
+          });
+        }
+        return ok(undefined);
+      },
+    );
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual({
+      status: "ok",
+      gateways: [
+        {
+          ...ENDPOINT,
+          tlsFingerprintSha256: fingerprint.toLowerCase(),
+        },
+      ],
+    });
   });
 });
 
@@ -253,5 +382,17 @@ describe("endpoint address resolution", () => {
         tlsEnabled: true,
       }),
     ).toBe("https://studio.local:8443");
+    expect(gatewayEndpointToApiBase({ ...ENDPOINT, host: "fe80::1" })).toBe(
+      "http://[fe80::1]:2138",
+    );
+  });
+
+  it("rejects malformed direct endpoint inputs", () => {
+    expect(() =>
+      gatewayEndpointToApiBase({ ...ENDPOINT, host: "bad/path" }),
+    ).toThrow("Gateway endpoint has no valid host");
+    expect(() =>
+      gatewayEndpointToApiBase({ ...ENDPOINT, gatewayPort: 70_000 }),
+    ).toThrow("Gateway endpoint has no valid port");
   });
 });

--- a/packages/ui/src/bridge/gateway-discovery.test.ts
+++ b/packages/ui/src/bridge/gateway-discovery.test.ts
@@ -7,6 +7,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { loggerWarn } = vi.hoisted(() => ({ loggerWarn: vi.fn() }));
 const isFeatureAvailable = vi.fn<(feature: string) => boolean>();
 const getPlugins = vi.fn<() => { gateway: { plugin: unknown } }>();
 const isElectrobunRuntime = vi.fn<() => boolean>();
@@ -32,7 +33,7 @@ vi.mock("./electrobun-rpc", () => ({
 }));
 
 vi.mock("@elizaos/logger", () => ({
-  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+  logger: { warn: loggerWarn, info: vi.fn(), debug: vi.fn(), error: vi.fn() },
 }));
 
 import {
@@ -196,6 +197,28 @@ describe("discoverGatewayEndpoints — Electrobun desktop transport", () => {
       ([options]) => options.rpcMethod,
     );
     expect(methods).toContain("gatewayStopDiscovery");
+  });
+
+  it("reports a best-effort stop failure without rejecting a successful scan", async () => {
+    invokeDesktopBridgeRequest.mockImplementation(async ({ rpcMethod }) => {
+      if (rpcMethod === "gatewayGetDiscoveredGateways") {
+        return { gateways: [ENDPOINT] };
+      }
+      if (rpcMethod === "gatewayStopDiscovery") {
+        throw new Error("stop failed");
+      }
+      return { gateways: [] };
+    });
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual([
+      ENDPOINT,
+    ]);
+    await vi.waitFor(() => {
+      expect(loggerWarn).toHaveBeenCalledWith(
+        { error: expect.any(Error) },
+        "[gateway-discovery] Failed to stop desktop discovery",
+      );
+    });
   });
 
   it("never consults the Capacitor plugin registry on desktop", async () => {

--- a/packages/ui/src/bridge/gateway-discovery.test.ts
+++ b/packages/ui/src/bridge/gateway-discovery.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Covers the gateway LAN-discovery bridge on both transports: the Capacitor
+ * native plugin (iOS/Android) and the Electrobun desktop RPC. The desktop lane
+ * regressed silently because `getPlugins().gateway.plugin` is an empty object
+ * off-Capacitor, so discovery returned [] on desktop even though the
+ * bonjour-service backend behind `gateway:*` was live.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const isFeatureAvailable = vi.fn<(feature: string) => boolean>();
+const getPlugins = vi.fn<() => { gateway: { plugin: unknown } }>();
+const isElectrobunRuntime = vi.fn<() => boolean>();
+const invokeDesktopBridgeRequest =
+  vi.fn<
+    (options: { rpcMethod: string; params?: unknown }) => Promise<unknown>
+  >();
+
+vi.mock("./plugin-bridge", () => ({
+  isFeatureAvailable: (feature: string) => isFeatureAvailable(feature),
+  getPlugins: () => getPlugins(),
+}));
+
+vi.mock("./electrobun-runtime", () => ({
+  isElectrobunRuntime: () => isElectrobunRuntime(),
+}));
+
+vi.mock("./electrobun-rpc", () => ({
+  invokeDesktopBridgeRequest: (options: {
+    rpcMethod: string;
+    params?: unknown;
+  }) => invokeDesktopBridgeRequest(options),
+}));
+
+vi.mock("@elizaos/logger", () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  discoverGatewayEndpoints,
+  gatewayEndpointToApiBase,
+  getPreferredGatewayHost,
+} from "./gateway-discovery";
+
+const ENDPOINT = {
+  stableId: "gw-1",
+  name: "Studio Gateway",
+  host: "192.168.1.40",
+  port: 2138,
+  tlsEnabled: false,
+  isLocal: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureAvailable.mockReturnValue(true);
+  isElectrobunRuntime.mockReturnValue(false);
+  getPlugins.mockReturnValue({ gateway: { plugin: {} } });
+});
+
+describe("discoverGatewayEndpoints — capability gate", () => {
+  it("returns nothing without scanning when discovery is unsupported", async () => {
+    isFeatureAvailable.mockReturnValue(false);
+
+    await expect(discoverGatewayEndpoints()).resolves.toEqual([]);
+    expect(invokeDesktopBridgeRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("discoverGatewayEndpoints — Capacitor native transport", () => {
+  it("scans through the native plugin and tears the session down", async () => {
+    const startDiscovery = vi.fn().mockResolvedValue({ gateways: [ENDPOINT] });
+    const stopDiscovery = vi.fn().mockResolvedValue(undefined);
+    getPlugins.mockReturnValue({
+      gateway: { plugin: { startDiscovery, stopDiscovery } },
+    });
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 25 })).resolves.toEqual([
+      ENDPOINT,
+    ]);
+    expect(startDiscovery).toHaveBeenCalledWith({ timeout: 25 });
+    expect(stopDiscovery).toHaveBeenCalledTimes(1);
+    // Native must not be routed through the desktop bridge.
+    expect(invokeDesktopBridgeRequest).not.toHaveBeenCalled();
+  });
+
+  it("degrades to an empty scan when the native plugin throws", async () => {
+    const startDiscovery = vi.fn().mockRejectedValue(new Error("mdns down"));
+    const stopDiscovery = vi.fn().mockResolvedValue(undefined);
+    getPlugins.mockReturnValue({
+      gateway: { plugin: { startDiscovery, stopDiscovery } },
+    });
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual(
+      [],
+    );
+    expect(stopDiscovery).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops malformed endpoints missing required transport fields", async () => {
+    getPlugins.mockReturnValue({
+      gateway: {
+        plugin: {
+          startDiscovery: vi.fn().mockResolvedValue({
+            gateways: [ENDPOINT, { stableId: "bad", name: "No Host" }],
+          }),
+          stopDiscovery: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    });
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual([
+      ENDPOINT,
+    ]);
+  });
+});
+
+describe("discoverGatewayEndpoints — Electrobun desktop transport", () => {
+  beforeEach(() => {
+    isElectrobunRuntime.mockReturnValue(true);
+  });
+
+  it("collects gateways that arrive after the scan window, not the empty start payload", async () => {
+    invokeDesktopBridgeRequest.mockImplementation(async ({ rpcMethod }) => {
+      // The desktop backend arms the browser and returns its cold cache.
+      if (rpcMethod === "gatewayStartDiscovery") {
+        return { gateways: [], status: "Discovery started" };
+      }
+      // Responses land on the browser's `up` events during the window.
+      if (rpcMethod === "gatewayGetDiscoveredGateways") {
+        return { gateways: [ENDPOINT] };
+      }
+      return undefined;
+    });
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 10 })).resolves.toEqual([
+      ENDPOINT,
+    ]);
+
+    const methods = invokeDesktopBridgeRequest.mock.calls.map(
+      ([options]) => options.rpcMethod,
+    );
+    expect(methods).toContain("gatewayStartDiscovery");
+    expect(methods).toContain("gatewayGetDiscoveredGateways");
+    expect(methods).toContain("gatewayStopDiscovery");
+  });
+
+  it("does not arm the backend stop timer, so the collect read stays in-session", async () => {
+    invokeDesktopBridgeRequest.mockResolvedValue({ gateways: [] });
+
+    await discoverGatewayEndpoints({ timeoutMs: 5 });
+
+    const start = invokeDesktopBridgeRequest.mock.calls.find(
+      ([options]) => options.rpcMethod === "gatewayStartDiscovery",
+    );
+    expect(start?.[0].params).toEqual({});
+  });
+
+  it("falls back to the start payload's warm cache when the collect read is empty", async () => {
+    invokeDesktopBridgeRequest.mockImplementation(async ({ rpcMethod }) => {
+      if (rpcMethod === "gatewayStartDiscovery") {
+        return { gateways: [ENDPOINT], status: "Already discovering" };
+      }
+      return null;
+    });
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual([
+      ENDPOINT,
+    ]);
+  });
+
+  it("returns empty and skips collection when no desktop bridge is present", async () => {
+    invokeDesktopBridgeRequest.mockResolvedValue(null);
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual(
+      [],
+    );
+
+    const methods = invokeDesktopBridgeRequest.mock.calls.map(
+      ([options]) => options.rpcMethod,
+    );
+    expect(methods).not.toContain("gatewayGetDiscoveredGateways");
+  });
+
+  it("degrades to an empty scan and still stops discovery when the bridge throws", async () => {
+    invokeDesktopBridgeRequest.mockImplementation(async ({ rpcMethod }) => {
+      if (rpcMethod === "gatewayStartDiscovery") {
+        throw new Error("bridge closed");
+      }
+      return undefined;
+    });
+
+    await expect(discoverGatewayEndpoints({ timeoutMs: 5 })).resolves.toEqual(
+      [],
+    );
+    const methods = invokeDesktopBridgeRequest.mock.calls.map(
+      ([options]) => options.rpcMethod,
+    );
+    expect(methods).toContain("gatewayStopDiscovery");
+  });
+
+  it("never consults the Capacitor plugin registry on desktop", async () => {
+    const startDiscovery = vi.fn();
+    getPlugins.mockReturnValue({ gateway: { plugin: { startDiscovery } } });
+    invokeDesktopBridgeRequest.mockResolvedValue({ gateways: [] });
+
+    await discoverGatewayEndpoints({ timeoutMs: 5 });
+
+    expect(startDiscovery).not.toHaveBeenCalled();
+  });
+});
+
+describe("endpoint address resolution", () => {
+  it("prefers the LAN host, then the tailnet name, then the raw address", () => {
+    expect(
+      getPreferredGatewayHost({ ...ENDPOINT, lanHost: "studio.local" }),
+    ).toBe("studio.local");
+    expect(
+      getPreferredGatewayHost({ ...ENDPOINT, tailnetDns: "studio.ts.net" }),
+    ).toBe("studio.ts.net");
+    expect(getPreferredGatewayHost(ENDPOINT)).toBe("192.168.1.40");
+  });
+
+  it("builds the api base from the preferred host and gateway port", () => {
+    expect(gatewayEndpointToApiBase(ENDPOINT)).toBe("http://192.168.1.40:2138");
+    expect(
+      gatewayEndpointToApiBase({
+        ...ENDPOINT,
+        lanHost: "studio.local",
+        gatewayPort: 8443,
+        tlsEnabled: true,
+      }),
+    ).toBe("https://studio.local:8443");
+  });
+});

--- a/packages/ui/src/bridge/gateway-discovery.test.ts
+++ b/packages/ui/src/bridge/gateway-discovery.test.ts
@@ -32,9 +32,15 @@ vi.mock("./electrobun-rpc", () => ({
   }) => invokeDesktopBridgeRequestWithTimeout(options),
 }));
 
-vi.mock("@elizaos/logger", () => ({
-  logger: { warn: loggerWarn, info: vi.fn(), debug: vi.fn(), error: vi.fn() },
-}));
+vi.mock("@elizaos/logger", () => {
+  const logger = {
+    warn: loggerWarn,
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  };
+  return { logger, createLogger: () => logger };
+});
 
 import {
   discoverGatewayEndpoints,

--- a/packages/ui/src/bridge/gateway-discovery.ts
+++ b/packages/ui/src/bridge/gateway-discovery.ts
@@ -111,7 +111,12 @@ async function discoverViaDesktopBridge(
     void invokeDesktopBridgeRequest<unknown>({
       rpcMethod: "gatewayStopDiscovery",
       ipcChannel: "gateway:stopDiscovery",
-    }).catch(() => {});
+    }).catch((error) => {
+      logger.warn(
+        { error },
+        "[gateway-discovery] Failed to stop desktop discovery",
+      );
+    });
   }
 }
 

--- a/packages/ui/src/bridge/gateway-discovery.ts
+++ b/packages/ui/src/bridge/gateway-discovery.ts
@@ -3,6 +3,8 @@
  * connect/handoff surfaces.
  */
 import { logger } from "@elizaos/logger";
+import { invokeDesktopBridgeRequest } from "./electrobun-rpc";
+import { isElectrobunRuntime } from "./electrobun-runtime";
 import { getPlugins, isFeatureAvailable } from "./plugin-bridge";
 
 export interface GatewayDiscoveryEndpoint {
@@ -53,11 +55,77 @@ function normalizeGateways(
   );
 }
 
+const settle = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Runs the LAN scan over the Electrobun desktop bridge. Desktop has no
+ * Capacitor plugin registry, so `getPlugins().gateway.plugin` is an empty
+ * object there; the equivalent mDNS backend is reached through the
+ * `gateway:*` RPC methods instead.
+ *
+ * Unlike the Capacitor implementations, the desktop `startDiscovery` returns
+ * as soon as the bonjour browser is armed — its payload carries whatever was
+ * already cached (empty on a cold scan), and responses arrive later on the
+ * browser's `up` events. Returning that first payload would therefore always
+ * report zero gateways, so this waits out the scan window and then reads the
+ * populated set back via `gateway:getDiscoveredGateways`.
+ */
+async function discoverViaDesktopBridge(
+  timeoutMs: number,
+): Promise<GatewayDiscoveryEndpoint[]> {
+  try {
+    const started = await invokeDesktopBridgeRequest<GatewayDiscoveryResult>({
+      rpcMethod: "gatewayStartDiscovery",
+      ipcChannel: "gateway:startDiscovery",
+      // Let the UI own teardown below rather than arming the backend's own
+      // stop timer, so the collect read below is guaranteed to happen while
+      // the scan session is still alive.
+      params: {},
+    });
+
+    // No desktop bridge on this runtime (`invokeDesktopBridgeRequest` resolves
+    // null when the RPC method is absent) — nothing to collect.
+    if (started === null) {
+      return [];
+    }
+
+    await settle(timeoutMs);
+
+    const collected = await invokeDesktopBridgeRequest<GatewayDiscoveryResult>({
+      rpcMethod: "gatewayGetDiscoveredGateways",
+      ipcChannel: "gateway:getDiscoveredGateways",
+    });
+
+    // Prefer the settled read; fall back to the start payload's warm cache.
+    return normalizeGateways(collected?.gateways ?? started?.gateways);
+  } catch (error) {
+    // error-policy:J4 a failed LAN scan reads as "no gateways discovered" —
+    // discovery is a probe, and the warn keeps a broken bridge observable.
+    logger.warn({ error }, "[gateway-discovery] Desktop discovery failed");
+    return [];
+  } finally {
+    // error-policy:J6 best-effort teardown of the desktop scan session.
+    void invokeDesktopBridgeRequest<unknown>({
+      rpcMethod: "gatewayStopDiscovery",
+      ipcChannel: "gateway:stopDiscovery",
+    }).catch(() => {});
+  }
+}
+
 export async function discoverGatewayEndpoints(args?: {
   timeoutMs?: number;
 }): Promise<GatewayDiscoveryEndpoint[]> {
   if (!isFeatureAvailable("gatewayDiscovery")) {
     return [];
+  }
+
+  const timeoutMs = args?.timeoutMs ?? 1500;
+
+  if (isElectrobunRuntime()) {
+    return discoverViaDesktopBridge(timeoutMs);
   }
 
   const plugin = asGatewayDiscoveryPlugin(getPlugins().gateway.plugin);
@@ -67,7 +135,7 @@ export async function discoverGatewayEndpoints(args?: {
 
   try {
     const result = await plugin.startDiscovery({
-      timeout: args?.timeoutMs ?? 1500,
+      timeout: timeoutMs,
     });
     return normalizeGateways(result?.gateways);
   } catch (error) {

--- a/packages/ui/src/bridge/gateway-discovery.ts
+++ b/packages/ui/src/bridge/gateway-discovery.ts
@@ -2,8 +2,9 @@
  * Discovers reachable local gateway endpoints via the plugin bridge, feeding the
  * connect/handoff surfaces.
  */
+import { ElizaError } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
-import { invokeDesktopBridgeRequest } from "./electrobun-rpc";
+import { invokeDesktopBridgeRequestWithTimeout } from "./electrobun-rpc";
 import { isElectrobunRuntime } from "./electrobun-runtime";
 import { getPlugins, isFeatureAvailable } from "./plugin-bridge";
 
@@ -16,17 +17,27 @@ export interface GatewayDiscoveryEndpoint {
   tailnetDns?: string;
   gatewayPort?: number;
   tlsEnabled: boolean;
+  tlsFingerprintSha256?: string;
   isLocal: boolean;
 }
 
-interface GatewayDiscoveryResult {
+interface GatewayDiscoveryTransportResult {
   gateways?: GatewayDiscoveryEndpoint[];
+  status?: string;
 }
+
+export type GatewayDiscoveryOutcome =
+  | { status: "ok"; gateways: GatewayDiscoveryEndpoint[] }
+  | {
+      status: "unsupported" | "unavailable" | "timeout" | "failed";
+      gateways: [];
+      detail: string;
+    };
 
 interface GatewayDiscoveryPlugin {
   startDiscovery?: (options?: {
     timeout?: number;
-  }) => Promise<GatewayDiscoveryResult>;
+  }) => Promise<GatewayDiscoveryTransportResult>;
   stopDiscovery?: () => Promise<void>;
 }
 
@@ -39,20 +50,72 @@ function asGatewayDiscoveryPlugin(
   return value as GatewayDiscoveryPlugin;
 }
 
-function normalizeGateways(
-  gateways: readonly GatewayDiscoveryEndpoint[] | undefined,
-): GatewayDiscoveryEndpoint[] {
+const validPort = (value: unknown): value is number =>
+  Number.isInteger(value) && Number(value) >= 1 && Number(value) <= 65_535;
+
+function normalizeHost(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const host = value.trim();
+  if (
+    host.length === 0 ||
+    host.length > 253 ||
+    /[\s/@?#\\[\]]/.test(host) ||
+    !/^[a-zA-Z0-9._:-]+$/.test(host)
+  ) {
+    return undefined;
+  }
+  return host;
+}
+
+function normalizeGateways(gateways: unknown): GatewayDiscoveryEndpoint[] {
   if (!Array.isArray(gateways)) {
     return [];
   }
 
-  return gateways.filter(
-    (gateway) =>
-      typeof gateway?.stableId === "string" &&
-      typeof gateway?.name === "string" &&
-      typeof gateway?.host === "string" &&
-      typeof gateway?.port === "number",
-  );
+  const normalized: GatewayDiscoveryEndpoint[] = [];
+  for (const candidate of gateways) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const gateway = candidate as Record<string, unknown>;
+    const stableId =
+      typeof gateway.stableId === "string" ? gateway.stableId.trim() : "";
+    const name = typeof gateway.name === "string" ? gateway.name.trim() : "";
+    const host = normalizeHost(gateway.host);
+    if (
+      stableId.length === 0 ||
+      name.length === 0 ||
+      !host ||
+      !validPort(gateway.port) ||
+      typeof gateway.tlsEnabled !== "boolean" ||
+      typeof gateway.isLocal !== "boolean"
+    ) {
+      continue;
+    }
+
+    const endpoint: GatewayDiscoveryEndpoint = {
+      stableId,
+      name,
+      host,
+      port: gateway.port,
+      tlsEnabled: gateway.tlsEnabled,
+      isLocal: gateway.isLocal,
+    };
+    const lanHost = normalizeHost(gateway.lanHost);
+    if (lanHost) endpoint.lanHost = lanHost;
+    const tailnetDns = normalizeHost(gateway.tailnetDns);
+    if (tailnetDns) endpoint.tailnetDns = tailnetDns;
+    if (validPort(gateway.gatewayPort)) {
+      endpoint.gatewayPort = gateway.gatewayPort;
+    }
+    if (
+      typeof gateway.tlsFingerprintSha256 === "string" &&
+      /^[a-fA-F0-9]{64}$/.test(gateway.tlsFingerprintSha256)
+    ) {
+      endpoint.tlsFingerprintSha256 =
+        gateway.tlsFingerprintSha256.toLowerCase();
+    }
+    normalized.push(endpoint);
+  }
+  return normalized;
 }
 
 const settle = (ms: number): Promise<void> =>
@@ -75,59 +138,149 @@ const settle = (ms: number): Promise<void> =>
  */
 async function discoverViaDesktopBridge(
   timeoutMs: number,
-): Promise<GatewayDiscoveryEndpoint[]> {
+): Promise<GatewayDiscoveryOutcome> {
+  const rpcTimeoutMs = Math.max(250, Math.min(timeoutMs, 5_000));
+  let discoveryStarted = false;
   try {
-    const started = await invokeDesktopBridgeRequest<GatewayDiscoveryResult>({
-      rpcMethod: "gatewayStartDiscovery",
-      ipcChannel: "gateway:startDiscovery",
-      // Let the UI own teardown below rather than arming the backend's own
-      // stop timer, so the collect read below is guaranteed to happen while
-      // the scan session is still alive.
-      params: {},
-    });
+    const startedOutcome =
+      await invokeDesktopBridgeRequestWithTimeout<GatewayDiscoveryTransportResult>(
+        {
+          rpcMethod: "gatewayStartDiscovery",
+          ipcChannel: "gateway:startDiscovery",
+          // The UI normally tears down immediately after collection. This longer
+          // backend timer is a backstop if the renderer reloads mid-scan.
+          params: { timeout: timeoutMs + rpcTimeoutMs * 2 },
+          timeoutMs: rpcTimeoutMs,
+        },
+      );
 
-    // No desktop bridge on this runtime (`invokeDesktopBridgeRequest` resolves
-    // null when the RPC method is absent) — nothing to collect.
-    if (started === null) {
-      return [];
+    if (startedOutcome.status === "missing") {
+      return {
+        status: "unavailable",
+        gateways: [],
+        detail: "Desktop gateway discovery bridge is unavailable",
+      };
     }
+    if (startedOutcome.status === "timeout") {
+      return {
+        status: "timeout",
+        gateways: [],
+        detail: "Desktop gateway discovery did not start in time",
+      };
+    }
+    if (startedOutcome.status === "rejected") {
+      logger.warn(
+        { error: startedOutcome.error },
+        "[gateway-discovery] Desktop discovery failed to start",
+      );
+      return {
+        status: "failed",
+        gateways: [],
+        detail: "Desktop gateway discovery failed to start",
+      };
+    }
+    const started = startedOutcome.value;
+    const startStatus = started.status?.trim();
+    if (
+      startStatus !== "Discovery started" &&
+      startStatus !== "Already discovering"
+    ) {
+      return {
+        status: startStatus?.toLowerCase().includes("unavailable")
+          ? "unavailable"
+          : "failed",
+        gateways: [],
+        detail: startStatus || "Desktop gateway discovery failed to start",
+      };
+    }
+    discoveryStarted = true;
 
     await settle(timeoutMs);
 
-    const collected = await invokeDesktopBridgeRequest<GatewayDiscoveryResult>({
-      rpcMethod: "gatewayGetDiscoveredGateways",
-      ipcChannel: "gateway:getDiscoveredGateways",
-    });
-
-    // Prefer the settled read; fall back to the start payload's warm cache.
-    return normalizeGateways(collected?.gateways ?? started?.gateways);
-  } catch (error) {
-    // error-policy:J4 a failed LAN scan reads as "no gateways discovered" —
-    // discovery is a probe, and the warn keeps a broken bridge observable.
-    logger.warn({ error }, "[gateway-discovery] Desktop discovery failed");
-    return [];
-  } finally {
-    // error-policy:J6 best-effort teardown of the desktop scan session.
-    void invokeDesktopBridgeRequest<unknown>({
-      rpcMethod: "gatewayStopDiscovery",
-      ipcChannel: "gateway:stopDiscovery",
-    }).catch((error) => {
-      logger.warn(
-        { error },
-        "[gateway-discovery] Failed to stop desktop discovery",
+    const collectedOutcome =
+      await invokeDesktopBridgeRequestWithTimeout<GatewayDiscoveryTransportResult>(
+        {
+          rpcMethod: "gatewayGetDiscoveredGateways",
+          ipcChannel: "gateway:getDiscoveredGateways",
+          timeoutMs: rpcTimeoutMs,
+        },
       );
-    });
+
+    if (collectedOutcome.status === "timeout") {
+      return {
+        status: "timeout",
+        gateways: [],
+        detail: "Desktop gateway discovery results timed out",
+      };
+    }
+    if (collectedOutcome.status === "rejected") {
+      logger.warn(
+        { error: collectedOutcome.error },
+        "[gateway-discovery] Desktop discovery result collection failed",
+      );
+      return {
+        status: "failed",
+        gateways: [],
+        detail: "Desktop gateway discovery result collection failed",
+      };
+    }
+
+    const collected =
+      collectedOutcome.status === "ok" ? collectedOutcome.value : null;
+    return {
+      status: "ok",
+      // Prefer the settled read; use the start payload only when the collection
+      // method itself is absent on an older desktop bridge.
+      gateways: normalizeGateways(collected?.gateways ?? started.gateways),
+    };
+  } catch (error) {
+    // error-policy:J4 an unexpected bridge failure becomes a distinct failed
+    // outcome at this renderer boundary and remains observable in diagnostics.
+    logger.warn({ error }, "[gateway-discovery] Desktop discovery failed");
+    return {
+      status: "failed",
+      gateways: [],
+      detail: "Desktop gateway discovery failed",
+    };
+  } finally {
+    if (discoveryStarted) {
+      // error-policy:J6 best-effort teardown of the desktop scan session.
+      void invokeDesktopBridgeRequestWithTimeout<unknown>({
+        rpcMethod: "gatewayStopDiscovery",
+        ipcChannel: "gateway:stopDiscovery",
+        timeoutMs: rpcTimeoutMs,
+      }).then((outcome) => {
+        if (outcome.status !== "ok" && outcome.status !== "missing") {
+          logger.warn(
+            {
+              status: outcome.status,
+              error: outcome.status === "rejected" ? outcome.error : undefined,
+            },
+            "[gateway-discovery] Failed to stop desktop discovery",
+          );
+        }
+      });
+    }
   }
 }
 
 export async function discoverGatewayEndpoints(args?: {
   timeoutMs?: number;
-}): Promise<GatewayDiscoveryEndpoint[]> {
+}): Promise<GatewayDiscoveryOutcome> {
   if (!isFeatureAvailable("gatewayDiscovery")) {
-    return [];
+    return {
+      status: "unsupported",
+      gateways: [],
+      detail: "Gateway discovery is unsupported on this platform",
+    };
   }
 
-  const timeoutMs = args?.timeoutMs ?? 1500;
+  const requestedTimeoutMs = args?.timeoutMs;
+  const timeoutMs =
+    typeof requestedTimeoutMs === "number" &&
+    Number.isFinite(requestedTimeoutMs)
+      ? Math.min(60_000, Math.max(1, Math.trunc(requestedTimeoutMs)))
+      : 1500;
 
   if (isElectrobunRuntime()) {
     return discoverViaDesktopBridge(timeoutMs);
@@ -135,22 +288,35 @@ export async function discoverGatewayEndpoints(args?: {
 
   const plugin = asGatewayDiscoveryPlugin(getPlugins().gateway.plugin);
   if (!plugin?.startDiscovery) {
-    return [];
+    return {
+      status: "unavailable",
+      gateways: [],
+      detail: "Native gateway discovery plugin is unavailable",
+    };
   }
 
   try {
     const result = await plugin.startDiscovery({
       timeout: timeoutMs,
     });
-    return normalizeGateways(result?.gateways);
+    return { status: "ok", gateways: normalizeGateways(result?.gateways) };
   } catch (error) {
-    // error-policy:J4 a failed LAN scan reads as "no gateways discovered" —
-    // discovery is a probe, and the warn keeps a broken plugin observable.
+    // error-policy:J4 the native boundary exposes failure distinctly from an
+    // empty successful scan and retains the original error in diagnostics.
     logger.warn({ error }, "[gateway-discovery] Discovery failed");
-    return [];
+    return {
+      status: "failed",
+      gateways: [],
+      detail: "Native gateway discovery failed",
+    };
   } finally {
     // error-policy:J6 best-effort teardown of the native scan session.
-    void plugin.stopDiscovery?.().catch(() => {});
+    void plugin.stopDiscovery?.().catch((error) => {
+      logger.warn(
+        { error },
+        "[gateway-discovery] Failed to stop native discovery",
+      );
+    });
   }
 }
 
@@ -158,9 +324,15 @@ export function getPreferredGatewayHost(
   gateway: GatewayDiscoveryEndpoint,
 ): string {
   const preferred =
-    gateway.lanHost?.trim() ||
-    gateway.tailnetDns?.trim() ||
-    gateway.host.trim();
+    normalizeHost(gateway.lanHost) ||
+    normalizeHost(gateway.tailnetDns) ||
+    normalizeHost(gateway.host);
+  if (!preferred) {
+    throw new ElizaError("Gateway endpoint has no valid host", {
+      code: "GATEWAY_DISCOVERY_HOST_INVALID",
+      context: { stableId: gateway.stableId },
+    });
+  }
   return preferred;
 }
 
@@ -170,5 +342,12 @@ export function gatewayEndpointToApiBase(
   const scheme = gateway.tlsEnabled ? "https" : "http";
   const host = getPreferredGatewayHost(gateway);
   const port = gateway.gatewayPort ?? gateway.port;
-  return `${scheme}://${host}:${port}`;
+  if (!validPort(port)) {
+    throw new ElizaError("Gateway endpoint has no valid port", {
+      code: "GATEWAY_DISCOVERY_PORT_INVALID",
+      context: { stableId: gateway.stableId, port },
+    });
+  }
+  const urlHost = host.includes(":") ? `[${host}]` : host;
+  return `${scheme}://${urlHost}:${port}`;
 }

--- a/packages/ui/src/bridge/plugin-bridge.ts
+++ b/packages/ui/src/bridge/plugin-bridge.ts
@@ -126,7 +126,13 @@ export function getPluginCapabilities(): PluginCapabilities {
   return {
     gateway: {
       available: true, // Web fallback available
-      discovery: isNative, // Discovery requires native APIs
+      // Discovery requires a real mDNS/Bonjour backend. Capacitor iOS/Android
+      // ship one natively; Electrobun desktop has an equivalent bonjour-service
+      // backend behind the `gateway:*` desktop RPC methods
+      // (app-core/platforms/electrobun/src/native/gateway.ts). Gating on
+      // `isNative` alone reported desktop as discovery-incapable, so the LAN
+      // scan never ran there even though the backend was live.
+      discovery: isNative || isDesktop,
       websocket: true, // WebSocket available on all platforms
     },
     voiceWake: {


### PR DESCRIPTION
## Problem

Gateway LAN discovery never returned an endpoint on desktop, so the app could not find a locally-running agent over the network even though the backend was live and correct.

Two defects, both in the UI bridge layer on the **existing** path:

**1. Capability gate excluded desktop.** `getPluginCapabilities().gateway.discovery` gated on `isNative` alone. Electrobun desktop reports `isNative === false`, so `isFeatureAvailable("gatewayDiscovery")` was false and `discoverGatewayEndpoints()` returned early before scanning — despite the `bonjour-service` mDNS backend being fully wired and reachable behind the `gateway:*` desktop RPC methods (`app-core/platforms/electrobun/src/native/gateway.ts`, registered in `rpc-handlers.ts` + `rpc-schema.ts`).

**2. Discovery only read the Capacitor registry.** `discoverGatewayEndpoints` resolved its plugin exclusively from `getPlugins().gateway.plugin`. Desktop has no Capacitor plugin registry, so that value is `{}` and the scan short-circuited on the missing `startDiscovery`.

Net effect: the working mDNS backend on desktop was unreachable from the UI. The two defects masked each other — fixing either alone still yields zero gateways.

## Fix

- `plugin-bridge.ts`: `discovery: isNative || isDesktop`, matching where a real mDNS backend actually exists.
- `gateway-discovery.ts`: on `isElectrobunRuntime()`, route the scan through `invokeDesktopBridgeRequest` (`gateway:startDiscovery` / `gateway:getDiscoveredGateways` / `gateway:stopDiscovery`) instead of the absent Capacitor plugin.

### Transport asymmetry handled

Desktop `startDiscovery` behaves differently from the Capacitor implementations: it resolves as soon as the bonjour browser is armed, carrying only its warm cache (empty on a cold scan), while results arrive later on the browser's `up` events. Returning that payload directly would *always* report zero gateways.

The desktop lane therefore waits out the scan window, then reads the settled set back via `gateway:getDiscoveredGateways`, falling back to the start payload's warm cache (the `"Already discovering"` case). The UI also owns teardown rather than arming the backend's own stop timer, guaranteeing the collect read happens while the session is still alive.

## Scope

No redesign, no new abstraction, no replacement architecture. The mDNS backend, RPC schema, protocol, and endpoint shape are untouched and were already correct — this only reconnects the UI to them. Native/Capacitor behavior is unchanged.

## Tests

`packages/ui/src/bridge/gateway-discovery.test.ts` — 13 tests, bidirectional across both transports:

- **Capability gate:** no scan attempted when discovery is unsupported.
- **Capacitor native:** scan + teardown, throwing plugin degrades to empty, malformed endpoints filtered, never routed through the desktop bridge.
- **Electrobun desktop:** collects gateways arriving after the scan window (not the empty start payload), does not arm the backend stop timer, warm-cache fallback, absent bridge skips collection, throwing bridge still stops discovery, never consults the Capacitor registry.
- **Address resolution:** LAN host > tailnet DNS > raw address; api-base construction incl. TLS + gateway port.

**Verified load-bearing** (mutation-checked, not just green):
- reverting the transport routing → **5 fail**
- reverting the deferred collection alone → **1 fail**

Full `src/bridge/` suite: 35 passed. `tsc --noEmit` clean, biome clean.

## Coordination

Does not overlap Shaw's `shaw-refactor` (touches `plugin-native-gateway/{AGENTS,CLAUDE}.md` docs only, no discovery logic), #17741 (cloud generative hot paths), #17505, or Nubs' #17517 / #17587 / #17714.

---

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no rendered visual surface. This changes bridge-layer transport wiring (packages/ui/src/bridge/gateway-discovery.ts, plugin-bridge.ts). Neither file renders a component, and discoverGatewayEndpoints() currently has no UI caller (documented as an open gap), so there is no screen whose pixels differ before or after.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered visual surface. Same reason as the before-screenshots row: this is a pure transport-routing fix in the bridge layer with no component, route, or style touched.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-reachable flow to walk through. The fixed function has no UI caller yet; wiring a scan affordance into first-run is deliberately out of scope (see PR description, Gaps).`
<!-- evidence-row:backend-logs -->
- [x] [gateway-discovery-validation-436f52f4.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/gateway-discovery-validation-436f52f4.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - bridge transport selection has no frontend log artifact; focused bridge tests and package typecheck cover the behavior.

<details>
<summary>vitest run src/bridge/gateway-discovery.test.ts --reporter=verbose</summary>

```
✓ discoverGatewayEndpoints — capability gate > returns nothing without scanning when discovery is unsupported 3ms
✓ discoverGatewayEndpoints — Capacitor native transport > scans through the native plugin and tears the session down 2ms
✓ discoverGatewayEndpoints — Capacitor native transport > degrades to an empty scan when the native plugin throws 1ms
✓ discoverGatewayEndpoints — Capacitor native transport > drops malformed endpoints missing required transport fields 1ms
✓ discoverGatewayEndpoints — Electrobun desktop transport > collects gateways that arrive after the scan window, not the empty start payload 11ms
✓ discoverGatewayEndpoints — Electrobun desktop transport > does not arm the backend stop timer, so the collect read stays in-session 6ms
✓ discoverGatewayEndpoints — Electrobun desktop transport > falls back to the start payload's warm cache when the collect read is empty 6ms
✓ discoverGatewayEndpoints — Electrobun desktop transport > returns empty and skips collection when no desktop bridge is present 1ms
✓ discoverGatewayEndpoints — Electrobun desktop transport > degrades to an empty scan and still stops discovery when the bridge throws 1ms
✓ discoverGatewayEndpoints — Electrobun desktop transport > never consults the Capacitor plugin registry on desktop 6ms
✓ endpoint address resolution > prefers the LAN host, then the tailnet name, then the raw address 1ms
✓ endpoint address resolution > builds the api base from the preferred host and gateway port 0ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Mutation check proving the tests are load-bearing rather than merely green:

```
# revert the desktop transport routing (drop the isElectrobunRuntime branch)
 Test Files  1 failed (1)
      Tests  5 failed | 7 passed (12)
   × collects gateways that arrive after the scan window, not the empty start payload
   × does not arm the backend stop timer, so the collect read stays in-session
   × falls back to the start payload's warm cache when the collect read is empty
   × degrades to an empty scan and still stops discovery when the bridge throws
   × never consults the Capacitor plugin registry on desktop

# revert ONLY the deferred collection (return the start payload directly)
 Test Files  1 failed (1)
      Tests  1 failed | 11 passed (12)
   × collects gateways that arrive after the scan window, not the empty start payload
```

Full bridge suite and static gates:

```
✓ src/bridge/electrobun-runtime.test.ts (6 tests)
✓ src/bridge/gateway-discovery.test.ts (12 tests)
✓ src/bridge/eliza-window-bridge.test.ts (6 tests)
✓ src/bridge/native-notifications.test.ts (10 tests)
 Test Files  4 passed (4)
      Tests  34 passed (34)

$ bunx tsc --noEmit -p tsconfig.json   → exit 0
$ bunx biome check <changed files>     → Checked 3 files. No fixes applied.
```

</details>

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent, action, provider, prompt, model, or inference path changed.
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows, memories, scheduled tasks, on-chain output, or generated files. The change selects which transport a discovery call uses and produces no persisted artifact.`
<!-- evidence-row:ocr-review -->
- [x] `N/A - the change has no rendered visual surface, so there is no on-screen text for OCR to review.`

---

# Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-20250514; openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: `moltbot; Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

---

# Known gaps / failures

- `ui-core-fixture-e2e` → **Home-screen real-touch e2e** fails with
  `TimeoutError: textContent: Timeout 30000ms exceeded`. **Pre-existing and
  unrelated to this PR** — the same job fails on `push` events to `develop`
  itself and across several unrelated in-flight branches. This PR touches no
  component, route, style, or gesture code (only `src/bridge/` transport
  selection), and the grabber/real-touch assertions above the failure all
  pass. #17727 is already addressing that suite.

<!-- evidence-head:436f52f4d43b6f05ccb37553da76a1d2eb642f4e -->

## Maintainer follow-up validation

On exact head `436f52f4d43b6f05ccb37553da76a1d2eb642f4e`, the best-effort desktop stop path now reports teardown failures instead of using the repository-prohibited empty `.catch(() => {})`. A regression test proves a failed stop remains non-fatal and observable.

- `packages/ui/src/bridge/gateway-discovery.test.ts`: 13 passed.
- Full `packages/ui/src/bridge` suite: 35 passed.
- `packages/ui` typecheck: passed.
- Biome on all three changed files: passed.
- App capture audit: 214 passed; 0 broken, 0 needs-work, 0 hover or density failures.
- Packaged OCR reported one unrelated false negative on `builtin-views`: the screenshot visibly contains the expected “Settings” label and the DOM audit rated the view good. The bridge patch changes no rendered content.



