### PR TITLE
fix(plugin-local-inference): isolate per-request TTS voices

### DIFF
--- a/plugins/plugin-local-inference/__tests__/provider.test.ts
+++ b/plugins/plugin-local-inference/__tests__/provider.test.ts
@@ -118,7 +118,23 @@ describe("local inference provider", () => {
 				text: "say this",
 			} as never),
 		).resolves.toEqual(wav);
-		expect(synthesizeSpeech).toHaveBeenCalledWith("say this", undefined);
+		expect(synthesizeSpeech).toHaveBeenCalledWith(
+			"say this",
+			undefined,
+			undefined,
+		);
+
+		await expect(
+			handlers[ModelType.TEXT_TO_SPEECH]?.(runtime as never, {
+				text: "use this voice",
+				voice: "  af_heart  ",
+			} as never),
+		).resolves.toEqual(wav);
+		expect(synthesizeSpeech).toHaveBeenLastCalledWith(
+			"use this voice",
+			undefined,
+			"af_heart",
+		);
 
 		const pcm = new Float32Array([0, 0.1, -0.1]);
 		await expect(

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -51,6 +51,7 @@ import { transcriptsRoutes } from "./routes/transcripts-routes.js";
 import { voiceProfilePluginRoutes } from "./routes/voice-profile-plugin-routes.js";
 import { handleVoiceEntityBound } from "./runtime/voice-entity-binding.js";
 import { augmentVisionRequest } from "./services/vision/augmenter.js";
+import { extractRequestedVoiceId } from "./services/voice/requested-voice.js";
 
 export const LOCAL_INFERENCE_PROVIDER_ID = "eliza-local-inference";
 export const LOCAL_INFERENCE_PRIORITY = -100;
@@ -131,9 +132,11 @@ interface LocalInferenceTextToSpeechService {
 	synthesizeSpeech?: (
 		text: string,
 		signal?: AbortSignal,
+		voiceId?: string,
 	) => Promise<Uint8Array | ArrayBuffer | Buffer>;
 	textToSpeech?: (args: {
 		text: string;
+		voice?: string;
 		signal?: AbortSignal;
 	}) => Promise<Uint8Array | ArrayBuffer | Buffer>;
 	/**
@@ -146,6 +149,7 @@ interface LocalInferenceTextToSpeechService {
 	synthesizeSpeechStream?: (
 		text: string,
 		signal?: AbortSignal,
+		voiceId?: string,
 	) => AsyncIterable<Uint8Array>;
 }
 
@@ -653,6 +657,7 @@ function createTextToSpeechHandler() {
 			extractSpeechText(params),
 		);
 		const signal = extractSpeechSignal(params);
+		const voice = extractRequestedVoiceId(params);
 		// Explicit opt-in (NOT the generic `stream` useModel injects from an
 		// ambient text-streaming turn) so byte-expecting callers keep a buffer.
 		const wantsStream =
@@ -663,7 +668,7 @@ function createTextToSpeechHandler() {
 		// Real chunked streaming when the backend implements the seam.
 		if (wantsStream && typeof service.synthesizeSpeechStream === "function") {
 			return streamingAudioStreamResult(
-				service.synthesizeSpeechStream(text, signal),
+				service.synthesizeSpeechStream(text, signal, voice),
 				LOCAL_TTS_MIME,
 			);
 		}
@@ -671,12 +676,16 @@ function createTextToSpeechHandler() {
 		const synthesizeBuffered = async (): Promise<Uint8Array> => {
 			if (typeof service.synthesizeSpeech === "function") {
 				return normalizeAudioBytes(
-					await service.synthesizeSpeech(text, signal),
+					await service.synthesizeSpeech(text, signal, voice),
 				);
 			}
 			if (typeof service.textToSpeech === "function") {
 				return normalizeAudioBytes(
-					await service.textToSpeech({ text, ...(signal ? { signal } : {}) }),
+					await service.textToSpeech({
+						text,
+						...(voice ? { voice } : {}),
+						...(signal ? { signal } : {}),
+					}),
 				);
 			}
 			throw unavailable(

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
@@ -251,6 +251,33 @@ describe("ensureLocalInferenceHandler", () => {
 		);
 	});
 
+	it("maps explicit legacy voice names without treating model ids as voices", async () => {
+		const { registrations, runtime } = makeRuntime();
+		await ensureLocalInferenceHandler(runtime);
+		const handler = findRegisteredHandler(
+			registrations,
+			ModelType.TEXT_TO_SPEECH,
+		);
+
+		await handler(runtime, {
+			text: "hello",
+			voice: "  Nova  ",
+			model: "tts-1",
+		});
+		expect(engineState.synthesizeSpeech).toHaveBeenLastCalledWith(
+			"hello",
+			undefined,
+			"af_nova",
+		);
+
+		await handler(runtime, { text: "hello again", model: "tts-1" });
+		expect(engineState.synthesizeSpeech).toHaveBeenLastCalledWith(
+			"hello again",
+			undefined,
+			undefined,
+		);
+	});
+
 	it("honors ELIZA_DISABLE_LOCAL_EMBEDDINGS by leaving TEXT_EMBEDDING unregistered", async () => {
 		process.env.ELIZA_DISABLE_LOCAL_EMBEDDINGS = "1";
 		const { registrations, runtime } = makeRuntime();

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -69,6 +69,7 @@ import {
 } from "../services/structured-output";
 import type { AgentModelSlot } from "../services/types";
 import { decodeMonoPcm16Wav, type TranscriptionAudio } from "../services/voice";
+import { extractRequestedKokoroVoiceId } from "../services/voice/requested-voice.js";
 import { DEFAULT_MODELS_DIR } from "./embedding-manager-support";
 import {
 	EMBEDDING_PRESETS,
@@ -897,6 +898,7 @@ function makeTextToSpeechHandler(): TextToSpeechHandler {
 		return localInferenceEngine.synthesizeSpeech(
 			text,
 			extractSpeechSignal(params),
+			extractRequestedKokoroVoiceId(params),
 		);
 	};
 }

--- a/plugins/plugin-local-inference/src/services/engine.ts
+++ b/plugins/plugin-local-inference/src/services/engine.ts
@@ -1683,6 +1683,7 @@ export class LocalInferenceEngine {
 	async synthesizeSpeech(
 		text: string,
 		signal?: AbortSignal,
+		voiceId?: string,
 	): Promise<Uint8Array> {
 		this.markActivity();
 		const bridge = this.requireVoiceBridge("synthesize speech");
@@ -1692,7 +1693,7 @@ export class LocalInferenceEngine {
 				"[voice] Cannot synthesize speech with StubTtsBackend (it emits silence). Start voice with useFfiBackend:true or inject a real backend.",
 			);
 		}
-		return bridge.synthesizeTextToWav(text, signal);
+		return bridge.synthesizeTextToWav(text, signal, voiceId);
 	}
 
 	async prewarmVoicePhrases(

--- a/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
+++ b/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
@@ -1588,6 +1588,7 @@ export class EngineVoiceBridge {
 	async synthesizeTextToWav(
 		text: string,
 		signal?: AbortSignal,
+		voiceId?: string,
 	): Promise<Uint8Array> {
 		this.assertVoiceOn("synthesize speech");
 		if (!this.hasRealTtsBackend()) {
@@ -1596,7 +1597,7 @@ export class EngineVoiceBridge {
 				"[voice] Direct speech synthesis requires a fused OmniVoice backend. The deterministic test backend is only allowed in scheduler/unit tests.",
 			);
 		}
-		const chunk = await this.scheduler.synthesizeText(text, signal);
+		const chunk = await this.scheduler.synthesizeText(text, signal, voiceId);
 		return encodeMonoPcm16Wav(chunk.pcm, chunk.sampleRate);
 	}
 

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/voices.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/voices.test.ts
@@ -31,6 +31,41 @@ describe("KOKORO_VOICE_PACKS", () => {
 		expect(new Set(ids).size).toBe(ids.length);
 	});
 
+	it("contains the complete upstream English v1.0 voice set", () => {
+		expect(listKokoroVoiceIds()).toEqual(
+			expect.arrayContaining([
+				"af_heart",
+				"af_alloy",
+				"af_aoede",
+				"af_bella",
+				"af_jessica",
+				"af_kore",
+				"af_nicole",
+				"af_nova",
+				"af_river",
+				"af_sarah",
+				"af_sky",
+				"am_adam",
+				"am_echo",
+				"am_eric",
+				"am_fenrir",
+				"am_liam",
+				"am_michael",
+				"am_onyx",
+				"am_puck",
+				"am_santa",
+				"bf_alice",
+				"bf_emma",
+				"bf_isabella",
+				"bf_lily",
+				"bm_daniel",
+				"bm_fable",
+				"bm_george",
+				"bm_lewis",
+			]),
+		);
+	});
+
 	it("listKokoroVoicesByLang filters correctly", () => {
 		const us = listKokoroVoicesByLang("a");
 		const uk = listKokoroVoicesByLang("b");

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/voice-presets.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/voice-presets.ts
@@ -6,8 +6,10 @@
  * `SpeakerPreset.voiceId` against this table; an unknown id falls through to
  * the backend's `defaultVoiceId`.
  *
- * The actual style tensor (256 fp32 values) lives at
- * `<modelRoot>/voices/<file>` and is loaded lazily on first use.
+ * The actual style tensor lives at `<modelRoot>/voices/<file>` and is loaded
+ * lazily on first use. English packs below match the full US/UK set from
+ * onnx-community/Kokoro-82M-v1.0-ONNX; non-English packs stay out of this
+ * table until the runtime phonemizer path for those langs is wired.
  *
  * Reference: https://huggingface.co/hexgrad/Kokoro-82M
  */
@@ -17,20 +19,20 @@ import type { KokoroVoicePack } from "./types";
 export const KOKORO_VOICE_PACKS: ReadonlyArray<KokoroVoicePack> = [
 	// American English — female
 	{
+		id: "af_heart",
+		displayName: "Heart (US English)",
+		lang: "a",
+		file: "af_heart.bin",
+		dim: 256,
+		tags: ["female", "warm", "high-quality"],
+	},
+	{
 		id: "af_bella",
 		displayName: "Bella (US English)",
 		lang: "a",
 		file: "af_bella.bin",
 		dim: 256,
 		tags: ["female", "warm", "default"],
-	},
-	{
-		id: "af_sarah",
-		displayName: "Sarah (US English)",
-		lang: "a",
-		file: "af_sarah.bin",
-		dim: 256,
-		tags: ["female", "professional"],
 	},
 	{
 		id: "af_nicole",
@@ -41,12 +43,68 @@ export const KOKORO_VOICE_PACKS: ReadonlyArray<KokoroVoicePack> = [
 		tags: ["female", "breathy"],
 	},
 	{
+		id: "af_sarah",
+		displayName: "Sarah (US English)",
+		lang: "a",
+		file: "af_sarah.bin",
+		dim: 256,
+		tags: ["female", "professional"],
+	},
+	{
 		id: "af_sky",
 		displayName: "Sky (US English)",
 		lang: "a",
 		file: "af_sky.bin",
 		dim: 256,
 		tags: ["female", "young"],
+	},
+	{
+		id: "af_alloy",
+		displayName: "Alloy (US English)",
+		lang: "a",
+		file: "af_alloy.bin",
+		dim: 256,
+		tags: ["female"],
+	},
+	{
+		id: "af_aoede",
+		displayName: "Aoede (US English)",
+		lang: "a",
+		file: "af_aoede.bin",
+		dim: 256,
+		tags: ["female"],
+	},
+	{
+		id: "af_kore",
+		displayName: "Kore (US English)",
+		lang: "a",
+		file: "af_kore.bin",
+		dim: 256,
+		tags: ["female"],
+	},
+	{
+		id: "af_nova",
+		displayName: "Nova (US English)",
+		lang: "a",
+		file: "af_nova.bin",
+		dim: 256,
+		tags: ["female"],
+	},
+	{
+		id: "af_jessica",
+		displayName: "Jessica (US English)",
+		lang: "a",
+		file: "af_jessica.bin",
+		dim: 256,
+		tags: ["female"],
+	},
+	{
+		id: "af_river",
+		displayName: "River (US English)",
+		lang: "a",
+		file: "af_river.bin",
+		dim: 256,
+		tags: ["female"],
 	},
 	// American English — male
 	{
@@ -58,6 +116,22 @@ export const KOKORO_VOICE_PACKS: ReadonlyArray<KokoroVoicePack> = [
 		tags: ["male", "warm"],
 	},
 	{
+		id: "am_fenrir",
+		displayName: "Fenrir (US English)",
+		lang: "a",
+		file: "am_fenrir.bin",
+		dim: 256,
+		tags: ["male"],
+	},
+	{
+		id: "am_puck",
+		displayName: "Puck (US English)",
+		lang: "a",
+		file: "am_puck.bin",
+		dim: 256,
+		tags: ["male"],
+	},
+	{
 		id: "am_adam",
 		displayName: "Adam (US English)",
 		lang: "a",
@@ -65,7 +139,47 @@ export const KOKORO_VOICE_PACKS: ReadonlyArray<KokoroVoicePack> = [
 		dim: 256,
 		tags: ["male", "neutral"],
 	},
-	// British English
+	{
+		id: "am_echo",
+		displayName: "Echo (US English)",
+		lang: "a",
+		file: "am_echo.bin",
+		dim: 256,
+		tags: ["male"],
+	},
+	{
+		id: "am_eric",
+		displayName: "Eric (US English)",
+		lang: "a",
+		file: "am_eric.bin",
+		dim: 256,
+		tags: ["male"],
+	},
+	{
+		id: "am_liam",
+		displayName: "Liam (US English)",
+		lang: "a",
+		file: "am_liam.bin",
+		dim: 256,
+		tags: ["male"],
+	},
+	{
+		id: "am_onyx",
+		displayName: "Onyx (US English)",
+		lang: "a",
+		file: "am_onyx.bin",
+		dim: 256,
+		tags: ["male"],
+	},
+	{
+		id: "am_santa",
+		displayName: "Santa (US English)",
+		lang: "a",
+		file: "am_santa.bin",
+		dim: 256,
+		tags: ["male", "character"],
+	},
+	// British English — female
 	{
 		id: "bf_emma",
 		displayName: "Emma (British English)",
@@ -83,6 +197,23 @@ export const KOKORO_VOICE_PACKS: ReadonlyArray<KokoroVoicePack> = [
 		tags: ["female", "british"],
 	},
 	{
+		id: "bf_alice",
+		displayName: "Alice (British English)",
+		lang: "b",
+		file: "bf_alice.bin",
+		dim: 256,
+		tags: ["female", "british"],
+	},
+	{
+		id: "bf_lily",
+		displayName: "Lily (British English)",
+		lang: "b",
+		file: "bf_lily.bin",
+		dim: 256,
+		tags: ["female", "british"],
+	},
+	// British English — male
+	{
 		id: "bm_george",
 		displayName: "George (British English)",
 		lang: "b",
@@ -95,6 +226,22 @@ export const KOKORO_VOICE_PACKS: ReadonlyArray<KokoroVoicePack> = [
 		displayName: "Lewis (British English)",
 		lang: "b",
 		file: "bm_lewis.bin",
+		dim: 256,
+		tags: ["male", "british"],
+	},
+	{
+		id: "bm_daniel",
+		displayName: "Daniel (British English)",
+		lang: "b",
+		file: "bm_daniel.bin",
+		dim: 256,
+		tags: ["male", "british"],
+	},
+	{
+		id: "bm_fable",
+		displayName: "Fable (British English)",
+		lang: "b",
+		file: "bm_fable.bin",
 		dim: 256,
 		tags: ["male", "british"],
 	},

--- a/plugins/plugin-local-inference/src/services/voice/requested-voice.ts
+++ b/plugins/plugin-local-inference/src/services/voice/requested-voice.ts
@@ -1,0 +1,38 @@
+/** Normalizes caller-supplied TTS voice identifiers without confusing provider model or endpoint settings for speaker names. */
+
+import type { TextToSpeechParams } from "@elizaos/core";
+
+/** Read the explicit `voice` contract plus the legacy `voiceId` spelling. */
+export function extractRequestedVoiceId(
+	params: TextToSpeechParams | string,
+): string | undefined {
+	if (typeof params !== "object" || params === null) return undefined;
+	const legacyVoiceId = (params as TextToSpeechParams & { voiceId?: unknown })
+		.voiceId;
+	const raw =
+		typeof params.voice === "string"
+			? params.voice
+			: typeof legacyVoiceId === "string"
+				? legacyVoiceId
+				: undefined;
+	const trimmed = raw?.trim();
+	return trimmed || undefined;
+}
+
+/** Historical Piper / OpenAI voice names mapped to bundled Kokoro ids. */
+const KOKORO_VOICE_ALIASES: Readonly<Record<string, string>> = {
+	"en_us-female-medium": "af_nicole",
+	"en_us-female": "af_bella",
+	"en_us-male-medium": "am_michael",
+	nova: "af_nova",
+	alloy: "af_alloy",
+};
+
+/** Resolve compatibility aliases only at the Kokoro-owned engine boundary. */
+export function extractRequestedKokoroVoiceId(
+	params: TextToSpeechParams | string,
+): string | undefined {
+	const requested = extractRequestedVoiceId(params);
+	if (!requested) return undefined;
+	return KOKORO_VOICE_ALIASES[requested.toLowerCase()] ?? requested;
+}

--- a/plugins/plugin-local-inference/src/services/voice/scheduler.ts
+++ b/plugins/plugin-local-inference/src/services/voice/scheduler.ts
@@ -168,6 +168,12 @@ export class VoiceScheduler {
 	readonly sink: AudioSink;
 	readonly preset: SpeakerPreset;
 	/**
+	 * Voice id the phrase cache was seeded for. Cache hits are only valid for
+	 * this speaker — otherwise Replay with a different dropdown voice would
+	 * return the wrong (default) clip.
+	 */
+	private readonly phraseCacheVoiceId: string;
+	/**
 	 * Prefix-preserving barge-in queue. When the streaming TTS path is active,
 	 * each audio chunk is enqueued here tagged with its token range. On
 	 * hard-stop (barge-in), `rollbackAt(divergencePoint)` partitions the
@@ -206,6 +212,7 @@ export class VoiceScheduler {
 			deps.phonemeTokenizer ?? null,
 		);
 		this.preset = config.preset;
+		this.phraseCacheVoiceId = config.preset.voiceId;
 		this.backend = deps.backend;
 		this.phraseCache = deps.phraseCache ?? new PhraseCache();
 		this.sampleRate = config.sampleRate;
@@ -291,7 +298,12 @@ export class VoiceScheduler {
 	async synthesizeText(
 		text: string,
 		signal?: AbortSignal,
+		voiceId?: string,
 	): Promise<AudioChunk> {
+		const requestedVoiceId = voiceId?.trim();
+		const preset = requestedVoiceId
+			? { ...this.preset, voiceId: requestedVoiceId }
+			: this.preset;
 		const phrase: Phrase = {
 			id: this.nextStandalonePhraseId--,
 			text,
@@ -304,7 +316,8 @@ export class VoiceScheduler {
 			throw new Error("[voice-scheduler] synthesis cancelled by abort signal");
 		}
 
-		const cached = this.phraseCache.get(text);
+		const cacheEligible = preset.voiceId === this.phraseCacheVoiceId;
+		const cached = cacheEligible ? this.phraseCache.get(text) : undefined;
 		if (cached) {
 			this.emitTelemetry({
 				type: "phrase-cache-hit",
@@ -356,7 +369,7 @@ export class VoiceScheduler {
 			});
 			const chunk = await this.backend.synthesize({
 				phrase,
-				preset: this.preset,
+				preset,
 				cancelSignal,
 				onKernelTick: () => this.tickKernel(),
 			});
@@ -372,11 +385,13 @@ export class VoiceScheduler {
 				samples: chunk.pcm.length,
 				sampleRate: chunk.sampleRate,
 			});
-			this.phraseCache.put({
-				text,
-				pcm: chunk.pcm,
-				sampleRate: chunk.sampleRate,
-			});
+			if (cacheEligible) {
+				this.phraseCache.put({
+					text,
+					pcm: chunk.pcm,
+					sampleRate: chunk.sampleRate,
+				});
+			}
 			return chunk;
 		} finally {
 			detach();

--- a/plugins/plugin-local-inference/src/services/voice/voice.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice.test.ts
@@ -39,6 +39,7 @@ function makePreset(): SpeakerPreset {
 
 class FakeBackend implements TtsBackend {
 	calls = 0;
+	voiceIds: string[] = [];
 	cancelObserved: number[] = [];
 	delay = 0;
 	samplesPerToken = 8;
@@ -50,6 +51,7 @@ class FakeBackend implements TtsBackend {
 		onKernelTick?: () => void;
 	}): Promise<AudioChunk> {
 		this.calls++;
+		this.voiceIds.push(args.preset.voiceId);
 		const tokenCount = args.phrase.toIndex - args.phrase.fromIndex + 1;
 		const len = Math.max(1, tokenCount * this.samplesPerToken);
 		if (this.delay > 0) {
@@ -680,6 +682,29 @@ describe("VoiceScheduler end-to-end", () => {
 
 		expect(backend.calls).toBe(1);
 		expect(Array.from(second.pcm)).toEqual(Array.from(first.pcm));
+	});
+
+	it("keeps per-request voice overrides isolated from the scheduler preset and cache", async () => {
+		const backend = new FakeBackend();
+		const preset = makePreset();
+		const sched = new VoiceScheduler(
+			{
+				chunkerConfig: { maxTokensPerPhrase: 10 },
+				preset,
+				ringBufferCapacity: 4096,
+				sampleRate: 24000,
+			},
+			{ backend },
+		);
+
+		await sched.synthesizeText("Same phrase.", undefined, "  af_heart  ");
+		await sched.synthesizeText("Same phrase.");
+		await sched.synthesizeText("Same phrase.");
+
+		expect(backend.voiceIds).toEqual(["af_heart", "default"]);
+		expect(backend.calls).toBe(2);
+		expect(preset.voiceId).toBe("default");
+		expect(sched.preset.voiceId).toBe("default");
 	});
 
 	it("pauses TTS on a provisional barge-in, resumes on a blip (no audio lost)", async () => {


### PR DESCRIPTION
# Relates to

N/A — this consolidates the complete local-inference voice work found while reviewing the open voice pull requests.

- [x] This PR targets `develop` and is synchronized with current `origin/develop`.
- [x] `bun run install:light` and `bun run verify` were run after synchronization.
- [x] A reviewer can confirm the behavior from exact-head tests and real native audio evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@fd55cb126e2b782a9ed1e27052b4b0605a380237:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Branch is based on `origin/develop` at `fd55cb126e2b782a9ed1e27052b4b0605a380237`.
- [x] `bun run verify` passes for the exact tree at the evidence head.

# Risks

Low and contained to local TTS voice selection plus Kokoro catalog metadata. Explicit voice overrides are now immutable per request; default-voice cache behavior remains unchanged. New catalog entries still fail loudly at the artifact boundary if their `.bin` pack is not staged.

# Background

## What does this PR do?

- Threads an explicit `TextToSpeechParams.voice` through both local-inference TTS adapters, buffered and streaming paths, the engine bridge, and the scheduler.
- Accepts the legacy `voiceId` spelling for compatibility, but never treats `model` or endpoint configuration as a voice ID.
- Maps historical Piper/OpenAI names such as `nova` only at the Kokoro-owned boundary.
- Builds a per-call `SpeakerPreset` instead of mutating the scheduler's caller-owned preset, so one request cannot change later synthesis or permanently disable the default phrase cache.
- Keeps cache reads/writes scoped to the voice for which the cache was seeded.
- Registers the complete English Kokoro v1.0 voice set from the [upstream ONNX Community model](https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX), while retaining the Eliza-1 research voice.

The prior branch also contained unfinished live-mic, Ollama ASR, curl downloader, manifest-kernel, device-tier, MTP, and FFI changes. Those unrelated changes were removed: three referenced modules did not exist, the ASR readiness path fabricated success from an environment variable, word timings were dropped, and the native-contract relaxation lacked evidence. The final diff is voice-only and builds cleanly.

## What kind of change is this?

Bug fix and additive Kokoro voice metadata (non-breaking).

# Documentation changes needed?

No public configuration or API changed.

# Testing

## Where should a reviewer start?

- `plugins/plugin-local-inference/src/services/voice/requested-voice.ts`
- `plugins/plugin-local-inference/src/services/voice/scheduler.ts`
- `plugins/plugin-local-inference/src/services/voice/kokoro/voice-presets.ts`
- `plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts`
- `plugins/plugin-local-inference/src/services/voice/voice.test.ts`

## Detailed testing steps

```bash
cd plugins/plugin-local-inference
NODE_OPTIONS='--experimental-sqlite' bunx vitest run \
  __tests__/provider.test.ts \
  src/runtime/ensure-local-inference-handler.test.ts \
  src/services/voice/voice.test.ts \
  src/services/voice/engine-bridge.test.ts \
  src/services/voice/kokoro/__tests__/voices.test.ts
NODE_OPTIONS='--experimental-sqlite' bun run test
bun run lint:check
bun run typecheck
bun run build
cd ../..
bun run verify
```

# Evidence Gate

<!-- evidence-head:08dc29051742817435dc3178f40833e5d26068ba -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - local TTS routing and Kokoro registry only; no rendered UI changed`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - local TTS routing and Kokoro registry only; no rendered UI changed`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no interactive surface changed; real audio evidence is recorded below`.
<!-- evidence-row:backend-logs -->
- [x] Backend/test logs:

<details>
<summary>Exact-tree automated and real native verification</summary>

```
Focused regression set:
 Test Files  5 passed (5)
      Tests  97 passed (97)

Complete plugin suite:
 Test Files  258 passed (258)
      Tests  2650 passed | 17 skipped (2667)
 CI script tests  3 passed (3)

Package gates:
 lint       PASS (482 files)
 typecheck  PASS
 build      PASS

Root bun run verify:
 Tasks: 343 successful, 343 total
 audit-build-typecheck: PASS
 audit-turbo-build-deps: PASS
 audit-tee-secret-leak: PASS
 hetzner-fleet-routing: PASS
 audit-scripts: PASS
 view-bundle inventory: PASS
 focused/skipped-test audit: PASS (7,579 test files)

Real fused Kokoro + local ASR smoke (Apple M4 Max, ABI v14):
 voice: af_heart (fresh upstream pack)
 audio: 81,000 samples @ 24,000 Hz (3.38 seconds)
 TTFA: 808 ms (explicit desktop smoke ceiling: 3,000 ms)
 speech envelope CV: 1.049 (required >= 0.4)
 ASR transcript: "Hello. This is a native Kakaro voice test."
 WER: 0.13 (required <= 0.50)
 result: PASS
```

The native library was rebuilt from the pinned llama.cpp submodule for this revision. The real smoke used the repository's documented desktop override; the default 700 ms value is the mobile-product budget and is not asserted by this desktop lane.

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - no frontend code in the final diff`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no language-model, prompt, action, provider, or planner path changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - no database or generated repository artifact changed; the native/audio evidence used local staged test assets only`.
<!-- evidence-row:ocr-review -->
- [x] OCR review `N/A - no visual surface changed`.

# Evidence Details

## Review findings resolved

- Removed all three imports of nonexistent source modules; package build is green.
- Removed the unrelated manifest-kernel relaxation and its deleted contract assertions.
- Removed environment-only Ollama readiness and the ASR path that discarded word timings.
- Removed the untested hard-coded FFI context-size workaround.
- Removed the duplicate broad `I am` rewrite; #17892 owns the tested Kokoro-only correction already merged to `develop`.
- Stopped reading `params.model` as a speaker voice.
- Replaced persistent scheduler preset mutation with an immutable per-request override and regression coverage.
- Updated the title, scope, and evidence to match the final diff.

## Known gaps / failures

None in the delivered voice-selection and catalog paths. The mobile 700 ms TTFA product budget requires a supported mobile target; this desktop proof uses the smoke lane's documented explicit host ceiling and does not claim mobile latency certification.
