### PR TITLE
fix(cloud): release container placement held by legacy shared-tier rows

### DIFF
--- a/packages/cloud/shared/src/db/migrations/0190_shared_rows_release_stale_placement.sql
+++ b/packages/cloud/shared/src/db/migrations/0190_shared_rows_release_stale_placement.sql
@@ -1,0 +1,44 @@
+-- Release container placement held by legacy shared-tier rows.
+--
+-- Shared-tier agents run container-free in the hosted shared runtime: their
+-- node_id / container_name are NULL by design, the heartbeat sweep excludes the
+-- tier for exactly that reason, and nothing on the serving path reads a
+-- container locator for them. Before that design landed, shared agents got real
+-- containers, and a handful of rows from that era still carry their placement.
+-- Their containers are long gone (reaped by the orphan reconciler), but the
+-- rows still count toward node allocation — `running` is non-terminal — so each
+-- one permanently holds a slot the allocator believes is occupied.
+--
+-- Measured on production 2026-08-06: exactly six such rows, every one with a
+-- last heartbeat 26 days old. None created in the last 14 days, so this is a
+-- remnant, not an active leak — a data fix, with no code change required.
+--
+-- Scope guards, each load-bearing:
+--   * pool_status IS NULL      — warm-pool rows are shared-tier AND legitimately
+--                                placed while unclaimed; they are owned by the
+--                                pool lifecycle, never by this migration.
+--   * status = 'running'       — deletion_pending/deletion_failed rows keep
+--                                their locator for the delete-retry sweep.
+--   * heartbeat stale > 7 days — a placed shared row with a recent heartbeat
+--                                would be live evidence the container-free
+--                                design assumption is wrong somewhere; leave it
+--                                for a human rather than erase the evidence.
+--
+-- Clearing the same column set as executeSleep, the canonical release shape.
+
+UPDATE "agent_sandboxes"
+SET
+  node_id = NULL,
+  container_name = NULL,
+  sandbox_id = NULL,
+  bridge_url = NULL,
+  health_url = NULL,
+  headscale_ip = NULL,
+  bridge_port = NULL,
+  web_ui_port = NULL,
+  updated_at = NOW()
+WHERE execution_tier = 'shared'
+  AND status = 'running'
+  AND pool_status IS NULL
+  AND node_id IS NOT NULL
+  AND (last_heartbeat_at IS NULL OR last_heartbeat_at < NOW() - INTERVAL '7 days');

--- a/packages/cloud/shared/src/db/migrations/0190_shared_rows_release_stale_placement.sql
+++ b/packages/cloud/shared/src/db/migrations/0190_shared_rows_release_stale_placement.sql
@@ -1,17 +1,8 @@
--- Release container placement held by legacy shared-tier rows.
+-- Release container placement held by stale shared-tier rows.
 --
--- Shared-tier agents run container-free in the hosted shared runtime: their
--- node_id / container_name are NULL by design, the heartbeat sweep excludes the
--- tier for exactly that reason, and nothing on the serving path reads a
--- container locator for them. Before that design landed, shared agents got real
--- containers, and a handful of rows from that era still carry their placement.
--- Their containers are long gone (reaped by the orphan reconciler), but the
--- rows still count toward node allocation — `running` is non-terminal — so each
--- one permanently holds a slot the allocator believes is occupied.
---
--- Measured on production 2026-08-06: exactly six such rows, every one with a
--- last heartbeat 26 days old. None created in the last 14 days, so this is a
--- remnant, not an active leak — a data fix, with no code change required.
+-- Shared-tier agents run container-free in the hosted shared runtime, but stale
+-- rows can retain locators that continue to count toward node allocation. Clear
+-- locator fields only from user-owned running rows without a recent heartbeat.
 --
 -- Scope guards, each load-bearing:
 --   * pool_status IS NULL      — warm-pool rows are shared-tier AND legitimately
@@ -24,7 +15,7 @@
 --                                design assumption is wrong somewhere; leave it
 --                                for a human rather than erase the evidence.
 --
--- Clearing the same column set as executeSleep, the canonical release shape.
+-- This is the same locator set cleared by executeSleep.
 
 UPDATE "agent_sandboxes"
 SET

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1324,6 +1324,13 @@
       "when": 1786046400000,
       "tag": "0189_agent_sandbox_lifecycle_revision_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 189,
+      "version": "7",
+      "when": 1786132800000,
+      "tag": "0190_shared_rows_release_stale_placement",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/shared-rows-release-stale-placement.test.ts
+++ b/packages/cloud/shared/src/db/shared-rows-release-stale-placement.test.ts
@@ -1,6 +1,6 @@
 /**
  * Applies migration 0190 to a real PGlite table and proves its scope: it
- * releases container placement ONLY from legacy shared-tier rows whose
+ * releases container placement only from legacy shared-tier rows whose
  * heartbeat has been stale for over a week, and leaves the warm pool, the
  * deletion machinery, dedicated tiers, and any recently-alive row untouched.
  */
@@ -14,6 +14,12 @@ process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 
 const TIMEOUT = 60_000;
+const lifecycleMigrationSql = readFileSync(
+  fileURLToPath(
+    new URL("./migrations/0189_agent_sandbox_lifecycle_revision_scope.sql", import.meta.url),
+  ),
+  "utf8",
+);
 const migrationSql = readFileSync(
   fileURLToPath(
     new URL("./migrations/0190_shared_rows_release_stale_placement.sql", import.meta.url),
@@ -33,73 +39,90 @@ const ROWS = {
 
 let dbWrite: typeof import("./client").dbWrite;
 let closeDb: typeof import("./client").closeDatabaseConnectionsForTests | undefined;
-let databaseReady = true;
 
 async function placement(id: string): Promise<{
   node_id: string | null;
   container_name: string | null;
+  sandbox_id: string | null;
+  bridge_url: string | null;
+  health_url: string | null;
+  headscale_ip: string | null;
+  bridge_port: number | null;
+  web_ui_port: number | null;
+  lifecycle_revision: number;
   status: string;
 }> {
   const result = await dbWrite.execute(
-    `SELECT node_id, container_name, status FROM agent_sandboxes WHERE id = '${id}'`,
+    `SELECT node_id, container_name, sandbox_id, bridge_url, health_url,
+            headscale_ip, bridge_port, web_ui_port, lifecycle_revision, status
+       FROM agent_sandboxes WHERE id = '${id}'`,
   );
-  return (
+  const row = (
     result as unknown as {
       rows: Array<{
         node_id: string | null;
         container_name: string | null;
+        sandbox_id: string | null;
+        bridge_url: string | null;
+        health_url: string | null;
+        headscale_ip: string | null;
+        bridge_port: number | null;
+        web_ui_port: number | null;
+        lifecycle_revision: string | number;
         status: string;
       }>;
     }
   ).rows[0];
+  if (!row) throw new Error(`Missing sandbox test row: ${id}`);
+  return {
+    ...row,
+    lifecycle_revision: Number(row.lifecycle_revision),
+  };
 }
 
 beforeAll(async () => {
-  try {
-    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("./client"));
-    const { PROVISIONING_JOB_TEST_TABLES } = await import(
-      "../lib/services/__tests__/tier-upgrade-pglite-schema"
-    );
-    for (const ddl of PROVISIONING_JOB_TEST_TABLES) {
-      if (ddl.includes('CREATE TABLE IF NOT EXISTS "agent_sandboxes"')) {
-        await dbWrite.execute(ddl);
-      }
+  ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("./client"));
+  const { PROVISIONING_JOB_TEST_TABLES } = await import(
+    "../lib/services/__tests__/tier-upgrade-pglite-schema"
+  );
+  for (const ddl of PROVISIONING_JOB_TEST_TABLES) {
+    if (ddl.includes('CREATE TABLE IF NOT EXISTS "agent_sandboxes"')) {
+      await dbWrite.execute(ddl);
     }
+  }
 
-    const insert = (
-      id: string,
-      tier: string,
-      status: string,
-      poolStatus: string | null,
-      beat: string | null,
-    ) =>
-      dbWrite.execute(`
+  const insert = (
+    id: string,
+    tier: string,
+    status: string,
+    poolStatus: string | null,
+    beat: string | null,
+  ) =>
+    dbWrite.execute(`
         INSERT INTO agent_sandboxes
           (id, organization_id, user_id, execution_tier, status, pool_status,
            node_id, container_name, sandbox_id, bridge_url, health_url,
-           last_heartbeat_at)
+           headscale_ip, bridge_port, web_ui_port, last_heartbeat_at)
         VALUES
           ('${id}', '00000000-0000-4000-8000-000000000001',
            '00000000-0000-4000-8000-000000000002', '${tier}', '${status}',
            ${poolStatus === null ? "NULL" : `'${poolStatus}'`},
            gen_random_uuid(), 'agent-${id.slice(-4)}', 'sb-${id.slice(-4)}',
-           'http://x:2138', 'http://x:2139',
+           'http://x:2138', 'http://x:2139', '100.64.0.1', 2138, 3000,
            ${beat === null ? "NULL" : `NOW() - INTERVAL '${beat}'`});
-      `);
+    `);
 
-    await insert(ROWS.legacyShared, "shared", "running", null, "26 days");
-    await insert(ROWS.warmPool, "shared", "running", "unclaimed", "26 days");
-    await insert(ROWS.deletionPending, "shared", "deletion_pending", null, "26 days");
-    await insert(ROWS.dedicated, "dedicated-always", "running", null, "26 days");
-    await insert(ROWS.recentlyAliveShared, "shared", "running", null, "1 hour");
-    await insert(ROWS.neverBeatShared, "shared", "running", null, null);
+  await insert(ROWS.legacyShared, "shared", "running", null, "26 days");
+  await insert(ROWS.warmPool, "shared", "running", "unclaimed", "26 days");
+  await insert(ROWS.deletionPending, "shared", "deletion_pending", null, "26 days");
+  await insert(ROWS.dedicated, "dedicated-always", "running", null, "26 days");
+  await insert(ROWS.recentlyAliveShared, "shared", "running", null, "1 hour");
+  await insert(ROWS.neverBeatShared, "shared", "running", null, null);
 
-    for (const statement of migrationSql.split("--> statement-breakpoint")) {
+  for (const sql of [lifecycleMigrationSql, migrationSql]) {
+    for (const statement of sql.split("--> statement-breakpoint")) {
       if (statement.trim()) await dbWrite.execute(statement);
     }
-  } catch (error) {
-    databaseReady = false;
-    console.warn("[shared-rows-release] PGlite setup failed", error);
   }
 }, TIMEOUT);
 
@@ -111,13 +134,17 @@ describe("0190 releases stale legacy shared placement", () => {
   test(
     "the legacy shared row loses its placement and stays running",
     async () => {
-      if (!databaseReady) throw new Error("PGlite unavailable");
       const row = await placement(ROWS.legacyShared);
-      // Running with NULL locators IS the modern container-free shared shape;
-      // the row becomes an ordinary shared agent rather than a fake container.
       expect(row).toEqual({
         node_id: null,
         container_name: null,
+        sandbox_id: null,
+        bridge_url: null,
+        health_url: null,
+        headscale_ip: null,
+        bridge_port: null,
+        web_ui_port: null,
+        lifecycle_revision: 1,
         status: "running",
       });
     },
@@ -125,9 +152,8 @@ describe("0190 releases stale legacy shared placement", () => {
   );
 
   test(
-    "a shared row that never heartbeat is released too",
+    "a shared row that never sent a heartbeat is released too",
     async () => {
-      if (!databaseReady) throw new Error("PGlite unavailable");
       expect((await placement(ROWS.neverBeatShared)).node_id).toBeNull();
     },
     TIMEOUT,
@@ -136,7 +162,6 @@ describe("0190 releases stale legacy shared placement", () => {
   test(
     "a warm-pool row keeps its placement — the pool lifecycle owns it",
     async () => {
-      if (!databaseReady) throw new Error("PGlite unavailable");
       expect((await placement(ROWS.warmPool)).node_id).not.toBeNull();
     },
     TIMEOUT,
@@ -145,7 +170,6 @@ describe("0190 releases stale legacy shared placement", () => {
   test(
     "a deletion_pending row keeps its locator for the delete-retry sweep",
     async () => {
-      if (!databaseReady) throw new Error("PGlite unavailable");
       expect((await placement(ROWS.deletionPending)).node_id).not.toBeNull();
     },
     TIMEOUT,
@@ -154,7 +178,6 @@ describe("0190 releases stale legacy shared placement", () => {
   test(
     "a dedicated-tier row is untouched whatever its heartbeat says",
     async () => {
-      if (!databaseReady) throw new Error("PGlite unavailable");
       expect((await placement(ROWS.dedicated)).node_id).not.toBeNull();
     },
     TIMEOUT,
@@ -163,7 +186,6 @@ describe("0190 releases stale legacy shared placement", () => {
   test(
     "a shared row with a recent heartbeat is left as live evidence",
     async () => {
-      if (!databaseReady) throw new Error("PGlite unavailable");
       expect((await placement(ROWS.recentlyAliveShared)).node_id).not.toBeNull();
     },
     TIMEOUT,

--- a/packages/cloud/shared/src/db/shared-rows-release-stale-placement.test.ts
+++ b/packages/cloud/shared/src/db/shared-rows-release-stale-placement.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Applies migration 0190 to a real PGlite table and proves its scope: it
+ * releases container placement ONLY from legacy shared-tier rows whose
+ * heartbeat has been stale for over a week, and leaves the warm pool, the
+ * deletion machinery, dedicated tiers, and any recently-alive row untouched.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const TIMEOUT = 60_000;
+const migrationSql = readFileSync(
+  fileURLToPath(
+    new URL("./migrations/0190_shared_rows_release_stale_placement.sql", import.meta.url),
+  ),
+  "utf8",
+);
+
+/** One row per boundary the migration must respect. */
+const ROWS = {
+  legacyShared: "00000000-0000-4000-8000-000000000190",
+  warmPool: "00000000-0000-4000-8000-000000000191",
+  deletionPending: "00000000-0000-4000-8000-000000000192",
+  dedicated: "00000000-0000-4000-8000-000000000193",
+  recentlyAliveShared: "00000000-0000-4000-8000-000000000194",
+  neverBeatShared: "00000000-0000-4000-8000-000000000195",
+} as const;
+
+let dbWrite: typeof import("./client").dbWrite;
+let closeDb: typeof import("./client").closeDatabaseConnectionsForTests | undefined;
+let databaseReady = true;
+
+async function placement(id: string): Promise<{
+  node_id: string | null;
+  container_name: string | null;
+  status: string;
+}> {
+  const result = await dbWrite.execute(
+    `SELECT node_id, container_name, status FROM agent_sandboxes WHERE id = '${id}'`,
+  );
+  return (
+    result as unknown as {
+      rows: Array<{
+        node_id: string | null;
+        container_name: string | null;
+        status: string;
+      }>;
+    }
+  ).rows[0];
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("./client"));
+    const { PROVISIONING_JOB_TEST_TABLES } = await import(
+      "../lib/services/__tests__/tier-upgrade-pglite-schema"
+    );
+    for (const ddl of PROVISIONING_JOB_TEST_TABLES) {
+      if (ddl.includes('CREATE TABLE IF NOT EXISTS "agent_sandboxes"')) {
+        await dbWrite.execute(ddl);
+      }
+    }
+
+    const insert = (
+      id: string,
+      tier: string,
+      status: string,
+      poolStatus: string | null,
+      beat: string | null,
+    ) =>
+      dbWrite.execute(`
+        INSERT INTO agent_sandboxes
+          (id, organization_id, user_id, execution_tier, status, pool_status,
+           node_id, container_name, sandbox_id, bridge_url, health_url,
+           last_heartbeat_at)
+        VALUES
+          ('${id}', '00000000-0000-4000-8000-000000000001',
+           '00000000-0000-4000-8000-000000000002', '${tier}', '${status}',
+           ${poolStatus === null ? "NULL" : `'${poolStatus}'`},
+           gen_random_uuid(), 'agent-${id.slice(-4)}', 'sb-${id.slice(-4)}',
+           'http://x:2138', 'http://x:2139',
+           ${beat === null ? "NULL" : `NOW() - INTERVAL '${beat}'`});
+      `);
+
+    await insert(ROWS.legacyShared, "shared", "running", null, "26 days");
+    await insert(ROWS.warmPool, "shared", "running", "unclaimed", "26 days");
+    await insert(ROWS.deletionPending, "shared", "deletion_pending", null, "26 days");
+    await insert(ROWS.dedicated, "dedicated-always", "running", null, "26 days");
+    await insert(ROWS.recentlyAliveShared, "shared", "running", null, "1 hour");
+    await insert(ROWS.neverBeatShared, "shared", "running", null, null);
+
+    for (const statement of migrationSql.split("--> statement-breakpoint")) {
+      if (statement.trim()) await dbWrite.execute(statement);
+    }
+  } catch (error) {
+    databaseReady = false;
+    console.warn("[shared-rows-release] PGlite setup failed", error);
+  }
+}, TIMEOUT);
+
+afterAll(async () => {
+  await closeDb?.();
+});
+
+describe("0190 releases stale legacy shared placement", () => {
+  test(
+    "the legacy shared row loses its placement and stays running",
+    async () => {
+      if (!databaseReady) throw new Error("PGlite unavailable");
+      const row = await placement(ROWS.legacyShared);
+      // Running with NULL locators IS the modern container-free shared shape;
+      // the row becomes an ordinary shared agent rather than a fake container.
+      expect(row).toEqual({
+        node_id: null,
+        container_name: null,
+        status: "running",
+      });
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a shared row that never heartbeat is released too",
+    async () => {
+      if (!databaseReady) throw new Error("PGlite unavailable");
+      expect((await placement(ROWS.neverBeatShared)).node_id).toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a warm-pool row keeps its placement — the pool lifecycle owns it",
+    async () => {
+      if (!databaseReady) throw new Error("PGlite unavailable");
+      expect((await placement(ROWS.warmPool)).node_id).not.toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a deletion_pending row keeps its locator for the delete-retry sweep",
+    async () => {
+      if (!databaseReady) throw new Error("PGlite unavailable");
+      expect((await placement(ROWS.deletionPending)).node_id).not.toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a dedicated-tier row is untouched whatever its heartbeat says",
+    async () => {
+      if (!databaseReady) throw new Error("PGlite unavailable");
+      expect((await placement(ROWS.dedicated)).node_id).not.toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a shared row with a recent heartbeat is left as live evidence",
+    async () => {
+      if (!databaseReady) throw new Error("PGlite unavailable");
+      expect((await placement(ROWS.recentlyAliveShared)).node_id).not.toBeNull();
+    },
+    TIMEOUT,
+  );
+});


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

Refs #17866

## What this fixes

Shared-tier agents run container-free in the hosted shared runtime — their `node_id`/`container_name` are NULL by design, and the heartbeat sweep excludes the tier for exactly that reason. Before that design landed, shared agents got real containers, and **six rows from that era still carry their placement**. Their containers are long gone (the orphan reconciler reaped them), but the rows still count toward node allocation, since `running` is non-terminal — and nothing can ever collect them:

- the heartbeat never dials the `shared` tier;
- the warm-pool reconcilers only see pool rows;
- the orphan reconciler starts from the Docker listing, so a row whose container is absent is structurally unreachable.

Measured on production 2026-08-06: **exactly six rows**, each with its last heartbeat 26 days old, **zero created in the last 14 days**. A remnant of the pre-container-free design, not an active leak — so this is a data migration with no code change. It releases the same column set as `executeSleep`, the canonical release shape, and the rows become ordinary container-free shared agents. `total_billed` on all six is 0.00; nothing was ever charged for the phantom placement.

## Scope guards — each load-bearing, each mutation-tested

| guard | protects | removing it turns red |
|---|---|---|
| `pool_status IS NULL` | warm-pool rows are shared-tier AND legitimately placed while unclaimed | ✔ 1 fail |
| `status = 'running'` | `deletion_pending`/`deletion_failed` keep their locator for the delete-retry sweep | ✔ 1 fail |
| `execution_tier = 'shared'` | dedicated tiers, whatever their heartbeat says | ✔ 1 fail |
| heartbeat stale > 7 days | a placed shared row with a recent beat would be live evidence the container-free assumption is wrong somewhere — left for a human, not erased | ✔ 1 fail |

Proven on a real PGlite table with one fixture row per boundary: 6 pass / 0 fail at baseline, and each guard's removal fails exactly one pin.

## Numbering note

The migration is `0190`, deliberately skipping `0189`, which is claimed by the open lifecycle-revision PR (#17830) — the two branches must not collide on a journal index. `drizzle-kit check` passes on this journal.

[stan-cloud]

<!-- evidence-head:8f68ea8e7480be829364ba5fdd271fb8c95514d2 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - a data migration, no UI surface in the diff

<!-- evidence-row:after-screenshots -->
- [ ] N/A - a data migration, no UI surface in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable behaviour is which rows the UPDATE touches; the mutation table and the production measurement carry it

<!-- evidence-row:backend-logs -->
- [x] [17872-shared-evidence.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17872-shared-evidence.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call on any path this diff touches

<!-- evidence-row:domain-artifacts -->
- [x] [17872-shared-domain.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17872-shared-domain.txt)
