### PR TITLE
fix(ui): source-alias native runtime in tests

### DIFF
--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -14,8 +14,9 @@ const coreSrc = resolve(monorepoRoot, "packages/core/src");
 const cloudRoutingSrc = resolve(monorepoRoot, "packages/cloud/routing/src");
 const cloudSharedSrc = resolve(monorepoRoot, "packages/cloud/shared/src");
 const loggerSrc = resolve(monorepoRoot, "packages/logger/src");
-const bunRuntimeSrc = createRequire(import.meta.url).resolve(
-  "@elizaos/capacitor-bun-runtime",
+const bunRuntimeSrc = resolve(
+  monorepoRoot,
+  "plugins/plugin-native-bun-runtime/src/index.ts",
 );
 const hostExternalStub = resolve(packageRoot, "test/stubs/host-external.ts");
 


### PR DESCRIPTION
# Relates to

Closes #17766.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@89d611be1a20ea3d43379d5e5faee2fafc34ce9d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# What changed

- Restores the UI Vitest alias for `@elizaos/capacitor-bun-runtime` to the workspace TypeScript source.
- Removes the clean-CI dependency on the package CommonJS export at the gitignored `dist/plugin.cjs.js`.
- Keeps the chat-shell render-parity lane boot-free; no native artifact build is needed before component tests.

# Failure and verification

Failed `develop` run: https://github.com/elizaOS/eliza/actions/runs/31016272651

The exact failure was reproduced by removing `plugins/plugin-native-bun-runtime/dist`, then the repaired command passed:

- `bun run --cwd packages/ui test -- src/components/chat/render-parity.contract.test.tsx` — 1 file, 12 tests passed.
- `bun run --cwd packages/ui typecheck` — passed.
- `bun run --cwd packages/ui lint:check` — passed.
- `bun test packages/scripts/__tests__/chat-gesture-workflow-contract.test.ts` — passed.
- `bun run verify` — 342/342 tasks and all repository audits passed.
- `bun run build` — 121/121 tasks; view-bundle guard 19/19 passed.

# Risk

Low. This changes only test-time module resolution and points at the package source that the workspace owns. Production exports and bundles are unchanged.

# Evidence Gate

<!-- evidence-head:dfbc0a3b85414e431c4056e9d89039e4ea7a2304 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A — test-config-only change with no rendered UI behavior.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A — test-config-only change with no rendered UI behavior.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A — no user-facing interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A — the failure occurs while loading Vitest config, before any backend starts; the failed run is linked above.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A — Vitest failed during config startup before a frontend was launched.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A — deterministic test module resolution; no model call exists on this path.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A — this is a test-time source-resolution correction with no generated domain artifact.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A — no visual output changed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@89d611be1a20ea3d43379d5e5faee2fafc34ce9d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@89d611be1a20ea3d43379d5e5faee2fafc34ce9d:packages/skills/skills/contribute-to-eliza"} -->