### PR TITLE
fix(agent): operator-configured embedding endpoints win over local ownership

### DIFF
--- a/plugins/plugin-local-inference/src/runtime/embedding-warmup-policy.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/embedding-warmup-policy.test.ts
@@ -14,6 +14,8 @@ const ENV_KEYS = [
 	"ELIZA_DISABLE_LOCAL_EMBEDDINGS",
 	"ELIZA_CLOUD_EMBEDDINGS_DISABLED",
 	"ELIZAOS_CLOUD_USE_EMBEDDINGS",
+	"EMBEDDING_PROVIDER",
+	"EMBEDDING_BASE_URL",
 ] as const;
 
 afterEach(() => {
@@ -59,5 +61,33 @@ describe("shouldWarmupLocalEmbeddingModel", () => {
 		process.env.ELIZA_CLOUD_EMBEDDINGS_DISABLED = "true";
 
 		expect(shouldWarmupLocalEmbeddingModel()).toBe(false);
+	});
+
+	it("cedes ownership to an operator-configured embedding endpoint", () => {
+		process.env.EMBEDDING_BASE_URL = "https://api.openai.com/v1";
+
+		expect(shouldUseLocalEmbeddingModel()).toBe(false);
+		expect(shouldWarmupLocalEmbeddingModel()).toBe(false);
+	});
+
+	it("cedes ownership to an operator-configured non-local provider", () => {
+		process.env.EMBEDDING_PROVIDER = "openai";
+
+		expect(shouldUseLocalEmbeddingModel()).toBe(false);
+		expect(shouldWarmupLocalEmbeddingModel()).toBe(false);
+	});
+
+	it("keeps local ownership when the operator explicitly picks local", () => {
+		process.env.EMBEDDING_PROVIDER = "local";
+		process.env.EMBEDDING_BASE_URL = "http://127.0.0.1:8290/v1";
+
+		expect(shouldUseLocalEmbeddingModel()).toBe(true);
+	});
+
+	it("cedes ownership to a configured endpoint even when cloud embeddings are disabled", () => {
+		process.env.ELIZA_CLOUD_EMBEDDINGS_DISABLED = "1";
+		process.env.EMBEDDING_BASE_URL = "http://127.0.0.1:8290/v1";
+
+		expect(shouldUseLocalEmbeddingModel()).toBe(false);
 	});
 });

--- a/plugins/plugin-local-inference/src/runtime/embedding-warmup-policy.ts
+++ b/plugins/plugin-local-inference/src/runtime/embedding-warmup-policy.ts
@@ -22,9 +22,30 @@ export function isLocalEmbeddingDisabledByEnv(): boolean {
 	return isTruthyEnv("ELIZA_DISABLE_LOCAL_EMBEDDINGS");
 }
 
+function trimmedEnv(name: string): string {
+	return process.env[name]?.trim() ?? "";
+}
+
 /** Whether this process should own embeddings through the on-device provider. */
 export function shouldUseLocalEmbeddingModel(): boolean {
 	if (isLocalEmbeddingDisabledByEnv()) {
+		return false;
+	}
+
+	// Explicit operator routing wins over every heuristic below.
+	// EMBEDDING_PROVIDER is only written by the runtime AFTER this gate approves
+	// local ownership, so any value present here is the operator's own choice.
+	// EMBEDDING_BASE_URL is the bring-your-own-endpoint contract that
+	// auto-enables plugin-embeddings. Without this check the local force
+	// overrides the operator's configured endpoint, and when the local plugin is
+	// also unavailable (e.g. skipped) the dimension probe can never succeed —
+	// embedding generation stays permanently disabled and memory writes persist
+	// without vectors.
+	const configuredProvider = trimmedEnv("EMBEDDING_PROVIDER").toLowerCase();
+	if (configuredProvider === "local") {
+		return true;
+	}
+	if (configuredProvider !== "" || trimmedEnv("EMBEDDING_BASE_URL") !== "") {
 		return false;
 	}
 


### PR DESCRIPTION
A live agent silently stopped embedding its memories: **105,503 memory rows, zero embeddings written after 2026-08-05 18:56 UTC** (241 memories in the following 24h, 0 vectors), with recall over new memories dead and the operator's explicitly configured embedding endpoint ignored.

## Root cause

`5827ea8a3f8` (Aug 4) made `ensureEmbeddingDimension` treat `EMBEDDING_PROVIDER=local` as an ownership boundary: registrations are filtered to `LOCAL_EMBEDDING_PROVIDERS` only. But `configureLocalEmbeddingPlugin` (packages/agent/src/runtime/eliza.ts:1053) **forces** `EMBEDDING_PROVIDER=local` whenever the local-embedding policy holds — even when the operator has explicitly configured a working remote endpoint (`EMBEDDING_BASE_URL`/`EMBEDDING_MODEL`/`EMBEDDING_DIMENSIONS` in the environment) and the deployment skips `plugin-local-inference` entirely (`ELIZA_SKIP_PLUGINS`). Result: the only registered working provider (`embeddings` → the operator's endpoint, source of all 28,222 stored vectors) is filtered out, the dimension probe fails every retry forever, and `disableEmbeddingGeneration()` turns off vector writes:

```
deferred embedding-dimension re-probe: every registered TEXT_EMBEDDING provider
failed; embedding generation stays disabled (memory writes persist without
vectors) (attempts=[{"provider":"local","error":"EMBEDDING_PROVIDER=local but
no on-device embedding handler is registered"}])
```

The bot restarted onto a build containing the filter at 18:56 Aug 5 — the exact minute embeddings stop in the store.

## Change

Operator-explicit embedding configuration wins over the local-ownership default: when the operator has set an embedding endpoint, `configureLocalEmbeddingPlugin` does not force `EMBEDDING_PROVIDER=local` (the existing `ELIZA_DISABLE_LOCAL_EMBEDDINGS` escape hatch keeps working and is now implied by explicit config). Deployments with no explicit config keep today's local-first behavior unchanged.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:ae19bf287367f767a06303f86bf430fdb1e4b9d3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - runtime embedding-provider resolution change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend provider-resolution change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the live incident from the affected agent's own store and logs.

<details><summary>Store ground truth + the permanent-failure loop</summary>

```text
store (read via the agent's own rows API; PGlite, single writer):
  memories total:                 105,503
  embeddings total:               28,226   (28,222 x dim_1536)
  newest embedding row:           2026-08-05 18:56:53 UTC
  memories written since:         243+ (241 in the last 24h) — 0 embedded
  per-day (memories/embeddings):  08-05: 55/13 · 08-06: 241/0 · 08-07: 6+/0

log (repeating forever — the only eligible provider is permanently skipped):
  deferred embedding-dimension re-probe: every registered TEXT_EMBEDDING
  provider failed; embedding generation stays disabled (memory writes persist
  without vectors) (attempts=[{"provider":"local","error":"EMBEDDING_PROVIDER=
  local but no on-device embedding handler is registered"}])
  Embedding generation is disabled ... recall over new memories is degraded
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in embedding-provider resolution.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic provider-resolution change; no model inference participates in the decision being fixed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - the resolution harness at this head.

<details><summary>Results at ae19bf287367f767a06303f86bf430fdb1e4b9d3</summary>

```text
embedding-resolution harness: 8/8 green
  operator-explicit config + local policy    -> operator endpoint wins,
                                                dimension probe passes
  no explicit config                          -> local-first unchanged
  ELIZA_DISABLE_LOCAL_EMBEDDINGS=1            -> unchanged behavior
  skip-plugins deployment w/ remote endpoint  -> generation stays ENABLED
typecheck + biome on touched files: clean
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
