### PR TITLE
fix(trajectories): give Agent bridge sole ownership of capture writes

### DIFF
--- a/packages/agent/src/runtime/trajectory-bridge.test.ts
+++ b/packages/agent/src/runtime/trajectory-bridge.test.ts
@@ -207,40 +207,36 @@ describe("installDatabaseTrajectoryLogger (capture bridge)", () => {
     ).toBe(true);
   });
 
-  it.each([
-    "metadata_json",
-    "metrics_json",
-    "reward_components_json",
-  ] as const)(
+  it.each(["metadata_json", "metrics_json", "reward_components_json"] as const)(
     "falls back to the legacy schema when %s is unavailable",
     async (missingColumn) => {
-    const { runtime, logger, execute } = makeRuntime();
-    execute.mockImplementation(async (query: unknown) => {
-      const sql = sqlText(query);
-      if (
-        /INSERT INTO trajectories\s*\(/i.test(sql) &&
-        sql.includes(missingColumn)
-      ) {
-        throw new Error(`column ${missingColumn} does not exist`);
-      }
-      return [];
-    });
-    await installDatabaseTrajectoryLogger(runtime);
+      const { runtime, logger, execute } = makeRuntime();
+      execute.mockImplementation(async (query: unknown) => {
+        const sql = sqlText(query);
+        if (
+          /INSERT INTO trajectories\s*\(/i.test(sql) &&
+          sql.includes(missingColumn)
+        ) {
+          throw new Error(`column ${missingColumn} does not exist`);
+        }
+        return [];
+      });
+      await installDatabaseTrajectoryLogger(runtime);
 
-    logger.logLlmCall({
-      stepId: "step-legacy",
-      model: "eliza-1-2b",
-      response: "hello",
-      purpose: "action",
-      actionType: "runtime.useModel",
-    });
-    await flushTrajectoryWrites(runtime);
+      logger.logLlmCall({
+        stepId: "step-legacy",
+        model: "eliza-1-2b",
+        response: "hello",
+        purpose: "action",
+        actionType: "runtime.useModel",
+      });
+      await flushTrajectoryWrites(runtime);
 
-    const writes = trajectoryInsertSql(execute);
-    expect(writes).toHaveLength(2);
-    expect(writes[0]).toContain(missingColumn);
-    expect(writes[1]).not.toContain(missingColumn);
-    expect(writes[1]).toContain("episode_length");
+      const writes = trajectoryInsertSql(execute);
+      expect(writes).toHaveLength(2);
+      expect(writes[0]).toContain(missingColumn);
+      expect(writes[1]).not.toContain(missingColumn);
+      expect(writes[1]).toContain("episode_length");
     },
   );
 

--- a/packages/agent/src/runtime/trajectory-bridge.test.ts
+++ b/packages/agent/src/runtime/trajectory-bridge.test.ts
@@ -182,6 +182,10 @@ describe("installDatabaseTrajectoryLogger (capture bridge)", () => {
         (query) =>
           query.includes("metrics_json") &&
           query.includes("metrics_json = EXCLUDED.metrics_json") &&
+          query.includes("reward_components_json") &&
+          query.includes(
+            "reward_components_json = EXCLUDED.reward_components_json",
+          ) &&
           query.includes('"episodeLength":1'),
       ),
     ).toBe(true);
@@ -203,15 +207,21 @@ describe("installDatabaseTrajectoryLogger (capture bridge)", () => {
     ).toBe(true);
   });
 
-  it("falls back to the legacy schema only when canonical columns are rejected", async () => {
+  it.each([
+    "metadata_json",
+    "metrics_json",
+    "reward_components_json",
+  ] as const)(
+    "falls back to the legacy schema when %s is unavailable",
+    async (missingColumn) => {
     const { runtime, logger, execute } = makeRuntime();
     execute.mockImplementation(async (query: unknown) => {
       const sql = sqlText(query);
       if (
         /INSERT INTO trajectories\s*\(/i.test(sql) &&
-        sql.includes("metrics_json")
+        sql.includes(missingColumn)
       ) {
-        throw new Error("column metrics_json does not exist");
+        throw new Error(`column ${missingColumn} does not exist`);
       }
       return [];
     });
@@ -228,10 +238,11 @@ describe("installDatabaseTrajectoryLogger (capture bridge)", () => {
 
     const writes = trajectoryInsertSql(execute);
     expect(writes).toHaveLength(2);
-    expect(writes[0]).toContain("metrics_json");
-    expect(writes[1]).not.toContain("metrics_json");
+    expect(writes[0]).toContain(missingColumn);
+    expect(writes[1]).not.toContain(missingColumn);
     expect(writes[1]).toContain("episode_length");
-  });
+    },
+  );
 
   it("does not mask a canonical write failure with a legacy write", async () => {
     const { runtime, logger, execute } = makeRuntime();

--- a/packages/agent/src/runtime/trajectory-capture.real.test.ts
+++ b/packages/agent/src/runtime/trajectory-capture.real.test.ts
@@ -38,8 +38,9 @@ interface TrajectoryDetailLike {
   steps?: Array<{
     llmCalls?: CapturedLlmCall[];
     providerAccesses?: Array<{ providerName?: string }>;
+    action?: unknown;
   }>;
-  metrics?: { finalStatus?: string };
+  metrics?: { episodeLength?: number; finalStatus?: string };
 }
 interface TrajLogger {
   startTrajectory: (
@@ -250,12 +251,14 @@ describe("trajectory capture -> DB -> viewer", () => {
 
     const detail = await logger.getTrajectoryDetail(trajectoryId);
     expect(detail?.metrics?.finalStatus).toBe("completed");
+    expect(detail?.metrics?.episodeLength).toBeGreaterThanOrEqual(1);
     const calls = (detail?.steps ?? []).flatMap((s) => s.llmCalls ?? []);
     const providers = new Set(
       calls.map((c) => c.provider).filter((p): p is string => Boolean(p)),
     );
     expect(providers.has("local-inference"), "local call persisted").toBe(true);
     expect(providers.has("openai"), "cloud call persisted").toBe(true);
+    expect((detail?.steps ?? []).every((step) => step.action == null)).toBe(true);
 
     const listRoute = await readRoute("/api/trajectories");
     expect(listRoute.status).toBe(200);

--- a/packages/agent/src/runtime/trajectory-capture.real.test.ts
+++ b/packages/agent/src/runtime/trajectory-capture.real.test.ts
@@ -258,7 +258,9 @@ describe("trajectory capture -> DB -> viewer", () => {
     );
     expect(providers.has("local-inference"), "local call persisted").toBe(true);
     expect(providers.has("openai"), "cloud call persisted").toBe(true);
-    expect((detail?.steps ?? []).every((step) => step.action == null)).toBe(true);
+    expect((detail?.steps ?? []).every((step) => step.action == null)).toBe(
+      true,
+    );
 
     const listRoute = await readRoute("/api/trajectories");
     expect(listRoute.status).toBe(200);

--- a/packages/agent/src/runtime/trajectory-export.ts
+++ b/packages/agent/src/runtime/trajectory-export.ts
@@ -203,7 +203,13 @@ export function persistedTrajectoryToDetailRecord(
     steps: persisted.steps.map((step) =>
       toPublicTrajectoryStep(step, persisted.id),
     ),
-    metrics: { finalStatus: persisted.status },
+    // Viewer + Core duck contracts require episodeLength + finalStatus on
+    // metrics. Actionless LLM steps stay action-optional; read routes map
+    // those to toolEvents: [] without fabrication (#17730).
+    metrics: {
+      episodeLength: persisted.steps.length,
+      finalStatus: persisted.status,
+    },
     metadata: persisted.metadata as Record<string, JsonValue | undefined>,
     stepsJson: JSON.stringify(persisted.steps),
   };

--- a/packages/agent/src/runtime/trajectory-export.ts
+++ b/packages/agent/src/runtime/trajectory-export.ts
@@ -88,6 +88,15 @@ function toPublicTrajectoryProviderAccess(
   };
 }
 
+/**
+ * Map a persisted step into the public step record shape.
+ *
+ * Does not invent an `action` field: Agent-bridge LLM-only captures are
+ * actionless by design (#17730). `TrajectoryStep` here is
+ * `TrajectoryStepRecord` (no required action). Training-side
+ * `features/trajectories` `TrajectoryStep.action` is optional for the same
+ * reason; ART conversion guards absence rather than assuming every step acted.
+ */
 function toPublicTrajectoryStep(
   step: PersistedStep,
   trajectoryId: string,

--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -846,10 +846,10 @@ function isDuplicateColumnError(error: unknown): boolean {
 
 function isMissingCurrentTrajectoryColumnError(error: unknown): boolean {
   return databaseErrorMatches(error, [
-    /column ["'`]?(?:metadata_json|metrics_json)["'`]?.*does not exist/i,
-    /no column named ["'`]?(?:metadata_json|metrics_json)["'`]?/i,
-    /has no column named ["'`]?(?:metadata_json|metrics_json)["'`]?/i,
-    /unknown column ["'`]?(?:metadata_json|metrics_json)["'`]?/i,
+    /column ["'`]?(?:metadata_json|metrics_json|reward_components_json)["'`]?.*does not exist/i,
+    /no column named ["'`]?(?:metadata_json|metrics_json|reward_components_json)["'`]?/i,
+    /has no column named ["'`]?(?:metadata_json|metrics_json|reward_components_json)["'`]?/i,
+    /unknown column ["'`]?(?:metadata_json|metrics_json|reward_components_json)["'`]?/i,
   ]);
 }
 
@@ -914,6 +914,13 @@ async function initializeTrajectoriesTable(
       const optionalColumns = [
         { name: "trajectory_id", def: "TEXT" },
         { name: "metadata", def: "TEXT NOT NULL DEFAULT '{}'" },
+        // Canonical Core columns (#17730): prefer these for primary writes.
+        { name: "metadata_json", def: "TEXT NOT NULL DEFAULT '{}'" },
+        { name: "metrics_json", def: "TEXT NOT NULL DEFAULT '{}'" },
+        {
+          name: "reward_components_json",
+          def: "TEXT NOT NULL DEFAULT '{}'",
+        },
         { name: "steps_json", def: "TEXT NOT NULL DEFAULT '[]'" },
         { name: "scenario_id", def: "TEXT" },
         { name: "batch_id", def: "TEXT" },
@@ -966,6 +973,9 @@ async function initializeTrajectoriesTable(
         batch_id TEXT,
         steps_json TEXT NOT NULL DEFAULT '[]',
         metadata TEXT NOT NULL DEFAULT '{}',
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        metrics_json TEXT NOT NULL DEFAULT '{}',
+        reward_components_json TEXT NOT NULL DEFAULT '{}',
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
         episode_length INTEGER,
@@ -1930,6 +1940,10 @@ export async function saveTrajectory(
     trajectory.updatedAt || new Date(endTime ?? summary.endTime).toISOString();
   const serializedSteps = sqlQuote(JSON.stringify(trajectory.steps));
   const serializedMetadata = sqlQuote(JSON.stringify(trajectory.metadata));
+  // Canonical metrics_json shape required by Core validators and the viewer
+  // duck contract. Primary write targets the current schema; legacy
+  // metadata/episode_length is only a fallback when those columns are absent
+  // (#17730).
   const serializedMetrics = sqlQuote(
     JSON.stringify({
       episodeLength: trajectory.steps.length,
@@ -1942,7 +1956,88 @@ export async function saveTrajectory(
       totalCacheCreationInputTokens: summary.totalCacheCreationInputTokens,
     }),
   );
+  const serializedRewardComponents = sqlQuote(
+    JSON.stringify({ environmentReward: trajectory.totalReward }),
+  );
 
+  // Current schema (Core TrajectoriesService): metrics_json / metadata_json /
+  // reward_components_json. Prefer this so active/completed metrics are always
+  // valid for strict Core readers that share the table.
+  const currentSchemaSql = `INSERT INTO trajectories (
+      id,
+      agent_id,
+      source,
+      status,
+      start_time,
+      end_time,
+      duration_ms,
+      step_count,
+      llm_call_count,
+      provider_access_count,
+      total_prompt_tokens,
+      total_completion_tokens,
+      total_cache_read_input_tokens,
+      total_cache_creation_input_tokens,
+      total_reward,
+      scenario_id,
+      batch_id,
+      steps_json,
+      metadata_json,
+      metrics_json,
+      reward_components_json,
+      created_at,
+      updated_at
+    ) VALUES (
+      ${sqlQuote(trajectory.id)},
+      ${sqlQuote(runtime.agentId)},
+      ${sqlQuote(trajectory.source)},
+      ${sqlQuote(trajectory.status)},
+      ${sqlNumber(summary.startTime)},
+      ${sqlNumber(endTime)},
+      ${sqlNumber(durationMs)},
+      ${sqlNumber(trajectory.steps.length)},
+      ${sqlNumber(summary.llmCallCount)},
+      ${sqlNumber(summary.providerAccessCount)},
+      ${sqlNumber(summary.totalPromptTokens)},
+      ${sqlNumber(summary.totalCompletionTokens)},
+      ${sqlNumber(summary.totalCacheReadInputTokens)},
+      ${sqlNumber(summary.totalCacheCreationInputTokens)},
+      ${sqlNumber(trajectory.totalReward)},
+      ${trajectory.scenarioId ? sqlQuote(trajectory.scenarioId) : "NULL"},
+      ${trajectory.batchId ? sqlQuote(trajectory.batchId) : "NULL"},
+      ${serializedSteps},
+      ${serializedMetadata},
+      ${serializedMetrics},
+      ${serializedRewardComponents},
+      ${sqlQuote(createdAt)},
+      ${sqlQuote(updatedAt)}
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      agent_id = EXCLUDED.agent_id,
+      source = EXCLUDED.source,
+      status = EXCLUDED.status,
+      start_time = EXCLUDED.start_time,
+      end_time = EXCLUDED.end_time,
+      duration_ms = EXCLUDED.duration_ms,
+      step_count = EXCLUDED.step_count,
+      llm_call_count = EXCLUDED.llm_call_count,
+      provider_access_count = EXCLUDED.provider_access_count,
+      total_prompt_tokens = EXCLUDED.total_prompt_tokens,
+      total_completion_tokens = EXCLUDED.total_completion_tokens,
+      total_cache_read_input_tokens = EXCLUDED.total_cache_read_input_tokens,
+      total_cache_creation_input_tokens = EXCLUDED.total_cache_creation_input_tokens,
+      total_reward = EXCLUDED.total_reward,
+      scenario_id = EXCLUDED.scenario_id,
+      batch_id = EXCLUDED.batch_id,
+      steps_json = EXCLUDED.steps_json,
+      metadata_json = EXCLUDED.metadata_json,
+      metrics_json = EXCLUDED.metrics_json,
+      reward_components_json = EXCLUDED.reward_components_json,
+      created_at = EXCLUDED.created_at,
+      updated_at = EXCLUDED.updated_at`;
+
+  // Legacy Eliza schema (metadata TEXT + episode_length) when canonical
+  // JSONB columns are missing on the adapter.
   const legacySchemaSql = `INSERT INTO trajectories (
       id,
       agent_id,
@@ -2012,76 +2107,6 @@ export async function saveTrajectory(
       created_at = EXCLUDED.created_at,
       updated_at = EXCLUDED.updated_at,
       episode_length = EXCLUDED.episode_length`;
-
-  const currentSchemaSql = `INSERT INTO trajectories (
-      id,
-      agent_id,
-      source,
-      status,
-      start_time,
-      end_time,
-      duration_ms,
-      step_count,
-      llm_call_count,
-      provider_access_count,
-      total_prompt_tokens,
-      total_completion_tokens,
-      total_cache_read_input_tokens,
-      total_cache_creation_input_tokens,
-      total_reward,
-      scenario_id,
-      batch_id,
-      steps_json,
-      metadata_json,
-      metrics_json,
-      created_at,
-      updated_at
-    ) VALUES (
-      ${sqlQuote(trajectory.id)},
-      ${sqlQuote(runtime.agentId)},
-      ${sqlQuote(trajectory.source)},
-      ${sqlQuote(trajectory.status)},
-      ${sqlNumber(summary.startTime)},
-      ${sqlNumber(endTime)},
-      ${sqlNumber(durationMs)},
-      ${sqlNumber(trajectory.steps.length)},
-      ${sqlNumber(summary.llmCallCount)},
-      ${sqlNumber(summary.providerAccessCount)},
-      ${sqlNumber(summary.totalPromptTokens)},
-      ${sqlNumber(summary.totalCompletionTokens)},
-      ${sqlNumber(summary.totalCacheReadInputTokens)},
-      ${sqlNumber(summary.totalCacheCreationInputTokens)},
-      ${sqlNumber(trajectory.totalReward)},
-      ${trajectory.scenarioId ? sqlQuote(trajectory.scenarioId) : "NULL"},
-      ${trajectory.batchId ? sqlQuote(trajectory.batchId) : "NULL"},
-      ${serializedSteps},
-      ${serializedMetadata},
-      ${serializedMetrics},
-      ${sqlQuote(createdAt)},
-      ${sqlQuote(updatedAt)}
-    )
-    ON CONFLICT (id) DO UPDATE SET
-      agent_id = EXCLUDED.agent_id,
-      source = EXCLUDED.source,
-      status = EXCLUDED.status,
-      start_time = EXCLUDED.start_time,
-      end_time = EXCLUDED.end_time,
-      duration_ms = EXCLUDED.duration_ms,
-      step_count = EXCLUDED.step_count,
-      llm_call_count = EXCLUDED.llm_call_count,
-      provider_access_count = EXCLUDED.provider_access_count,
-      total_prompt_tokens = EXCLUDED.total_prompt_tokens,
-      total_completion_tokens = EXCLUDED.total_completion_tokens,
-      total_cache_read_input_tokens = EXCLUDED.total_cache_read_input_tokens,
-      total_cache_creation_input_tokens = EXCLUDED.total_cache_creation_input_tokens,
-      total_reward = EXCLUDED.total_reward,
-      scenario_id = EXCLUDED.scenario_id,
-      batch_id = EXCLUDED.batch_id,
-      steps_json = EXCLUDED.steps_json,
-      metadata_json = EXCLUDED.metadata_json,
-      metrics_json = EXCLUDED.metrics_json,
-      created_at = EXCLUDED.created_at,
-      updated_at = EXCLUDED.updated_at`;
 
   let saved = false;
   try {

--- a/packages/core/src/features/trajectories/art-format.test.ts
+++ b/packages/core/src/features/trajectories/art-format.test.ts
@@ -46,6 +46,31 @@ describe("toARTMessages", () => {
 		expect(messages.some((m) => m.role === "user")).toBe(true);
 		expect(messages.some((m) => m.role === "assistant")).toBe(true);
 	});
+
+	it("does not throw on actionless bridge steps (#17730)", () => {
+		const messages = toARTMessages(
+			traj({
+				steps: [
+					{
+						...step(),
+						action: undefined,
+						llmCalls: [
+							{
+								purpose: "response",
+								systemPrompt: "sys",
+								userPrompt: "user",
+								response: "hello from bridge",
+							},
+						],
+					},
+				],
+			} as never),
+		);
+		expect(messages.some((m) => m.role === "assistant")).toBe(true);
+		expect(messages.find((m) => m.role === "assistant")?.content).toContain(
+			"hello from bridge",
+		);
+	});
 });
 
 describe("validateARTCompatibility", () => {

--- a/packages/core/src/features/trajectories/art-format.ts
+++ b/packages/core/src/features/trajectories/art-format.ts
@@ -100,7 +100,14 @@ function buildAssistantMessage(step: TrajectoryStep): string | null {
 		return llmCall.response;
 	}
 
+	// Actionless bridge steps (LLM-only capture) have no ActionAttempt — prefer
+	// any non-action LLM response, else omit the assistant turn (#17730).
 	const action = step.action;
+	if (!action) {
+		const anyResponse = step.llmCalls.find((call) => call.response)?.response;
+		return anyResponse ?? null;
+	}
+
 	const parts: string[] = [];
 
 	parts.push(`I will ${action.actionType}.`);
@@ -138,10 +145,13 @@ export function toARTTrajectory(trajectory: Trajectory): ARTTrajectory {
 				...(trajectory.metrics.finalPnL !== undefined
 					? { finalPnL: trajectory.metrics.finalPnL }
 					: {}),
-				actionsTaken: trajectory.steps.map((s) => s.action.actionType),
-				errors: trajectory.steps
-					.filter((s) => !s.action.success)
-					.map((s) => s.action.error || "Unknown error"),
+				actionsTaken: trajectory.steps.flatMap((s) =>
+					s.action?.actionType ? [s.action.actionType] : [],
+				),
+				errors: trajectory.steps.flatMap((s) => {
+					if (!s.action || s.action.success) return [];
+					return [s.action.error || "Unknown error"];
+				}),
 			},
 			gameKnowledge: extractGameKnowledge(trajectory),
 			metrics: JSON.parse(JSON.stringify(trajectory.metrics)) as Record<

--- a/packages/core/src/features/trajectories/read-routes.test.ts
+++ b/packages/core/src/features/trajectories/read-routes.test.ts
@@ -238,7 +238,7 @@ describe("tryHandleTrajectoryReadRoutes", () => {
 				agentId: "agent-1",
 				startTime: 500,
 				endTime: 1000,
-				metrics: { finalStatus: "completed" },
+				metrics: { episodeLength: 1, finalStatus: "completed" },
 				metadata: { source: "chat" },
 				steps: [
 					{
@@ -249,9 +249,11 @@ describe("tryHandleTrajectoryReadRoutes", () => {
 								model: "m",
 								response: "hello",
 								stepType: "reasoning",
+								provider: "openai",
 							},
 						],
 						providerAccesses: [],
+						// Agent bridge action-optional step — no action field.
 					},
 				],
 			}),

--- a/packages/core/src/features/trajectories/read-routes.ts
+++ b/packages/core/src/features/trajectories/read-routes.ts
@@ -59,6 +59,7 @@ interface ServiceTrajectoryStep {
 	stepId: string;
 	llmCalls: ServiceLlmCall[];
 	providerAccesses: ServiceProviderAccess[];
+	/** Absent on action-optional Agent-bridge steps (LLM-only capture). */
 	action?: ServiceActionAttempt;
 }
 
@@ -189,6 +190,8 @@ function detailToUi(
 				...(p.purpose ? { purpose: p.purpose } : {}),
 			});
 		}
+		// Genuinely actionless steps (Agent bridge LLM-only capture) contribute
+		// nothing to toolEvents — never fabricate a synthetic action (#17730).
 		const action = step.action;
 		if (action && (action.actionName || action.actionType)) {
 			const failed = action.success === false || Boolean(action.error);

--- a/packages/core/src/features/trajectories/types.ts
+++ b/packages/core/src/features/trajectories/types.ts
@@ -205,8 +205,9 @@ export interface TrajectoryStep {
 	providerAccesses: ProviderAccess[];
 	reasoning?: string;
 
-	// Action taken
-	action: ActionAttempt;
+	// Action taken. Optional: Agent-bridge LLM-only captures have no action and
+	// must not fabricate one (#17730 / #17762). ART and other readers must guard.
+	action?: ActionAttempt;
 
 	// Feedback
 	reward: number;

--- a/packages/core/src/services/trajectory-types.ts
+++ b/packages/core/src/services/trajectory-types.ts
@@ -274,11 +274,10 @@ export interface TrajectoryDetailRecord {
 	batchId?: string;
 	steps?: TrajectoryStepRecord[];
 	metrics?: {
-    finalStatus?: string;
-    /** Step count at last persist; required by Core validators (#17730). */
-    episodeLength?: number;
-    [key: string]: unknown;
-  };
+		finalStatus?: string;
+		/** Step count at last persist; required by Core validators (#17730). */
+		episodeLength?: number;
+	};
 	/** Plain JSON-like bag; values are not validated as {@link JsonValue} at the boundary. */
 	metadata?: Record<string, unknown>;
 	stepsJson?: string;

--- a/packages/core/src/services/trajectory-types.ts
+++ b/packages/core/src/services/trajectory-types.ts
@@ -273,7 +273,12 @@ export interface TrajectoryDetailRecord {
 	scenarioId?: string;
 	batchId?: string;
 	steps?: TrajectoryStepRecord[];
-	metrics?: { finalStatus?: string };
+	metrics?: {
+    finalStatus?: string;
+    /** Step count at last persist; required by Core validators (#17730). */
+    episodeLength?: number;
+    [key: string]: unknown;
+  };
 	/** Plain JSON-like bag; values are not validated as {@link JsonValue} at the boundary. */
 	metadata?: Record<string, unknown>;
 	stepsJson?: string;


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: grok, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@1e3dec2d06f15ca71f1966eed158ac8e3d711c4b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: self-reported

Closes #17730.

# Sync with develop

- [x] Rebased on origin/develop @ 1e3dec2d06f15ca71f1966eed158ac8e3d711c4b
- [x] Focused tests run on this head

# Risks

Medium-low. Changes who owns trajectory capture writes after the Agent bridge installs. Core validators remain strict; the bridge no longer dual-invokes Core's logLlmCall/logProviderAccess (which produced detachedWrite noise on action-optional rows).

# Background

## What does this PR do?

The installed Agent trajectory bridge and Core TrajectoriesService both wrote the same capture into the shared trajectories table with incompatible shapes. Core required full action/environment/metrics; the bridge wrote action-optional LLM steps. Core then failed `rowToTrajectory` / detached writes after successful chat turns.

This PR:

1. **Sole ownership** — after `installDatabaseTrajectoryLogger`, capture goes only through the bridge (no dual call into Core's original logLlmCall/logProviderAccess).
2. **Current-schema primary write** — persist valid `metrics_json` / `metadata_json` / `reward_components_json` first; legacy `metadata`+`episode_length` only when canonical columns are missing.
3. **Schema forward-migration** — Agent table init adds the canonical JSON columns when absent.
4. **Detail metrics** — `episodeLength` + `finalStatus` on bridge detail records.
5. **Read routes** — actionless steps produce `toolEvents: []` without fabrication.

## What kind of change is this?

Runtime bug fix.

# Documentation changes needed?

N/A - behavior now matches the intended Agent-bridge ownership contract.

# Testing

## Where should a reviewer start?

- `packages/agent/src/runtime/trajectory-storage.ts` (sole ownership)
- `packages/agent/src/runtime/trajectory-internals.ts` (save order + schema)
- `packages/core/src/features/trajectories/read-routes.ts` (actionless toolEvents)

## Detailed testing steps

```bash
bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/runtime/trajectory-bridge.test.ts
bun run --cwd packages/core test -- src/features/trajectories/read-routes.test.ts
bun test --conditions=eliza-source packages/agent/src/runtime/trajectory-capture.real.test.ts
```

# Evidence Gate

<!-- evidence-head:5eb4ba83e9dd13b9bc942c4db51a181a0f63172b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; trajectory ownership is server/runtime only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.

<!-- evidence-row:backend-logs -->
- [x] Focused test output on head `1184123a707144975ee5cd5bf3bea799491ddc0a`:

<details><summary>trajectory-bridge (5/5) + read-routes (9/9) + real PGlite capture (pass)</summary>

```text

 RUN  v4.1.5 /Users/studio/Documents/GitHub/eliza/packages/agent

 ✓ src/runtime/trajectory-bridge.test.ts (5 tests) 11ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  18:31:01
   Duration  5.29s (transform 3.99s, setup 50ms, import 5.12s, tests 11ms, environment 0ms)

---

$ node ../scripts/run-vitest.mjs run src/features/trajectories/read-routes.test.ts

 RUN  v4.1.5 /Users/studio/Documents/GitHub/eliza/packages/core

 ✓ src/features/trajectories/read-routes.test.ts (9 tests) 7ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  18:31:07
   Duration  166ms (transform 47ms, setup 0ms, import 57ms, tests 7ms, environment 0ms)

---

23:(pass) trajectory capture -> DB -> viewer > persists LOCAL and CLOUD LLM calls into the trajectory_steps store the viewer reads [22.79ms]
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client on this path.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt/provider behavior change; capture ownership only.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no separate domain store artifact beyond SQL trajectories; PGlite capture + bridge/read-route tests on this head are the domain proof (metrics.finalStatus, episodeLength, toolEvents:[]).

<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

# Known gaps / failures

- Full packages/agent typecheck still reports pre-existing missing optional plugin type modules on this checkout; none of those errors are in the trajectory files changed here (trajectory-export episodeLength typing fixed via TrajectoryDetailRecord).

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@1e3dec2d06f15ca71f1966eed158ac8e3d711c4b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok/wtfsayo]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/eliza@1e3dec2d06f15ca71f1966eed158ac8e3d711c4b:packages/skills/skills/contribute-to-eliza"} -->






