### PR TITLE
fix(ci): certification runner capacity — robot pool option and 300-minute cap

### DIFF
--- a/.github/workflows/certification-hosted.yml
+++ b/.github/workflows/certification-hosted.yml
@@ -29,6 +29,12 @@ on:
         default: "full"
         type: choice
         options: [cpu, gpu, full]
+      runner:
+        description: "Runner pool: hosted (ubuntu-24.04) or the self-hosted hetzner-robot fleet"
+        required: false
+        default: "hosted"
+        type: choice
+        options: [hosted, robot]
 
 concurrency:
   group: certification-hosted
@@ -39,8 +45,13 @@ permissions:
 
 jobs:
   hosted-certification:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 150
+    # The full matrix at --concurrency=3 exceeds 150 minutes on a 4-vCPU
+    # hosted runner (run 31067341248 was killed by the cap mid-matrix). The
+    # hetzner-robot pool — installed for exactly this weight class (the
+    # certification-image builds) — finishes it in a fraction of the time;
+    # hosted stays the default so a missing fleet never strands a dispatch.
+    runs-on: ${{ inputs.runner == 'robot' && fromJSON('["self-hosted","hetzner-robot"]') || 'ubuntu-24.04' }}
+    timeout-minutes: 300
     steps:
       - name: Preflight secrets
         env:


### PR DESCRIPTION
Run 31067341248 got further than any certification attempt yet — scenario lane green, chain healthy, matrix executing — and was then **killed by `timeout-minutes: 150` mid-matrix**. Every failure class before it is fixed; the remaining problem is pure compute: the full `run-all-tests.mjs --only=test --no-cloud --concurrency=3` lane does not fit 150 minutes on a 4-vCPU hosted runner.

Two changes:
1. `timeout-minutes: 300` — room for the honest full run on hosted hardware.
2. A `runner` dispatch input (`hosted` default | `robot`) targeting the **idle self-hosted `hetzner-robot` pool**, which the org installed for exactly this weight class (the ~15 GB certification-image builds run there). Verified online and idle at time of writing. Hosted stays the default so a missing fleet never strands a dispatch.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:6bf22faeb1fc95db23d764366b377dc4c48058ce -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow change, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow yaml change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the timeout kill and the runner-pool state justifying the two changes.

<details><summary>Run 31067341248 + runner inventory</summary>

```text
run 31067341248 (develop 35feb8791a3, all prior failure classes fixed):
  Produce evidence — deterministic scenario lane   success
  Run certification (orchestrated certify)          failure (killed at cap)
  conclusion: cancelled  — timeout-minutes: 150 elapsed mid-matrix

$ gh api repos/elizaOS/eliza/actions/runners (excerpt)
  eliza-prod-robot-2-r1..r6  online  busy=false  labels=self-hosted,Linux,X64,hetzner-robot
  eliza-prod-robot-3-r1..    online  busy=false  labels=self-hosted,Linux,X64,hetzner-robot
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the certification chain.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - workflow capacity change; no model inference is part of this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - yaml validity and the exact two-line behavioral diff.

<details><summary>Diff + parse</summary>

```text
$ git diff HEAD~1 --stat
 .github/workflows/certification-hosted.yml | 16 ++++++++++++++--
 1 file changed, 14 insertions(+), 2 deletions(-)

runs-on:         inputs.runner == 'robot' -> ["self-hosted","hetzner-robot"], else ubuntu-24.04
timeout-minutes: 150 -> 300
+ runner dispatch input (hosted default | robot)

$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/certification-hosted.yml'));print('parses')"
parses
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
