### PR TITLE
fix(ci): certification matrix mirrors the proven develop-pr lane; allowlist the sso bridge public page

### DIFF
--- a/.github/workflows/certification-hosted.yml
+++ b/.github/workflows/certification-hosted.yml
@@ -70,9 +70,20 @@ jobs:
         uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: "1.3.14"
+          install-command: bun install --frozen-lockfile
+          install-native-deps: "false"
 
       - name: Generate shared i18n data
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
+      # The develop-pr test lane documents why: package-owned test scripts
+      # assume the core dependency graph and view bundles exist; on a clean
+      # hosted runner absent generated artifacts fail tests that have nothing
+      # wrong (diagnostic run 31062965483: plugin-meetings dist unresolved).
+      - name: Build core dependency graph and view bundles
+        run: |
+          bun run build:core
+          bun run build:views
 
       # The bundle ingests evidence silos produced by real lanes on the
       # certified sha; a fresh runner has none, and certify:sign honestly
@@ -101,6 +112,9 @@ jobs:
           --tier "${{ inputs.tier }}"
           --reviewer-id "certification-hosted@github-actions"
           --reviewer-kind agent
+          --matrix-arg --only=test
+          --matrix-arg --no-cloud
+          --matrix-arg --concurrency=3
           --cert-out "$GITHUB_WORKSPACE/certification.json"
 
       - name: Collect artifacts

--- a/packages/agent/src/api/__tests__/public-route-allowlist.test.ts
+++ b/packages/agent/src/api/__tests__/public-route-allowlist.test.ts
@@ -356,6 +356,8 @@ const ALLOWLIST: Record<string, string> = {
   "auth/cli-login": "cloud public page: CLI auth flow, pre-authentication",
   "auth/callback/email":
     "cloud public page: email auth callback, pre-authentication",
+  "auth/bridge":
+    "cloud public page: sso bridge leg between the dashboard and app origins; must render pre-auth to carry the one-time code, and every privileged step happens server-side behind Origin, referrer, and PKCE checks",
   "app-auth/authorize": "cloud public page: app-auth flow, pre-authentication",
   "terms-of-service": "cloud public page: legal page, no auth",
   "privacy-policy": "cloud public page: legal page, no auth",

--- a/packages/evidence/src/certify/orchestrate.test.ts
+++ b/packages/evidence/src/certify/orchestrate.test.ts
@@ -110,6 +110,62 @@ function reviewerDoc(
   return { schema: 1, reviewer: REVIEWER, verdicts };
 }
 
+describe("orchestrateCertify — matrix args forwarding", () => {
+  it("forwards options.matrixArgs to the matrix runner", async () => {
+    const repoRoot = tmpGitRepo();
+    let seenArgs: readonly string[] | undefined;
+    const runMatrix: MatrixRunner = async ({ args }) => {
+      seenArgs = args;
+      return {
+        command: "fake-matrix",
+        lanes: [
+          { lane: "matrix", passed: 1, failed: 0, skipped: 0, log: "ok\n" },
+        ],
+      };
+    };
+    const result = await orchestrateCertify({
+      tier: "cpu",
+      repoRoot,
+      outDir: tmpDir("evidence-orch-out-"),
+      signingKey: KEYPAIR.privateKeyPem,
+      reviewer: REVIEWER,
+      runMatrix,
+      matrixArgs: ["--only=test", "--no-cloud"],
+      env: {},
+      now: NOW,
+    });
+
+    expect(result.overallVerdict).toBe("green");
+    expect(seenArgs).toEqual(["--only=test", "--no-cloud"]);
+  });
+
+  it("defaults the runner's args to an empty list", async () => {
+    const repoRoot = tmpGitRepo();
+    let seenArgs: readonly string[] | undefined;
+    const runMatrix: MatrixRunner = async ({ args }) => {
+      seenArgs = args;
+      return {
+        command: "fake-matrix",
+        lanes: [
+          { lane: "matrix", passed: 1, failed: 0, skipped: 0, log: "ok\n" },
+        ],
+      };
+    };
+    await orchestrateCertify({
+      tier: "cpu",
+      repoRoot,
+      outDir: tmpDir("evidence-orch-out-"),
+      signingKey: KEYPAIR.privateKeyPem,
+      reviewer: REVIEWER,
+      runMatrix,
+      env: {},
+      now: NOW,
+    });
+
+    expect(seenArgs).toEqual([]);
+  });
+});
+
 describe("orchestrateCertify — fresh bundle green path", () => {
   it("captures a passing matrix lane, signs, and self-verifies green", async () => {
     const repoRoot = tmpGitRepo();

--- a/packages/evidence/src/certify/orchestrate.ts
+++ b/packages/evidence/src/certify/orchestrate.ts
@@ -164,6 +164,8 @@ export type MatrixRunner = (context: {
   repoRoot: string;
   tier: Tier;
   io: CertifyIo;
+  /** Extra argv forwarded to the matrix command (e.g. `--only=test`). */
+  args?: readonly string[];
 }) => Promise<MatrixRunResult>;
 
 /** How one orchestration step resolved, recorded in the run summary. */
@@ -207,6 +209,8 @@ export interface CertifyOptions {
   gpuQueueTimeoutMs?: number;
   /** Test matrix runner; default spawns `packages/scripts/run-all-tests.mjs`. */
   runMatrix?: MatrixRunner;
+  /** Extra argv forwarded to the matrix runner (`--matrix-arg` on the CLI). */
+  matrixArgs?: readonly string[];
   /** Env for vision-QA backend resolution + provenance; default `process.env`. */
   env?: NodeJS.ProcessEnv;
   now?: () => Date;
@@ -242,17 +246,19 @@ const CERTIFY_QUESTION: VisionQuestion = {
  * a red matrix produces a red certification. The full output is captured as the
  * lane log so a reviewer can read what failed.
  */
-export const spawnRunAllTests: MatrixRunner = ({ repoRoot, io }) => {
+export const spawnRunAllTests: MatrixRunner = ({ repoRoot, io, args = [] }) => {
   const script = path.join(
     repoRoot,
     "packages",
     "scripts",
     "run-all-tests.mjs",
   );
-  const command = `node ${path.relative(repoRoot, script)}`;
+  const command = [`node ${path.relative(repoRoot, script)}`, ...args].join(
+    " ",
+  );
   io.out(`  matrix: ${command}`);
   return new Promise<MatrixRunResult>((resolve, reject) => {
-    const child = spawn("node", [script], {
+    const child = spawn("node", [script, ...args], {
       cwd: repoRoot,
       env: process.env,
     });
@@ -579,7 +585,12 @@ export async function orchestrateCertify(
       io.out("  matrix: skipped (--skip-matrix)");
     } else {
       const runMatrix = options.runMatrix ?? spawnRunAllTests;
-      const matrix = await runMatrix({ repoRoot: options.repoRoot, tier, io });
+      const matrix = await runMatrix({
+        repoRoot: options.repoRoot,
+        tier,
+        io,
+        args: options.matrixArgs ?? [],
+      });
       for (const lane of matrix.lanes) await addLaneResult(bundle, lane);
       const failedLanes = matrix.lanes.filter((lane) => lane.failed > 0);
       steps.push({

--- a/packages/evidence/src/cli.ts
+++ b/packages/evidence/src/cli.ts
@@ -33,6 +33,7 @@ const USAGE = `Usage:
   bundle:verify -- <bundle-dir>
   certify       -- --tier <cpu|gpu|full> --reviewer-id <id> --reviewer-kind <agent|human>
                    [--reviewer-model <m>] [--reviewer-verdicts <file>] [--skip-matrix]
+                   [--matrix-arg <argv>]...
                    [--bundle <existing-dir>] [--requirements <file>] [--base-ref <ref>]
                    [--expires-hours <n>] [--key-file <pem>] [--cert-out <path>]
                    [--out <dir>] [--repo-root <dir>]
@@ -207,6 +208,7 @@ interface CertifyArgs {
   requirementsPath?: string;
   existingBundleDir?: string;
   skipMatrix: boolean;
+  matrixArgs: string[];
   baseRef?: string;
   expiresHours?: number;
   keyFile?: string;
@@ -220,6 +222,7 @@ interface CertifyArgs {
 function parseCertifyArgs(argv: string[]): CertifyArgs {
   const value = new Map<string, string>();
   const flags = new Set<string>();
+  const matrixArgs: string[] = [];
   const valueFlags = new Set([
     "--tier",
     "--reviewer-id",
@@ -241,6 +244,17 @@ function parseCertifyArgs(argv: string[]): CertifyArgs {
     const arg = argv[index];
     if (arg === "--skip-matrix") {
       flags.add(arg);
+      continue;
+    }
+    if (arg === "--matrix-arg") {
+      const next = argv[index + 1];
+      if (next === undefined) {
+        throw new EvidenceError(`${arg} requires a value`, {
+          code: "CLI_USAGE",
+        });
+      }
+      matrixArgs.push(next);
+      index += 1;
       continue;
     }
     if (valueFlags.has(arg)) {
@@ -326,6 +340,7 @@ function parseCertifyArgs(argv: string[]): CertifyArgs {
     requirementsPath: value.get("--requirements"),
     existingBundleDir: value.get("--bundle"),
     skipMatrix: flags.has("--skip-matrix"),
+    matrixArgs,
     baseRef: value.get("--base-ref"),
     expiresHours,
     keyFile: value.get("--key-file"),
@@ -375,6 +390,7 @@ async function runCertify(argv: string[], io: CliIo): Promise<number> {
         }
       : {}),
     skipMatrix: args.skipMatrix,
+    matrixArgs: args.matrixArgs,
     ...(reviewerVerdicts !== undefined ? { reviewerVerdicts } : {}),
     ...(requirements !== undefined ? { requirements } : {}),
     ...(args.existingBundleDir !== undefined


### PR DESCRIPTION
The diagnostic certification run (31062965483 — first with the always-uploaded bundle from #17799) recorded the full matrix failure log. Three failure classes, three fixes, one of which is a **real security-hygiene gap from the SSO merge**:

## 1. `auth/bridge` was an unlisted `public: true` route

`public-route-allowlist.test.ts` failed because #17788's bridge page sets `public: true` without an allowlist entry. The SSO PR's own CI could not catch this — `packages/agent` sat outside its changed-set `--min-tasks` floor, so the guard suite never ran. Enumerated now with the honest rationale: the bridge leg must render pre-auth to carry the one-time code, and every privileged step happens server-side behind Origin, referrer, and PKCE checks.

## 2. Plugin dists absent on a clean runner

`inbox-thread-mute.test.ts` (and two siblings) died on `Failed to resolve entry for package "@elizaos/plugin-meetings"` — the cert workflow installed with `--ignore-scripts` and never built the dependency graph. The develop-pr lane documents this exact hazard in its own comment: *"builds the core dependency graph and view bundles before invoking package-owned test scripts... prevents a clean hosted runner from failing on absent generated artifacts."* The workflow now installs like CI and runs `build:core` + `build:views` first.

## 3. The matrix ran bare where every green gate runs a recipe

Every proven-green gate invokes `run-all-tests.mjs --only=test --no-cloud --concurrency=3`; the certifier hardcoded a bare spawn. New repeatable `--matrix-arg` certify flag (threaded through `CertifyOptions.matrixArgs` to the runner), and the recorded lane command now includes the argv — the certification states exactly what was run. Cloud suites remain covered per-PR by the required Cloud Tests workflow.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:e921967f67fb8c46d834e40c7305e42e826e076f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow, test-allowlist, and evidence-package change; no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing user-visible renders differently; auth/bridge itself is unchanged.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - tooling change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the three failure classes from the diagnostic bundle's lanes/matrix/log.

<details><summary>Diagnostic run 31062965483 - lanes/matrix/log excerpts</summary>

```text
FAIL src/api/__tests__/public-route-allowlist.test.ts
  AssertionError: Unlisted public:true route(s) found. ...
  + "auth/bridge  [packages/ui/src/cloud/public-pages/register.ts]"

FAIL src/api/__tests__/inbox-thread-mute.test.ts
  Error: route error: failed to load inbox chats: Failed to resolve entry
  for package "@elizaos/plugin-meetings". The package may have incorrect
  main/module/exports specified in its package.json.

FAIL src/api/dispatch-route-stdio-envelope.test.ts   (same resolution class)

[agent-test] 369/369, 9 batch(es) failed
[eliza-test] FAIL @elizaos/agent (packages/agent)#test
Error: @elizaos/agent (packages/agent)#test failed with exit code 1
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the certification chain.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - test-lane wiring and an allowlist entry; no model inference is part of this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - the guard suite green at this head plus the evidence-package suites covering the new flag.

<details><summary>Test results at e921967f67fb8c46d834e40c7305e42e826e076f</summary>

```text
$ bunx vitest run src/api/__tests__/public-route-allowlist.test.ts   (packages/agent)
  Test Files  1 passed (1)
       Tests  6 passed (6)   (was 5 pass / 1 fail before the allowlist entry)

$ bunx vitest run src/certify/orchestrate.test.ts src/certify/cli.test.ts   (packages/evidence)
  Test Files  2 passed (2)
       Tests  22 passed (22)  (includes the two new matrixArgs forwarding tests)

$ bunx tsc --noEmit   (packages/evidence)   exit 0
$ bunx biome check    (3 changed source files)   clean
$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/certification-hosted.yml'))"   parses
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
