### PR TITLE
fix(cloud): fence app cache hydration across mutations

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -58,6 +58,8 @@ const FRESH_UUID = "00000000-0000-4000-8000-00000000ffff";
 
 let appsService: typeof import("../../../lib/services/apps").appsService;
 let appAnalyticsService: typeof import("../../../lib/services/app-analytics").appAnalyticsService;
+let cache: typeof import("../../../lib/cache/client").cache;
+let CacheKeys: typeof import("../../../lib/cache/keys").CacheKeys;
 let pgliteReady = true;
 
 // Monotonic counter keeps seeded slugs/identities unique across tests without
@@ -104,6 +106,8 @@ beforeAll(async () => {
   try {
     ({ appsService } = await import("../../../lib/services/apps"));
     ({ appAnalyticsService } = await import("../../../lib/services/app-analytics"));
+    ({ cache } = await import("../../../lib/cache/client"));
+    ({ CacheKeys } = await import("../../../lib/cache/keys"));
 
     // Generate DDL from the real schema objects and apply it to the same
     // PGlite connection the repository queries through (`dbWrite`). Enums must
@@ -263,6 +267,60 @@ describe("AppsRepository.update", () => {
     // evicted rather than returning the stale cached "Cache Warm".
     const after = await appsService.getById(created.id);
     expect(after?.name).toBe("Cache Evicted");
+  });
+
+  test("update prevents an older in-flight hydration from republishing stale state", async () => {
+    expect(pgliteReady).toBe(true);
+    const { organizationId, userId } = await seedOrgAndUser();
+    const created = await createApp({
+      name: "Before Concurrent Update",
+      organization_id: organizationId,
+      created_by_user_id: userId,
+    });
+    await appsService.invalidateCache(
+      created.id,
+      created.api_key_id ?? undefined,
+      created.slug ?? undefined,
+    );
+
+    const originalFindById = appsRepository.findById.bind(appsRepository);
+    let signalReadStarted: (() => void) | undefined;
+    const readStarted = new Promise<void>((resolve) => {
+      signalReadStarted = resolve;
+    });
+    let releaseRead: (() => void) | undefined;
+    const readRelease = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+
+    appsRepository.findById = async (id: string): Promise<App | undefined> => {
+      const captured = await originalFindById(id);
+      signalReadStarted?.();
+      await readRelease;
+      return captured;
+    };
+
+    const background: Promise<unknown>[] = [];
+    try {
+      expect(
+        await appsService.getByIdCacheOnly(created.id, {
+          executionCtx: { waitUntil: (promise) => background.push(promise) },
+        }),
+      ).toEqual({ kind: "warming", cacheRead: "miss" });
+      expect(background).toHaveLength(1);
+      await readStarted;
+
+      await appsRepository.update(created.id, { name: "After Concurrent Update" });
+      releaseRead?.();
+      await background[0];
+
+      expect(await cache.get<App>(CacheKeys.app.byId(created.id))).toBeNull();
+    } finally {
+      releaseRead?.();
+      appsRepository.findById = originalFindById;
+    }
+
+    expect((await appsService.getById(created.id))?.name).toBe("After Concurrent Update");
   });
 });
 

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -28,8 +28,11 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
 const CAN_USE_ISOLATED_PGLITE =
   AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+const PREVIOUS_CACHE_ENABLED = process.env.CACHE_ENABLED;
+const PREVIOUS_MOCK_REDIS = process.env.MOCK_REDIS;
 process.env.DATABASE_URL ||= "pglite://memory";
 process.env.NODE_ENV ||= "test";
+process.env.CACHE_ENABLED = "true";
 process.env.MOCK_REDIS = "1";
 
 import { pushSchema } from "drizzle-kit/api";
@@ -139,7 +142,15 @@ beforeAll(async () => {
 }, PGLITE_TIMEOUT);
 
 afterAll(async () => {
-  await closeDatabaseConnectionsForTests();
+  try {
+    await closeDatabaseConnectionsForTests();
+  } finally {
+    if (PREVIOUS_CACHE_ENABLED === undefined) delete process.env.CACHE_ENABLED;
+    else process.env.CACHE_ENABLED = PREVIOUS_CACHE_ENABLED;
+
+    if (PREVIOUS_MOCK_REDIS === undefined) delete process.env.MOCK_REDIS;
+    else process.env.MOCK_REDIS = PREVIOUS_MOCK_REDIS;
+  }
 });
 
 /** Insert an app row directly through the repository with sane defaults. */

--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -2,7 +2,7 @@
 import { and, count, countDistinct, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { cache } from "../../lib/cache/client";
 import { CacheKeys } from "../../lib/cache/keys";
-import { evictInferenceAppMemoryCache } from "../../lib/services/inference-app-memory-cache";
+import { invalidateInferenceAppByIdState } from "../../lib/services/inference-app-memory-cache";
 import { sqlRows } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
 import {
@@ -33,7 +33,7 @@ async function invalidateAppCacheEntries(
   apiKeyId?: string | null,
   slug?: string | null,
 ): Promise<void> {
-  evictInferenceAppMemoryCache(appId);
+  invalidateInferenceAppByIdState(appId);
   const keys: Promise<void>[] = [
     cache.del(CacheKeys.app.byId(appId)),
     cache.del(CacheKeys.app.costMarkup(appId)),

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -4,7 +4,12 @@
 
 import crypto from "crypto";
 import { type App, type AppUser, appsRepository, type NewApp } from "../../db/repositories/apps";
-import { inferenceAppMemoryCache } from "./inference-app-memory-cache";
+import {
+  getAppByIdHydrationGeneration,
+  getInferenceAppById,
+  invalidateInferenceAppByIdState,
+  setInferenceAppById,
+} from "./inference-app-memory-cache";
 
 // Re-export the app row types so consumers (and tests) can import them from the
 // service module rather than reaching into the repository directly.
@@ -19,7 +24,6 @@ import { managedDomainsService } from "./managed-domains";
 
 const DEFAULT_MAX_APPS_PER_ORG = 25;
 const appByIdHydrations = new Map<string, Promise<void>>();
-const appByIdHydrationGeneration = new Map<string, number>();
 
 export interface AppCacheExecutionContext {
   waitUntil(promise: Promise<unknown>): void;
@@ -142,7 +146,7 @@ export class AppsService {
    * Negative cache: missing apps are remembered briefly to absorb invalid IDs.
    */
   async getById(id: string): Promise<App | undefined> {
-    const inMemory = inferenceAppMemoryCache.get(id);
+    const inMemory = getInferenceAppById(id);
     if (inMemory) return structuredClone(inMemory);
     const cacheKey = CacheKeys.app.byId(id);
 
@@ -152,7 +156,7 @@ export class AppsService {
         return undefined;
       }
       if (isCachedApp(cached, id)) {
-        inferenceAppMemoryCache.set(id, cached);
+        setInferenceAppById(id, cached);
         return cached;
       }
     }
@@ -162,14 +166,14 @@ export class AppsService {
 
   private async loadAndCacheAppById(id: string): Promise<App | undefined> {
     const cacheKey = CacheKeys.app.byId(id);
-    const generation = appByIdHydrationGeneration.get(id) ?? 0;
+    const generation = getAppByIdHydrationGeneration(id);
     const app = await appsRepository.findById(id);
-    if ((appByIdHydrationGeneration.get(id) ?? 0) !== generation) {
+    if (getAppByIdHydrationGeneration(id) !== generation) {
       return app;
     }
     if (app) {
       await cache.set(cacheKey, app, CacheTTL.app.byId);
-      inferenceAppMemoryCache.set(id, app);
+      setInferenceAppById(id, app);
     } else {
       await cache.set(cacheKey, { __none: true }, CacheTTL.app.none);
     }
@@ -206,7 +210,7 @@ export class AppsService {
     id: string,
     options: { executionCtx?: AppCacheExecutionContext } = {},
   ): Promise<InferenceAppCacheResolution> {
-    const inMemory = inferenceAppMemoryCache.get(id);
+    const inMemory = getInferenceAppById(id);
     if (inMemory) {
       return { kind: "ready", app: structuredClone(inMemory) };
     }
@@ -214,7 +218,7 @@ export class AppsService {
     if (outcome.kind === "hit") {
       if (isNoneMarker(outcome.value)) return { kind: "ready", app: null };
       if (isCachedApp(outcome.value, id)) {
-        inferenceAppMemoryCache.set(id, outcome.value);
+        setInferenceAppById(id, outcome.value);
         return { kind: "ready", app: outcome.value };
       }
     }
@@ -338,8 +342,7 @@ export class AppsService {
    * would leave stale data; we look up the existing row's slug to evict it too.
    */
   async invalidateCache(appId: string, apiKeyId?: string, slug?: string): Promise<void> {
-    inferenceAppMemoryCache.delete(appId);
-    appByIdHydrationGeneration.set(appId, (appByIdHydrationGeneration.get(appId) ?? 0) + 1);
+    invalidateInferenceAppByIdState(appId);
     const promises: Promise<void>[] = [
       cache.del(CacheKeys.app.byId(appId)),
       cache.del(CacheKeys.app.costMarkup(appId)),

--- a/packages/cloud/shared/src/lib/services/inference-app-memory-cache.ts
+++ b/packages/cloud/shared/src/lib/services/inference-app-memory-cache.ts
@@ -1,20 +1,33 @@
 /**
- * Worker-lifetime memory cache for inference app rows, shared between the
- * apps service (reads) and the apps repository (eviction on mutation). Lives
- * in its own module so the repository can evict without importing the service
- * layer, which itself imports the repository.
+ * Worker-lifetime state for inference app reads, shared between the apps
+ * service and repository mutation boundary. Cache eviction and hydration
+ * generations move together so an in-flight read cannot republish a row that
+ * a concurrent mutation already invalidated.
  */
 import type { App } from "../../db/repositories/apps";
 import { InMemoryLRUCache } from "../cache/in-memory-lru-cache";
 
-export const inferenceAppMemoryCache = new InMemoryLRUCache<App>(100, 30_000);
+const inferenceAppMemoryCache = new InMemoryLRUCache<App>(100, 30_000);
+const appByIdHydrationGeneration = new Map<string, number>();
+
+export function getInferenceAppById(appId: string): App | null {
+  return inferenceAppMemoryCache.get(appId);
+}
+
+export function setInferenceAppById(appId: string, app: App): void {
+  inferenceAppMemoryCache.set(appId, app);
+}
+
+export function getAppByIdHydrationGeneration(appId: string): number {
+  return appByIdHydrationGeneration.get(appId) ?? 0;
+}
 
 /**
- * Evict one app from the worker-lifetime memory cache. Called by the apps
- * repository after every persisting mutation so a same-worker read cannot
- * return the pre-mutation row for up to the cache TTL — the shared-cache
- * eviction alone cannot reach this layer.
+ * Invalidates the memory cache and any authoritative read already in flight.
+ * Callers must use this single boundary rather than deleting the LRU directly;
+ * the generation bump prevents an older read from restoring stale state.
  */
-export function evictInferenceAppMemoryCache(appId: string): void {
+export function invalidateInferenceAppByIdState(appId: string): void {
   inferenceAppMemoryCache.delete(appId);
+  appByIdHydrationGeneration.set(appId, getAppByIdHydrationGeneration(appId) + 1);
 }


### PR DESCRIPTION
# Relates to

Relates to #17806. The seven IAC v2 test updates formerly carried by this PR are already on `develop` through #17835, so this rewritten head keeps only the unique cache-coherence repair and the real concurrency regression requested in review.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Rebased directly onto current `develop@d2509cb7e15284ddd3dda42ebea799f5f77389ed`.
- [x] Proved the race fails on the exact base before applying the fix.
- [x] Proved the repaired path with the real PGlite repository/service harness.
- [x] Cloud API typecheck and Worker dry-run passed.
- [x] Full root `bun run verify` passed: 343/343 tasks.

# What changed

The worker-lifetime app cache and its hydration generation now have one shared owner. Repository update/delete boundaries atomically invalidate that state before clearing external cache keys. A read that began before a mutation can no longer resume afterwards and republish its stale row into the process-local or shared cache.

The new real PGlite regression deliberately pauses `findById` after it captures the old row, performs a repository update, resumes the older hydration, and proves the stale row is not republished. A fresh service read then returns the updated Postgres row.

# Why this is narrower than the previous head

The previous head also carried seven IAC v2 test files. Those exact test semantics are now present on `develop`, and retaining them here would duplicate upstream work and preserve a review-blocked broad status assertion. This head changes four cache-ownership paths only and directly pins the stronger generation-fence invariant identified by the reviewer.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`, `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`, `Claude Code CLI`
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no repository contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Sync with develop

- [x] Exact head: `1ea48ca296dd8633158f6753b2e858f5a2d4bfb7`.
- [x] Exact tree: `9ebedc80f6eecdebc89391a51e35795922516f0e`.
- [x] Exact base: `develop@d2509cb7e15284ddd3dda42ebea799f5f77389ed`.
- [x] Two linear commits; clean worktree; `git diff --check` passed.

# Risks

Bounded to app-by-id cache coherence. The repair removes stale reads and does not add a fallback, fabricate a value, or alter model/UI behavior.

# Testing

```text
Red proof on exact develop@a0fbf37c752:
  older in-flight hydration test FAILS
  received cached row name: "Before Concurrent Update"

Repaired exact head 1ea48ca296d:
  real PGlite AppsRepository + AppsService: 23 pass / 0 fail
  exact CI env (CACHE_ENABLED=false):       23 pass / 0 fail
  focused concurrency regression:            1 pass / 0 fail
  packages/cloud/shared typecheck:            pass
  packages/cloud/api typecheck + Worker dry-run: pass
  targeted Biome (4 files):                   pass
  git diff --check:                           pass
  bun run verify:                             343/343 tasks
```

# Evidence Gate

<!-- evidence-head:1ea48ca296dd8633158f6753b2e858f5a2d4bfb7 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head backend proof:

  <details><summary>Race reproduction and repaired boundary</summary>

  ```text
  Base: update invalidates the cache, but the already-running hydration resumes
  and writes the captured pre-update row back into the shared cache.

  Head: the repository mutation advances the shared hydration generation.
  The older hydration detects the generation change and does not publish.
  The shared cache remains empty and the next read returns the updated DB row.
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head real PGlite domain artifacts:

  ```text
  BEFORE_DB name="Before Concurrent Update"; paused hydration holds the pre-mutation row
  MUTATION_DB name="After Concurrent Update"; generation advances and shared cache stays empty
  AFTER_DB name="After Concurrent Update"; stale hydration is rejected and fresh read returns the updated row
  ```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Known gaps / failures

No known product failure on the exact head. The prior Cloud unit red was a test-harness capability mismatch: CI globally disables cache, so the new real-cache race test never entered its intended path. The harness now explicitly enables the in-memory cache for this suite and restores both environment variables afterward. Exact CI-environment reproduction and full local verification are green; fresh GitHub checks are running.