### PR TITLE
fix(cloud): re-bootstrap the gateway JWT on 401 instead of waiting the hour

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
@@ -1,10 +1,10 @@
-// Pins the 401 recovery contract: when the cloud Worker redeploys, the token
-// the gateway holds turns invalid until its scheduled refresh, up to ~48
-// minutes away — and every cloud call in that window runs post-ack, so each
-// 401 is a user-visible silence. Each call site must re-bootstrap once via the
-// injected reauth hook and retry; a second 401 follows the normal error path,
-// and a 404 must never trigger a re-bootstrap. The real reauth (single-flight
-// against the token endpoint) is pinned separately below.
+/**
+ * Verifies one-shot JWT recovery for gateway-to-cloud requests.
+ *
+ * The deterministic harness covers identity and webhook-config retries plus
+ * the real auth module's single-flight behavior. Handler-level onboarding
+ * recovery is exercised by the webhook end-to-end suite.
+ */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import type { GatewayRedis } from "../src/redis";
 import { resolveIdentity } from "../src/server-router";
@@ -19,6 +19,7 @@ class MemoryRedis implements GatewayRedis {
     try {
       return JSON.parse(value) as T;
     } catch {
+      // error-policy:J3 Test Redis mirrors string values that are not JSON.
       return value as T;
     }
   }
@@ -47,7 +48,7 @@ const STALE = { Authorization: "Bearer stale" };
 /** Upstream that 401s stale tokens and serves fresh ones. */
 function upstream(body: unknown): { calls: Array<string | null> } {
   const seen: Array<string | null> = [];
-  globalThis.fetch = mock(async (input: unknown, init?: RequestInit) => {
+  globalThis.fetch = mock(async (_input: unknown, init?: RequestInit) => {
     const auth = new Headers(init?.headers as HeadersInit).get("authorization");
     seen.push(auth);
     if (auth === "Bearer stale") {
@@ -159,8 +160,8 @@ describe("resolveWebhookConfig re-bootstraps once on 401", () => {
 
 describe("reacquireAuthHeader is single-flight", () => {
   test("concurrent 401 recoveries share one bootstrap request", async () => {
-    // Drive the REAL auth module: init against a stub token endpoint, then
-    // fire concurrent reacquisitions and count how many bootstrap POSTs land.
+    // Drive the auth module against a stub token endpoint, then count the
+    // bootstrap POSTs from concurrent reacquisitions.
     let bootstraps = 0;
     globalThis.fetch = mock(async (input: unknown) => {
       if (String(input).endsWith("/api/internal/auth/token")) {
@@ -194,8 +195,7 @@ describe("reacquireAuthHeader is single-flight", () => {
       reacquireAuthHeader(),
     ]);
 
-    // One shared bootstrap for the burst, and every caller gets the SAME
-    // fresh token from it.
+    // One shared bootstrap serves the burst and returns one fresh token.
     expect(bootstraps).toBe(2);
     for (const header of headers) {
       expect(header).toEqual({ Authorization: "Bearer tok-2" });

--- a/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
@@ -1,0 +1,206 @@
+// Pins the 401 recovery contract: when the cloud Worker redeploys, the token
+// the gateway holds turns invalid until its scheduled refresh, up to ~48
+// minutes away — and every cloud call in that window runs post-ack, so each
+// 401 is a user-visible silence. Each call site must re-bootstrap once via the
+// injected reauth hook and retry; a second 401 follows the normal error path,
+// and a 404 must never trigger a re-bootstrap. The real reauth (single-flight
+// against the token endpoint) is pinned separately below.
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { GatewayRedis } from "../src/redis";
+import { resolveIdentity } from "../src/server-router";
+import { resolveWebhookConfig } from "../src/webhook-config";
+
+class MemoryRedis implements GatewayRedis {
+  readonly store = new Map<string, string>();
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    const value = this.store.get(key);
+    if (value === undefined) return null;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return value as T;
+    }
+  }
+
+  async set(key: string, value: string): Promise<unknown> {
+    this.store.set(key, value);
+    return "OK";
+  }
+
+  async lpush(): Promise<unknown> {
+    return 1;
+  }
+
+  async ltrim(): Promise<unknown> {
+    return "OK";
+  }
+
+  async expire(): Promise<unknown> {
+    return 1;
+  }
+}
+
+const originalFetch = globalThis.fetch;
+const STALE = { Authorization: "Bearer stale" };
+
+/** Upstream that 401s stale tokens and serves fresh ones. */
+function upstream(body: unknown): { calls: Array<string | null> } {
+  const seen: Array<string | null> = [];
+  globalThis.fetch = mock(async (input: unknown, init?: RequestInit) => {
+    const auth = new Headers(init?.headers as HeadersInit).get("authorization");
+    seen.push(auth);
+    if (auth === "Bearer stale") {
+      return new Response("unauthorized", { status: 401 });
+    }
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { calls: seen };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  mock.restore();
+});
+
+describe("resolveIdentity re-bootstraps once on 401", () => {
+  test("stale token → reauth → retry succeeds and the identity is served", async () => {
+    const { calls } = upstream({
+      success: true,
+      userId: "user-1",
+      organizationId: "org-1",
+      agentId: "agent-1",
+    });
+    const reauth = mock(async () => ({ Authorization: "Bearer fresh" }));
+
+    const identity = await resolveIdentity(
+      new MemoryRedis(),
+      "https://api.test",
+      STALE,
+      "telegram",
+      "42",
+      undefined,
+      reauth,
+    );
+
+    expect(reauth).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(["Bearer stale", "Bearer fresh"]);
+    expect(identity).toEqual({
+      userId: "user-1",
+      organizationId: "org-1",
+      agentId: "agent-1",
+    });
+  });
+
+  test("a second 401 follows the error path — no retry loop", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("unauthorized", { status: 401 }),
+    ) as typeof fetch;
+    const reauth = mock(async () => ({ Authorization: "Bearer fresh" }));
+
+    await expect(
+      resolveIdentity(
+        new MemoryRedis(),
+        "https://api.test",
+        STALE,
+        "telegram",
+        "42",
+        undefined,
+        reauth,
+      ),
+    ).rejects.toThrow("Identity resolve failed: 401");
+    expect(reauth).toHaveBeenCalledTimes(1);
+  });
+
+  test("a 404 is an unknown sender, never a reauth trigger", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("not found", { status: 404 }),
+    ) as typeof fetch;
+    const reauth = mock(async () => ({ Authorization: "Bearer fresh" }));
+
+    const identity = await resolveIdentity(
+      new MemoryRedis(),
+      "https://api.test",
+      STALE,
+      "telegram",
+      "42",
+      undefined,
+      reauth,
+    );
+
+    expect(identity).toBeNull();
+    expect(reauth).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveWebhookConfig re-bootstraps once on 401", () => {
+  test("stale token → reauth → retry returns the config", async () => {
+    const { calls } = upstream({ verifyToken: "vt", appSecret: "as" });
+    const reauth = mock(async () => ({ Authorization: "Bearer fresh" }));
+
+    const config = await resolveWebhookConfig(
+      new MemoryRedis(),
+      "https://api.test",
+      STALE,
+      "whatsapp",
+      "eliza-app",
+      "agent-42",
+      reauth,
+    );
+
+    expect(reauth).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(["Bearer stale", "Bearer fresh"]);
+    expect(config).toEqual({ verifyToken: "vt", appSecret: "as" });
+  });
+});
+
+describe("reacquireAuthHeader is single-flight", () => {
+  test("concurrent 401 recoveries share one bootstrap request", async () => {
+    // Drive the REAL auth module: init against a stub token endpoint, then
+    // fire concurrent reacquisitions and count how many bootstrap POSTs land.
+    let bootstraps = 0;
+    globalThis.fetch = mock(async (input: unknown) => {
+      if (String(input).endsWith("/api/internal/auth/token")) {
+        bootstraps += 1;
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return new Response(
+          JSON.stringify({
+            access_token: `tok-${bootstraps}`,
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    }) as typeof fetch;
+
+    const { initAuth, reacquireAuthHeader, shutdownAuth } = await import(
+      "../src/auth"
+    );
+    await initAuth({
+      cloudUrl: "https://api.test",
+      bootstrapSecret: "bootstrap",
+      podName: "test-pod",
+    });
+    expect(bootstraps).toBe(1);
+
+    const headers = await Promise.all([
+      reacquireAuthHeader(),
+      reacquireAuthHeader(),
+      reacquireAuthHeader(),
+    ]);
+
+    // One shared bootstrap for the burst, and every caller gets the SAME
+    // fresh token from it.
+    expect(bootstraps).toBe(2);
+    for (const header of headers) {
+      expect(header).toEqual({ Authorization: "Bearer tok-2" });
+    }
+
+    shutdownAuth();
+  });
+});

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -1,4 +1,4 @@
-// Exercises the gateway-webhook webhook handler.e2e path with deterministic cloud service fixtures.
+/** Exercises gateway webhook routing with deterministic cloud-service fixtures. */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import type {
   ChatEvent,
@@ -203,6 +203,77 @@ describe("gateway webhook handler e2e routing", () => {
       platformUserId: "+15551234567",
       platformDisplayName: "Ada",
     });
+  });
+
+  test("retries onboarding once with fresh auth and the same idempotency key", async () => {
+    configureEnv();
+    const redis = new MemoryRedis();
+    const event = createTwilioEvent({ messageId: "SM_onboarding_retry" });
+    const adapter = createAdapter(event);
+    const reauth = mock(async () => ({ Authorization: "Bearer fresh" }));
+    const onboardingRequests: Array<{
+      authorization: string | null;
+      idempotencyKey: string | null;
+    }> = [];
+
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        request.url ===
+        "https://api.elizacloud.ai/api/internal/identity/resolve"
+      ) {
+        return new Response(JSON.stringify({ success: false }), {
+          status: 404,
+        });
+      }
+      if (
+        request.url ===
+        "https://api.elizacloud.ai/api/eliza-app/onboarding/chat"
+      ) {
+        onboardingRequests.push({
+          authorization: request.headers.get("authorization"),
+          idempotencyKey: request.headers.get("idempotency-key"),
+        });
+        if (onboardingRequests.length === 1) {
+          return new Response("unauthorized", { status: 401 });
+        }
+        return new Response(
+          JSON.stringify({ data: { reply: "fresh-token reply" } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    const response = await handleWebhook(
+      requestFor(event),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer stale" }),
+        reacquireAuthHeader: reauth,
+      },
+      "eliza-app",
+    );
+
+    expect(response.status).toBe(200);
+    await waitFor(
+      () => adapter.replies.length === 1,
+      "retried onboarding reply",
+    );
+    expect(reauth).toHaveBeenCalledTimes(1);
+    expect(onboardingRequests).toEqual([
+      {
+        authorization: "Bearer stale",
+        idempotencyKey: event.messageId,
+      },
+      {
+        authorization: "Bearer fresh",
+        idempotencyKey: event.messageId,
+      },
+    ]);
+    expect(adapter.replies).toEqual(["fresh-token reply"]);
   });
 
   test("routes linked Twilio identity to the running agent server and sends the agent reply", async () => {

--- a/packages/cloud/services/gateway-webhook/src/auth.ts
+++ b/packages/cloud/services/gateway-webhook/src/auth.ts
@@ -139,6 +139,23 @@ export async function initAuth(authConfig: AuthConfig): Promise<void> {
   await acquireToken();
 }
 
+let reacquireInFlight: Promise<void> | null = null;
+
+/**
+ * Re-bootstraps the JWT and returns a fresh header. Single-flight: a Worker
+ * redeploy invalidates the token for EVERY in-flight message at once, and
+ * without the latch each 401 would race its own bootstrap against the token
+ * endpoint. Callers retry their request exactly once with the fresh header; a
+ * second 401 follows the normal error path.
+ */
+export async function reacquireAuthHeader(): Promise<{ Authorization: string }> {
+  reacquireInFlight ??= acquireToken().finally(() => {
+    reacquireInFlight = null;
+  });
+  await reacquireInFlight;
+  return getAuthHeader();
+}
+
 export function getAuthHeader(): { Authorization: string } {
   if (!accessToken) {
     throw new Error("No access token available - call initAuth first");

--- a/packages/cloud/services/gateway-webhook/src/auth.ts
+++ b/packages/cloud/services/gateway-webhook/src/auth.ts
@@ -1,4 +1,4 @@
-// Handles webhook gateway auth behavior for authenticated connector fan-in.
+/** Handles webhook gateway authentication for authenticated connector fan-in. */
 import { logger } from "./logger";
 
 const HTTP_TIMEOUT_MS = 10_000;
@@ -143,12 +143,14 @@ let reacquireInFlight: Promise<void> | null = null;
 
 /**
  * Re-bootstraps the JWT and returns a fresh header. Single-flight: a Worker
- * redeploy invalidates the token for EVERY in-flight message at once, and
+ * redeploy invalidates the token for every in-flight message at once, and
  * without the latch each 401 would race its own bootstrap against the token
  * endpoint. Callers retry their request exactly once with the fresh header; a
  * second 401 follows the normal error path.
  */
-export async function reacquireAuthHeader(): Promise<{ Authorization: string }> {
+export async function reacquireAuthHeader(): Promise<{
+  Authorization: string;
+}> {
   reacquireInFlight ??= acquireToken().finally(() => {
     reacquireInFlight = null;
   });

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -1,4 +1,4 @@
-// Handles webhook gateway server router behavior for authenticated connector fan-in.
+/** Routes authenticated connector traffic to cloud identities and agent servers. */
 import { readFileSync } from "node:fs";
 import { reacquireAuthHeader } from "./auth";
 import { getHashTargets, refreshHashRing } from "./hash-router";

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -1,5 +1,6 @@
 // Handles webhook gateway server router behavior for authenticated connector fan-in.
 import { readFileSync } from "node:fs";
+import { reacquireAuthHeader } from "./auth";
 import { getHashTargets, refreshHashRing } from "./hash-router";
 import { logger } from "./logger";
 import type { GatewayRedis } from "./redis";
@@ -42,6 +43,7 @@ export async function resolveIdentity(
   platform: string,
   platformId: string,
   platformName?: string,
+  reauth: () => Promise<Record<string, string>> = reacquireAuthHeader,
 ): Promise<ResolvedIdentity | null> {
   const cacheKey = `identity:${platform}:${platformId}`;
   const cached = await redis.get<ResolvedIdentity | { notFound: true }>(
@@ -57,16 +59,30 @@ export async function resolveIdentity(
   const timeoutId = setTimeout(() => controller.abort(), FORWARD_TIMEOUT_MS);
 
   try {
-    const res = await fetch(url, {
+    const body = JSON.stringify({
+      platform,
+      platformId,
+      ...(platformName ? { platformName } : {}),
+    });
+    let res = await fetch(url, {
       method: "POST",
       headers: authHeader,
-      body: JSON.stringify({
-        platform,
-        platformId,
-        ...(platformName ? { platformName } : {}),
-      }),
+      body,
       signal: controller.signal,
     });
+    // A Worker redeploy invalidates the gateway's token until its scheduled
+    // refresh, up to ~48 minutes away — and this call runs post-ack, so every
+    // 401 in that window is a user-visible silence. Re-bootstrap and retry
+    // exactly once; a second 401 falls through to the error path below.
+    if (res.status === 401) {
+      const freshHeader = await reauth();
+      res = await fetch(url, {
+        method: "POST",
+        headers: freshHeader,
+        body,
+        signal: controller.signal,
+      });
+    }
     if (res.status === 404) {
       await redis.set(cacheKey, JSON.stringify({ notFound: true }), {
         ex: IDENTITY_TRANSIENT_CACHE_TTL_SECONDS,

--- a/packages/cloud/services/gateway-webhook/src/webhook-config.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-config.ts
@@ -1,5 +1,6 @@
 // Handles webhook gateway webhook config behavior for authenticated connector fan-in.
 import type { Platform, WebhookConfig } from "./adapters/types";
+import { reacquireAuthHeader } from "./auth";
 import { logger } from "./logger";
 import { getProjectEnv } from "./project-config";
 import type { GatewayRedis } from "./redis";
@@ -57,6 +58,7 @@ export async function resolveWebhookConfig(
   platform: Platform,
   project: string,
   agentId?: string,
+  reauth: () => Promise<Record<string, string>> = reacquireAuthHeader,
 ): Promise<WebhookConfig | null> {
   if (!agentId) {
     return buildSharedWebhookConfig(platform, project);
@@ -72,10 +74,18 @@ export async function resolveWebhookConfig(
     const timeoutId = setTimeout(() => controller.abort(), 10_000);
 
     try {
-      const res = await fetch(url, {
+      let res = await fetch(url, {
         headers: authHeader,
         signal: controller.signal,
       });
+      // Same 401 shape as resolveIdentity: a Worker redeploy strands the
+      // cached token until the scheduled refresh. One re-bootstrapped retry.
+      if (res.status === 401) {
+        res = await fetch(url, {
+          headers: await reauth(),
+          signal: controller.signal,
+        });
+      }
 
       if (res.status === 404) {
         await redis.set(cacheKey, JSON.stringify({ notFound: true }), {

--- a/packages/cloud/services/gateway-webhook/src/webhook-config.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-config.ts
@@ -1,4 +1,4 @@
-// Handles webhook gateway webhook config behavior for authenticated connector fan-in.
+/** Resolves shared and per-agent webhook configuration for connector fan-in. */
 import type { Platform, WebhookConfig } from "./adapters/types";
 import { reacquireAuthHeader } from "./auth";
 import { logger } from "./logger";

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -1,4 +1,4 @@
-// Handles webhook gateway webhook handler behavior for authenticated connector fan-in.
+/** Handles authenticated connector webhooks from verification through reply delivery. */
 import type {
   ChatEvent,
   Platform,
@@ -22,6 +22,7 @@ interface HandlerDeps {
   redis: GatewayRedis;
   cloudBaseUrl: string;
   getAuthHeader: () => { Authorization: string };
+  reacquireAuthHeader?: () => Promise<Record<string, string>>;
 }
 
 export async function handleWebhook(
@@ -32,6 +33,7 @@ export async function handleWebhook(
   agentId?: string,
 ): Promise<Response> {
   const { redis, cloudBaseUrl, getAuthHeader } = deps;
+  const reauth = deps.reacquireAuthHeader ?? reacquireAuthHeader;
   const authHeader = getAuthHeader();
 
   const rawBody = await request.text();
@@ -45,6 +47,7 @@ export async function handleWebhook(
     adapter.platform,
     project,
     agentId,
+    reauth,
   );
   if (!config) {
     logger.warn("No webhook config found", {
@@ -112,6 +115,7 @@ async function processMessage(
   explicitAgentId?: string,
 ): Promise<void> {
   const { redis, cloudBaseUrl, getAuthHeader } = deps;
+  const reauth = deps.reacquireAuthHeader ?? reacquireAuthHeader;
   const authHeader = getAuthHeader();
 
   const identity = await resolveIdentity(
@@ -121,6 +125,7 @@ async function processMessage(
     adapter.platform,
     event.senderId,
     event.senderName,
+    reauth,
   );
 
   if (!identity) {
@@ -244,9 +249,9 @@ async function sendOnboardingReply(
   config: WebhookConfig,
   event: ChatEvent,
   deps: HandlerDeps,
-  reauth: () => Promise<Record<string, string>> = reacquireAuthHeader,
 ): Promise<void> {
   const { cloudBaseUrl, getAuthHeader } = deps;
+  const reauth = deps.reacquireAuthHeader ?? reacquireAuthHeader;
 
   const postOnboarding = (authHeader: Record<string, string>) =>
     fetch(`${cloudBaseUrl}/api/eliza-app/onboarding/chat`, {
@@ -281,6 +286,7 @@ async function sendOnboardingReply(
     }
 
     if (!response.ok) {
+      // error-policy:J1 Preserve optional upstream diagnostics at this boundary.
       const body = await response.text().catch(() => "");
       throw new Error(
         `onboarding chat failed (${response.status}) ${body.slice(0, 200)}`,

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -5,6 +5,7 @@ import type {
   PlatformAdapter,
   WebhookConfig,
 } from "./adapters/types";
+import { reacquireAuthHeader } from "./auth";
 import { logger } from "./logger";
 import type { GatewayRedis } from "./redis";
 import {
@@ -243,34 +244,41 @@ async function sendOnboardingReply(
   config: WebhookConfig,
   event: ChatEvent,
   deps: HandlerDeps,
+  reauth: () => Promise<Record<string, string>> = reacquireAuthHeader,
 ): Promise<void> {
   const { cloudBaseUrl, getAuthHeader } = deps;
 
-  try {
-    const response = await fetch(
-      `${cloudBaseUrl}/api/eliza-app/onboarding/chat`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          // The onboarding route and its session coordinator both keep a replay
-          // ledger on this header. Without it the only protection against a
-          // platform redelivering a message is the 5-minute dedup key, and a
-          // later retry would append the message to the transcript twice and
-          // re-enter provisioning.
-          "Idempotency-Key": event.messageId,
-          ...getAuthHeader(),
-        },
-        body: JSON.stringify({
-          sessionId: `platform:${adapter.platform}:${event.senderId}`,
-          message: event.text,
-          platform: adapter.platform,
-          platformUserId: event.senderId,
-          platformDisplayName: event.senderName,
-        }),
-        signal: AbortSignal.timeout(30_000),
+  const postOnboarding = (authHeader: Record<string, string>) =>
+    fetch(`${cloudBaseUrl}/api/eliza-app/onboarding/chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        // The onboarding route and its session coordinator both keep a replay
+        // ledger on this header. Without it the only protection against a
+        // platform redelivering a message is the 5-minute dedup key, and a
+        // later retry would append the message to the transcript twice and
+        // re-enter provisioning.
+        "Idempotency-Key": event.messageId,
+        ...authHeader,
       },
-    );
+      body: JSON.stringify({
+        sessionId: `platform:${adapter.platform}:${event.senderId}`,
+        message: event.text,
+        platform: adapter.platform,
+        platformUserId: event.senderId,
+        platformDisplayName: event.senderName,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+  try {
+    let response = await postOnboarding(getAuthHeader());
+    // A Worker redeploy strands the cached token until its scheduled refresh;
+    // the Idempotency-Key above makes this replay safe. One retry, then the
+    // normal error path.
+    if (response.status === 401) {
+      response = await postOnboarding(await reauth());
+    }
 
     if (!response.ok) {
       const body = await response.text().catch(() => "");


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

Closes #17877

## What was wrong

Every deploy of the cloud Worker strands the gateway's cached JWT until the gateway's next scheduled refresh — up to **~48 minutes** (refresh at 80% of the 3600s TTL). Every cloud call the gateway makes in that window fails 401, and those calls run in the post-ack background phase, so each failure is a **silently dropped user message**.

Observed on production, 2026-08-07, with a real user's message:

```
23:56:58  gateway: JWT token refreshed (expiresIn 3600s)   ← against the OLD Worker
~00:00    prod Worker redeployed (run 31125155708)
00:03:32  [ERRO] Background message processing failed
          messageId="919799294" error="Identity resolve failed: 401"
00:05:59  manual gateway restart → fresh bootstrap → same identity resolves 200
```

A freshly bootstrapped token against the new Worker resolved the same telegram identity with 200 — verified directly against production. The token endpoint and the Worker were healthy the whole time; only the cached token was stale.

## The fix

`auth.ts` already recovers from a failed **refresh** by re-acquiring; nothing reacted to a 401 on a **data call**. Now:

- **`reacquireAuthHeader()`** re-runs the bootstrap under a **single-flight latch**. A Worker deploy 401s every in-flight message at once; without the latch, N messages race N bootstraps against the token endpoint. Every concurrent caller awaits the same bootstrap and gets the same fresh token.
- The three cloud-calling sites — identity resolve, webhook config, onboarding reply — **retry exactly once** with the fresh header. A second 401 follows the existing error path (no loop). A **404 never triggers a re-bootstrap** — it is an answer, not an auth failure.
- The onboarding retry is replay-safe because that call already carries `Idempotency-Key: <messageId>`.

The retry hook is injectable with the real function as default: the e2e suites drive these functions with fake headers and no initialized auth module, and a hard import would throw `No access token available` inside every test.

## Evidence

<details>
<summary>Tests — each pin mutation-verified</summary>

| pin | mutation | result |
|---|---|---|
| stale token → reauth → retry → identity served | remove the retry (= develop) | 2 fail |
| a second 401 errors, no retry loop | — (same removal covers it) | |
| a 404 never triggers reauth | widen the condition to `!res.ok` | 1 fail |
| concurrent recoveries share ONE bootstrap, same token for all | remove the single-flight latch | 1 fail |
| webhook-config 401 → retry → config served | site-level removal | covered by M1 shape |

```
auth-rebootstrap-on-401        5 pass  0 fail
gateway-webhook full package  58 pass  0 fail
typecheck + biome              clean
```

The single-flight test drives the REAL auth module against a stub token endpoint — init, then three concurrent `reacquireAuthHeader()` calls — and counts exactly two bootstrap POSTs total (one at init, one shared by the burst), with all three callers receiving the same fresh token.

</details>

## Deploy note

This service ships via manual `railway up` from the repository root (no repo trigger — see the package guide). The fix protects production only after the next gateway deploy. Until then the workaround for a Worker deploy remains a gateway restart, which is what recovered production tonight.

[stan-cloud]

<!-- evidence-head:d46e547a4ef5f9417167b967468077dede6ac687 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - a background auth path in a webhook gateway, no UI surface in the diff

<!-- evidence-row:after-screenshots -->
- [ ] N/A - a background auth path in a webhook gateway, no UI surface in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable behaviour is an auth retry on 401; the verbatim test runs and the production incident timeline carry it

<!-- evidence-row:backend-logs -->
- [x] [17878-jwt-evidence.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17878-jwt-evidence.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call on any path this diff touches

<!-- evidence-row:domain-artifacts -->
- [x] [17878-jwt-domain.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17878-jwt-domain.txt)
