### PR TITLE
fix(core): a fired automation delivers its output, not an acknowledgement

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -5310,9 +5310,11 @@ describe("sub-agent completion relay vs the direct-candidate injection backstop"
 			responseId: "00000000-0000-0000-0000-0000000000aa" as UUID,
 		});
 
-		const stage1Content = ((useModelCalls(runtime)[0]?.[1] as {
+		const firstCall = useModelCalls(runtime)[0];
+		const params = firstCall?.[1] as {
 			messages?: Array<{ content?: string | null }>;
-		}).messages ?? [])
+		};
+		const stage1Content = (params?.messages ?? [])
 			.map((entry) => entry.content ?? "")
 			.join("\n");
 		expect(stage1Content).toContain("trigger_automation_policy:");
@@ -5336,12 +5338,13 @@ describe("sub-agent completion relay vs the direct-candidate injection backstop"
 			state: makeState(),
 			responseId: "00000000-0000-0000-0000-0000000000ab" as UUID,
 		});
-		const stage1Content = ((useModelCalls(runtime)[0]?.[1] as {
+		const firstCall = useModelCalls(runtime)[0];
+		const params = firstCall?.[1] as {
 			messages?: Array<{ content?: string | null }>;
-		}).messages ?? [])
+		};
+		const stage1Content = (params?.messages ?? [])
 			.map((entry) => entry.content ?? "")
 			.join("\n");
 		expect(stage1Content).not.toContain("trigger_automation_policy");
 	});
-
 });

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -5285,4 +5285,63 @@ describe("sub-agent completion relay vs the direct-candidate injection backstop"
 		const calls = useModelCalls(runtime);
 		expect(calls[1]?.[0]).toBe(ModelType.ACTION_PLANNER);
 	});
+
+	it("tells a fired prompt-automation that its reply is the automation's output, not an acknowledgement", async () => {
+		// Live incident 2026-08-05 01:00: a "take vitamins" reminder fired and
+		// the turn replied "noted." — the model read the trigger's own
+		// "Do this now:" framing as a status message about itself and
+		// acknowledged it, so the user received an acknowledgement instead of
+		// the reminder. The policy is gated on the connector-set source, never
+		// on message text.
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "Automation fired.",
+				contexts: ["general"],
+				replyText: "time to take your vitamins.",
+			}),
+		]);
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: 'Scheduled trigger "take vitamins" fired. Do this now: remind me to take my vitamins',
+				source: "trigger-prompt",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-0000000000aa" as UUID,
+		});
+
+		const stage1Content = ((useModelCalls(runtime)[0]?.[1] as {
+			messages?: Array<{ content?: string | null }>;
+		}).messages ?? [])
+			.map((entry) => entry.content ?? "")
+			.join("\n");
+		expect(stage1Content).toContain("trigger_automation_policy:");
+		expect(stage1Content).toContain(
+			"whatever you reply is delivered to the user",
+		);
+		expect(stage1Content).toContain("Never reply with an acknowledgement");
+	});
+
+	it("keeps the prompt byte-identical for an ordinary user turn (no automation policy)", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "Ordinary turn.",
+				contexts: ["general"],
+				replyText: "sure.",
+			}),
+		]);
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "remind me to take my vitamins" }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-0000000000ab" as UUID,
+		});
+		const stage1Content = ((useModelCalls(runtime)[0]?.[1] as {
+			messages?: Array<{ content?: string | null }>;
+		}).messages ?? [])
+			.map((entry) => entry.content ?? "")
+			.join("\n");
+		expect(stage1Content).not.toContain("trigger_automation_policy");
+	});
+
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3065,6 +3065,26 @@ async function createV5MessageContextObject(args: {
 		});
 	}
 
+	// A fired prompt-automation is an INSTRUCTION to carry out now, not a
+	// notification to acknowledge. Live incident 2026-08-05 01:00: a "take
+	// vitamins" reminder fired and the turn replied "noted." — the model read
+	// "Scheduled trigger ... fired. Do this now: <instructions>" as a status
+	// message about itself and acknowledged it, so the user got an
+	// acknowledgement instead of the reminder. Gated on the connector-set
+	// source (never on message text), the same structural shape the ambient
+	// classifier uses: the reply of an automation turn IS its user-facing
+	// output.
+	if (args.message.content.source === MESSAGE_SOURCE_TRIGGER_PROMPT) {
+		events.push({
+			id: "trigger-automation-policy",
+			type: "instruction",
+			source: "message-service",
+			stable: false,
+			content:
+				'trigger_automation_policy: The final message:user below is a scheduled automation of yours firing, not a person talking to you. Its "Do this now:" clause is the instruction you must carry out on this turn, and whatever you reply is delivered to the user as the automation\'s output. Produce that output: if the instruction is to remind, the reply IS the reminder addressed to the user; if it is to check or report something, run the needed tools and reply with the result. Never reply with an acknowledgement of the instruction itself ("noted.", "got it", "will do") — the user never sees the instruction, so an acknowledgement reaches them as a bare non-sequitur.',
+		});
+	}
+
 	const replyReferenceEvent = replyReferenceEventForContext(args.message);
 	if (replyReferenceEvent) {
 		events.push(replyReferenceEvent);


### PR DESCRIPTION
## What

A scheduled prompt-automation that fires now delivers **its output**. Previously the turn could reply with a bare acknowledgement, which reached the user as a non-sequitur because they never see the instruction that triggered it.

## The bug

Live, 2026-08-05 01:00 — a "take vitamins" reminder fired and the agent replied:

```
noted.
```

The trigger dispatches `Scheduled trigger "<name>" fired. Do this now: <instructions>` (`packages/agent/src/triggers/runtime.ts`). Stage 1 read that as a status message *about the agent* and acknowledged it, so the user got "noted." instead of the reminder.

## The fix

A `trigger_automation_policy` instruction, rendered only when `content.source === MESSAGE_SOURCE_TRIGGER_PROMPT` — the connector-set source, never message text — mirroring the existing structural classifiers. It states the turn's actual contract: the automation's "Do this now:" clause is the instruction to carry out, whatever the turn replies is delivered to the user as the automation's output, and an acknowledgement of the instruction is never a valid reply.

Ordinary user turns render byte-identical context (pinned by test).

Repair after review (`4f48398a5a4`, rebased onto develop keeping both the ambient-turn and trigger-automation policy blocks): both flagged extraction sites in `message-runtime-stage1.test.ts` now use the file's lint-clean idiom (bind the first model call to a const, optional-chain from it), so an absent first call produces a readable assertion failure instead of a `TypeError` - exactly the failure mode the review flagged.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:4f48398a5a42996e32649c0ba9b453f724e46a27 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend prompt-composition change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend prompt-composition change, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - prompt-instruction change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the production failing turn this PR fixes.

<details><summary>Production log - vitamins reminder acknowledged instead of delivered</summary>

```text
2026-08-05 01:00:00  [SERVICE:MESSAGE] Processing message
                     (messagePreview=Scheduled trigger "take vitamins" fired.
                      Do this now: remind nubs to take his vitamins)
2026-08-05 01:00:02  [SERVICE:MESSAGE] planner stage-1 classified turn as
                     status-about-agent; reply drafted as acknowledgement
2026-08-05 01:00:03  [BASIC-CAPABILITIES] Message sent (text=noted.)
                     -> user received "noted." with no reminder content;
                        the instruction text is never shown to the user

after fix (same trigger shape, test-pinned):
  trigger_automation_policy renders only when
  content.source === MESSAGE_SOURCE_TRIGGER_PROMPT; the turn's reply is the
  automation's output; an acknowledgement of the instruction is not a valid
  reply.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the trigger-prompt code path.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - the change adds a structurally gated prompt instruction; its behavior is pinned by deterministic prompt-render tests (policy present on trigger-source turns, byte-absent on ordinary turns), no live inference is exercised by this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - full suite, lint, and typecheck at the current head.

<details><summary>Test, lint, typecheck output at 4f48398a5a4</summary>

```text
$ cd packages/core && bunx vitest run src/__tests__/message-runtime-stage1.test.ts
  Test Files  1 passed (1)
       Tests  105 passed (105)
  the new automation test is red without the fix (stash-verified:
  1 failed / 104 passed) and green with it

$ cd packages/core && bun run lint:check
  Checked 1165 files in 4s. No fixes applied.   (0 errors -
  the 3 CI errors on the reviewed head are gone)

$ bun run --cwd packages/core typecheck
  exit 0
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
