### PR TITLE
fix(ci): upload the certification bundle even when the verdict is red

### DIFF
--- a/.github/workflows/certification-hosted.yml
+++ b/.github/workflows/certification-hosted.yml
@@ -104,17 +104,21 @@ jobs:
           --cert-out "$GITHUB_WORKSPACE/certification.json"
 
       - name: Collect artifacts
+        if: always()
         run: |
           set -euo pipefail
-          test -f certification.json
-          bundle_dir=$(ls -dt evidence/runs/*/ | head -1)
-          test -f "${bundle_dir}certification.json"
           mkdir -p "$RUNNER_TEMP/cert-out/evidence"
-          cp certification.json "$RUNNER_TEMP/cert-out/certification.json"
-          cp -R "$bundle_dir" "$RUNNER_TEMP/cert-out/evidence/bundle"
-          echo "bundle: $bundle_dir"
+          [ -f certification.json ] && cp certification.json "$RUNNER_TEMP/cert-out/certification.json"
+          bundle_dir=$(ls -dt evidence/runs/*/ 2>/dev/null | head -1 || true)
+          if [ -n "$bundle_dir" ]; then
+            cp -R "$bundle_dir" "$RUNNER_TEMP/cert-out/evidence/bundle"
+            echo "bundle: $bundle_dir"
+          else
+            echo "no bundle dir produced" > "$RUNNER_TEMP/cert-out/NO_BUNDLE.txt"
+          fi
 
-      - name: Upload signed certification + bundle
+      - name: Upload certification + bundle (also on RED — the lane logs are the diagnosis)
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: certification-${{ inputs.sha != '' && inputs.sha || github.sha }}


### PR DESCRIPTION
Run 31060590880 was the first time the whole certification chain executed end to end — scenario lane, full test matrix, ingest, analysis, rollup, signing — and it produced a **RED certification**: `verdict-failures: 1 failing verdict(s): lane:matrix`. That is the chain working: the matrix failed on the runner, so the signer refused to call the commit green.

The problem: the only record of **why** the matrix failed is `lanes/matrix/log` inside the bundle — and the upload step is skipped when the chain exits non-zero, so the evidence was discarded exactly when it was needed.

Fix: `if: always()` on collect and upload, with the collect step tolerating missing artifacts on early failures (preflight/checkout deaths upload a `NO_BUNDLE.txt` marker instead of nothing). A red certification is a diagnosis, not garbage.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:2cf0cde86dee5eae3e30ea60f67b2662b1895152 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow change, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow yaml change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the first full-chain run reaching a signed RED verdict, whose diagnosis was then discarded by the skipped upload.

<details><summary>Run 31060590880 - RED certification, evidence discarded</summary>

```text
  matrix: node packages/scripts/run-all-tests.mjs        (00:49:30)
  finalize: manifest sha256 5db0606f3e297696952b0738d534a82aee87c6bb020bf341c47f8a281f76b365
certification RED — /home/runner/work/eliza/eliza/certification.json
  failures: verdict-failures
  bundle:   /home/runner/work/eliza/eliza/evidence/runs/20260806-004930-67270bf-full
  verdict:  RED
  verdict-failures: 1 failing verdict(s): lane:matrix
error: script "certify" exited with code 1
(collect + upload steps: skipped — lanes/matrix/log lost with them)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the certification chain.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - workflow step-condition change; no model inference is part of this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - yaml validity and the exact condition/tolerance diff.

<details><summary>Diff + parse</summary>

```text
$ git diff HEAD~1 --stat
 .github/workflows/certification-hosted.yml | 22 +++++++++++++++-------
 1 file changed, 15 insertions(+), 7 deletions(-)

collect:  if: always()  + tolerant of missing certification.json / bundle dir
upload:   if: always()  (renamed to say why: red-run logs are the diagnosis)

$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/certification-hosted.yml'));print('parses')"
parses
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
