### PR TITLE
fix(ci): restore certification workflows deleted by the tsbuildinfo untrack sweep

### DIFF
--- a/.github/workflows/certification-image.yml
+++ b/.github/workflows/certification-image.yml
@@ -1,0 +1,108 @@
+# certification-image — builds and publishes the GPU certification image
+# (docker/certification/Dockerfile.gpu) that vast.ai certification runs boot
+# (#14548, epic #14541). The image bakes everything the 16 KB onstart script
+# cannot carry: CUDA llama-server, the sha256-pinned gpu-vision models,
+# node24/bun/playwright/tesseract/ffmpeg. Pushes
+# ghcr.io/elizaos/certification-gpu:{latest,sha-<short>} via GITHUB_TOKEN —
+# no extra registry secret. Rebuilds are rare (image inputs only), so this
+# triggers on dispatch plus pushes that touch its own inputs, never on PRs.
+
+name: certification-image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [develop]
+    paths:
+      - "docker/certification/Dockerfile.gpu"
+      - "scripts/gpu-vision/setup.mjs"
+      - "scripts/gpu-vision/lib.mjs"
+      - "scripts/gpu-vision/models.lock.json"
+      - ".github/workflows/certification-image.yml"
+
+concurrency:
+  group: certification-image-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/certification-gpu
+
+jobs:
+  build-and-push:
+    name: build-and-push
+    # Same fleet fallback as build-agent-image: hetzner when online (the
+    # image is ~15 GB with baked models and CUDA layers; hosted runners need
+    # the disk-free step below to survive it).
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+          show-progress: false
+
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
+          sudo docker image prune -a -f || true
+          df -h /
+
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+        with:
+          driver-opts: |
+            env.BUILDKIT_STEP_LOG_MAX_SIZE=10485760
+            env.BUILDKIT_STEP_LOG_MAX_SPEED=10485760
+
+      # Docker tags must be lowercase; github.repository_owner is "elizaOS".
+      - id: image
+        run: echo "name=${REGISTRY}/${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
+
+      - id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
+        with:
+          images: ${{ steps.image.outputs.name }}
+          # :latest tracks develop — it is what run-certification.mjs boots by
+          # default; :sha-<short> pins for reproducible re-runs.
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: .
+          file: docker/certification/Dockerfile.gpu
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Single-manifest image: vast pulls by tag, provenance attestation
+          # manifests confuse some of its pullers.
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image summary
+        run: |
+          {
+            echo "## certification-image"
+            echo ""
+            echo "Pushed tags:"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+            echo ""
+            echo "Boot it on vast: \`node scripts/vast/run-certification.mjs --image ${{ steps.image.outputs.name }}:latest ...\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/certification-vast.yml
+++ b/.github/workflows/certification-vast.yml
@@ -1,0 +1,199 @@
+# certification-vast — dispatches an automated full-tier certification run on
+# a rented vast.ai GPU (#14548, epic #14541). Thin caller of
+# scripts/vast/run-certification.mjs: search offers → create from the
+# prebuilt certification image → onstart runs the packages/evidence chain
+# (bundle:create → certify:rollup → certify:sign) → poll → pull the signed
+# certification.json → DESTROY the instance in the script's own finally.
+#
+# Triggers: workflow_dispatch (any certifier with repo write), plus a nightly
+# cron that is a no-op unless the repo variable ELIZA_VAST_CERT_ENABLED is
+# the string 'true' — cost is real money, so nightly spend is owner-opt-in.
+# Deliberately NO pull_request trigger: this job holds VAST_API_KEY and the
+# ELIZA_CERT_SIGNING_KEY; PR-triggered code must never see either.
+#
+# Secrets discipline: both secrets are exposed only to the single step that
+# runs the script, and the script forwards the signing key solely inside the
+# create-instance env payload (never the onstart text, never logs). When vast
+# fails for ANY reason the job goes red with a "local certification required"
+# summary carrying the exact fallback command — same chain, same output; the
+# develop→main gate (certification-verify.yml) cannot tell the difference.
+
+name: certification-vast
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit sha to certify (default: the ref this workflow runs on)"
+        required: false
+        type: string
+      tier:
+        description: "Certification tier"
+        required: false
+        default: "full"
+        type: choice
+        options: [cpu, gpu, full]
+      max_dph:
+        description: "Budget cap in $/hr per offer"
+        required: false
+        default: "0.60"
+        type: string
+      max_attempts:
+        description: "Max offers tried before giving up"
+        required: false
+        default: "3"
+        type: string
+      timeout_minutes:
+        description: "Hard wall-clock cap per attempt"
+        required: false
+        default: "120"
+        type: string
+  schedule:
+    # Nightly on develop, 06:17 UTC (off the top-of-hour crunch); gated below
+    # on vars.ELIZA_VAST_CERT_ENABLED == 'true'.
+    - cron: "17 6 * * *"
+
+concurrency:
+  group: certification-vast
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  vast-certification:
+    name: vast-certification
+    if: github.event_name == 'workflow_dispatch' || vars.ELIZA_VAST_CERT_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 400
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+          show-progress: false
+
+      - name: Resolve certified sha
+        id: sha
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+        run: |
+          set -euo pipefail
+          sha="${INPUT_SHA:-$GITHUB_SHA}"
+          if ! [[ "$sha" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+            echo "::error title=certification-vast::input sha '$sha' is not a git sha"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      # Fail in seconds — before any vast spend — when the run cannot possibly
+      # produce a verifiable certification.
+      - name: Preflight secrets
+        env:
+          HAS_VAST_KEY: ${{ secrets.VAST_API_KEY != '' }}
+          HAS_SIGNING_KEY: ${{ secrets.ELIZA_CERT_SIGNING_KEY != '' }}
+        run: |
+          set -euo pipefail
+          missing=""
+          [ "$HAS_VAST_KEY" = "true" ] || missing="$missing VAST_API_KEY"
+          [ "$HAS_SIGNING_KEY" = "true" ] || missing="$missing ELIZA_CERT_SIGNING_KEY"
+          if [ -n "$missing" ]; then
+            echo "::error title=certification-vast::missing repo secret(s):$missing"
+            exit 1
+          fi
+
+      # Node 24 to match the script's target runtime (plain node, zero
+      # workspace deps — no bun install on this runner).
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24"
+
+      - name: Dry-run plan (no API calls, no secrets in output)
+        env:
+          CERT_SHA: ${{ steps.sha.outputs.sha }}
+          TIER: ${{ inputs.tier || 'full' }}
+          MAX_DPH: ${{ inputs.max_dph || '0.60' }}
+          MAX_ATTEMPTS: ${{ inputs.max_attempts || '3' }}
+          TIMEOUT_MINUTES: ${{ inputs.timeout_minutes || '120' }}
+        run: |
+          set -euo pipefail
+          node scripts/vast/run-certification.mjs \
+            --sha "$CERT_SHA" --tier "$TIER" \
+            --max-dph "$MAX_DPH" --max-attempts "$MAX_ATTEMPTS" \
+            --timeout-minutes "$TIMEOUT_MINUTES" \
+            --dry-run
+
+      # The ONLY step with secret access. The signing key travels to the
+      # instance exclusively inside the create-payload env; the vast key never
+      # leaves this runner. CERT_PUSH_CMD is optional owner-configured storage
+      # push (R2/S3) — without it the signed certification still comes back
+      # via the instance logs.
+      - name: Run certification on vast.ai
+        id: run
+        env:
+          VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+          ELIZA_CERT_SIGNING_KEY: ${{ secrets.ELIZA_CERT_SIGNING_KEY }}
+          CERT_PUSH_CMD: ${{ secrets.ELIZA_CERT_PUSH_CMD }}
+          CERT_SHA: ${{ steps.sha.outputs.sha }}
+          TIER: ${{ inputs.tier || 'full' }}
+          MAX_DPH: ${{ inputs.max_dph || '0.60' }}
+          MAX_ATTEMPTS: ${{ inputs.max_attempts || '3' }}
+          TIMEOUT_MINUTES: ${{ inputs.timeout_minutes || '120' }}
+        run: |
+          set -euo pipefail
+          node scripts/vast/run-certification.mjs \
+            --sha "$CERT_SHA" --tier "$TIER" \
+            --max-dph "$MAX_DPH" --max-attempts "$MAX_ATTEMPTS" \
+            --timeout-minutes "$TIMEOUT_MINUTES" \
+            --out vast-certification-output
+
+      # The signed certification + instance logs are the run's product; the
+      # promotion PR author downloads this artifact and commits
+      # certification.json (+ the pushed bundle) per the gate's runbook.
+      - name: Upload certification artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: vast-certification-${{ steps.sha.outputs.sha }}
+          path: vast-certification-output/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Success summary
+        if: success()
+        env:
+          CERT_SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          {
+            echo "## certification-vast ✅"
+            echo ""
+            echo "Signed certification for \`$CERT_SHA\` pulled from the vast instance"
+            echo "(artifact **vast-certification-$CERT_SHA**, cost logged in the run step)."
+            echo ""
+            echo "To use it on a promotion PR: download the artifact, commit"
+            echo "\`certification.json\` at the repo root and the bundle at \`evidence/bundle/\`"
+            echo "per [.github/certification/README.md](https://github.com/${GITHUB_REPOSITORY}/blob/develop/.github/certification/README.md)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # The documented fallback: same chain, same output, run by a human/agent
+      # holding the signing key. Kept in lockstep with scripts/vast/README.md.
+      - name: Local certification required (vast run failed)
+        if: failure()
+        env:
+          CERT_SHA: ${{ steps.sha.outputs.sha }}
+          TIER: ${{ inputs.tier || 'full' }}
+        run: |
+          {
+            echo "## certification-vast ❌ — local certification required"
+            echo ""
+            echo "The vast.ai run for \`$CERT_SHA\` failed (dead key / no offers / stuck instance /"
+            echo "onstart failure — exit code in the run step above; every path attempts instance"
+            echo "destroy first). Certify locally on a machine holding \`ELIZA_CERT_SIGNING_KEY\`:"
+            echo ""
+            echo '```bash'
+            echo "git fetch origin $CERT_SHA && git checkout $CERT_SHA"
+            echo "node scripts/vast/local-certify.mjs --tier $TIER"
+            echo '```'
+            echo ""
+            echo "Runbook (costs, kill paths, storage push): [scripts/vast/README.md](https://github.com/${GITHUB_REPOSITORY}/blob/develop/scripts/vast/README.md)"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error title=certification-vast::vast run failed — local certification required: node scripts/vast/local-certify.mjs --tier $TIER (see scripts/vast/README.md)"


### PR DESCRIPTION
Restores `.github/workflows/certification-vast.yml` and `.github/workflows/certification-image.yml` to `develop`, verbatim from `main`.

## What happened

`dfdab13ef23` ("chore(scripts): untrack vitest tsconfig.tsbuildinfo build artifact") deleted far more than the build artifact — its diffstat removes 8+ workflow files, including both certification workflows:

```text
 .github/workflows/build-example-app-images.yml     |  354 -------
 .github/workflows/certification-image.yml          |  108 --
 .github/workflows/certification-vast.yml           |  199 ----
 .github/workflows/eliza-army-release-label.yml     |   62 --
 .github/workflows/eliza-computer.yml               |  448 --------
 .github/workflows/feed-apply-migrations.yml        |   57 -
 .github/workflows/feed-env-audit.yml               |   49 -
 .github/workflows/feed-test.yml                    |  136 ---
```

## Why it matters

`develop` is the repository's default branch, and GitHub resolves `workflow_dispatch` triggers from the default branch's copy of a workflow. With the file gone from `develop`, dispatching the certification signer fails:

```text
$ gh workflow run certification-vast.yml --repo elizaOS/eliza --ref develop -f sha=<develop tip> -f tier=full
could not create workflow dispatch event: HTTP 422:
Workflow does not have 'workflow_dispatch' trigger
```

That makes it impossible to produce a signed `certification.json` through the sanctioned pipeline, which the `certification-verify` gate requires for every develop→main promotion. The promotion path is currently unusable — while `develop` sits 400+ commits ahead of `main`, carrying (among others) the fix for the 50% "billing authorization is warming" production failure.

The nightly cron shows the symptom too: every scheduled run since the deletion reports `skipped`.

## Scope

Verbatim restore of the two certification workflows only. The other six deleted workflows are flagged here for a follow-up decision — some may have been intentionally retired in the test-harness move, and restoring them is not needed to unblock promotion.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:47b9e69411f2daa145bd5a73f67643557675db28 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow file restore, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow file restore, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow yaml restore with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the failing dispatch against the current default branch, and the deletion diffstat proving the sweep.

<details><summary>Dispatch failure + deletion diffstat</summary>

```text
$ gh workflow run certification-vast.yml --repo elizaOS/eliza --ref develop \
    -f sha=14290f19dbc76888bca5b14b23c160ed5246496b -f tier=full
could not create workflow dispatch event: HTTP 422:
Workflow does not have 'workflow_dispatch' trigger

$ gh run list --workflow certification-vast.yml --limit 5
skipped  2026-08-04T07:10  develop
skipped  2026-08-03T07:24  develop
skipped  2026-08-02T07:08  develop
skipped  2026-08-01T07:06  develop
skipped  2026-07-31T07:15  develop

$ git show --stat dfdab13ef23 | grep -E "workflows"
 .github/workflows/build-example-app-images.yml     |  354 -------
 .github/workflows/certification-image.yml          |  108 --
 .github/workflows/certification-vast.yml           |  199 ----
 .github/workflows/eliza-army-release-label.yml     |   62 --
 .github/workflows/eliza-computer.yml               |  448 --------
 .github/workflows/feed-apply-migrations.yml        |   57 -
 .github/workflows/feed-env-audit.yml               |   49 -
 .github/workflows/feed-test.yml                    |  136 ---
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in workflow dispatch or CI triggers.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - CI configuration restore, no model inference is invoked by this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - byte-identity proof against main and yaml validity.

<details><summary>Verbatim-restore proof</summary>

```text
$ git diff origin/main -- .github/workflows/certification-vast.yml \
                          .github/workflows/certification-image.yml
(empty - byte-identical to main)

$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/certification-vast.yml'));yaml.safe_load(open('.github/workflows/certification-image.yml'));print('both parse')"
both parse
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
