### PR TITLE
fix(cloud): let Meta verify the WhatsApp callback URL

### DIFF
--- a/packages/cloud/api/__tests__/eliza-app-webhook-whatsapp-verification.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-webhook-whatsapp-verification.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Meta's WhatsApp callback-URL verification handshake through the eliza-app
+ * webhook forwarder.
+ *
+ * Meta verifies a callback URL with a `GET` carrying `hub.mode=subscribe`,
+ * `hub.verify_token` and `hub.challenge`, and no signature header — there is no
+ * body to sign. The forwarder used to run its HMAC check on that request, which
+ * could only ever fail, so the URL could never be registered.
+ *
+ * These tests drive the real forwarder with a mocked upstream and assert both
+ * halves of the contract: the handshake reaches the gateway, and every other
+ * WhatsApp request still has to be signed.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(), info: mock(), warn: mock(), debug: mock() },
+}));
+
+const { forwardToWebhookGateway } = (await import(
+  "../eliza-app/webhook/_forward"
+)) as typeof import("../eliza-app/webhook/_forward");
+
+const GATEWAY = "https://gateway.internal.test";
+const ENV = {
+  ELIZA_APP_WEBHOOK_GATEWAY_URL: GATEWAY,
+  ELIZA_APP_WHATSAPP_APP_SECRET: "whatsapp-app-secret",
+  ENVIRONMENT: "production",
+};
+
+let upstreamUrl: string | null = null;
+let upstreamCalls = 0;
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  upstreamUrl = null;
+  upstreamCalls = 0;
+  globalThis.fetch = mock(async (input: unknown) => {
+    upstreamCalls += 1;
+    upstreamUrl = String(input);
+    return new Response("CHALLENGE_ECHO", { status: 200 });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function call(
+  path: string,
+  init: RequestInit = {},
+  env: Record<string, unknown> = ENV,
+): Promise<Response> {
+  const app = new Hono();
+  app.all("/api/eliza-app/webhook/whatsapp", (c) =>
+    forwardToWebhookGateway(
+      c as unknown as Parameters<typeof forwardToWebhookGateway>[0],
+      "whatsapp",
+    ),
+  );
+  return await app.request(
+    `https://api.elizacloud.ai${path}`,
+    { method: "GET", ...init },
+    env,
+  );
+}
+
+const VERIFY_QUERY =
+  "?hub.mode=subscribe&hub.verify_token=the-verify-token&hub.challenge=CHALLENGE_ECHO";
+
+describe("WhatsApp callback-URL verification handshake", () => {
+  test("forwards Meta's verification GET to the gateway instead of rejecting it", async () => {
+    const response = await call(
+      `/api/eliza-app/webhook/whatsapp${VERIFY_QUERY}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("CHALLENGE_ECHO");
+    expect(upstreamCalls).toBe(1);
+    // The gateway owns the verify-token comparison and echoes the challenge, so
+    // the query string has to survive the hop intact.
+    expect(upstreamUrl).toBe(
+      `${GATEWAY}/webhook/eliza-app/whatsapp${VERIFY_QUERY}`,
+    );
+  });
+
+  test("still requires a signature on a WhatsApp POST", async () => {
+    const response = await call("/api/eliza-app/webhook/whatsapp", {
+      method: "POST",
+      body: JSON.stringify({ entry: [] }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      code: "WEBHOOK_SIGNATURE_INVALID",
+    });
+    expect(upstreamCalls).toBe(0);
+  });
+
+  test("still requires a signature on a GET that is not the handshake", async () => {
+    // A bare GET, or one missing hub.mode/hub.challenge, is not Meta's
+    // handshake and gets no exemption.
+    for (const query of [
+      "",
+      "?hub.mode=unsubscribe&hub.challenge=X",
+      "?hub.mode=subscribe",
+      "?hub.challenge=X",
+    ]) {
+      const response = await call(`/api/eliza-app/webhook/whatsapp${query}`);
+      expect(response.status).toBe(401);
+    }
+    expect(upstreamCalls).toBe(0);
+  });
+
+  test("does not exempt a handshake-shaped GET on another platform", async () => {
+    const app = new Hono();
+    app.all("/api/eliza-app/webhook/twilio", (c) =>
+      forwardToWebhookGateway(
+        c as unknown as Parameters<typeof forwardToWebhookGateway>[0],
+        "twilio",
+      ),
+    );
+
+    const response = await app.request(
+      `https://api.elizacloud.ai/api/eliza-app/webhook/twilio${VERIFY_QUERY}`,
+      { method: "GET" },
+      { ...ENV, ELIZA_APP_TWILIO_AUTH_TOKEN: "twilio-token" },
+    );
+
+    expect(response.status).toBe(401);
+    expect(upstreamCalls).toBe(0);
+  });
+});

--- a/packages/cloud/api/__tests__/eliza-app-webhook-whatsapp-verification.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-webhook-whatsapp-verification.test.ts
@@ -27,7 +27,7 @@ const GATEWAY = "https://gateway.internal.test";
 const ENV = {
   ELIZA_APP_WEBHOOK_GATEWAY_URL: GATEWAY,
   ELIZA_APP_WHATSAPP_APP_SECRET: "whatsapp-app-secret",
-  ENVIRONMENT: "production",
+  NODE_ENV: "production",
 };
 
 let upstreamUrl: string | null = null;
@@ -54,12 +54,19 @@ async function call(
   env: Record<string, unknown> = ENV,
 ): Promise<Response> {
   const app = new Hono();
-  app.all("/api/eliza-app/webhook/whatsapp", (c) =>
-    forwardToWebhookGateway(
-      c as unknown as Parameters<typeof forwardToWebhookGateway>[0],
-      "whatsapp",
-    ),
-  );
+  // The real route is a wildcard (`app.all("/*")` in whatsapp/route.ts), so the
+  // per-agent suffix has to be reachable here too.
+  for (const route of [
+    "/api/eliza-app/webhook/whatsapp",
+    "/api/eliza-app/webhook/whatsapp/*",
+  ]) {
+    app.all(route, (c) =>
+      forwardToWebhookGateway(
+        c as unknown as Parameters<typeof forwardToWebhookGateway>[0],
+        "whatsapp",
+      ),
+    );
+  }
   return await app.request(
     `https://api.elizacloud.ai${path}`,
     { method: "GET", ...init },
@@ -86,6 +93,30 @@ describe("WhatsApp callback-URL verification handshake", () => {
     );
   });
 
+  test("exempts the per-agent callback URL too, and forwards the agent id", async () => {
+    // `/webhook/whatsapp/<agentId>` is a real callback URL — per-agent
+    // registrations are the reason the exemption cannot be restricted to the
+    // bare path. This pins that widening rather than leaving it implicit: the
+    // route is a wildcard, so the exemption reaches the suffix whether or not
+    // anyone remembers it does.
+    const response = await call(
+      `/api/eliza-app/webhook/whatsapp/agent-42${VERIFY_QUERY}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("CHALLENGE_ECHO");
+    expect(upstreamUrl).toBe(
+      `${GATEWAY}/webhook/eliza-app/whatsapp/agent-42${VERIFY_QUERY}`,
+    );
+  });
+
+  test("still requires a signature on a per-agent GET that is not the handshake", async () => {
+    const response = await call("/api/eliza-app/webhook/whatsapp/agent-42");
+
+    expect(response.status).toBe(401);
+    expect(upstreamCalls).toBe(0);
+  });
+
   test("still requires a signature on a WhatsApp POST", async () => {
     const response = await call("/api/eliza-app/webhook/whatsapp", {
       method: "POST",
@@ -107,6 +138,7 @@ describe("WhatsApp callback-URL verification handshake", () => {
       "?hub.mode=unsubscribe&hub.challenge=X",
       "?hub.mode=subscribe",
       "?hub.challenge=X",
+      "?hub.mode=subscribe&hub.challenge=X",
     ]) {
       const response = await call(`/api/eliza-app/webhook/whatsapp${query}`);
       expect(response.status).toBe(401);

--- a/packages/cloud/api/eliza-app/webhook/_forward.ts
+++ b/packages/cloud/api/eliza-app/webhook/_forward.ts
@@ -317,6 +317,7 @@ function isWhatsAppVerificationHandshake(
     platform === "whatsapp" &&
     c.req.method === "GET" &&
     c.req.query("hub.mode") === "subscribe" &&
+    Boolean(c.req.query("hub.verify_token")) &&
     Boolean(c.req.query("hub.challenge"))
   );
 }

--- a/packages/cloud/api/eliza-app/webhook/_forward.ts
+++ b/packages/cloud/api/eliza-app/webhook/_forward.ts
@@ -297,6 +297,30 @@ async function validateLocalWebhookSignature(
   return { body };
 }
 
+/**
+ * Meta verifies a WhatsApp callback URL by calling it with a `GET` carrying
+ * `hub.mode=subscribe`, `hub.verify_token` and `hub.challenge`, and no
+ * signature header — there is no body to sign. Running the HMAC check on that
+ * request can therefore only ever fail, which is what made the callback URL
+ * impossible to register: Meta's challenge was answered 401 before it was read.
+ *
+ * The handshake carries its own credential. The gateway compares
+ * `hub.verify_token` against the token configured for the project (or the
+ * agent) and echoes the challenge, so skipping the body signature here removes
+ * a check that proves nothing and leaves the one that does.
+ */
+function isWhatsAppVerificationHandshake(
+  c: AppContext,
+  platform: GatewayPlatform,
+): boolean {
+  return (
+    platform === "whatsapp" &&
+    c.req.method === "GET" &&
+    c.req.query("hub.mode") === "subscribe" &&
+    Boolean(c.req.query("hub.challenge"))
+  );
+}
+
 interface ForwardOptions {
   body?: BodyInit | null;
 }
@@ -398,8 +422,14 @@ export async function forwardToWebhookGateway(
     );
   }
 
-  const validation = await validateLocalWebhookSignature(c, platform);
-  if (validation.response) return validation.response;
+  let signedBody: string | undefined;
+  if (isWhatsAppVerificationHandshake(c, platform)) {
+    logger.info("[ElizaAppWebhook] forwarding WhatsApp verification handshake");
+  } else {
+    const validation = await validateLocalWebhookSignature(c, platform);
+    if (validation.response) return validation.response;
+    signedBody = validation.body;
+  }
 
   const project =
     readStringEnv(c, ["ELIZA_APP_WEBHOOK_PROJECT"]) ?? "eliza-app";
@@ -410,7 +440,7 @@ export async function forwardToWebhookGateway(
 
   return proxyRequest(c, target, "webhook gateway", {
     ...options,
-    body: options.body ?? validation.body,
+    body: options.body ?? signedBody,
     stampGatewaySecret: true,
   });
 }

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-config-miss-cache.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-config-miss-cache.test.ts
@@ -1,0 +1,137 @@
+// Pins the negative half of the per-agent webhook-config cache. An agent id
+// that resolves to nothing must be remembered briefly: since Meta's
+// verification handshake became exempt from signature checking, this lookup is
+// reachable without a signature, and an uncached miss would let a caller drive
+// one authenticated round trip to the cloud API per request with cache keys of
+// their choosing.
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { GatewayRedis } from "../src/redis";
+import { resolveWebhookConfig } from "../src/webhook-config";
+
+class MemoryRedis implements GatewayRedis {
+  readonly store = new Map<string, string>();
+  readonly ttls = new Map<string, number | undefined>();
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    const value = this.store.get(key);
+    if (value === undefined) return null;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return value as T;
+    }
+  }
+
+  async set(
+    key: string,
+    value: string,
+    options: { ex?: number } = {},
+  ): Promise<unknown> {
+    this.store.set(key, value);
+    this.ttls.set(key, options.ex);
+    return "OK";
+  }
+
+  async lpush(): Promise<unknown> {
+    return 1;
+  }
+
+  async ltrim(): Promise<unknown> {
+    return "OK";
+  }
+
+  async expire(): Promise<unknown> {
+    return 1;
+  }
+}
+
+const originalFetch = globalThis.fetch;
+const AUTH = { Authorization: "Bearer gateway-jwt" };
+const CACHE_KEY = "webhook-config:whatsapp:agent:agent-42";
+
+function resolve(redis: GatewayRedis, agentId = "agent-42") {
+  return resolveWebhookConfig(
+    redis,
+    "https://api.elizacloud.ai",
+    AUTH,
+    "whatsapp",
+    "eliza-app",
+    agentId,
+  );
+}
+
+describe("per-agent webhook config cache", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    mock.restore();
+  });
+
+  test("remembers an unknown agent id briefly instead of re-asking every time", async () => {
+    const redis = new MemoryRedis();
+    let upstreamCalls = 0;
+    globalThis.fetch = mock(async () => {
+      upstreamCalls += 1;
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    expect(await resolve(redis)).toBeNull();
+    expect(upstreamCalls).toBe(1);
+    expect(redis.ttls.get(CACHE_KEY)).toBe(15);
+
+    // Second request for the same unknown id is answered from Redis.
+    expect(await resolve(redis)).toBeNull();
+    expect(upstreamCalls).toBe(1);
+  });
+
+  test("caches a resolved config for the full TTL and returns it", async () => {
+    const redis = new MemoryRedis();
+    globalThis.fetch = mock(
+      async () =>
+        new Response(JSON.stringify({ verifyToken: "vt", appSecret: "as" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as typeof fetch;
+
+    expect(await resolve(redis)).toEqual({
+      verifyToken: "vt",
+      appSecret: "as",
+    });
+    expect(redis.ttls.get(CACHE_KEY)).toBe(300);
+  });
+
+  test("does not cache a transport failure, so a recovered API is reached again", async () => {
+    // A 5xx or a network error is the cloud API being unwell, not a statement
+    // about this agent id. Remembering it would extend an outage.
+    const redis = new MemoryRedis();
+    let upstreamCalls = 0;
+    globalThis.fetch = mock(async () => {
+      upstreamCalls += 1;
+      return new Response("boom", { status: 500 });
+    }) as typeof fetch;
+
+    expect(await resolve(redis)).toBeNull();
+    expect(redis.store.has(CACHE_KEY)).toBe(false);
+
+    expect(await resolve(redis)).toBeNull();
+    expect(upstreamCalls).toBe(2);
+  });
+
+  test("never queries the API for the shared (agent-less) config", async () => {
+    const redis = new MemoryRedis();
+    globalThis.fetch = mock(async () => {
+      throw new Error("shared config must not hit the API");
+    }) as typeof fetch;
+
+    expect(
+      await resolveWebhookConfig(
+        redis,
+        "https://api.elizacloud.ai",
+        AUTH,
+        "whatsapp",
+        "eliza-app",
+      ),
+    ).not.toBeNull();
+    expect(redis.store.size).toBe(0);
+  });
+});

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-config-miss-cache.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-config-miss-cache.test.ts
@@ -1,9 +1,11 @@
-// Pins the negative half of the per-agent webhook-config cache. An agent id
-// that resolves to nothing must be remembered briefly: since Meta's
-// verification handshake became exempt from signature checking, this lookup is
-// reachable without a signature, and an uncached miss would let a caller drive
-// one authenticated round trip to the cloud API per request with cache keys of
-// their choosing.
+/**
+ * Pins the negative half of the per-agent webhook-config cache.
+ *
+ * An agent id that resolves to nothing must be remembered briefly: since
+ * Meta's verification handshake became exempt from signature checking, this
+ * lookup is reachable without a signature, and an uncached miss would let a
+ * caller drive one authenticated round trip to the cloud API per request.
+ */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import type { GatewayRedis } from "../src/redis";
 import { resolveWebhookConfig } from "../src/webhook-config";

--- a/packages/cloud/services/gateway-webhook/src/webhook-config.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-config.ts
@@ -5,6 +5,15 @@ import { getProjectEnv } from "./project-config";
 import type { GatewayRedis } from "./redis";
 
 const CONFIG_CACHE_TTL_SECONDS = 300;
+// An agent id that resolves to no config is cached too, briefly. Without it
+// every request naming an unknown agent pays a fresh authenticated round trip
+// to the cloud API, on a route reachable without a signature since Meta's
+// verification handshake became exempt — an amplifier with caller-chosen cache
+// keys. The TTL stays short so a config created seconds later is picked up,
+// matching the transient identity cache in `server-router.ts`.
+const CONFIG_MISS_CACHE_TTL_SECONDS = 15;
+
+type CachedWebhookConfig = WebhookConfig | { notFound: true };
 
 function buildSharedWebhookConfig(
   platform: Platform,
@@ -54,8 +63,8 @@ export async function resolveWebhookConfig(
   }
 
   const cacheKey = `webhook-config:${platform}:agent:${agentId}`;
-  const cached = await redis.get<WebhookConfig>(cacheKey);
-  if (cached) return cached;
+  const cached = await redis.get<CachedWebhookConfig>(cacheKey);
+  if (cached) return "notFound" in cached ? null : cached;
 
   try {
     const url = `${cloudBaseUrl}/api/internal/webhook/config?agentId=${encodeURIComponent(agentId)}&platform=${encodeURIComponent(platform)}`;
@@ -68,7 +77,12 @@ export async function resolveWebhookConfig(
         signal: controller.signal,
       });
 
-      if (res.status === 404) return null;
+      if (res.status === 404) {
+        await redis.set(cacheKey, JSON.stringify({ notFound: true }), {
+          ex: CONFIG_MISS_CACHE_TTL_SECONDS,
+        });
+        return null;
+      }
       if (!res.ok) {
         logger.error("Webhook config fetch failed", {
           status: res.status,


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

Closes #17823

## What was broken

Meta could not register the WhatsApp callback URL. Measured against production on 2026-08-05:

```
GET https://api.elizacloud.ai/api/eliza-app/webhook/whatsapp?hub.mode=subscribe&hub.verify_token=<token>&hub.challenge=PROBE123
→ 401 {"success":false,"code":"WEBHOOK_SIGNATURE_INVALID"}
```

Meta verifies a callback URL with a `GET` carrying `hub.mode=subscribe`, `hub.verify_token` and `hub.challenge`, **and no signature header** — there is no body to sign. `forwardToWebhookGateway` ran `validateLocalWebhookSignature` on every request regardless of method; for a GET the body is `""` and `verifyWhatsAppSignature` returns `false` the moment `x-hub-signature-256` is absent. Meta's challenge was refused before it was read.

The gateway on the other side already implements the handshake correctly — `GET /webhook/:project/whatsapp[/:agentId]` compares `hub.verify_token` and echoes `hub.challenge` — but Meta hits the Worker URL, so it never got there.

## The fix

Skip the body signature for exactly that handshake — `whatsapp`, `GET`, `hub.mode=subscribe`, `hub.challenge` present — and let it proxy through to the gateway.

This removes a check that cannot pass and cannot prove anything: an HMAC over an empty body is not evidence of anything. The credential Meta's protocol uses for this step is the verify token, and the gateway owns that comparison. The route is a wildcard, so the exemption reaches the per-agent callback URL (`/webhook/whatsapp/<agentId>`) as well — deliberately, since otherwise per-agent URLs could never be registered either. That widening is pinned by its own test rather than left implicit, and the lookup it exposes is bounded: `resolveWebhookConfig` now caches an unresolved agent id for 15s, so an unauthenticated caller can no longer drive one authenticated internal round trip per request with cache keys of their choosing. A transport failure is still not cached, so a recovering API is reached again immediately.

Everything else is unchanged and pinned by tests: every WhatsApp POST still requires a signature, a GET that is not the handshake still requires one (including on the per-agent path), and a handshake-shaped GET aimed at another platform gets no exemption.

## Why this is the first of two

There are two independent WhatsApp failures in production and the order is mandatory. The Meta access token has been expired since 2026-02-09 (`Session has expired on Monday, 09-Feb-26 09:00:00 PST`), but regenerating it changes nothing while the URL cannot be registered. This one is the blocker.

Current state: `SELECT count(*) FROM user_identities WHERE whatsapp_id IS NOT NULL` → **0**. No WhatsApp user has ever existed.

## Evidence

<details>
<summary>Tests — each mutation-verified</summary>

| pin | mutation | result |
|---|---|---|
| Meta's verification GET reaches the gateway with its query string intact | remove the exemption (i.e. the behaviour on develop) | 1 fail |
| a WhatsApp POST without a signature is still 401 | exempt every WhatsApp GET rather than the handshake | 1 fail |
| a GET that is not the handshake is still 401 (4 shapes) | — as above | 1 fail |
| a handshake-shaped GET on twilio gets no exemption | drop the platform check | 1 fail |

The first mutation is the one that matters: it reproduces develop exactly, and the handshake test goes red — so this test would have caught the production bug.

```
eliza-app-webhook-whatsapp-verification   4 pass  0 fail
eliza-app-webhook-suffix                 17 pass  0 fail
eliza-app-webhook-gateway-secret          6 pass  0 fail
cloud-api unit lane                     219/224 files pass
```

The 5 remaining failures (`agent-a2a-trust-boundary`, two `chat-completions-*`, `src/index`, `src/inference-app`) fail identically with this change reverted — verified by checking out the parent revision of both touched files and re-running them. They are pre-existing and unrelated to this diff.

Typecheck and biome clean on both touched files.

</details>

## Not done here

The gateway compares the verify token with `token === verifyToken` rather than a constant-time helper, in both `GET /webhook/:project/whatsapp` handlers. A timing oracle on a verify token is impractical over the network and the code predates this change, so it is left alone rather than widened into this diff — but it is worth a follow-up since the package already has a constant-time compare in `internal-auth.ts`.

[stan-cloud]

<!-- evidence-head:cce1fb6efc5d6c75a148960a1002d50a8e36c20c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend only: a Cloudflare Worker webhook forwarder, no UI surface in the diff

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend only: a Cloudflare Worker webhook forwarder, no UI surface in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend only: the observable behaviour is an HTTP status and an echoed challenge, both in the backend-logs and domain-artifacts rows

<!-- evidence-row:backend-logs -->
- [x] [17824-wa-traces-v3.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17824-wa-traces-v3.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call on any path this diff touches

<!-- evidence-row:domain-artifacts -->
- [x] [17824-wa-domain.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17824-wa-domain.txt)







