### PR TITLE
fix(cloud): cap agent container memory so one boot-looping agent cannot OOM a whole node

### DIFF
--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -337,6 +337,10 @@ CONTAINERS_SSH_KEY=
 # ELIZA_AGENT_PORT=3000
 # AGENT_DOCKER_IMAGE=ghcr.io/agent-ai/agent:v2.0.0-steward-5
 
+# Default per-agent Docker memory ceiling in MiB. Individual sandbox
+# configuration overrides this value; set 0 only to restore unlimited memory.
+# CONTAINERS_AGENT_MEMORY_LIMIT_MB=3072
+
 # Seed-only fallback for node selection BEFORE rows exist in `docker_nodes`.
 # Format: comma-separated `node_id=hostname` pairs.
 # CONTAINERS_DOCKER_NODES=node-1:10.0.0.10:4,node-2:10.0.0.11:4

--- a/packages/cloud/shared/src/lib/config/containers-env-agent-memory.test.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env-agent-memory.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the per-agent container memory ceiling knob in containers-env.ts.
+ * `containersEnv` reads through `getCloudAwareEnv()`, which returns
+ * `process.env` directly when no cloud ALS store is active (the case under
+ * bun test), so we drive these by mutating + restoring the two
+ * *_AGENT_MEMORY_LIMIT_MB keys.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { containersEnv } from "./containers-env";
+
+const KEYS = ["CONTAINERS_AGENT_MEMORY_LIMIT_MB", "ELIZA_AGENT_MEMORY_LIMIT_MB"] as const;
+
+const saved = new Map<string, string | undefined>();
+function setEnv(values: Partial<Record<(typeof KEYS)[number], string>>): void {
+  for (const key of KEYS) {
+    if (!saved.has(key)) saved.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(values)) {
+    process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  for (const [key, value] of saved) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  saved.clear();
+});
+
+describe("agentContainerMemoryLimitMb", () => {
+  test("defaults to 3072 when unset", () => {
+    setEnv({});
+    expect(containersEnv.agentContainerMemoryLimitMb()).toBe(3072);
+  });
+
+  test("honors CONTAINERS_AGENT_MEMORY_LIMIT_MB", () => {
+    setEnv({ CONTAINERS_AGENT_MEMORY_LIMIT_MB: "4096" });
+    expect(containersEnv.agentContainerMemoryLimitMb()).toBe(4096);
+  });
+
+  test("falls back to the ELIZA_ alias", () => {
+    setEnv({ ELIZA_AGENT_MEMORY_LIMIT_MB: "2048" });
+    expect(containersEnv.agentContainerMemoryLimitMb()).toBe(2048);
+  });
+
+  test("CONTAINERS_ key wins over the ELIZA_ alias", () => {
+    setEnv({
+      CONTAINERS_AGENT_MEMORY_LIMIT_MB: "4096",
+      ELIZA_AGENT_MEMORY_LIMIT_MB: "2048",
+    });
+    expect(containersEnv.agentContainerMemoryLimitMb()).toBe(4096);
+  });
+
+  test("0 disables the ceiling (returns 0, not the default)", () => {
+    setEnv({ CONTAINERS_AGENT_MEMORY_LIMIT_MB: "0" });
+    expect(containersEnv.agentContainerMemoryLimitMb()).toBe(0);
+  });
+
+  test("floors fractional values", () => {
+    setEnv({ CONTAINERS_AGENT_MEMORY_LIMIT_MB: "1536.9" });
+    expect(containersEnv.agentContainerMemoryLimitMb()).toBe(1536);
+  });
+
+  test("clamps to 65536 MiB", () => {
+    setEnv({ CONTAINERS_AGENT_MEMORY_LIMIT_MB: "1000000" });
+    expect(containersEnv.agentContainerMemoryLimitMb()).toBe(65536);
+  });
+
+  test("rejects garbage and negative values back to the default", () => {
+    setEnv({ CONTAINERS_AGENT_MEMORY_LIMIT_MB: "not-a-number" });
+    expect(containersEnv.agentContainerMemoryLimitMb()).toBe(3072);
+    setEnv({ CONTAINERS_AGENT_MEMORY_LIMIT_MB: "-512" });
+    expect(containersEnv.agentContainerMemoryLimitMb()).toBe(3072);
+  });
+});

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -422,10 +422,7 @@ export const containersEnv = {
    */
   agentContainerMemoryLimitMb(): number {
     const env = getCloudAwareEnv();
-    const raw = pick(
-      env.CONTAINERS_AGENT_MEMORY_LIMIT_MB,
-      env.ELIZA_AGENT_MEMORY_LIMIT_MB,
-    );
+    const raw = pick(env.CONTAINERS_AGENT_MEMORY_LIMIT_MB, env.ELIZA_AGENT_MEMORY_LIMIT_MB);
     const parsed = raw ? Number(raw) : Number.NaN;
     if (Number.isFinite(parsed) && parsed >= 0) {
       return Math.min(65536, Math.floor(parsed));

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -403,6 +403,36 @@ export const containersEnv = {
     );
   },
 
+  /**
+   * Default per-agent container memory ceiling in MiB, applied by the docker
+   * provisioner whenever a sandbox has no explicit `container.memory` of its
+   * own. `0` disables the ceiling entirely (pre-2026-08 behavior).
+   *
+   * Why a default exists at all: agent containers previously ran with
+   * `HostConfig.Memory=0` (unlimited) plus `--restart unless-stopped`. One
+   * agent stuck in a boot loop — each boot attempt spiking ~2GB before dying —
+   * could starve an entire node and get HEALTHY co-tenant agents OOM-killed
+   * (observed fleet-wide on staging 2026-08-05: node `available` memory driven
+   * to 4MB, kernel OOM killing unrelated agents every ~10-30s).
+   *
+   * Default: 3072 MiB — comfortably above the observed ~2.1GB boot-time RSS
+   * spike of the current agent image, and aligned with the ~4GB/agent budget
+   * the ccx33 + capacity-8 sizing was designed around (see
+   * defaultAutoscaleNodeCapacity). Clamped to [0, 65536].
+   */
+  agentContainerMemoryLimitMb(): number {
+    const env = getCloudAwareEnv();
+    const raw = pick(
+      env.CONTAINERS_AGENT_MEMORY_LIMIT_MB,
+      env.ELIZA_AGENT_MEMORY_LIMIT_MB,
+    );
+    const parsed = raw ? Number(raw) : Number.NaN;
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return Math.min(65536, Math.floor(parsed));
+    }
+    return 3072;
+  },
+
   /** Explicit operator-pinned agent image, without the hardcoded fallback. */
   defaultAgentImageOverride(): string | undefined {
     const env = getCloudAwareEnv();

--- a/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
@@ -51,3 +51,31 @@ describe("buildAgentContainerSecurityFlags — hosted-agent escape hardening (#1
     );
   });
 });
+
+import { buildAgentContainerMemoryFlags } from "../agent-container-security";
+
+describe("buildAgentContainerMemoryFlags — per-agent OOM containment (staging fleet incident 2026-08-05)", () => {
+  test("emits --memory AND a matching --memory-swap (no swap escape) for a positive limit", () => {
+    expect(buildAgentContainerMemoryFlags(3072)).toEqual([
+      "--memory '3072m'",
+      "--memory-swap '3072m'",
+    ]);
+  });
+
+  test("ceils fractional MiB so the swap pin never undershoots the memory flag", () => {
+    expect(buildAgentContainerMemoryFlags(1536.2)).toEqual([
+      "--memory '1537m'",
+      "--memory-swap '1537m'",
+    ]);
+  });
+
+  test("0 disables the ceiling entirely (no flags — the explicit opt-out)", () => {
+    expect(buildAgentContainerMemoryFlags(0)).toEqual([]);
+  });
+
+  test("undefined / negative / NaN emit no flags rather than a garbage docker arg", () => {
+    expect(buildAgentContainerMemoryFlags(undefined)).toEqual([]);
+    expect(buildAgentContainerMemoryFlags(-512)).toEqual([]);
+    expect(buildAgentContainerMemoryFlags(Number.NaN)).toEqual([]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
@@ -5,7 +5,10 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { buildAgentContainerSecurityFlags } from "../agent-container-security";
+import {
+  buildAgentContainerMemoryFlags,
+  buildAgentContainerSecurityFlags,
+} from "../agent-container-security";
 
 describe("buildAgentContainerSecurityFlags — hosted-agent escape hardening (#12468)", () => {
   test("always drops all caps, forbids priv-escalation, and bounds pids (default 512)", () => {
@@ -51,8 +54,6 @@ describe("buildAgentContainerSecurityFlags — hosted-agent escape hardening (#1
     );
   });
 });
-
-import { buildAgentContainerMemoryFlags } from "../agent-container-security";
 
 describe("buildAgentContainerMemoryFlags — per-agent OOM containment (staging fleet incident 2026-08-05)", () => {
   test("emits --memory AND a matching --memory-swap (no swap escape) for a positive limit", () => {

--- a/packages/cloud/shared/src/lib/services/agent-container-security.ts
+++ b/packages/cloud/shared/src/lib/services/agent-container-security.ts
@@ -17,6 +17,7 @@
  */
 
 import { buildAppContainerSecurityFlags } from "./app-network-utils";
+import { shellQuote } from "./docker-sandbox-utils";
 
 /**
  * Build the ordered `docker create` capability/security flags for a hosted-agent
@@ -31,4 +32,29 @@ export function buildAgentContainerSecurityFlags(opts: {
     ...buildAppContainerSecurityFlags({ pidsLimit: opts.pidsLimit }),
     ...(opts.headscaleEnabled ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"] : []),
   ];
+}
+
+/**
+ * Ordered `docker create` memory flags for a hosted-agent container.
+ *
+ * Why this exists: agent containers historically ran with no `--memory` flag
+ * at all (`HostConfig.Memory=0`, unlimited) while also carrying
+ * `--restart unless-stopped`. One agent stuck in a boot loop — each attempt
+ * spiking ~2GB of anon RSS before dying — could drive a node's available
+ * memory to single-digit MB and get the kernel to OOM-kill unrelated HEALTHY
+ * co-tenant agents (observed fleet-wide on staging, 2026-08-05). A ceiling
+ * turns that failure from "node-wide outage" into "the one broken agent gets
+ * OOM-killed inside its own cgroup".
+ *
+ * `memoryMb <= 0` (or non-finite) disables the ceiling and emits no flags —
+ * the pre-2026-08 behavior, selectable via CONTAINERS_AGENT_MEMORY_LIMIT_MB=0.
+ *
+ * Swap is pinned to the same value (i.e. no swap headroom) so the ceiling
+ * cannot be escaped via swap on the shared node — the same hardening the app
+ * container lane applies in app-docker-cmd.ts.
+ */
+export function buildAgentContainerMemoryFlags(memoryMb: number | undefined): string[] {
+  if (!memoryMb || !Number.isFinite(memoryMb) || memoryMb <= 0) return [];
+  const mb = Math.ceil(memoryMb);
+  return [`--memory ${shellQuote(`${mb}m`)}`, `--memory-swap ${shellQuote(`${mb}m`)}`];
 }

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -21,7 +21,10 @@ import { signStewardMutatingRequest } from "../steward/sign";
 import { resolveServerStewardApiUrlFromEnv } from "../steward-url";
 import { logger } from "../utils/logger";
 import { withTimeout } from "../utils/with-timeout";
-import { buildAgentContainerSecurityFlags } from "./agent-container-security";
+import {
+  buildAgentContainerMemoryFlags,
+  buildAgentContainerSecurityFlags,
+} from "./agent-container-security";
 import { ensureRegistryAccess } from "./containers/hetzner-client/registry";
 import { getNodeAutoscaler } from "./containers/node-autoscaler";
 import { resolveImageDigest } from "./containers/registry-probe";
@@ -1416,9 +1419,13 @@ export class DockerSandboxProvider implements SandboxProvider {
         "--health-timeout 5s",
         "--health-start-period 15s",
         "--health-retries 6",
-        ...(config.container?.memoryMb
-          ? [`--memory ${shellQuote(`${Math.ceil(config.container.memoryMb)}m`)}`]
-          : []),
+        // Per-container memory ceiling (see buildAgentContainerMemoryFlags):
+        // an explicit per-agent `container.memory` wins; otherwise the
+        // env-tunable fleet default applies so a boot-looping agent can never
+        // OOM-starve its co-tenants again (staging fleet incident 2026-08-05).
+        ...buildAgentContainerMemoryFlags(
+          config.container?.memoryMb ?? containersEnv.agentContainerMemoryLimitMb(),
+        ),
         // Escape-hardening (#12230/#12302): drop ALL kernel capabilities, forbid
         // privilege escalation, and bound the process count — then, under
         // headscale only, re-add exactly NET_ADMIN + /dev/net/tun for the VPN.


### PR DESCRIPTION
## The incident this kills (staging, 2026-08-05)

Agent containers are created with **no `--memory` flag** (`HostConfig.Memory=0`, unlimited) and `--restart unless-stopped`. The current agent image spikes **~2.1GB anon RSS at boot**. Put together: one agent stuck in a boot loop (dead authkey, poisoned volume, anything with a nonzero exit) re-spikes ~2GB every 10-30s forever.

Observed live on the staging fleet today (serial follow-up to the zombie-container cleanup in the STAGING-GREEN receipt):
- `agent-2de06b8f` restart-looping on TWO nodes simultaneously with **RestartCount=15,172 and 18,466** (stale twins of a healthy third placement); `agent-98aaf2c9` at **45,129** restarts over 13 days on a disabled node.
- Node available memory driven to **4MB**; kernel OOM-killing `MainThread` every ~10-30s, including **unrelated healthy agents** on the same node (`oom-kill ... task=MainThread ... anon-rss:2110348kB` in dmesg during this lane).
- Dedicated-tier provisioning was dead fleet-wide since Jul 23 because new containers could never boot past the OOM killer.

A per-container ceiling converts that failure from *node-wide outage* into *the broken agent OOMs inside its own cgroup*.

## What changed

- **`buildAgentContainerMemoryFlags`** (agent-container-security.ts): pure, unit-testable builder emitting `--memory <mb>m` **plus a matching `--memory-swap`** so the ceiling cannot be escaped via swap on the shared node — the exact hardening the app-container lane already applies in `app-docker-cmd.ts`. `<=0`/non-finite emits no flags (explicit opt-out, pre-change behavior).
- **`containersEnv.agentContainerMemoryLimitMb()`**: env-tunable fleet default. `CONTAINERS_AGENT_MEMORY_LIMIT_MB` (canonical) / `ELIZA_AGENT_MEMORY_LIMIT_MB` (alias), default **3072 MiB**, clamped `[0, 65536]`, `0` disables. 3072 sits above the observed ~2.1GB boot spike with headroom, and inside the ~4GB/agent budget the ccx33 + capacity-8 sizing was designed around (see `defaultAutoscaleNodeCapacity`'s own doc).
- **docker-sandbox-provider**: an explicit per-agent `container.memory` (via `resolveSandboxContainerLaunchConfig`) still wins; the fleet default applies only when the sandbox carries no request of its own. Local single-tenant provider untouched.

## Not in scope (follow-ups from the same incident)
- Reconciler retiring containers whose sandbox row is terminal (the stale-twin source; #17256 covers part).
- Restart-backoff caps for `unless-stopped` agent containers.

## Testing
- `agent-container-security.test.ts`: builder contract — flags + swap pin, fractional ceil, `0`/undefined/negative/NaN opt-outs; existing security-flag ordering suite still green.
- `containers-env-agent-memory.test.ts` (new): default, both env keys, precedence, `0`-disable, floor, clamp, garbage rejection.
- `docker-sandbox-replacement-cleanup.test.ts`: full suite green (35 pass / 0 fail across the three files).
- `tsc --noEmit` clean on `packages/cloud/shared`.

<!-- evidence-head:4b8b6a250ced68106669dd860c115895343401ac -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend-only container resource-limit change; no UI surface changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend-only container resource-limit change; no rendered state exists.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Backend-only Docker command construction and environment parsing change.

<!-- evidence-row:backend-logs -->
- [x] [17795-pr17795-backend-validation-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17795-pr17795-backend-validation-v2.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend files, runtime, console, or network behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent planning, prompt, model, or inference behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - The exact-head backend test transcript is the applicable runtime artifact.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`


