### PR TITLE
fix(cloud): never encrypt the ws-query-token platform flag

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-env-crypto.ts
+++ b/packages/cloud/shared/src/lib/services/agent-env-crypto.ts
@@ -48,10 +48,21 @@ const SENSITIVE_ENV_KEY_PATTERN = /(KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|
  * row (bridge auth, proxies, pairing) — never encrypted. All of them are
  * blocked from the user PATCH surface by the reserved-key gate except
  * `ELIZAOS_API_KEY`, the legacy bridge-token alias `getAgentApiToken` falls
- * back to.
+ * back to, and `ELIZA_ALLOW_WS_QUERY_TOKEN`.
+ *
+ * `ELIZA_ALLOW_WS_QUERY_TOKEN` is NOT a secret: `prepareManagedElizaEnvironment`
+ * stamps the literal `"1"` on every managed agent as a boolean feature flag
+ * (managed-eliza-config.ts). It only lands here because the deliberately broad
+ * `SENSITIVE_ENV_KEY_PATTERN` matches the substring `TOKEN` in its NAME. Left
+ * encryptable it makes the flag the single at-rest ciphertext on every agent
+ * row, so any environment whose Worker holds `SECRETS_MASTER_KEY` while its
+ * provisioning daemon does not fails EVERY provision closed at env
+ * materialization — with no user secret involved at all.
  */
 const NEVER_ENCRYPT_ENV_KEYS: ReadonlySet<string> = new Set(
-  [...RESERVED_PLATFORM_ENV_KEYS, "ELIZAOS_API_KEY"].map((key) => key.toUpperCase()),
+  [...RESERVED_PLATFORM_ENV_KEYS, "ELIZAOS_API_KEY", "ELIZA_ALLOW_WS_QUERY_TOKEN"].map((key) =>
+    key.toUpperCase(),
+  ),
 );
 
 /** Whether a caller-supplied env key should be encrypted at rest. */


### PR DESCRIPTION
Live staging incident tonight, with a production landmine attached.

`prepareManagedElizaEnvironment` stamps `ELIZA_ALLOW_WS_QUERY_TOKEN: "1"` — a boolean platform flag — on every managed agent. Its NAME matches the `/TOKEN/` sensitivity pattern, so the Worker encrypts it at rest. But **no provisioning daemon in any environment holds `SECRETS_MASTER_KEY`** (the cloud-cf-deploy workflow never syncs it — it exists only as a wrangler.toml comment; the daemon deploy workflow's reconcile is skip-when-empty and the GH secret is unset for both environments). Result: every cold provision of an agent carrying the encrypted flag dies with:

```
Your cloud agent failed to start: Environment decryption failed:
Failed to decrypt agent environment variable ELIZA_ALLOW_WS_QUERY_TOKEN:
SECRETS_MASTER_KEY must be set for field encryption
```

Verified ground truth from both databases: the ONLY key ever encrypted is this flag (staging 27 rows, prod 26 rows — zero user BYO secrets affected). Staging failed live tonight for a real user; **prod shows zero failures only because nothing cold-provisioned recently — the next one fails identically.**

Fix: add the flag to `NEVER_ENCRYPT_ENV_KEYS`, the established escape hatch for platform-stamped non-secrets (`ELIZAOS_API_KEY` precedent), with the failure mode documented in a comment.

Data remediation (out of band, backed up): staging's 27 rows rewritten to plaintext and the lane verified recovered end-to-end (three agents reached `running` post-fix, including the affected user's). Prod's 26 rows get the same treatment.

Follow-ups worth their own issues (reported, not in this diff): the never-synced `SECRETS_MASTER_KEY` means real BYO-secret encryption is inert platform-wide; POST /eliza/agents does two bounded container pushes inline before responding (observed 15s+ client timeouts); the staging agent-lane worker box is SSH-unreachable with any held credential.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:a385ba898eca4b1d83061b6d8a4aad0691555ce1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - env-crypto classification change in the shared backend, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing user-visible renders differently; agents simply stop dying on cold boot.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend field-encryption policy change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the live failure and the database ground truth motivating the change.

<details><summary>Live incident + both-database audit</summary>

```text
staging, real user, 08:16Z: agent cf286167 cold boot ->
  Environment decryption failed: Failed to decrypt agent environment
  variable ELIZA_ALLOW_WS_QUERY_TOKEN: SECRETS_MASTER_KEY must be set
  for field encryption

decryption site: eliza-sandbox.ts:2254 decryptAgentEnvVars (provisioning
daemon, before docker run); throw at agent-env-crypto.ts:111-131; message
from field-encryption.ts:77-81

encrypted-key audit (enc:v1: values grouped by env key):
  staging: ELIZA_ALLOW_WS_QUERY_TOKEN only - 27 rows
  prod:    ELIZA_ALLOW_WS_QUERY_TOKEN only - 26 rows   (read-only audit)
  user BYO secrets encrypted anywhere: none

post-remediation (staging): 0 enc:v1: values; agents cf286167, c403f67e
and a warm-pool replenish all reached running; user agent heartbeat 08:54Z
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in env-at-rest encryption.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic key-classification change, no model inference participates.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - the crypto module's suite at this head.

<details><summary>Test results at 7143337523a34c1eb200757207da17c1dfc73388</summary>

```text
$ bun test src/lib/services/agent-env-crypto.test.ts   (packages/cloud/shared)
  7 pass / 0 fail   (43 expect() calls)
  includes: the flag passes through plaintext; real TOKEN-named user
  secrets still encrypt; enc:v1: values never double-encrypt

$ bunx biome check (1 file)   clean
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- gate-refresh:14:44 -->
