### PR TITLE
fix(ci): repair develop push regressions

### DIFF
--- a/.github/workflows/certification-image.yml
+++ b/.github/workflows/certification-image.yml
@@ -37,7 +37,7 @@ jobs:
     # Same fleet fallback as build-agent-image: hetzner when online (the
     # image is ~15 GB with baked models and CUDA layers; hosted runners need
     # the disk-free step below to survive it).
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 180
     permissions:
       contents: read

--- a/packages/app/e2e/accounts-ui/tsconfig.e2e-paths.json
+++ b/packages/app/e2e/accounts-ui/tsconfig.e2e-paths.json
@@ -10,7 +10,9 @@
     "since #14459): otherwise it resolves to the package's `dist/index.js`, which does",
     "not exist on the CI --ignore-scripts install, and the API server crashes at boot.",
     "Core subpath exports need their own mapping because the exact root path does not",
-    "cover imports such as @elizaos/core/atomic-json."
+    "cover imports such as @elizaos/core/atomic-json. Core and auth also reach logger",
+    "and vault source during this clean-install lane, so neither may fall through to",
+    "an absent dist build."
   ],
   "compilerOptions": {
     "baseUrl": "../../../..",
@@ -22,8 +24,11 @@
       "@elizaos/core/atomic-json": ["packages/core/src/utils/atomic-json.ts"],
       "@elizaos/cloud-routing": ["packages/cloud/routing/src/index.ts"],
       "@elizaos/cloud-routing/*": ["packages/cloud/routing/src/*"],
+      "@elizaos/logger": ["packages/logger/src/index.ts"],
       "@elizaos/shared": ["packages/shared/src/index.ts"],
-      "@elizaos/shared/*": ["packages/shared/src/*"]
+      "@elizaos/shared/*": ["packages/shared/src/*"],
+      "@elizaos/vault": ["packages/vault/src/index.ts"],
+      "@elizaos/vault/*": ["packages/vault/src/*"]
     }
   }
 }

--- a/packages/cloud/api/__tests__/generative-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/generative-cache-hotpath.test.ts
@@ -74,6 +74,7 @@ describe("canonical generative cache-only hot path", () => {
     ).text();
     expect(source.match(/resolveInferenceAuthContext\(/g)).toHaveLength(1);
     expect(source).toContain("cacheOnly: Boolean(executionCtx)");
+    expect(source).toContain("cacheOnly: Boolean(resolution.ctx.admission)");
     expect(source).toContain("inferenceRateLimitConfig(");
   });
 });

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -174,6 +174,61 @@ app.post("/", async (c) => {
   const id = c.req.param("id");
   if (!id) return c.json({ error: "Missing id" }, 400);
 
+  const executionCtx = getGenerativeExecutionContext(c);
+  const characterResolution = executionCtx
+    ? await charactersService.getByIdCacheOnly(id, { executionCtx })
+    : {
+        kind: "ready" as const,
+        character: (await charactersService.getById(id)) ?? null,
+      };
+  if (characterResolution.kind !== "ready") {
+    // A cache-only miss cannot distinguish a real agent from an unknown id.
+    // Confirm only the negative case authoritatively; an existing cold agent
+    // still gets the retryable response and never joins Postgres to dispatch.
+    if (!(await charactersService.getById(id))) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: { code: -32001, message: "Agent not found" },
+          id: null,
+        },
+        404,
+      );
+    }
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32004,
+          message: "Agent cache is warming; retry shortly",
+        },
+        id: null,
+      },
+      503,
+    );
+  }
+  const character = characterResolution.character;
+  if (!character) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Agent not found" },
+        id: null,
+      },
+      404,
+    );
+  }
+  if (!character.is_public || !character.a2a_enabled) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Agent not accessible" },
+        id: null,
+      },
+      403,
+    );
+  }
+
   let body: unknown;
   try {
     body = await c.req.json();
@@ -202,48 +257,6 @@ app.post("/", async (c) => {
   }
 
   const { method, params, id: rpcId } = validation.data;
-
-  const executionCtx = getGenerativeExecutionContext(c);
-  const characterResolution = executionCtx
-    ? await charactersService.getByIdCacheOnly(id, { executionCtx })
-    : {
-        kind: "ready" as const,
-        character: (await charactersService.getById(id)) ?? null,
-      };
-  if (characterResolution.kind !== "ready") {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: {
-          code: -32004,
-          message: "Agent cache is warming; retry shortly",
-        },
-        id: rpcId,
-      },
-      503,
-    );
-  }
-  const character = characterResolution.character;
-  if (!character) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32001, message: "Agent not found" },
-        id: rpcId,
-      },
-      404,
-    );
-  }
-  if (!character.is_public || !character.a2a_enabled) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32001, message: "Agent not accessible" },
-        id: rpcId,
-      },
-      403,
-    );
-  }
 
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {

--- a/packages/cloud/api/agents/[id]/mcp/route.ts
+++ b/packages/cloud/api/agents/[id]/mcp/route.ts
@@ -148,6 +148,60 @@ app.post("/", async (c) => {
   const id = c.req.param("id");
   if (!id) return c.json({ error: "Missing id" }, 400);
 
+  const executionCtx = getGenerativeExecutionContext(c);
+  const characterResolution = executionCtx
+    ? await charactersService.getByIdCacheOnly(id, { executionCtx })
+    : {
+        kind: "ready" as const,
+        character: (await charactersService.getById(id)) ?? null,
+      };
+  if (characterResolution.kind !== "ready") {
+    // Confirm only the negative cold-cache case. Existing agents remain
+    // fail-closed until their cached character is ready for inference.
+    if (!(await charactersService.getById(id))) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: { code: -32001, message: "Agent not found" },
+          id: null,
+        },
+        404,
+      );
+    }
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32004,
+          message: "Agent cache is warming; retry shortly",
+        },
+        id: null,
+      },
+      503,
+    );
+  }
+  const character = characterResolution.character;
+  if (!character) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Agent not found" },
+        id: null,
+      },
+      404,
+    );
+  }
+  if (!character.is_public || !character.mcp_enabled) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "MCP not accessible" },
+        id: null,
+      },
+      403,
+    );
+  }
+
   let body: unknown;
   try {
     body = await c.req.json();
@@ -175,48 +229,6 @@ app.post("/", async (c) => {
   }
 
   const { method, params, id: rpcId } = validation.data;
-
-  const executionCtx = getGenerativeExecutionContext(c);
-  const characterResolution = executionCtx
-    ? await charactersService.getByIdCacheOnly(id, { executionCtx })
-    : {
-        kind: "ready" as const,
-        character: (await charactersService.getById(id)) ?? null,
-      };
-  if (characterResolution.kind !== "ready") {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: {
-          code: -32004,
-          message: "Agent cache is warming; retry shortly",
-        },
-        id: rpcId,
-      },
-      503,
-    );
-  }
-  const character = characterResolution.character;
-  if (!character) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32001, message: "Agent not found" },
-        id: rpcId,
-      },
-      404,
-    );
-  }
-  if (!character.is_public || !character.mcp_enabled) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32001, message: "MCP not accessible" },
-        id: rpcId,
-      },
-      403,
-    );
-  }
 
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -209,7 +209,11 @@ export async function requireGenerativeRouteCaller(
         resolution.ctx.orgId,
         options.rateLimitEndpoint,
         {
-          cacheOnly: true,
+          // The combined decision carries the rate policy only when the hot
+          // cache is enabled. Development and integration Workers still have
+          // an execution context, but their authoritative origin decision has
+          // no snapshot and must retain the compatibility limiter path.
+          cacheOnly: Boolean(resolution.ctx.admission),
           executionCtx,
           config: inferenceRateLimitConfig(
             resolution.ctx.admission,


### PR DESCRIPTION
# Relates to

Closes #17806.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the changed contracts from the commands and evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@4fa232298f68fccdd9628a5ef24ae762e57fc1b8:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. The cloud change preserves cache-only production admission when a combined snapshot exists, while restoring the established compatibility limiter only when that snapshot is absent. Unknown-agent confirmation adds one authoritative lookup only on a cache miss; existing cold agents remain fail-closed.

# Background

## What does this PR do?

- Makes the certification-image runner selector fail safely to GitHub-hosted runners unless `HETZNER_FLEET_ONLINE` is exactly `true`.
- Pins logger and vault source in the clean-install accounts UI e2e resolver.
- Resolves A2A/MCP agent existence before parsing JSON-RPC input, confirming true cache-miss negatives as `404` while retaining `503` for existing cold agents.
- Uses cache-only organization rate limiting only when the combined auth decision actually carries an admission snapshot.
- Adds a hot-path source contract for that admission guard.

## What kind of change is this?

Bug fixes (non-breaking changes which repair four develop CI regressions).

# Documentation changes needed?

No project documentation change is required; the affected behavior is already specified by workflow and integration contracts.

# Testing

## Where should a reviewer start?

Review the four linked failures in #17806, then the runner selector, accounts e2e path map, generative auth helper, and A2A/MCP route ordering.

## Detailed testing steps

- `bun test --coverage-reporter lcov packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts packages/cloud/api/__tests__/generative-cache-hotpath.test.ts packages/cloud/api/__tests__/agent-a2a-billing.test.ts packages/cloud/api/__tests__/agent-mcp-billing.test.ts` — 54 pass, 0 fail.
- `bun run --cwd packages/app test:e2e:accounts-ui` — all assertions pass; 15 desktop/mobile captures; zero page errors.
- `E2E_ONLY=group-c-agents,group-d-ai-media bun run --cwd packages/cloud/api test:e2e` — both real Worker/PGlite groups pass, including all 12 previously failing status contracts.
- `bun run --cwd packages/cloud/api lint:check` — pass.
- `bun run --cwd packages/cloud/api typecheck` — pass, including production Worker dry-run.
- `bun run verify` with Node 24.15.0 and Bun 1.3.14 — 342 workspace tasks and all repository audits pass.

# Evidence Gate

<!-- evidence-head:bc88daea13bdacb1b038b9100cb09fd52c5b293d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes; the accounts edit is an e2e-only source-resolution map.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes; the accounts e2e produced and reviewed 15 unchanged-state captures.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow or pixels changed.
<!-- evidence-row:backend-logs -->
- [x] [17807-cloud-worker-pglite.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17807-cloud-worker-pglite.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime code changed; accounts e2e reports zero page errors.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, model, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain data, schema, scheduled item, wallet, or generated media changes.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed.

# Evidence Details

## Backend + frontend logs

The backend evidence is the real local Workerd/PGlite run for `group-c-agents` and `group-d-ai-media`; its log is attached in the evidence row. The accounts UI e2e completed its full browser flow with 15 captures and `PASS zero page errors across the whole flow`.

## Known gaps / failures

- The optional 971 MiB local-model artifact bundle was skipped with the repository-supported `ELIZA_SKIP_ARTIFACT_SYNC=1` install path; these CI, browser fixture, and cloud Worker tests do not consume that bundle.
- Provider-backed live A2A/MCP receipt and Responses tests remained skipped because no external model API keys were supplied; none of the fixes changes provider inference behavior.

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@4fa232298f68fccdd9628a5ef24ae762e57fc1b8:packages/skills/skills/contribute-to-eliza"} -->

