### PR TITLE
fix(core): stale-serve the relationships graph and bound the rolodex provider

### DIFF
--- a/packages/agent/src/providers/rolodex.ts
+++ b/packages/agent/src/providers/rolodex.ts
@@ -59,6 +59,11 @@ export const rolodexProvider: Provider = {
   contextGate: { anyOf: ["contacts", "memory"] },
   cacheStable: false,
   cacheScope: "turn",
+  // The contact list is supplemental context; a cold relationships-graph
+  // rebuild over a large store must not stall the turn (#17490 gave its
+  // siblings budgets but missed this provider).
+  timeoutMs: 3_000,
+  timeoutMode: "degrade",
   // roleGate ADMIN is enforced by applyPluginRoleGating (#12087 Item 14); the
   // declared gate is authoritative, not the handler body.
   roleGate: { minRole: "ADMIN" },

--- a/packages/core/src/services/relationships-graph-builder.ts
+++ b/packages/core/src/services/relationships-graph-builder.ts
@@ -9,6 +9,7 @@
  * lookup across every member of a person's identity cluster.
  */
 import { getCloudAuthService } from "../cloud-auth-service";
+import { logger } from "../logger";
 import type {
 	Entity,
 	IAgentRuntime,
@@ -2241,8 +2242,14 @@ async function buildGraphModel(
 	};
 }
 
-/** TTL cache for the expensive graph model build. */
-const MODEL_CACHE_TTL_MS = 30_000; // 30 seconds
+/**
+ * TTL cache for the expensive graph model build. Expiry serves the stale
+ * snapshot while a single-flight rebuild refreshes it in the background (see
+ * getCachedModel), so the TTL governs snapshot staleness only, never turn
+ * latency. Five minutes matches how fast a human-scale contact graph actually
+ * changes; merge mutations still invalidate immediately.
+ */
+const MODEL_CACHE_TTL_MS = 300_000;
 
 type CachedModel = Awaited<ReturnType<typeof buildGraphModel>>;
 type ModelCache = { model: CachedModel; timestamp: number };
@@ -2285,11 +2292,29 @@ export function createNativeRelationshipsGraphService(
 					return model;
 				})
 				.catch((err) => {
-					// error-policy:J5 The shared promise is returned to callers, who observe
-					// the rejection; this branch only clears the single-flight slot.
+					// error-policy:J5 First-build callers await the shared promise and
+					// observe the rejection; the single observer attached below logs it
+					// for stale-serving callers. This branch only clears the
+					// single-flight slot so the next expired read retries.
 					modelBuildPromise = null;
 					throw err;
 				});
+			modelBuildPromise.catch((err) => {
+				// error-policy:J5 Observed once per build here (and by any first-build
+				// awaiter); prevents an unhandled rejection when stale-serving callers
+				// never await the background refresh. The last good snapshot stays.
+				logger.warn(
+					`[RelationshipsGraph] Graph model rebuild failed; last good snapshot retained: ${
+						err instanceof Error ? err.message : String(err)
+					}`,
+				);
+			});
+		}
+		// Stale-while-revalidate: an expired snapshot answers the turn
+		// immediately while the single-flight rebuild refreshes it in the
+		// background. Only the first-ever build (no snapshot at all) awaits.
+		if (modelCache) {
+			return modelCache.model;
 		}
 		return modelBuildPromise;
 	}


### PR DESCRIPTION
A turn-latency regression measured on a live agent: memory/recall turns took **33–56 seconds** where the previous release served the same store in ~2s.

## Root cause

`44e6088774e` (#17490, "make provider deadlines cancellation-safe") did two things: it declared explicit budgets for `relevant-conversations` (10s) and `recent-conversations` (8s), and it removed the **default** budget in `packages/core/src/runtime.ts` (`return 3_000` → `return undefined`). `rolodex` declares no budget, so it became unbounded.

`rolodex` awaits a relationships-graph snapshot. On a large store the cold rebuild issues thousands of queries against the in-process PGlite — WASM Postgres on the **main JS thread** — so while it runs, no I/O callback in the process can complete. The turn's model response had already arrived and sat unread in the socket.

The deleted default's own comment predicted this verbatim: *"Without an enforced deadline a provider doing synchronous network work can hold every message turn hostage for tens of seconds and still count as healthy."*

## Change

- **`rolodex` declares `timeoutMs: 3_000, timeoutMode: "degrade"`** — the same pattern #17490 applied to its siblings. Contact context is supplemental; degrading beats stalling. `degrade` is required because declared budgets default to `fail`, which would turn an overrun into a failed composition.
- **`getCachedModel` serves an expired snapshot immediately** and refreshes through the existing single-flight promise in the background; only the first-ever build (no snapshot at all) awaits. TTL 30s → 5min, since it now governs staleness rather than turn latency, and merge mutations still invalidate eagerly. A single observer logs rebuild failures and the last good snapshot is retained.

Also worth flagging for a follow-up (not in this diff): `CLOUD_ACCOUNT`, `elizacloud_credits`, `CLOUD_APPS`, `elizacloud_models` and `adminPanel` are likewise undeclared and unbounded since #17490.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:3a7d57ad5ff6cf4006dad22691a09c5ed2837e2b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - runtime provider-scheduling change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing renders differently; the change is turn timing.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend latency change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - before/after on a live agent, from its own InferenceTiming lines.

<details><summary>Live before/after (same agent, same store, 1,255 entities)</summary>

```text
BEFORE (unbounded, three independent slow turns):
  total=35,884ms  provider:rolodex=28,047ms  model:TEXT_LARGE=28,114ms
  total=32,971ms  provider:rolodex=24,516ms
  total=55,855ms  provider:rolodex=21,802ms  message:planner=81,993ms(x2)

  event-loop pinning proven directly: a cold GET /api/relationships/graph?limit=1
  took 23.97s while a concurrent trivial GET /api/agents took 21.64s, then
  7-27ms on every sample afterwards. CPU ~100% of one core throughout.
  In all three turns the model span ends 24-1,193ms AFTER the rolodex span --
  the response had arrived and was waiting on the blocked loop.

AFTER (this change, same live agent):
  provider:rolodex=28.8ms          <- was 21,802ms
  ordinary turn total=2,389ms      <- warm band 1,810-3,034ms, no regression

CONTROL (previous release, same store, default 3s budget still present):
  median turn 2,017ms, zero turns over 20s across a full day
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in provider composition.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - provider-scheduling change; the model call is unmodified and was measured healthy (0.72-1.14s direct floor, zero retries) throughout, so the stall was never in generation. The live turn measurements are recorded under Backend logs above.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - the exonerating measurements that pin the cause to scheduling rather than any of the usual suspects.

<details><summary>What the investigation ruled out</summary>

```text
provider/key       0 retries and 0 rate-limit lines in 90,000 log lines;
                   correct base URL and model; direct floor 0.72-1.14s
embeddings         1.3-8.0% of slow-turn time (391-2,751ms); the slowest
                   turn had the FASTEST embeddings of the sample
cloud providers    a probe composing ZERO cloud providers still took
                   32,971ms; they measure 13.8ms in steady state
facts stage        prompt hard-capped ~2.1K tokens; a victim of the same
                   blocked loop, co-terminating within 24ms of rolodex
host load          baseline turns stayed 2-3s under identical load
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
