### PR TITLE
fix(ci): gate the certification robot dispatch on HETZNER_FLEET_ONLINE — restores the develop verify gate

### DIFF
--- a/.github/workflows/certification-hosted.yml
+++ b/.github/workflows/certification-hosted.yml
@@ -30,7 +30,10 @@ on:
         type: choice
         options: [cpu, gpu, full]
       runner:
-        description: "Runner pool: hosted (ubuntu-24.04) or the self-hosted hetzner-robot fleet"
+        # Wording deliberately avoids the fleet label strings: the routing
+        # contract's collector flags any YAML scalar containing them, and this
+        # description is prose, not a route.
+        description: "Runner pool: hosted (ubuntu-24.04) or the self-hosted robot fleet"
         required: false
         default: "hosted"
         type: choice
@@ -47,10 +50,14 @@ jobs:
   hosted-certification:
     # The full matrix at --concurrency=3 exceeds 150 minutes on a 4-vCPU
     # hosted runner (run 31067341248 was killed by the cap mid-matrix). The
-    # hetzner-robot pool — installed for exactly this weight class (the
-    # certification-image builds) — finishes it in a fraction of the time;
-    # hosted stays the default so a missing fleet never strands a dispatch.
-    runs-on: ${{ inputs.runner == 'robot' && fromJSON('["self-hosted","hetzner-robot"]') || 'ubuntu-24.04' }}
+    # robot pool — installed for exactly this weight class (the
+    # certification-image builds) — finishes it in a fraction of the time.
+    # Routing composes the dispatch input WITH the HETZNER_FLEET_ONLINE gate
+    # (#17813): hosted is the default, and an explicit robot dispatch degrades
+    # to hosted when the fleet is offline instead of queuing against zero
+    # registered runners. This exact selector is allowlisted in
+    # packages/scripts/hetzner-fleet-routing-contract.mjs.
+    runs-on: ${{ fromJSON(inputs.runner != 'robot' && '["ubuntu-24.04"]' || vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 300
     steps:
       - name: Preflight secrets

--- a/packages/scripts/hetzner-fleet-routing-contract.mjs
+++ b/packages/scripts/hetzner-fleet-routing-contract.mjs
@@ -22,9 +22,17 @@ const PULL_REQUEST_HOSTED_SELECTOR =
 const JANITOR_ROBOT_SELECTOR =
   EXPRESSION_OPEN +
   ' vars.HETZNER_FLEET_ONLINE != \'true\' && \'["ubuntu-latest"]\' || vars.ACTIONS_JANITOR_ROBOT_LANE_DISABLED == \'true\' && \'["ubuntu-latest"]\' || vars.ACTIONS_JANITOR_ROBOT_RUNNER_JSON || \'["self-hosted","Linux","X64","hetzner-robot"]\' }}';
+// certification-hosted.yml only: a workflow_dispatch-only surface where the
+// operator may explicitly request the robot pool. The input NEVER overrides
+// the fleet gate — `robot` degrades to hosted whenever HETZNER_FLEET_ONLINE
+// is not exactly 'true', so an offline fleet can strand nothing (#17813).
+const CERTIFICATION_DISPATCH_SELECTOR =
+  EXPRESSION_OPEN +
+  " fromJSON(inputs.runner != 'robot' && '[\"ubuntu-24.04\"]' || vars.HETZNER_FLEET_ONLINE != 'true' && '[\"ubuntu-24.04\"]' || '[\"self-hosted\",\"hetzner-robot\"]') }}";
 const DIRECT_RUNNER_SELECTORS = new Set([
   CANONICAL_SELECTOR,
   PULL_REQUEST_HOSTED_SELECTOR,
+  CERTIFICATION_DISPATCH_SELECTOR,
 ]);
 const JANITOR_WORKFLOW = "actions-zombie-janitor.yml";
 const MATRIX_RUNNER_PATH =


### PR DESCRIPTION
# Relates to

Fixes #17813. Repairs the `develop` verify gate broken by #17812 (called out pre-merge in that PR's review); preserves #17812's capacity fix in full.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, branched from its current head `bc3be9cae` (the breaking commit itself); zero conflicts.
- [x] The single adjudicating command — `bun run audit:hetzner-fleet-routing` — proven red on `develop`'s tree and green on this head (both runs below).
- [x] Biome clean on the contract file; `git diff --check` clean.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@64942cd44461ecc24b3ca1421de74900906e9506:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `bc3be9cae`; zero conflicts.

# Risks

Low. Two files. The workflow change is routing-only on a `workflow_dispatch`-only surface: the `robot` choice now defers to `HETZNER_FLEET_ONLINE` exactly like every other fleet route in the repository, and `hosted` behavior is byte-identical. The contract change adds one allowlisted selector; the audit's own pass over all 78 workflows is the regression check for the other 157 selectors.

# Background

## What does this PR do?

#17812 routed `certification-hosted.yml` to the `hetzner-robot` pool on the dispatch input alone:

```yaml
runs-on: ${{ inputs.runner == 'robot' && fromJSON('["self-hosted","hetzner-robot"]') || 'ubuntu-24.04' }}
```

Two consequences:

1. **`bun run verify` is red on `develop` for everyone.** `audit:hetzner-fleet-routing` allowlists exact, `HETZNER_FLEET_ONLINE`-gated selectors and throws on anything else touching the fleet labels. The collector also flags the input's `description` scalar, which contained the literal label string.
2. **The behavioral gap the contract exists to prevent:** an operator dispatching `runner: robot` while the fleet is offline queues the run against zero registered runners indefinitely. #17812's "hosted stays the default" fail-safe covers only the default, not the explicit choice.

The fix composes the input **with** the gate, in the same shape as the contract's existing `PULL_REQUEST_HOSTED_SELECTOR`:

```yaml
runs-on: ${{ fromJSON(inputs.runner != 'robot' && '["ubuntu-24.04"]' || vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
```

Truth table: `hosted` (or anything non-`robot`) → `ubuntu-24.04` always; `robot` + fleet online → the pool; `robot` + fleet offline/missing/false → `ubuntu-24.04`, never a stranded queue. That exact string is added to `DIRECT_RUNNER_SELECTORS` with a comment naming the workflow, why a dispatch input is a safe discriminator there, and the degrade guarantee. The description is reworded so prose no longer carries collector trigger substrings, with an inline comment explaining that constraint for the next editor.

Kept from #17812, untouched: the `runner` input itself, `timeout-minutes: 300`, and the run-31067341248 rationale.

## What kind of change is this?

Bug fix (non-breaking): restores the repository verify gate and the fleet fail-safe.

# Documentation changes needed?

None; the constraint is documented at both edit sites.

# Testing

## Where should a reviewer start?

Run the adjudicating audit yourself — it is deterministic and file-local:

```bash
bun run audit:hetzner-fleet-routing
```

## Detailed testing steps

Red on `develop`'s exact workflow tree (extracted via `git archive origin/develop .github/workflows`, unmodified contract script):

```text
AUDIT FAILS:
Hetzner runner routing must require explicit HETZNER_FLEET_ONLINE opt-in; missing, empty, false, and noncanonical values must use a hosted runner:
certification-hosted.yml:33 (on.workflow_dispatch.inputs.runner.description): Runner pool: hosted (ubuntu-24.04) or the self-hosted hetzner-robot fleet
certification-hosted.yml:53 (jobs.hosted-certification.runs-on): ${{ inputs.runner == 'robot' && fromJSON('["self-hosted","hetzner-robot"]') || 'ubuntu-24.04' }}
```

Green on this head:

```text
$ node packages/scripts/hetzner-fleet-routing-contract.mjs
[hetzner-fleet-routing] verified 158 selectors across 78 workflows
```

Also run: `bunx @biomejs/biome check packages/scripts/hetzner-fleet-routing-contract.mjs` clean; `git diff --check` clean; byte-identity between the workflow's `runs-on` value and the allowlisted constant verified by reading both from disk in one script.

# Evidence Gate

<!-- evidence-head:1c0164adc4e3541615a90ad5c6f5d71627d6fb01 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI routing + audit allowlist; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow; the behavior is the red-to-green audit transition recorded above.
<!-- evidence-row:backend-logs -->
- [x] Red-on-develop and green-on-this-head audit runs:

<details><summary>audit:hetzner-fleet-routing — FAILS on develop tree</summary>

```text
AUDIT FAILS:
Hetzner runner routing must require explicit HETZNER_FLEET_ONLINE opt-in; missing, empty, false, and noncanonical values must use a hosted runner:
certification-hosted.yml:33 (on.workflow_dispatch.inputs.runner.description): Runner pool: hosted (ubuntu-24.04) or the self-hosted hetzner-robot fleet
certification-hosted.yml:53 (jobs.hosted-certification.runs-on): ${{ inputs.runner == 'robot' && fromJSON('["self-hosted","hetzner-robot"]') || 'ubuntu-24.04' }}
```

</details>

<details><summary>green on 1c0164adc</summary>

```text
$ node packages/scripts/hetzner-fleet-routing-contract.mjs
[hetzner-fleet-routing] verified 158 selectors across 78 workflows
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, or action path.
<!-- evidence-row:domain-artifacts -->
- [x] The audit verdict lines are the domain artifacts for a routing-contract change:

<details><summary>flagged scalars (broken tree) and the 158/78 pass (fixed tree)</summary>

```text
broken : certification-hosted.yml:33 (inputs.runner.description) + :53 (jobs.hosted-certification.runs-on)
fixed  : [hetzner-fleet-routing] verified 158 selectors across 78 workflows
identity: workflow runs-on value === CERTIFICATION_DISPATCH_SELECTOR (byte-compared from disk)
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.
