### PR TITLE
fix(plugin-elizacloud): retry cold-gateway warming 503 in place instead of consuming the failover ladder

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/text-warming-retry.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-warming-retry.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Offline unit coverage for the cold-gateway warming retry: a 503 whose body
+ * carries a structural `*_cache_warming` code (or the retryable
+ * service_unavailable envelope) is retried in place with bounded backoff so
+ * the runtime's useModel failover ladder is never consumed by a gateway that
+ * recovers in ~3s, while every other failure still throws immediately. The
+ * fetch is mocked; timers are faked to drive the backoff deterministically.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  generateNativeChatCompletion,
+  isWarmingUnavailableResponse,
+  nextWarmingRetryDelayMs,
+  requestNativeWithWarmingRetry,
+  streamNativeChatCompletion,
+} from "../../src/models/text";
+
+type RuntimeFixture = Pick<IAgentRuntime, "character" | "emitEvent" | "getSetting"> &
+  Partial<IAgentRuntime>;
+
+function runtime(): IAgentRuntime {
+  const settings: Record<string, string | undefined> = {
+    ELIZAOS_CLOUD_API_KEY: "eliza_test_key",
+  };
+  const fixture: RuntimeFixture = {
+    character: { name: "Eliza", bio: [] },
+    getSetting: (key: string) => settings[key],
+    emitEvent: vi.fn(),
+  };
+  return fixture as IAgentRuntime;
+}
+
+const WARMING_BODY = {
+  error: {
+    message: "Authorization cache is warming. Retry shortly.",
+    type: "service_unavailable",
+    code: "auth_cache_warming",
+  },
+};
+
+const REAL_FAILURE_BODY = {
+  error: {
+    message: "upstream provider exploded",
+    type: "api_error",
+    code: "upstream_error",
+  },
+};
+
+function warmingResponse(headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(WARMING_BODY), {
+    status: 503,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+function realFailureResponse(): Response {
+  return new Response(JSON.stringify(REAL_FAILURE_BODY), {
+    status: 503,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function successResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: "ok" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+function sseResponse(): Response {
+  const frames = [
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: "hi" } }] })}`,
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: "" }, finish_reason: "stop" }] })}`,
+    `data: ${JSON.stringify({ choices: [], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } })}`,
+    "data: [DONE]",
+    "",
+  ].join("\n\n");
+  return new Response(frames, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+function mockFetchSequence(responses: Array<() => Response>): ReturnType<typeof vi.fn> {
+  let call = 0;
+  const impl = vi.fn(async () => {
+    const factory = responses[Math.min(call, responses.length - 1)];
+    call += 1;
+    return factory();
+  });
+  vi.spyOn(globalThis, "fetch").mockImplementation(impl as unknown as typeof fetch);
+  return impl;
+}
+
+const CONTEXT = { modelName: "gemma-4-31b", prompt: "hello" };
+const NATIVE_PARAMS = {
+  prompt: "hello",
+  messages: [{ role: "user", content: "hello" }],
+} as Parameters<typeof generateNativeChatCompletion>[2];
+
+describe("warming 503 classification", () => {
+  it("recognizes every *_cache_warming code and the retryable envelope", () => {
+    expect(isWarmingUnavailableResponse(503, JSON.stringify(WARMING_BODY))).toBe(true);
+    expect(
+      isWarmingUnavailableResponse(
+        503,
+        JSON.stringify({ error: { code: "rate_limit_cache_warming" } })
+      )
+    ).toBe(true);
+    expect(
+      isWarmingUnavailableResponse(
+        503,
+        JSON.stringify({ error: { code: "inference_dependency_cache_warming" } })
+      )
+    ).toBe(true);
+    expect(
+      isWarmingUnavailableResponse(
+        503,
+        JSON.stringify({
+          success: false,
+          error: "Authorization cache is warming; retry shortly",
+          code: "service_unavailable",
+          details: { retryable: true, retryAfterSeconds: 1 },
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("rejects real failures, non-503 statuses, and unparseable bodies", () => {
+    expect(isWarmingUnavailableResponse(503, JSON.stringify(REAL_FAILURE_BODY))).toBe(false);
+    expect(isWarmingUnavailableResponse(200, JSON.stringify(WARMING_BODY))).toBe(false);
+    expect(isWarmingUnavailableResponse(502, JSON.stringify(WARMING_BODY))).toBe(false);
+    expect(
+      isWarmingUnavailableResponse(
+        503,
+        JSON.stringify({ success: false, code: "service_unavailable" })
+      )
+    ).toBe(false);
+    expect(isWarmingUnavailableResponse(503, "<html>bad gateway</html>")).toBe(false);
+    expect(isWarmingUnavailableResponse(503, "")).toBe(false);
+  });
+
+  it("bounds the retry budget and honors Retry-After within the cap", () => {
+    const state = { attempt: 0 };
+    const delays: number[] = [];
+    for (;;) {
+      const delay = nextWarmingRetryDelayMs(state, warmingResponse(), JSON.stringify(WARMING_BODY));
+      if (delay === undefined) break;
+      delays.push(delay);
+      expect(delays.length).toBeLessThan(10);
+    }
+    expect(delays).toEqual([250, 500, 1000, 1500]);
+    expect(delays.reduce((a, b) => a + b, 0)).toBeGreaterThanOrEqual(3000);
+
+    const headerState = { attempt: 0 };
+    expect(
+      nextWarmingRetryDelayMs(
+        headerState,
+        warmingResponse({ "Retry-After": "1" }),
+        JSON.stringify(WARMING_BODY)
+      )
+    ).toBe(1000);
+    expect(
+      nextWarmingRetryDelayMs(
+        headerState,
+        warmingResponse({ "Retry-After": "30" }),
+        JSON.stringify(WARMING_BODY)
+      )
+    ).toBe(2000);
+  });
+});
+
+describe("buffered native chat completion", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("retries a warming 503 with backoff and succeeds without throwing", async () => {
+    const fetchMock = mockFetchSequence([warmingResponse, warmingResponse, successResponse]);
+    const pending = generateNativeChatCompletion(runtime(), "TEXT_SMALL", NATIVE_PARAMS, CONTEXT);
+    await vi.runAllTimersAsync();
+    const result = await pending;
+    expect(result.text).toBe("ok");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails over immediately on a real provider 503 (no retry, no delay)", async () => {
+    const fetchMock = mockFetchSequence([realFailureResponse]);
+    const pending = generateNativeChatCompletion(
+      runtime(),
+      "TEXT_SMALL",
+      NATIVE_PARAMS,
+      CONTEXT
+    ).catch((error: Error & { status?: number }) => error);
+    await vi.runAllTimersAsync();
+    const error = await pending;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error & { status?: number }).status).toBe(503);
+    expect((error as Error).message).toBe("upstream provider exploded");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("gives up after the bounded budget on persistent warming", async () => {
+    const fetchMock = mockFetchSequence([warmingResponse]);
+    const pending = generateNativeChatCompletion(
+      runtime(),
+      "TEXT_SMALL",
+      NATIVE_PARAMS,
+      CONTEXT
+    ).catch((error: Error & { status?: number }) => error);
+    await vi.runAllTimersAsync();
+    const error = await pending;
+    expect((error as Error & { status?: number }).status).toBe(503);
+    // 1 initial attempt + 4 bounded retries, then the normal error path.
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("waits the server-declared Retry-After before the next attempt", async () => {
+    const fetchMock = mockFetchSequence([
+      () => warmingResponse({ "Retry-After": "1" }),
+      successResponse,
+    ]);
+    const pending = generateNativeChatCompletion(runtime(), "TEXT_SMALL", NATIVE_PARAMS, CONTEXT);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const result = await pending;
+    expect(result.text).toBe("ok");
+  });
+});
+
+describe("streaming native chat completion", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("retries a warming 503 then streams the recovered response", async () => {
+    const fetchMock = mockFetchSequence([warmingResponse, sseResponse]);
+    const pending = streamNativeChatCompletion(runtime(), "TEXT_SMALL", NATIVE_PARAMS, CONTEXT);
+    await vi.runAllTimersAsync();
+    const result = await pending;
+    const chunks: string[] = [];
+    for await (const chunk of result.textStream) {
+      chunks.push(chunk);
+    }
+    expect(chunks.join("")).toBe("hi");
+    await expect(result.text).resolves.toBe("hi");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws immediately on a real provider 503 without consuming retries", async () => {
+    const fetchMock = mockFetchSequence([realFailureResponse]);
+    const pending = streamNativeChatCompletion(
+      runtime(),
+      "TEXT_SMALL",
+      NATIVE_PARAMS,
+      CONTEXT
+    ).catch((error: Error & { status?: number }) => error);
+    await vi.runAllTimersAsync();
+    const error = await pending;
+    expect((error as Error & { status?: number }).status).toBe(503);
+    expect((error as Error).message).toBe("upstream provider exploded");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("requestNativeWithWarmingRetry contract", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns the final response with its body pre-read", async () => {
+    let calls = 0;
+    const pending = requestNativeWithWarmingRetry(async () => {
+      calls += 1;
+      return calls === 1 ? warmingResponse() : successResponse();
+    }, "responses");
+    await vi.runAllTimersAsync();
+    const { response, bodyText } = await pending;
+    expect(response.status).toBe(200);
+    expect(JSON.parse(bodyText).choices[0].message.content).toBe("ok");
+    expect(calls).toBe(2);
+  });
+});

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -453,6 +453,118 @@ function firstNumber(...values: unknown[]): number | undefined {
   return undefined;
 }
 
+/**
+ * Bounded retry for the cold-gateway "warming" 503 (first turn after idle).
+ *
+ * A cold Cloudflare Worker answers with 503 and a machine-readable warming
+ * code (`*_cache_warming`, or the generative ApiError retryable envelope)
+ * while it hydrates auth/billing caches under waitUntil — recovery is ~3s.
+ * That 503 is a retry-shortly signal, NOT a dead provider, but the runtime's
+ * useModel failover ladder classifies any thrown 503 as fallback-class and
+ * advances instantly, so one cold gateway spent the whole
+ * RESPONSE_HANDLER→TEXT_NANO→TEXT_SMALL→TEXT_LARGE ladder in ~500ms and the
+ * turn died. Retrying the SAME request here (inside the handler) keeps the
+ * ladder intact for real provider failures. The gate is structural — HTTP
+ * status + typed body code/flag — never message prose, so a genuinely dead
+ * provider (any other 503 body, or any non-503) still throws immediately.
+ * The schedule is bounded and sums past the measured ~3s recovery; a
+ * Retry-After header or `details.retryAfterSeconds` stretches an individual
+ * wait up to a hard cap but never adds attempts.
+ */
+const WARMING_RETRY_DELAYS_MS: readonly number[] = [250, 500, 1000, 1500];
+const WARMING_RETRY_MAX_WAIT_MS = 2_000;
+
+function parseJsonRecord(text: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    // error-policy:J3 a non-JSON error body is an explicit "not warming"
+    // predicate result; the caller surfaces the original HTTP failure.
+    return undefined;
+  }
+}
+
+/**
+ * True only for the gateway's explicit cache-warming 503 shape:
+ * `{ error: { code: "*_cache_warming" } }` (chat/completions, embeddings) or
+ * the generative ApiError envelope `{ code: "service_unavailable",
+ * details: { retryable: true } }`. Everything else — including provider-5xx
+ * mapped 503s (`api_error`, upstream codes) and `ai_not_configured` — is a
+ * real failure and must keep failing over promptly.
+ */
+export function isWarmingUnavailableResponse(status: number, bodyText: string): boolean {
+  if (status !== 503) return false;
+  const body = parseJsonRecord(bodyText);
+  if (!body) return false;
+  const errorCode = asRecord(body.error).code;
+  if (typeof errorCode === "string" && errorCode.endsWith("_cache_warming")) {
+    return true;
+  }
+  return body.code === "service_unavailable" && asRecord(body.details).retryable === true;
+}
+
+interface WarmingRetryState {
+  attempt: number;
+}
+
+/**
+ * Next backoff wait for a warming 503, or undefined when the response is not
+ * a warming 503 or the bounded budget is spent. Respects `Retry-After`
+ * (seconds) and the envelope's `retryAfterSeconds` when present, clamped to
+ * [scheduled delay, WARMING_RETRY_MAX_WAIT_MS] so the server can stretch a
+ * wait but never shrink the schedule below recovery or grow it unbounded.
+ */
+export function nextWarmingRetryDelayMs(
+  state: WarmingRetryState,
+  response: Response,
+  bodyText: string
+): number | undefined {
+  if (!isWarmingUnavailableResponse(response.status, bodyText)) return undefined;
+  if (state.attempt >= WARMING_RETRY_DELAYS_MS.length) return undefined;
+  const scheduled = WARMING_RETRY_DELAYS_MS[state.attempt];
+  state.attempt += 1;
+  const retryAfterSeconds = firstNumber(
+    response.headers.get("retry-after") ?? undefined,
+    asRecord(parseJsonRecord(bodyText)?.details).retryAfterSeconds
+  );
+  if (retryAfterSeconds === undefined || retryAfterSeconds < 0) return scheduled;
+  return Math.min(
+    Math.max(Math.round(retryAfterSeconds * 1000), scheduled),
+    WARMING_RETRY_MAX_WAIT_MS
+  );
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run a buffered cloud text round-trip under the shared concurrency cap,
+ * retrying in place while the gateway reports the structural warming 503.
+ * The permit is held only across each network attempt — body reads and
+ * backoff sleeps run unguarded. Returns the final response with its body
+ * already read so callers never double-consume it; non-warming failures and
+ * an exhausted budget return immediately for the caller's normal error path.
+ */
+export async function requestNativeWithWarmingRetry(
+  doRequest: () => Promise<Response>,
+  label: string
+): Promise<{ response: Response; bodyText: string }> {
+  const state: WarmingRetryState = { attempt: 0 };
+  for (;;) {
+    const response = await withNativeChatLimit(doRequest, label);
+    const bodyText = await response.text();
+    if (response.status !== 503) return { response, bodyText };
+    const delayMs = nextWarmingRetryDelayMs(state, response, bodyText);
+    if (delayMs === undefined) return { response, bodyText };
+    logger.warn(
+      `[ELIZAOS_CLOUD] cloud gateway is warming (503) on ${label}; retrying in ${delayMs}ms (attempt ${state.attempt}/${WARMING_RETRY_DELAYS_MS.length})`
+    );
+    await sleepMs(delayMs);
+  }
+}
+
 const NATIVE_TOOL_CALL_ERROR_CODE = "ELIZA_CLOUD_TOOL_CALL_INVALID";
 const NATIVE_STREAM_ERROR_CODE = "ELIZA_CLOUD_STREAM_INVALID";
 
@@ -1179,7 +1291,9 @@ async function generateTextWithModel(
   }
   // Same shared cerebras key as the /chat/completions route, so gate this
   // bare-prompt round-trip through the SAME limiter (parsing stays unguarded).
-  const response = await withNativeChatLimit(
+  // A cold gateway's warming 503 is retried in place instead of throwing into
+  // the runtime failover ladder (see requestNativeWithWarmingRetry).
+  const { response, bodyText: responseText } = await requestNativeWithWarmingRetry(
     () =>
       createCloudApiClient(runtime).requestRaw("POST", "/responses", {
         headers: responsesHeaders,
@@ -1188,7 +1302,6 @@ async function generateTextWithModel(
       }),
     "responses"
   );
-  const responseText = await response.text();
   let data: ResponsesApiResponse = {};
   if (responseText) {
     try {
@@ -1285,8 +1398,10 @@ export async function generateNativeChatCompletion(
   // semaphore the /responses route uses, so N simultaneous native cloud text
   // calls don't overrun the one shared cerebras key's concurrent limit (-> 429
   // -> retries -> 30-63s). The permit is held only across the network
-  // round-trip; the text()/JSON parse below runs unguarded.
-  const response = await withNativeChatLimit(
+  // round-trip; the text()/JSON parse below runs unguarded. A cold gateway's
+  // warming 503 is retried in place instead of throwing into the runtime
+  // failover ladder (see requestNativeWithWarmingRetry).
+  const { response, bodyText: responseText } = await requestNativeWithWarmingRetry(
     () =>
       createCloudApiClient(runtime).requestRaw("POST", "/chat/completions", {
         headers,
@@ -1295,7 +1410,6 @@ export async function generateNativeChatCompletion(
       }),
     "chat/completions"
   );
-  const responseText = await response.text();
   let data: ChatCompletionsResponse = {};
   if (responseText) {
     try {
@@ -1703,12 +1817,7 @@ export async function streamNativeChatCompletion(
   const signal = buildStreamAbortSignal(abortSignal, resolveTextTimeoutMs());
 
   const limiter = getNativeChatLimiter();
-  const waitStartedAt = Date.now();
-  await limiter.acquire();
-  recordInferenceSpan("cloud.semaphore-wait", Date.now() - waitStartedAt, {
-    route: "chat/completions:stream",
-  });
-  let permitReleased = false;
+  let permitReleased = true;
   const releasePermit = (): void => {
     if (!permitReleased) {
       permitReleased = true;
@@ -1716,16 +1825,50 @@ export async function streamNativeChatCompletion(
     }
   };
 
+  // Per-attempt permit: acquired before each round-trip, released across
+  // warming-retry sleeps so a cold gateway never starves concurrent calls.
+  // A warming 503's body is consumed for classification, so its terminal
+  // throw happens here; every other non-ok status leaves the body unread for
+  // the error path below.
+  const warmingRetryState: WarmingRetryState = { attempt: 0 };
   let response: Response;
-  try {
-    response = await createCloudApiClient(runtime).requestRaw("POST", "/chat/completions", {
-      headers,
-      json: requestBody,
-      ...(signal ? { signal } : {}),
+  for (;;) {
+    const waitStartedAt = Date.now();
+    await limiter.acquire();
+    permitReleased = false;
+    recordInferenceSpan("cloud.semaphore-wait", Date.now() - waitStartedAt, {
+      route: "chat/completions:stream",
     });
-  } catch (err) {
+    try {
+      response = await createCloudApiClient(runtime).requestRaw("POST", "/chat/completions", {
+        headers,
+        json: requestBody,
+        ...(signal ? { signal } : {}),
+      });
+    } catch (err) {
+      releasePermit();
+      throw err;
+    }
+    if (response.status !== 503) break;
+    const warmingBodyText = await response.text();
     releasePermit();
-    throw err;
+    const delayMs = nextWarmingRetryDelayMs(warmingRetryState, response, warmingBodyText);
+    if (delayMs === undefined || signal?.aborted) {
+      const errorBody = asRecord(parseJsonRecord(warmingBodyText)?.error);
+      const message =
+        firstString(errorBody.message) ?? `elizaOS Cloud error ${response.status}`;
+      const requestError = new Error(message) as Error & {
+        status?: number;
+        error?: unknown;
+      };
+      requestError.status = response.status;
+      if (Object.keys(errorBody).length > 0) requestError.error = errorBody;
+      throw requestError;
+    }
+    logger.warn(
+      `[ELIZAOS_CLOUD] cloud gateway is warming (503) on chat/completions:stream; retrying in ${delayMs}ms (attempt ${warmingRetryState.attempt}/${WARMING_RETRY_DELAYS_MS.length})`
+    );
+    await sleepMs(delayMs);
   }
 
   if (!response.ok) {


### PR DESCRIPTION
A cold Cloudflare Worker answers the first request after idle with a 503 carrying a structural `*_cache_warming` code (`auth_cache_warming`, `rate_limit_cache_warming`, `inference_dependency_cache_warming`, `billing_cache_warming`) while it hydrates its caches. The container treated that 503 as a hard provider failure: the runtime `useModel` failover ladder classifies any thrown 503 as fallback-class and advances instantly, so the whole `RESPONSE_HANDLER -> TEXT_NANO -> TEXT_SMALL -> TEXT_LARGE` ladder was spent in ~83ms while real gateway recovery is 1,000-1,410ms. Measured baseline: the first turn after idle FAILED 4/4 with a canned error delivered at 3,800-4,600ms.

## Fix

Gate on the structural status+code shape (never message prose) and retry the same request in place with a bounded backoff schedule (250/500/1000/1500ms; `Retry-After` respected up to a 2s cap), across both buffered routes and the streaming path. Any other 503 body, any non-503 status, non-JSON 503 bodies, and network errors still throw immediately, so genuine outages keep failing over promptly.

## Production capture

The warming 503 was captured from the live gateway three times: the billing lane after a 40-minute natural idle (cf-ray `a271385cde41b15f-BOS`, 2026-08-06 21:43:58 UTC) and the auth lane induced (cf-ray `a27147c469398fb5-BOS`). The full capture is pasted in the Evidence Gate below.

## Bench proof (differential harness, captured prod 503 body replayed by a local server)

Adversarial-review bench: old code threw all 4 ladder rungs in 83ms and failed the turn; new code succeeded at 3,283ms buffered / 3,314ms streaming against a 3,000ms recovery window, and 784ms/763ms for a realistic 600ms recovery. Retry budget is 3,250ms vs measured production recovery of 1,000-1,410ms = 3.5x margin.

Fresh re-run of the same harness at this head (109f7ef9e23):

- 3,000ms recovery: OLD exhausted all 4 rungs in 9ms and the turn failed; NEW first rung succeeded at 3,370ms buffered / 3,293ms streaming — ladder never consumed.
- 600ms recovery: OLD exhausted in 53ms and failed; NEW succeeded at 791ms buffered / 780ms streaming.
- Inverse: a real provider 503 (`api_error`) threw in 1ms with a single attempt — the ladder is preserved for real outages.

Real failures fail fast at +0ms in every class: non-503 status, 503 with a non-warming code, non-JSON 503 body, network error (all pinned in the new unit suite).

## Caveats (stated plainly — adversarial review verdict: SHIP WITH CAVEAT)

- (a) The fixed container has never contacted the real gateway: the image build is blocked by the GitHub Actions outage. The post-deploy first-turn-after-idle test is MANDATORY before trusting this in production.
- (b) The `/responses` path change is dead code against the currently deployed worker (it never emits the warming shape on that route today).
- (c) A sustained warming outage now costs ~15-19s before the canned error instead of ~0.5s — that is the deliberate price of surviving the normal 1-1.4s warm-up.

## Local CI (GitHub Actions major outage)

GitHub Actions is in a major outage, so the suites CI would run for the touched package were executed locally at this head (109f7ef9e23, on top of develop c43d283cf5d) in `/home/milady/iqlabs/.compose-fix-wt`. Exact counts:

- `plugins/plugin-elizacloud` full suite (`vitest run`): **444 passed / 5 skipped / 0 failed** (test files: 50 passed, 2 skipped)
- new suite `__tests__/unit/text-warming-retry.test.ts` standalone: **10 passed / 0 failed**
- core model-ladder batch (`use-model-provider-fallback`, `model-provider-failover`, `streaming-use-model`, `guarded-stream-use-model`, `model-registrations`, `model-stream-chunk-hooks`): **6 files, 46 passed / 0 failed**
- typecheck (`tsc --noEmit -p tsconfig.json`, plugin-elizacloud): **exit 0**
- biome (`bunx @biomejs/biome check .`, plugin-elizacloud): **56 files checked, no diagnostics**

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:109f7ef9e2301bc9a37838f0976df7dd737e3650 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend plugin retry-path change; no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend plugin retry-path change; nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - server-side HTTP retry behavior; proven by the wall-clock differential bench and the unit suite, not a screen flow.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the captured production warming 503 (auth lane, induced) and the fresh differential bench output at this head.

<details><summary>Production 503 capture + differential bench logs</summary>

```text
$ curl -sD - https://elizacloud.ai/api/v1/chat/completions   (auth lane, induced cold start)
HTTP/2 503
date: Thu, 06 Aug 2026 21:54:29 GMT
content-type: application/json
server-timing: auth_extract;dur=0, auth_resolve;dur=148, auth_cache_available;dur=0, auth_cache_read;dur=148, cloud_worker;dur=148;desc="Cloud_API_until_response_headers"
x-eliza-auth-trace: v=1;credential=bearer_api_key;probe=off;available=available;backend=cloudflare_kv;read=miss;authoritative=not_run;write=not_run;result=warming
cf-ray: a27147c469398fb5-BOS

{"error":{"message":"Authorization cache is warming. Retry shortly.","type":"service_unavailable","code":"auth_cache_warming"}}

(billing lane after 40-min natural idle: billing_cache_warming, cf-ray a271385cde41b15f-BOS, 2026-08-06 21:43:58 UTC)

$ bun harness-composewt-slow.ts   (recovery window 3000ms, captured prod body replayed)
SCENARIO 1: OLD handler (c43d283cf5d) + runtime ladder vs cold gateway
  rung RESPONSE_HANDLER(TEXT_LARGE): THREW after 7ms status=503 -> ladder advances
  rung TEXT_NANO: THREW after 1ms status=503 -> ladder advances
  rung TEXT_SMALL: THREW after 0ms status=503 -> ladder advances
  rung TEXT_LARGE: THREW after 1ms status=503 -> ladder advances
  OLD RESULT: ladder EXHAUSTED, turn FAILED (canned error) in 9ms (gateway needed 3000ms)
SCENARIO 2: NEW handler (109f7ef9e23) vs cold gateway — buffered path
  Warn [ELIZAOS_CLOUD] cloud gateway is warming (503) on chat/completions; retrying in 250ms (attempt 1/4)
  NEW RESULT: first rung SUCCEEDED "pong" in 3370ms — ladder never consumed
SCENARIO 3: NEW handler vs cold gateway — streaming path
  Warn [ELIZAOS_CLOUD] cloud gateway is warming (503) on chat/completions:stream; retrying in 250ms (attempt 1/4)
  NEW STREAM RESULT: stream handle returned in 3293ms (post-recovery attempt accepted)
SCENARIO 4: NEW handler vs REAL provider 503 (api_error) — must fail over instantly
  NEW RESULT: threw in 1ms status=503 "upstream provider exploded" — single attempt, ladder preserved
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates; this is the container-side model provider talking to the cloud gateway.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - the retry gate is structural (status + code shape, never prose) and is pinned by deterministic suites against a local replay server; no live inference is exercised by this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - full local suite counts at this head (GitHub Actions outage; local execution of the same suites CI runs).

<details><summary>Local test output at 109f7ef9e2301bc9a37838f0976df7dd737e3650</summary>

```text
plugins/plugin-elizacloud $ bun run test        (vitest run)
 Test Files  50 passed | 2 skipped (52)
      Tests  444 passed | 5 skipped (449)

plugins/plugin-elizacloud $ bunx vitest run __tests__/unit/text-warming-retry.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)

packages/core $ node ../scripts/run-vitest.mjs run \
    src/runtime/__tests__/use-model-provider-fallback.test.ts \
    src/runtime/__tests__/model-provider-failover.test.ts \
    src/runtime/__tests__/streaming-use-model.test.ts \
    src/runtime/__tests__/guarded-stream-use-model.test.ts \
    src/runtime/__tests__/model-registrations.test.ts \
    src/runtime/__tests__/model-stream-chunk-hooks.test.ts
 Test Files  6 passed (6)
      Tests  46 passed (46)

plugins/plugin-elizacloud $ bun run typecheck   (tsc --noEmit) -> exit 0
plugins/plugin-elizacloud $ bun run lint:check  (biome check .) -> Checked 56 files. No fixes applied.
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
