### PR TITLE
fix(ci): target autoheal pull requests at develop

### DIFF
--- a/.github/workflows/claude-ci-autoheal.yml
+++ b/.github/workflows/claude-ci-autoheal.yml
@@ -142,7 +142,7 @@ jobs:
                their passing output into the PR body. An unverified fix does not ship.
             5. Deliver on branch `${{ steps.context.outputs.branch }}` (create or
                force-update it from origin/develop), then open (or update) the pull
-               request to `develop` with `gh pr create` / `gh pr edit`:
+               request to `develop` with `gh pr create --base develop` / `gh pr edit`:
                - title: `fix(ci): autoheal ${{ steps.context.outputs.workflow_slug }} — <root cause>`
                - label: `ci-autoheal` (add with `gh pr edit --add-label`)
                - body MUST keep every `<!-- evidence-row:... -->` marker from


### PR DESCRIPTION
# Relates to

Closes #17815. Rebased patch-identically onto current `develop`; the one-line workflow delta is unchanged.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Exact one-file scope; zero conflicts on `develop@a0fbf37c7522be3a8397e26547a25cfa1c43e095`.
- [x] Frozen install passed.
- [x] Focused PR-policy suite passed 17/17.
- [x] Fleet-routing audit passed (151 selectors across 75 workflows).
- [x] Full `bun run verify` passed on the exact head: 343/343 Turbo tasks plus all repository audits.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no repository contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Sync with develop

- [x] Based directly on current `develop@a0fbf37c7522be3a8397e26547a25cfa1c43e095`.
- [x] One commit and one workflow file; `git diff --check` clean.

# Risks

Low. This changes only the instruction supplied to the CI autoheal agent. It prevents `gh pr create` from inferring the repository default branch; no production, UI, runtime, model, cloud, or device path changes.

# Background

## What does this PR do?

Changes the autoheal instruction from `gh pr create` to `gh pr create --base develop`.

It deliberately does not carry closed #17718's review-rejected marker-conditioned discovery filter. The policy test file is byte-identical to current `develop`.

## What kind of change is this?

CI correctness fix.

# Documentation changes needed?

N/A - the durable instruction lives in the workflow itself.

# Testing

## Where should a reviewer start?

`.github/workflows/claude-ci-autoheal.yml`, one changed line.

## Detailed testing steps

```text
bun test packages/scripts/__tests__/claude-autoheal-workflow-contract.test.ts
17 tests / 17 pass

bun run audit:hetzner-fleet-routing
verified 151 selectors across 75 workflows

git diff --check
pass
```

# Evidence Gate

<!-- evidence-head:cfa0921e14b03f1bef120bbc5cff3c9f13d7ad34 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow instruction only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow instruction only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - CI workflow instruction only; no backend process or request path is changed or exercised.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the change does not alter an Eliza model/action/provider path; it changes a CI authoring instruction.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head verification transcript:

  <details><summary>Workflow contract and repository gates</summary>

  ```text
  HEAD cfa0921e14b03f1bef120bbc5cff3c9f13d7ad34; parent develop@a0fbf37c7522be3a8397e26547a25cfa1c43e095
  bun test packages/scripts/__tests__/claude-autoheal-workflow-contract.test.ts: 17 pass, 0 fail
  bun run verify: 343 successful / 343 total; fleet routing verified 151 selectors across 75 workflows
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Known gaps / failures

No known failures on the exact head. The inherited develop-wide fleet audit is green after #17814.


