### PR TITLE
fix(ci): hosted certification uses the orchestrated certify command

### DIFF
--- a/.github/workflows/certification-hosted.yml
+++ b/.github/workflows/certification-hosted.yml
@@ -85,14 +85,24 @@ jobs:
           TZ: UTC
         run: bun run --cwd packages/scenario-runner test:pr:e2e
 
-      - name: Run certification chain (bundle:create → rollup → sign)
+      # The orchestrated command is the complete chain — ingest → ANALYZE →
+      # vision-qa → rollup → reviewer merge → sign → self-verify. The manual
+      # bundle:create→rollup→sign chain skips the analyze step, so rollup sees
+      # zero subjects and sign honestly refuses (runs 31056825214, 31057802513
+      # — the latter with 226 ingested scenario artifacts). --skip-matrix is
+      # the supported mode when lane evidence comes from ingested silos, which
+      # the scenario lane above provides on the certified sha.
+      - name: Run certification (orchestrated certify)
         env:
           ELIZA_CERT_SIGNING_KEY: ${{ secrets.ELIZA_CERT_SIGNING_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: >-
-          node scripts/vast/local-certify.mjs
+          bun run --cwd packages/evidence certify --
           --tier "${{ inputs.tier }}"
           --reviewer-id "certification-hosted@github-actions"
+          --reviewer-kind agent
+          --skip-matrix
+          --cert-out "$GITHUB_WORKSPACE/certification.json"
 
       - name: Collect artifacts
         run: |


### PR DESCRIPTION
Fourth live-run fix for the certification chain (#17792 → #17794 → #17796 → this). Run 31057802513 proved the scenario lane works — **226 artifacts ingested into the scenario-runner silo** — and still died at signing:

```text
scenario-runner          ingested  226
error [VERDICTS_INVALID]: invalid verdicts document (...-verdicts.json):
verdicts: Too small: expected array to have >=1 items
```

Root cause: the manual `bundle:create → certify:rollup → certify:sign` chain (inherited from `local-certify.mjs` / the vast onstart) **skips the analyze step**. `rollupBundle` drafts verdicts from analyzed subjects, not raw silo artifacts, so with no `analysis.json` beside any subject the rollup is empty and `certify:sign` honestly refuses.

The evidence package already owns the complete chain: `bun run --cwd packages/evidence certify` runs ingest → **analyze** → vision-qa → rollup → reviewer merge → sign → **self-verify**, and exits 0 only when the signed certification self-verifies green. This PR points the hosted workflow at it, with `--skip-matrix` (the documented mode where lane verdicts come from ingested silos — which the deterministic scenario lane step fills on the certified sha) and `--reviewer-kind agent` (this is an automated run; claiming human review would be dishonest).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:9ef27ae4af03ba8d9955ec00549e795a79283d25 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow change, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow yaml change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - run 31057802513 proving silo ingestion works and the manual chain still cannot produce verdicts.

<details><summary>Hosted run 31057802513 - 226 artifacts ingested, rollup still empty</summary>

```text
  e2e-recordings           absent    -
  aesthetic-audit          absent    -
  device-e2e               absent    -
  playwright-test-results  absent    -
  walkthrough-reports      absent    -
  live-test-runs           absent    -
  scenario-runner          ingested  226

[local-certify] certify:sign: bun run --cwd packages/evidence certify:sign --
  --bundle .../20260806-000351-d1fc3ca-full
  --verdicts .../20260806-000351-d1fc3ca-full-verdicts.json
error [VERDICTS_INVALID]: invalid verdicts document
  (.../20260806-000351-d1fc3ca-full-verdicts.json):
  verdicts: Too small: expected array to have >=1 items
error: script "certify:sign" exited with code 1
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the certification chain.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - workflow wiring change; the vision-qa model pass it enables runs inside the dispatched certification, not in this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - the orchestrated command's own contract, from the CLI help and orchestrate.ts.

<details><summary>The chain the workflow now calls</summary>

```text
$ bun run --cwd packages/evidence certify -- --help (excerpt)
certify  One command: matrix -> ingest -> analyze -> vision-qa -> rollup ->
         reviewer merge -> sign -> self-verify. Writes a signed
         certification.json and exits 0 only when it self-verifies (green),
         1 when red.

orchestrate.ts:
  "Honesty is structural, not advisory. The mechanical rollup drafts every
   lane ... analyze step writes analysis.json beside each subject ...
   --skip-matrix: lane verdicts then come only from ingested silos"

$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/certification-hosted.yml'))"
(parses)
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
