### PR TITLE
fix(core): keep expected embedding unavailability out of chat escalation

### DIFF
--- a/packages/core/src/features/documents/recall-embed.test.ts
+++ b/packages/core/src/features/documents/recall-embed.test.ts
@@ -1,17 +1,17 @@
 /**
  * Unit tests for `embedRecallQuery` + `aliasRecallQuery`: the embed returns the
- * vector on success, fails open to `null` on an embed error (never throwing
- * onto the reply path), and caches/dedupes identical normalized recall queries
- * within a turn (including across providers); the alias maps a rewritten
- * (document-augmented) prompt onto the clean prompt's cached or in-flight
- * vector so a rewrite never costs a second per-turn embed. Runs against
- * a real AgentRuntime with deterministic embedding API handlers registered
- * through the production model router.
+ * vector on success, distinguishes provider-owned capability-unavailable states
+ * from unexpected failures before populating RECENT_ERRORS/escalation, and
+ * caches/dedupes identical normalized recall queries within a turn (including
+ * across providers); the alias maps a rewritten (document-augmented) prompt
+ * onto the clean prompt's cached or in-flight vector so a rewrite never costs a
+ * second per-turn embed. Runs against a real AgentRuntime with deterministic
+ * embedding API handlers registered through the production model router.
  */
 import { describe, expect, test } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";
-import { ModelType } from "../../types";
+import { EventType, ModelType } from "../../types";
 import { aliasRecallQuery, embedRecallQuery } from "./recall-embed.ts";
 
 const MSG_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
@@ -19,6 +19,21 @@ const MSG_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
 
 interface RuntimeMockOpts {
 	embed: (params: { text: string; signal?: AbortSignal }) => Promise<number[]>;
+}
+
+type LocalUnavailableReason =
+	| "backend_unavailable"
+	| "capability_unavailable"
+	| "invalid_input"
+	| "invalid_output";
+
+function localEmbeddingUnavailable(reason: LocalUnavailableReason): Error {
+	return Object.assign(new Error(`local embedding ${reason}`), {
+		code: "LOCAL_INFERENCE_UNAVAILABLE",
+		modelType: ModelType.TEXT_EMBEDDING,
+		provider: "eliza-local-inference",
+		reason,
+	});
 }
 
 function makeRuntime(opts: RuntimeMockOpts): {
@@ -78,7 +93,83 @@ describe("embedRecallQuery — resolve / fail-open", () => {
 			},
 		});
 		await expect(embedRecallQuery(runtime, "boom")).resolves.toBeNull();
+		expect(runtime.getRecentReportedErrors()).toMatchObject([
+			{
+				scope: "DocumentRecall.embedding",
+				code: "RECALL_EMBEDDING_FAILED",
+				context: { phase: "asynchronous" },
+			},
+		]);
 	});
+
+	test.each(["backend_unavailable", "capability_unavailable"] as const)(
+		"repeated typed %s states stay keyword-only without entering RECENT_ERRORS or escalation",
+		async (reason) => {
+			const { runtime, calls } = makeRuntime({
+				embed: async () => {
+					throw localEmbeddingUnavailable(reason);
+				},
+			});
+			const reportedCodes: string[] = [];
+			runtime.registerEvent(EventType.ERROR_REPORTED, async (payload) => {
+				reportedCodes.push(payload.code);
+			});
+
+			for (const query of ["first turn", "second turn", "third turn"]) {
+				await expect(embedRecallQuery(runtime, query)).resolves.toBeNull();
+				runtime.startRun();
+			}
+
+			expect(calls.count).toBe(3);
+			// RECENT_ERRORS reads this ring and owner escalation consumes the event;
+			// an expected provider capability state belongs in neither path.
+			expect(runtime.getRecentReportedErrors()).toEqual([]);
+			expect(reportedCodes).toEqual([]);
+		},
+	);
+
+	test.each(["invalid_input", "invalid_output"] as const)(
+		"repeated unexpected provider %s failures retain a stable diagnostic code and escalation events",
+		async (reason) => {
+			const { runtime, calls } = makeRuntime({
+				embed: async () => {
+					throw localEmbeddingUnavailable(reason);
+				},
+			});
+			const reportedCodes: string[] = [];
+			runtime.registerEvent(EventType.ERROR_REPORTED, async (payload) => {
+				reportedCodes.push(payload.code);
+			});
+
+			for (const query of ["first turn", "second turn", "third turn"]) {
+				await expect(embedRecallQuery(runtime, query)).resolves.toBeNull();
+				runtime.startRun();
+			}
+
+			expect(calls.count).toBe(3);
+			const reported = runtime.getRecentReportedErrors();
+			expect(reported).toHaveLength(3);
+			for (const entry of reported) {
+				expect(entry).toMatchObject({
+					code: "RECALL_EMBEDDING_FAILED",
+					context: {
+						phase: "asynchronous",
+						providerErrorCode: "LOCAL_INFERENCE_UNAVAILABLE",
+						modelType: ModelType.TEXT_EMBEDDING,
+						provider: "eliza-local-inference",
+						reason,
+					},
+				});
+			}
+			// Three stable ERROR_REPORTED events remain eligible for the agent's
+			// configured repeat-failure escalation threshold.
+			expect(reportedCodes).toEqual([
+				"RECALL_EMBEDDING_FAILED",
+				"RECALL_EMBEDDING_FAILED",
+				"RECALL_EMBEDDING_FAILED",
+			]);
+		},
+	);
 
 	test("propagates explicit turn cancellation instead of degrading it to a cache miss", async () => {
 		const controller = new AbortController();

--- a/packages/core/src/features/documents/recall-embed.ts
+++ b/packages/core/src/features/documents/recall-embed.ts
@@ -43,8 +43,11 @@
  * **Fail-open on error only.** A failed embed (the model handler rejects — e.g.
  * its own request timeout aborts, or the provider errors) returns `null`; the
  * caller falls open to keyword/BM25 recall (or, for callers with no keyword
- * path, to empty recall context) — recall richness is lost, the reply is never
- * blocked on an *error*, and recall is never silently dropped (we log it).
+ * path, to empty recall context) — recall richness is lost, but the reply is
+ * never blocked on an *error*. The provider owns diagnosis of a typed, expected
+ * capability-unavailable state; every unexpected failure is reported here with
+ * a stable recall code so it remains eligible for runtime diagnostics and
+ * escalation without turning a known missing capability into chat noise.
  *
  * There is deliberately NO app-level latency timeout here. A short, arbitrary
  * race on every healthy-but-slow embed would silently degrade vector recall to
@@ -55,10 +58,75 @@
  * (fail-open), with no silent middle ground.
  */
 
+import { toElizaError } from "../../errors";
 import { recordInferenceSpan } from "../../inference-timing";
 import { getStreamingContext } from "../../streaming-context";
 import type { IAgentRuntime } from "../../types";
 import { ModelType } from "../../types";
+
+const LOCAL_INFERENCE_UNAVAILABLE_CODE = "LOCAL_INFERENCE_UNAVAILABLE";
+const EXPECTED_UNAVAILABLE_REASONS = new Set([
+	"backend_unavailable",
+	"capability_unavailable",
+]);
+
+interface ModelProviderFailureDetails {
+	code?: string;
+	modelType?: string;
+	provider?: string;
+	reason?: string;
+}
+
+/** Read the stable cross-package error fields exposed by model providers. */
+function modelProviderFailureDetails(
+	error: unknown,
+): ModelProviderFailureDetails {
+	if (typeof error !== "object" || error === null) return {};
+	const candidate = error as Record<string, unknown>;
+	return {
+		code: typeof candidate.code === "string" ? candidate.code : undefined,
+		modelType:
+			typeof candidate.modelType === "string" ? candidate.modelType : undefined,
+		provider:
+			typeof candidate.provider === "string" ? candidate.provider : undefined,
+		reason: typeof candidate.reason === "string" ? candidate.reason : undefined,
+	};
+}
+
+/**
+ * The local provider already diagnoses these states at registration/probe time.
+ * Re-reporting one for every recall query would turn a stable missing capability
+ * into RECENT_ERRORS and repeat-failure owner escalation.
+ */
+function isExpectedEmbeddingCapabilityUnavailable(error: unknown): boolean {
+	const details = modelProviderFailureDetails(error);
+	return (
+		details.code === LOCAL_INFERENCE_UNAVAILABLE_CODE &&
+		details.modelType === ModelType.TEXT_EMBEDDING &&
+		details.reason !== undefined &&
+		EXPECTED_UNAVAILABLE_REASONS.has(details.reason)
+	);
+}
+
+function reportUnexpectedEmbeddingFailure(
+	runtime: IAgentRuntime,
+	error: unknown,
+	phase: "synchronous" | "asynchronous",
+): void {
+	if (isExpectedEmbeddingCapabilityUnavailable(error)) return;
+	const details = modelProviderFailureDetails(error);
+	runtime.reportError(
+		"DocumentRecall.embedding",
+		toElizaError(error, "RECALL_EMBEDDING_FAILED"),
+		{
+			phase,
+			...(details.code ? { providerErrorCode: details.code } : {}),
+			...(details.modelType ? { modelType: details.modelType } : {}),
+			...(details.provider ? { provider: details.provider } : {}),
+			...(details.reason ? { reason: details.reason } : {}),
+		},
+	);
+}
 
 /** Normalize query text so trivially-different strings share one cache slot. */
 function normalizeQuery(text: string): string {
@@ -214,10 +282,9 @@ export async function embedRecallQuery(
 				throw signal.reason ?? error;
 			}
 			// error-policy:J4 semantic recall explicitly degrades to keyword recall;
-			// surface the embedding failure before returning the unavailable signal.
-			runtime.reportError("DocumentRecall.embedding", error, {
-				phase: "synchronous",
-			});
+			// unexpected failures remain observable, while a provider-owned typed
+			// unavailable state is already diagnosed at its registration/probe boundary.
+			reportUnexpectedEmbeddingFailure(runtime, error, "synchronous");
 			return null;
 		}
 		cache?.inFlight.set(normalized, pending);
@@ -249,10 +316,9 @@ export async function embedRecallQuery(
 			throw signal.reason ?? error;
 		}
 		// error-policy:J4 semantic recall explicitly degrades to keyword recall;
-		// surface the embedding failure before returning the unavailable signal.
-		runtime.reportError("DocumentRecall.embedding", error, {
-			phase: "asynchronous",
-		});
+		// unexpected failures remain observable, while a provider-owned typed
+		// unavailable state is already diagnosed at its registration/probe boundary.
+		reportUnexpectedEmbeddingFailure(runtime, error, "asynchronous");
 		return null;
 	}
 }


### PR DESCRIPTION
> Latest publication sync (2026-08-06): exact head `2497b4039162e73122aed093100e5dbc67e8a1d1`; cumulative top `3bd520d18fa54d13809248acae52452e2694b866`; 0 behind `origin/develop@35f6345511c8bc5ad00fc4cd01da40e4fb11c203`. The 107-commit replay is patch-identical; the only final-tree delta is develop's already-merged CI browser-runner provisioning.

# Relates to

Closes #17728.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no repository contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Stack position

- [x] Exact parent: #17722 at `b11f86e947a9200f425d47f6afba8c391b9989e5`.
- [x] Exact head: `8d8cdad54733a33074d718ce3fbcafa2af3b9c1d`.
- [x] Exact tree: `aa593afba6c53b50887358d79f5ead0e7856a590`.
- [x] Frozen install passed without tracked changes.

# Background

## What does this PR do?

Keeps an expected, typed local embedding capability-unavailable state on the designed keyword-recall degradation path without re-reporting it once per query into `RECENT_ERRORS` and owner chat escalation.

Unexpected provider failures remain observable under the stable `RECALL_EMBEDDING_FAILED` code with provider details. Turn cancellation still propagates rather than degrading.

## What kind of change is this?

Runtime error-boundary and recall-degradation correctness fix.

# Risks

Low and bounded to recall diagnostics. Vector recall remains unavailable when the provider is unavailable, keyword recall remains active, and unexpected failures continue to report and escalate.

# Documentation changes needed?

N/A - the boundary rationale is documented directly in the owning module.

# Testing

```text
bun run --cwd packages/core test src/features/documents/recall-embed.test.ts
1 file passed; 25 tests passed; 0 failed

bun run --cwd packages/core typecheck
PASS

bunx biome check <two touched files>
PASS

git diff --check
PASS
```

# Evidence Gate

<!-- evidence-head:2497b4039162e73122aed093100e5dbc67e8a1d1 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no new interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head runtime-boundary transcript:

  <details><summary>Expected versus unexpected provider states</summary>

  ```text
  backend_unavailable x3: keyword-only result returned; RECENT_ERRORS=[]; ERROR_REPORTED events=[].
  capability_unavailable x3: keyword-only result returned; RECENT_ERRORS=[]; ERROR_REPORTED events=[].
  invalid_input / invalid_output x3: stable RECALL_EMBEDDING_FAILED entries and ERROR_REPORTED events retained.
  Focused result: 25 passed, 0 failed; core typecheck passed.
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] [17831-live-cerebras-trajectories-exact-head.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17831-live-cerebras-trajectories-exact-head.json)
<!-- evidence-row:domain-artifacts -->
- [x] [17831-domain-artifacts-exact-head.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17831-domain-artifacts-exact-head.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Known gaps / failures

Draft until the exact-head live runtime trajectory and idle log tail are captured and manually reviewed. No focused code/test/typecheck failure is known.


