### PR TITLE
fix(gateway): answer messaging users whose agent is still provisioning

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -334,4 +334,149 @@ describe("gateway webhook handler e2e routing", () => {
     await new Promise((resolve) => setTimeout(resolve, 200));
     expect(adapter.replies).toEqual([]);
   });
+
+  test("routes a linked user whose agent is still provisioning to onboarding", async () => {
+    // Identity resolve returns a real user with `agent: null` while the
+    // provisioning job is still in flight. Previously resolveIdentity threw on
+    // the missing agentId, which aborted processMessage and dropped the user's
+    // message with no reply at all. The user must instead get the onboarding
+    // worker's provisioning status, and must NOT be routed to the project
+    // default agent (a runtime that belongs to nobody in particular).
+    configureEnv();
+    const redis = new MemoryRedis();
+    const event = createTwilioEvent({
+      messageId: "SM_provisioning_1",
+      text: "is my agent ready?",
+    });
+    const adapter = createAdapter(event);
+    let onboardingBody: Record<string, unknown> | null = null;
+
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        request.url ===
+        "https://api.elizacloud.ai/api/internal/identity/resolve"
+      ) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            userId: "user-7",
+            organizationId: "org-7",
+            agentId: null,
+            data: {
+              user: { id: "user-7", organizationId: "org-7" },
+              agent: null,
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (
+        request.url ===
+        "https://api.elizacloud.ai/api/eliza-app/onboarding/chat"
+      ) {
+        onboardingBody = (await request.json()) as Record<string, unknown>;
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: { reply: "still setting up your agent, one moment" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    const response = await handleWebhook(
+      requestFor(event),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+
+    expect(response.status).toBe(200);
+    await waitFor(() => adapter.replies.length === 1, "provisioning reply");
+    expect(adapter.replies).toEqual([
+      "still setting up your agent, one moment",
+    ]);
+    expect(onboardingBody).toMatchObject({
+      sessionId: "platform:twilio:+15551234567",
+      platform: "twilio",
+      platformUserId: "+15551234567",
+    });
+  });
+
+  test("caches an unresolved identity only briefly so linking takes effect quickly", async () => {
+    // The negative result must be cached (so webhook retries don't stampede the
+    // resolver) but on a short TTL: the message right after the user links their
+    // account has to reach their real agent, not another onboarding turn.
+    configureEnv();
+    const redis = new MemoryRedis();
+    const event = createTwilioEvent({ messageId: "SM_negcache_1" });
+    const adapter = createAdapter(event);
+    let resolveCalls = 0;
+
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        request.url ===
+        "https://api.elizacloud.ai/api/internal/identity/resolve"
+      ) {
+        resolveCalls += 1;
+        return new Response(JSON.stringify({ success: false }), {
+          status: 404,
+        });
+      }
+      if (
+        request.url ===
+        "https://api.elizacloud.ai/api/eliza-app/onboarding/chat"
+      ) {
+        return new Response(
+          JSON.stringify({ success: true, data: { reply: "hi there" } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    await handleWebhook(
+      requestFor(event),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+    await waitFor(() => adapter.replies.length === 1, "first onboarding reply");
+
+    // Second inbound message from the same still-unlinked sender reuses the
+    // cached negative result instead of re-querying the resolver.
+    const second = createTwilioEvent({ messageId: "SM_negcache_2" });
+    const secondAdapter = createAdapter(second);
+    await handleWebhook(
+      requestFor(second),
+      secondAdapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+    await waitFor(
+      () => secondAdapter.replies.length === 1,
+      "second onboarding reply",
+    );
+
+    expect(resolveCalls).toBe(1);
+    expect(redis.store.get("identity:twilio:+15551234567")).toBe(
+      JSON.stringify({ notFound: true }),
+    );
+  });
 });

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -10,6 +10,11 @@ const RETRY_ATTEMPTS = 5;
 const RETRY_BASE_DELAY_MS = 2_000;
 const RETRY_INCREMENT_MS = 1_000;
 const IDENTITY_CACHE_TTL_SECONDS = 300;
+// A linked identity with no agent yet is a transient provisioning state, and an
+// unlinked identity becomes linked the moment onboarding finishes. Both are
+// cached only long enough to blunt webhook retry storms; a long TTL would strand
+// a just-provisioned or just-linked user in onboarding for the rest of the TTL.
+const IDENTITY_TRANSIENT_CACHE_TTL_SECONDS = 15;
 
 interface ServerRoute {
   serverName: string;
@@ -24,7 +29,10 @@ export type RoutingRedis = Pick<
 export interface ResolvedIdentity {
   userId: string;
   organizationId: string;
-  agentId: string;
+  // Null when the identity is linked to a cloud user that has no provisioned
+  // agent yet. Callers must treat this as an onboarding/provisioning condition,
+  // never as an agent-server routing target.
+  agentId: string | null;
 }
 
 export async function resolveIdentity(
@@ -60,6 +68,9 @@ export async function resolveIdentity(
       signal: controller.signal,
     });
     if (res.status === 404) {
+      await redis.set(cacheKey, JSON.stringify({ notFound: true }), {
+        ex: IDENTITY_TRANSIENT_CACHE_TTL_SECONDS,
+      });
       return null;
     }
     if (!res.ok) throw new Error(`Identity resolve failed: ${res.status}`);
@@ -95,18 +106,24 @@ export async function resolveIdentity(
         : "data" in data
           ? (data.data?.agent?.id ?? undefined)
           : undefined;
-    if (!userId || !organizationId || !agentId) {
+    // agentId is legitimately null while provisioning is still in flight, so it
+    // is not part of the resolution contract. Throwing here used to abort the
+    // whole background message pass for a linked-but-unprovisioned user, which
+    // dropped their message with no reply at all.
+    if (!userId || !organizationId) {
       throw new Error(
-        "Identity resolve response missing userId, organizationId, or agentId",
+        "Identity resolve response missing userId or organizationId",
       );
     }
     const identity: ResolvedIdentity = {
       userId,
       organizationId,
-      agentId,
+      agentId: agentId ?? null,
     };
     await redis.set(cacheKey, JSON.stringify(identity), {
-      ex: IDENTITY_CACHE_TTL_SECONDS,
+      ex: identity.agentId
+        ? IDENTITY_CACHE_TTL_SECONDS
+        : IDENTITY_TRANSIENT_CACHE_TTL_SECONDS,
     });
     return identity;
   } finally {

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -132,6 +132,20 @@ async function processMessage(
     return;
   }
 
+  // A linked user whose agent is still provisioning has no runtime target. The
+  // shared onboarding worker owns provisioning status, so route there rather
+  // than falling back to the project default agent (which would answer from a
+  // stranger's runtime) or dropping the message on a missing-server lookup.
+  if (!explicitAgentId && !identity.agentId) {
+    logger.info("Identity linked without an agent; routing to onboarding", {
+      project,
+      platform: adapter.platform,
+      userId: identity.userId,
+    });
+    await sendOnboardingReply(adapter, config, event, deps);
+    return;
+  }
+
   const agentId = explicitAgentId || identity.agentId || config.agentId;
 
   const server = await resolveAgentServer(redis, agentId);


### PR DESCRIPTION
## Problem

The onboarding gateway (the shared agent users reach over iMessage/SMS, Telegram, WhatsApp) **silently dropped messages** from users who had linked their cloud account but whose agent had not finished provisioning yet.

`/api/internal/identity/resolve` returns `agentId: null` for that state, because the sandbox row does not exist yet. But `resolveIdentity` in `server-router.ts` treated a missing `agentId` as a malformed response:

```ts
if (!userId || !organizationId || !agentId) {
  throw new Error("Identity resolve response missing userId, organizationId, or agentId");
}
```

That throw escaped into the fire-and-forget `processMessage(...)`, whose only handler is a `logger.error`. The user got **no reply at all**, precisely during the window when they are waiting to hear that their agent is being set up. First impression of the product, on the surface where they cannot retry meaningfully.

A second, related bug: the identity cache read path already handled a `{ notFound: true }` sentinel, but **nothing in the codebase ever wrote one**. Every message from an unlinked sender re-hit the resolver.

## Root cause fixes (along the existing design, no redesign)

- **`agentId` is now nullable in the `ResolvedIdentity` contract**, matching what the resolve route actually returns. Only `userId`/`organizationId` are required for a resolution to be valid. This is the actual root cause: the contract disagreed with the producer.
- **A linked identity without an agent routes to the shared onboarding worker**, which already owns provisioning status. Notably it must *not* fall back to `config.agentId` (the project default agent), which would answer the user from a runtime that is not theirs.
- **Unresolved identities now write the short-lived negative cache entry** the read path already expected, so webhook retries stop stampeding the resolver.
- **Transient states use a 15s TTL** instead of the 300s linked TTL. A just-linked or just-provisioned user reaches their real agent on their next message rather than being stranded in onboarding for up to 5 minutes.

This matches the behavior the messaging onboarding gateway design doc already specifies: *"Linked identities without an active agentId must route to onboarding/provisioning status rather than throwing in the gateway resolver"* and *"Negative identity cache entries must be short-lived and invalidated on link confirmation."*

## Tests

Two new bidirectional e2e cases in `webhook-handler.e2e.test.ts`:
- a linked user whose agent is still provisioning gets the onboarding/provisioning reply, and is **not** routed to the default agent
- the negative cache is written, reused on a second inbound message (resolver called exactly once), and holds the `{notFound:true}` sentinel

Existing linked-routing and deliberate-agent-silence paths are unchanged.

```
37 pass, 0 fail   (bun test, full package)
tsc --noEmit      clean
biome check       clean
```

## Scope

Three files, all in `packages/cloud/services/gateway-webhook`. No schema change, no new endpoint, no provisioning changes, no prod config touched. Discord's gateway-manager path is untouched.

Remaining gateway gaps (identity-link start/confirm routes, Mac-hosted BlueBubbles relay contract, transcript idempotency) are documented in `messaging-onboarding-gateway-design.md` and are **not** in this PR.

# Evidence Gate

<!-- evidence-head:b20cb4bb8374a0104689fb5b85fc4bcdb5b6caca -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend-only change. Three files in packages/cloud/services/gateway-webhook (resolver contract, webhook routing, tests); no rendered UI surface in the diff.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend-only change. The user-visible effect is a messaging reply over Twilio/Telegram webhooks, not a UI; the routing proof is the e2e transcript in the domain-artifacts row.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI flow to walk through. The observable behavior is webhook-in -> reply-out, captured as e2e test transcripts in the rows below.`
<!-- evidence-row:backend-logs -->
- [x] Full package suite + typecheck on the PR head, fresh install:

```text
$ bun test   # packages/cloud/services/gateway-webhook, head b20cb4bb837
Ran 37 tests across 6 files. [519.00ms]
 37 pass / 0 fail / 82 expect() calls
(includes all 5 webhook-handler.e2e.test.ts routing cases and the MemoryRedisAdapter MOCK_REDIS=1 suite)

$ tsc --noEmit
(clean, exit 0)

$ biome check src __tests__
(clean)
```

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend surface in the diff. The client leg is an inbound provider webhook (Twilio/Telegram); its observed behavior is asserted in the e2e transcript in the domain-artifacts row.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model change. The diff only changes identity resolution and routing ahead of the agent; which runtime answers is the thing under test, not what it says.`
<!-- evidence-row:domain-artifacts -->
- [x] The two new bidirectional e2e cases plus the untouched existing routing paths, with the structured routing logs the fix emits:

```text
(pass) routes unresolved Twilio identity into the Eliza Cloud onboarding chat [12.62ms]
(pass) routes linked Twilio identity to the running agent server and sends the agent reply [12.42ms]
(pass) skips sendReply when the agent server returns an empty (no-response) reply [201.84ms]
{"level":"info","message":"Identity linked without an agent; routing to onboarding","platform":"twilio","userId":"user-7"}
(pass) routes a linked user whose agent is still provisioning to onboarding [11.33ms]
{"level":"info","message":"Identity not linked; routing message to onboarding chat","platform":"twilio","senderId":"+15551234567"}
(pass) caches an unresolved identity only briefly so linking takes effect quickly [23.84ms]

 5 pass / 0 fail (40 expect() calls)
```

Bidirectional proof: with the two production files reverted to base `1e3dec2d06f` and the new tests kept, `routes a linked user whose agent is still provisioning to onboarding` fails (2004ms timeout - the real dropped-message symptom) and `caches an unresolved identity only briefly` fails; with the fix, 5/5 pass.

<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface in this change; the diff is gateway-webhook identity routing and its tests.`

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-6`
<!-- attribution-row:client -->
- Client / agent tooling: `moltbot`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`
