### PR TITLE
fix(ci): restore scripts/vast and add hosted certification fallback

### DIFF
--- a/.github/workflows/certification-hosted.yml
+++ b/.github/workflows/certification-hosted.yml
@@ -1,0 +1,100 @@
+# certification-hosted — runs the certification chain on a GitHub-hosted
+# runner, as the sanctioned fallback for certification-vast when the vast.ai
+# path is unavailable (dead VAST_API_KEY, no offers). Thin caller of
+# scripts/vast/local-certify.mjs, which runs the exact chain the vast onstart
+# runs — packages/evidence bundle:create → certify:rollup → certify:sign —
+# "same commands, same output; the gate cannot tell the difference (by design
+# — the signature is what matters)".
+#
+# The gpu/full-tier vision analyzers resolve their backend from env
+# (packages/evidence/src/vision-qa/config.ts): with ANTHROPIC_API_KEY present
+# they use the Anthropic Messages API, so no local GPU is required. A rented
+# GPU only ever served the local llama-server backend.
+#
+# Secrets discipline mirrors certification-vast: workflow_dispatch only (no
+# pull_request trigger — PR-controlled code must never see the signing key),
+# and both secrets are exposed only to the single step that runs the chain.
+name: certification-hosted
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit sha to certify (default: the ref this workflow runs on)"
+        required: false
+        type: string
+      tier:
+        description: "Certification tier"
+        required: false
+        default: "full"
+        type: choice
+        options: [cpu, gpu, full]
+
+concurrency:
+  group: certification-hosted
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  hosted-certification:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 150
+    steps:
+      - name: Preflight secrets
+        env:
+          HAS_SIGNING_KEY: ${{ secrets.ELIZA_CERT_SIGNING_KEY != '' }}
+          HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+          TIER: ${{ inputs.tier }}
+        run: |
+          set -euo pipefail
+          missing=""
+          [ "$HAS_SIGNING_KEY" = "true" ] || missing="$missing ELIZA_CERT_SIGNING_KEY"
+          if [ "$TIER" != "cpu" ]; then
+            [ "$HAS_ANTHROPIC_KEY" = "true" ] || missing="$missing ANTHROPIC_API_KEY"
+          fi
+          if [ -n "$missing" ]; then
+            echo "::error title=certification-hosted::missing repo secret(s):$missing"
+            exit 1
+          fi
+
+      - name: Checkout commit to certify
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.sha != '' && inputs.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14"
+
+      - name: Run certification chain (bundle:create → rollup → sign)
+        env:
+          ELIZA_CERT_SIGNING_KEY: ${{ secrets.ELIZA_CERT_SIGNING_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: >-
+          node scripts/vast/local-certify.mjs
+          --tier "${{ inputs.tier }}"
+          --reviewer-id "certification-hosted@github-actions"
+
+      - name: Collect artifacts
+        run: |
+          set -euo pipefail
+          test -f certification.json
+          bundle_dir=$(ls -dt evidence/runs/*/ | head -1)
+          test -f "${bundle_dir}certification.json"
+          mkdir -p "$RUNNER_TEMP/cert-out/evidence"
+          cp certification.json "$RUNNER_TEMP/cert-out/certification.json"
+          cp -R "$bundle_dir" "$RUNNER_TEMP/cert-out/evidence/bundle"
+          echo "bundle: $bundle_dir"
+
+      - name: Upload signed certification + bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: certification-${{ inputs.sha != '' && inputs.sha || github.sha }}
+          path: ${{ runner.temp }}/cert-out/
+          if-no-files-found: error
+          retention-days: 30

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -265,3 +265,18 @@ commits = [
   "84076db8c101861e1010781abc569ff571639791",
   "c118ecb29ce8b66518e57092e0426cdf52bd5045",
 ]
+
+# The vast run-certification test drives its offer/create/destroy flow with an
+# obviously fake fixture credential ("vast-key-hunter3"). The generic-api-key
+# rule keys on the apiKey field name regardless of value. Match the exact
+# fixture string in the one test file so any real-looking value still fails.
+[[allowlists]]
+description = "vast run-certification test fixture credential"
+condition = "AND"
+paths = [
+  '''(^|/)scripts/vast/run-certification\.test\.mjs$''',
+]
+regexTarget = "line"
+regexes = [
+  '''apiKey:\s*"vast-key-hunter3"''',
+]

--- a/scripts/vast/README.md
+++ b/scripts/vast/README.md
@@ -1,0 +1,138 @@
+# vast.ai certification runner
+
+Automated full-tier certification on rented vast.ai GPUs, plus the local
+fallback (#14548, epic #14541). The product of a run is a **signed
+`certification.json`** — the artifact the develop→main promotion gate
+(`.github/workflows/certification-verify.yml`) verifies. Whether it was
+signed on a vast instance or on a laptop is invisible to the gate by design;
+the Ed25519 signature is what matters (trust model:
+[`.github/certification/README.md`](../../.github/certification/README.md)).
+
+## Files
+
+| File | What |
+| --- | --- |
+| `run-certification.mjs` | The vast driver: search → create → poll → pull → **destroy** (plain node, zero workspace deps) |
+| `run-certification.test.mjs` | Unit tests for the pure pieces (`bun run test:vast` / `node --test scripts/vast/*.test.mjs`) |
+| `local-certify.mjs` | One-command local fallback (same chain, same output) |
+| `../../docker/certification/Dockerfile.gpu` | The prebuilt image the instance boots (models + toolchain baked; onstart is capped at 16 KB) |
+| `../../.github/workflows/certification-vast.yml` | Dispatch/nightly workflow that drives the driver |
+| `../../.github/workflows/certification-image.yml` | Builds + pushes `ghcr.io/elizaos/certification-gpu` |
+
+## Automated run (vast.ai)
+
+Preferred path: dispatch **certification-vast** in the Actions tab (inputs:
+`sha`, `tier`, `max_dph`, `max_attempts`, `timeout_minutes`). Nightly runs
+happen only while the repo variable `ELIZA_VAST_CERT_ENABLED` is `'true'`.
+Required repo secrets: `VAST_API_KEY` (scoped vast key) and
+`ELIZA_CERT_SIGNING_KEY`; optional `ELIZA_CERT_PUSH_CMD` (shell run on the
+instance with `CERT_BUNDLE_DIR`/`CERT_FILE` exported, e.g. an `rclone copy`
+to R2) — without it the signed certification still travels back via the
+instance logs, but the full bundle stays on the instance and dies with it.
+
+From a laptop:
+
+```bash
+export VAST_API_KEY=...            # https://cloud.vast.ai/ → account → API keys
+export ELIZA_CERT_SIGNING_KEY=...  # PEM or base64-wrapped PEM
+node scripts/vast/run-certification.mjs --sha <full-sha> --tier full
+```
+
+Always available with **zero API calls and zero secrets**:
+
+```bash
+node scripts/vast/run-certification.mjs --sha <sha> --dry-run
+```
+
+prints the complete plan: offer query, client-side re-filters, redacted
+create payload, the exact onstart script (with its byte count vs the 16 KB
+vast cap), poll/timeout config, budget worst case, and the exit-code table.
+
+What a real run does, in order:
+
+1. `POST /search/asks/` — verified, rentable, `reliability2 > 0.98`,
+   `inet_down > 500`, `gpu_name` (default `RTX_4090`), `num_gpus 1`, priced
+   `<= --max-dph`, sorted cheapest-first. Results are **re-checked
+   client-side**; offers missing a field are rejected, never assumed fine.
+2. `PUT /asks/{offer}/` — boots `ghcr.io/elizaos/certification-gpu:latest`
+   (override: `--image`). The signing key and push command ride **only** in
+   the create-payload env; the onstart text contains no secret material.
+3. The onstart script clones the repo at exactly `--sha`, `bun run
+   install:light`, starts the baked gpu-vision `llama-server` when present,
+   then `bundle:create --tier <tier>` → `certify:rollup` → `certify:sign`
+   (reviewer kind `agent`), prints the signed certification between log
+   markers, and runs the push command if configured.
+4. Poll `GET /instances/{id}/` every 15 s, pulling log tails: success/failure
+   markers, `exited`, debounced `offline`/`unknown`, a loading-phase cap and
+   a hard `--timeout-minutes` wall clock all terminate the run.
+5. Pull final logs, extract `certification.json` into `--out`
+   (`vast-certification-output/` by default).
+6. **DESTROY the instance in a `finally`** — never stop (stopped vast
+   instances keep billing disk). 3 retries; if all fail the script exits 12
+   and prints an unmissable banner with the instance id and a one-line
+   `curl -X DELETE` to kill it by hand.
+
+## Costs
+
+| Item | Figure |
+| --- | --- |
+| RTX 4090 offer band (verified, reliable) | ~$0.31–0.40/hr; default budget cap `--max-dph 0.60` |
+| Typical full-tier run | 1–2 h ≈ **$0.35–0.80** |
+| Worst case per dispatch | `max_dph × max_attempts × timeout` = 0.60 × 3 × 2 h = **$3.60**, and retries only fire on host-side failures (stuck loading / instance lost), which bill minutes, not hours |
+| Nightly (if enabled) | ≈ $12–25/month |
+
+Every run logs its estimated spend (`elapsed × dph` per attempt, then the
+total) so the workflow log doubles as the cost record.
+
+## Kill paths
+
+Every failure destroys (or at minimum attempts to destroy) the instance
+first, then exits with a distinct code:
+
+| Exit | Meaning | What to do |
+| --- | --- | --- |
+| 2 | usage / missing key env / onstart over 16 KB | fix the invocation |
+| 3 | `VAST_API_KEY` dead or unscoped (HTTP 401/403) | rotate the key; run the local fallback meanwhile |
+| 4 | no eligible offers after client-side re-check | raise `--max-dph`, relax `--gpu-name`, or retry later |
+| 5 | `--max-attempts` exhausted on retryable host failures | vast is having a day; local fallback |
+| 6 | create rejected on every tried offer | as above |
+| 7 | instance stuck in `loading` past `--loading-timeout-minutes` | auto-retries next offer; else local fallback |
+| 8 | hard `--timeout-minutes` wall clock hit | check pulled logs — the chain is too slow or hung; not auto-retried (expensive) |
+| 9 | instance went `offline`/`unknown` (debounced ×3) | auto-retries next offer |
+| 10 | onstart chain failed (marker names the step in pulled logs) | fix the chain — deterministic, so **not** retried on another machine |
+| 11 | run succeeded but no parseable certification in logs | inspect `--out` logs; likely truncated tail — re-dispatch |
+| 12 | **destroy failed after 3 retries — instance still billing** | kill it NOW: `https://cloud.vast.ai/instances/` or `curl -X DELETE -H "Authorization: Bearer $VAST_API_KEY" https://console.vast.ai/api/v0/instances/<id>/` |
+
+The workflow mirrors any failure as a red run whose summary says exactly:
+*local certification required*, with the command below.
+
+## Local fallback (one command)
+
+Same chain, same signed output — on your machine (M-series covers the cpu
+tier; a CUDA box with `llama-server` + `bun run test:gpu-vision` models for
+gpu/full):
+
+```bash
+export ELIZA_CERT_SIGNING_KEY=...   # from the keyholder; never committed
+node scripts/vast/local-certify.mjs --tier full
+```
+
+It runs `bundle:create → certify:rollup → certify:sign` from
+`packages/evidence`, then copies `certification.json` to the repo root ready
+to commit on the promotion branch (plus prints the `evidence/bundle/` copy
+command the gate requires). `--no-sign` stops after rollup so you can
+hand-review `verdicts.json` first — signing refuses to mark mechanically
+non-pass subjects as `pass` either way, so the one-command path cannot
+fabricate green.
+
+## Image
+
+`docker/certification/Dockerfile.gpu` bakes CUDA `llama-server` (pinned to
+llama.cpp `b8525`, the minimum `scripts/gpu-vision` accepts), the
+sha256-pinned OCR/VLM GGUFs via `scripts/gpu-vision/setup.mjs --with-vlm`,
+Node 24, Bun 1.3.14, Playwright Chromium (+ OS deps), tesseract, and ffmpeg.
+Rebuilds publish from `.github/workflows/certification-image.yml`
+(dispatch, or automatically when the Dockerfile / model pins change) to
+`ghcr.io/elizaos/certification-gpu:{latest,sha-<short>}` using the
+workflow's own `GITHUB_TOKEN` — no extra registry secret. Secrets are never
+baked into the image.

--- a/scripts/vast/local-certify.mjs
+++ b/scripts/vast/local-certify.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * One-command local certification fallback (#14548). Runs the exact chain
+ * the vast.ai onstart runs — packages/evidence bundle:create →
+ * certify:rollup → certify:sign — on this machine, so when vast is down or
+ * the API key is dead a certifier holding ELIZA_CERT_SIGNING_KEY can produce
+ * the same signed certification.json the develop→main gate verifies. Same
+ * commands, same output; the gate cannot tell the difference (by design —
+ * the signature is what matters).
+ *
+ * Signing enforces its own honesty: certify:sign refuses to sign
+ * mechanically non-pass subjects as pass, so "one command" cannot fabricate
+ * a green certification. Use --no-sign to stop after rollup, hand-review
+ * verdicts.json (waivers require notes), then run certify:sign yourself —
+ * that is the diligent-reviewer path the trust model expects.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const SIGNING_KEY_ENV_VAR = "ELIZA_CERT_SIGNING_KEY";
+const TIERS = ["cpu", "gpu", "full"];
+
+const USAGE = `Usage: node scripts/vast/local-certify.mjs [--tier cpu|gpu|full] [options]
+
+Options:
+  --tier <cpu|gpu|full>   Certification tier (default: full)
+  --reviewer-id <id>      Reviewer identity in the signed cert (default: $USER@host)
+  --no-sign               Stop after rollup for hand review of verdicts.json
+  --help                  This text
+
+Requires env ${SIGNING_KEY_ENV_VAR} (PEM or base64-wrapped PEM) unless --no-sign.
+Output: the bundle dir under evidence/runs/ with certification.json inside,
+plus a copy of certification.json at the repo root ready to commit on the
+promotion branch (bundle → evidence/bundle/ per .github/certification/README.md).`;
+
+function parseArgs(argv) {
+  const opts = {
+    tier: "full",
+    reviewerId: `${os.userInfo().username}@${os.hostname()}`,
+    sign: true,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--tier") {
+      opts.tier = argv[++index];
+      if (!TIERS.includes(opts.tier)) {
+        throw new Error(
+          `--tier must be one of ${TIERS.join("|")}, got: ${opts.tier}`,
+        );
+      }
+    } else if (arg === "--reviewer-id") {
+      const value = argv[++index];
+      if (!value) throw new Error("--reviewer-id requires a value");
+      opts.reviewerId = value;
+    } else if (arg === "--no-sign") {
+      opts.sign = false;
+    } else if (arg === "--help") {
+      opts.help = true;
+    } else {
+      throw new Error(`unknown argument: ${arg}\n\n${USAGE}`);
+    }
+  }
+  return opts;
+}
+
+function run(label, command, args) {
+  console.log(`\n[local-certify] ${label}: ${command} ${args.join(" ")}`);
+  const result = spawnSync(command, args, { cwd: REPO_ROOT, stdio: "inherit" });
+  if (result.status !== 0) {
+    throw new Error(`${label} failed (exit ${result.status ?? "signal"})`);
+  }
+}
+
+function newestBundleDir() {
+  const runsDir = path.join(REPO_ROOT, "evidence", "runs");
+  const entries = fs
+    .readdirSync(runsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const dir = path.join(runsDir, entry.name);
+      return { dir, mtimeMs: fs.statSync(dir).mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+  if (entries.length === 0) {
+    throw new Error(`no bundle directory appeared under ${runsDir}`);
+  }
+  return entries[0].dir;
+}
+
+function main(argv, env) {
+  const opts = parseArgs(argv);
+  if (opts.help) {
+    console.log(USAGE);
+    return 0;
+  }
+  if (opts.sign && !env[SIGNING_KEY_ENV_VAR]) {
+    console.error(
+      `[local-certify] no signing key: export ${SIGNING_KEY_ENV_VAR} (or use --no-sign to produce reviewable verdicts without signing)`,
+    );
+    return 2;
+  }
+
+  run("bundle:create", "bun", [
+    "run",
+    "--cwd",
+    "packages/evidence",
+    "bundle:create",
+    "--",
+    "--tier",
+    opts.tier,
+  ]);
+  const bundleDir = newestBundleDir();
+  const verdictsPath = path.join(bundleDir, "verdicts.json");
+  run("certify:rollup", "bun", [
+    "run",
+    "--cwd",
+    "packages/evidence",
+    "certify:rollup",
+    "--",
+    "--bundle",
+    bundleDir,
+    "--out",
+    verdictsPath,
+  ]);
+
+  if (!opts.sign) {
+    console.log(`\n[local-certify] stopped before signing (--no-sign).`);
+    console.log(`[local-certify] review ${verdictsPath}, then:`);
+    console.log(
+      `  bun run --cwd packages/evidence certify:sign -- --bundle ${bundleDir} --verdicts ${verdictsPath} --reviewer-id <you> --reviewer-kind human`,
+    );
+    return 0;
+  }
+
+  run("certify:sign", "bun", [
+    "run",
+    "--cwd",
+    "packages/evidence",
+    "certify:sign",
+    "--",
+    "--bundle",
+    bundleDir,
+    "--verdicts",
+    verdictsPath,
+    "--reviewer-id",
+    opts.reviewerId,
+    "--reviewer-kind",
+    "human",
+  ]);
+
+  const certSource = path.join(bundleDir, "certification.json");
+  const certTarget = path.join(REPO_ROOT, "certification.json");
+  fs.copyFileSync(certSource, certTarget);
+  console.log(`\n[local-certify] done.`);
+  console.log(`[local-certify] bundle:        ${bundleDir}`);
+  console.log(
+    `[local-certify] certification: ${certTarget} (copied from the bundle)`,
+  );
+  console.log(
+    `[local-certify] for a promotion PR also commit the bundle: rm -rf evidence/bundle && mkdir -p evidence && cp -R '${bundleDir}' evidence/bundle`,
+  );
+  return 0;
+}
+
+try {
+  process.exitCode = main(process.argv.slice(2), process.env);
+} catch (error) {
+  console.error(`[local-certify] ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/vast/run-certification.mjs
+++ b/scripts/vast/run-certification.mjs
@@ -1,0 +1,1088 @@
+#!/usr/bin/env node
+/**
+ * Automated full-tier certification runs on vast.ai (#14548, epic #14541).
+ * Searches cheap verified RTX 4090 offers, rents the cheapest one from the
+ * prebuilt certification image, runs the certification chain on the instance
+ * via onstart (clone @ --sha → bundle:create → certify:rollup → certify:sign,
+ * from packages/evidence), pulls the signed certification.json back through
+ * the instance logs, and ALWAYS destroys the instance in a finally block —
+ * never "stop", because stopped vast instances keep billing disk.
+ *
+ * Plain node with zero workspace imports so the certification-vast.yml
+ * workflow (and a laptop) can run it without a bun install. The pure pieces —
+ * offer filtering/sorting, onstart assembly + the 16 KB vast onstart cap,
+ * the poll state machine, and the budget guard — are exported for
+ * run-certification.test.mjs; only main() touches the network.
+ *
+ * Secrets discipline: the Ed25519 signing key (ELIZA_CERT_SIGNING_KEY) and
+ * the optional storage push command (CERT_PUSH_CMD, may embed credentials)
+ * travel ONLY in the create-instance env payload, never in the onstart text,
+ * never in logs or the --dry-run plan. Every failure path exits with a
+ * distinct code (see EXIT) and a one-line reason; a failed destroy prints the
+ * instance id loudly so a human can kill the billing by hand.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+export const API_BASE = "https://console.vast.ai/api/v0";
+export const DEFAULT_IMAGE = "ghcr.io/elizaos/certification-gpu:latest";
+export const DEFAULT_REPO_URL = "https://github.com/elizaOS/eliza.git";
+/** vast.ai rejects onstart-cmd payloads larger than 16 KB. */
+export const ONSTART_MAX_BYTES = 16 * 1024;
+export const SIGNING_KEY_ENV_VAR = "ELIZA_CERT_SIGNING_KEY";
+export const PUSH_CMD_ENV_VAR = "CERT_PUSH_CMD";
+export const API_KEY_ENV_VAR = "VAST_API_KEY";
+export const TIERS = ["cpu", "gpu", "full"];
+
+/** Log markers the onstart script emits; the poller keys terminal states off them. */
+export const SUCCESS_MARKER = "ELIZA-CERT-RUN-SUCCESS";
+export const FAILURE_MARKER = "ELIZA-CERT-RUN-FAILURE";
+export const CERT_BEGIN_MARKER = "-----BEGIN ELIZA CERTIFICATION JSON-----";
+export const CERT_END_MARKER = "-----END ELIZA CERTIFICATION JSON-----";
+
+/**
+ * One distinct exit code per kill path so the workflow (and the runbook's
+ * kill-path table) can name the failure without parsing prose.
+ */
+export const EXIT = {
+  OK: 0,
+  USAGE: 2,
+  DEAD_API_KEY: 3,
+  NO_OFFERS: 4,
+  BUDGET_EXCEEDED: 5,
+  CREATE_FAILED: 6,
+  STUCK_LOADING: 7,
+  RUN_TIMEOUT: 8,
+  INSTANCE_LOST: 9,
+  ONSTART_FAILED: 10,
+  RESULTS_PULL_FAILED: 11,
+  DESTROY_FAILED: 12,
+};
+
+export class UsageError extends Error {}
+
+/**
+ * API error carrying the HTTP status and vast's structured error code so
+ * auth failures map to DEAD_API_KEY. vast does NOT use 401 for a dead key:
+ * it answers HTTP 404 with {"success":false,"error":"auth_error","msg":
+ * "Invalid user key"} (verified against the live API), so the body's error
+ * code is the reliable signal and bare status codes are only a fallback.
+ */
+export class VastApiError extends Error {
+  constructor(message, { status, body, errorCode } = {}) {
+    super(message);
+    this.status = status;
+    this.body = body;
+    this.errorCode = errorCode;
+  }
+  get isAuthFailure() {
+    return (
+      this.errorCode === "auth_error" ||
+      this.status === 401 ||
+      this.status === 403
+    );
+  }
+}
+
+/** Pull vast's machine-readable error code out of a failure body, if any. */
+export function parseVastErrorCode(bodyText) {
+  if (typeof bodyText !== "string") return undefined;
+  try {
+    const parsed = JSON.parse(bodyText);
+    return typeof parsed?.error === "string" ? parsed.error : undefined;
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — vast serves HTML error
+    // pages for some failures; "no structured code" is the explicit result.
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+
+const DEFAULTS = {
+  gpuName: "RTX_4090",
+  numGpus: 1,
+  minReliability: 0.98,
+  minInetDown: 500,
+  maxDph: 0.6,
+  maxAttempts: 3,
+  timeoutMinutes: 120,
+  loadingTimeoutMinutes: 20,
+  pollIntervalSeconds: 15,
+  image: DEFAULT_IMAGE,
+  diskGb: 80,
+  tier: "full",
+  repoUrl: DEFAULT_REPO_URL,
+  reviewerId: "vast-certification-runner",
+  outDir: "vast-certification-output",
+};
+
+const USAGE = `Usage: node scripts/vast/run-certification.mjs --sha <commit> [options]
+
+Required:
+  --sha <commit>              Full commit sha to certify (cloned on the instance)
+
+Options:
+  --tier <cpu|gpu|full>       Certification tier (default: ${DEFAULTS.tier})
+  --image <ref>               Docker image (default: ${DEFAULTS.image})
+  --repo-url <url>            Repo to clone on the instance (default: ${DEFAULTS.repoUrl})
+  --gpu-name <name>           Offer GPU filter, underscores for spaces (default: ${DEFAULTS.gpuName})
+  --max-dph <usd>             Budget cap in $/hr; offers above are rejected (default: ${DEFAULTS.maxDph})
+  --max-attempts <n>          Max offers tried before giving up (default: ${DEFAULTS.maxAttempts})
+  --timeout-minutes <n>       Hard wall-clock cap per attempt (default: ${DEFAULTS.timeoutMinutes})
+  --loading-timeout-minutes <n>  Cap on the loading/provisioning phase (default: ${DEFAULTS.loadingTimeoutMinutes})
+  --disk-gb <n>               Instance disk allocation (default: ${DEFAULTS.diskGb})
+  --reviewer-id <id>          Reviewer identity baked into the signed cert (default: ${DEFAULTS.reviewerId})
+  --push-cmd <shell>          Command run on-instance to push bundle+cert to storage
+                              (else env ${PUSH_CMD_ENV_VAR}; gets CERT_BUNDLE_DIR/CERT_FILE)
+  --out <dir>                 Where pulled logs + certification.json land (default: ${DEFAULTS.outDir})
+  --api-key <key>             vast.ai API key (else env ${API_KEY_ENV_VAR})
+  --dry-run                   Print the full plan (query, payload, onstart, budget) with ZERO API calls
+  --help                      This text
+
+Signing key: env ${SIGNING_KEY_ENV_VAR} (required unless --dry-run); injected into the
+instance env at create time only — never written into the onstart text or this plan.`;
+
+/** Parse argv (no positionals). Throws UsageError; never exits — main() maps to EXIT.USAGE. */
+export function parseCliArgs(argv, env = {}) {
+  const opts = { ...DEFAULTS, dryRun: false, sha: undefined };
+  opts.apiKey = env[API_KEY_ENV_VAR];
+  opts.pushCmd = env[PUSH_CMD_ENV_VAR];
+  opts.signingKey = env[SIGNING_KEY_ENV_VAR];
+
+  const takeValue = (flag, index) => {
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new UsageError(`${flag} requires a value`);
+    }
+    return value;
+  };
+  const takeNumber = (flag, index, { integer = false, min } = {}) => {
+    const raw = takeValue(flag, index);
+    const value = Number(raw);
+    if (
+      !Number.isFinite(value) ||
+      (integer && !Number.isInteger(value)) ||
+      (min !== undefined && value < min)
+    ) {
+      throw new UsageError(
+        `${flag} must be a${integer ? "n integer" : " number"}${min !== undefined ? ` >= ${min}` : ""}, got: ${raw}`,
+      );
+    }
+    return value;
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--sha":
+        opts.sha = takeValue(arg, index);
+        index += 1;
+        break;
+      case "--tier": {
+        const tier = takeValue(arg, index);
+        if (!TIERS.includes(tier)) {
+          throw new UsageError(
+            `--tier must be one of ${TIERS.join("|")}, got: ${tier}`,
+          );
+        }
+        opts.tier = tier;
+        index += 1;
+        break;
+      }
+      case "--image":
+        opts.image = takeValue(arg, index);
+        index += 1;
+        break;
+      case "--repo-url":
+        opts.repoUrl = takeValue(arg, index);
+        index += 1;
+        break;
+      case "--gpu-name":
+        opts.gpuName = takeValue(arg, index);
+        index += 1;
+        break;
+      case "--max-dph":
+        opts.maxDph = takeNumber(arg, index, { min: 0.01 });
+        index += 1;
+        break;
+      case "--max-attempts":
+        opts.maxAttempts = takeNumber(arg, index, { integer: true, min: 1 });
+        index += 1;
+        break;
+      case "--timeout-minutes":
+        opts.timeoutMinutes = takeNumber(arg, index, { min: 1 });
+        index += 1;
+        break;
+      case "--loading-timeout-minutes":
+        opts.loadingTimeoutMinutes = takeNumber(arg, index, { min: 1 });
+        index += 1;
+        break;
+      case "--disk-gb":
+        opts.diskGb = takeNumber(arg, index, { integer: true, min: 10 });
+        index += 1;
+        break;
+      case "--reviewer-id":
+        opts.reviewerId = takeValue(arg, index);
+        index += 1;
+        break;
+      case "--push-cmd":
+        opts.pushCmd = takeValue(arg, index);
+        index += 1;
+        break;
+      case "--out":
+        opts.outDir = takeValue(arg, index);
+        index += 1;
+        break;
+      case "--api-key":
+        opts.apiKey = takeValue(arg, index);
+        index += 1;
+        break;
+      case "--dry-run":
+        opts.dryRun = true;
+        break;
+      case "--help":
+        opts.help = true;
+        break;
+      default:
+        throw new UsageError(`unknown argument: ${arg}`);
+    }
+  }
+
+  if (opts.help) return opts;
+  if (!opts.sha || !/^[0-9a-f]{7,40}$/i.test(opts.sha)) {
+    throw new UsageError(
+      "--sha is required and must be a git commit sha (7-40 hex chars)",
+    );
+  }
+  if (!opts.dryRun) {
+    if (!opts.apiKey) {
+      throw new UsageError(
+        `no vast.ai API key: pass --api-key or set ${API_KEY_ENV_VAR}`,
+      );
+    }
+    if (!opts.signingKey) {
+      throw new UsageError(
+        `no signing key: set ${SIGNING_KEY_ENV_VAR} (PEM or base64-wrapped PEM)`,
+      );
+    }
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Offer search + budget guard
+
+/**
+ * Server-side search query for PUT /search/asks/. vast's own CLI writes GPU
+ * names with spaces ("RTX 4090") but its flag syntax uses underscores; we
+ * accept the underscore form and translate here.
+ */
+export function buildOfferQuery(opts) {
+  return {
+    gpu_name: { eq: opts.gpuName.replaceAll("_", " ") },
+    num_gpus: { eq: opts.numGpus },
+    verified: { eq: true },
+    rentable: { eq: true },
+    reliability2: { gt: opts.minReliability },
+    inet_down: { gt: opts.minInetDown },
+    dph_total: { lte: opts.maxDph },
+    type: "ask",
+    order: [["dph_total", "asc"]],
+  };
+}
+
+/**
+ * Client-side re-check of everything the server query already promised, plus
+ * the budget cap. The server-side query language has drifted before (e.g.
+ * reliability vs reliability2); trusting it blindly risks renting a machine
+ * that violates the acceptance filters. Offers missing a numeric field are
+ * rejected, never assumed compliant. Returns eligible offers sorted cheapest
+ * first (reliability desc as tie-break) and the rejects with reasons for the
+ * failure summary.
+ */
+export function filterAndSortOffers(offers, opts) {
+  const eligible = [];
+  const rejected = [];
+  for (const offer of offers) {
+    const reliability =
+      typeof offer.reliability2 === "number"
+        ? offer.reliability2
+        : offer.reliability;
+    const reason = (() => {
+      if (typeof offer.id !== "number") return "missing offer id";
+      if (typeof offer.dph_total !== "number") return "missing dph_total";
+      if (offer.dph_total > opts.maxDph) {
+        return `dph_total ${offer.dph_total.toFixed(4)} > --max-dph ${opts.maxDph}`;
+      }
+      if (typeof reliability !== "number") return "missing reliability";
+      if (reliability <= opts.minReliability) {
+        return `reliability ${reliability} <= ${opts.minReliability}`;
+      }
+      if (
+        typeof offer.inet_down !== "number" ||
+        offer.inet_down <= opts.minInetDown
+      ) {
+        return `inet_down ${offer.inet_down} <= ${opts.minInetDown}`;
+      }
+      if (offer.num_gpus !== opts.numGpus)
+        return `num_gpus ${offer.num_gpus} != ${opts.numGpus}`;
+      return null;
+    })();
+    if (reason === null) {
+      eligible.push({ ...offer, reliabilityResolved: reliability });
+    } else {
+      rejected.push({ id: offer.id, reason });
+    }
+  }
+  eligible.sort(
+    (a, b) =>
+      a.dph_total - b.dph_total ||
+      b.reliabilityResolved - a.reliabilityResolved,
+  );
+  return { eligible, rejected };
+}
+
+/**
+ * Budget guard: which offers may actually be attempted. Cheapest-first,
+ * capped by --max-attempts; every offer already passed the --max-dph cap in
+ * filterAndSortOffers, so total worst-case spend is bounded by
+ * maxAttempts * maxDph * timeoutHours.
+ */
+export function selectAttemptOffers(eligible, opts) {
+  return eligible.slice(0, opts.maxAttempts);
+}
+
+// ---------------------------------------------------------------------------
+// Onstart assembly
+
+/**
+ * The script vast runs inside the container on boot. Everything heavy
+ * (models, browsers, toolchains) is baked into the image; this only clones
+ * the repo at the exact sha, installs workspace deps, and runs the
+ * certification chain. It deliberately contains NO secrets: the signing key
+ * and push command arrive via the create-payload env (docker -e), so the
+ * onstart text is safe to print in --dry-run and store server-side.
+ *
+ * Every step failure prints "${FAILURE_MARKER}: <step>" — the poller treats
+ * that marker (or an exit without the success marker) as ONSTART_FAILED. The
+ * signed certification.json is emitted between BEGIN/END markers so the
+ * controller can recover it from the instance logs even when no push command
+ * is configured (the full bundle is too big for logs and needs CERT_PUSH_CMD).
+ */
+export function buildOnstart(opts) {
+  const lines = [
+    "#!/bin/bash",
+    "set -uo pipefail",
+    `fail() { echo "${FAILURE_MARKER}: $1"; exit 1; }`,
+    `echo "[cert-run] begin sha=${opts.sha} tier=${opts.tier}"`,
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: bash env expansion, not a JS template
+    "export HOME=${HOME:-/root}",
+    'export PATH="$HOME/.bun/bin:$PATH"',
+    "export ELIZA_EVIDENCE_RUNNER=vast",
+    "mkdir -p /workspace && cd /workspace || fail workspace",
+    "rm -rf eliza && mkdir eliza && cd eliza",
+    "git init -q -b certification || fail git-init",
+    `git remote add origin '${opts.repoUrl}' || fail git-remote`,
+    // Blobless-shallow fetch of the exact sha: the monorepo history is huge
+    // and the certification binds to one commit anyway.
+    `git fetch --depth 1 origin ${opts.sha} || fail fetch-sha`,
+    "git checkout -q FETCH_HEAD || fail checkout",
+    "bun run install:light || fail install",
+    // GPU vision lane, as available: the image bakes llama-server + pinned
+    // models; a cpu-tier image without them skips explicitly instead of
+    // half-starting.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: bash env expansion, not a JS template
+    'if command -v llama-server >/dev/null 2>&1 && [ -n "${ELIZA_GPU_VISION_CACHE:-}" ]; then',
+    "  node scripts/gpu-vision/serve.mjs --vlm --verify || fail gpu-vision-serve",
+    "else",
+    '  echo "[cert-run] gpu-vision service unavailable in this image; vision lanes will record as absent"',
+    "fi",
+    `bun run --cwd packages/evidence bundle:create -- --tier ${opts.tier} || fail bundle-create`,
+    // Absolute path: the certify steps below run with cwd packages/evidence
+    // (bun run --cwd), so a repo-root-relative bundle path would not resolve.
+    'BUNDLE_DIR="$(ls -td "$PWD"/evidence/runs/*/ 2>/dev/null | head -1)"',
+    '[ -n "$BUNDLE_DIR" ] || fail bundle-dir',
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: bash env expansion, not a JS template
+    'BUNDLE_DIR="${BUNDLE_DIR%/}"',
+    'bun run --cwd packages/evidence certify:rollup -- --bundle "$BUNDLE_DIR" --out "$BUNDLE_DIR/verdicts.json" || fail rollup',
+    `bun run --cwd packages/evidence certify:sign -- --bundle "$BUNDLE_DIR" --verdicts "$BUNDLE_DIR/verdicts.json" --reviewer-id '${opts.reviewerId}' --reviewer-kind agent || fail sign`,
+    `echo "${CERT_BEGIN_MARKER}"`,
+    'cat "$BUNDLE_DIR/certification.json" || fail cert-read',
+    'echo ""',
+    `echo "${CERT_END_MARKER}"`,
+    `if [ -n "\${${PUSH_CMD_ENV_VAR}:-}" ]; then`,
+    '  export CERT_BUNDLE_DIR="$BUNDLE_DIR"',
+    '  export CERT_FILE="$BUNDLE_DIR/certification.json"',
+    `  bash -c "$${PUSH_CMD_ENV_VAR}" || fail push`,
+    "else",
+    '  echo "[cert-run] no CERT_PUSH_CMD configured; bundle stays on the instance (certification travels via logs)"',
+    "fi",
+    `echo "${SUCCESS_MARKER}"`,
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+/** vast rejects onstart payloads over 16 KB; fail before spending money. */
+export function assertOnstartSize(onstart) {
+  const bytes = Buffer.byteLength(onstart, "utf8");
+  if (bytes > ONSTART_MAX_BYTES) {
+    throw new UsageError(
+      `onstart script is ${bytes} bytes; vast caps onstart-cmd at ${ONSTART_MAX_BYTES}. ` +
+        "Move logic into the baked image or shorten the embedded values (--repo-url, --reviewer-id).",
+    );
+  }
+  return bytes;
+}
+
+/**
+ * PUT /asks/{offer_id}/ payload. Secrets live only here (env → docker -e).
+ * runtype ssh keeps the container alive after onstart so logs stay pullable;
+ * lifecycle is bounded by our destroy-in-finally, not container exit.
+ */
+export function buildCreatePayload(opts, onstart) {
+  const env = { ELIZA_EVIDENCE_RUNNER: "vast" };
+  if (opts.signingKey) env[SIGNING_KEY_ENV_VAR] = opts.signingKey;
+  if (opts.pushCmd) env[PUSH_CMD_ENV_VAR] = opts.pushCmd;
+  return {
+    client_id: "me",
+    image: opts.image,
+    env,
+    onstart,
+    runtype: "ssh",
+    disk: opts.diskGb,
+    label: `eliza-certification-${opts.sha.slice(0, 12)}`,
+  };
+}
+
+/** Dry-run/logging view of the create payload: env values never printed. */
+export function redactCreatePayload(payload) {
+  return {
+    ...payload,
+    env: Object.fromEntries(
+      Object.keys(payload.env).map((key) => [key, "<redacted>"]),
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Poll state machine
+
+const LOADING_STATUSES = new Set(["", "loading", "created", "connecting"]);
+const LOST_STATUSES = new Set(["offline", "unknown", "deleted"]);
+
+/**
+ * Pure reducer over instance snapshots so every kill path is unit-testable
+ * without a network. Feed it {actualStatus, elapsedMs, marker} on each poll
+ * tick; it returns a new state whose .outcome is set once terminal:
+ *   {ok:true}                                — success marker seen in logs
+ *   {ok:false, code, reason}                 — one of the EXIT kill paths
+ * offline/unknown are debounced (offlineGraceCount consecutive sightings)
+ * because the vast API intermittently blips those for healthy instances.
+ */
+export function createPollState({
+  timeoutMs,
+  loadingTimeoutMs,
+  offlineGraceCount = 3,
+}) {
+  return {
+    timeoutMs,
+    loadingTimeoutMs,
+    offlineGraceCount,
+    consecutiveLost: 0,
+    sawRunning: false,
+    outcome: null,
+  };
+}
+
+export function reducePoll(state, snapshot) {
+  if (state.outcome) return state;
+  const { elapsedMs, marker } = snapshot;
+  const actualStatus =
+    typeof snapshot.actualStatus === "string" ? snapshot.actualStatus : "";
+  const next = { ...state };
+
+  if (marker === "failure") {
+    next.outcome = {
+      ok: false,
+      code: EXIT.ONSTART_FAILED,
+      reason: "onstart reported failure (see pulled logs for the failing step)",
+    };
+    return next;
+  }
+  if (marker === "success") {
+    next.outcome = { ok: true };
+    return next;
+  }
+  if (actualStatus === "exited") {
+    // Container stopped without ever printing the success marker: the run
+    // died (OOM, docker pull failure surfaced late, onstart killed).
+    next.outcome = {
+      ok: false,
+      code: EXIT.ONSTART_FAILED,
+      reason: "instance exited without the success marker",
+    };
+    return next;
+  }
+  if (LOST_STATUSES.has(actualStatus)) {
+    next.consecutiveLost = state.consecutiveLost + 1;
+    if (next.consecutiveLost >= state.offlineGraceCount) {
+      next.outcome = {
+        ok: false,
+        code: EXIT.INSTANCE_LOST,
+        reason: `instance ${actualStatus} for ${next.consecutiveLost} consecutive polls`,
+      };
+    }
+    return next;
+  }
+  next.consecutiveLost = 0;
+  if (actualStatus === "running") next.sawRunning = true;
+
+  if (elapsedMs > state.timeoutMs) {
+    next.outcome = {
+      ok: false,
+      code: EXIT.RUN_TIMEOUT,
+      reason: `run exceeded --timeout-minutes (${Math.round(state.timeoutMs / 60000)}m)`,
+    };
+    return next;
+  }
+  if (
+    !next.sawRunning &&
+    LOADING_STATUSES.has(actualStatus) &&
+    elapsedMs > state.loadingTimeoutMs
+  ) {
+    next.outcome = {
+      ok: false,
+      code: EXIT.STUCK_LOADING,
+      reason: `instance stuck in '${actualStatus || "provisioning"}' past --loading-timeout-minutes (${Math.round(state.loadingTimeoutMs / 60000)}m)`,
+    };
+    return next;
+  }
+  return next;
+}
+
+/** Kill paths where trying the next-cheapest offer can plausibly succeed. */
+export function isRetryableOutcome(code) {
+  return (
+    code === EXIT.STUCK_LOADING ||
+    code === EXIT.INSTANCE_LOST ||
+    code === EXIT.CREATE_FAILED
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Log parsing
+
+/** 'failure' | 'success' | null. Failure wins: a failed step never prints SUCCESS. */
+export function detectMarker(logsText) {
+  if (typeof logsText !== "string" || logsText.length === 0) return null;
+  if (logsText.includes(FAILURE_MARKER)) return "failure";
+  if (logsText.includes(SUCCESS_MARKER)) return "success";
+  return null;
+}
+
+/**
+ * Extract the LAST complete certification JSON block from pulled logs (last,
+ * because a retried onstart may print more than one) and verify it parses.
+ * Returns the raw JSON string or null.
+ */
+export function extractCertification(logsText) {
+  if (typeof logsText !== "string") return null;
+  const begin = logsText.lastIndexOf(CERT_BEGIN_MARKER);
+  if (begin === -1) return null;
+  const end = logsText.indexOf(CERT_END_MARKER, begin);
+  if (end === -1) return null;
+  const raw = logsText.slice(begin + CERT_BEGIN_MARKER.length, end).trim();
+  try {
+    JSON.parse(raw);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — log tails can truncate the
+    // block mid-JSON; an explicit null (RESULTS_PULL_FAILED upstream) beats
+    // writing a corrupt certification.json.
+    return null;
+  }
+  return raw;
+}
+
+// ---------------------------------------------------------------------------
+// Dry-run plan
+
+/** The complete plan, printable with zero API calls and zero secret material. */
+export function buildDryRunPlan(opts) {
+  const onstart = buildOnstart(opts);
+  const onstartBytes = assertOnstartSize(onstart);
+  const payload = buildCreatePayload(opts, onstart);
+  return {
+    api: {
+      base: API_BASE,
+      searchEndpoint: "PUT /search/asks/",
+      createEndpoint: "PUT /asks/{offer_id}/",
+      pollEndpoint: "GET /instances/{instance_id}/",
+      logsEndpoint: "PUT /instances/request_logs/{instance_id}/",
+      destroyEndpoint: "DELETE /instances/{instance_id}/",
+    },
+    query: buildOfferQuery(opts),
+    clientSideFilters: {
+      maxDph: opts.maxDph,
+      minReliability: opts.minReliability,
+      minInetDown: opts.minInetDown,
+      numGpus: opts.numGpus,
+    },
+    budget: {
+      maxDph: opts.maxDph,
+      maxAttempts: opts.maxAttempts,
+      timeoutMinutes: opts.timeoutMinutes,
+      worstCaseUsd: Number(
+        (opts.maxDph * opts.maxAttempts * (opts.timeoutMinutes / 60)).toFixed(
+          2,
+        ),
+      ),
+    },
+    createPayload: {
+      ...redactCreatePayload(payload),
+      onstart: `<${onstartBytes} bytes, printed below>`,
+    },
+    poll: {
+      intervalSeconds: opts.pollIntervalSeconds,
+      timeoutMinutes: opts.timeoutMinutes,
+      loadingTimeoutMinutes: opts.loadingTimeoutMinutes,
+      terminalStatuses: ["exited", "offline", "unknown"],
+      successSignal: SUCCESS_MARKER,
+      failureSignal: FAILURE_MARKER,
+    },
+    cleanup: {
+      action: "DESTROY (never stop; stopped instances keep billing disk)",
+      retries: 3,
+      onFailure: `exit ${EXIT.DESTROY_FAILED} + loud instance-id banner`,
+    },
+    secrets: {
+      [SIGNING_KEY_ENV_VAR]: opts.signingKey
+        ? "present (create-env only)"
+        : "NOT SET",
+      [PUSH_CMD_ENV_VAR]: opts.pushCmd
+        ? "present (create-env only)"
+        : "not set (cert travels via logs; bundle stays on instance)",
+      [API_KEY_ENV_VAR]: opts.apiKey ? "present" : "NOT SET",
+    },
+    exitCodes: EXIT,
+    onstart,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// vast.ai REST client (thin; only main() uses it)
+
+export class VastClient {
+  constructor(apiKey, { fetchImpl = fetch } = {}) {
+    this.apiKey = apiKey;
+    this.fetch = fetchImpl;
+  }
+
+  async request(method, apiPath, body) {
+    const response = await this.fetch(`${API_BASE}${apiPath}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      const errorCode = parseVastErrorCode(text);
+      throw new VastApiError(
+        `vast API ${method} ${apiPath} → HTTP ${response.status}${errorCode ? ` (${errorCode})` : ""}`,
+        {
+          status: response.status,
+          body: text.slice(0, 2000),
+          errorCode,
+        },
+      );
+    }
+    try {
+      return JSON.parse(text);
+    } catch (cause) {
+      throw new VastApiError(
+        `vast API ${method} ${apiPath} returned non-JSON`,
+        {
+          status: response.status,
+          body: text.slice(0, 2000),
+          cause,
+        },
+      );
+    }
+  }
+
+  async searchOffers(query) {
+    // PUT with a {q: ...} wrapper is what the live API accepts (vast-python's
+    // "new search endpoint" path); select_cols is omitted because the API
+    // rejects the CLI's "*" wildcard and the default columns include
+    // everything the client-side re-filter reads.
+    const result = await this.request("PUT", "/search/asks/", { q: query });
+    if (!Array.isArray(result?.offers)) {
+      throw new VastApiError("vast search response has no offers array", {
+        body: result,
+      });
+    }
+    return result.offers;
+  }
+
+  async createInstance(offerId, payload) {
+    const result = await this.request("PUT", `/asks/${offerId}/`, payload);
+    if (result?.success !== true || typeof result?.new_contract !== "number") {
+      throw new VastApiError(`create on offer ${offerId} not accepted`, {
+        body: result,
+      });
+    }
+    return result.new_contract;
+  }
+
+  async getInstance(instanceId) {
+    const result = await this.request("GET", `/instances/${instanceId}/`);
+    const instance = result?.instances;
+    if (!instance || typeof instance !== "object") {
+      throw new VastApiError(`instance ${instanceId} missing from response`, {
+        body: result,
+      });
+    }
+    return instance;
+  }
+
+  /**
+   * Instance logs arrive indirectly: the request_logs call returns a
+   * result_url that 404s until vast's agent uploads the tail; poll it briefly.
+   */
+  async fetchLogs(
+    instanceId,
+    { tail = 100000, waitMs = 45000, stepMs = 3000 } = {},
+  ) {
+    const result = await this.request(
+      "PUT",
+      `/instances/request_logs/${instanceId}/`,
+      {
+        tail: String(tail),
+      },
+    );
+    const url = result?.result_url;
+    if (typeof url !== "string" || url.length === 0) {
+      throw new VastApiError(`no result_url for instance ${instanceId} logs`, {
+        body: result,
+      });
+    }
+    const deadline = Date.now() + waitMs;
+    for (;;) {
+      const response = await this.fetch(url);
+      if (response.ok) return await response.text();
+      if (Date.now() >= deadline) {
+        throw new VastApiError(
+          `logs for instance ${instanceId} never became available`,
+          {
+            status: response.status,
+          },
+        );
+      }
+      await delay(stepMs);
+    }
+  }
+
+  async destroyInstance(instanceId) {
+    await this.request("DELETE", `/instances/${instanceId}/`, {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration (network + process boundary; console IS the product here)
+
+/**
+ * DESTROY with retries. Returns true when the instance is gone. On total
+ * failure prints an unmissable banner with the id — a dangling instance is
+ * live billing and a human must kill it in the vast console.
+ */
+async function destroyWithRetries(
+  client,
+  instanceId,
+  { retries = 3, backoffMs = 5000 } = {},
+) {
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
+    try {
+      await client.destroyInstance(instanceId);
+      console.log(
+        `[cert-run] destroyed instance ${instanceId} (attempt ${attempt})`,
+      );
+      return true;
+    } catch (error) {
+      // error-policy:J2 context-adding rethrow deferred — retry loop; the
+      // final failure surfaces as the banner + EXIT.DESTROY_FAILED below.
+      console.error(
+        `[cert-run] destroy attempt ${attempt}/${retries} for instance ${instanceId} failed: ${error.message}`,
+      );
+      if (attempt < retries) await delay(backoffMs * attempt);
+    }
+  }
+  console.error("");
+  console.error(
+    "################################################################",
+  );
+  console.error(`##  FAILED TO DESTROY VAST INSTANCE ${instanceId}`);
+  console.error("##  IT IS STILL BILLING. Destroy it NOW in the vast console:");
+  console.error(
+    `##    https://cloud.vast.ai/instances/  (instance id ${instanceId})`,
+  );
+  console.error(
+    `##  or: curl -X DELETE -H "Authorization: Bearer $${API_KEY_ENV_VAR}" ${API_BASE}/instances/${instanceId}/`,
+  );
+  console.error(
+    "################################################################",
+  );
+  return false;
+}
+
+/** One rental attempt against one offer: create → poll → pull → destroy (finally). */
+async function runAttempt(client, offer, opts) {
+  const onstart = buildOnstart(opts);
+  assertOnstartSize(onstart);
+  const payload = buildCreatePayload(opts, onstart);
+
+  let instanceId;
+  try {
+    instanceId = await client.createInstance(offer.id, payload);
+  } catch (error) {
+    if (error instanceof VastApiError && error.isAuthFailure) throw error;
+    console.error(
+      `[cert-run] create on offer ${offer.id} failed: ${error.message}`,
+    );
+    return {
+      ok: false,
+      code: EXIT.CREATE_FAILED,
+      reason: `create failed: ${error.message}`,
+      costUsd: 0,
+    };
+  }
+  console.log(
+    `[cert-run] created instance ${instanceId} from offer ${offer.id} @ $${offer.dph_total.toFixed(4)}/hr`,
+  );
+
+  const startedAt = Date.now();
+  const logEveryMs = 60_000;
+  let lastLogPull = 0;
+  let logsText = "";
+  let state = createPollState({
+    timeoutMs: opts.timeoutMinutes * 60_000,
+    loadingTimeoutMs: opts.loadingTimeoutMinutes * 60_000,
+  });
+
+  try {
+    while (!state.outcome) {
+      await delay(opts.pollIntervalSeconds * 1000);
+      const elapsedMs = Date.now() - startedAt;
+      let actualStatus = "";
+      try {
+        const instance = await client.getInstance(instanceId);
+        actualStatus =
+          typeof instance.actual_status === "string"
+            ? instance.actual_status
+            : "";
+      } catch (error) {
+        if (error instanceof VastApiError && error.isAuthFailure) throw error;
+        // error-policy:J3 untrusted-input sanitizing — a transient poll
+        // failure becomes an explicit "unknown" status, which the reducer
+        // debounces and turns into INSTANCE_LOST if it persists.
+        console.error(
+          `[cert-run] poll failed (treating as unknown): ${error.message}`,
+        );
+        actualStatus = "unknown";
+      }
+      let marker = null;
+      const shouldPullLogs =
+        actualStatus === "running" || actualStatus === "exited"
+          ? Date.now() - lastLogPull >= logEveryMs || actualStatus === "exited"
+          : false;
+      if (shouldPullLogs) {
+        lastLogPull = Date.now();
+        try {
+          logsText = await client.fetchLogs(instanceId);
+        } catch (error) {
+          if (error instanceof VastApiError && error.isAuthFailure) throw error;
+          // error-policy:J7 diagnostics-must-not-kill-the-loop — a missed log
+          // tail only delays marker detection by one interval; instance
+          // status still drives every hard kill path.
+          console.error(
+            `[cert-run] log pull failed (will retry): ${error.message}`,
+          );
+        }
+        marker = detectMarker(logsText);
+      }
+      state = reducePoll(state, { actualStatus, elapsedMs, marker });
+      console.log(
+        `[cert-run] t+${Math.round(elapsedMs / 1000)}s status=${actualStatus || "provisioning"}${marker ? ` marker=${marker}` : ""}`,
+      );
+    }
+
+    const elapsedHours = (Date.now() - startedAt) / 3_600_000;
+    const costUsd = elapsedHours * offer.dph_total;
+    const outcome = { ...state.outcome, costUsd };
+
+    // Final log pull for the artifact directory, success or not — failures
+    // need the logs even more than successes do.
+    try {
+      logsText = await client.fetchLogs(instanceId);
+    } catch (error) {
+      // error-policy:J6 best-effort teardown — the run outcome is already
+      // decided; missing final logs degrade the artifact, not the verdict.
+      console.error(`[cert-run] final log pull failed: ${error.message}`);
+    }
+    fs.mkdirSync(opts.outDir, { recursive: true });
+    const logPath = path.join(opts.outDir, `instance-${instanceId}.log`);
+    fs.writeFileSync(logPath, logsText);
+    console.log(`[cert-run] instance logs → ${logPath}`);
+
+    if (outcome.ok) {
+      const cert = extractCertification(logsText);
+      if (cert === null) {
+        return {
+          ok: false,
+          code: EXIT.RESULTS_PULL_FAILED,
+          reason:
+            "run succeeded but no parseable certification JSON in pulled logs",
+          costUsd,
+        };
+      }
+      const certPath = path.join(opts.outDir, "certification.json");
+      fs.writeFileSync(certPath, `${cert}\n`);
+      console.log(`[cert-run] certification → ${certPath}`);
+    }
+    return outcome;
+  } finally {
+    const destroyed = await destroyWithRetries(client, instanceId);
+    if (!destroyed) {
+      // Overrides any other outcome via the flag main() checks: a dangling
+      // billed instance is worse than a failed run.
+      process.exitCode = EXIT.DESTROY_FAILED;
+    }
+  }
+}
+
+export async function main(argv, env) {
+  let opts;
+  try {
+    opts = parseCliArgs(argv, env);
+  } catch (error) {
+    if (error instanceof UsageError) {
+      console.error(`[cert-run] ${error.message}\n\n${USAGE}`);
+      return EXIT.USAGE;
+    }
+    throw error;
+  }
+  if (opts.help) {
+    console.log(USAGE);
+    return EXIT.OK;
+  }
+
+  if (opts.dryRun) {
+    const plan = buildDryRunPlan(opts);
+    const { onstart, ...rest } = plan;
+    console.log("[cert-run] DRY RUN — no API calls will be made");
+    console.log(JSON.stringify(rest, null, 2));
+    console.log("\n--- onstart script ---");
+    console.log(onstart);
+    return EXIT.OK;
+  }
+
+  const client = new VastClient(opts.apiKey);
+  let offers;
+  try {
+    offers = await client.searchOffers(buildOfferQuery(opts));
+  } catch (error) {
+    if (error instanceof VastApiError && error.isAuthFailure) {
+      console.error(
+        `[cert-run] vast API key rejected (HTTP ${error.status}${error.errorCode ? `, ${error.errorCode}` : ""}) — dead or unscoped ${API_KEY_ENV_VAR}`,
+      );
+      return EXIT.DEAD_API_KEY;
+    }
+    throw error;
+  }
+
+  const { eligible, rejected } = filterAndSortOffers(offers, opts);
+  console.log(
+    `[cert-run] ${offers.length} offers from search; ${eligible.length} eligible after client-side re-check (${rejected.length} rejected)`,
+  );
+  for (const reject of rejected.slice(0, 10)) {
+    console.log(`[cert-run]   rejected offer ${reject.id}: ${reject.reason}`);
+  }
+  if (eligible.length === 0) {
+    console.error(
+      `[cert-run] no eligible offers (gpu=${opts.gpuName}, dph<=${opts.maxDph}, reliability>${opts.minReliability}, inet_down>${opts.minInetDown}). Raise --max-dph or retry later.`,
+    );
+    return EXIT.NO_OFFERS;
+  }
+
+  const attempts = selectAttemptOffers(eligible, opts);
+  let totalCostUsd = 0;
+  let lastFailure = null;
+  try {
+    for (let index = 0; index < attempts.length; index += 1) {
+      const offer = attempts[index];
+      console.log(
+        `[cert-run] attempt ${index + 1}/${attempts.length}: offer ${offer.id} (${offer.gpu_name}, $${offer.dph_total.toFixed(4)}/hr, reliability ${offer.reliabilityResolved})`,
+      );
+      const outcome = await runAttempt(client, offer, opts);
+      totalCostUsd += outcome.costUsd;
+      if (outcome.ok) {
+        console.log(
+          `[cert-run] SUCCESS — certification pulled. Estimated spend this run: $${totalCostUsd.toFixed(3)}`,
+        );
+        return EXIT.OK;
+      }
+      lastFailure = outcome;
+      console.error(
+        `[cert-run] attempt ${index + 1} failed (exit ${outcome.code}): ${outcome.reason}`,
+      );
+      if (!isRetryableOutcome(outcome.code)) break;
+    }
+  } catch (error) {
+    if (error instanceof VastApiError && error.isAuthFailure) {
+      console.error(
+        `[cert-run] vast API key rejected mid-run (HTTP ${error.status}${error.errorCode ? `, ${error.errorCode}` : ""})`,
+      );
+      return EXIT.DEAD_API_KEY;
+    }
+    throw error;
+  } finally {
+    console.log(
+      `[cert-run] estimated total spend: $${totalCostUsd.toFixed(3)}`,
+    );
+  }
+  if (
+    lastFailure &&
+    isRetryableOutcome(lastFailure.code) &&
+    attempts.length >= opts.maxAttempts
+  ) {
+    console.error(
+      `[cert-run] budget guard: --max-attempts (${opts.maxAttempts}) exhausted`,
+    );
+    return EXIT.BUDGET_EXCEEDED;
+  }
+  return lastFailure ? lastFailure.code : EXIT.BUDGET_EXCEEDED;
+}
+
+const isDirectRun =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirectRun) {
+  main(process.argv.slice(2), process.env).then(
+    (code) => {
+      // A failed destroy (set via process.exitCode in the finally) must not
+      // be overwritten by a happier code from the run itself.
+      if (process.exitCode !== EXIT.DESTROY_FAILED) process.exitCode = code;
+    },
+    (error) => {
+      console.error(`[cert-run] fatal: ${error.stack ?? error.message}`);
+      process.exitCode = 1;
+    },
+  );
+}

--- a/scripts/vast/run-certification.test.mjs
+++ b/scripts/vast/run-certification.test.mjs
@@ -1,0 +1,536 @@
+/**
+ * Unit tests for the pure pieces of the vast.ai certification runner: offer
+ * filtering/sorting, onstart assembly + the 16 KB vast cap, the poll state
+ * machine's kill paths, budget guards, CLI parsing, log-marker/certification
+ * extraction, and dry-run secret redaction. No network, no vast account —
+ * everything here is a pure function imported from run-certification.mjs
+ * (the real-instance acceptance run is owner-gated on VAST_API_KEY).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  API_KEY_ENV_VAR,
+  assertOnstartSize,
+  buildCreatePayload,
+  buildDryRunPlan,
+  buildOfferQuery,
+  buildOnstart,
+  CERT_BEGIN_MARKER,
+  CERT_END_MARKER,
+  createPollState,
+  detectMarker,
+  EXIT,
+  extractCertification,
+  FAILURE_MARKER,
+  filterAndSortOffers,
+  isRetryableOutcome,
+  ONSTART_MAX_BYTES,
+  PUSH_CMD_ENV_VAR,
+  parseCliArgs,
+  redactCreatePayload,
+  reducePoll,
+  SIGNING_KEY_ENV_VAR,
+  SUCCESS_MARKER,
+  selectAttemptOffers,
+  UsageError,
+} from "./run-certification.mjs";
+
+const SHA = "a".repeat(40);
+
+function baseOpts(overrides = {}) {
+  return parseCliArgs(["--sha", SHA, "--dry-run"], {
+    [SIGNING_KEY_ENV_VAR]: undefined,
+    ...overrides.env,
+  });
+}
+
+function offer(overrides = {}) {
+  return {
+    id: 1,
+    dph_total: 0.35,
+    reliability2: 0.995,
+    inet_down: 900,
+    num_gpus: 1,
+    gpu_name: "RTX 4090",
+    ...overrides,
+  };
+}
+
+describe("buildOfferQuery", () => {
+  it("translates underscore GPU names and pins the acceptance filters", () => {
+    const query = buildOfferQuery(baseOpts());
+    assert.equal(query.gpu_name.eq, "RTX 4090");
+    assert.equal(query.num_gpus.eq, 1);
+    assert.equal(query.verified.eq, true);
+    assert.equal(query.rentable.eq, true);
+    assert.equal(query.reliability2.gt, 0.98);
+    assert.equal(query.inet_down.gt, 500);
+    assert.deepEqual(query.order, [["dph_total", "asc"]]);
+    assert.equal(query.type, "ask");
+  });
+});
+
+describe("filterAndSortOffers", () => {
+  it("sorts eligible offers cheapest-first with reliability tie-break", () => {
+    const { eligible } = filterAndSortOffers(
+      [
+        offer({ id: 1, dph_total: 0.4 }),
+        offer({ id: 2, dph_total: 0.3, reliability2: 0.99 }),
+        offer({ id: 3, dph_total: 0.3, reliability2: 0.999 }),
+      ],
+      baseOpts(),
+    );
+    assert.deepEqual(
+      eligible.map((entry) => entry.id),
+      [3, 2, 1],
+    );
+  });
+
+  it("rejects offers over --max-dph with a reason (budget guard)", () => {
+    const { eligible, rejected } = filterAndSortOffers(
+      [offer({ id: 7, dph_total: 0.99 })],
+      baseOpts(),
+    );
+    assert.equal(eligible.length, 0);
+    assert.equal(rejected[0].id, 7);
+    assert.match(rejected[0].reason, /--max-dph/);
+  });
+
+  it("re-checks reliability, inet_down and num_gpus client-side", () => {
+    const { eligible, rejected } = filterAndSortOffers(
+      [
+        offer({ id: 1, reliability2: 0.9 }),
+        offer({ id: 2, inet_down: 100 }),
+        offer({ id: 3, num_gpus: 4 }),
+        offer({ id: 4 }),
+      ],
+      baseOpts(),
+    );
+    assert.deepEqual(
+      eligible.map((entry) => entry.id),
+      [4],
+    );
+    assert.equal(rejected.length, 3);
+  });
+
+  it("falls back to legacy `reliability` and rejects offers missing both", () => {
+    const { eligible, rejected } = filterAndSortOffers(
+      [
+        offer({ id: 1, reliability2: undefined, reliability: 0.999 }),
+        offer({ id: 2, reliability2: undefined, reliability: undefined }),
+      ],
+      baseOpts(),
+    );
+    assert.deepEqual(
+      eligible.map((entry) => entry.id),
+      [1],
+    );
+    assert.match(rejected[0].reason, /missing reliability/);
+  });
+
+  it("never assumes compliance for offers missing dph_total or id", () => {
+    const { eligible } = filterAndSortOffers(
+      [offer({ id: undefined }), offer({ dph_total: undefined })],
+      baseOpts(),
+    );
+    assert.equal(eligible.length, 0);
+  });
+});
+
+describe("selectAttemptOffers", () => {
+  it("caps attempts at --max-attempts, cheapest-first", () => {
+    const { eligible } = filterAndSortOffers(
+      [1, 2, 3, 4, 5].map((id) => offer({ id, dph_total: id / 10 })),
+      baseOpts(),
+    );
+    const attempts = selectAttemptOffers(eligible, { maxAttempts: 2 });
+    assert.deepEqual(
+      attempts.map((entry) => entry.id),
+      [1, 2],
+    );
+  });
+});
+
+describe("buildOnstart", () => {
+  it("clones the exact sha and runs the certification chain in order", () => {
+    const onstart = buildOnstart(baseOpts());
+    const cloneIndex = onstart.indexOf(`git fetch --depth 1 origin ${SHA}`);
+    const installIndex = onstart.indexOf("bun run install:light");
+    const bundleIndex = onstart.indexOf("bundle:create -- --tier full");
+    const rollupIndex = onstart.indexOf("certify:rollup");
+    const signIndex = onstart.indexOf("certify:sign");
+    assert.ok(
+      cloneIndex > -1 && installIndex > cloneIndex,
+      "clone then install",
+    );
+    assert.ok(bundleIndex > installIndex, "bundle after install");
+    assert.ok(rollupIndex > bundleIndex, "rollup after bundle");
+    assert.ok(signIndex > rollupIndex, "sign after rollup");
+    assert.ok(onstart.includes(SUCCESS_MARKER));
+    assert.ok(onstart.includes(CERT_BEGIN_MARKER));
+    assert.ok(onstart.includes("ELIZA_EVIDENCE_RUNNER=vast"));
+  });
+
+  it("never embeds secret material in the onstart text", () => {
+    const opts = {
+      ...baseOpts(),
+      signingKey: "-----BEGIN PRIVATE KEY-----SECRETSECRET",
+      pushCmd: "aws s3 cp --secret-token hunter2",
+      apiKey: "vast-key-hunter3",
+    };
+    const onstart = buildOnstart(opts);
+    assert.ok(!onstart.includes("SECRETSECRET"));
+    assert.ok(!onstart.includes("hunter2"));
+    assert.ok(!onstart.includes("hunter3"));
+    // The push command is referenced by env var NAME only.
+    assert.ok(onstart.includes(`\${${PUSH_CMD_ENV_VAR}:-}`));
+  });
+
+  it("stays comfortably under the 16 KB vast cap with defaults", () => {
+    const bytes = assertOnstartSize(buildOnstart(baseOpts()));
+    assert.ok(
+      bytes < ONSTART_MAX_BYTES / 4,
+      `expected small onstart, got ${bytes} bytes`,
+    );
+  });
+});
+
+describe("assertOnstartSize", () => {
+  it("throws UsageError past 16 KB (multi-byte aware)", () => {
+    assert.throws(
+      () => assertOnstartSize("é".repeat(ONSTART_MAX_BYTES / 2 + 1)),
+      UsageError,
+    );
+    assert.throws(
+      () =>
+        assertOnstartSize(
+          buildOnstart({ ...baseOpts(), reviewerId: "x".repeat(17000) }),
+        ),
+      /16384/,
+    );
+  });
+
+  it("accepts exactly 16 KB", () => {
+    assert.equal(
+      assertOnstartSize("x".repeat(ONSTART_MAX_BYTES)),
+      ONSTART_MAX_BYTES,
+    );
+  });
+});
+
+describe("buildCreatePayload / redactCreatePayload", () => {
+  it("injects signing key and push cmd via env only, destroy-safe defaults", () => {
+    const opts = { ...baseOpts(), signingKey: "PEMPEM", pushCmd: "push it" };
+    const payload = buildCreatePayload(opts, "onstart");
+    assert.equal(payload.env[SIGNING_KEY_ENV_VAR], "PEMPEM");
+    assert.equal(payload.env[PUSH_CMD_ENV_VAR], "push it");
+    assert.equal(payload.env.ELIZA_EVIDENCE_RUNNER, "vast");
+    assert.equal(payload.client_id, "me");
+    assert.equal(payload.image, "ghcr.io/elizaos/certification-gpu:latest");
+    assert.equal(payload.label, `eliza-certification-${SHA.slice(0, 12)}`);
+  });
+
+  it("redacts every env value, keeps the key names visible", () => {
+    const payload = buildCreatePayload(
+      { ...baseOpts(), signingKey: "PEMPEM", pushCmd: "s3 cp secret" },
+      "onstart",
+    );
+    const redacted = redactCreatePayload(payload);
+    assert.deepEqual(
+      Object.values(redacted.env),
+      Object.keys(payload.env).map(() => "<redacted>"),
+    );
+    assert.ok(JSON.stringify(redacted).includes(SIGNING_KEY_ENV_VAR));
+    assert.ok(!JSON.stringify(redacted).includes("PEMPEM"));
+  });
+});
+
+describe("poll state machine", () => {
+  const config = { timeoutMs: 60 * 60_000, loadingTimeoutMs: 10 * 60_000 };
+
+  function run(snapshots, stateConfig = config) {
+    let state = createPollState(stateConfig);
+    for (const snapshot of snapshots) {
+      state = reducePoll(state, { marker: null, ...snapshot });
+      if (state.outcome) return state;
+    }
+    return state;
+  }
+
+  it("happy path: loading → running → success marker", () => {
+    const state = run([
+      { actualStatus: "loading", elapsedMs: 60_000 },
+      { actualStatus: "running", elapsedMs: 300_000 },
+      { actualStatus: "running", elapsedMs: 900_000, marker: "success" },
+    ]);
+    assert.deepEqual(state.outcome, { ok: true });
+  });
+
+  it("failure marker → ONSTART_FAILED even while still running", () => {
+    const state = run([
+      { actualStatus: "running", elapsedMs: 300_000, marker: "failure" },
+    ]);
+    assert.equal(state.outcome.ok, false);
+    assert.equal(state.outcome.code, EXIT.ONSTART_FAILED);
+  });
+
+  it("exited without success marker → ONSTART_FAILED", () => {
+    const state = run([
+      { actualStatus: "running", elapsedMs: 300_000 },
+      { actualStatus: "exited", elapsedMs: 600_000 },
+    ]);
+    assert.equal(state.outcome.code, EXIT.ONSTART_FAILED);
+    assert.match(state.outcome.reason, /without the success marker/);
+  });
+
+  it("exited WITH success marker in the same tick is a success", () => {
+    const state = run([
+      { actualStatus: "exited", elapsedMs: 600_000, marker: "success" },
+    ]);
+    assert.deepEqual(state.outcome, { ok: true });
+  });
+
+  it("stuck in loading past the loading timeout → STUCK_LOADING", () => {
+    const state = run([
+      { actualStatus: "loading", elapsedMs: 60_000 },
+      { actualStatus: "loading", elapsedMs: 11 * 60_000 },
+    ]);
+    assert.equal(state.outcome.code, EXIT.STUCK_LOADING);
+  });
+
+  it("blank/provisioning status counts as loading for the stuck check", () => {
+    const state = run([{ actualStatus: "", elapsedMs: 11 * 60_000 }]);
+    assert.equal(state.outcome.code, EXIT.STUCK_LOADING);
+  });
+
+  it("loading timeout does NOT fire once the instance has been running", () => {
+    const state = run([
+      { actualStatus: "running", elapsedMs: 60_000 },
+      { actualStatus: "loading", elapsedMs: 11 * 60_000 },
+    ]);
+    assert.equal(state.outcome, null);
+  });
+
+  it("offline/unknown are debounced, then INSTANCE_LOST", () => {
+    const state = run([
+      { actualStatus: "running", elapsedMs: 60_000 },
+      { actualStatus: "offline", elapsedMs: 120_000 },
+      { actualStatus: "unknown", elapsedMs: 180_000 },
+      { actualStatus: "offline", elapsedMs: 240_000 },
+    ]);
+    assert.equal(state.outcome.code, EXIT.INSTANCE_LOST);
+  });
+
+  it("a healthy poll resets the offline debounce", () => {
+    const state = run([
+      { actualStatus: "offline", elapsedMs: 60_000 },
+      { actualStatus: "offline", elapsedMs: 120_000 },
+      { actualStatus: "running", elapsedMs: 180_000 },
+      { actualStatus: "offline", elapsedMs: 240_000 },
+      { actualStatus: "offline", elapsedMs: 300_000 },
+    ]);
+    assert.equal(state.outcome, null);
+    assert.equal(state.consecutiveLost, 2);
+  });
+
+  it("hard wall-clock timeout → RUN_TIMEOUT", () => {
+    const state = run([{ actualStatus: "running", elapsedMs: 61 * 60_000 }]);
+    assert.equal(state.outcome.code, EXIT.RUN_TIMEOUT);
+  });
+
+  it("terminal state is sticky", () => {
+    let state = run([{ actualStatus: "running", elapsedMs: 61 * 60_000 }]);
+    state = reducePoll(state, {
+      actualStatus: "running",
+      elapsedMs: 62 * 60_000,
+      marker: "success",
+    });
+    assert.equal(state.outcome.code, EXIT.RUN_TIMEOUT);
+  });
+});
+
+describe("isRetryableOutcome", () => {
+  it("retries only host-side failures, never chain failures or timeouts", () => {
+    assert.ok(isRetryableOutcome(EXIT.STUCK_LOADING));
+    assert.ok(isRetryableOutcome(EXIT.INSTANCE_LOST));
+    assert.ok(isRetryableOutcome(EXIT.CREATE_FAILED));
+    assert.ok(!isRetryableOutcome(EXIT.ONSTART_FAILED));
+    assert.ok(!isRetryableOutcome(EXIT.RUN_TIMEOUT));
+    assert.ok(!isRetryableOutcome(EXIT.DEAD_API_KEY));
+  });
+});
+
+describe("VastApiError auth classification", () => {
+  it("maps vast's 404 + auth_error body to a dead key (live-API behavior)", async () => {
+    const { parseVastErrorCode, VastApiError } = await import(
+      "./run-certification.mjs"
+    );
+    // Verified against the live API: a dead key answers HTTP 404 with
+    // {"success":false,"error":"auth_error","msg":"Invalid user key"}.
+    const body =
+      '{"success":false,"error":"auth_error","msg":"Invalid user key"}';
+    assert.equal(parseVastErrorCode(body), "auth_error");
+    const authByCode = new VastApiError("x", {
+      status: 404,
+      errorCode: "auth_error",
+    });
+    assert.ok(authByCode.isAuthFailure);
+    const authByStatus = new VastApiError("x", { status: 401 });
+    assert.ok(authByStatus.isAuthFailure);
+    const plain404 = new VastApiError("x", { status: 404 });
+    assert.ok(!plain404.isAuthFailure);
+  });
+
+  it("returns undefined for HTML error pages, never throws", async () => {
+    const { parseVastErrorCode } = await import("./run-certification.mjs");
+    assert.equal(parseVastErrorCode("<html>404</html>"), undefined);
+    assert.equal(parseVastErrorCode('{"msg":"no error field"}'), undefined);
+    assert.equal(parseVastErrorCode(undefined), undefined);
+  });
+});
+
+describe("detectMarker / extractCertification", () => {
+  it("failure marker wins over a later success marker", () => {
+    assert.equal(
+      detectMarker(`${FAILURE_MARKER}: rollup\n${SUCCESS_MARKER}\n`),
+      "failure",
+    );
+    assert.equal(detectMarker(`all good\n${SUCCESS_MARKER}\n`), "success");
+    assert.equal(detectMarker("still going"), null);
+    assert.equal(detectMarker(""), null);
+    assert.equal(detectMarker(undefined), null);
+  });
+
+  it("extracts the LAST complete certification block and validates JSON", () => {
+    const first = JSON.stringify({ commit: "old" });
+    const second = JSON.stringify({ commit: SHA, verdicts: [] });
+    const logs = [
+      CERT_BEGIN_MARKER,
+      first,
+      CERT_END_MARKER,
+      "retry noise",
+      CERT_BEGIN_MARKER,
+      second,
+      CERT_END_MARKER,
+      SUCCESS_MARKER,
+    ].join("\n");
+    assert.equal(extractCertification(logs), second);
+  });
+
+  it("returns null for truncated or unparseable blocks (never corrupt output)", () => {
+    assert.equal(extractCertification(`${CERT_BEGIN_MARKER}\n{"a": 1`), null);
+    assert.equal(
+      extractCertification(
+        `${CERT_BEGIN_MARKER}\n{"a": tru\n${CERT_END_MARKER}`,
+      ),
+      null,
+    );
+    assert.equal(extractCertification("no markers"), null);
+  });
+});
+
+describe("parseCliArgs", () => {
+  it("requires --sha as hex and validates --tier", () => {
+    assert.throws(() => parseCliArgs(["--dry-run"], {}), /--sha is required/);
+    assert.throws(
+      () => parseCliArgs(["--sha", "not-hex!", "--dry-run"], {}),
+      /--sha/,
+    );
+    assert.throws(
+      () => parseCliArgs(["--sha", SHA, "--tier", "mega", "--dry-run"], {}),
+      /--tier must be one of/,
+    );
+  });
+
+  it("requires api + signing keys for real runs, but not for --dry-run", () => {
+    assert.throws(
+      () => parseCliArgs(["--sha", SHA], {}),
+      new RegExp(API_KEY_ENV_VAR),
+    );
+    assert.throws(
+      () => parseCliArgs(["--sha", SHA], { [API_KEY_ENV_VAR]: "k" }),
+      new RegExp(SIGNING_KEY_ENV_VAR),
+    );
+    const opts = parseCliArgs(["--sha", SHA, "--dry-run"], {});
+    assert.equal(opts.dryRun, true);
+  });
+
+  it("parses budget guards and rejects non-positive values", () => {
+    const opts = parseCliArgs(
+      [
+        "--sha",
+        SHA,
+        "--dry-run",
+        "--max-dph",
+        "0.45",
+        "--max-attempts",
+        "2",
+        "--timeout-minutes",
+        "90",
+      ],
+      {},
+    );
+    assert.equal(opts.maxDph, 0.45);
+    assert.equal(opts.maxAttempts, 2);
+    assert.equal(opts.timeoutMinutes, 90);
+    assert.throws(
+      () =>
+        parseCliArgs(["--sha", SHA, "--dry-run", "--max-attempts", "0"], {}),
+      /--max-attempts/,
+    );
+    assert.throws(
+      () =>
+        parseCliArgs(["--sha", SHA, "--dry-run", "--max-dph", "banana"], {}),
+      /--max-dph/,
+    );
+    assert.throws(
+      () => parseCliArgs(["--sha", SHA, "--dry-run", "--unknown"], {}),
+      /unknown argument/,
+    );
+  });
+
+  it("reads keys and push cmd from the environment", () => {
+    const opts = parseCliArgs(["--sha", SHA], {
+      [API_KEY_ENV_VAR]: "api-key",
+      [SIGNING_KEY_ENV_VAR]: "pem",
+      [PUSH_CMD_ENV_VAR]: "rclone copy",
+    });
+    assert.equal(opts.apiKey, "api-key");
+    assert.equal(opts.signingKey, "pem");
+    assert.equal(opts.pushCmd, "rclone copy");
+  });
+});
+
+describe("buildDryRunPlan", () => {
+  it("summarizes budget worst-case and never leaks secret values", () => {
+    const opts = parseCliArgs(
+      [
+        "--sha",
+        SHA,
+        "--dry-run",
+        "--max-dph",
+        "0.5",
+        "--max-attempts",
+        "2",
+        "--timeout-minutes",
+        "60",
+      ],
+      {
+        [SIGNING_KEY_ENV_VAR]: "-----BEGIN PRIVATE KEY-----LEAKME",
+        [API_KEY_ENV_VAR]: "vast-LEAKME",
+        [PUSH_CMD_ENV_VAR]: "s3 cp --token LEAKME",
+      },
+    );
+    const plan = buildDryRunPlan(opts);
+    assert.equal(plan.budget.worstCaseUsd, 1);
+    const serialized = JSON.stringify(plan);
+    assert.ok(!serialized.includes("LEAKME"));
+    assert.equal(
+      plan.secrets[SIGNING_KEY_ENV_VAR],
+      "present (create-env only)",
+    );
+    assert.ok(plan.onstart.includes(SHA));
+    assert.equal(plan.cleanup.retries, 3);
+  });
+});


### PR DESCRIPTION
Second tranche of repair for the `dfdab13ef23` workflow sweep (first: #17790), plus the fallback that makes certification runnable today.

## What

1. **Restores `scripts/vast/` verbatim from `main`** — the sweep deleted it from develop along with the workflows. It contains `local-certify.mjs`, the documented fallback: *"when vast is down or the API key is dead a certifier holding ELIZA_CERT_SIGNING_KEY can produce the same signed certification.json the develop→main gate verifies. Same commands, same output; the gate cannot tell the difference (by design — the signature is what matters)."*
2. **Adds `.github/workflows/certification-hosted.yml`** — a `workflow_dispatch`-only thin caller of `local-certify.mjs` on a GitHub-hosted runner, uploading `certification.json` + the evidence bundle as an artifact.

## Why a hosted fallback is needed now

Dispatching the restored `certification-vast.yml` fails preflight: the repo has `ELIZA_CERT_SIGNING_KEY` but **`VAST_API_KEY` is absent**:

```text
env:
  HAS_VAST_KEY: false
  HAS_SIGNING_KEY: true
##[error]missing repo secret(s): VAST_API_KEY
```

The signing key only exists as a repo secret, so the fallback chain must run on a GitHub runner — hence a workflow.

**No GPU is required for full tier.** The gpu/full-tier vision analyzers resolve their backend from env (`packages/evidence/src/vision-qa/config.ts`): with `ANTHROPIC_API_KEY` present (it is, other CI uses it) they call the Anthropic Messages API. The rented vast GPU only ever served the optional local llama-server backend.

## Security posture (mirrors certification-vast)

- `workflow_dispatch` only — no `pull_request` trigger, so PR-controlled code can never see the signing key
- both secrets exposed only to the single step that runs the chain
- `permissions: contents: read`; checkout with `persist-credentials: false`
- signing honesty is enforced by `certify:sign` itself: it refuses to sign mechanically non-pass subjects as pass, so this workflow cannot fabricate a green certification

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:8583e1db9ebccf66d2b7162a9c9c388ac185135f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow and script restore, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow and script restore, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow yaml and node script with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the preflight failure of the restored vast workflow proving VAST_API_KEY is gone while the signing key is present.

<details><summary>certification-vast dispatch, run 31054320755</summary>

```text
$ gh workflow run certification-vast.yml --repo elizaOS/eliza --ref develop \
    -f sha=b101d0364529f21ba41bd0a5c5870676542efaf7 -f tier=full
(dispatch accepted after #17790 restored the file)

vast-certification / Preflight secrets:
  env:
    HAS_VAST_KEY: false
    HAS_SIGNING_KEY: true
  ##[error]missing repo secret(s): VAST_API_KEY
  ##[error]Process completed with exit code 1.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in workflow dispatch or certification.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - CI configuration change; the vision-QA model calls happen only when the certification workflow is later dispatched, not in this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - byte-identity of the restored scripts and yaml validity of the new workflow.

<details><summary>Verbatim-restore + parse proof</summary>

```text
$ git diff origin/main --stat -- scripts/vast/
(empty - byte-identical to main)

$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/certification-hosted.yml'));print('parses')"
parses

$ node --check scripts/vast/local-certify.mjs && node --check scripts/vast/run-certification.mjs
(both parse)
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
