### PR TITLE
fix(cloud): scope the lifecycle-revision counter to lifecycle writes

### DIFF
--- a/packages/cloud/shared/src/db/agent-sandbox-lifecycle-revision-scope.test.ts
+++ b/packages/cloud/shared/src/db/agent-sandbox-lifecycle-revision-scope.test.ts
@@ -37,25 +37,20 @@ async function revision(): Promise<number> {
 beforeAll(async () => {
   try {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("./client"));
-    // Only the columns this trigger reasons about: the fenced ones, the billing
-    // ones it must ignore, and the counter itself.
-    await dbWrite.execute(`
-      CREATE TABLE agent_sandboxes (
-        id uuid PRIMARY KEY,
-        organization_id uuid NOT NULL,
-        status text NOT NULL,
-        environment_revision integer NOT NULL DEFAULT 0,
-        warm_claim_credential_state text,
-        lifecycle_revision bigint NOT NULL DEFAULT 0,
-        billing_status text,
-        hourly_rate numeric,
-        last_billed_at timestamp,
-        total_billed numeric,
-        scheduled_shutdown_at timestamp,
-        shutdown_warning_sent_at timestamp,
-        updated_at timestamp NOT NULL DEFAULT now()
-      );
-    `);
+    // The WHEN clause is `to_jsonb(OLD) - ARRAY[...]`, so it ranges over
+    // whatever columns the table actually has. A hand-rolled subset would be the
+    // one shape where the trigger under test sees a different row than
+    // production does, and `jsonb - text[]` ignores absent keys silently.
+    const { PROVISIONING_JOB_TEST_TABLES } = await import(
+      "../lib/services/__tests__/tier-upgrade-pglite-schema"
+    );
+    for (const ddl of PROVISIONING_JOB_TEST_TABLES) {
+      // The table only — the migration under test installs the function and the
+      // trigger, and the shared block still carries the 0187 pair.
+      if (ddl.includes('CREATE TABLE IF NOT EXISTS "agent_sandboxes"')) {
+        await dbWrite.execute(ddl);
+      }
+    }
     for (const statement of migrationSql.split("--> statement-breakpoint")) {
       if (statement.trim()) await dbWrite.execute(statement);
     }
@@ -73,8 +68,9 @@ describe("agent_sandboxes lifecycle-revision trigger", () => {
   beforeAll(async () => {
     if (!databaseReady) return;
     await dbWrite.execute(`
-      INSERT INTO agent_sandboxes (id, organization_id, status, billing_status)
-      VALUES ('${SANDBOX_ID}', '00000000-0000-4000-8000-000000000001', 'provisioning', 'active')
+      INSERT INTO agent_sandboxes (id, organization_id, user_id, status, billing_status)
+      VALUES ('${SANDBOX_ID}', '00000000-0000-4000-8000-000000000001',
+              '00000000-0000-4000-8000-000000000002', 'provisioning', 'active')
       ON CONFLICT (id) DO NOTHING;
     `);
   }, TIMEOUT);
@@ -209,23 +205,56 @@ describe("lifecycle-revision exclusion list drift guard", () => {
     expect(excluded.has("lifecycle_revision")).toBe(false);
   });
 
-  test("no column a lifecycle fence compares on is excluded", async () => {
-    const sandboxService = readFileSync(
-      fileURLToPath(new URL("../lib/services/eliza-sandbox.ts", import.meta.url)),
-      "utf8",
+  // Every fence, from both files and both spellings: raw SQL predicates and the
+  // Drizzle builder. Scanning one file or one form fails open — which is the
+  // failure mode this guard exists to prevent.
+  function scanFences(): Set<string> {
+    const columns = new Set(
+      Array.from(
+        readFileSync(
+          fileURLToPath(new URL("./schemas/agent-sandboxes.ts", import.meta.url)),
+          "utf8",
+        ).matchAll(/^\s{4}([a-z_]+):/gm),
+        (match) => match[1],
+      ),
     );
 
-    // Columns compared in the same predicate as `lifecycle_revision` are, by
-    // definition, what the fences read.
     const fenced = new Set<string>();
-    for (const block of sandboxService.split("lifecycle_revision")) {
-      for (const [, column] of block.slice(-1200).matchAll(/AND\s+([a-z_]+)\s+(?:=|IS)/g)) {
-        fenced.add(column);
+    for (const source of [
+      "../lib/services/eliza-sandbox.ts",
+      "./repositories/agent-sandboxes.ts",
+    ]) {
+      const text = readFileSync(fileURLToPath(new URL(source, import.meta.url)), "utf8");
+      // Look both ways: the revision is not always last in its predicate, and
+      // assuming it is made an earlier version of this window silently wrong.
+      for (const at of text.matchAll(/lifecycle_revision|lifecycleRevision/g)) {
+        const index = at.index ?? 0;
+        const window = text.slice(Math.max(0, index - 1500), index + 1500);
+        for (const [, column] of window.matchAll(/AND\s+([a-z_]+)\s+(?:=|IS)/g)) {
+          if (columns.has(column)) fenced.add(column);
+        }
+        for (const [, column] of window.matchAll(/eq\(\s*agentSandboxes\.([a-z_]+)/g)) {
+          if (columns.has(column)) fenced.add(column);
+        }
       }
     }
     fenced.delete("lifecycle_revision");
+    return fenced;
+  }
 
-    expect(fenced.size).toBeGreaterThan(5);
-    expect([...fenced].filter((column) => excluded.has(column))).toEqual([]);
+  test("no column a lifecycle fence compares on is excluded", () => {
+    expect([...scanFences()].filter((column) => excluded.has(column))).toEqual([]);
+  });
+
+  test("the scan reaches both fence files and both fence spellings", () => {
+    // Structural pins rather than a count floor: a count only fails once the
+    // number happens to drop below it, so it can lose a whole source silently.
+    // Each of these dies with exactly one gap: `execution_tier` is fenced only
+    // in the repository file, `id` only through the Drizzle builder, and
+    // `warm_claim_attested_at` only ahead of its predicate's revision clause.
+    const fenced = scanFences();
+    expect(fenced.has("execution_tier")).toBe(true);
+    expect(fenced.has("id")).toBe(true);
+    expect(fenced.has("warm_claim_attested_at")).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/db/agent-sandbox-lifecycle-revision-scope.test.ts
+++ b/packages/cloud/shared/src/db/agent-sandbox-lifecycle-revision-scope.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Applies the lifecycle-revision trigger to a real PGlite table and proves what
+ * the counter means: it advances for a lifecycle write, stays put for a
+ * billing-only write, and cannot be forged by a writer that supplies its own
+ * value. The last suite is a drift guard over the migration text itself.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const TIMEOUT = 60_000;
+const SANDBOX_ID = "00000000-0000-4000-8000-000000017694";
+const migrationUrl = new URL(
+  "./migrations/0189_agent_sandbox_lifecycle_revision_scope.sql",
+  import.meta.url,
+);
+const migrationSql = readFileSync(fileURLToPath(migrationUrl), "utf8");
+
+let dbWrite: typeof import("./client").dbWrite;
+let closeDb: typeof import("./client").closeDatabaseConnectionsForTests | undefined;
+let databaseReady = true;
+
+async function revision(): Promise<number> {
+  const rows = await dbWrite.execute(
+    `SELECT lifecycle_revision FROM agent_sandboxes WHERE id = '${SANDBOX_ID}'`,
+  );
+  return Number(
+    (rows as unknown as { rows: Array<{ lifecycle_revision: string }> }).rows[0].lifecycle_revision,
+  );
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("./client"));
+    // Only the columns this trigger reasons about: the fenced ones, the billing
+    // ones it must ignore, and the counter itself.
+    await dbWrite.execute(`
+      CREATE TABLE agent_sandboxes (
+        id uuid PRIMARY KEY,
+        organization_id uuid NOT NULL,
+        status text NOT NULL,
+        environment_revision integer NOT NULL DEFAULT 0,
+        warm_claim_credential_state text,
+        lifecycle_revision bigint NOT NULL DEFAULT 0,
+        billing_status text,
+        hourly_rate numeric,
+        last_billed_at timestamp,
+        total_billed numeric,
+        scheduled_shutdown_at timestamp,
+        shutdown_warning_sent_at timestamp,
+        updated_at timestamp NOT NULL DEFAULT now()
+      );
+    `);
+    for (const statement of migrationSql.split("--> statement-breakpoint")) {
+      if (statement.trim()) await dbWrite.execute(statement);
+    }
+  } catch (error) {
+    databaseReady = false;
+    console.warn("[lifecycle-revision-scope] PGlite setup failed", error);
+  }
+}, TIMEOUT);
+
+afterAll(async () => {
+  await closeDb?.();
+});
+
+describe("agent_sandboxes lifecycle-revision trigger", () => {
+  beforeAll(async () => {
+    if (!databaseReady) return;
+    await dbWrite.execute(`
+      INSERT INTO agent_sandboxes (id, organization_id, status, billing_status)
+      VALUES ('${SANDBOX_ID}', '00000000-0000-4000-8000-000000000001', 'provisioning', 'active')
+      ON CONFLICT (id) DO NOTHING;
+    `);
+  }, TIMEOUT);
+
+  test(
+    "a billing-cycle write leaves the revision alone",
+    async () => {
+      if (!databaseReady) throw new Error("PGlite unavailable");
+      const before = await revision();
+
+      // Exactly what active-billing.ts writes on suspension.
+      await dbWrite.execute(`
+        UPDATE agent_sandboxes
+        SET billing_status = 'suspended',
+            scheduled_shutdown_at = NULL,
+            shutdown_warning_sent_at = NULL,
+            updated_at = now()
+        WHERE id = '${SANDBOX_ID}';
+      `);
+
+      expect(await revision()).toBe(before);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "the hourly billing write leaves the revision alone",
+    async () => {
+      if (!databaseReady) throw new Error("PGlite unavailable");
+      const before = await revision();
+
+      await dbWrite.execute(`
+        UPDATE agent_sandboxes
+        SET last_billed_at = now(),
+            billing_status = 'active',
+            hourly_rate = '0.25',
+            total_billed = COALESCE(total_billed, 0) + 0.25,
+            scheduled_shutdown_at = NULL,
+            shutdown_warning_sent_at = NULL,
+            updated_at = now()
+        WHERE id = '${SANDBOX_ID}';
+      `);
+
+      expect(await revision()).toBe(before);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a lifecycle write still advances the revision",
+    async () => {
+      if (!databaseReady) throw new Error("PGlite unavailable");
+      const before = await revision();
+
+      await dbWrite.execute(`
+        UPDATE agent_sandboxes SET status = 'running', updated_at = now()
+        WHERE id = '${SANDBOX_ID}';
+      `);
+      expect(await revision()).toBe(before + 1);
+
+      await dbWrite.execute(`
+        UPDATE agent_sandboxes SET environment_revision = environment_revision + 1
+        WHERE id = '${SANDBOX_ID}';
+      `);
+      expect(await revision()).toBe(before + 2);
+
+      await dbWrite.execute(`
+        UPDATE agent_sandboxes SET warm_claim_credential_state = 'revoking'
+        WHERE id = '${SANDBOX_ID}';
+      `);
+      expect(await revision()).toBe(before + 3);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a billing write that also sets the revision by hand cannot forge it",
+    async () => {
+      if (!databaseReady) throw new Error("PGlite unavailable");
+      const before = await revision();
+
+      // The revision is not in the excluded set precisely so this fires.
+      await dbWrite.execute(`
+        UPDATE agent_sandboxes
+        SET billing_status = 'suspended', lifecycle_revision = -100
+        WHERE id = '${SANDBOX_ID}';
+      `);
+
+      expect(await revision()).toBe(before + 1);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "an update that changes nothing at all leaves the revision alone",
+    async () => {
+      if (!databaseReady) throw new Error("PGlite unavailable");
+      const before = await revision();
+
+      await dbWrite.execute(`
+        UPDATE agent_sandboxes SET status = status WHERE id = '${SANDBOX_ID}';
+      `);
+
+      expect(await revision()).toBe(before);
+    },
+    TIMEOUT,
+  );
+});
+
+describe("lifecycle-revision exclusion list drift guard", () => {
+  // The trigger's blind spot is whatever the migration excludes. If a fence is
+  // ever added on one of those columns, the fence silently stops working: the
+  // write it wants to detect no longer advances the counter. This reads both
+  // sides from source rather than asking anyone to remember.
+  const excluded = new Set(
+    Array.from(migrationSql.matchAll(/^\s*'([a-z_]+)',?$/gm), (match) => match[1]),
+  );
+
+  test("the migration really does exclude the billing columns and nothing else", () => {
+    expect([...excluded].sort()).toEqual([
+      "billing_status",
+      "hourly_rate",
+      "last_billed_at",
+      "scheduled_shutdown_at",
+      "shutdown_warning_sent_at",
+      "total_billed",
+      "updated_at",
+    ]);
+  });
+
+  test("the counter itself is compared, so a supplied value cannot survive", () => {
+    expect(excluded.has("lifecycle_revision")).toBe(false);
+  });
+
+  test("no column a lifecycle fence compares on is excluded", async () => {
+    const sandboxService = readFileSync(
+      fileURLToPath(new URL("../lib/services/eliza-sandbox.ts", import.meta.url)),
+      "utf8",
+    );
+
+    // Columns compared in the same predicate as `lifecycle_revision` are, by
+    // definition, what the fences read.
+    const fenced = new Set<string>();
+    for (const block of sandboxService.split("lifecycle_revision")) {
+      for (const [, column] of block.slice(-1200).matchAll(/AND\s+([a-z_]+)\s+(?:=|IS)/g)) {
+        fenced.add(column);
+      }
+    }
+    fenced.delete("lifecycle_revision");
+
+    expect(fenced.size).toBeGreaterThan(5);
+    expect([...fenced].filter((column) => excluded.has(column))).toEqual([]);
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/0189_agent_sandbox_lifecycle_revision_scope.sql
+++ b/packages/cloud/shared/src/db/migrations/0189_agent_sandbox_lifecycle_revision_scope.sql
@@ -1,0 +1,63 @@
+-- Scope the lifecycle-revision counter to lifecycle writes.
+--
+-- 0187 added the counter with an unconditional BEFORE UPDATE trigger, so the
+-- revision advanced on every write to the table. Inside one transaction that is
+-- exactly right and makes the counter unforgeable. Across two it means something
+-- weaker than the fences assume: `lifecycle_revision = $expected` reads as "did a
+-- lifecycle operation intervene?" but asserts "did anything at all touch this
+-- row?". The periodic billing writers touch the row and are not lifecycle
+-- operations, so a billing cycle landing inside a cross-transaction fence turned
+-- a successful warm claim into a terminal provisioning failure.
+--
+-- The WHEN clause is written as an EXCLUSION rather than a list of the columns
+-- the fences read. That direction is deliberate: an under-specified positive list
+-- silently stops advancing the counter for a genuine lifecycle write, which
+-- reopens the ABA window the fence exists to close — worse than the bug being
+-- fixed. Excluding instead means a column added later is compared by default, so
+-- a new lifecycle column is covered the day it appears and only an explicit edit
+-- here can widen the blind spot.
+--
+-- `lifecycle_revision` is deliberately NOT excluded. A writer touching only
+-- billing columns while also setting the revision by hand makes the two sides
+-- differ, so the trigger fires and the function overwrites the supplied value
+-- with OLD + 1. Excluding it would leave exactly that forgery open.
+
+CREATE OR REPLACE FUNCTION advance_agent_sandbox_lifecycle_revision()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.lifecycle_revision := OLD.lifecycle_revision + 1;
+  RETURN NEW;
+END;
+$$;
+--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS agent_sandboxes_lifecycle_revision_trigger ON "agent_sandboxes";
+--> statement-breakpoint
+
+CREATE TRIGGER agent_sandboxes_lifecycle_revision_trigger
+BEFORE UPDATE ON "agent_sandboxes"
+FOR EACH ROW
+WHEN (
+  to_jsonb(OLD) - ARRAY[
+    'billing_status',
+    'last_billed_at',
+    'hourly_rate',
+    'total_billed',
+    'shutdown_warning_sent_at',
+    'scheduled_shutdown_at',
+    'updated_at'
+  ]::text[]
+  IS DISTINCT FROM
+  to_jsonb(NEW) - ARRAY[
+    'billing_status',
+    'last_billed_at',
+    'hourly_rate',
+    'total_billed',
+    'shutdown_warning_sent_at',
+    'scheduled_shutdown_at',
+    'updated_at'
+  ]::text[]
+)
+EXECUTE FUNCTION advance_agent_sandbox_lifecycle_revision();

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1317,6 +1317,13 @@
       "when": 1785960000000,
       "tag": "0188_sso_bridge_store",
       "breakpoints": true
+    },
+    {
+      "idx": 188,
+      "version": "7",
+      "when": 1786046400000,
+      "tag": "0189_agent_sandbox_lifecycle_revision_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
@@ -226,6 +226,27 @@ $$`,
   `CREATE TRIGGER agent_sandboxes_lifecycle_revision_trigger
 BEFORE UPDATE ON "agent_sandboxes"
 FOR EACH ROW
+WHEN (
+  to_jsonb(OLD) - ARRAY[
+    'billing_status',
+    'last_billed_at',
+    'hourly_rate',
+    'total_billed',
+    'shutdown_warning_sent_at',
+    'scheduled_shutdown_at',
+    'updated_at'
+  ]::text[]
+  IS DISTINCT FROM
+  to_jsonb(NEW) - ARRAY[
+    'billing_status',
+    'last_billed_at',
+    'hourly_rate',
+    'total_billed',
+    'shutdown_warning_sent_at',
+    'scheduled_shutdown_at',
+    'updated_at'
+  ]::text[]
+)
 EXECUTE FUNCTION advance_agent_sandbox_lifecycle_revision()`,
   `CREATE TABLE IF NOT EXISTS "api_keys" (
   "id" uuid NOT NULL DEFAULT gen_random_uuid(),


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

Closes #17694 · Refs #17262

## What was wrong

I added `lifecycle_revision` in #17262 with an unconditional trigger:

```sql
BEFORE UPDATE ON "agent_sandboxes" FOR EACH ROW
EXECUTE FUNCTION advance_agent_sandbox_lifecycle_revision();
```

No `WHEN`. That is what makes the counter unforgeable — a raw SQL writer cannot dodge it — and **inside a single transaction it is exactly right**.

**Across two transactions it means something weaker than the code assumes.** `lifecycle_revision = $expected` reads as *"did a lifecycle operation intervene?"*. What it actually asserts is *"did anything at all touch this row?"*. Those coincide only if every writer is a lifecycle operation, and two are not: `active-billing.ts` and `agent-billing.ts` write `billing_status`, `scheduled_shutdown_at`, `shutdown_warning_sent_at`, `hourly_rate`, `last_billed_at` and `total_billed` on a periodic cycle, outside the lifecycle advisory lock.

`revokeWarmClaimSourceCredential` reads the revision in one transaction, performs out-of-band credential work, then re-fences in a second. On a miss it does **not** retry — it throws `Warm-claim credential finalization lost its state CAS`, which is terminal. So a billing cycle landing in that window converts a **successful** warm claim into a hard provisioning failure, triggered by a periodic job that has nothing to do with the agent's lifecycle. The replacement-cleanup fences span docker and VPN I/O, holding the same window open for seconds.

Found by @ss251 while reviewing #17262.

## The fix, and why it is written backwards

The `WHEN` clause is an **exclusion** of the billing columns, not a list of the columns the fences read.

That direction is the whole design. A positive list that is missing one column silently stops advancing the counter for a genuine lifecycle write — which reopens the ABA window the fence exists to close, and that is **worse than the bug being fixed**. Excluding instead means a column added later is compared by default: a new lifecycle column is covered the day it appears, and only an explicit edit to this migration can widen the blind spot.

**`lifecycle_revision` is deliberately not excluded.** A writer touching only billing columns while also supplying its own revision makes the two sides differ, so the trigger fires and the function overwrites the supplied value with `OLD + 1`. Excluding it would leave exactly that forgery open — there is a test for it, because I got this wrong the first time I designed it.

Two alternatives considered and rejected: routing the billing writers through the lifecycle advisory lock couples billing to lifecycle contention for no benefit, and making each call site retry turns a correctness bug into a latency bug while leaving the predicate lying.

## Evidence

<details>
<summary>Proof on a real Postgres engine, plus a drift guard — every pin mutation-verified</summary>

The suite applies the migration to a real PGlite table (a Postgres engine, not a mock) and drives it with the exact statements the billing writers issue.

| pin | mutation that must turn it red | result |
|---|---|---|
| the suspension write leaves the counter alone | restore the unconditional trigger (= the bug) | 4 fail |
| the hourly billing write leaves the counter alone | as above | 4 fail |
| `status`, `environment_revision` and `warm_claim_credential_state` each advance it | as above | 4 fail |
| a billing write supplying `lifecycle_revision = -100` is overwritten | add `lifecycle_revision` to the exclusion list | 3 fail |
| a no-op update changes nothing | — | |
| the exclusion list is exactly the billing columns | exclude a fenced column (`status`) | 3 fail |
| no column a fence compares on is excluded | as above | 3 fail |

```
agent-sandbox-lifecycle-revision-scope   8 pass  0 fail
drizzle-kit check (journal + migrations) Everything's fine
```

The drift guard is the part that outlives me: it reads the fenced columns straight out of the CAS predicates in `eliza-sandbox.ts` and asserts none of them is excluded. Adding a fence on a billing column fails the suite instead of silently disarming that fence — a guard, not a comment asking people to remember.

</details>

## Cost

`to_jsonb(OLD)`/`to_jsonb(NEW)` per updated row on this table. `agent_sandboxes` is small and its updates are lifecycle-paced, not request-paced, so this is not on a hot path. The alternative — a positive `IS DISTINCT FROM` list — is cheaper and fails unsafe, which is the wrong trade for a correctness fence.

[stan-cloud]

<!-- evidence-head:1da12d1f3ae930decac3193e9fe1ffc2c2280fdd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - a database trigger, no UI surface in the diff

<!-- evidence-row:after-screenshots -->
- [ ] N/A - a database trigger, no UI surface in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable behaviour is a counter value per statement, tabulated in the domain-artifacts row

<!-- evidence-row:backend-logs -->
- [x] [17830-lifecycle-evidence-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17830-lifecycle-evidence-v2.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call on any path this diff touches

<!-- evidence-row:domain-artifacts -->
- [x] [17830-rev-domain.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17830-rev-domain.txt)





