### PR TITLE
fix(core): detach early-exit RUN_ENDED from the message return path

### DIFF
--- a/packages/core/src/services/message.mute-drop.test.ts
+++ b/packages/core/src/services/message.mute-drop.test.ts
@@ -13,6 +13,7 @@ import type { Room, World } from "../types/environment";
 import { EventType } from "../types/events";
 import type { IAgentRuntime, Memory, UUID } from "../types/index";
 import { DefaultMessageService } from "./message";
+import { drainPostDeliveryTasks } from "./post-delivery-task-tracker.ts";
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
 const USER_ID = "00000000-0000-0000-0000-0000000000c1" as UUID;
@@ -100,7 +101,12 @@ function room(extra?: Partial<Room>): Room {
 	} as Room;
 }
 
-function runEndedStatuses(emitEvent: ReturnType<typeof vi.fn>): string[] {
+async function runEndedStatuses(
+	runtime: IAgentRuntime,
+	emitEvent: ReturnType<typeof vi.fn>,
+): Promise<string[]> {
+	// RUN_ENDED is detached onto the post-delivery tracker; drain before assert.
+	await drainPostDeliveryTasks(runtime);
 	return emitEvent.mock.calls
 		.filter(([event]) => event === EventType.RUN_ENDED)
 		.map(([, payload]) => (payload as { status: string }).status);
@@ -118,7 +124,7 @@ describe("DefaultMessageService — muted room drops even a direct mention", () 
 		expect(result.didRespond).toBe(false);
 		expect(result.mode).toBe("none");
 		expect(useModel).not.toHaveBeenCalled();
-		expect(runEndedStatuses(emitEvent)).toContain("muted");
+		expect(await runEndedStatuses(runtime, emitEvent)).toContain("muted");
 	});
 
 	it("server-level mute: a mention in an unmuted room of a muted guild drops too", async () => {
@@ -137,7 +143,7 @@ describe("DefaultMessageService — muted room drops even a direct mention", () 
 		const result = await service.handleMessage(runtime, mentionMessage());
 		expect(result.didRespond).toBe(false);
 		expect(useModel).not.toHaveBeenCalled();
-		expect(runEndedStatuses(emitEvent)).toContain("muted");
+		expect(await runEndedStatuses(runtime, emitEvent)).toContain("muted");
 	});
 
 	it("expired timed mute: auto-unmutes at the ISO time and the turn proceeds past the gate", async () => {
@@ -153,7 +159,7 @@ describe("DefaultMessageService — muted room drops even a direct mention", () 
 		// the turn NOT ending with status "muted" (it fails deeper instead).
 		await service.handleMessage(runtime, mentionMessage()).catch(() => {});
 		expect(states.get(`${ROOM_ID}:${AGENT_ID}`)).toBeNull();
-		expect(runEndedStatuses(emitEvent)).not.toContain("muted");
+		expect(await runEndedStatuses(runtime, emitEvent)).not.toContain("muted");
 	});
 
 	it("unmuted room: the same mention proceeds past the mute gate", async () => {
@@ -163,6 +169,6 @@ describe("DefaultMessageService — muted room drops even a direct mention", () 
 		});
 		const service = new DefaultMessageService();
 		await service.handleMessage(runtime, mentionMessage()).catch(() => {});
-		expect(runEndedStatuses(emitEvent)).not.toContain("muted");
+		expect(await runEndedStatuses(runtime, emitEvent)).not.toContain("muted");
 	});
 });

--- a/packages/core/src/services/message.run-ended-detach.test.ts
+++ b/packages/core/src/services/message.run-ended-detach.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Residual #17072: early-exit RUN_ENDED must not block handleMessage return.
+ * A slow lifecycle observer on RUN_ENDED used to sit on the await path for
+ * self/mute/off exits; it now rides the post-delivery tracker so the caller
+ * returns immediately and shutdown can still drain the work.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { TurnControllerRegistry } from "../runtime/turn-controller";
+import { EventType } from "../types/events";
+import type { IAgentRuntime, Memory, UUID } from "../types/index";
+import { DefaultMessageService } from "./message";
+import {
+	drainPostDeliveryTasks,
+	pendingPostDeliveryTaskCount,
+} from "./post-delivery-task-tracker.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
+const RUN_ID = "00000000-0000-0000-0000-0000000000f1" as UUID;
+
+describe("DefaultMessageService — RUN_ENDED post-delivery detach", () => {
+	it("returns from a self-message exit before a slow RUN_ENDED handler finishes", async () => {
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		let runEndedStarted = false;
+		let runEndedFinished = false;
+		const emitEvent = vi.fn(async (event: string) => {
+			if (event === EventType.RUN_ENDED) {
+				runEndedStarted = true;
+				await gate;
+				runEndedFinished = true;
+			}
+		});
+		const runtime = {
+			agentId: AGENT_ID,
+			character: { name: "Eliza", username: "eliza" },
+			logger: {
+				debug: () => {},
+				info: () => {},
+				warn: () => {},
+				error: () => {},
+			},
+			stateCache: new Map(),
+			turnControllers: new TurnControllerRegistry(),
+			emitEvent,
+			reportError: vi.fn(),
+			useModel: vi.fn(async () => {
+				throw new Error("useModel must not run on self-message exit");
+			}),
+			getService: () => null,
+			getSetting: () => undefined,
+			startRun: () => RUN_ID,
+			runActionsByMode: async () => undefined,
+			getMemoryById: async () => null,
+			createMemory: async (memory: Memory) => memory.id,
+			queueEmbeddingGeneration: async () => undefined,
+			getParticipantUserState: async () => null,
+			getRoom: async () => null,
+			getWorld: async () => null,
+		} as unknown as IAgentRuntime;
+
+		const selfMessage = {
+			id: "00000000-0000-0000-0000-0000000000b1" as UUID,
+			entityId: AGENT_ID, // same as agent → self skip
+			agentId: AGENT_ID,
+			roomId: "00000000-0000-0000-0000-0000000000d1" as UUID,
+			content: { text: "loopback", source: "test" },
+		} as unknown as Memory;
+
+		const service = new DefaultMessageService();
+		const started = Date.now();
+		const result = await service.handleMessage(runtime, selfMessage);
+		const elapsedMs = Date.now() - started;
+
+		expect(result.didRespond).toBe(false);
+		expect(result.mode).toBe("none");
+		// Must not have waited on the gated RUN_ENDED handler.
+		expect(elapsedMs).toBeLessThan(200);
+		expect(runEndedStarted).toBe(true);
+		expect(runEndedFinished).toBe(false);
+		expect(pendingPostDeliveryTaskCount(runtime)).toBeGreaterThan(0);
+
+		release();
+		await drainPostDeliveryTasks(runtime);
+		expect(runEndedFinished).toBe(true);
+		expect(pendingPostDeliveryTaskCount(runtime)).toBe(0);
+		const ended = emitEvent.mock.calls
+			.filter(([event]) => event === EventType.RUN_ENDED)
+			.map(([, payload]) => (payload as { status: string }).status);
+		expect(ended).toContain("self");
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -11961,13 +11961,7 @@ export class DefaultMessageService implements IMessageService {
 					// Mirror the ignore-path sibling below: a superseded turn ends
 					// its run as "replaced" so the discard is an observable terminal
 					// outcome instead of an unrecorded nothing.
-					await this.emitRunEnded(
-						runtime,
-						runId,
-						message,
-						startTime,
-						"replaced",
-					);
+					this.emitRunEnded(runtime, runId, message, startTime, "replaced");
 					return {
 						didRespond: false,
 						responseContent: null,
@@ -13246,7 +13240,7 @@ export class DefaultMessageService implements IMessageService {
 		runId: UUID,
 		message: Memory,
 		startTime: number,
-		status: string,
+		status: RunEventPayload["status"],
 	): void {
 		detachPostDeliverySideEffect(runtime, "RUN_ENDED", () =>
 			runtime.emitEvent(EventType.RUN_ENDED, {
@@ -13257,7 +13251,7 @@ export class DefaultMessageService implements IMessageService {
 				roomId: message.roomId,
 				entityId: message.entityId,
 				startTime,
-				status: status as "completed" | "timeout",
+				status,
 				endTime: Date.now(),
 				duration: Date.now() - startTime,
 			} as RunEventPayload),

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -11118,7 +11118,7 @@ export class DefaultMessageService implements IMessageService {
 				{ src: "service:message", agentId: runtime.agentId },
 				"Skipping message from self",
 			);
-			await this.emitRunEnded(runtime, runId, message, startTime, "self");
+			this.emitRunEnded(runtime, runId, message, startTime, "self");
 			return {
 				didRespond: false,
 				responseContent: null,
@@ -11193,7 +11193,7 @@ export class DefaultMessageService implements IMessageService {
 
 		if (defLllmOff && agentUserState === null) {
 			runtime.logger.debug({ src: "service:message" }, "LLM is off by default");
-			await this.emitRunEnded(runtime, runId, message, startTime, "off");
+			this.emitRunEnded(runtime, runId, message, startTime, "off");
 			return {
 				didRespond: false,
 				responseContent: null,
@@ -11236,7 +11236,7 @@ export class DefaultMessageService implements IMessageService {
 				},
 				"Ignoring muted room",
 			);
-			await this.emitRunEnded(runtime, runId, message, startTime, "muted");
+			this.emitRunEnded(runtime, runId, message, startTime, "muted");
 			return {
 				didRespond: false,
 				responseContent: null,
@@ -11271,7 +11271,7 @@ export class DefaultMessageService implements IMessageService {
 					},
 					"Reply suppressed by personality reply_gate",
 				);
-				await this.emitRunEnded(
+				this.emitRunEnded(
 					runtime,
 					runId,
 					message,
@@ -11312,13 +11312,7 @@ export class DefaultMessageService implements IMessageService {
 				},
 				"Unaddressed bot/webhook message ignored by small-model triage (skipped Stage 1)",
 			);
-			await this.emitRunEnded(
-				runtime,
-				runId,
-				message,
-				startTime,
-				"bot_noise_triage",
-			);
+			this.emitRunEnded(runtime, runId, message, startTime, "bot_noise_triage");
 			return {
 				didRespond: false,
 				responseContent: null,
@@ -12223,7 +12217,7 @@ export class DefaultMessageService implements IMessageService {
 					},
 					"Ignore response discarded - newer message being processed",
 				);
-				await this.emitRunEnded(runtime, runId, message, startTime, "replaced");
+				this.emitRunEnded(runtime, runId, message, startTime, "replaced");
 				return {
 					didRespond: false,
 					responseContent: null,
@@ -12238,13 +12232,7 @@ export class DefaultMessageService implements IMessageService {
 					{ src: "service:message", agentId: runtime.agentId },
 					"Message ID is missing, cannot create ignore response",
 				);
-				await this.emitRunEnded(
-					runtime,
-					runId,
-					message,
-					startTime,
-					"noMessageId",
-				);
+				this.emitRunEnded(runtime, runId, message, startTime, "noMessageId");
 				return {
 					didRespond: false,
 					responseContent: null,
@@ -13248,27 +13236,32 @@ export class DefaultMessageService implements IMessageService {
 	}
 
 	/**
-	 * Helper to emit run ended events
+	 * Emit RUN_ENDED after the handler return path is free. Lifecycle observers
+	 * and persistence attached to RUN_ENDED must not delay early-exit replies
+	 * (self/mute/off/replaced/…); failures stay observable through the
+	 * post-delivery tracker (residual #17072).
 	 */
-	private async emitRunEnded(
+	private emitRunEnded(
 		runtime: IAgentRuntime,
 		runId: UUID,
 		message: Memory,
 		startTime: number,
 		status: string,
-	): Promise<void> {
-		await runtime.emitEvent(EventType.RUN_ENDED, {
-			runtime,
-			source: "messageHandler",
-			runId,
-			messageId: message.id,
-			roomId: message.roomId,
-			entityId: message.entityId,
-			startTime,
-			status: status as "completed" | "timeout",
-			endTime: Date.now(),
-			duration: Date.now() - startTime,
-		} as RunEventPayload);
+	): void {
+		detachPostDeliverySideEffect(runtime, "RUN_ENDED", () =>
+			runtime.emitEvent(EventType.RUN_ENDED, {
+				runtime,
+				source: "messageHandler",
+				runId,
+				messageId: message.id,
+				roomId: message.roomId,
+				entityId: message.entityId,
+				startTime,
+				status: status as "completed" | "timeout",
+				endTime: Date.now(),
+				duration: Date.now() - startTime,
+			} as RunEventPayload),
+		);
 	}
 
 	private async emitMessageSent(

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -220,13 +220,26 @@ export interface InvokePayload extends EventPayload {
 /**
  * Run event payload type
  */
+export type RunEventStatus =
+	| "started"
+	| "completed"
+	| "timeout"
+	| "error"
+	| "self"
+	| "off"
+	| "muted"
+	| "personality_gate"
+	| "bot_noise_triage"
+	| "replaced"
+	| "noMessageId";
+
 export interface RunEventPayload extends EventPayload {
 	runId: UUID;
 	messageId: UUID;
 	roomId: UUID;
 	entityId: UUID;
 	startTime: number | bigint;
-	status: "started" | "completed" | "timeout";
+	status: RunEventStatus;
 	endTime?: number | bigint;
 	duration?: number | bigint;
 	error?: string | Error;


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: grok, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@1e3dec2d06f15ca71f1966eed158ac8e3d711c4b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: self-reported

# Relates to

Residual slice of #17072 (does not reimplement #17077).

- [x] Targets `develop`, branched from current `origin/develop`.
- [x] Focused tests green: `message.run-ended-detach` + `message.mute-drop` (5/5).
- [x] A reviewer can confirm the fix from the new test without reading the implementation.

# Sync with develop

- [x] Branched from current `origin/develop`; zero conflicts.
- [x] Focused package tests pass on the final head.

# Risks

Low. Only changes when `RUN_ENDED` is awaited on early-exit paths (self/mute/off/personality_gate/bot_noise_triage/replaced/noMessageId). Failures remain observable via `trackPostDeliveryTask` → `runtime.reportError`. Shutdown already drains post-delivery work.

# Background

## What does this PR do?

#17077 already detached happy-path `RUN_ENDED` via `detachPostDeliverySideEffect`. Early exits still used `await this.emitRunEnded(...)`, so a slow lifecycle observer could block `handleMessage` after the handler had already decided not to respond.

This routes those early exits through the same post-delivery detach helper and adds a regression test that proves return latency is independent of a gated `RUN_ENDED` handler.

## What kind of change is this?

Bug fix / residual performance correctness (non-breaking).

## Deliberately not claimed

- Live Cerebras rolling-history cache-hit telemetry (needs credentials / shared lever).
- Prompt-prefix stability work already covered by `cache-key-stability` tests and later cache work on develop.
- Reimplementation of any #17077 completed item.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/core/src/services/message.run-ended-detach.test.ts`

## Detailed testing steps

```bash
bun test packages/core/src/services/message.run-ended-detach.test.ts packages/core/src/services/message.mute-drop.test.ts
```

Expected: 5 pass / 0 fail.

# Evidence Gate

<!-- evidence-head:3423811cdff913b0283c3ffcad72934d36561d92 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - core message-service lifecycle path; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - core message-service lifecycle path; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; observable artifact is handler return timing vs RUN_ENDED completion.
<!-- evidence-row:backend-logs -->
- [x] Focused test transcript:

<details><summary>bun test (verbatim)</summary>

```
bun test packages/core/src/services/message.run-ended-detach.test.ts packages/core/src/services/message.mute-drop.test.ts
 5 pass
 0 fail
 19 expect() calls
Ran 5 tests across 2 files.
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface in this change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt/provider behavior change; early-exit paths never call the model.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/wallet/device artifact; domain proof is RUN_ENDED status plus post-delivery drain assertions in packages/core/src/services/message.run-ended-detach.test.ts (see backend-logs).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

---

AI provider/model: xai / grok-4.5
Client / agent tooling: pi
Contribution skill revision: elizaOS/eliza@1e3dec2d06f15ca71f1966eed158ac8e3d711c4b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pi/wtfsayo]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"pi","skill_revision":"elizaOS/eliza@1e3dec2d06f15ca71f1966eed158ac8e3d711c4b:packages/skills/skills/contribute-to-eliza"} -->


