### PR TITLE
fix(ui): gate the synthetic-host WS skip on Capacitor native

### DIFF
--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -81,6 +81,29 @@ function stubWindowProtocol(protocol: string): void {
   );
 }
 
+// Stub the page origin (protocol + host) the same-origin WS derivation reads
+// when the client has no explicit base — the self-hosted "nginx in front of
+// the agent on a portless HTTPS domain" shape.
+function stubWindowOrigin(protocol: string, host: string): void {
+  const jsdomWindow = window;
+  const location = new Proxy(jsdomWindow.location, {
+    get(target, property) {
+      if (property === "protocol") return protocol;
+      if (property === "host") return host;
+      return Reflect.get(target, property, target);
+    },
+  });
+  vi.stubGlobal(
+    "window",
+    new Proxy(jsdomWindow, {
+      get(target, property) {
+        if (property === "location") return location;
+        return Reflect.get(target, property, target);
+      },
+    }),
+  );
+}
+
 describe("ElizaClient websocket connection policy", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -130,6 +153,36 @@ describe("ElizaClient websocket connection policy", () => {
     expect(createdUrls).toHaveLength(1);
     expect(createdUrls[0]).toContain("wss://agent.example.test/ws?");
     expect(createdUrls[0]).toContain("token=agent-token");
+  });
+
+  it("opens a same-origin websocket from a portless HTTPS host in a plain browser", () => {
+    // Regression (sol-dev 2026-08-05): the Capacitor synthetic-host guard was
+    // unconditional, so a browser served same-origin from `https://host/` (no
+    // port — nginx terminating TLS in front of the agent) silently never
+    // opened /ws. REST kept working, so server-pushed WS events
+    // (proactive-message: voice-turn mirrors, proactive sends) never rendered
+    // live in the open thread.
+    const createdUrls = stubWebSocket();
+    stubWindowOrigin("https:", "sol-dev.example.test");
+
+    const client = new ElizaClient("", "agent-token");
+    client.connectWs();
+
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("wss://sol-dev.example.test/ws?");
+    expect(createdUrls[0]).toContain("token=agent-token");
+  });
+
+  it("still skips the synthetic-host websocket on Capacitor native", () => {
+    const createdUrls = stubWebSocket();
+    stubWindowOrigin("https:", "myapp.app");
+    vi.stubGlobal("Capacitor", { isNativePlatform: () => true });
+
+    const client = new ElizaClient("", "agent-token");
+    client.connectWs();
+
+    // Native WebView bundle host has no server behind it — no socket attempt.
+    expect(createdUrls).toEqual([]);
   });
 
   it("does not open mixed-content ws from an https origin", () => {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -504,6 +504,26 @@ function shouldUseRestOnlyForInsecureWebSocket(
   return rendererProtocol === "https:" || rendererProtocol === "capacitor:";
 }
 
+/**
+ * True only inside a Capacitor NATIVE app (iOS/Android WebView), where the
+ * page origin is a synthetic bundle host with no server behind it. A plain
+ * browser (including one loading a Capacitor-built web bundle over HTTP) has
+ * no `Capacitor.isNativePlatform()` → false, so same-origin deployments keep
+ * their realtime WebSocket.
+ */
+function isCapacitorNativeRuntime(): boolean {
+  try {
+    const cap = (globalThis as Record<string, unknown>).Capacitor as
+      | { isNativePlatform?: () => boolean }
+      | undefined;
+    return Boolean(cap?.isNativePlatform?.());
+  } catch {
+    // error-policy:J4 an unanswerable platform probe reads as "not native",
+    // preserving the browser's WebSocket path.
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Network status — listens for the bridged Capacitor `networkStatusChange`
 // event so the WS reconnect scheduler can park itself during airplane mode
@@ -1432,9 +1452,21 @@ export class ElizaClient {
 
     // On Capacitor native (iosScheme/androidScheme = "https"), the origin host
     // is a synthetic bundle host (e.g. "localhost" with no server behind it).
-    // Skip WS if we have no explicit baseUrl and the host doesn't look like a
-    // real backend (no port, not an IP, not a known API domain).
-    if (!this.baseUrl && typeof host === "string") {
+    // Skip WS there when we have no explicit baseUrl and the host doesn't look
+    // like a real backend (no port, not an IP, not a known API domain).
+    //
+    // The skip is gated on the Capacitor native runtime: a plain BROWSER served
+    // same-origin from a portless HTTPS host (nginx terminating TLS in front of
+    // the agent — the standard self-hosted deployment shape) is a real backend
+    // whose /ws must connect. Ungated, this guard silently disabled the
+    // realtime WebSocket (proactive-message, conversation-updated, agent
+    // events) for every such deployment while REST kept working, so live
+    // server-pushed messages never rendered until a manual reload.
+    if (
+      !this.baseUrl &&
+      isCapacitorNativeRuntime() &&
+      typeof host === "string"
+    ) {
       const hasPort = host.includes(":");
       const isLoopback =
         host.startsWith("127.") || host.startsWith("localhost:");


### PR DESCRIPTION
## Problem

`ElizaClient.connectWs()` carries a guard for Capacitor native builds, where the page origin is a synthetic bundle host (e.g. `https://localhost`) with no server behind it:

```ts
if (!this.baseUrl && typeof host === "string") {
  const hasPort = host.includes(":");
  const isLoopback = host.startsWith("127.") || host.startsWith("localhost:");
  if (!hasPort && !isLoopback) return;
}
```

The guard is **unconditional**: any client with no explicit `baseUrl`, served same-origin from a portless HTTPS host, silently never opens `/ws`. That is the standard self-hosted deployment shape (nginx terminating TLS on 443 in front of the agent server, UI served same-origin).

REST keeps working, so the breakage is invisible except that every server-pushed WS event is lost: `proactive-message` (proactive sends, voice-turn mirrors), `conversation-updated`, agent events. Live-pushed messages never render in the open chat thread until a manual reload.

Found live on a self-hosted deploy while QAing realtime voice: spoken turns were persisted server-side and mirrored over `proactive-message`, but the browser had no `/ws` socket at all, so the open thread stayed stale at every sheet detent.

## Fix

Gate the skip on `Capacitor.isNativePlatform()` — the only environment where the origin host is genuinely synthetic. Plain browsers (including a Capacitor-built web bundle served over HTTP/HTTPS, where the `Capacitor` global has no native platform) keep the same-origin WebSocket. Probe failure reads as "not native", preserving the browser WS path.

## Tests

`packages/ui/src/api/client-base-websocket.test.ts`:
- **fails before / passes after**: `opens a same-origin websocket from a portless HTTPS host in a plain browser` — stubs `location` = `https://sol-dev.example.test` (no port), client with no baseUrl, asserts `wss://…/ws` is opened with the token param.
- native contract preserved: `still skips the synthetic-host websocket on Capacitor native` — same origin shape + `Capacitor.isNativePlatform() === true`, asserts no socket attempt.
- all 16 existing websocket-policy tests unchanged and green (18/18 total).

Also verified end-to-end on the live self-hosted deploy: after the fix the page opens `wss://<host>/ws`, and voice-turn `proactive-message` mirrors render live in the open thread (half and full detents, no duplicates, reconcile-by-id intact).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

<!-- evidence-head:f2e03f08e1215f11cc909154e33f9c6608c78550 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Runtime WebSocket transport policy only; no rendered component or style changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Runtime WebSocket transport policy only; rendered pixels are unchanged.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - The deterministic socket construction contract is covered by focused tests.

<!-- evidence-row:backend-logs -->
- [ ] N/A - No backend code or server contract changed.

<!-- evidence-row:frontend-logs -->
- [x] [17801-pr17801-frontend-validation.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17801-pr17801-frontend-validation.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No prompt, model, provider, planner, or inference behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No database, memory, task, wallet, or generated artifact changed.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered text changed; the applicable capture audit is recorded in frontend logs.

