### PR TITLE
fix(ui): recover the join flow from a stale binding to a deleted agent

### DIFF
--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -13,6 +13,7 @@ import { ElizaClient } from "./client-base";
 // Side-effect import: patches selectOrProvisionCloudAgent onto the prototype.
 import "./client-cloud";
 import type { CloudCompatAgent } from "./client-types-cloud";
+import { isCloudAgentGoneError } from "./client-types-core";
 
 /**
  * selectOrProvisionCloudAgent reuses an existing cloud agent instead of minting
@@ -328,6 +329,35 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
       /network down|find your agents/i,
     );
     expect(createCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("keeps the structural agent-gone shape on the cause chain of a failed lookup", async () => {
+    const { client, getCloudCompatAgents } = fakeClient();
+    // What a stale binding produces: the deleted agent's origin answers the
+    // compat agent list with the cloud router's 404 shape.
+    getCloudCompatAgents.mockRejectedValue(
+      Object.assign(new Error("agent not found or not running"), {
+        kind: "http",
+        status: 404,
+        path: "/api/cloud/compat/agents",
+      }),
+    );
+
+    const rejection = await client
+      .selectOrProvisionCloudAgent(BASE_OPTS)
+      .then(() => null)
+      .catch((error: unknown) => error);
+
+    expect(rejection).toBeInstanceOf(Error);
+    // The join flow's stale-binding recovery classifies by status/code via
+    // the cause chain — the flattened message alone cannot carry it.
+    expect(isCloudAgentGoneError(rejection)).toBe(true);
+    expect(isCloudAgentGoneError(new TypeError("Failed to fetch"))).toBe(false);
+    expect(
+      isCloudAgentGoneError(
+        Object.assign(new Error("unauthorized"), { status: 401 }),
+      ),
+    ).toBe(false);
   });
 
   it("does NOT provision when the list returns success:false (e.g. expired auth)", async () => {

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3424,16 +3424,22 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
           // "it creates multiple agents" report. Only an authoritative success
           // list may conclude the user has no agent to reuse; otherwise surface
           // the error so the caller can retry rather than duplicate.
-          return await this.getCloudCompatAgents().catch((cause) => ({
+          return await this.getCloudCompatAgents().catch((cause: unknown) => ({
             success: false as const,
             data: [] as CloudCompatAgent[],
             error: cause instanceof Error ? cause.message : undefined,
+            cause,
           }));
         })();
     if (!list.success) {
+      // Keep the original rejection on the cause chain: callers (the join
+      // flow's stale-binding recovery) classify the structural agent-gone
+      // shape by status/code via `isCloudAgentGoneError`, which the flattened
+      // message alone cannot carry.
       throw new Error(
         list.error ||
           "Couldn't reach Eliza Cloud to find your agents. Check your connection and try again.",
+        { cause: "cause" in list ? list.cause : undefined },
       );
     }
     // Dedicated mode must not bind a temporary shared bridge as if it were a

--- a/packages/ui/src/api/client-types-core.ts
+++ b/packages/ui/src/api/client-types-core.ts
@@ -525,6 +525,34 @@ export function isRateLimitedError(value: unknown): value is ApiError {
   );
 }
 
+/**
+ * The Cloud's structural "agent gone" shape: an HTTP 404 carrying the
+ * `agent_not_found` code (code-carrying cloud routes) or the agent router's
+ * code-less body `{ error: "agent not found or not running" }` — what every
+ * request through a bound agent origin gets once that agent has been deleted.
+ * Distinct from transport failure (network down produces no HTTP status), so
+ * callers can treat a stale binding as invalid without masking real outages.
+ * Walks the `cause` chain so wrapped selection/provisioning errors classify.
+ */
+export function isCloudAgentGoneError(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current instanceof Error; depth += 1) {
+    const { status, code } = current as Error & {
+      status?: unknown;
+      code?: unknown;
+    };
+    if (
+      status === 404 &&
+      (code === "agent_not_found" ||
+        current.message.includes("agent not found or not running"))
+    ) {
+      return true;
+    }
+    current = (current as Error & { cause?: unknown }).cause;
+  }
+  return false;
+}
+
 export interface RuntimeDebugSnapshot {
   runtimeAvailable: boolean;
   generatedAt: number;

--- a/packages/ui/src/cloud/join/JoinPage.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.tsx
@@ -22,6 +22,7 @@ import { Navigate } from "react-router-dom";
 import { client } from "../../api";
 import { Button } from "../../components/ui/button";
 import {
+  clearPersistedActiveServer,
   savePersistedActiveServer,
   savePersistedFirstRunComplete,
 } from "../../state/persistence";
@@ -84,7 +85,11 @@ export default function JoinPage(): React.JSX.Element {
     try {
       const result = await runJoinFlow({
         client,
-        effects: { savePersistedActiveServer, savePersistedFirstRunComplete },
+        effects: {
+          savePersistedActiveServer,
+          clearPersistedActiveServer,
+          savePersistedFirstRunComplete,
+        },
         cloudApiBase: resolveJoinCloudApiBase(),
         authToken,
         agentName: DEFAULT_AGENT_NAME,

--- a/packages/ui/src/cloud/join/lib/run-join-flow.test.ts
+++ b/packages/ui/src/cloud/join/lib/run-join-flow.test.ts
@@ -41,18 +41,35 @@ function makeClient(
 function makeEffects(): {
   effects: JoinFlowEffects;
   saveServer: ReturnType<typeof vi.fn>;
+  clearServer: ReturnType<typeof vi.fn>;
   saveFirstRun: ReturnType<typeof vi.fn>;
 } {
   const saveServer = vi.fn();
+  const clearServer = vi.fn();
   const saveFirstRun = vi.fn();
   return {
     effects: {
       savePersistedActiveServer: saveServer,
+      clearPersistedActiveServer: clearServer,
       savePersistedFirstRunComplete: saveFirstRun,
     },
     saveServer,
+    clearServer,
     saveFirstRun,
   };
+}
+
+/** The wrapped list-lookup failure `selectOrProvisionCloudAgent` throws when
+ * the bound (deleted) agent's origin answers the agent list with the cloud
+ * router's structural agent-gone shape. */
+function agentGoneError(): Error {
+  return new Error("agent not found or not running", {
+    cause: Object.assign(new Error("agent not found or not running"), {
+      kind: "http",
+      status: 404,
+      path: "/api/cloud/compat/agents",
+    }),
+  });
 }
 
 describe("dedicatedSubdomainBase", () => {
@@ -184,6 +201,129 @@ describe("runJoinFlow", () => {
       "https://elizacloud.ai/api/v1/eliza/agents/agent-new",
     );
     expect(result.dedicated).toBe(false);
+  });
+
+  test("clears a stale binding and reselects fresh when the bound agent is gone (404)", async () => {
+    const setBaseUrl = vi.fn();
+    const setToken = vi.fn();
+    const select = vi
+      .fn()
+      .mockRejectedValueOnce(agentGoneError())
+      .mockResolvedValueOnce({
+        agentId: "agent-alive",
+        agentName: "Eliza",
+        apiBase: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-alive",
+        bridgeUrl: null,
+        created: false,
+      });
+    const client: JoinFlowClient = {
+      selectOrProvisionCloudAgent: select,
+      setBaseUrl,
+      setToken,
+    };
+    const { effects, saveServer, clearServer, saveFirstRun } = makeEffects();
+
+    const result = await runJoinFlow({
+      client,
+      effects,
+      cloudApiBase: CLOUD_API_BASE,
+      authToken: "tok",
+      agentName: "Eliza",
+      preferAgentId: "agent-deleted",
+    });
+
+    // The stale binding is dropped and the client reset to the fresh-visit
+    // state BEFORE the fallback selection, so the retry resolves the control
+    // plane instead of misrouting through the dead agent origin again.
+    expect(clearServer).toHaveBeenCalledTimes(1);
+    expect(setBaseUrl.mock.calls[0]).toEqual([null]);
+    expect(select).toHaveBeenCalledTimes(2);
+    expect(select.mock.calls[1][0]).not.toHaveProperty("preferAgentId");
+    // The fallback selection binds normally — no terminal error state.
+    expect(result.agentId).toBe("agent-alive");
+    expect(saveServer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "cloud:agent-alive" }),
+    );
+    expect(saveFirstRun).toHaveBeenCalledWith(true);
+  });
+
+  test("reaches the provisioning path when the org has zero agents after dropping the stale binding", async () => {
+    const select = vi
+      .fn()
+      .mockRejectedValueOnce(agentGoneError())
+      .mockResolvedValueOnce({
+        agentId: "agent-created",
+        agentName: "Eliza",
+        apiBase: "https://agent-created.elizacloud.ai",
+        bridgeUrl: null,
+        created: true,
+      });
+    const client: JoinFlowClient = {
+      selectOrProvisionCloudAgent: select,
+      setBaseUrl: vi.fn(),
+      setToken: vi.fn(),
+    };
+    const { effects, clearServer } = makeEffects();
+
+    const result = await runJoinFlow({
+      client,
+      effects,
+      cloudApiBase: CLOUD_API_BASE,
+      authToken: "tok",
+      agentName: "Eliza",
+      preferAgentId: "agent-deleted",
+    });
+
+    expect(clearServer).toHaveBeenCalledTimes(1);
+    expect(result.created).toBe(true);
+    expect(result.agentId).toBe("agent-created");
+  });
+
+  test("keeps the terminal error for a transport-level failure of a valid binding", async () => {
+    const select = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    const client: JoinFlowClient = {
+      selectOrProvisionCloudAgent: select,
+      setBaseUrl: vi.fn(),
+      setToken: vi.fn(),
+    };
+    const { effects, clearServer, saveFirstRun } = makeEffects();
+
+    await expect(
+      runJoinFlow({
+        client,
+        effects,
+        cloudApiBase: CLOUD_API_BASE,
+        authToken: "tok",
+        agentName: "Eliza",
+        preferAgentId: "agent-bound",
+      }),
+    ).rejects.toThrow(/failed to fetch/i);
+    // Network-down is not agent-gone: the binding survives, no blind retry.
+    expect(clearServer).not.toHaveBeenCalled();
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(saveFirstRun).not.toHaveBeenCalled();
+  });
+
+  test("rethrows an agent-gone failure when no binding was remembered", async () => {
+    const select = vi.fn().mockRejectedValue(agentGoneError());
+    const client: JoinFlowClient = {
+      selectOrProvisionCloudAgent: select,
+      setBaseUrl: vi.fn(),
+      setToken: vi.fn(),
+    };
+    const { effects, clearServer } = makeEffects();
+
+    await expect(
+      runJoinFlow({
+        client,
+        effects,
+        cloudApiBase: CLOUD_API_BASE,
+        authToken: "tok",
+        agentName: "Eliza",
+      }),
+    ).rejects.toThrow(/agent not found/i);
+    expect(clearServer).not.toHaveBeenCalled();
+    expect(select).toHaveBeenCalledTimes(1);
   });
 
   test("throws when no agent id is returned", async () => {

--- a/packages/ui/src/cloud/join/lib/run-join-flow.ts
+++ b/packages/ui/src/cloud/join/lib/run-join-flow.ts
@@ -17,11 +17,16 @@
  *      reconnects to it.
  *   4. mark first-run complete so the app lands in CHAT, not the setup wizard.
  *
+ * A remembered binding whose agent was deleted server-side answers step 1 with
+ * the structural agent-gone shape; the flow then clears the stale binding and
+ * re-runs selection from the fresh-visit state instead of dead-ending.
+ *
  * The caller (JoinPage) then navigates to `/` — the tab/view app, where chat is
  * home. There is no "No agents yet" empty table: a brand-new user is talking to
  * an agent within seconds.
  */
 
+import { isCloudAgentGoneError } from "../../../api/client-types-core";
 import {
   buildCloudSharedAgentApiBase,
   ELIZA_CLOUD_CONTROL_PLANE_HOSTS,
@@ -57,6 +62,7 @@ export interface JoinFlowEffects {
     apiBase?: string;
     accessToken?: string;
   }): void;
+  clearPersistedActiveServer(): void;
   savePersistedFirstRunComplete(complete: boolean): void;
 }
 
@@ -132,15 +138,39 @@ export async function runJoinFlow(
     onProgress,
   } = args;
 
-  const selected = await client.selectOrProvisionCloudAgent({
+  const selectionOptions = {
     cloudApiBase,
     authToken,
     name: agentName,
     ...(bio?.length ? { bio } : {}),
-    ...(preferAgentId ? { preferAgentId } : {}),
     ...(forceCreate ? { forceCreate } : {}),
     ...(onProgress ? { onProgress } : {}),
-  });
+  };
+
+  let selected: Awaited<
+    ReturnType<JoinFlowClient["selectOrProvisionCloudAgent"]>
+  >;
+  try {
+    selected = await client.selectOrProvisionCloudAgent({
+      ...selectionOptions,
+      ...(preferAgentId ? { preferAgentId } : {}),
+    });
+  } catch (error) {
+    // error-policy:J4 only the structural agent-gone shape (404 +
+    // agent_not_found code / the router's known body) from a remembered
+    // binding is recovered here. A stale persisted binding keeps the live
+    // client pointed at a DELETED agent's origin, so the selection lookup
+    // misroutes through that dead origin and 404s forever — retrying can
+    // never succeed. Drop the binding, reset the client to the fresh-visit
+    // state (empty base → control-plane resolution), and re-run selection:
+    // existing agents are picked normally, zero agents fall through to the
+    // provisioning path. Transport failures of a valid binding (and every
+    // other shape) still rethrow into the terminal error state.
+    if (!preferAgentId || !isCloudAgentGoneError(error)) throw error;
+    effects.clearPersistedActiveServer();
+    client.setBaseUrl(null);
+    selected = await client.selectOrProvisionCloudAgent(selectionOptions);
+  }
 
   if (!selected.agentId) {
     throw new Error("Cloud did not return an agent to connect to.");

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
@@ -6,8 +6,8 @@
  * three device shapes (web, desktop/Electrobun, native mobile). Proves it
  * posts presence once the runtime reports running, re-emits on
  * lifecycle/visibility events, dedupes rapid repeats, maps native mobile
- * snapshots, degrades quietly on runtime-unavailable/network/signed-out (401)
- * errors, surfaces
+ * snapshots, degrades quietly on runtime-unavailable/network/signed-out
+ * (401)/agent-gone (structural 404) errors, surfaces
  * unexpected failures observably, is idempotent across repeated starts,
  * enforces the permission consent gate, survives stop() racing any awaited
  * native operation without leaking handles/monitors/intervals, and fully
@@ -55,6 +55,24 @@ const h = vi.hoisted(() => {
       signal: { id: "sig-1" },
     })),
     isApiError: vi.fn((_error: unknown) => false),
+    isCloudAgentGoneError: vi.fn((error: unknown) => {
+      let current: unknown = error;
+      for (let depth = 0; depth < 5 && current instanceof Error; depth += 1) {
+        const { status, code } = current as Error & {
+          status?: unknown;
+          code?: unknown;
+        };
+        if (
+          status === 404 &&
+          (code === "agent_not_found" ||
+            current.message.includes("agent not found or not running"))
+        ) {
+          return true;
+        }
+        current = (current as Error & { cause?: unknown }).cause;
+      }
+      return false;
+    }),
     isElectrobunRuntime: vi.fn(() => false),
     loadDesktopWorkspaceSnapshot: vi.fn(async () => ({ supported: false })),
     dispatchStatus: vi.fn(),
@@ -66,13 +84,14 @@ const h = vi.hoisted(() => {
 
 // The four @elizaos/ui subpath specifiers (/api, /bridge, /browser, /events)
 // all alias to the same stub file under this package's vitest config, so each
-// mock returns the same combined shape: client + isApiError + ElizaClient
+// mock returns the same combined shape: client + error classifiers + ElizaClient
 // (/api), isElectrobunRuntime (/bridge), loadDesktopWorkspaceSnapshot
 // (/browser), lifecycle event names (/events). The object literal is inlined
 // per call and reads only the hoisted `h` — any module-scope const would sit
 // in its TDZ when the hoisted `vi.mock` and source import run.
 vi.mock("@elizaos/ui/api", () => ({
   isApiError: h.isApiError,
+  isCloudAgentGoneError: h.isCloudAgentGoneError,
   ElizaClient: h.ElizaClient,
   isElectrobunRuntime: h.isElectrobunRuntime,
   loadDesktopWorkspaceSnapshot: h.loadDesktopWorkspaceSnapshot,
@@ -92,6 +111,7 @@ vi.mock("@elizaos/ui/bridge", () => ({
   },
   isElectrobunRuntime: h.isElectrobunRuntime,
   isApiError: h.isApiError,
+  isCloudAgentGoneError: h.isCloudAgentGoneError,
   ElizaClient: h.ElizaClient,
   loadDesktopWorkspaceSnapshot: h.loadDesktopWorkspaceSnapshot,
 }));
@@ -104,6 +124,7 @@ vi.mock("@elizaos/ui/events", () => ({
   },
   isElectrobunRuntime: h.isElectrobunRuntime,
   isApiError: h.isApiError,
+  isCloudAgentGoneError: h.isCloudAgentGoneError,
   ElizaClient: h.ElizaClient,
   loadDesktopWorkspaceSnapshot: h.loadDesktopWorkspaceSnapshot,
 }));
@@ -111,6 +132,7 @@ vi.mock("@elizaos/ui/browser", () => ({
   loadDesktopWorkspaceSnapshot: h.loadDesktopWorkspaceSnapshot,
   isElectrobunRuntime: h.isElectrobunRuntime,
   isApiError: h.isApiError,
+  isCloudAgentGoneError: h.isCloudAgentGoneError,
   ElizaClient: h.ElizaClient,
   APP_PAUSE_EVENT: "eliza:app-pause",
   APP_RESUME_EVENT: "eliza:app-resume",
@@ -679,6 +701,74 @@ describe("startLifeOpsActivitySignalCapture", () => {
 
     expect(h.captureLifeOpsActivitySignal).toHaveBeenCalled();
     expect(h.dispatchStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "capture_error" }),
+    );
+  });
+
+  it("treats a structural agent-gone status probe (stale binding to a deleted agent) as an expected stand-down", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    h.isApiError.mockImplementation(
+      (error) => typeof error === "object" && error !== null && "kind" in error,
+    );
+    // The cloud router's code-less shape for a deleted agent's origin.
+    h.getStatus.mockRejectedValue(
+      Object.assign(new Error("agent not found or not running"), {
+        kind: "http",
+        status: 404,
+      }),
+    );
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await settle();
+
+    expect(h.captureLifeOpsActivitySignal).not.toHaveBeenCalled();
+    expect(h.dispatchStatus).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("swallows an agent_not_found capture failure (agent deleted mid-session) without a capture_error", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    h.isApiError.mockImplementation(
+      (error) => typeof error === "object" && error !== null && "kind" in error,
+    );
+    h.captureLifeOpsActivitySignal.mockRejectedValue(
+      Object.assign(new Error("agent not found"), {
+        kind: "http",
+        status: 404,
+        code: "agent_not_found",
+      }),
+    );
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await settle();
+
+    expect(h.captureLifeOpsActivitySignal).toHaveBeenCalled();
+    expect(h.dispatchStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "capture_error" }),
+    );
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("still surfaces an ordinary 404 (missing route, no agent-gone shape) as a capture_error", async () => {
+    h.isApiError.mockImplementation(
+      (error) => typeof error === "object" && error !== null && "kind" in error,
+    );
+    h.captureLifeOpsActivitySignal.mockRejectedValue({
+      kind: "http",
+      status: 404,
+      message: "Not Found",
+    });
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await settle();
+
+    expect(h.dispatchStatus).toHaveBeenCalledWith(
       expect.objectContaining({ status: "capture_error" }),
     );
   });

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
@@ -27,7 +27,8 @@
  *
  * Expected unavailability (no authenticated session yet — every capture
  * endpoint 401s on signed-out pages, runtime not yet running, transient
- * network/timeout, endpoint 503) quietly stands the capture down.
+ * network/timeout, endpoint 503, a stale binding whose deleted agent answers
+ * with the structural agent-gone 404) quietly stands the capture down.
  * Capability-specific 503s use a bounded retry interval because the global
  * runtime status cannot prove that this optional plugin route is active.
  * Anything else is surfaced observably: a `capture_error` status event plus a
@@ -51,7 +52,11 @@ import "../api/client-lifeops.js";
 // the full component tree into this headless register chunk, which both
 // bloats the renderer bundle and breaks under node module resolution in test
 // lanes. (isApiError also only carries its type-guard on the /api subpath.)
-import { client as apiClient, isApiError } from "@elizaos/ui/api";
+import {
+  client as apiClient,
+  isApiError,
+  isCloudAgentGoneError,
+} from "@elizaos/ui/api";
 import { isElectrobunRuntime } from "@elizaos/ui/bridge";
 import { loadDesktopWorkspaceSnapshot } from "@elizaos/ui/browser";
 import { APP_PAUSE_EVENT, APP_RESUME_EVENT } from "@elizaos/ui/events";
@@ -247,7 +252,11 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
       standDownActivitySignals();
       return;
     }
-    if (isExpectedTransientError(error) || isUnauthenticatedError(error)) {
+    if (
+      isExpectedTransientError(error) ||
+      isUnauthenticatedError(error) ||
+      isCloudAgentGoneError(error)
+    ) {
       return;
     }
     // Unexpected failure: surface it observably — status event for in-app
@@ -260,13 +269,15 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
     });
   };
 
-  // Runtime not up yet (boot, restart) and signed-out (401) are the designed
-  // stand-down states; only transport loss, the 503 "runtime starting" shape,
-  // and the pre-auth 401 count as those states. Anything else coming out of
-  // the status probe (persistent 500s included) is a real defect and must
-  // surface, not read as "not ready" forever (#16504).
+  // Runtime not up yet (boot, restart), signed-out (401), and a stale binding
+  // to a deleted agent (structural agent-gone 404) are the designed
+  // stand-down states; only those plus transport loss and the 503 "runtime
+  // starting" shape count. Anything else coming out of the status probe
+  // (persistent 500s included) is a real defect and must surface, not read as
+  // "not ready" forever (#16504).
   const isExpectedProbeFailure = (error: unknown): boolean =>
     isUnauthenticatedError(error) ||
+    isCloudAgentGoneError(error) ||
     (isApiError(error) &&
       (error.kind === "network" ||
         error.kind === "timeout" ||


### PR DESCRIPTION
> Publication sync (2026-08-06): exact head `149437f056ae97d827b74797d4cf4d768cc92811` is one scoped commit above merged `develop@acf5fe75b4e95fef33710f5003101abd74f521cc`. The original patch is preserved and the sole reviewer follow-up now reuses the shared agent-gone classifier. Exact-head frozen install, 33/33 UI tests, 31/31 LifeOps tests, targeted Biome, and full 343/343 root verification pass; refreshed CI is rerunning after a GitHub Actions service outage. Exact-head desktop and mobile join-surface audits passed 2/2 with zero broken or needs-work findings; the recovery screenshots/video remain explicitly labeled as behavioral-reference artifacts because the only post-capture semantic change is shared-classifier reuse.

Live user report tonight (staging): a browser holding a persisted agent binding to a **deleted** agent is permanently stuck on /join — every retry re-reads the dead binding, fires at the dead agent origin, gets the router's `404 {"error":"agent not found or not running"}`, and renders the terminal "Couldn't connect to your agent". The org actually had zero agents; the correct outcome was the create path.

Mechanism: the persisted `elizaos:active-server` binding points the client's base at `https://<agentId>.<env>.elizacloud.ai`; `selectOrProvisionCloudAgent`'s list step routes through that base, so *every* step of selection misroutes through the corpse.

Fix (structural, in the join controller): a new shared `isCloudAgentGoneError` classifier (404 + the router's structural agent-gone shape, cause-chain aware — transport failures never match); on agent-gone from a REMEMBERED binding, the flow clears the persisted binding, resets the client base to the fresh-visit control-plane path, and re-runs selection without the preference — zero agents → existing create path, agents exist → normal chooser. Real transport failures of a valid binding keep the existing terminal state. The LifeOps activity capture gets the same agent-gone shape added to its expected-degrade set (mirroring #17817's 401 pattern).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:149437f056ae97d827b74797d4cf4d768cc92811 -->

<!-- evidence-row:before-screenshots -->
- [x] Before/preserved - the terminal error surface, still shown for real transport failures of a valid binding (unchanged by this fix; dev-server render at the real hostname via request interception, bound origin mocked to refuse connections): ![terminal error](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/joinfix-terminal-error.png)

<!-- evidence-row:after-screenshots -->
- [x] After - stale-binding recovery, both outcomes: zero agents → create path ![recovery to create](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/joinfix-recovery-create.png), two running agents → normal chooser ![recovery to selection](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/joinfix-recovery-selection.png) (behavioral-reference source head `ce7fca0e832d48797323bf21d29e1faac4f74582` at the real hostname, API mocked with the router's real agent-gone body).

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough - stale binding planted → /join → dead-origin 404 → binding cleared → create path → "Cloud agent ready!": https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/joinfix-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] N/A - client-side join-flow recovery; no server code path is touched by this diff.

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs - the live user console that motivated the fix, plus in-browser verification of the recovery.

<details><summary>Live report + verified recovery</summary>

```text
live user, app-staging /join (before fix):
  GET https://0b402068-....staging.elizacloud.ai/api/cloud/compat/agents 404
  [LifeOpsActivitySignals] unexpected capture failure: ApiError: agent not
  found or not running
  page: "Couldn't connect to your agent / agent not found or not running /
  Try again"  (retry loops forever; binding never cleared)

capture-run verification (behavioral-reference source head `ce7fca0e832d48797323bf21d29e1faac4f74582`, in-browser, not just pixels):
  dead-origin 404 agent-gone -> binding cleared -> client base reset ->
  control-plane re-list -> create path (zero agents) / chooser (two agents);
  no terminal error on either recovery path
```

</details>

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic client routing/recovery change, no model inference participates.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - join-flow, client, and capture suites at this head.

<details><summary>Exact-head test results at 149437f056ae97d827b74797d4cf4d768cc92811</summary>

```text
packages/ui:
  run-join-flow + client-cloud-select-or-provision     33 pass / 0 fail
    (bound-agent-404 -> binding cleared, base reset, re-select without
     preference, no terminal error; zero-agents -> create; transport
     failure -> terminal preserved, binding kept; classifier negatives)
  neighboring client/cloud suites                       79 pass / 0 fail
  first-run conductor + startup-phase                  135 pass / 0 fail
  typecheck                                             clean
plugin-personal-assistant:
  activity-signals-capture (+client-extension)          31 pass / 0 fail
    (agent-gone probe stands down silently; plain 404 still loud)
biome (8 touched files)                                 clean
root verify (workspace build/typecheck/lint + audits) 343 pass / 0 fail
```

</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review - [tesseract 5.3.4 readout of every capture](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/joinfix-ocr-review.txt), verified against intended copy (terminal error, "Creating Eliza...", PICK YOUR AGENT chooser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- gate-refresh:14:44 -->

