### PR TITLE
fix(lifeops): treat 401 as the expected signed-out state in activity-signal capture

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
@@ -6,7 +6,8 @@
  * three device shapes (web, desktop/Electrobun, native mobile). Proves it
  * posts presence once the runtime reports running, re-emits on
  * lifecycle/visibility events, dedupes rapid repeats, maps native mobile
- * snapshots, degrades quietly on runtime-unavailable/network errors, surfaces
+ * snapshots, degrades quietly on runtime-unavailable/network/signed-out (401)
+ * errors, surfaces
  * unexpected failures observably, is idempotent across repeated starts,
  * enforces the permission consent gate, survives stop() racing any awaited
  * native operation without leaking handles/monitors/intervals, and fully
@@ -644,6 +645,42 @@ describe("startLifeOpsActivitySignalCapture", () => {
 
     expect(h.captureLifeOpsActivitySignal).not.toHaveBeenCalled();
     expect(h.dispatchStatus).not.toHaveBeenCalled();
+  });
+
+  it("treats a 401 status-probe response as the expected signed-out state (no console error, no status event)", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    h.isApiError.mockImplementation(
+      (error) => typeof error === "object" && error !== null && "kind" in error,
+    );
+    h.getStatus.mockRejectedValue({ kind: "http", status: 401 });
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await settle();
+
+    expect(h.captureLifeOpsActivitySignal).not.toHaveBeenCalled();
+    expect(h.dispatchStatus).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("swallows a 401 on the capture endpoint as the signed-out state (session expired mid-capture)", async () => {
+    h.isApiError.mockImplementation(
+      (error) => typeof error === "object" && error !== null && "kind" in error,
+    );
+    h.captureLifeOpsActivitySignal.mockRejectedValue({
+      kind: "http",
+      status: 401,
+    });
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await settle();
+
+    expect(h.captureLifeOpsActivitySignal).toHaveBeenCalled();
+    expect(h.dispatchStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "capture_error" }),
+    );
   });
 
   it("backs off a capability-specific 503 and resumes after a bounded probe", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
@@ -25,11 +25,13 @@
  *   is surfaced as a `permission_unavailable` status event, then re-checked on
  *   each app resume so a grant made in Settings activates without a restart.
  *
- * Expected unavailability (runtime not yet running, transient network/timeout,
- * endpoint 503) quietly stands the capture down. Capability-specific 503s use
- * a bounded retry interval because the global runtime status cannot prove that
- * this optional plugin route is active. Anything else is surfaced observably:
- * a `capture_error` status event plus a prefixed console.error.
+ * Expected unavailability (no authenticated session yet — every capture
+ * endpoint 401s on signed-out pages, runtime not yet running, transient
+ * network/timeout, endpoint 503) quietly stands the capture down.
+ * Capability-specific 503s use a bounded retry interval because the global
+ * runtime status cannot prove that this optional plugin route is active.
+ * Anything else is surfaced observably: a `capture_error` status event plus a
+ * prefixed console.error.
  */
 import { Capacitor } from "@capacitor/core";
 import {
@@ -232,12 +234,20 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
   const isExpectedTransientError = (error: unknown): boolean =>
     isApiError(error) && (error.kind === "network" || error.kind === "timeout");
 
+  // A 401 is the designed signed-out state, not a capture defect: every
+  // capture endpoint sits behind session auth, so anonymous pages (pre
+  // sign-in, post sign-out) reject each probe and signal. The ready poll
+  // keeps checking quietly and the capture engages on the first poll after a
+  // session exists — no console noise in between.
+  const isUnauthenticatedError = (error: unknown): boolean =>
+    isApiError(error) && error.kind === "http" && error.status === 401;
+
   const reportCaptureError = (error: unknown): void => {
     if (isRuntimeUnavailableError(error)) {
       standDownActivitySignals();
       return;
     }
-    if (isExpectedTransientError(error)) {
+    if (isExpectedTransientError(error) || isUnauthenticatedError(error)) {
       return;
     }
     // Unexpected failure: surface it observably — status event for in-app
@@ -250,15 +260,17 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
     });
   };
 
-  // Runtime not up yet (boot, restart) is the designed stand-down state; only
-  // transport loss and the 503 "runtime starting" shape count as that state.
-  // Anything else coming out of the status probe (persistent 500s included) is
-  // a real defect and must surface, not read as "not ready" forever (#16504).
+  // Runtime not up yet (boot, restart) and signed-out (401) are the designed
+  // stand-down states; only transport loss, the 503 "runtime starting" shape,
+  // and the pre-auth 401 count as those states. Anything else coming out of
+  // the status probe (persistent 500s included) is a real defect and must
+  // surface, not read as "not ready" forever (#16504).
   const isExpectedProbeFailure = (error: unknown): boolean =>
-    isApiError(error) &&
-    (error.kind === "network" ||
-      error.kind === "timeout" ||
-      (error.kind === "http" && error.status === 503));
+    isUnauthenticatedError(error) ||
+    (isApiError(error) &&
+      (error.kind === "network" ||
+        error.kind === "timeout" ||
+        (error.kind === "http" && error.status === 503)));
 
   const refreshRuntimeReady = async (): Promise<boolean> => {
     try {


### PR DESCRIPTION
Every signed-out page load spams the console with `[LifeOpsActivitySignals] unexpected capture failure: ApiError: Unauthorized`, repeating on each 5-second readiness poll. Observed on the live staging deployment during tonight's smoke test (both origins, every anonymous page).

Cause: the capture's readiness probe hits `/api/status` on mount and every 5s; signed-out it rejects with `ApiError { kind: "http", status: 401 }`, and `isExpectedProbeFailure` only recognized network/timeout/503 — so the 401 fell through to `reportCaptureError` → `console.error`.

Fix (J4-style expected degrade, matching the module's existing classifier convention): a `isUnauthenticatedError` predicate (ApiError, http, 401) joins `isExpectedProbeFailure` — quiet stand-down, poll keeps checking so capture engages on the first post-sign-in poll — and `reportCaptureError`'s expected-shape early return, covering a session that expires between probe and signal send. Deliberately NOT auth-state gating: wiring React session state into this headless service would add cross-layer coupling the file avoids; and deliberately not a blanket catch — 500s, parse errors, and non-ApiError failures still surface as `capture_error` + console.error, preserved by the existing tests.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:2377c45ded32d2dc3a31d541722a9a03faadc7fb -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - headless capture-service classifier change in a plugin, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing renders differently; the console simply stops filling with expected-state errors.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no on-screen user flow; the observable change is console output on anonymous pages.

<!-- evidence-row:backend-logs -->
- [x] N/A - client-side capture service; no server code path is touched by this diff.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console logs - the live staging observation this fixes, and the spied-console proof.

<details><summary>Live staging console + new test assertions</summary>

```text
live staging smoke (2026-08-06, both origins, every signed-out page, 1-3x per page):
  [LifeOpsActivitySignals] unexpected capture failure: ApiError: Unauthorized
  (readiness poll -> /api/status -> 401 -> unexpected-failure path -> console.error,
   repeating every 5s for as long as the anonymous page stays open)

new tests (console.error spied):
  401 probe   -> no capture, no status event, ZERO console.error calls
  401 mid-session on the capture endpoint -> swallowed, no capture_error event
  (503/network/timeout expected-shapes and 500/parse-error loud paths preserved
   by the 25 pre-existing tests)
```

</details>

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic error-classification change, no model inference participates.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - module suites at this head.

<details><summary>Test results at 2377c45ded32d2dc3a31d541722a9a03faadc7fb</summary>

```text
$ bunx vitest run src/lifeops/activity-signals-capture.test.ts   (plugin-personal-assistant)
  27 pass / 0 fail   (25 existing + 2 new)

$ bunx vitest run activity-signals-capture.client-extension.test.ts register.test.ts
  6 pass / 0 fail

typecheck: changed file clean; the package lane's 167 pre-existing TS errors
from unbuilt sibling plugin dists are byte-identical with this change stashed
biome check (2 files): clean
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
