### PR TITLE
fix(ci): hosted certification runs the test matrix it certifies

### DIFF
--- a/.github/workflows/certification-hosted.yml
+++ b/.github/workflows/certification-hosted.yml
@@ -85,13 +85,13 @@ jobs:
           TZ: UTC
         run: bun run --cwd packages/scenario-runner test:pr:e2e
 
-      # The orchestrated command is the complete chain — ingest → ANALYZE →
-      # vision-qa → rollup → reviewer merge → sign → self-verify. The manual
-      # bundle:create→rollup→sign chain skips the analyze step, so rollup sees
-      # zero subjects and sign honestly refuses (runs 31056825214, 31057802513
-      # — the latter with 226 ingested scenario artifacts). --skip-matrix is
-      # the supported mode when lane evidence comes from ingested silos, which
-      # the scenario lane above provides on the certified sha.
+      # The orchestrated command is the complete chain — matrix → ingest →
+      # analyze → vision-qa → rollup → reviewer merge → sign → self-verify.
+      # The matrix is NOT skippable here: rollup scores lanes only from
+      # lanes/<lane>/result.json, which only the matrix step records (run
+      # 31059202533: --skip-matrix + no visual subjects → zero verdicts →
+      # honest refusal). Certification therefore means: the repo test matrix
+      # passes on the certified sha, recorded and signed.
       - name: Run certification (orchestrated certify)
         env:
           ELIZA_CERT_SIGNING_KEY: ${{ secrets.ELIZA_CERT_SIGNING_KEY }}
@@ -101,7 +101,6 @@ jobs:
           --tier "${{ inputs.tier }}"
           --reviewer-id "certification-hosted@github-actions"
           --reviewer-kind agent
-          --skip-matrix
           --cert-out "$GITHUB_WORKSPACE/certification.json"
 
       - name: Collect artifacts


### PR DESCRIPTION
Fifth and (structurally) final fix in the certification-chain series (#17790 → #17792 → #17794 → #17796 → #17797 → this). Run 31059202533 with the orchestrated command:

```text
  matrix: skipped (--skip-matrix)
  analyze: 0 subject(s) at tier full
error [CERTIFICATION_INVALID]: invalid certification payload (payload to sign):
verdicts: Too small: expected array to have >=1 items
```

Reading `rollup.ts` closes the loop: lane verdicts come **exclusively** from bundle paths matching `lanes/<lane>/result.json` (`LANE_RESULT_PATTERN`, rollup.ts:301), and the only writer of those files is the orchestrated **matrix** step, which spawns `packages/scripts/run-all-tests.mjs` and records its outcome. Silo artifacts are evidence attachments, not verdict subjects; visual analysis subjects need screenshots the hosted run does not produce.

So `--skip-matrix` on this runner can never yield a signable certification — and that is the honesty contract saying something true: **a certification is the claim that the repo's test matrix passed on the certified sha.** Run the matrix.

The deterministic scenario lane step stays: its reports ride the bundle as evidence artifacts alongside the matrix verdict.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:e39638ece1036a69a6437e0a52fbbc3676a25239 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow change, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow yaml change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - run 31059202533 output proving skip-matrix cannot produce verdicts, and the rollup source lines that explain why.

<details><summary>Run 31059202533 + rollup.ts subject sourcing</summary>

```text
$ bun src/cli.ts certify --tier full --reviewer-id certification-hosted@github-actions
    --reviewer-kind agent --skip-matrix --cert-out .../certification.json
  matrix: skipped (--skip-matrix)
  analyze: 0 subject(s) at tier full
error [CERTIFICATION_INVALID]: invalid certification payload (payload to sign):
  verdicts: Too small: expected array to have >=1 items
error: script "certify" exited with code 1

rollup.ts:301  const LANE_RESULT_PATTERN = /^lanes\/([^/]+)\/result\.json$/;
rollup.ts:343  const match = LANE_RESULT_PATTERN.exec(artifact.path);
orchestrate.ts:311  "Add a lane's result.json (+ log, when present) so rollup scores the lane."
orchestrate.ts:239  "Default matrix runner: spawn the repo's cross-package test runner and record
                     a single `matrix` lane from its exit code."
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the certification chain.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - workflow wiring change; model passes run inside the dispatched certification, not in this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - yaml validity and the diff's whole content (one flag removed, comment corrected).

<details><summary>Diff summary + parse</summary>

```text
$ git diff HEAD~1 --stat
 .github/workflows/certification-hosted.yml | 15 +++++++--------
 1 file changed, 7 insertions(+), 8 deletions(-)

removed:  --skip-matrix
comment:  rewritten to record WHY the matrix is the thing being certified

$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/certification-hosted.yml'));print('parses')"
parses
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
