### PR TITLE
fix(ci): harden snap-publish workflow inputs

### DIFF
--- a/.github/workflows/snap-publish.yml
+++ b/.github/workflows/snap-publish.yml
@@ -37,7 +37,12 @@ on:
       channel:
         description: Snap Store channel (edge | beta | candidate | stable)
         required: false
-        type: string
+        type: choice
+        options:
+          - stable
+          - candidate
+          - beta
+          - edge
         default: stable
       tag:
         description: Git tag e.g. v2.0.1
@@ -81,6 +86,9 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
+          case "$VERSION" in
+            *[!0-9.]*|.*|*..*|*.) echo "::error::version must be numeric dotted, got: $VERSION"; exit 1 ;;
+          esac
           # Update the version in snapcraft.yaml to match the release
           sed -i "s/^version: .*/version: \"${VERSION}\"/" packages/app-core/packaging/snap/snapcraft.yaml
 
@@ -98,6 +106,10 @@ jobs:
         env:
           CHANNEL: ${{ inputs.channel }}
         run: |
+          case "$CHANNEL" in
+            stable|candidate|beta|edge) ;;
+            *) echo "::error::channel must be stable|candidate|beta|edge, got: $CHANNEL"; exit 1 ;;
+          esac
           cd packages/app-core/packaging/snap
           snapcraft upload "$SNAP_FILE" --release "$CHANNEL"
           echo "Published snap to channel: $CHANNEL"

--- a/.github/workflows/snap-publish.yml
+++ b/.github/workflows/snap-publish.yml
@@ -78,9 +78,11 @@ jobs:
         run: sudo snap install snapcraft --classic
 
       - name: Update snap version
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           # Update the version in snapcraft.yaml to match the release
-          sed -i "s/^version: .*/version: \"${{ inputs.version }}\"/" packages/app-core/packaging/snap/snapcraft.yaml
+          sed -i "s/^version: .*/version: \"${VERSION}\"/" packages/app-core/packaging/snap/snapcraft.yaml
 
       - name: Build snap
         run: |
@@ -93,10 +95,12 @@ jobs:
 
       - name: Publish to Snap Store
         if: steps.creds_check.outputs.can_publish == 'true'
+        env:
+          CHANNEL: ${{ inputs.channel }}
         run: |
           cd packages/app-core/packaging/snap
-          snapcraft upload "$SNAP_FILE" --release ${{ inputs.channel }}
-          echo "Published snap to channel: ${{ inputs.channel }}"
+          snapcraft upload "$SNAP_FILE" --release "$CHANNEL"
+          echo "Published snap to channel: $CHANNEL"
 
       - name: Upload snap artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a


### PR DESCRIPTION
## Summary
- CI hygiene for `.github/workflows/snap-publish.yml`: bind `inputs.version` / `inputs.channel` under `env:` and use shell variables in `run:` (quoted).
- Avoids Actions expanding free-string dispatch inputs into the script text before bash parses it.
- Defense-in-depth for a privileged release workflow (Snap Store credentials on the runner). Not framed as a vulnerability ticket.
- **Version guard:** reject non numeric-dotted `VERSION` before the `sed` that writes `snapcraft.yaml` (closes GNU sed delimiter/`e` injection via the shell-expanded sed expression).
- **Channel constraint:** `workflow_dispatch` uses `type: choice` with `stable|candidate|beta|edge`; `workflow_call` keeps `type: string` (no choice support) and adds a matching body `case` guard before `snapcraft upload`.
- **Scope note — `tag` intentionally unbound:** `inputs.tag` still flows into `actions/checkout` as `ref`. That is inherent to a release dispatcher choosing source; this PR does not attempt to constrain it. Artifact name `elizaos-snap-${{ inputs.version }}` is a non-shell context; the version guard covers the value shape for that use as a side effect.

## Test plan
- [x] Workflow YAML review
- [x] Local dry-run of version sed step (scratch copy of `snapcraft.yaml`):
  - benign `VERSION=2.0.1` → accepted; version line updated
  - slash-bearing `VERSION='1.0.0/;e echo pwned;#'` → guard rejects with `version must be numeric dotted`
- [x] Local channel guard dry-run: `stable`/`edge` accepted; multi-word / arbitrary strings rejected
- [ ] Optional: dispatch is not run here (publishes to Snap Store; no authorization for live publish)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok (as declared by the author: xAI Grok via Cursor)
<!-- attribution-row:client -->
- Client / agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - external contributor PR, no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

<!-- evidence-head:3f1e72444af91528baad80959e9c6366a8f144a4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - workflow-only change, no rendered surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - workflow-only change, no rendered surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - workflow-only change, no rendered surface

<!-- evidence-row:backend-logs -->
- [x] Local execution of the exact guard logic added by this PR (the `case` statements from the workflow body, run verbatim against benign and adversarial inputs), plus the `sed` dry-run on a scratch `snapcraft.yaml`:

<details>
<summary>Transcript: version guard, channel guard, and sed dry-run</summary>

```
== version guard ==
ACCEPT 2.0.1
REJECT version must be numeric dotted, got: 1.0.0/;e echo pwned;#
REJECT version must be numeric dotted, got: 1.2.3"; rm -rf /;"
REJECT version must be numeric dotted, got: .1.2
REJECT version must be numeric dotted, got: 1..2
REJECT version must be numeric dotted, got: 1.2.
== channel guard ==
ACCEPT stable
ACCEPT edge
REJECT channel must be stable|candidate|beta|edge, got: beta; curl evil
REJECT channel must be stable|candidate|beta|edge, got: stable --release=candidate
== sed dry-run on a scratch snapcraft.yaml ==
version: "2.0.1"
```
</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - workflow-only change, no rendered surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - workflow-only change, no rendered surface

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - workflow-only change, no rendered surface

