### PR TITLE
fix(cloud): probe warm-pool entries again so dead ones stop holding node slots

### DIFF
--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
@@ -210,6 +210,12 @@ describe("real one-shot daemon entrypoint", () => {
     }));
     const drainNode = mock(async () => {});
     const drainIdle = mock(async () => ({ drained: ["warm-agent"] }));
+    const healthCheck = mock(async () => ({
+      probed: 2,
+      alive: 2,
+      reconciliation: {},
+      removed: [],
+    }));
     const replenish = mock(async () => ({
       created: ["warm-agent-next"],
       failed: [],
@@ -246,6 +252,7 @@ describe("real one-shot daemon entrypoint", () => {
 
     class OneShotWarmPoolManager {
       drainIdle = drainIdle;
+      healthCheck = healthCheck;
       replenish = replenish;
     }
 
@@ -420,6 +427,7 @@ describe("real one-shot daemon entrypoint", () => {
         expect(provisionNode).toHaveBeenCalledTimes(1);
         expect(drainNode).not.toHaveBeenCalled();
         expect(drainIdle).toHaveBeenCalledWith(configuredImage);
+        expect(healthCheck).toHaveBeenCalledTimes(1);
         expect(replenish).toHaveBeenCalledWith(configuredImage);
         expect(reconcileOrphanContainersOnNodes).toHaveBeenCalledTimes(1);
         expect(reconcileOrphanAppContainersOnNodes).toHaveBeenCalledTimes(1);

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.pool-health.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.pool-health.test.ts
@@ -1,17 +1,10 @@
 /**
- * Daemon-phase test for the warm-pool HEALTH CHECK wiring.
+ * Verifies the daemon phase that drives ready warm-pool health checks.
  *
- * `WarmPoolManager.healthCheck()` is the only thing in the tree that probes a
- * READY pool entry and collects it when its container is gone, and it had no
- * live caller: the sole historical one was `/api/v1/cron/pool-health-check` on
- * the deprecated container-control-plane. Nothing else can see those rows — the
- * heartbeat sweep filters them out by execution tier, and the unclaimable
- * reconciler excludes rows that ARE ready — so a dead ready entry kept its node
- * slot indefinitely and made its node undrainable.
- *
- * The manager's own probe/destroy behaviour is pinned in the warm-pool suites;
- * what is under test here is that the daemon drives it, in the right order, and
- * stays error-isolated.
+ * Ready pool rows are outside both the shared-tier heartbeat sweep and the
+ * unclaimable-row reconciler. The manager's probe and teardown behavior is
+ * covered separately; this suite pins the daemon call, summary mapping, error
+ * propagation, and ordering before replenishment.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.pool-health.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.pool-health.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Daemon-phase test for the warm-pool HEALTH CHECK wiring.
+ *
+ * `WarmPoolManager.healthCheck()` is the only thing in the tree that probes a
+ * READY pool entry and collects it when its container is gone, and it had no
+ * live caller: the sole historical one was `/api/v1/cron/pool-health-check` on
+ * the deprecated container-control-plane. Nothing else can see those rows — the
+ * heartbeat sweep filters them out by execution tier, and the unclaimable
+ * reconciler excludes rows that ARE ready — so a dead ready entry kept its node
+ * slot indefinitely and made its node undrainable.
+ *
+ * The manager's own probe/destroy behaviour is pinned in the warm-pool suites;
+ * what is under test here is that the daemon drives it, in the right order, and
+ * stays error-isolated.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  __setDepsForTests,
+  processPoolHealthCheckCycle,
+} from "./provisioning-worker";
+
+type HealthCheckResultShape = {
+  probed: number;
+  alive: number;
+  reconciliation: Record<string, unknown>;
+  removed: Array<{ id: string; reason: string }>;
+};
+
+/**
+ * A real-shaped WarmPoolManager stand-in whose `healthCheck` is a mock, so the
+ * daemon phase's call and summary mapping is what is exercised.
+ */
+function fakeDeps(healthCheckImpl: () => Promise<HealthCheckResultShape>) {
+  const healthCheck = mock(healthCheckImpl);
+  const calls: string[] = [];
+  class FakeManager {
+    healthCheck() {
+      calls.push("healthCheck");
+      return healthCheck();
+    }
+    replenish() {
+      calls.push("replenish");
+      return Promise.resolve({
+        decision: { toCreate: 0, reason: "" },
+        state: {},
+        created: [],
+        failed: [],
+      });
+    }
+    drainIdle() {
+      calls.push("drainIdle");
+      return Promise.resolve({
+        decision: { toDrain: [], reason: "" },
+        drained: [],
+        failed: [],
+      });
+    }
+  }
+  const deps = {
+    containersEnv: { defaultAgentImage: () => "img:tag" },
+    WarmPoolManager: FakeManager,
+    getHetznerPoolContainerCreator: () => ({}),
+  } as unknown as Parameters<typeof __setDepsForTests>[0];
+  return { deps, healthCheck, calls };
+}
+
+afterEach(() => {
+  __setDepsForTests(null);
+});
+
+describe("processPoolHealthCheckCycle (daemon phase wiring)", () => {
+  test("drives WarmPoolManager.healthCheck and maps the collected count", async () => {
+    const { deps, healthCheck } = fakeDeps(async () => ({
+      probed: 5,
+      alive: 3,
+      reconciliation: {},
+      removed: [
+        { id: "dead-1", reason: "health probe failed" },
+        { id: "dead-2", reason: "health probe failed" },
+      ],
+    }));
+    __setDepsForTests(deps);
+
+    const summary = await processPoolHealthCheckCycle();
+
+    expect(healthCheck).toHaveBeenCalledTimes(1);
+    expect(summary).toEqual({ probed: 5, alive: 3, removed: 2 });
+  });
+
+  test("reports zero collected when every ready entry answers its probe", async () => {
+    const { deps } = fakeDeps(async () => ({
+      probed: 4,
+      alive: 4,
+      reconciliation: {},
+      removed: [],
+    }));
+    __setDepsForTests(deps);
+
+    expect(await processPoolHealthCheckCycle()).toEqual({
+      probed: 4,
+      alive: 4,
+      removed: 0,
+    });
+  });
+
+  test("lets a probe failure propagate rather than reporting a healthy pool", async () => {
+    // The manager deliberately lets an internal failure throw instead of
+    // folding it into "container dead" — swallowing it here would turn a DB
+    // blip into a report that the pool is fine, which is how this class of bug
+    // stayed invisible in the first place. The daemon's runBoundedPhase is what
+    // isolates the cycle, not this function.
+    const { deps } = fakeDeps(async () => {
+      throw new Error("pool lookup failed");
+    });
+    __setDepsForTests(deps);
+
+    await expect(processPoolHealthCheckCycle()).rejects.toThrow(
+      "pool lookup failed",
+    );
+  });
+});
+
+describe("infra cycle ordering", () => {
+  test("the health check runs before replenish in the daemon source", () => {
+    // Order is load-bearing: replenish sizes the refill from current pool
+    // depth, so it has to see the depth left AFTER dead entries are collected,
+    // or it refills against a count inflated by entries that no longer exist.
+    const source = Bun.file(
+      new URL("./provisioning-worker.ts", import.meta.url).pathname,
+    );
+    return source.text().then((text) => {
+      const drain = text.indexOf('"warm pool drain cycle"');
+      const health = text.indexOf('"warm pool health check cycle"');
+      const replenish = text.indexOf('"warm pool replenish cycle"');
+
+      expect(drain).toBeGreaterThan(-1);
+      expect(health).toBeGreaterThan(-1);
+      expect(replenish).toBeGreaterThan(-1);
+      expect(health).toBeGreaterThan(drain);
+      expect(replenish).toBeGreaterThan(health);
+    });
+  });
+});

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -1059,26 +1059,14 @@ async function processPoolDrainIdleCycle(): Promise<PoolDrainSummary> {
 }
 
 /**
- * Probe every ready warm-pool entry and destroy the ones whose container is
- * gone. THIS IS THE MISSING CALLER, the same omission as `replenish` below and
- * with a worse consequence: `WarmPoolManager.healthCheck()` was reachable only
- * from `/api/v1/cron/pool-health-check` on the deprecated container-control-
- * plane, so nothing has probed a ready pool entry since that service stopped
- * being deployed.
+ * Probe ready warm-pool entries and destroy entries whose containers are gone.
  *
- * Nothing else can see those entries. The heartbeat sweep skips them —
- * `listRunning()` filters on `execution_tier != 'shared'` and `createPoolEntry`
- * never sets the tier, so every pool row defaults to `shared` while still
- * holding a real `node_id` and `container_name`. `reconcileUnclaimable` cannot
- * reach them either: its candidate query excludes rows that ARE ready. So a
- * ready pool entry whose container died stayed `running` forever, kept its slot,
- * counted against the node's allocation, and — because `findDrainCandidates`
- * treats any allocation as proof of a workload — made its node permanently
- * undrainable. Measured on production 2026-08-06: three autoscaled nodes empty
- * of containers, four such rows each, counted full for ten days.
- *
- * Runs BEFORE replenish so the refill decision sees the depth left after dead
- * entries are collected, and self-gates on `WARM_POOL_ENABLED`.
+ * Ready pool rows use the shared execution tier, so the agent heartbeat sweep
+ * skips them, while the unclaimable reconciler deliberately excludes rows that
+ * already satisfy the runtime-ready predicate. This phase is therefore the
+ * authoritative liveness sweep for ready pool containers. It runs after drain
+ * and before replenish so refill decisions use the surviving pool depth, and
+ * the manager self-gates on `WARM_POOL_ENABLED`.
  */
 export async function processPoolHealthCheckCycle(): Promise<PoolHealthCheckSummary> {
   const pool = await getWarmPoolManager();

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -777,6 +777,12 @@ interface PoolReplenishSummary {
   reason: string;
 }
 
+interface PoolHealthCheckSummary {
+  probed: number;
+  alive: number;
+  removed: number;
+}
+
 /**
  * Health-checks every enabled `docker_nodes` row (SSH + `docker info`) and
  * persists the resulting status. Runs on the orchestrator host that already
@@ -1050,6 +1056,38 @@ async function processPoolDrainIdleCycle(): Promise<PoolDrainSummary> {
   const pool = await getWarmPoolManager();
   const result = await pool.drainIdle(image);
   return { drained: result.drained.length };
+}
+
+/**
+ * Probe every ready warm-pool entry and destroy the ones whose container is
+ * gone. THIS IS THE MISSING CALLER, the same omission as `replenish` below and
+ * with a worse consequence: `WarmPoolManager.healthCheck()` was reachable only
+ * from `/api/v1/cron/pool-health-check` on the deprecated container-control-
+ * plane, so nothing has probed a ready pool entry since that service stopped
+ * being deployed.
+ *
+ * Nothing else can see those entries. The heartbeat sweep skips them —
+ * `listRunning()` filters on `execution_tier != 'shared'` and `createPoolEntry`
+ * never sets the tier, so every pool row defaults to `shared` while still
+ * holding a real `node_id` and `container_name`. `reconcileUnclaimable` cannot
+ * reach them either: its candidate query excludes rows that ARE ready. So a
+ * ready pool entry whose container died stayed `running` forever, kept its slot,
+ * counted against the node's allocation, and — because `findDrainCandidates`
+ * treats any allocation as proof of a workload — made its node permanently
+ * undrainable. Measured on production 2026-08-06: three autoscaled nodes empty
+ * of containers, four such rows each, counted full for ten days.
+ *
+ * Runs BEFORE replenish so the refill decision sees the depth left after dead
+ * entries are collected, and self-gates on `WARM_POOL_ENABLED`.
+ */
+export async function processPoolHealthCheckCycle(): Promise<PoolHealthCheckSummary> {
+  const pool = await getWarmPoolManager();
+  const result = await pool.healthCheck();
+  return {
+    probed: result.probed,
+    alive: result.alive,
+    removed: result.removed.length,
+  };
 }
 
 /**
@@ -1760,6 +1798,25 @@ async function runInfraMaintenanceCycle(
       if (result.drained > 0) {
         logger.info("[provisioning-worker] warm pool drain cycle complete", {
           drained: result.drained,
+        });
+      }
+    },
+  );
+
+  // Probe ready warm-pool entries and collect the ones whose container is gone.
+  // Runs BEFORE replenish so the refill decision sees real depth, and after
+  // drain so it does not probe entries the drain just removed.
+  await runBoundedPhase(
+    logger,
+    "warm pool health check cycle",
+    () => processPoolHealthCheckCycle(),
+    (result) => {
+      if (result.removed > 0) {
+        logger.info("[provisioning-worker] warm pool health check complete", {
+          event: "warm_pool.dead_entries_collected",
+          probed: result.probed,
+          alive: result.alive,
+          removed: result.removed,
         });
       }
     },


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

Closes #17866

## What was wrong

`WarmPoolManager.healthCheck()` is the only thing in the tree that probes a **ready** warm-pool entry and collects it when its container is gone. It had no live caller — the only one was `/api/v1/cron/pool-health-check` on the container-control-plane, which this daemon's own comments call deprecated.

This is the same omission as `replenish`, documented fifteen lines away in the same file, with a worse consequence: **nothing else can see those rows.**

- The heartbeat skips them. `listRunning()` filters `execution_tier != 'shared'`, and `createPoolEntry` never sets the tier, so every pool row falls to the schema default `shared` — while holding a real `node_id` and `container_name`. The docblock's premise, that shared rows are container-free by design, is simply false for pool rows.
- `reconcileUnclaimable` cannot reach them: its candidate query ends `NOT (warmPoolRuntimeReadyConditions)`, and these rows *are* ready.
- The orphan reconciler cannot reach them: it starts from the Docker listing, so an empty node yields an empty candidate set.

A ready pool entry whose container died therefore stayed `running` forever. `running` is not terminal, so it counts toward the node's allocation, and `findDrainCandidates` refuses any node with `allocated > 0` — a row is treated as proof of a workload. **The node can never be drained.**

## What it cost

Measured on production 2026-08-06 by diffing `docker ps -a` on all nine nodes against the rows that claim them:

| | |
|---|---|
| real agent containers | 169 |
| rows claiming a container | 238 |
| **rows claiming a container that does not exist** | **77** |

Three autoscaled ccx33 bought on 26, 27 and 28 July hold four such rows each, have **zero containers**, and have read as fully allocated for ten days. `syncAllocatedCounts` re-asserts that count every five minutes, and the billing crons select on `status = 'running'` with no node-side check — so those rows are billed hourly.

## The change

One phase, wired between drain and replenish: after drain so it does not probe entries just removed, before replenish so the refill sizes itself against the depth left once dead entries are collected.

This does not give `healthCheck()` new power — it was written to destroy dead entries and ran that way through the control-plane. It puts it back in service.

## Evidence

<details>
<summary>Tests — each pin mutation-verified</summary>

| pin | mutation | result |
|---|---|---|
| the infra cycle drives `healthCheck` and maps the collected count | remove the phase (= develop) | 1 fail |
| it runs after drain and before replenish | move it after replenish | 1 fail |
| a probe failure propagates instead of reporting a healthy pool | swallow it into a zero result | 1 fail |

```
provisioning-worker.pool-health      4 pass  0 fail
provisioning-worker                 51 pass  0 fail
provisioning-worker.replenish        3 pass  0 fail
provisioning-worker.backup-verify    2 pass  0 fail
```

`provisioning-worker.image-rollout` fails 1 of 3 identically with this change stashed — a pre-existing `@elizaos/core` resolution failure in this worktree, unrelated to the diff.

</details>

## Deliberately not in this PR

**The 77 rows already stranded.** Cleaning them needs the reverse reconciler — "row claims container C on node N, `docker ps` does not list it past a grace window → release the placement". No such path exists today: every writer that NULLs `node_id`/`container_name` (`executeSleep`, `retireFailedWarmClaimForRetry`, `trySetProvisioning`) is triggered by a job or an error string, never by container absence. That is a new subsystem mutating production rows and deserves its own review. **This PR stops producing them.**

**`shutdown` / `executeSuspend` keep their placement** after removing the container, which is a real asymmetry against `executeSleep`. It costs no capacity — `stopped` is terminal for both the allocation and the retention count — so fixing it here would be a behaviour change to the suspend/resume path with no measured problem behind it.

**Arming `ORPHAN_RECONCILER_ENABLED`** (it issues `docker rm -f`) and the node `capacity` values (the autoscaler declares ccx33 as 4 slots while the original nodes declared 24 carry 38) are ops decisions, listed in the issue.

[stan-cloud]

<!-- evidence-head:4ae68e11b32c9442e2a70ffd49c669788a08a712 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - a daemon maintenance phase, no UI surface in the diff

<!-- evidence-row:after-screenshots -->
- [ ] N/A - a daemon maintenance phase, no UI surface in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable behaviour is which phases the infra cycle runs; the mutation table and the fleet measurement carry it

<!-- evidence-row:backend-logs -->
- [x] [17867-pool-run-log-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17867-pool-run-log-v2.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call on any path this diff touches

<!-- evidence-row:domain-artifacts -->
- [x] [17867-pool-domain.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17867-pool-domain.txt)


