### PR TITLE
fix(cloud): repository mutations evict the inference app memory cache

### DIFF
--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -2,6 +2,7 @@
 import { and, count, countDistinct, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { cache } from "../../lib/cache/client";
 import { CacheKeys } from "../../lib/cache/keys";
+import { evictInferenceAppMemoryCache } from "../../lib/services/inference-app-memory-cache";
 import { sqlRows } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
 import {
@@ -32,6 +33,7 @@ async function invalidateAppCacheEntries(
   apiKeyId?: string | null,
   slug?: string | null,
 ): Promise<void> {
+  evictInferenceAppMemoryCache(appId);
   const keys: Promise<void>[] = [
     cache.del(CacheKeys.app.byId(appId)),
     cache.del(CacheKeys.app.costMarkup(appId)),

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -4,13 +4,13 @@
 
 import crypto from "crypto";
 import { type App, type AppUser, appsRepository, type NewApp } from "../../db/repositories/apps";
+import { inferenceAppMemoryCache } from "./inference-app-memory-cache";
 
 // Re-export the app row types so consumers (and tests) can import them from the
 // service module rather than reaching into the repository directly.
 export type { App, AppUser, NewApp } from "../../db/repositories/apps";
 
 import { cache } from "../cache/client";
-import { InMemoryLRUCache } from "../cache/in-memory-lru-cache";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { isAllowedOrigin } from "../security/origin-validation";
 import { logger } from "../utils/logger";
@@ -20,7 +20,6 @@ import { managedDomainsService } from "./managed-domains";
 const DEFAULT_MAX_APPS_PER_ORG = 25;
 const appByIdHydrations = new Map<string, Promise<void>>();
 const appByIdHydrationGeneration = new Map<string, number>();
-const inferenceAppMemoryCache = new InMemoryLRUCache<App>(100, 30_000);
 
 export interface AppCacheExecutionContext {
   waitUntil(promise: Promise<unknown>): void;

--- a/packages/cloud/shared/src/lib/services/inference-app-memory-cache.ts
+++ b/packages/cloud/shared/src/lib/services/inference-app-memory-cache.ts
@@ -1,0 +1,20 @@
+/**
+ * Worker-lifetime memory cache for inference app rows, shared between the
+ * apps service (reads) and the apps repository (eviction on mutation). Lives
+ * in its own module so the repository can evict without importing the service
+ * layer, which itself imports the repository.
+ */
+import type { App } from "../../db/repositories/apps";
+import { InMemoryLRUCache } from "../cache/in-memory-lru-cache";
+
+export const inferenceAppMemoryCache = new InMemoryLRUCache<App>(100, 30_000);
+
+/**
+ * Evict one app from the worker-lifetime memory cache. Called by the apps
+ * repository after every persisting mutation so a same-worker read cannot
+ * return the pre-mutation row for up to the cache TTL — the shared-cache
+ * eviction alone cannot reach this layer.
+ */
+export function evictInferenceAppMemoryCache(appId: string): void {
+  inferenceAppMemoryCache.delete(appId);
+}


### PR DESCRIPTION
Fifth (and per current forensics, final) at-sha matrix red on develop. #17805 put a worker-lifetime `InMemoryLRUCache` in front of `appsService.getById`, but the repository's `invalidateAppCacheEntries` only deletes shared-cache keys — after `update`/`delete`, a same-worker read returns the **pre-mutation row for up to the 30s TTL**. `apps.test.ts` pins exactly that eviction contract and has been red at every sha since (the robot certification never reached it: its cloud-shared lane stopped at batch 23 on the billing failure fixed in #17825; this was next in line).

This is a real production staleness bug, not just a test skew: dashboard edits and deletes could read back stale for the TTL window on the same worker.

Fix: the memory cache moves to its own module (`inference-app-memory-cache.ts`) so the repository can evict without a service↔repository import cycle; `invalidateAppCacheEntries` now evicts it on every persisting mutation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:38b4d6465f0daa9b01b28735340f93619df85674 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - cache-eviction wiring in the shared backend, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing user-visible renders differently; reads simply stop being stale after mutations.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend cache-coherency change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the deterministic red at develop tip, reproduced before the fix.

<details><summary>apps.test.ts at develop tip 9fd96031949 (pre-fix)</summary>

```text
$ bun test src/db/repositories/__tests__/apps.test.ts   (packages/cloud/shared)

  265 |     expect(after?.name).toBe("Cache Evicted");
  error: expect(received).toBe(expected)
    Expected: "Cache Evicted"
    Received: "Cache Warm"        <- same-worker read after update() is stale
  x AppsRepository.update > update evicts the service read-cache

  286 |     expect(await appsService.getById(created.id)).toBeUndefined();
  error: expect(received).toBeUndefined()
  x AppsRepository.delete > delete removes the row and evicts the cache

  20 pass / 2 fail
  cause: appsService.getById consults inferenceAppMemoryCache (added by
  4fa232298f6 #17805) before the shared cache; invalidateAppCacheEntries
  never evicts that layer
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in repository cache eviction.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic cache-coherency change, no model inference participates.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - suite green at this head, typecheck and lint clean.

<details><summary>Results at 38b4d6465f0daa9b01b28735340f93619df85674</summary>

```text
$ bun test src/db/repositories/__tests__/apps.test.ts
  22 pass / 0 fail   (118 expect() calls; the 2 red cases above now green)

$ bunx tsc --noEmit (packages/cloud/shared)   0 errors
$ bunx biome check (3 files)                  clean
files: lib/services/inference-app-memory-cache.ts (new),
       lib/services/apps.ts, db/repositories/apps.ts
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
