### PR TITLE
fix(test): forward accounts e2e vault environment

### DIFF
--- a/packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs
+++ b/packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs
@@ -187,6 +187,8 @@ const child = spawn(
       HOME: process.env.HOME,
       ELIZA_HOME: elizaHome,
       ELIZA_STATE_DIR: elizaHome,
+      ELIZA_VAULT_DISABLE_KEYCHAIN: process.env.ELIZA_VAULT_DISABLE_KEYCHAIN,
+      ELIZA_VAULT_PASSPHRASE: process.env.ELIZA_VAULT_PASSPHRASE,
       ACCOUNTS_E2E_PORT: process.env.ACCOUNTS_E2E_PORT || "34110",
       ACCOUNTS_E2E_FIXTURE_DIR: fixtureDir,
     },


### PR DESCRIPTION
# Relates to

Final follow-up to #17806 and #17809.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun run verify` and the app audit were run after sync.
- [x] The hosted failure was reproduced locally with keychain access explicitly disabled.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@02e903644fa129606a6383b841988f95c6bf8cf3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Two existing vault environment variables are forwarded only to the scratch Accounts e2e API child process. No production process, UI behavior, or vault policy changes.

# Background

## What does this PR do?

Forwards `ELIZA_VAULT_PASSPHRASE` and `ELIZA_VAULT_DISABLE_KEYCHAIN` through the Accounts e2e launcher minimal environment. #17809 correctly configured the GitHub step, but the launcher whitelist dropped the value before starting the real API server.

## What kind of change is this?

Test harness bug fix.

# Documentation changes needed?

No. The Accounts fixture and vault documentation already describe the real disk store and headless passphrase mechanism.

# Testing

## Where should a reviewer start?

Inspect failed job 92522117673 in run 31071952487, where the parent step displays the passphrase but the child reports it absent, then review the two forwarded variables.

## Detailed testing steps

- `ELIZA_VAULT_DISABLE_KEYCHAIN=1 ELIZA_VAULT_PASSPHRASE=accounts-ui-e2e-headless-only bun run --cwd packages/app test:e2e:accounts-ui` — all assertions pass; 15 captures; zero page errors; real encrypted disk writes verified.
- `bun run --cwd packages/app audit:app` — 214/214 captures pass; broken=0; needs-work=0; OCR broken=0.
- `bun run verify` with Node 24.15.0 and Bun 1.3.14 — 342 workspace tasks and all repository audits pass.
- `git diff --check` — pass.

# Evidence Gate

<!-- evidence-head:f966d328a244038f893a64c70dc60e7a551c1db9 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI code changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI code changed; app audit passed 214 captures.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - the linked Actions job is the failure artifact; the forced-headless rerun passed.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - fixture rerun reported zero page errors.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - only scratch test credentials are written and removed.
<!-- evidence-row:ocr-review -->
- [x] N/A - packaged OCR completed with zero broken views.

# Evidence Details

## Visual review

The mandatory app audit passed 214/214 desktop/mobile captures with zero broken or needs-work verdicts. Packaged OCR reviewed 212 views with zero broken verdicts.

## Known gaps / failures

None. The exact child-process environment boundary is covered by the forced keychain-disable rerun.

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@02e903644fa129606a6383b841988f95c6bf8cf3:packages/skills/skills/contribute-to-eliza"} -->
