### PR TITLE
fix(cloud): bump the hydration generation on repository-side cache eviction

### DIFF
--- a/packages/cloud/shared/src/lib/services/apps-inference-cache.test.ts
+++ b/packages/cloud/shared/src/lib/services/apps-inference-cache.test.ts
@@ -12,10 +12,16 @@ import type { App } from "../../db/repositories/apps";
 let appRows = new Map<string, App>();
 let appReads = 0;
 
+// `holdFindById` lets a test park an authoritative read mid-flight, which is
+// the only way to reproduce an invalidation racing a read already past its
+// generation sample.
+let holdFindById: Promise<void> | null = null;
+
 mock.module("../../db/repositories/apps", () => ({
   appsRepository: {
     findById: async (id: string) => {
       appReads += 1;
+      if (holdFindById) await holdFindById;
       return appRows.get(id);
     },
   },
@@ -32,6 +38,9 @@ mock.module("./managed-domains", () => ({
 const { cache } = await import("../cache/client");
 const { CacheKeys, CacheTTL } = await import("../cache/keys");
 const { appsService } = await import("./apps");
+const { evictInferenceAppMemoryCache, inferenceAppMemoryCache } = await import(
+  "./inference-app-memory-cache"
+);
 
 let sequence = 0;
 
@@ -52,6 +61,7 @@ function app(overrides: Partial<App> = {}): App {
 beforeEach(() => {
   appRows = new Map();
   appReads = 0;
+  holdFindById = null;
 });
 
 describe("AppsService inference cache-only lookup", () => {
@@ -129,5 +139,33 @@ describe("AppsService inference cache-only lookup", () => {
       cacheRead: "invalid",
     });
     expect(appReads).toBe(0);
+  });
+  // A mutation invalidates through the repository (`invalidateAppCacheEntries`
+  // -> `evictInferenceAppMemoryCache`) while an authoritative read is already
+  // awaiting its DB round trip. The read sampled the hydration generation
+  // BEFORE the invalidation, so it must notice the bump and decline to publish
+  // the row it is holding — otherwise the pre-mutation row lands back in the
+  // SHARED cache, where every worker serves it for the full TTL.
+  test("an invalidation racing an in-flight read is not undone by that read", async () => {
+    const row = app();
+    appRows.set(row.id, row);
+
+    let release: () => void = () => {};
+    holdFindById = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const read = appsService.getById(row.id);
+    // Wait until the read is genuinely parked inside `findById`. `appReads`
+    // increments before the hold is awaited, and the generation is sampled
+    // before that call — so this guarantees the invalidation below lands
+    // AFTER the sample, which is the interleaving under test.
+    while (appReads === 0) await Promise.resolve();
+    evictInferenceAppMemoryCache(row.id);
+    release();
+    await read;
+
+    expect(inferenceAppMemoryCache.get(row.id)).toBeNull();
+    expect((await appsService.getByIdCacheOnly(row.id)).kind).toBe("warming");
   });
 });

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -4,7 +4,11 @@
 
 import crypto from "crypto";
 import { type App, type AppUser, appsRepository, type NewApp } from "../../db/repositories/apps";
-import { inferenceAppMemoryCache } from "./inference-app-memory-cache";
+import {
+  evictInferenceAppMemoryCache,
+  getInferenceAppCacheGeneration,
+  inferenceAppMemoryCache,
+} from "./inference-app-memory-cache";
 
 // Re-export the app row types so consumers (and tests) can import them from the
 // service module rather than reaching into the repository directly.
@@ -19,7 +23,6 @@ import { managedDomainsService } from "./managed-domains";
 
 const DEFAULT_MAX_APPS_PER_ORG = 25;
 const appByIdHydrations = new Map<string, Promise<void>>();
-const appByIdHydrationGeneration = new Map<string, number>();
 
 export interface AppCacheExecutionContext {
   waitUntil(promise: Promise<unknown>): void;
@@ -162,9 +165,9 @@ export class AppsService {
 
   private async loadAndCacheAppById(id: string): Promise<App | undefined> {
     const cacheKey = CacheKeys.app.byId(id);
-    const generation = appByIdHydrationGeneration.get(id) ?? 0;
+    const generation = getInferenceAppCacheGeneration(id);
     const app = await appsRepository.findById(id);
-    if ((appByIdHydrationGeneration.get(id) ?? 0) !== generation) {
+    if (getInferenceAppCacheGeneration(id) !== generation) {
       return app;
     }
     if (app) {
@@ -338,8 +341,7 @@ export class AppsService {
    * would leave stale data; we look up the existing row's slug to evict it too.
    */
   async invalidateCache(appId: string, apiKeyId?: string, slug?: string): Promise<void> {
-    inferenceAppMemoryCache.delete(appId);
-    appByIdHydrationGeneration.set(appId, (appByIdHydrationGeneration.get(appId) ?? 0) + 1);
+    evictInferenceAppMemoryCache(appId);
     const promises: Promise<void>[] = [
       cache.del(CacheKeys.app.byId(appId)),
       cache.del(CacheKeys.app.costMarkup(appId)),

--- a/packages/cloud/shared/src/lib/services/inference-app-memory-cache.ts
+++ b/packages/cloud/shared/src/lib/services/inference-app-memory-cache.ts
@@ -3,18 +3,38 @@
  * apps service (reads) and the apps repository (eviction on mutation). Lives
  * in its own module so the repository can evict without importing the service
  * layer, which itself imports the repository.
+ *
+ * The hydration generation lives here too, alongside the cache it guards. An
+ * authoritative read samples it before its DB round trip and re-checks it
+ * afterwards, so any invalidation that raced the read is visible and the read
+ * declines to publish its now-stale row. Splitting the two — evicting here
+ * while the counter lived in the service — let the repository path evict
+ * without advancing the generation, which is the failure this module exists
+ * to make unrepresentable.
  */
 import type { App } from "../../db/repositories/apps";
 import { InMemoryLRUCache } from "../cache/in-memory-lru-cache";
 
 export const inferenceAppMemoryCache = new InMemoryLRUCache<App>(100, 30_000);
 
+const appByIdHydrationGeneration = new Map<string, number>();
+
+/** The current hydration generation for an app, 0 before any invalidation. */
+export function getInferenceAppCacheGeneration(appId: string): number {
+  return appByIdHydrationGeneration.get(appId) ?? 0;
+}
+
 /**
- * Evict one app from the worker-lifetime memory cache. Called by the apps
- * repository after every persisting mutation so a same-worker read cannot
- * return the pre-mutation row for up to the cache TTL — the shared-cache
- * eviction alone cannot reach this layer.
+ * Invalidate one app's worker-lifetime state after a persisting mutation.
+ *
+ * Deletes the memory entry AND advances the hydration generation. Both halves
+ * are required: the delete stops a same-worker read from returning the
+ * pre-mutation row for up to the cache TTL, and the generation bump stops an
+ * authoritative read that started BEFORE this call from republishing that same
+ * row into the shared cache after it — where every worker would then read it
+ * for the full shared TTL.
  */
 export function evictInferenceAppMemoryCache(appId: string): void {
   inferenceAppMemoryCache.delete(appId);
+  appByIdHydrationGeneration.set(appId, getInferenceAppCacheGeneration(appId) + 1);
 }


### PR DESCRIPTION
# Relates to

Fixes #17857.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Branched from `origin/develop` at `35f634551`; zero conflicts.
- [x] Red-first: the new regression test fails against the previous delete-only evictor and passes with the fix (both runs below).
- [x] `bun test packages/cloud/shared/src/lib/services/apps-inference-cache.test.ts` — 6/6 pass.
- [x] Biome clean on all three files; package `typecheck` reports nothing for them.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@64942cd44461ecc24b3ca1421de74900906e9506:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `35f634551`; zero conflicts.

# Risks

Low, and narrowing rather than widening. No TTL, read path, or cache key changes. The only behavioral difference is that the repository-side invalidation now advances the hydration generation as the service-side one always has — so a read racing a mutation declines to publish instead of publishing a superseded row. The failure mode being removed is a stale publish; the fix cannot itself publish anything new.

# Background

## What does this PR do?

`invalidateCache` in the apps service has always done two things: delete the memory entry **and** advance `appByIdHydrationGeneration`. That counter is load-bearing — `loadAndCacheAppById` samples it before its DB round trip and re-checks it afterwards, so a read that began before an invalidation notices and declines to publish the row it is holding.

When the repository gained its own eviction path, only the delete came with it:

```ts
export function evictInferenceAppMemoryCache(appId: string): void {
  inferenceAppMemoryCache.delete(appId);
}
```

The counter stayed private to `services/apps.ts`, so `invalidateAppCacheEntries` (`repositories/apps.ts:36`, reached from `:480`, `:496`, `:498` — each awaited after the write commits) evicted without bumping. That leaves this interleaving open:

1. A read enters `loadAndCacheAppById(id)`, samples `generation = 0`, awaits `findById(id)` → pre-mutation row **R**.
2. A mutation commits and invalidates. Generation is still `0`.
3. The read resumes, `0 !== 0` is false, and it publishes **R** into `cache.set(cacheKey, …)` *and* `inferenceAppMemoryCache.set(id, …)`.

The bug the evictor was added to fix stranded a stale row in one worker's memory for the 30s LRU TTL. This interleaving is worse: the row is republished into the **shared** cache, so the staleness escapes the worker and is served cluster-wide for the full `CacheTTL.app.byId`. It is also not exotic — `scheduleAppByIdHydration` runs hydrations in the background under `waitUntil`, so reads overlapping mutations are the steady state.

The fix moves the generation into `inference-app-memory-cache.ts` next to the cache it guards, and has the evictor do both halves. Evicting without bumping is no longer expressible, which is the actual defect — not either call site individually.

## What kind of change is this?

Bug fix (non-breaking): restores an invariant the service path already held.

# Documentation changes needed?

None. The module header now states why the two pieces of state live together.

# Testing

## Where should a reviewer start?

```bash
bun test packages/cloud/shared/src/lib/services/apps-inference-cache.test.ts
```

Then revert `evictInferenceAppMemoryCache` to a delete-only body and re-run — the new case fails, and nothing else does.

## Detailed testing steps

The test parks an authoritative read inside `findById` (waiting on `appReads` so the invalidation provably lands *after* the generation sample), invalidates through the repository primitive, releases the read, and asserts it did not republish into either cache.

# Evidence Gate

<!-- evidence-head:55d600f1c95419cff5434b3bad2405632c570805 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side cache invariant; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow; the behavior is the red-to-green transition recorded below.
<!-- evidence-row:backend-logs -->
- [x] Red-first proof — the same suite against the previous evictor and against this head:

<details><summary>RED — evictor reverted to delete-only (develop behavior)</summary>

```text
$ bun test packages/cloud/shared/src/lib/services/apps-inference-cache.test.ts
(fail) AppsService inference cache-only lookup > an invalidation racing an in-flight read is not undone by that read
  expect(inferenceAppMemoryCache.get(row.id)).toBeNull()
  Received: { id: "app-1", ... monetization_enabled: true }

 5 pass
 1 fail
```

</details>

<details><summary>GREEN — this head</summary>

```text
$ bun test packages/cloud/shared/src/lib/services/apps-inference-cache.test.ts
 6 pass
 0 fail
Ran 6 tests across 1 file.
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path; the change is server-side cache state.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, or action path is touched.
<!-- evidence-row:domain-artifacts -->
- [x] The cache state after the raced invalidation is the domain artifact here:

<details><summary>observed state after a mutation races an in-flight read</summary>

```text
before fix:
  inferenceAppMemoryCache.get(id) -> { id: "app-1", ... }   # republished by the resumed read
  appsService.getByIdCacheOnly(id) -> { kind: "ready", app: <pre-mutation row> }

after fix:
  inferenceAppMemoryCache.get(id) -> null
  appsService.getByIdCacheOnly(id) -> { kind: "warming" }    # forces an authoritative re-read
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.
