### PR TITLE
fix(ci): restore develop validation gates

### DIFF
--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -40,7 +40,11 @@ env:
 
 jobs:
   fixture-e2e:
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    # WebKit needs host libraries that the generic Hetzner fleet does not
+    # provision, and those runners do not grant the installer passwordless
+    # sudo. Keep this cross-engine lane on a disposable, fully provisionable
+    # host so a green result certifies WebKit actually launched.
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -3,10 +3,10 @@
  * uniquely named, referenced, and free of duplicate UI fixture ownership.
  */
 
+import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, test } from "bun:test";
 
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 const githubRoot = join(repoRoot, ".github");
@@ -25,7 +25,9 @@ describe("GitHub action supply-chain references", () => {
 
     for (const file of collectYamlFiles(githubRoot)) {
       const source = readFileSync(file, "utf8");
-      for (const match of source.matchAll(/^\s*(?:-\s*)?uses:\s+(\S+)\s*$/gmu)) {
+      for (const match of source.matchAll(
+        /^\s*(?:-\s*)?uses:\s+(\S+)\s*$/gmu,
+      )) {
         const reference = match[1];
         if (reference.startsWith("./") || reference.startsWith("docker://")) {
           continue;
@@ -56,7 +58,9 @@ describe("GitHub action supply-chain references", () => {
 
   test("does not retain orphaned local composite actions", () => {
     const yamlFiles = collectYamlFiles(githubRoot);
-    const graph = yamlFiles.map((file) => readFileSync(file, "utf8")).join("\n");
+    const graph = yamlFiles
+      .map((file) => readFileSync(file, "utf8"))
+      .join("\n");
     const orphaned = yamlFiles
       .filter((file) => /^action\.ya?ml$/u.test(file.split("/").at(-1) ?? ""))
       .map((file) => `./${relative(repoRoot, dirname(file))}`)
@@ -68,13 +72,28 @@ describe("GitHub action supply-chain references", () => {
   test("assigns each UI fixture suite to one parallel workflow", () => {
     const suites = (name: string) =>
       new Set(
-        [...readFileSync(join(githubRoot, "workflows", name), "utf8").matchAll(
-          /^\s*run:\s+(?:[A-Z_][A-Z0-9_]*=\S+\s+)*bun run --cwd packages\/ui (test:[^\s#]+)/gmu,
-        )].map((match) => match[1]),
+        [
+          ...readFileSync(join(githubRoot, "workflows", name), "utf8").matchAll(
+            /^\s*run:\s+(?:[A-Z_][A-Z0-9_]*=\S+\s+)*bun run --cwd packages\/ui (test:[^\s#]+)/gmu,
+          ),
+        ].map((match) => match[1]),
       );
     const core = suites("ui-e2e-gate.yml");
     const extended = suites("ui-fixture-e2e.yml");
 
     expect([...core].filter((suite) => extended.has(suite))).toEqual([]);
+  });
+
+  test("keeps the WebKit fixture lane on a provisionable hosted runner", () => {
+    const source = readFileSync(
+      join(githubRoot, "workflows", "ui-fixture-e2e.yml"),
+      "utf8",
+    );
+
+    expect(source).toMatch(/^\s{4}runs-on:\s*ubuntu-24\.04$/m);
+    expect(source).not.toContain("hetzner-robot");
+    expect(source).toContain(
+      ".github/scripts/install-playwright-browsers.sh chromium webkit",
+    );
   });
 });

--- a/packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
+++ b/packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
@@ -23,6 +23,11 @@ jobs:
   test:
     runs-on: \${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-24.04"]' || vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
 `;
+const MANUAL_FLEET_WORKFLOW = `name: Test
+jobs:
+  test:
+    runs-on: \${{ fromJSON(inputs.runner == 'robot' && vars.HETZNER_FLEET_ONLINE == 'true' && '["self-hosted","hetzner-robot"]' || '["ubuntu-24.04"]') }}
+`;
 const SAFE_MATRIX_WORKFLOW = `name: Test
 jobs:
   test:
@@ -88,6 +93,34 @@ describe("Hetzner fleet routing contract", () => {
         files: 1,
         selectors: 1,
       });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts a manual fleet choice only behind the repository opt-in", () => {
+    const root = buildRepo(MANUAL_FLEET_WORKFLOW);
+    try {
+      expect(validateHetznerFleetRouting(root)).toEqual({
+        files: 1,
+        selectors: 1,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a manual fleet choice without the repository opt-in", () => {
+    const root = buildRepo(
+      MANUAL_FLEET_WORKFLOW.replace(
+        " && vars.HETZNER_FLEET_ONLINE == 'true'",
+        "",
+      ),
+    );
+    try {
+      expect(() => validateHetznerFleetRouting(root)).toThrow(
+        /must require explicit HETZNER_FLEET_ONLINE opt-in/,
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
+++ b/packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
@@ -26,7 +26,7 @@ jobs:
 const MANUAL_FLEET_WORKFLOW = `name: Test
 jobs:
   test:
-    runs-on: \${{ fromJSON(inputs.runner == 'robot' && vars.HETZNER_FLEET_ONLINE == 'true' && '["self-hosted","hetzner-robot"]' || '["ubuntu-24.04"]') }}
+    runs-on: \${{ fromJSON(inputs.runner != 'robot' && '["ubuntu-24.04"]' || vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
 `;
 const SAFE_MATRIX_WORKFLOW = `name: Test
 jobs:
@@ -113,7 +113,7 @@ describe("Hetzner fleet routing contract", () => {
   test("rejects a manual fleet choice without the repository opt-in", () => {
     const root = buildRepo(
       MANUAL_FLEET_WORKFLOW.replace(
-        " && vars.HETZNER_FLEET_ONLINE == 'true'",
+        "vars.HETZNER_FLEET_ONLINE != 'true' && '[\"ubuntu-24.04\"]' || ",
         "",
       ),
     );

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -4574,6 +4574,7 @@ export function ChatOverlay({
   ]);
 
   const pullBinding: PullGestureBinding = usePullGesture({
+    preventTouchCompatibilityEvents: true,
     onStart: resetPullPeak,
     onDrag: onDragOffset,
     onDragReset: settleDrag,

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -1012,6 +1012,12 @@ async function runContinuumSuite(p, pointer, tag) {
     (await detent(p)) === "half",
     `[${tag}-continuum] grabber tap from INPUT reveals the thread at HALF`,
   );
+  assert(
+    (await p.evaluate(
+      () => document.activeElement?.getAttribute("data-testid"),
+    )) !== "chat-composer-textarea",
+    `[${tag}-continuum] grabber tap keeps the keyboard down after the handle moves`,
+  );
   await grabberTap();
   assert(
     (await detent(p)) === "collapsed" && (await variant(p)) === "closed",

--- a/packages/ui/src/components/shell/use-pull-gesture.test.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.test.ts
@@ -158,6 +158,23 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
     expect(setPointerCapture).toHaveBeenCalledWith(1);
   });
 
+  it("can suppress a touch compatibility click before a gesture-owned tap moves its target", () => {
+    const preventDefault = vi.fn();
+    const onTap = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({ onTap, preventTouchCompatibilityEvents: true }),
+    );
+
+    result.current.onPointerDown(
+      pointer(100, 300, 1, undefined, {
+        pointerType: "touch",
+        preventDefault,
+      }),
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
   it("flushes the latest coalesced drag before free-settle release", () => {
     const raf: { cb: ((t: number) => void) | null } = { cb: null };
     vi.stubGlobal(

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -66,6 +66,9 @@ export interface PullGestureOptions {
   onCancel?: () => void;
   /** Enable horizontal swipe recognition. Defaults to true when swipe handlers exist. */
   swipeEnabled?: boolean;
+  /** Cancel touch pointerdown's compatibility mouse/click sequence. Use on
+   *  gesture-owned controls whose tap callback moves the hit target. */
+  preventTouchCompatibilityEvents?: boolean;
   /** Minimum vertical travel (px) to count as a pull. Default 56. */
   distanceThreshold?: number;
   /** Minimum vertical speed (px/ms) to count as a flick. Default 0.5. */
@@ -113,6 +116,7 @@ export function usePullGesture(
     onSettleFree,
     onCancel,
     swipeEnabled = true,
+    preventTouchCompatibilityEvents = false,
     distanceThreshold = DEFAULT_PULL_DISTANCE,
     velocityThreshold = DEFAULT_PULL_VELOCITY,
     distanceThresholdX = DEFAULT_SWIPE_DISTANCE,
@@ -180,6 +184,13 @@ export function usePullGesture(
         event.pointerType !== "mouse"
       )
         return;
+      // Pointer-driven controls resolve their tap in `finish`. When that tap
+      // moves or replaces the control, a touch compatibility click can be
+      // re-hit-tested onto the newly exposed element (for example, the chat
+      // composer) and perform an unrelated default action such as focus.
+      if (preventTouchCompatibilityEvents && event.pointerType === "touch") {
+        event.preventDefault();
+      }
       // A press that reaches here is the primary pointer (a secondary touch
       // finger returned above), so it is the ONLY pointer down and it begins a
       // fresh gesture. Any `start` still held is therefore stale and must be
@@ -216,7 +227,13 @@ export function usePullGesture(
         }
       }
     },
-    [hasSwipe, hasVerticalPull, onStart, eventTime],
+    [
+      hasSwipe,
+      hasVerticalPull,
+      onStart,
+      eventTime,
+      preventTouchCompatibilityEvents,
+    ],
   );
 
   const onPointerMove = React.useCallback(

--- a/packages/ui/src/components/ui/__tests__/primitives-stories-smoke.test.tsx
+++ b/packages/ui/src/components/ui/__tests__/primitives-stories-smoke.test.tsx
@@ -11,4 +11,10 @@ import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../*.stories.tsx", { eager: true });
 
-smokeStoryModules("primitive", modules, { minModules: 20 });
+smokeStoryModules("primitive", modules, {
+  minModules: 20,
+  expectCaughtError: [
+    "error-boundary/CaughtError",
+    "error-boundary/CustomLabels",
+  ],
+});

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -2029,6 +2029,9 @@ describe("device RAM-tier gating + reversible onboarding (#14390)", () => {
     expect(provider.text).toContain("__first_run__:back:runtime=");
 
     // The blocked on-device pick is refused with a fresh provider choice.
+    // Freeze the wall clock across both rejected picks: their retry turns must
+    // remain distinct even when the user moves faster than clock resolution.
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_789_000_000_000);
     expect(tryHandleFirstRunAction("__first_run__:provider:on-device")).toBe(
       true,
     );
@@ -2047,6 +2050,7 @@ describe("device RAM-tier gating + reversible onboarding (#14390)", () => {
     // Configure-later is a full local runtime mode, so it retains the 8 GB
     // floor even though it does not download a model immediately.
     expect(tryHandleFirstRunAction("__first_run__:provider:other")).toBe(true);
+    nowSpy.mockRestore();
     await waitFor(() => {
       expect(
         transcript.current.some((m) =>

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -481,6 +481,9 @@ export function useFirstRunConductor(): void {
   // per send even when two land in the same millisecond, so `seedTurn`'s id
   // dedup never silently swallows an acknowledged message.
   const textTurnSeqRef = React.useRef(0);
+  // Re-offered choice turns have the same collision risk: a user can reject
+  // two unavailable options before the wall clock advances.
+  const choiceTurnSeqRef = React.useRef(0);
 
   // ── Transcript seam ──────────────────────────────────────────────────────
   const seedTurn = React.useCallback(
@@ -509,8 +512,8 @@ export function useFirstRunConductor(): void {
         if (!prev.some((m) => m.id === baseId)) {
           return [...prev, makeTurn(baseId, text)];
         }
-        const retryId = `${baseId}:retry:${Date.now()}`;
-        if (prev.some((m) => m.id === retryId)) return prev;
+        choiceTurnSeqRef.current += 1;
+        const retryId = `${baseId}:retry:${Date.now()}:${choiceTurnSeqRef.current}`;
         return [...prev, makeTurn(retryId, text)];
       });
     },

--- a/packages/ui/src/testing/real-touch-gestures.ts
+++ b/packages/ui/src/testing/real-touch-gestures.ts
@@ -195,7 +195,12 @@ export async function touchTap(page: Page, selector: string): Promise<void> {
         "pointerup",
         (event) => {
           const pointerEvent = event as PointerEvent;
-          if (pointerEvent.pointerId === probe.pointerId) probe.terminal = "up";
+          if (
+            pointerEvent.pointerId === probe.pointerId &&
+            probe.terminal === null
+          ) {
+            probe.terminal = "up";
+          }
         },
         { once: true },
       );
@@ -203,8 +208,12 @@ export async function touchTap(page: Page, selector: string): Promise<void> {
         "pointercancel",
         (event) => {
           const pointerEvent = event as PointerEvent;
-          if (pointerEvent.pointerId === probe.pointerId)
+          if (
+            pointerEvent.pointerId === probe.pointerId &&
+            probe.terminal === null
+          ) {
             probe.terminal = "cancel";
+          }
         },
         { once: true },
       );
@@ -264,6 +273,12 @@ export async function touchTap(page: Page, selector: string): Promise<void> {
     if (terminal !== "up") {
       throw new Error(`real-touch: tap ended with pointer${terminal}`);
     }
+    // Keep the input session alive until the release has crossed two renderer
+    // frames. The target's native pointerup precedes React's delegated state
+    // commit; a physical next gesture begins from the released frame the user
+    // can see, so make that ordering part of this real-touch helper too.
+    await settleMainThread(page);
+    await settleMainThread(page);
   } finally {
     try {
       await page.evaluate(() => {

--- a/packages/ui/src/testing/real-touch-gestures.ts
+++ b/packages/ui/src/testing/real-touch-gestures.ts
@@ -170,6 +170,11 @@ export async function touchTap(page: Page, selector: string): Promise<void> {
       type: "touchStart",
       touchPoints: [point(cx, cy)],
     });
+    // Give the renderer one produced frame to observe pointerdown and establish
+    // implicit capture before releasing. Back-to-back CDP commands can complete
+    // compositor-side on a busy runner before the page's handlers see the press,
+    // which is faster than a physical tap and silently drops the interaction.
+    await settleMainThread(page);
     await client.send("Input.dispatchTouchEvent", {
       type: "touchEnd",
       touchPoints: [],

--- a/packages/ui/src/testing/real-touch-gestures.ts
+++ b/packages/ui/src/testing/real-touch-gestures.ts
@@ -166,20 +166,116 @@ export async function touchTap(page: Page, selector: string): Promise<void> {
   const { cx, cy } = await centerOf(page, selector);
   const client = await page.context().newCDPSession(page);
   try {
+    await page.evaluate((selector) => {
+      const target = document.querySelector(selector);
+      if (!target) throw new Error(`real-touch: no target for ${selector}`);
+      const root = globalThis as typeof globalThis & {
+        __elizaRealTouchTapProbe?: {
+          pointerId: number | null;
+          down: boolean;
+          terminal: "up" | "cancel" | null;
+        };
+      };
+      const probe: {
+        pointerId: number | null;
+        down: boolean;
+        terminal: "up" | "cancel" | null;
+      } = { pointerId: null, down: false, terminal: null };
+      root.__elizaRealTouchTapProbe = probe;
+      target.addEventListener(
+        "pointerdown",
+        (event) => {
+          const pointerEvent = event as PointerEvent;
+          probe.pointerId = pointerEvent.pointerId;
+          probe.down = true;
+        },
+        { once: true },
+      );
+      target.addEventListener(
+        "pointerup",
+        (event) => {
+          const pointerEvent = event as PointerEvent;
+          if (pointerEvent.pointerId === probe.pointerId) probe.terminal = "up";
+        },
+        { once: true },
+      );
+      target.addEventListener(
+        "pointercancel",
+        (event) => {
+          const pointerEvent = event as PointerEvent;
+          if (pointerEvent.pointerId === probe.pointerId)
+            probe.terminal = "cancel";
+        },
+        { once: true },
+      );
+    }, selector);
     await client.send("Input.dispatchTouchEvent", {
       type: "touchStart",
       touchPoints: [point(cx, cy)],
     });
-    // Give the renderer one produced frame to observe pointerdown and establish
-    // implicit capture before releasing. Back-to-back CDP commands can complete
-    // compositor-side on a busy runner before the page's handlers see the press,
-    // which is faster than a physical tap and silently drops the interaction.
+    await page.waitForFunction(
+      () =>
+        (
+          globalThis as typeof globalThis & {
+            __elizaRealTouchTapProbe?: { down: boolean };
+          }
+        ).__elizaRealTouchTapProbe?.down === true,
+      undefined,
+      { timeout: 1500 },
+    );
+    // Keep the finger down for a physical two-frame dwell after pointerdown has
+    // reached the target. CDP command acknowledgement alone is compositor-side
+    // and can otherwise race the page's pointer/capture handlers on busy hosts.
+    await settleMainThread(page);
     await settleMainThread(page);
     await client.send("Input.dispatchTouchEvent", {
       type: "touchEnd",
       touchPoints: [],
     });
+    await page.waitForFunction(
+      () =>
+        (
+          globalThis as typeof globalThis & {
+            __elizaRealTouchTapProbe?: {
+              terminal: "up" | "cancel" | null;
+            };
+          }
+        ).__elizaRealTouchTapProbe?.terminal === "up" ||
+        (
+          globalThis as typeof globalThis & {
+            __elizaRealTouchTapProbe?: {
+              terminal: "up" | "cancel" | null;
+            };
+          }
+        ).__elizaRealTouchTapProbe?.terminal === "cancel",
+      undefined,
+      { timeout: 1500 },
+    );
+    const terminal = await page.evaluate(
+      () =>
+        (
+          globalThis as typeof globalThis & {
+            __elizaRealTouchTapProbe?: {
+              terminal: "up" | "cancel" | null;
+            };
+          }
+        ).__elizaRealTouchTapProbe?.terminal,
+    );
+    if (terminal !== "up") {
+      throw new Error(`real-touch: tap ended with pointer${terminal}`);
+    }
   } finally {
+    try {
+      await page.evaluate(() => {
+        delete (
+          globalThis as typeof globalThis & {
+            __elizaRealTouchTapProbe?: unknown;
+          }
+        ).__elizaRealTouchTapProbe;
+      });
+    } catch {
+      // error-policy:J6 The page may close during teardown; the probe is page-local.
+    }
     await client.detach();
   }
 }

--- a/packages/ui/test/portable-stories.tsx
+++ b/packages/ui/test/portable-stories.tsx
@@ -82,12 +82,20 @@ export function smokeStoryModules(
      * browser story gate's `needs-runtime` path and the live `audit:app`.
      */
     skip?: string[];
+    /**
+     * `"<Module>/<Story>"` keys whose render deliberately exercises a React
+     * error boundary. React reports caught errors through `onCaughtError`; the
+     * harness consumes that expected diagnostic while leaving the global
+     * fail-on-console guard intact for every other story.
+     */
+    expectCaughtError?: string[];
   } = {},
 ): void {
   const wrap =
     options.wrap ??
     ((node: ReactNode) => <TooltipProvider>{node}</TooltipProvider>);
   const skip = new Set(options.skip ?? []);
+  const expectCaughtError = new Set(options.expectCaughtError ?? []);
 
   beforeAll(() => {
     installJsdomUiPolyfills();
@@ -129,7 +137,8 @@ export function smokeStoryModules(
     if (!stories.length) continue;
     describe(`${label}: ${name}`, () => {
       for (const [storyName, Story] of stories) {
-        const testFn = skip.has(`${name}/${storyName}`) ? it.skip : it;
+        const storyKey = `${name}/${storyName}`;
+        const testFn = skip.has(storyKey) ? it.skip : it;
         testFn(`${storyName} renders without throwing`, async () => {
           // The coverage here IS the absence of a throw: composing the story
           // (above) and mounting it must not error. There is intentionally no
@@ -139,7 +148,20 @@ export function smokeStoryModules(
           // ShortcutsOverlay/Open, …). Blank-render detection that needs that
           // runtime lives in the browser story gate (its needs-runtime path) and
           // the live audit:app — not this fast offline smoke.
-          const { container } = render(wrap(<Story />) as ReactElement);
+          const caughtErrors: unknown[] = [];
+          const { container } = render(
+            wrap(<Story />) as ReactElement,
+            expectCaughtError.has(storyKey)
+              ? {
+                  onCaughtError: (error) => {
+                    caughtErrors.push(error);
+                  },
+                }
+              : undefined,
+          );
+          if (expectCaughtError.has(storyKey)) {
+            expect(caughtErrors).not.toHaveLength(0);
+          }
           // If the story defines an interaction (`play`), run it — so authoring a
           // play function automatically gets it exercised in this lane, with no
           // per-component test to wire up.

--- a/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
@@ -529,10 +529,10 @@ describe("ComputerUseService file and terminal execution (real host I/O)", () =>
   }, 15_000);
 
   // executeCommand maps each command string onto an action and dispatches it.
-  // Malformed desktop/window commands fail fast at validation (no display or
-  // input driver touched); the maps and per-verb approval-command lookups run
-  // for every string, so the routing switch and its helper switches are covered
-  // without actuating the host. Each dispatch returns a structured result.
+  // Desktop commands are malformed so they fail before touching the host. The
+  // window route stubs the platform-facing service method: `arrange_windows`
+  // is valid without parameters and would otherwise rearrange the developer's
+  // real desktop while a routing test is running.
   it("routes every desktop command string through executeCommand", async () => {
     const commands = [
       "click",
@@ -564,20 +564,32 @@ describe("ComputerUseService file and terminal execution (real host I/O)", () =>
   }, 20_000);
 
   it("routes every window command string through executeCommand", async () => {
-    const commands = [
-      "list_windows",
-      "switch_to_window",
-      "arrange_windows",
-      "move_window",
-      "minimize_window",
-      "maximize_window",
-      "restore_window",
-      "close_window",
-    ];
-    for (const command of commands) {
-      const result = await service.executeCommand(command, {});
-      expect(typeof result.success).toBe("boolean");
+    const commands = {
+      list_windows: "list",
+      switch_to_window: "switch",
+      arrange_windows: "arrange",
+      move_window: "move",
+      minimize_window: "minimize",
+      maximize_window: "maximize",
+      restore_window: "restore",
+      close_window: "close",
+    } as const;
+    const routedActions: string[] = [];
+    const executeWindowAction = service.executeWindowAction;
+    service.executeWindowAction = async (params) => {
+      routedActions.push(params.action);
+      return { success: false, error: "routing probe" };
+    };
+    try {
+      for (const command of Object.keys(commands)) {
+        const result = await service.executeCommand(command, {});
+        expect(typeof result.success).toBe("boolean");
+      }
+    } finally {
+      service.executeWindowAction = executeWindowAction;
     }
+
+    expect(routedActions).toEqual(Object.values(commands));
   }, 20_000);
 
   it("routes every file command string through executeCommand", async () => {
@@ -636,7 +648,6 @@ describe("ComputerUseService file and terminal execution (real host I/O)", () =>
       "get_current_window_id",
       "get_window_size",
       "get_window_position",
-      "arrange",
     ] as const) {
       const result = await service.executeWindowAction({ action });
       expect(typeof result.success).toBe("boolean");


### PR DESCRIPTION
## Summary

- preserve React 19 error-boundary diagnostics in portable UI stories
- keep onboarding retry turn IDs unique under same-millisecond retries
- isolate computer-use command-routing tests from real window arrangement
- strengthen certification fleet fallback coverage and prevent moving touch handles from retargeting compatibility clicks onto the composer

This is the validated follow-up needed to restore the full `develop` gate after #17733 and the subsequent repair PRs. The SSO fix was independently merged in #17826, and the cloud IAC v2/cache repairs landed in #17835; their superseded branch commits were dropped during the final rebase.

Refs #17774

## Validation

- `bun run verify` - passed on `ced0189874c` (342/342 Turbo tasks plus repository audits)
- Workflow routing contract tests - 19/19 passed on `ced0189874c`
- `bun run build` - 121/121 workspaces; 19/19 view bundles; final UI package build passed on `83133e50bda`
- `bun run test` - passed on exact final SHA `ced0189874c` across the full repository lane and script-test inventory
- `bun run --cwd packages/ui test:chat-sheet-e2e` - 72 captures passed with zero page or console errors on `83133e50bda`
- `bun run --cwd packages/app audit:app` - 214/214 captures passed; 0 broken, 0 needs-work; OCR verified all four affected Chat layouts
- SSO bridge focused tests - 49/49 passed on `d3d8d2f9267`
- computer-use - 85 files, 750 passed, 17 skipped
- UI - 878 files, 9,075 passed, 7 skipped
- core - 476 files, 4,648 passed, 1 skipped



<!-- evidence-head:ced0189874cc2e1ac5f274b0072558fffe741485 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17839-before-mobile-continuum-final-input.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17839-after-mobile-continuum-final-input.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17839-chat-sheet-drag-suite.webm

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend production behavior changes; the CI-only fleet-selection condition has deterministic contract coverage

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered UI changed; the shared real-touch test helper and touch compatibility-click fix are proven by the full 72-capture chat-sheet browser suite

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent action provider prompt or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent user domain artifact is produced by these validation and test-harness fixes

<!-- evidence-row:ocr-review -->
- [x] [17839-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17839-ocr-triage.json)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@ced0189874cc2e1ac5f274b0072558fffe741485:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`










