### PR TITLE
fix(app-core): pin the macOS stager staple block contiguously

### DIFF
--- a/packages/app-core/scripts/release-check-mac-stager.test.ts
+++ b/packages/app-core/scripts/release-check-mac-stager.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Mutation tests for the macOS artifact-stager gate (#17680).
+ *
+ * These run against the REAL stager script, not a fixture: the gate's whole job
+ * is to notice edits to that file, so a fixture would test the fixture. Each
+ * case mutates a copy of the real script and asserts the gate's own predicate
+ * changes verdict. A test that only checks the unmodified script passes is the
+ * failure mode that let this regression exist.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  containsContiguousBlock,
+  requiredMacStaplerFailureBlock,
+} from "./release-check";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const stagerPath = path.join(
+  here,
+  "../platforms/electrobun/scripts/stage-macos-release-artifacts.sh",
+);
+const stager = readFileSync(stagerPath, "utf8");
+
+/**
+ * Index of `trimmed` INSIDE the guarded block, not merely the first in the file.
+ *
+ * `exit 1` occurs nine times in this script and `fi` fifty-eight — the first
+ * `exit 1` is at line 15, nowhere near the staple logic. Anchoring on the block
+ * is the whole point: a mutation aimed at an unrelated occurrence proves
+ * nothing, and writing this helper naively is how the original gate's blind
+ * spot reproduces itself in its own test.
+ */
+function indexInBlock(lines: string[], trimmed: string): number {
+  const anchor = lines.findIndex(
+    (line) => line.trim() === requiredMacStaplerFailureBlock[0],
+  );
+  if (anchor === -1) throw new Error("staple-failure block anchor not found");
+  const limit = anchor + requiredMacStaplerFailureBlock.length;
+  for (let index = anchor; index < limit && index < lines.length; index++) {
+    if (lines[index].trim() === trimmed) return index;
+  }
+  throw new Error(
+    `no line matching ${JSON.stringify(trimmed)} inside the block`,
+  );
+}
+
+/** Drop the guarded block's copy of `trimmed`, preserving everything else. */
+function deleteFirstLine(script: string, trimmed: string): string {
+  const lines = script.split("\n");
+  lines.splice(indexInBlock(lines, trimmed), 1);
+  return lines.join("\n");
+}
+
+/** Swap the guarded block's copy of `trimmed` with the line after it. */
+function swapWithNextLine(script: string, trimmed: string): string {
+  const lines = script.split("\n");
+  const index = indexInBlock(lines, trimmed);
+  const [moved] = lines.splice(index, 1);
+  lines.splice(index + 1, 0, moved);
+  return lines.join("\n");
+}
+
+describe("macOS stager staple-failure gate", () => {
+  it("passes on the unmodified stager", () => {
+    expect(
+      containsContiguousBlock(stager, requiredMacStaplerFailureBlock),
+    ).toBe(true);
+  });
+
+  it("fails when the require-staple `exit 1` is deleted", () => {
+    // The regression this gate exists to prevent: without it, a release that
+    // REQUIRES a stapled DMG falls through to the warning and ships unstapled.
+    const mutated = deleteFirstLine(stager, "exit 1");
+
+    expect(
+      containsContiguousBlock(mutated, requiredMacStaplerFailureBlock),
+    ).toBe(false);
+  });
+
+  it("fails when two lines of the block are reordered without deleting any", () => {
+    // Every line still exists, so any per-line presence check still passes.
+    const mutated = swapWithNextLine(stager, "exit 1");
+
+    expect(mutated.includes("exit 1")).toBe(true);
+    expect(
+      containsContiguousBlock(mutated, requiredMacStaplerFailureBlock),
+    ).toBe(false);
+  });
+
+  it("fails when the block is split apart but every line survives", () => {
+    const lines = stager.split("\n");
+    lines.splice(
+      indexInBlock(lines, "exit 1") + 1,
+      0,
+      '    echo "interposed" >&2',
+    );
+    const mutated = lines.join("\n");
+
+    expect(
+      containsContiguousBlock(mutated, requiredMacStaplerFailureBlock),
+    ).toBe(false);
+  });
+
+  it("survives reindentation of the guarded block", () => {
+    // Order and adjacency carry the contract; leading whitespace does not, so
+    // reformatting must not turn the gate red.
+    const lines = stager.split("\n");
+    const index = indexInBlock(lines, "exit 1");
+    lines[index] = `\t\t${lines[index].trim()}`;
+
+    expect(
+      containsContiguousBlock(lines.join("\n"), requiredMacStaplerFailureBlock),
+    ).toBe(true);
+  });
+
+  it("demonstrates why per-line assertions cannot catch these mutations", () => {
+    // This is the old gate's predicate. It is green on both mutations above —
+    // which is precisely the defect, and why the block check has to exist.
+    const perLinePasses = (script: string) =>
+      requiredMacStaplerFailureBlock.every((line) =>
+        script.includes(line.trim()),
+      );
+
+    expect(perLinePasses(deleteFirstLine(stager, "exit 1"))).toBe(true);
+    expect(perLinePasses(swapWithNextLine(stager, "exit 1"))).toBe(true);
+  });
+});
+
+describe("containsContiguousBlock", () => {
+  it("requires the lines to be consecutive and ordered", () => {
+    const content = "alpha\nbeta\ngamma";
+
+    expect(containsContiguousBlock(content, ["alpha", "beta"])).toBe(true);
+    expect(containsContiguousBlock(content, ["beta", "alpha"])).toBe(false);
+    expect(containsContiguousBlock(content, ["alpha", "gamma"])).toBe(false);
+  });
+
+  it("matches a block that ends the content", () => {
+    expect(containsContiguousBlock("alpha\nbeta", ["alpha", "beta"])).toBe(
+      true,
+    );
+  });
+
+  it("does not read past the end of the content", () => {
+    expect(containsContiguousBlock("alpha", ["alpha", "beta"])).toBe(false);
+  });
+
+  it("treats an empty block as vacuously present", () => {
+    expect(containsContiguousBlock("alpha", [])).toBe(true);
+  });
+});

--- a/packages/app-core/scripts/release-check.ts
+++ b/packages/app-core/scripts/release-check.ts
@@ -228,6 +228,55 @@ export function findMissingRequiredSnippets(
   return snippets.filter((snippet) => !content.includes(snippet));
 }
 
+/**
+ * Whether `lines` appear in `content` as CONSECUTIVE lines, in order.
+ *
+ * `content.includes(line)` per line proves only that each line exists somewhere
+ * in the file, in any order, at any distance. That is worthless when a line's
+ * whole meaning is positional: `exit 1` occurs nine times in the macOS stager
+ * and `fi` fifty-eight, so deleting the one `exit 1` that fails a
+ * require-staple release still satisfies a per-line check (#17680).
+ *
+ * Indentation is compared after trimming so the guard survives reformatting,
+ * but order and adjacency — the properties that carry the meaning — are pinned.
+ */
+export function containsContiguousBlock(
+  content: string,
+  lines: readonly string[],
+): boolean {
+  if (lines.length === 0) return true;
+  const haystack = content.split("\n").map((line) => line.trim());
+  const needle = lines.map((line) => line.trim());
+  const last = haystack.length - needle.length;
+  for (let start = 0; start <= last; start++) {
+    let matched = true;
+    for (let offset = 0; offset < needle.length; offset++) {
+      if (haystack[start + offset] !== needle[offset]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) return true;
+  }
+  return false;
+}
+
+/**
+ * The staple-failure block of the macOS stager, asserted as one unit.
+ *
+ * Every line here is individually ambiguous or individually meaningless; the
+ * contract lives in their arrangement. Keep this in sync with
+ * `platforms/electrobun/scripts/stage-macos-release-artifacts.sh`.
+ */
+export const requiredMacStaplerFailureBlock = [
+  'if ! retry_command "$STAPLER_ATTEMPTS" "$STAPLER_DELAY_SECONDS" xcrun stapler staple "$TEMP_DMG_PATH"; then',
+  'if [[ "${ELECTROBUN_REQUIRE_STAPLED_DMG:-0}" == "1" ]]; then',
+  "exit 1",
+  "fi",
+  'echo "stage-macos-release-artifacts: notarization accepted but stapler ticket was not available; continuing without stapled DMG" >&2',
+  "fi",
+] as const;
+
 const forbiddenWorkflowSnippets = [
   ' -name "*.exe" -o \\',
   'bun install -g "rcedit@4.0.1"',
@@ -1045,17 +1094,26 @@ function assertMacArtifactStagerLooksCorrect() {
     "retry_notarytool_log >&2 || true",
     'STAPLER_ATTEMPTS="${ELECTROBUN_STAPLER_ATTEMPTS:-12}"',
     'STAPLER_DELAY_SECONDS="${ELECTROBUN_STAPLER_DELAY_SECONDS:-30}"',
-    'if ! retry_command "$STAPLER_ATTEMPTS" "$STAPLER_DELAY_SECONDS" xcrun stapler staple "$TEMP_DMG_PATH"; then',
-    '  if [[ "${ELECTROBUN_REQUIRE_STAPLED_DMG:-0}" == "1" ]]; then',
-    "    exit 1",
-    "  fi",
-    '  echo "stage-macos-release-artifacts: notarization accepted but stapler ticket was not available; continuing without stapled DMG" >&2',
-    "fi",
+    // The staple-failure block is asserted contiguously below, not here: each
+    // of its lines is ambiguous alone (#17680).
     'mv "$TEMP_DMG_PATH" "$FINAL_DMG_PATH"',
   ];
   const missing = requiredSnippets.filter(
     (snippet) => !script.includes(snippet),
   );
+
+  if (!containsContiguousBlock(script, requiredMacStaplerFailureBlock)) {
+    console.error(
+      "release-check: macOS artifact stager's staple-failure block is missing, reordered, or no longer contiguous:",
+    );
+    for (const line of requiredMacStaplerFailureBlock) {
+      console.error(`  | ${line}`);
+    }
+    console.error(
+      "  A require-staple release must exit non-zero rather than fall through to the warning.",
+    );
+    process.exit(1);
+  }
 
   if (missing.length > 0) {
     console.error(


### PR DESCRIPTION
Closes #17680.

`assertMacArtifactStagerLooksCorrect` transcribed the staple-failure block as
independent substrings, each tested with `script.includes(snippet)` in
isolation. Three of them are bare shell punctuation that recur throughout the
guarded file:

| asserted literal | occurrences in `stage-macos-release-artifacts.sh` |
| --- | --- |
| `    exit 1` | 9 |
| `  fi` | 26 |
| `fi` | 58 |

So the gate proved only that each line existed *somewhere*, in any order, at any
distance. Deleting the `exit 1` that fails a require-staple release left the
gate green while the release fell through to the warning and shipped an
unstapled DMG.

## The change

Assert that block as one contiguous, ordered run instead of six independent
lines. `containsContiguousBlock` compares trimmed lines, so reformatting the
script does not turn the gate red, while order and adjacency — the properties
that actually carry the contract — are pinned.

The remaining single-occurrence snippets are left as they are; the defect is
specific to the block whose entire payload lives in a punctuation line.

## Proof the tests catch the regression

Passing tests are not the claim. I reverted `containsContiguousBlock` to the old
per-line semantics and re-ran the suite:

```
## BASELINE — fixed implementation
      Tests  10 passed (10)

## MUTATION — revert containsContiguousBlock to the OLD per-line semantics
   × fails when the require-staple `exit 1` is deleted
   × fails when two lines of the block are reordered without deleting any
   × fails when the block is split apart but every line survives
   × requires the lines to be consecutive and ordered
   Tests  4 failed | 6 passed (10)

## RESTORED
      Tests  10 passed (10)
```

Four cases go red against the old behaviour and green against the fix. The suite
also keeps one test asserting the **old** predicate stays green on both
mutations, so the defect is preserved in executable form and cannot be quietly
reintroduced.

Acceptance criteria, mapped to tests:

- deleting the require-staple `exit 1` fails the assertion — `fails when the require-staple exit 1 is deleted`
- reordering two lines without deleting any fails it — `fails when two lines of the block are reordered without deleting any`
- the unmodified stager passes — `passes on the unmodified stager`
- no asserted literal is individually load-bearing — the three ambiguous literals are no longer standalone assertions; they exist only inside the ordered block

## A note on the tests themselves

My first version of the mutation helpers targeted the first `exit 1` in the
file. That is line 15, nowhere near the staple logic, and three tests failed
because the guarded block was still intact. That is this very issue reproduced
inside its own test, so `indexInBlock` now anchors every mutation on the block
and says why in a comment — the naive version is the obvious thing to write.

## Checks

`bun run --cwd packages/app-core test -- scripts/release-check-mac-stager.test.ts`
→ 10 passed. `biome check` → clean.

`bun run --cwd packages/app-core typecheck` fails with 22 errors, and I want to
be straight about it: they are **pre-existing**, in unrelated files
(`native-plugin-entrypoints.ts`, `ios-local-agent-transport.ts`) about missing
Capacitor optional dependencies. I confirmed by stashing this change and
re-running — the count is identical without it.

# Evidence Gate

<!-- evidence-head:a4996ceb326bc709c99f16b79b1e0ccfbe370838 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - a release-gate predicate in packages/app-core/scripts; there is no rendered surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - a release-gate predicate in packages/app-core/scripts; there is no rendered surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - there is no user flow; this changes a CI assertion and adds a test.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end:

<details>
<summary>Mutation matrix — each block is a separate run against the real stager</summary>

```
INFO release-check macOS stager gate -- mutation matrix
INFO PR head a4996ceb326bc709c99f16b79b1e0ccfbe370838

## BASELINE -- fixed implementation
 Test Files  1 passed (1)
      Tests  10 passed (10)

## MUTATION -- revert containsContiguousBlock to the OLD per-line semantics
   x fails when the require-staple `exit 1` is deleted 3ms
   x fails when two lines of the block are reordered without deleting any 0ms
   x fails when the block is split apart but every line survives 0ms
   x requires the lines to be consecutive and ordered 0ms
   Tests  4 failed | 6 passed (10)

## RESTORED
      Tests  10 passed (10)
INFO working tree restored: git diff --quiet -> clean
```
</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend surface and no requests; this is a build-time assertion over a shell script.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model call is involved; the change adds no agent, action, provider, or prompt behavior.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the ambiguity measurement that makes this a defect rather than a style preference:

<details>
<summary>Occurrence counts of each asserted literal in the guarded script</summary>

```
INFO measured against packages/app-core/platforms/electrobun/scripts/stage-macos-release-artifacts.sh
INFO grep -c per asserted literal, whole file

    literal                                              occurrences
    "    exit 1"                                                   9
    "  fi"                                                        26
    "fi"                                                          58
    "if ! retry_command ... xcrun stapler staple ..."               1
    "  if [[ \"${ELECTROBUN_REQUIRE_STAPLED_DMG:-0}\" == \"1\" ]]; then"   1
    "  echo \"stage-macos-release-artifacts: notarization ...\" >&2"  1

INFO first "exit 1" in the file is at line 15; the guarded one is at line 487
INFO a per-line check therefore cannot distinguish them -- deleting line 487
INFO still matches the other eight, which is why the gate stayed green
```
</details>

No DB rows, memories, scheduled tasks, or generated files result from this change.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Client / agent tooling: Genki Studio by GenkiAI (Claude Code / Claude Agent SDK)
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

— [greatcodeeer-agent]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Genki Studio by GenkiAI (Claude Code / Claude Agent SDK)","skill_revision":"elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza"} -->

