### PR TITLE
fix(cloud): republish org-balance gate hint after an inference debit

### DIFF
--- a/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
@@ -485,3 +485,33 @@ export async function lowerOrgBalanceHint(
   if (existing.balanceUsd <= balanceUsd) return;
   await writeOrgBalanceHint(orgId, balanceUsd, balanceAt, existing.balanceRevision);
 }
+
+/**
+ * Publish an AUTHORITATIVE balance snapshot as the gate hint without ever
+ * raising the gate above a lower value another writer already published.
+ *
+ * Unlike {@link lowerOrgBalanceHint} this seeds an entry when none exists,
+ * which is what the post-debit settlers need: the committed debit's
+ * `onCreditMutation` DELETES the hint, and a lower-only repair is a no-op on an
+ * absent key, so the next Worker turn hit a `cacheOnly` miss and fail-closed
+ * with a user-visible cache-warming 503.
+ *
+ * The min-clamp preserves the over-admit bound: a concurrent debit that
+ * committed and lowered the hint between this caller's authoritative read and
+ * its write must not be undone. Equal-or-higher cached values are replaced,
+ * since the authoritative snapshot is the source of truth for those.
+ */
+export async function republishOrgBalanceHint(
+  orgId: string,
+  balanceUsd: number,
+  balanceAt: number,
+  balanceRevision: string,
+): Promise<void> {
+  const existing = await readOrgBalanceHint(orgId);
+  if (existing && existing.balanceUsd < balanceUsd) {
+    // A concurrent debit already published a stricter gate. Keep it — but keep
+    // it PRESENT, which is the whole point of republishing.
+    return;
+  }
+  await writeOrgBalanceHint(orgId, balanceUsd, balanceAt, balanceRevision);
+}

--- a/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
+++ b/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
@@ -1,0 +1,56 @@
+/**
+ * Post-debit gate-hint republication.
+ *
+ * This lives in its own module ON PURPOSE. Both inference settlers need it:
+ * the KV fast path (`inference-billing-fast-path.ts`) and the DB ledger
+ * (`inference-billing-ledger.ts`). Hanging it off the fast path instead would
+ * force the ledger to import that module, which transitively pulls in
+ * `api-keys` -> `db/repositories` -> `dbRead`, widening the ledger's module
+ * graph for a single helper (and breaking callers that mock `db/helpers` at
+ * its previous, narrower boundary).
+ *
+ * Its dependencies are exactly the three the ledger already carries or that are
+ * leaves: `credits`, `inference-auth-cache`, and the isolate-local
+ * `inference-admission-refusal`.
+ */
+
+import { creditsService } from "./credits";
+import { clearOrgAdmissionRefused } from "./inference-admission-refusal";
+import { republishOrgBalanceHint } from "./inference-auth-cache";
+
+/**
+ * Republish the gate hint with authoritative state after a committed inference
+ * debit.
+ *
+ * A debit necessarily runs `CacheInvalidation.onCreditMutation`, which DELETES
+ * `CacheKeys.inference.orgBalance`. That delete is correct for mutations whose
+ * caller cannot know the resulting balance (top-ups, refunds, admin
+ * adjustments), but the inference settler is the one mutation that both lowers
+ * the balance and immediately knows the new value. Leaving the key absent made
+ * the *next* turn a full miss, and on the Worker hot path a full miss is read
+ * `cacheOnly` — a hard, user-visible 503 "Billing authorization is warming",
+ * not a slow read. Every settled turn therefore armed a guaranteed failure for
+ * the following turn (observed on staging as a strict 200/503 alternation).
+ *
+ * `lowerOrgBalanceHint` cannot repair this: it is lower-only and bails when no
+ * entry exists, so after the delete it is always a no-op.
+ *
+ * Republishing authoritatively (balance AND revision) costs nothing net: the
+ * identical `getOrganizationBalanceSnapshot` read already happened moments
+ * later as the 503's background hydration. This only moves that read off the
+ * next request's critical path, and it keeps the revision fresh rather than
+ * preserving a stale one.
+ *
+ * The write is min-clamped (`republishOrgBalanceHint`) so the #9899 over-admit
+ * bound survives: a concurrent debit that published a STRICTER gate while this
+ * snapshot was in flight is never raised back up.
+ */
+export async function republishOrgBalanceHintAfterDebit(organizationId: string): Promise<void> {
+  // Captured BEFORE the authoritative read, matching `refreshOrgBalanceHint`:
+  // the timestamp marks when the read started, so a delayed old query can never
+  // masquerade as fresher than a debit that committed while it was in flight.
+  const balanceAt = Date.now();
+  const snapshot = await creditsService.getOrganizationBalanceSnapshot(organizationId);
+  await republishOrgBalanceHint(organizationId, snapshot.balanceUsd, balanceAt, snapshot.revision);
+  clearOrgAdmissionRefused(organizationId);
+}

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -57,6 +57,16 @@ mock.module("./credits", () => ({
         idempotencyKey: args.stripePaymentIntentId,
       });
       if (deductError) throw deductError;
+      // Mirror production: a committed debit runs
+      // `CacheInvalidation.onCreditMutation`, which DELETES the org-balance
+      // gate hint before the settler's post-debit cache step runs. Modelling
+      // this is what makes the "next turn is warm" assertions real — without
+      // it the hint survives and the test cannot observe the 503 flap.
+      if (deductResult.success) {
+        const { CacheKeys: Keys } = await import("../cache/keys");
+        const { cache: c } = await import("../cache/client");
+        await c.del(Keys.inference.orgBalance(args.organizationId));
+      }
       if (deductResult.success) {
         return {
           ...deductResult,
@@ -379,13 +389,74 @@ describe("createOptimisticDebitSettler", () => {
     expect(await cache.get(CacheKeys.inference.pendingCharge(input.requestId))).toBeNull();
   });
 
-  test("on debit success lowers an existing org-balance hint", async () => {
+  test("on debit success republishes the org-balance hint the credit mutation evicted", async () => {
     const input = chargeInput();
     deductResult = { success: true, newBalance: 7.5, transaction: { id: "debit-2" } };
+    // Authoritative post-debit balance the republish must pick up.
+    freshBalanceUsd = 7.5;
     await writeOrgBalanceHint(input.organizationId, 10, Date.now(), "1");
     await writePendingInferenceCharge(input, Date.now());
     await createOptimisticDebitSettler(input)(0.02);
     expect((await readOrgBalanceHint(input.organizationId))?.balanceUsd).toBe(7.5);
+  });
+
+  // REGRESSION (staging 2026-08-05): every settled turn left the gate hint
+  // ABSENT, because the committed debit's `onCreditMutation` deletes it and the
+  // old lower-only repair bails when no entry exists. On the Worker hot path a
+  // missing hint is read `cacheOnly`, so the next turn fail-closed with a
+  // user-visible 503 "Billing authorization is warming" — producing a strict
+  // 200/503 alternation on a healthy, funded org.
+  test("leaves a warm hint so the NEXT turn does not fail closed on a cacheOnly read", async () => {
+    const input = chargeInput();
+    deductResult = { success: true, newBalance: 4.25, transaction: { id: "debit-flap" } };
+    freshBalanceUsd = 4.25;
+    await writeOrgBalanceHint(input.organizationId, 9, Date.now(), "1");
+    await writePendingInferenceCharge(input, Date.now());
+
+    await createOptimisticDebitSettler(input)(0.02);
+
+    // The settled turn must NOT leave the org unhinted.
+    expect(await readOrgBalanceHint(input.organizationId)).not.toBeNull();
+    // And the next turn's hot-path read must succeed instead of throwing the
+    // cache-warming error the route surfaces as a 503.
+    await expect(getGateBalanceUsd(input.organizationId, { cacheOnly: true })).resolves.toBe(4.25);
+  });
+
+  // Opposite direction: the republish must not resurrect a hint for an org the
+  // settler deliberately forced off the fast path.
+  test("a REFUSED debit still leaves the hint absent so the next turn slow-paths", async () => {
+    const input = chargeInput();
+    deductResult = {
+      success: false,
+      newBalance: 0,
+      transaction: null,
+      reason: "insufficient_balance",
+    };
+    await writeOrgBalanceHint(input.organizationId, 999, Date.now(), "1");
+    await writePendingInferenceCharge(input, Date.now());
+
+    await createOptimisticDebitSettler(input)(0.02);
+
+    expect(await readOrgBalanceHint(input.organizationId)).toBeNull();
+    await expect(
+      getGateBalanceUsd(input.organizationId, { cacheOnly: true }),
+    ).rejects.toBeInstanceOf(InferenceBalanceCacheWarmingError);
+  });
+
+  test("republished hint carries authoritative balance AND revision, not the stale pre-debit ones", async () => {
+    const input = chargeInput();
+    deductResult = { success: true, newBalance: 3, transaction: { id: "debit-rev" } };
+    freshBalanceUsd = 3;
+    // Stale entry: higher balance, older revision "1". The credits seam reports
+    // revision "2" as authoritative.
+    await writeOrgBalanceHint(input.organizationId, 42, Date.now(), "1");
+    await writePendingInferenceCharge(input, Date.now());
+
+    await createOptimisticDebitSettler(input)(0.02);
+
+    const hint = await readOrgBalanceHint(input.organizationId);
+    expect(hint?.balanceUsd).toBe(3);
+    expect(hint?.balanceRevision).toBe("2");
   });
 
   test("on FAILED debit (insufficient) forces org off the fast path", async () => {
@@ -596,21 +667,45 @@ describe("#9899 hardening: backstop durability, lower-only hint, claim atomicity
     expect(isOptimisticBackstopAvailable()).toBe(true);
   });
 
-  test("debit hint write is lower-only: a stale-high concurrent debit never raises the gate", async () => {
+  // The gate must never be raised above authoritative state by an out-of-order
+  // debit (#9899 over-admit bound). The settler no longer trusts the debit's
+  // own `newBalance` for this at all: the committed debit's `onCreditMutation`
+  // evicts the hint, so the settler re-reads AUTHORITATIVE state and republishes
+  // that. A transaction reporting a stale-high balance therefore cannot raise
+  // the gate, because its reported number is never written.
+  test("a stale-high debit report never raises the gate; authoritative state wins", async () => {
     const input = chargeInput();
     await writeOrgBalanceHint(input.organizationId, 10, Date.now(), "1");
-    // A debit that reports a HIGHER balance (out-of-order) must NOT raise the hint.
+    // Out-of-order: the debit claims 20, but the database says 6.
     deductResult = { success: true, newBalance: 20, transaction: { id: "debit-high" } };
+    freshBalanceUsd = 6;
     await writePendingInferenceCharge(input, Date.now());
     await createOptimisticDebitSettler(input)(0.01);
-    expect((await readOrgBalanceHint(input.organizationId))?.balanceUsd).toBe(10);
+    // The stale-high 20 is never published; the authoritative 6 is.
+    expect((await readOrgBalanceHint(input.organizationId))?.balanceUsd).toBe(6);
 
-    // A debit that reports a LOWER balance DOES lower the hint.
+    // A subsequent debit lowers it further, still from authoritative state.
     const input2 = chargeInput({ organizationId: input.organizationId });
     deductResult = { success: true, newBalance: 4, transaction: { id: "debit-low" } };
+    freshBalanceUsd = 4;
     await writePendingInferenceCharge(input2, Date.now());
     await createOptimisticDebitSettler(input2)(0.01);
     expect((await readOrgBalanceHint(input.organizationId))?.balanceUsd).toBe(4);
+  });
+
+  // Clamp direction: if a concurrent debit published a STRICTER gate between
+  // this settler's authoritative read and its write, that stricter value must
+  // survive — while the entry still stays PRESENT (never absent).
+  test("republish is min-clamped against a concurrent stricter gate", async () => {
+    const { republishOrgBalanceHint } = await import("./inference-auth-cache");
+    const orgId = uid("org");
+    await writeOrgBalanceHint(orgId, 2, Date.now(), "5");
+    // An authoritative snapshot that is HIGHER than what a concurrent debit
+    // already published must not raise the gate back up.
+    await republishOrgBalanceHint(orgId, 9, Date.now(), "6");
+    const hint = await readOrgBalanceHint(orgId);
+    expect(hint?.balanceUsd).toBe(2);
+    expect(hint).not.toBeNull();
   });
 
   test("two concurrent inline claims of one request charge exactly once (atomic getAndDelete)", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -18,8 +18,8 @@ import { clearOrgAdmissionRefused, markOrgAdmissionRefused } from "./inference-a
 import {
   INFERENCE_AUTH_CONTEXT_VERSION,
   invalidateOrgBalanceHint,
-  lowerOrgBalanceHint,
   readOrgBalanceHint,
+  republishOrgBalanceHint,
   writeOrgBalanceHint,
 } from "./inference-auth-cache";
 
@@ -182,6 +182,40 @@ export function scheduleOrgBalanceHintHydration(
   executionCtx.waitUntil(
     observeBackgroundBalanceRefresh(organizationId, refreshOrgBalanceHint(organizationId)),
   );
+}
+
+/**
+ * Republish the gate hint with authoritative state after a committed inference
+ * debit.
+ *
+ * A debit necessarily runs `CacheInvalidation.onCreditMutation`, which DELETES
+ * `CacheKeys.inference.orgBalance`. That delete is correct for mutations whose
+ * caller cannot know the resulting balance (top-ups, refunds, admin
+ * adjustments), but the inference settler is the one mutation that both lowers
+ * the balance and immediately knows the new value. Leaving the key absent made
+ * the *next* turn a full miss, and on the Worker hot path a full miss is read
+ * `cacheOnly` — a hard, user-visible 503 "Billing authorization is warming",
+ * not a slow read. Every settled turn therefore armed a guaranteed failure for
+ * the following turn (observed on staging as a strict 200/503 alternation).
+ *
+ * `lowerOrgBalanceHint` cannot repair this: it is lower-only and bails when no
+ * entry exists, so after the delete it is always a no-op.
+ *
+ * Republishing authoritatively (balance AND revision) costs nothing net: the
+ * identical `getOrganizationBalanceSnapshot` read already happened moments
+ * later as the 503's background hydration. This only moves that read off the
+ * next request's critical path, and it keeps the revision fresh rather than
+ * preserving a stale one.
+ *
+ * The write is min-clamped (`republishOrgBalanceHint`) so the #9899 over-admit
+ * bound survives: a concurrent debit that published a STRICTER gate while this
+ * snapshot was in flight is never raised back up.
+ */
+export async function republishOrgBalanceHintAfterDebit(organizationId: string): Promise<void> {
+  const balanceAt = Date.now();
+  const snapshot = await creditsService.getOrganizationBalanceSnapshot(organizationId);
+  await republishOrgBalanceHint(organizationId, snapshot.balanceUsd, balanceAt, snapshot.revision);
+  clearOrgAdmissionRefused(organizationId);
 }
 
 export async function getGateBalanceHint(
@@ -430,11 +464,13 @@ export async function debitInferenceCost(
         persistedAmountUsd,
       });
     }
-    // Lower-only: a debit can only REDUCE the balance, so never let an
-    // out-of-order concurrent debit raise the cached gate hint (#9899 #12).
-    // Top-ups go through a separate path that invalidates the hint.
+    // The committed debit already evicted the gate hint via onCreditMutation.
+    // Republish authoritative balance + revision so the NEXT turn hits a warm
+    // entry instead of a fail-closed cache-warming 503. A concurrent debit can
+    // only lower the value afterwards (lowerOrgBalanceHint), so this can never
+    // raise the gate above authoritative state.
     try {
-      await lowerOrgBalanceHint(ctx.organizationId, result.newBalance, Date.now());
+      await republishOrgBalanceHintAfterDebit(ctx.organizationId);
     } catch (cause) {
       markOrgAdmissionRefused(ctx.organizationId);
       try {

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -19,9 +19,16 @@ import {
   INFERENCE_AUTH_CONTEXT_VERSION,
   invalidateOrgBalanceHint,
   readOrgBalanceHint,
-  republishOrgBalanceHint,
   writeOrgBalanceHint,
 } from "./inference-auth-cache";
+import { republishOrgBalanceHintAfterDebit } from "./inference-balance-republish";
+
+/**
+ * Re-exported so the settler call site below and existing importers keep a
+ * single name. The implementation lives in `inference-balance-republish` to
+ * keep it reachable from the DB ledger without widening that module's graph.
+ */
+export { republishOrgBalanceHintAfterDebit };
 
 /** A durable record of an in-flight optimistic charge (the backstop). */
 export interface PendingInferenceCharge {
@@ -182,40 +189,6 @@ export function scheduleOrgBalanceHintHydration(
   executionCtx.waitUntil(
     observeBackgroundBalanceRefresh(organizationId, refreshOrgBalanceHint(organizationId)),
   );
-}
-
-/**
- * Republish the gate hint with authoritative state after a committed inference
- * debit.
- *
- * A debit necessarily runs `CacheInvalidation.onCreditMutation`, which DELETES
- * `CacheKeys.inference.orgBalance`. That delete is correct for mutations whose
- * caller cannot know the resulting balance (top-ups, refunds, admin
- * adjustments), but the inference settler is the one mutation that both lowers
- * the balance and immediately knows the new value. Leaving the key absent made
- * the *next* turn a full miss, and on the Worker hot path a full miss is read
- * `cacheOnly` — a hard, user-visible 503 "Billing authorization is warming",
- * not a slow read. Every settled turn therefore armed a guaranteed failure for
- * the following turn (observed on staging as a strict 200/503 alternation).
- *
- * `lowerOrgBalanceHint` cannot repair this: it is lower-only and bails when no
- * entry exists, so after the delete it is always a no-op.
- *
- * Republishing authoritatively (balance AND revision) costs nothing net: the
- * identical `getOrganizationBalanceSnapshot` read already happened moments
- * later as the 503's background hydration. This only moves that read off the
- * next request's critical path, and it keeps the revision fresh rather than
- * preserving a stale one.
- *
- * The write is min-clamped (`republishOrgBalanceHint`) so the #9899 over-admit
- * bound survives: a concurrent debit that published a STRICTER gate while this
- * snapshot was in flight is never raised back up.
- */
-export async function republishOrgBalanceHintAfterDebit(organizationId: string): Promise<void> {
-  const balanceAt = Date.now();
-  const snapshot = await creditsService.getOrganizationBalanceSnapshot(organizationId);
-  await republishOrgBalanceHint(organizationId, snapshot.balanceUsd, balanceAt, snapshot.revision);
-  clearOrgAdmissionRefused(organizationId);
 }
 
 export async function getGateBalanceHint(

--- a/packages/cloud/shared/src/lib/services/inference-billing-invalidation-logged.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-invalidation-logged.test.ts
@@ -49,9 +49,23 @@ mock.module("./inference-auth-cache", () => ({
   invalidateOrgBalanceHint: async () => {
     throw invalidationErr;
   },
+  // The settler now REPUBLISHES the gate hint after a committed debit instead
+  // of leaving it absent (the 200/503 flap fix). This is the same cache target
+  // (`balance-hint`) reached through a different call, so the induced failure
+  // moves here — the assertion that a failing balance-hint repair still warns
+  // rather than vanishing is unchanged.
+  republishOrgBalanceHint: async () => {
+    throw invalidationErr;
+  },
 }));
 mock.module("./credits", () => ({
-  creditsService: { notifyBalanceDecrease: () => {} },
+  creditsService: {
+    notifyBalanceDecrease: () => {},
+    // The authoritative read the republish performs before writing. It must
+    // SUCCEED here so the induced failure under test is unambiguously the cache
+    // write, not the database read.
+    getOrganizationBalanceSnapshot: async () => ({ balanceUsd: 5, revision: "2" }),
+  },
 }));
 
 const { createLedgerDebitSettler } = await import("./inference-billing-ledger");

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -47,7 +47,7 @@ import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { type CreditReconciliationResult, creditsService } from "./credits";
 import { invalidateOrgBalanceHint } from "./inference-auth-cache";
-import { republishOrgBalanceHintAfterDebit } from "./inference-billing-fast-path";
+import { republishOrgBalanceHintAfterDebit } from "./inference-balance-republish";
 
 export type InferenceBillingLedger = "db" | "kv";
 

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -47,6 +47,7 @@ import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { type CreditReconciliationResult, creditsService } from "./credits";
 import { invalidateOrgBalanceHint } from "./inference-auth-cache";
+import { republishOrgBalanceHintAfterDebit } from "./inference-billing-fast-path";
 
 export type InferenceBillingLedger = "db" | "kv";
 
@@ -316,7 +317,12 @@ async function settleLedgerCharge(
     invalidateOrganizationCache(ctx.organizationId).catch(
       reportInvalidationFailure(ctx.organizationId, "organization-cache"),
     );
-    invalidateOrgBalanceHint(ctx.organizationId).catch(
+    // onCreditMutation above already DELETED the gate hint. Republish it with
+    // authoritative state instead of leaving it absent: on the Worker hot path
+    // a missing hint is read `cacheOnly`, so an absent entry turns the NEXT
+    // turn into a user-visible "Billing authorization is warming" 503 rather
+    // than a slow read. Same defect as the KV fast-path settler.
+    republishOrgBalanceHintAfterDebit(ctx.organizationId).catch(
       reportInvalidationFailure(ctx.organizationId, "balance-hint"),
     );
     // Parity with deductCredits: fire low-credits email + auto-top-up + the waifu


### PR DESCRIPTION
## Symptom (live on staging)

On `api-staging.elizacloud.ai` (@`1e3dec2d`), a **funded org with a warm shared agent** alternates 200/503 on every other chat turn:

```
1: 503  Agent authorization cache is warming
2: 503  Agent authorization cache is warming
3: 503  Agent authorization cache is warming
4: 200  OK
5: 503  Billing authorization is warming
6: 200  OK
7: 503  Billing authorization is warming
8: 200  OK
9: 503  Billing authorization is warming
10: 200 OK
```

Strict alternation, reproducible: **every successful turn is followed by a guaranteed failure.** Org balance was healthy ($6.29), agent warm, no rate limit. The UI does not auto-retry a `retryable` 503 — it renders a failed turn ("The agent is still waking up — give it a moment and resend"). So in practice a user sees every second message fail.

## Root cause

A committed inference debit runs `CacheInvalidation.onCreditMutation`, which **deletes** `CacheKeys.inference.orgBalance` (correct for top-ups/refunds/admin adjustments, where the caller cannot know the resulting balance).

The settler's only post-debit cache repair was `lowerOrgBalanceHint`:

```ts
const existing = await readOrgBalanceHint(orgId);
if (!existing) return;              // <-- always taken, the debit just deleted it
```

Lower-only **and** bails on an absent entry, so after the delete it was a permanent no-op. The hint stayed **absent**.

On the Worker hot path a missing hint is read `cacheOnly` — fail-closed by design, to keep a synchronous Postgres read off the inference path. So an absent entry is not a slow read, it is a **hard 503**. Each settled turn therefore armed the next one to fail.

`deductCredits` → `onCreditMutation` (delete) → `lowerOrgBalanceHint` (no-op) → next turn `cacheOnly` miss → `InferenceBalanceCacheWarmingError` → 503.

## Fix

After a committed debit, re-read authoritative balance state and **republish** the hint rather than leaving the key absent.

Net cost is zero: the identical `getOrganizationBalanceSnapshot` read already happened moments later as the 503's own background hydration. This just moves it off the next request's critical path, and keeps the **revision** fresh instead of preserving a stale one.

Safety — the #9899 over-admit bound is preserved and slightly tightened:
- new `republishOrgBalanceHint` is **min-clamped**: a concurrent debit that published a *stricter* gate while this snapshot was in flight is never raised back up (but the entry stays **present**, which is the point).
- the settler no longer writes the debit's self-reported `newBalance` at all, so an out-of-order **stale-high** transaction cannot raise the gate. Authoritative state wins.
- a **refused** debit still leaves the hint absent, so a drained org still slow-paths exactly as before.

Applied to both settlers — KV fast-path (`inference-billing-fast-path`) and DB ledger (`inference-billing-ledger`). Staging runs the KV path (`Inference (deferred): …`).

## Tests (bidirectional)

- ✅ settled turn leaves a warm hint **and** the next `cacheOnly` read succeeds — *fails before this change*
- ✅ a REFUSED debit still leaves the hint absent so the org slow-paths
- ✅ republished hint carries authoritative balance **and** revision (not stale pre-debit ones)
- ✅ stale-high debit report never raises the gate; authoritative state wins
- ✅ republish is min-clamped against a concurrent stricter gate

The credits test seam now models production by deleting the hint on a committed debit. Without that, this regression is **structurally unobservable** in test — which is why it shipped. The pre-existing lower-only test asserted a premise (hint survives a debit) that production contradicts; it is rewritten to assert the real invariant.

`inference-billing-fast-path.test.ts`: **42 pass / 0 fail**. `inference-auth-cache` + `app-inference-admission` green. (`organization-inference-admission.test.ts` fails identically on a stashed baseline — needs a `@elizaos/core` build, unrelated.)

## Verification note

Needs a **staging deploy to verify live**. The reproduction above is the pre-fix baseline; re-running the same 10-turn loop after deploy should be 10/10 200s. QA steps in `MORNING-QA-2026-08-05.md`.

## Not in scope

The first-turn cold sequence still walks **four** separate warming layers (agent scope → conversation → rate-limit → billing), each costing a 503 round-trip. That is a separate latency/UX issue; this PR fixes the one that recurs forever on a warm agent. Filing separately.

## Review round 2 (dual-pass) — module-graph regression found and fixed

`ced6de785c0`.

The previous head `d3bbc755e2d` was **CI-red on `unit-tests`** (run 30981483860, batch 6/12) and the failure was real, not flake:

```
SyntaxError: Export named 'dbRead' not found in module packages/cloud/shared/src/db/helpers.ts
  (inference-billing-invalidation-logged.test.ts)
```

Cause: this PR added `inference-billing-ledger` → `inference-billing-fast-path`. The fast path pulls `api-keys` → `db/repositories` → `dbRead`. The existing test mocks `db/helpers` with only `{ dbWrite, writeTransaction }` — sufficient for the ledger's old graph, not once the fast path was dragged in. The whole 80-file batch aborted. Reproduced locally, so it is deterministic.

Rejected the symptom fix (widening the test mock): that leaves a layering violation where the DB ledger transitively depends on the KV fast path and `api-keys` for one helper.

Root fix: extracted `republishOrgBalanceHintAfterDebit` into a leaf module `inference-balance-republish.ts`, whose only deps (`credits`, `inference-auth-cache`, `inference-admission-refusal`) the ledger **already carried** — so its module graph does not widen at all. The fast path re-exports the symbol; no other importer changes.

The invalidation-logged test's induced failure moves from `invalidateOrgBalanceHint` to `republishOrgBalanceHint` — same `balance-hint` target, reached via the settler's new call. Its assertion (a failing balance-hint repair must WARN, not be swallowed) is unchanged, and the mocked authoritative read succeeds so the failure under test is unambiguously the cache write. **No check weakened.**

Verified: fast-path 42/42, invalidation-logged 1/1, `packages/cloud/shared` typecheck exit 0, biome clean.

### Residual noted for reviewers

`republishOrgBalanceHint` does a non-atomic read-then-write, so two concurrent settlers that both see an absent key can race, last-writer-wins. Not a blocker: the KV entry is a hint, and the authoritative over-admit bound is the Durable Object gate, whose `applyBalanceSnapshot` re-clamps by **revision** (a lower/equal revision can never raise the ceiling). The pre-existing `lowerOrgBalanceHint` had the identical shape, and it is bounded by the 5-minute TTL. Deliberately not "fixed" by switching the clamp from balance to revision, since that would change a documented safety bound for a race the DO already contains.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-6`
<!-- attribution-row:client -->
- Client / agent tooling: `moltbot`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Evidence Gate

<!-- evidence-head:ced6de785c0ac9febff9e4dfb794e79a914c9cd3 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface changed. This PR touches three server-side billing/cache modules in packages/cloud/shared/src/lib/services (inference-billing-fast-path, inference-auth-cache, inference-billing-ledger). No component, style, or rendered surface is modified.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface changed (server-side cache/billing only). The user-visible effect is that an existing error state stops occurring; there is no new or altered rendered surface to screenshot.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no interactive flow changed. The behavior is a server cache-population fix; the reproduction and verification are HTTP-level and are pasted below as real staging transcripts.`
<!-- evidence-row:backend-logs -->
- [x] Real staging HTTP transcript of the production code path (shared-runtime stream endpoint on `api-staging.elizacloud.ai` @ `1e3dec2d`, funded org, warm agent). 12 sequential turns, 3s apart:

<details>
<summary>Live staging reproduction — strict 200/503 alternation (ok=5 err=7)</summary>

```
1: 503 130ms  Agent authorization cache is warming. Retry shortly.
2: 503 100ms  Agent authorization cache is warming. Retry shortly.
3: 503 1443ms Billing authorization is warming. Retry shortly.
4: 200 864ms
5: 503 292ms  Billing authorization is warming. Retry shortly.
6: 200 869ms
7: 503 292ms  Billing authorization is warming. Retry shortly.
8: 200 864ms
9: 503 308ms  Billing authorization is warming. Retry shortly.
10: 200 762ms
11: 503 297ms Billing authorization is warming. Retry shortly.
12: 200 914ms
SUMMARY ok=5 err=7
```

Every success is followed by a guaranteed failure. Org balance was healthy
($6.29 credit_balance, verified in the staging Postgres `organizations` row),
the agent was warm, and no rate limit was in play — isolating the cause to the
balance-hint eviction described above.
</details>

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code changed. The client-side consequence is documented rather than captured: packages/ui/src/state/useChatSend.ts buildSendFailureNotice maps status 503 to "The agent is still waking up - give it a moment and resend." and does not auto-retry, which is why this server bug surfaces as a failed turn.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model behavior changed. This PR does not touch prompt construction or model selection; it only fixes whether the billing gate cache entry is present between turns. A real model turn does appear in the staging transcript above (the 200s are real streamed gemma-4-31b completions, billed as "Inference (deferred): gemma-4-31b").`
<!-- evidence-row:domain-artifacts -->
- [x] Real DB rows from staging showing the debits whose post-commit cache eviction is the root cause:

<details>
<summary>credit_transactions — staging, the settled turns behind the transcript</summary>

```
  amount   | type  |            description            |         created_at
-----------+-------+-----------------------------------+----------------------------
 -0.000160 | debit | Inference (deferred): gemma-4-31b | 2026-08-05 06:04:41.102263
 -0.000139 | debit | Inference (deferred): gemma-4-31b | 2026-08-05 06:04:36.005320
 -0.000119 | debit | Inference (deferred): gemma-4-31b | 2026-08-05 06:04:30.883386
 -0.000099 | debit | Inference (deferred): gemma-4-31b | 2026-08-05 06:04:25.510854
 -0.000105 | debit | Inference (deferred): gemma-4-31b | 2026-08-05 06:02:36.254924
 -0.000104 | debit | Inference (deferred): gemma-4-31b | 2026-08-05 06:02:29.195338
```

The `(deferred)` source confirms staging runs the KV fast-path settler
(`inference-billing-fast-path.ts`), which is the primary site fixed here; the
DB-ledger settler receives the identical fix. `inference_pending_charges` was
empty for this org, consistent with the KV path rather than the DB ledger.
</details>

<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface. This change is confined to server-side cache and billing modules with no UI output to OCR.`

# Evidence Details

## Test results

```
bun test packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
 42 pass
 0 fail
Ran 42 tests across 1 file.
```

Bidirectional coverage added:
- settled turn leaves a warm hint AND the next `cacheOnly` read succeeds (fails without the fix)
- a REFUSED debit still leaves the hint absent so a drained org slow-paths
- republished hint carries authoritative balance AND revision
- stale-high debit report never raises the gate
- republish is min-clamped against a concurrent stricter gate

`inference-auth-cache.test.ts` and `app-inference-admission.test.ts` also pass.
`organization-inference-admission.test.ts` fails identically on a stashed
baseline (needs an `@elizaos/core` build) — pre-existing, unrelated.

## Verification note

The transcript above is the **pre-fix baseline** captured on the currently
deployed staging commit. Live confirmation of the fix requires a staging deploy;
after deploy, the same 12-turn loop should return 12/12 `200`.

