### PR TITLE
fix(release): restore release workflow contracts

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -306,6 +306,62 @@ jobs:
           ELIZA_VALIDATE_CDN: "1"
         run: bun run release:check
 
+  build-browser-companions:
+    name: Build Agent Browser Bridge companions
+    if: ${{ inputs.platform == '' || inputs.platform == 'all' }}
+    needs: [prepare, validate-release]
+    runs-on: macos-15
+    timeout-minutes: 60
+    outputs:
+      packaged: ${{ steps.package-browser-bridge.outputs.packaged }}
+    defaults:
+      run:
+        shell: bash -euo pipefail {0}
+    env:
+      ELIZA_RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup Bun workspace
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --frozen-lockfile --ignore-scripts
+          install-native-deps: "false"
+          run-postinstall: "true"
+          init-submodules: "false"
+
+      - name: Package Agent Browser Bridge release bundles
+        id: package-browser-bridge
+        run: |
+          if bun run browser-bridge:package:release; then
+            echo "packaged=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Agent Browser Bridge packaging failed; desktop release will continue without browser companion bundles."
+            echo "packaged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload Agent Browser Bridge release artifacts
+        if: steps.package-browser-bridge.outputs.packaged == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: browser-bridge-store-bundles
+          path: |
+            packages/browser-extension/dist/artifacts/browser-bridge-chrome-v*.zip
+            packages/browser-extension/dist/artifacts/browser-bridge-safari-v*.zip
+            packages/browser-extension/dist/artifacts/browser-bridge-safari-project-v*.zip
+            packages/browser-extension/dist/artifacts/browser-bridge-release-manifest-v*.json
+          if-no-files-found: error
+          retention-days: 30
+
   build:
     name: Build ${{ matrix.platform.name }}
     if: ${{ always() && needs.prepare.result == 'success' && (needs.validate-release.result == 'success' || needs.validate-release.result == 'skipped') }}
@@ -1692,6 +1748,38 @@ jobs:
             update-channel/ \
             releases@releases.elizaos.ai:/var/www/releases/
           rm -f /tmp/release_key
+
+  publish-browser-companions:
+    name: Publish Agent Browser Bridge companions
+    if: ${{ (github.event_name != 'workflow_call' || inputs.publish_release) && needs.build-browser-companions.outputs.packaged == 'true' && needs.release.result == 'success' }}
+    needs: [prepare, build-browser-companions, release]
+    runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-24.04' }}
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Download Agent Browser Bridge artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          path: browser-bridge-release
+          pattern: browser-bridge-*
+          merge-multiple: false
+
+      - name: List Agent Browser Bridge artifacts
+        run: find browser-bridge-release -type f | sort 2>/dev/null || echo "No Agent Browser Bridge artifacts"
+
+      - name: Attach Agent Browser Bridge assets to GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          find browser-bridge-release -type f \
+            \( \
+              -name "browser-bridge-chrome-v*.zip" -o \
+              -name "browser-bridge-safari-v*.zip" -o \
+              -name "browser-bridge-release-manifest-v*.json" \
+            \) \
+            -print0 | xargs -0 -r gh release upload "${{ needs.prepare.outputs.tag }}" --repo "$GH_REPO" --clobber
 
   ota-publish:
     name: Publish OTA Channel Manifest

--- a/packages/app-core/scripts/release-check.ts
+++ b/packages/app-core/scripts/release-check.ts
@@ -258,7 +258,7 @@ const requiredElectrobunPrWorkflowSnippets = [
   "contents: read",
   'BUN_VERSION: "1.3.14"',
   "name: Release Workflow Contract",
-  "bun install --ignore-scripts",
+  "bun install --frozen-lockfile --ignore-scripts",
   'run-postinstall: "true"',
   "bun run test:regression-matrix:release-contract",
   "bun run test:release:contract",
@@ -1340,10 +1340,14 @@ function assertStartApiServerCatchBlockSafety() {
       catchBlock.includes("opts?.serverOnly") ||
       catchBlock.includes("options?.serverOnly")
     ) ||
-    !catchBlock.includes("process.exit(1)")
+    !catchBlock.includes(
+      'throw new ElizaError("API server is required in server-only mode"',
+    ) ||
+    !catchBlock.includes('code: "AGENT_API_START_FAILED"') ||
+    !catchBlock.includes('severity: "fatal"')
   ) {
     console.error(
-      "release-check: eliza.ts startApiServer catch block must call process.exit(1) when opts?.serverOnly is true.",
+      "release-check: eliza.ts startApiServer catch block must throw a fatal AGENT_API_START_FAILED ElizaError in server-only mode.",
     );
     process.exit(1);
   }

--- a/packages/app-core/test/regression-matrix.json
+++ b/packages/app-core/test/regression-matrix.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "manualChecklistDoc": "packages/docs/apps/desktop/release-regression-checklist.md",
+  "manualChecklistDoc": "packages/app-core/test/release-regression-checklist.md",
   "workflowContracts": {
     "pr": {
       "files": [".github/workflows/test.yml"],
@@ -232,7 +232,7 @@
           "desktop-playwright"
         ]
       },
-      "manualChecklist": "packages/docs/apps/desktop/release-regression-checklist.md"
+      "manualChecklist": "packages/app-core/test/release-regression-checklist.md"
     },
     {
       "name": "workflow-and-release-contracts",
@@ -492,7 +492,7 @@
       "test:e2e": ["apps-e2e.e2e.test.ts"]
     },
     "desktopInventorySources": [
-      "packages/docs/apps/desktop/release-heavy-inventory.md"
+      "packages/app-core/test/release-heavy-inventory.md"
     ],
     "forbiddenDesktopInventoryMarkers": [
       ["it.", "todo", "("],

--- a/packages/app-core/test/release-heavy-inventory.md
+++ b/packages/app-core/test/release-heavy-inventory.md
@@ -1,0 +1,48 @@
+# Desktop Release Regression Inventory
+
+This inventory records desktop regression coverage that is intentionally outside
+the deterministic PR gate. The release matrix validator keeps these entries
+visible so they are reviewed before a production desktop release.
+
+## Packaged and E2E Coverage
+
+- gameOpenWindow — full round-trip with openGameWindow mock (needs canvas mock update)
+- Abnormal window position (off-screen) is corrected to safe defaults (e2e)
+- Deep link received while app is closed causes app to launch (e2e)
+- Deep link received while app is open does not launch second instance (e2e)
+- Shortcuts survive window focus changes (e2e)
+- App launches automatically after system restart (e2e)
+- Auto-launch survives app updates (e2e)
+- Keyboard shortcut Cmd+Q triggers quit (e2e)
+- Keyboard shortcut Cmd+R triggers reload (e2e)
+- Keyboard shortcut Cmd+Option+I opens devtools (e2e)
+- Gateway discovery sends gatewayDiscovery push event to renderer (integration)
+- Canvas window is sandboxed — cannot access main app origin (integration)
+- Canvas navigate blocks external URLs (integration)
+- Agent port is reachable via HTTP after status reaches 'running' (integration)
+- Agent crash triggers automatic restart (integration)
+- Stopping agent while starting does not leave zombie process (integration)
+- Check for updates contacts the release server (network)
+- Applying update relaunches the app (e2e)
+- Update check works on both canary and stable channels (network)
+- Tray icon persists after main window is closed (e2e)
+- Main window has native vibrancy effect on macOS (e2e)
+- Context menu closes when clicking elsewhere (e2e)
+
+## Hardware and Manual Coverage
+
+- Microphone input works after permission is granted (hardware)
+- Swabble fires 'wakeWordDetected' event when wake word is spoken (hardware)
+- Audio transcription produces non-empty text for clear speech (hardware)
+- Camera preview renders in the UI when stream is started (hardware)
+- Switching between front/rear camera works (hardware)
+- takeScreenshot returns a non-empty base64 PNG (hardware)
+- Frame capture mode streams frames at configured interval (hardware)
+- Left-clicking the tray icon opens the companion window (visual)
+- Right-clicking the tray icon shows the tray context menu (visual)
+- Window can be dragged by clicking the header region (visual)
+- Photo quality is acceptable at default settings (hardware)
+- Requesting accessibility opens System Preferences (OS interaction)
+- Permission status reflects actual system state (OS interaction)
+- Context menu appears at cursor position (visual)
+- Power state reflects actual battery status (hardware)

--- a/packages/app-core/test/release-regression-checklist.md
+++ b/packages/app-core/test/release-regression-checklist.md
@@ -1,0 +1,13 @@
+# Desktop Release Regression Checklist
+
+Complete these manual checks for desktop release candidates after packaged smoke
+tests pass on the target platform.
+
+- [ ] Left-clicking the tray icon opens the companion window (visual)
+- [ ] Right-clicking the tray icon shows the tray context menu (visual)
+- [ ] Window can be dragged by clicking the header region (visual)
+- [ ] Photo quality is acceptable at default settings (hardware)
+- [ ] Requesting accessibility opens System Preferences (OS interaction)
+- [ ] Permission status reflects actual system state (OS interaction)
+- [ ] Context menu appears at cursor position (visual)
+- [ ] Power state reflects actual battery status (hardware)


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@403dd7a7eb253000fe89be7319e0425c3bf33b6e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Summary

Repairs the release workflow contracts broken during the latest branch promotion. The desktop manual checklist and heavy regression inventory move into the owning app-core test package, and the deleted Browser Bridge packaging/publishing jobs are restored.

The checklist files were absent from the public Mintlify docs tree while `regression-matrix.json` still required them there. The promotion also hardened frozen installs and typed API startup failure handling without updating their release assertions.

This change:

- restores both existing release artifacts verbatim under `packages/app-core/test/`;
- updates all three regression-matrix references;
- leaves the public docs package free of internal release coordination files;
- restores the Browser Bridge release artifact build and publish jobs;
- aligns release assertions with frozen installs and fatal typed server-only startup errors.

Closes #17907.

## Testing

- `bun run test:regression-matrix:release-contract` — pass
- `bun run test:release:contract` — pass
- `bun run --cwd packages/app-core typecheck` — pass after dependency-aware workspace build
- `bun run --cwd packages/app-core lint:check` — pass
- `bun run verify` — pass; 343/343 workspace tasks plus all repository audits
- full app-core test lane — 202 files passed, 1 skipped; 1,603 tests passed and 18 skipped. Two existing `desktop-view-windows.test.ts` assertions fail because main's menu omits the `browser` view while `BUILTIN_VIEWS` includes it; none of the three changed files participate in that catalog.

## Evidence Gate

<!-- evidence-head:493e52aeb6e491d62bfe08ff6cec1a34a4ac96b8 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - release contract data and internal Markdown only

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changes

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - no runtime backend path changed; command results are listed above

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network behavior changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the release checklist and inventory are the reviewed repository artifacts

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@403dd7a7eb253000fe89be7319e0425c3bf33b6e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-gateway]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@403dd7a7eb253000fe89be7319e0425c3bf33b6e:packages/skills/skills/contribute-to-eliza"} -->