### PR TITLE
test(app): realign live settings round trips

### DIFF
--- a/packages/app/test/ui-smoke/provider-config.spec.ts
+++ b/packages/app/test/ui-smoke/provider-config.spec.ts
@@ -1,17 +1,14 @@
 // Provider-switch round-trip against the REAL live stack.
 //
-// Settings → Providers (the `ai-model` section) lists every AI provider as a
-// selectable card. Selecting a non-active provider surfaces its API-key panel
-// with a "Use provider" button that calls client.switchProvider() →
-// POST /api/provider/switch, which the real app-core runtime services by
-// persisting the provider config and restarting the agent. The keyless stub does
-// not actually restart or re-derive the active provider, so the "active provider
-// moved" read-back only holds against the real runtime (ELIZA_UI_SMOKE_LIVE_STACK=1).
-// Classified LIVE_ONLY. It NEVER stubs the route under test — POST
-// /api/provider/switch hits the real backend.
+// Settings → Models & Providers (the `ai-model` section) exposes connected
+// direct-provider accounts with a primary "Use for chat" action. That action
+// calls client.switchProvider() → POST /api/provider/switch, which the real
+// app-core runtime services. Classified LIVE_ONLY. It NEVER stubs the route
+// under test — POST /api/provider/switch hits the real backend.
 //
-// Flow: open Providers → pick the first non-active provider card → "Use provider"
-// → assert the real POST /api/provider/switch fired carrying that provider id.
+// Flow: open Models & Providers → click the first enabled "Use for chat"
+// account action → assert the real POST /api/provider/switch fired with a
+// concrete provider id.
 
 import { expect, type Page, test } from "@playwright/test";
 import { openAppPath, openSettingsSection, seedAppStorage } from "./helpers";
@@ -55,44 +52,19 @@ test.describe("provider config deep round-trip", () => {
     const switches = captureProviderSwitches(page);
 
     await openAppPath(page, "/settings");
-    await openSettingsSection(page, /Providers/);
+    await openSettingsSection(page, /Models & Providers/);
     await expect(page.locator("#ai-model")).toBeVisible({ timeout: 30_000 });
 
-    // Provider cards are buttons labelled "<Provider>, <state>". The active one
-    // reads "<Provider>, Active". Wait for the grid, then resolve a concrete
-    // non-active card by reading aria-labels directly: any card whose label does
-    // not end in ", Active" is a switch target.
-    await expect(
-      page.locator("#ai-model button[aria-label]").first(),
-    ).toBeVisible({ timeout: 15_000 });
-    const labels = await page
-      .locator("#ai-model button[aria-label]")
-      .evaluateAll((els) =>
-        (els as HTMLButtonElement[]).map(
-          (el) => el.getAttribute("aria-label") ?? "",
-        ),
-      );
-    const targetLabel = labels.find(
-      (label) => label.length > 0 && !/,\s*Active$/.test(label),
-    );
-    expect(
-      targetLabel,
-      "Providers section must offer a non-active provider to switch to",
-    ).toBeTruthy();
-
-    await page
+    // Connected direct-provider rows expose this as their primary routing
+    // action. The active provider instead renders a disabled "Chat" button, so
+    // the first enabled match is necessarily a real switch target.
+    const useForChat = page
       .locator("#ai-model")
-      .getByRole("button", { name: targetLabel as string })
-      .first()
-      .click();
-
-    // The selected provider's API-key panel exposes the "Use provider" switch.
-    const useProvider = page
-      .locator("#ai-model")
-      .getByRole("button", { name: /Use provider/i })
+      .getByRole("button", { name: /^Use for chat$/i })
       .first();
-    await expect(useProvider).toBeVisible({ timeout: 15_000 });
-    await useProvider.click();
+    await expect(useForChat).toBeVisible({ timeout: 15_000 });
+    await expect(useForChat).toBeEnabled();
+    await useForChat.click();
 
     // Real POST /api/provider/switch carrying a concrete provider id — the
     // load-bearing contract, independent of whether the restart later succeeds
@@ -105,12 +77,7 @@ test.describe("provider config deep round-trip", () => {
       ),
     ).toBe(true);
 
-    // The clicked card is now the selected panel (aria-current="true").
-    await expect(
-      page
-        .locator("#ai-model")
-        .getByRole("button", { name: targetLabel as string })
-        .first(),
-    ).toHaveAttribute("aria-current", "true", { timeout: 10_000 });
+    // The clicked account action becomes the active, disabled "Chat" state.
+    await expect(useForChat).toHaveCount(0, { timeout: 10_000 });
   });
 });

--- a/packages/app/test/ui-smoke/settings-sections-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/settings-sections-interactions.spec.ts
@@ -1,7 +1,7 @@
 // Real interaction coverage for the Settings sections + character editor.
 // all-pages-clicksafe only render-smokes settings; this drives the actual
 // controls (voice wake-word toggle, appearance theme, capability switch, app-
-// permission refresh, backup modal, character bio save) and asserts they
+// permission refresh, backup modal, character bio autosave) and asserts they
 // DO something. Keyless against the stub.
 
 import { expect, type Page, test } from "@playwright/test";
@@ -164,14 +164,12 @@ test("backup settings: Back Up opens its modal", async ({ page }) => {
   await expect(page.getByRole("dialog")).toBeVisible({ timeout: 10_000 });
 });
 
-// Deep character round-trip against the REAL backend. The previous keyless
-// version stubbed PUT /api/character via page.route so Save resolved — a LARP
-// that proved the button fired a request but never that the edit persisted (the
-// stub's GET /api/character returns a static character, so a reload would not
-// reflect the new bio). This rewrite removes the stub entirely and does the real
-// write→reload→read-back: it hits the live app-core runtime, which persists the
-// character to the runtime + DB, so the reloaded editor shows the saved bio.
-// LIVE_ONLY: the keyless stub cannot persist a character edit.
+// Deep character round-trip against the REAL backend. Personality now renders
+// inline and autosaves after a 700 ms debounce; there is no open step or manual
+// Save button. The shared client and app-core route currently use PUT for the
+// partial character edit. This test observes a successful real response and
+// proves write→reload→read-back persistence. LIVE_ONLY: the keyless stub cannot
+// persist a character edit.
 test.describe("character editor deep round-trip", () => {
   test.skip(
     !LIVE_STACK,
@@ -183,10 +181,12 @@ test.describe("character editor deep round-trip", () => {
     page,
   }) => {
     let characterSaves = 0;
-    page.on("request", (req) => {
+    page.on("response", (res) => {
+      const req = res.request();
       if (
         req.method() === "PUT" &&
-        /\/api\/character(?:\?|$)/.test(req.url())
+        /\/api\/character(?:\?|$)/.test(req.url()) &&
+        res.ok()
       ) {
         characterSaves += 1;
       }
@@ -198,23 +198,16 @@ test.describe("character editor deep round-trip", () => {
     await expect(page.getByTestId("character-editor-view")).toBeVisible({
       timeout: 60_000,
     });
-    await page
-      .getByRole("button", { name: /Open Personality/i })
-      .first()
-      .click();
 
     const bio = page
-      .getByRole("textbox", { name: /About Me/i })
+      .locator('[data-agent-id="identity-bio"]')
       .or(page.getByPlaceholder(/Describe who your agent is/i))
       .first();
     await expect(bio).toBeVisible({ timeout: 15_000 });
     await bio.fill(uniqueBio);
 
-    const save = page.getByRole("button", { name: /^Save$/ }).first();
-    await expect(save).toBeEnabled({ timeout: 10_000 });
-    await save.click();
-
-    // Real PUT /api/character — the backend handler runs and persists.
+    // Real debounced PUT /api/character → 2xx — the backend handler runs and
+    // persists before the read-back navigation begins.
     await expect.poll(() => characterSaves).toBeGreaterThan(0);
 
     // Read-back: reload the character editor and confirm the saved bio survives
@@ -223,12 +216,8 @@ test.describe("character editor deep round-trip", () => {
     await expect(page.getByTestId("character-editor-view")).toBeVisible({
       timeout: 60_000,
     });
-    await page
-      .getByRole("button", { name: /Open Personality/i })
-      .first()
-      .click();
     const reloadedBio = page
-      .getByRole("textbox", { name: /About Me/i })
+      .locator('[data-agent-id="identity-bio"]')
       .or(page.getByPlaceholder(/Describe who your agent is/i))
       .first();
     await expect(reloadedBio).toBeVisible({ timeout: 15_000 });

--- a/packages/app/test/ui-smoke/vault-modal-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/vault-modal-interactions.spec.ts
@@ -13,7 +13,7 @@
 // keeps the run isolated and the trailing delete cleans up the created secret.
 
 import { expect, type Page, test } from "@playwright/test";
-import { openAppPath, seedAppStorage } from "./helpers";
+import { openAppPath, openSettingsSection, seedAppStorage } from "./helpers";
 
 const LIVE_STACK = process.env.ELIZA_UI_SMOKE_LIVE_STACK === "1";
 
@@ -34,9 +34,8 @@ function countSecretWrites(page: Page): () => number {
 
 async function openVaultModal(page: Page): Promise<void> {
   await openAppPath(page, "/settings");
-  await page.locator("body").click({ position: { x: 4, y: 4 } });
-  // Global chord opens the secrets-manager modal (useSecretsManagerShortcut).
-  await page.keyboard.press("Control+Alt+Shift+V");
+  await openSettingsSection(page, /^Vault$/);
+  await page.locator('[data-agent-id="secrets-manage"]').click();
   await expect(page.getByTestId("vault-tab-overview")).toBeVisible({
     timeout: 20_000,
   });
@@ -82,7 +81,7 @@ test.describe("vault modal deep secret round-trip", () => {
     }
 
     // Add the secret through the real form.
-    await page.getByTestId("vault-add-secret").click();
+    await page.locator('[data-agent-id="vault-add-secret"]').click();
     const form = page.getByTestId("vault-add-secret-form");
     await expect(form).toBeVisible({ timeout: 10_000 });
     await form

--- a/packages/app/test/ui-smoke/vault-routing.spec.ts
+++ b/packages/app/test/ui-smoke/vault-routing.spec.ts
@@ -14,7 +14,7 @@
 // deletes the rule and the seeded key so the live vault is left clean.
 
 import { expect, type Page, test } from "@playwright/test";
-import { openAppPath, seedAppStorage } from "./helpers";
+import { openAppPath, openSettingsSection, seedAppStorage } from "./helpers";
 
 const LIVE_STACK = process.env.ELIZA_UI_SMOKE_LIVE_STACK === "1";
 
@@ -39,8 +39,8 @@ function countRoutingWrites(page: Page): () => number {
 
 async function openVaultModal(page: Page): Promise<void> {
   await openAppPath(page, "/settings");
-  await page.locator("body").click({ position: { x: 4, y: 4 } });
-  await page.keyboard.press("Control+Alt+Shift+V");
+  await openSettingsSection(page, /^Vault$/);
+  await page.locator('[data-agent-id="secrets-manage"]').click();
   await expect(page.getByTestId("vault-tab-overview")).toBeVisible({
     timeout: 20_000,
   });
@@ -99,7 +99,7 @@ test.describe("vault routing deep round-trip", () => {
 
     // Seed a key, then enable profiles + add a non-default profile so the rule
     // form has a profile to bind to.
-    await page.getByTestId("vault-add-secret").click();
+    await page.locator('[data-agent-id="vault-add-secret"]').click();
     const addForm = page.getByTestId("vault-add-secret-form");
     await expect(addForm).toBeVisible({ timeout: 10_000 });
     await addForm
@@ -141,7 +141,7 @@ test.describe("vault routing deep round-trip", () => {
 
     // Routing tab → add a rule scoped to an agent, bound to the `work` profile.
     await gotoRoutingTab(page);
-    await page.getByRole("button", { name: /Add rule/i }).click();
+    await page.locator('[data-agent-id="routing-add-rule-toggle"]').click();
     const ruleForm = page.getByTestId("routing-add-rule-form");
     await expect(ruleForm).toBeVisible({ timeout: 10_000 });
 
@@ -175,7 +175,7 @@ test.describe("vault routing deep round-trip", () => {
       await page.getByRole("option").last().click();
     }
 
-    await ruleForm.getByRole("button", { name: /Save rule/i }).click();
+    await ruleForm.locator('[data-agent-id="routing-rule-save"]').click();
 
     // Real PUT /api/secrets/routing → 200, and the saved config comes back so the
     // rules table renders the new row.

--- a/packages/app/test/ui-smoke/wallet-keys.spec.ts
+++ b/packages/app/test/ui-smoke/wallet-keys.spec.ts
@@ -69,7 +69,7 @@ test.describe("wallet keys deep round-trip", () => {
     await form
       .locator('[data-agent-id="wallet-keys-private-key"]')
       .fill(WALLET_VALUE);
-    await form.getByTestId("wallet-keys-save").click();
+    await form.locator('[data-agent-id="wallet-keys-save"]').click();
 
     // Real PUT /api/secrets/inventory/E2E_WALLET_KEY (category=wallet) → 200, then
     // the section reloads its wallet inventory and the row shows up.
@@ -80,11 +80,7 @@ test.describe("wallet keys deep round-trip", () => {
     // Reveal goes through the real GET /api/secrets/inventory/:key and surfaces
     // the masked value (12+ char keys render as a 6…4 mask) in the row.
     await revealButton.click();
-    const row = page
-      .getByTestId("wallet-keys-list")
-      .locator("li")
-      .filter({ has: page.getByTestId(`wallet-keys-reveal-${WALLET_KEY}`) });
-    await expect(row).toContainText(
+    await expect(section).toContainText(
       `${WALLET_VALUE.slice(0, 6)}…${WALLET_VALUE.slice(-4)}`,
       { timeout: 10_000 },
     );


### PR DESCRIPTION
# Relates to

Closes #16211

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`14622a4ad5f79909b360cd1d3bdd1a195768e8f7`).
- [x] `bun install` and `bun run verify` passed after sync on Node 24.15.0 and Bun 1.3.14.
- [x] A reviewer can confirm the deterministic changed flows from the exact-head real-backend results and traces below.
- [ ] The credentialed provider account case still requires the upstream App Live lane; no mock or synthetic success was substituted.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex CLI 0.146.0`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync (`VERIFY_EXIT=0`).

# Risks

Low. The diff changes five App Live test specs only. It does not alter rendered UI, backend routes, persistence semantics, timeouts, or skip conditions. Risk is limited to selector and interaction drift in the live test lane.

# Background

## What does this PR do?

Realigns the five live settings/vault round trips with the current UI:

- provider activation now drives the connected-account `Use for chat` action and still asserts a real `POST /api/provider/switch`;
- Character Personality is edited inline and the debounced real `PUT /api/character` must return 2xx and survive reload;
- Vault opens through its visible Settings launcher, and Vault/Wallet controls use their accessible `data-agent-id` contracts;
- routing and wallet assertions target the current semantic structure while retaining real write/read/delete persistence and cleanup.

The maintainer triage described Character autosave as PATCH, but current `client-agent.ts`, `character-routes.ts`, iOS kernel, and route contract all use PUT. This PR follows the audited wire contract and still requires the debounced successful response plus reload read-back.

## What kind of change is this?

Bug fix to live E2E coverage. No product code changes.

# Documentation changes needed?

No project documentation change is required; this is test-only contract maintenance.

# Testing

## Where should a reviewer start?

`packages/app/test/ui-smoke/provider-config.spec.ts` and the four other changed specs in the same directory.

## Detailed testing steps

1. Use Node 24.15.0 and Bun 1.3.14.
2. Run the four deterministic real-local specs with `ELIZA_UI_SMOKE_LIVE_STACK=1 ELIZA_UI_SMOKE_REAL_LOCAL_STACK=1 PGLITE_WASM_MODE=node`.
3. Confirm 10/10 tests pass, including Character reload persistence and Vault/Wallet cleanup.
4. Run the exact five-spec App Live command in `.github/workflows/app-live-e2e.yml` with repository provider secrets, then inspect the uploaded trace and client/server logs.

Local evidence:

- fails-before on untouched `35feb8791a3f22cea390fbd60fa852e8a862f872`: 5 failed, 6 passed with the issue's five exact signatures;
- exact rebased head `d517fec454f5beb08741cb97443627cb111efe55`: 10 passed, 0 skipped, 0 unexpected, 0 flaky in 75.766s for settings/character/vault/routing/wallet;
- `bun run verify`: passed with exit 0.

# Evidence Gate

<!-- evidence-head:d517fec454f5beb08741cb97443627cb111efe55 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only TypeScript spec diff; no rendered UI source changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only TypeScript spec diff; no rendered UI source changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI behavior changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - exact-head log is linked below, but fork release files are outside the canonical evidence-upload allowlist.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - exact-head result is linked below, but fork release files are outside the canonical evidence-upload allowlist.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic UI persistence tests do not invoke an LLM.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact-head traces are linked below, but fork release archives are outside the canonical evidence-upload allowlist.
<!-- evidence-row:ocr-review -->
- [ ] N/A - screenshots are trace diagnostics, not changed UI.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

Exact-head local evidence:

- [Verification summary](https://github.com/ryan-foo/eliza/releases/download/issue-16211-evidence-dfb7a183/verification-summary.txt)
- [Backend log](https://github.com/ryan-foo/eliza/releases/download/issue-16211-evidence-dfb7a183/backend.log)
- [Playwright JSON results](https://github.com/ryan-foo/eliza/releases/download/issue-16211-evidence-dfb7a183/results.json)
- [Four deep-flow Playwright traces](https://github.com/ryan-foo/eliza/releases/download/issue-16211-evidence-dfb7a183/deep-round-trip-traces.tar.gz)

Exact-head App Live attempt [31151177915](https://github.com/elizaOS/eliza/actions/runs/31151177915) failed during live-stack web-server startup with `TypeError: fetch failed`, before Playwright or any changed spec executed. Retry [31153132994](https://github.com/elizaOS/eliza/actions/runs/31153132994) remained self-hosted-runner constrained and was cancelled after all required checks passed and the PR merged; no synthetic provider success was substituted.

## Screenshots (before / after) + video walkthrough

N/A - no rendered source changed.

## Audio / voice walkthrough

N/A - no voice code changed.

## Known gaps / failures

- The deterministic real-local helper cannot validate the provider account action: `GET /api/accounts` returns 500 because its account-pool singleton is uninitialized. No route mock or fake provider account was added. The credentialed App Live lane is the authoritative proof.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex CLI 0.146.0
Contribution skill revision: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex/ryan-foo-16211]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex CLI 0.146.0","skill_revision":"elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza"} -->
