### PR TITLE
fix(ci): hermetic environment for robot-pool certification runs

### DIFF
--- a/.github/workflows/certification-hosted.yml
+++ b/.github/workflows/certification-hosted.yml
@@ -96,6 +96,64 @@ jobs:
           bun run build:core
           bun run build:views
 
+      # SECURITY: the hetzner-robot runners execute on a production box whose
+      # service environment carries real credentials — run 31073689058 showed a
+      # live ELIZA_VAULT_PASSPHRASE visible to every test process, plus
+      # TTY/color vars that changed logger output under test. This workflow is
+      # workflow_dispatch-only, so PR-controlled code never runs here, but the
+      # runner environment itself should be reviewed org-side: any workflow
+      # granted this pool inherits it. The wrapper below keeps repo test
+      # processes from seeing that environment at all.
+      #
+      # The evidence + certify steps run through `env -i` with an explicit
+      # allowlist derived from what a hosted ubuntu-24.04 runner provides:
+      # PATH, a fresh scratch HOME/TMPDIR under $RUNNER_TEMP (isolates
+      # keychain/vault/dotfile state), TZ=UTC + LANG=C.UTF-8 (hosted image
+      # defaults), CI, the GITHUB_*/RUNNER_* context, and the two secrets the
+      # chain needs (ELIZA_CERT_SIGNING_KEY, ANTHROPIC_API_KEY). Everything
+      # else — box credentials, POSTGRES_URL, TERM/FORCE_COLOR, D-Bus/XDG
+      # session state — is dropped. The command also runs inside a private
+      # session bus (dbus-run-session) because hosted runners have a per-user
+      # session bus and packages/vault's keychain-safety heuristic
+      # (isKeychainUnsafe) branches on its reachability; without it the vault
+      # master-key suite honestly reports the headless-host gap.
+      - name: Prepare hermetic runner (robot pool)
+        if: ${{ inputs.runner == 'robot' }}
+        run: |
+          set -euo pipefail
+          wrapper="$RUNNER_TEMP/hermetic-run.sh"
+          cat > "$wrapper" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          scratch_home="$RUNNER_TEMP/hermetic-home"
+          scratch_tmp="$RUNNER_TEMP/hermetic-tmp"
+          mkdir -p "$scratch_home" "$scratch_tmp"
+          allow=(
+            "PATH=$PATH"
+            "HOME=$scratch_home"
+            "TMPDIR=$scratch_tmp"
+            "TZ=UTC"
+            "LANG=C.UTF-8"
+            "CI=true"
+            "USER=${USER:-ci}"
+          )
+          while IFS= read -r name; do
+            case "$name" in
+              GITHUB_*|RUNNER_*) allow+=("$name=${!name}") ;;
+            esac
+          done < <(compgen -e)
+          for name in ELIZA_CERT_SIGNING_KEY ANTHROPIC_API_KEY; do
+            [ -n "${!name:-}" ] && allow+=("$name=${!name}")
+          done
+          if command -v dbus-run-session >/dev/null 2>&1; then
+            exec env -i "${allow[@]}" dbus-run-session -- "$@"
+          fi
+          echo "hermetic-run: dbus-run-session unavailable; vault keychain-safety suites will see a headless host" >&2
+          exec env -i "${allow[@]}" "$@"
+          EOF
+          chmod +x "$wrapper"
+          echo "HERMETIC_RUN=$wrapper" >> "$GITHUB_ENV"
+
       # The bundle ingests evidence silos produced by real lanes on the
       # certified sha; a fresh runner has none, and certify:sign honestly
       # refuses an empty verdicts document (proven by hosted run
@@ -105,7 +163,7 @@ jobs:
       - name: Produce evidence — deterministic scenario lane
         env:
           TZ: UTC
-        run: bun run --cwd packages/scenario-runner test:pr:e2e
+        run: ${HERMETIC_RUN:-} bun run --cwd packages/scenario-runner test:pr:e2e
 
       # The orchestrated command is the complete chain — matrix → ingest →
       # analyze → vision-qa → rollup → reviewer merge → sign → self-verify.
@@ -119,6 +177,7 @@ jobs:
           ELIZA_CERT_SIGNING_KEY: ${{ secrets.ELIZA_CERT_SIGNING_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: >-
+          ${HERMETIC_RUN:-}
           bun run --cwd packages/evidence certify --
           --tier "${{ inputs.tier }}"
           --reviewer-id "certification-hosted@github-actions"


### PR DESCRIPTION
Robot-pool certification run 31073689058 completed the **full matrix in ~78 minutes** (the capacity fix works) and honestly signed RED with 9 failing tasks. Forensics on the bundle classified every failure; this PR fixes the classes the runner environment owns:

- **(a) env contamination** — the production box's TTY/color vars leak ANSI codes into captured stderr, breaking the agent early-logs mirror suppression; and the runner env exposes a **real `ELIZA_VAULT_PASSPHRASE` to test processes** (security concern, flagged in a workflow comment for org-side review).
- **(b) machine capability** — vault's keychain tests need a D-Bus session bus, which hosted runners have and the robot service lacks (`isKeychainUnsafe()` branches on it). The brief's own hypothesis inverted honestly: the keychain was *bypassed*, not real.
- **(c) load timing** — noted, deliberately NOT band-aided with retries (5s/10s hooks on a box also running production workloads; if it persists post-sanitization the lever is scheduling, not retries).
- **(d) genuine at-sha regressions** — cloud-shared and a ui guard fail on ANY runner at that sha (fixed separately; sanitization must not hide them).

Change: a `Prepare hermetic runner` step (gated `inputs.runner == 'robot'`) builds an `env -i` wrapper — explicit allowlist (PATH, fresh HOME under RUNNER_TEMP, TMPDIR, TZ=UTC, LANG, CI, USER, GITHUB_*/RUNNER_*, and only the two chain secrets) — run under `dbus-run-session` for hosted parity. The scenario-lane and certify steps are prefixed with the wrapper; **the hosted path is byte-unchanged**. Everything else drops: the vault passphrase, POSTGRES_URL, TERM/FORCE_COLOR, ambient DBUS/XDG state.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:51f82a685a302f11c7287a459b6924f0d994038d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow change, nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow yaml change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the classified failures from the robot run's signed bundle.

<details><summary>Run 31073689058 bundle - lanes/matrix/log excerpts by class</summary>

```text
(a) agent early-logs: captured stderr arrives ANSI-colored
    "[1m[97m[41m Error ... [EARLY-LOGS-TEST] early-log-a473f0f4"
    ADZE_PRETTY_PREFIX cannot match an ESC-prefixed message -> mirror not
    suppressed -> "expected length 1 but got 2"

(b) vault master-key x2:
    "expected 'passphrase://test (keychain bypassed: host unsafe)' to contain 'keychain://'"
    isKeychainUnsafe(): no DBUS_SESSION_BUS_ADDRESS and no XDG_RUNTIME_DIR/bus
    on the robot service; hosted runners provide a per-user session bus
    + the runner env carried a REAL ELIZA_VAULT_PASSPHRASE into test processes

(c) timing (box also runs production workloads; trivial unit tests took 8-20s):
    plugin-calendar  beforeAll PGlite WASM init: Hook timed out in 10000ms
    plugin-imessage  4x Test timed out in 5000ms (bun:sqlite test db)
    plugin-local-inference 2x 5s CPU-bound timeouts
    plugin-agent-orchestrator createRealTestRuntime: Hook timed out in 10000ms

(d) at-sha regressions (fail on ANY runner; fixed in separate PRs):
    cloud-shared inference-billing-fast-path.test.ts:246 - test hardcodes
      IAC v:1, develop bumped INFERENCE_AUTH_CONTEXT_VERSION to 2 (#17805)
    ui surface-realm-reserved-writers.guard - sso-bridge.ts:314/:323 raw
      localStorage writes of eliza_sso_logged_out (#17788)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the certification chain.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - workflow environment change; no model inference is part of this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - functional verification of the wrapper and yaml validity.

<details><summary>Wrapper verification + parse</summary>

```text
local functional check of the generated hermetic wrapper:
  planted ELIZA_VAULT_PASSPHRASE / POSTGRES_URL / FORCE_COLOR  -> STRIPPED
  ELIZA_CERT_SIGNING_KEY / ANTHROPIC_API_KEY / GITHUB_*        -> FORWARDED
  DBUS_SESSION_BUS_ADDRESS                                     -> fresh private
                                                        session (dbus-run-session)

$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/certification-hosted.yml'));print('parses')"
parses

diff: 1 file, +60/-1; hosted path byte-unchanged; no test files touched;
no matrix-arg changes (nothing honest to skip - capability gates were satisfied)
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
