### PR TITLE
perf(telemetry): surface reasoning-token usage on inference spans and bound failure replies

### DIFF
--- a/packages/core/src/__tests__/inference-timing.test.ts
+++ b/packages/core/src/__tests__/inference-timing.test.ts
@@ -96,6 +96,33 @@ describe("InferenceTurnTimer", () => {
 		timer.setModelProvider("other");
 		expect(timer.summary().modelProvider).toBe("elizaOSCloud");
 	});
+
+	it("preserves arbitrary meta (e.g. reasoningTokens) on a recorded span", () => {
+		// A reasoning burst must be attributable per model call (#16394): the
+		// span meta is where the runtime threads reasoningTokens, and it must
+		// round-trip through the summary unchanged.
+		const timer = new InferenceTurnTimer({ turnId: "t8", label: "test" });
+		timer.recordSpan("model:RESPONSE_HANDLER", 3200, {
+			modelKey: "zai-glm-4.7",
+			provider: "cerebras",
+			outcome: "success",
+			reasoningTokens: 400,
+		});
+		// A span with no reasoning meta omits the field entirely (missing stays
+		// missing, never zero).
+		timer.recordSpan("model:TEXT_SMALL", 120, {
+			modelKey: "zai-glm-4.7",
+			provider: "cerebras",
+			outcome: "success",
+		});
+		const s = timer.summary();
+		const reasoningSpan = s.spans.find(
+			(sp) => sp.name === "model:RESPONSE_HANDLER",
+		);
+		const plainSpan = s.spans.find((sp) => sp.name === "model:TEXT_SMALL");
+		expect(reasoningSpan?.meta?.reasoningTokens).toBe(400);
+		expect(plainSpan?.meta?.reasoningTokens).toBeUndefined();
+	});
 });
 
 describe("exclusive inference flow breakdown", () => {

--- a/packages/core/src/__tests__/message-failure-reply.test.ts
+++ b/packages/core/src/__tests__/message-failure-reply.test.ts
@@ -221,4 +221,25 @@ describe("DefaultMessageService structured failure replies", () => {
 		expect(result.responseContent?.text).not.toContain('"action"');
 		expect(runtime.reportError).toHaveBeenCalledTimes(4);
 	});
+
+	it("bounds reasoning on every failure-reply model slot (thinking=off)", async () => {
+		// #16394: the failure-reply fallback is a plain-text path that must stay
+		// low-latency on reasoning models. Every useModel call it makes carries
+		// providerOptions.eliza.thinking = "off", matching Stage-1, the
+		// evaluator, and every planner iteration.
+		const service =
+			new DefaultMessageService() as unknown as FailureReplyService;
+		const runtime = makeRuntimeReturning(["Sorry, that broke on my side."]);
+		await service.generateFailureReplyText(runtime, "recent messages", "test");
+		const useModel = runtime.useModel as unknown as {
+			mock: { calls: unknown[][] };
+		};
+		expect(useModel.mock.calls.length).toBeGreaterThanOrEqual(1);
+		for (const call of useModel.mock.calls) {
+			const params = call[1] as {
+				providerOptions?: { eliza?: { thinking?: string } };
+			};
+			expect(params?.providerOptions?.eliza?.thinking).toBe("off");
+		}
+	});
 });

--- a/packages/core/src/__tests__/reasoning-token-telemetry.test.ts
+++ b/packages/core/src/__tests__/reasoning-token-telemetry.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Covers reasoning-token surfacing for inference telemetry (#16394):
+ * `readReasoningTokensFromResponse` extracts the hidden reasoning-token count
+ * from a model response's usage object and provider metadata so a reasoning
+ * burst is attributable per model call. Deterministic — no live model.
+ */
+import { describe, expect, it } from "vitest";
+import { readReasoningTokensFromResponse } from "../runtime";
+
+describe("readReasoningTokensFromResponse", () => {
+	it("reads reasoningTokens from a native result usage object", () => {
+		const response = {
+			text: "pong",
+			usage: {
+				promptTokens: 10,
+				completionTokens: 407,
+				totalTokens: 417,
+				reasoningTokens: 400,
+			},
+		};
+		expect(readReasoningTokensFromResponse(response)).toBe(400);
+	});
+
+	it("falls back to providerMetadata.completion_tokens_details.reasoning_tokens", () => {
+		// Some OpenAI-compatible paths expose the field only under provider
+		// metadata when the adapter did not normalize it into usage.
+		const response = {
+			text: "pong",
+			usage: {
+				promptTokens: 10,
+				completionTokens: 407,
+				totalTokens: 417,
+			},
+			providerMetadata: {
+				completion_tokens_details: { reasoning_tokens: 350 },
+			},
+		};
+		expect(readReasoningTokensFromResponse(response)).toBe(350);
+	});
+
+	it("falls back to camelCase completionTokenDetails.reasoningTokens", () => {
+		const response = {
+			text: "pong",
+			usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+			providerMetadata: {
+				completionTokensDetails: { reasoningTokens: 22 },
+			},
+		};
+		expect(readReasoningTokensFromResponse(response)).toBe(22);
+	});
+
+	it("prefers the usage.reasoningTokens value over provider metadata", () => {
+		const response = {
+			text: "pong",
+			usage: {
+				promptTokens: 10,
+				completionTokens: 407,
+				totalTokens: 417,
+				reasoningTokens: 400,
+			},
+			providerMetadata: {
+				completion_tokens_details: { reasoning_tokens: 1 },
+			},
+		};
+		expect(readReasoningTokensFromResponse(response)).toBe(400);
+	});
+
+	it("returns undefined when no reasoning tokens are reported (missing stays missing)", () => {
+		// A confirmed-none call (thinking=off) and an unattributed call must
+		// both surface as undefined here; the caller distinguishes them by the
+		// presence of a usage object, never by coercing missing to zero.
+		const response = {
+			text: "pong",
+			usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+		};
+		expect(readReasoningTokensFromResponse(response)).toBeUndefined();
+	});
+
+	it("returns undefined for a plain-text string result (no usage object)", () => {
+		// Stage-1 plain-text responses collapse to a string and carry no usage;
+		// the span meta omits the field entirely rather than inventing zero.
+		expect(readReasoningTokensFromResponse("pong")).toBeUndefined();
+	});
+
+	it("returns undefined for null/undefined/non-object responses", () => {
+		expect(readReasoningTokensFromResponse(null)).toBeUndefined();
+		expect(readReasoningTokensFromResponse(undefined)).toBeUndefined();
+		expect(readReasoningTokensFromResponse(42)).toBeUndefined();
+	});
+
+	it("rejects non-finite and negative values (keeps missing as missing)", () => {
+		const withNaN = {
+			text: "x",
+			usage: { reasoningTokens: Number.NaN },
+		};
+		const withNegative = {
+			text: "x",
+			usage: { reasoningTokens: -5 },
+		};
+		expect(readReasoningTokensFromResponse(withNaN)).toBeUndefined();
+		expect(readReasoningTokensFromResponse(withNegative)).toBeUndefined();
+	});
+
+	it("accepts a confirmed-zero reasoning-token count (thinking=off proof)", () => {
+		// reasoning_effort "none" returns 0 reasoning tokens — that is a real,
+		// attributable zero, distinct from an unattributed missing field.
+		const response = {
+			text: "pong",
+			usage: {
+				promptTokens: 10,
+				completionTokens: 5,
+				totalTokens: 15,
+				reasoningTokens: 0,
+			},
+		};
+		expect(readReasoningTokensFromResponse(response)).toBe(0);
+	});
+});

--- a/packages/core/src/features/trajectories/TrajectoriesService.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.ts
@@ -525,6 +525,7 @@ function normalizeLlmCall(value: unknown): LLMCall | null {
 		"latencyMs",
 		"cacheReadInputTokens",
 		"cacheCreationInputTokens",
+		"reasoningTokens",
 	] as const) {
 		const numericValue = numberValue(value[key]);
 		if (numericValue !== null) {

--- a/packages/core/src/features/trajectories/types.ts
+++ b/packages/core/src/features/trajectories/types.ts
@@ -94,6 +94,15 @@ export interface LLMCall {
 	cacheCreationInputTokens?: number;
 
 	/**
+	 * Hidden reasoning tokens reported inside the completion budget by
+	 * reasoning models (Cerebras zai-glm-4.7, OpenAI o-series, gpt-oss).
+	 * Surfaced so a tail-latency burst is attributable per call (#16394).
+	 * Missing stays missing — never zero — so an unattributed burst is
+	 * distinguishable from a confirmed-none call.
+	 */
+	reasoningTokens?: number;
+
+	/**
 	 * Pipeline stage identifier. Canonical values:
 	 * "action" | "reasoning" | "evaluation" | "response" |
 	 * "should_respond" | "compose_state" | "other".

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -44,6 +44,7 @@ import {
 } from "./features/basic-capabilities/index";
 import {
 	INFERENCE_MARKS,
+	type InferenceTimingMeta,
 	markInference,
 	recordInferenceSpan,
 	setInferenceModelProvider,
@@ -756,6 +757,64 @@ function isTextStreamResult(
 		"usage" in value &&
 		"finishReason" in value
 	);
+}
+
+/**
+ * Read the hidden reasoning-token count from a model response so it can be
+ * surfaced on the successful model span (#16394). Native results (tool-call
+ * shape) carry a `.usage` object; plain-text results do not, and the field is
+ * left undefined there. Returns a finite non-negative number or `undefined`;
+ * missing is preserved as missing rather than coerced to zero so an
+ * unattributed burst stays distinguishable from a confirmed-none call.
+ *
+ * Covers the elizaOS `TokenUsage.reasoningTokens` field plus the two raw
+ * provider shapes the AI SDK exposes (`usage.reasoningTokens` and
+ * `providerMetadata.completion_tokens_details.reasoning_tokens`).
+ */
+export function readReasoningTokensFromResponse(
+	response: unknown,
+): number | undefined {
+	if (typeof response !== "object" || response === null) return undefined;
+	const record = response as Record<string, unknown>;
+	const usageRaw = isPlainObject(record.usage) ? record.usage : undefined;
+	const usage = usageRaw as Record<string, unknown> | undefined;
+	const fromUsage =
+		usage && typeof usage.reasoningTokens === "number"
+			? usage.reasoningTokens
+			: undefined;
+	if (fromUsage !== undefined) {
+		return Number.isFinite(fromUsage) && fromUsage >= 0 ? fromUsage : undefined;
+	}
+	// Fall back to provider metadata when the adapter did not normalize the
+	// field into the usage object (some OpenAI-compatible paths expose it only
+	// under completion_tokens_details).
+	const providerMetadataRaw = isPlainObject(record.providerMetadata)
+		? record.providerMetadata
+		: undefined;
+	const providerMetadata = providerMetadataRaw as
+		| Record<string, unknown>
+		| undefined;
+	const detailsRaw = providerMetadata
+		? isPlainObject(providerMetadata.completion_tokens_details)
+			? providerMetadata.completion_tokens_details
+			: isPlainObject(providerMetadata.completionTokensDetails)
+				? providerMetadata.completionTokensDetails
+				: undefined
+		: undefined;
+	const details = detailsRaw as Record<string, unknown> | undefined;
+	const fromDetails = details
+		? typeof details.reasoning_tokens === "number"
+			? details.reasoning_tokens
+			: typeof details.reasoningTokens === "number"
+				? details.reasoningTokens
+				: undefined
+		: undefined;
+	if (fromDetails !== undefined) {
+		return Number.isFinite(fromDetails) && fromDetails >= 0
+			? fromDetails
+			: undefined;
+	}
+	return undefined;
 }
 
 function getSearchCategoryKey(category: string): string {
@@ -5944,11 +6003,20 @@ export class AgentRuntime implements IAgentRuntime {
 		// funnels through here is covered exactly once.
 		const resolvedProvider =
 			provider || this.models.get(modelKey)?.[0]?.provider || "unknown";
-		recordInferenceSpan(`model:${modelType}`, elapsedTime, {
+		// Surface reasoning-token usage on the successful model span so a
+		// reasoning burst is attributable per call (#16394). Native results
+		// (tool-call shape) carry `.usage`; plain-text results do not, in which
+		// case the field is omitted entirely — missing stays missing, never zero.
+		const spanMeta: InferenceTimingMeta = {
 			modelKey,
 			provider: resolvedProvider,
 			outcome: "success",
-		});
+		};
+		const reasoningTokens = readReasoningTokensFromResponse(response);
+		if (reasoningTokens !== undefined) {
+			spanMeta.reasoningTokens = reasoningTokens;
+		}
+		recordInferenceSpan(`model:${modelType}`, elapsedTime, spanMeta);
 		if (modelType !== ModelType.TEXT_EMBEDDING) {
 			setInferenceModelProvider(resolvedProvider);
 		}
@@ -7089,6 +7157,7 @@ export class AgentRuntime implements IAgentRuntime {
 				cacheCreationInputTokens: asNumber(
 					usageRecord.cacheCreationInputTokens,
 				),
+				reasoningTokens: asNumber(usageRecord.reasoningTokens),
 				modelSlot: args.modelType,
 				runId: trajCtx.runId,
 				roomId: trajCtx.roomId,

--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -104,6 +104,7 @@ describe("JsonFileTrajectoryRecorder", () => {
 					promptTokens: 1000,
 					completionTokens: 50,
 					cacheReadInputTokens: 800,
+					reasoningTokens: 400,
 					totalTokens: 1050,
 				},
 			},
@@ -209,6 +210,12 @@ describe("JsonFileTrajectoryRecorder", () => {
 		expect(parsed.metrics.totalPromptTokens).toBe(1000 + 1500 + 1700);
 		expect(parsed.metrics.totalCompletionTokens).toBe(50 + 80 + 40);
 		expect(parsed.metrics.totalCacheReadTokens).toBe(800 + 1000);
+		// #16394: reasoning tokens roll up across stages; only the
+		// message-handler stage carried them here (400), the others omit the
+		// field and contribute 0.
+		expect(parsed.metrics.totalReasoningTokens).toBe(400);
+		expect(parsed.stages[0]?.model?.usage?.reasoningTokens).toBe(400);
+		expect(parsed.stages[1]?.model?.usage?.reasoningTokens).toBeUndefined();
 		expect(parsed.metrics.finalDecision).toBe("FINISH");
 		expect(parsed.metrics.totalLatencyMs).toBe(300 + 600 + 110 + 270);
 	});

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -60,6 +60,7 @@ export interface RecordedUsage {
 	completionTokens?: number;
 	cacheReadInputTokens?: number;
 	cacheCreationInputTokens?: number;
+	reasoningTokens?: number;
 	totalTokens?: number;
 }
 
@@ -305,6 +306,7 @@ export interface RecordedTrajectoryMetrics {
 	totalCompletionTokens: number;
 	totalCacheReadTokens: number;
 	totalCacheCreationTokens: number;
+	totalReasoningTokens: number;
 	totalCostUsd: number;
 	plannerIterations: number;
 	toolCallsExecuted: number;
@@ -598,7 +600,7 @@ function renderTrajectoryMarkdown(trajectory: RecordedTrajectory): string {
 		`- total: ${formatDuration(metrics.totalLatencyMs)} · $${metrics.totalCostUsd.toFixed(6)}`,
 	);
 	lines.push(
-		`- tokens: ${metrics.totalPromptTokens} input · ${metrics.totalCompletionTokens} output · ${metrics.totalCacheReadTokens} cache-read · ${metrics.totalCacheCreationTokens} cache-created`,
+		`- tokens: ${metrics.totalPromptTokens} input · ${metrics.totalCompletionTokens} output · ${metrics.totalCacheReadTokens} cache-read · ${metrics.totalCacheCreationTokens} cache-created · ${metrics.totalReasoningTokens} reasoning`,
 	);
 	lines.push(`- root message id: \`${trajectory.rootMessage.id}\``);
 	if (trajectory.rootMessage.text) {
@@ -629,7 +631,7 @@ function renderTrajectoryMarkdown(trajectory: RecordedTrajectory): string {
 			);
 			if (stage.model.usage) {
 				lines.push(
-					`- usage: ${stage.model.usage.promptTokens ?? "n/a"} input · ${stage.model.usage.completionTokens ?? "n/a"} output · ${stage.model.usage.cacheReadInputTokens ?? "n/a"} cache-read · ${stage.model.usage.cacheCreationInputTokens ?? "n/a"} cache-created`,
+					`- usage: ${stage.model.usage.promptTokens ?? "n/a"} input · ${stage.model.usage.completionTokens ?? "n/a"} output · ${stage.model.usage.cacheReadInputTokens ?? "n/a"} cache-read · ${stage.model.usage.cacheCreationInputTokens ?? "n/a"} cache-created · ${stage.model.usage.reasoningTokens ?? "n/a"} reasoning`,
 				);
 			}
 			if (typeof stage.model.costUsd === "number") {
@@ -749,6 +751,7 @@ function applyMetricsForStage(
 		metrics.totalCacheReadTokens += stage.model.usage.cacheReadInputTokens ?? 0;
 		metrics.totalCacheCreationTokens +=
 			stage.model.usage.cacheCreationInputTokens ?? 0;
+		metrics.totalReasoningTokens += stage.model.usage.reasoningTokens ?? 0;
 	}
 	if (typeof stage.model?.costUsd === "number") {
 		metrics.totalCostUsd += stage.model.costUsd;
@@ -1253,6 +1256,7 @@ class JsonFileTrajectoryRecorder implements TrajectoryRecorder {
 				totalCompletionTokens: 0,
 				totalCacheReadTokens: 0,
 				totalCacheCreationTokens: 0,
+				totalReasoningTokens: 0,
 				totalCostUsd: 0,
 				plannerIterations: 0,
 				toolCallsExecuted: 0,

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -306,7 +306,7 @@ export interface RecordedTrajectoryMetrics {
 	totalCompletionTokens: number;
 	totalCacheReadTokens: number;
 	totalCacheCreationTokens: number;
-	totalReasoningTokens: number;
+	totalReasoningTokens?: number;
 	totalCostUsd: number;
 	plannerIterations: number;
 	toolCallsExecuted: number;
@@ -751,7 +751,9 @@ function applyMetricsForStage(
 		metrics.totalCacheReadTokens += stage.model.usage.cacheReadInputTokens ?? 0;
 		metrics.totalCacheCreationTokens +=
 			stage.model.usage.cacheCreationInputTokens ?? 0;
-		metrics.totalReasoningTokens += stage.model.usage.reasoningTokens ?? 0;
+		metrics.totalReasoningTokens =
+			(metrics.totalReasoningTokens ?? 0) +
+			(stage.model.usage.reasoningTokens ?? 0);
 	}
 	if (typeof stage.model?.costUsd === "number") {
 		metrics.totalCostUsd += stage.model.costUsd;

--- a/packages/core/src/runtime/trajectory-usage-rollup.test.ts
+++ b/packages/core/src/runtime/trajectory-usage-rollup.test.ts
@@ -20,6 +20,7 @@ function metrics(
 		totalCompletionTokens: 0,
 		totalCacheReadTokens: 0,
 		totalCacheCreationTokens: 0,
+		totalReasoningTokens: 0,
 		totalCostUsd: 0,
 		plannerIterations: 0,
 		toolCallsExecuted: 0,
@@ -96,6 +97,36 @@ describe("rollUpTrajectoryUsage", () => {
 		expect(rollup.byTrace.map((b) => b.traceId)).toEqual(["trace-Z", ""]);
 		expect(rollup.promptTokens).toBe(15);
 		expect(rollup.trajectoryCount).toBe(2);
+	});
+
+	it("sums reasoning tokens into the grand total and the correct byTrace bucket", () => {
+		const rollup = rollUpTrajectoryUsage([
+			trajectory("trace-A", { totalReasoningTokens: 7 }),
+			trajectory("trace-A", { totalReasoningTokens: 13 }),
+			trajectory("trace-B", { totalReasoningTokens: 5 }),
+			// A trajectory that omits reasoning entirely (pre-rollout / no
+			// thinking) must contribute 0, not NaN or undefined.
+			trajectory("trace-B", {}),
+		]);
+
+		const a = rollup.byTrace.find((b) => b.traceId === "trace-A");
+		expect(a?.reasoningTokens).toBe(20);
+		const b = rollup.byTrace.find((b) => b.traceId === "trace-B");
+		expect(b?.reasoningTokens).toBe(5);
+		// Grand total spans both traces.
+		expect(rollup.reasoningTokens).toBe(25);
+	});
+
+	it("guards NaN/undefined reasoning tokens so a truncated file can't poison the total", () => {
+		const bad = trajectory("trace-nan", {});
+		(bad.metrics as unknown as Record<string, unknown>).totalReasoningTokens =
+			Number.NaN;
+		const rollup = rollUpTrajectoryUsage([
+			bad,
+			trajectory("trace-nan", { totalReasoningTokens: 10 }),
+		]);
+		expect(Number.isNaN(rollup.reasoningTokens)).toBe(false);
+		expect(rollup.reasoningTokens).toBe(10);
 	});
 
 	it("treats NaN/undefined metric fields as zero so a truncated file can't poison the total", () => {

--- a/packages/core/src/runtime/trajectory-usage-rollup.ts
+++ b/packages/core/src/runtime/trajectory-usage-rollup.ts
@@ -33,6 +33,11 @@ export interface TrajectoryUsageTotals {
 	completionTokens: number;
 	cacheReadTokens: number;
 	cacheCreationTokens: number;
+	/** Sum of per-trajectory reasoning tokens (thinking/chain-of-thought spend),
+	 * mirroring `cacheCreationTokens`. Reported separately from
+	 * `totalTokens` because reasoning tokens are billed independently and
+	 * must be attributable (#16394). */
+	reasoningTokens: number;
 	/** prompt + completion (cache tokens reported separately, mirroring the
 	 * orchestrator's `TaskUsageSummary.totalTokens` convention). */
 	totalTokens: number;
@@ -55,6 +60,7 @@ function emptyTotals(): TrajectoryUsageTotals {
 		completionTokens: 0,
 		cacheReadTokens: 0,
 		cacheCreationTokens: 0,
+		reasoningTokens: 0,
 		totalTokens: 0,
 		costUsd: 0,
 		trajectoryCount: 0,
@@ -74,6 +80,7 @@ function addMetrics(
 	into.completionTokens += n(metrics.totalCompletionTokens);
 	into.cacheReadTokens += n(metrics.totalCacheReadTokens);
 	into.cacheCreationTokens += n(metrics.totalCacheCreationTokens);
+	into.reasoningTokens += n(metrics.totalReasoningTokens);
 	into.costUsd += n(metrics.totalCostUsd);
 	into.totalTokens +=
 		n(metrics.totalPromptTokens) + n(metrics.totalCompletionTokens);

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8671,6 +8671,7 @@ function extractMessageHandlerUsage(raw: GenerateTextResult):
 			completionTokens: number;
 			cacheReadInputTokens?: number;
 			cacheCreationInputTokens?: number;
+			reasoningTokens?: number;
 			totalTokens: number;
 	  }
 	| undefined {
@@ -8684,6 +8685,7 @@ function extractMessageHandlerUsage(raw: GenerateTextResult):
 		completionTokens: number;
 		cacheReadInputTokens?: number;
 		cacheCreationInputTokens?: number;
+		reasoningTokens?: number;
 		totalTokens: number;
 	} = { promptTokens, completionTokens, totalTokens };
 	if (typeof usage.cacheReadInputTokens === "number") {
@@ -8697,6 +8699,9 @@ function extractMessageHandlerUsage(raw: GenerateTextResult):
 	}
 	if (typeof usage.cacheCreationInputTokens === "number") {
 		out.cacheCreationInputTokens = usage.cacheCreationInputTokens;
+	}
+	if (typeof usage.reasoningTokens === "number") {
+		out.reasoningTokens = usage.reasoningTokens;
 	}
 	return out;
 }
@@ -12687,7 +12692,15 @@ export class DefaultMessageService implements IMessageService {
 			ModelType.TEXT_NANO,
 		] as const) {
 			try {
-				const response = await runtime.useModel(modelType, { prompt });
+				// Bound reasoning on reasoning models (#16394): the failure-reply
+				// path is a plain-text fallback that must stay low-latency, so every
+				// slot carries thinking="off" like Stage-1, the evaluator, and every
+				// planner iteration. Without it a drained/failed turn can still spend
+				// hundreds of hidden reasoning tokens before producing visible text.
+				const response = await runtime.useModel(modelType, {
+					prompt,
+					providerOptions: { eliza: { thinking: "off" } },
+				});
 				if (typeof response !== "string") {
 					continue;
 				}

--- a/packages/core/src/services/trajectory-export.ts
+++ b/packages/core/src/services/trajectory-export.ts
@@ -470,6 +470,7 @@ function buildNativeResponse(
 	const cacheCreationInputTokens = toOptionalFiniteNumber(
 		call.cacheCreationInputTokens,
 	);
+	const reasoningTokens = toOptionalFiniteNumber(call.reasoningTokens);
 	const usage: NonNullable<ElizaNativeModelResponseRecord["usage"]> = {};
 	if (promptTokens !== undefined) usage.promptTokens = promptTokens;
 	if (completionTokens !== undefined) usage.completionTokens = completionTokens;
@@ -481,6 +482,9 @@ function buildNativeResponse(
 	}
 	if (cacheCreationInputTokens !== undefined) {
 		usage.cacheCreationInputTokens = cacheCreationInputTokens;
+	}
+	if (reasoningTokens !== undefined) {
+		usage.reasoningTokens = reasoningTokens;
 	}
 
 	const response: ElizaNativeModelResponseRecord = {

--- a/packages/core/src/services/trajectory-types.ts
+++ b/packages/core/src/services/trajectory-types.ts
@@ -120,6 +120,7 @@ export interface TrajectoryLlmCallRecord {
 	completionTokens?: number;
 	cacheReadInputTokens?: number;
 	cacheCreationInputTokens?: number;
+	reasoningTokens?: number;
 	modelSlot?: string;
 	runId?: string;
 	roomId?: string;
@@ -332,6 +333,7 @@ export interface ElizaNativeModelResponseRecord {
 		totalTokens?: number;
 		cacheReadInputTokens?: number;
 		cacheCreationInputTokens?: number;
+		reasoningTokens?: number;
 	};
 	providerMetadata?: unknown;
 }

--- a/packages/core/src/trajectory-utils.ts
+++ b/packages/core/src/trajectory-utils.ts
@@ -98,6 +98,7 @@ export type TrajectoryLlmCallDetails = {
 	completionTokens?: number;
 	cacheReadInputTokens?: number;
 	cacheCreationInputTokens?: number;
+	reasoningTokens?: number;
 	providerOrder?: string[];
 	providerAttributions?: TrajectoryProviderAttribution[];
 };

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -279,6 +279,7 @@ export interface ModelEventPayload extends EventPayload {
 		total: number;
 		cacheReadInputTokens?: number;
 		cacheCreationInputTokens?: number;
+		reasoningTokens?: number;
 		cachedInputTokens?: number;
 		/** @deprecated Use `cachedInputTokens` or `cacheReadInputTokens`. */
 		cached?: number;

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -716,6 +716,13 @@ export interface GenerateTextParams {
  * for v5 cache observability. Not in the protobuf today; adapters that know
  * about provider-side cache (Anthropic prompt caching, OpenAI cached input,
  * etc.) populate them. Consumers that don't care can ignore them.
+ *
+ * `reasoningTokens` is the hidden reasoning-token count that reasoning models
+ * (Cerebras zai-glm-4.7, OpenAI o-series, gpt-oss) report inside the
+ * completion budget (`completion_tokens_details.reasoning_tokens`). It is
+ * additive: adapters surface it only when the provider returns it, and
+ * consumers that don't care can ignore it. Missing stays missing — never zero
+ * — so an unattributed burst is distinguishable from a confirmed none.
  */
 export interface TokenUsage {
 	promptTokens: number;
@@ -723,6 +730,7 @@ export interface TokenUsage {
 	totalTokens: number;
 	cacheReadInputTokens?: number;
 	cacheCreationInputTokens?: number;
+	reasoningTokens?: number;
 }
 
 /**

--- a/plugins/plugin-openai/__tests__/events.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/events.shape.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Shape tests for `emitModelUsageEvent`: the MODEL_USED emission that converts
+ * token usage from the three shapes the plugin sees (local TokenUsage, AI SDK
+ * usage, raw OpenAI API usage) into one payload. Focus is the regression
+ * witness that hidden reasoning tokens survive onto `payload.tokens.reasoningTokens`
+ * after `normalizeUsage` (utils/events.ts) — a field that was dropped before
+ * PR #17783, making the event-path spread dead code.
+ */
+
+import { EventType, ModelType } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelRetryTelemetry } from "../utils/events";
+import { emitModelUsageEvent } from "../utils/events";
+
+function createRuntime() {
+  return {
+    character: { name: "Ada" },
+    emitEvent: vi.fn(async () => undefined),
+    // emitModelUsageEvent → getUsageProvider → getSetting/isCerebrasMode read
+    // provider mode off the runtime; a bare mock returns undefined, which
+    // means "no override" (default openai provider) — the expected path.
+    getSetting: vi.fn(() => undefined),
+    getService: vi.fn(() => null),
+    getServicesByType: vi.fn(() => []),
+  } as never;
+}
+
+function findModelUsedPayload(runtime: { emitEvent: ReturnType<typeof vi.fn> }) {
+  const call = runtime.emitEvent.mock.calls.find(([event]) => event === EventType.MODEL_USED);
+  if (!call) {
+    throw new Error("MODEL_USED was never emitted");
+  }
+  return call[1] as { tokens: Record<string, number> };
+}
+
+beforeEach(() => {
+  vi.stubEnv("OPENAI_BASE_URL", "");
+  vi.stubEnv("ELIZA_PROVIDER", "");
+  vi.stubEnv("CEREBRAS_API_KEY", "");
+});
+
+describe("emitModelUsageEvent — reasoningTokens on MODEL_USED", () => {
+  it("carries reasoningTokens when AI SDK usage reports outputTokenDetails.reasoningTokens", () => {
+    const runtime = createRuntime();
+    emitModelUsageEvent(
+      runtime,
+      ModelType.TEXT_LARGE,
+      "burst",
+      {
+        // AI SDK shape: inputTokens/outputTokens + detail block
+        inputTokens: 10,
+        outputTokens: 407,
+        outputTokenDetails: { reasoningTokens: 400 },
+      },
+      "gpt-test-large"
+    );
+
+    const payload = findModelUsedPayload(runtime);
+    expect(payload.tokens.reasoningTokens).toBe(400);
+  });
+
+  it("prefers outputTokenDetails.reasoningTokens over a top-level reasoningTokens on AI SDK usage", () => {
+    const runtime = createRuntime();
+    emitModelUsageEvent(
+      runtime,
+      ModelType.TEXT_LARGE,
+      "burst",
+      {
+        inputTokens: 10,
+        outputTokens: 407,
+        reasoningTokens: 7,
+        outputTokenDetails: { reasoningTokens: 400 },
+      },
+      "gpt-test-large"
+    );
+
+    const payload = findModelUsedPayload(runtime);
+    expect(payload.tokens.reasoningTokens).toBe(400);
+  });
+
+  it("falls back to top-level reasoningTokens on AI SDK usage when detail block is absent", () => {
+    const runtime = createRuntime();
+    emitModelUsageEvent(
+      runtime,
+      ModelType.TEXT_LARGE,
+      "burst",
+      {
+        inputTokens: 10,
+        outputTokens: 407,
+        reasoningTokens: 5,
+      },
+      "gpt-test-large"
+    );
+
+    const payload = findModelUsedPayload(runtime);
+    expect(payload.tokens.reasoningTokens).toBe(5);
+  });
+
+  it("carries reasoningTokens when raw OpenAI API usage reports reasoningTokens", () => {
+    const runtime = createRuntime();
+    emitModelUsageEvent(
+      runtime,
+      ModelType.TEXT_LARGE,
+      "burst",
+      {
+        // OpenAI API shape: promptTokens/completionTokens
+        promptTokens: 10,
+        completionTokens: 407,
+        totalTokens: 417,
+        reasoningTokens: 5,
+      },
+      "gpt-test-large"
+    );
+
+    const payload = findModelUsedPayload(runtime);
+    expect(payload.tokens.reasoningTokens).toBe(5);
+  });
+
+  it("keeps reasoningTokens absent when the usage object reports none (missing stays missing)", () => {
+    const runtime = createRuntime();
+    emitModelUsageEvent(
+      runtime,
+      ModelType.TEXT_SMALL,
+      "plain",
+      {
+        inputTokens: 2,
+        outputTokens: 1,
+      },
+      "gpt-test-small"
+    );
+
+    const payload = findModelUsedPayload(runtime);
+    // Absent — never zero — so a plain-text call is distinguishable from a
+    // confirmed-none (thinking=off) call. This is the design contract.
+    expect(payload.tokens).not.toHaveProperty("reasoningTokens");
+  });
+
+  it("keeps reasoningTokens absent for a plain prompt/completion usage shape", () => {
+    const runtime = createRuntime();
+    emitModelUsageEvent(
+      runtime,
+      ModelType.TEXT_SMALL,
+      "plain",
+      {
+        promptTokens: 2,
+        completionTokens: 1,
+        totalTokens: 3,
+      },
+      "gpt-test-small"
+    );
+
+    const payload = findModelUsedPayload(runtime);
+    expect(payload.tokens).not.toHaveProperty("reasoningTokens");
+  });
+
+  it("rejects non-finite / negative reasoningTokens and keeps the field absent (no poisoned zero)", () => {
+    const runtime = createRuntime();
+    emitModelUsageEvent(
+      runtime,
+      ModelType.TEXT_LARGE,
+      "burst",
+      {
+        inputTokens: 10,
+        outputTokens: 407,
+        // Same finite-non-negative discipline readReasoningTokensFromResponse
+        // establishes: NaN, Infinity, and negatives → undefined.
+        reasoningTokens: Number.NaN,
+        outputTokenDetails: { reasoningTokens: -1 },
+      },
+      "gpt-test-large"
+    );
+
+    const payload = findModelUsedPayload(runtime);
+    expect(payload.tokens).not.toHaveProperty("reasoningTokens");
+  });
+
+  it("confirms zero (thinking=off proof): a real attributable 0 is emitted, not dropped", () => {
+    const runtime = createRuntime();
+    emitModelUsageEvent(
+      runtime,
+      ModelType.TEXT_SMALL,
+      "thinking-off",
+      {
+        inputTokens: 2,
+        outputTokens: 1,
+        outputTokenDetails: { reasoningTokens: 0 },
+      },
+      "gpt-test-small"
+    );
+
+    const payload = findModelUsedPayload(runtime);
+    expect(payload.tokens.reasoningTokens).toBe(0);
+  });
+
+  it("still emits the base token fields alongside reasoningTokens", () => {
+    const runtime = createRuntime();
+    const retry: ModelRetryTelemetry = { retryCount: 1, lastRetryReason: "5xx" };
+    emitModelUsageEvent(
+      runtime,
+      ModelType.TEXT_LARGE,
+      "burst",
+      {
+        inputTokens: 10,
+        outputTokens: 407,
+        cachedInputTokens: 4,
+        outputTokenDetails: { reasoningTokens: 400 },
+      },
+      "gpt-test-large",
+      retry
+    );
+
+    const payload = findModelUsedPayload(runtime);
+    expect(payload.tokens).toMatchObject({
+      prompt: 10,
+      completion: 407,
+      total: 417,
+      cached: 4,
+      cachedInputTokens: 4,
+      cacheReadInputTokens: 4,
+      reasoningTokens: 400,
+    });
+  });
+});

--- a/plugins/plugin-openai/utils/events.ts
+++ b/plugins/plugin-openai/utils/events.ts
@@ -130,6 +130,9 @@ export function emitModelUsageEvent(
             cacheReadInputTokens: normalized.cachedPromptTokens,
           }
         : {}),
+      ...(normalized.reasoningTokens !== undefined
+        ? { reasoningTokens: normalized.reasoningTokens }
+        : {}),
     },
   };
 

--- a/plugins/plugin-openai/utils/events.ts
+++ b/plugins/plugin-openai/utils/events.ts
@@ -37,6 +37,11 @@ interface AISDKUsage {
   outputTokens?: number;
   totalTokens?: number;
   cachedInputTokens?: number;
+  /** Hidden reasoning tokens the provider reports inside the output budget. */
+  reasoningTokens?: number;
+  outputTokenDetails?: {
+    reasoningTokens?: number;
+  };
 }
 
 interface OpenAIAPIUsage {
@@ -44,6 +49,8 @@ interface OpenAIAPIUsage {
   completionTokens?: number;
   totalTokens?: number;
   cachedPromptTokens?: number;
+  /** Hidden reasoning tokens the provider reports inside the completion budget. */
+  reasoningTokens?: number;
   promptTokensDetails?: {
     cachedTokens?: number;
   };
@@ -63,22 +70,31 @@ function normalizeUsage(usage: ModelUsage): TokenUsage {
     const promptTokensDetails =
       "promptTokensDetails" in usage ? usage.promptTokensDetails : undefined;
     const cachedPromptTokens = usage.cachedPromptTokens ?? promptTokensDetails?.cachedTokens;
+    const reasoning = usage.reasoningTokens;
     return {
       promptTokens: usage.promptTokens ?? 0,
       completionTokens: usage.completionTokens ?? 0,
       totalTokens: usage.totalTokens ?? (usage.promptTokens ?? 0) + (usage.completionTokens ?? 0),
       cachedPromptTokens,
+      ...(typeof reasoning === "number" && Number.isFinite(reasoning) && reasoning >= 0
+        ? { reasoningTokens: reasoning }
+        : {}),
     };
   }
   if ("inputTokens" in usage || "outputTokens" in usage) {
     const input = (usage as AISDKUsage).inputTokens ?? 0;
     const output = (usage as AISDKUsage).outputTokens ?? 0;
     const total = (usage as AISDKUsage).totalTokens ?? input + output;
+    const details = (usage as AISDKUsage).outputTokenDetails;
+    const reasoning = details?.reasoningTokens ?? (usage as AISDKUsage).reasoningTokens;
     return {
       promptTokens: input,
       completionTokens: output,
       totalTokens: total,
       cachedPromptTokens: (usage as AISDKUsage).cachedInputTokens,
+      ...(typeof reasoning === "number" && Number.isFinite(reasoning) && reasoning >= 0
+        ? { reasoningTokens: reasoning }
+        : {}),
     };
   }
   return {


### PR DESCRIPTION
## Summary

Closes #16394.

Surfaces hidden reasoning-token usage (`completion_tokens_details.reasoning_tokens`) on inference spans so a Cerebras/OpenAI reasoning burst is attributable per model call, and bounds the last unbounded turn-critical helper (`generateFailureReplyText`) on reasoning models.

On Cerebras reasoning models (zai-glm-4.7, gpt-oss-120b), hidden reasoning tokens dominate tail latency — live Stage-1 latencies on the same model/prompt ranged 1.2s → 12.8s, with direct-API measurement showing ~400 hidden reasoning tokens of 407 completion tokens. The OpenAI adapter already captured `outputTokenDetails.reasoningTokens` / `usage.reasoningTokens` in its local usage object, but `@elizaos/core` `TokenUsage` could not represent the field, `AgentRuntime` did not propagate it into the model-call span, and `generateFailureReplyText` still tried four text model slots with only `{prompt}`.

### Ask 1 — surface reasoning tokens on inference spans

- Add an optional finite non-negative `reasoningTokens?` to the core `TokenUsage` type (`packages/core/src/types/model.ts`). Missing stays missing — never zero — so an unattributed burst is distinguishable from a confirmed-none call (thinking=off returns a real attributable `0`).
- Thread the field through every type that mirrors token usage: the trajectory recorder (`RecordedUsage`, `RecordedTrajectoryMetrics.totalReasoningTokens`), the trajectory service (`LLMCall`, `TrajectoryLlmCallRecord`, `TrajectoryLlmCallDetails`, `TrajectoryRuntimeLlmCallParams`), the export path (`ElizaNativeModelResponseRecord`), and the `MODEL_USED` event payload.
- `logModelCall` reads reasoning tokens from the successful model result via the new `readReasoningTokensFromResponse` helper (covers `usage.reasoningTokens` plus the `providerMetadata.completion_tokens_details.reasoning_tokens` / camelCase fallbacks) and attaches them to the `model:*` inference span meta. Covers both streaming and non-streaming return paths that funnel through `logModelCall`.
- The OpenAI adapter's `convertUsage` already normalized the field; `emitModelUsageEvent` now emits it on `MODEL_USED`.
- The trajectory recorder rolls `reasoningTokens` into per-call usage, the per-turn `totalReasoningTokens` metric, and the markdown report (summary + per-stage lines).
- `recordUseModelTrajectory` propagates `reasoningTokens` into the trajectory LLM-call record, and `normalizeLlmCall` persists it.

### Ask 2 — bound the residual unbounded call site

The triage confirmed Stage-1, the evaluator, every planner iteration, callback rewrites, and API fallback/direct rewrites already set `thinking=off`. The confirmed residual was `generateFailureReplyText`, which tried four text model slots (`TEXT_LARGE`, `RESPONSE_HANDLER`, `TEXT_SMALL`, `TEXT_NANO`) with only `{prompt}`. It now carries `providerOptions.eliza.thinking = "off"` on every fallback slot, matching the other turn-critical helpers. Without it a drained/failed turn could still spend hundreds of hidden reasoning tokens before producing visible text.

### Per-trajectory metric coercion note

The per-trajectory `totalReasoningTokens` metric uses `?? 0` coercion (matching `totalCacheReadTokens` / `totalCacheCreationTokens`), so unattributable and confirmed-zero are indistinguishable at the metric-accumulator level. The missing-stays-missing discipline applies to the span/event/result surfaces (where `undefined` vs `0` distinguishes no-data from confirmed-zero), not the numeric totals bucket. This is consistent with the sibling cache-token totals.

## How to verify

```
bun run --cwd packages/core typecheck
bun run --cwd plugins/plugin-openai typecheck
bun run --cwd packages/core test -- reasoning-token-telemetry inference-timing message-failure-reply trajectory-recorder trajectory-usage-rollup
```

## Evidence

### Type propagation — `readReasoningTokensFromResponse` (deterministic, no live model)

`bun run --cwd packages/core test -- reasoning-token-telemetry` → 9 passed.

Captures: usage-shape extraction, provider-metadata fallback (`completion_tokens_details.reasoning_tokens` + camelCase), usage-preferred-over-metadata, missing-stays-missing (plain-text string result, no usage object), null/undefined/non-object, non-finite/negative rejection, and confirmed-zero (thinking=off proof).

```
✓ src/__tests__/reasoning-token-telemetry.test.ts (9 tests) 3ms
```

### Inference span meta round-trips reasoningTokens

`bun run --cwd packages/core test -- inference-timing` → 18 passed. The new test records a `model:RESPONSE_HANDLER` span with `reasoningTokens: 400` and a `model:TEXT_SMALL` span without it; the summary preserves `400` on the first and `undefined` on the second (missing stays missing).

### Trajectory recorder rolls reasoningTokens into metrics + per-stage usage

`bun run --cwd packages/core test -- trajectory-recorder` → 55 passed. The message-handler stage now carries `reasoningTokens: 400`; `metrics.totalReasoningTokens` rolls up to `400`, stage 0 keeps `400`, stage 1 (no field) is `undefined`.

### Failure-reply bounding — thinking=off on every slot

`bun run --cwd packages/core test -- message-failure-reply` → 9 passed. The new test calls `generateFailureReplyText`, then asserts every `useModel` call carries `providerOptions.eliza.thinking === "off"`.

```
✓ src/__tests__/message-failure-reply.test.ts (9 tests) 6ms
```

### Focused package checks

- `bun run --cwd packages/core typecheck` → pass
- `bun run --cwd plugins/plugin-openai typecheck` → pass
- `bun run --cwd plugins/plugin-openai test` → 163 passed
- message/planner/evaluator/stage1 lane → 1025 passed
- trajectory/pricing/token lane → 156 passed

### Live Cerebras trajectory

Live-credential path (Cerebras direct, zai-glm-4.7) is noted as a blocker for this run rather than fabricated: the adapter capture and type propagation are statically verifiable (covered above), and the existing `cerebras-config.live.test.ts` / `cerebras-evidence.live.test.ts` in plugin-openai already assert `result.usage?.reasoningTokens` end to end against the real provider. A fresh default-vs-thinking-off trajectory capture should be attached by a runner with Cerebras credentials; the unit/integration proof above does not require them.

## Checklist

- [x] `reasoningTokens` is represented in the core `TokenUsage` type and emitted on the model-call inference span so a reasoning burst is attributable per model call.
- [x] OpenAI/Cerebras adapter captures the value end to end (adapter-side already done; event emission + span meta + trajectory now wired).
- [x] `generateFailureReplyText` (the residual unbounded helper) is bounded on reasoning models consistent with the existing `thinking: "off"` suppression.
- [x] Real tests for the success + edge paths (model returns no reasoning tokens; reasoning tokens present; bound call paths; missing-vs-zero; non-finite/negative).
- [x] Focused package checks pass (`packages/core`, `plugins/plugin-openai`).

---

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@abca7ec002ee88ac3eb10ae39a19108d6c0701ba:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [lane hermes]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@abca7ec002ee88ac3eb10ae39a19108d6c0701ba:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:57c10877b650e5e1741840819a863b3023e45b3f -->

<!-- evidence-row:backend-logs -->
- [ ] N/A - real test output is inline in the PR body (How to verify + Evidence sections); binary asset upload is blocked for this fork lane: elizaOS/eliza release uploads require push access and the user-attachments/files uploader needs a browser session, neither available headless

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend telemetry type-propagation change; no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend telemetry type-propagation change; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend telemetry change with no user-visible UI; test output in backend-logs

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed (packages/core types/runtime + plugin-openai event emitter only)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no live model call in scope; adapter capture and type propagation are statically verifiable (see backend-logs). Live Cerebras trajectory noted as a credential blocker in the PR body; existing plugin-openai cerebras live tests already assert reasoningTokens end to end.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - core telemetry type + span meta change; no domain artifact produced

<!-- CI retrigger 2026-08-07: no code change, head unchanged. Develop PR Gate failed on the fork-PR workflow approval gate (action_required), not a code failure. -->
