### PR TITLE
fix: #17859 guard fallout — desktop view catalogs + scenario coverage classification

### DIFF
--- a/packages/app-core/platforms/electrobun/src/application-menu.ts
+++ b/packages/app-core/platforms/electrobun/src/application-menu.ts
@@ -103,6 +103,7 @@ export interface ViewMenuEntry {
 
 const VIEW_MENU_ENTRIES: readonly ViewMenuEntry[] = [
   { id: "chat", label: "Messages", path: "/chat" },
+  { id: "browser", label: "Browser", path: "/browser" },
   { id: "character", label: "Character", path: "/character" },
   { id: "documents", label: "Knowledge", path: "/character/documents" },
   { id: "settings", label: "Settings", path: "/settings" },

--- a/packages/app-core/src/runtime/desktop/tray-menu.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.ts
@@ -54,6 +54,12 @@ export const DESKTOP_VIEW_WINDOWS: readonly DesktopViewWindow[] = [
     path: "/chat",
   },
   {
+    id: "browser",
+    label: "Browser",
+    labelKey: "desktop.views.browser",
+    path: "/browser",
+  },
+  {
     id: "character",
     label: "Character",
     labelKey: "desktop.views.character",

--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -777,6 +777,10 @@ const PROSE_ONLY_LLM_SCENARIOS: Record<string, string> = {
     "live-only real-LLM EXPERIENCE deletion flow; the live model routes EXPERIENCE with no deterministic ACTION_PLANNER fixture, so it cannot satisfy STRICT_LLM_ROUTING's fixture contract. Keyless gating proof: the experience service unit suites.",
   "live-help-knowledge":
     "live-only real-LLM help-knowledge lane (#14360); the model answers from bundled help documents in prose, routing no action.",
+  "live-history-recall-memory-routing":
+    "live-only real-LLM proof of the Stage-1 history-capability gate (#17564, with-MEMORY branch); the live model routes MEMORY op:search with no deterministic ACTION_PLANNER fixture, so it cannot satisfy STRICT_LLM_ROUTING's fixture contract. Keyless gating proof: the message-runtime-stage1 capability-matrix suites in core.",
+  "live-history-recall-honest-denial":
+    "live-only real-LLM proof of the Stage-1 history-capability gate (#17564, no-action branch); the runtime has no role-visible MEMORY search action and the model must answer in prose without calling it, routing no action. Keyless gating proof: the message-runtime-stage1 denial-branch suites in core.",
   "live-lifeops-task-filter-due-window":
     "live-only real-LLM counterpart of the deterministic lifeops scheduled-task lanes; the live model routes SCHEDULED_TASKS with no deterministic ACTION_PLANNER fixture. The deterministic twins gate the keyless lane.",
   "live-missing-input-terminal-relay":


### PR DESCRIPTION
#17859 flipped the `browser` builtin view to `desktopTabEnabled: true`, but the two curated desktop catalogs that must mirror the desktop-eligible set — renderer `DESKTOP_VIEW_WINDOWS` (tray "Views") and bun `VIEW_MENU_ENTRIES` (menu bar) — were not extended. The parity guard `desktop-view-windows.test.ts` fails deterministically at every sha since (caught by a local full-matrix run at `acf5fe75b4e`; reproduced solo).

Fix: add the `browser` entry to both catalogs, mirroring the sibling entries.

Second #17859 guard-fallout in the same PR: the two new `live-history-recall-*` scenarios landed without entries in `deterministic-action-coverage`'s classification map (guard red at every sha since) — both now classified in the no-deterministic-fixture bucket with precedent-style rationales (17/17 green).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:3a547071b438fc6b3e706362923f8930f2ae8304 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - catalog data change; the new menu row renders only in the desktop app shell, which has no CI-rendered surface in this diff (menu shape is pinned by the parity suite).

<!-- evidence-row:after-screenshots -->
- [x] N/A - same; the diff adds one entry to two typed lists, both asserted by the guard suite.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no on-screen flow; desktop menu content is unit-pinned.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the deterministic guard failure at develop tip before the fix.

<details><summary>Guard failure at acf5fe75b4e (pre-fix), local run</summary>

```text
FAIL desktop-view-windows.test.ts > renderer DESKTOP_VIEW_WINDOWS matches
     BUILTIN_VIEWS desktop-eligible ids
FAIL desktop-view-windows.test.ts > bun VIEW_MENU_ENTRIES matches
     BUILTIN_VIEWS desktop-eligible ids
  AssertionError: expected [ 'background', 'character', ... ] to deeply
  equal [ 'background', 'browser', ... ]
  - "browser"   <- desktop-eligible since #17859, absent from both catalogs
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client/network path participates; pure catalog parity.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic catalog change, no model inference participates.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - the guard suite green at this head.

<details><summary>Results at 3107e9849a919a23c45202c85978948b84b627dc</summary>

```text
$ bunx vitest run src/runtime/desktop/desktop-view-windows.test.ts  (app-core)
  Test Files  1 passed (1)
       Tests  8 passed (8)     (was 6 pass / 2 fail before the fix)

$ bunx biome check (2 files)   clean
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
