### PR TITLE
fix(ui): preserve launcher icon URLs in e2e

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
@@ -29,10 +29,17 @@
  * Run: bun run --cwd packages/ui test:launcher-loop-e2e
  */
 
-import { mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { builtinModules } from "node:module";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { chromium } from "playwright";
 import {
   stubNodeBuiltins,
@@ -140,6 +147,29 @@ const stubResolver = {
     }));
   },
 };
+
+// The production launcher resolves packaged PNGs relative to the generated
+// module with `new URL(..., import.meta.url)`. This fixture is intentionally an
+// inline IIFE, where esbuild otherwise replaces import.meta with an empty
+// object and every icon URL throws before React can mount. Bind only that
+// module's import.meta.url to its source file URL, matching the sibling home
+// fixture that exercises the same surface.
+const fixtureViewIconUrls = {
+  name: "launcher-loop-fixture-view-icon-urls",
+  setup(b) {
+    b.onLoad({ filter: /view-icons\.generated\.ts$/ }, async (args) => {
+      const source = await readFile(args.path, "utf8");
+      return {
+        contents: source.replaceAll(
+          "import.meta.url",
+          JSON.stringify(pathToFileURL(args.path).href),
+        ),
+        loader: "ts",
+      };
+    });
+  },
+};
+
 const stubElizaCore = {
   name: "stub-eliza-core",
   setup(b) {
@@ -199,7 +229,12 @@ const url = await writeFixturePage({
   outDir,
   htmlName: "launcher-loop.html",
   title: "launcher loop e2e",
-  plugins: [stubResolver, stubElizaCore, stubNodeBuiltins()],
+  plugins: [
+    stubResolver,
+    fixtureViewIconUrls,
+    stubElizaCore,
+    stubNodeBuiltins(),
+  ],
   processShim: true,
   headHtml,
   background: "#0a0d16",


### PR DESCRIPTION
# Relates to

Closes #17766.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@4ac932455a80eacb2b33fe43405ec89ddcacd67b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# What changed

- Makes the launcher long-loop fixture preserve `import.meta.url` specifically for the generated packaged icon module.
- Matches the sibling home-screen fixture that already handles this inline-IIFE constraint.
- Prevents every `new URL(icon, import.meta.url)` from throwing before React mounts in the chat-shell CI lane.

# Failure and verification

Failed `develop` run: https://github.com/elizaOS/eliza/actions/runs/31020100358

- Before: the exact seeded launcher loop timed out waiting for `home-launcher-surface`; the inline IIFE had replaced the icon module’s `import.meta` with an empty object.
- After: `ELIZA_LOOP_SEED=12375 bun run --cwd packages/ui test:launcher-loop-e2e` passed all 500 touch actions across five batches, with both no-blue scans passing.
- `bun run --cwd packages/ui lint:check` — passed.
- `bun run verify` — 342/342 tasks and all repository audits passed.
- `bun run build` — 121/121 tasks; view-bundle guard 19/19 passed.

# Risk

Low. This changes only the launcher E2E bundler. Production source, generated icon code, and production bundles are unchanged.

# Evidence Gate

<!-- evidence-head:b1b966d86bf5cedcd67e01c9948db8416000d3a9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A — the pre-fix fixture crashed before React mounted.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A — test-harness-only correction; the application render is unchanged.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A — the seeded runner produced its local walkthrough artifact, but this PR changes only fixture URL binding.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A — this browser-only fixture starts no backend.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A — the failed GitHub Actions run is linked above and the repaired local runner exited cleanly.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A — deterministic browser fixture with no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A — no production artifact changes; the relevant output is the seeded 500-action runner result.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A — no product pixels changed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@4ac932455a80eacb2b33fe43405ec89ddcacd67b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@4ac932455a80eacb2b33fe43405ec89ddcacd67b:packages/skills/skills/contribute-to-eliza"} -->