### PR TITLE
feat(registry): add @iqlabs-official/plugin-clawbal — on-chain AI chatrooms on Solana

### DIFF
--- a/packages/registry/entries/third-party/iqlabs-official__plugin-clawbal.json
+++ b/packages/registry/entries/third-party/iqlabs-official__plugin-clawbal.json
@@ -1,0 +1,9 @@
+{
+  "package": "@iqlabs-official/plugin-clawbal",
+  "repository": "github:IQCoreTeam/milady-clawbal",
+  "kind": "plugin",
+  "description": "Clawbal — on-chain AI chatrooms on Solana with PnL tracking, token launching, and leaderboards.",
+  "homepage": "https://github.com/IQCoreTeam/milady-clawbal",
+  "version": "1.0.2",
+  "tags": ["solana", "chat", "on-chain", "pnl", "trading"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -138,6 +138,51 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@iqlabs-official/plugin-clawbal": {
+      "git": {
+        "repo": "IQCoreTeam/milady-clawbal",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@iqlabs-official/plugin-clawbal",
+        "v0": null,
+        "v1": null,
+        "v2": "1.0.2"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Clawbal — on-chain AI chatrooms on Solana with PnL tracking, token launching, and leaderboards.",
+      "homepage": "https://github.com/IQCoreTeam/milady-clawbal",
+      "topics": [
+        "solana",
+        "chat",
+        "on-chain",
+        "pnl",
+        "trading"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@lmxcloud/plugin-lmxcloud": {
       "git": {
         "repo": "LMXCloud/plugin-lmxcloud",


### PR DESCRIPTION
## Summary

- Adds `@iqlabs-official/plugin-clawbal` (on-chain AI chatrooms on Solana) to the in-repo community plugin registry.
- Ports elizaos-plugins/registry#276 by @NubsCarson: that repo is archived/read-only, and `packages/registry/README.md` names this package as its replacement.
- One new entry JSON + regenerated `generated-registry.json` (31 third-party entries).

## Verification

- Entry validated against `schema/registry-entry.schema.json` via `bun run validate`.
- `generated-registry.json` regenerated with `bun run generate` (never hand-edited).
- Registry vitest suite: 36/36 pass with the new entry present.
- npm package `@iqlabs-official/plugin-clawbal@1.0.2` exists; its `repository` field points at `IQCoreTeam/milady-clawbal`, which exports a real `Plugin` from `@elizaos/core` (20 actions, 5 providers, peer-dep `@elizaos/core >=1.0.0`, repo topic `elizaos-plugins`). No duplicate entry for the package or repo exists in `entries/` or `generated-registry.json`.

## Evidence

<!-- evidence-head:ded0b6ce5489d8b24e333cace2730a5fe5aa6964 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - registry metadata JSON only; no rendered UI source file is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - registry metadata JSON only; no rendered UI source file is touched by this diff.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing flow changes; the diff adds one registry entry JSON and its generated wire-format counterpart.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend, API, database, worker, or service behavior changed; the registry is consumed as static JSON.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs/checks: N/A - no frontend code changed; validator, generator, and unit-test transcripts are attached under domain artifacts.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent prompt, model, provider, or action behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the new entry `packages/registry/entries/third-party/iqlabs-official__plugin-clawbal.json` and regenerated `packages/registry/generated-registry.json` in the [PR file diff](https://github.com/elizaOS/eliza/pull/17904/files), plus the validator/generator/test transcript below.
  <details>
  <summary>bun run validate / generate / vitest transcript</summary>

  ```text
  $ bun run validate
  $ bun run src/validate-cli.ts
  [registry] 31 third-party entries validated

  $ bun run generate
  $ bun run src/generate.ts
  Generated packages/registry/generated-registry.json (31 third-party entries)

  $ bunx vitest run
   ✓ src/first-party/local-inference-boot-hook.test.ts (1 test) 39ms
   ✓ src/first-party/personal-assistant-app-registry.test.ts (1 test) 40ms
   Test Files  6 passed (6)
        Tests  36 passed (36)
     Duration  556ms

  $ npm view @iqlabs-official/plugin-clawbal version repository.url
  version = '1.0.2'
  repository.url = 'git+https://github.com/IQCoreTeam/milady-clawbal.git'
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: N/A - no screenshots or rendered UI in this change; nothing to OCR.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code CLI`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - contribution made directly with Claude Code CLI; no in-repo skill was used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Notes

Ports elizaos-plugins/registry#276 (archived repo, cannot be merged or closed there). Original submission by @NubsCarson; entry metadata cross-checked against the published npm package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
