### PR TITLE
fix(app-core): materialize lockfile-pinned type packages, not newest cached

### DIFF
--- a/packages/app-core/scripts/ensure-type-package-aliases.mjs
+++ b/packages/app-core/scripts/ensure-type-package-aliases.mjs
@@ -137,28 +137,91 @@ function collectBrokenBundledTypePackages() {
   return [...packageNames].sort();
 }
 
-function findCachedTypePackageDir(packageName) {
-  return findCachedPackageDir(GLOBAL_TYPES_CACHE_DIR, packageName);
+const LOCKFILE_PIN_CACHE = new Map();
+
+/**
+ * Reads the resolved version each root-level package pins in a bun.lock.
+ * bun.lock is JSONC (trailing commas), so scan resolution entries of the
+ * form `"<name>": ["<name>@<version>", ...]` textually instead of JSON.parse.
+ * Nested resolutions are keyed `"<parent>/<name>"` and fail the back-reference,
+ * so only the root resolution for each package matches.
+ */
+export function readLockfilePinnedVersions(lockfilePath) {
+  const pins = new Map();
+  if (!existsSync(lockfilePath)) {
+    return pins;
+  }
+  const lockText = readFileSync(lockfilePath, "utf8");
+  const entryPattern = /"((?:@[^/"]+\/)?[^/"]+)": \["\1@([^"]+)"/g;
+  for (const match of lockText.matchAll(entryPattern)) {
+    if (!pins.has(match[1])) {
+      pins.set(match[1], match[2]);
+    }
+  }
+  return pins;
 }
 
-function findCachedPackageDir(cacheDir, packageName) {
+function lockfilePinsFor(nodeModulesDir) {
+  const lockfilePath = path.join(path.dirname(nodeModulesDir), "bun.lock");
+  if (!LOCKFILE_PIN_CACHE.has(lockfilePath)) {
+    LOCKFILE_PIN_CACHE.set(
+      lockfilePath,
+      readLockfilePinnedVersions(lockfilePath),
+    );
+  }
+  return LOCKFILE_PIN_CACHE.get(lockfilePath);
+}
+
+function findCachedTypePackageDir(packageName, pinnedVersion) {
+  return findCachedPackageDir(
+    GLOBAL_TYPES_CACHE_DIR,
+    packageName,
+    pinnedVersion,
+  );
+}
+
+export function findCachedPackageDir(cacheDir, packageName, pinnedVersion) {
   if (!existsSync(cacheDir)) {
     return null;
   }
 
   const prefix = `${packageName}@`;
-  const matches = readdirSync(cacheDir)
-    .filter((entry) => entry.startsWith(prefix))
-    .sort((a, b) =>
-      b.localeCompare(a, undefined, {
-        numeric: true,
-        sensitivity: "base",
-      }),
-    );
+  const matches = readdirSync(cacheDir).filter((entry) =>
+    entry.startsWith(prefix),
+  );
 
   if (matches.length === 0) {
     return null;
   }
+
+  // The machine-global cache accumulates every version any checkout on the
+  // host ever resolved, so "newest cached" can be newer than what this
+  // checkout's lockfile pins. Materializing that newer copy over the
+  // installed pin is how typechecking drifts from `bun install
+  // --frozen-lockfile` (a cached @types/node@26.x once broke every
+  // packages/core build on runners whose lockfile pinned 25.x). Prefer the
+  // pinned version; if it is not cached, keep the installed copy rather than
+  // stomp it with a mismatched one.
+  if (pinnedVersion) {
+    const pinnedEntry = `${prefix}${pinnedVersion}`;
+    const pinned = matches.find(
+      (entry) => entry === pinnedEntry || entry.startsWith(`${pinnedEntry}@`),
+    );
+    if (pinned) {
+      return path.join(cacheDir, pinned);
+    }
+    console.warn(
+      `[ensure-type-package-aliases] ${packageName}@${pinnedVersion} is pinned by bun.lock but not in the bun cache; keeping the installed copy`,
+    );
+    return null;
+  }
+
+  matches.sort((a, b) =>
+    b.localeCompare(a, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    }),
+  );
 
   return path.join(cacheDir, matches[0]);
 }
@@ -233,7 +296,11 @@ function removeExistingTypeEntry(targetPath) {
 }
 
 function materializeTypePackage(targetTypesDir, packageName) {
-  const sourceDir = findCachedTypePackageDir(packageName);
+  const pins = lockfilePinsFor(path.dirname(targetTypesDir));
+  const sourceDir = findCachedTypePackageDir(
+    packageName,
+    pins.get(`@types/${packageName}`),
+  );
   if (!sourceDir) {
     return false;
   }
@@ -250,7 +317,11 @@ function materializeTypePackage(targetTypesDir, packageName) {
 }
 
 function materializePackage(targetNodeModulesDir, packageName) {
-  const sourceDir = findCachedPackageDir(GLOBAL_PACKAGE_CACHE_DIR, packageName);
+  const sourceDir = findCachedPackageDir(
+    GLOBAL_PACKAGE_CACHE_DIR,
+    packageName,
+    lockfilePinsFor(targetNodeModulesDir).get(packageName),
+  );
   if (!sourceDir || !existsSync(targetNodeModulesDir)) {
     return false;
   }

--- a/packages/app-core/scripts/ensure-type-package-aliases.test.mjs
+++ b/packages/app-core/scripts/ensure-type-package-aliases.test.mjs
@@ -1,0 +1,110 @@
+/**
+ * Locks the lockfile-pin contract of the type-package materializer: the bun
+ * cache is machine-global and accumulates versions from every checkout on the
+ * host, so cache selection must prefer the bun.lock-pinned version and never
+ * stomp a correctly installed pin with a newer cached copy (a cached
+ * @types/node@26.x once broke every packages/core build whose lockfile pinned
+ * 25.x). Deterministic filesystem fixtures; no network, no real bun cache.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  findCachedPackageDir,
+  readLockfilePinnedVersions,
+} from "./ensure-type-package-aliases.mjs";
+
+const cleanups = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    rmSync(cleanups.pop(), { recursive: true, force: true });
+  }
+});
+
+function makeFixtureDir() {
+  const dir = mkdtempSync(path.join(tmpdir(), "type-aliases-test-"));
+  cleanups.push(dir);
+  return dir;
+}
+
+function makeCacheDir(entries) {
+  const dir = makeFixtureDir();
+  for (const entry of entries) {
+    mkdirSync(path.join(dir, entry), { recursive: true });
+  }
+  return dir;
+}
+
+describe("readLockfilePinnedVersions", () => {
+  it("reads root resolutions and ignores nested per-parent resolutions", () => {
+    const dir = makeFixtureDir();
+    const lockfilePath = path.join(dir, "bun.lock");
+    // Shape copied from a real bun.lock packages section (JSONC, trailing
+    // commas): root entries key the bare name; nested entries key
+    // "<parent>/<name>" and must not win over the root pin.
+    writeFileSync(
+      lockfilePath,
+      [
+        "{",
+        '  "packages": {',
+        '    "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-root"],',
+        '    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bun"],',
+        '    "some-parent/@types/node": ["@types/node@26.1.1", "", {}, "sha512-nested"],',
+        "  },",
+        "}",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const pins = readLockfilePinnedVersions(lockfilePath);
+    expect(pins.get("@types/node")).toBe("25.6.2");
+    expect(pins.get("bun-types")).toBe("1.3.14");
+    expect(pins.has("some-parent/@types/node")).toBe(false);
+  });
+
+  it("returns no pins when the lockfile does not exist", () => {
+    const pins = readLockfilePinnedVersions(
+      path.join(makeFixtureDir(), "missing", "bun.lock"),
+    );
+    expect(pins.size).toBe(0);
+  });
+});
+
+describe("findCachedPackageDir", () => {
+  it("prefers the pinned version over a numerically newer cache entry", () => {
+    const cacheDir = makeCacheDir(["node@25.6.2", "node@26.1.1"]);
+    expect(findCachedPackageDir(cacheDir, "node", "25.6.2")).toBe(
+      path.join(cacheDir, "node@25.6.2"),
+    );
+  });
+
+  it("matches pinned cache entries that carry a registry suffix", () => {
+    const cacheDir = makeCacheDir([
+      "node@25.6.2@@registry.npmjs.org",
+      "node@26.1.1",
+    ]);
+    expect(findCachedPackageDir(cacheDir, "node", "25.6.2")).toBe(
+      path.join(cacheDir, "node@25.6.2@@registry.npmjs.org"),
+    );
+  });
+
+  it("keeps the installed copy (null) when the pin is not cached", () => {
+    const cacheDir = makeCacheDir(["node@26.1.1"]);
+    expect(findCachedPackageDir(cacheDir, "node", "25.6.2")).toBeNull();
+  });
+
+  it("falls back to the newest cache entry when nothing is pinned", () => {
+    const cacheDir = makeCacheDir(["node@25.6.2", "node@26.1.1"]);
+    expect(findCachedPackageDir(cacheDir, "node", undefined)).toBe(
+      path.join(cacheDir, "node@26.1.1"),
+    );
+  });
+
+  it("does not confuse a package prefix with a longer package name", () => {
+    const cacheDir = makeCacheDir(["node-fetch@2.7.0"]);
+    expect(findCachedPackageDir(cacheDir, "node", undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Every agent-image build on develop and main is red tonight with the same error (4 workflow dispatches + 6 push builds, e.g. runs 31142129542, 31138063488, 31136084812, 31135884682):

```text
@elizaos/core:build: src/security/kms/local-adapter.ts(201,38): error TS2345:
  Argument of type 'KeyObject' is not assignable to parameter of type
  'BinaryLike | JsonWebKeyInput | PublicKeyInput | RawPublicKeyInput'.
@elizaos/core:build: src/security/kms/local-adapter.ts(216,37): error TS2345: (same)
```

The adapter code is NOT wrong. Both `createPublicKey(privateKey)` call sites are valid under the lockfile-pinned `@types/node@25.6.2` (`createPublicKey(key: PublicKeyInput | string | Buffer | KeyObject | JsonWebKeyInput)`) and under today's latest `@types/node@26.1.2` (`... | KeyLike` where `KeyLike = BinaryLike | KeyObject`). The rejected union only exists in intermediate `@types/node` releases (e.g. 26.1.1) that dropped bare `KeyObject` from the signature.

## Root cause

`packages/app-core/scripts/ensure-type-package-aliases.mjs` — the "Apply postinstall patches" step of `build-agent-image.yml` — materializes `@types/*` copies from the machine-global bun cache by picking the **numerically newest** cache entry (`findCachedPackageDir` sorts descending), not the version bun.lock pins.

The failing run's own log shows the sequence (run 31142129542):

1. `bun install --frozen-lockfile` installs the pinned `@types/node@25.6.2` (log line: `+ @types/node@25.6.2`);
2. `node packages/app-core/scripts/ensure-type-package-aliases.mjs` replaces `node_modules/@types/node` with the newest `node@*` entry in `~/.bun/install/cache/@types/` — on the self-hosted runners that shared cache now holds a `@types/node@26.1.x` pulled by some other checkout, so the pinned install is stomped with a version whose `createPublicKey` rejects `KeyObject`;
3. `@elizaos/core` `tsc` fails at local-adapter.ts:201,216.

The correlation with #17859 is cache-key rotation, not code: the merge changed `bun.lock`, so the `bun-…-${hashFiles('bun.lock')}` cache key missed and the prefix restore-key pulled a sibling cache carrying the newer `@types/node`. Nothing in the merge touched the KMS adapter or type pins.

## Fix

Structural, in the materializer itself — builds must be hermetic with respect to the shared cache:

- `readLockfilePinnedVersions(lockfilePath)`: textual scan of bun.lock (it is JSONC) for root resolutions `"<name>": ["<name>@<version>", ...]`; nested `"<parent>/<name>"` resolutions fail the back-reference and are ignored.
- `findCachedPackageDir(cacheDir, packageName, pinnedVersion)`: prefer the cache entry matching the pin (exact or with a registry suffix). If the pin is not cached, **keep the installed copy** (return null + warn) instead of stomping it with a mismatched version. Nothing-pinned falls back to the previous newest-first behavior.
- Pins resolve against the bun.lock adjacent to each materialization root, so the nested `eliza/` tree keeps its own lockfile authority.

No change to `local-adapter.ts` — rewriting valid crypto call sites to appease a types version the lockfile does not pin would mask the non-hermetic build.

## Tests

- New `packages/app-core/scripts/ensure-type-package-aliases.test.mjs` (vitest, 7 tests): root-pin parsing ignores nested resolutions; pinned-over-newer selection (the exact `25.6.2` vs `26.1.1` regression); registry-suffixed cache entries; pin-not-cached keeps the installed copy; no-pin newest-first fallback preserved; package-name prefix confusion guard.
- Local end-to-end reproduction and fix proof under Domain artifacts below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:37d4957f94b69ae963a4c62ba3d966d2fae06bcc -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI/build-tooling change; no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - nothing renders; the change is which @types package version a postinstall step copies.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no on-screen user flow; the observable behavior is a CI build turning green.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - the failing workflow runs and the exact error, from the runs' own logs.

<details><summary>Failing build-agent-image runs (before this change)</summary>

```text
Failing Build Agent Image runs on develop (2026-08-06/07), all the same error:
  31142129542  push      perf(core): alias security-envelope rewrites...   failure
  31138063488  push      fix(local-inference): refresh fused embedding...  failure
  31136084812  dispatch  Build Agent Image                                 failure
  31135884682  push      fix(core): align private voice with direct...     failure
  31135108606  dispatch  Build Agent Image                                 failure
  31135010943  dispatch  Build Agent Image                                 failure

Run 31142129542, step "Install dependencies":
  bun install --frozen-lockfile
  + @types/node@25.6.2            <- the pinned version IS installed

Step "Apply postinstall patches":
  node packages/app-core/scripts/ensure-type-package-aliases.mjs
  [ensure-type-package-aliases] materialized 24 @types package copies, ...

Step "Build Docker workspace artifacts":
  @elizaos/core:build: src/security/kms/local-adapter.ts(201,38): error TS2345:
    Argument of type 'KeyObject' is not assignable to parameter of type
    'BinaryLike | JsonWebKeyInput | PublicKeyInput | RawPublicKeyInput'.
    Type 'KeyObject' is missing the following properties from type
    'RawPublicKeyInput': key, format
  @elizaos/core:build: src/security/kms/local-adapter.ts(216,37): error TS2345: (same)
  @elizaos/core#build: ERROR  command ... bun run build exited (1)

Signature census (npm tarballs, function createPublicKey):
  @types/node@25.6.2 (pinned): key: PublicKeyInput | string | Buffer | KeyObject | JsonWebKeyInput   -> accepts KeyObject
  @types/node@26.1.1:          key: PublicKeyInput | RawPublicKeyInput | JsonWebKeyInput | BinaryLike -> REJECTS KeyObject (matches CI error)
  @types/node@26.1.2 (latest): key: PublicKeyInput | RawPublicKeyInput | JsonWebKeyInput | KeyLike    -> accepts KeyObject again
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the agent-image build.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model prompt, response, or runtime behavior changes; this is a build-tooling version-selection fix.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - deterministic local reproduction of the CI failure and proof of the fix.

<details><summary>Local reproduction and fix proof (fresh worktree of develop @ bf3b7d8e464)</summary>

```text
Setup: bun install --frozen-lockfile -> "Checked 3464 installs ... (no changes)";
node_modules/@types/node = 25.6.2. Seeded a controlled bun cache shaped like the poisoned
runner cache: @types/{node@25.6.2, node@26.1.1}.

REPRODUCE (script at develop HEAD, unmodified):
  $ HOME=<seeded-cache-home> node packages/app-core/scripts/ensure-type-package-aliases.mjs
  [ensure-type-package-aliases] materialized 2 @types package copies, ...
  node_modules/@types/node/package.json -> "version": "26.1.1"     (STOMPED)
  $ bun run --cwd packages/core typecheck
  src/security/kms/local-adapter.ts:201:38 - error TS2345: Argument of type
    'KeyObject' is not assignable to parameter of type
    'JsonWebKeyInput | PublicKeyInput | RawPublicKeyInput | BinaryLike'.
  src/security/kms/local-adapter.ts:216:37 - error TS2345: (same)
  Found 2 errors in the same file  <- byte-for-byte the CI failure

FIX APPLIED (this PR), same poisoned state, same fixture cache:
  $ HOME=<seeded-cache-home> node packages/app-core/scripts/ensure-type-package-aliases.mjs
  node_modules/@types/node/package.json -> "version": "25.6.2"     (pin restored)
  $ bun run --cwd packages/core typecheck                          -> clean, exit 0
  $ node ../scripts/run-vitest.mjs run src/security/kms/           -> 7 files, 51/51 passed
  $ node ../scripts/run-vitest.mjs run --config vitest.config.ts \
      scripts/ensure-type-package-aliases.test.mjs                 -> 7/7 passed
  $ NODE_ENV=production node packages/scripts/run-turbo.mjs run build \
      --concurrency=8 --filter=@elizaos/core   (the image workflow's build step,
      filtered to the failing package)          -> Tasks: 3 successful, 3 total
  $ biome check (both changed files)            -> clean
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
