### PR TITLE
fix(cloud): treat missing docker-node metadata as ignorable during sandbox stop/delete teardown

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -3709,6 +3709,80 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     }
   });
 
+  test("(d) a missing-node-metadata hydration failure (node purged from docker_nodes) → ignorable, delete proceeds", async () => {
+    const svc = await makeSvc();
+    const deletedSandbox = { ...customSandbox(), id: AGENT, organization_id: ORG };
+    const prepare = spyOn(svc, "prepareAgentDelete").mockResolvedValue({
+      ok: true,
+      sandboxId: SANDBOX_ID,
+      status: "running",
+      sourcePoolId: null,
+    });
+    // The exact shape hydrateContainerFromDb throws when the sandbox row
+    // points at a node that no longer has a docker_nodes record: the host is
+    // gone, so there is nothing left to stop.
+    const stop = spyOn(svc, "runBoundedSandboxStop").mockResolvedValue({
+      error: new Error(
+        '[docker-sandbox] Missing persisted docker node metadata for node "node-decommissioned"',
+      ),
+    });
+    const commit = spyOn(svc, "commitAgentRowDelete").mockResolvedValue({
+      success: true,
+      deletedSandbox,
+    });
+    const apiKeySpy = spyOn(apiKeysService, "revokeForAgent").mockResolvedValue(undefined as never);
+    const historySpy = spyOn(sharedRuntimeHistoryRepository, "deleteByAgent").mockResolvedValue(0);
+    const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      const res = (await svc.deleteAgent(AGENT, ORG)) as { success: boolean };
+      expect(res.success).toBe(true);
+      expect(commit).toHaveBeenCalledTimes(1);
+      const infoed = infoSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(infoed).toContain("already absent");
+      const warned = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(warned).not.toContain("ABANDONING");
+    } finally {
+      prepare.mockRestore();
+      stop.mockRestore();
+      commit.mockRestore();
+      apiKeySpy.mockRestore();
+      historySpy.mockRestore();
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("(e) an unrelated hydration failure (missing port data) → still NOT ignorable, delete aborts", async () => {
+    const svc = await makeSvc();
+    const prepare = spyOn(svc, "prepareAgentDelete").mockResolvedValue({
+      ok: true,
+      sandboxId: SANDBOX_ID,
+      status: "running",
+      sourcePoolId: null,
+    });
+    // A sibling hydrateContainerFromDb failure that does NOT mean the host is
+    // gone — the container may still be running, so the delete must escalate.
+    const stop = spyOn(svc, "runBoundedSandboxStop").mockResolvedValue({
+      error: new Error(
+        '[docker-sandbox] Missing port data for "sandbox-e06bb509": bridge=null, webUi=null',
+      ),
+    });
+    const commit = spyOn(svc, "commitAgentRowDelete");
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      const res = (await svc.deleteAgent(AGENT, ORG)) as { success: boolean; error?: string };
+      expect(res.success).toBe(false);
+      expect(res.error).toBe("Failed to delete sandbox");
+      expect(commit).not.toHaveBeenCalled();
+    } finally {
+      prepare.mockRestore();
+      stop.mockRestore();
+      commit.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
   test("the bounded teardown runs OUTSIDE the row-delete phase (sequenced, not nested)", async () => {
     const svc = await makeSvc();
     const order: string[] = [];

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -9789,7 +9789,13 @@ export class ElizaSandboxService {
       normalized.includes("not found") ||
       normalized.includes("already gone") ||
       normalized.includes("no longer exists") ||
-      normalized.includes("404")
+      normalized.includes("404") ||
+      // docker-sandbox-provider's hydrateContainerFromDb throws this when the
+      // sandbox row points at a node purged from docker_nodes (decommissioned
+      // node). For stop/delete teardown the container's host no longer exists,
+      // so there is nothing left to stop — without this the delete escalates,
+      // exhausts retries, and wedges the agent in deletion_failed forever.
+      normalized.includes("missing persisted docker node metadata")
     );
   }
 


### PR DESCRIPTION
Any agent whose sandbox row points at a node that was later purged from `docker_nodes` can **never be deleted by its owner**: `hydrateContainerFromDb` throws `Missing persisted docker node metadata for node "..."`, `isIgnorableSandboxStopError` doesn't recognize the shape, and the delete escalates → retries 3x → lands in `deletion_failed` permanently.

Found live on staging tonight: agent `0b402068` (user-visible as "Provisioning permanently failed... / deletion failed") was undeletable through the platform until the dangling node pointer was cleared by hand; two other orgs' agents (`15bd4e15`, `25abaceb`) sit in `deletion_failed` from the same cause.

Fix: the missing-node-metadata shape joins the ignorable set for stop/delete teardown — the container's node no longer exists, so there is nothing to stop, and deletion proceeds to credential revocation + row delete. The predicate is consumed at exactly one call site (the `deleteAgent` phase-2 bounded-teardown classification), so the ignorable treatment is scoped to teardown by construction. Sibling hydration failures (missing hostname/port data) remain non-ignorable — pinned by a new negative test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:43f3f029abdb72ff3c3c1988c36205e35cec0856 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - control-plane teardown-classification change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing user-visible renders differently; the dashboard simply stops accumulating undeletable rows.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend teardown path with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the live staging reproduction that motivated the fix.

<details><summary>Staging agent 0b402068 - undeletable until the node pointer was cleared</summary>

```text
delete job f1f85acb: failed 3/3
  error: Missing persisted docker node metadata for node "eliza-core-3c948842"
  (node purged from docker_nodes; isIgnorableSandboxStopError -> false;
   escalation -> retry -> exhausted -> sandbox status deletion_failed)

manual unblock (out-of-band, staging only):
  UPDATE agent_sandboxes SET node_id = NULL WHERE id = '0b402068-...';
  re-enqueued delete job 17b9cc70: completed, row gone

same-cause rows observed in two other orgs: 15bd4e15, 25abaceb
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in sandbox teardown.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic teardown-classification change, no model inference is invoked by this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - full sandbox suite with the two new teardown-cap tests.

<details><summary>Test results at 43f3f029abdb72ff3c3c1988c36205e35cec0856</summary>

```text
$ bun test src/lib/services/eliza-sandbox.test.ts   (packages/cloud/shared)
  174 pass / 0 fail   (1336 expect() calls)
  deleteAgent teardown cap (#9066): 10/10, including:
    (new) missing-node-metadata error -> delete proceeds, row deleted,
          logged as already-absent, no ABANDONING warning
    (new) unrelated hydration error (missing port data) -> delete aborts,
          commitAgentRowDelete never called

$ bun run --cwd packages/cloud/shared typecheck   exit 0
$ bun run verify                                  343/343 tasks
$ biome check (2 files)                            clean
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

