### PR TITLE
fix(certify): write verdicts beside the bundle, not inside it

### DIFF
--- a/scripts/vast/local-certify.mjs
+++ b/scripts/vast/local-certify.mjs
@@ -118,7 +118,10 @@ function main(argv, env) {
     opts.tier,
   ]);
   const bundleDir = newestBundleDir();
-  const verdictsPath = path.join(bundleDir, "verdicts.json");
+  // Sibling of the bundle dir, never inside it: certify:sign's integrity
+  // check refuses to sign a bundle containing files the manifest does not
+  // list, and verdicts.json is reviewer input, not bundle evidence.
+  const verdictsPath = `${bundleDir.replace(/\/+$/, "")}-verdicts.json`;
   run("certify:rollup", "bun", [
     "run",
     "--cwd",

--- a/scripts/vast/run-certification.mjs
+++ b/scripts/vast/run-certification.mjs
@@ -409,8 +409,11 @@ export function buildOnstart(opts) {
     '[ -n "$BUNDLE_DIR" ] || fail bundle-dir',
     // biome-ignore lint/suspicious/noTemplateCurlyInString: bash env expansion, not a JS template
     'BUNDLE_DIR="${BUNDLE_DIR%/}"',
-    'bun run --cwd packages/evidence certify:rollup -- --bundle "$BUNDLE_DIR" --out "$BUNDLE_DIR/verdicts.json" || fail rollup',
-    `bun run --cwd packages/evidence certify:sign -- --bundle "$BUNDLE_DIR" --verdicts "$BUNDLE_DIR/verdicts.json" --reviewer-id '${opts.reviewerId}' --reviewer-kind agent || fail sign`,
+    // Verdicts live beside the bundle, never inside it: certify:sign's
+    // integrity check refuses a bundle containing unlisted files.
+    'VERDICTS="${BUNDLE_DIR%/}-verdicts.json"',
+    'bun run --cwd packages/evidence certify:rollup -- --bundle "$BUNDLE_DIR" --out "$VERDICTS" || fail rollup',
+    `bun run --cwd packages/evidence certify:sign -- --bundle "$BUNDLE_DIR" --verdicts "$VERDICTS" --reviewer-id '${opts.reviewerId}' --reviewer-kind agent || fail sign`,
     `echo "${CERT_BEGIN_MARKER}"`,
     'cat "$BUNDLE_DIR/certification.json" || fail cert-read',
     'echo ""',


### PR DESCRIPTION
First live run of the restored certification chain (hosted run 31055768727, on develop tip `fa20ce53462`) failed at the signing step:

```text
[local-certify] certify:sign: ... --bundle .../20260805-231828-fa20ce5-full
                              --verdicts .../20260805-231828-fa20ce5-full/verdicts.json
  unlisted: verdicts.json
error [SIGN_BUNDLE_TAMPERED]: refusing to sign: bundle integrity check failed with 1 issue(s)
```

`certify:sign` now (correctly) refuses to sign a bundle that contains files its manifest does not list. Both certification chains — `local-certify.mjs` and the vast onstart built by `run-certification.mjs` — write `verdicts.json` **into** the bundle dir, so every run of either chain dies this way. The scripts predate the stricter integrity check; the evidence package's own CLI tests keep verdicts in a tmpdir outside the bundle.

Fix: both chains write verdicts to a sibling path (`<bundle-dir>-verdicts.json`). Reviewer input is not bundle evidence.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:6de995020a9098bed4a44af2f89ddd9e6b5106a2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - certification tooling script change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - certification tooling script change, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - node script change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the failing signing step from the first live hosted certification run.

<details><summary>Hosted certification run 31055768727 - SIGN_BUNDLE_TAMPERED</summary>

```text
[local-certify] certify:sign: bun run --cwd packages/evidence certify:sign --
  --bundle /home/runner/work/eliza/eliza/evidence/runs/20260805-231828-fa20ce5-full
  --verdicts /home/runner/work/eliza/eliza/evidence/runs/20260805-231828-fa20ce5-full/verdicts.json
  --reviewer-id certification-hosted@github-actions --reviewer-kind human

  unlisted: verdicts.json
error [SIGN_BUNDLE_TAMPERED]: refusing to sign: bundle integrity check failed with 1 issue(s)
error: script "certify:sign" exited with code 1
[local-certify] certify:sign failed (exit 1)
##[error]Process completed with exit code 1.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the certification chain.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - script path-handling fix; the vision-QA model calls inside bundle creation are unaffected by where verdicts are written.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - the script suite covering both chains.

<details><summary>node --test scripts/vast/run-certification.test.mjs</summary>

```text
$ node --test scripts/vast/run-certification.test.mjs
# tests 36
# suites 9
# pass 36
# fail 0
# cancelled 0
# skipped 0
# duration_ms 401.28

$ node --check scripts/vast/run-certification.mjs
$ node --check scripts/vast/local-certify.mjs
(both parse clean; the onstart builder test suite covers the generated
 shell chain, including the rollup/sign lines this change rewrites)
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
