### PR TITLE
fix(ui): route sso-bridge logout-marker writes through the shell storage channel

### DIFF
--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
@@ -53,6 +53,7 @@ import {
   readStoredStewardToken,
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
+import { shellLocalStorage } from "../../surface-realm-channel";
 import { appModeNavigation } from "../app-mode/app-mode";
 import { decodeJwtPayload } from "../lib/jwt";
 import {
@@ -311,7 +312,9 @@ export function isSsoLoggedOut(): boolean {
 
 export function markSsoLoggedOut(): void {
   try {
-    localStorage.setItem(SSO_LOGGED_OUT_KEY, "1");
+    // Reserved shell key: raw localStorage writes throw SurfaceRealmDeniedError
+    // while a view scope is foreground (surface-realm-broker guard, #13452).
+    shellLocalStorage.setItem(SSO_LOGGED_OUT_KEY, "1");
   } catch {
     // error-policy:J6 best-effort marker; isSsoLoggedOut fails closed when
     // storage is unavailable.
@@ -320,7 +323,7 @@ export function markSsoLoggedOut(): void {
 
 export function clearSsoLoggedOut(): void {
   try {
-    localStorage.removeItem(SSO_LOGGED_OUT_KEY);
+    shellLocalStorage.removeItem(SSO_LOGGED_OUT_KEY);
   } catch {
     // error-policy:J6 best-effort cleanup; an over-persistent marker only
     // suppresses auto-bridge, never login itself.


### PR DESCRIPTION
#17788 introduced two raw `localStorage` writes of the reserved key `eliza_sso_logged_out` (`sso-bridge.ts` `markSsoLoggedOut`/`clearSsoLoggedOut`), which fails the repo-wide reserved-writers guard (`surface-realm-reserved-writers.guard.test.ts`) at every sha since — caught by certification-run forensics (31073689058), reproduced with the scanner locally.

Fix: both writes route through `shellLocalStorage` (`surface-realm-channel.ts`), the privileged shell channel the scanner enforces. The read stays raw by the channel's own contract ("read the global directly" — it deliberately exposes no `getItem`), matching every passing consumer.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:d3e53235799a2bf7ad50a5ea0c1822d2fd491df5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - storage-channel routing change with identical runtime behavior, no rendered surface differs.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - one-file storage-write routing change, no on-screen flow to record.

<!-- evidence-row:backend-logs -->
- [x] N/A - client-side storage write; no server code path is touched by this diff.

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs - the guard scanner before/after.

<details><summary>scan-reserved-storage-writers</summary>

```text
before (develop b8bbfdee9f7):
  $ node packages/ui/scripts/scan-reserved-storage-writers.mjs
  VIOLATION src/cloud/sso-bridge/sso-bridge.ts:314 setItem(SSO_LOGGED_OUT_KEY)
  VIOLATION src/cloud/sso-bridge/sso-bridge.ts:323 removeItem(SSO_LOGGED_OUT_KEY)
  (introduced by 67accented... 67270bfd0e1 #17788; guard red repo-wide)

after (this head):
  $ node packages/ui/scripts/scan-reserved-storage-writers.mjs
  OK - 0 raw writers
```

</details>

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic storage routing; no model inference participates.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - guard + sso-bridge suites at this head.

<details><summary>Test results at d3e53235799a2bf7ad50a5ea0c1822d2fd491df5</summary>

```text
$ bunx vitest run src/surface-realm-reserved-writers.guard.test.ts src/cloud/sso-bridge
  Test Files  3 passed (3)
       Tests  50 passed (50)

$ tsc --noEmit (packages/ui)   clean
$ biome check (1 file)          clean
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
