### PR TITLE
fix(voice): warm every cold cache a realtime turn reads

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Proves realtime voice cold-start hydration warms EVERY cache a turn reads.
+ *
+ * The production voice turn is cache-only twice: the scope gate reads the voice
+ * shared-agent entry, and `SharedRuntimeChatService.characterFor` then reads
+ * `character:data:{characterId}`. Warming only the first left the second cold,
+ * so a session that survived `agent_cache_warming` immediately failed with
+ * `shared_runtime_cache_warming` on the next turn (measured live on staging,
+ * 2026-08-05: turns alternated between the two 503s and produced no audio).
+ *
+ * These tests are bidirectional: hydration must FILL both entries, and must
+ * still publish the authorization scope when the optional character prefill
+ * fails, so a character outage cannot regress cold start into a hard failure.
+ */
+
+import { afterEach, expect, mock, test } from "bun:test";
+
+process.env.MOCK_REDIS = "1";
+
+const AGENT_ID = "0f1f3a2a-32c1-4f10-8a3f-3b6a3a4bb001";
+const CHARACTER_ID = "6a1c8bf0-6d54-4f21-9c31-2a0cbb77aa02";
+const ORGANIZATION_ID = "org-voice-hydration";
+const USER_ID = "user-voice-hydration";
+const CONVERSATION_ID = "conversation-voice-hydration";
+
+const claims = {
+  agentId: AGENT_ID,
+  conversationId: CONVERSATION_ID,
+  organizationId: ORGANIZATION_ID,
+  userId: USER_ID,
+};
+
+const sharedAgent = {
+  id: AGENT_ID,
+  organization_id: ORGANIZATION_ID,
+  user_id: USER_ID,
+  execution_tier: "shared",
+  agent_name: "Voice Hydration",
+  character_id: CHARACTER_ID,
+};
+
+const linkedCharacter = {
+  id: CHARACTER_ID,
+  organization_id: ORGANIZATION_ID,
+  name: "Hydrated Character",
+};
+
+const findByIdAndOrg = mock(async () => sharedAgent);
+const findByIdInOrganization = mock(async () => linkedCharacter);
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: { findByIdAndOrg },
+}));
+mock.module("@/db/repositories/characters", () => ({
+  userCharactersRepository: { findByIdInOrganization },
+}));
+mock.module("@/db/client", () => ({
+  runWithDbCacheAsync: async (fn: () => Promise<void>) => await fn(),
+}));
+
+const { cache } = await import("@/lib/cache/client");
+const { CacheKeys } = await import("@/lib/cache/keys");
+const { runWithCloudBindingsAsync } = await import(
+  "@/lib/runtime/cloud-bindings"
+);
+const { hydrateVoiceSharedAgentScope } = await import(
+  "../lib/voice-agent-scope-hydration"
+);
+
+const SCOPE_KEY = CacheKeys.sharedAgentScope.voice(
+  ORGANIZATION_ID,
+  USER_ID,
+  AGENT_ID,
+);
+const CHARACTER_KEY = `character:data:${CHARACTER_ID}`;
+const env = {
+  CACHE_ENABLED: "true",
+  DATABASE_URL: "postgresql://must-not-connect.invalid/eliza",
+};
+
+afterEach(async () => {
+  await runWithCloudBindingsAsync(env, async () => {
+    await cache.del(SCOPE_KEY);
+    await cache.del(CHARACTER_KEY);
+  });
+  findByIdAndOrg.mockClear();
+  findByIdInOrganization.mockClear();
+  findByIdInOrganization.mockImplementation(async () => linkedCharacter);
+});
+
+test("one cold hydration warms BOTH the scope gate and the linked character", async () => {
+  await runWithCloudBindingsAsync(env, async () => {
+    expect(await cache.get(SCOPE_KEY)).toBeFalsy();
+    expect(await cache.get(CHARACTER_KEY)).toBeFalsy();
+
+    await hydrateVoiceSharedAgentScope(
+      env as unknown as Parameters<typeof hydrateVoiceSharedAgentScope>[0],
+      claims,
+    );
+
+    // Both cache-only reads the next turn performs must now hit. Warming only
+    // the scope entry is exactly what burned a second turn on staging.
+    expect(await cache.get(SCOPE_KEY)).toMatchObject({ id: AGENT_ID });
+    expect(await cache.get(CHARACTER_KEY)).toMatchObject({ id: CHARACTER_ID });
+    expect(findByIdInOrganization).toHaveBeenCalledWith(
+      CHARACTER_ID,
+      ORGANIZATION_ID,
+    );
+  });
+});
+
+test("publishes the authorization scope even when the character prefill fails", async () => {
+  findByIdInOrganization.mockImplementation(async () => {
+    throw new Error("character store unavailable");
+  });
+
+  await runWithCloudBindingsAsync(env, async () => {
+    await hydrateVoiceSharedAgentScope(
+      env as unknown as Parameters<typeof hydrateVoiceSharedAgentScope>[0],
+      claims,
+    );
+
+    // The scope entry is the authorization gate: an optional prefill outage
+    // must not hold it back, or cold start regresses into a hard failure.
+    expect(await cache.get(SCOPE_KEY)).toMatchObject({ id: AGENT_ID });
+    expect(await cache.get(CHARACTER_KEY)).toBeFalsy();
+  });
+});
+
+test("does not overwrite an already-warm character entry", async () => {
+  await runWithCloudBindingsAsync(env, async () => {
+    await cache.set(CHARACTER_KEY, { id: CHARACTER_ID, name: "Existing" }, 60);
+
+    await hydrateVoiceSharedAgentScope(
+      env as unknown as Parameters<typeof hydrateVoiceSharedAgentScope>[0],
+      claims,
+    );
+
+    expect(findByIdInOrganization).not.toHaveBeenCalled();
+    expect(await cache.get(CHARACTER_KEY)).toMatchObject({ name: "Existing" });
+  });
+});
+
+test("refuses to publish scope for an agent outside the verified voice claims", async () => {
+  findByIdAndOrg.mockImplementation(async () => ({
+    ...sharedAgent,
+    user_id: "someone-else",
+  }));
+
+  await runWithCloudBindingsAsync(env, async () => {
+    await hydrateVoiceSharedAgentScope(
+      env as unknown as Parameters<typeof hydrateVoiceSharedAgentScope>[0],
+      claims,
+    );
+
+    expect(await cache.get(SCOPE_KEY)).toBeFalsy();
+    expect(await cache.get(CHARACTER_KEY)).toBeFalsy();
+  });
+
+  findByIdAndOrg.mockImplementation(async () => sharedAgent);
+});

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -7,8 +7,10 @@
 
 import { runWithDbCacheAsync } from "@/db/client";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import { userCharactersRepository } from "@/db/repositories/characters";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys, CacheTTL } from "@/lib/cache/keys";
+import { logger } from "@/lib/utils/logger";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
 import type { Bindings } from "@/types/cloud-worker-env";
 import type { InternalElizaConversationFetchClaims } from "./internal-eliza-conversation-fetch";
@@ -34,6 +36,39 @@ export async function hydrateVoiceSharedAgentScope(
         ) {
           return;
         }
+
+        // The turn needs BOTH cold caches. Hydrating only the scope entry left
+        // the linked-character entry cold, so the very next turn passed the
+        // scope gate and then threw SharedRuntimeCacheWarmingError from
+        // `characterFor` (cacheOnly) — a SECOND burned turn, and on a session
+        // whose turns are spaced by human think-time the two 503s could
+        // alternate indefinitely. Warm the character entry in the SAME
+        // background task, under the same db/bindings context, so one
+        // hydration makes the next turn fully serviceable.
+        const characterId = agent.character_id;
+        const hydrateCharacter = async (): Promise<void> => {
+          if (!characterId) return;
+          const cacheKey = `character:data:${characterId}`;
+          if (await cache.get(cacheKey)) return;
+          const character = await userCharactersRepository.findByIdInOrganization(
+            characterId,
+            claims.organizationId,
+          );
+          if (!character) return;
+          await cache.set(cacheKey, character, CacheTTL.agent.characterData);
+        };
+
+        // The scope entry is the authorization gate: never let an optional
+        // character prefill failure prevent it from being written.
+        // error-policy:J7 a failed character prefill leaves the next turn on
+        // its existing retryable warming path rather than failing hydration.
+        await hydrateCharacter().catch((error) => {
+          logger.warn("[voice-scope-hydration] character prefill failed", {
+            agentId: claims.agentId,
+            characterId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
 
         await cache.set(
           CacheKeys.sharedAgentScope.voice(

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -10,8 +10,8 @@ import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@/db/repositories/characters";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys, CacheTTL } from "@/lib/cache/keys";
-import { logger } from "@/lib/utils/logger";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { logger } from "@/lib/utils/logger";
 import type { Bindings } from "@/types/cloud-worker-env";
 import type { InternalElizaConversationFetchClaims } from "./internal-eliza-conversation-fetch";
 
@@ -50,10 +50,11 @@ export async function hydrateVoiceSharedAgentScope(
           if (!characterId) return;
           const cacheKey = `character:data:${characterId}`;
           if (await cache.get(cacheKey)) return;
-          const character = await userCharactersRepository.findByIdInOrganization(
-            characterId,
-            claims.organizationId,
-          );
+          const character =
+            await userCharactersRepository.findByIdInOrganization(
+              characterId,
+              claims.organizationId,
+            );
           if (!character) return;
           await cache.set(cacheKey, character, CacheTTL.agent.characterData);
         };


### PR DESCRIPTION
# Relates to

Realtime voice cold-start reliability on staging. Found while validating the Fish Audio TTS landing (#17709) end to end on staging.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is cut from the current `origin/develop` head (`1e3dec2d06f`) with zero conflicts.
- [x] Targeted install/typecheck/tests were run after sync; the one unrelated blocker is recorded in **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the staging transcript and test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-6`
<!-- attribution-row:client -->
- Client / agent tooling: `moltbot`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Cut from the latest `origin/develop` (`1e3dec2d06f`); zero conflicts.
- [x] Targeted verification passes post-sync. One pre-existing, unrelated failure documented in **Known gaps / failures**.

# Risks

**Low.** Backend-only, confined to the realtime-voice cold-start hydration task that already runs in `waitUntil`. It only ever *adds* a cache write. No flag, provider, billing, schema, or auth-decision change. The character prefill is best-effort and ordered so it can never block publishing the authorization scope, so the worst case is the pre-existing retryable warming behaviour.

# Background

## What does this PR do?

A realtime voice turn performs **two** cache-only reads, but cold-start hydration only warmed **one** of them:

1. `internal-eliza-conversation-fetch.ts` reads the voice shared-agent scope entry. Miss -> schedules `hydrateVoiceSharedAgentScope`, returns retryable `agent_cache_warming` 503.
2. `SharedRuntimeChatService.characterFor` (cacheOnly) then reads `character:data:{characterId}`. Miss -> throws `SharedRuntimeCacheWarmingError`, surfaced as `shared_runtime_cache_warming` 503.

`hydrateVoiceSharedAgentScope` wrote only #1, so a turn that finally cleared #1 died on #2 and burned a second turn. Each 503 only schedules hydration for the cache *it* missed, and `sharedAgentScope.resolve` TTL is 30s, so with human-paced turns the two warming states alternate and the user may never hear audio.

This PR hydrates both entries in the same background task, under the same bindings/db context, so one hydration makes the next turn fully serviceable.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts`, then the new bidirectional tests in `packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts`.

## Detailed testing steps

```bash
cd packages/cloud/api
bun test v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
bun test v1/voice/session/__tests__/
bun run typecheck
```

# Evidence Gate

<!-- evidence-head:279a53d6facc5b761c0e407f22cca164d1e34460 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend-only change. Touches a Cloudflare Worker waitUntil cache-hydration task and its tests; no rendered UI surface in the diff.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend-only change. No rendered UI surface in the diff; the user-visible effect is audio, captured in the domain-artifacts row.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - the observable output is streamed audio over a WebSocket, not a UI flow. The live staging round-trip transcript is in the backend-logs and domain-artifacts rows.`
<!-- evidence-row:backend-logs -->
- [x] Live staging round-trip against the real production voice path, showing the two alternating cache-warming 503s this PR fixes.

<details>
<summary>Staging n=8 real-speech round-trip, develop head <code>1e3dec2d06f</code></summary>

```text
turn 1: stt_final="if you're going to different cultures, t" ttfa=null audioBytes=0 errors=["agent_cache_warming"] closed=timeout
turn 2: stt_final="if you're going to different cultures, t" ttfa=null audioBytes=0 errors=["shared_runtime_cache_warming"] closed=timeout
turn 3: stt_final="if you're going to different cultures, t" ttfa=null audioBytes=0 errors=["agent_cache_warming"] closed=timeout
turn 4: stt_final="if you're going to different cultures, t" ttfa_after_send=1033.8 audioBytes=1518080 errors=[] closed=speaking_end
turn 5: stt_final="if you're going to different cultures, t" ttfa=null audioBytes=0 errors=["shared_runtime_cache_warming"] closed=timeout
turn 6: stt_final="if you're going to different cultures, t" ttfa=null audioBytes=0 errors=["agent_cache_warming"] closed=timeout
turn 7: stt_final="if you're going to different cultures, t" ttfa_after_send=934.2 audioBytes=1351680 errors=[] closed=speaking_end
turn 8: stt_final="if you're going to different cultures, t" ttfa=null audioBytes=0 errors=["shared_runtime_cache_warming"] closed=timeout
```

First 8 of a 12-turn run (full run: **3/12 turns produced audio**, 9 produced none). Path exercised: consent -> mint -> WS -> Deepgram Flux STT -> conversation Durable Object -> `SharedRuntimeChatService.stream` -> Cartesia -> streamed audio. Not the legacy sandbox bridge. Note turns 1-3 and 5-6-8 alternating between `agent_cache_warming` and `shared_runtime_cache_warming`: that is the two-cache gap reproducing directly. An independent earlier n=12 run produced audio on only 1 turn.

</details>

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend surface in the diff. The client leg is a WebSocket audio stream; its observed frames (stt_final, error codes, audio byte counts) are captured in the backend-logs row above.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model change. The diff only adds a cache write in a hydration task; model selection and prompting are untouched.`
<!-- evidence-row:domain-artifacts -->
- [x] New bidirectional unit tests, plus measured audio output from the live staging run.

<details>
<summary>bun test voice-agent-scope-hydration.test.ts</summary>

```text
(pass) one cold hydration warms BOTH the scope gate and the linked character [11.98ms]
[voice-scope-hydration] character prefill failed {
  agentId: "0f1f3a2a-32c1-4f10-8a3f-3b6a3a4bb001",
  characterId: "6a1c8bf0-6d54-4f21-9c31-2a0cbb77aa02",
  error: "character store unavailable",
}
(pass) publishes the authorization scope even when the character prefill fails [1.14ms]
(pass) does not overwrite an already-warm character entry [0.34ms]
(pass) refuses to publish scope for an agent outside the verified voice claims [0.28ms]

 4 pass
 0 fail
 11 expect() calls
Ran 4 tests across 1 file. [761.00ms]
```

</details>

Audio actually produced on the successful staging turns: **1,518,080 bytes** (turn 4) and **1,351,680 bytes** (turn 7), each ending in a clean `speaking_end`, with first-audio latency of 1033.8 ms and 934.2 ms after end-of-speech. Across the full 12-turn run: **4,241,920 total audio bytes**, first-audio p50 **1033.8 ms** / max **1657.7 ms** over the 3 turns that survived. The path is fast when it works; the defect is that 9 of 12 turns never got there.

<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface in this change; the diff is a Worker-side cache hydration task and its tests.`

# Known gaps / failures

- `v1/voice/session/__tests__/ws-route-upgrade.test.ts` fails with `Cannot find module '@elizaos/core' from plugins/plugin-sql`. This is **pre-existing and unrelated**: I reproduced it on the unmodified develop head via `git stash`. The rest of the voice session suite is `75 pass`.
- The staging run above still shows failures because it was captured **before** this fix is deployed; it is the reproduction, not a post-fix result. A post-merge re-measure of warm-turn p50/p95 at n>=10 is the follow-up.
- Separately: Fish Audio is deployed to staging but gated off (`ELIZA_TTS_FISH_ENABLED=0`, `FISH_AUDIO_DATA_GOVERNANCE_APPROVED=0`), so the TTS leg above ran on Cartesia. Flipping those is an owner policy decision and is out of scope here.
- Harness note, so it is not re-filed as a product bug: an earlier run showed turns with no `stt_final`. That was my probe stopping audio too early and starving Deepgram Flux's end-of-turn detector, not a product defect. Fixed in the harness; the cache failures reproduce identically under both harness versions.
