### PR TITLE
fix(ci): require hosted CI capabilities

### DIFF
--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -33,7 +33,7 @@ jobs:
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it
     # queued indefinitely and pile up runs (#13617/#8501).
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
@@ -68,7 +68,9 @@ jobs:
     name: Build production Docker image (+ smoke boot)
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.docker == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    # The smoke builds and boots a real container. The general Hetzner fleet
+    # does not expose a Docker daemon, so use the provisioned hosted image.
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     env:
       BUN_VERSION: "1.3.14"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -53,8 +53,10 @@ permissions:
 jobs:
   homepage-build:
     name: Homepage Build (PR smoke)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
-    timeout-minutes: 30
+    # The visual suite needs a provisionable browser image and predictable
+    # software-GPU timing; the general fleet supplies neither consistently.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -116,8 +118,7 @@ jobs:
 
       - name: Install homepage browser
         if: steps.homepage-scope.outputs.run == 'true'
-        working-directory: packages/homepage
-        run: ./node_modules/.bin/playwright install --with-deps chromium
+        run: PLAYWRIGHT_INSTALL_CWD=packages/homepage .github/scripts/install-playwright-browsers.sh chromium
 
       - name: Validate homepage snapshot inventory
         if: steps.homepage-scope.outputs.run == 'true'
@@ -212,7 +213,9 @@ jobs:
 
   format-check:
     name: Format
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    # This short required gate should not spend its entire budget bootstrapping
+    # or recovering an unhealthy general-fleet runner.
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -260,8 +263,10 @@ jobs:
   # mirroring the lean install used by `format-check`.
   develop-static-gate:
     name: Develop Gate (secret scan + UI determinism)
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
-    timeout-minutes: 8
+    # Keep the required security/determinism checks independent of fleet
+    # bootstrap stalls and runner-internal setup failures.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -126,4 +126,45 @@ describe("GitHub action supply-chain references", () => {
       "ELIZA_VAULT_PASSPHRASE: dev-smoke-headless-vault-only",
     );
   });
+
+  test("provisions homepage Chromium without requiring self-hosted sudo", () => {
+    const source = readFileSync(
+      join(githubRoot, "workflows", "quality.yml"),
+      "utf8",
+    );
+    const workflow = Bun.YAML.parse(source) as {
+      jobs?: Record<
+        string,
+        { "runs-on"?: string; "timeout-minutes"?: number }
+      >;
+    };
+    const job = workflow.jobs?.["homepage-build"];
+    const formatGate = workflow.jobs?.["format-check"];
+    const staticGate = workflow.jobs?.["develop-static-gate"];
+
+    expect(job?.["runs-on"]).toBe("ubuntu-24.04");
+    expect(job?.["timeout-minutes"]).toBeGreaterThanOrEqual(45);
+    expect(formatGate?.["runs-on"]).toBe("ubuntu-24.04");
+    expect(staticGate?.["runs-on"]).toBe("ubuntu-24.04");
+    expect(staticGate?.["timeout-minutes"]).toBeGreaterThanOrEqual(15);
+    expect(source).toContain(
+      "PLAYWRIGHT_INSTALL_CWD=packages/homepage .github/scripts/install-playwright-browsers.sh chromium",
+    );
+    expect(source).not.toContain("playwright install --with-deps chromium");
+  });
+
+  test("keeps the Docker smoke on a runner with a Docker daemon", () => {
+    const source = readFileSync(
+      join(githubRoot, "workflows", "docker-ci-smoke.yml"),
+      "utf8",
+    );
+    const workflow = Bun.YAML.parse(source) as {
+      jobs?: Record<string, { "runs-on"?: string }>;
+    };
+    const classifier = workflow.jobs?.changes;
+    const job = workflow.jobs?.["docker-ci-smoke"];
+
+    expect(classifier?.["runs-on"]).toBe("ubuntu-24.04");
+    expect(job?.["runs-on"]).toBe("ubuntu-24.04");
+  });
 });


### PR DESCRIPTION
# Relates to

- Fixes the remaining final-develop workflow failures tracked in #17774.

- [x] Targets `develop` and is rebased onto latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` passed after sync.
- [x] The linked real workflow failures and executable contracts make the behavior reviewable.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `c765dee8b45`; zero conflicts.
- [x] `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile` and `bun run verify` pass on exact head `7ebc732acc26e69197e89e7cac2680d666c0122f`.

# Risks

Low. This changes only CI provisioning. The homepage visual suite and short Format and secret/UI-determinism gates move to hosted Ubuntu for a provisionable browser image and predictable software-GPU timing, with a 45-minute ceiling; the secret/UI-determinism gate receives 15 minutes so fleet dependency setup cannot consume its entire budget. Docker smoke and its classifier also use hosted Ubuntu because the general Hetzner fleet lacks Docker and has produced runner setup collisions.

# Background

## What does this PR do?

- Replaces homepage's direct Playwright `--with-deps` invocation with the repository's sudo-aware installer.
- Pins the homepage visual job, short Quality gates, Docker path classifier, and real Docker image build/boot job to `ubuntu-24.04`; the homepage suite receives a 45-minute ceiling.
- Adds workflow contract assertions that prevent both broken capability assignments from returning.

The exact develop failures are:

- Quality homepage browser provisioning: https://github.com/elizaOS/eliza/actions/runs/31106070808
- Docker smoke (`docker daemon is not available`): https://github.com/elizaOS/eliza/actions/runs/31106071004

## What kind of change is this?

Bug fix (non-breaking CI workflow repair).

# Documentation changes needed?

No user-facing documentation change is needed; workflow comments and tests record the capability constraints.

# Testing

## Where should a reviewer start?

Review `.github/workflows/quality.yml`, `.github/workflows/docker-ci-smoke.yml`, and the new assertions in `packages/scripts/__tests__/github-action-pinning.test.ts`.

## Detailed testing steps

- `bun test packages/scripts/__tests__/github-action-pinning.test.ts packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts` — 23 passed, 0 failed.
- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile` — passed after rebasing to latest develop.
- `bun run verify` — passed on exact head `7ebc732acc26e69197e89e7cac2680d666c0122f` (342/342 tasks).
- Before merge, manually dispatch Quality and Docker smoke on this branch and require both real jobs to pass.

# Evidence Gate

<!-- evidence-head:7ebc732acc26e69197e89e7cac2680d666c0122f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only change with no rendered product surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only change with no rendered product surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow-only change with no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - workflow-only provisioning change; failing Actions run URLs are linked in Background and no backend production code changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend application behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduling, wallet, audio, or generated-domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-backed behavior changed.

## Backend + frontend logs

N/A - the linked GitHub Actions logs are the relevant runtime evidence for this workflow-only change.

## Screenshots (before / after) + video walkthrough

N/A - the diff only changes GitHub Actions provisioning.

## Audio / voice walkthrough

N/A - no voice behavior changed.

## Known gaps / failures

None. The real branch workflow proof will be added before merge, followed by a final develop-SHA audit.