### PR TITLE
fix(agent): correct DexPaprika slugs and summary.price_usd path

### DIFF
--- a/packages/agent/src/api/wallet-dex-prices.test.ts
+++ b/packages/agent/src/api/wallet-dex-prices.test.ts
@@ -1,11 +1,13 @@
 /**
- * Tests for the wallet USD value math (#8801 / #9943). computeValueUsd renders a
- * money figure shown to the user; the cents rounding and the guards against
- * non-positive / unparseable inputs are finance-correctness concerns, and it was
- * untested.
+ * Tests for the wallet USD value math (#8801 / #9943) and the DexPaprika
+ * fallback path (#17691): correct network slugs and summary.price_usd extraction.
  */
-import { describe, expect, it } from "vitest";
-import { computeValueUsd } from "./wallet-dex-prices";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEXPAPRIKA_CHAIN_MAP,
+  computeValueUsd,
+  fetchDexPaprikaPrices,
+} from "./wallet-dex-prices";
 
 describe("computeValueUsd", () => {
   it("multiplies balance by price to two decimals", () => {
@@ -31,5 +33,62 @@ describe("computeValueUsd", () => {
     expect(computeValueUsd("abc", "1")).toBe("0");
     expect(computeValueUsd("1", "")).toBe("0");
     expect(computeValueUsd("", "")).toBe("0");
+  });
+});
+
+describe("DEXPAPRIKA_CHAIN_MAP", () => {
+  it("uses live DexPaprika network slugs for Arbitrum and Polygon", () => {
+    expect(DEXPAPRIKA_CHAIN_MAP[42161]).toBe("arbitrum");
+    expect(DEXPAPRIKA_CHAIN_MAP[137]).toBe("polygon");
+  });
+});
+
+describe("fetchDexPaprikaPrices", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reads price from summary.price_usd and builds the correct network URL", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      expect(url).toBe(
+        "https://api.dexpaprika.com/networks/arbitrum/tokens/0xAbC",
+      );
+      return new Response(
+        JSON.stringify({
+          id: "0xAbC",
+          summary: { price_usd: 1879.41, liquidity_usd: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const results = await fetchDexPaprikaPrices(42161, ["0xAbC"]);
+    expect(results.get("0xabc")?.price).toBe("1879.41");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns empty when summary is missing or invalid", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ id: "0xdef", price_usd: 99 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+    const results = await fetchDexPaprikaPrices(137, ["0xdef"]);
+    expect(results.size).toBe(0);
+  });
+
+  it("returns empty for unsupported chain ids", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const results = await fetchDexPaprikaPrices(999, ["0xabc"]);
+    expect(results.size).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/api/wallet-dex-prices.test.ts
+++ b/packages/agent/src/api/wallet-dex-prices.test.ts
@@ -4,8 +4,8 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  DEXPAPRIKA_CHAIN_MAP,
   computeValueUsd,
+  DEXPAPRIKA_CHAIN_MAP,
   fetchDexPaprikaPrices,
 } from "./wallet-dex-prices";
 
@@ -50,11 +50,9 @@ describe("fetchDexPaprikaPrices", () => {
   });
 
   it("reads price from summary.price_usd and builds the correct network URL", async () => {
+    let requestedUrl: string | undefined;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      expect(url).toBe(
-        "https://api.dexpaprika.com/networks/arbitrum/tokens/0xAbC",
-      );
+      requestedUrl = String(input);
       return new Response(
         JSON.stringify({
           id: "0xAbC",
@@ -66,18 +64,26 @@ describe("fetchDexPaprikaPrices", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const results = await fetchDexPaprikaPrices(42161, ["0xAbC"]);
+    expect(requestedUrl).toBe(
+      "https://api.dexpaprika.com/networks/arbitrum/tokens/0xAbC",
+    );
     expect(results.get("0xabc")?.price).toBe("1879.41");
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
-  it("returns empty when summary is missing or invalid", async () => {
+  it.each([
+    ["missing summary", { id: "0xdef", price_usd: 99 }],
+    ["zero price", { id: "0xdef", summary: { price_usd: 0 } }],
+    ["unparseable price", { id: "0xdef", summary: { price_usd: "invalid" } }],
+  ])("returns empty for %s", async (_case, payload) => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () =>
-        new Response(JSON.stringify({ id: "0xdef", price_usd: 99 }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
       ),
     );
     const results = await fetchDexPaprikaPrices(137, ["0xdef"]);

--- a/packages/agent/src/api/wallet-dex-prices.ts
+++ b/packages/agent/src/api/wallet-dex-prices.ts
@@ -23,9 +23,9 @@ export const DEXPAPRIKA_CHAIN_MAP: Record<number, string> = {
   1: "ethereum",
   56: "bsc",
   8453: "base",
-  42161: "arbitrum_one",
+  42161: "arbitrum",
   10: "optimism",
-  137: "polygon_pos",
+  137: "polygon",
   43114: "avalanche",
 };
 
@@ -133,7 +133,9 @@ export async function fetchDexPaprikaPrices(
         if (!res.ok) return;
         const data = await res.json();
         if (!isRecord(data)) return;
-        const price = Number(data.price_usd);
+        // DexPaprika token-details puts the spot at summary.price_usd (no top-level price_usd).
+        const summary = isRecord(data.summary) ? data.summary : undefined;
+        const price = Number(summary?.price_usd);
         if (Number.isFinite(price) && price > 0) {
           results.set(addr.toLowerCase(), { price: price.toString() });
         }


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: grok, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@4aebb109c8e0a106ddd7c02b9d5fea08309310a5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: self-reported

## Summary

Repairs [#17693](https://github.com/elizaOS/eliza/pull/17693) (does not force-push the author branch) and closes #17691.

DexPaprika fallback returned **zero prices on every chain** because:

1. Network slugs for Arbitrum/Polygon were wrong (`arbitrum_one` / `polygon_pos` → 404; live API uses `arbitrum` / `polygon`).
2. Spot price lives at `summary.price_usd`, not top-level `price_usd`.

This PR applies both fixes and addresses the review on #17693:

- Narrow `summary` with the existing `isRecord` helper before reading `price_usd` (no new TS2339).
- Unit tests pin slug map, URL construction, `summary.price_usd` extraction, and fail-closed missing-summary behavior.

## Test plan

- [x] `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/api/wallet-dex-prices.test.ts` — 8/8

## Evidence

<!-- evidence-head:78eb4012c469a090cbfef3b7fba54d97a85fd739 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server/API data path only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.

<!-- evidence-row:backend-logs -->
- [x] Focused unit output on head `00255aa97b51a5815c700b3a10564d953aff127f`:

<details><summary>wallet-dex-prices.test.ts 8/8</summary>

```text

 RUN  v4.1.5 /Users/studio/Documents/GitHub/eliza/packages/agent

 ✓ src/api/wallet-dex-prices.test.ts (8 tests) 5ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  20:51:28
   Duration  2.65s (transform 1.99s, setup 36ms, import 2.54s, tests 5ms, environment 0ms)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client on this path.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt behavior change.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - domain proof is the unit suite asserting Map price results from mocked DexPaprika JSON shapes (summary.price_usd present / absent); no separate DB/wallet store artifact.

<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@4aebb109c8e0a106ddd7c02b9d5fea08309310a5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok/wtfsayo]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/eliza@4aebb109c8e0a106ddd7c02b9d5fea08309310a5:packages/skills/skills/contribute-to-eliza"} -->


