### PR TITLE
fix(cloud): install, probe, and self-heal the node embedding sidecar

### DIFF
--- a/packages/cloud/scripts/admin/onboard-docker-node.ts
+++ b/packages/cloud/scripts/admin/onboard-docker-node.ts
@@ -17,8 +17,10 @@
  *      `denied`). Reuses `ensureRegistryAccess`.
  *   4. clean zombie/stale agent containers (exited/created orphans matching the
  *      agent naming scheme — never an active sandbox),
- *   5. upsert the node into `docker_nodes` (update if it already exists),
- *   6. print a clear summary of what changed vs. was already in place.
+ *   5. ensure the local-embedding sidecar is running (same contract the
+ *      cloud-init bootstrap installs; see `embedding-sidecar.ts`),
+ *   6. upsert the node into `docker_nodes` (update if it already exists),
+ *   7. print a clear summary of what changed vs. was already in place.
  *
  * No secrets are hard-coded: the registry token (if any) comes from the
  * control-plane env via `containersEnv`; the DB target from `DATABASE_URL`.
@@ -50,6 +52,7 @@ async function loadDeps() {
     { ensureRegistryAccess },
     dockerUtils,
     { DockerSSHClient },
+    { buildEnsureEmbeddingSidecarCmd },
   ] = await Promise.all([
     import("@elizaos/cloud-shared/db/repositories/docker-nodes"),
     import(
@@ -57,6 +60,7 @@ async function loadDeps() {
     ),
     import("@elizaos/cloud-shared/lib/services/docker-sandbox-utils"),
     import("@elizaos/cloud-shared/lib/services/docker-ssh"),
+    import("@elizaos/cloud-shared/lib/services/containers/embedding-sidecar"),
   ]);
   return {
     dockerNodesRepository,
@@ -65,6 +69,7 @@ async function loadDeps() {
     buildEnsureNetworkCmd: dockerUtils.buildEnsureNetworkCmd,
     shellQuote: dockerUtils.shellQuote,
     DockerSSHClient,
+    buildEnsureEmbeddingSidecarCmd,
   };
 }
 
@@ -264,6 +269,7 @@ async function main(): Promise<void> {
     buildEnsureNetworkCmd,
     shellQuote,
     DockerSSHClient,
+    buildEnsureEmbeddingSidecarCmd,
   } = await loadDeps();
   const summary: string[] = [];
   const existing = await dockerNodesRepository.findByNodeId(args.nodeId);
@@ -330,7 +336,24 @@ async function main(): Promise<void> {
       summary.push("no zombie containers");
     }
 
-    // 5. Pull the agent image now so the first deploy on this node is warm.
+    // 5. Ensure the local-embedding sidecar is running. Non-fatal on failure —
+    // the node still registers and the control plane's health loop both
+    // surfaces the missing sidecar (docker_nodes metadata) and self-heals it,
+    // so a transient pull failure here cannot silently strand the node on the
+    // cloud embedding path forever.
+    await ssh
+      .exec(buildEnsureEmbeddingSidecarCmd(), 10 * 60 * 1000)
+      .then(() => summary.push("embedding sidecar ensured"))
+      .catch((err) => {
+        console.warn(
+          `[onboard] embedding sidecar install failed (health loop will surface + self-heal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+        summary.push(
+          "embedding sidecar install FAILED (health loop will self-heal)",
+        );
+      });
+
+    // 6. Pull the agent image now so the first deploy on this node is warm.
     console.log(
       `[onboard] pre-pulling ${image} (first run can take a few minutes)`,
     );
@@ -344,7 +367,7 @@ async function main(): Promise<void> {
         summary.push("agent image pre-pull FAILED (non-fatal)");
       });
 
-    // 6. Register / upsert into docker_nodes — same shape as bootstrap-callback.
+    // 7. Register / upsert into docker_nodes — same shape as bootstrap-callback.
     if (existing) {
       await dockerNodesRepository.update(existing.id, {
         hostname: args.host,

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
@@ -7,6 +7,7 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import * as realHelpers from "../helpers";
 
 let capturedWhere: SQL | undefined;
+let capturedSet: Record<string, unknown> | undefined;
 
 const limit = mock(() => []);
 const orderBy = mock(() => ({ limit }));
@@ -17,6 +18,13 @@ const where = mock((clause: SQL) => {
 const from = mock(() => ({ where }));
 const select = mock(() => ({ from }));
 
+const updateWhere = mock(() => Promise.resolve([]));
+const set = mock((values: Record<string, unknown>) => {
+  capturedSet = values;
+  return { where: updateWhere };
+});
+const update = mock(() => ({ set }));
+
 let useRepositoryMocks = false;
 const dbReadMock = new Proxy(realHelpers.dbRead as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
@@ -24,10 +32,17 @@ const dbReadMock = new Proxy(realHelpers.dbRead as unknown as Record<PropertyKey
     return Reflect.get(target, prop, receiver);
   },
 });
+const dbWriteMock = new Proxy(realHelpers.dbWrite as unknown as Record<PropertyKey, unknown>, {
+  get(target, prop, receiver) {
+    if (prop === "update" && useRepositoryMocks) return update;
+    return Reflect.get(target, prop, receiver);
+  },
+});
 
 mock.module("../helpers", () => ({
   ...realHelpers,
   dbRead: dbReadMock,
+  dbWrite: dbWriteMock,
 }));
 
 afterAll(() => {
@@ -40,6 +55,7 @@ describe("DockerNodesRepository environment guard", () => {
   beforeEach(() => {
     useRepositoryMocks = true;
     capturedWhere = undefined;
+    capturedSet = undefined;
     process.env.ENVIRONMENT = "staging";
   });
 
@@ -78,6 +94,28 @@ describe("DockerNodesRepository environment guard", () => {
     expect(sql).toContain("->>'environment'");
     expect(sql).toContain("coalesce");
     expect(sql).toContain("= ''");
+  });
+
+  test("setEmbeddingSidecarHealth merges into metadata instead of replacing it", async () => {
+    const { DockerNodesRepository } = await import("./docker-nodes");
+
+    await new DockerNodesRepository().setEmbeddingSidecarHealth("node-1", "missing");
+
+    if (!capturedSet) throw new Error("setEmbeddingSidecarHealth did not build a set payload");
+    // A jsonb `||` merge, not a column overwrite: concurrent writers of other
+    // metadata keys (environment stamp, onboard provenance) must survive the
+    // health cycle's write.
+    const query = new PgDialect().sqlToQuery(capturedSet.metadata as SQL);
+    expect(query.sql).toContain('"metadata" ||');
+    expect(query.sql).toContain("::jsonb");
+    const patch = query.params.find(
+      (param) => typeof param === "string" && param.includes("embeddingSidecar"),
+    ) as string;
+    const parsed = JSON.parse(patch) as {
+      embeddingSidecar: { status: string; checkedAt: string };
+    };
+    expect(parsed.embeddingSidecar.status).toBe("missing");
+    expect(Date.parse(parsed.embeddingSidecar.checkedAt)).toBeGreaterThan(0);
   });
 
   test("findLeastLoaded applies the same environment guard to schedulable capacity", async () => {

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.ts
@@ -199,6 +199,28 @@ export class DockerNodesRepository {
   }
 
   /**
+   * Persist the health loop's local-embedding-sidecar verdict into the node's
+   * metadata (`metadata.embeddingSidecar = { status, checkedAt }`). A jsonb
+   * merge so concurrent writers of other metadata keys (environment stamp,
+   * onboard provenance) are never clobbered by the health cycle.
+   */
+  async setEmbeddingSidecarHealth(
+    nodeId: string,
+    status: "running" | "unresponsive" | "missing",
+  ): Promise<void> {
+    const patch = JSON.stringify({
+      embeddingSidecar: { status, checkedAt: new Date().toISOString() },
+    });
+    await dbWrite
+      .update(dockerNodes)
+      .set({
+        metadata: sql`${dockerNodes.metadata} || ${patch}::jsonb`,
+        updated_at: new Date(),
+      })
+      .where(eq(dockerNodes.node_id, nodeId));
+  }
+
+  /**
    * Set allocated_count to an exact value (used during sync).
    */
   async setAllocatedCount(nodeId: string, count: number): Promise<void> {

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -114,6 +114,66 @@ export const containersEnv = {
     return pick(env.CONTAINERS_DOCKER_NETWORK, env.AGENT_DOCKER_NETWORK) ?? "containers-isolated";
   },
 
+  /**
+   * Image for the per-node local-embedding sidecar (text-embeddings-inference,
+   * CPU build). Pinned to a known tag rather than `latest` so every node in the
+   * fleet runs the same server; bump deliberately via this env.
+   */
+  embeddingSidecarImage(): string {
+    const env = getCloudAwareEnv();
+    return (
+      pick(env.CONTAINERS_EMBEDDING_SIDECAR_IMAGE, env.ELIZA_EMBEDDING_SIDECAR_IMAGE) ??
+      "ghcr.io/huggingface/text-embeddings-inference:cpu-1.8"
+    );
+  },
+
+  /**
+   * Model the embedding sidecar serves. gte-small is the platform's local
+   * embedding standard (384-dim, ~50ms on node CPU) — the same model the
+   * on-device `plugin-local-inference` path uses, so a per-agent cutover to the
+   * sidecar never changes vector width.
+   */
+  embeddingSidecarModelId(): string {
+    const env = getCloudAwareEnv();
+    return (
+      pick(env.CONTAINERS_EMBEDDING_SIDECAR_MODEL_ID, env.ELIZA_EMBEDDING_SIDECAR_MODEL_ID) ??
+      "thenlper/gte-small"
+    );
+  },
+
+  /**
+   * Loopback host port the sidecar publishes on each node (127.0.0.1 only —
+   * the node-side health probe curls it; agents use the bridge network, and
+   * nothing is reachable off-node). Default 8290. Clamped to [1, 65535].
+   */
+  embeddingSidecarHostPort(): number {
+    const env = getCloudAwareEnv();
+    const raw = pick(
+      env.CONTAINERS_EMBEDDING_SIDECAR_HOST_PORT,
+      env.ELIZA_EMBEDDING_SIDECAR_HOST_PORT,
+    );
+    const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+    return Number.isFinite(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : 8290;
+  },
+
+  /**
+   * Whether the node health loop may (re)install a missing embedding sidecar.
+   *
+   * DEFAULT: ON — the durable remediation this exists for: nodes provisioned
+   * before the sidecar shipped in bootstrap converge on the next health cycle
+   * instead of waiting for a hand-install (the failure mode that lost the
+   * fleet's sidecars in the first place). The health verdict is persisted
+   * either way, so disabling self-heal (`false`/`0`) still surfaces absence.
+   */
+  embeddingSidecarSelfHealEnabled(): boolean {
+    const env = getCloudAwareEnv();
+    const raw = pick(
+      env.CONTAINERS_EMBEDDING_SIDECAR_SELF_HEAL,
+      env.ELIZA_EMBEDDING_SIDECAR_SELF_HEAL,
+    );
+    return raw !== "false" && raw !== "0";
+  },
+
   /** Username used for Docker registry pulls on container nodes. */
   registryUsername(): string | undefined {
     const env = getCloudAwareEnv();

--- a/packages/cloud/shared/src/lib/services/containers/embedding-sidecar.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/embedding-sidecar.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Guards the embedding-sidecar contract: the ensure/probe shell commands and
+ * probe parser every consumer (cloud-init bootstrap, operator onboard, health
+ * loop) shares. Deterministic — the builders are pure; no SSH or docker here.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  buildEmbeddingSidecarProbeCmd,
+  buildEnsureEmbeddingSidecarCmd,
+  EMBEDDING_SIDECAR_CONTAINER_NAME,
+  embeddingSidecarStatusFromMetadata,
+  parseEmbeddingSidecarProbe,
+  resolveEmbeddingSidecarConfig,
+} from "./embedding-sidecar";
+
+const SIDECAR_ENV_KEYS = [
+  "CONTAINERS_EMBEDDING_SIDECAR_IMAGE",
+  "ELIZA_EMBEDDING_SIDECAR_IMAGE",
+  "CONTAINERS_EMBEDDING_SIDECAR_MODEL_ID",
+  "ELIZA_EMBEDDING_SIDECAR_MODEL_ID",
+  "CONTAINERS_EMBEDDING_SIDECAR_HOST_PORT",
+  "ELIZA_EMBEDDING_SIDECAR_HOST_PORT",
+];
+
+afterEach(() => {
+  for (const key of SIDECAR_ENV_KEYS) delete process.env[key];
+});
+
+describe("buildEnsureEmbeddingSidecarCmd", () => {
+  test("is idempotent: leaves a running sidecar untouched, replaces anything else", () => {
+    const cmd = buildEnsureEmbeddingSidecarCmd();
+    // Running-check short-circuits the whole install group.
+    expect(cmd).toMatch(
+      new RegExp(
+        `^docker inspect -f '\\{\\{\\.State\\.Running\\}\\}' ${EMBEDDING_SIDECAR_CONTAINER_NAME} 2>/dev/null \\| grep -q true \\|\\| \\{`,
+      ),
+    );
+    // Not-running path replaces (rm -f) rather than docker-start, so a config/
+    // image drift heals to the currently pinned contract.
+    expect(cmd).toContain(
+      `docker rm -f ${EMBEDDING_SIDECAR_CONTAINER_NAME} >/dev/null 2>&1 || true`,
+    );
+  });
+
+  test("supervises via docker restart policy and survives the disk-clean prune", () => {
+    const cmd = buildEnsureEmbeddingSidecarCmd();
+    expect(cmd).toContain("--restart always");
+    // The disk-clean cycle prunes stopped containers NOT carrying the
+    // managed-by label — an unlabeled sidecar is exactly how hand-installed
+    // ones vanished. The label is load-bearing, not cosmetic.
+    expect(cmd).toContain("--label ai.elizaos.managed-by=eliza-cloud");
+  });
+
+  test("serves gte-small on the shared bridge network with a loopback-only publish", () => {
+    const cmd = buildEnsureEmbeddingSidecarCmd();
+    expect(cmd).toContain("--network containers-isolated");
+    expect(cmd).toContain("-p 127.0.0.1:8290:80");
+    expect(cmd).toContain("--model-id thenlper/gte-small");
+    expect(cmd).toContain("ghcr.io/huggingface/text-embeddings-inference:cpu-1.8");
+    // Model cache persists across container replacement.
+    expect(cmd).toContain("-v /data/embedding-models:/data");
+  });
+
+  test("single line — embeddable in a cloud-init runcmd entry", () => {
+    expect(buildEnsureEmbeddingSidecarCmd()).not.toMatch(/[\r\n]/);
+  });
+
+  test("honors env overrides for image, model, and port", () => {
+    process.env.CONTAINERS_EMBEDDING_SIDECAR_IMAGE = "ghcr.io/example/tei:cpu-9.9";
+    process.env.CONTAINERS_EMBEDDING_SIDECAR_MODEL_ID = "example/gte-small-v2";
+    process.env.CONTAINERS_EMBEDDING_SIDECAR_HOST_PORT = "9411";
+    const cmd = buildEnsureEmbeddingSidecarCmd();
+    expect(cmd).toContain("ghcr.io/example/tei:cpu-9.9");
+    expect(cmd).toContain("--model-id example/gte-small-v2");
+    expect(cmd).toContain("-p 127.0.0.1:9411:80");
+  });
+
+  test("refuses shell-unsafe config instead of quoting around it", () => {
+    expect(() =>
+      buildEnsureEmbeddingSidecarCmd({
+        ...resolveEmbeddingSidecarConfig(),
+        image: "evil; rm -rf /",
+      }),
+    ).toThrow(/refusing to build a shell command/);
+    expect(() =>
+      buildEnsureEmbeddingSidecarCmd({
+        ...resolveEmbeddingSidecarConfig(),
+        hostPort: 0,
+      }),
+    ).toThrow(/invalid host port/);
+  });
+});
+
+describe("buildEmbeddingSidecarProbeCmd + parseEmbeddingSidecarProbe", () => {
+  test("probe emits exactly one status token and the parser round-trips all three", () => {
+    const cmd = buildEmbeddingSidecarProbeCmd();
+    expect(cmd).toContain("echo running");
+    expect(cmd).toContain("echo unresponsive");
+    expect(cmd).toContain("echo missing");
+    // HTTP-level: a container that is up but cannot serve must not read present.
+    expect(cmd).toContain("curl -fsS -m 5 http://127.0.0.1:8290/health");
+
+    expect(parseEmbeddingSidecarProbe("running\n")).toBe("running");
+    expect(parseEmbeddingSidecarProbe("unresponsive")).toBe("unresponsive");
+    expect(parseEmbeddingSidecarProbe("missing\n")).toBe("missing");
+  });
+
+  test("parser tolerates interleaved stderr/noise and rejects unusable output", () => {
+    expect(parseEmbeddingSidecarProbe("[stderr] warning: something\nrunning\n")).toBe("running");
+    expect(parseEmbeddingSidecarProbe("motd banner\nmissing")).toBe("missing");
+    expect(parseEmbeddingSidecarProbe("")).toBeNull();
+    expect(parseEmbeddingSidecarProbe("[stderr] connection reset")).toBeNull();
+    expect(parseEmbeddingSidecarProbe("garbage output")).toBeNull();
+  });
+});
+
+describe("embeddingSidecarStatusFromMetadata", () => {
+  test("reads the persisted verdict and defaults to unknown for pre-rollout rows", () => {
+    expect(
+      embeddingSidecarStatusFromMetadata({
+        embeddingSidecar: { status: "missing", checkedAt: "2026-08-05T00:00:00.000Z" },
+      }),
+    ).toBe("missing");
+    expect(embeddingSidecarStatusFromMetadata({ embeddingSidecar: { status: "running" } })).toBe(
+      "running",
+    );
+    expect(embeddingSidecarStatusFromMetadata({})).toBe("unknown");
+    expect(embeddingSidecarStatusFromMetadata(null)).toBe("unknown");
+    expect(embeddingSidecarStatusFromMetadata({ embeddingSidecar: "corrupt" })).toBe("unknown");
+    expect(embeddingSidecarStatusFromMetadata({ embeddingSidecar: { status: "bogus" } })).toBe(
+      "unknown",
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/embedding-sidecar.ts
+++ b/packages/cloud/shared/src/lib/services/containers/embedding-sidecar.ts
@@ -1,0 +1,174 @@
+/**
+ * Node-local embedding sidecar contract: one text-embeddings-inference (TEI)
+ * container per Docker node serving gte-small so every agent on the node gets
+ * local ~50ms embeddings instead of the cloud round-trip.
+ *
+ * THE GAP THIS CLOSES
+ * The sidecar used to be hand-installed on nodes and silently vanished: an
+ * autoscaled node is rebuilt from `buildContainerNodeUserData` (which never
+ * installed one), and the disk-clean cycle's `docker container prune
+ * --filter 'label!=ai.elizaos.managed-by'` reaps any stopped container that
+ * does not carry the managed-by label — exactly what a hand-run sidecar was.
+ * Nothing probed for it, so agents silently rode the cloud embedding path.
+ * This module is the single source of truth all three consumers share:
+ *   - `node-bootstrap.ts` (cloud-init for autoscaled nodes) installs it,
+ *   - `onboard-docker-node.ts` (operator onboarding) installs it,
+ *   - `docker-node-manager.ts` health checks probe it, surface its absence in
+ *     node metadata / the capacity report, and self-heal it.
+ *
+ * Supervision is Docker-native: `--restart always` plus the bootstrap's
+ * `systemctl enable --now docker` restarts the sidecar across daemon and host
+ * reboots; the managed-by label keeps every reclamation path away from it.
+ *
+ * Agents consume it over the shared bridge network via plugin-embeddings
+ * (`EMBEDDING_BASE_URL=http://eliza-embedding-sidecar:80/v1`, 384-dim). That
+ * per-agent env cutover is a separate rollout (existing 1536-dim stores must
+ * re-embed first — the #9911 recall-degradation class), so this module only
+ * guarantees the endpoint exists and its absence is loudly visible.
+ *
+ * Pure command builders + parser only (no I/O), mirroring node-disk-manager:
+ * the SSH/cloud-init boundary stays with the callers and everything here
+ * unit-tests exhaustively.
+ */
+
+import { containersEnv } from "../../config/containers-env";
+import {
+  CONTAINER_LABEL_MANAGED_BY,
+  CONTAINER_LABEL_MANAGED_BY_VALUE,
+} from "../docker-sandbox-utils";
+
+/**
+ * Fixed container name. Deliberately outside the agent naming scheme
+ * (`agent-`/`cloud-container-`) so the zombie-container reaper in node
+ * onboarding can never select it, and stable so agents can resolve it by DNS
+ * name on the shared bridge network.
+ */
+export const EMBEDDING_SIDECAR_CONTAINER_NAME = "eliza-embedding-sidecar";
+
+/** Host bind-mount for the TEI model cache so weights survive re-creates. */
+const MODEL_CACHE_HOST_DIR = "/data/embedding-models";
+
+/** Result of the node-side probe (see {@link buildEmbeddingSidecarProbeCmd}). */
+export type EmbeddingSidecarStatus = "running" | "unresponsive" | "missing";
+
+/**
+ * Reject values that would break out of the single-line shell commands built
+ * below. Image refs, model ids, network names, and the container name all fit
+ * this charset; anything else is a misconfiguration worth failing loudly on
+ * rather than quoting around.
+ */
+function assertShellSafe(value: string, label: string): string {
+  if (!/^[A-Za-z0-9._/:@-]+$/.test(value)) {
+    throw new Error(
+      `[embedding-sidecar] ${label} "${value}" contains characters outside [A-Za-z0-9._/:@-]; refusing to build a shell command with it`,
+    );
+  }
+  return value;
+}
+
+export interface EmbeddingSidecarConfig {
+  image: string;
+  modelId: string;
+  hostPort: number;
+  network: string;
+}
+
+/** Effective sidecar config from `containersEnv` (each value overridable). */
+export function resolveEmbeddingSidecarConfig(): EmbeddingSidecarConfig {
+  return {
+    image: containersEnv.embeddingSidecarImage(),
+    modelId: containersEnv.embeddingSidecarModelId(),
+    hostPort: containersEnv.embeddingSidecarHostPort(),
+    network: containersEnv.dockerNetwork(),
+  };
+}
+
+/**
+ * Idempotent single-line command that guarantees the sidecar is running:
+ * a healthy running sidecar is left untouched (so re-runs are free), anything
+ * else (stopped, crashed, half-created) is replaced with a fresh container at
+ * the currently pinned image/config. The final `docker run` exit code is the
+ * command's exit code, so callers can distinguish "ensured" from "failed".
+ *
+ * The port publish binds loopback only — the HTTP surface reachable from off
+ * the node is nothing; agents reach the sidecar via the shared bridge network,
+ * and the health probe reaches it via 127.0.0.1.
+ */
+export function buildEnsureEmbeddingSidecarCmd(
+  config: EmbeddingSidecarConfig = resolveEmbeddingSidecarConfig(),
+): string {
+  const name = EMBEDDING_SIDECAR_CONTAINER_NAME;
+  const image = assertShellSafe(config.image, "image");
+  const modelId = assertShellSafe(config.modelId, "model id");
+  const network = assertShellSafe(config.network, "network");
+  const port = config.hostPort;
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`[embedding-sidecar] invalid host port: ${port}`);
+  }
+  return (
+    `docker inspect -f '{{.State.Running}}' ${name} 2>/dev/null | grep -q true || { ` +
+    // `|| true` on rm/pull: a missing container / transient pull failure must
+    // not mask the `docker run` verdict (run pulls implicitly when needed).
+    `docker rm -f ${name} >/dev/null 2>&1 || true; ` +
+    `docker pull ${image} >/dev/null 2>&1 || true; ` +
+    `docker run -d --name ${name} --restart always ` +
+    `--label ${CONTAINER_LABEL_MANAGED_BY}=${CONTAINER_LABEL_MANAGED_BY_VALUE} ` +
+    `--network ${network} -p 127.0.0.1:${port}:80 ` +
+    `-v ${MODEL_CACHE_HOST_DIR}:/data ${image} --model-id ${modelId}; }`
+  );
+}
+
+/**
+ * Single-line probe emitting exactly one of the {@link EmbeddingSidecarStatus}
+ * tokens: `missing` (no running container), `unresponsive` (container runs but
+ * TEI's `/health` does not answer 200 within 5s — e.g. still downloading the
+ * model, or wedged), `running` (serving). HTTP-level on purpose: a container
+ * that is "up" but cannot embed must not read as present.
+ */
+export function buildEmbeddingSidecarProbeCmd(
+  hostPort: number = containersEnv.embeddingSidecarHostPort(),
+): string {
+  const name = EMBEDDING_SIDECAR_CONTAINER_NAME;
+  return (
+    `docker inspect -f '{{.State.Running}}' ${name} 2>/dev/null | grep -q true` +
+    ` && { curl -fsS -m 5 http://127.0.0.1:${hostPort}/health >/dev/null 2>&1 && echo running || echo unresponsive; }` +
+    ` || echo missing`
+  );
+}
+
+/**
+ * Parse the probe output (tolerant of `[stderr]` lines and shell noise the SSH
+ * transport may interleave). Returns null when no status token is present —
+ * an unusable probe, distinct from every real verdict, so the caller can log
+ * it instead of misfiling it as any of the three real states.
+ */
+export function parseEmbeddingSidecarProbe(output: string): EmbeddingSidecarStatus | null {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("[stderr]"));
+  for (let index = lines.length - 1; index >= 0; index--) {
+    const line = lines[index];
+    if (line === "running" || line === "unresponsive" || line === "missing") {
+      return line;
+    }
+  }
+  return null;
+}
+
+/**
+ * Read the last persisted sidecar verdict off a node's `docker_nodes.metadata`
+ * (written by the health loop). `"unknown"` = never probed (pre-rollout rows).
+ */
+export function embeddingSidecarStatusFromMetadata(
+  metadata: unknown,
+): EmbeddingSidecarStatus | "unknown" {
+  if (!metadata || typeof metadata !== "object") return "unknown";
+  const entry = (metadata as Record<string, unknown>).embeddingSidecar;
+  if (!entry || typeof entry !== "object") return "unknown";
+  const status = (entry as Record<string, unknown>).status;
+  if (status === "running" || status === "unresponsive" || status === "missing") {
+    return status;
+  }
+  return "unknown";
+}

--- a/packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts
@@ -88,6 +88,28 @@ describe("buildContainerNodeUserData — ghcr access", () => {
     expect(networkIdx).toBeGreaterThan(guardIdx);
   });
 
+  test("installs the supervised embedding sidecar after network + ghcr access", () => {
+    clearRegistryEnv();
+    const userData = buildContainerNodeUserData(baseInput);
+    // The ensure command attaches the sidecar to the shared network (needs the
+    // network to exist) and pulls a public ghcr image (needs the stale-cred
+    // cleanup first — the same `denied` failure the robot fix exists for). A
+    // failed install must not abort the rest of boot: registration still runs
+    // and the health loop surfaces + self-heals the sidecar.
+    const networkIdx = userData.indexOf("docker network create");
+    const accessIdx = userData.indexOf("docker logout 'ghcr.io'");
+    const sidecarIdx = userData.indexOf("eliza-embedding-sidecar");
+    expect(networkIdx).toBeGreaterThanOrEqual(0);
+    expect(accessIdx).toBeGreaterThan(networkIdx);
+    expect(sidecarIdx).toBeGreaterThan(accessIdx);
+    expect(userData).toContain("--restart always");
+    expect(userData).toContain("--label ai.elizaos.managed-by=eliza-cloud");
+    expect(userData).toContain("--model-id thenlper/gte-small");
+    expect(userData).toContain(
+      "|| echo '[bootstrap] embedding sidecar install failed; the node health loop will surface and self-heal it'",
+    );
+  });
+
   test("self-registration includes the node host-key fingerprint and fails closed if it cannot be read", () => {
     clearRegistryEnv();
     const userData = buildContainerNodeUserData({

--- a/packages/cloud/shared/src/lib/services/containers/node-bootstrap.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-bootstrap.ts
@@ -7,9 +7,12 @@
  *   2. Creates the shared bridge network (`containers-isolated` by default).
  *   3. Adds the control plane's deploy SSH key to /root/.ssh/authorized_keys.
  *   4. Pre-creates the per-node volume root /data/containers/.
- *   5. Optionally pre-pulls a list of images so the first deployment on
+ *   5. Installs the local-embedding sidecar (see `embedding-sidecar.ts`):
+ *      `--restart always` supervises it, and the health loop probes/repairs
+ *      it, so it is never a hand-installed one-off again.
+ *   6. Optionally pre-pulls a list of images so the first deployment on
  *      this node has warm cache (huge UX win for multi-GiB agent images).
- *   6. Pings a self-registration endpoint on the control plane so the
+ *   7. Pings a self-registration endpoint on the control plane so the
  *      node lands in the docker_nodes table without operator action.
  *
  * The script is yaml-shaped (cloud-init User-Data MIME), so it must keep
@@ -20,6 +23,7 @@
 import { containersEnv } from "../../config/containers-env";
 import { CLOUD_METADATA_IP } from "../app-firewall-utils";
 import { validateDockerPlatform } from "../docker-sandbox-utils";
+import { buildEnsureEmbeddingSidecarCmd } from "./embedding-sidecar";
 import { getImageRegistryHost } from "./hetzner-client/registry";
 
 export interface NodeBootstrapInput {
@@ -172,6 +176,7 @@ runcmd:
   - systemctl enable --now eliza-container-egress-guard.service
   - docker network inspect '${sanitizeShellSingleQuoted(network)}' >/dev/null 2>&1 || docker network create --driver bridge '${sanitizeShellSingleQuoted(network)}'
 ${registryAccessCommands}
+  - ${buildEnsureEmbeddingSidecarCmd()} || echo '[bootstrap] embedding sidecar install failed; the node health loop will surface and self-heal it'
 ${prePullCommands}${registerSection}
 `;
 }

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-embedding-sidecar.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-embedding-sidecar.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Embedding-sidecar health surfacing + self-heal tests.
+ *
+ * A node without its local-embedding sidecar must never be silent about it —
+ * that silence is how the fleet's hand-installed sidecars vanished while
+ * agents fell back to the cloud embedding path. These tests drive the REAL
+ * `healthCheckNode` / `getCapacityReport` with a stubbed SSH client +
+ * repository and assert:
+ *   1. a missing sidecar is self-healed via the ensure command and the
+ *      recovered verdict is persisted;
+ *   2. self-heal attempts are cooldown-gated (no image re-pull every cycle)
+ *      and a still-broken sidecar persists as missing;
+ *   3. the env kill-switch disables self-heal but NOT the surfacing;
+ *   4. the sidecar verdict never owns the node's reachability status;
+ *   5. the capacity report exposes the persisted verdict per node.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as realDockerNodesNs from "../../db/repositories/docker-nodes";
+import type { DockerNode } from "../../db/schemas/docker-nodes";
+import * as realDockerNodeWorkloadsNs from "./docker-node-workloads";
+import * as realDockerSshNs from "./docker-ssh";
+import * as realNodeDiskNs from "./node-disk-manager";
+
+const realDockerNodes = { ...realDockerNodesNs };
+const realDockerNodeWorkloads = { ...realDockerNodeWorkloadsNs };
+const realDockerSsh = { ...realDockerSshNs };
+const realNodeDisk = { ...realNodeDiskNs };
+
+const repoCalls = {
+  updateStatus: [] as Array<{ nodeId: string; status: string }>,
+  setEmbeddingSidecarHealth: [] as Array<{ nodeId: string; status: string }>,
+};
+
+let findAllNodes: DockerNode[] = [];
+
+const sshMock = {
+  connect: mock(),
+  exec: mock(),
+};
+
+mock.module("../../db/repositories/docker-nodes", () => ({
+  dockerNodesRepository: {
+    updateStatus: (nodeId: string, status: string) => {
+      repoCalls.updateStatus.push({ nodeId, status });
+      return Promise.resolve();
+    },
+    setEmbeddingSidecarHealth: (nodeId: string, status: string) => {
+      repoCalls.setEmbeddingSidecarHealth.push({ nodeId, status });
+      return Promise.resolve();
+    },
+    markOfflineAndDisable: () => Promise.resolve(),
+    setHostKeyFingerprint: () => Promise.resolve(),
+    findAll: () => Promise.resolve(findAllNodes),
+  },
+}));
+
+mock.module("./docker-node-workloads", () => ({
+  countAllocatedWorkloadsOnNode: () => Promise.resolve(0),
+}));
+
+mock.module("./docker-ssh", () => ({
+  DockerSSHClient: {
+    getClient: () => sshMock,
+  },
+}));
+
+mock.module("./node-disk-manager", () => ({
+  ...realNodeDisk,
+  probeNodeDiskUsage: () => Promise.resolve(null),
+}));
+
+afterAll(() => {
+  mock.module("../../db/repositories/docker-nodes", () => realDockerNodes);
+  mock.module("./docker-node-workloads", () => realDockerNodeWorkloads);
+  mock.module("./docker-ssh", () => realDockerSsh);
+  mock.module("./node-disk-manager", () => realNodeDisk);
+});
+
+import {
+  __resetEmbeddingSidecarSelfHealStateForTests,
+  __resetNodeHealthFailureStateForTests,
+  DockerNodeManager,
+} from "./docker-node-manager";
+
+function node(nodeId: string, metadata: Record<string, unknown> = {}): DockerNode {
+  return {
+    id: `${nodeId}-uuid`,
+    node_id: nodeId,
+    hostname: `${nodeId}.example.test`,
+    ssh_port: 22,
+    capacity: 4,
+    enabled: true,
+    status: "healthy",
+    allocated_count: 0,
+    last_health_check: null,
+    ssh_user: "root",
+    host_key_fingerprint: "SHA256:test",
+    metadata,
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    updated_at: new Date("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+/**
+ * Dispatching exec stub: docker-info answers healthy, sidecar probes consume
+ * `probeResults` in order, and ensure invocations are recorded. Everything the
+ * real healthCheckNode execs is distinguishable by command content.
+ */
+function wireExec(probeResults: string[]): { ensures: string[] } {
+  const state = { ensures: [] as string[], probeIndex: 0 };
+  sshMock.connect.mockResolvedValue(undefined);
+  sshMock.exec.mockImplementation((command: string) => {
+    if (command.includes("docker info")) return Promise.resolve("DOCKER-ID-123");
+    if (command.includes("echo missing")) {
+      const result = probeResults[Math.min(state.probeIndex, probeResults.length - 1)];
+      state.probeIndex += 1;
+      return Promise.resolve(result ?? "missing");
+    }
+    if (command.includes("docker run -d")) {
+      state.ensures.push(command);
+      return Promise.resolve("");
+    }
+    return Promise.resolve("");
+  });
+  return state;
+}
+
+beforeEach(() => {
+  __resetNodeHealthFailureStateForTests();
+  __resetEmbeddingSidecarSelfHealStateForTests();
+  repoCalls.updateStatus = [];
+  repoCalls.setEmbeddingSidecarHealth = [];
+  findAllNodes = [];
+  sshMock.connect.mockReset();
+  sshMock.exec.mockReset();
+});
+
+afterEach(() => {
+  delete process.env.CONTAINERS_EMBEDDING_SIDECAR_SELF_HEAL;
+});
+
+describe("healthCheckNode embedding-sidecar surfacing", () => {
+  test("missing sidecar is self-healed and the recovered verdict is persisted", async () => {
+    const manager = DockerNodeManager.getInstance();
+    const state = wireExec(["missing", "running"]);
+
+    const status = await manager.healthCheckNode(node("node-a"));
+
+    expect(status).toBe("healthy");
+    expect(state.ensures).toHaveLength(1);
+    expect(state.ensures[0]).toContain("eliza-embedding-sidecar");
+    expect(repoCalls.setEmbeddingSidecarHealth).toEqual([{ nodeId: "node-a", status: "running" }]);
+  });
+
+  test("self-heal is cooldown-gated and a still-broken sidecar persists as missing", async () => {
+    const manager = DockerNodeManager.getInstance();
+    const state = wireExec(["missing", "missing", "missing", "missing"]);
+
+    await manager.healthCheckNode(node("node-b"));
+    await manager.healthCheckNode(node("node-b"));
+
+    // One ensure attempt across both cycles: the second is inside the cooldown.
+    expect(state.ensures).toHaveLength(1);
+    expect(repoCalls.setEmbeddingSidecarHealth).toEqual([
+      { nodeId: "node-b", status: "missing" },
+      { nodeId: "node-b", status: "missing" },
+    ]);
+  });
+
+  test("kill-switch disables self-heal but absence is still persisted", async () => {
+    process.env.CONTAINERS_EMBEDDING_SIDECAR_SELF_HEAL = "false";
+    const manager = DockerNodeManager.getInstance();
+    const state = wireExec(["missing"]);
+
+    const status = await manager.healthCheckNode(node("node-c"));
+
+    expect(status).toBe("healthy");
+    expect(state.ensures).toHaveLength(0);
+    expect(repoCalls.setEmbeddingSidecarHealth).toEqual([{ nodeId: "node-c", status: "missing" }]);
+  });
+
+  test("running sidecar persists as running without any ensure attempt", async () => {
+    const manager = DockerNodeManager.getInstance();
+    const state = wireExec(["running"]);
+
+    await manager.healthCheckNode(node("node-d"));
+
+    expect(state.ensures).toHaveLength(0);
+    expect(repoCalls.setEmbeddingSidecarHealth).toEqual([{ nodeId: "node-d", status: "running" }]);
+  });
+
+  test("an unusable probe never fabricates a verdict and never owns node status", async () => {
+    const manager = DockerNodeManager.getInstance();
+    wireExec(["total garbage"]);
+
+    const status = await manager.healthCheckNode(node("node-e"));
+
+    expect(status).toBe("healthy");
+    expect(repoCalls.setEmbeddingSidecarHealth).toHaveLength(0);
+    expect(repoCalls.updateStatus).toContainEqual({ nodeId: "node-e", status: "healthy" });
+  });
+});
+
+describe("getCapacityReport embedding-sidecar field", () => {
+  test("exposes the persisted verdict per node and unknown for unprobed rows", async () => {
+    const manager = DockerNodeManager.getInstance();
+    findAllNodes = [
+      node("probed-missing", {
+        embeddingSidecar: { status: "missing", checkedAt: "2026-08-05T00:00:00.000Z" },
+      }),
+      node("probed-running", {
+        embeddingSidecar: { status: "running", checkedAt: "2026-08-05T00:00:00.000Z" },
+      }),
+      node("never-probed"),
+    ];
+
+    const report = await manager.getCapacityReport();
+    const byId = new Map(report.nodes.map((entry) => [entry.nodeId, entry.embeddingSidecar]));
+
+    expect(byId.get("probed-missing")).toBe("missing");
+    expect(byId.get("probed-running")).toBe("running");
+    expect(byId.get("never-probed")).toBe("unknown");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -12,6 +12,13 @@ import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import type { DockerNode, DockerNodeStatus } from "../../db/schemas/docker-nodes";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
+import {
+  buildEmbeddingSidecarProbeCmd,
+  buildEnsureEmbeddingSidecarCmd,
+  type EmbeddingSidecarStatus,
+  embeddingSidecarStatusFromMetadata,
+  parseEmbeddingSidecarProbe,
+} from "./containers/embedding-sidecar";
 import { countAllocatedWorkloadsOnNode } from "./docker-node-workloads";
 import {
   dockerPlatformFlag,
@@ -72,6 +79,27 @@ export function __resetNodeHealthFailureStateForTests(): void {
 }
 
 // ---------------------------------------------------------------------------
+// Embedding-sidecar self-heal bookkeeping
+// ---------------------------------------------------------------------------
+
+/**
+ * Last self-heal attempt per node. In-memory for the same reason as the
+ * pre-pull/health state above: the provisioning worker owns the loop and a
+ * restart is a clean slate. The cooldown exists because the ensure command may
+ * pull the sidecar image (hundreds of MB) — a node whose install keeps failing
+ * must not re-pull every health cycle.
+ */
+const embeddingSidecarSelfHealState = new Map<string, number>();
+/** Minimum gap between sidecar self-heal attempts on the same node. */
+const EMBEDDING_SIDECAR_SELF_HEAL_COOLDOWN_MS = 30 * 60 * 1000;
+/** Generous ensure timeout: first run pulls the TEI image + model weights. */
+const EMBEDDING_SIDECAR_ENSURE_TIMEOUT_MS = 5 * 60 * 1000;
+
+export function __resetEmbeddingSidecarSelfHealStateForTests(): void {
+  embeddingSidecarSelfHealState.clear();
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -84,6 +112,12 @@ export interface NodeCapacityReport {
   status: DockerNodeStatus;
   enabled: boolean;
   lastHealthCheck: Date | null;
+  /**
+   * Last persisted local-embedding-sidecar verdict for the node ("unknown"
+   * until the health loop has probed it). Surfaced so a fleet silently missing
+   * its sidecars is visible in every capacity read, not just node-local logs.
+   */
+  embeddingSidecar: EmbeddingSidecarStatus | "unknown";
 }
 
 export interface CapacitySummary {
@@ -356,6 +390,13 @@ export class DockerNodeManager {
               `[docker-node-manager] Canonical node ${node.node_id} (${node.hostname}) is reachable but disk is critically full; leaving healthy so the disk-clean cycle can reclaim space (canonical nodes are not autoscaler-replaced). Operators: free space or set enabled=false.`,
             );
           }
+          // Embedding-sidecar sub-verdict: surfaced (metadata + capacity report
+          // + ERROR log) and self-healed, but it never owns the node status —
+          // no agent is scheduled onto the sidecar itself, and flipping a whole
+          // fleet to degraded because sidecars are missing would zero scheduling
+          // capacity. The invariant is "absence is loud and converges", not
+          // "absence drains the node".
+          await this.embeddingSidecarHealth(node, ssh);
           // A reachable node clears any accumulated consecutive-failure count so
           // one recovered cycle undoes prior transient failures.
           nodeHealthFailureState.delete(node.node_id);
@@ -449,6 +490,74 @@ export class DockerNodeManager {
   }
 
   /**
+   * Probe the node's local-embedding sidecar and persist the verdict to
+   * `docker_nodes.metadata.embeddingSidecar` so its absence is a queryable
+   * fleet fact (capacity report, admin API) instead of a silent fall-through
+   * to the cloud embedding path — the failure mode that lost the fleet's
+   * hand-installed sidecars unnoticed. When the sidecar is not serving, one
+   * cooldown-gated ensure attempt re-installs it (the durable remediation for
+   * nodes provisioned before the sidecar shipped in bootstrap); the persisted
+   * verdict is re-probed AFTER the repair so recovery is visible immediately.
+   *
+   * Runs only after `docker info` confirmed reachability and never throws out
+   * of the health check: like the disk sub-probe, the sidecar never owns
+   * reachability — the docker-info probe does.
+   */
+  async embeddingSidecarHealth(node: DockerNode, ssh: DockerSSHClient): Promise<void> {
+    try {
+      let status = await this.probeEmbeddingSidecar(ssh);
+      if (status === null) return;
+
+      if (status !== "running" && containersEnv.embeddingSidecarSelfHealEnabled()) {
+        const lastAttempt = embeddingSidecarSelfHealState.get(node.node_id) ?? 0;
+        if (Date.now() - lastAttempt >= EMBEDDING_SIDECAR_SELF_HEAL_COOLDOWN_MS) {
+          // Stamp BEFORE the attempt so a hanging/failing ensure still honors
+          // the cooldown next cycle instead of re-pulling the image every tick.
+          embeddingSidecarSelfHealState.set(node.node_id, Date.now());
+          logger.warn(
+            `[docker-node-manager] Embedding sidecar ${status} on node ${node.node_id} (${node.hostname}); attempting self-heal install`,
+          );
+          await ssh.exec(buildEnsureEmbeddingSidecarCmd(), EMBEDDING_SIDECAR_ENSURE_TIMEOUT_MS);
+          status = (await this.probeEmbeddingSidecar(ssh)) ?? status;
+        }
+      }
+
+      if (status === "running") {
+        embeddingSidecarSelfHealState.delete(node.node_id);
+      } else {
+        logger.error(
+          `[docker-node-manager] Embedding sidecar ${status} on node ${node.node_id} (${node.hostname}) — agents on this node cannot reach local embeddings. Self-heal ${containersEnv.embeddingSidecarSelfHealEnabled() ? "will retry after cooldown" : "is disabled"}.`,
+          { nodeId: node.node_id, hostname: node.hostname, embeddingSidecar: status },
+        );
+      }
+      await dockerNodesRepository.setEmbeddingSidecarHealth(node.node_id, status);
+    } catch (error) {
+      // error-policy:J7 the sidecar sub-probe/self-heal is diagnostics on the
+      // health loop; a thrown SSH/exec failure is logged loudly here and must
+      // not take down the reachability verdict the loop exists to produce.
+      logger.warn("[docker-node-manager] Embedding sidecar probe/self-heal failed", {
+        nodeId: node.node_id,
+        hostname: node.hostname,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /** Run the sidecar probe over SSH; null = probe output was unusable. */
+  private async probeEmbeddingSidecar(
+    ssh: DockerSSHClient,
+  ): Promise<EmbeddingSidecarStatus | null> {
+    const output = await ssh.exec(buildEmbeddingSidecarProbeCmd(), 20_000);
+    const status = parseEmbeddingSidecarProbe(output);
+    if (status === null) {
+      logger.warn("[docker-node-manager] Embedding sidecar probe returned no status token", {
+        output: output.slice(0, 200),
+      });
+    }
+    return status;
+  }
+
+  /**
    * Single-attempt readiness probe used during scheduling. This prevents stale
    * healthy rows from receiving new work when SSH credentials or the Docker
    * daemon are no longer valid.
@@ -532,6 +641,7 @@ export class DockerNodeManager {
       status: node.status,
       enabled: node.enabled,
       lastHealthCheck: node.last_health_check,
+      embeddingSidecar: embeddingSidecarStatusFromMetadata(node.metadata),
     }));
 
     const enabledNodes = nodeReports.filter((n) => n.enabled && n.status === "healthy");


### PR DESCRIPTION
Production agent nodes have no local embedding sidecar and every agent runs on the pure cloud-embedding path. This adds the sidecar to node provisioning, surfaces its absence in node health, and self-heals nodes that lost it.

## Verified fleet state

All 8 production agent nodes were checked directly — running containers, stopped containers, pulled images, and systemd units:

| Hostname | Agent containers | Sidecar |
|---|---|---|
| eliza-prod-robot-5 | 34 healthy | none |
| eliza-prod-robot-3 | 28 healthy | none |
| eliza-prod-robot-2 | 33 healthy | none |
| eliza-prod-robot-4 | 38 healthy | none |
| eliza-prod-robot-6 | 28 healthy | none |
| eliza-core-3702b6f8 | 4 healthy | none |
| eliza-core-c5830c06 | 4 healthy | none |
| eliza-core-7226e98b | 4 healthy | none |

**Zero of 8** have a sidecar in any form. `docker inspect` across ~170 agent containers shows `ELIZAOS_CLOUD_EMBEDDING_URL=https://api.elizacloud.ai`, `EMBEDDING_DIMENSION=1536`, and no `EMBEDDING_BASE_URL`.

## Root cause

The sidecar has only ever existed as hand-installed state — **no provisioning path installs one**. Autoscaled nodes boot from `buildContainerNodeUserData` (`node-bootstrap.ts`); operator boxes come up via `onboard-docker-node.ts`. Neither mentions it, and the repo contained zero references to `text-embeddings-inference`. Two mechanisms then erase hand-installs: autoscaled nodes are rebuilt from user-data that never had it, and the disk-reclaim cycle prunes unlabelled containers. That is why this regresses after every infra churn, and why "restored on 3 nodes" does not persist.

## Change

- **New `containers/embedding-sidecar.ts`** — single source of truth: container `eliza-embedding-sidecar`, pinned `ghcr.io/huggingface/text-embeddings-inference:cpu-1.8` serving `thenlper/gte-small`, shared bridge network, loopback-only health port, model-cache bind mount, `--restart always`, and the `ai.elizaos.managed-by=eliza-cloud` label that makes it **prune-immune**. Pure builders; shell-unsafe config fails fast; all overridable via `CONTAINERS_EMBEDDING_SIDECAR_*`.
- **Bootstrap installs it** — cloud-init runs the idempotent ensure command after network setup and ghcr stale-credential cleanup (the same `denied`-pull hazard applies to this image). `onboard-docker-node.ts` gains the identical step, non-fatal.
- **Health surfaces and self-heals it** — `healthCheckNode` probes `/health` after `docker info` answers, persists the verdict to `docker_nodes.metadata.embeddingSidecar`, exposes it on `NodeCapacityReport`, ERROR-logs absence, and reinstalls with a 30-minute per-node cooldown (kill-switch `CONTAINERS_EMBEDDING_SIDECAR_SELF_HEAL=false`). The verdict never owns node status.

**The self-heal is the convergence path for the existing 8 nodes**: deploying the control plane installs sidecars fleet-wide on the next health cycle, with no hand-installs.

## Deliberately out of scope

Flipping agent containers to consume the sidecar. `applyManagedAgentInferenceEnvDefaults` pins 1536-dim cloud embeddings; a hot switch to 384-dim degrades recall until existing stores are re-embedded (#9911 class). That cutover belongs on the existing per-agent flag lane, after this lands.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:8dd8562fbd5bdf85009a969130d2de69a757929c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - control-plane provisioning change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - control-plane provisioning change, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - infrastructure bootstrap change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - live fleet probe across all 8 production agent nodes establishing the defect this PR fixes.

<details><summary>Fleet probe - zero of 8 nodes carry an embedding sidecar</summary>

```text
$ for n in "${NODES[@]}"; do ssh "$n" 'echo "host=$(hostname)"; \
    echo "agents=$(docker ps -q --filter name=agent- | wc -l)"; \
    echo "sidecar_running=$(docker ps    --filter name=embed --filter name=tei -q | wc -l)"; \
    echo "sidecar_stopped=$(docker ps -a --filter name=embed --filter name=tei -q | wc -l)"; \
    echo "images=$(docker images | grep -ciE "text-embeddings|infinity|tei" || true)"; \
    echo "units=$(systemctl list-units --all | grep -ciE "tei|embed" || true)"'; done

host=eliza-prod-robot-5   agents=34  sidecar_running=0  sidecar_stopped=0  images=0  units=0
host=eliza-prod-robot-3   agents=28  sidecar_running=0  sidecar_stopped=0  images=0  units=0
host=eliza-prod-robot-2   agents=33  sidecar_running=0  sidecar_stopped=0  images=0  units=0
host=eliza-prod-robot-4   agents=38  sidecar_running=0  sidecar_stopped=0  images=0  units=0
host=eliza-prod-robot-6   agents=28  sidecar_running=0  sidecar_stopped=0  images=0  units=0
host=eliza-core-3702b6f8  agents=4   sidecar_running=0  sidecar_stopped=0  images=0  units=0
host=eliza-core-c5830c06  agents=4   sidecar_running=0  sidecar_stopped=0  images=0  units=0
host=eliza-core-7226e98b  agents=4   sidecar_running=0  sidecar_stopped=0  images=0  units=0
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in node bootstrap or node health checks.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - provisioning and health-check code path, no model inference is invoked by this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - full suite on the changed packages, including the new sidecar suites.

<details><summary>Test and typecheck output</summary>

```text
$ bun test --isolate   # packages/cloud/shared: containers + config + docker-node-manager
 476 pass
   0 fail
  47 files

   new: containers/embedding-sidecar.test.ts                    12 pass
   new: docker-node-manager-embedding-sidecar.test.ts            6 pass
        (self-heal, cooldown, kill-switch, unusable-probe never
         fabricates a verdict, capacity-report surfacing)
   ext: containers/node-bootstrap.test.ts     ordering + supervision + prune label
   ext: db/repositories/docker-nodes.test.ts  jsonb-merge write

$ bun test packages/cloud/scripts/admin      # onboard-docker-node
  17 pass / 0 fail

$ bun run --cwd packages/cloud/shared typecheck
  exit 0 - no errors

$ bunx biome check   # 10 changed files
  Checked 10 files. No fixes applied. 0 errors.
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
