### PR TITLE
fix(ci): seed accounts e2e vault on hosted Linux

### DIFF
--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -688,6 +688,11 @@ jobs:
         run: bunx playwright install --with-deps chromium
 
       - name: Accounts UI browser e2e — real AccountList + real accounts routes + real AccountPool
+        env:
+          # The fixture writes encrypted credentials to a scratch ELIZA_HOME.
+          # Hosted Linux has no keychain session, so give this isolated test
+          # process a non-production passphrase instead of weakening the vault.
+          ELIZA_VAULT_PASSPHRASE: accounts-ui-e2e-headless-only
         run: bun run --cwd packages/app test:e2e:accounts-ui
 
       - name: Upload accounts-ui evidence artifacts


### PR DESCRIPTION
# Relates to

Follow-up to #17806, #17807, and #17808.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun run verify` was run after sync.
- [x] The exact hosted-Linux failure path was reproduced and passed locally with the same vault environment.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@b2e1dc6977e4efe2542ac34e15c47b794de28be8:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. The non-production passphrase is scoped to one browser fixture step and its scratch `ELIZA_HOME`. Production vault behavior and all other jobs remain fail-closed.

# Background

## What does this PR do?

Supplies the Accounts UI e2e process with a test-only vault passphrase on hosted Linux. The earlier source-resolution fix allowed the real encrypted credential path to execute, revealing that GitHub hosted runners correctly have no usable OS keychain session.

## What kind of change is this?

CI test-environment bug fix.

# Documentation changes needed?

No. The vault already documents `ELIZA_VAULT_PASSPHRASE` as the headless-host mechanism.

# Testing

## Where should a reviewer start?

Inspect failed job 92519430552 in run 31071187411, then the single-step environment in `.github/workflows/scenario-pr.yml`.

## Detailed testing steps

- `ELIZA_VAULT_PASSPHRASE=accounts-ui-e2e-headless-only bun run --cwd packages/app test:e2e:accounts-ui` — all assertions pass; 15 captures; zero page errors; real encrypted disk writes verified.
- `bun run verify` with Node 24.15.0 and Bun 1.3.14 — 342 workspace tasks and all repository audits pass.
- `git diff --check` — pass.

# Evidence Gate

<!-- evidence-head:8b33ea53a18e2800cc8daa2b8e66b7aa7433fd9b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI code changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI code changed; the fixture produced 15 passing captures.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - the linked Actions job contains the headless vault failure log.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - the rerun reported zero page errors.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - only scratch test credentials are written and removed.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual surface changed.

# Evidence Details

## Known gaps / failures

None. The exact accounts browser fixture passed against the same passphrase configuration.

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@b2e1dc6977e4efe2542ac34e15c47b794de28be8:packages/skills/skills/contribute-to-eliza"} -->
