### PR TITLE
fix(ci): provision develop browser lanes

### DIFF
--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -78,7 +78,9 @@ env:
 jobs:
   chat-shell-gestures:
     name: Chat shell gesture + parity e2e
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    # WebKit needs distro libraries that the Hetzner fleet cannot install
+    # without passwordless sudo. Keep this browser lane on a provisioned host.
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -106,7 +108,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright chromium + webkit
-        run: bunx playwright install --with-deps chromium webkit
+        run: .github/scripts/install-playwright-browsers.sh chromium webkit
 
       # Boot-free coverage gate: fails when a gesture-handler site in
       # packages/ui/src lacks a CHAT_GESTURE_COVERAGE matrix row (#12188).

--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -54,6 +54,9 @@ env:
   GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
   OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
   ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY }}
+  # Headless Linux has no safe OS keychain. This fixed, CI-only passphrase
+  # unlocks the ephemeral vault so runtime and model-provider boot can finish.
+  ELIZA_VAULT_PASSPHRASE: dev-smoke-headless-vault-only
 
 jobs:
   changes:
@@ -128,7 +131,7 @@ jobs:
           no-vision-deps: "true"
 
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Generate shared i18n assets
         run: bun run --cwd packages/shared build:i18n
@@ -199,7 +202,7 @@ jobs:
           no-vision-deps: "true"
 
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Generate shared i18n assets
         run: bun run --cwd packages/shared build:i18n

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -96,4 +96,34 @@ describe("GitHub action supply-chain references", () => {
       ".github/scripts/install-playwright-browsers.sh chromium webkit",
     );
   });
+
+  test("keeps the chat WebKit lane on a provisionable hosted runner", () => {
+    const source = readFileSync(
+      join(githubRoot, "workflows", "chat-shell-gestures.yml"),
+      "utf8",
+    );
+
+    expect(source).toMatch(/^\s{4}runs-on:\s*ubuntu-24\.04$/m);
+    expect(source).not.toContain("hetzner-robot");
+    expect(source).toContain(
+      ".github/scripts/install-playwright-browsers.sh chromium webkit",
+    );
+  });
+
+  test("installs dev-smoke Chromium without requiring self-hosted sudo", () => {
+    const source = readFileSync(
+      join(githubRoot, "workflows", "dev-smoke.yml"),
+      "utf8",
+    );
+
+    expect(
+      source.match(
+        /\.github\/scripts\/install-playwright-browsers\.sh chromium/g,
+      ),
+    ).toHaveLength(2);
+    expect(source).not.toContain("playwright install --with-deps chromium");
+    expect(source).toContain(
+      "ELIZA_VAULT_PASSPHRASE: dev-smoke-headless-vault-only",
+    );
+  });
 });


### PR DESCRIPTION
# Relates to

- Fixes the remaining develop workflow failures tracked in #17774.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` passed after sync.
- [x] The workflow logs and contract tests below let a reviewer confirm the change without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `21ace3bd943e2f0405a01060749d7b409e630cc7`; zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` pass post-sync at `2993c62aa1daa2bbcc80464844d318e3601107c0`.

# Risks

Low. The change only affects GitHub Actions runner/browser provisioning. The WebKit gesture lane uses GitHub-hosted Ubuntu instead of the self-hosted Hetzner fleet; Chromium-only dev smoke jobs retain fleet routing but no longer require interactive sudo.

# Background

## What does this PR do?

- Routes the WebKit chat gesture lane to `ubuntu-24.04`, whose image contains provisionable WebKit system dependencies.
- Uses the repository.s sudo-aware Playwright installer in both dev-smoke jobs and the chat gesture lane.
- Supplies a fixed CI-only vault passphrase so the headless dev runtime can bootstrap and register its model provider.
- Adds contract coverage that rejects restoring the unprovisionable runner/install combinations.

The develop run failed before any browser test executed:

- Dev Smoke: https://github.com/elizaOS/eliza/actions/runs/31103376603
- Chat shell gestures: https://github.com/elizaOS/eliza/actions/runs/31103376578

Both failures were `sudo: a terminal is required` from `playwright install --with-deps`; the self-hosted runners do not provide passwordless sudo. The earlier UI Extended repair also established that WebKit cannot launch on this fleet without its missing distro libraries. A first proof run then reached the real onboarding path and exposed a missing headless vault passphrase; https://github.com/elizaOS/eliza/actions/runs/31104122870 records that second failure.

## What kind of change is this?

Bug fix (non-breaking CI workflow repair).

# Documentation changes needed?

No user-facing documentation change is needed; the workflow comments and executable contracts document the runner constraint.

# Testing

## Where should a reviewer start?

Review `.github/workflows/dev-smoke.yml`, `.github/workflows/chat-shell-gestures.yml`, and the new assertions in `packages/scripts/__tests__/github-action-pinning.test.ts`.

## Detailed testing steps

- `bun test packages/scripts/__tests__/github-action-pinning.test.ts packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts packages/scripts/__tests__/chat-gesture-workflow-contract.test.ts` — 22 passed, 0 failed.
- `bun install --frozen-lockfile` — passed after rebasing to the latest `origin/develop`.
- `bun run verify` — passed on exact head `2993c62aa1daa2bbcc80464844d318e3601107c0` after install.
- Real Dev Smoke on exact head (HMR + onboarding chat): passed — https://github.com/elizaOS/eliza/actions/runs/31105432742
- Real Chat shell gestures (Chromium + WebKit): passed — https://github.com/elizaOS/eliza/actions/runs/31104125355
- After merge, require the same push workflows to pass on the final develop SHA before closing #17774.

# Evidence Gate

<!-- evidence-head:2993c62aa1daa2bbcc80464844d318e3601107c0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only change with no rendered product surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only change with no rendered product surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow-only change with no user flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - workflow-only runner provisioning change; the failing GitHub Actions run URLs are linked in Background and no backend production code path changed
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend application behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduling, wallet, audio, or generated-domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-backed behavior changed.

## Backend + frontend logs

The linked develop runs show both affected jobs failing specifically in Playwright installation before their browser tests. The PR checks and post-merge develop reruns provide the after-state proof.

## Screenshots (before / after) + video walkthrough

N/A - the diff only changes GitHub Actions runner and dependency provisioning.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

None. The real post-merge workflow proof will be attached to #17774 after the final develop SHA completes.






