### PR TITLE
fix(app-core): mount account-pool broker routes under /api/internal so the dispatcher can reach them

### DIFF
--- a/packages/app-core/src/api/account-pool-broker-routes.dispatch.test.ts
+++ b/packages/app-core/src/api/account-pool-broker-routes.dispatch.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Production-path regression coverage for the account-pool broker mount.
+ *
+ * The pre-existing broker tests (`account-pool-broker-routes.test.ts`) call
+ * `handleAccountPoolBrokerRoute` DIRECTLY with whatever path the test fixture
+ * chooses, so they cannot detect a prefix that the real dispatcher never
+ * routes to the handler. That is exactly the gap that shipped: with
+ * `ROUTE_PREFIX = "/internal/account-pool/v1"` (missing `/api`) the handler
+ * was dead code in production — the compat dispatcher only reaches
+ * `handleInternalWakeRoute` (which delegates to the broker) for
+ * `/api/internal/*` paths and never strips `/api`, so every lease request
+ * fell through to generic auth (401) and fail-closed pool proxies surfaced
+ * that as 503 "broker unavailable".
+ *
+ * These tests drive the REAL dispatcher entrypoint (`handleElizaCompatRoute`
+ * → compat route chain → `handleInternalWakeRoute` → broker handler) with the
+ * canonical `/api/internal/account-pool/v1/*` paths the pool proxy actually
+ * calls, so a future prefix regression fails here instead of in production.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import * as http from "node:http";
+import { Socket } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { saveAccount } from "@elizaos/auth/account-storage";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __resetDefaultAccountPoolForTests } from "../services/account-pool.js";
+import { __resetAccountPoolBrokerRoutesForTests } from "./account-pool-broker-routes.js";
+import type { CompatRuntimeState } from "./compat-route-shared";
+import { handleElizaCompatRoute } from "./server";
+
+const SECRET = "dispatch-broker-fixture-secret-at-least-32-chars";
+const REFRESH_SECRET = "sk-ant-oat-dispatch-primary-refresh";
+const FAR_FUTURE = Date.now() + 10 * 365 * 24 * 60 * 60 * 1000;
+
+const STATE: CompatRuntimeState = {
+  current: null,
+  pendingAgentName: null,
+  pendingRestartReasons: [],
+};
+
+let home: string;
+let saved: Record<string, string | undefined>;
+const ENV_KEYS = [
+  "ELIZA_HOME",
+  "ELIZA_STATE_DIR",
+  "ELIZA_ACCOUNT_POOL_BROKER_ENABLED",
+  "ELIZA_ACCOUNT_POOL_BROKER_SECRET",
+  "ELIZA_ACCOUNT_POOL_BROKER_LEASE_TTL_MS",
+] as const;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  home = mkdtempSync(path.join(tmpdir(), "account-pool-broker-dispatch-"));
+  process.env.ELIZA_HOME = home;
+  process.env.ELIZA_STATE_DIR = home;
+  process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED = "1";
+  process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET = SECRET;
+  delete process.env.ELIZA_ACCOUNT_POOL_BROKER_LEASE_TTL_MS;
+  __resetDefaultAccountPoolForTests();
+  __resetAccountPoolBrokerRoutesForTests();
+});
+
+afterEach(() => {
+  __resetAccountPoolBrokerRoutesForTests();
+  __resetDefaultAccountPoolForTests();
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  rmSync(home, { recursive: true, force: true });
+});
+
+function loopbackReq(
+  method: string,
+  pathname: string,
+  options: { auth?: string; body?: Record<string, unknown> } = {},
+): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = method;
+  req.url = pathname;
+  req.headers = { host: "127.0.0.1:18792" };
+  if (options.auth !== undefined) req.headers.authorization = options.auth;
+  if (options.body !== undefined) {
+    (req as { body?: unknown }).body = options.body;
+  }
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  return req;
+}
+
+function captureRes() {
+  let body = "";
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  const socket = new Socket();
+  res.assignSocket(socket);
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") body += chunk;
+    else if (chunk) body += chunk.toString("utf8");
+    socket.destroy();
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    status: () => res.statusCode,
+    json: () => (body ? JSON.parse(body) : null),
+  };
+}
+
+describe("account-pool broker routes through the real compat dispatcher", () => {
+  it("serves /api/internal/account-pool/v1/health via the dispatcher path", async () => {
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      loopbackReq("GET", "/api/internal/account-pool/v1/health", {
+        auth: `Bearer ${SECRET}`,
+      }),
+      cap.res,
+      STATE,
+    );
+
+    expect(handled).toBe(true);
+    // On the broken prefix this request never reaches the broker: it falls
+    // through to generic auth / terminal compat handlers and the body has no
+    // broker health shape. The assertion below pins the production contract
+    // the pool proxy depends on.
+    expect(cap.status()).toBe(200);
+    expect(cap.json()).toMatchObject({ ok: true, enabled: true });
+  });
+
+  it("leases an account via POST /api/internal/account-pool/v1/lease through the dispatcher", async () => {
+    saveAccount({
+      id: "dispatch-primary",
+      providerId: "anthropic-subscription",
+      label: "dispatch-primary",
+      source: "oauth",
+      credentials: {
+        access: "sk-ant-oat-dispatch-primary",
+        refresh: REFRESH_SECRET,
+        expires: FAR_FUTURE,
+      },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      loopbackReq("POST", "/api/internal/account-pool/v1/lease", {
+        auth: `Bearer ${SECRET}`,
+        body: {
+          providerId: "anthropic-subscription",
+          sessionKey: "dispatch-test:s1",
+        },
+      }),
+      cap.res,
+      STATE,
+    );
+
+    expect(handled).toBe(true);
+    expect(cap.status()).toBe(200);
+    const body = cap.json() as Record<string, unknown>;
+    expect(body.accountId).toBe("dispatch-primary");
+    expect(body.accessToken).toBe("sk-ant-oat-dispatch-primary");
+    // Two independent leak checks: the saved refresh secret must never appear
+    // in a lease response (value-level, independent of fixture spelling), and
+    // no `refresh*` key should be serialized either (shape-level).
+    expect(JSON.stringify(body)).not.toContain(REFRESH_SECRET);
+    expect(JSON.stringify(body)).not.toContain("refresh");
+  });
+
+  it("still 401s a wrong bearer with the broker's own error shape (not generic auth)", async () => {
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      loopbackReq("GET", "/api/internal/account-pool/v1/health", {
+        auth: "Bearer wrong-secret-wrong-secret-wrong-secret",
+      }),
+      cap.res,
+      STATE,
+    );
+
+    expect(handled).toBe(true);
+    expect(cap.status()).toBe(401);
+    // Broker shape is {ok:false,error:"unauthorized"}; the generic /api
+    // fallback is {"error":"Unauthorized"}. The distinction is exactly how
+    // the production outage was diagnosed, so pin it.
+    expect(cap.json()).toEqual({ ok: false, error: "unauthorized" });
+  });
+});

--- a/packages/app-core/src/api/account-pool-broker-routes.test.ts
+++ b/packages/app-core/src/api/account-pool-broker-routes.test.ts
@@ -122,7 +122,7 @@ async function postBroker(
 ): Promise<FakeRes> {
   const res = fakeRes();
   await handleAccountPoolBrokerRoute(
-    fakeReq(`/internal/account-pool/v1/${pathSuffix}`, {
+    fakeReq(`/api/internal/account-pool/v1/${pathSuffix}`, {
       auth: `Bearer ${SECRET}`,
       body,
     }),
@@ -179,7 +179,7 @@ describe("account-pool broker route auth", () => {
     delete process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED;
     const res = fakeRes();
     const handled = await handleAccountPoolBrokerRoute(
-      fakeReq("/internal/account-pool/v1/health", {
+      fakeReq("/api/internal/account-pool/v1/health", {
         method: "GET",
         auth: `Bearer ${SECRET}`,
       }),
@@ -192,7 +192,7 @@ describe("account-pool broker route auth", () => {
     const weak = fakeRes();
     expect(
       await handleAccountPoolBrokerRoute(
-        fakeReq("/internal/account-pool/v1/health", {
+        fakeReq("/api/internal/account-pool/v1/health", {
           method: "GET",
           auth: "Bearer short",
         }),
@@ -204,7 +204,7 @@ describe("account-pool broker route auth", () => {
   it("rejects non-loopback callers before serving the broker", async () => {
     const res = fakeRes();
     const handled = await handleAccountPoolBrokerRoute(
-      fakeReq("/internal/account-pool/v1/health", {
+      fakeReq("/api/internal/account-pool/v1/health", {
         method: "GET",
         auth: `Bearer ${SECRET}`,
         remoteAddress: "10.0.0.8",
@@ -220,7 +220,7 @@ describe("account-pool broker route auth", () => {
   it("requires bearer auth and never echoes the secret in errors", async () => {
     const res = fakeRes();
     await handleAccountPoolBrokerRoute(
-      fakeReq("/internal/account-pool/v1/health", {
+      fakeReq("/api/internal/account-pool/v1/health", {
         method: "GET",
         auth: "Bearer wrong-secret",
       }),
@@ -310,7 +310,7 @@ describe("account-pool broker consumer key management", () => {
   it("returns structured no-store 400 for malformed consumer key ids", async () => {
     const res = fakeRes();
     await handleAccountPoolBrokerRoute(
-      fakeReq("/internal/account-pool/v1/consumer-keys/%E0%A4%A", {
+      fakeReq("/api/internal/account-pool/v1/consumer-keys/%E0%A4%A", {
         method: "PATCH",
         auth: `Bearer ${SECRET}`,
         body: {
@@ -345,7 +345,7 @@ describe("account-pool broker consumer key management", () => {
 
     const listed = fakeRes();
     await handleAccountPoolBrokerRoute(
-      fakeReq("/internal/account-pool/v1/consumer-keys", {
+      fakeReq("/api/internal/account-pool/v1/consumer-keys", {
         method: "GET",
         auth: `Bearer ${SECRET}`,
       }),
@@ -369,7 +369,7 @@ describe("account-pool broker consumer key management", () => {
 
     const updated = fakeRes();
     await handleAccountPoolBrokerRoute(
-      fakeReq(`/internal/account-pool/v1/consumer-keys/${id}`, {
+      fakeReq(`/api/internal/account-pool/v1/consumer-keys/${id}`, {
         method: "PATCH",
         auth: `Bearer ${SECRET}`,
         body: {
@@ -393,7 +393,7 @@ describe("account-pool broker consumer key management", () => {
 
     const rotated = fakeRes();
     await handleAccountPoolBrokerRoute(
-      fakeReq(`/internal/account-pool/v1/consumer-keys/${id}/rotate`, {
+      fakeReq(`/api/internal/account-pool/v1/consumer-keys/${id}/rotate`, {
         method: "POST",
         auth: `Bearer ${SECRET}`,
       }),

--- a/packages/app-core/src/api/account-pool-broker-routes.ts
+++ b/packages/app-core/src/api/account-pool-broker-routes.ts
@@ -24,7 +24,13 @@ import {
 import { readCompatJsonBody } from "./compat-route-shared.js";
 import { sendJson } from "./response.js";
 
-const ROUTE_PREFIX = "/internal/account-pool/v1";
+// The dispatcher (`handleInternalWakeRoute`, reached via the compat route
+// chain) only sees this handler for `/api/internal/*` paths, and the router
+// never strips `/api`. The prefix therefore MUST include `/api` — an
+// un-prefixed value makes every broker route unreachable dead code: lease
+// calls fall through to generic device-secret auth (401) and fail-closed
+// proxies surface that as 503 "broker unavailable".
+const ROUTE_PREFIX = "/api/internal/account-pool/v1";
 const MIN_BROKER_SECRET_LENGTH = 32;
 
 let brokerSingleton: AccountPoolBroker | null = null;

--- a/packages/app-core/src/api/internal-routes.test.ts
+++ b/packages/app-core/src/api/internal-routes.test.ts
@@ -377,13 +377,23 @@ describe("getDeviceSecret", () => {
   it("delegates account-pool broker routes before wake handling", async () => {
     const previousEnabled = process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED;
     const previousSecret = process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET;
+    // Isolate account storage: the broker health handler enumerates real
+    // accounts, so without a scratch ELIZA_HOME/STATE_DIR this test reads
+    // (and may fail to decrypt) the developer's actual account vault.
+    const previousHome = process.env.ELIZA_HOME;
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const scratch = fs.mkdtempSync(
+      path.join(os.tmpdir(), "internal-routes-broker-"),
+    );
+    process.env.ELIZA_HOME = scratch;
+    process.env.ELIZA_STATE_DIR = scratch;
     process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED = "1";
     process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET =
       "test-broker-secret-at-least-thirty-two-chars";
     try {
       const response = fakeRes();
       const handled = await handleInternalWakeRoute(
-        fakeReq("/internal/account-pool/v1/health", {
+        fakeReq("/api/internal/account-pool/v1/health", {
           method: "GET",
           auth: "Bearer test-broker-secret-at-least-thirty-two-chars",
         }),
@@ -404,6 +414,11 @@ describe("getDeviceSecret", () => {
       if (previousSecret === undefined)
         delete process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET;
       else process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET = previousSecret;
+      if (previousHome === undefined) delete process.env.ELIZA_HOME;
+      else process.env.ELIZA_HOME = previousHome;
+      if (previousStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+      else process.env.ELIZA_STATE_DIR = previousStateDir;
+      fs.rmSync(scratch, { recursive: true, force: true });
     }
   });
 

--- a/packages/app-core/src/services/account-pool-consumer-metering.md
+++ b/packages/app-core/src/services/account-pool-consumer-metering.md
@@ -15,7 +15,7 @@ public request, the proxy should:
    with `Cache-Control: no-store`.
 3. Use `upstreamHeaders` from the result when building the upstream request;
    both `x-api-key` and `Authorization` caller credentials are stripped.
-4. Lease an upstream account through `/internal/account-pool/v1/lease`.
+4. Lease an upstream account through `/api/internal/account-pool/v1/lease`.
 5. For non-streaming Anthropic responses, parse the response JSON and pass
    `extractAnthropicUsageFromJson(json)` plus the returned `admission` to
    `recordAccountPoolConsumerUsage`.
@@ -35,11 +35,11 @@ current behavior.
 Consumer key management is admin-only under the existing loopback bearer-gated
 broker API:
 
-- `GET /internal/account-pool/v1/consumer-keys`
-- `POST /internal/account-pool/v1/consumer-keys`
-- `PATCH /internal/account-pool/v1/consumer-keys/:id`
-- `POST /internal/account-pool/v1/consumer-keys/:id/rotate`
-- `GET /internal/account-pool/v1/usage?consumerId=&startMs=&endMs=`
+- `GET /api/internal/account-pool/v1/consumer-keys`
+- `POST /api/internal/account-pool/v1/consumer-keys`
+- `PATCH /api/internal/account-pool/v1/consumer-keys/:id`
+- `POST /api/internal/account-pool/v1/consumer-keys/:id/rotate`
+- `GET /api/internal/account-pool/v1/usage?consumerId=&startMs=&endMs=`
 
 Plaintext consumer keys are returned only by create and rotate. The state store
 persists a SHA-256 digest plus public metadata.


### PR DESCRIPTION
## Why

The account-pool broker HTTP surface was unreachable in production. `account-pool-broker-routes.ts` declared `ROUTE_PREFIX = "/internal/account-pool/v1"`, but the compat dispatcher only reaches `handleInternalWakeRoute` (which delegates to `handleAccountPoolBrokerRoute`) for `/api/internal/*` paths, and the router never strips `/api`. The two conditions can never both hold:

- to be dispatched to the handler at all, the path must start with `/api/internal/`
- to match `ROUTE_PREFIX`, it must start with `/internal/account-pool/v1`

So every broker route was dead code. A lease request to the canonical `/api/internal/account-pool/v1/lease` fell through to the generic `/api/internal/` device-secret auth and got `401 {"error":"Unauthorized"}` (note the shape: NOT the broker's own `{"ok":false,"error":"unauthorized"}` — that shape difference is how this was diagnosed). Fail-closed pool proxies translate that 401 into `503 "Account broker unavailable before upstream request"` on every single completion.

**Local repro evidence (2026-08-05):** this took down an entire local account pool — every session erroring with instant 503s (~10ms, i.e. failing at the lease step before any upstream call). Path probing pinned it:

```
POST /api/internal/account-pool/v1/lease -> 401 {"error":"Unauthorized"}   (generic /api auth)
POST /internal/account-pool/v1/lease     -> 404 {"error":"Not found"}      (not routed at all)
```

Ruled out along the way: lease exhaustion (restarts didn't help), token mismatch (proxy token == backend secret byte-for-byte), env not loading (running process had ENABLED=1 + correct SECRET), orphan process on the port. Applying this one-line prefix fix and restarting: broker health 200 with a real snapshot, 3/3 end-to-end completions through the proxy. Full diagnosis receipt: workspace `POOL-503-ROOTCAUSE-FIX-2026-08-05.md`.

## Fix

`ROUTE_PREFIX` -> `/api/internal/account-pool/v1`, matching the path the pool proxy actually calls and the only prefix the dispatcher can deliver. Direct-call tests and the consumer-metering doc updated to the canonical path. Comment added at the constant explaining why `/api` is load-bearing.

## Why existing tests missed it (production-path gap)

The existing suites (`account-pool-broker-routes.test.ts`, the delegation test in `internal-routes.test.ts`) invoke `handleAccountPoolBrokerRoute` / `handleInternalWakeRoute` **directly** with whatever path the fixture chooses — the same un-prefixed path the handler declared. Handler and tests agreed with each other while both disagreed with production routing, so the suite stayed green while the route was unreachable. That is exactly the gap that let this ship.

## Bidirectional test

New `account-pool-broker-routes.dispatch.test.ts` drives the REAL dispatcher entrypoint (`handleElizaCompatRoute` -> compat route chain -> `handleInternalWakeRoute` -> broker) with `/api/internal/account-pool/v1/*` from a loopback peer:

- `GET .../health` returns the broker health snapshot (200, `{ok:true,enabled:true}`)
- `POST .../lease` returns a real lease (accountId + accessToken, no refresh token echoed)
- wrong bearer gets the broker's own 401 shape `{ok:false,error:"unauthorized"}`, not generic auth's `{"error":"Unauthorized"}` — pinning the exact discriminator used to diagnose the outage

**Verified both directions:** with `ROUTE_PREFIX` reverted to the old un-prefixed value, all 3 dispatch tests fail (handler never reached); with the fix, all pass.

Also isolates the `internal-routes.test.ts` broker-delegation test into a scratch `ELIZA_HOME`/`ELIZA_STATE_DIR`: broker health enumerates real accounts, and without isolation that test read (and failed to decrypt) the developer's actual account vault.

## Consumers checked

Grepped the tree for `/internal/account-pool` — the only un-prefixed references were the handler constant itself, the direct-call tests, and the metering doc (all updated here). The pool-proxy side already calls the `/api`-prefixed path, so no consumer depends on the old prefix (it never worked).

## Verification

- vitest: `account-pool-broker-routes.dispatch.test.ts` + `account-pool-broker-routes.test.ts` + `internal-routes.test.ts` + `route-auth-policy.dispatch.test.ts` + `route-auth-policy.test.ts` — 43/43 pass
- `tsc --noEmit` — no new errors in touched files (remaining errors are pre-existing unbuilt-sibling-package imports: plugin-meetings, cloud-routing)

Co-authored-by: 0xSolace <shadow@shad0w.xyz>

# Evidence

<!-- evidence-head:6d917f6367954fde7408f88c1cfe923c1ca4b320 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend-only routing constant. Five files in the diff (route constant, three test files, one doc); no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend-only change. The user-visible effect is HTTP routing (lease/health served instead of 401/503), proven by the transcripts in the backend-logs and domain-artifacts rows.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI flow to walk through. The observable behavior is request-in -> broker-response-out, captured as transcripts below.`
<!-- evidence-row:backend-logs -->
- [x] The path probe that diagnosed the outage (before the fix, live backend):

```text
POST /api/internal/account-pool/v1/lease -> 401 {"error":"Unauthorized"}   (generic /api auth; note shape: no "ok" field)
POST /internal/account-pool/v1/lease     -> 404 {"error":"Not found"}      (not routed at all)
proxy completion -> HTTP 503 {"error":{"type":"overloaded_error","message":"Account broker unavailable before upstream request."}}  (~10ms, fails at lease step)
```

After the one-line prefix fix + backend restart:

```text
GET /api/internal/account-pool/v1/health (Bearer <secret>)
-> 200 {"ok":true,"enabled":true,"activeLeases":0,"accounts":{...ready...}}
End-to-end completions through the pool proxy: 3/3 HTTP 200, real model responses (~1.5-3s)
```

Test suites on head `6d917f636`:

```text
$ npx vitest run account-pool-broker-routes.dispatch + account-pool-broker-routes + internal-routes + route-auth-policy.dispatch + route-auth-policy
 Test Files  5 passed (5)
      Tests  43 passed (43)

$ node_modules/.bin/biome check <4 changed .ts files>
Checked 4 files. No fixes applied.
```

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend surface in the diff. The caller is the loopback pool proxy, not a browser; its observed behavior is the 503->200 transcript in the backend-logs row.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model change. The diff is an HTTP route prefix and its tests; whether the broker route is reachable is the thing under test.`
<!-- evidence-row:domain-artifacts -->
- [x] Bidirectional proof from the new dispatcher-level suite (drives the real `handleElizaCompatRoute` entrypoint):

```text
With ROUTE_PREFIX reverted to the old un-prefixed value: all 3 dispatch tests FAIL (handler never reached; health falls through to generic auth, lease 401s, wrong-bearer case gets generic {"error":"Unauthorized"} instead of the broker's {"ok":false,"error":"unauthorized"}).
With the fix: 3/3 pass -
 (pass) serves /api/internal/account-pool/v1/health via the dispatcher path
 (pass) leases an account via POST /api/internal/account-pool/v1/lease through the dispatcher
 (pass) still 401s a wrong bearer with the broker's own error shape (not generic auth)
Full diagnosis receipt (topology, ruled-out hypotheses, live 503->200 recovery): workspace POOL-503-ROOTCAUSE-FIX-2026-08-05.md
```

<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface in this change; the diff is a server route prefix, tests, and a doc.`

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-6`
<!-- attribution-row:client -->
- Client / agent tooling: `moltbot`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`
