### PR TITLE
feat(cloud): app-mode — logging in on the app host lands you in your dedicated agent

### DIFF
--- a/packages/app/scripts/forced-host-mode-guard.mjs
+++ b/packages/app/scripts/forced-host-mode-guard.mjs
@@ -1,0 +1,29 @@
+/**
+ * Deploy-config guard for the forced host-mode escape hatches.
+ * VITE_FORCE_APP_MODE (packages/ui cloud/app-mode) and VITE_FORCE_APEX_CONSOLE
+ * (packages/ui cloud/shell/apex-host) deliberately short-circuit their
+ * hostname checks so `vite dev` on localhost can exercise those surfaces at
+ * all. Baked into a deployed bundle, either flag reroutes EVERY host —
+ * including the elizacloud.ai apex — so the production/staging Pages builds
+ * (cloud-cf-deploy.yml, both the eliza-cloud and eliza-app projects run
+ * `build:web` in production mode) must fail loudly at build time when a deploy
+ * config sets one, instead of silently shipping a hijacked apex.
+ */
+
+export const FORCED_HOST_MODE_FLAGS = Object.freeze([
+  "VITE_FORCE_APP_MODE",
+  "VITE_FORCE_APEX_CONSOLE",
+]);
+
+/**
+ * Names of forced host-mode flags present (set to any non-blank value — a
+ * deploy config must not contain them at all) in the given env record.
+ * Feed it Vite's `loadEnv` output so `.env*` files are covered, not just
+ * `process.env`.
+ */
+export function forbiddenForcedHostModeFlags(env = process.env) {
+  return FORCED_HOST_MODE_FLAGS.filter((flag) => {
+    const value = env[flag];
+    return typeof value === "string" && value.trim() !== "";
+  });
+}

--- a/packages/app/scripts/forced-host-mode-guard.test.mjs
+++ b/packages/app/scripts/forced-host-mode-guard.test.mjs
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for the forced host-mode deploy guard: production-mode builds must
+ * refuse to bake VITE_FORCE_APP_MODE / VITE_FORCE_APEX_CONSOLE, the flags that
+ * override the app-mode and apex hostname checks for every host.
+ */
+import { describe, expect, it } from "vitest";
+import { forbiddenForcedHostModeFlags } from "./forced-host-mode-guard.mjs";
+
+describe("forbiddenForcedHostModeFlags", () => {
+  it("passes a clean deploy env", () => {
+    expect(forbiddenForcedHostModeFlags({})).toEqual([]);
+    expect(
+      forbiddenForcedHostModeFlags({ VITE_ENVIRONMENT: "production" }),
+    ).toEqual([]);
+  });
+
+  it("flags VITE_FORCE_APP_MODE when set", () => {
+    expect(
+      forbiddenForcedHostModeFlags({ VITE_FORCE_APP_MODE: "true" }),
+    ).toEqual(["VITE_FORCE_APP_MODE"]);
+  });
+
+  it("flags VITE_FORCE_APEX_CONSOLE when set", () => {
+    expect(
+      forbiddenForcedHostModeFlags({ VITE_FORCE_APEX_CONSOLE: "true" }),
+    ).toEqual(["VITE_FORCE_APEX_CONSOLE"]);
+  });
+
+  it("flags ANY non-blank value — deploy config must not contain the var at all", () => {
+    expect(
+      forbiddenForcedHostModeFlags({ VITE_FORCE_APP_MODE: "false" }),
+    ).toEqual(["VITE_FORCE_APP_MODE"]);
+  });
+
+  it("treats unset and blank values as absent", () => {
+    expect(
+      forbiddenForcedHostModeFlags({
+        VITE_FORCE_APP_MODE: "",
+        VITE_FORCE_APEX_CONSOLE: "   ",
+      }),
+    ).toEqual([]);
+  });
+
+  it("reports both flags when both are set", () => {
+    expect(
+      forbiddenForcedHostModeFlags({
+        VITE_FORCE_APP_MODE: "true",
+        VITE_FORCE_APEX_CONSOLE: "true",
+      }),
+    ).toEqual(["VITE_FORCE_APP_MODE", "VITE_FORCE_APEX_CONSOLE"]);
+  });
+});

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -17,6 +17,7 @@ import { visualizer } from "rollup-plugin-visualizer";
 import {
   createLogger,
   defineConfig,
+  loadEnv,
   type Plugin,
   transformWithOxc,
 } from "vite";
@@ -44,6 +45,7 @@ import {
   shouldSkipBuildStamp,
 } from "./scripts/build-stamp.mjs";
 import { CAPACITOR_PLUGIN_NAMES } from "./scripts/capacitor-plugin-names.mjs";
+import { forbiddenForcedHostModeFlags } from "./scripts/forced-host-mode-guard.mjs";
 import { normalizeEnvPrefix } from "./src/env-prefix.js";
 import { appSideEffectModulesPlugin } from "./vite/app-side-effect-modules.ts";
 import { calendarOptimizeDeps } from "./vite/calendar-optimize-deps.ts";
@@ -1063,6 +1065,39 @@ function productionBuildStampGuardPlugin(): Plugin {
 }
 
 /**
+ * Fails any production-mode build in which a forced host-mode escape hatch
+ * (VITE_FORCE_APP_MODE / VITE_FORCE_APEX_CONSOLE) is set. The flags override
+ * the app-mode and apex hostname checks for EVERY host, so a Pages deploy that
+ * carries one silently turns the elizacloud.ai apex into the forced surface —
+ * this guard makes that misconfiguration fail loudly at build time instead.
+ * The production/staging Pages builds (cloud-cf-deploy.yml) run plain
+ * `vite build` (mode "production"), so both are covered; `vite dev` and
+ * development-mode bundles keep the escape hatch.
+ */
+function forcedHostModeFlagGuardPlugin(): Plugin {
+  return {
+    name: "eliza-forced-host-mode-flag-guard",
+    configResolved(config) {
+      if (config.command !== "build" || config.mode !== "production") return;
+      // loadEnv covers `.env*` files as well as process.env.
+      const offending = forbiddenForcedHostModeFlags(
+        loadEnv(config.mode, config.envDir, "VITE_FORCE_"),
+      );
+      if (offending.length > 0) {
+        throw new Error(
+          `${offending.join(", ")} must not be set in a production-mode build: ` +
+            "the forced host-mode flags override the app-mode/apex hostname " +
+            "checks for every host, so a deployed bundle with one baked in " +
+            "hijacks the elizacloud.ai apex. Remove the flag from the deploy " +
+            "config (cloud-cf-deploy.yml / wrangler.toml); to test a built " +
+            "bundle with the flag locally, build with --mode development.",
+        );
+      }
+    },
+  };
+}
+
+/**
  * Pinned @elizaos/core from the repo root (must match the agent/runtime lock).
  */
 function getPinnedElizaCoreVersion(): string {
@@ -2064,6 +2099,7 @@ export default defineConfig({
     ),
   },
   plugins: [
+    forcedHostModeFlagGuardPlugin(),
     productionBuildStampGuardPlugin(),
     bufferEsmShimPlugin(),
     // Manifest-driven renderer side-effect plugin registration (#9178): resolves

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
@@ -62,6 +62,7 @@ interface StubRoutes {
 
 const realFetch = globalThis.fetch;
 const realAssign = appModeNavigation.assign;
+const realReplace = appModeNavigation.replace;
 let fetchLog: string[];
 let assignedUrls: string[];
 
@@ -87,7 +88,12 @@ function stubNetwork(routes: StubRoutes): void {
     );
   }) as typeof fetch;
   assignedUrls = [];
+  // Both seams feed one log: automatic entry replaces history, an explicit
+  // chooser pick pushes; the replace-vs-assign split is pinned in app-mode.test.ts.
   appModeNavigation.assign = (url: string) => {
+    assignedUrls.push(url);
+  };
+  appModeNavigation.replace = (url: string) => {
     assignedUrls.push(url);
   };
 }
@@ -139,6 +145,7 @@ afterEach(() => {
   localStorage.clear();
   globalThis.fetch = realFetch;
   appModeNavigation.assign = realAssign;
+  appModeNavigation.replace = realReplace;
 });
 
 describe("AppModeEntryRoute — auth gating", () => {

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
@@ -1,0 +1,275 @@
+/** Verifies the AppModeEntryRoute gate — auth gating, the agents-driven routing table, and the pairing redirect outcomes (200 / 202 / error) — through the package's configured test harness (jsdom, real render, hand-rolled fetch stub; no Steward provider mounted, sessions come from the persisted localStorage JWT). */
+// @vitest-environment jsdom
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import { AppModeEntryRoute } from "./AppModeEntryRoute";
+import { type AppModeAgent, appModeNavigation } from "./app-mode";
+
+function base64url(value: unknown): string {
+  return btoa(JSON.stringify(value))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+// A minimally-valid Steward JWT: readStewardSessionFromStorage only
+// base64-decodes the payload (userId + a future exp); no signature check.
+function stewardToken(): string {
+  return [
+    base64url({ alg: "none", typ: "JWT" }),
+    base64url({
+      userId: "u1",
+      email: "a@b.test",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }),
+    "sig",
+  ].join(".");
+}
+
+function signIn(): void {
+  localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken());
+}
+
+function agent(
+  overrides: Partial<AppModeAgent> & { id: string },
+): AppModeAgent {
+  return {
+    agentName: overrides.id,
+    status: "running",
+    executionTier: "dedicated-always",
+    lastHeartbeatAt: null,
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+interface StubRoutes {
+  /** Response for GET /api/v1/eliza/agents. */
+  agents: () => Response;
+  /** Response for POST /api/v1/eliza/agents/:id/pairing-token. */
+  pairing?: (agentId: string) => Response;
+}
+
+const realFetch = globalThis.fetch;
+const realAssign = appModeNavigation.assign;
+let fetchLog: string[];
+let assignedUrls: string[];
+
+function stubNetwork(routes: StubRoutes): void {
+  fetchLog = [];
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    fetchLog.push(`${init?.method ?? "GET"} ${url}`);
+    const pairing = /^\/api\/v1\/eliza\/agents\/([^/]+)\/pairing-token$/.exec(
+      url,
+    );
+    if (pairing && routes.pairing) {
+      return Promise.resolve(routes.pairing(pairing[1]));
+    }
+    if (url === "/api/v1/eliza/agents") {
+      return Promise.resolve(routes.agents());
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ error: `unstubbed ${url}` }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+  assignedUrls = [];
+  appModeNavigation.assign = (url: string) => {
+    assignedUrls.push(url);
+  };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function agentsOk(list: AppModeAgent[]): () => Response {
+  return () => jsonResponse(200, { success: true, data: list });
+}
+
+function LoginProbe(): React.JSX.Element {
+  const location = useLocation();
+  return <div data-testid="login-page">{location.search}</div>;
+}
+
+function renderEntry(initialPath = "/"): void {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/login" element={<LoginProbe />} />
+          <Route
+            path="/dashboard/agents"
+            element={<div data-testid="instances-page" />}
+          />
+          <Route path="/join" element={<div data-testid="join-page" />} />
+          <Route
+            path="*"
+            element={
+              <AppModeEntryRoute appElement={<div data-testid="agent-app" />} />
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  globalThis.fetch = realFetch;
+  appModeNavigation.assign = realAssign;
+});
+
+describe("AppModeEntryRoute — auth gating", () => {
+  it("unauthenticated → the existing login flow, returnTo pointing back at the entry", () => {
+    stubNetwork({ agents: agentsOk([]) });
+    renderEntry("/");
+
+    expect(screen.getByTestId("login-page").textContent).toBe("?returnTo=%2F");
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+    // Signed out, nothing to decide: no app-mode network calls at all.
+    expect(fetchLog).toEqual([]);
+  });
+
+  it("unauthenticated on a deep non-app path → login preserves that path for the post-login re-run", () => {
+    stubNetwork({ agents: agentsOk([]) });
+    renderEntry("/pricing");
+
+    expect(screen.getByTestId("login-page").textContent).toBe(
+      "?returnTo=%2Fpricing",
+    );
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+  });
+});
+
+describe("AppModeEntryRoute — routing table", () => {
+  it("exactly one running dedicated agent → full-page pairing redirect into its web UI", async () => {
+    signIn();
+    const redirectUrl = "https://agent-1.elizacloud.ai/pair?token=tok";
+    stubNetwork({
+      agents: agentsOk([agent({ id: "agent-1" })]),
+      pairing: () => jsonResponse(200, { data: { redirectUrl } }),
+    });
+    renderEntry();
+
+    await waitFor(() => expect(assignedUrls).toEqual([redirectUrl]));
+    expect(fetchLog).toContain(
+      "POST /api/v1/eliza/agents/agent-1/pairing-token",
+    );
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+  });
+
+  it("pairing 202 (agent must resume) → lands on the Instances view", async () => {
+    signIn();
+    stubNetwork({
+      agents: agentsOk([agent({ id: "agent-1" })]),
+      pairing: () => jsonResponse(202, { data: { status: "starting" } }),
+    });
+    renderEntry();
+
+    expect(await screen.findByTestId("instances-page")).toBeTruthy();
+    expect(assignedUrls).toEqual([]);
+  });
+
+  it("pairing failure → visible error state with an escape to Instances, never a blank screen", async () => {
+    signIn();
+    stubNetwork({
+      agents: agentsOk([agent({ id: "agent-1" })]),
+      pairing: () => jsonResponse(503, { error: "agent not reachable" }),
+    });
+    renderEntry();
+
+    expect(await screen.findByText("agent not reachable")).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Go to your instances" }),
+    );
+    expect(await screen.findByTestId("instances-page")).toBeTruthy();
+  });
+
+  it("several running dedicated agents → chooser (most recently active first), rows pair on demand", async () => {
+    signIn();
+    const redirectUrl = "https://fresh.elizacloud.ai/pair?token=tok";
+    stubNetwork({
+      agents: agentsOk([
+        agent({ id: "stale", lastHeartbeatAt: "2026-08-01T00:00:00.000Z" }),
+        agent({ id: "fresh", lastHeartbeatAt: "2026-08-05T00:00:00.000Z" }),
+      ]),
+      pairing: (agentId) =>
+        agentId === "fresh"
+          ? jsonResponse(200, { data: { redirectUrl } })
+          : jsonResponse(503, { error: "wrong agent" }),
+    });
+    renderEntry();
+
+    const rows = await screen.findAllByRole("button", { name: /Open/ });
+    expect(rows.map((row) => row.textContent)).toEqual([
+      "freshOpen",
+      "staleOpen",
+    ]);
+
+    fireEvent.click(rows[0]);
+    await waitFor(() => expect(assignedUrls).toEqual([redirectUrl]));
+    expect(fetchLog).toContain("POST /api/v1/eliza/agents/fresh/pairing-token");
+  });
+
+  it("dedicated agents exist but none running → the Instances view (resume from there)", async () => {
+    signIn();
+    stubNetwork({
+      agents: agentsOk([agent({ id: "agent-1", status: "stopped" })]),
+    });
+    renderEntry();
+
+    expect(await screen.findByTestId("instances-page")).toBeTruthy();
+    expect(assignedUrls).toEqual([]);
+  });
+
+  it("no agents at all → the /join deploy-first-agent flow", async () => {
+    signIn();
+    stubNetwork({ agents: agentsOk([]) });
+    renderEntry();
+
+    expect(await screen.findByTestId("join-page")).toBeTruthy();
+  });
+
+  it("shared-tier-only org → the same-origin chat app, unchanged", async () => {
+    signIn();
+    stubNetwork({
+      agents: agentsOk([agent({ id: "s1", executionTier: "shared" })]),
+    });
+    renderEntry();
+
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
+    expect(assignedUrls).toEqual([]);
+  });
+
+  it("agents fetch failure → graceful fallback to the Instances view", async () => {
+    signIn();
+    stubNetwork({
+      agents: () => jsonResponse(500, { error: "backend down" }),
+    });
+    renderEntry();
+
+    expect(await screen.findByTestId("instances-page")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
@@ -150,7 +150,7 @@ function AgentChooser({
   async function openAgent(agentId: string): Promise<void> {
     setPendingId(agentId);
     setError(null);
-    const result = await redirectToAgentWebUI(agentId);
+    const result = await redirectToAgentWebUI(agentId, "user-initiated");
     if (!result.ok) {
       setPendingId(null);
       setError(

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
@@ -1,0 +1,195 @@
+/**
+ * App-mode entry gate for the Eliza app hosts (app.elizacloud.ai). Rendered by
+ * the cloud router shell's catch-all INSTEAD of the tab/view app whenever
+ * `isAppModeHost()` is true, so it owns every non-registered path on the app
+ * hosts; registered cloud routes (login / auth / dashboard / payment / join)
+ * match before the catch-all and stay reachable.
+ *
+ * After the existing Steward session auth resolves, the gate fetches the org's
+ * agents and routes per `decideAppModeRoute`: one running dedicated agent →
+ * full-page pairing redirect into its web UI (202 "must resume" and pairing
+ * failures degrade to the Instances console); several → a minimal chooser;
+ * dedicated-but-stopped → Instances; shared-tier-only orgs fall through to the
+ * same-origin chat app unchanged; no agents at all → the `/join`
+ * deploy-first-agent flow. Unauthenticated visitors take the normal login flow
+ * and return here. None of this mounts on apex control-plane hosts — the
+ * shell's apex branch runs first — so the apex console never issues app-mode
+ * network calls.
+ */
+
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
+import { Button } from "../../components/ui/button";
+import { useAgents } from "../instances/lib/data/eliza-agents";
+import { useSessionAuth } from "../lib/use-session-auth";
+import {
+  APP_MODE_INSTANCES_PATH,
+  type AppModeAgent,
+  decideAppModeRoute,
+  redirectToAgentWebUI,
+} from "./app-mode";
+
+function EntryNotice({
+  label,
+  children,
+}: {
+  label: string;
+  children?: ReactNode;
+}): React.JSX.Element {
+  return (
+    <div className="theme-cloud flex min-h-dvh flex-col items-center justify-center gap-4 bg-black px-6 text-center text-white">
+      <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-white/62">
+        {label}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+export function AppModeEntryRoute({
+  appElement,
+}: {
+  appElement: ReactNode;
+}): React.JSX.Element {
+  const { ready, authenticated } = useSessionAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const agentsQuery = useAgents();
+
+  const redirectStartedRef = useRef(false);
+  const [redirectError, setRedirectError] = useState<string | null>(null);
+
+  const route =
+    authenticated && agentsQuery.data !== undefined
+      ? decideAppModeRoute(agentsQuery.data)
+      : null;
+  const entryAgent = route?.kind === "enter-agent" ? route.agent : null;
+
+  // Exactly one running dedicated agent → full-page redirect into its web UI.
+  // The ref makes the pairing POST once-per-mount: the agents query repolls and
+  // re-derives `route`, and a second POST would burn another one-time token.
+  useEffect(() => {
+    if (!entryAgent || redirectStartedRef.current) return;
+    redirectStartedRef.current = true;
+    void redirectToAgentWebUI(entryAgent.id).then((result) => {
+      if (result.ok) return;
+      if (result.starting) {
+        // 202 — the server queued a resume; land on Instances where the agent's
+        // status and wake progress are visible.
+        navigate(APP_MODE_INSTANCES_PATH, { replace: true });
+        return;
+      }
+      setRedirectError(result.error);
+    });
+  }, [entryAgent, navigate]);
+
+  if (!ready) {
+    return <EntryNotice label="Loading" />;
+  }
+
+  if (!authenticated) {
+    // The existing login flow; returnTo brings the user back to this entry,
+    // which re-runs with a session.
+    const returnTo = encodeURIComponent(
+      `${location.pathname}${location.search}`,
+    );
+    return <Navigate to={`/login?returnTo=${returnTo}`} replace />;
+  }
+
+  if (agentsQuery.isError) {
+    // Never a blank screen: the Instances console owns the failure surface
+    // (skeleton / error state / retry) for the same list.
+    return <Navigate to={APP_MODE_INSTANCES_PATH} replace />;
+  }
+
+  if (!route) {
+    return <EntryNotice label="Loading your agent" />;
+  }
+
+  switch (route.kind) {
+    case "enter-agent":
+      if (redirectError) {
+        return (
+          <EntryNotice label="Connection failed">
+            <p className="max-w-sm text-sm text-white/62">{redirectError}</p>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => navigate(APP_MODE_INSTANCES_PATH)}
+            >
+              Go to your instances
+            </Button>
+          </EntryNotice>
+        );
+      }
+      return <EntryNotice label="Connecting to your agent" />;
+
+    case "choose-agent":
+      return <AgentChooser running={route.running} />;
+
+    case "resume":
+    case "create":
+      return <Navigate to={route.to} replace />;
+
+    case "chat-home":
+      return <>{appElement}</>;
+  }
+}
+
+/** Minimal chooser for orgs with several running dedicated agents; each row
+ * deep-links through the same pairing redirect as automatic entry. */
+function AgentChooser({
+  running,
+}: {
+  running: AppModeAgent[];
+}): React.JSX.Element {
+  const navigate = useNavigate();
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function openAgent(agentId: string): Promise<void> {
+    setPendingId(agentId);
+    setError(null);
+    const result = await redirectToAgentWebUI(agentId);
+    if (!result.ok) {
+      setPendingId(null);
+      setError(
+        result.starting
+          ? "Agent is still starting — try again shortly."
+          : result.error,
+      );
+    }
+  }
+
+  return (
+    <EntryNotice label="Pick your agent">
+      <div className="w-full max-w-sm space-y-2 text-left">
+        {running.map((agent) => (
+          <button
+            key={agent.id}
+            type="button"
+            disabled={pendingId !== null}
+            onClick={() => void openAgent(agent.id)}
+            className="flex w-full items-center justify-between border border-white/15 bg-white/5 px-4 py-3 text-sm text-white transition-colors hover:bg-white/10 disabled:opacity-50"
+          >
+            <span className="truncate">{agent.agentName ?? agent.id}</span>
+            <span className="ml-3 shrink-0 font-mono text-[11px] uppercase tracking-widest text-white/62">
+              {pendingId === agent.id ? "Connecting…" : "Open"}
+            </span>
+          </button>
+        ))}
+      </div>
+      {error ? <p className="max-w-sm text-sm text-red-400">{error}</p> : null}
+      <Button
+        type="button"
+        variant="link"
+        className="text-xs text-white/62"
+        onClick={() => navigate(APP_MODE_INSTANCES_PATH)}
+      >
+        Manage all instances
+      </Button>
+    </EntryNotice>
+  );
+}
+
+export default AppModeEntryRoute;

--- a/packages/ui/src/cloud/app-mode/app-mode.test.ts
+++ b/packages/ui/src/cloud/app-mode/app-mode.test.ts
@@ -51,6 +51,19 @@ describe("isAppModeHostname — hostname matrix", () => {
     expect(isAppModeHostname("localhost", true)).toBe(true);
     expect(isAppModeHostname("elizacloud.ai", false)).toBe(false);
   });
+
+  it("dev escape hatch DOES override the apex — deliberate, pinned decision", () => {
+    // VITE_FORCE_APP_MODE short-circuits BEFORE the hostname set on purpose:
+    // the flag exists so `vite dev` (localhost) can exercise app-mode entry at
+    // all, and a partial override that carved out the apex would make the flag
+    // lie about what it forces. The apex is protected at BUILD time instead —
+    // packages/app's vite config fails any production-mode build in which
+    // VITE_FORCE_APP_MODE or VITE_FORCE_APEX_CONSOLE is set
+    // (packages/app/scripts/forced-host-mode-guard.mjs), so the flag can never
+    // reach a deployed bundle. If this test surprises you, that guard is the
+    // invariant you are looking for.
+    expect(isAppModeHostname("elizacloud.ai", true)).toBe(true);
+  });
 });
 
 describe("decideAppModeRoute — decision table", () => {

--- a/packages/ui/src/cloud/app-mode/app-mode.test.ts
+++ b/packages/ui/src/cloud/app-mode/app-mode.test.ts
@@ -1,0 +1,260 @@
+/** Verifies the app-mode hostname matrix, entry-routing decision table, and pairing redirect through the package's configured test harness (jsdom, hand-rolled fetch stub — no module mocks). */
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  APP_MODE_CREATE_PATH,
+  APP_MODE_INSTANCES_PATH,
+  type AppModeAgent,
+  appModeNavigation,
+  decideAppModeRoute,
+  isAppModeHostname,
+  redirectToAgentWebUI,
+} from "./app-mode";
+
+function agent(
+  overrides: Partial<AppModeAgent> & { id: string },
+): AppModeAgent {
+  return {
+    agentName: overrides.id,
+    status: "running",
+    executionTier: "dedicated-always",
+    lastHeartbeatAt: null,
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("isAppModeHostname — hostname matrix", () => {
+  const matrix: Array<[string, boolean]> = [
+    ["app.elizacloud.ai", true],
+    ["app-staging.elizacloud.ai", true],
+    ["APP.ELIZACLOUD.AI", true],
+    ["elizacloud.ai", false],
+    ["www.elizacloud.ai", false],
+    ["staging.elizacloud.ai", false],
+    ["api.elizacloud.ai", false],
+    ["api-staging.elizacloud.ai", false],
+    ["abc123def.elizacloud.ai", false],
+    ["app.elizacloud.ai.evil.example", false],
+    ["localhost", false],
+    ["127.0.0.1", false],
+  ];
+
+  for (const [hostname, expected] of matrix) {
+    it(`${hostname} → ${expected}`, () => {
+      expect(isAppModeHostname(hostname, false)).toBe(expected);
+    });
+  }
+
+  it("dev escape hatch turns app-mode on regardless of hostname", () => {
+    expect(isAppModeHostname("localhost", true)).toBe(true);
+    expect(isAppModeHostname("elizacloud.ai", false)).toBe(false);
+  });
+});
+
+describe("decideAppModeRoute — decision table", () => {
+  it("no agents at all → the /join deploy-first-agent flow", () => {
+    expect(decideAppModeRoute([])).toEqual({
+      kind: "create",
+      to: APP_MODE_CREATE_PATH,
+    });
+  });
+
+  it("exactly one running dedicated agent → enter-agent", () => {
+    const a = agent({ id: "a1" });
+    expect(decideAppModeRoute([a])).toEqual({ kind: "enter-agent", agent: a });
+  });
+
+  it("a running dedicated agent wins over running shared + stopped dedicated noise", () => {
+    const winner = agent({ id: "ded-1" });
+    const route = decideAppModeRoute([
+      agent({ id: "shared-1", executionTier: "shared" }),
+      agent({ id: "ded-stopped", status: "stopped" }),
+      winner,
+    ]);
+    expect(route).toEqual({ kind: "enter-agent", agent: winner });
+  });
+
+  it("several running dedicated agents → chooser ordered most-recently-active first (lastHeartbeatAt ?? updatedAt)", () => {
+    const stale = agent({
+      id: "stale",
+      lastHeartbeatAt: "2026-08-01T00:00:00.000Z",
+    });
+    const fresh = agent({
+      id: "fresh",
+      lastHeartbeatAt: "2026-08-05T00:00:00.000Z",
+    });
+    const heartbeatless = agent({
+      id: "no-heartbeat",
+      lastHeartbeatAt: null,
+      updatedAt: "2026-08-03T00:00:00.000Z",
+    });
+    const route = decideAppModeRoute([stale, heartbeatless, fresh]);
+    expect(route.kind).toBe("choose-agent");
+    if (route.kind !== "choose-agent") throw new Error("unreachable");
+    expect(route.running.map((a) => a.id)).toEqual([
+      "fresh",
+      "no-heartbeat",
+      "stale",
+    ]);
+  });
+
+  it("unparseable activity stamps sort last instead of throwing", () => {
+    const broken = agent({ id: "broken", lastHeartbeatAt: "not-a-date" });
+    const fresh = agent({
+      id: "fresh",
+      lastHeartbeatAt: "2026-08-05T00:00:00.000Z",
+    });
+    const route = decideAppModeRoute([broken, fresh]);
+    if (route.kind !== "choose-agent") throw new Error("expected chooser");
+    expect(route.running.map((a) => a.id)).toEqual(["fresh", "broken"]);
+  });
+
+  it("custom-tier agents are pairing candidates (per-container tier)", () => {
+    const custom = agent({ id: "c1", executionTier: "custom" });
+    expect(decideAppModeRoute([custom])).toEqual({
+      kind: "enter-agent",
+      agent: custom,
+    });
+  });
+
+  it("dedicated agents exist but none running → Instances resume", () => {
+    const route = decideAppModeRoute([
+      agent({ id: "d1", status: "stopped" }),
+      agent({ id: "d2", status: "sleeping" }),
+    ]);
+    expect(route).toEqual({ kind: "resume", to: APP_MODE_INSTANCES_PATH });
+  });
+
+  it("deletion_pending is not running → Instances resume", () => {
+    const route = decideAppModeRoute([
+      agent({ id: "d1", status: "deletion_pending" }),
+    ]);
+    expect(route).toEqual({ kind: "resume", to: APP_MODE_INSTANCES_PATH });
+  });
+
+  it("shared-tier-only org → chat-home (the same-origin chat app, unchanged)", () => {
+    const route = decideAppModeRoute([
+      agent({ id: "s1", executionTier: "shared" }),
+      agent({ id: "s2", executionTier: "shared", status: "stopped" }),
+    ]);
+    expect(route).toEqual({ kind: "chat-home" });
+  });
+});
+
+describe("redirectToAgentWebUI — pairing redirect", () => {
+  const realFetch = globalThis.fetch;
+  const realAssign = appModeNavigation.assign;
+  let fetchCalls: Array<{ url: string; method: string | undefined }>;
+  let assignedUrls: string[];
+
+  function stubFetch(respond: () => Response | Promise<Response>): void {
+    fetchCalls = [];
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      fetchCalls.push({ url: String(input), method: init?.method });
+      return Promise.resolve(respond());
+    }) as typeof fetch;
+  }
+
+  function captureAssign(): void {
+    assignedUrls = [];
+    appModeNavigation.assign = (url: string) => {
+      assignedUrls.push(url);
+    };
+  }
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    appModeNavigation.assign = realAssign;
+  });
+
+  function jsonResponse(status: number, body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  it("200 with a redirectUrl → full-page assign to the agent's /pair URL", async () => {
+    const redirectUrl = "https://agent-1.elizacloud.ai/pair?token=tok";
+    stubFetch(() => jsonResponse(200, { data: { redirectUrl } }));
+    captureAssign();
+
+    const result = await redirectToAgentWebUI("agent-1");
+
+    expect(result).toEqual({ ok: true, redirectUrl });
+    expect(assignedUrls).toEqual([redirectUrl]);
+    expect(fetchCalls).toEqual([
+      { url: "/api/v1/eliza/agents/agent-1/pairing-token", method: "POST" },
+    ]);
+  });
+
+  it("202 (agent must resume first) → starting result, no navigation", async () => {
+    stubFetch(() =>
+      jsonResponse(202, { data: { status: "starting", retryAfterMs: 5000 } }),
+    );
+    captureAssign();
+
+    const result = await redirectToAgentWebUI("agent-1");
+
+    expect(result).toEqual({ ok: false, starting: true });
+    expect(assignedUrls).toEqual([]);
+  });
+
+  it("error status → the server's error message, no navigation", async () => {
+    stubFetch(() => jsonResponse(503, { error: "agent not reachable" }));
+    captureAssign();
+
+    const result = await redirectToAgentWebUI("agent-1");
+
+    expect(result).toEqual({
+      ok: false,
+      starting: false,
+      error: "agent not reachable",
+    });
+    expect(assignedUrls).toEqual([]);
+  });
+
+  it("non-JSON error body → HTTP-status fallback message", async () => {
+    stubFetch(() => new Response("<html>bad gateway</html>", { status: 502 }));
+    captureAssign();
+
+    const result = await redirectToAgentWebUI("agent-1");
+
+    expect(result).toEqual({
+      ok: false,
+      starting: false,
+      error: "Failed to generate pairing token (HTTP 502)",
+    });
+    expect(assignedUrls).toEqual([]);
+  });
+
+  it("200 without a redirectUrl → explicit error, no navigation", async () => {
+    stubFetch(() => jsonResponse(200, { data: {} }));
+    captureAssign();
+
+    const result = await redirectToAgentWebUI("agent-1");
+
+    expect(result.ok).toBe(false);
+    if (result.ok || result.starting) throw new Error("expected error result");
+    expect(result.error).toMatch(/no redirect url/i);
+    expect(assignedUrls).toEqual([]);
+  });
+
+  it("transport failure → error result, never a throw", async () => {
+    fetchCalls = [];
+    globalThis.fetch = (() =>
+      Promise.reject(new Error("network down"))) as typeof fetch;
+    captureAssign();
+
+    const result = await redirectToAgentWebUI("agent-1");
+
+    expect(result).toEqual({
+      ok: false,
+      starting: false,
+      error: "network down",
+    });
+    expect(assignedUrls).toEqual([]);
+  });
+});

--- a/packages/ui/src/cloud/app-mode/app-mode.test.ts
+++ b/packages/ui/src/cloud/app-mode/app-mode.test.ts
@@ -146,6 +146,7 @@ describe("decideAppModeRoute — decision table", () => {
 describe("redirectToAgentWebUI — pairing redirect", () => {
   const realFetch = globalThis.fetch;
   const realAssign = appModeNavigation.assign;
+  const realReplace = appModeNavigation.replace;
   let fetchCalls: Array<{ url: string; method: string | undefined }>;
   let assignedUrls: string[];
 
@@ -159,7 +160,12 @@ describe("redirectToAgentWebUI — pairing redirect", () => {
 
   function captureAssign(): void {
     assignedUrls = [];
+    // Both seams feed one log: automatic entry replaces history, an explicit
+    // pick pushes; the distinction is asserted in its own test below.
     appModeNavigation.assign = (url: string) => {
+      assignedUrls.push(url);
+    };
+    appModeNavigation.replace = (url: string) => {
       assignedUrls.push(url);
     };
   }
@@ -167,6 +173,7 @@ describe("redirectToAgentWebUI — pairing redirect", () => {
   afterEach(() => {
     globalThis.fetch = realFetch;
     appModeNavigation.assign = realAssign;
+    appModeNavigation.replace = realReplace;
   });
 
   function jsonResponse(status: number, body: unknown): Response {
@@ -176,7 +183,7 @@ describe("redirectToAgentWebUI — pairing redirect", () => {
     });
   }
 
-  it("200 with a redirectUrl → full-page assign to the agent's /pair URL", async () => {
+  it("200 with a redirectUrl → full-page navigation to the agent's /pair URL", async () => {
     const redirectUrl = "https://agent-1.elizacloud.ai/pair?token=tok";
     stubFetch(() => jsonResponse(200, { data: { redirectUrl } }));
     captureAssign();
@@ -188,6 +195,29 @@ describe("redirectToAgentWebUI — pairing redirect", () => {
     expect(fetchCalls).toEqual([
       { url: "/api/v1/eliza/agents/agent-1/pairing-token", method: "POST" },
     ]);
+  });
+
+  it("automatic entry REPLACES history; an explicit pick pushes", async () => {
+    // The gate is a transient "connecting" screen. Left in history, Back from
+    // the agent UI re-enters it, mints another one-time pairing token, and
+    // bounces forward — trapping the user. An explicit chooser pick is a real
+    // navigation the user should be able to back out of.
+    const redirectUrl = "https://agent-1.elizacloud.ai/pair?token=tok";
+    const seen: Array<"assign" | "replace"> = [];
+    appModeNavigation.assign = () => {
+      seen.push("assign");
+    };
+    appModeNavigation.replace = () => {
+      seen.push("replace");
+    };
+
+    stubFetch(() => jsonResponse(200, { data: { redirectUrl } }));
+    await redirectToAgentWebUI("agent-1");
+    expect(seen).toEqual(["replace"]);
+
+    stubFetch(() => jsonResponse(200, { data: { redirectUrl } }));
+    await redirectToAgentWebUI("agent-1", "user-initiated");
+    expect(seen).toEqual(["replace", "assign"]);
   });
 
   it("202 (agent must resume first) → starting result, no navigation", async () => {

--- a/packages/ui/src/cloud/app-mode/app-mode.ts
+++ b/packages/ui/src/cloud/app-mode/app-mode.ts
@@ -122,6 +122,9 @@ export const appModeNavigation = {
   assign(url: string): void {
     window.location.assign(url);
   },
+  replace(url: string): void {
+    window.location.replace(url);
+  },
 };
 
 export type PairingRedirectResult =
@@ -152,6 +155,14 @@ function pairingErrorMessage(payload: unknown, status: number): string {
  */
 export async function redirectToAgentWebUI(
   agentId: string,
+  /**
+   * Automatic entry replaces the gate in history: the gate page is a
+   * transient "connecting" state, and leaving it in history traps the user
+   * (Back from the agent UI re-enters the gate, which mints another one-time
+   * pairing token and bounces forward again). An explicit chooser click is a
+   * real navigation the user should be able to back out of.
+   */
+  navigation: "automatic" | "user-initiated" = "automatic",
 ): Promise<PairingRedirectResult> {
   try {
     const { status, data } = await apiWithStatus<unknown>(
@@ -183,7 +194,11 @@ export async function redirectToAgentWebUI(
       };
     }
 
-    appModeNavigation.assign(redirectUrl);
+    if (navigation === "automatic") {
+      appModeNavigation.replace(redirectUrl);
+    } else {
+      appModeNavigation.assign(redirectUrl);
+    }
     return { ok: true, redirectUrl };
   } catch (err) {
     // error-policy:J4 network/transport failure becomes the gate's visibly

--- a/packages/ui/src/cloud/app-mode/app-mode.ts
+++ b/packages/ui/src/cloud/app-mode/app-mode.ts
@@ -1,0 +1,198 @@
+/**
+ * App-mode: hostname detection and entry-routing decisions for the Eliza app
+ * hosts (app.elizacloud.ai / app-staging.elizacloud.ai). The same packages/app
+ * bundle serves the apex console AND the app hosts; on the app hosts the entry
+ * must BECOME the product — a signed-in visitor is routed straight into their
+ * dedicated agent's own web UI via the pairing-token flow instead of landing in
+ * the generic same-origin shell.
+ *
+ * Every app-mode hostname check lives here (mirroring `../shell/apex-host.ts`
+ * for the apex set); never scatter `window.location.hostname` comparisons —
+ * import {@link isAppModeHost}. Consumed by the cloud router shell's catch-all
+ * (`AppCatchAllRoute`) and the {@link AppModeEntryRoute} gate; the apex check
+ * runs first there, so apex behavior can never be affected by this module.
+ */
+
+import type {
+  AgentExecutionTier,
+  AgentSandboxStatus,
+  IsoDateString,
+} from "@elizaos/cloud-shared/lib/types/cloud-api";
+import { apiWithStatus } from "../lib/api-client";
+
+/** Production + staging Eliza app hosts (the staging Pages deploy serves the
+ * identical bundle on `app-staging.*`, so staging must mirror prod behavior). */
+export const APP_MODE_HOSTNAMES: ReadonlySet<string> = new Set([
+  "app.elizacloud.ai",
+  "app-staging.elizacloud.ai",
+]);
+
+/** Dev-only app-mode emulation: the app hosts are never `localhost`, so the
+ * entry routing is otherwise untestable in `vite dev`. Vite inlines the env
+ * read on literal access; production builds ship without the flag. Mirrors
+ * `VITE_FORCE_APEX_CONSOLE` in `../shell/apex-host.ts`. */
+function readAppModeDevFlag(): boolean {
+  return import.meta.env?.VITE_FORCE_APP_MODE === "true";
+}
+
+/**
+ * Pure hostname decision, exposed for the test matrix. `devFlag` defaults to
+ * the Vite env escape hatch; tests inject it explicitly.
+ */
+export function isAppModeHostname(
+  hostname: string,
+  devFlag: boolean = readAppModeDevFlag(),
+): boolean {
+  if (devFlag) return true;
+  return APP_MODE_HOSTNAMES.has(hostname.toLowerCase());
+}
+
+/** True when the current document is served in app-mode. No-DOM (SSR /
+ * prerender / native) → false, so server and native builds never branch. */
+export function isAppModeHost(): boolean {
+  if (typeof window === "undefined") return false;
+  return isAppModeHostname(window.location.hostname);
+}
+
+/** Minimal structural slice of `AgentListItemDto` the routing decision needs
+ * (assignable from the full DTO; test fixtures stay small). */
+export interface AppModeAgent {
+  id: string;
+  agentName: string | null;
+  status: AgentSandboxStatus;
+  executionTier: AgentExecutionTier;
+  lastHeartbeatAt: IsoDateString | null;
+  updatedAt: IsoDateString;
+}
+
+/** Where the instances console lives — the resume / manage surface. A
+ * registered cloud route, reachable on every host. */
+export const APP_MODE_INSTANCES_PATH = "/dashboard/agents";
+/** The deploy-first-agent flow: `/join` select-or-provisions a Cloud agent and
+ * drops the user straight into chat. */
+export const APP_MODE_CREATE_PATH = "/join";
+
+export type AppModeRoute =
+  /** Exactly one running dedicated agent — straight into its web UI via pairing. */
+  | { kind: "enter-agent"; agent: AppModeAgent }
+  /** Several running dedicated agents — minimal chooser, most recent first. */
+  | { kind: "choose-agent"; running: AppModeAgent[] }
+  /** Dedicated agents exist but none running — Instances, resume from there. */
+  | { kind: "resume"; to: string }
+  /** No agents at all — the `/join` deploy-first-agent flow. */
+  | { kind: "create"; to: string }
+  /** Only shared-tier agents (no per-agent web UI to pair into) — the existing
+   * same-origin chat app stays their home, exactly as before app-mode. */
+  | { kind: "chat-home" };
+
+function activityStamp(agent: AppModeAgent): number {
+  const stamp = Date.parse(agent.lastHeartbeatAt ?? agent.updatedAt);
+  return Number.isNaN(stamp) ? 0 : stamp;
+}
+
+/**
+ * Given the org's agents (GET /api/v1/eliza/agents), decide where app-mode
+ * entry lands. Only dedicated-capable tiers (everything but `"shared"`) are
+ * pairing candidates: shared-tier agents serve chat through the control-plane
+ * REST adapter and have no per-agent subdomain to redirect into, so a
+ * shared-only org keeps the same-origin chat app ({@link AppModeRoute}
+ * `chat-home`) instead of a pairing call that cannot succeed.
+ */
+export function decideAppModeRoute(
+  agents: readonly AppModeAgent[],
+): AppModeRoute {
+  const dedicated = agents.filter((a) => a.executionTier !== "shared");
+  const running = dedicated
+    .filter((a) => a.status === "running")
+    .sort((a, b) => activityStamp(b) - activityStamp(a));
+
+  if (running.length === 1) return { kind: "enter-agent", agent: running[0] };
+  if (running.length > 1) return { kind: "choose-agent", running };
+  if (dedicated.length > 0)
+    return { kind: "resume", to: APP_MODE_INSTANCES_PATH };
+  if (agents.length > 0) return { kind: "chat-home" };
+  return { kind: "create", to: APP_MODE_CREATE_PATH };
+}
+
+/**
+ * Indirection over `window.location.assign` so tests can observe the redirect
+ * (jsdom forbids stubbing `location.assign` directly).
+ */
+export const appModeNavigation = {
+  assign(url: string): void {
+    window.location.assign(url);
+  },
+};
+
+export type PairingRedirectResult =
+  | { ok: true; redirectUrl: string }
+  /** 202 — the agent must resume first; the server has queued the wake. */
+  | { ok: false; starting: true }
+  | { ok: false; starting: false; error: string };
+
+function pairingErrorMessage(payload: unknown, status: number): string {
+  if (typeof payload === "object" && payload !== null) {
+    const body = payload as { error?: unknown; message?: unknown };
+    if (typeof body.error === "string" && body.error) return body.error;
+    if (typeof body.message === "string" && body.message) return body.message;
+  }
+  return `Failed to generate pairing token (HTTP ${status})`;
+}
+
+/**
+ * Send the user INTO a dedicated agent's web UI with a FULL-PAGE redirect.
+ *
+ * Same pairing-token endpoint as `openWebUIWithPairing`
+ * (`../instances/lib/open-web-ui.ts`) but via `window.location.assign` instead
+ * of a popup: automatic entry runs outside a click handler, where popups are
+ * blocked and full-page navigation is not. Rides {@link apiWithStatus} — the
+ * canonical status-branching transport for endpoints whose HTTP status IS the
+ * protocol (202 = "agent must resume first") — so auth (steward cookie +
+ * Bearer) matches every other cloud call.
+ */
+export async function redirectToAgentWebUI(
+  agentId: string,
+): Promise<PairingRedirectResult> {
+  try {
+    const { status, data } = await apiWithStatus<unknown>(
+      `/api/v1/eliza/agents/${encodeURIComponent(agentId)}/pairing-token`,
+      { method: "POST" },
+    );
+
+    if (status === 202) {
+      return { ok: false, starting: true };
+    }
+
+    if (status < 200 || status >= 300) {
+      return {
+        ok: false,
+        starting: false,
+        error: pairingErrorMessage(data, status),
+      };
+    }
+
+    const redirectUrl =
+      typeof data === "object" && data !== null
+        ? (data as { data?: { redirectUrl?: unknown } }).data?.redirectUrl
+        : undefined;
+    if (typeof redirectUrl !== "string" || !redirectUrl) {
+      return {
+        ok: false,
+        starting: false,
+        error: "No redirect URL returned from the pairing endpoint",
+      };
+    }
+
+    appModeNavigation.assign(redirectUrl);
+    return { ok: true, redirectUrl };
+  } catch (err) {
+    // error-policy:J4 network/transport failure becomes the gate's visibly
+    // distinct "connection failed" state with an escape to Instances — the
+    // entry must degrade to a navigable screen, never rethrow into a blank one.
+    return {
+      ok: false,
+      starting: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/ui/src/cloud/app-mode/app-mode.ts
+++ b/packages/ui/src/cloud/app-mode/app-mode.ts
@@ -29,7 +29,9 @@ export const APP_MODE_HOSTNAMES: ReadonlySet<string> = new Set([
 
 /** Dev-only app-mode emulation: the app hosts are never `localhost`, so the
  * entry routing is otherwise untestable in `vite dev`. Vite inlines the env
- * read on literal access; production builds ship without the flag. Mirrors
+ * read on literal access, and production-mode packages/app builds REFUSE to
+ * bake the flag (`packages/app/scripts/forced-host-mode-guard.mjs` throws at
+ * build time), so it can never reach a deployed bundle. Mirrors
  * `VITE_FORCE_APEX_CONSOLE` in `../shell/apex-host.ts`. */
 function readAppModeDevFlag(): boolean {
   return import.meta.env?.VITE_FORCE_APP_MODE === "true";

--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -1,9 +1,11 @@
-/** Verifies CloudRouterShell apex catch-all through the package's configured test harness. */
+/** Verifies the CloudRouterShell catch-all host matrix — apex console redirects (with zero network), app-mode gating on the Eliza app hosts, and untouched fall-through everywhere else — through the package's configured test harness. */
 // @vitest-environment jsdom
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
-import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
+import { appModeNavigation } from "../app-mode/app-mode";
 import { AppCatchAllRoute, DASHBOARD_REDIRECTS } from "./CloudRouterShell";
 
 /**
@@ -62,6 +64,67 @@ function renderCatchAll(initialPath = "/"): void {
       </Routes>
     </MemoryRouter>,
   );
+}
+
+/** Same catch-all render, plus the query provider + route markers the lazy
+ * app-mode gate needs. Used by the app-host tests; the apex tests keep the
+ * bare render above, proving the apex path needs none of this. */
+function renderCatchAllWithAppModeMarkers(initialPath = "/"): void {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/login" element={<div data-testid="login-page" />} />
+          <Route
+            path="/dashboard"
+            element={<div data-testid="console-home" />}
+          />
+          <Route
+            path="/dashboard/agents"
+            element={<div data-testid="instances-page" />}
+          />
+          <Route path="/join" element={<div data-testid="join-page" />} />
+          <Route
+            path="*"
+            element={
+              <AppCatchAllRoute appElement={<div data-testid="agent-app" />} />
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const realFetch = globalThis.fetch;
+let fetchLog: string[] = [];
+
+/** Hand-rolled fetch recorder: logs `METHOD url` for every call and answers
+ * with `respond` (defaulting to an empty agents list). */
+function installFetchRecorder(
+  respond?: (url: string, init?: RequestInit) => Response,
+): void {
+  fetchLog = [];
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    fetchLog.push(`${init?.method ?? "GET"} ${url}`);
+    return Promise.resolve(
+      respond
+        ? respond(url, init)
+        : new Response(JSON.stringify({ success: true, data: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+    );
+  }) as typeof fetch;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("CloudRouterShell apex catch-all", () => {
@@ -141,6 +204,126 @@ describe("CloudRouterShell apex catch-all", () => {
     renderCatchAll();
     expect(screen.getByTestId("agent-app")).toBeTruthy();
     expect(screen.queryByTestId("login-page")).toBeNull();
+  });
+});
+
+describe("CloudRouterShell apex catch-all — zero app-mode network", () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    globalThis.fetch = realFetch;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: realLocation,
+    });
+  });
+
+  it("an unauthenticated apex render performs ZERO fetches (byte-identical apex)", async () => {
+    setHostname("elizacloud.ai");
+    installFetchRecorder();
+    renderCatchAll();
+    expect(screen.getByTestId("login-page")).toBeTruthy();
+    await flushMicrotasks();
+    expect(fetchLog).toEqual([]);
+  });
+
+  it("an authenticated apex render performs ZERO fetches (no agents probe, no pairing)", async () => {
+    setHostname("elizacloud.ai");
+    installFetchRecorder();
+    localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken(FUTURE_EXP));
+    renderCatchAll();
+    expect(screen.getByTestId("console-home")).toBeTruthy();
+    await flushMicrotasks();
+    expect(fetchLog).toEqual([]);
+  });
+});
+
+describe("CloudRouterShell app-mode catch-all (app.elizacloud.ai)", () => {
+  const realAssign = appModeNavigation.assign;
+  let assignedUrls: string[] = [];
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    globalThis.fetch = realFetch;
+    appModeNavigation.assign = realAssign;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: realLocation,
+    });
+  });
+
+  it("sends an unauthenticated app-host visitor through the login flow, not the agent app", async () => {
+    setHostname("app.elizacloud.ai");
+    installFetchRecorder();
+    renderCatchAllWithAppModeMarkers();
+    // The gate chunk is lazy; the login redirect lands after it loads.
+    expect(await screen.findByTestId("login-page")).toBeTruthy();
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+    expect(fetchLog).toEqual([]);
+  });
+
+  it("gates every non-registered (marketing/app) path on the app host, not just the root", async () => {
+    setHostname("app.elizacloud.ai");
+    installFetchRecorder();
+    renderCatchAllWithAppModeMarkers("/some/marketing-path");
+    expect(await screen.findByTestId("login-page")).toBeTruthy();
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+  });
+
+  it("routes a signed-in app-host visitor with one running dedicated agent into its web UI via pairing", async () => {
+    setHostname("app.elizacloud.ai");
+    const redirectUrl = "https://agent-1.elizacloud.ai/pair?token=tok";
+    installFetchRecorder((url, init) => {
+      if (url === "/api/v1/eliza/agents/agent-1/pairing-token") {
+        return new Response(JSON.stringify({ data: { redirectUrl } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "/api/v1/eliza/agents" && (init?.method ?? "GET") === "GET") {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: [
+              {
+                id: "agent-1",
+                agentName: "Eliza",
+                status: "running",
+                executionTier: "dedicated-always",
+                lastHeartbeatAt: "2026-08-05T00:00:00.000Z",
+                updatedAt: "2026-08-05T00:00:00.000Z",
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ error: `unstubbed ${url}` }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    assignedUrls = [];
+    appModeNavigation.assign = (url: string) => {
+      assignedUrls.push(url);
+    };
+    localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken(FUTURE_EXP));
+    renderCatchAllWithAppModeMarkers();
+
+    await waitFor(() => expect(assignedUrls).toEqual([redirectUrl]));
+    expect(fetchLog).toContain(
+      "POST /api/v1/eliza/agents/agent-1/pairing-token",
+    );
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+  });
+
+  it("app-staging.elizacloud.ai is an app-mode host too (staging mirrors prod)", async () => {
+    setHostname("app-staging.elizacloud.ai");
+    installFetchRecorder();
+    renderCatchAllWithAppModeMarkers();
+    expect(await screen.findByTestId("login-page")).toBeTruthy();
+    expect(screen.queryByTestId("agent-app")).toBeNull();
   });
 });
 

--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -240,6 +240,7 @@ describe("CloudRouterShell apex catch-all — zero app-mode network", () => {
 
 describe("CloudRouterShell app-mode catch-all (app.elizacloud.ai)", () => {
   const realAssign = appModeNavigation.assign;
+  const realReplace = appModeNavigation.replace;
   let assignedUrls: string[] = [];
 
   afterEach(() => {
@@ -247,6 +248,7 @@ describe("CloudRouterShell app-mode catch-all (app.elizacloud.ai)", () => {
     localStorage.clear();
     globalThis.fetch = realFetch;
     appModeNavigation.assign = realAssign;
+    appModeNavigation.replace = realReplace;
     Object.defineProperty(window, "location", {
       configurable: true,
       value: realLocation,
@@ -305,7 +307,12 @@ describe("CloudRouterShell app-mode catch-all (app.elizacloud.ai)", () => {
       });
     });
     assignedUrls = [];
+    // Both seams feed one log: automatic entry replaces history, an explicit
+    // chooser pick pushes; the split itself is pinned in app-mode.test.ts.
     appModeNavigation.assign = (url: string) => {
+      assignedUrls.push(url);
+    };
+    appModeNavigation.replace = (url: string) => {
       assignedUrls.push(url);
     };
     localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken(FUTURE_EXP));

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -20,7 +20,7 @@
  */
 
 import { QueryClientProvider } from "@tanstack/react-query";
-import { type ComponentType, type ReactNode, Suspense } from "react";
+import { type ComponentType, lazy, type ReactNode, Suspense } from "react";
 import {
   BrowserRouter,
   Navigate,
@@ -29,6 +29,7 @@ import {
   useLocation,
   useParams,
 } from "react-router-dom";
+import { isAppModeHost } from "../app-mode/app-mode";
 import { queryClient } from "../lib/query-client";
 import { useSessionAuth } from "../lib/use-session-auth";
 import { isApexControlPlaneHost } from "./apex-host";
@@ -276,8 +277,15 @@ const APEX_AUTHENTICATED_HOME = "/dashboard";
  *    the app while auth resolves lets its tab system rewrite the URL and
  *    strand the visitor before the redirect can fire.
  *
- * Every non-apex host (per-agent subdomains, app.elizacloud.ai, localhost) is
- * untouched: chat stays home.
+ * On the Eliza APP hosts (app.elizacloud.ai / app-staging — checked AFTER the
+ * apex branch, so apex behavior is untouched) the catch-all renders the
+ * app-mode entry gate instead: signed-in visitors are routed into their
+ * dedicated agent via the pairing flow (see `../app-mode/AppModeEntryRoute`),
+ * and only its `chat-home` decision falls through to the agent app. The gate
+ * chunk is lazy so no app-mode code loads on any other host.
+ *
+ * Every other host (per-agent subdomains, localhost) is untouched: chat stays
+ * home.
  */
 export function AppCatchAllRoute({
   appElement,
@@ -298,8 +306,19 @@ export function AppCatchAllRoute({
     }
     return <Navigate to={APEX_AUTHENTICATED_HOME} replace />;
   }
+  if (isAppModeHost()) {
+    return (
+      <Suspense fallback={<RouteChunkFallback />}>
+        <AppModeEntryRoute appElement={appElement} />
+      </Suspense>
+    );
+  }
   return <>{appElement}</>;
 }
+
+/** App-mode entry gate, loaded only on the Eliza app hosts (see
+ * {@link AppCatchAllRoute}); apex + per-agent hosts never fetch this chunk. */
+const AppModeEntryRoute = lazy(() => import("../app-mode/AppModeEntryRoute"));
 
 /**
  * The shell. Mounts the registered cloud routes + the `/dashboard/*` compat

--- a/packages/ui/src/cloud/shell/apex-host.ts
+++ b/packages/ui/src/cloud/shell/apex-host.ts
@@ -24,7 +24,8 @@ export function isApexControlPlaneHost(): boolean {
   // Dev-only apex emulation: localhost is never a control-plane host, so the
   // console's apex behavior (root → /dashboard, unauth → /login, agent app
   // never boots) is otherwise untestable in `vite dev`. Vite inlines the env
-  // read on literal access; production builds ship without the flag.
+  // read on literal access, and production-mode packages/app builds refuse to
+  // bake the flag (packages/app/scripts/forced-host-mode-guard.mjs).
   if (import.meta.env?.VITE_FORCE_APEX_CONSOLE === "true") return true;
   return APEX_UI_CONTROL_PLANE_HOSTS.has(
     window.location.hostname.toLowerCase(),


### PR DESCRIPTION
## What

`app.elizacloud.ai` served the marketing site byte-for-byte — nothing in the codebase branched on the hostname, so the "app" domain was only a second name on the apex build. This adds **app-mode**: on the app hosts, an authenticated visitor lands in *their* dedicated agent instead of the marketing page.

Routing (all gated on the app hostname; the apex is untouched):

| State | Behavior |
|---|---|
| one running dedicated agent | full-page redirect into its web UI via the existing pairing-token flow |
| several running | minimal chooser, most-recently-active first |
| agents exist, none running | Instances view with a resume affordance |
| no agents | the existing "deploy your first agent" flow |
| shared-tier agents only | `chat-home` - shared agents have no per-agent subdomain to pair into, so a pairing call could not succeed |
| not signed in | the existing login flow, returning to the app entry |
| agents fetch fails | falls back to Instances — never a blank screen |

Automatic entry uses `location.replace`, not `assign`: the gate is a transient "connecting" screen, and leaving it in history let Back from the agent UI re-enter it, mint another one-time pairing token, and bounce forward — trapping the user on Firefox/Safari. An explicit chooser pick still pushes so it stays backable.

## Why

The dashboard (funds, instance management) already works end to end. The missing half of the product was the app surface actually *being* the app.

## Scope

6 files under `packages/ui/src/cloud`, +1135/-5. No codegen, no lockfile churn, no API changes — the pairing/auth contracts already existed and are reused as-is.

## Repair after review (`4e73f8dc7cc`)

- **Flag-overrides-apex is now a pinned, recorded decision**: `app-mode.test.ts` asserts `isAppModeHostname("elizacloud.ai", true) === true` with a comment pointing at the build guard as the real invariant.
- **Production builds hard-fail if a forced host-mode flag is set**: new `packages/app/scripts/forced-host-mode-guard.mjs` wired as a vite plugin - any production-mode build (all four Pages `build:web` invocations in `cloud-cf-deploy.yml`, prod and staging, console and app) throws at `configResolved` when `VITE_FORCE_APP_MODE` or `VITE_FORCE_APEX_CONSOLE` is set (loadEnv-aware, so `.env` files are covered). Dev server and `--mode development` keep the escape hatch. A misconfigured deploy now fails loudly at build time instead of silently turning the apex into a redirect gate.
- **Fixed a latent test break on the reviewed head**: the replace-instead-of-push commit stubbed only `assign`, so jsdom's unimplemented `location.replace` failed both automatic-entry pairing tests; both stubs now land in the same log, and the replace/push split is itself pinned in `app-mode.test.ts`.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:4e73f8dc7cc7611cef85780052889ad430180dc7 -->

<!-- evidence-row:before-screenshots -->
- [x] Before - the current production app host, captured live: desktop ![before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-before-desktop.png) and mobile ![before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-before-mobile.png) - the host serves the generic chat/sign-in shell with no app-mode routing.

<!-- evidence-row:after-screenshots -->
- [x] After - component renders from this head (states stubbed): chooser desktop ![chooser desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-after-chooser-desktop.png), chooser mobile ![chooser mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-after-chooser-mobile.png), connecting ![connecting](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-after-connecting-desktop.png) / mobile ![connecting mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-after-connecting-mobile.png), error-fallback ![error](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-after-error-desktop.png) / mobile ![error mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-after-error-mobile.png), loading ![loading](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-after-loading-desktop.png), resume-instances ![resume](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-after-resume-instances-desktop.png).

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough - scripted app-host entry -> connecting -> chooser -> agent pick (stubbed redirect): https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] N/A - frontend-only routing change; no server code path is touched by this diff.

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs - the apex-unchanged proof and the build-guard proof, both deterministic.

<details><summary>Fetch-recorder and build-guard output</summary>

```text
$ bunx vitest run src/cloud/app-mode src/cloud/shell   (packages/ui)
  Test Files  12 passed (12)
       Tests  108 passed (108)
  includes: real fetch recorder asserting fetchLog === [] for authed and
  unauthed apex renders (the apex performs zero app-mode calls), and the
  flag-overrides-apex pin

$ VITE_FORCE_APP_MODE=true bun run --cwd packages/app build:web
  error: VITE_FORCE_APP_MODE must not be set in a production-mode build
  (exit 1, thrown at configResolved before bundling)

$ VITE_FORCE_APEX_CONSOLE=true bun run --cwd packages/app build:web
  (same guard, exit 1)

$ VITE_FORCE_APP_MODE=true bunx vite build --mode development
  guard silent, build proceeds (escape hatch preserved for dev)
```

</details>

<!-- evidence-row:llm-trajectory -->
- [x] N/A - client-side routing and auth-gate logic, no model inference participates in this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - guard unit suite and typecheck at the current head.

<details><summary>packages/app guard suite + typecheck</summary>

```text
$ bun test scripts/forced-host-mode-guard.test.mjs   (packages/app)
  6 pass / 0 fail

$ bun run --cwd packages/ui typecheck
  exit 0

$ bunx biome check   (8 touched files)
  clean, no fixes
```

</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review - [tesseract 5.3.4 text readout of every attached capture](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17752-ocr-review.txt), reviewed against the intended copy of each state (before sign-in shell, PICK YOUR AGENT chooser, connecting, error-fallback, loading, resume-instances).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
