### PR TITLE
fix: enforce native view-catalog policy and isolate Calendar's Google SDK import (port of #17596)

### DIFF
--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -7,6 +7,7 @@
  * config + desktop tabs mocked, no runtime.
  */
 
+import { Capacitor } from "@capacitor/core";
 import { createNavigateViewEvent } from "@elizaos/shared/events";
 import {
   act,
@@ -57,6 +58,10 @@ const desktopTabsState = vi.hoisted(() => ({
 
 const mediaQueryState = vi.hoisted(() => ({
   matches: false,
+}));
+
+const electrobunRuntimeState = vi.hoisted(() => ({
+  enabled: true,
 }));
 
 const desktopBridgeMock = vi.hoisted(() => ({
@@ -245,7 +250,7 @@ vi.mock("@capacitor/keyboard", () => ({
 vi.mock("./bridge/electrobun-rpc", () => desktopBridgeMock);
 
 vi.mock("./bridge/electrobun-runtime", () => ({
-  isElectrobunRuntime: () => true,
+  isElectrobunRuntime: () => electrobunRuntimeState.enabled,
 }));
 
 vi.mock("./platform/init", () => ({
@@ -534,6 +539,7 @@ describe("App navigate-view event wiring", () => {
     authStatusMock.phase = "authenticated";
     cloudOriginMock.agentless = false;
     mediaQueryState.matches = false;
+    electrobunRuntimeState.enabled = true;
     desktopTabsState.tabs = [];
     resetMockAvailableViews();
     appState.setTab.mockClear();
@@ -788,6 +794,34 @@ describe("App navigate-view event wiring", () => {
       expect(appState.setTab).not.toHaveBeenCalled();
     },
   );
+
+  it("mounts an exact signed native renderer when stale registry metadata still advertises a remote bundle", async () => {
+    electrobunRuntimeState.enabled = false;
+    const platform = vi
+      .spyOn(Capacitor, "getPlatform")
+      .mockReturnValue("android");
+    mockAvailableViews.push(notesFullscreenView);
+    registerAppShellPage({
+      id: "notes",
+      pluginId: "@elizaos/plugin-notes",
+      label: "Notes",
+      path: "/notes",
+      surface: { header: "fullscreen" },
+      Component: () => <div data-testid="signed-notes" />,
+    });
+    appState.tab = "views";
+    window.history.replaceState(null, "", "/notes");
+
+    try {
+      const { getByTestId, queryByTestId } = render(<App />);
+
+      await waitFor(() => getByTestId("signed-notes"));
+      expect(queryByTestId("dynamic-view-loader")).toBeNull();
+      expect(dynamicViewLoaderMock.render).not.toHaveBeenCalled();
+    } finally {
+      platform.mockRestore();
+    }
+  });
 
   it("lets a fullscreen plugin view fill behind the floating composer", async () => {
     mockAvailableViews.push(notesFullscreenView);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -246,6 +246,7 @@ import {
   type ViewRegistryEntry,
 } from "./hooks/useAvailableViews";
 import { useDesktopTabs } from "./hooks/useDesktopTabs";
+import { isDynamicViewLoadingAllowed } from "./platform/platform-guards";
 import { useEnabledViewKinds } from "./state/useViewKinds";
 import { WidgetHost } from "./widgets";
 
@@ -1398,6 +1399,27 @@ function renderViewRouterContent({
       walletNav,
     });
   }
+  const appShellPageForRoute = findAppShellPageForRoute(navigationPath);
+  const visibleAppShellPage =
+    appShellPageForRoute && isViewVisible(appShellPageForRoute, enabledKinds)
+      ? appShellPageForRoute
+      : undefined;
+  const renderAppShellPage = (registration: AppShellPageRegistration) => (
+    <TabContentView
+      nav={walletNav}
+      reserveChatClearance={!surfaceOwnsViewport(registration)}
+    >
+      <RegisteredAppShellPage registration={registration} />
+    </TabContentView>
+  );
+
+  // Restricted native renderers cannot execute an agent-served bundle. Prefer
+  // an exact signed registration at the final renderer boundary even if a
+  // stale/web-shaped registry snapshot still carries bundleUrl for the same
+  // id/path. Web and desktop deliberately retain remote-bundle precedence.
+  if (visibleAppShellPage && !isDynamicViewLoadingAllowed()) {
+    return renderAppShellPage(visibleAppShellPage);
+  }
   const remoteView = findRemoteViewForRoute(
     availableViews,
     navigationPath,
@@ -1407,19 +1429,8 @@ function renderViewRouterContent({
   if (remoteView?.bundleUrl || remoteView?.frameUrl) {
     return renderRemoteView(remoteView, walletNav);
   }
-  const appShellPageForRoute = findAppShellPageForRoute(navigationPath);
-  if (
-    appShellPageForRoute &&
-    isViewVisible(appShellPageForRoute, enabledKinds)
-  ) {
-    return (
-      <TabContentView
-        nav={walletNav}
-        reserveChatClearance={!surfaceOwnsViewport(appShellPageForRoute)}
-      >
-        <RegisteredAppShellPage registration={appShellPageForRoute} />
-      </TabContentView>
-    );
+  if (visibleAppShellPage) {
+    return renderAppShellPage(visibleAppShellPage);
   }
 
   if (visibleDynamicPage(dynamicPage, enabledKinds)) {

--- a/packages/ui/src/hooks/useAvailableViews-platform.test.ts
+++ b/packages/ui/src/hooks/useAvailableViews-platform.test.ts
@@ -1,0 +1,51 @@
+/** Regression coverage for enforcing native dynamic-view policy in the client catalog. */
+
+import { describe, expect, it } from "vitest";
+import {
+  enforceDynamicViewPolicy,
+  type ViewRegistryEntry,
+} from "./useAvailableViews";
+
+const signedInProcessView: ViewRegistryEntry = {
+  id: "settings",
+  label: "Settings",
+  path: "/settings",
+  pluginName: "@elizaos/builtin",
+  available: true,
+};
+const remoteNotes: ViewRegistryEntry = {
+  id: "notes",
+  label: "Notes",
+  path: "/notes",
+  pluginName: "@elizaos/plugin-notes",
+  bundleUrl: "/api/views/notes/bundle.js",
+  available: true,
+};
+const remoteFrame: ViewRegistryEntry = {
+  id: "remote-frame",
+  label: "Remote frame",
+  path: "/remote-frame",
+  pluginName: "@local/remote-frame",
+  frameUrl: "/api/views/remote-frame/frame.html",
+  available: true,
+};
+
+describe("enforceDynamicViewPolicy", () => {
+  it("removes leaked remote bundles and frames on restricted native clients", () => {
+    expect(
+      enforceDynamicViewPolicy(
+        [signedInProcessView, remoteNotes, remoteFrame],
+        false,
+      ),
+    ).toEqual([signedInProcessView]);
+  });
+
+  it("preserves remote views on web and desktop clients", () => {
+    expect(
+      enforceDynamicViewPolicy(
+        [signedInProcessView, remoteNotes, remoteFrame],
+        true,
+      ),
+    ).toEqual([signedInProcessView, remoteNotes, remoteFrame]);
+  });
+});

--- a/packages/ui/src/hooks/useAvailableViews.ts
+++ b/packages/ui/src/hooks/useAvailableViews.ts
@@ -261,6 +261,19 @@ function isViewRegistryEntry(value: unknown): value is ViewRegistryEntry {
   );
 }
 
+export function enforceDynamicViewPolicy(
+  views: ViewRegistryEntry[],
+  dynamicLoadingAllowed: boolean,
+): ViewRegistryEntry[] {
+  if (dynamicLoadingAllowed) return views;
+  // Restricted native clients cannot execute agent-served JavaScript or
+  // frames. Enforce the platform policy locally as well as on the agent route:
+  // a gateway may omit X-Eliza-Platform and return the unfiltered registry.
+  // Removing those network entries lets the signed app-shell registrations
+  // fill the same ids in mergeWithAppShellViews below.
+  return views.filter((view) => !view.bundleUrl && !view.frameUrl);
+}
+
 async function fetchViewList(): Promise<ViewRegistryEntry[]> {
   const platform = getFrontendPlatform();
   const response = await fetchWithCsrf("/api/views", {
@@ -289,7 +302,7 @@ async function fetchViewList(): Promise<ViewRegistryEntry[]> {
       context: { status: response.status },
     });
   }
-  return data.views.map((view, index) => {
+  const views = data.views.map((view, index) => {
     if (!isViewRegistryEntry(view)) {
       throw new ElizaError(`GET /api/views entry ${index} is invalid`, {
         code: "VIEW_REGISTRY_RESPONSE_INVALID",
@@ -298,6 +311,10 @@ async function fetchViewList(): Promise<ViewRegistryEntry[]> {
     }
     return view;
   });
+  return enforceDynamicViewPolicy(
+    views,
+    platform === "web" || platform === "desktop",
+  );
 }
 
 /**

--- a/plugins/plugin-calendar/src/plugin-google-import-boundary.test.ts
+++ b/plugins/plugin-calendar/src/plugin-google-import-boundary.test.ts
@@ -1,0 +1,36 @@
+/** Verifies Calendar can boot without evaluating the optional Google API SDK. */
+
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const rejectGoogleapisLoader = fileURLToPath(
+  new URL("../test/reject-googleapis-loader.mjs", import.meta.url),
+);
+
+describe("Calendar Google import boundary", () => {
+  it("loads the plugin and local calendar view without the Google SDK", () => {
+    const output = execFileSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "--conditions=eliza-source",
+        "--experimental-loader",
+        rejectGoogleapisLoader,
+        "--input-type=module",
+        "--eval",
+        [
+          'const { calendarPlugin } = await import("./plugins/plugin-calendar/src/plugin.ts");',
+          'const view = calendarPlugin.views?.find(({ id }) => id === "calendar");',
+          'if (view?.componentExport !== "CalendarView") process.exit(2);',
+          'process.stdout.write("calendar-loaded");',
+        ].join("\n"),
+      ],
+      { cwd: repoRoot, encoding: "utf8", timeout: 30_000 },
+    );
+
+    expect(output).toBe("calendar-loaded");
+  }, 35_000);
+});

--- a/plugins/plugin-calendar/src/service/CalendarService.ts
+++ b/plugins/plugin-calendar/src/service/CalendarService.ts
@@ -18,11 +18,16 @@ import {
   Service,
   SsrfBlockedError,
 } from "@elizaos/core";
+import type { GoogleCalendarEvent } from "@elizaos/plugin-google-workspace";
+// Runtime error classes come from the dependency-light calendar subpath so
+// importing CalendarService never evaluates the Google Workspace root barrel
+// (whose client factory eagerly imports the optional `googleapis` SDK — absent
+// from lean production images, which aborted plugin import before the local
+// calendar view could register). Types stay on the root barrel (erased).
 import {
-  type GoogleCalendarEvent,
   GoogleCalendarMutationError,
   GoogleCalendarSyncTokenExpiredError,
-} from "@elizaos/plugin-google-workspace";
+} from "@elizaos/plugin-google-workspace/calendar";
 import type {
   DispatchResult,
   ScheduledTaskDispatchRecord,

--- a/plugins/plugin-calendar/test/reject-googleapis-loader.mjs
+++ b/plugins/plugin-calendar/test/reject-googleapis-loader.mjs
@@ -1,0 +1,7 @@
+/** Test-only loader that simulates a production image without googleapis. */
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "googleapis" || specifier.startsWith("googleapis/")) {
+    throw new Error("googleapis must not be evaluated while Calendar boots");
+  }
+  return nextResolve(specifier, context);
+}


### PR DESCRIPTION
# Relates to

- #17114
- #17557
- Supersedes and replaces #17596 (pre-refactor branch could not be rebased: its target surfaces were consolidated away)

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic-proxy/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Risks

Low. Native clients defensively remove remote JS/frame entries that platform policy already prohibits; web and desktop behavior is unchanged. Calendar's Google error classes move to the Workspace package's existing dependency-light `calendar` subpath (type imports stay on the root barrel, erased at compile time).

# Background

## What does this PR do?

Ports the still-applicable slices of #17596 onto the post-refactor develop tree. Shaw's plugin-surface consolidation (`6c25cf6d339`) split `plugin-simple-views` into `plugin-notes` and deleted the duplicate simple-calendar in favor of `plugin-calendar`'s CalendarView, which **already fixed** the original PR's largest slice (the default-profile registration gap). Two independent production boundaries from #17596 still reproduce on develop head and are fixed here:

- **Native view catalog policy (`packages/ui`):** the agent route filters dynamic views using `X-Eliza-Platform`, but a live phone gateway can omit the header and return the unfiltered registry, leaking `bundleUrl`/`frameUrl` entries (e.g. Notes) to restricted native clients. The renderer then selected `DynamicViewLoader` for ids whose signed in-process registrations should have won, dead-ending on `ViewRestrictedState`. Fix is two defense-in-depth boundaries: `fetchViewList` strips remote JavaScript/frame entries on iOS/Android before the app-shell merge, and `renderViewRouterContent` prefers an exact signed app-shell registration over a stale remote-bundle registry snapshot on restricted platforms only. Web/desktop keep remote bundles and remote-bundle precedence.
- **Calendar import isolation (`plugins/plugin-calendar`):** `CalendarService` imported two runtime error classes from the `@elizaos/plugin-google-workspace` root barrel. Importing Calendar therefore evaluated the Workspace SDK graph (client-factory eagerly imports `googleapis`) and aborted plugin import on production images without the optional SDK, before the local calendar view could register. Runtime values now come from the dependency-light `@elizaos/plugin-google-workspace/calendar` subpath; the root import is type-only.

## What was NOT carried forward (superseded by the refactor)

- `MOBILE_VIEW_PLUGINS` / optional-plugin-import registration of `plugin-simple-views`: the package no longer exists. `plugin-notes` is in `LEAN_CHAT_PLUGINS` + `RUNTIME_APP_PLUGIN_SUBPATHS`, and calendar is owned by `plugin-calendar` with its signed `CalendarView`.
- `shared-nav-targets` `calendar → simple-calendar` translation and the `views-show.ts` matcher-namespace fallback: develop's `calendar` matcher id now equals the live view id (`plugin-calendar` registers `id: "calendar"`), so the namespace split this compensated for is gone.
- The simple-views production-path Playwright spec: exercises deleted surfaces.

## What kind of change is this?

Bug fix, non-breaking.

# Testing

## Develop-red proof (both slices, on this branch's base)

1. **Calendar import boundary:** on develop head, booting `calendarPlugin` under a loader that rejects `googleapis` aborts with `googleapis must not be evaluated while Calendar boots` before the view registers. With the fix the plugin loads and `views[calendar].componentExport === "CalendarView"`.
2. **Native catalog policy:** stashing the two UI fixes while keeping the new expectations fails 3/3 targeted assertions (`enforceDynamicViewPolicy is not a function` x2; the signed-renderer test selects `DynamicViewLoader` instead of the signed component).

## Validation (at head `f0eb290b04d`, base `53a0d09910a`)

- `packages/ui` targeted suites (`useAvailableViews-platform`, `App.navigate-view-wiring`): 23 passed
- `plugins/plugin-calendar` import-boundary suite: 1 passed
- Typecheck: `packages/ui`, `packages/shared`, `plugins/plugin-calendar` all clean
- Biome on all changed files: clean; `git diff --check`: clean

# Evidence Gate

<!-- evidence-head:a485e34c5f680cea272b782b5a5aae60420d25e6 -->

<!-- evidence-row:before-screenshots -->
- [x] Inherited from #17596: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17596-173b9dc-native-simple-views-contact-sheet.jpg (pre-fix baseline; the leaked-bundle catalog shape is identical, only the owning plugin id changed in the refactor)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17834-after-plugin-calendar-desktop.png)
<!-- evidence-row:walkthrough-video -->
- [x] Inherited from #17596: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17596-633ec378-native-simple-views.webm
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend deployment; deterministic import tests exercise the changed boot boundary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - the leaked-bundle catalog shape is covered by the native policy regression test.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, or LLM action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database rows, memories, scheduled tasks, wallet state, or generated user artifacts changed.
<!-- evidence-row:ocr-review -->
- [x] [17834-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17834-ocr-triage.json)

# Known gaps / failures

- Physical device confirmation not available in this worktree; the restricted-renderer boundary is pinned by the jsdom Android-platform test.
- Full monorepo `bun run verify` was not run; targeted tests, typechecks, and Biome are listed above.

No workflow files changed. No checks weakened.

