### PR TITLE
fix(cloud): await ledger post-debit gate-hint republish

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -19,6 +19,8 @@
  *   - Sweep: drains stale pending charging the ESTIMATE; skips young rows;
  *     age-ordered across batches; inline-then-sweep never double-charges.
  *   - Concurrency: a same-org burst cannot collectively overdraw.
+ *   - Post-debit gate hint: a successful settle leaves a warm cacheOnly hint;
+ *     an uncollected (refused) debit leaves the hint absent (#17768).
  *
  * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
@@ -524,6 +526,59 @@ describe("createLedgerDebitSettler — exactly-once inline settlement", () => {
       } finally {
         notify.mockRestore();
       }
+    },
+    PGLITE_TIMEOUT,
+  );
+
+
+  test(
+    "leaves a warm gate hint so the NEXT turn does not fail closed on a cacheOnly read (#17768)",
+    async () => {
+      if (!pgliteReady) return;
+      const { readOrgBalanceHint } = await import("../inference-auth-cache");
+      const { getGateBalanceUsd } = await import("../inference-billing-fast-path");
+      const reqId = nextRequestId();
+      await ledger.admitInferenceChargeViaLedger({
+        charge: charge(reqId),
+        estimatedCostUsd: 3,
+        thresholdUsd: 1,
+      });
+      await ledger.createLedgerDebitSettler(charge(reqId))(2.5);
+
+      // Settle awaited the republish; the hint must be present for cacheOnly reads.
+      const hint = await readOrgBalanceHint(ORG_ID);
+      expect(hint).not.toBeNull();
+      expect(hint?.balanceUsd).toBeCloseTo(7.5, 6);
+      await expect(getGateBalanceUsd(ORG_ID, { cacheOnly: true })).resolves.toBeCloseTo(
+        7.5,
+        6,
+      );
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "uncollected debit leaves the gate hint absent (parity with refused KV settle) (#17768)",
+    async () => {
+      if (!pgliteReady) return;
+      const { readOrgBalanceHint, writeOrgBalanceHint } = await import(
+        "../inference-auth-cache"
+      );
+      const reqId = nextRequestId();
+      // Warm hint present before the refused settle, as a real org would have.
+      await writeOrgBalanceHint(ORG_ID, 0.5, Date.now(), "1");
+      await ledger.admitInferenceChargeViaLedger({
+        charge: charge(reqId),
+        estimatedCostUsd: 1,
+        thresholdUsd: 0.5,
+      });
+      await dbWrite.execute(
+        `UPDATE organizations SET credit_balance = '0.500000' WHERE id = '${ORG_ID}';`,
+      );
+      await ledger.createLedgerDebitSettler(charge(reqId))(5);
+      // onCreditMutation + invalidate on uncollected must not leave a stale warm
+      // gate that would over-admit; absent is correct.
+      expect(await readOrgBalanceHint(ORG_ID)).toBeNull();
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -207,7 +207,6 @@ describe("admitInferenceChargeViaLedger — atomic admission gate", () => {
     if (!pgliteReady) return;
     await seedOrg("10.000000");
   });
-
   test(
     "admits an affordable charge and writes exactly one pending row at the estimate",
     async () => {
@@ -530,7 +529,6 @@ describe("createLedgerDebitSettler — exactly-once inline settlement", () => {
     PGLITE_TIMEOUT,
   );
 
-
   test(
     "leaves a warm gate hint so the NEXT turn does not fail closed on a cacheOnly read (#17768)",
     async () => {
@@ -549,10 +547,7 @@ describe("createLedgerDebitSettler — exactly-once inline settlement", () => {
       const hint = await readOrgBalanceHint(ORG_ID);
       expect(hint).not.toBeNull();
       expect(hint?.balanceUsd).toBeCloseTo(7.5, 6);
-      await expect(getGateBalanceUsd(ORG_ID, { cacheOnly: true })).resolves.toBeCloseTo(
-        7.5,
-        6,
-      );
+      await expect(getGateBalanceUsd(ORG_ID, { cacheOnly: true })).resolves.toBeCloseTo(7.5, 6);
     },
     PGLITE_TIMEOUT,
   );
@@ -564,11 +559,9 @@ describe("createLedgerDebitSettler — exactly-once inline settlement", () => {
       const { creditsService: credits } = await import("../credits");
       const { isOrgAdmissionRefused } = await import("../inference-admission-refusal");
       const { readOrgBalanceHint } = await import("../inference-auth-cache");
-      const snap = spyOn(credits, "getOrganizationBalanceSnapshot").mockImplementation(
-        async () => {
-          throw new Error("forced snapshot failure for test");
-        },
-      );
+      const snap = spyOn(credits, "getOrganizationBalanceSnapshot").mockImplementation(async () => {
+        throw new Error("forced snapshot failure for test");
+      });
       try {
         const reqId = nextRequestId();
         await ledger.admitInferenceChargeViaLedger({
@@ -596,9 +589,7 @@ describe("createLedgerDebitSettler — exactly-once inline settlement", () => {
     "uncollected debit leaves the gate hint absent (parity with refused KV settle) (#17768)",
     async () => {
       if (!pgliteReady) return;
-      const { readOrgBalanceHint, writeOrgBalanceHint } = await import(
-        "../inference-auth-cache"
-      );
+      const { readOrgBalanceHint, writeOrgBalanceHint } = await import("../inference-auth-cache");
       const reqId = nextRequestId();
       // Warm hint present before the refused settle, as a real org would have.
       await writeOrgBalanceHint(ORG_ID, 0.5, Date.now(), "1");

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -558,6 +558,41 @@ describe("createLedgerDebitSettler — exactly-once inline settlement", () => {
   );
 
   test(
+    "republish failure leaves the debit outcome intact and forces the org off the fast path (#17768)",
+    async () => {
+      if (!pgliteReady) return;
+      const { creditsService: credits } = await import("../credits");
+      const { isOrgAdmissionRefused } = await import("../inference-admission-refusal");
+      const { readOrgBalanceHint } = await import("../inference-auth-cache");
+      const snap = spyOn(credits, "getOrganizationBalanceSnapshot").mockImplementation(
+        async () => {
+          throw new Error("forced snapshot failure for test");
+        },
+      );
+      try {
+        const reqId = nextRequestId();
+        await ledger.admitInferenceChargeViaLedger({
+          charge: charge(reqId),
+          estimatedCostUsd: 3,
+          thresholdUsd: 1,
+        });
+        const settle = ledger.createLedgerDebitSettler(charge(reqId));
+        // Debit committed; settle must not throw even if the post-debit republish fails.
+        await expect(settle(2.5)).resolves.toMatchObject({
+          actualCost: 2.5,
+          adjustmentType: "none",
+        });
+        expect(await readBalance()).toBeCloseTo(7.5, 6);
+        expect(isOrgAdmissionRefused(ORG_ID)).toBe(true);
+        expect(await readOrgBalanceHint(ORG_ID)).toBeNull();
+      } finally {
+        snap.mockRestore();
+      }
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
     "uncollected debit leaves the gate hint absent (parity with refused KV settle) (#17768)",
     async () => {
       if (!pgliteReady) return;

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -315,7 +315,7 @@ async function settleLedgerCharge(
     await CacheInvalidation.onCreditMutation(ctx.organizationId).catch(
       reportInvalidationFailure(ctx.organizationId, "credit-mutation"),
     );
-    invalidateOrganizationCache(ctx.organizationId).catch(
+    await invalidateOrganizationCache(ctx.organizationId).catch(
       reportInvalidationFailure(ctx.organizationId, "organization-cache"),
     );
     // onCreditMutation above already DELETED the gate hint. Republish it with
@@ -332,6 +332,9 @@ async function settleLedgerCharge(
     try {
       await republishOrgBalanceHintAfterDebit(ctx.organizationId);
     } catch (cause) {
+      // error-policy:J7 diagnostics must not kill the settle path: debit already
+      // committed; refuse the org and clear the gate rather than throw into the
+      // user's response (KV rethrows for task replay; ledger does not).
       markOrgAdmissionRefused(ctx.organizationId);
       await invalidateOrgBalanceHint(ctx.organizationId).catch(
         reportInvalidationFailure(ctx.organizationId, "balance-hint"),
@@ -367,7 +370,10 @@ async function settleLedgerCharge(
       amountUsd,
       source,
     });
-    invalidateOrgBalanceHint(ctx.organizationId).catch(
+    // Awaited (not fire-and-forget): this invalidation forces the org off the
+    // cacheOnly optimistic path after a refused debit. Dropped, a warm hint
+    // would over-admit on the next turn (#17768 review).
+    await invalidateOrgBalanceHint(ctx.organizationId).catch(
       reportInvalidationFailure(ctx.organizationId, "balance-hint"),
     );
   }

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -332,9 +332,9 @@ async function settleLedgerCharge(
     try {
       await republishOrgBalanceHintAfterDebit(ctx.organizationId);
     } catch (cause) {
-      // error-policy:J7 diagnostics must not kill the settle path: debit already
-      // committed; refuse the org and clear the gate rather than throw into the
-      // user's response (KV rethrows for task replay; ledger does not).
+      // error-policy:J4 the debit is already committed; convert the post-commit
+      // cache failure into an explicit admission refusal instead of presenting
+      // a healthy fast path (KV rethrows for task replay; ledger does not).
       markOrgAdmissionRefused(ctx.organizationId);
       await invalidateOrgBalanceHint(ctx.organizationId).catch(
         reportInvalidationFailure(ctx.organizationId, "balance-hint"),

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -46,6 +46,7 @@ import { invalidateOrganizationCache } from "../cache/organizations-cache";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { type CreditReconciliationResult, creditsService } from "./credits";
+import { markOrgAdmissionRefused } from "./inference-admission-refusal";
 import { invalidateOrgBalanceHint } from "./inference-auth-cache";
 import { republishOrgBalanceHintAfterDebit } from "./inference-balance-republish";
 
@@ -322,9 +323,28 @@ async function settleLedgerCharge(
     // a missing hint is read `cacheOnly`, so an absent entry turns the NEXT
     // turn into a user-visible "Billing authorization is warming" 503 rather
     // than a slow read. Same defect as the KV fast-path settler.
-    republishOrgBalanceHintAfterDebit(ctx.organizationId).catch(
-      reportInvalidationFailure(ctx.organizationId, "balance-hint"),
-    );
+    //
+    // Awaited (not fire-and-forget): this is a Postgres snapshot + cache write,
+    // and a floating promise is not guaranteed to survive Worker isolate
+    // teardown after settle returns (#17768). Match the KV settler's lifetime
+    // guarantee; on failure force the org off the fast path rather than leave a
+    // silent absent hint.
+    try {
+      await republishOrgBalanceHintAfterDebit(ctx.organizationId);
+    } catch (cause) {
+      markOrgAdmissionRefused(ctx.organizationId);
+      await invalidateOrgBalanceHint(ctx.organizationId).catch(
+        reportInvalidationFailure(ctx.organizationId, "balance-hint"),
+      );
+      logger.error(
+        "[InferenceLedger] post-debit balance-hint republish failed; org forced off fast path",
+        {
+          organizationId: ctx.organizationId,
+          requestId: ctx.requestId,
+          error: cause instanceof Error ? cause.message : String(cause),
+        },
+      );
+    }
     // Parity with deductCredits: fire low-credits email + auto-top-up + the waifu
     // hosted-agent pause webhook so an org draining via optimistic inference still
     // gets low-balance warnings (the ledger debits with its own SQL, not deductCredits).


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: grok, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@4ac932455a80eacb2b33fe43405ec89ddcacd67b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: self-reported

## Summary

**Review remediation (krutftw):** await invalidateOrgBalanceHint on the uncollected branch; await org-cache invalidation; error-policy:J7 on the republish catch; red-first test for forced snapshot failure.


Closes #17768 (residual from #17745).

On the **KV** fast path, post-debit `republishOrgBalanceHintAfterDebit` is awaited. On the **DB ledger** path it was fire-and-forget:

```ts
republishOrgBalanceHintAfterDebit(ctx.organizationId).catch(...);
```

That helper is a Postgres snapshot + cache write. On Worker `settleLedgerCharge(..., \"inline\")`, a floating promise has no lifetime guarantee after the response returns. If dropped, the gate hint stays absent and the next `cacheOnly` read fails closed with \"Billing authorization is warming\" — the same user-visible 503 #17745 fixed on the KV path.

### Fix

1. **Await** the republish after a successful ledger debit.
2. On failure: `markOrgAdmissionRefused` + invalidate hint + log (debit already committed; force org off the fast path rather than leave a silent miss).
3. **PGlite tests**: warm-hint after settle; uncollected debit leaves hint absent.

## Test plan

- [x] `bun test packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts` — **30 pass / 0 fail**

## Evidence

<!-- evidence-head:8261e29421b37f058c178864e92182edae3b2c1c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - billing settler/runtime only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.

<!-- evidence-row:backend-logs -->
- [x] Focused ledger suite on head `b6dc8dca742a1335a4e1d7b661165448a826564a` (retested 30/0 after CR remediations):

<details><summary>inference-billing-ledger.test.ts 30/30</summary>

```text
(pass) admitInferenceChargeViaLedger — atomic admission gate > admits an affordable charge and writes exactly one pending row at the estimate [5.62ms]
(pass) admitInferenceChargeViaLedger — atomic admission gate > rejects when the balance does not clear the threshold (no row written) [2.49ms]
(pass) admitInferenceChargeViaLedger — atomic admission gate > HARD overdraw bound: admission accounts for in-flight pending charges [4.06ms]
(pass) admitInferenceChargeViaLedger — atomic admission gate > rejects an unknown organization with reason org_not_found [2.09ms]
(pass) admitInferenceChargeViaLedger — atomic admission gate > fails SAFE on a +Infinity threshold (misconfigured SAFE_BALANCE_THRESHOLD) without touching the DB [0.73ms]
(pass) admitInferenceChargeViaLedger — atomic admission gate > idempotent re-delivery: the same request id never writes a second pending row [2.49ms]
(pass) admitInferenceChargeViaLedger — atomic admission gate > a same-org concurrent burst cannot collectively overdraw [3.38ms]
(pass) admitInferenceChargeViaLedger — atomic admission gate > admission accounts for in-flight via the pending rows themselves (self-correcting, no separate counter) [9.84ms]
(pass) createLedgerDebitSettler — exactly-once inline settlement > settles the ACTUAL cost: claims the row, debits once, moves the balance by -actual [4.74ms]
(pass) createLedgerDebitSettler — exactly-once inline settlement > EXACTLY-ONCE: a second settle of the same request charges nothing more [3.86ms]
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt behavior change.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - domain proof is PGlite settle + cache hint assertions (warm after debit; absent after uncollected).

<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@4ac932455a80eacb2b33fe43405ec89ddcacd67b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok/wtfsayo]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/eliza@4ac932455a80eacb2b33fe43405ec89ddcacd67b:packages/skills/skills/contribute-to-eliza"} -->




