### PR TITLE
fix(local-inference): refresh fused embedding bundle

### DIFF
--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -21,8 +21,6 @@
  * Parallels `ensure-text-to-speech-handler.ts` — same shape, same guards.
  */
 
-import { existsSync, linkSync, mkdirSync, symlinkSync } from "node:fs";
-import path from "node:path";
 import {
 	type AgentRuntime,
 	applyBackgroundInferenceBudget,
@@ -77,6 +75,7 @@ import {
 	selectEmbeddingPresetFromHardware,
 } from "./embedding-presets";
 import { isLocalEmbeddingDisabledByEnv } from "./embedding-warmup-policy";
+import { resolveFusedEmbeddingBundleRoot } from "./fused-embedding-bundle";
 
 type GenerateTextHandler = (
 	runtime: IAgentRuntime,
@@ -675,58 +674,6 @@ function resolveDesktopEmbeddingConfig(
 }
 
 /**
- * Resolve (or stage) the bundle root the fused `eliza_inference_embed` should
- * anchor at for the dedicated embedding model. The fused C side embeds over the
- * single GGUF under `<root>/text/`, so we must point it at an isolated bundle
- * that contains ONLY the embedding model — never the chat bundle's text model
- * (whose decoder-as-embedder output has a different dimension). Resolution:
- *   1. `ELIZA_EMBED_BUNDLE_ROOT` — explicit override.
- *   2. The model already lives under a `text/` dir (`<root>/text/<model>.gguf`).
- *   3. `<modelsDir>/text/<model>` exists → anchor at `<modelsDir>`.
- *   4. Otherwise STAGE the dedicated embedding GGUF as the sole entry under
- *      `<modelsDir>/.eliza-embed-bundle/text/` (hardlink, symlink fallback) so
- *      the fused lib loads gte-small (384-dim bi-encoder, SQL dim384) — the
- *      same model the retired libllama path used, now through the fused lib.
- * Returns null only when the embedding GGUF is not present (boot warmup may
- * still be downloading) — the handler then raises LocalInferenceUnavailable and
- * the runtime falls through to the next embedding provider.
- */
-function resolveFusedEmbedBundleRoot(
-	cfg: DesktopEmbeddingConfig,
-): string | null {
-	const override = process.env.ELIZA_EMBED_BUNDLE_ROOT?.trim();
-	if (override && existsSync(path.join(override, "text"))) return override;
-	const modelPath = path.resolve(cfg.modelsDir, cfg.model);
-	const parent = path.dirname(modelPath);
-	if (path.basename(parent) === "text" && existsSync(modelPath)) {
-		return path.dirname(parent);
-	}
-	if (existsSync(path.join(cfg.modelsDir, "text", cfg.model))) {
-		return cfg.modelsDir;
-	}
-	if (!existsSync(modelPath)) return null;
-	const root = path.join(cfg.modelsDir, ".eliza-embed-bundle");
-	const textDir = path.join(root, "text");
-	const staged = path.join(textDir, path.basename(cfg.model));
-	try {
-		mkdirSync(textDir, { recursive: true });
-		if (!existsSync(staged)) {
-			try {
-				linkSync(modelPath, staged);
-			} catch {
-				symlinkSync(modelPath, staged);
-			}
-		}
-		return root;
-	} catch (err) {
-		logger.warn(
-			`[local-inference] could not stage the fused embed bundle for "${cfg.model}": ${String(err)}`,
-		);
-		return null;
-	}
-}
-
-/**
  * Lazily-resolved fused embedding handle. When the fused `libelizainference`
  * (ABI v9) is present, reports `embedSupported()`, and a `<root>/text/` bundle
  * root resolves for the embedding model, the desktop TEXT_EMBEDDING handler
@@ -799,7 +746,20 @@ async function getFusedEmbeddingHandle(cfg: DesktopEmbeddingConfig): Promise<{
 			const { resolveFusedLibraryPath } = await import(
 				"../services/desktop-fused-ffi-backend-runtime"
 			);
-			const bundleRoot = resolveFusedEmbedBundleRoot(cfg);
+			let bundleRoot: string | null;
+			try {
+				bundleRoot = resolveFusedEmbeddingBundleRoot({
+					...cfg,
+					override: process.env.ELIZA_EMBED_BUNDLE_ROOT?.trim(),
+				});
+			} catch (error) {
+				// error-policy:J4 a failed local artifact stage is an explicit
+				// unavailable provider state; the runtime can select another provider.
+				logger.warn(
+					`[local-inference] could not stage the fused embed bundle for "${cfg.model}": ${String(error)}`,
+				);
+				return null;
+			}
 			if (!bundleRoot) {
 				logger.warn(
 					`[local-inference] fused embed unavailable: no bundle root for "${cfg.model}" under "${cfg.modelsDir}"`,
@@ -867,7 +827,8 @@ async function getFusedEmbeddingHandle(cfg: DesktopEmbeddingConfig): Promise<{
  * Desktop TEXT_EMBEDDING handler over the FUSED `libelizainference`
  * (`eliza_inference_embed`, ABI v9). The dedicated embedding GGUF (gte-small,
  * 384-dim — an exact match for plugin-sql's dim384 column) is staged as the
- * sole entry of an isolated fused embed bundle (see `resolveFusedEmbedBundleRoot`)
+ * sole entry of an isolated fused embed bundle (see
+ * `resolveFusedEmbeddingBundleRoot`)
  * so the fused lib loads it directly. libllama is retired: there is no
  * capacitor/libllama fallback. When the fused embed cannot resolve (no bun:ffi,
  * no fused lib, or the embedding GGUF is still downloading) this throws so the

--- a/plugins/plugin-local-inference/src/runtime/fused-embedding-bundle.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/fused-embedding-bundle.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Exercises fused embedding bundle staging against real temporary files so
+ * artifact replacement and inode ownership are proven without filesystem mocks.
+ */
+
+import {
+	linkSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveFusedEmbeddingBundleRoot } from "./fused-embedding-bundle";
+
+const temporaryRoots: string[] = [];
+
+function temporaryRoot(): string {
+	const root = mkdtempSync(path.join(os.tmpdir(), "eliza-embed-bundle-"));
+	temporaryRoots.push(root);
+	return root;
+}
+
+afterEach(() => {
+	for (const root of temporaryRoots.splice(0)) {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe("resolveFusedEmbeddingBundleRoot", () => {
+	it("stages the configured model as the bundle's sole text artifact", () => {
+		const modelsDir = temporaryRoot();
+		const model = "gte-small.gguf";
+		const source = path.join(modelsDir, model);
+		writeFileSync(source, "current-model");
+
+		const root = resolveFusedEmbeddingBundleRoot({ modelsDir, model });
+		const staged = path.join(root ?? "", "text", model);
+
+		expect(root).toBe(path.join(modelsDir, ".eliza-embed-bundle"));
+		expect(readFileSync(staged, "utf8")).toBe("current-model");
+		expect(statSync(staged).ino).toBe(statSync(source).ino);
+	});
+
+	it("replaces a staged hardlink after the downloader replaces its source inode", () => {
+		const modelsDir = temporaryRoot();
+		const model = "gte-small.gguf";
+		const source = path.join(modelsDir, model);
+		writeFileSync(source, "truncated");
+		const root = path.join(modelsDir, ".eliza-embed-bundle");
+		const staged = path.join(root, "text", model);
+		mkdirSync(path.dirname(staged), { recursive: true });
+		linkSync(source, staged);
+		const obsoleteInode = statSync(staged).ino;
+
+		unlinkSync(source);
+		writeFileSync(source, "complete-model-artifact");
+		expect(statSync(source).ino).not.toBe(obsoleteInode);
+
+		expect(resolveFusedEmbeddingBundleRoot({ modelsDir, model })).toBe(root);
+		expect(readFileSync(staged, "utf8")).toBe("complete-model-artifact");
+		expect(statSync(staged).ino).toBe(statSync(source).ino);
+	});
+
+	it("honors an explicit native bundle root without staging another model", () => {
+		const modelsDir = temporaryRoot();
+		const override = path.join(modelsDir, "operator-bundle");
+		mkdirSync(path.join(override, "text"), { recursive: true });
+
+		expect(
+			resolveFusedEmbeddingBundleRoot({
+				modelsDir,
+				model: "missing.gguf",
+				override,
+			}),
+		).toBe(override);
+	});
+
+	it("returns null when neither a bundle nor the configured model exists", () => {
+		const modelsDir = temporaryRoot();
+		expect(
+			resolveFusedEmbeddingBundleRoot({
+				modelsDir,
+				model: "missing.gguf",
+			}),
+		).toBeNull();
+	});
+});

--- a/plugins/plugin-local-inference/src/runtime/fused-embedding-bundle.ts
+++ b/plugins/plugin-local-inference/src/runtime/fused-embedding-bundle.ts
@@ -32,9 +32,11 @@ function stageCurrentModel(source: string, staged: string): void {
 	if (referencesCurrentModel(source, staged)) return;
 
 	if (process.platform === "win32") {
-		// Windows file symlinks require privileges on many supported hosts. A
-		// refreshed source inode is detected above, so replacing the hardlink here
-		// retains the same follow-the-current-artifact invariant.
+		// Windows file symlinks require privileges on many supported hosts. The
+		// resolver refreshes this hardlink when a new process observes a replaced
+		// source inode; a process that already opened its fused handle remains pinned
+		// until restart. Removing first also means this path is briefly absent while
+		// the startup-only repair runs.
 		rmSync(staged, { force: true });
 		linkSync(source, staged);
 		return;

--- a/plugins/plugin-local-inference/src/runtime/fused-embedding-bundle.ts
+++ b/plugins/plugin-local-inference/src/runtime/fused-embedding-bundle.ts
@@ -1,0 +1,77 @@
+/**
+ * Resolves the isolated model bundle consumed by fused desktop embeddings.
+ * The staged entry follows replacement downloads so the native loader cannot
+ * remain pinned to an obsolete GGUF inode after an artifact refresh.
+ */
+
+import {
+	existsSync,
+	linkSync,
+	mkdirSync,
+	renameSync,
+	rmSync,
+	statSync,
+	symlinkSync,
+} from "node:fs";
+import path from "node:path";
+
+export interface FusedEmbeddingBundleConfig {
+	modelsDir: string;
+	model: string;
+	override?: string;
+}
+
+function referencesCurrentModel(source: string, staged: string): boolean {
+	if (!existsSync(staged)) return false;
+	const sourceStat = statSync(source);
+	const stagedStat = statSync(staged);
+	return sourceStat.dev === stagedStat.dev && sourceStat.ino === stagedStat.ino;
+}
+
+function stageCurrentModel(source: string, staged: string): void {
+	if (referencesCurrentModel(source, staged)) return;
+
+	if (process.platform === "win32") {
+		// Windows file symlinks require privileges on many supported hosts. A
+		// refreshed source inode is detected above, so replacing the hardlink here
+		// retains the same follow-the-current-artifact invariant.
+		rmSync(staged, { force: true });
+		linkSync(source, staged);
+		return;
+	}
+
+	// POSIX rename replaces the previous staged entry atomically. A symlink is
+	// deliberate: artifact managers replace downloads by pathname, and the
+	// native bundle must follow that pathname rather than retain the old inode.
+	const pending = `${staged}.${process.pid}.pending`;
+	rmSync(pending, { force: true });
+	symlinkSync(source, pending);
+	renameSync(pending, staged);
+}
+
+/**
+ * Returns a fused embedding bundle root, staging the dedicated GGUF when the
+ * configured model is not already inside a native bundle layout.
+ */
+export function resolveFusedEmbeddingBundleRoot({
+	modelsDir,
+	model,
+	override,
+}: FusedEmbeddingBundleConfig): string | null {
+	if (override && existsSync(path.join(override, "text"))) return override;
+
+	const modelPath = path.resolve(modelsDir, model);
+	const parent = path.dirname(modelPath);
+	if (path.basename(parent) === "text" && existsSync(modelPath)) {
+		return path.dirname(parent);
+	}
+	if (existsSync(path.join(modelsDir, "text", model))) return modelsDir;
+	if (!existsSync(modelPath)) return null;
+
+	const root = path.join(modelsDir, ".eliza-embed-bundle");
+	const textDir = path.join(root, "text");
+	const staged = path.join(textDir, path.basename(model));
+	mkdirSync(textDir, { recursive: true });
+	stageCurrentModel(modelPath, staged);
+	return root;
+}


### PR DESCRIPTION
# Fixes

Fixes #17860.

# What changed

- Extracts fused `gte-small` embedding-bundle ownership from the superseded local-voice draft #17843.
- Detects when a staged embedding entry no longer references the current downloaded GGUF.
- Replaces the stale staged entry atomically on POSIX and safely on Windows.
- Preserves explicit bundle overrides and already-native bundle layouts.
- Adds real temporary-filesystem coverage for initial staging and source-inode replacement.

This PR contains no local ASR, VAD, Kokoro, local text-model, or Cartesia behavior.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no repository contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Sync with develop

- Base: `738d605ebc8aea093ab5fd38a40b12761f3b84a5`
- Head: `acc7cedada07675294d90012ef01f16f77484985`
- Tree: `b6e0a5007add24fae6ff711d61b08c653ec1556a`
- Ahead/behind at publication: `2/0`
- Frozen install left tracked files unchanged.

# Verification

- `bunx vitest run plugins/plugin-local-inference/src/runtime/fused-embedding-bundle.test.ts plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts` - 27 passed.
- `bun run --cwd plugins/plugin-local-inference test` - 2,641 passed, 17 existing gated skips; package CI scripts 3/3 passed.
- `bun run --cwd plugins/plugin-local-inference typecheck` - passed.
- Targeted Biome and `git diff --check` - passed.
- `bun run verify` - 343/343 workspace tasks and all follow-on audits passed; anti-larp clean.
- Real native proof - finite 384-dimensional `gte-small` vector through `libelizainference`.

# Evidence Gate

<!-- evidence-head:acc7cedada07675294d90012ef01f16f77484985 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - filesystem/runtime artifact ownership only.
<!-- evidence-row:backend-logs -->
- [x] Exact-head native fused embedding output ([full proof](https://github.com/elizaOS/eliza/pull/17861#issuecomment-5210622526)):
```text
INFO [local-inference] Desktop embeddings via fused libelizainference anchored at /Users/nubs/.local/state/eliza/models/.eliza-embed-bundle
INFO [embedding:real-proof] model=gte-small_fp16.gguf dimensions=384 finite=true pooling=mean
INFO [embedding:real-proof] context created, vector returned, native context destroyed, library closed
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, action, provider selection, or text-generation behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head real filesystem artifact transcript ([full proof](https://github.com/elizaOS/eliza/pull/17861#issuecomment-5210626842)):
```text
BEFORE sourceInode=233940663 stagedResolvedInode=233940663 stagedBytes=old-truncated-artifact
AFTER sourceInode=233940668 stagedEntryInode=233940669 stagedResolvedInode=233940668 stagedBytes=new-complete-artifact
RESULT followsCurrentSource=true
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Risk

Low and narrow. The resolver is invoked only for the dedicated desktop fused embedding bundle. Failure remains an explicit unavailable-provider state at the existing runtime boundary.