### PR TITLE
fix(core): rebind trajectory provider spans to the recorded model prompt

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -95,7 +95,11 @@ import {
 	resolveEffectiveSystemPrompt,
 	textFromChatMessageContent,
 } from "./runtime/system-prompt";
-import { buildProviderAttributionsFromState } from "./runtime/trajectory-provider-attribution";
+import {
+	buildProviderAttributionsFromState,
+	canonicalPromptForModelCall,
+	omitUnvalidatedProviderSpans,
+} from "./runtime/trajectory-provider-attribution";
 import {
 	TurnAbortedError,
 	TurnControllerRegistry,
@@ -4952,6 +4956,10 @@ export class AgentRuntime implements IAgentRuntime {
 			},
 			text: providersText,
 		} as State;
+		// Spans against `providersText` are composition-local only. Model-call
+		// writers rebind from `providerAttributionState` against the exact
+		// recorded messages/prompt; do not treat these offsets as model-prompt
+		// indices.
 		const providerAttribution = buildProviderAttributionsFromState({
 			state: attributionState,
 			prompt: providersText,
@@ -4967,6 +4975,7 @@ export class AgentRuntime implements IAgentRuntime {
 			activeTrajectoryContext.providerOrder = providerAttribution.providerOrder;
 			activeTrajectoryContext.providerAttributions =
 				providerAttribution.providerAttributions;
+			activeTrajectoryContext.providerAttributionState = attributionState;
 		}
 		if (trajectoryStepId && trajLogger) {
 			const userText =
@@ -5001,8 +5010,9 @@ export class AgentRuntime implements IAgentRuntime {
 						sha256: attribution?.sha256,
 						tokenCount: attribution?.tokenCount,
 						position: attribution?.position,
-						spanStart: attribution?.spanStart,
-						spanEnd: attribution?.spanEnd,
+						// Spans index providersText, which is not persisted on the
+						// access row — omit them so readers do not slice a different
+						// string with compose-local offsets.
 						purpose: "compose_state",
 						query: { message: userText.slice(0, 2000) },
 						runId: trajCtx?.runId,
@@ -5047,8 +5057,6 @@ export class AgentRuntime implements IAgentRuntime {
 						sha256: attribution?.sha256,
 						tokenCount: attribution?.tokenCount,
 						position: attribution?.position,
-						spanStart: attribution?.spanStart,
-						spanEnd: attribution?.spanEnd,
 						purpose: "compose_state",
 						query: { message: userText.slice(0, 2000) },
 						runId: trajCtx?.runId,
@@ -7076,6 +7084,31 @@ export class AgentRuntime implements IAgentRuntime {
 			const resultRecord = isPlainObject(args.result)
 				? (args.result as Record<string, unknown>)
 				: {};
+			const messages = Array.isArray(paramsRecord.messages)
+				? paramsRecord.messages
+				: undefined;
+			const prompt =
+				typeof paramsRecord.prompt === "string"
+					? paramsRecord.prompt
+					: userPrompt;
+			// Rebind provider spans to the exact string this call persists. Copying
+			// composeState's providersText offsets onto a larger messages prompt
+			// produces false exact-match slices (#14877).
+			const canonicalPrompt = canonicalPromptForModelCall({
+				messages,
+				prompt,
+			});
+			const reboundAttributions = trajCtx.providerAttributionState
+				? buildProviderAttributionsFromState({
+						state: trajCtx.providerAttributionState,
+						prompt: canonicalPrompt,
+					})
+				: undefined;
+			const providerOrder =
+				reboundAttributions?.providerOrder ?? trajCtx.providerOrder;
+			const providerAttributions =
+				reboundAttributions?.providerAttributions ??
+				omitUnvalidatedProviderSpans(trajCtx.providerAttributions);
 			const usageRecord = isPlainObject(resultRecord.usage)
 				? (resultRecord.usage as Record<string, unknown>)
 				: {};
@@ -7089,13 +7122,8 @@ export class AgentRuntime implements IAgentRuntime {
 				provider: args.provider,
 				systemPrompt,
 				userPrompt,
-				prompt:
-					typeof paramsRecord.prompt === "string"
-						? paramsRecord.prompt
-						: userPrompt,
-				messages: Array.isArray(paramsRecord.messages)
-					? paramsRecord.messages
-					: undefined,
+				prompt,
+				messages,
 				tools: paramsRecord.tools,
 				toolChoice: paramsRecord.toolChoice,
 				responseSchema: paramsRecord.responseSchema,
@@ -7127,8 +7155,8 @@ export class AgentRuntime implements IAgentRuntime {
 				roomId: trajCtx.roomId,
 				messageId: trajCtx.messageId,
 				executionTraceId: activeTrace?.id,
-				providerOrder: trajCtx.providerOrder,
-				providerAttributions: trajCtx.providerAttributions,
+				providerOrder,
+				providerAttributions,
 			});
 		} catch (error) {
 			// error-policy:J7 Trajectory logging must never break core model flow.

--- a/packages/core/src/runtime/__tests__/trajectory-provider-attribution.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-provider-attribution.test.ts
@@ -1,12 +1,16 @@
 /**
  * Unit coverage for trajectory provider attribution: hash-first provider
- * records, ordered prompt spans, and exact prompt-slice round trips.
+ * records, ordered prompt spans, compose→model rebinding, and estimate labels.
  */
 import { describe, expect, it } from "vitest";
 import type { State } from "../../types/state";
 import {
 	buildProviderAttributionsFromState,
+	canonicalPromptForModelCall,
+	estimatedProviderInputCostShareUsd,
+	estimateTrajectoryTextTokens,
 	flattenTrajectoryMessages,
+	omitUnvalidatedProviderSpans,
 	sha256Text,
 } from "../trajectory-provider-attribution";
 
@@ -49,6 +53,7 @@ describe("trajectory provider attribution", () => {
 		for (const entry of result.providerAttributions) {
 			expect(entry.sha256).toHaveLength(64);
 			expect(entry.tokenCount).toBeGreaterThan(0);
+			expect(entry.tokenCountEstimated).toBe(true);
 			expect(entry.spanStart).toBeGreaterThanOrEqual(0);
 			expect(entry.spanEnd).toBeGreaterThan(entry.spanStart ?? 0);
 		}
@@ -86,8 +91,117 @@ describe("trajectory provider attribution", () => {
 				providerName: "ACTIONS",
 				sha256: sha256Text("tool catalog"),
 				tokenCount: 4,
+				tokenCountEstimated: true,
 				position: 0,
 			},
 		]);
+	});
+
+	it("rebinding compose providersText spans onto the larger model messages prompt", () => {
+		// Regression for #14877: composeState locates spans against the joined
+		// providers block alone; useModel must re-locate against the full
+		// recorded messages prompt or omit spans.
+		const characterText = "Character voice: precise and brief.";
+		const recentText = "User: remind me tomorrow.";
+		const state = {
+			data: {
+				providerOrder: ["CHARACTER", "RECENT_MESSAGES"],
+				providers: {
+					CHARACTER: { providerName: "CHARACTER", text: characterText },
+					RECENT_MESSAGES: {
+						providerName: "RECENT_MESSAGES",
+						text: recentText,
+					},
+				},
+			},
+		} as State;
+		const providersText = `${characterText}\n${recentText}`;
+		const composeLocal = buildProviderAttributionsFromState({
+			state,
+			prompt: providersText,
+		});
+		// Compose-local spans index into providersText, not the model prompt.
+		expect(
+			providersText.slice(
+				composeLocal.providerAttributions[0].spanStart,
+				composeLocal.providerAttributions[0].spanEnd,
+			),
+		).toBe(characterText);
+
+		const messages = [
+			{ role: "system", content: "You are Eliza." },
+			{
+				role: "user",
+				content: `Context:\n${characterText}\n\nRecent:\n${recentText}`,
+			},
+		];
+		const modelPrompt = canonicalPromptForModelCall({ messages });
+		// Copying compose spans onto the model prompt would slice the wrong text.
+		const falseSlice = modelPrompt.slice(
+			composeLocal.providerAttributions[0].spanStart,
+			composeLocal.providerAttributions[0].spanEnd,
+		);
+		expect(falseSlice).not.toBe(characterText);
+
+		const rebound = buildProviderAttributionsFromState({
+			state,
+			prompt: modelPrompt,
+		});
+		const [character, recent] = rebound.providerAttributions;
+		expect(modelPrompt.slice(character.spanStart, character.spanEnd)).toBe(
+			characterText,
+		);
+		expect(modelPrompt.slice(recent.spanStart, recent.spanEnd)).toBe(
+			recentText,
+		);
+		expect(character.tokenCountEstimated).toBe(true);
+		expect(character.tokenCount).toBe(
+			estimateTrajectoryTextTokens(characterText),
+		);
+	});
+
+	it("omitUnvalidatedProviderSpans drops offsets while keeping estimate labels", () => {
+		const stripped = omitUnvalidatedProviderSpans([
+			{
+				providerName: "CHARACTER",
+				sha256: sha256Text("x"),
+				tokenCount: 1,
+				position: 0,
+				spanStart: 0,
+				spanEnd: 1,
+			},
+		]);
+		expect(stripped).toEqual([
+			{
+				providerName: "CHARACTER",
+				sha256: sha256Text("x"),
+				tokenCount: 1,
+				tokenCountEstimated: true,
+				position: 0,
+			},
+		]);
+	});
+
+	it("estimatedProviderInputCostShareUsd allocates only the prompt-token share", () => {
+		// $1 call, half prompt tokens, one provider owns all estimate tokens → $0.50.
+		expect(
+			estimatedProviderInputCostShareUsd({
+				costUsd: 1,
+				promptTokens: 50,
+				completionTokens: 50,
+				providerTokenEstimate: 10,
+				totalProviderTokenEstimates: 10,
+			}),
+		).toBeCloseTo(0.5, 8);
+		// No prompt tokens observed → refuse to allocate (do not dump full cost).
+		expect(
+			estimatedProviderInputCostShareUsd({
+				costUsd: 1,
+				promptTokens: undefined,
+				completionTokens: 50,
+				providerTokenEstimate: 10,
+				totalProviderTokenEstimates: 10,
+			}),
+		).toBe(0);
 	});
 });

--- a/packages/core/src/runtime/__tests__/trajectory-provider-attribution.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-provider-attribution.test.ts
@@ -183,7 +183,7 @@ describe("trajectory provider attribution", () => {
 	});
 
 	it("estimatedProviderInputCostShareUsd allocates only the prompt-token share", () => {
-		// $1 call, half prompt tokens, one provider owns all estimate tokens → $0.50.
+		// $1 call, half prompt tokens, provider text covers 10/50 prompt tokens → $0.10.
 		expect(
 			estimatedProviderInputCostShareUsd({
 				costUsd: 1,
@@ -192,7 +192,17 @@ describe("trajectory provider attribution", () => {
 				providerTokenEstimate: 10,
 				totalProviderTokenEstimates: 10,
 			}),
-		).toBeCloseTo(0.5, 8);
+		).toBeCloseTo(0.1, 8);
+		// Over-estimation is capped at the full input share rather than overclaiming it.
+		expect(
+			estimatedProviderInputCostShareUsd({
+				costUsd: 1,
+				promptTokens: 50,
+				completionTokens: 50,
+				providerTokenEstimate: 50,
+				totalProviderTokenEstimates: 100,
+			}),
+		).toBeCloseTo(0.25, 8);
 		// No prompt tokens observed → refuse to allocate (do not dump full cost).
 		expect(
 			estimatedProviderInputCostShareUsd({

--- a/packages/core/src/runtime/trajectory-provider-attribution.ts
+++ b/packages/core/src/runtime/trajectory-provider-attribution.ts
@@ -3,6 +3,11 @@
  * composition already knows the ordered provider blocks that fed a model call;
  * these helpers persist hash-first spans so optimizers can reason about
  * provider selection without storing another copy of provider text.
+ *
+ * Spans are only meaningful against one exact canonical prompt string — the
+ * flattened `messages` (or bare `prompt`) persisted on the consuming model
+ * call. composeState may snapshot provider text early; every model-call writer
+ * must rebind (or omit) spans against that call's recorded representation.
  */
 import { createHash } from "node:crypto";
 import type { ChatMessage } from "../types/model";
@@ -11,8 +16,15 @@ import type { State } from "../types/state";
 export interface TrajectoryProviderAttribution {
 	providerName: string;
 	sha256: string;
+	/**
+	 * Character-based estimate (`ceil(len / 3.5)`), not a model tokenizer count.
+	 * Always paired with `tokenCountEstimated: true` from the runtime helpers.
+	 */
 	tokenCount: number;
+	/** True when `tokenCount` is the length-based estimate, not billed usage. */
+	tokenCountEstimated?: boolean;
 	position: number;
+	/** Inclusive-exclusive offsets into the call's canonical prompt, when exact. */
 	spanStart?: number;
 	spanEnd?: number;
 }
@@ -27,6 +39,10 @@ export function sha256Text(text: string): string {
 	return createHash("sha256").update(text).digest("hex");
 }
 
+/**
+ * Length-based token estimate for trajectory diagnostics only. Do not treat
+ * the result as billed or tokenizer-accurate usage.
+ */
 export function estimateTrajectoryTextTokens(text: string): number {
 	return Math.ceil(text.length / 3.5);
 }
@@ -53,6 +69,42 @@ export function flattenTrajectoryMessages(
 			return `${role}:\n${content}`;
 		})
 		.join("\n\n");
+}
+
+/**
+ * Canonical prompt representation for a recorded model call. Prefer the
+ * flattened `messages` array (the persisted source of truth); fall back to a
+ * bare prompt string when messages are absent.
+ */
+export function canonicalPromptForModelCall(args: {
+	messages?: readonly ChatMessage[] | readonly unknown[] | undefined;
+	prompt?: string | null | undefined;
+}): string {
+	const fromMessages = flattenTrajectoryMessages(args.messages);
+	if (fromMessages.length > 0) {
+		return fromMessages;
+	}
+	return typeof args.prompt === "string" ? args.prompt : "";
+}
+
+/**
+ * Drop span offsets that are not proven against a known prompt. Keeps hash,
+ * order, and estimated token fields so consumers still see contribution
+ * identity without a false exact-match claim.
+ */
+export function omitUnvalidatedProviderSpans(
+	attributions: readonly TrajectoryProviderAttribution[] | undefined,
+): TrajectoryProviderAttribution[] | undefined {
+	if (!attributions || attributions.length === 0) {
+		return attributions === undefined ? undefined : [];
+	}
+	return attributions.map((entry) => {
+		const { spanStart: _spanStart, spanEnd: _spanEnd, ...rest } = entry;
+		return {
+			...rest,
+			tokenCountEstimated: rest.tokenCountEstimated ?? true,
+		};
+	});
 }
 
 function providerSnapshotsFromState(state: State | undefined): {
@@ -124,6 +176,10 @@ function locateProviderSpan(
 
 export function buildProviderAttributionsFromState(args: {
 	state?: State;
+	/**
+	 * Exact canonical prompt for the consuming call. Spans are located only
+	 * inside this string; when a provider is not present, spans are omitted.
+	 */
 	prompt?: string;
 }): {
 	providerOrder: string[];
@@ -138,6 +194,7 @@ export function buildProviderAttributionsFromState(args: {
 			providerName: snapshot.providerName,
 			sha256: sha256Text(snapshot.text),
 			tokenCount: estimateTrajectoryTextTokens(snapshot.text),
+			tokenCountEstimated: true as const,
 			position: snapshot.position,
 			...(span.start !== undefined && span.end !== undefined
 				? { spanStart: span.start, spanEnd: span.end }
@@ -145,4 +202,47 @@ export function buildProviderAttributionsFromState(args: {
 		};
 	});
 	return { providerOrder, providerAttributions };
+}
+
+/**
+ * Defensible input-cost share for provider rollups. Allocates only the
+ * prompt/input fraction of `costUsd` when usage is known; returns 0 when the
+ * call has no finite cost or no prompt tokens to attribute.
+ */
+export function estimatedProviderInputCostShareUsd(args: {
+	costUsd: number | undefined;
+	promptTokens: number | undefined;
+	completionTokens: number | undefined;
+	providerTokenEstimate: number;
+	totalProviderTokenEstimates: number;
+}): number {
+	const cost = args.costUsd;
+	if (typeof cost !== "number" || !Number.isFinite(cost) || cost <= 0) {
+		return 0;
+	}
+	const totalEstimates = args.totalProviderTokenEstimates;
+	const providerEstimate = Math.max(0, args.providerTokenEstimate);
+	if (!(totalEstimates > 0) || !(providerEstimate > 0)) {
+		return 0;
+	}
+	const promptTokens =
+		typeof args.promptTokens === "number" &&
+		Number.isFinite(args.promptTokens) &&
+		args.promptTokens > 0
+			? args.promptTokens
+			: undefined;
+	const completionTokens =
+		typeof args.completionTokens === "number" &&
+		Number.isFinite(args.completionTokens) &&
+		args.completionTokens > 0
+			? args.completionTokens
+			: 0;
+	// Without a prompt-token observation we cannot separate input spend from
+	// completion spend; refuse to allocate the full call cost across providers.
+	if (promptTokens === undefined) {
+		return 0;
+	}
+	const totalTokens = promptTokens + completionTokens;
+	const inputShare = totalTokens > 0 ? promptTokens / totalTokens : 1;
+	return cost * inputShare * (providerEstimate / totalEstimates);
 }

--- a/packages/core/src/runtime/trajectory-provider-attribution.ts
+++ b/packages/core/src/runtime/trajectory-provider-attribution.ts
@@ -206,8 +206,9 @@ export function buildProviderAttributionsFromState(args: {
 
 /**
  * Defensible input-cost share for provider rollups. Allocates only the
- * prompt/input fraction of `costUsd` when usage is known; returns 0 when the
- * call has no finite cost or no prompt tokens to attribute.
+ * prompt/input fraction of `costUsd`, then only the fraction of the prompt
+ * represented by the provider estimate. Returns 0 when the call has no finite
+ * cost or no prompt tokens to attribute.
  */
 export function estimatedProviderInputCostShareUsd(args: {
 	costUsd: number | undefined;
@@ -220,8 +221,12 @@ export function estimatedProviderInputCostShareUsd(args: {
 	if (typeof cost !== "number" || !Number.isFinite(cost) || cost <= 0) {
 		return 0;
 	}
-	const totalEstimates = args.totalProviderTokenEstimates;
-	const providerEstimate = Math.max(0, args.providerTokenEstimate);
+	const totalEstimates = Number.isFinite(args.totalProviderTokenEstimates)
+		? Math.max(0, args.totalProviderTokenEstimates)
+		: 0;
+	const providerEstimate = Number.isFinite(args.providerTokenEstimate)
+		? Math.max(0, args.providerTokenEstimate)
+		: 0;
 	if (!(totalEstimates > 0) || !(providerEstimate > 0)) {
 		return 0;
 	}
@@ -244,5 +249,6 @@ export function estimatedProviderInputCostShareUsd(args: {
 	}
 	const totalTokens = promptTokens + completionTokens;
 	const inputShare = totalTokens > 0 ? promptTokens / totalTokens : 1;
-	return cost * inputShare * (providerEstimate / totalEstimates);
+	const attributionDenominator = Math.max(promptTokens, totalEstimates);
+	return cost * inputShare * (providerEstimate / attributionDenominator);
 }

--- a/packages/core/src/trajectory-context.ts
+++ b/packages/core/src/trajectory-context.ts
@@ -11,6 +11,7 @@ import type { TrajectoryProviderAttribution } from "./runtime/trajectory-provide
 import type { PseudonymSession } from "./security/pii-pseudonymizer";
 import type { SecretSwapSession } from "./security/secret-swap";
 import type { RoleGateRole } from "./types/contexts";
+import type { State } from "./types/state";
 import { StackContextManager } from "./utils/stack-context-manager";
 
 export interface TrajectoryContext {
@@ -40,12 +41,16 @@ export interface TrajectoryContext {
 	/** Pipeline stage purpose for trajectory logging (e.g. "should_respond", "response", "action", "evaluation"). */
 	purpose?: string;
 	/**
-	 * Latest composed provider contribution snapshot for the active step. The
-	 * runtime stamps it onto the next model call so DB trajectories can
-	 * reconstruct provider order and prompt spans without storing provider text.
+	 * Latest composed provider contribution snapshot for the active step.
+	 * `providerAttributionState` retains provider text so model-call writers can
+	 * rebind spans against the exact prompt they persist; precomputed
+	 * `providerAttributions` may carry spans only for the composition snapshot
+	 * and must not be copied onto a larger model prompt without rebinding.
 	 */
 	providerOrder?: string[];
 	providerAttributions?: TrajectoryProviderAttribution[];
+	/** Minimal State used to re-locate provider spans for a consuming model call. */
+	providerAttributionState?: State;
 	/**
 	 * Turn-scoped secret-swap session (#10469). Minted on the first `useModel`
 	 * call of a turn when secret-swap is enabled, then reused by every subsequent

--- a/packages/scripts/trajectory.ts
+++ b/packages/scripts/trajectory.ts
@@ -1151,8 +1151,12 @@ function providerRows(trajectory: RecordedTrajectory): ProviderRollupRow[] {
             ? completionTokens
             : 0;
         const inputShare = promptTokens / (promptTokens + completion);
+        const attributionDenominator = Math.max(
+          promptTokens,
+          totalProviderTokens,
+        );
         current.costUsd +=
-          cost * inputShare * (providerEstimate / totalProviderTokens);
+          cost * inputShare * (providerEstimate / attributionDenominator);
       }
       if (
         typeof entry.spanStart === "number" &&

--- a/packages/scripts/trajectory.ts
+++ b/packages/scripts/trajectory.ts
@@ -1117,6 +1117,8 @@ function providerRows(trajectory: RecordedTrajectory): ProviderRollupRow[] {
       (total, entry) => total + Math.max(0, entry.tokenCount || 0),
       0,
     );
+    const promptTokens = model.usage?.promptTokens;
+    const completionTokens = model.usage?.completionTokens;
     for (const entry of attributions) {
       const current = rows.get(entry.providerName) ?? {
         providerName: entry.providerName,
@@ -1128,14 +1130,29 @@ function providerRows(trajectory: RecordedTrajectory): ProviderRollupRow[] {
       };
       current.calls += 1;
       current.tokens += Math.max(0, entry.tokenCount || 0);
+      // Only the defensible input-cost share: require observed prompt tokens so
+      // we never allocate completion (or full-call) spend across providers.
+      const cost = model.costUsd;
+      const providerEstimate = Math.max(0, entry.tokenCount || 0);
       if (
-        typeof model.costUsd === "number" &&
-        Number.isFinite(model.costUsd) &&
-        totalProviderTokens > 0
+        typeof cost === "number" &&
+        Number.isFinite(cost) &&
+        cost > 0 &&
+        totalProviderTokens > 0 &&
+        providerEstimate > 0 &&
+        typeof promptTokens === "number" &&
+        Number.isFinite(promptTokens) &&
+        promptTokens > 0
       ) {
+        const completion =
+          typeof completionTokens === "number" &&
+          Number.isFinite(completionTokens) &&
+          completionTokens > 0
+            ? completionTokens
+            : 0;
+        const inputShare = promptTokens / (promptTokens + completion);
         current.costUsd +=
-          model.costUsd *
-          (Math.max(0, entry.tokenCount || 0) / totalProviderTokens);
+          cost * inputShare * (providerEstimate / totalProviderTokens);
       }
       if (
         typeof entry.spanStart === "number" &&
@@ -1164,12 +1181,15 @@ async function cmdProviders(id: string): Promise<void> {
   const widths = {
     provider: Math.max(8, ...rows.map((row) => row.providerName.length)),
     calls: 5,
-    tokens: Math.max(6, ...rows.map((row) => String(row.tokens).length)),
-    cost: 10,
+    tokens: Math.max(10, ...rows.map((row) => String(row.tokens).length + 4)),
+    cost: 14,
     spans: 5,
     sha: 12,
   };
-  const header = `${"provider".padEnd(widths.provider)}  ${"calls".padEnd(widths.calls)}  ${"tokens".padEnd(widths.tokens)}  ${"cost".padEnd(widths.cost)}  ${"spans".padEnd(widths.spans)}  sha256`;
+  // tokenCount is a character estimate; cost is the input-cost share only when
+  // prompt usage is known (otherwise 0). Label both so the table is not read as
+  // billed tokenizer usage or full-call spend.
+  const header = `${"provider".padEnd(widths.provider)}  ${"calls".padEnd(widths.calls)}  ${"est.tok".padEnd(widths.tokens)}  ${"est.in$".padEnd(widths.cost)}  ${"spans".padEnd(widths.spans)}  sha256`;
   console.log(c.bold(header));
   console.log(c.dim("-".repeat(header.length)));
   for (const row of rows) {
@@ -1177,6 +1197,11 @@ async function cmdProviders(id: string): Promise<void> {
       `${row.providerName.padEnd(widths.provider)}  ${String(row.calls).padEnd(widths.calls)}  ${String(row.tokens).padEnd(widths.tokens)}  ${formatUsd(row.costUsd).padEnd(widths.cost)}  ${String(row.spans).padEnd(widths.spans)}  ${row.sha256.slice(0, widths.sha)}`,
     );
   }
+  console.log(
+    c.dim(
+      "est.tok = ceil(chars/3.5); est.in$ = prompt-token share of costUsd when usage is present.",
+    ),
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`, `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: grok, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@8d21653bb334e78f37a5e3d7ef1dcbcee720b783:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: self-reported

## Summary

Closes residual acceptance on #14877 after #15079: provider spans and cost tables must not overclaim precision.

### Problem
`composeState` located provider `spanStart`/`spanEnd` against the joined `providersText` snapshot and stored them on the trajectory context. `recordUseModelTrajectory` then copied those offsets onto the next model call whose recorded `messages`/`prompt` is a larger representation. Slicing the model prompt with compose-local offsets produces false exact-match provenance. Separately, `tokenCount` is `ceil(len/3.5)` and `trajectory providers` allocated the entire call `costUsd` (including completion) across providers in proportion to that estimate.

### Fix
- Keep provider text on `TrajectoryContext.providerAttributionState` so model-call writers can rebind.
- `recordUseModelTrajectory` rebuilds attributions against `canonicalPromptForModelCall({ messages, prompt })`; if state is missing, strip unvalidated spans rather than copying compose offsets.
- Omit spans on `compose_state` provider-access rows (they indexed a non-persisted `providersText`).
- Mark `tokenCountEstimated: true` on runtime-built attributions.
- `trajectory providers` allocates only the prompt-token share of `costUsd` when usage is present; otherwise 0. Table headers label estimates.

### Tests
- New unit cases: compose→model rebinding regression, span strip, input-cost share math.
- Existing attribution + TrajectoriesService suites green.

## Linked issue
Fixes residual correctness on #14877 (implementation base #15079).

## Evidence Gate

<!-- evidence-head:3cd55dd85897762f8895b4f412011d7434d21039 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core trajectory attribution; no UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core trajectory attribution; no UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive user flow.

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic backend unit proof only: bun test packages/core/src/runtime/__tests__/trajectory-provider-attribution.test.ts packages/core/src/features/trajectories/TrajectoriesService.test.ts → 12 pass / 0 fail; bun run --cwd packages/core typecheck pass on head c4322509c91e38e6807a152932ae5e0b85dca3b7.

```
bun test packages/core/src/runtime/__tests__/trajectory-provider-attribution.test.ts packages/core/src/features/trajectories/TrajectoriesService.test.ts
# 12 pass / 0 fail
bun run --cwd packages/core typecheck  # pass
```

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - residual is source-level span/estimate honesty; no live model keys in this shell. Deterministic compose→model rebinding test covers the #14877 failure mode.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - unit assertions are the domain proof: compose-local spans mis-slice model prompt; rebound spans round-trip; input-cost share math; refuse full-cost allocation without prompt tokens (see backend-logs row and PR test summary).

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@8d21653bb334e78f37a5e3d7ef1dcbcee720b783:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok/wtfsayo]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/eliza@8d21653bb334e78f37a5e3d7ef1dcbcee720b783:packages/skills/skills/contribute-to-eliza"} -->


