### PR TITLE
fix(core): habit asks reach a real scheduler; page-delegate dead-ends stop retrying

### DIFF
--- a/packages/agent/src/actions/page-action-groups.test.ts
+++ b/packages/agent/src/actions/page-action-groups.test.ts
@@ -1,7 +1,8 @@
 /**
- * PAGE_DELEGATE boundary tests for canonical child dispatch. The runtime stand-in
- * uses a real Action shape so alias repair exercises the same context, simile,
- * discriminator, and parameter contracts as production without a model.
+ * PAGE_DELEGATE boundary tests for canonical child dispatch and the structured
+ * non-retryable child-unavailable failure. The runtime stand-in uses a real
+ * Action shape so alias repair and failure listing exercise the same context,
+ * simile, discriminator, and parameter contracts as production without a model.
  */
 import type {
   Action,
@@ -143,5 +144,132 @@ describe("PAGE_DELEGATE workflow alias repair", () => {
     expect(pageDelegateAction.routingHint).toContain(
       "never wrap them in PAGE_DELEGATE",
     );
+  });
+});
+
+function makeChildAction(
+  overrides: Partial<Action> & { name: string },
+): Action {
+  return {
+    description: `${overrides.name} test child action.`,
+    contexts: ["tasks"],
+    validate: async () => true,
+    handler: async (): Promise<ActionResult> => ({
+      success: true,
+      text: "ok",
+    }),
+    ...overrides,
+  } as Action;
+}
+
+async function invokeOnPage(
+  runtime: IAgentRuntime,
+  page: string,
+  action: string,
+): Promise<ActionResult> {
+  const result = await pageDelegateAction.handler(
+    runtime,
+    makeMessage(),
+    undefined,
+    { parameters: { page, action } } as HandlerOptions,
+  );
+  if (!result) throw new Error("PAGE_DELEGATE returned no result");
+  return result;
+}
+
+describe("PAGE_DELEGATE structured child-unavailable failure", () => {
+  it("returns a non-retryable PAGE_CHILD_UNAVAILABLE failure listing the page's real actions", async () => {
+    const runtime = {
+      actions: [
+        pageDelegateAction,
+        makeChildAction({ name: "OWNER_REMINDERS", contexts: ["tasks"] }),
+        makeChildAction({ name: "OWNER_ROUTINES", contexts: ["tasks"] }),
+        // Not on the owner page's context set — must NOT be listed.
+        makeChildAction({ name: "BROWSER", contexts: ["browser"] }),
+      ],
+    } as IAgentRuntime;
+
+    const result = await invokeOnPage(runtime, "owner", "CREATE_HABIT");
+
+    expect(result.success).toBe(false);
+    expect(result.data).toEqual({
+      actionName: "PAGE_DELEGATE",
+      code: "PAGE_CHILD_UNAVAILABLE",
+      page: "owner",
+      requestedAction: "CREATE_HABIT",
+      availableActions: ["OWNER_REMINDERS", "OWNER_ROUTINES"],
+      retryable: false,
+    });
+    expect(result.text).toContain(
+      "CREATE_HABIT is not available on the owner page.",
+    );
+    expect(result.text).toContain(
+      "Actions available on the owner page: OWNER_REMINDERS, OWNER_ROUTINES.",
+    );
+    // The delegate parent never lists itself as a correction target.
+    expect(result.text).not.toContain("PAGE_DELEGATE,");
+  });
+
+  it("says explicitly when the deployment registers no child actions for the page", async () => {
+    const actions: Action[] = [pageDelegateAction];
+    const runtime = { actions } as IAgentRuntime;
+
+    const result = await invokeOnPage(runtime, "owner", "CREATE_HABIT");
+
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({
+      code: "PAGE_CHILD_UNAVAILABLE",
+      availableActions: [],
+      retryable: false,
+    });
+    expect(result.text).toContain(
+      "No child actions are registered for the owner page in this deployment.",
+    );
+  });
+
+  it("caps the listed actions at 40 and keeps the list sorted and deduplicated", async () => {
+    const children = Array.from({ length: 45 }, (_value, index) =>
+      makeChildAction({
+        name: `CHILD_${String(index).padStart(2, "0")}`,
+        contexts: ["tasks"],
+      }),
+    );
+    const runtime = {
+      actions: [pageDelegateAction, ...children],
+    } as IAgentRuntime;
+
+    const result = await invokeOnPage(runtime, "owner", "NOT_A_REAL_ACTION");
+
+    expect(result.success).toBe(false);
+    const availableActions = (result.data as { availableActions: string[] })
+      .availableActions;
+    expect(availableActions).toHaveLength(40);
+    expect(availableActions[0]).toBe("CHILD_00");
+    expect(availableActions[39]).toBe("CHILD_39");
+    expect([...availableActions].sort()).toEqual(availableActions);
+  });
+
+  it("returns a non-retryable PAGE_CHILD_VALIDATE_REJECTED failure when the child refuses", async () => {
+    const runtime = {
+      actions: [
+        pageDelegateAction,
+        makeChildAction({
+          name: "OWNER_REMINDERS",
+          contexts: ["tasks"],
+          validate: async () => false,
+        }),
+      ],
+    } as IAgentRuntime;
+
+    const result = await invokeOnPage(runtime, "owner", "OWNER_REMINDERS");
+
+    expect(result.success).toBe(false);
+    expect(result.data).toEqual({
+      actionName: "PAGE_DELEGATE",
+      code: "PAGE_CHILD_VALIDATE_REJECTED",
+      page: "owner",
+      requestedAction: "OWNER_REMINDERS",
+      retryable: false,
+    });
   });
 });

--- a/packages/agent/src/actions/page-action-groups.ts
+++ b/packages/agent/src/actions/page-action-groups.ts
@@ -165,6 +165,31 @@ function actionMatchesContexts(
   );
 }
 
+// Bounds the available-action listing embedded in the structured
+// child-unavailable failure so a wide page (owner spans nine contexts) cannot
+// flood the planner prompt.
+const MAX_LISTED_PAGE_CHILD_ACTIONS = 40;
+
+/**
+ * Names of the child actions actually registered for a page's context set.
+ * Fed back on a failed dispatch so the planner corrects to a real capability
+ * instead of blind-guessing further child names (observed live: CREATE_HABIT →
+ * CREATE_REMINDER → SET_HABIT, three dead iterations with zero information).
+ */
+function availablePageChildActionNames(
+  runtime: IAgentRuntime,
+  contexts: AgentContext[],
+): string[] {
+  const allowedContexts = new Set(contexts.map(normalizeContext));
+  const names = new Set<string>();
+  for (const action of runtime.actions) {
+    if (isPageDelegate(action)) continue;
+    if (!actionMatchesContexts(action, allowedContexts)) continue;
+    names.add(normalizeActionName(action.name));
+  }
+  return [...names].sort().slice(0, MAX_LISTED_PAGE_CHILD_ACTIONS);
+}
+
 function findChildAction(
   runtime: IAgentRuntime,
   actionName: string,
@@ -342,9 +367,29 @@ export const pageDelegateAction: PageActionGroup = {
       }
     }
     if (!childAction) {
+      // Structured, non-retryable failure: the same page+action combination
+      // cannot succeed later this turn (registration does not change
+      // mid-turn), and listing what IS registered turns the next planner
+      // iteration into a correction instead of another guess.
+      const availableActions = availablePageChildActionNames(
+        runtime,
+        childContexts,
+      );
       return {
         success: false,
-        text: `${requestedAction} is not available on the ${page} page.`,
+        text:
+          `${requestedAction} is not available on the ${page} page.` +
+          (availableActions.length > 0
+            ? ` Actions available on the ${page} page: ${availableActions.join(", ")}.`
+            : ` No child actions are registered for the ${page} page in this deployment.`),
+        data: {
+          actionName: "PAGE_DELEGATE",
+          code: "PAGE_CHILD_UNAVAILABLE",
+          page,
+          requestedAction,
+          availableActions,
+          retryable: false,
+        },
       };
     }
 
@@ -352,6 +397,13 @@ export const pageDelegateAction: PageActionGroup = {
       return {
         success: false,
         text: `${childAction.name} is not available for this request.`,
+        data: {
+          actionName: "PAGE_DELEGATE",
+          code: "PAGE_CHILD_VALIDATE_REJECTED",
+          page,
+          requestedAction: childAction.name,
+          retryable: false,
+        },
       };
     }
     if (aliasedDiscriminator) {

--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -611,6 +611,54 @@ describe("action catalogue and retrieval", () => {
 		}
 	});
 
+	// Habit/reminder-shaped invented names must hint the owner-life umbrella AND
+	// the TRIGGER scheduler, so deployments without plugin-personal-assistant
+	// keep the only real scheduled-work capability on the planner surface.
+	it("hints habit/routine candidates at OWNER_ROUTINES and TRIGGER", () => {
+		for (const candidate of [
+			"ADD_HABIT",
+			"CREATE_HABIT",
+			"CREATE_ROUTINE",
+			"DAILY_HABIT",
+			"HABIT_CREATE",
+			"NEW_HABIT",
+			"SAVE_HABIT",
+			"SET_HABIT",
+			"TRACK_HABIT",
+		]) {
+			expect(parentAliasesForCandidateAction(candidate)).toEqual([
+				"OWNER_ROUTINES",
+				"TRIGGER",
+			]);
+		}
+		// Lookup is keyed on the normalized UPPER_SNAKE form: camelCase and
+		// spaced/mixed-case emissions hit the same rows.
+		expect(parentAliasesForCandidateAction("setHabit")).toEqual([
+			"OWNER_ROUTINES",
+			"TRIGGER",
+		]);
+	});
+
+	it("hints reminder candidates at OWNER_REMINDERS and TRIGGER", () => {
+		for (const candidate of [
+			"ADD_REMINDER",
+			"CREATE_REMINDER",
+			"DAILY_REMINDER",
+			"NEW_REMINDER",
+			"RECURRING_REMINDER",
+			"REMINDER_CREATE",
+		]) {
+			expect(parentAliasesForCandidateAction(candidate)).toEqual([
+				"OWNER_REMINDERS",
+				"TRIGGER",
+			]);
+		}
+		expect(parentAliasesForCandidateAction("create reminder")).toEqual([
+			"OWNER_REMINDERS",
+			"TRIGGER",
+		]);
+	});
+
 	it("leaves non-permission candidates off the SETTINGS parent", () => {
 		// A bare person-scoped access revoke is BLOCK, not a settings write; view /
 		// app surface candidates keep their existing VIEWS/APP hints untouched.

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -17,6 +17,7 @@ import {
 	PROGRESS_ONLY_ANSWER_REJECT,
 	PROGRESS_ONLY_REPLY_OPENERS_PATTERN,
 	parsePlannerOutput,
+	partitionRedundantSucceededCalls,
 	runPlannerLoop,
 	TURN_SCOPE_ARG,
 	TURN_SCOPE_FINAL,
@@ -1587,6 +1588,156 @@ describe("v5 planner loop skeleton", () => {
 		expect(executeToolCall).toHaveBeenCalledTimes(1);
 		expect(result.status).toBe("finished");
 		expect(result.finalMessage).toContain("42");
+	});
+
+	it("does not re-execute an identical call that failed with retryable:false and forces a terminal synthesis", async () => {
+		// Live regression: PAGE_DELEGATE returned "CREATE_HABIT is not available
+		// on the owner page" and the planner re-issued the SAME page+action call
+		// on every iteration — a deterministic dead end (registration cannot
+		// change mid-turn). The structural `data.retryable === false` marker must
+		// settle the identity exactly like a success does.
+		const sameCall = {
+			id: "delegate-1",
+			name: "PAGE_DELEGATE",
+			arguments: { page: "owner", action: "CREATE_HABIT" },
+		};
+		const runtime = {
+			useModel: vi
+				.fn()
+				// iter 1 (fresh) → executes and fails non-retryably; iters 2-3
+				// repeat it → skipped dead rounds; then forced synthesis.
+				.mockResolvedValueOnce({ text: "", toolCalls: [sameCall] })
+				.mockResolvedValueOnce({ text: "", toolCalls: [sameCall] })
+				.mockResolvedValueOnce({ text: "", toolCalls: [sameCall] })
+				.mockResolvedValueOnce(
+					'{"thought":"That capability is unavailable.","messageToUser":"I cannot create habits here.","toolCalls":[]}',
+				),
+			logger: { debug: vi.fn(), warn: vi.fn() },
+		};
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: "CREATE_HABIT is not available on the owner page.",
+			data: {
+				actionName: "PAGE_DELEGATE",
+				code: "PAGE_CHILD_UNAVAILABLE",
+				retryable: false,
+			},
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "CONTINUE" as const,
+			thought: "Keep going.",
+		}));
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "PAGE_DELEGATE", description: "Delegate to a page." }],
+			config: { maxRepeatedToolCalls: 1 },
+			executeToolCall,
+			evaluate,
+		});
+
+		// The dead call ran exactly once; identical repeats were skipped, and the
+		// loop ended in synthesis instead of burning iterations to the token cap.
+		expect(executeToolCall).toHaveBeenCalledTimes(1);
+		expect(result.status).toBe("finished");
+		const instructions = (result.trajectory.context.events ?? [])
+			.filter((event) => event.type === "instruction")
+			.map((event) => event.content)
+			.join(" ");
+		expect(instructions).toContain("non-retryable");
+	});
+
+	it("re-executes an identical failed call when the failure is not marked non-retryable", async () => {
+		// Contrast case: an ordinary failure (no structural retryable:false) may
+		// be transient, so an identical retry is still allowed to run.
+		const sameCall = {
+			id: "fetch-1",
+			name: "WEB_FETCH",
+			arguments: { url: "https://api.example.test/price" },
+		};
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({ text: "", toolCalls: [sameCall] })
+				.mockResolvedValueOnce({ text: "", toolCalls: [sameCall] }),
+			logger: { debug: vi.fn(), warn: vi.fn() },
+		};
+		const executeToolCall = vi
+			.fn()
+			.mockResolvedValueOnce({ success: false, text: "upstream timeout" })
+			.mockResolvedValueOnce({ success: true, text: "price=42" });
+		const evaluate = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: true,
+				decision: "CONTINUE" as const,
+				thought: "Retry once.",
+			})
+			.mockResolvedValueOnce({
+				success: true,
+				decision: "FINISH" as const,
+				thought: "Done.",
+				messageToUser: "The price is 42.",
+			});
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "WEB_FETCH", description: "Fetch a URL." }],
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(executeToolCall).toHaveBeenCalledTimes(2);
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe("The price is 42.");
+	});
+
+	it("keeps settled call identities across mid-turn compaction into archivedSteps", () => {
+		// partitionRedundantSucceededCalls must scan archived (compacted) steps
+		// too: input-budget compaction moves steps out of `trajectory.steps`, and
+		// a call settled before compaction must not become executable again.
+		const archivedSuccess = {
+			name: "WEB_FETCH",
+			params: { url: "https://api.example.test/price" },
+		};
+		const archivedDeadEnd = {
+			name: "PAGE_DELEGATE",
+			params: { page: "owner", action: "CREATE_HABIT" },
+		};
+		const trajectory = {
+			context: { id: "ctx" },
+			steps: [],
+			archivedSteps: [
+				{
+					iteration: 1,
+					toolCall: archivedSuccess,
+					result: { success: true, text: "price=42" },
+				},
+				{
+					iteration: 2,
+					toolCall: archivedDeadEnd,
+					result: {
+						success: false,
+						text: "CREATE_HABIT is not available on the owner page.",
+						data: { retryable: false },
+					},
+				},
+			],
+			plannedQueue: [],
+			evaluatorOutputs: [],
+		};
+
+		const freshCall = { name: "WEB_FETCH", params: { url: "https://other" } };
+		const partitioned = partitionRedundantSucceededCalls(
+			[archivedSuccess, archivedDeadEnd, freshCall],
+			trajectory,
+		);
+		expect(partitioned.redundant).toEqual([archivedSuccess]);
+		expect(partitioned.nonRetryable).toEqual([archivedDeadEnd]);
+		expect(partitioned.fresh).toEqual([freshCall]);
 	});
 
 	it("does not capture native text fallback as a required-tool refusal", async () => {

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -179,7 +179,33 @@ const COMPRESS_MODE_TOP_K_CAP = 8;
 // arbitrate from the exposed descriptions (#9950).
 const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	ADD_GOAL: ["OWNER_GOALS"],
+	// Habit/reminder-shaped candidates hint BOTH the owner-life umbrella and the
+	// always-registered TRIGGER scheduler. Stage-1 routinely invents these names
+	// ("can u help me to brush my teeth everyday" → SET_HABIT), and on
+	// deployments without @elizaos/plugin-personal-assistant the OWNER_* similes
+	// resolve to nothing — the candidate narrow then demoted the retrieved
+	// TRIGGER_* actions off the planner surface entirely, leaving only
+	// PAGE_DELEGATE guesses ("CREATE_HABIT is not available on the owner page"
+	// x4, live trajectory tj-9e6b825e91d725). With the TRIGGER hint the only
+	// real scheduled-work capability stays exposed; on full deployments the
+	// owner umbrella is also kept and its de-claim description still routes new
+	// habits to OWNER_ROUTINES_CREATE (#10722).
+	ADD_HABIT: ["OWNER_ROUTINES", "TRIGGER"],
+	ADD_REMINDER: ["OWNER_REMINDERS", "TRIGGER"],
 	CONFIRM_GOAL: ["OWNER_GOALS"],
+	CREATE_HABIT: ["OWNER_ROUTINES", "TRIGGER"],
+	CREATE_REMINDER: ["OWNER_REMINDERS", "TRIGGER"],
+	CREATE_ROUTINE: ["OWNER_ROUTINES", "TRIGGER"],
+	DAILY_HABIT: ["OWNER_ROUTINES", "TRIGGER"],
+	DAILY_REMINDER: ["OWNER_REMINDERS", "TRIGGER"],
+	HABIT_CREATE: ["OWNER_ROUTINES", "TRIGGER"],
+	NEW_HABIT: ["OWNER_ROUTINES", "TRIGGER"],
+	NEW_REMINDER: ["OWNER_REMINDERS", "TRIGGER"],
+	RECURRING_REMINDER: ["OWNER_REMINDERS", "TRIGGER"],
+	REMINDER_CREATE: ["OWNER_REMINDERS", "TRIGGER"],
+	SAVE_HABIT: ["OWNER_ROUTINES", "TRIGGER"],
+	SET_HABIT: ["OWNER_ROUTINES", "TRIGGER"],
+	TRACK_HABIT: ["OWNER_ROUTINES", "TRIGGER"],
 	CROSS_CHANNEL_SEARCH: ["MESSAGE"],
 	CREATE_GOAL: ["OWNER_GOALS"],
 	CREATE_SAVINGS_PLAN: ["OWNER_GOALS"],

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3486,9 +3486,11 @@ function toolCallIdentity(toolCall: PlannerToolCall): string {
  * which either already SUCCEEDED — a repeat cannot return new information — or
  * already FAILED with the structural `data.retryable === false` marker — a
  * deterministic unavailability (e.g. PAGE_DELEGATE's PAGE_CHILD_UNAVAILABLE)
- * that cannot change within the turn. Neither kind is re-executed.
+ * that cannot change within the turn. Neither kind is re-executed. Archived
+ * (compacted) steps still count: mid-turn input-budget compaction moves steps
+ * to `archivedSteps`, and a settled call must stay settled across that move.
  */
-function partitionRedundantSucceededCalls(
+export function partitionRedundantSucceededCalls(
 	calls: PlannerToolCall[],
 	trajectory: PlannerTrajectory,
 ): {
@@ -3498,7 +3500,7 @@ function partitionRedundantSucceededCalls(
 } {
 	const succeeded = new Set<string>();
 	const failedNonRetryable = new Set<string>();
-	for (const step of trajectory.steps) {
+	for (const step of [...trajectory.archivedSteps, ...trajectory.steps]) {
 		if (!step.toolCall || !step.result) continue;
 		const identity = toolCallIdentity(step.toolCall);
 		if (step.result.success === true) {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -941,24 +941,46 @@ async function runPlannerLoopIterations(
 				}
 			}
 			// Loop-breaker: a non-terminal call that exactly repeats one already
-			// SUCCEEDED this turn (same name + args) cannot return new data. Execute
-			// only genuinely-fresh calls; when every call this iteration is such a
-			// repeat, count a dead round and — past `maxRepeatedToolCalls` — force a
-			// terminal synthesis instead of looping to the prompt-token budget.
-			const { fresh: validNonTerminalCalls, redundant: redundantCalls } =
-				partitionRedundantSucceededCalls(unavailable.valid, trajectory);
-			if (validNonTerminalCalls.length === 0 && redundantCalls.length > 0) {
+			// SUCCEEDED this turn (same name + args) cannot return new data, and one
+			// that already FAILED with the structural non-retryable marker cannot
+			// start succeeding mid-turn. Execute only genuinely-fresh calls; when
+			// every call this iteration is such a repeat, count a dead round and —
+			// past `maxRepeatedToolCalls` — force a terminal synthesis instead of
+			// looping to the prompt-token budget.
+			const {
+				fresh: validNonTerminalCalls,
+				redundant: redundantCalls,
+				nonRetryable: nonRetryableCalls,
+			} = partitionRedundantSucceededCalls(unavailable.valid, trajectory);
+			if (
+				validNonTerminalCalls.length === 0 &&
+				(redundantCalls.length > 0 || nonRetryableCalls.length > 0)
+			) {
 				repeatedNonTerminalToolCalls++;
+				const instructionParts: string[] = [];
+				if (redundantCalls.length > 0) {
+					instructionParts.push(
+						"You already have a successful result this turn for " +
+							`${redundantCalls.map((call) => call.name).join(", ")} with these ` +
+							"exact arguments. Re-running it cannot return new information.",
+					);
+				}
+				if (nonRetryableCalls.length > 0) {
+					instructionParts.push(
+						`${nonRetryableCalls.map((call) => call.name).join(", ")} already ` +
+							"failed this turn with these exact arguments and that failure is " +
+							"non-retryable — the identical call cannot succeed. Choose a " +
+							"different tool or different arguments.",
+					);
+				}
 				trajectory.context = appendContextEvent(trajectory.context, {
 					id: `redundant-tool-call:${iteration}`,
 					type: "instruction",
 					source: "planner-loop",
 					createdAt: Date.now(),
 					content:
-						"You already have a successful result this turn for " +
-						`${redundantCalls.map((call) => call.name).join(", ")} with these ` +
-						"exact arguments. Re-running it cannot return new information — " +
-						"answer the user now from the results already gathered.",
+						`${instructionParts.join(" ")} Answer the user now from the ` +
+						"results already gathered.",
 				});
 				if (repeatedNonTerminalToolCalls > config.maxRepeatedToolCalls) {
 					return finishWithForcedSynthesis({
@@ -972,10 +994,14 @@ async function runPlannerLoopIterations(
 				trajectory.plannedQueue.length = 0;
 				continue;
 			}
-			if (redundantCalls.length > 0) {
+			if (redundantCalls.length > 0 || nonRetryableCalls.length > 0) {
 				params.runtime.logger?.debug?.(
-					{ iteration, skipped: redundantCalls.map((call) => call.name) },
-					"Skipping tool calls that already succeeded with identical args this turn",
+					{
+						iteration,
+						skippedSucceeded: redundantCalls.map((call) => call.name),
+						skippedNonRetryable: nonRetryableCalls.map((call) => call.name),
+					},
+					"Skipping tool calls already settled with identical args this turn (succeeded or non-retryable failure)",
 				);
 			}
 			repeatedNonTerminalToolCalls = 0;
@@ -3456,27 +3482,41 @@ function toolCallIdentity(toolCall: PlannerToolCall): string {
 
 /**
  * Split a set of planned non-terminal calls into those that are genuinely new
- * this turn and those that exactly repeat a call which already SUCCEEDED (same
- * tool name + arguments). A repeat of a successful call cannot return new
- * information, so the loop should not re-execute it.
+ * this turn and those that exactly repeat a call (same tool name + arguments)
+ * which either already SUCCEEDED — a repeat cannot return new information — or
+ * already FAILED with the structural `data.retryable === false` marker — a
+ * deterministic unavailability (e.g. PAGE_DELEGATE's PAGE_CHILD_UNAVAILABLE)
+ * that cannot change within the turn. Neither kind is re-executed.
  */
 function partitionRedundantSucceededCalls(
 	calls: PlannerToolCall[],
 	trajectory: PlannerTrajectory,
-): { fresh: PlannerToolCall[]; redundant: PlannerToolCall[] } {
+): {
+	fresh: PlannerToolCall[];
+	redundant: PlannerToolCall[];
+	nonRetryable: PlannerToolCall[];
+} {
 	const succeeded = new Set<string>();
+	const failedNonRetryable = new Set<string>();
 	for (const step of trajectory.steps) {
-		if (step.toolCall && step.result?.success === true) {
-			succeeded.add(toolCallIdentity(step.toolCall));
+		if (!step.toolCall || !step.result) continue;
+		const identity = toolCallIdentity(step.toolCall);
+		if (step.result.success === true) {
+			succeeded.add(identity);
+		} else if (step.result.data?.retryable === false) {
+			failedNonRetryable.add(identity);
 		}
 	}
 	const fresh: PlannerToolCall[] = [];
 	const redundant: PlannerToolCall[] = [];
+	const nonRetryable: PlannerToolCall[] = [];
 	for (const call of calls) {
-		if (succeeded.has(toolCallIdentity(call))) redundant.push(call);
+		const identity = toolCallIdentity(call);
+		if (succeeded.has(identity)) redundant.push(call);
+		else if (failedNonRetryable.has(identity)) nonRetryable.push(call);
 		else fresh.push(call);
 	}
-	return { fresh, redundant };
+	return { fresh, redundant, nonRetryable };
 }
 
 /**


### PR DESCRIPTION
A live user asked their agent *"can u like help me to brush my teeth everyday"* and got, 31 seconds later: *"I tried to complete that, but the available runtime step failed before it produced a usable result."* The planner burned 5 iterations guessing capability names against pages that kept answering "not available", then created a garbage 12-hour trigger named from the security envelope. Three stacked defects, none prose-matchable, all structural:

## 1. Habit/reminder candidate names resolve to nothing

Stage-1 emits candidates like `SET_HABIT` / `CREATE_HABIT` / `CREATE_REMINDER`. Those are similes of `OWNER_ROUTINES`/`OWNER_REMINDERS` — but plugin-personal-assistant is `OPTIONAL_CORE_PLUGINS` and commonly not enabled, and none of these names appear in `CANDIDATE_ACTION_PARENT_ALIASES`. So the candidate matches nothing, and…

## 2. …the tiering demotes the only real scheduler

Retrieval **did** find `TRIGGER_CREATE` at 0.742 — the exact action that served every prior reminder on this deployment — but `action-tiering.ts` keeps only candidate-matched parents or score ≥ 0.97. With the candidate unresolvable, every TRIGGER_* was demoted and only `PAGE_DELEGATE` (keyword-vocabulary aggregate, score 1.0) and `TASKS` survived.

Fix: the habit/reminder candidate family (16 variants) joins `CANDIDATE_ACTION_PARENT_ALIASES`, hinting `OWNER_ROUTINES`/`OWNER_REMINDERS` **and** the always-registered `TRIGGER` — mirroring the existing OWNER_GOALS rows.

## 3. PAGE_DELEGATE dead-ends invited blind retries

`"X is not available on the owner page."` carried zero information and no structural marker, so the model guessed 4 name/page combos across 4 planner iterations. Fix: child-not-found returns a structured non-retryable failure (`data: {code: "PAGE_CHILD_UNAVAILABLE", page, requestedAction, availableActions[<=40], retryable: false}`), and the planner-loop's redundant-call partition now refuses to re-execute an identical call that already failed with the structural `retryable: false` marker — a distinct corrective instruction, no prose matching.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:f6e0290d869afe159b8493905857a4b77c474b52 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - planner routing and action-catalog change, no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing user-visible renders differently; the user-visible change is the reply content and latency.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend routing change with no on-screen user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the live failing turn this fixes, from its trajectory and InferenceTiming.

<details><summary>Live failing turn (before)</summary>

```text
user (api-webhook): "can u like help me to brush my teeth everyday"
turn total 31,379ms  ttreply 30,271ms
  model:ACTION_PLANNER x5 (10,639ms)  evaluators:planner x5 (7,584ms)
planner tool results across 5 iterations:
  "CREATE_HABIT is not available on the owner page."
  "CREATE_REMINDER is not available on the owner page."
  "SET_HABIT is not available on the owner page."
  "CREATE_HABIT is not available on the automation page."
final reply: "I tried to complete that, but the available runtime step
             failed before it produced a usable result."
side effect: garbage recurring trigger created (name from the security
             envelope, every 43,200,000ms) — since deleted via API
contrast (older build, same deployment): "take vitamins" ask -> Stage-1
  candidates OWNER_REMINDERS, TRIGGER -> TRIGGER_CREATE exact 1.0 -> worked
retrieval evidence this turn: TRIGGER_CREATE found at 0.742, demoted by
  the candidate-narrow (threshold 0.97)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in planner routing.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory - [native trajectory JSON of the live failing turn](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/17884-trajectory-trimmed.json) (tj-9e6b825e91d725, long string fields trimmed to fit the 2MB verification limit; full stage-1 output, retrieval scores, all 5 planner iterations with tool calls and results, terminal reply).

<details><summary>tj-9e6b825e91d725 - planner iterations (live model, provider=openai/cerebras)</summary>

```text
turn: message-turn  total=31,379ms  ttft=5,774ms  ttreply=30,271ms
stage-1 (RESPONSE_HANDLER): candidates emitted CREATE_TASK, SET_HABIT, VIEWS
retrieval: TRIGGER_CREATE scored 0.742 (demoted by candidate-narrow, threshold 0.97)
planner surface survivors: PAGE_DELEGATE (keyword 1.0), TASKS

iter 1  ACTION_PLANNER 3,681ms -> PAGE_DELEGATE(owner, CREATE_HABIT)
        tool result: "CREATE_HABIT is not available on the owner page."
iter 2  ACTION_PLANNER 1,868ms -> PAGE_DELEGATE(owner, CREATE_REMINDER)
        tool result: "CREATE_REMINDER is not available on the owner page."
iter 3  ACTION_PLANNER 1,951ms -> PAGE_DELEGATE(owner, SET_HABIT)
        tool result: "SET_HABIT is not available on the owner page."
iter 4  ACTION_PLANNER 1,287ms -> PAGE_DELEGATE(automation, CREATE_HABIT)
        tool result: "CREATE_HABIT is not available on the automation page."
iter 5  ACTION_PLANNER 1,852ms -> terminal
final reply: "I tried to complete that, but the available runtime step
             failed before it produced a usable result."
side effect: recurring trigger created with envelope-derived name (deleted)
```

</details>

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - targeted suites at this head.

<details><summary>Results at 583bd913d692d6d4d4d16c613d2bc5a96775c517</summary>

```text
63 targeted unit tests pass across:
  action-retrieval (alias resolution incl. the 16 new candidate names)
  action-tiering   (TRIGGER survives the narrow with a habit candidate)
  planner-loop     (retryable:false calls are not re-executed; corrective
                    instruction distinct from the redundant-call one)
  page-action-groups (structured PAGE_CHILD_UNAVAILABLE with
                    availableActions listing; validate-reject non-retryable)
typecheck: core + agent clean
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

