### PR TITLE
fix(ci): hosted certification produces real evidence before bundling

### DIFF
--- a/.github/workflows/certification-hosted.yml
+++ b/.github/workflows/certification-hosted.yml
@@ -71,6 +71,20 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      - name: Generate shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
+      # The bundle ingests evidence silos produced by real lanes on the
+      # certified sha; a fresh runner has none, and certify:sign honestly
+      # refuses an empty verdicts document (proven by hosted run
+      # 31056825214). Run the same deterministic scenario lane the
+      # develop-exhaustive matrix runs — real runtime, deterministic model,
+      # keyless — which writes the reports/scenarios silo.
+      - name: Produce evidence — deterministic scenario lane
+        env:
+          TZ: UTC
+        run: bun run --cwd packages/scenario-runner test:pr:e2e
+
       - name: Run certification chain (bundle:create → rollup → sign)
         env:
           ELIZA_CERT_SIGNING_KEY: ${{ secrets.ELIZA_CERT_SIGNING_KEY }}


### PR DESCRIPTION
Third fix surfaced by live runs of the certification chain (#17792, #17794): the hosted run now fails at signing with an honestly empty verdicts document:

```text
error [VERDICTS_INVALID]: invalid verdicts document (...-verdicts.json):
verdicts: Too small: expected array to have >=1 items
```

`bundle:create` ingests evidence **silos** written by real test lanes on the certified sha (`packages/evidence/src/ingest.ts`: e2e-recordings, aesthetic-audit, playwright results, walkthrough reports, live-test-runs, `reports/scenarios`, ...). A fresh runner checkout has none of them, so the bundle finalizes with zero artifacts, the rollup emits `verdicts: []`, and `certify:sign` refuses - which is the honesty contract working as designed.

Fix: before the chain, run the exact deterministic scenario lane the develop-exhaustive matrix already runs (`bun run --cwd packages/scenario-runner test:pr:e2e` - real runtime, deterministic model, keyless, TZ=UTC), which writes real subjects into the `reports/scenarios` silo on the certified sha. Plus the `ensure-shared-i18n-data` step that lane depends on.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:0ceca70f062c4d130c8642b85fac8e770c986440 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow change, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow yaml change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the failing signing step of hosted run 31056825214 proving the empty-bundle path.

<details><summary>Hosted certification run 31056825214 - VERDICTS_INVALID</summary>

```text
[local-certify] certify:sign: bun run --cwd packages/evidence certify:sign --
  --bundle /home/runner/work/eliza/eliza/evidence/runs/20260805-233626-9a3c630-full
  --verdicts /home/runner/work/eliza/eliza/evidence/runs/20260805-233626-9a3c630-full-verdicts.json
  --reviewer-id certification-hosted@github-actions --reviewer-kind human

error [VERDICTS_INVALID]: invalid verdicts document
  (.../20260805-233626-9a3c630-full-verdicts.json):
  verdicts: Too small: expected array to have >=1 items
error: script "certify:sign" exited with code 1
[local-certify] certify:sign failed (exit 1)
##[error]Process completed with exit code 1.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the certification chain.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - the added lane runs the deterministic scenario model by design (SCENARIO_USE_DETERMINISTIC_MODEL=1); no live-model inference is part of this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - yaml validity and the silo-root mapping this fix targets.

<details><summary>Parse check + silo roots from packages/evidence/src/ingest.ts</summary>

```text
$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/certification-hosted.yml'));print('parses')"
parses

silo roots (ingest.ts):
  e2e-recordings            e2e-recordings/
  aesthetic-audit           packages/app/aesthetic-audit-output/
  device-e2e                device-e2e-output/, packages/app/device-e2e-output/
  playwright-test-results   packages/app/test-results/
  walkthrough-reports       reports/walkthrough/, packages/app/reports/walkthrough/
  live-test-runs            reports/live-test-runs/
  scenario-runner           packages/scenario-runner/reports/, reports/scenarios/   <- fed by this fix
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
