### PR TITLE
feat(ui): stale-token recovery, remote-agent pairing gate, vite-dev-shell detection

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -109,6 +109,7 @@ import {
   NotificationsDataBoot,
   NotificationsShellBoot,
 } from "./components/shell/notifications-boot";
+import { PairingView } from "./components/shell/PairingView";
 import { ShellControllerProvider } from "./components/shell/ShellControllerContext";
 import { useShellControllerContext } from "./components/shell/ShellControllerContext.hooks";
 import { ShellOverlays } from "./components/shell/ShellOverlays";
@@ -175,6 +176,7 @@ import {
 import {
   authProbeShouldHoldShell,
   firstRunOwnsLoginSurface,
+  shouldShowRemoteAgentPairingGate,
   topLevelAuthGateOwnsSurface,
 } from "./state/top-level-auth-gate";
 import {
@@ -2703,6 +2705,19 @@ function AppContent() {
         return (
           <BugReportProvider value={bugReport}>
             <StartupScreen />
+            <BugReportModal />
+          </BugReportProvider>
+        );
+      }
+      if (
+        shouldShowRemoteAgentPairingGate({
+          reason: authState.reason,
+          access: authState.access,
+        })
+      ) {
+        return (
+          <BugReportProvider value={bugReport}>
+            <PairingView />
             <BugReportModal />
           </BugReportProvider>
         );

--- a/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
+++ b/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
@@ -10,6 +10,12 @@
 
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config-store";
+import {
+  createPersistedActiveServer,
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "../state/persistence";
 import {
   __resetAuthStatusForTests,
   __setAuthStatusForTests,
@@ -39,7 +45,9 @@ describe("primeAuthStatusProbe + activation reuse", () => {
 
   beforeEach(() => {
     localStorage.clear();
+    setBootConfig({ branding: {} });
     __resetAuthStatusForTests();
+    setBootConfig({ branding: {} });
     fetchMock = vi.fn();
     globalThis.fetch = fetchMock as unknown as typeof fetch;
   });
@@ -95,6 +103,50 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       }),
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes a rejected remote bearer before retrying the primed auth probe", async () => {
+    setBootConfig({
+      branding: {},
+      apiBase: "https://runtime.example.test",
+      apiToken: "stale-token",
+    });
+    savePersistedActiveServer(
+      createPersistedActiveServer({
+        kind: "remote",
+        apiBase: "https://runtime.example.test",
+        accessToken: "stale-token",
+      }),
+    );
+    const unauthorized = {
+      reason: "remote_auth_required",
+      access: {
+        mode: "remote",
+        passwordConfigured: true,
+        ownerConfigured: false,
+      },
+    };
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, unauthorized))
+      .mockResolvedValueOnce(jsonResponse(401, unauthorized));
+
+    await act(async () => {
+      primeAuthStatusProbe();
+    });
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({
+        phase: "unauthenticated",
+        reason: "remote_auth_required",
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    const retryHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
+    expect(firstHeaders.get("Authorization")).toBe("Bearer stale-token");
+    expect(retryHeaders.has("Authorization")).toBe(false);
+    expect(loadPersistedActiveServer()?.accessToken).toBeUndefined();
   });
 
   it("discards a mid-boot 503 prime and the activation fetch re-probes", async () => {

--- a/packages/ui/src/hooks/useAuthStatus.ts
+++ b/packages/ui/src/hooks/useAuthStatus.ts
@@ -23,6 +23,9 @@ import {
   type AuthSessionInfo,
   authMe,
 } from "../api/auth-client";
+import { getBootConfig, setBootConfig } from "../config/boot-config-store";
+import { scrubRejectedActiveServerCredential } from "../state/active-server-credential";
+import { loadPersistedActiveServer } from "../state/persistence";
 
 export type AuthStatusState =
   | { phase: "loading" }
@@ -83,6 +86,25 @@ function publishAuthStatus(state: AuthStatusState): void {
   }
 }
 
+async function authMeWithRejectedBearerRecovery() {
+  const result = await authMe();
+  if (result.ok || result.status !== 401 || result.access?.mode !== "remote") {
+    return result;
+  }
+
+  const apiToken = getBootConfig().apiToken?.trim();
+  const activeServer = loadPersistedActiveServer();
+  if (!apiToken || activeServer?.kind === "cloud") return result;
+
+  // A 401 makes this bearer definitively unusable for the selected non-cloud
+  // target. Remove it before the one retry so a valid cookie can win, or the
+  // server can return the unauthenticated pairing/password contract instead of
+  // seeing the same rejected Authorization header twice.
+  setBootConfig({ ...getBootConfig(), apiToken: undefined });
+  scrubRejectedActiveServerCredential(apiToken);
+  return authMe();
+}
+
 async function fetchAuthStatus(): Promise<void> {
   if (authStatusFetch) return authStatusFetch;
 
@@ -93,7 +115,7 @@ async function fetchAuthStatus(): Promise<void> {
 
   authStatusFetch = (async () => {
     for (let attempt = 0; ; attempt += 1) {
-      const result = await authMe();
+      const result = await authMeWithRejectedBearerRecovery();
       if (result.ok === true) {
         publishAuthStatus({
           phase: "authenticated",
@@ -152,7 +174,7 @@ export function primeAuthStatusProbe(): void {
   if (authStatusPrime || authStatusFetch) return;
   if (authStatusSnapshot.phase !== "loading") return;
   authStatusPrime = (async () => {
-    const result = await authMe();
+    const result = await authMeWithRejectedBearerRecovery();
     // A real fetch started (or a state was published) while the prime was in
     // flight — that path owns the snapshot; drop the primed result.
     if (authStatusFetch || authStatusSnapshot.phase !== "loading") return;

--- a/packages/ui/src/platform/vite-dev-ui-shell.test.ts
+++ b/packages/ui/src/platform/vite-dev-ui-shell.test.ts
@@ -1,0 +1,16 @@
+/** Verifies deterministic standalone Vite-shell detection without a live browser origin. */
+
+import { describe, expect, it } from "vitest";
+import { isViteDevUiShell } from "./vite-dev-ui-shell";
+
+describe("isViteDevUiShell", () => {
+  it("recognizes the configured standalone Vite UI port", () => {
+    expect(isViteDevUiShell({ port: "2138" })).toBe(true);
+  });
+
+  it("rejects backend, production, and server-side locations", () => {
+    expect(isViteDevUiShell({ port: "31337" })).toBe(false);
+    expect(isViteDevUiShell({ port: "" })).toBe(false);
+    expect(isViteDevUiShell()).toBe(false);
+  });
+});

--- a/packages/ui/src/platform/vite-dev-ui-shell.ts
+++ b/packages/ui/src/platform/vite-dev-ui-shell.ts
@@ -1,0 +1,9 @@
+/** Detects the standalone Vite renderer shell whose origin has no embedded backend. */
+
+const VITE_DEV_UI_PORT = "2138";
+
+export function isViteDevUiShell(location?: Pick<Location, "port">): boolean {
+  const browserLocation =
+    location ?? (typeof window === "undefined" ? undefined : window.location);
+  return browserLocation?.port === VITE_DEV_UI_PORT;
+}

--- a/packages/ui/src/state/active-server-credential.test.ts
+++ b/packages/ui/src/state/active-server-credential.test.ts
@@ -7,7 +7,10 @@
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
-import { persistActiveServerCredential } from "./active-server-credential";
+import {
+  persistActiveServerCredential,
+  scrubRejectedActiveServerCredential,
+} from "./active-server-credential";
 import { getActiveProfile } from "./agent-profiles";
 import {
   createPersistedActiveServer,
@@ -34,5 +37,25 @@ describe("persistActiveServerCredential", () => {
 
     expect(loadPersistedActiveServer()?.accessToken).toBe("session-token");
     expect(getActiveProfile()?.accessToken).toBe("session-token");
+  });
+
+  it("scrubs a rejected active credential without dropping the target", () => {
+    savePersistedActiveServer(
+      createPersistedActiveServer({
+        kind: "remote",
+        apiBase: "https://runtime.example.test",
+        accessToken: "stale-token",
+      }),
+    );
+    persistActiveServerCredential("stale-token");
+
+    scrubRejectedActiveServerCredential("stale-token");
+
+    expect(loadPersistedActiveServer()).toMatchObject({
+      kind: "remote",
+      apiBase: "https://runtime.example.test",
+    });
+    expect(loadPersistedActiveServer()?.accessToken).toBeUndefined();
+    expect(getActiveProfile()?.accessToken).toBeUndefined();
   });
 });

--- a/packages/ui/src/state/active-server-credential.ts
+++ b/packages/ui/src/state/active-server-credential.ts
@@ -21,3 +21,24 @@ export function persistActiveServerCredential(token: string): void {
     updateAgentProfile(activeProfile.id, { accessToken: token });
   }
 }
+
+/**
+ * Removes only the rejected bearer from the active target and profile. Other
+ * saved targets keep their credentials so one expired agent cannot sign the
+ * user out of every configured runtime.
+ */
+export function scrubRejectedActiveServerCredential(token: string): void {
+  const rejected = token.trim();
+  if (!rejected) return;
+
+  const activeServer = loadPersistedActiveServer();
+  if (activeServer?.accessToken === rejected) {
+    const { accessToken: _rejected, ...serverWithoutToken } = activeServer;
+    savePersistedActiveServer(serverWithoutToken);
+  }
+
+  const activeProfile = getActiveProfile();
+  if (activeProfile?.accessToken === rejected) {
+    updateAgentProfile(activeProfile.id, { accessToken: undefined });
+  }
+}

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -40,6 +40,7 @@ import { readMobileRuntimeBuildTruth } from "../first-run/reconcile-mobile-runti
 import type { FirstRunRuntimeTarget } from "../first-run/runtime-target";
 import type { UiLanguage } from "../i18n";
 import { isAndroid, isIOS } from "../platform";
+import { isViteDevUiShell } from "../platform/vite-dev-ui-shell";
 import {
   dedicatedCloudAgentIdFromBase,
   isDedicatedCloudAgentBase,
@@ -565,9 +566,6 @@ export async function runPollingBackend(
     }
   };
 
-  const isDevUiPort = () =>
-    typeof window !== "undefined" && window.location.port === "2138";
-
   const routeToOfflineFirstRun = (why: string) => {
     logger.warn(
       { reason: why },
@@ -585,7 +583,7 @@ export async function runPollingBackend(
   if (
     !cancelled.current &&
     effectRunRef.current === effectRunId &&
-    isDevUiPort() &&
+    isViteDevUiShell() &&
     isSameOriginProxyBase() &&
     !ctx?.persistedActiveServer &&
     !ctx?.hadPriorFirstRun
@@ -1195,7 +1193,7 @@ export async function runPollingBackend(
         return;
       }
       if (
-        isDevUiPort() &&
+        isViteDevUiShell() &&
         !policy.supportsLocalRuntime &&
         isSameOriginProxyBase() &&
         (ae?.status === undefined ||

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -47,6 +47,7 @@ import {
   isOnboardingReplayRequested,
   wasForceFreshResetApplied,
 } from "../platform";
+import { isViteDevUiShell } from "../platform/vite-dev-ui-shell";
 import {
   buildCloudSharedAgentApiBase,
   buildDedicatedCloudAgentApiBase,
@@ -107,10 +108,6 @@ function recoverCloudAgentId(active: PersistedActiveServer): string | null {
     : "";
   if (rawId && !rawId.includes("/")) return rawId;
   return dedicatedCloudAgentIdFromBase(active.apiBase);
-}
-
-function isDevUiPort(): boolean {
-  return typeof window !== "undefined" && window.location.port === "2138";
 }
 
 /**
@@ -728,7 +725,7 @@ export async function runRestoringSession(
     (isAndroid || isIOS) &&
     isCommittedOnDeviceMobileRuntimeMode(readPersistedMobileRuntimeMode());
   const shouldProbeExistingInstall =
-    !forceFreshFirstRun && !persistedActiveServer && !isDevUiPort();
+    !forceFreshFirstRun && !persistedActiveServer && !isViteDevUiShell();
   let probed: ExistingFirstRunProbeResult | null = null;
   if (shouldProbeExistingInstall) {
     try {

--- a/packages/ui/src/state/top-level-auth-gate.test.ts
+++ b/packages/ui/src/state/top-level-auth-gate.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   authProbeShouldHoldShell,
   firstRunOwnsLoginSurface,
+  shouldShowRemoteAgentPairingGate,
   topLevelAuthGateOwnsSurface,
 } from "./top-level-auth-gate";
 
@@ -104,5 +105,43 @@ describe("authProbeShouldHoldShell — pre-auth poll suppression", () => {
       authProbeShouldHoldShell("first-run-required", false, "loading"),
     ).toBe(false);
     expect(authProbeShouldHoldShell("ready", false, "loading")).toBe(false);
+  });
+});
+
+describe("shouldShowRemoteAgentPairingGate — LAN standalone agent auth", () => {
+  it("prefers pairing for a standalone remote agent with a configured bearer", () => {
+    expect(
+      shouldShowRemoteAgentPairingGate({
+        reason: "remote_auth_required",
+        access: {
+          mode: "remote",
+          passwordConfigured: true,
+          ownerConfigured: false,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not replace app-core password login or password-not-configured screens", () => {
+    expect(
+      shouldShowRemoteAgentPairingGate({
+        reason: "remote_auth_required",
+        access: {
+          mode: "remote",
+          passwordConfigured: true,
+          ownerConfigured: true,
+        },
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowRemoteAgentPairingGate({
+        reason: "remote_password_not_configured",
+        access: {
+          mode: "remote",
+          passwordConfigured: false,
+          ownerConfigured: false,
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/ui/src/state/top-level-auth-gate.ts
+++ b/packages/ui/src/state/top-level-auth-gate.ts
@@ -63,3 +63,28 @@ export function authProbeShouldHoldShell(
     !firstRunOwnsLoginSurface(coordinatorPhase, firstRunComplete)
   );
 }
+
+/** Access metadata from GET /api/auth/me 401 bodies. */
+export interface RemoteAuthGateAccess {
+  mode?: "local" | "session" | "remote" | "bearer";
+  passwordConfigured?: boolean;
+  ownerConfigured?: boolean;
+}
+
+/**
+ * Standalone agents (`bun run start`) reached over a private LAN authenticate
+ * via a one-time pairing code that mints a bearer token — not the owner
+ * password session LoginView expects from app-core.
+ */
+export function shouldShowRemoteAgentPairingGate(args: {
+  reason?: "remote_auth_required" | "remote_password_not_configured";
+  access?: RemoteAuthGateAccess;
+}): boolean {
+  const access = args.access;
+  return (
+    args.reason === "remote_auth_required" &&
+    access?.mode === "remote" &&
+    access.passwordConfigured === true &&
+    access.ownerConfigured === false
+  );
+}

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -38,6 +38,7 @@ import { clearStaleStewardSession } from "../cloud/shell/StewardProviderShared";
 import { getBootConfig, setBootConfig } from "../config/boot-config";
 import { dispatchElizaCloudStatusUpdated } from "../events";
 import { isElizaCloudRuntimeLocked } from "../first-run/mobile-runtime-mode";
+import { isViteDevUiShell } from "../platform/vite-dev-ui-shell";
 import {
   closeExternalBrowser,
   confirmDesktopAction,
@@ -120,8 +121,7 @@ function isSameOriginLocalHttpBackend(): boolean {
 }
 
 function isDevUiPortWithoutEmbeddedBackend(): boolean {
-  if (typeof window === "undefined") return false;
-  return window.location.port === "2138";
+  return isViteDevUiShell();
 }
 
 function isTrustedCloudAuthMessageOrigin(


### PR DESCRIPTION
## Summary

- recovers from a rejected standalone/LAN bearer token by clearing only the matching active-server credential and retrying `/api/auth/me` once without the rejected bearer
- routes `remote_auth_required` to the existing, tested `PairingView` only when remote access has a configured password but no owner; app-core password login and password-not-configured states keep their existing behavior
- centralizes Vite development-shell detection and covers it with focused tests
- removes the draft's unreachable live-ASR event path, dead token persistence, polling short-circuits, and unrelated generation-timeout changes

## Risk

Medium. This changes client-side authentication recovery and the top-level auth gate. Recovery is constrained to a single remote-mode retry, excludes cloud credentials, scrubs only the rejected active server/profile credential, and has focused request-header and persistence coverage.

## Verification

- `bun run verify` — passed (346/346 Turbo tasks plus repository audit gates)
- focused UI/auth regression suites — passed (85/85)
- `bun run --cwd packages/ui typecheck` — passed
- `bun run --cwd packages/ui lint:check` — passed (8 existing `document.cookie` warnings)
- `bun run --cwd packages/ui build` — passed; verified 44 runtime exports
- `bun run --cwd packages/app audit:app` — passed (214/214 captures, 0 broken, 0 needs-work; OCR reviewed 212 views with 0 broken)
- full UI suite — 9,241 passed, 7 skipped, with one unrelated current-`develop` hardcoded-color baseline failure in untouched `NotificationsHomeCenter.tsx`

Evidence revision: `74479cd969861ab078d50f8ff2173301587e55bc`

The verified commit is rebased directly onto `ea4bf9f9dc8503b69f5dc6ef7c905ae31e125f28` from `develop`. GitHub CI reruns the exact revision.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- `yes`
<!-- attribution-row:models -->
- `openai/gpt-5.6`
<!-- attribution-row:client -->
- `Codex desktop`
<!-- attribution-row:skill-revision -->
- `N/A - GitHub plugin workflow only`
<!-- attribution-row:status -->
- `self-reported`

<!-- evidence-head:74479cd969861ab078d50f8ff2173301587e55bc -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17895-before-chat-desktop-mobile.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17895-after-chat-desktop-mobile.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17895-chat-before-after-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - this is a client-side retry; focused tests assert the first request carries the rejected bearer and the retry omits it

<!-- evidence-row:frontend-logs -->
- [ ] N/A - request headers, retry count, state transition, and credential scrubbing are asserted directly in the UI test harness

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model handler, action planning, or model output behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduled-task, wallet, generated-media, or audio artifact is produced; focused auth-state tests are the domain evidence

<!-- evidence-row:ocr-review -->
- [x] [17895-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17895-ocr-triage.json)

---
AI provider/model: openai / GPT-5.6
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - GitHub plugin workflow only
Attribution status: self-reported
— [implementation-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex desktop","skill_revision":"N/A - GitHub plugin workflow only"} -->

