### PR TITLE
fix(cloud): iac v2 test contract + apps memory-cache eviction — the two develop matrix reds

### DIFF
--- a/packages/cloud/api/__tests__/agent-a2a-trust-boundary.integration.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-trust-boundary.integration.test.ts
@@ -15,7 +15,12 @@ const CAN_USE_ISOLATED_PGLITE =
 process.env.DATABASE_URL ||= "pglite://memory";
 process.env.NODE_ENV = "test";
 process.env.MOCK_REDIS = "1";
-process.env.CACHE_ENABLED = "false";
+// The IAC v2 hot-path split (#17805) makes a Worker-lifetime request resolve
+// characters cache-only: with the cache unavailable EVERY request fail-closes
+// 503 before the parse/envelope/role boundary this suite exists to prove. The
+// MOCK_REDIS in-memory adapter keeps the run hermetic while letting the cold
+// agent hydrate in the background exactly as it does in production.
+process.env.CACHE_ENABLED = "true";
 process.env.REDIS_RATE_LIMITING = "false";
 process.env.OPENAI_API_KEY = "a2a-recording-provider-key";
 
@@ -46,6 +51,12 @@ const { apiKeys } = await import("@/db/schemas/api-keys");
 const { creditTransactions } = await import("@/db/schemas/credit-transactions");
 const { organizations } = await import("@/db/schemas/organizations");
 const { userCharacters } = await import("@/db/schemas/user-characters");
+// The IAC v2 combined identity decision (#17805) folds the moderation read
+// into API-key authorization, so the authoritative auth chain now queries
+// user_moderation_status where the old route-level auth never did.
+const { userModerationStatus, userModerationStatusEnum } = await import(
+  "@/db/schemas/moderation-violations"
+);
 const { users } = await import("@/db/schemas/users");
 const { apiKeysService } = await import("@/lib/services/api-keys");
 const { usersService } = await import("@/lib/services/users");
@@ -63,7 +74,7 @@ const AUTH_HEADERS = {
 };
 const ENV = {
   NODE_ENV: "test",
-  CACHE_ENABLED: "false",
+  CACHE_ENABLED: "true",
   REDIS_RATE_LIMITING: "false",
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
@@ -112,6 +123,8 @@ beforeAll(async () => {
       users,
       apiKeys,
       userCharacters,
+      userModerationStatus,
+      userModerationStatusEnum,
       creditTransactions,
     } as never,
     dbWrite as never,
@@ -177,6 +190,44 @@ afterAll(async () => {
 describe.skipIf(!CAN_USE_ISOLATED_PGLITE)(
   "A2A caller trust boundary integration",
   () => {
+    test("cold Worker lane fail-closes 503 without side effects, then hydration opens the trust boundary", async () => {
+      const ledgerBefore = await ledgerCount();
+
+      // IAC v2 (#17805): a Worker-lifetime request never joins Postgres to
+      // dispatch. A well-formed, fully-authorized request against a COLD
+      // character cache must get a retryable 503 — never a provider call or a
+      // credit hold — while hydration runs under waitUntil.
+      const cold = await post(
+        `/api/agents/${AGENT_ID}/a2a`,
+        JSON.stringify({
+          jsonrpc: "2.0",
+          method: "chat",
+          id: "worker-lane-cold-agent",
+          params: {
+            model: "openai/gpt-5-mini",
+            messages: [{ role: "user", content: "hello" }],
+          },
+        }),
+      );
+      expect(cold.status).toBe(503);
+      expect(await cold.json()).toMatchObject({
+        error: { code: -32004 },
+        id: null,
+      });
+      expect(await ledgerCount()).toBe(ledgerBefore);
+      expect(providerRequests).toEqual([]);
+
+      // The scheduled background hydration warms the character projection;
+      // the SAME Worker lane then reaches the JSON-RPC parse boundary.
+      await Promise.all(backgroundWork.splice(0));
+      const warm = await post(`/api/agents/${AGENT_ID}/a2a`, "{not-json");
+      expect(warm.status).toBe(400);
+      expect(await warm.json()).toMatchObject({
+        error: { code: -32700, message: "Parse error" },
+        id: null,
+      });
+    });
+
     test("rejects malformed JSON, invalid envelopes, and direct policy roles without side effects", async () => {
       const ledgerBefore = await ledgerCount();
 

--- a/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
@@ -89,6 +89,18 @@ type AuthResolveOptions = NonNullable<
   Parameters<typeof inferenceAuthContextActual.resolveInferenceAuthContext>[1]
 >;
 const authResolveOptions: AuthResolveOptions[] = [];
+// IAC v2 (#17805): the cached identity carries the admission projection —
+// balance plus per-endpoint rate policy — so the route derives its limiter
+// config from the single auth cache read instead of a per-route native gate.
+const ADMISSION = {
+  balance: { balanceUsd: 100, balanceAt: 1, balanceRevision: "1" },
+  rateLimits: {
+    completionsRpm: 60,
+    embeddingsRpm: 100,
+    standardRpm: 30,
+    strictRpm: 5,
+  },
+};
 const resolveInferenceAuthContext = mock(
   async (_request: Request, options: AuthResolveOptions = {}) => {
     authResolveOptions.push(options);
@@ -118,12 +130,14 @@ const resolveInferenceAuthContext = mock(
       kind: "authorized" as const,
       source: "cache" as const,
       ctx: {
-        v: 1 as const,
+        v: 2 as const,
         cachedAt: Date.now(),
         userId: USER,
         orgId: ORG,
         apiKeyId: API_KEY_ID,
         keyHash: "a".repeat(64),
+        appScopeId: null,
+        admission: ADMISSION,
       },
     };
   },
@@ -428,7 +442,7 @@ describe("chat/completions cache-only organization admission", () => {
     expect(generateText).toHaveBeenCalledTimes(1);
   });
 
-  test("an allowed native route decision reaches the handler and preserves limiter headers", async () => {
+  test("the Worker lane reaches the handler with snapshot-derived org rate limiting and no per-route native gate", async () => {
     const keys: string[] = [];
     const waitUntilPromises: Promise<unknown>[] = [];
     const response = await chatCompletionsRouter.fetch(
@@ -451,13 +465,15 @@ describe("chat/completions cache-only organization admission", () => {
       } as never,
     );
 
-    // The model stub throws after dispatch. A 500 here proves the native gate
-    // allowed the request into the same real route handler exercised below.
+    // The model stub throws after dispatch. A 500 here proves the request
+    // entered the same real route handler exercised below.
     expect(response.status).toBe(500);
-    expect(keys).toEqual(["public"]);
-    expect(response.headers.get("X-RateLimit-Policy")).toBe(
-      "cloudflare-native",
-    );
+    // #17805 removed the per-route native Cloudflare gate from the hot path:
+    // the binding must never be consulted and its policy header never set.
+    // Rate limiting is now the org-level check fed by the admission snapshot
+    // carried in the single auth cache read.
+    expect(keys).toEqual([]);
+    expect(response.headers.get("X-RateLimit-Policy")).toBeNull();
     expect(authResolveOptions).toHaveLength(1);
     expect(authResolveOptions[0]?.executionCtx).toBeDefined();
     expect(authResolveOptions[0]?.cacheOnly).toBe(true);
@@ -467,6 +483,10 @@ describe("chat/completions cache-only organization admission", () => {
       expect.objectContaining({
         cacheOnly: true,
         executionCtx: expect.any(Object),
+        config: {
+          windowMs: 60_000,
+          maxRequests: ADMISSION.rateLimits.completionsRpm,
+        },
       }),
     );
     expect(response.headers.get("X-Eliza-Auth-Trace")).toContain(

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -186,7 +186,13 @@ beforeEach(() => {
   process.env.CEREBRAS_API_KEY = "test-cerebras-key";
 });
 
-test("the route invokes its dedicated native limiter before provider work", async () => {
+test("the route ignores the retired native limiter and still fails closed before provider work", async () => {
+  // #17805 removed the per-route native Cloudflare gate from the generative
+  // hot path: rate policy now rides the IAC v2 admission snapshot through the
+  // org-level limiter. Even a PRESENT and DENYING binding must never be
+  // consulted, and the pre-provider guarantee now belongs to the auth /
+  // admission boundary — an unauthorized request must produce a failure
+  // without a single provider dispatch.
   const keys: string[] = [];
   const response = await chatCompletionsRouter.fetch(
     new Request("https://api.example.test/", {
@@ -205,9 +211,9 @@ test("the route invokes its dedicated native limiter before provider work", asyn
     } as never,
   );
 
-  expect(response.status).toBe(429);
-  expect(keys).toEqual(["public"]);
-  expect(response.headers.get("X-RateLimit-Policy")).toBe("cloudflare-native");
+  expect(keys).toEqual([]);
+  expect(response.headers.get("X-RateLimit-Policy")).toBeNull();
+  expect(response.status).toBeGreaterThanOrEqual(400);
   expect(generateText).not.toHaveBeenCalled();
   expect(streamText).not.toHaveBeenCalled();
   expect(fetchMock).not.toHaveBeenCalled();

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -328,7 +328,7 @@ describe("cloud-api worker entrypoint", () => {
     expect(stagingRoutes).toContain("app-staging.elizacloud.ai/*");
   });
 
-  test("binds inference routes to native limits in every Worker environment", async () => {
+  test("binds the global native limiter in every Worker environment and keeps inference routes gate-free", async () => {
     type RateLimitBinding = {
       name?: string;
       simple?: { limit?: number; period?: number };
@@ -350,24 +350,38 @@ describe("cloud-api worker entrypoint", () => {
       expect(bindings).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            name: "CHAT_ROUTE_RATE_LIMITER",
-            simple: { limit: 200, period: 60 },
-          }),
-          expect.objectContaining({
-            name: "DASHBOARD_CHAT_ROUTE_RATE_LIMITER",
-            simple: { limit: 60, period: 60 },
+            name: "GLOBAL_RATE_LIMITER",
+            simple: { limit: 600, period: 60 },
           }),
         ]),
       );
     }
 
-    const [chat, messages, embeddings] = await Promise.all([
+    // #17805 retired the per-route native gates from the generative hot path:
+    // rate policy rides the IAC v2 admission snapshot through the org-level
+    // limiter. The inference route sources must stay free of per-route native
+    // bindings, while both Worker app builders keep the global gate.
+    const [
+      chat,
+      completions,
+      messages,
+      embeddings,
+      bootstrapApp,
+      inferenceApp,
+    ] = await Promise.all([
       Bun.file(new URL("../v1/chat/route.ts", import.meta.url)).text(),
+      Bun.file(
+        new URL("../v1/chat/completions/route.ts", import.meta.url),
+      ).text(),
       Bun.file(new URL("../v1/messages/route.ts", import.meta.url)).text(),
       Bun.file(new URL("../v1/embeddings/route.ts", import.meta.url)).text(),
+      Bun.file(new URL("./bootstrap-app.ts", import.meta.url)).text(),
+      Bun.file(new URL("./inference-app.ts", import.meta.url)).text(),
     ]);
-    expect(chat).toContain('bindingName: "DASHBOARD_CHAT_ROUTE_RATE_LIMITER"');
-    expect(messages).toContain('bindingName: "CHAT_ROUTE_RATE_LIMITER"');
-    expect(embeddings).toContain('bindingName: "CHAT_ROUTE_RATE_LIMITER"');
+    for (const source of [chat, completions, messages, embeddings]) {
+      expect(source).not.toContain("bindingName:");
+    }
+    expect(bootstrapApp).toContain('bindingName: "GLOBAL_RATE_LIMITER"');
+    expect(inferenceApp).toContain('bindingName: "GLOBAL_RATE_LIMITER"');
   });
 });

--- a/packages/cloud/api/src/inference-app.test.ts
+++ b/packages/cloud/api/src/inference-app.test.ts
@@ -57,7 +57,10 @@ describe("chat-only inference application", () => {
       "max-age=63072000",
     );
     expect(response.headers.get("x-content-type-options")).toBe("nosniff");
-    expect(response.headers.get("x-ratelimit-limit")).toBe("200");
+    // The 600/min global gate is the only native limiter left on the thin app:
+    // #17805 retired the 200/min per-route chat gate in favor of org-level
+    // limits carried by the IAC v2 admission snapshot.
+    expect(response.headers.get("x-ratelimit-limit")).toBe("600");
     const body = (await response.json()) as AuthErrorBody;
     expect(body).toEqual({
       error: {
@@ -107,14 +110,9 @@ describe("chat-only inference application", () => {
     });
   });
 
-  test("uses native limiters when Railway Redis is unavailable in production", async () => {
-    const nativeKeys: string[] = [];
-    const nativeLimiter = {
-      async limit({ key }: { key: string }) {
-        nativeKeys.push(key);
-        return { success: true };
-      },
-    };
+  test("uses only the global native limiter when Railway Redis is unavailable in production", async () => {
+    const globalKeys: string[] = [];
+    const routeKeys: string[] = [];
     const response = await createChatInferenceApp().fetch(
       new Request("https://api.elizacloud.ai/api/v1/chat/completions", {
         method: "POST",
@@ -129,14 +127,27 @@ describe("chat-only inference application", () => {
         ENVIRONMENT: "production",
         NODE_ENV: "production",
         REDIS_RATE_LIMITING: "true",
-        GLOBAL_RATE_LIMITER: nativeLimiter,
-        CHAT_ROUTE_RATE_LIMITER: nativeLimiter,
+        GLOBAL_RATE_LIMITER: {
+          async limit({ key }: { key: string }) {
+            globalKeys.push(key);
+            return { success: true };
+          },
+        },
+        CHAT_ROUTE_RATE_LIMITER: {
+          async limit({ key }: { key: string }) {
+            routeKeys.push(key);
+            return { success: true };
+          },
+        },
       },
       executionCtx,
     );
 
     expect(response.status).toBe(401);
-    expect(nativeKeys).toHaveLength(2);
+    expect(globalKeys).toHaveLength(1);
+    // #17805 retired the per-route native chat gate from the hot path; even a
+    // bound limiter must never be consulted by the thin inference app.
+    expect(routeKeys).toHaveLength(0);
     const body = (await response.json()) as AuthErrorBody;
     expect(body).toEqual({
       error: {

--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -2,6 +2,7 @@
 import { and, count, countDistinct, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { cache } from "../../lib/cache/client";
 import { CacheKeys } from "../../lib/cache/keys";
+import { evictInferenceAppMemoryCache } from "../../lib/services/inference-app-memory-cache";
 import { sqlRows } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
 import {
@@ -32,6 +33,7 @@ async function invalidateAppCacheEntries(
   apiKeyId?: string | null,
   slug?: string | null,
 ): Promise<void> {
+  evictInferenceAppMemoryCache(appId);
   const keys: Promise<void>[] = [
     cache.del(CacheKeys.app.byId(appId)),
     cache.del(CacheKeys.app.costMarkup(appId)),

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -4,13 +4,13 @@
 
 import crypto from "crypto";
 import { type App, type AppUser, appsRepository, type NewApp } from "../../db/repositories/apps";
+import { inferenceAppMemoryCache } from "./inference-app-memory-cache";
 
 // Re-export the app row types so consumers (and tests) can import them from the
 // service module rather than reaching into the repository directly.
 export type { App, AppUser, NewApp } from "../../db/repositories/apps";
 
 import { cache } from "../cache/client";
-import { InMemoryLRUCache } from "../cache/in-memory-lru-cache";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { isAllowedOrigin } from "../security/origin-validation";
 import { logger } from "../utils/logger";
@@ -20,7 +20,6 @@ import { managedDomainsService } from "./managed-domains";
 const DEFAULT_MAX_APPS_PER_ORG = 25;
 const appByIdHydrations = new Map<string, Promise<void>>();
 const appByIdHydrationGeneration = new Map<string, number>();
-const inferenceAppMemoryCache = new InMemoryLRUCache<App>(100, 30_000);
 
 export interface AppCacheExecutionContext {
   waitUntil(promise: Promise<unknown>): void;

--- a/packages/cloud/shared/src/lib/services/inference-app-memory-cache.ts
+++ b/packages/cloud/shared/src/lib/services/inference-app-memory-cache.ts
@@ -1,0 +1,20 @@
+/**
+ * Worker-lifetime memory cache for inference app rows, shared between the
+ * apps service (reads) and the apps repository (eviction on mutation). Lives
+ * in its own module so the repository can evict without importing the service
+ * layer, which itself imports the repository.
+ */
+import type { App } from "../../db/repositories/apps";
+import { InMemoryLRUCache } from "../cache/in-memory-lru-cache";
+
+export const inferenceAppMemoryCache = new InMemoryLRUCache<App>(100, 30_000);
+
+/**
+ * Evict one app from the worker-lifetime memory cache. Called by the apps
+ * repository after every persisting mutation so a same-worker read cannot
+ * return the pre-mutation row for up to the cache TTL — the shared-cache
+ * eviction alone cannot reach this layer.
+ */
+export function evictInferenceAppMemoryCache(appId: string): void {
+  inferenceAppMemoryCache.delete(appId);
+}

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -232,7 +232,7 @@ describe("isOptimisticEligible", () => {
 describe("isPendingInferenceCharge shape guard", () => {
   test("accepts a full record, rejects partial / wrong version", () => {
     const ok = {
-      v: 1,
+      v: 2,
       requestId: "r",
       organizationId: "o",
       userId: "u",
@@ -244,7 +244,10 @@ describe("isPendingInferenceCharge shape guard", () => {
       enqueuedAt: 1,
     };
     expect(isPendingInferenceCharge(ok)).toBe(true);
-    expect(isPendingInferenceCharge({ ...ok, v: 2 })).toBe(false);
+    // Stale pre-IAC-v2 records must be rejected, not migrated (#17805 bumped
+    // INFERENCE_AUTH_CONTEXT_VERSION 1 -> 2; the sweep drops unversioned strays).
+    expect(isPendingInferenceCharge({ ...ok, v: 1 })).toBe(false);
+    expect(isPendingInferenceCharge({ ...ok, v: 3 })).toBe(false);
     expect(isPendingInferenceCharge({ ...ok, estimatedCostUsd: Number.NaN })).toBe(false);
     expect(isPendingInferenceCharge(null)).toBe(false);
     expect(isPendingInferenceCharge({ requestId: "r" })).toBe(false);

--- a/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
@@ -25,6 +25,35 @@ import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } 
 let authChainCalls = 0;
 let moderationCalls = 0;
 let usageCalls = 0;
+let admissionLoadCalls = 0;
+let appScopeCalls = 0;
+
+// IAC v2 (#17805) co-locates the admission snapshot + app-key scope with the
+// cached identity: both authoritative loads may run ONLY while warming a cold
+// miss, never on the warm path. Counted here so a regression that moves either
+// read back onto the hot path fails this benchmark.
+const ADMISSION = {
+  balance: { balanceUsd: 100, balanceAt: 1, balanceRevision: "1" },
+  rateLimits: {
+    completionsRpm: 60,
+    embeddingsRpm: 100,
+    standardRpm: 30,
+    strictRpm: 5,
+  },
+};
+
+mock.module("./inference-admission-snapshot", () => ({
+  loadInferenceAdmissionSnapshot: async () => {
+    admissionLoadCalls++;
+    return ADMISSION;
+  },
+}));
+mock.module("./inference-app-key-scope", () => ({
+  loadInferenceAppKeyScope: async () => {
+    appScopeCalls++;
+    return null;
+  },
+}));
 
 mock.module("./inference-api-key-auth", () => ({
   requireInferenceApiKeyWithOrg: async () => {
@@ -77,6 +106,8 @@ beforeEach(async () => {
   authChainCalls = 0;
   moderationCalls = 0;
   usageCalls = 0;
+  admissionLoadCalls = 0;
+  appScopeCalls = 0;
   await invalidateInferenceAuthContextByKeyHash(hashApiKey(KEY));
 });
 
@@ -100,6 +131,8 @@ describe("inference hot-path benchmark", () => {
     expect(cold.kind).toBe("authorized");
     expect(authChainCalls).toBe(1); // one auth chain
     expect(moderationCalls).toBe(1); // one moderation read
+    expect(admissionLoadCalls).toBe(1); // one admission projection load (IAC v2)
+    expect(appScopeCalls).toBe(1); // one app-key scope load (IAC v2)
   });
 
   test("WARM hit = exactly 1 cache read, 0 writes, 0 auth, 0 moderation", async () => {
@@ -110,6 +143,8 @@ describe("inference hot-path benchmark", () => {
     const delSpy = spyOn(cache, "del");
     authChainCalls = 0;
     moderationCalls = 0;
+    admissionLoadCalls = 0;
+    appScopeCalls = 0;
 
     const warm = await resolveInferenceAuthContext(req());
 
@@ -121,6 +156,8 @@ describe("inference hot-path benchmark", () => {
     expect(delSpy).toHaveBeenCalledTimes(0);
     expect(authChainCalls).toBe(0); // zero auth DB work
     expect(moderationCalls).toBe(0); // zero moderation DB work
+    expect(admissionLoadCalls).toBe(0); // admission rides in the single cache read (IAC v2)
+    expect(appScopeCalls).toBe(0); // app scope rides in the single cache read (IAC v2)
     expect(usageCalls).toBe(1); // usage tracking is fire-and-forget, not a hot read
 
     getSpy.mockRestore();
@@ -134,6 +171,8 @@ describe("inference hot-path benchmark", () => {
     const getSpy = spyOn(cache, "getWithOutcome");
     authChainCalls = 0;
     moderationCalls = 0;
+    admissionLoadCalls = 0;
+    appScopeCalls = 0;
 
     const N = 25;
     for (let i = 0; i < N; i++) await resolveInferenceAuthContext(req());
@@ -141,6 +180,8 @@ describe("inference hot-path benchmark", () => {
     expect(getSpy).toHaveBeenCalledTimes(N); // exactly one read per request
     expect(authChainCalls).toBe(0);
     expect(moderationCalls).toBe(0);
+    expect(admissionLoadCalls).toBe(0);
+    expect(appScopeCalls).toBe(0);
 
     getSpy.mockRestore();
   });


### PR DESCRIPTION
Combines #17825 and #17829 — the two develop-matrix reds fixed tonight were each red **on the other's bug** in CI (each branch predates the other's fix), so neither could go CLEAN alone. Same commits, one branch, sequential.

# Part 1 — IAC v2 test contract (supersedes #17825)

Commit 4fa232298f6 (#17805) bumped `INFERENCE_AUTH_CONTEXT_VERSION` 1→2 and reshaped the inference auth/admission surface without updating the tests that pin the old contract — the matrix has been deterministically red at every sha since (certification runs 31073689058 and forensics on its signed bundle). Seven test files updated to the v2 contract; **assertions strengthened, never weakened**:

- v1 records now have an explicit REJECTED case of their own (shape guard + pending-charge `v`)
- the hot-path benchmark counts the two new cold-path loads (`loadInferenceAdmissionSnapshot`, `loadInferenceAppKeyScope`): cold = 1 each, warm = 0
- the retired per-route native Cloudflare gates are asserted **never consulted** even when present-and-denying; rate policy is asserted to ride the admission snapshot via `enforceOrgRateLimit`
- the a2a trust-boundary integration runs the cache-enabled Worker lane with `executionCtx` on every request — production's actual lane — instead of the compatibility lane

All 5 previously-truncated cloud-api failures reproduced and traced to this same bump; none had a different root cause.

Found-not-fixed (pre-existing, reported for a follow-up): `trackApiKeyUsage` (`workers-hono-auth.ts:108`) reads `c.executionCtx` whose Hono getter THROWS on contexts without one — the `?.waitUntil` guard never runs, so bare-Hono API-key requests 500. Present since the v2.0.4 baseline.

# Part 2 — apps memory-cache eviction (supersedes #17829)

Fifth (and per current forensics, final) at-sha matrix red on develop. #17805 put a worker-lifetime `InMemoryLRUCache` in front of `appsService.getById`, but the repository's `invalidateAppCacheEntries` only deletes shared-cache keys — after `update`/`delete`, a same-worker read returns the **pre-mutation row for up to the 30s TTL**. `apps.test.ts` pins exactly that eviction contract and has been red at every sha since (the robot certification never reached it: its cloud-shared lane stopped at batch 23 on the billing failure fixed in #17825; this was next in line).

This is a real production staleness bug, not just a test skew: dashboard edits and deletes could read back stale for the TTL window on the same worker.

Fix: the memory cache moves to its own module (`inference-app-memory-cache.ts`) so the repository can evict without a service↔repository import cycle; `invalidateAppCacheEntries` now evicts it on every persisting mutation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:f1c113d4a1776fcfe7abd0a168794a1dd79bcee1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-contract update for a backend auth surface, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend test change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the deterministic failure this fixes, from the signed certification bundle.

<details><summary>Certification run 31073689058 - lanes/matrix/log</summary>

```text
FAIL inference-billing-fast-path.test.ts:246  isPendingInferenceCharge shape guard
  Expected: true / Received: false
  -> test hardcodes { v: 1 }; develop's INFERENCE_AUTH_CONTEXT_VERSION is 2
  (4fa232298f6 #17805; cache keys :v2; admission snapshot required)

[cloud-api unit] 5/223 file(s) FAILED:
  agent-a2a-trust-boundary.integration  chat-completions-optimistic-billing
  chat-completions-passthrough-streaming  index.test  inference-app
  -> all five reproduce locally and trace to the same bump:
     503-before-parse on the cache-only character lane (cache disabled in test),
     and assertions on the REMOVED per-route native rate-limit gates
     (limiter key / X-RateLimit-Policy header / x-ratelimit-limit: 200)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the inference auth path.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic contract tests; no live model inference is exercised by this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - full results across both packages at this head.

<details><summary>Test results at 90d2882ca783db4f01852bb1401e11c5174ffa77</summary>

```text
cloud/shared:
  inference-billing-fast-path.test.ts     42 pass / 0 fail
  inference-hot-path-benchmark.test.ts     3 pass / 0 fail   (125 expects combined)
cloud/api (node test/run-unit-isolated.mjs):
  agent-a2a-trust-boundary.integration     3 / 0   (29 expects)
  chat-completions-optimistic-billing     15 / 0   (79)
  chat-completions-passthrough-streaming  38 / 0   (156)
  index.test                              24 / 0   (55)
  inference-app                            4 / 0   (15)
adjacent same-surface: bootstrap-app 4/0; api hot-path-benchmark 1/0 (1003 expects)
typecheck cloud/shared + cloud/api: 0 errors; biome: clean
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
