### PR TITLE
fix(cloud): normalize Twilio WhatsApp gateway identities

### DIFF
--- a/packages/cloud/services/gateway-webhook/src/adapters/twilio.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/twilio.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Exercises Twilio webhook normalization and outbound channel addressing with
+ * deterministic SMS and WhatsApp payloads while mocking the Twilio REST edge.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { twilioAdapter } from "./twilio";
+import type { ChatEvent, WebhookConfig } from "./types";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  mock.restore();
+});
+
+describe("Twilio adapter channel addressing", () => {
+  test("normalizes a WhatsApp sender for phone identity resolution", async () => {
+    const rawBody = new URLSearchParams({
+      MessageSid: "SM_whatsapp_inbound",
+      AccountSid: "AC_test",
+      From: "whatsapp:+15551234567",
+      To: "whatsapp:+14155238886",
+      Body: "hello from WhatsApp",
+      ProfileName: "Ada",
+      WaId: "15551234567",
+    }).toString();
+
+    const event = await twilioAdapter.extractEvent(rawBody);
+
+    expect(event).toMatchObject({
+      platform: "twilio",
+      messageId: "SM_whatsapp_inbound",
+      chatId: "whatsapp:+15551234567",
+      senderId: "+15551234567",
+      senderName: "Ada",
+      text: "hello from WhatsApp",
+    });
+  });
+
+  test("restores the WhatsApp prefix when replying through a WhatsApp sender", async () => {
+    let requestBody: URLSearchParams | undefined;
+    globalThis.fetch = mock(async (_input, init) => {
+      requestBody = new URLSearchParams(String(init?.body));
+      return Response.json({ sid: "SM_whatsapp_reply" });
+    }) as unknown as typeof fetch;
+
+    const config: WebhookConfig = {
+      accountSid: "AC_test",
+      authToken: "twilio-secret",
+      phoneNumber: "whatsapp:+14155238886",
+    };
+    const event: ChatEvent = {
+      platform: "twilio",
+      messageId: "SM_whatsapp_inbound",
+      chatId: "whatsapp:+15551234567",
+      senderId: "+15551234567",
+      text: "hello from WhatsApp",
+      rawPayload: {},
+    };
+
+    await twilioAdapter.sendReply(config, event, "hello from Eliza");
+
+    expect(requestBody?.get("To")).toBe("whatsapp:+15551234567");
+    expect(requestBody?.get("From")).toBe("whatsapp:+14155238886");
+    expect(requestBody?.get("Body")).toBe("hello from Eliza");
+  });
+
+  test("keeps SMS sender identities and reply addresses unchanged", async () => {
+    const rawBody = new URLSearchParams({
+      MessageSid: "SM_sms_inbound",
+      AccountSid: "AC_test",
+      From: "+15551234567",
+      To: "+15550000000",
+      Body: "hello from SMS",
+    }).toString();
+    const event = await twilioAdapter.extractEvent(rawBody);
+    expect(event?.senderId).toBe("+15551234567");
+    if (!event) throw new Error("Expected a valid SMS event");
+
+    let requestBody: URLSearchParams | undefined;
+    globalThis.fetch = mock(async (_input, init) => {
+      requestBody = new URLSearchParams(String(init?.body));
+      return Response.json({ sid: "SM_sms_reply" });
+    }) as unknown as typeof fetch;
+
+    await twilioAdapter.sendReply(
+      {
+        accountSid: "AC_test",
+        authToken: "twilio-secret",
+        phoneNumber: "+15550000000",
+      },
+      event,
+      "hello from Eliza",
+    );
+
+    expect(requestBody?.get("To")).toBe("+15551234567");
+    expect(requestBody?.get("From")).toBe("+15550000000");
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/adapters/twilio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/twilio.ts
@@ -33,6 +33,7 @@ const TwilioWebhookEventSchema = z
     From: z.string().min(1),
     To: z.string().min(1),
     Body: z.string().optional(),
+    ProfileName: z.string().optional(),
     NumMedia: z.string().optional(),
     MediaUrl0: z.string().optional(),
     MediaUrl1: z.string().optional(),
@@ -43,6 +44,23 @@ const TwilioWebhookEventSchema = z
 type TwilioEvent = z.infer<typeof TwilioWebhookEventSchema>;
 
 const ALLOWED_MEDIA_DOMAINS = ["api.twilio.com", "media.twiliocdn.com"];
+const WHATSAPP_ADDRESS_PREFIX = "whatsapp:";
+
+function normalizeSenderIdentity(address: string): string {
+  return address.toLowerCase().startsWith(WHATSAPP_ADDRESS_PREFIX)
+    ? address.slice(WHATSAPP_ADDRESS_PREFIX.length)
+    : address;
+}
+
+function replyAddress(senderId: string, fromAddress: string): string {
+  if (
+    fromAddress.toLowerCase().startsWith(WHATSAPP_ADDRESS_PREFIX) &&
+    !senderId.toLowerCase().startsWith(WHATSAPP_ADDRESS_PREFIX)
+  ) {
+    return `${WHATSAPP_ADDRESS_PREFIX}${senderId}`;
+  }
+  return senderId;
+}
 
 function isValidMediaUrl(url: string): boolean {
   try {
@@ -186,7 +204,8 @@ export const twilioAdapter: PlatformAdapter = {
       platform: "twilio",
       messageId: event.MessageSid,
       chatId: event.From,
-      senderId: event.From,
+      senderId: normalizeSenderIdentity(event.From),
+      senderName: event.ProfileName,
       text:
         mediaUrls.length > 0 && !text
           ? `[media: ${mediaUrls.join(", ")}]`
@@ -211,7 +230,7 @@ export const twilioAdapter: PlatformAdapter = {
     ).toString("base64");
 
     const body = new URLSearchParams({
-      To: event.senderId,
+      To: replyAddress(event.senderId, config.phoneNumber),
       From: config.phoneNumber,
       Body: text,
     });


### PR DESCRIPTION
# Relates to

Refs #17344

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the transport contract from the focused adapter tests and repository verification below. Live production evidence remains intentionally pending deployment.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@403dd7a7eb253000fe89be7319e0425c3bf33b6e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. The change is isolated to Twilio webhook address normalization. SMS addresses remain byte-for-byte unchanged. The added channel-aware reply logic only adds `whatsapp:` when the configured Twilio sender is itself a WhatsApp address.

# Background

## What does this PR do?

Twilio sends WhatsApp identities as `whatsapp:+E164`, while Cloud's trusted phone identity links are stored and resolved as plain E.164 values. The adapter previously forwarded the prefixed value as `senderId`, so a correctly linked WhatsApp user could not resolve to their Eliza Cloud account or assigned agent.

This PR:

- strips the case-insensitive `whatsapp:` transport prefix from inbound `senderId` before Cloud identity resolution;
- preserves the raw prefixed address in `chatId`;
- carries Twilio's `ProfileName` as `senderName`;
- restores `whatsapp:` on outbound `To` only when replying from a configured WhatsApp sender; and
- proves ordinary SMS behavior remains unchanged.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is required. This corrects an internal adapter boundary to match the existing trusted-phone identity contract.

# Testing

## Where should a reviewer start?

Review `packages/cloud/services/gateway-webhook/src/adapters/twilio.ts`, then run the new deterministic adapter contract tests in `twilio.test.ts`.

## Detailed testing steps

1. `bun test packages/cloud/services/gateway-webhook/src/adapters/twilio.test.ts`
2. `bun run --cwd packages/cloud/services/gateway-webhook test`
3. `bun run --cwd packages/cloud/services/gateway-webhook typecheck`
4. `bun run --cwd packages/cloud/services/gateway-webhook lint`
5. `bun run --cwd packages/cloud/services/gateway-webhook build`
6. `bun run verify`

Observed results:

- Gateway webhook: 56 tests passed, 0 failed, 123 assertions.
- Package typecheck, lint, and build passed.
- Repository verify: 343 tasks passed, 0 failed; subsequent audit gates passed.

# Evidence Gate

<!-- evidence-head:644f3be16028a1785dc25e5dfc2d39610c007db2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this PR changes a server-side transport adapter only.
<!-- evidence-row:backend-logs -->
- [x] N/A - the corrected revision is not deployed; claiming live production logs before deployment would be false. Deterministic request-body assertions cover inbound and outbound adapter boundaries.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, or state change is affected.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or planner behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this changes transport identity normalization only and produces no separate domain artifact; the executable contract is covered by the backend test transcript above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

Backend live logs: N/A - requires deployment of this exact revision; production verification is deliberately not fabricated.

Frontend logs: N/A - no frontend code path changes.

## Screenshots (before / after) + video walkthrough

N/A - no UI or native surface changes.
