### PR TITLE
feat: polish built-in calendar, notes, chat, and LP3 voice demo

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -242,6 +242,7 @@
         "@elizaos/plugin-agent-orchestrator": "workspace:*",
         "@elizaos/plugin-blocker": "workspace:*",
         "@elizaos/plugin-browser": "workspace:*",
+        "@elizaos/plugin-calendar": "workspace:*",
         "@elizaos/plugin-contacts": "workspace:*",
         "@elizaos/plugin-elizacloud": "workspace:*",
         "@elizaos/plugin-messages": "workspace:*",

--- a/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
+++ b/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
@@ -146,6 +146,24 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
     );
   });
 
+  it("records originating-client navigation without broadcasting to unrelated shells", async () => {
+    const { ctx, json, broadcastWs } = makeNavigateCtx("notes", {
+      delivery: "originating-client",
+    });
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(broadcastWs).not.toHaveBeenCalled();
+    expect(getCurrentViewState()).toMatchObject({
+      viewId: "notes",
+      source: "agent",
+    });
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({ ok: true, viewId: "notes" }),
+    );
+  });
+
   it("includes action and alwaysOnTop in the frame only when present in the body", async () => {
     const { ctx, broadcastWs } = makeNavigateCtx("settings", {
       action: "pin-tab",

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -13,7 +13,7 @@
  *   GET  /api/views/:id/frame.html     — sandboxed iframe document (HTML)
  *   GET  /api/views/:id/<asset>        — compiled bundle chunk/asset
  *   GET  /api/views/:id/hero           — hero image (image/*)
- *   POST /api/views/:id/navigate       — broadcast shell navigation event (JSON)
+ *   POST /api/views/:id/navigate       — deliver a shell navigation event (JSON)
  *   POST /api/views/:id/elements       — report the view's addressable element snapshot
  *   POST /api/views/:id/interact       — agent-view interaction (capability dispatch)
  *   POST /api/views/interact-result    — frontend result callback (resolves pending interact)
@@ -901,9 +901,10 @@ export async function handleViewsRoutes(
   }
 
   // ── POST /api/views/:id/navigate ─────────────────────────────────────────
-  // Broadcasts a shell:navigate:view WebSocket event to all connected clients.
-  // The frontend's startup-phase-hydrate WS handler dispatches eliza:navigate:view
-  // on window when it receives this message, which App.tsx handles.
+  // Broadcasts a shell:navigate:view WebSocket event to connected clients unless
+  // the caller owns a narrower delivery channel. Realtime voice returns the
+  // validated VIEWS result through its originating WebSocket session, so a
+  // global echo here would navigate unrelated browsers and devices.
   //
   // Optional body fields:
   //   action: "pin-tab"    — tells the shell to add to desktop tab bar
@@ -918,6 +919,7 @@ export async function handleViewsRoutes(
   //   path: string         — override the navigation path
   //   alwaysOnTop: boolean — for open-window, ask the shell to keep it above normal windows
   //   payload: unknown     — opaque deep-link state consumed by the target view
+  //   delivery: "originating-client" — caller will navigate its own client
   if (method === "POST" && subResource === "navigate") {
     const body = await readJsonBody<Record<string, unknown>>(req, res).catch(
       () => null,
@@ -963,6 +965,7 @@ export async function handleViewsRoutes(
         : undefined;
     const payload =
       body && Object.hasOwn(body, "payload") ? body.payload : undefined;
+    const originatingClientDelivery = body?.delivery === "originating-client";
     const layoutPayload = {
       ...(layoutViews && layoutViews.length > 0 ? { views: layoutViews } : {}),
       ...(layout ? { layout } : {}),
@@ -1049,8 +1052,9 @@ export async function handleViewsRoutes(
       }
     }
 
-    // Skip the echo for user-reported switches (the client already navigated).
-    if (reportedSource !== "user") {
+    // Skip the echo when the client already navigated or when the caller owns a
+    // narrower delivery channel such as the realtime voice session.
+    if (reportedSource !== "user" && !originatingClientDelivery) {
       const navigatePayload: ShellNavigateViewPayload = {
         viewId: id,
         viewPath,

--- a/packages/agent/src/services/approval/service.test.ts
+++ b/packages/agent/src/services/approval/service.test.ts
@@ -556,6 +556,53 @@ describe("ApprovalService", () => {
     });
   });
 
+  it("preserves the built-in calendar provider version for conditional writes", async () => {
+    const runtime = createApprovalTableRuntime("agent-eliza-calendar-approval");
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+
+    const confirmed = await queue.enqueueConfirmed(
+      {
+        requestedBy: "OWNER_CALENDAR_EDITOR",
+        subjectUserId: "owner-123",
+        action: "modify_event",
+        payload: {
+          action: "modify_event",
+          side: "owner",
+          grantId: "eliza-calendar",
+          calendarId: "primary",
+          eventId: "built-in-event-1",
+          expectedProvider: "eliza",
+          expectedProviderVersion: '"eliza-1"',
+          expectedEventUpdatedAt: "2027-10-01T00:00:00.000Z",
+          expectedEventStartAtMs: Date.parse("2027-10-15T16:00:00.000Z"),
+          patch: {
+            title: "Pickup moved",
+            startsAtMs: Date.parse("2027-10-15T17:00:00.000Z"),
+            endsAtMs: Date.parse("2027-10-15T18:00:00.000Z"),
+            attendees: [],
+            location: null,
+            description: null,
+          },
+        },
+        channel: "internal",
+        reason: "Authenticated owner editor gesture",
+        idempotencyKey: "calendar-editor-eliza-1",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      },
+      {
+        resolvedBy: "owner-123",
+        resolutionReason: "Authenticated owner editor gesture",
+      },
+    );
+
+    expect(confirmed.payload).toMatchObject({
+      action: "modify_event",
+      grantId: "eliza-calendar",
+      expectedProvider: "eliza",
+      expectedProviderVersion: '"eliza-1"',
+    });
+  });
+
   it("approving an approval auto-reads its notification by groupKey (§C.5)", async () => {
     const notifier = createNotifierSpy();
     const runtime = createApprovalTableRuntime("agent-autoread", notifier);

--- a/packages/agent/src/services/approval/store.ts
+++ b/packages/agent/src/services/approval/store.ts
@@ -545,7 +545,7 @@ function assertApprovalPayload(
         record,
         "expectedProvider",
         label,
-        new Set(["google", "microsoft", "apple_calendar", "ics"]),
+        new Set(["google", "microsoft", "apple_calendar", "ics", "eliza"]),
       );
       requireOptionalNullableStringField(
         record,
@@ -601,7 +601,7 @@ function assertApprovalPayload(
         record,
         "expectedProvider",
         label,
-        new Set(["google", "microsoft", "apple_calendar", "ics"]),
+        new Set(["google", "microsoft", "apple_calendar", "ics", "eliza"]),
       );
       requireOptionalNullableStringField(
         record,

--- a/packages/agent/src/services/approval/types.ts
+++ b/packages/agent/src/services/approval/types.ts
@@ -152,6 +152,7 @@ export type ApprovalPayload =
         | "microsoft"
         | "apple_calendar"
         | "ics"
+        | "eliza"
         | null;
       expectedProviderVersion?: string | null;
       expectedEventUpdatedAt?: string | null;
@@ -186,6 +187,7 @@ export type ApprovalPayload =
         | "microsoft"
         | "apple_calendar"
         | "ics"
+        | "eliza"
         | null;
       expectedProviderVersion?: string | null;
       expectedEventUpdatedAt?: string | null;

--- a/packages/app-core/scripts/dev-ui.mjs
+++ b/packages/app-core/scripts/dev-ui.mjs
@@ -16,7 +16,13 @@
  *   node …/dev-ui.mjs --check-acp-hot-reload=31337             # one-shot reload safety probe
  */
 import { execSync, spawn } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, realpathSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
 import { createConnection } from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -32,6 +38,7 @@ import { isRedundantApiListenLine } from "./lib/dev-ui-log-filter.mjs";
 import { buildVisionDepsFailureMessage } from "./lib/dev-ui-vision.mjs";
 import { resolveViteCommand } from "./lib/dev-ui-vite.mjs";
 import { signalSpawnedProcessTree } from "./lib/kill-process-tree.mjs";
+import { resolveMacNativeEffectsDevPlan } from "./lib/macos-native-effects-dev.mjs";
 import { extendNodePathEnv } from "./lib/node-path-env.mjs";
 import { syncElizaEnvAliases } from "./lib/sync-eliza-env-aliases.mjs";
 import {
@@ -275,6 +282,43 @@ function createDevChildEnv(baseEnv) {
     );
   }
   return nextEnv;
+}
+
+function prepareMacNativeEffectsForDev() {
+  const plan = resolveMacNativeEffectsDevPlan({
+    cwd,
+    env: process.env,
+    platform: process.platform,
+    exists: existsSync,
+    modifiedAt: (value) => statSync(value).mtimeMs,
+  });
+  if (plan.kind === "skip") return;
+
+  if (plan.kind === "build") {
+    try {
+      console.log(
+        `  ${green(logPrefix)} ${dim("Building macOS Calendar/EventKit bridge...")}`,
+      );
+      execSync("bun run build:native-effects", {
+        cwd: plan.packageDir,
+        env: process.env,
+        stdio: "inherit",
+      });
+    } catch (error) {
+      console.warn(
+        `  ${green(logPrefix)} ${dim(`macOS native bridge unavailable; Calendar stays explicit-unavailable (${error instanceof Error ? error.message : String(error)}).`)}`,
+      );
+      return;
+    }
+    if (!existsSync(plan.dylibPath)) {
+      console.warn(
+        `  ${green(logPrefix)} ${dim("macOS native bridge build completed without its declared dylib; Calendar stays explicit-unavailable.")}`,
+      );
+      return;
+    }
+  }
+
+  process.env.ELIZA_NATIVE_PERMISSIONS_DYLIB = plan.dylibPath;
 }
 
 function shellQuoteArg(value) {
@@ -1077,6 +1121,8 @@ if (uiOnly) {
       }`,
     )}`,
   );
+
+  prepareMacNativeEffectsForDev();
 
   let devServerEntry = resolveDevServerEntryRelativePath(cwd);
   // Resolve to absolute so it stays valid when we anchor the API child cwd

--- a/packages/app-core/scripts/lib/macos-native-effects-dev.mjs
+++ b/packages/app-core/scripts/lib/macos-native-effects-dev.mjs
@@ -1,0 +1,68 @@
+/**
+ * Resolves the generated macOS EventKit/effects bridge used by source-checkout
+ * dev servers. The plan stays pure so bootstrap can distinguish an existing
+ * explicit override from a missing or stale local artifact before spawning the
+ * API process that consumes it.
+ */
+import path from "node:path";
+
+function sourceCheckoutRoot(cwd, exists) {
+  const roots = [cwd, path.join(cwd, "eliza")];
+  return (
+    roots.find((root) =>
+      exists(
+        path.join(
+          root,
+          "packages",
+          "app-core",
+          "platforms",
+          "electrobun",
+          "native",
+          "macos",
+          "window-effects.mm",
+        ),
+      ),
+    ) ?? null
+  );
+}
+
+export function resolveMacNativeEffectsDevPlan({
+  cwd,
+  env,
+  platform,
+  exists,
+  modifiedAt,
+}) {
+  if (platform !== "darwin" || env.ELIZA_DEV_NATIVE_EFFECTS === "0") {
+    return { kind: "skip" };
+  }
+
+  const configuredPath = env.ELIZA_NATIVE_PERMISSIONS_DYLIB?.trim();
+  if (configuredPath && exists(configuredPath)) {
+    return { kind: "use", dylibPath: configuredPath };
+  }
+
+  const root = sourceCheckoutRoot(cwd, exists);
+  if (!root) return { kind: "skip" };
+
+  const packageDir = path.join(
+    root,
+    "packages",
+    "app-core",
+    "platforms",
+    "electrobun",
+  );
+  const sourcePath = path.join(
+    packageDir,
+    "native",
+    "macos",
+    "window-effects.mm",
+  );
+  const dylibPath = path.join(packageDir, "src", "libMacWindowEffects.dylib");
+
+  if (exists(dylibPath) && modifiedAt(dylibPath) >= modifiedAt(sourcePath)) {
+    return { kind: "use", dylibPath };
+  }
+
+  return { kind: "build", packageDir, dylibPath };
+}

--- a/packages/app-core/scripts/lib/macos-native-effects-dev.test.mjs
+++ b/packages/app-core/scripts/lib/macos-native-effects-dev.test.mjs
@@ -1,0 +1,70 @@
+/** Verifies source-checkout discovery and staleness policy for the macOS native bridge. */
+import { describe, expect, it } from "vitest";
+import { resolveMacNativeEffectsDevPlan } from "./macos-native-effects-dev.mjs";
+
+const cwd = "/repo";
+const source =
+  "/repo/packages/app-core/platforms/electrobun/native/macos/window-effects.mm";
+const output =
+  "/repo/packages/app-core/platforms/electrobun/src/libMacWindowEffects.dylib";
+
+function plan({
+  env = {},
+  platform = "darwin",
+  existing = [source],
+  mtimes = {},
+} = {}) {
+  const files = new Set(existing);
+  return resolveMacNativeEffectsDevPlan({
+    cwd,
+    env,
+    platform,
+    exists: (value) => files.has(value),
+    modifiedAt: (value) => mtimes[value] ?? 0,
+  });
+}
+
+describe("macOS native effects dev plan", () => {
+  it("skips hosts that cannot load the Darwin bridge", () => {
+    expect(plan({ platform: "linux" })).toEqual({ kind: "skip" });
+  });
+
+  it("keeps an existing operator override authoritative", () => {
+    expect(
+      plan({
+        env: { ELIZA_NATIVE_PERMISSIONS_DYLIB: "/custom/native.dylib" },
+        existing: [source, "/custom/native.dylib"],
+      }),
+    ).toEqual({ kind: "use", dylibPath: "/custom/native.dylib" });
+  });
+
+  it("builds a missing source-checkout artifact", () => {
+    expect(plan()).toEqual({
+      kind: "build",
+      packageDir: "/repo/packages/app-core/platforms/electrobun",
+      dylibPath: output,
+    });
+  });
+
+  it("reuses a fresh artifact and rebuilds a stale one", () => {
+    expect(
+      plan({
+        existing: [source, output],
+        mtimes: { [source]: 10, [output]: 11 },
+      }),
+    ).toEqual({ kind: "use", dylibPath: output });
+
+    expect(
+      plan({
+        existing: [source, output],
+        mtimes: { [source]: 12, [output]: 11 },
+      }),
+    ).toMatchObject({ kind: "build", dylibPath: output });
+  });
+
+  it("honors an explicit dev opt-out", () => {
+    expect(plan({ env: { ELIZA_DEV_NATIVE_EFFECTS: "0" } })).toEqual({
+      kind: "skip",
+    });
+  });
+});

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -1,0 +1,29 @@
+/**
+ * Resolves renderer feature flags and cache policy for mobile build lanes.
+ * LP3 debug artifacts always enable the realtime voice client, while every
+ * Android cloud-debug build starts from a fresh renderer because the current
+ * lane stamp does not encode optional Vite feature flags.
+ */
+
+const ANDROID_CLOUD_DEBUG = "android-cloud-debug";
+
+export function resolveMobileRendererFeatureEnv({ platform, env = {} } = {}) {
+  if (typeof platform !== "string" || platform.length === 0) {
+    throw new Error("resolveMobileRendererFeatureEnv: platform is required");
+  }
+  const isLp3Debug =
+    platform === ANDROID_CLOUD_DEBUG &&
+    env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED === "1";
+  if (!isLp3Debug) return {};
+  return {
+    VITE_VOICE_REALTIME_WS: "1",
+    VITE_VOICE_REALTIME_FORCE: "1",
+  };
+}
+
+export function mobileRendererRequiresFreshBuild({ platform } = {}) {
+  if (typeof platform !== "string" || platform.length === 0) {
+    throw new Error("mobileRendererRequiresFreshBuild: platform is required");
+  }
+  return platform === ANDROID_CLOUD_DEBUG;
+}

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -1,0 +1,58 @@
+/**
+ * Locks the mobile renderer feature boundary that keeps LP3 realtime voice in
+ * the packaged APK and prevents cross-feature reuse of debug renderer output.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  mobileRendererRequiresFreshBuild,
+  resolveMobileRendererFeatureEnv,
+} from "./mobile-renderer-feature-env.mjs";
+
+describe("resolveMobileRendererFeatureEnv", () => {
+  it("enables the realtime voice client for the LP3 cloud-debug lane", () => {
+    expect(
+      resolveMobileRendererFeatureEnv({
+        platform: "android-cloud-debug",
+        env: { ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1" },
+      }),
+    ).toEqual({
+      VITE_VOICE_REALTIME_WS: "1",
+      VITE_VOICE_REALTIME_FORCE: "1",
+    });
+  });
+
+  it("does not change ordinary Android cloud-debug builds", () => {
+    expect(
+      resolveMobileRendererFeatureEnv({
+        platform: "android-cloud-debug",
+        env: {},
+      }),
+    ).toEqual({});
+  });
+
+  it("does not leak LP3 renderer flags into another lane", () => {
+    expect(
+      resolveMobileRendererFeatureEnv({
+        platform: "android-cloud",
+        env: { ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1" },
+      }),
+    ).toEqual({});
+  });
+
+  it("requires an explicit platform", () => {
+    expect(() => resolveMobileRendererFeatureEnv()).toThrow(
+      /platform is required/,
+    );
+  });
+});
+
+describe("mobileRendererRequiresFreshBuild", () => {
+  it("rebuilds cloud-debug renderers because their optional flags are not stamped", () => {
+    expect(
+      mobileRendererRequiresFreshBuild({ platform: "android-cloud-debug" }),
+    ).toBe(true);
+    for (const platform of ["android", "android-cloud", "ios", "ios-local"]) {
+      expect(mobileRendererRequiresFreshBuild({ platform })).toBe(false);
+    }
+  });
+});

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -98,6 +98,10 @@ import {
   resolveExpectedRendererStamp,
 } from "./lib/mobile-lane-stamp.mjs";
 import {
+  mobileRendererRequiresFreshBuild,
+  resolveMobileRendererFeatureEnv,
+} from "./lib/mobile-renderer-feature-env.mjs";
+import {
   formatMobileWebDistProblems,
   mobileWebDistReuseStatus,
 } from "./lib/mobile-web-build-reuse.mjs";
@@ -1127,7 +1131,11 @@ async function buildWeb(platform) {
   // below, so the loud-fail-on-stale guarantee is preserved: a stale or
   // mismatched dist simply does not match here and falls through to a rebuild.
   // Explicit ELIZA_MOBILE_SKIP_WEB_BUILD=1 keeps its force-reuse semantics below.
-  if (process.env.ELIZA_MOBILE_SKIP_WEB_BUILD !== "1") {
+  const requiresFreshRenderer = mobileRendererRequiresFreshBuild({ platform });
+  if (
+    process.env.ELIZA_MOBILE_SKIP_WEB_BUILD !== "1" &&
+    !requiresFreshRenderer
+  ) {
     const autoStatus = mobileWebDistReuseStatus({
       appDir,
       repoRoot,
@@ -1145,6 +1153,14 @@ async function buildWeb(platform) {
       );
       return;
     }
+  }
+  if (
+    process.env.ELIZA_MOBILE_SKIP_WEB_BUILD !== "1" &&
+    requiresFreshRenderer
+  ) {
+    console.log(
+      `[mobile-build] Rebuilding renderer for '${platform}': debug feature flags require fresh output.`,
+    );
   }
   if (process.env.ELIZA_MOBILE_SKIP_WEB_BUILD === "1") {
     const status = mobileWebDistReuseStatus({
@@ -1242,6 +1258,7 @@ async function buildWeb(platform) {
             process.env.ELIZA_FORCE_LOCAL_UPSTREAMS ?? "1",
         }
       : {}),
+    ...resolveMobileRendererFeatureEnv({ platform, env: process.env }),
   });
   const bun = resolveBunExecutable();
   const packageStylesPatch = path.join(

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -240,7 +240,7 @@ All env vars use the `ELIZA_` prefix (set in `app.config.ts` → `envPrefix: "EL
 |---|---|
 | `ELIZA_API_PORT` | Agent API server port (default 31337; `ELIZA_PORT` is a fallback) |
 | `ELIZA_UI_PORT` | Vite dev/UI server port (default 2138) |
-| `ELIZA_LOCAL_VOICE_GATEWAY_PORT` | Dev-only loopback realtime-voice gateway port; when set, Vite routes only `/api/v1/voice/session` HTTP/WS traffic there |
+| `ELIZA_LOCAL_VOICE_GATEWAY_PORT` | Dev-only loopback voice gateway port; when set, Vite routes `/api/v1/voice` HTTP/WS traffic there, including realtime sessions and TTS |
 | `ELIZA_APP_SOURCEMAP` | Enable source maps in production build |
 | `ELIZA_DESKTOP_VITE_FAST_DIST` | Set by Electrobun dev orchestrator for Rollup watch mode |
 | `ELIZA_DEV_POLLING` | Enable filesystem polling for watch (useful in VMs) |

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -240,7 +240,7 @@ All env vars use the `ELIZA_` prefix (set in `app.config.ts` → `envPrefix: "EL
 |---|---|
 | `ELIZA_API_PORT` | Agent API server port (default 31337; `ELIZA_PORT` is a fallback) |
 | `ELIZA_UI_PORT` | Vite dev/UI server port (default 2138) |
-| `ELIZA_LOCAL_VOICE_GATEWAY_PORT` | Dev-only loopback realtime-voice gateway port; when set, Vite routes only `/api/v1/voice/session` HTTP/WS traffic there |
+| `ELIZA_LOCAL_VOICE_GATEWAY_PORT` | Dev-only loopback voice gateway port; when set, Vite routes `/api/v1/voice` HTTP/WS traffic there, including realtime sessions and TTS |
 | `ELIZA_APP_SOURCEMAP` | Enable source maps in production build |
 | `ELIZA_DESKTOP_VITE_FAST_DIST` | Set by Electrobun dev orchestrator for Rollup watch mode |
 | `ELIZA_DEV_POLLING` | Enable filesystem polling for watch (useful in VMs) |

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -191,6 +191,7 @@
     "@elizaos/plugin-agent-orchestrator": "workspace:*",
     "@elizaos/plugin-blocker": "workspace:*",
     "@elizaos/plugin-browser": "workspace:*",
+    "@elizaos/plugin-calendar": "workspace:*",
     "@elizaos/plugin-contacts": "workspace:*",
     "@elizaos/plugin-elizacloud": "workspace:*",
     "@elizaos/plugin-messages": "workspace:*",

--- a/packages/app/src/plugin-registrations.test.ts
+++ b/packages/app/src/plugin-registrations.test.ts
@@ -32,6 +32,7 @@ const SCAN_ROOTS = [
 // Role-qualified loader identities expected to self-declare renderer
 // registration: `<canonical package name>#<appRegister mode>`.
 const EXPECTED_SIDE_EFFECT_MODULES = [
+  "@elizaos/plugin-calendar#register",
   "@elizaos/plugin-contacts#register",
   "@elizaos/plugin-native-settings#register",
   "@elizaos/plugin-notes#register",

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -1,6 +1,6 @@
 /**
  * Closed semantic OCR contracts for every view in the app aesthetic audit.
- * Positive labels come from stable view chrome and designed states; universal
+ * Positive labels come from designed view states; universal
  * developer-string and placeholder rejection remains in `ocr-content-rules`.
  * Typed exemptions retain a fallback expectation, so they waive only ownership
  * of distinct view semantics rather than pixel correctness.
@@ -56,11 +56,9 @@ export const VIEW_OCR_POLICIES = {
     requireAll: ["Mostly clear"],
   }),
   "builtin-phone": expected({
-    requireAll: ["Phone"],
     requireAny: ["call-blocked", "dialer", "recent"],
   }),
   "builtin-messages": expected({
-    requireAll: ["Messages"],
     requireAny: ["Set default SMS", "bridge-only", "compose"],
   }),
   "builtin-contacts": expected({
@@ -240,10 +238,10 @@ export const VIEW_OCR_POLICIES = {
     requireAny: ["address book", "phone, or email", "search"],
   }),
   "plugin-focus-gui": expected({
-    requireAll: ["Focus", "Idle"],
+    requireAll: ["Idle"],
   }),
   "plugin-calendar-gui": expected({
-    requireAll: ["Calendar"],
+    requireAny: ["Choose month & year", "No plans yet", "Ask Eliza in chat"],
   }),
   "plugin-documents-gui": exempt(
     "unregistered-remote-bundle",
@@ -251,11 +249,9 @@ export const VIEW_OCR_POLICIES = {
     VIEW_REGISTRY_FALLBACK,
   ),
   "plugin-finances-gui": expected({
-    requireAll: ["Finances"],
     requireAny: ["Balance", "Transactions", "Recurring"],
   }),
   "plugin-goals-gui": expected({
-    requireAll: ["Goals"],
     requireAny: ["Active", "needs a review", "paused"],
   }),
   "plugin-lifeops-live-test-gui": exempt(
@@ -268,27 +264,21 @@ export const VIEW_OCR_POLICIES = {
     requireAny: ["Last sleep", "Regularity", "Baseline"],
   }),
   "plugin-inbox-gui": expected({
-    requireAll: ["Inbox"],
     requireAny: ["needs a reply", "Email", "Discord"],
   }),
   "plugin-relationships-gui": expected({
-    requireAll: ["Relationships"],
     requireAny: ["People", "Organizations", "Graph"],
   }),
   "plugin-todos-gui": expected({
-    requireAll: ["Todos"],
     requireAny: ["Today", "Upcoming", "Someday"],
   }),
   "plugin-messages-gui": expected({
-    requireAll: ["Messages"],
     requireAny: ["Set default SMS", "bridge-only", "compose"],
   }),
   "plugin-phone-gui": expected({
-    requireAll: ["Phone"],
     requireAny: ["call-blocked", "dialer", "recent"],
   }),
   "plugin-wallet-gui": expected({
-    requireAll: ["Wallet"],
     requireAny: ["Tokens", "RPC", "ETH", "SOL"],
   }),
   "plugin-views-manager-gui": expected({
@@ -300,7 +290,6 @@ export const VIEW_OCR_POLICIES = {
     requireAny: ["Cloud agent", "demo recording"],
   }),
   "plugin-task-coordinator-gui": expected({
-    requireAll: ["Task Coordinator"],
     requireAny: ["Dispatch a coding agent", "search tasks", "tasks"],
   }),
   "plugin-orchestrator-gui": expected({
@@ -312,7 +301,6 @@ export const VIEW_OCR_POLICIES = {
     VIEW_REGISTRY_FALLBACK,
   ),
   "plugin-trajectory-logger-gui": expected({
-    requireAll: ["Trajectory Logger"],
     requireAny: ["Back to apps", "HANDLE", "PLAN"],
   }),
 } as const satisfies Record<string, ViewOcrPolicy>;

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -241,7 +241,20 @@ export const VIEW_OCR_POLICIES = {
     requireAll: ["Idle"],
   }),
   "plugin-calendar-gui": expected({
-    requireAny: ["Choose month & year", "No plans yet", "Ask Eliza in chat"],
+    requireAny: [
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December",
+    ],
   }),
   "plugin-documents-gui": exempt(
     "unregistered-remote-bundle",

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -3237,7 +3237,7 @@ export const INVALID_TRACER_PROVIDER = {};
     proxy: {
       ...(localVoiceGatewayPort
         ? {
-            "/api/v1/voice/session": {
+            "/api/v1/voice": {
               target: `http://127.0.0.1:${localVoiceGatewayPort}`,
               changeOrigin: true,
               xfwd: true,

--- a/packages/cloud/api/types/workspace-shims.d.ts
+++ b/packages/cloud/api/types/workspace-shims.d.ts
@@ -7,6 +7,8 @@
  */
 
 declare module "@elizaos/shared" {
+  export const REALTIME_VOICE_CLIENT_TRANSPORT: "realtime_voice";
+
   export interface CoinGeckoMarketRecord {
     id: string;
     symbol: string;

--- a/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/local-runtime-conversation-fetch.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
 import {
   createLocalRuntimeConversationFetch,
   LocalRuntimeConversationFetchError,
@@ -40,7 +41,12 @@ describe("local runtime conversation fetch", () => {
           "X-Eliza-User-Id": "user-a",
           "X-Eliza-Voice-Trace-Id": "trace-a",
         },
-        body: JSON.stringify({ text: "hello locally" }),
+        body: JSON.stringify({
+          text: "hello locally",
+          metadata: {
+            clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT,
+          },
+        }),
       },
     );
 
@@ -52,6 +58,9 @@ describe("local runtime conversation fetch", () => {
     expect(calls[0]?.init?.signal).toBe(signal);
     expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
       text: "hello locally",
+      metadata: {
+        clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT,
+      },
     });
     const headers = new Headers(calls[0]?.init?.headers);
     expect(headers.has("Authorization")).toBe(false);
@@ -73,7 +82,12 @@ describe("local runtime conversation fetch", () => {
     await expect(
       bridge("https://cloud.example/not-a-conversation", {
         method: "POST",
-        body: JSON.stringify({ text: "hello" }),
+        body: JSON.stringify({
+          text: "hello",
+          metadata: {
+            clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT,
+          },
+        }),
       }),
     ).rejects.toThrow(LocalRuntimeConversationFetchError);
   });
@@ -89,7 +103,21 @@ describe("local runtime conversation fetch", () => {
       bridge(url, { method: "POST", body: "{nope" }),
     ).rejects.toThrow(LocalRuntimeConversationFetchError);
     await expect(
-      bridge(url, { method: "POST", body: JSON.stringify({ text: "" }) }),
+      bridge(url, {
+        method: "POST",
+        body: JSON.stringify({
+          text: "",
+          metadata: {
+            clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT,
+          },
+        }),
+      }),
+    ).rejects.toThrow(LocalRuntimeConversationFetchError);
+    await expect(
+      bridge(url, {
+        method: "POST",
+        body: JSON.stringify({ text: "hello" }),
+      }),
     ).rejects.toThrow(LocalRuntimeConversationFetchError);
   });
 });

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -530,7 +530,10 @@ describe("voice-session WS lifecycle", () => {
     expect(new URL(requests[0].url).pathname).toBe(
       "/api/v1/eliza/agents/agent-1/api/conversations/conv-1/messages/stream",
     );
-    expect(requests[0].body).toEqual({ text: "hello agent" });
+    expect(requests[0].body).toEqual({
+      text: "hello agent",
+      metadata: { clientTransport: "realtime_voice" },
+    });
     expect(requests[0].headers.authorization).toBe("Bearer eliza-server");
     expect(requests[0].headers["x-service-key"]).toBe("Bearer eliza-server");
     expect(requests[0].headers["x-eliza-agent-id"]).toBe("agent-1");
@@ -674,7 +677,7 @@ describe("voice-session WS lifecycle", () => {
           {
             actionName: "VIEWS",
             success: true,
-            values: { mode: "show", viewId: "notes" },
+            values: { mode: "show", viewId: "notes", viewPath: "/notes" },
           },
           {
             actionName: "UNRELATED_ACTION",
@@ -697,6 +700,7 @@ describe("voice-session WS lifecycle", () => {
       {
         t: "navigate_view",
         viewId: "notes",
+        viewPath: "/notes",
         traceId: expect.any(String),
       },
     ]);

--- a/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
+++ b/packages/cloud/api/v1/voice/session/lib/harness-real-server.ts
@@ -111,6 +111,11 @@ import type {
   CartesiaInkWebSocket,
   CartesiaInkWebSocketFactory,
 } from "../../stt/providers/cartesia-ink";
+import { synthesizeCartesiaWav } from "../../tts/cartesia-synthesis";
+
+const LOCAL_TTS_SAMPLE_RATE = 24_000;
+const MAX_LOCAL_TTS_PCM_BYTES = 16 * 1024 * 1024;
+const MAX_LOCAL_TTS_TEXT_LENGTH = 4_000;
 
 // -------------------------------------------------------------------------
 // SHIM 2: node `ws`-package outbound provider factories (header-preserving,
@@ -420,6 +425,36 @@ export async function startRealVoiceServer(
       url.pathname === "/api/v1/voice/session/health"
     ) {
       writeJson(res, 200, { ready: true });
+      return;
+    }
+    if (req.method === "POST" && url.pathname === "/api/v1/voice/tts") {
+      const body = await readJsonBody(req);
+      const text = readRequiredString(body, "text");
+      if (text.length > MAX_LOCAL_TTS_TEXT_LENGTH) {
+        throw new LocalVoiceRequestError(
+          `text exceeds ${MAX_LOCAL_TTS_TEXT_LENGTH} characters`,
+        );
+      }
+      const synthesis = await synthesizeCartesiaWav({
+        apiKey: config.cartesiaApiKey,
+        voiceId: config.cartesiaVoiceId,
+        text,
+        sampleRate: LOCAL_TTS_SAMPLE_RATE,
+        maxPcmBytes: MAX_LOCAL_TTS_PCM_BYTES,
+        webSocketFactory: makeNodeCartesiaFactory(hooks),
+      });
+      hooks.log("info", "Cartesia message playback synthesized", {
+        bytes: synthesis.wav.byteLength,
+        firstAudioMs: synthesis.firstAudioMs,
+        totalMs: synthesis.totalMs,
+      });
+      res.writeHead(200, {
+        "Content-Type": "audio/wav",
+        "Content-Length": String(synthesis.wav.byteLength),
+        "Cache-Control": "no-store",
+        "X-Eliza-TTS-Provider": "cartesia-sonic-3.5",
+      });
+      res.end(Buffer.from(synthesis.wav));
       return;
     }
     if (

--- a/packages/cloud/api/v1/voice/session/lib/local-runtime-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/local-runtime-conversation-fetch.ts
@@ -5,6 +5,8 @@
  * removes cloud-only credentials.
  */
 
+import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
+
 const CLOUD_CONVERSATION_STREAM_PATH =
   /^\/api\/v1\/eliza\/agents\/[^/]+\/api\/conversations\/([^/]+)\/messages\/stream$/;
 
@@ -96,6 +98,7 @@ function resolveRequestUrl(input: RequestInfo | URL): URL {
 
 function parseRequestBody(body: BodyInit | null | undefined): {
   text: string;
+  metadata: { clientTransport: typeof REALTIME_VOICE_CLIENT_TRANSPORT };
 } {
   if (typeof body !== "string") {
     throw new LocalRuntimeConversationFetchError(
@@ -103,13 +106,30 @@ function parseRequestBody(body: BodyInit | null | undefined): {
     );
   }
   try {
-    const parsed = JSON.parse(body) as { text?: unknown };
+    const parsed = JSON.parse(body) as {
+      text?: unknown;
+      metadata?: unknown;
+    };
     if (typeof parsed.text !== "string" || parsed.text.trim() === "") {
       throw new LocalRuntimeConversationFetchError(
         "local voice conversation text is required",
       );
     }
-    return { text: parsed.text };
+    const metadata =
+      typeof parsed.metadata === "object" &&
+      parsed.metadata !== null &&
+      !Array.isArray(parsed.metadata)
+        ? (parsed.metadata as Record<string, unknown>)
+        : null;
+    if (metadata?.clientTransport !== REALTIME_VOICE_CLIENT_TRANSPORT) {
+      throw new LocalRuntimeConversationFetchError(
+        "local voice conversation transport metadata is required",
+      );
+    }
+    return {
+      text: parsed.text,
+      metadata: { clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT },
+    };
   } catch (error) {
     // error-policy:J3 The generated upstream body crosses a transport boundary;
     // malformed input fails explicitly instead of becoming an empty chat turn.

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -722,6 +722,9 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         this.send({
           t: "navigate_view",
           viewId: result.viewHandoff.viewId,
+          ...(result.viewHandoff.viewPath
+            ? { viewPath: result.viewHandoff.viewPath }
+            : {}),
           ...(result.viewHandoff.subview
             ? { subview: result.viewHandoff.subview }
             : {}),

--- a/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
 
 import { streamElizaConversation, VOICE_TRACE_HEADER } from "../eliza-sse-bridge";
 
@@ -134,7 +135,12 @@ describe("eliza sse bridge", () => {
     expect(seenUrl).toBe(
       "http://x/api/v1/eliza/agents/agent-XYZ/api/conversations/conv-ABC/messages/stream",
     );
-    expect(seenBody).toEqual({ text: "hi" });
+    expect(seenBody).toEqual({
+      text: "hi",
+      metadata: {
+        clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT,
+      },
+    });
     expect(seenHeaders?.get("Authorization")).toBe("Bearer s");
     expect(seenHeaders?.get("X-Service-Key")).toBe("Bearer s");
     expect(seenHeaders?.get("X-Eliza-Agent-Id")).toBe("agent-XYZ");
@@ -143,16 +149,23 @@ describe("eliza sse bridge", () => {
     expect(seenHeaders?.get("X-Eliza-User-Id")).toBe("user-456");
   });
 
-  test("returns only a successful model-selected VIEWS handoff from terminal metadata", async () => {
+  test("returns the originating-client VIEWS handoff from the local runtime done frame", async () => {
     const fetchImpl = (async () =>
       sseResponse([
-        `event: chunk\ndata: ${JSON.stringify({ chunk: "Opened Notes." })}\n\n`,
-        `event: done\ndata: ${JSON.stringify({
+        `data: ${JSON.stringify({ type: "token", text: "Opened Notes." })}\n\n`,
+        `data: ${JSON.stringify({
+          type: "done",
+          fullText: "Opened Notes.",
           actionResults: [
             {
               actionName: "VIEWS",
               success: true,
-              values: { mode: "show", viewId: "notes", subview: "recent" },
+              values: {
+                mode: "show",
+                viewId: "notes",
+                viewPath: "/notes",
+                subview: "recent",
+              },
             },
           ],
         })}\n\n`,
@@ -176,7 +189,11 @@ describe("eliza sse bridge", () => {
     expect(result).toEqual({
       completed: true,
       aborted: false,
-      viewHandoff: { viewId: "notes", subview: "recent" },
+      viewHandoff: {
+        viewId: "notes",
+        viewPath: "/notes",
+        subview: "recent",
+      },
     });
   });
 
@@ -220,7 +237,7 @@ describe("eliza sse bridge", () => {
   test("surfaces canonical agent stream errors instead of completing an empty turn", async () => {
     const fetchImpl = (async () =>
       sseResponse([
-        `event: error\ndata: ${JSON.stringify({ message: "agent failed" })}\n\n`,
+        `data: ${JSON.stringify({ type: "error", message: "agent failed" })}\n\n`,
       ])) as unknown as typeof fetch;
     await expect(
       streamElizaConversation(

--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -17,6 +17,8 @@
  * decoding path, no live model.
  */
 
+import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
+
 export const VOICE_TRACE_HEADER = "X-Eliza-Voice-Trace-Id";
 /** Scope headers so the configured endpoint routes the turn to the right agent. */
 export const VOICE_AGENT_HEADER = "X-Eliza-Agent-Id";
@@ -61,6 +63,7 @@ export interface ElizaSseBridgeResult {
 
 export interface ElizaVoiceViewHandoff {
   viewId: string;
+  viewPath?: string;
   subview?: string;
 }
 
@@ -117,7 +120,12 @@ export async function streamElizaConversation(
       // This is the canonical message contract. Agent and conversation identity
       // are structural URL segments, so the route cannot silently discard them;
       // sharedRestMessageSend/bridgeStream executes and persists this turn.
-      body: JSON.stringify({ text: request.transcript }),
+      body: JSON.stringify({
+        text: request.transcript,
+        metadata: {
+          clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT,
+        },
+      }),
       signal: request.signal,
     });
   } catch (error) {
@@ -202,7 +210,8 @@ export async function streamElizaConversation(
         if (!line.startsWith("data:")) continue;
         const payload = line.slice(5).trim();
         if (payload === "") continue;
-        if (payload === "[DONE]" || eventType === "done") {
+        const payloadType = extractPayloadType(payload);
+        if (payload === "[DONE]" || eventType === "done" || payloadType === "done") {
           const viewHandoff = payload === "[DONE]" ? null : extractViewHandoff(payload);
           return {
             completed: true,
@@ -210,7 +219,7 @@ export async function streamElizaConversation(
             ...(viewHandoff ? { viewHandoff } : {}),
           };
         }
-        if (eventType === "error") {
+        if (eventType === "error" || payloadType === "error") {
           throw new ElizaSseBridgeError(
             `Eliza agent stream error: ${extractErrorMessage(payload)}`,
             "upstream_error",
@@ -348,6 +357,18 @@ function extractErrorMessage(payload: string): string {
   return payload.slice(0, 256) || "unknown agent stream error";
 }
 
+function extractPayloadType(payload: string): string | null {
+  try {
+    const parsed = JSON.parse(payload) as { type?: unknown };
+    return typeof parsed.type === "string" ? parsed.type : null;
+  } catch (ignoredError) {
+    void ignoredError;
+    // error-policy:J3 untrusted SSE payloads without JSON have no typed control
+    // meaning; token extraction and explicit event labels still handle them.
+    return null;
+  }
+}
+
 function extractDeltaContent(payload: string): string | null {
   let parsed: unknown;
   try {
@@ -396,18 +417,26 @@ function extractViewHandoff(payload: string): ElizaVoiceViewHandoff | null {
   for (let index = parsed.actionResults.length - 1; index >= 0; index--) {
     const candidate = parsed.actionResults[index];
     if (!isRecord(candidate) || candidate.success !== true) continue;
-    if (
-      typeof candidate.actionName !== "string" ||
-      candidate.actionName.toUpperCase() !== "VIEWS" ||
-      !isRecord(candidate.values)
-    ) {
+    const data = isRecord(candidate.data) ? candidate.data : null;
+    const actionName =
+      typeof candidate.actionName === "string"
+        ? candidate.actionName
+        : typeof data?.actionName === "string"
+          ? data.actionName
+          : null;
+    if (actionName?.toUpperCase() !== "VIEWS" || !isRecord(candidate.values)) {
       continue;
     }
     const mode = readBoundedString(candidate.values.mode)?.toLowerCase();
     const viewId = readBoundedString(candidate.values.viewId);
     if ((mode !== "show" && mode !== "open") || !viewId) continue;
+    const viewPath = readBoundedString(candidate.values.viewPath);
     const subview = readBoundedString(candidate.values.subview);
-    return { viewId, ...(subview ? { subview } : {}) };
+    return {
+      viewId,
+      ...(viewPath ? { viewPath } : {}),
+      ...(subview ? { subview } : {}),
+    };
   }
   return null;
 }

--- a/packages/cloud/shared/src/lib/voice-session/protocol.ts
+++ b/packages/cloud/shared/src/lib/voice-session/protocol.ts
@@ -86,6 +86,7 @@ export type ServerControlFrame =
   | {
       t: "navigate_view";
       viewId: string;
+      viewPath?: string;
       subview?: string;
       traceId: string;
     }

--- a/packages/shared/src/contracts/calendar.ts
+++ b/packages/shared/src/contracts/calendar.ts
@@ -39,6 +39,7 @@ export interface LifeOpsCalendarEventAttendee {
 }
 
 export type LifeOpsCalendarProvider =
+  | "eliza"
   | "google"
   | "microsoft"
   | "apple_calendar"

--- a/packages/shared/src/voice.ts
+++ b/packages/shared/src/voice.ts
@@ -1,7 +1,15 @@
 /**
- * Shared voice-related types and data used by VoiceConfigView, CharacterView,
- * and any other app that provides ElevenLabs / Edge voice selection.
+ * Shared voice contracts and voice-selection data consumed across runtime,
+ * cloud, plugins, and UI surfaces.
  */
+
+/**
+ * Client-transport marker for turns owned by a realtime voice WebSocket
+ * session. It travels in message metadata so normal client-chat role and
+ * response policy remain unchanged while side effects can return through the
+ * originating session.
+ */
+export const REALTIME_VOICE_CLIENT_TRANSPORT = "realtime_voice" as const;
 
 export interface VoicePreset {
   id: string;

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -689,6 +689,7 @@ describe("App navigate-view event wiring", () => {
     );
     expect(loader.getAttribute("data-view-id")).toBe("remote-ledger");
     expect(loader.getAttribute("data-view-type")).toBe("gui");
+    expect(queryByTestId("view-header")).toBeNull();
     expect(
       container
         .querySelector('[data-shell-content-region="true"]')

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -979,19 +979,15 @@ function findRemoteViewForRoute(
 
 function renderRemoteView(view: ViewRegistryEntry, nav?: ReactNode): ReactNode {
   if (!view.bundleUrl && !view.frameUrl) return null;
-  // Remote plugin bundles render only their own content (a SpatialSurface), not
-  // the app-shell chrome — so the shell owns the standard top bar for them. Every
-  // `normal`-policy view gets the shared ViewHeader (title + back-to-launcher),
-  // matching #13586 ("the shell enforces the shared ViewHeader on every normal
-  // view"); `fullscreen`/`modal`/`immersive` opt out. A section nav (Wallet /
-  // Character strip) already supplies the header, so it suppresses this one.
+  // Plugin views own their canvas and stay flush with the shell. Repeating a
+  // route title above every plugin wasted the narrowest part of mobile screens
+  // and duplicated view-owned headings; navigation remains available from the
+  // persistent chat-actions menu and the browser/OS back affordance.
   const manifest = resolveSurfaceManifest(view);
-  const showHeader = !nav && manifest.header === "normal";
   const ownsViewport =
     manifest.header === "fullscreen" || manifest.header === "immersive";
   return (
     <TabContentView nav={nav} reserveChatClearance={!ownsViewport}>
-      {showHeader ? <ViewHeader title={view.label} /> : null}
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <DynamicViewLoader
           bundleUrl={view.bundleUrl}

--- a/packages/ui/src/chat/composer-core.ts
+++ b/packages/ui/src/chat/composer-core.ts
@@ -1,10 +1,10 @@
 /**
  * Headless composer core shared by every chat input surface. One
  * implementation of the composer keyboard contract — IME-safe Enter-to-send
- * (#9148), slash-menu key interception, Shift+Enter newline, Escape — and of
- * the clipboard contract — a pasted image/file attaches, an oversized text
- * paste becomes a collapsed text-attachment chip, small text falls through to
- * the input (#12188 Phase 3).
+ * (#9148), slash-menu and optional sent-history interception, Shift+Enter
+ * newline, Escape — and of the clipboard contract — a pasted image/file
+ * attaches, an oversized text paste becomes a collapsed text-attachment chip,
+ * small text falls through to the input (#12188 Phase 3).
  *
  * Together with `useChatComposerOrLocal` (draft state,
  * state/ChatComposerContext.hooks.ts) and `usePushToTalk` (mic hold machine,
@@ -61,7 +61,7 @@ export interface ComposerSlashKeydown {
   dismiss(): void;
 }
 
-export interface ComposerKeydownOptions {
+export interface ComposerKeydownOptions<T extends HTMLElement = HTMLElement> {
   /** Enter (no Shift, no composing IME) sends. */
   onSend: () => void;
   /** Slash-menu interception, consulted while its `open` flag is true. */
@@ -71,6 +71,11 @@ export interface ComposerKeydownOptions {
    * Return true when consumed so the core preventDefaults it.
    */
   onEscape?: () => boolean;
+  /**
+   * Physical ArrowUp/ArrowDown history navigation. The surface owns its history
+   * source and returns true only when it consumed the key.
+   */
+  onHistory?: (direction: -1 | 1, event: ReactKeyboardEvent<T>) => boolean;
   /** Ignore every key while locked (mirrors the disabled-input guard). */
   locked?: boolean;
 }
@@ -78,18 +83,19 @@ export interface ComposerKeydownOptions {
 /**
  * The one composer keydown handler. Ordering is the contract: locked guard →
  * IME-commit Enter passthrough → slash-menu interception (ArrowUp/ArrowDown/
- * Tab/Enter/Escape) → Enter sends (Shift+Enter falls through as a newline) →
- * Escape surface hook. Returns a stable handler; options are read through a
- * ref so surfaces may pass fresh closures every render.
+ * Tab/Enter/Escape) → optional sent-history interception → Enter sends
+ * (Shift+Enter falls through as a newline) → Escape surface hook. Returns a
+ * stable handler; options are read through a ref so surfaces may pass fresh
+ * closures every render.
  */
 export function useComposerKeydown<T extends HTMLElement>(
-  options: ComposerKeydownOptions,
+  options: ComposerKeydownOptions<T>,
 ): (event: ReactKeyboardEvent<T>) => void {
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
   return useCallback((event: ReactKeyboardEvent<T>) => {
-    const { onSend, slash, onEscape, locked } = optionsRef.current;
+    const { onSend, slash, onEscape, onHistory, locked } = optionsRef.current;
     if (locked) return;
     if (isImeComposingEnter(event)) return;
     if (slash?.open) {
@@ -121,6 +127,14 @@ export function useComposerKeydown<T extends HTMLElement>(
         slash.dismiss();
         return;
       }
+    }
+    if (event.key === "ArrowUp" && onHistory?.(-1, event)) {
+      event.preventDefault();
+      return;
+    }
+    if (event.key === "ArrowDown" && onHistory?.(1, event)) {
+      event.preventDefault();
+      return;
     }
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();

--- a/packages/ui/src/components/pages/chat-view-hooks.test.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.test.tsx
@@ -62,6 +62,7 @@ const realtimeHarness = vi.hoisted(() => {
     agentSpeaking: false,
     needsUnlock: false,
     paused: false,
+    microphoneMuted: false,
     error: null as RealtimeVoiceError | null,
     fallbackReason: null,
     reportFallback: vi.fn(),
@@ -71,6 +72,7 @@ const realtimeHarness = vi.hoisted(() => {
     })),
     stop: vi.fn(async () => {}),
     bargeIn: vi.fn(),
+    toggleMicrophoneMute: vi.fn(),
     unlock: vi.fn(async () => {}),
   };
   return { state };

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -2331,9 +2331,8 @@ describe("ChatOverlay", () => {
   });
 
   it("returns to the launcher from the chat-actions menu", () => {
-    const onNavigate = vi.fn();
-    window.addEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
-    render(<ChatOverlay controller={makeController()} />);
+    const navigateHome = vi.fn();
+    render(<ChatOverlay controller={makeController({ navigateHome })} />);
 
     const plus = screen.getByTestId("chat-composer-plus");
     fireEvent.pointerDown(plus, {
@@ -2348,14 +2347,7 @@ describe("ChatOverlay", () => {
     });
     fireEvent.click(screen.getByText("Back to Home"));
 
-    expect(onNavigate).toHaveBeenCalledTimes(1);
-    expect((onNavigate.mock.calls[0][0] as CustomEvent).detail).toEqual({
-      viewId: "views",
-      viewPath: "/views",
-      viewLabel: "Home",
-      source: "user",
-    });
-    window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+    expect(navigateHome).toHaveBeenCalledTimes(1);
   });
 
   it.each(["half", "full"] as const)(

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -2134,8 +2134,10 @@ describe("ChatOverlay", () => {
               active: true,
               connecting: false,
               paused: false,
+              microphoneMuted: false,
               status,
               error: null,
+              toggleMicrophoneMute: vi.fn(),
             },
           })}
         />,
@@ -2187,8 +2189,10 @@ describe("ChatOverlay", () => {
       active: true,
       connecting: false,
       paused: false,
+      microphoneMuted: false,
       status: "listening" as const,
       error: null,
+      toggleMicrophoneMute: vi.fn(),
     };
     const { rerender } = render(
       <ChatOverlay
@@ -2268,8 +2272,10 @@ describe("ChatOverlay", () => {
             active: false,
             connecting: false,
             paused: false,
+            microphoneMuted: false,
             status: "idle",
             error: "Cartesia voice could not connect. Tap Talk to retry.",
+            toggleMicrophoneMute: vi.fn(),
           },
         })}
       />,
@@ -2295,7 +2301,7 @@ describe("ChatOverlay", () => {
     expect(screen.getAllByTestId("chat-composer-textarea")).toHaveLength(1);
   });
 
-  it("keeps chat actions focused on search and upload", () => {
+  it("keeps Home above the surface-local search and upload actions", () => {
     render(<ChatOverlay controller={makeController()} />);
     const plus = screen.getByTestId("chat-composer-plus");
     expect(screen.getByLabelText("chat actions")).toBeTruthy();
@@ -2311,11 +2317,45 @@ describe("ChatOverlay", () => {
       pointerType: "mouse",
     });
 
-    expect(screen.getByText("Search chat…")).toBeTruthy();
+    const home = screen.getByText("Back to Home");
+    const search = screen.getByText("Search chat…");
+    expect(home).toBeTruthy();
+    expect(search).toBeTruthy();
     expect(screen.getByText("Upload file")).toBeTruthy();
+    expect(
+      home.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(screen.queryByText("Record long-form transcript…")).toBeNull();
     expect(screen.queryByText("Enable camera")).toBeNull();
     expect(screen.queryByText("Stop transcribing")).toBeNull();
+  });
+
+  it("returns to the launcher from the chat-actions menu", () => {
+    const onNavigate = vi.fn();
+    window.addEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+    render(<ChatOverlay controller={makeController()} />);
+
+    const plus = screen.getByTestId("chat-composer-plus");
+    fireEvent.pointerDown(plus, {
+      button: 0,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
+    fireEvent.pointerUp(plus, {
+      button: 0,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
+    fireEvent.click(screen.getByText("Back to Home"));
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect((onNavigate.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      viewId: "views",
+      viewPath: "/views",
+      viewLabel: "Home",
+      source: "user",
+    });
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
   });
 
   it.each(["half", "full"] as const)(
@@ -2956,17 +2996,61 @@ describe("ChatOverlay", () => {
     expect(screen.getByTestId("chat-composer-action")).toBeTruthy();
   });
 
-  it("keeps one Talk control while realtime voice is active", () => {
-    render(
+  it("adds one microphone mute toggle immediately left of Stop during realtime voice", () => {
+    const toggleMicrophoneMute = vi.fn();
+    const realtimeVoice = {
+      enabled: true,
+      active: true,
+      connecting: false,
+      paused: false,
+      microphoneMuted: false,
+      status: "listening" as const,
+      error: null,
+      toggleMicrophoneMute,
+    };
+    const { rerender } = render(
       <ChatOverlay
         controller={makeController({
           handsFree: true,
           phase: "listening",
           recording: true,
-        } as unknown as Partial<ShellController>)}
+          realtimeVoice,
+        })}
       />,
     );
-    expect(screen.getByTestId("chat-composer-mic")).toBeTruthy();
+    const stop = screen.getByTestId("chat-composer-mic");
+    const mute = screen.getByTestId("chat-composer-voice-mute");
+    expect(
+      screen.getByTestId("chat-composer-control-slot-right").contains(stop),
+    ).toBe(true);
+    expect(
+      screen.getByTestId("chat-composer-control-slot-left").contains(mute),
+    ).toBe(true);
+    expect(mute.getAttribute("aria-label")).toBe("mute microphone");
+    expect(mute.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(mute);
+    expect(toggleMicrophoneMute).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ChatOverlay
+        controller={makeController({
+          handsFree: true,
+          phase: "listening",
+          recording: true,
+          realtimeVoice: { ...realtimeVoice, microphoneMuted: true },
+        })}
+      />,
+    );
+    expect(
+      screen
+        .getByRole("button", { name: "unmute microphone" })
+        .getAttribute("aria-label"),
+    ).toBe("unmute microphone");
+    expect(
+      screen
+        .getByRole("button", { name: "unmute microphone" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
     expect(screen.getAllByTestId("chat-composer-mic")).toHaveLength(1);
     expect(screen.queryByTestId("chat-composer-transcribe")).toBeNull();
   });

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -759,7 +759,7 @@ describe("ChatOverlay", () => {
     expect(document.activeElement).not.toBe(composer);
   });
 
-  it("preserves focused typing through one agent-command view navigation", () => {
+  it("preserves focused typing when an agent view id resolves through the views tab", () => {
     const { rerender } = render(
       <ChatOverlay
         controller={makeController({
@@ -773,8 +773,7 @@ describe("ChatOverlay", () => {
       window.dispatchEvent(
         new CustomEvent(NAVIGATE_VIEW_EVENT, {
           detail: {
-            viewId: "notes",
-            viewPath: "/notes",
+            viewId: "calendar",
             source: "agent",
           },
         }),
@@ -784,7 +783,7 @@ describe("ChatOverlay", () => {
     rerender(
       <ChatOverlay
         controller={makeController({
-          currentTab: "notes",
+          currentTab: "views",
         } as Partial<ShellController>)}
       />,
     );
@@ -2348,6 +2347,57 @@ describe("ChatOverlay", () => {
     fireEvent.click(screen.getByText("Back to Home"));
 
     expect(navigateHome).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the redundant Home action while already on Home", () => {
+    render(<ChatOverlay controller={makeController({ currentTab: "chat" })} />);
+
+    const plus = screen.getByTestId("chat-composer-plus");
+    fireEvent.pointerDown(plus, {
+      button: 0,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
+    fireEvent.pointerUp(plus, {
+      button: 0,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
+
+    expect(screen.queryByText("Back to Home")).toBeNull();
+    expect(screen.getByText("Search chat…")).toBeTruthy();
+  });
+
+  it("cycles sent messages with desktop arrow keys and restores the draft", () => {
+    render(
+      <ChatOverlay
+        controller={makeController({
+          messages: [
+            { id: "u1", role: "user", content: "first", createdAt: 1 },
+            {
+              id: "a1",
+              role: "assistant",
+              content: "reply",
+              createdAt: 2,
+            },
+            { id: "u2", role: "user", content: "second", createdAt: 3 },
+          ],
+        })}
+      />,
+    );
+    const input = screen.getByTestId(
+      "chat-composer-textarea",
+    ) as HTMLTextAreaElement;
+
+    fireEvent.change(input, { target: { value: "unfinished" } });
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(input.value).toBe("second");
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(input.value).toBe("first");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input.value).toBe("second");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input.value).toBe("unfinished");
   });
 
   it.each(["half", "full"] as const)(

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -52,7 +52,6 @@ import {
   CHAT_OPEN_EVENT,
   CHAT_PREFILL_EVENT,
   type ChatPrefillEventDetail,
-  dispatchNavigateViewEvent,
   ELIZA_BACK_INTENT_EVENT,
   NAVIGATE_VIEW_EVENT,
   type NavigateViewDetail,
@@ -1206,6 +1205,7 @@ export function ChatOverlay({
     needsAudioUnlock,
     unlockAudio,
     openSettings,
+    navigateHome,
     currentTab,
     stop,
     speak,
@@ -6305,13 +6305,8 @@ export function ChatOverlay({
                     <DropdownMenuItem
                       className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
                       onSelect={() => {
+                        navigateHome?.();
                         collapseToPill();
-                        dispatchNavigateViewEvent({
-                          viewId: "views",
-                          viewPath: "/views",
-                          viewLabel: "Home",
-                          source: "user",
-                        });
                       }}
                     >
                       <House

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -74,7 +74,6 @@ import {
 import { useLoadOlderOnScroll } from "../../hooks/useLoadOlderOnScroll";
 import { Z_SHELL_OVERLAY } from "../../lib/floating-layers";
 import { cn } from "../../lib/utils";
-import { tabFromPath } from "../../navigation";
 import { claimAssistantLaunchPayloadFromHash } from "../../platform/assistant-launch-payload";
 import { isIOS, isNative, isStandalonePwa } from "../../platform/init";
 import {
@@ -1400,6 +1399,26 @@ export function ChatOverlay({
     setChatReplyTarget,
   } = useChatComposerOrLocal();
   const activeConversationId = conversationNav.activeId;
+  const sentMessageHistory = React.useMemo(
+    () =>
+      messages.flatMap((message) => {
+        const content = message.content.trim();
+        return message.role === "user" && content ? [content] : [];
+      }),
+    [messages],
+  );
+  const messageHistoryCursorRef = React.useRef<number | null>(null);
+  const messageHistoryDraftRef = React.useRef("");
+  const resetMessageHistory = React.useCallback(() => {
+    messageHistoryCursorRef.current = null;
+    messageHistoryDraftRef.current = "";
+  }, []);
+  const messageHistoryConversationRef = React.useRef(activeConversationId);
+  React.useEffect(() => {
+    if (messageHistoryConversationRef.current === activeConversationId) return;
+    messageHistoryConversationRef.current = activeConversationId;
+    resetMessageHistory();
+  }, [activeConversationId, resetMessageHistory]);
   // Live handle to the draft for callbacks that must read the current text
   // without subscribing (dictation append), same pattern as messagesRef above.
   const draftRef = React.useRef(draft);
@@ -1757,7 +1776,7 @@ export function ChatOverlay({
   }, []);
   const [imageError, setImageError] = React.useState<string | null>(null);
   const inputRef = React.useRef<HTMLTextAreaElement>(null);
-  const preserveFocusOnAgentNavigationRef = React.useRef<string | null>(null);
+  const preserveComposerFocusUntilRef = React.useRef(0);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const overlayRef = React.useRef<HTMLDivElement>(null);
   const panelRef = React.useRef<HTMLFieldSetElement>(null);
@@ -2422,6 +2441,7 @@ export function ChatOverlay({
       // synthetic draft entry point that reaches submit, and keep setup choice
       // handling inside the transcript widgets.
       if (firstRunOpen) {
+        resetMessageHistory();
         setDraft("");
         setSlashDismissed(false);
         setPendingImages([]);
@@ -2435,6 +2455,7 @@ export function ChatOverlay({
       // canSend gate because the tour is fully client-side and must work with
       // the agent stopped.
       if (trimmed && images.length === 0 && tryHandleTutorialText(trimmed)) {
+        resetMessageHistory();
         clearChatDraft(activeConversationIdRef.current);
         setDraft("");
         setSlashDismissed(false);
@@ -2445,6 +2466,7 @@ export function ChatOverlay({
       }
       // Post-onboarding: a stopped agent can't take a turn.
       if (!canSend) return;
+      resetMessageHistory();
       // Successful submit: drop the persisted draft for this conversation NOW
       // (not just via the debounced persist of the now-empty draft) so a reload
       // in the debounce window can't restore an already-sent draft.
@@ -2495,7 +2517,15 @@ export function ChatOverlay({
       detentHaptic();
       inputRef.current?.focus();
     },
-    [canSend, firstRunOpen, send, setDraft, setPendingImages, viewChatBinding],
+    [
+      canSend,
+      firstRunOpen,
+      resetMessageHistory,
+      send,
+      setDraft,
+      setPendingImages,
+      viewChatBinding,
+    ],
   );
 
   const finishTranscription = React.useCallback(async () => {
@@ -3743,33 +3773,32 @@ export function ChatOverlay({
     if (preFocusCollapsedRef.current) collapse();
   }, [collapse]);
 
-  // A chat-command navigation is different from a direct tile/tab navigation:
-  // the user just pressed Enter and should be able to keep typing. Capture that
-  // one transition before App updates currentTab; the blur effect below consumes
-  // the lease. Direct navigation carries no agent source and keeps the existing
-  // iOS keyboard cleanup.
+  // View navigation changes the canvas underneath this persistent composer; it
+  // is not a chat dismissal. Preserve an actively focused input through the
+  // route commit even when a plugin view maps its view id onto the generic
+  // `views` tab. Explicit close/open-window actions retain their own focus
+  // ownership instead.
   React.useEffect(() => {
     if (typeof window === "undefined") return undefined;
     const preserveFocusedComposer = (event: Event) => {
       const detail = (event as CustomEvent<NavigateViewDetail>).detail;
       const action = detail?.action;
-      const targetTab =
-        action === "close" || action === "close-all" || action === "open-window"
-          ? null
-          : action === "split-view" || action === "tile-views"
-            ? "views"
-            : detail?.viewId && detail.viewPath === `/${detail.viewId}`
-              ? detail.viewId
-              : detail?.viewPath
-                ? (tabFromPath(detail.viewPath) ?? detail.viewId ?? null)
-                : (detail?.viewId ?? null);
-      preserveFocusOnAgentNavigationRef.current =
-        detail?.source === "agent" &&
-        targetTab !== null &&
+      const staysInShell =
+        action !== "close" &&
+        action !== "close-all" &&
+        action !== "open-window";
+      const shouldPreserve =
+        staysInShell &&
         typeof document !== "undefined" &&
-        document.activeElement === inputRef.current
-          ? targetTab
-          : null;
+        document.activeElement === inputRef.current;
+      preserveComposerFocusUntilRef.current = shouldPreserve
+        ? performance.now() + 1000
+        : 0;
+      if (shouldPreserve) {
+        window.requestAnimationFrame(() => {
+          inputRef.current?.focus({ preventScroll: true });
+        });
+      }
     };
     window.addEventListener(NAVIGATE_VIEW_EVENT, preserveFocusedComposer);
     return () =>
@@ -3788,12 +3817,12 @@ export function ChatOverlay({
   // accessory bar, not just the soft keyboard.
   React.useEffect(() => {
     if (currentTab === "chat") {
-      preserveFocusOnAgentNavigationRef.current = null;
+      preserveComposerFocusUntilRef.current = 0;
       return;
     }
     const preserveFocus =
-      preserveFocusOnAgentNavigationRef.current === currentTab;
-    preserveFocusOnAgentNavigationRef.current = null;
+      preserveComposerFocusUntilRef.current >= performance.now();
+    preserveComposerFocusUntilRef.current = 0;
     const input = inputRef.current;
     if (
       typeof document === "undefined" ||
@@ -4191,11 +4220,69 @@ export function ChatOverlay({
     [slashMenu, runExecution],
   );
 
+  const cycleMessageHistory = React.useCallback(
+    (
+      direction: -1 | 1,
+      event: React.KeyboardEvent<HTMLTextAreaElement>,
+    ): boolean => {
+      if (
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey ||
+        event.nativeEvent.isComposing ||
+        event.currentTarget.selectionStart !==
+          event.currentTarget.selectionEnd ||
+        sentMessageHistory.length === 0
+      ) {
+        return false;
+      }
+
+      const cursor = messageHistoryCursorRef.current;
+      if (cursor === null) {
+        if (direction > 0) return false;
+        const firstLineEnd = draft.indexOf("\n");
+        if (
+          firstLineEnd >= 0 &&
+          event.currentTarget.selectionStart > firstLineEnd
+        ) {
+          return false;
+        }
+        messageHistoryDraftRef.current = draft;
+        messageHistoryCursorRef.current = sentMessageHistory.length - 1;
+      } else if (direction < 0) {
+        messageHistoryCursorRef.current = Math.max(0, cursor - 1);
+      } else if (cursor < sentMessageHistory.length - 1) {
+        messageHistoryCursorRef.current = cursor + 1;
+      } else {
+        messageHistoryCursorRef.current = null;
+        setDraft(messageHistoryDraftRef.current);
+        return true;
+      }
+
+      const nextCursor = messageHistoryCursorRef.current;
+      if (nextCursor === null) return false;
+      const next = sentMessageHistory[nextCursor];
+      if (next === undefined) {
+        resetMessageHistory();
+        return false;
+      }
+      setDraft(next);
+      window.requestAnimationFrame(() => {
+        inputRef.current?.setSelectionRange(next.length, next.length);
+      });
+      return true;
+    },
+    [draft, resetMessageHistory, sentMessageHistory, setDraft],
+  );
+
   // The shared composer-core keydown: IME-commit guard (#9148) → slash-menu
-  // interception → Enter sends → Escape collapses the open sheet. The slash
-  // binding adapts the overlay's menu/executor onto the core's key contract.
+  // interception → sent-message history → Enter sends → Escape collapses the
+  // open sheet. The slash binding adapts the overlay's menu/executor onto the
+  // core's key contract.
   const handleComposerKeyDown = useComposerKeydown<HTMLTextAreaElement>({
     onSend: submit,
+    onHistory: cycleMessageHistory,
     slash: {
       open: slashOpen,
       move: (delta) => slashMenu.move(delta),
@@ -6302,18 +6389,20 @@ export function ChatOverlay({
                     glass
                     className="min-w-[13rem]"
                   >
-                    <DropdownMenuItem
-                      className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
-                      onSelect={() => {
-                        navigateHome?.();
-                      }}
-                    >
-                      <House
-                        className="h-4 w-4 shrink-0 text-muted"
-                        aria-hidden
-                      />
-                      Back to Home
-                    </DropdownMenuItem>
+                    {currentTab !== "chat" ? (
+                      <DropdownMenuItem
+                        className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
+                        onSelect={() => {
+                          navigateHome?.();
+                        }}
+                      >
+                        <House
+                          className="h-4 w-4 shrink-0 text-muted"
+                          aria-hidden
+                        />
+                        Back to Home
+                      </DropdownMenuItem>
+                    ) : null}
                     <DropdownMenuItem
                       className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
                       onSelect={() => openSearch()}
@@ -6366,6 +6455,7 @@ export function ChatOverlay({
                   disabled={firstRunOpen}
                   onChange={(e) => {
                     const nextDraft = e.target.value;
+                    resetMessageHistory();
                     if (
                       draft.trim().length > 0 &&
                       nextDraft.trim().length === 0

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -6306,7 +6306,6 @@ export function ChatOverlay({
                       className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
                       onSelect={() => {
                         navigateHome?.();
-                        collapseToPill();
                       }}
                     >
                       <House

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -9,7 +9,10 @@ import {
   AudioLines,
   FileText,
   Film,
+  House,
   Loader2,
+  Mic,
+  MicOff,
   Music,
   Paperclip,
   Search,
@@ -49,6 +52,7 @@ import {
   CHAT_OPEN_EVENT,
   CHAT_PREFILL_EVENT,
   type ChatPrefillEventDetail,
+  dispatchNavigateViewEvent,
   ELIZA_BACK_INTENT_EVENT,
   NAVIGATE_VIEW_EVENT,
   type NavigateViewDetail,
@@ -1216,6 +1220,11 @@ export function ChatOverlay({
         realtimeVoice.active ||
         realtimeVoice.connecting ||
         realtimeVoice.status !== "idle"),
+  );
+  const realtimeVoiceControlsVisible = Boolean(
+    realtimeVoice?.enabled &&
+      handsFree &&
+      (realtimeVoice.active || realtimeVoice.connecting),
   );
   // True once the server has reported no LLM/model provider is configured (a
   // `no_provider` assistant turn). Defaulted for minimal mock controllers.
@@ -5757,9 +5766,8 @@ export function ChatOverlay({
             {/* Sheet header — shown at the HALF detent and up (not just FULL).
               One infinite thread (#13531): no maximize/minimize (that's a
               vertical pull now) and no clear/new-chat (the thread never resets).
-              It carries NO buttons — search/upload/camera/transcribe moved to the
-              composer "+" menu and Home lives in the launcher — so the chat stops
-              acting like a second app nav bar. The bar remains only to reserve
+              It carries NO buttons — Home/search/upload live in the composer
+              "+" menu — so the chat stops acting like a second app nav bar. The bar remains only to reserve
               the safe-area top inset at full-bleed and host the transcribe badge. */}
             {threadPresented ? (
               <motion.div
@@ -5798,9 +5806,8 @@ export function ChatOverlay({
                   "mx-auto w-full max-w-3xl",
                 )}
               >
-                {/* The header carries no nav/search buttons — thread Search and
-                    Upload live in the composer "+" menu, while Home lives in
-                    the launcher. This bar exists only to reserve the safe-area
+                {/* The header carries no nav/search buttons — Home, Search, and
+                    Upload live in the composer "+" menu. This bar exists only to reserve the safe-area
                     top inset at full-bleed and host the transcription badge. */}
                 {transcriptionComposerActive ? (
                   <div
@@ -6262,8 +6269,8 @@ export function ChatOverlay({
                   onPick={pickSlashItem}
                 />
               ) : null}
-              {/* The "+" opens surface-local Search and Upload actions for this
-                  in-app conversation, never connector actions on a
+              {/* The "+" opens shell navigation plus surface-local Search and
+                  Upload actions for this in-app conversation, never connector actions on a
                   Discord/Telegram room. Search is agent-driveable; Upload is a
                   pure client affordance. */}
               {!transcriptionComposerActive ? (
@@ -6295,6 +6302,24 @@ export function ChatOverlay({
                     glass
                     className="min-w-[13rem]"
                   >
+                    <DropdownMenuItem
+                      className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
+                      onSelect={() => {
+                        collapseToPill();
+                        dispatchNavigateViewEvent({
+                          viewId: "views",
+                          viewPath: "/views",
+                          viewLabel: "Home",
+                          source: "user",
+                        });
+                      }}
+                    >
+                      <House
+                        className="h-4 w-4 shrink-0 text-muted"
+                        aria-hidden
+                      />
+                      Back to Home
+                    </DropdownMenuItem>
                     <DropdownMenuItem
                       className="cursor-pointer gap-2.5 data-[highlighted]:bg-bg-hover"
                       onSelect={() => openSearch()}
@@ -6437,8 +6462,35 @@ export function ChatOverlay({
               {/* Trailing controls. */}
               <div
                 data-testid="chat-composer-trailing-controls"
-                className="grid shrink-0 grid-cols-1 items-center"
+                className={cn(
+                  "grid shrink-0 items-center",
+                  realtimeVoiceControlsVisible ? "grid-cols-2" : "grid-cols-1",
+                )}
               >
+                {realtimeVoiceControlsVisible && realtimeVoice ? (
+                  <ComposerControlSlot
+                    slot="left"
+                    reduceMotion={reduce}
+                    controlKey={
+                      realtimeVoice.microphoneMuted
+                        ? "voice-microphone-muted"
+                        : "voice-microphone-live"
+                    }
+                  >
+                    <SoftButton
+                      icon={realtimeVoice.microphoneMuted ? MicOff : Mic}
+                      label={
+                        realtimeVoice.microphoneMuted
+                          ? "unmute microphone"
+                          : "mute microphone"
+                      }
+                      active={realtimeVoice.microphoneMuted}
+                      pressed={realtimeVoice.microphoneMuted}
+                      onClick={realtimeVoice.toggleMicrophoneMute}
+                      testId="chat-composer-voice-mute"
+                    />
+                  </ComposerControlSlot>
+                ) : null}
                 {/* One stable rightmost slot owns every primary action. Talk no
                     longer shares the row with an ambiguous second mic, and a
                     held pointer has exactly the same Cartesia action as a tap. */}

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -130,6 +130,7 @@ const realtimeVoiceMock = vi.hoisted(() => {
     stop: vi.fn(async () => {}),
     unlock: vi.fn(async () => {}),
     bargeIn: vi.fn(),
+    toggleMicrophoneMute: vi.fn(),
   };
   holder.start.mockImplementation(async () => {
     holder.startedConversationIds.push(holder.options?.conversationId);
@@ -146,6 +147,7 @@ const realtimeVoiceMock = vi.hoisted(() => {
       agentSpeaking: false,
       needsUnlock: false,
       paused: false,
+      microphoneMuted: false,
       error: null as {
         kind:
           | "permission"
@@ -163,6 +165,7 @@ const realtimeVoiceMock = vi.hoisted(() => {
       start: holder.start,
       stop: holder.stop,
       bargeIn: holder.bargeIn,
+      toggleMicrophoneMute: holder.toggleMicrophoneMute,
       unlock: holder.unlock,
     },
   });
@@ -325,6 +328,7 @@ afterEach(() => {
   realtimeVoiceMock.stop.mockClear();
   realtimeVoiceMock.unlock.mockClear();
   realtimeVoiceMock.bargeIn.mockClear();
+  realtimeVoiceMock.toggleMicrophoneMute.mockClear();
   realtimeVoiceMock.state.active = false;
   realtimeVoiceMock.state.connecting = false;
   realtimeVoiceMock.state.status = "idle";
@@ -333,6 +337,7 @@ afterEach(() => {
   realtimeVoiceMock.state.agentSpeaking = false;
   realtimeVoiceMock.state.needsUnlock = false;
   realtimeVoiceMock.state.paused = false;
+  realtimeVoiceMock.state.microphoneMuted = false;
   realtimeVoiceMock.state.error = null;
   try {
     window.localStorage.clear();
@@ -2208,14 +2213,18 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
     realtimeVoiceMock.state.transcriptPartial = "stale partial";
     realtimeVoiceMock.state.agentSpeaking = true;
     realtimeVoiceMock.state.needsUnlock = true;
+    realtimeVoiceMock.state.microphoneMuted = true;
 
     const { result } = renderHook(() => useShellController());
 
     expect(result.current.realtimeVoice).toMatchObject({
       enabled: true,
       active: true,
+      microphoneMuted: true,
       status: "speaking",
     });
+    result.current.realtimeVoice?.toggleMicrophoneMute();
+    expect(realtimeVoiceMock.toggleMicrophoneMute).toHaveBeenCalledTimes(1);
     expect(result.current.transcript).toBe("");
     expect(result.current.speaking).toBe(true);
     expect(result.current.needsAudioUnlock).toBe(true);

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -2303,6 +2303,7 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
         onServerEvent?.({
           t: "navigate_view",
           viewId: "notes",
+          viewPath: "/notes",
           subview: "recent",
           traceId: "trace-voice-navigation",
         });
@@ -2311,6 +2312,7 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
       expect(navigationEvents).toHaveLength(1);
       expect(navigationEvents[0]?.detail).toEqual({
         viewId: "notes",
+        viewPath: "/notes",
         source: "agent",
         subview: "recent",
       });

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -473,6 +473,7 @@ export function useShellController(): ShellController {
       if (event.t === "navigate_view") {
         dispatchNavigateViewEvent({
           viewId: event.viewId,
+          ...(event.viewPath ? { viewPath: event.viewPath } : {}),
           source: "agent",
           ...(event.subview ? { subview: event.subview } : {}),
         });

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -1598,6 +1598,7 @@ export function useShellController(): ShellController {
       connected: elizaCloudConnected,
       proxyAvailable: elizaCloudVoiceProxyAvailable,
     }),
+    realtimeVoiceEnabled,
   });
   // Wire the forward ref so the conversation-switch / clear handlers (defined
   // above `voiceOutput`) can stop in-flight assistant speech at gesture time.

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -206,8 +206,12 @@ export interface ShellController {
     active: boolean;
     connecting: boolean;
     paused: boolean;
+    /** True when realtime mic frames are replaced with silence. */
+    microphoneMuted: boolean;
     status: VoiceContinuousStatus;
     error: string | null;
+    /** Mute/unmute the realtime microphone without ending the conversation. */
+    toggleMicrophoneMute: () => void;
   };
   /** Toggle the hands-free conversation loop (mic ↔ spoken reply ↔ mic). */
   toggleHandsFree: () => void;
@@ -2371,8 +2375,10 @@ export function useShellController(): ShellController {
       active: realtimeVoice.active,
       connecting: realtimeVoice.connecting,
       paused: realtimeVoice.paused,
+      microphoneMuted: realtimeVoice.microphoneMuted,
       status: realtimeVoice.status,
       error: realtimeVoiceErrorMessage,
+      toggleMicrophoneMute: realtimeVoice.toggleMicrophoneMute,
     },
     toggleHandsFree,
     micPermission,

--- a/packages/ui/src/components/shell/useShellVoiceOutput.test.tsx
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.test.tsx
@@ -10,6 +10,7 @@ import type { ConversationMessage } from "../../api/client-types-chat";
 const hoisted = vi.hoisted(() => ({
   queueAssistantSpeech: vi.fn(),
   stopSpeaking: vi.fn(),
+  voiceChatOptions: null as Record<string, unknown> | null,
   cfg: {
     isSpeaking: false,
     voiceBootstrapTick: 1,
@@ -21,24 +22,27 @@ const hoisted = vi.hoisted(() => ({
 
 // The single TTS engine — mocked to capture the output calls the overlay makes.
 vi.mock("../../hooks/useVoiceChat", () => ({
-  useVoiceChat: () => ({
-    queueAssistantSpeech: hoisted.queueAssistantSpeech,
-    stopSpeaking: hoisted.stopSpeaking,
-    isSpeaking: hoisted.cfg.isSpeaking,
-    // Unused by the output hook, present to satisfy the shape.
-    isListening: false,
-    captureMode: "idle",
-    mouthOpen: 0,
-    interimTranscript: "",
-    supported: true,
-    usingAudioAnalysis: false,
-    toggleListening: () => {},
-    startListening: async () => {},
-    stopListening: async () => {},
-    speak: () => {},
-    voiceUnlockedGeneration: 0,
-    assistantTtsQuality: "standard",
-  }),
+  useVoiceChat: (options: Record<string, unknown>) => {
+    hoisted.voiceChatOptions = options;
+    return {
+      queueAssistantSpeech: hoisted.queueAssistantSpeech,
+      stopSpeaking: hoisted.stopSpeaking,
+      isSpeaking: hoisted.cfg.isSpeaking,
+      // Unused by the output hook, present to satisfy the shape.
+      isListening: false,
+      captureMode: "idle",
+      mouthOpen: 0,
+      interimTranscript: "",
+      supported: true,
+      usingAudioAnalysis: false,
+      toggleListening: () => {},
+      startListening: async () => {},
+      stopListening: async () => {},
+      speak: () => {},
+      voiceUnlockedGeneration: 0,
+      assistantTtsQuality: "standard",
+    };
+  },
 }));
 
 vi.mock("../../voice/useVoiceConfig", () => ({
@@ -79,6 +83,7 @@ const BASE: ShellVoiceOutputOptions = {
   toggleAgentVoiceMute: vi.fn(),
   uiLanguage: "en",
   cloudConnected: false,
+  realtimeVoiceEnabled: false,
 };
 
 function render(initial: ShellVoiceOutputOptions) {
@@ -96,11 +101,21 @@ beforeEach(() => {
   hoisted.cfg.isSpeaking = false;
   hoisted.cfg.voiceBootstrapTick = 1;
   hoisted.cfg.voiceConfig = { provider: "local-inference" };
+  hoisted.voiceChatOptions = null;
 });
 
 afterEach(cleanup);
 
 describe("useShellVoiceOutput", () => {
+  it("routes shell playback through the realtime Cartesia gateway", () => {
+    render({ ...BASE, realtimeVoiceEnabled: true });
+
+    expect(hoisted.voiceChatOptions).toMatchObject({
+      voiceConfig: { provider: "eliza-cloud" },
+      ttsRouteOverride: "/api/v1/voice/tts",
+    });
+  });
+
   it("speaks the assistant reply after a voice turn", () => {
     const { rerender } = render({
       ...BASE,

--- a/packages/ui/src/components/shell/useShellVoiceOutput.ts
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.ts
@@ -66,6 +66,8 @@ export interface ShellVoiceOutputOptions {
   toggleAgentVoiceMute: () => void;
   uiLanguage: string;
   cloudConnected: boolean;
+  /** Route manual shell playback through the active realtime voice provider. */
+  realtimeVoiceEnabled: boolean;
 }
 
 /**
@@ -91,9 +93,17 @@ export function useShellVoiceOutput(
     toggleAgentVoiceMute,
     uiLanguage,
     cloudConnected,
+    realtimeVoiceEnabled,
   } = options;
 
   const { voiceConfig, voiceBootstrapTick } = useVoiceConfig(uiLanguage);
+  const playbackVoiceConfig = React.useMemo(
+    () =>
+      realtimeVoiceEnabled
+        ? { ...voiceConfig, provider: "eliza-cloud" as const }
+        : voiceConfig,
+    [realtimeVoiceEnabled, voiceConfig],
+  );
 
   const {
     queueAssistantSpeech,
@@ -103,8 +113,9 @@ export function useShellVoiceOutput(
     needsAudioUnlock,
     unlockAudio,
   } = useVoiceChat({
-    voiceConfig,
+    voiceConfig: playbackVoiceConfig,
     cloudConnected,
+    ...(realtimeVoiceEnabled ? { ttsRouteOverride: "/api/v1/voice/tts" } : {}),
     // Output-only here: the overlay's capture owns the mic, so `useVoiceChat`'s
     // own speech-interrupt path is unused — barge-in is driven by `recording`.
     interruptOnSpeech: false,

--- a/packages/ui/src/hooks/useAvailableViews.test.tsx
+++ b/packages/ui/src/hooks/useAvailableViews.test.tsx
@@ -5,6 +5,8 @@
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerAppShellPage } from "../app-shell-registry";
+import { resetUiRegistryHostForTests } from "../registry-host";
 import { emitViewEvent } from "../views/view-event-bus";
 import { VIEW_EVENTS } from "../views/view-event-types";
 import { __resetResourceCache } from "./resource-cache";
@@ -58,6 +60,7 @@ function view(
 
 describe("useAvailableViews", () => {
   beforeEach(() => {
+    resetUiRegistryHostForTests();
     __resetResourceCache();
     client.getBaseUrl.mockReturnValue("");
     fetchWithCsrf.mockReset();
@@ -66,6 +69,7 @@ describe("useAvailableViews", () => {
   });
 
   afterEach(() => {
+    resetUiRegistryHostForTests();
     vi.clearAllTimers();
     vi.useRealTimers();
   });
@@ -144,6 +148,78 @@ describe("useAvailableViews", () => {
       headers: { "X-Eliza-Platform": "desktop" },
     });
     expect(fetchWithCsrf).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the signed in-process page instead of remote JavaScript on Android", async () => {
+    getFrontendPlatform.mockReturnValue("android");
+    registerAppShellPage({
+      id: "calendar",
+      pluginId: "@elizaos/plugin-calendar",
+      label: "Calendar",
+      path: "/calendar",
+      surface: { header: "fullscreen" },
+      Component: () => null,
+    });
+    fetchWithCsrf.mockResolvedValueOnce(
+      response(200, {
+        views: [
+          view("calendar", {
+            path: "/calendar",
+            bundleUrl: "/api/views/calendar/bundle.js",
+          }),
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() => useAvailableViews());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const calendar = result.current.views.find(
+      (entry) => entry.id === "calendar",
+    );
+    expect(calendar).toEqual(
+      expect.objectContaining({
+        id: "calendar",
+        path: "/calendar",
+        pluginName: "@elizaos/plugin-calendar",
+      }),
+    );
+    expect(calendar?.bundleUrl).toBeUndefined();
+    expect(fetchWithCsrf).toHaveBeenCalledWith("/api/views", {
+      headers: { "X-Eliza-Platform": "android" },
+    });
+  });
+
+  it("keeps the runtime bundle authoritative on desktop", async () => {
+    getFrontendPlatform.mockReturnValue("desktop");
+    registerAppShellPage({
+      id: "calendar",
+      pluginId: "@elizaos/plugin-calendar",
+      label: "Calendar",
+      path: "/calendar",
+      Component: () => null,
+    });
+    fetchWithCsrf.mockResolvedValueOnce(
+      response(200, {
+        views: [
+          view("calendar", {
+            path: "/calendar",
+            bundleUrl: "/api/views/calendar/bundle.js",
+          }),
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() => useAvailableViews());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.views).toContainEqual(
+      expect.objectContaining({
+        id: "calendar",
+        bundleUrl: "/api/views/calendar/bundle.js",
+        pluginName: "test-plugin",
+      }),
+    );
   });
 
   it("accepts the current view-capability transport contract", async () => {

--- a/packages/ui/src/hooks/useAvailableViews.ts
+++ b/packages/ui/src/hooks/useAvailableViews.ts
@@ -567,7 +567,14 @@ function mergeViewRegistryEntries(
 function mergeWithAppShellViews(
   networkViews: ViewRegistryEntry[],
   appShellViews: ViewRegistryEntry[],
+  platform: ReturnType<typeof getFrontendPlatform>,
 ): ViewRegistryEntry[] {
+  // Native binaries must execute the signed in-process renderer when both the
+  // connected runtime and the app declare the same view. Web and desktop keep
+  // the runtime bundle so plugin reloads remain live during development.
+  if (platform === "ios" || platform === "android") {
+    return mergeViewRegistryEntries(appShellViews, [networkViews]);
+  }
   return mergeViewRegistryEntries(networkViews, [appShellViews]);
 }
 
@@ -627,8 +634,13 @@ export function useAvailableViews(
   );
   const networkViews =
     resource.status === "success" ? resource.data : EMPTY_VIEWS;
+  const platform = getFrontendPlatform();
   const views = useMemo(() => {
-    const merged = mergeWithAppShellViews(networkViews, appShellViews);
+    const merged = mergeWithAppShellViews(
+      networkViews,
+      appShellViews,
+      platform,
+    );
     // Native device-OS surfaces (phone, messages, contacts, camera) exist only
     // on the AOSP ElizaOS fork. Each such view declares `nativeOs: true` on its
     // `ViewDeclaration`; strip them from the view manager + router on every
@@ -636,7 +648,7 @@ export function useAvailableViews(
     // AOSP-gated home tiles (`nativeOs`) and the route gates in App.tsx.
     if (isAospShellEnabled()) return merged;
     return merged.filter((view) => !view.nativeOs);
-  }, [networkViews, appShellViews]);
+  }, [networkViews, appShellViews, platform]);
 
   return {
     views,

--- a/packages/ui/src/hooks/useContinuousVoiceSession.test.tsx
+++ b/packages/ui/src/hooks/useContinuousVoiceSession.test.tsx
@@ -73,6 +73,7 @@ function makeRealtime(
     agentSpeaking: false,
     needsUnlock: false,
     paused: false,
+    microphoneMuted: false,
     error: null,
     fallbackReason: null,
     reportFallback: vi.fn(),
@@ -80,6 +81,7 @@ function makeRealtime(
     start: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockResolvedValue(undefined),
     bargeIn: vi.fn(),
+    toggleMicrophoneMute: vi.fn(),
     unlock: vi.fn().mockResolvedValue(undefined),
     ...over,
   };

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.ts
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.ts
@@ -160,6 +160,8 @@ export interface UseRealtimeVoiceSessionState {
    * visibility-hide — a PAUSED state, not a broken one. Clears on resume.
    */
   paused: boolean;
+  /** True when the live microphone uplink is intentionally sending silence. */
+  microphoneMuted: boolean;
   /** Actionable/typed error, or null. */
   error: RealtimeVoiceError | null;
   /** Last reason realtime handed this interaction to batch. */
@@ -178,6 +180,8 @@ export interface UseRealtimeVoiceSessionState {
   stop: () => Promise<void>;
   /** Barge-in: flush local playback + notify server. No-op when not speaking. */
   bargeIn: () => void;
+  /** Toggle microphone uplink mute without ending or re-minting the session. */
+  toggleMicrophoneMute: () => void;
   /** Resume the AudioContext on a user gesture (iOS autoplay). */
   unlock: () => Promise<void>;
 }
@@ -294,6 +298,7 @@ export function useRealtimeVoiceSession(
   const [agentSpeaking, setAgentSpeaking] = useState(false);
   const [needsUnlock, setNeedsUnlock] = useState(false);
   const [paused, setPaused] = useState(false);
+  const [microphoneMuted, setMicrophoneMuted] = useState(false);
   const [active, setActive] = useState(false);
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState<RealtimeVoiceError | null>(null);
@@ -420,6 +425,7 @@ export function useRealtimeVoiceSession(
       setAgentSpeaking(false);
       setNeedsUnlock(false);
       setPaused(false);
+      setMicrophoneMuted(false);
       setStatus("idle");
       setTranscriptPartial("");
     }
@@ -444,6 +450,7 @@ export function useRealtimeVoiceSession(
 
     startingRef.current = true;
     micOwnedRef.current = false;
+    setMicrophoneMuted(false);
     setError(null);
     setFallbackReason(null);
     setNeedsUnlock(false);
@@ -671,6 +678,16 @@ export function useRealtimeVoiceSession(
     clientRef.current?.bargeIn();
   }, []);
 
+  const toggleMicrophoneMute = useCallback(() => {
+    const client = clientRef.current;
+    if (!client) return;
+    setMicrophoneMuted((current) => {
+      const next = !current;
+      client.setMicrophoneMuted(next);
+      return next;
+    });
+  }, []);
+
   const unlock = useCallback(async () => {
     try {
       await clientRef.current?.unlockPlayback();
@@ -762,6 +779,7 @@ export function useRealtimeVoiceSession(
       agentSpeaking,
       needsUnlock,
       paused,
+      microphoneMuted,
       error,
       fallbackReason,
       reportFallback,
@@ -769,6 +787,7 @@ export function useRealtimeVoiceSession(
       start,
       stop,
       bargeIn,
+      toggleMicrophoneMute,
       unlock,
     }),
     [
@@ -781,6 +800,7 @@ export function useRealtimeVoiceSession(
       agentSpeaking,
       needsUnlock,
       paused,
+      microphoneMuted,
       error,
       fallbackReason,
       reportFallback,
@@ -788,6 +808,7 @@ export function useRealtimeVoiceSession(
       start,
       stop,
       bargeIn,
+      toggleMicrophoneMute,
       unlock,
     ],
   );

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -436,6 +436,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   // Voice config ref (latest value always available to callbacks)
   const voiceConfigRef = useRef<VoiceConfig | null>(effectiveVoiceConfig);
   voiceConfigRef.current = effectiveVoiceConfig;
+  const ttsRouteOverrideRef = useRef(options.ttsRouteOverride);
+  ttsRouteOverrideRef.current = options.ttsRouteOverride;
   // Cloud-session ref for capture-time route resolution (#16524): whether the
   // cloud STT proxy is a viable fallback when local-inference is unready.
   const cloudConnectedRef = useRef(options.cloudConnected === true);
@@ -1847,13 +1849,20 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           //  - otherwise the on-device `/api/tts/cloud` proxy is preserved.
           // Same `{ text }` body, same audio-bytes response — only the URL and
           // bearer change.
-          const route = resolveForcedCloudTtsRoute({
-            proxyUrl,
-            proxyBearer: apiToken || null,
-            sharedRuntimeOrigin: currentSharedRuntimeVoiceOrigin(),
-            configuredCloudOrigin: configuredCloudVoiceOrigin(),
-            cloudSessionToken: getCloudAuthToken(),
-          });
+          const routeOverride = ttsRouteOverrideRef.current?.trim();
+          const route = routeOverride
+            ? {
+                url: resolveApiUrl(routeOverride),
+                bearer: null,
+                via: "on-device-proxy" as const,
+              }
+            : resolveForcedCloudTtsRoute({
+                proxyUrl,
+                proxyBearer: apiToken || null,
+                sharedRuntimeOrigin: currentSharedRuntimeVoiceOrigin(),
+                configuredCloudOrigin: configuredCloudVoiceOrigin(),
+                cloudSessionToken: getCloudAuthToken(),
+              });
           // Debug-only correlation headers. Proxy/shared paths only: they are
           // not in the cloud worker's CORS allow-list, so sending them on the
           // direct cross-origin POST would fail the browser preflight.

--- a/packages/ui/src/voice/__tests__/voice-session-client.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-client.test.ts
@@ -352,6 +352,66 @@ describe("voice-session client (real framing/state/barge-in/reconnect)", () => {
     await client.stop();
   });
 
+  it("mutes the live microphone as PCM silence without ending the session", async () => {
+    const mint = makeMintFetch();
+    const ws = makeWsFactory();
+    const micCtx = new FakeMicAudioContext(16_000);
+    const clientWithMic = createVoiceSessionClient({
+      agentId: "11111111-1111-1111-1111-111111111111",
+      conversationId: "22222222-2222-2222-2222-222222222222",
+      getConsentNonce: async () => "mute",
+      fetch: mint.fetch,
+      webSocketFactory: ws.factory,
+      getUserMedia: fakeGetUserMedia(),
+      createMicAudioContext: () => micCtx,
+      createPlaybackAudioContext: () => new FakePlaybackAudioContext(16_000),
+    });
+    await clientWithMic.start();
+    await flush();
+    const socket = ws.last();
+    socket.emitOpen();
+    socket.emitControl({
+      t: "ready",
+      sessionId: "sess-mute",
+      traceId: "T-mute",
+    });
+    await flush();
+
+    const input = new Float32Array(1600).fill(0.25);
+    micCtx.scriptNode?.feed(input);
+    let frames = socket.sent.filter(
+      (value): value is ArrayBuffer => value instanceof ArrayBuffer,
+    );
+    expect(frames).toHaveLength(1);
+    expect(
+      Array.from(new Uint8Array(frames[0])).some((byte) => byte !== 0),
+    ).toBe(true);
+
+    clientWithMic.setMicrophoneMuted(true);
+    expect(clientWithMic.microphoneMuted).toBe(true);
+    micCtx.scriptNode?.feed(input);
+    frames = socket.sent.filter(
+      (value): value is ArrayBuffer => value instanceof ArrayBuffer,
+    );
+    expect(frames).toHaveLength(2);
+    expect(
+      Array.from(new Uint8Array(frames[1])).every((byte) => byte === 0),
+    ).toBe(true);
+    expect(clientWithMic.state.phase).toBe("listening");
+
+    clientWithMic.setMicrophoneMuted(false);
+    micCtx.scriptNode?.feed(input);
+    frames = socket.sent.filter(
+      (value): value is ArrayBuffer => value instanceof ArrayBuffer,
+    );
+    expect(frames).toHaveLength(3);
+    expect(
+      Array.from(new Uint8Array(frames[2])).some((byte) => byte !== 0),
+    ).toBe(true);
+    await clientWithMic.stop();
+    expect(clientWithMic.microphoneMuted).toBe(false);
+  });
+
   it("an empty stt_final (noise EOT) loops straight back to listening (#16662)", async () => {
     const mint = makeMintFetch();
     const ws = makeWsFactory();

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -202,6 +202,12 @@ export interface VoiceChatOptions {
   lang?: string;
   /** Saved voice configuration — switches TTS provider when set */
   voiceConfig?: VoiceConfig | null;
+  /**
+   * Trusted same-origin TTS route owned by the active realtime voice lane.
+   * This lets shell playback reuse that lane's provider without persisting a
+   * dev-only endpoint or silently falling back to a different voice.
+   */
+  ttsRouteOverride?: string;
 }
 
 export interface VoiceAssistantSpeechTelemetry {

--- a/packages/ui/src/voice/voice-session-client.ts
+++ b/packages/ui/src/voice/voice-session-client.ts
@@ -203,6 +203,10 @@ export interface VoiceSessionClient {
   start(): Promise<void>;
   /** Barge-in: flush local playback NOW + notify server. */
   bargeIn(): void;
+  /** Whether uplink audio is currently replaced with silence. */
+  readonly microphoneMuted: boolean;
+  /** Mute/unmute uplink audio without tearing down the realtime session. */
+  setMicrophoneMuted(muted: boolean): void;
   /** Unlock playback on a user gesture (iOS autoplay). */
   unlockPlayback(): Promise<void>;
   /** Send a clean `bye` and tear everything down. */
@@ -245,6 +249,7 @@ export function createVoiceSessionClient(
   let recoveryPromise: Promise<void> | null = null;
   let captureSocket: VoiceWebSocketLike | null = null;
   let captureAbort: AbortController | null = null;
+  let microphoneMuted = false;
   // Whether the caller explicitly stopped us (clean bye) — suppresses reconnect.
   let intentionalClose = false;
 
@@ -396,8 +401,13 @@ export function createVoiceSessionClient(
     if (!ws || connPhase !== "open") return;
     try {
       // Copy into a standalone ArrayBuffer so a shared/pooled backing store from
-      // the capture path is never observed mutated after send.
-      ws.send(bytes.slice().buffer);
+      // the capture path is never observed mutated after send. A muted session
+      // keeps its normal packet cadence but substitutes PCM silence, allowing
+      // server VAD to close a partial utterance without leaking microphone data.
+      const uplink = microphoneMuted
+        ? new Uint8Array(bytes.byteLength)
+        : bytes.slice();
+      ws.send(uplink.buffer);
     } catch (ignoredError) {
       // error-policy:J5 a dropped uplink frame on a dying socket is observed by the close handler's reconnect path.
       void ignoredError;
@@ -707,6 +717,7 @@ export function createVoiceSessionClient(
   async function stop(): Promise<void> {
     disposed = true;
     intentionalClose = true;
+    microphoneMuted = false;
     const stoppedGeneration = ++lifecycleGeneration;
     lifecycleAbort?.abort();
     lifecycleAbort = null;
@@ -770,6 +781,7 @@ export function createVoiceSessionClient(
       disposed = false;
       intentionalClose = false;
       reconnectsUsed = 0;
+      microphoneMuted = false;
       setState({ ...INITIAL_VOICE_SESSION_STATE, phase: "connecting" });
       // Create playback up front so an early user-gesture unlock is possible and
       // downlink frames after `ready` have a sink.
@@ -832,6 +844,16 @@ export function createVoiceSessionClient(
       setState(applyClientAction(state, { type: "client/local_barge_in" }));
       sendControl({ t: "barge_in" });
       mark("barge_in_sent", state.traceId);
+    },
+
+    get microphoneMuted() {
+      return microphoneMuted;
+    },
+
+    setMicrophoneMuted(muted) {
+      if (disposed || microphoneMuted === muted) return;
+      microphoneMuted = muted;
+      mark(muted ? "mic_muted" : "mic_unmuted", state.traceId);
     },
 
     async unlockPlayback() {

--- a/packages/ui/src/voice/voice-session-protocol.test.ts
+++ b/packages/ui/src/voice/voice-session-protocol.test.ts
@@ -10,6 +10,7 @@ describe("voice session server protocol", () => {
         JSON.stringify({
           t: "navigate_view",
           viewId: " notes ",
+          viewPath: " /notes ",
           subview: " recent ",
           traceId: " trace-1 ",
         }),
@@ -17,6 +18,7 @@ describe("voice session server protocol", () => {
     ).toEqual({
       t: "navigate_view",
       viewId: "notes",
+      viewPath: "/notes",
       subview: "recent",
       traceId: "trace-1",
     });
@@ -42,6 +44,19 @@ describe("voice session server protocol", () => {
           t: "navigate_view",
           viewId: "notes",
           subview: {},
+          traceId: "trace-1",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects an invalid optional view path rather than falling back", () => {
+    expect(
+      parseServerControl(
+        JSON.stringify({
+          t: "navigate_view",
+          viewId: "notes",
+          viewPath: {},
           traceId: "trace-1",
         }),
       ),

--- a/packages/ui/src/voice/voice-session-protocol.ts
+++ b/packages/ui/src/voice/voice-session-protocol.ts
@@ -107,6 +107,7 @@ export interface ServerSpeakingEndEvent {
 export interface ServerNavigateViewEvent {
   t: "navigate_view";
   viewId: string;
+  viewPath?: string;
   subview?: string;
   traceId: string;
 }
@@ -201,15 +202,24 @@ export function parseServerControl(raw: string): ServerControlFrame | null {
     const traceId = readBoundedString(
       (parsed as { traceId?: unknown }).traceId,
     );
+    const rawViewPath = (parsed as { viewPath?: unknown }).viewPath;
+    const viewPath =
+      rawViewPath === undefined ? null : readBoundedString(rawViewPath);
     const rawSubview = (parsed as { subview?: unknown }).subview;
     const subview =
       rawSubview === undefined ? null : readBoundedString(rawSubview);
-    if (!viewId || !traceId || (rawSubview !== undefined && !subview)) {
+    if (
+      !viewId ||
+      !traceId ||
+      (rawViewPath !== undefined && !viewPath) ||
+      (rawSubview !== undefined && !subview)
+    ) {
       return null;
     }
     return {
       t,
       viewId,
+      ...(viewPath ? { viewPath } : {}),
       ...(subview ? { subview } : {}),
       traceId,
     };

--- a/plugins/plugin-app-control/src/actions/views-show.ts
+++ b/plugins/plugin-app-control/src/actions/views-show.ts
@@ -11,6 +11,7 @@ import type {
 	ViewType,
 } from "@elizaos/core";
 import { logger, resolveServerOnlyPort } from "@elizaos/core";
+import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
 import { SHARED_NAV_TARGETS } from "@elizaos/shared/views/shared-nav-targets";
 import { resolveSettingsSectionToken } from "@elizaos/ui/components/settings/settings-section-tokens";
 import {
@@ -53,6 +54,17 @@ const FILLER_WORDS = new Set([
 
 const DOCUMENT_SURFACE_WORDS =
 	/\b(?:documents?|docs?|files?|knowledge|uploads?|retrieval|papers?)\b/i;
+
+function isRealtimeVoiceTurn(message: Memory): boolean {
+	const metadata = message.content.metadata;
+	return (
+		typeof metadata === "object" &&
+		metadata !== null &&
+		!Array.isArray(metadata) &&
+		(metadata as Record<string, unknown>).clientTransport ===
+			REALTIME_VOICE_CLIENT_TRANSPORT
+	);
+}
 const NOTES_SURFACE_WORD = /\bnotes?\b/i;
 
 // Match a show-verb on WORD BOUNDARIES at the earliest position in the text.
@@ -388,6 +400,7 @@ async function navigateToView(
 	requestedViewType?: ViewType,
 	subview?: string,
 	navigationLabel = view.label,
+	delivery?: "originating-client",
 ): Promise<NavigateResult> {
 	// Emit navigate event via POST /api/views/:id/navigate (shell listens).
 	// A 501/404 means this shell doesn't implement the navigate route — opening
@@ -409,6 +422,7 @@ async function navigateToView(
 					path: view.path,
 					viewType: requestedViewType,
 					...(resolvedSubview ? { subview: resolvedSubview } : {}),
+					...(delivery ? { delivery } : {}),
 				}),
 				signal: AbortSignal.timeout(5_000),
 			},
@@ -554,6 +568,7 @@ export async function runViewsShow({
 		viewType,
 		subview ?? undefined,
 		navigationLabel,
+		isRealtimeVoiceTurn(message) ? "originating-client" : undefined,
 	);
 
 	logger.info(
@@ -577,6 +592,7 @@ export async function runViewsShow({
 		values: {
 			mode: "show",
 			viewId: view.id,
+			...(view.path ? { viewPath: view.path } : {}),
 			viewType: view.viewType ?? viewType ?? "gui",
 			label: navigationLabel,
 			...(result.subview ? { subview: result.subview } : {}),

--- a/plugins/plugin-app-control/src/actions/views-switching.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-switching.test.ts
@@ -12,6 +12,7 @@
  * registry and a captured navigate fetch.
  */
 
+import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CURATED_MULTILINGUAL } from "./view-matrix.fixtures.js";
 import { createViewsAction } from "./views.js";
@@ -45,12 +46,15 @@ vi.mock("@elizaos/core", async (importOriginal) => {
 	};
 });
 
-function message(text: string, roomId = "room-1") {
+function message(text: string, roomId = "room-1", clientTransport?: string) {
 	return {
 		entityId: "user-1",
 		roomId,
 		agentId: "agent-1",
-		content: { text },
+		content: {
+			text,
+			...(clientTransport ? { metadata: { clientTransport } } : {}),
+		},
 	};
 }
 
@@ -371,6 +375,36 @@ describe("view switching — VIEWS action resolver", () => {
 			);
 		});
 
+		it("routes realtime voice navigation back through the originating client", async () => {
+			installNavigateCapture();
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: vi.fn(async () => true),
+			});
+
+			await action.handler(
+				{ agentId: "agent-1" } as never,
+				message(
+					"open calendar",
+					"room-1",
+					REALTIME_VOICE_CLIENT_TRANSPORT,
+				) as never,
+				undefined,
+				{ action: "show", view: "calendar" },
+				vi.fn(),
+			);
+
+			const lastCall = vi.mocked(globalThis.fetch).mock.calls.at(-1);
+			expect(lastCall).toBeDefined();
+			if (!lastCall) {
+				throw new Error("expected the view navigation request");
+			}
+			const [, init] = lastCall;
+			expect(JSON.parse(String(init?.body))).toMatchObject({
+				delivery: "originating-client",
+			});
+		});
+
 		it("resolves an explicit view option without verb parsing", async () => {
 			const { navigated } = installNavigateCapture();
 			const { result } = await runShow(REGISTRY, "do it", {
@@ -398,6 +432,7 @@ describe("view switching — VIEWS action resolver", () => {
 				values: {
 					mode: "show",
 					viewId: "calendar",
+					viewPath: "/calendar",
 					viewType: "gui",
 					label: "Calendar",
 				},

--- a/plugins/plugin-calendar/package.json
+++ b/plugins/plugin-calendar/package.json
@@ -4,8 +4,10 @@
   "type": "module",
   "description": "First-class calendar plugin for elizaOS agents: Google, Microsoft, Apple, and ICS feeds; scheduling; event management; and owner-facing calendar views.",
   "sideEffects": [
+    "./src/register.ts",
     "./src/api/client-calendar.ts",
     "./src/ui.ts",
+    "./dist/register.js",
     "./dist/api/client-calendar.js",
     "./dist/ui.js"
   ],
@@ -123,6 +125,7 @@
     }
   },
   "elizaos": {
+    "appRegister": "register",
     "app": {
       "permissions": [
         "calendar"

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -50,7 +50,6 @@ import {
   parseCalendarJsonRecord,
   toActionData,
 } from "../internal/detail.js";
-import { ELIZA_CALENDAR_GRANT_ID } from "../internal/eliza-calendar.js";
 import { CalendarServiceError } from "../internal/errors.js";
 import {
   formatCalendarEventDateTime,
@@ -169,8 +168,14 @@ function requireCompleteFreshCalendarFeed(
   return feed;
 }
 
-function mutationGrantId(details: Record<string, unknown> | undefined): string {
-  return detailString(details, "grantId") ?? ELIZA_CALENDAR_GRANT_ID;
+// Mutation lookups must stay unscoped when the planner omits grantId: the
+// aggregated feed already includes the built-in Eliza source alongside every
+// connected provider, so defaulting the lookup to one grant would hide
+// external events (and their busy windows) from update/delete/create flows.
+function mutationGrantId(
+  details: Record<string, unknown> | undefined,
+): string | undefined {
+  return detailString(details, "grantId");
 }
 
 type CreateEventTravelIntent = CalendarTravelIntent;

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -50,6 +50,7 @@ import {
   parseCalendarJsonRecord,
   toActionData,
 } from "../internal/detail.js";
+import { ELIZA_CALENDAR_GRANT_ID } from "../internal/eliza-calendar.js";
 import { CalendarServiceError } from "../internal/errors.js";
 import {
   formatCalendarEventDateTime,
@@ -166,6 +167,10 @@ function requireCompleteFreshCalendarFeed(
     );
   }
   return feed;
+}
+
+function mutationGrantId(details: Record<string, unknown> | undefined): string {
+  return detailString(details, "grantId") ?? ELIZA_CALENDAR_GRANT_ID;
 }
 
 type CreateEventTravelIntent = CalendarTravelIntent;
@@ -1893,7 +1898,7 @@ async function loadCreateEventCalendarContext(
       | "cloud_managed"
       | undefined,
     side: detailString(details, "side") as "owner" | "agent" | undefined,
-    grantId: detailString(details, "grantId"),
+    grantId: mutationGrantId(details),
     calendarId: detailString(details, "calendarId"),
     timeZone: requestTimeZone,
     forceSync: true,
@@ -3998,7 +4003,7 @@ const calendarAction: CalendarHandlerAction = {
                 | "owner"
                 | "agent"
                 | undefined,
-              grantId: detailString(details, "grantId"),
+              grantId: mutationGrantId(details),
               forceSync: true,
               ...feedRequest,
             }),
@@ -4102,7 +4107,7 @@ const calendarAction: CalendarHandlerAction = {
                 | "owner"
                 | "agent"
                 | undefined,
-              grantId: detailString(details, "grantId"),
+              grantId: mutationGrantId(details),
               calendarId: resolvedCalendarId,
               eventId: resolvedEventId,
             },
@@ -4304,7 +4309,7 @@ const calendarAction: CalendarHandlerAction = {
                 | "owner"
                 | "agent"
                 | undefined,
-              grantId: detailString(details, "grantId"),
+              grantId: mutationGrantId(details),
               forceSync: true,
               ...feedRequest,
             }),
@@ -4371,7 +4376,7 @@ const calendarAction: CalendarHandlerAction = {
                 | "owner"
                 | "agent"
                 | undefined,
-              grantId: detailString(details, "grantId"),
+              grantId: mutationGrantId(details),
               calendarId: detailString(details, "calendarId"),
               eventId: explicitEventId,
             },

--- a/plugins/plugin-calendar/src/actions/calendar-sources.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-sources.ts
@@ -187,7 +187,8 @@ function providerValue(value: unknown): LifeOpsCalendarProvider | null {
   return normalized === "google" ||
     normalized === "microsoft" ||
     normalized === "apple_calendar" ||
-    normalized === "ics"
+    normalized === "ics" ||
+    normalized === "eliza"
     ? normalized
     : null;
 }
@@ -611,8 +612,15 @@ async function connectionIntent(args: {
   if (!provider) {
     throw new CalendarServiceError(
       400,
-      "Calendar source connection requires provider=google, microsoft, apple_calendar, or ics.",
+      "Calendar source connection requires provider=google, microsoft, apple_calendar, or ics. The built-in Eliza calendar needs no connection.",
       "CALENDAR_SOURCE_PROVIDER_REQUIRED",
+    );
+  }
+  if (provider === "eliza") {
+    throw new CalendarServiceError(
+      400,
+      "The built-in Eliza calendar is already available. Use list, select, or deselect instead of connecting it.",
+      "ELIZA_CALENDAR_CONNECTION_NOT_REQUIRED",
     );
   }
   if (provider === "apple_calendar") {
@@ -1085,11 +1093,11 @@ export function createCalendarSourcesAction(
       {
         name: "provider",
         description:
-          "Exact provider for selection or connection: google, microsoft, apple_calendar, or ics.",
+          "Exact provider for selection: eliza, google, microsoft, apple_calendar, or ics. Connection operations apply only to external providers.",
         required: false,
         schema: {
           type: "string",
-          enum: ["google", "microsoft", "apple_calendar", "ics"],
+          enum: ["eliza", "google", "microsoft", "apple_calendar", "ics"],
         },
       },
       {

--- a/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
@@ -236,6 +236,7 @@ function makeResult(
     windowStart,
     windowEnd,
     refresh,
+    goToDate: vi.fn(),
     goToToday,
     goPrevious,
     goNext,

--- a/plugins/plugin-calendar/src/components/EventEditorDrawer.test.tsx
+++ b/plugins/plugin-calendar/src/components/EventEditorDrawer.test.tsx
@@ -233,7 +233,10 @@ vi.mock("@elizaos/ui/agent-surface", () => ({
   useAgentElement: () => ({ ref: () => {}, agentProps: {} }),
 }));
 
-import { EventEditorDrawer } from "./EventEditorDrawer.js";
+import {
+  EventEditorDrawer,
+  eventEditorMutability,
+} from "./EventEditorDrawer.js";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -795,6 +798,34 @@ describe("EventEditorDrawer", () => {
       screen.queryByText("Save and continue", { selector: "span.sr-only" }),
     ).toBeNull();
   }
+
+  it("keeps built-in calendar events editable with their local version token", () => {
+    const builtInEvent: LifeOpsCalendarEvent = {
+      ...editEvent,
+      provider: "eliza",
+      grantId: "eliza-calendar",
+      calendarId: "primary",
+      metadata: { etag: '"eliza-1"', version: 1 },
+    };
+
+    expect(eventEditorMutability(builtInEvent)).toEqual({
+      kind: "editable",
+      providerVersion: '"eliza-1"',
+    });
+
+    render(
+      <EventEditorDrawer
+        open
+        mode="edit"
+        event={builtInEvent}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Save", { selector: "span.sr-only" })).toBeTruthy();
+    expect(deleteButton().disabled).toBe(false);
+    expect(screen.queryByTestId("event-editor-read-only-reason")).toBeNull();
+  });
 
   it("renders Apple events read-only instead of offering saves that dead-end", async () => {
     const appleEvent: LifeOpsCalendarEvent = {

--- a/plugins/plugin-calendar/src/components/EventEditorDrawer.tsx
+++ b/plugins/plugin-calendar/src/components/EventEditorDrawer.tsx
@@ -414,16 +414,17 @@ export type EventEditorMutability =
  * Which edit affordances the owner-editor mutation pipeline can actually
  * honor for this event. The pipeline (client → route → owner-editor gateway →
  * trusted executor) performs etag-conditional writes and supports them only
- * for Google events; Microsoft mutations, ICS subscription feeds, and the
- * Apple native bridge are all rejected server-side. Rendering a Save/Delete
- * button for those events would dead-end on every click, so the drawer
- * derives its affordances from this capability instead.
+ * for Google and built-in Eliza events; Microsoft mutations, ICS subscription
+ * feeds, and the Apple native bridge are rejected server-side. Rendering a
+ * Save/Delete button for those events would dead-end on every click, so the
+ * drawer derives its affordances from this capability instead.
  */
 export function eventEditorMutability(
   event: LifeOpsCalendarEvent,
 ): EventEditorMutability {
   switch (event.provider) {
-    case "google": {
+    case "google":
+    case "eliza": {
       const etag = event.metadata.etag;
       return typeof etag === "string" && etag.trim().length > 0
         ? { kind: "editable", providerVersion: etag.trim() }

--- a/plugins/plugin-calendar/src/components/calendar/CalendarView.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarView.test.tsx
@@ -122,6 +122,7 @@ function makeResult(
     windowStart: new Date("2026-06-14T00:00:00.000Z"),
     windowEnd: new Date("2026-06-21T00:00:00.000Z"),
     refresh,
+    goToDate: vi.fn(),
     goToToday,
     goPrevious,
     goNext,

--- a/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.test.tsx
@@ -20,6 +20,7 @@ vi.mock("../../hooks/useCalendarWeek.js", () => ({
 }));
 
 vi.mock("@elizaos/ui/events", () => ({
+  NETWORK_STATUS_CHANGE_EVENT: "eliza:network-status-change",
   VIEW_EVENTS: { VIEW_REFRESH: "view:refresh" },
   useViewEvent: (eventType: string, callback: () => void) => {
     fixtures.viewEvents.set(eventType, callback);
@@ -113,7 +114,11 @@ describe("SimpleCalendarView", () => {
     expect(
       screen.getByRole("main", { name: "Calendar. 2 events" }),
     ).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "August 2026" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: "Choose month and year. Current month is August 2026",
+      }),
+    ).toBeTruthy();
     expect(screen.getByText("Demo")).toBeTruthy();
     expect(screen.getByText("Team sync")).toBeTruthy();
     expect(
@@ -122,10 +127,6 @@ describe("SimpleCalendarView", () => {
     expect(screen.getByRole("button", { name: /Previous month/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Next month/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Today" })).toBeTruthy();
-    expect(
-      screen.getByLabelText("Choose calendar month and year"),
-    ).toBeTruthy();
-
     const augustSixth = screen.getByRole("button", {
       name: "Thursday, August 6, 2026",
     });
@@ -142,9 +143,15 @@ describe("SimpleCalendarView", () => {
     fixtures.calendar.mockReturnValue(calendarState({ goToDate }));
     render(<SimpleCalendarView />);
 
-    fireEvent.change(screen.getByLabelText("Choose calendar month and year"), {
-      target: { value: "2027-03" },
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Choose month and year. Current month is August 2026",
+      }),
+    );
+    fireEvent.change(screen.getByLabelText("Calendar year"), {
+      target: { value: "2027" },
     });
+    fireEvent.click(screen.getByRole("button", { name: "Mar" }));
 
     expect(goToDate).toHaveBeenCalledTimes(1);
     expect(goToDate.mock.calls[0]?.[0]).toEqual(

--- a/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { LifeOpsCalendarEvent } from "@elizaos/shared";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UseCalendarWeekResult } from "../../hooks/useCalendarWeek.js";
 
@@ -86,6 +86,7 @@ function calendarState(
     windowStart,
     windowEnd,
     refresh: vi.fn().mockResolvedValue(undefined),
+    goToDate: vi.fn(),
     goToToday: vi.fn(),
     goPrevious: vi.fn(),
     goNext: vi.fn(),
@@ -101,7 +102,7 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("SimpleCalendarView", () => {
-  it("renders today's canonical events without direct controls", () => {
+  it("renders canonical events with month navigation and selectable days", () => {
     const events = [event("Demo", 10), event("Team sync", 15)];
     fixtures.calendar.mockReturnValue(
       calendarState({ events, status: "ready" }),
@@ -118,9 +119,37 @@ describe("SimpleCalendarView", () => {
     expect(
       screen.getByLabelText("2 events on Tuesday, August 4, 2026"),
     ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Previous month/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Next month/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Today" })).toBeTruthy();
     expect(
-      view.container.querySelector("button, input, textarea, form"),
-    ).toBeNull();
+      screen.getByLabelText("Choose calendar month and year"),
+    ).toBeTruthy();
+
+    const augustSixth = screen.getByRole("button", {
+      name: "Thursday, August 6, 2026",
+    });
+    fireEvent.click(augustSixth);
+    expect(augustSixth.getAttribute("aria-pressed")).toBe("true");
+    expect(
+      screen.getByRole("region", { name: "Events for 2026-08-06" }),
+    ).toBeTruthy();
+    expect(view.container.querySelector("form")).toBeNull();
+  });
+
+  it("changes month/year without walking every intermediate month", () => {
+    const goToDate = vi.fn();
+    fixtures.calendar.mockReturnValue(calendarState({ goToDate }));
+    render(<SimpleCalendarView />);
+
+    fireEvent.change(screen.getByLabelText("Choose calendar month and year"), {
+      target: { value: "2027-03" },
+    });
+
+    expect(goToDate).toHaveBeenCalledTimes(1);
+    expect(goToDate.mock.calls[0]?.[0]).toEqual(
+      new Date(2027, 2, 1, 12, 0, 0, 0),
+    );
   });
 
   it("extends content beneath chat while keeping its tail reachable", () => {
@@ -141,6 +170,7 @@ describe("SimpleCalendarView", () => {
     expect(scroll.style.gridTemplateColumns).toBe(
       "repeat(auto-fit, minmax(280px, 1fr))",
     );
+    expect(scroll.style.alignContent).toBe("start");
   });
 
   it("refreshes the canonical feed after a completed chat action", () => {

--- a/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx
@@ -7,8 +7,13 @@
 
 import type { LifeOpsCalendarEvent } from "@elizaos/shared";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@elizaos/ui/components";
 import { useViewEvent, VIEW_EVENTS } from "@elizaos/ui/events";
-import { ChevronLeft, ChevronRight, Clock3 } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight, Clock3 } from "lucide-react";
 import {
   type CSSProperties,
   useCallback,
@@ -19,6 +24,11 @@ import {
 import { useCalendarWeek } from "../../hooks/useCalendarWeek.js";
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MONTHS = Array.from({ length: 12 }, (_, month) =>
+  new Intl.DateTimeFormat(undefined, { month: "short" }).format(
+    new Date(2024, month, 1, 12),
+  ),
+);
 const TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 
 const ROOT_STYLE: CSSProperties = {
@@ -115,21 +125,6 @@ function formatMonth(date: Date): string {
   }).format(date);
 }
 
-function monthInputValue(date: Date): string {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
-}
-
-function dateFromMonthInput(value: string): Date {
-  const match = /^(\d{4})-(\d{2})$/.exec(value);
-  if (!match) throw new Error("Calendar month is invalid.");
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  if (!Number.isSafeInteger(year) || month < 1 || month > 12) {
-    throw new Error("Calendar month is invalid.");
-  }
-  return new Date(year, month - 1, 1, 12);
-}
-
 function formatSelectedDate(value: string): string {
   return new Intl.DateTimeFormat(undefined, {
     weekday: "long",
@@ -202,6 +197,8 @@ function CalendarDay({
     <button
       ref={cell.ref}
       {...cell.agentProps}
+      className="eliza-calendar-day"
+      data-selected={selected ? "true" : "false"}
       type="button"
       onClick={selectDay}
       aria-label={formatSelectedDate(key)}
@@ -215,14 +212,16 @@ function CalendarDay({
         borderRadius: 11,
         padding: "6px clamp(4px, .8vw, 8px)",
         background: selected
-          ? "color-mix(in srgb, var(--surface, rgba(255,255,255,.08)) 88%, transparent)"
+          ? "color-mix(in srgb, var(--accent, #ff6a1f) 22%, var(--surface, rgba(255,255,255,.08)))"
           : currentMonth
             ? "color-mix(in srgb, var(--surface, rgba(255,255,255,.06)) 78%, transparent)"
             : "transparent",
         color: currentMonth
           ? "var(--txt, #f5f5f5)"
           : "var(--muted, rgba(255,255,255,.5))",
-        boxShadow: selected ? "inset 0 0 0 1px rgba(255,255,255,.78)" : "none",
+        boxShadow: selected
+          ? "inset 0 0 0 2px color-mix(in srgb, var(--accent, #ff6a1f) 82%, white), 0 8px 20px rgba(0,0,0,.18)"
+          : "none",
         display: "flex",
         flexDirection: "column",
         justifyContent: "space-between",
@@ -303,6 +302,24 @@ function MonthControls({
   onMonthChange: (month: Date) => void;
 }) {
   const month = formatMonth(cursor);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerYear, setPickerYear] = useState(cursor.getFullYear());
+  useEffect(() => setPickerYear(cursor.getFullYear()), [cursor]);
+  const yearOptions = useMemo(
+    () =>
+      Array.from(
+        { length: 25 },
+        (_, index) => cursor.getFullYear() - 12 + index,
+      ),
+    [cursor],
+  );
+  const chooseMonth = useCallback(
+    (monthIndex: number) => {
+      onMonthChange(new Date(pickerYear, monthIndex, 1, 12));
+      setPickerOpen(false);
+    },
+    [onMonthChange, pickerYear],
+  );
   const navigationButton: CSSProperties = {
     width: 44,
     height: 44,
@@ -334,54 +351,124 @@ function MonthControls({
       >
         <ChevronLeft size={19} aria-hidden />
       </button>
-      <div
-        style={{
-          position: "relative",
-          minWidth: 0,
-          textAlign: "center",
-          borderRadius: 13,
-        }}
-      >
-        <h2
-          style={{
-            margin: 0,
-            fontSize: 17,
-            lineHeight: 1.25,
-            fontWeight: 760,
-            textAlign: "center",
-          }}
+      <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={`Choose month and year. Current month is ${month}`}
+            style={{
+              minWidth: 0,
+              minHeight: 44,
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 6,
+              border: 0,
+              borderRadius: 13,
+              background: "transparent",
+              color: "var(--txt, #f5f5f5)",
+              fontFamily: "inherit",
+              fontSize: 17,
+              lineHeight: 1.25,
+              fontWeight: 760,
+              cursor: "pointer",
+            }}
+          >
+            <span>{month}</span>
+            <ChevronDown size={15} aria-hidden />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="center"
+          className="w-[min(19rem,calc(100vw-2rem))] rounded-2xl border-border/70 bg-card/95 p-3 shadow-2xl backdrop-blur-xl"
         >
-          {month}
-        </h2>
-        <span
-          aria-hidden
-          style={{
-            display: "block",
-            marginTop: 1,
-            color: "var(--muted, rgba(255,255,255,.58))",
-            fontSize: 10,
-            lineHeight: 1.3,
-          }}
-        >
-          Choose month &amp; year
-        </span>
-        <input
-          type="month"
-          aria-label="Choose calendar month and year"
-          value={monthInputValue(cursor)}
-          onChange={(event) =>
-            onMonthChange(dateFromMonthInput(event.target.value))
-          }
-          style={{
-            position: "absolute",
-            inset: 0,
-            width: "100%",
-            height: "100%",
-            opacity: 0,
-            cursor: "pointer",
-          }}
-        />
-      </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 8,
+              marginBottom: 10,
+            }}
+          >
+            <button
+              type="button"
+              aria-label="Previous year"
+              onClick={() => setPickerYear((year) => year - 1)}
+              style={{ ...navigationButton, width: 36, height: 36 }}
+            >
+              <ChevronLeft size={17} aria-hidden />
+            </button>
+            <select
+              aria-label="Calendar year"
+              value={pickerYear}
+              onChange={(event) => setPickerYear(Number(event.target.value))}
+              style={{
+                minHeight: 36,
+                border: "1px solid var(--border, rgba(255,255,255,.14))",
+                borderRadius: 10,
+                padding: "0 28px 0 12px",
+                background: "var(--surface, #171717)",
+                color: "var(--txt, #f5f5f5)",
+                fontFamily: "inherit",
+                fontSize: 14,
+                fontWeight: 720,
+                cursor: "pointer",
+              }}
+            >
+              {yearOptions.map((year) => (
+                <option key={year} value={year}>
+                  {year}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              aria-label="Next year"
+              onClick={() => setPickerYear((year) => year + 1)}
+              style={{ ...navigationButton, width: 36, height: 36 }}
+            >
+              <ChevronRight size={17} aria-hidden />
+            </button>
+          </div>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+              gap: 6,
+            }}
+          >
+            {MONTHS.map((label, monthIndex) => {
+              const active =
+                pickerYear === cursor.getFullYear() &&
+                monthIndex === cursor.getMonth();
+              return (
+                <button
+                  key={label}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => chooseMonth(monthIndex)}
+                  style={{
+                    minHeight: 38,
+                    border: 0,
+                    borderRadius: 10,
+                    background: active
+                      ? "var(--accent, #ff6a1f)"
+                      : "color-mix(in srgb, var(--surface, rgba(255,255,255,.06)) 74%, transparent)",
+                    color: active ? "#fff" : "var(--txt, #f5f5f5)",
+                    fontFamily: "inherit",
+                    fontSize: 12,
+                    fontWeight: active ? 760 : 650,
+                    cursor: "pointer",
+                  }}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </PopoverContent>
+      </Popover>
       <button
         type="button"
         aria-label={`Next month, ${month}`}
@@ -490,6 +577,7 @@ export function SimpleCalendarView() {
   const [selectedDate, setSelectedDate] = useState(() =>
     localDateKey(calendar.baseDate),
   );
+  const baseDateKey = localDateKey(calendar.baseDate);
   const cursor = useMemo(
     () => monthStart(calendar.baseDate),
     [calendar.baseDate],
@@ -500,8 +588,8 @@ export function SimpleCalendarView() {
     [calendar.events, selectedDate],
   );
   useEffect(() => {
-    setSelectedDate(localDateKey(calendar.baseDate));
-  }, [calendar.baseDate]);
+    setSelectedDate(baseDateKey);
+  }, [baseDateKey]);
   const selectDay = useCallback(
     (day: Date) => {
       setSelectedDate(localDateKey(day));
@@ -534,6 +622,21 @@ export function SimpleCalendarView() {
       data-testid="simple-calendar-view"
       style={ROOT_STYLE}
     >
+      <style>{`
+        .eliza-calendar-day:focus { outline: none; }
+        .eliza-calendar-day:focus-visible {
+          outline: 2px solid var(--accent, #ff6a1f);
+          outline-offset: 2px;
+        }
+        .eliza-calendar-day:active { transform: scale(.98); }
+        @media (prefers-reduced-motion: reduce) {
+          .eliza-calendar-day { transition: none !important; }
+        }
+        @keyframes eliza-calendar-hydrate {
+          0%, 100% { opacity: .35; }
+          50% { opacity: .7; }
+        }
+      `}</style>
       <div
         data-testid="simple-calendar-scroll-region"
         style={{
@@ -557,116 +660,128 @@ export function SimpleCalendarView() {
           </div>
         ) : null}
 
-        {!loaded && calendar.loading ? (
-          <div role="status" style={{ ...PANEL_STYLE, padding: 24 }}>
-            Loading…
+        <section
+          aria-label="Calendar month"
+          style={{
+            ...PANEL_STYLE,
+            padding: "14px clamp(4px, 1.6vw, 16px)",
+          }}
+        >
+          <MonthControls
+            cursor={cursor}
+            onPrevious={calendar.goPrevious}
+            onNext={calendar.goNext}
+            onToday={calendar.goToToday}
+            onMonthChange={chooseMonth}
+          />
+          <div
+            aria-hidden
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(7, minmax(0, 1fr))",
+              gap: 3,
+              marginBottom: 5,
+            }}
+          >
+            {WEEKDAYS.map((weekday) => (
+              <span
+                key={weekday}
+                style={{
+                  color: "var(--muted, rgba(255,255,255,.58))",
+                  fontSize: 10,
+                  fontWeight: 680,
+                  textAlign: "center",
+                }}
+              >
+                {weekday.slice(0, 1)}
+              </span>
+            ))}
           </div>
-        ) : (
-          <>
-            <section
-              aria-label="Calendar month"
-              style={{
-                ...PANEL_STYLE,
-                padding: "14px clamp(4px, 1.6vw, 16px)",
-              }}
-            >
-              <MonthControls
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(7, minmax(0, 1fr))",
+              gap: 3,
+            }}
+          >
+            {days.map((day) => (
+              <CalendarDay
+                key={localDateKey(day)}
+                day={day}
                 cursor={cursor}
-                onPrevious={calendar.goPrevious}
-                onNext={calendar.goNext}
-                onToday={calendar.goToToday}
-                onMonthChange={chooseMonth}
+                selectedDate={selectedDate}
+                events={calendar.events}
+                onSelect={selectDay}
               />
-              <div
-                aria-hidden
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "repeat(7, minmax(0, 1fr))",
-                  gap: 3,
-                  marginBottom: 5,
-                }}
-              >
-                {WEEKDAYS.map((weekday) => (
-                  <span
-                    key={weekday}
-                    style={{
-                      color: "var(--muted, rgba(255,255,255,.58))",
-                      fontSize: 10,
-                      fontWeight: 680,
-                      textAlign: "center",
-                    }}
-                  >
-                    {weekday.slice(0, 1)}
-                  </span>
-                ))}
-              </div>
-              <div
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "repeat(7, minmax(0, 1fr))",
-                  gap: 3,
-                }}
-              >
-                {days.map((day) => (
-                  <CalendarDay
-                    key={localDateKey(day)}
-                    day={day}
-                    cursor={cursor}
-                    selectedDate={selectedDate}
-                    events={calendar.events}
-                    onSelect={selectDay}
-                  />
-                ))}
-              </div>
-            </section>
+            ))}
+          </div>
+        </section>
 
-            <section
-              aria-label={`Events for ${selectedDate}`}
-              style={{ ...PANEL_STYLE, padding: 16 }}
-            >
-              <div
+        <section
+          aria-label={`Events for ${selectedDate}`}
+          style={{ ...PANEL_STYLE, padding: 16 }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              marginBottom: selectedEvents.length > 0 ? 6 : 12,
+            }}
+          >
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <h2
                 style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 10,
-                  marginBottom: selectedEvents.length > 0 ? 6 : 12,
+                  margin: 0,
+                  fontSize: 15,
+                  lineHeight: 1.35,
+                  fontWeight: 720,
                 }}
               >
-                <div style={{ minWidth: 0, flex: 1 }}>
-                  <h2
-                    style={{
-                      margin: 0,
-                      fontSize: 15,
-                      lineHeight: 1.35,
-                      fontWeight: 720,
-                    }}
-                  >
-                    {formatSelectedDate(selectedDate)}
-                  </h2>
-                  <p style={{ ...SECONDARY_STYLE, marginTop: 3, fontSize: 11 }}>
-                    {selectedEvents.length === 0
-                      ? "No plans yet"
-                      : `${selectedEvents.length} ${selectedEvents.length === 1 ? "event" : "events"}`}
-                  </p>
-                </div>
-                <Clock3
-                  size={16}
+                {formatSelectedDate(selectedDate)}
+              </h2>
+              <p style={{ ...SECONDARY_STYLE, marginTop: 3, fontSize: 11 }}>
+                {!loaded
+                  ? "\u00a0"
+                  : selectedEvents.length === 0
+                    ? "No plans yet"
+                    : `${selectedEvents.length} ${selectedEvents.length === 1 ? "event" : "events"}`}
+              </p>
+            </div>
+            <Clock3 size={16} aria-hidden style={{ color: "var(--muted)" }} />
+          </div>
+          {!loaded ? (
+            <div
+              role="status"
+              aria-label="Calendar events are loading"
+              style={{ display: "grid", gap: 8, paddingBlock: 2 }}
+            >
+              {["72%", "48%"].map((width) => (
+                <span
+                  key={width}
                   aria-hidden
-                  style={{ color: "var(--muted)" }}
+                  style={{
+                    width,
+                    height: 9,
+                    borderRadius: 9999,
+                    background:
+                      "color-mix(in srgb, var(--surface, rgba(255,255,255,.08)) 82%, transparent)",
+                    animation:
+                      "eliza-calendar-hydrate 1.2s ease-in-out infinite",
+                  }}
                 />
-              </div>
-              {selectedEvents.length === 0 ? (
-                <p style={SECONDARY_STYLE}>
-                  Ask Eliza in chat to schedule something for today.
-                </p>
-              ) : (
-                selectedEvents.map((event) => (
-                  <EventRow key={event.id} event={event} />
-                ))
-              )}
-            </section>
-          </>
-        )}
+              ))}
+            </div>
+          ) : selectedEvents.length === 0 ? (
+            <p style={SECONDARY_STYLE}>
+              Ask Eliza in chat to schedule something for today.
+            </p>
+          ) : (
+            selectedEvents.map((event) => (
+              <EventRow key={event.id} event={event} />
+            ))
+          )}
+        </section>
       </div>
     </main>
   );

--- a/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx
@@ -1,15 +1,21 @@
 /**
- * Chat-first Calendar projection over the canonical multi-provider feed. The
- * surface is intentionally read-only: the CALENDAR action owns mutations,
- * while this view refreshes after chat actions and renders the local month and
- * today's agenda without introducing a second calendar store.
+ * Interactive Calendar projection over the canonical multi-provider feed.
+ * Month/day navigation stays client-side, while event mutations remain on the
+ * CALENDAR action and owner-approval path so the view never introduces a
+ * second calendar store or write boundary.
  */
 
 import type { LifeOpsCalendarEvent } from "@elizaos/shared";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { useViewEvent, VIEW_EVENTS } from "@elizaos/ui/events";
-import { Clock3 } from "lucide-react";
-import { type CSSProperties, useMemo } from "react";
+import { ChevronLeft, ChevronRight, Clock3 } from "lucide-react";
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useCalendarWeek } from "../../hooks/useCalendarWeek.js";
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -50,7 +56,7 @@ const SCROLL_STYLE: CSSProperties = {
 const PANEL_STYLE: CSSProperties = {
   boxSizing: "border-box",
   border: "none",
-  borderRadius: 22,
+  borderRadius: 24,
   background:
     "color-mix(in srgb, var(--card, rgba(16,16,16,.88)) 76%, transparent)",
   boxShadow: "inset 0 1px 0 rgba(255,255,255,.10), 0 18px 48px rgba(0,0,0,.20)",
@@ -109,6 +115,21 @@ function formatMonth(date: Date): string {
   }).format(date);
 }
 
+function monthInputValue(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function dateFromMonthInput(value: string): Date {
+  const match = /^(\d{4})-(\d{2})$/.exec(value);
+  if (!match) throw new Error("Calendar month is invalid.");
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (!Number.isSafeInteger(year) || month < 1 || month > 12) {
+    throw new Error("Calendar month is invalid.");
+  }
+  return new Date(year, month - 1, 1, 12);
+}
+
 function formatSelectedDate(value: string): string {
   return new Intl.DateTimeFormat(undefined, {
     weekday: "long",
@@ -146,21 +167,24 @@ function CalendarDay({
   cursor,
   selectedDate,
   events,
+  onSelect,
 }: {
   day: Date;
   cursor: Date;
   selectedDate: string;
   events: LifeOpsCalendarEvent[];
+  onSelect: (day: Date) => void;
 }) {
   const key = localDateKey(day);
   const dayEvents = eventsOnDate(events, key);
   const selected = key === selectedDate;
   const currentMonth = day.getMonth() === cursor.getMonth();
   const today = key === localDateKey(new Date());
-  const cell = useAgentElement<HTMLDivElement>({
+  const selectDay = useCallback(() => onSelect(day), [day, onSelect]);
+  const cell = useAgentElement<HTMLButtonElement>({
     id: `calendar-day-${key}`,
     label: formatSelectedDate(key),
-    role: "card",
+    role: "button",
     group: "calendar-grid",
     description:
       dayEvents.length === 0
@@ -171,17 +195,23 @@ function CalendarDay({
       : currentMonth
         ? "current-month"
         : "outside-month",
+    onActivate: selectDay,
   });
 
   return (
-    <div
+    <button
       ref={cell.ref}
       {...cell.agentProps}
+      type="button"
+      onClick={selectDay}
+      aria-label={formatSelectedDate(key)}
+      aria-pressed={selected}
       aria-current={today ? "date" : undefined}
       style={{
         boxSizing: "border-box",
         minWidth: 0,
         minHeight: "clamp(38px, 7vw, 62px)",
+        border: 0,
         borderRadius: 11,
         padding: "6px clamp(4px, .8vw, 8px)",
         background: selected
@@ -197,6 +227,11 @@ function CalendarDay({
         flexDirection: "column",
         justifyContent: "space-between",
         gap: 5,
+        cursor: "pointer",
+        fontFamily: "inherit",
+        textAlign: "start",
+        transition:
+          "background-color 140ms ease, box-shadow 140ms ease, color 140ms ease, transform 140ms ease",
       }}
     >
       <span
@@ -216,7 +251,7 @@ function CalendarDay({
             style={{
               width: 5,
               height: 5,
-              borderRadius: 999,
+              borderRadius: 9999,
               background: "var(--accent, #ff6a1f)",
             }}
           />
@@ -243,13 +278,138 @@ function CalendarDay({
             style={{
               width: 6,
               height: 6,
-              borderRadius: 999,
+              borderRadius: 9999,
               background: "#35df8d",
             }}
           />
           <span aria-hidden>{dayEvents.length}</span>
         </span>
       ) : null}
+    </button>
+  );
+}
+
+function MonthControls({
+  cursor,
+  onPrevious,
+  onNext,
+  onToday,
+  onMonthChange,
+}: {
+  cursor: Date;
+  onPrevious: () => void;
+  onNext: () => void;
+  onToday: () => void;
+  onMonthChange: (month: Date) => void;
+}) {
+  const month = formatMonth(cursor);
+  const navigationButton: CSSProperties = {
+    width: 44,
+    height: 44,
+    display: "grid",
+    placeItems: "center",
+    border: 0,
+    borderRadius: 13,
+    background:
+      "color-mix(in srgb, var(--surface, rgba(255,255,255,.06)) 72%, transparent)",
+    color: "var(--txt, #f5f5f5)",
+    cursor: "pointer",
+  };
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "44px minmax(0, 1fr) 44px",
+        alignItems: "center",
+        gap: 8,
+        marginBottom: 12,
+      }}
+    >
+      <button
+        type="button"
+        aria-label={`Previous month, ${month}`}
+        title="Previous month"
+        onClick={onPrevious}
+        style={navigationButton}
+      >
+        <ChevronLeft size={19} aria-hidden />
+      </button>
+      <div
+        style={{
+          position: "relative",
+          minWidth: 0,
+          textAlign: "center",
+          borderRadius: 13,
+        }}
+      >
+        <h2
+          style={{
+            margin: 0,
+            fontSize: 17,
+            lineHeight: 1.25,
+            fontWeight: 760,
+            textAlign: "center",
+          }}
+        >
+          {month}
+        </h2>
+        <span
+          aria-hidden
+          style={{
+            display: "block",
+            marginTop: 1,
+            color: "var(--muted, rgba(255,255,255,.58))",
+            fontSize: 10,
+            lineHeight: 1.3,
+          }}
+        >
+          Choose month &amp; year
+        </span>
+        <input
+          type="month"
+          aria-label="Choose calendar month and year"
+          value={monthInputValue(cursor)}
+          onChange={(event) =>
+            onMonthChange(dateFromMonthInput(event.target.value))
+          }
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            opacity: 0,
+            cursor: "pointer",
+          }}
+        />
+      </div>
+      <button
+        type="button"
+        aria-label={`Next month, ${month}`}
+        title="Next month"
+        onClick={onNext}
+        style={navigationButton}
+      >
+        <ChevronRight size={19} aria-hidden />
+      </button>
+      <button
+        type="button"
+        onClick={onToday}
+        style={{
+          gridColumn: "2",
+          justifySelf: "center",
+          border: 0,
+          borderRadius: 9999,
+          padding: "4px 10px",
+          background: "transparent",
+          color: "var(--muted-strong, rgba(255,255,255,.76))",
+          fontFamily: "inherit",
+          fontSize: 11,
+          fontWeight: 650,
+          cursor: "pointer",
+        }}
+      >
+        Today
+      </button>
     </div>
   );
 }
@@ -276,7 +436,7 @@ function EventRow({ event }: { event: LifeOpsCalendarEvent }) {
         padding: "10px 0",
       }}
     >
-      <span aria-hidden style={{ borderRadius: 999, background: "#35df8d" }} />
+      <span aria-hidden style={{ borderRadius: 9999, background: "#35df8d" }} />
       <div style={{ minWidth: 0 }}>
         <div
           style={{
@@ -327,7 +487,9 @@ export function SimpleCalendarView() {
     void calendar.refresh();
   }, [calendar.refresh]);
 
-  const selectedDate = localDateKey(calendar.baseDate);
+  const [selectedDate, setSelectedDate] = useState(() =>
+    localDateKey(calendar.baseDate),
+  );
   const cursor = useMemo(
     () => monthStart(calendar.baseDate),
     [calendar.baseDate],
@@ -336,6 +498,25 @@ export function SimpleCalendarView() {
   const selectedEvents = useMemo(
     () => eventsOnDate(calendar.events, selectedDate),
     [calendar.events, selectedDate],
+  );
+  useEffect(() => {
+    setSelectedDate(localDateKey(calendar.baseDate));
+  }, [calendar.baseDate]);
+  const selectDay = useCallback(
+    (day: Date) => {
+      setSelectedDate(localDateKey(day));
+      if (
+        day.getFullYear() !== cursor.getFullYear() ||
+        day.getMonth() !== cursor.getMonth()
+      ) {
+        calendar.goToDate(day);
+      }
+    },
+    [calendar.goToDate, cursor],
+  );
+  const chooseMonth = useCallback(
+    (month: Date) => calendar.goToDate(month),
+    [calendar.goToDate],
   );
   const loaded = calendar.feedState !== null;
   const detail = calendar.error
@@ -361,6 +542,9 @@ export function SimpleCalendarView() {
           gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
           gap: 14,
           alignItems: "start",
+          alignContent: "start",
+          maxWidth: 1040,
+          marginInline: "auto",
         }}
       >
         {calendar.error ? (
@@ -386,16 +570,13 @@ export function SimpleCalendarView() {
                 padding: "14px clamp(4px, 1.6vw, 16px)",
               }}
             >
-              <h2
-                style={{
-                  margin: "0 0 13px",
-                  fontSize: 16,
-                  lineHeight: 1.3,
-                  fontWeight: 740,
-                }}
-              >
-                {formatMonth(cursor)}
-              </h2>
+              <MonthControls
+                cursor={cursor}
+                onPrevious={calendar.goPrevious}
+                onNext={calendar.goNext}
+                onToday={calendar.goToToday}
+                onMonthChange={chooseMonth}
+              />
               <div
                 aria-hidden
                 style={{
@@ -433,6 +614,7 @@ export function SimpleCalendarView() {
                     cursor={cursor}
                     selectedDate={selectedDate}
                     events={calendar.events}
+                    onSelect={selectDay}
                   />
                 ))}
               </div>

--- a/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx
@@ -740,9 +740,9 @@ export function SimpleCalendarView() {
               >
                 {formatSelectedDate(selectedDate)}
               </h2>
-              <p style={{ ...SECONDARY_STYLE, marginTop: 3, fontSize: 11 }}>
+              <p style={{ ...SECONDARY_STYLE, marginTop: 3, fontSize: 12 }}>
                 {!loaded
-                  ? "\u00a0"
+                  ? "Loading calendar\u2026"
                   : selectedEvents.length === 0
                     ? "No plans yet"
                     : `${selectedEvents.length} ${selectedEvents.length === 1 ? "event" : "events"}`}

--- a/plugins/plugin-calendar/src/components/calendar/source-health.ts
+++ b/plugins/plugin-calendar/src/components/calendar/source-health.ts
@@ -30,6 +30,7 @@ const PROVIDER_LABELS: Record<
   microsoft: "Outlook",
   apple_calendar: "Apple",
   ics: "Subscription",
+  eliza: "Eliza",
 };
 
 function sourceId(source: LifeOpsCalendarSourceHealth): string {
@@ -102,11 +103,16 @@ export function toCalendarSourceHealthRows(
   return sources.map((source) => {
     const provider = PROVIDER_LABELS[source.key.provider];
     const summary = source.summary.trim();
+    const presentation = sourcePresentation(source, now);
     return {
       id: sourceId(source),
       label: summary ? `${provider} · ${summary}` : provider,
       status: source.status,
-      ...sourcePresentation(source, now),
+      ...presentation,
+      freshnessLabel:
+        source.key.provider === "eliza" && source.status === "fresh"
+          ? "stored locally"
+          : presentation.freshnessLabel,
     };
   });
 }

--- a/plugins/plugin-calendar/src/components/calendar/source-manager.test.ts
+++ b/plugins/plugin-calendar/src/components/calendar/source-manager.test.ts
@@ -148,4 +148,33 @@ describe("calendar source manager model", () => {
     );
     expect(calendarSourceIdentityKey(excluded)).toContain("grant-one");
   });
+
+  it("presents the built-in calendar as local instead of a connector account", () => {
+    const builtIn = calendar({
+      provider: "eliza",
+      grantId: "eliza-calendar",
+      connectorAccountId: "eliza-calendar",
+      accountEmail: null,
+      calendarId: "primary",
+      summary: "My calendar",
+    });
+    const model = toCalendarSourceManagerModel(
+      [builtIn],
+      [health(builtIn, { syncedAt: null })],
+    );
+
+    expect(model.rows).toEqual([
+      expect.objectContaining({
+        providerLabel: "Eliza Calendar",
+        accountLabel: "Built in",
+        calendarLabel: "My calendar",
+        statusLabel: "Current",
+        freshnessLabel: "stored locally",
+        included: true,
+        toggleAvailable: true,
+        reconnectConnectorId: null,
+        reconnectUnavailable: false,
+      }),
+    ]);
+  });
 });

--- a/plugins/plugin-calendar/src/components/calendar/source-manager.ts
+++ b/plugins/plugin-calendar/src/components/calendar/source-manager.ts
@@ -70,6 +70,7 @@ const PROVIDER_LABELS: Record<LifeOpsCalendarProvider, string> = {
   microsoft: "Microsoft Outlook",
   apple_calendar: "Apple Calendar",
   ics: "Calendar subscription",
+  eliza: "Eliza Calendar",
 };
 
 export function calendarSourceIdentityKey(
@@ -266,7 +267,8 @@ export function toCalendarSourceManagerModel(
       actionId,
       providerLabel: providerLabel(provider),
       accountLabel:
-        calendar?.accountEmail?.trim() || "Account details unavailable",
+        calendar?.accountEmail?.trim() ||
+        (provider === "eliza" ? "Built in" : "Account details unavailable"),
       calendarLabel: calendarLabel(calendar, health),
       primary: calendar?.primary ?? false,
       accessLabel: normalizeAccessRole(

--- a/plugins/plugin-calendar/src/hooks/useCalendarWeek.test.ts
+++ b/plugins/plugin-calendar/src/hooks/useCalendarWeek.test.ts
@@ -266,6 +266,28 @@ describe("useCalendarWeek", () => {
     });
   });
 
+  it("jumps directly to a chosen month and rejects invalid dates", async () => {
+    const { result } = renderHook(() =>
+      useCalendarWeek({
+        baseDate: new Date(2026, 7, 4, 12),
+        viewMode: "month",
+      }),
+    );
+    await waitFor(() =>
+      expect(uiClient.getLifeOpsCalendarFeed).toHaveBeenCalled(),
+    );
+
+    act(() => result.current.goToDate(new Date(2028, 2, 1, 12)));
+    await waitFor(() => {
+      expect(result.current.baseDate.getFullYear()).toBe(2028);
+      expect(result.current.baseDate.getMonth()).toBe(2);
+    });
+
+    expect(() => result.current.goToDate(new Date(Number.NaN))).toThrow(
+      "Calendar date must be valid.",
+    );
+  });
+
   it("surfaces an error message when the feed fetch rejects", async () => {
     uiClient.getLifeOpsCalendarFeed.mockRejectedValue(
       new Error("network down"),

--- a/plugins/plugin-calendar/src/hooks/useCalendarWeek.ts
+++ b/plugins/plugin-calendar/src/hooks/useCalendarWeek.ts
@@ -47,6 +47,7 @@ export interface UseCalendarWeekResult {
   windowStart: Date;
   windowEnd: Date;
   refresh: () => Promise<void>;
+  goToDate: (date: Date) => void;
   goToToday: () => void;
   goPrevious: () => void;
   goNext: () => void;
@@ -131,6 +132,13 @@ export function useCalendarWeek(
   );
 
   const goToToday = useCallback(() => setBaseDate(new Date()), []);
+  const goToDate = useCallback((date: Date) => {
+    const next = new Date(date);
+    if (!Number.isFinite(next.getTime())) {
+      throw new RangeError("Calendar date must be valid.");
+    }
+    setBaseDate(next);
+  }, []);
   const goPrevious = useCallback(() => shiftBase(-1), [shiftBase]);
   const goNext = useCallback(() => shiftBase(1), [shiftBase]);
 
@@ -207,6 +215,7 @@ export function useCalendarWeek(
     windowStart,
     windowEnd,
     refresh: fetch,
+    goToDate,
     goToToday,
     goPrevious,
     goNext,

--- a/plugins/plugin-calendar/src/index.ts
+++ b/plugins/plugin-calendar/src/index.ts
@@ -77,6 +77,14 @@ export {
   type UseCalendarWeekResult,
   useCalendarWeek,
 } from "./hooks/useCalendarWeek.js";
+export {
+  ELIZA_CALENDAR_ACCOUNT_ID,
+  ELIZA_CALENDAR_GRANT_ID,
+  ELIZA_CALENDAR_ID,
+  ELIZA_CALENDAR_PROVIDER,
+  isElizaCalendarEventId,
+  isElizaCalendarGrant,
+} from "./internal/eliza-calendar.js";
 export { CalendarServiceError } from "./internal/errors.js";
 export * from "./meetings/index.js";
 export * from "./microsoft/index.js";

--- a/plugins/plugin-calendar/src/internal/eliza-calendar.ts
+++ b/plugins/plugin-calendar/src/internal/eliza-calendar.ts
@@ -1,0 +1,252 @@
+/**
+ * Built-in Eliza calendar identity and event mapping. The provider persists in
+ * the canonical calendar repository, so a new agent has one writable source
+ * without an external account while retaining the same feed, approval, audit,
+ * reminder, and optimistic-concurrency contracts as connected providers.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  CreateLifeOpsCalendarEventAttendee,
+  CreateLifeOpsCalendarEventRequest,
+  LifeOpsCalendarEvent,
+  LifeOpsCalendarSummary,
+} from "@elizaos/shared";
+import { CalendarServiceError } from "./errors.js";
+
+export const ELIZA_CALENDAR_PROVIDER = "eliza" as const;
+export const ELIZA_CALENDAR_GRANT_ID = "eliza-calendar" as const;
+export const ELIZA_CALENDAR_ACCOUNT_ID = "eliza-calendar" as const;
+export const ELIZA_CALENDAR_ID = "primary" as const;
+
+function calendarEtag(revision: number): string {
+  return `"eliza-${revision}"`;
+}
+
+function calendarRevision(event: LifeOpsCalendarEvent): number {
+  const revision = event.metadata.version;
+  if (!Number.isSafeInteger(revision) || Number(revision) < 1) {
+    throw new CalendarServiceError(
+      500,
+      "The built-in calendar event has an invalid version.",
+      "ELIZA_CALENDAR_VERSION_INVALID",
+    );
+  }
+  return Number(revision);
+}
+
+function eventExternalId(agentId: string, idempotencyKey?: string): string {
+  const operationKey = idempotencyKey?.trim();
+  if (!operationKey) return `event-${randomUUID()}`;
+  const digest = createHash("sha256")
+    .update(`${agentId}\u0000${operationKey}`)
+    .digest("hex");
+  return `event-${digest}`;
+}
+
+function eventId(agentId: string, externalId: string): string {
+  return [
+    agentId,
+    ELIZA_CALENDAR_PROVIDER,
+    "owner",
+    "grant",
+    ELIZA_CALENDAR_GRANT_ID,
+    "calendar",
+    ELIZA_CALENDAR_ID,
+    externalId,
+  ].join(":");
+}
+
+function eventAttendees(
+  attendees: readonly CreateLifeOpsCalendarEventAttendee[],
+): LifeOpsCalendarEvent["attendees"] {
+  return attendees.map((attendee) => ({
+    email: attendee.email,
+    displayName: attendee.displayName ?? null,
+    responseStatus: null,
+    self: false,
+    organizer: false,
+    optional: attendee.optional === true,
+  }));
+}
+
+export function isElizaCalendarGrant(
+  grantId: string | null | undefined,
+): boolean {
+  return grantId === ELIZA_CALENDAR_GRANT_ID;
+}
+
+export function isElizaCalendarEventId(
+  value: string | null | undefined,
+  agentId: string,
+): boolean {
+  return Boolean(
+    value?.startsWith(`${agentId}:${ELIZA_CALENDAR_PROVIDER}:owner:grant:`),
+  );
+}
+
+export function elizaCalendarSummary(
+  timeZone: string | null = null,
+): LifeOpsCalendarSummary {
+  return {
+    provider: ELIZA_CALENDAR_PROVIDER,
+    side: "owner",
+    grantId: ELIZA_CALENDAR_GRANT_ID,
+    connectorAccountId: ELIZA_CALENDAR_ACCOUNT_ID,
+    accountEmail: null,
+    calendarId: ELIZA_CALENDAR_ID,
+    summary: "Eliza Calendar",
+    description: "Built-in calendar stored with this Eliza agent.",
+    primary: true,
+    accessRole: "owner",
+    backgroundColor: null,
+    foregroundColor: null,
+    timeZone,
+    selected: true,
+    includeInFeed: true,
+    selectionVersion: 0,
+  };
+}
+
+export function createElizaCalendarEvent(args: {
+  agentId: string;
+  request: CreateLifeOpsCalendarEventRequest;
+  startAt: string;
+  endAt: string;
+  timeZone: string;
+  attendees: readonly CreateLifeOpsCalendarEventAttendee[];
+  now: Date;
+}): LifeOpsCalendarEvent {
+  const title = args.request.title.trim();
+  if (!title) {
+    throw new CalendarServiceError(
+      400,
+      "Calendar event title is required.",
+      "CALENDAR_EVENT_TITLE_REQUIRED",
+    );
+  }
+  if (
+    args.request.calendarId &&
+    args.request.calendarId !== ELIZA_CALENDAR_ID
+  ) {
+    throw new CalendarServiceError(
+      404,
+      "The built-in Eliza calendar has one primary calendar.",
+      "ELIZA_CALENDAR_NOT_FOUND",
+    );
+  }
+  if (args.request.notifyAttendees === true) {
+    throw new CalendarServiceError(
+      400,
+      "The built-in Eliza calendar cannot email attendees. Connect an external calendar to send invitations.",
+      "ELIZA_CALENDAR_ATTENDEE_NOTIFICATIONS_UNSUPPORTED",
+    );
+  }
+  if (args.request.recurrence?.length) {
+    throw new CalendarServiceError(
+      400,
+      "Recurring events require a connected calendar provider.",
+      "ELIZA_CALENDAR_RECURRENCE_UNSUPPORTED",
+    );
+  }
+  const externalId = eventExternalId(args.agentId, args.request.idempotencyKey);
+  const timestamp = args.now.toISOString();
+  return {
+    id: eventId(args.agentId, externalId),
+    externalId,
+    agentId: args.agentId,
+    provider: ELIZA_CALENDAR_PROVIDER,
+    side: "owner",
+    calendarId: ELIZA_CALENDAR_ID,
+    title,
+    description: args.request.description?.trim() ?? "",
+    location: args.request.location?.trim() ?? "",
+    status: "confirmed",
+    startAt: args.startAt,
+    endAt: args.endAt,
+    isAllDay: false,
+    timezone: args.timeZone,
+    htmlLink: null,
+    conferenceLink: null,
+    organizer: { self: true, displayName: "You" },
+    attendees: eventAttendees(args.attendees),
+    metadata: {
+      managedBy: ELIZA_CALENDAR_PROVIDER,
+      version: 1,
+      etag: calendarEtag(1),
+    },
+    syncedAt: timestamp,
+    updatedAt: timestamp,
+    connectorAccountId: ELIZA_CALENDAR_ACCOUNT_ID,
+    grantId: ELIZA_CALENDAR_GRANT_ID,
+  };
+}
+
+export function updateElizaCalendarEvent(args: {
+  event: LifeOpsCalendarEvent;
+  title?: string;
+  description?: string;
+  location?: string;
+  startAt?: string;
+  endAt?: string;
+  timeZone?: string;
+  attendees?: readonly CreateLifeOpsCalendarEventAttendee[];
+  now: Date;
+}): LifeOpsCalendarEvent {
+  if (args.event.provider !== ELIZA_CALENDAR_PROVIDER) {
+    throw new CalendarServiceError(
+      409,
+      "The event is not owned by the built-in Eliza calendar.",
+      "ELIZA_CALENDAR_EVENT_PROVIDER_MISMATCH",
+    );
+  }
+  const title = args.title === undefined ? args.event.title : args.title.trim();
+  if (!title) {
+    throw new CalendarServiceError(
+      400,
+      "Calendar event title is required.",
+      "CALENDAR_EVENT_TITLE_REQUIRED",
+    );
+  }
+  const startAt = args.startAt ?? args.event.startAt;
+  const endAt = args.endAt ?? args.event.endAt;
+  const startMs = Date.parse(startAt);
+  const endMs = Date.parse(endAt);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+    throw new CalendarServiceError(
+      400,
+      "Calendar event times must be valid ISO date-times.",
+      "CALENDAR_EVENT_TIME_INVALID",
+    );
+  }
+  if (endMs <= startMs) {
+    throw new CalendarServiceError(
+      400,
+      "endAt must be later than startAt",
+      "CALENDAR_EVENT_RANGE_INVALID",
+    );
+  }
+  const revision = calendarRevision(args.event) + 1;
+  const timestamp = args.now.toISOString();
+  return {
+    ...args.event,
+    title,
+    description: args.description?.trim() ?? args.event.description,
+    location: args.location?.trim() ?? args.event.location,
+    startAt,
+    endAt,
+    timezone: args.timeZone ?? args.event.timezone,
+    attendees:
+      args.attendees === undefined
+        ? args.event.attendees
+        : eventAttendees(args.attendees),
+    metadata: {
+      ...args.event.metadata,
+      managedBy: ELIZA_CALENDAR_PROVIDER,
+      version: revision,
+      etag: calendarEtag(revision),
+    },
+    syncedAt: timestamp,
+    updatedAt: timestamp,
+  };
+}

--- a/plugins/plugin-calendar/src/plugin.ts
+++ b/plugins/plugin-calendar/src/plugin.ts
@@ -65,7 +65,10 @@ export const calendarPlugin: Plugin = {
       // First-party instrumented view (data-agent-id controls): grant the
       // agent-surface capability so the view broker admits agent-driven
       // fills/clicks (#13452 manifest gate).
-      surface: { capabilities: ["agent-surface"] },
+      surface: {
+        header: "fullscreen",
+        capabilities: ["agent-surface"],
+      },
       componentExport: "CalendarView",
       tags: ["calendar", "schedule", "events"],
       relatedActions: ["CALENDAR", "CALENDAR_SOURCES", "CONFLICT_DETECT"],

--- a/plugins/plugin-calendar/src/register.test.ts
+++ b/plugins/plugin-calendar/src/register.test.ts
@@ -1,0 +1,34 @@
+/** Verifies that signed native clients receive the canonical Calendar page. */
+
+import { listAppShellPages } from "@elizaos/ui/app-shell-registry";
+import { describe, expect, it } from "vitest";
+import "./register.ts";
+
+describe("Calendar app registration", () => {
+  it("matches the runtime route and grants the Calendar surface contract", () => {
+    const pages = listAppShellPages().filter(
+      (page) => page.pluginId === "@elizaos/plugin-calendar",
+    );
+
+    expect(
+      pages.map(({ id, label, path, viewKind }) => ({
+        id,
+        label,
+        path,
+        viewKind,
+      })),
+    ).toEqual([
+      {
+        id: "calendar",
+        label: "Calendar",
+        path: "/calendar",
+        viewKind: "release",
+      },
+    ]);
+    expect(pages[0]?.loader).toBeTypeOf("function");
+    expect(pages[0]?.surface).toEqual({
+      header: "fullscreen",
+      capabilities: ["agent-surface"],
+    });
+  });
+});

--- a/plugins/plugin-calendar/src/register.ts
+++ b/plugins/plugin-calendar/src/register.ts
@@ -1,0 +1,27 @@
+/**
+ * Registers Calendar as a signed app-shell page for native clients.
+ *
+ * The runtime remains the sole owner of calendar data, actions, and routes;
+ * only the React surface is bundled locally because mobile stores prohibit
+ * downloading executable view JavaScript from the connected agent.
+ */
+
+import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
+
+registerAppShellPage({
+  id: "calendar",
+  pluginId: "@elizaos/plugin-calendar",
+  label: "Calendar",
+  icon: "Calendar",
+  path: "/calendar",
+  order: 910,
+  viewKind: "release",
+  surface: {
+    header: "fullscreen",
+    capabilities: ["agent-surface"],
+  },
+  loader: () =>
+    import("./components/calendar/SimpleCalendarView.tsx").then((module) => ({
+      default: module.SimpleCalendarView,
+    })),
+});

--- a/plugins/plugin-calendar/src/service/CalendarRepository.ts
+++ b/plugins/plugin-calendar/src/service/CalendarRepository.ts
@@ -280,6 +280,38 @@ function calendarEventValues(event: LifeOpsCalendarEvent): string {
 export class CalendarRepository {
   constructor(private readonly runtime: IAgentRuntime) {}
 
+  async insertCalendarEventIfAbsent(
+    event: LifeOpsCalendarEvent,
+  ): Promise<{ event: LifeOpsCalendarEvent; inserted: boolean }> {
+    const rows = await executeRawSql(
+      this.runtime,
+      `INSERT INTO app_calendar.life_calendar_events (
+        id, agent_id, provider, side, calendar_id, external_event_id, title,
+        description, location, status, start_at, end_at, is_all_day,
+        timezone, html_link, conference_link, organizer_json, attendees_json,
+        connector_account_id, grant_id, metadata_json, synced_at, updated_at
+      ) VALUES ${calendarEventValues(event)}
+      ON CONFLICT DO NOTHING
+      RETURNING *`,
+    );
+    const inserted = rows[0];
+    if (inserted) {
+      return { event: parseCalendarEvent(inserted), inserted: true };
+    }
+    const existing = await this.getCalendarEventById(event.agentId, event.id);
+    if (!existing) {
+      throw new ElizaError(
+        "Calendar event idempotency conflict did not resolve to its original row.",
+        {
+          code: "CALENDAR_EVENT_IDEMPOTENCY_CONFLICT",
+          context: { agentId: event.agentId, eventId: event.id },
+          severity: "fatal",
+        },
+      );
+    }
+    return { event: existing, inserted: false };
+  }
+
   async upsertCalendarEvent(
     event: LifeOpsCalendarEvent,
     side: LifeOpsConnectorSide = event.side,
@@ -396,6 +428,22 @@ export class CalendarRepository {
     );
   }
 
+  async deleteCalendarEventByIdIfVersion(args: {
+    agentId: string;
+    eventId: string;
+    expectedVersion: string;
+  }): Promise<boolean> {
+    const rows = await executeRawSql(
+      this.runtime,
+      `DELETE FROM app_calendar.life_calendar_events
+        WHERE agent_id = ${sqlQuote(args.agentId)}
+          AND id = ${sqlQuote(args.eventId)}
+          AND metadata_json::jsonb ->> 'etag' = ${sqlQuote(args.expectedVersion)}
+      RETURNING id`,
+    );
+    return rows.length === 1;
+  }
+
   async pruneCalendarEventsInWindow(
     agentId: string,
     provider: LifeOpsCalendarProvider,
@@ -451,6 +499,70 @@ export class CalendarRepository {
         WHERE agent_id = ${sqlQuote(agentId)}
           AND id = ${sqlQuote(eventId)}
         LIMIT 1`,
+    );
+    const row = rows[0];
+    return row ? parseCalendarEvent(row) : null;
+  }
+
+  async getCalendarEventByExternalId(args: {
+    agentId: string;
+    provider: LifeOpsCalendarProvider;
+    externalEventId: string;
+    calendarId?: string | null;
+    side?: LifeOpsConnectorSide;
+    grantId?: string;
+  }): Promise<LifeOpsCalendarEvent | null> {
+    const calendarClause =
+      args.calendarId && args.calendarId !== "all"
+        ? `AND calendar_id = ${sqlQuote(args.calendarId)}`
+        : "";
+    const sideClause = args.side ? `AND side = ${sqlQuote(args.side)}` : "";
+    const grantClause = args.grantId
+      ? `AND grant_id = ${sqlQuote(args.grantId)}`
+      : "";
+    const rows = await executeRawSql(
+      this.runtime,
+      `SELECT *
+         FROM app_calendar.life_calendar_events
+        WHERE agent_id = ${sqlQuote(args.agentId)}
+          AND provider = ${sqlQuote(args.provider)}
+          AND external_event_id = ${sqlQuote(args.externalEventId)}
+          ${calendarClause}
+          ${sideClause}
+          ${grantClause}
+        LIMIT 1`,
+    );
+    const row = rows[0];
+    return row ? parseCalendarEvent(row) : null;
+  }
+
+  async replaceCalendarEventIfVersion(args: {
+    event: LifeOpsCalendarEvent;
+    expectedVersion: string;
+  }): Promise<LifeOpsCalendarEvent | null> {
+    const event = args.event;
+    const rows = await executeRawSql(
+      this.runtime,
+      `UPDATE app_calendar.life_calendar_events SET
+        title = ${sqlQuote(event.title)},
+        description = ${sqlQuote(event.description)},
+        location = ${sqlQuote(event.location)},
+        status = ${sqlQuote(event.status)},
+        start_at = ${sqlQuote(event.startAt)},
+        end_at = ${sqlQuote(event.endAt)},
+        is_all_day = ${sqlBoolean(event.isAllDay)},
+        timezone = ${sqlText(event.timezone)},
+        html_link = ${sqlText(event.htmlLink)},
+        conference_link = ${sqlText(event.conferenceLink)},
+        organizer_json = ${event.organizer ? sqlJson(event.organizer) : "NULL"},
+        attendees_json = ${sqlJson(event.attendees)},
+        metadata_json = ${sqlJson(event.metadata)},
+        synced_at = ${sqlQuote(event.syncedAt)},
+        updated_at = ${sqlQuote(event.updatedAt)}
+        WHERE agent_id = ${sqlQuote(event.agentId)}
+          AND id = ${sqlQuote(event.id)}
+          AND metadata_json::jsonb ->> 'etag' = ${sqlQuote(args.expectedVersion)}
+      RETURNING *`,
     );
     const row = rows[0];
     return row ? parseCalendarEvent(row) : null;

--- a/plugins/plugin-calendar/src/service/CalendarService.ts
+++ b/plugins/plugin-calendar/src/service/CalendarService.ts
@@ -6030,6 +6030,30 @@ export class CalendarService extends Service {
       }
       return this.resolveElizaCalendarEvent(request);
     }
+    // An unscoped external-id lookup may still name a built-in event: the
+    // built-in calendar is a first-class source, so consult it before binding
+    // the mutation to an external provider grant. A miss falls through to the
+    // existing provider resolution unchanged.
+    if (!request.grantId) {
+      const builtIn = await this.repo.getCalendarEventByExternalId({
+        agentId: this.agentId(),
+        provider: ELIZA_CALENDAR_PROVIDER,
+        externalEventId: requireNonEmptyString(request.eventId, "eventId"),
+        calendarId: request.calendarId,
+        side: "owner",
+        grantId: ELIZA_CALENDAR_GRANT_ID,
+      });
+      if (builtIn) {
+        if (normalizeRecurrenceScope(request.recurrenceScope)) {
+          fail(
+            400,
+            "Recurring events require a connected calendar provider.",
+            "ELIZA_CALENDAR_RECURRENCE_UNSUPPORTED",
+          );
+        }
+        return builtIn;
+      }
+    }
     if (
       isAppleCalendarGrant(request.grantId) ||
       isMicrosoftCalendarGrantId(request.grantId) ||

--- a/plugins/plugin-calendar/src/service/CalendarService.ts
+++ b/plugins/plugin-calendar/src/service/CalendarService.ts
@@ -105,6 +105,16 @@ import {
   resolveNextCalendarEventWindow,
 } from "../internal/calendar-normalize.js";
 import { DEFAULT_CALENDAR_REMINDER_STEPS } from "../internal/constants.js";
+import {
+  createElizaCalendarEvent,
+  ELIZA_CALENDAR_GRANT_ID,
+  ELIZA_CALENDAR_ID,
+  ELIZA_CALENDAR_PROVIDER,
+  elizaCalendarSummary,
+  isElizaCalendarEventId,
+  isElizaCalendarGrant,
+  updateElizaCalendarEvent,
+} from "../internal/eliza-calendar.js";
 import { CalendarServiceError, fail } from "../internal/errors.js";
 import {
   accountIdForGrant,
@@ -253,11 +263,20 @@ function shouldIncludeIcsCalendars(request: {
   if (
     request.grantId &&
     (isAppleCalendarGrant(request.grantId) ||
-      isMicrosoftCalendarGrantId(request.grantId))
+      isMicrosoftCalendarGrantId(request.grantId) ||
+      isElizaCalendarGrant(request.grantId))
   ) {
     return false;
   }
   return true;
+}
+
+function shouldIncludeElizaCalendar(request: {
+  side?: LifeOpsConnectorSide | null;
+  grantId?: string | null;
+}): boolean {
+  if (request.side && request.side !== "owner") return false;
+  return !request.grantId || isElizaCalendarGrant(request.grantId);
 }
 
 function googleEventIntersectsWindow(
@@ -310,6 +329,7 @@ function normalizeCalendarProvider(value: unknown): LifeOpsCalendarProvider {
     case "microsoft":
     case "apple_calendar":
     case "ics":
+    case "eliza":
       return provider;
     default:
       throw new CalendarServiceError(
@@ -924,6 +944,8 @@ export function mergeAggregatedCalendarFeedEvents(
       case "google":
       case "microsoft":
         return 4;
+      case "eliza":
+        return 5;
       case "apple_calendar":
         return 3;
       case "ics":
@@ -1095,7 +1117,7 @@ export function mergeAggregatedCalendarFeedEvents(
 export class CalendarService extends Service {
   static override serviceType = "calendar";
   capabilityDescription =
-    "Google, Microsoft, Apple, and guarded ICS calendar feeds, event management, guest free/busy, and next-event context for Eliza agents.";
+    "Built-in Eliza, Google, Microsoft, Apple, and guarded ICS calendar feeds, event management, guest free/busy, and next-event context for Eliza agents.";
 
   private readonly repo: CalendarRepository;
   private gate: CalendarHostGate;
@@ -1181,6 +1203,12 @@ export class CalendarService extends Service {
           nowIso,
           horizonIso,
         )),
+        ...(await this.repo.listCalendarEvents(
+          this.agentId(),
+          ELIZA_CALENDAR_PROVIDER,
+          nowIso,
+          horizonIso,
+        )),
       ];
       await restoreMeetingAutoJoinAnchors(this.runtime, this.agentId(), events);
     } catch (error) {
@@ -1237,6 +1265,12 @@ export class CalendarService extends Service {
       ...(await this.repo.listCalendarEvents(
         this.agentId(),
         MICROSOFT_CALENDAR_PROVIDER,
+        nowIso,
+        horizonIso,
+      )),
+      ...(await this.repo.listCalendarEvents(
+        this.agentId(),
+        ELIZA_CALENDAR_PROVIDER,
         nowIso,
         horizonIso,
       )),
@@ -2407,6 +2441,12 @@ export class CalendarService extends Service {
         undefined,
         undefined,
       )),
+      ...(await this.repo.listCalendarEvents(
+        this.agentId(),
+        ELIZA_CALENDAR_PROVIDER,
+        undefined,
+        undefined,
+      )),
     ];
     const reservations = events.filter((event) => {
       const parentEventId = availabilityReservationParentEventId(event);
@@ -2425,7 +2465,8 @@ export class CalendarService extends Service {
     const side = normalizeOptionalConnectorSide(request?.side, "side");
     const targetsNonGoogleProvider =
       isMicrosoftCalendarGrantId(request?.grantId) ||
-      isAppleCalendarGrant(request?.grantId);
+      isAppleCalendarGrant(request?.grantId) ||
+      isElizaCalendarGrant(request?.grantId);
     const statuses = targetsNonGoogleProvider
       ? []
       : await this.gate.getGoogleConnectorAccounts(requestUrl, side);
@@ -2439,6 +2480,9 @@ export class CalendarService extends Service {
       .filter((grant) => grant.capabilities.includes("google.calendar.read"));
     const summaries: LifeOpsCalendarSummary[] = [];
     const failures: LifeOpsCalendarSourceHealth[] = [];
+    if (shouldIncludeElizaCalendar({ side, grantId: request?.grantId })) {
+      summaries.push(elizaCalendarSummary());
+    }
     if (grants.length > 0) {
       const listCalendars = requireGoogleServiceMethod(
         this.runtime,
@@ -2568,7 +2612,7 @@ export class CalendarService extends Service {
       if (appleCalendars.ok) {
         summaries.push(...appleCalendars.data);
       } else if (
-        appleCalendars.reason !== "not_supported" ||
+        appleCalendars.reason === "native_error" ||
         isAppleCalendarGrant(request?.grantId)
       ) {
         const calendar = appleCalendarPlaceholderSummary({
@@ -4004,6 +4048,47 @@ export class CalendarService extends Service {
     };
   }
 
+  private async readElizaCalendarFeed(args: {
+    calendar: LifeOpsCalendarSummary;
+    timeMin: string;
+    timeMax: string;
+  }): Promise<LifeOpsCalendarFeed> {
+    const events = await this.repo.listCalendarEvents(
+      this.agentId(),
+      ELIZA_CALENDAR_PROVIDER,
+      args.timeMin,
+      args.timeMax,
+      "owner",
+      ELIZA_CALENDAR_GRANT_ID,
+    );
+    // The built-in source is authoritative local state, not a polled remote.
+    // Its observation token therefore advances only when stored events change;
+    // stamping every read with wall-clock time would make receipts non-replayable.
+    const syncedAt =
+      events
+        .map((event) => event.updatedAt)
+        .filter((value) => Number.isFinite(Date.parse(value)))
+        .sort()
+        .at(-1) ?? null;
+    return {
+      calendarId: args.calendar.calendarId,
+      events,
+      source: "synced",
+      state: "complete",
+      sources: [
+        calendarSourceHealth({
+          calendar: args.calendar,
+          status: "fresh",
+          syncedAt,
+          error: null,
+        }),
+      ],
+      timeMin: args.timeMin,
+      timeMax: args.timeMax,
+      syncedAt,
+    };
+  }
+
   async getCalendarFeed(
     requestUrl: URL,
     request: GetLifeOpsCalendarFeedRequest = {},
@@ -4183,6 +4268,17 @@ export class CalendarService extends Service {
   ): Promise<LifeOpsCalendarFeed> {
     const sources: AggregatedCalendarFeedSource[] = [];
     for (const calendar of calendars) {
+      if (calendar.provider === ELIZA_CALENDAR_PROVIDER) {
+        sources.push({
+          calendar,
+          feed: await this.readElizaCalendarFeed({
+            calendar,
+            timeMin,
+            timeMax,
+          }),
+        });
+        continue;
+      }
       if (calendar.provider === "ics") {
         const source = await this.repo.getIcsCalendarSource(
           this.agentId(),
@@ -4418,10 +4514,10 @@ export class CalendarService extends Service {
   }
 
   /**
-   * Resolve a conversational create into one concrete, writable Google source
-   * and absolute interval without performing the external write. Approval
-   * callers persist this exact binding so execution cannot silently switch
-   * accounts, providers, calendars, or relative-time interpretations.
+   * Resolve a conversational create into one concrete writable source and
+   * absolute interval without performing the write. Approval callers persist
+   * this exact binding so execution cannot silently switch providers,
+   * calendars, or relative-time interpretations.
    */
   async prepareCalendarEventCreate(
     requestUrl: URL,
@@ -4442,6 +4538,32 @@ export class CalendarService extends Service {
     const calendarId = normalizeCalendarId(request.calendarId);
     const recurrence = normalizeRecurrence(request.recurrence);
     const range = resolveCalendarEventRange(request, now);
+    if (!request.grantId || isElizaCalendarGrant(request.grantId)) {
+      if (calendarId !== ELIZA_CALENDAR_ID) {
+        fail(
+          404,
+          "The built-in Eliza calendar has one primary calendar.",
+          "ELIZA_CALENDAR_NOT_FOUND",
+        );
+      }
+      if (recurrence) {
+        fail(
+          400,
+          "Recurring events require a connected calendar provider.",
+          "ELIZA_CALENDAR_RECURRENCE_UNSUPPORTED",
+        );
+      }
+      return {
+        ...request,
+        side: "owner",
+        grantId: ELIZA_CALENDAR_GRANT_ID,
+        calendarId: ELIZA_CALENDAR_ID,
+        startAt: range.startAt,
+        endAt: range.endAt,
+        timeZone: range.timeZone,
+        ...(recurrence ? { recurrence } : {}),
+      };
+    }
     if (isAppleCalendarGrant(request.grantId)) {
       failConditionalMutationUnsupported("Apple");
     }
@@ -4571,6 +4693,56 @@ export class CalendarService extends Service {
       request,
       now,
     );
+    if (!request.grantId || isElizaCalendarGrant(request.grantId)) {
+      if (calendarId !== ELIZA_CALENDAR_ID) {
+        fail(
+          404,
+          "The built-in Eliza calendar has one primary calendar.",
+          "ELIZA_CALENDAR_NOT_FOUND",
+        );
+      }
+      const event = createElizaCalendarEvent({
+        agentId: this.agentId(),
+        request: {
+          ...request,
+          calendarId: ELIZA_CALENDAR_ID,
+          grantId: ELIZA_CALENDAR_GRANT_ID,
+          side: "owner",
+        },
+        startAt,
+        endAt,
+        timeZone,
+        attendees: normalizeCalendarAttendees(request.attendees),
+        now,
+      });
+      const receipt = await this.repo.insertCalendarEventIfAbsent(event);
+      const persisted = receipt.event;
+      if (receipt.inserted) {
+        await this.syncCalendarReminderPlans([persisted]);
+        await reconcileMeetingAutoJoin({
+          runtime: this.runtime,
+          agentId: this.agentId(),
+          events: [persisted],
+        });
+        await this.recordCalendarEventAudit(
+          persisted.id,
+          "calendar event created in the built-in Eliza calendar",
+          {
+            calendarId: persisted.calendarId,
+            title: request.title,
+          },
+          {
+            externalId: persisted.externalId,
+            providerVersion: persisted.metadata.etag,
+          },
+        );
+      }
+      return {
+        outcome: "event",
+        event: persisted,
+        writeOnlyReceipt: null,
+      };
+    }
     if (isMicrosoftCalendarGrantId(request.grantId)) {
       if (recurrence) {
         failMicrosoftRecurrenceUnsupported("creation");
@@ -4794,6 +4966,176 @@ export class CalendarService extends Service {
     };
   }
 
+  private async resolveElizaCalendarEvent(args: {
+    eventId: string;
+    calendarId?: string | null;
+  }): Promise<LifeOpsCalendarEvent> {
+    const eventId = requireNonEmptyString(args.eventId, "eventId");
+    const event = isElizaCalendarEventId(eventId, this.agentId())
+      ? await this.repo.getCalendarEventById(this.agentId(), eventId)
+      : await this.repo.getCalendarEventByExternalId({
+          agentId: this.agentId(),
+          provider: ELIZA_CALENDAR_PROVIDER,
+          externalEventId: eventId,
+          calendarId: args.calendarId,
+          side: "owner",
+          grantId: ELIZA_CALENDAR_GRANT_ID,
+        });
+    if (!event || event.provider !== ELIZA_CALENDAR_PROVIDER) {
+      throw new CalendarServiceError(
+        404,
+        "The built-in calendar event was not found.",
+        "CALENDAR_EVENT_NOT_FOUND",
+      );
+    }
+    return event;
+  }
+
+  private async updateBuiltInCalendarEvent(args: {
+    request: {
+      calendarId?: string | null;
+      eventId: string;
+      title?: string;
+      description?: string;
+      location?: string;
+      startAt?: string;
+      endAt?: string;
+      timeZone?: string;
+      attendees?: CreateLifeOpsCalendarEventAttendee[] | null;
+      recurrence?: string[] | null;
+      recurrenceScope?: LifeOpsCalendarRecurrenceScope | null;
+      notifyAttendees?: boolean;
+      expectedProviderVersion?: string;
+    };
+    now?: Date;
+  }): Promise<LifeOpsCalendarEvent> {
+    if (args.request.recurrence?.length || args.request.recurrenceScope) {
+      fail(
+        400,
+        "Recurring events require a connected calendar provider.",
+        "ELIZA_CALENDAR_RECURRENCE_UNSUPPORTED",
+      );
+    }
+    if (args.request.notifyAttendees === true) {
+      fail(
+        400,
+        "The built-in Eliza calendar cannot email attendees. Connect an external calendar to send updates.",
+        "ELIZA_CALENDAR_ATTENDEE_NOTIFICATIONS_UNSUPPORTED",
+      );
+    }
+    const expectedVersion = requireNonEmptyString(
+      args.request.expectedProviderVersion,
+      "expectedProviderVersion",
+    );
+    const existing = await this.resolveElizaCalendarEvent(args.request);
+    const updated = updateElizaCalendarEvent({
+      event: existing,
+      ...(args.request.title !== undefined
+        ? { title: args.request.title }
+        : {}),
+      ...(args.request.description !== undefined
+        ? { description: args.request.description }
+        : {}),
+      ...(args.request.location !== undefined
+        ? { location: args.request.location }
+        : {}),
+      ...(args.request.startAt !== undefined
+        ? { startAt: args.request.startAt }
+        : {}),
+      ...(args.request.endAt !== undefined
+        ? { endAt: args.request.endAt }
+        : {}),
+      ...(args.request.timeZone !== undefined
+        ? { timeZone: args.request.timeZone }
+        : {}),
+      attendees:
+        args.request.attendees === undefined || args.request.attendees === null
+          ? undefined
+          : normalizeCalendarAttendees(args.request.attendees),
+      now: args.now ?? new Date(),
+    });
+    const persisted = await this.repo.replaceCalendarEventIfVersion({
+      event: updated,
+      expectedVersion,
+    });
+    if (!persisted) {
+      fail(
+        409,
+        "The built-in calendar event changed after approval; refresh and retry.",
+        "PROVIDER_PRECONDITION_FAILED",
+      );
+    }
+    await this.syncCalendarReminderPlans([persisted]);
+    await reconcileMeetingAutoJoin({
+      runtime: this.runtime,
+      agentId: this.agentId(),
+      events: [persisted],
+    });
+    await this.recordCalendarEventAudit(
+      persisted.id,
+      "calendar event updated in the built-in Eliza calendar",
+      { eventId: existing.externalId },
+      { providerVersion: persisted.metadata.etag },
+      "calendar_event_updated",
+    );
+    return persisted;
+  }
+
+  private async deleteBuiltInCalendarEvent(args: {
+    eventId: string;
+    calendarId?: string | null;
+    expectedProviderVersion?: string;
+    recurrenceScope?: LifeOpsCalendarRecurrenceScope | null;
+    notifyAttendees?: boolean;
+  }): Promise<void> {
+    if (args.recurrenceScope) {
+      fail(
+        400,
+        "Recurring events require a connected calendar provider.",
+        "ELIZA_CALENDAR_RECURRENCE_UNSUPPORTED",
+      );
+    }
+    if (args.notifyAttendees === true) {
+      fail(
+        400,
+        "The built-in Eliza calendar cannot email attendees.",
+        "ELIZA_CALENDAR_ATTENDEE_NOTIFICATIONS_UNSUPPORTED",
+      );
+    }
+    const expectedVersion = requireNonEmptyString(
+      args.expectedProviderVersion,
+      "expectedProviderVersion",
+    );
+    const event = await this.resolveElizaCalendarEvent(args);
+    const deleted = await this.repo.deleteCalendarEventByIdIfVersion({
+      agentId: this.agentId(),
+      eventId: event.id,
+      expectedVersion,
+    });
+    if (!deleted) {
+      fail(
+        409,
+        "The built-in calendar event changed after approval; refresh and retry.",
+        "PROVIDER_PRECONDITION_FAILED",
+      );
+    }
+    await this.deleteAvailabilityReservationsForParentIds([event.id]);
+    await this.deleteCalendarReminderPlansForEvents([event.id]);
+    await reconcileMeetingAutoJoin({
+      runtime: this.runtime,
+      agentId: this.agentId(),
+      events: [],
+      removedEventIds: [event.id],
+    });
+    await this.recordCalendarEventAudit(
+      event.id,
+      "calendar event deleted from the built-in Eliza calendar",
+      { eventId: event.externalId },
+      { deleted: true, providerVersion: expectedVersion },
+      "calendar_event_deleted",
+    );
+  }
+
   async updateCalendarEvent(
     requestUrl: URL,
     request: {
@@ -4863,6 +5205,19 @@ export class CalendarService extends Service {
           ? undefined
           : normalizeCalendarAttendees(request.attendees),
     };
+    if (
+      isElizaCalendarGrant(request.grantId) ||
+      isElizaCalendarEventId(request.eventId, this.agentId())
+    ) {
+      return this.updateBuiltInCalendarEvent({
+        request: {
+          ...request,
+          ...nativePatch,
+          recurrence,
+          recurrenceScope,
+        },
+      });
+    }
     if (isAppleCalendarGrant(request.grantId)) {
       if (request.expectedProviderVersion) {
         failConditionalMutationUnsupported("Apple");
@@ -5509,6 +5864,19 @@ export class CalendarService extends Service {
     }
     const recurrenceScope = normalizeRecurrenceScope(request.recurrenceScope);
     const eventId = requireNonEmptyString(request.eventId, "eventId");
+    if (
+      isElizaCalendarGrant(request.grantId) ||
+      isElizaCalendarEventId(eventId, this.agentId())
+    ) {
+      await this.deleteBuiltInCalendarEvent({
+        eventId,
+        calendarId: request.calendarId,
+        expectedProviderVersion: request.expectedProviderVersion,
+        recurrenceScope,
+        notifyAttendees: request.notifyAttendees,
+      });
+      return;
+    }
     if (isAppleCalendarGrant(request.grantId)) {
       if (request.expectedProviderVersion) {
         failConditionalMutationUnsupported("Apple");
@@ -5632,8 +6000,9 @@ export class CalendarService extends Service {
   }
 
   /**
-   * Resolve the exact Google object a conditional update/delete will mutate.
-   * Series operations return the master rather than the flattened occurrence.
+   * Resolve the exact object a conditional update/delete will mutate. Google
+   * series operations return the master rather than a flattened occurrence;
+   * built-in events bind directly to their repository version.
    */
   async getConditionalCalendarMutationTarget(
     requestUrl: URL,
@@ -5648,6 +6017,19 @@ export class CalendarService extends Service {
   ): Promise<LifeOpsCalendarEvent> {
     const mode = normalizeOptionalConnectorMode(request.mode, "mode");
     const side = normalizeOptionalConnectorSide(request.side, "side");
+    if (
+      isElizaCalendarGrant(request.grantId) ||
+      isElizaCalendarEventId(request.eventId, this.agentId())
+    ) {
+      if (normalizeRecurrenceScope(request.recurrenceScope)) {
+        fail(
+          400,
+          "Recurring events require a connected calendar provider.",
+          "ELIZA_CALENDAR_RECURRENCE_UNSUPPORTED",
+        );
+      }
+      return this.resolveElizaCalendarEvent(request);
+    }
     if (
       isAppleCalendarGrant(request.grantId) ||
       isMicrosoftCalendarGrantId(request.grantId) ||

--- a/plugins/plugin-calendar/src/service/feed-preferences.ts
+++ b/plugins/plugin-calendar/src/service/feed-preferences.ts
@@ -59,6 +59,7 @@ const VALID_PROVIDERS = new Set<LifeOpsCalendarProvider>([
   "microsoft",
   "apple_calendar",
   "ics",
+  "eliza",
 ]);
 const VALID_SIDES = new Set<LifeOpsConnectorSide>(["owner", "agent"]);
 

--- a/plugins/plugin-calendar/test/apple-calendar.integration.test.ts
+++ b/plugins/plugin-calendar/test/apple-calendar.integration.test.ts
@@ -65,6 +65,9 @@ describe("native Apple Calendar bridge dylib candidates", () => {
       "../../../../../../../libMacWindowEffects.dylib",
     );
     expect(candidatePaths).toContain(
+      "../../../packages/app-core/platforms/electrobun/src/libMacWindowEffects.dylib",
+    );
+    expect(candidatePaths).toContain(
       "../../../../packages/app-core/platforms/electrobun/src/libMacWindowEffects.dylib",
     );
   });

--- a/plugins/plugin-calendar/test/calendar-ics-source.pglite.test.ts
+++ b/plugins/plugin-calendar/test/calendar-ics-source.pglite.test.ts
@@ -659,6 +659,11 @@ describe("CalendarService guarded ICS sources (real PGlite)", {
     expect(conflictSnapshot).toEqual({
       sources: [
         expect.objectContaining({
+          id: expect.stringContaining(":eliza:"),
+          status: "fresh",
+          events: [],
+        }),
+        expect.objectContaining({
           status: "fresh",
           events: [
             expect.objectContaining({

--- a/plugins/plugin-calendar/test/calendar-recurrence-service.test.ts
+++ b/plugins/plugin-calendar/test/calendar-recurrence-service.test.ts
@@ -334,6 +334,7 @@ beforeEach(async () => {
 describe("createCalendarEvent — recurrence", () => {
   it("normalizes recurrence to the provider and surfaces it on readback", async () => {
     const created = await calendar.createCalendarEvent(INTERNAL_URL, {
+      grantId: GRANT_A.id,
       title: "Morning Run",
       startAt: "2026-07-06T13:00:00.000Z",
       endAt: "2026-07-06T13:30:00.000Z",

--- a/plugins/plugin-calendar/test/eliza-calendar.pglite.test.ts
+++ b/plugins/plugin-calendar/test/eliza-calendar.pglite.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Exercises the built-in Eliza calendar through CalendarService against the
+ * production PGlite schema. External providers stay disconnected so default
+ * discovery, exact-once creation, feed truth, and versioned writes are proven
+ * without a connector or a second event store.
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import type { IAgentRuntime } from "@elizaos/core";
+import { RuntimeMigrator } from "@elizaos/plugin-sql/runtime-migrator";
+import type { LifeOpsReminderPlan } from "@elizaos/shared";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { __testing } from "../src/apple-calendar.js";
+import {
+  ELIZA_CALENDAR_GRANT_ID,
+  ELIZA_CALENDAR_ID,
+} from "../src/internal/eliza-calendar.js";
+import {
+  type CalendarHostGate,
+  CalendarService,
+  calendarSchema,
+} from "../src/service/index.js";
+
+const AGENT_ID = "eliza-calendar-pglite-agent";
+const INTERNAL_URL = new URL("http://internal.local/api/calendar");
+const WINDOW = {
+  timeMin: "2026-08-01T00:00:00.000Z",
+  timeMax: "2026-09-01T00:00:00.000Z",
+};
+
+let pg: PGlite;
+let service: CalendarService;
+const reminderPlans: LifeOpsReminderPlan[] = [];
+
+function gate(): CalendarHostGate {
+  return {
+    getGoogleConnectorAccounts: async () => [],
+    resolveGuestAvailabilityGrants: async () => {
+      throw new Error("Guest availability is outside this test.");
+    },
+    requireGoogleCalendarGrant: async () => {
+      throw new Error("Google is outside this test.");
+    },
+    requireGoogleCalendarWriteGrant: async () => {
+      throw new Error("Google is outside this test.");
+    },
+    createReminderPlan: async (plan) => {
+      reminderPlans.push(plan);
+    },
+    updateReminderPlan: async () => {},
+    deleteReminderPlan: async () => {},
+    listReminderPlansForOwners: async () => [],
+    createAuditEvent: async () => {},
+  };
+}
+
+beforeAll(async () => {
+  pg = new PGlite();
+  const db = drizzle(pg);
+  await new RuntimeMigrator(db).migrate(
+    "@elizaos/plugin-calendar",
+    calendarSchema,
+  );
+  const runtime = {
+    agentId: AGENT_ID,
+    adapter: { db },
+    db,
+    initPromise: Promise.resolve(),
+    getCache: async () => undefined,
+    setCache: async () => undefined,
+    getService: (serviceType: string) =>
+      serviceType === CalendarService.serviceType ? service : null,
+    reportError: async () => {},
+  } as unknown as IAgentRuntime;
+  service = new CalendarService(runtime);
+  service.setGate(gate());
+  __testing.setNativeCalendarBridgeForTest(null);
+}, 30_000);
+
+beforeEach(async () => {
+  await pg.query("DELETE FROM app_calendar.life_calendar_events");
+  await pg.query("DELETE FROM app_calendar.life_calendar_sync_states");
+  await pg.query("DELETE FROM app_calendar.life_calendar_feed_preferences");
+  reminderPlans.length = 0;
+});
+
+afterAll(async () => {
+  __testing.setNativeCalendarBridgeForTest(undefined as never);
+  await pg.close();
+});
+
+describe("built-in Eliza calendar (real PGlite)", { timeout: 30_000 }, () => {
+  it("is the fresh writable default when no external account is connected", async () => {
+    const calendars = await service.listCalendars(INTERNAL_URL);
+    expect(calendars[0]).toMatchObject({
+      provider: "eliza",
+      grantId: ELIZA_CALENDAR_GRANT_ID,
+      calendarId: ELIZA_CALENDAR_ID,
+      primary: true,
+      accessRole: "owner",
+    });
+
+    const feed = await service.getCalendarFeed(INTERNAL_URL, WINDOW);
+    expect(feed).toMatchObject({
+      state: "complete",
+      events: [],
+      sources: [
+        {
+          key: {
+            provider: "eliza",
+            grantId: ELIZA_CALENDAR_GRANT_ID,
+            calendarId: ELIZA_CALENDAR_ID,
+          },
+          status: "fresh",
+        },
+      ],
+    });
+  });
+
+  it("creates once, replays idempotently, and returns the event through the canonical feed", async () => {
+    const request = {
+      title: "Demo with Shaw",
+      startAt: "2026-08-06T23:00:00.000Z",
+      endAt: "2026-08-07T00:00:00.000Z",
+      timeZone: "America/Los_Angeles",
+      idempotencyKey: "demo-with-shaw-2026-08-06",
+    };
+    const first = await service.createCalendarEventMutation(
+      INTERNAL_URL,
+      request,
+    );
+    expect(first.event).toMatchObject({
+      provider: "eliza",
+      grantId: ELIZA_CALENDAR_GRANT_ID,
+      calendarId: ELIZA_CALENDAR_ID,
+      title: "Demo with Shaw",
+      metadata: { version: 1, etag: '"eliza-1"' },
+    });
+    const reminderCount = reminderPlans.length;
+    expect(reminderCount).toBeGreaterThan(0);
+
+    const replay = await service.createCalendarEventMutation(
+      INTERNAL_URL,
+      request,
+    );
+    expect(replay.event?.id).toBe(first.event?.id);
+    expect(reminderPlans).toHaveLength(reminderCount);
+    const rows = await pg.query<{ count: string }>(
+      "SELECT COUNT(*)::text AS count FROM app_calendar.life_calendar_events",
+    );
+    expect(rows.rows[0]?.count).toBe("1");
+
+    const feed = await service.getCalendarFeed(INTERNAL_URL, WINDOW);
+    expect(feed.state).toBe("complete");
+    expect(feed.events.map((event) => event.title)).toEqual(["Demo with Shaw"]);
+  });
+
+  it("uses event ETags for atomic update and delete", async () => {
+    const created = await service.createCalendarEventMutation(INTERNAL_URL, {
+      title: "Calendar rehearsal",
+      startAt: "2026-08-09T18:00:00.000Z",
+      endAt: "2026-08-09T19:00:00.000Z",
+      timeZone: "America/Los_Angeles",
+      idempotencyKey: "calendar-rehearsal",
+    });
+    const event = created.event;
+    if (!event) throw new Error("Built-in calendar create returned no event.");
+
+    const updated = await service.updateCalendarEvent(INTERNAL_URL, {
+      grantId: ELIZA_CALENDAR_GRANT_ID,
+      calendarId: ELIZA_CALENDAR_ID,
+      eventId: event.externalId,
+      title: "Calendar rehearsal moved",
+      expectedProviderVersion: '"eliza-1"',
+    });
+    expect(updated).toMatchObject({
+      title: "Calendar rehearsal moved",
+      metadata: { version: 2, etag: '"eliza-2"' },
+    });
+
+    await expect(
+      service.updateCalendarEvent(INTERNAL_URL, {
+        grantId: ELIZA_CALENDAR_GRANT_ID,
+        calendarId: ELIZA_CALENDAR_ID,
+        eventId: event.externalId,
+        title: "Stale update",
+        expectedProviderVersion: '"eliza-1"',
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "PROVIDER_PRECONDITION_FAILED",
+    });
+
+    await expect(
+      service.deleteCalendarEvent(INTERNAL_URL, {
+        grantId: ELIZA_CALENDAR_GRANT_ID,
+        calendarId: ELIZA_CALENDAR_ID,
+        eventId: event.externalId,
+        expectedProviderVersion: '"eliza-1"',
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "PROVIDER_PRECONDITION_FAILED",
+    });
+
+    await service.deleteCalendarEvent(INTERNAL_URL, {
+      grantId: ELIZA_CALENDAR_GRANT_ID,
+      calendarId: ELIZA_CALENDAR_ID,
+      eventId: event.externalId,
+      expectedProviderVersion: '"eliza-2"',
+    });
+    expect(await service.getCalendarEventById(event.id)).toBeNull();
+  });
+
+  it("rejects unsupported or invalid built-in mutations without changing the event", async () => {
+    const created = await service.createCalendarEventMutation(INTERNAL_URL, {
+      title: "Keep this event",
+      startAt: "2026-08-09T18:00:00.000Z",
+      endAt: "2026-08-09T19:00:00.000Z",
+      timeZone: "America/Los_Angeles",
+      idempotencyKey: "built-in-mutation-guards",
+    });
+    const event = created.event;
+    if (!event) throw new Error("Built-in calendar create returned no event.");
+    const base = {
+      grantId: ELIZA_CALENDAR_GRANT_ID,
+      calendarId: ELIZA_CALENDAR_ID,
+      eventId: event.externalId,
+      expectedProviderVersion: '"eliza-1"',
+    };
+
+    await expect(
+      service.updateCalendarEvent(INTERNAL_URL, { ...base, title: "   " }),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "CALENDAR_EVENT_TITLE_REQUIRED",
+    });
+    await expect(
+      service.updateCalendarEvent(INTERNAL_URL, {
+        ...base,
+        recurrence: ["RRULE:FREQ=DAILY"],
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "ELIZA_CALENDAR_RECURRENCE_UNSUPPORTED",
+    });
+    await expect(
+      service.deleteCalendarEvent(INTERNAL_URL, {
+        ...base,
+        notifyAttendees: true,
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "ELIZA_CALENDAR_ATTENDEE_NOTIFICATIONS_UNSUPPORTED",
+    });
+
+    await expect(service.getCalendarEventById(event.id)).resolves.toMatchObject(
+      {
+        title: "Keep this event",
+        metadata: { version: 1, etag: '"eliza-1"' },
+      },
+    );
+  });
+});

--- a/plugins/plugin-calendar/test/eliza-calendar.pglite.test.ts
+++ b/plugins/plugin-calendar/test/eliza-calendar.pglite.test.ts
@@ -213,6 +213,37 @@ describe("built-in Eliza calendar (real PGlite)", { timeout: 30_000 }, () => {
     expect(await service.getCalendarEventById(event.id)).toBeNull();
   });
 
+  it("resolves an unscoped mutation target to the built-in event without hijacking external grants", async () => {
+    const created = await service.createCalendarEventMutation(INTERNAL_URL, {
+      title: "Unscoped lookup",
+      startAt: "2026-08-11T18:00:00.000Z",
+      endAt: "2026-08-11T19:00:00.000Z",
+      timeZone: "America/Los_Angeles",
+      idempotencyKey: "unscoped-lookup",
+    });
+    const event = created.event;
+    if (!event) throw new Error("Built-in calendar create returned no event.");
+
+    // A planner that omits grantId still binds to the built-in event.
+    await expect(
+      service.getConditionalCalendarMutationTarget(INTERNAL_URL, {
+        eventId: event.externalId,
+      }),
+    ).resolves.toMatchObject({
+      id: event.id,
+      provider: "eliza",
+      grantId: ELIZA_CALENDAR_GRANT_ID,
+    });
+
+    // An unknown external id must NOT be claimed by the built-in calendar;
+    // it falls through to external-provider resolution (disconnected here).
+    await expect(
+      service.getConditionalCalendarMutationTarget(INTERNAL_URL, {
+        eventId: "google-event-id-that-is-not-built-in",
+      }),
+    ).rejects.toThrow();
+  });
+
   it("rejects unsupported or invalid built-in mutations without changing the event", async () => {
     const created = await service.createCalendarEventMutation(INTERNAL_URL, {
       title: "Keep this event",

--- a/plugins/plugin-native-calendar/src/macos-bridge-policy.test.ts
+++ b/plugins/plugin-native-calendar/src/macos-bridge-policy.test.ts
@@ -30,6 +30,10 @@ describe("Apple Calendar macOS bridge policy", () => {
       },
       {
         label: "local Apple permissions bridge",
+        path: `../../../packages/app-core/platforms/electrobun/src/${APPLE_CALENDAR_MACOS_BRIDGE_DYLIB_BASENAME}`,
+      },
+      {
+        label: "nested local Apple permissions bridge",
         path: `../../../../packages/app-core/platforms/electrobun/src/${APPLE_CALENDAR_MACOS_BRIDGE_DYLIB_BASENAME}`,
       },
     ]);

--- a/plugins/plugin-native-calendar/src/macos-bridge-policy.ts
+++ b/plugins/plugin-native-calendar/src/macos-bridge-policy.ts
@@ -32,6 +32,10 @@ export function appleCalendarMacosBridgeCandidates(args?: {
     },
     {
       label: "local Apple permissions bridge",
+      path: `../../../packages/app-core/platforms/electrobun/src/${APPLE_CALENDAR_MACOS_BRIDGE_DYLIB_BASENAME}`,
+    },
+    {
+      label: "nested local Apple permissions bridge",
       path: `../../../../packages/app-core/platforms/electrobun/src/${APPLE_CALENDAR_MACOS_BRIDGE_DYLIB_BASENAME}`,
     },
   ].filter((candidate) => candidate.path.trim().length > 0);

--- a/plugins/plugin-notes/AGENTS.md
+++ b/plugins/plugin-notes/AGENTS.md
@@ -7,7 +7,12 @@ can create, inspect, update, and delete together.
 
 This package owns one intentionally focused Cloud surface:
 
-- `notes` — sticky-note CRUD with title, body, and color.
+- `notes` — note CRUD with one user-authored content field and optional color.
+
+The persisted schema retains a derived first-line label plus body for stable
+lookup and compatibility with existing notes. That split is deterministic:
+planner capabilities accept one `content` value and never ask a model to invent
+a separate title or summary. The view renders the combined content as one field.
 
 Managed dedicated agents load the runtime plugin through the `lean-chat`
 profile. The app build loads `src/register.ts` through the manifest-driven app

--- a/plugins/plugin-notes/CLAUDE.md
+++ b/plugins/plugin-notes/CLAUDE.md
@@ -7,7 +7,12 @@ can create, inspect, update, and delete together.
 
 This package owns one intentionally focused Cloud surface:
 
-- `notes` — sticky-note CRUD with title, body, and color.
+- `notes` — note CRUD with one user-authored content field and optional color.
+
+The persisted schema retains a derived first-line label plus body for stable
+lookup and compatibility with existing notes. That split is deterministic:
+planner capabilities accept one `content` value and never ask a model to invent
+a separate title or summary. The view renders the combined content as one field.
 
 Managed dedicated agents load the runtime plugin through the `lean-chat`
 profile. The app build loads `src/register.ts` through the manifest-driven app

--- a/plugins/plugin-notes/src/__tests__/backend.test.ts
+++ b/plugins/plugin-notes/src/__tests__/backend.test.ts
@@ -382,14 +382,14 @@ describe("Notes capabilities", () => {
     await expect(
       serverInteract(
         "create-note",
-        { title: "First runtime", body: "A" },
+        { content: "First runtime\nA" },
         { runtime: firstRuntime },
       ),
     ).resolves.toMatchObject({ success: true });
     await expect(
       serverInteract(
         "create-note",
-        { title: "Second runtime", body: "B" },
+        { content: "Second runtime\nB" },
         { runtime: secondRuntime },
       ),
     ).resolves.toMatchObject({ success: true });
@@ -411,7 +411,7 @@ describe("Notes capabilities", () => {
 
     const createdNote = await interact(
       "create-note",
-      { title: "Workbench", body: "First draft", color: "yellow" },
+      { content: "Workbench\nFirst draft", color: "yellow" },
       service,
     );
     expect(createdNote).toMatchObject({ success: true });
@@ -423,7 +423,7 @@ describe("Notes capabilities", () => {
     });
 
     await expect(
-      interact("get-notes", { title: "Workbench" }, service),
+      interact("get-notes", { query: "Workbench" }, service),
     ).resolves.toMatchObject({
       success: true,
       data: { notes: [{ id: noteId, title: "Workbench" }] },
@@ -431,7 +431,11 @@ describe("Notes capabilities", () => {
 
     const updatedNote = await interact(
       "update-note",
-      { query: "Workbench", body: "Polished draft", color: "green" },
+      {
+        query: "Workbench",
+        content: "Workbench\nPolished draft",
+        color: "green",
+      },
       service,
     );
     expect(updatedNote).toMatchObject({ success: true });
@@ -446,7 +450,7 @@ describe("Notes capabilities", () => {
     await expect(
       interact(
         "update-note",
-        { oldTitle: "Workbench", title: "Workbench ready" },
+        { query: "Workbench", content: "Workbench ready\nPolished draft" },
         service,
       ),
     ).resolves.toMatchObject({ success: true });
@@ -472,16 +476,8 @@ describe("Notes capabilities", () => {
     });
     expect(service.listNotes()).toEqual([]);
 
-    await interact(
-      "create-note",
-      { title: "One", body: "", color: "slate" },
-      service,
-    );
-    await interact(
-      "create-note",
-      { title: "Two", body: "", color: "rose" },
-      service,
-    );
+    await interact("create-note", { content: "One", color: "slate" }, service);
+    await interact("create-note", { content: "Two", color: "rose" }, service);
     const clearedNotes = await interact("clear-notes", {}, service);
     expect(clearedNotes).toMatchObject({
       success: true,
@@ -497,19 +493,19 @@ describe("Notes capabilities", () => {
     const service = await serviceFor(await temporaryStateFile());
     await interact(
       "create-note",
-      { title: "Daily plan", body: "Morning", color: "yellow" },
+      { content: "Daily plan\nMorning", color: "yellow" },
       service,
     );
     await interact(
       "create-note",
-      { title: "Daily plan", body: "Evening", color: "rose" },
+      { content: "Daily plan\nEvening", color: "rose" },
       service,
     );
 
     await expect(
       interact(
         "update-note",
-        { query: "Daily plan", body: "Changed" },
+        { query: "Daily plan", content: "Daily plan\nChanged" },
         service,
       ),
     ).resolves.toMatchObject({
@@ -519,7 +515,7 @@ describe("Notes capabilities", () => {
     await expect(
       interact(
         "update-note",
-        { query: "does not exist", body: "Changed" },
+        { query: "does not exist", content: "Changed" },
         service,
       ),
     ).resolves.toMatchObject({
@@ -535,7 +531,7 @@ describe("Notes capabilities", () => {
   it("returns explicit failures for invalid input and rejects undeclared capabilities", async () => {
     const service = await serviceFor(await temporaryStateFile());
     await expect(
-      interact("create-note", { title: "   " }, service),
+      interact("create-note", { content: "   " }, service),
     ).resolves.toMatchObject({
       success: false,
       error: { code: "NOTES_VALIDATION_FAILED" },

--- a/plugins/plugin-notes/src/capabilities.ts
+++ b/plugins/plugin-notes/src/capabilities.ts
@@ -6,18 +6,21 @@
 
 import type { ViewCapability, ViewCapabilityParameter } from "@elizaos/core";
 
-const TITLE_PARAM: ViewCapabilityParameter = {
+const CONTENT_PARAM: ViewCapabilityParameter = {
   type: "string",
-  description: "Title text.",
+  description:
+    "The complete note exactly as the user wants it written. Put an optional short label on the first line and details on later lines; never invent a separate title or summary.",
   minLength: 1,
-  maxLength: 240,
+  maxLength: 20_000,
   pattern: "\\S",
 };
 
-const BODY_PARAM: ViewCapabilityParameter = {
+const QUERY_PARAM: ViewCapabilityParameter = {
   type: "string",
-  description: "Optional body or details text.",
+  description: "Unique text contained anywhere in the note.",
+  minLength: 1,
   maxLength: 20_000,
+  pattern: "\\S",
 };
 
 const COLOR_PARAM: ViewCapabilityParameter = {
@@ -41,73 +44,42 @@ export const NOTES_CAPABILITIES: ViewCapability[] = [
   {
     id: "get-notes",
     description:
-      "List sticky notes as structured data, optionally narrowed by exact title or unique query.",
+      "List notes as structured data, optionally narrowed by unique text they contain.",
     params: {
-      title: { ...TITLE_PARAM, description: "Optional exact note title." },
-      query: {
-        type: "string",
-        description: "Optional unique title/body search text.",
-        minLength: 1,
-        maxLength: 20_000,
-        pattern: "\\S",
-      },
+      query: { ...QUERY_PARAM, description: "Optional unique note text." },
     },
   },
   {
     id: "get-note",
-    description: "Read one sticky note by id, exact title, or unique query.",
+    description: "Read one note by id or unique text it contains.",
     params: {
       id: { ...ID_PARAM.id, required: false },
-      title: { ...TITLE_PARAM, description: "Exact note title." },
-      query: {
-        type: "string",
-        description: "Unique title/body search text.",
-        minLength: 1,
-        maxLength: 20_000,
-        pattern: "\\S",
-      },
+      query: QUERY_PARAM,
     },
   },
   {
     id: "create-note",
     description:
-      "Create a durable sticky note. Use this whenever the user explicitly asks to make, create, write, or save a note; dates and times inside the requested note remain note content unless the user also asks to schedule a calendar event or reminder.",
+      "Create a durable note from one user-authored content field. Preserve the user's wording; never invent a separate title or description. Dates and times remain note content unless the user also asks to schedule them.",
     params: {
-      title: {
-        ...TITLE_PARAM,
-        description: "Required note title.",
-        required: true,
-      },
-      body: { ...BODY_PARAM, description: "Optional note body." },
+      content: { ...CONTENT_PARAM, required: true },
       color: COLOR_PARAM,
     },
   },
   {
     id: "update-note",
     description:
-      "Update one or more fields on a sticky note identified by id, exact title, or unique query.",
+      "Replace a note's complete user-authored content, change its color, or both. Identify it by id or unique existing text; never synthesize a separate title.",
     params: {
       id: { ...ID_PARAM.id, description: "Stable note id.", required: false },
-      oldTitle: {
-        ...TITLE_PARAM,
-        description:
-          "Current exact title when title supplies the replacement title.",
-      },
-      title: {
-        ...TITLE_PARAM,
-        description:
-          "Current exact title, or replacement title when oldTitle is supplied.",
-      },
       query: {
-        type: "string",
-        description:
-          "Current exact title or unique title/body text identifying the note to update.",
-        minLength: 1,
-        maxLength: 20_000,
-        pattern: "\\S",
+        ...QUERY_PARAM,
+        description: "Unique existing text identifying the note to update.",
       },
-      newTitle: { ...TITLE_PARAM, description: "Replacement note title." },
-      body: { ...BODY_PARAM, description: "Replacement note body." },
+      content: {
+        ...CONTENT_PARAM,
+        description: "Replacement complete note content.",
+      },
       color: {
         ...COLOR_PARAM,
         description: "Replacement color: yellow, green, rose, or slate.",
@@ -116,17 +88,10 @@ export const NOTES_CAPABILITIES: ViewCapability[] = [
   },
   {
     id: "delete-note",
-    description: "Delete one sticky note by id, exact title, or unique query.",
+    description: "Delete one note by id or unique text it contains.",
     params: {
       id: { ...ID_PARAM.id, description: "Stable note id.", required: false },
-      title: { ...TITLE_PARAM, description: "Exact note title." },
-      query: {
-        type: "string",
-        description: "Unique title/body search text.",
-        minLength: 1,
-        maxLength: 20_000,
-        pattern: "\\S",
-      },
+      query: QUERY_PARAM,
     },
   },
   {

--- a/plugins/plugin-notes/src/interact.ts
+++ b/plugins/plugin-notes/src/interact.ts
@@ -13,7 +13,7 @@ import {
 } from "@elizaos/core";
 import { getNotesService, type NotesService } from "./service.js";
 import type { NotesSnapshot, StickyNote } from "./types.js";
-import { isRecord } from "./validation.js";
+import { isRecord, parseNoteContent } from "./validation.js";
 
 export interface NotesInteractResult {
   success: boolean;
@@ -89,59 +89,6 @@ function assertOnlyParams(
   }
 }
 
-function withoutParams(
-  params: Record<string, unknown>,
-  excluded: readonly string[],
-): Record<string, unknown> {
-  const excludedKeys = new Set(excluded);
-  return Object.fromEntries(
-    Object.entries(params).filter(([key]) => !excludedKeys.has(key)),
-  );
-}
-
-function updatePatch(
-  params: Record<string, unknown>,
-  selectors: readonly string[],
-): Record<string, unknown> {
-  const patch = withoutParams(params, [...selectors, "newTitle"]);
-  if (Object.hasOwn(params, "newTitle")) patch.title = params.newTitle;
-  return patch;
-}
-
-function normalizeRenameParams(
-  params: Record<string, unknown>,
-  capability: string,
-): Record<string, unknown> {
-  if (!Object.hasOwn(params, "oldTitle")) return params;
-  if (Object.hasOwn(params, "id") || Object.hasOwn(params, "query")) {
-    throw new ElizaError(
-      `${capability} oldTitle cannot be combined with id or query.`,
-      {
-        code: "NOTES_VALIDATION_FAILED",
-        context: { fields: ["oldTitle", "id", "query"] },
-        severity: "ephemeral",
-      },
-    );
-  }
-  if (Object.hasOwn(params, "title") && Object.hasOwn(params, "newTitle")) {
-    throw new ElizaError(
-      `${capability} accepts title or newTitle as the replacement, not both.`,
-      {
-        code: "NOTES_VALIDATION_FAILED",
-        context: { fields: ["title", "newTitle"] },
-        severity: "ephemeral",
-      },
-    );
-  }
-  const normalized: Record<string, unknown> = {
-    ...params,
-    title: params.oldTitle,
-  };
-  if (Object.hasOwn(params, "title")) normalized.newTitle = params.title;
-  delete normalized.oldTitle;
-  return normalized;
-}
-
 function summarizeNotes(notes: StickyNote[]): string {
   if (notes.length === 0) return "You don't have any notes yet.";
   const visible = notes
@@ -157,12 +104,12 @@ function summarizeNotes(notes: StickyNote[]): string {
 
 type NoteSelector =
   | { selector: "id"; value: string }
-  | { selector: "title" | "query"; value: string };
+  | { selector: "query"; value: string };
 
 function parseLookupTarget(
   params: Record<string, unknown>,
   capability: string,
-  selectorNames: readonly ("id" | "title" | "query")[],
+  selectorNames: readonly ("id" | "query")[],
 ): NoteSelector {
   const providedSelectors = selectorNames.filter((name) =>
     Object.hasOwn(params, name),
@@ -198,21 +145,6 @@ function parseLookupTarget(
   }
   const value = selectorValue.trim();
   return selector === "id" ? { selector, value } : { selector, value };
-}
-
-function parseNamedLookupTarget(
-  params: Record<string, unknown>,
-  capability: string,
-): { selector: "title" | "query"; value: string } {
-  const target = parseLookupTarget(params, capability, ["title", "query"]);
-  if (target.selector === "id") {
-    throw new ElizaError("Named lookup unexpectedly resolved an id selector.", {
-      code: "NOTES_LOOKUP_RESOLUTION_FAILED",
-      context: { capability },
-      severity: "fatal",
-    });
-  }
-  return target;
 }
 
 function success(
@@ -269,23 +201,19 @@ async function dispatchCapability(
 ): Promise<NotesInteractResult> {
   const params = paramsRecord(paramsValue);
   if (capability === "get-notes") {
-    assertOnlyParams(params, ["title", "query"]);
+    assertOnlyParams(params, ["query"]);
     const target =
       Object.keys(params).length === 0
         ? null
-        : parseNamedLookupTarget(params, capability);
+        : parseLookupTarget(params, capability, ["query"]);
     const notes = target
-      ? [service.getNoteByLookup(target.selector, target.value)]
+      ? [service.getNoteByLookup("query", target.value)]
       : service.listNotes();
     return success(service, summarizeNotes(notes), { notes });
   }
   if (capability === "get-note") {
-    assertOnlyParams(params, ["id", "title", "query"]);
-    const target = parseLookupTarget(params, capability, [
-      "id",
-      "title",
-      "query",
-    ]);
+    assertOnlyParams(params, ["id", "query"]);
+    const target = parseLookupTarget(params, capability, ["id", "query"]);
     const note =
       target.selector === "id"
         ? service.getNote(target.value)
@@ -293,8 +221,12 @@ async function dispatchCapability(
     return success(service, sentence(noteSummary(note)), { note });
   }
   if (capability === "create-note") {
-    const { value: note, snapshot } =
-      await service.createNoteWithCommit(params);
+    assertOnlyParams(params, ["content", "color"]);
+    const input = {
+      ...parseNoteContent(params.content),
+      ...(Object.hasOwn(params, "color") ? { color: params.color } : {}),
+    };
+    const { value: note, snapshot } = await service.createNoteWithCommit(input);
     return mutationSuccess(
       snapshot,
       capability,
@@ -304,19 +236,14 @@ async function dispatchCapability(
     );
   }
   if (capability === "update-note") {
-    assertOnlyParams(params, [
-      "id",
-      "oldTitle",
-      "title",
-      "query",
-      "newTitle",
-      "body",
-      "color",
-    ]);
-    const normalized = normalizeRenameParams(params, capability);
-    const selectors = ["id", "title", "query"] as const;
-    const target = parseLookupTarget(normalized, capability, selectors);
-    const patch = updatePatch(normalized, selectors);
+    assertOnlyParams(params, ["id", "query", "content", "color"]);
+    const target = parseLookupTarget(params, capability, ["id", "query"]);
+    const patch: Record<string, unknown> = {
+      ...(Object.hasOwn(params, "content")
+        ? parseNoteContent(params.content)
+        : {}),
+      ...(Object.hasOwn(params, "color") ? { color: params.color } : {}),
+    };
     const { value: note, snapshot } =
       target.selector === "id"
         ? await service.updateNoteWithCommit(target.value, patch)
@@ -334,12 +261,8 @@ async function dispatchCapability(
     );
   }
   if (capability === "delete-note") {
-    assertOnlyParams(params, ["id", "title", "query"]);
-    const target = parseLookupTarget(params, capability, [
-      "id",
-      "title",
-      "query",
-    ]);
+    assertOnlyParams(params, ["id", "query"]);
+    const target = parseLookupTarget(params, capability, ["id", "query"]);
     const { value: note, snapshot } =
       target.selector === "id"
         ? await service.deleteNoteWithCommit(target.value)

--- a/plugins/plugin-notes/src/validation.ts
+++ b/plugins/plugin-notes/src/validation.ts
@@ -18,6 +18,7 @@ import {
 const ENTITY_ID_PATTERN = /^[a-z][a-z0-9-]{2,127}$/;
 const MAX_TITLE_LENGTH = 240;
 const MAX_BODY_LENGTH = 20_000;
+const MAX_NOTE_CONTENT_LENGTH = 20_000;
 
 function validationError(message: string, field: string): ElizaError {
   return new ElizaError(message, {
@@ -93,6 +94,30 @@ function parseText(value: unknown, field: string): string {
     allowEmpty: true,
     maxLength: MAX_BODY_LENGTH,
   });
+}
+
+/**
+ * Split the one user-authored note field into the storage schema's stable list
+ * label and remainder. The first line is the label; overflow and later lines
+ * stay in the body, so the transformation never asks a model to invent text or
+ * discards user content.
+ */
+export function parseNoteContent(
+  value: unknown,
+  field = "content",
+): Pick<CreateNoteInput, "title" | "body"> {
+  const content = parseString(value, field, {
+    allowEmpty: false,
+    maxLength: MAX_NOTE_CONTENT_LENGTH,
+  });
+  const [firstLine = "", ...remainingLines] = content.split(/\r?\n/);
+  const title = firstLine.slice(0, MAX_TITLE_LENGTH).trim();
+  const overflow = firstLine.slice(MAX_TITLE_LENGTH).trim();
+  const body = [overflow, ...remainingLines].join("\n").trim();
+  return {
+    title: parseRequiredTitle(title, `${field}.firstLine`),
+    body: parseText(body, `${field}.remainder`),
+  };
 }
 
 export function parseEntityId(value: unknown, field = "id"): string {

--- a/plugins/plugin-notes/src/views/NotesView.tsx
+++ b/plugins/plugin-notes/src/views/NotesView.tsx
@@ -30,7 +30,13 @@ function formatUpdatedAt(value: string): string {
   }).format(new Date(timestamp));
 }
 
+function noteContent(note: StickyNoteModel): string {
+  const body = note.body.trim();
+  return body ? `${note.title}\n${body}` : note.title;
+}
+
 function NoteCard({ note }: { note: StickyNoteModel }) {
+  const content = noteContent(note);
   const card = useAgentElement<HTMLElement>({
     // The agent surface is also planner context. Sharing the domain id keeps a
     // follow-up such as “delete that note” addressable by the same identifier
@@ -40,7 +46,7 @@ function NoteCard({ note }: { note: StickyNoteModel }) {
     label: `Note ${note.title}`,
     role: "card",
     group: "notes-list",
-    description: note.body || "Empty note body",
+    description: content,
     status: note.color,
   });
   const material = COLOR_MATERIALS[note.color];
@@ -51,53 +57,50 @@ function NoteCard({ note }: { note: StickyNoteModel }) {
       {...card.agentProps}
       style={{
         ...GLASS_PANEL_STYLE,
-        minHeight: 178,
+        minHeight: 150,
         padding: 16,
         display: "flex",
         flexDirection: "column",
-        gap: 11,
+        gap: 9,
         background: `linear-gradient(145deg, ${material.fill}, color-mix(in srgb, var(--card, #111) 78%, transparent))`,
       }}
     >
-      <div style={{ minWidth: 0 }}>
-        <h2
-          style={{
-            margin: 0,
-            fontSize: 15,
-            lineHeight: 1.35,
-            fontWeight: 720,
-            overflowWrap: "anywhere",
-          }}
-        >
-          {note.title}
-        </h2>
-        <p style={{ ...SECONDARY_TEXT_STYLE, marginTop: 3, fontSize: 11 }}>
-          {formatUpdatedAt(note.updatedAt)}
-        </p>
-      </div>
       <p
         style={{
           margin: 0,
           flex: 1,
-          color: "var(--muted-strong, rgba(255,255,255,.78))",
+          color: "var(--txt, #f5f5f5)",
           fontSize: 14,
           lineHeight: 1.5,
+          fontWeight: 560,
           whiteSpace: "pre-wrap",
           overflowWrap: "anywhere",
         }}
       >
-        {note.body || "No details"}
+        {content}
       </p>
-      <span
-        aria-hidden
+      <div
         style={{
-          width: 28,
-          height: 3,
-          borderRadius: 999,
-          background: material.dot,
-          opacity: 0.78,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
         }}
-      />
+      >
+        <p style={{ ...SECONDARY_TEXT_STYLE, margin: 0, fontSize: 11 }}>
+          {formatUpdatedAt(note.updatedAt)}
+        </p>
+        <span
+          aria-hidden
+          style={{
+            width: 28,
+            height: 3,
+            borderRadius: 999,
+            background: material.dot,
+            opacity: 0.78,
+          }}
+        />
+      </div>
     </article>
   );
 }

--- a/plugins/plugin-notes/src/views/NotesViews.test.tsx
+++ b/plugins/plugin-notes/src/views/NotesViews.test.tsx
@@ -173,8 +173,9 @@ describe("chat-only presentation", () => {
 
     const notes = render(<NotesView />);
 
-    expect(screen.getByText("Release checklist")).toBeTruthy();
-    expect(screen.getByText("Verify the signed build")).toBeTruthy();
+    expect(
+      notes.container.querySelector('[data-agent-id="note-1"] p')?.textContent,
+    ).toBe("Release checklist\nVerify the signed build");
     expect(
       notes.container
         .querySelector("[data-agent-id]")

--- a/plugins/plugin-notes/src/views/notes.e2e.test.tsx
+++ b/plugins/plugin-notes/src/views/notes.e2e.test.tsx
@@ -117,21 +117,26 @@ describe("Notes capability-to-UI journey", () => {
     await interactWithService(
       "create-note",
       {
-        title: "Demo briefing",
-        body: "Keep the note wall durable",
+        content: "Demo briefing\nKeep the note wall durable",
         color: "green",
       },
       activeService(),
     );
     await interactWithService(
       "update-note",
-      { query: "Demo briefing", newTitle: "Demo briefing ready" },
+      {
+        query: "Demo briefing",
+        content: "Demo briefing ready\nKeep the note wall durable",
+      },
       activeService(),
     );
 
     const populatedNotes = render(<NotesView />);
-    expect(await screen.findByText("Demo briefing ready")).toBeTruthy();
-    expect(screen.getByText("Keep the note wall durable")).toBeTruthy();
+    expect(
+      await screen.findByText(
+        "Demo briefing ready\nKeep the note wall durable",
+      ),
+    ).toBeTruthy();
     expect(
       screen
         .getByLabelText("Note Demo briefing ready")
@@ -142,7 +147,11 @@ describe("Notes capability-to-UI journey", () => {
     ).toBeNull();
     populatedNotes.unmount();
     render(<NotesView />);
-    expect(await screen.findByText("Demo briefing ready")).toBeTruthy();
+    expect(
+      await screen.findByText(
+        "Demo briefing ready\nKeep the note wall durable",
+      ),
+    ).toBeTruthy();
 
     await waitFor(() => {
       expect(activeService().snapshot()).toMatchObject({

--- a/plugins/plugin-notes/src/views/notesData.test.ts
+++ b/plugins/plugin-notes/src/views/notesData.test.ts
@@ -47,7 +47,7 @@ describe("Notes browser interaction broker", () => {
     transport.fetchWithCsrf.mockResolvedValueOnce(brokerResponse(4));
 
     await expect(
-      interact("create-note", { title: "Brokered note" }),
+      interact("create-note", { content: "Brokered note" }),
     ).resolves.toMatchObject({ success: true, state: { revision: 4 } });
 
     expect(transport.fetchWithCsrf).toHaveBeenCalledWith(
@@ -56,7 +56,7 @@ describe("Notes browser interaction broker", () => {
         method: "POST",
         body: JSON.stringify({
           capability: "create-note",
-          params: { title: "Brokered note" },
+          params: { content: "Brokered note" },
         }),
       }),
     );

--- a/plugins/plugin-personal-assistant/src/actions/calendar.ts
+++ b/plugins/plugin-personal-assistant/src/actions/calendar.ts
@@ -40,6 +40,7 @@ import {
   CalendarServiceError,
   createCalendarActionRunner,
   isAppleCalendarGrant,
+  isElizaCalendarGrant,
   isMicrosoftCalendarGrantId,
 } from "@elizaos/plugin-calendar";
 import { CALENDAR_DETAILS_PARAMETER_SCHEMA } from "@elizaos/plugin-calendar/calendar-action-schema";
@@ -251,6 +252,8 @@ function calendarApprovalChannel(
       return "apple_calendar";
     case "ics":
       return "ics_calendar";
+    case "eliza":
+      return "internal";
   }
 }
 
@@ -263,6 +266,7 @@ function calendarApprovalChannel(
 function boundCalendarProviderForGrant(
   grantId: string,
 ): LifeOpsCalendarProvider {
+  if (isElizaCalendarGrant(grantId)) return "eliza";
   if (isAppleCalendarGrant(grantId)) return "apple_calendar";
   if (isMicrosoftCalendarGrantId(grantId)) return "microsoft";
   return "google";

--- a/plugins/plugin-personal-assistant/src/lifeops/approval-queue.types.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/approval-queue.types.ts
@@ -192,6 +192,7 @@ export type ApprovalPayload =
         | "microsoft"
         | "apple_calendar"
         | "ics"
+        | "eliza"
         | null;
       expectedEventUpdatedAt?: string | null;
       expectedEventStartAtMs?: number | null;
@@ -221,6 +222,7 @@ export type ApprovalPayload =
         | "microsoft"
         | "apple_calendar"
         | "ics"
+        | "eliza"
         | null;
       expectedEventUpdatedAt?: string | null;
       expectedEventStartAtMs?: number | null;

--- a/plugins/plugin-personal-assistant/src/lifeops/calendar-mutations/ledger.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/calendar-mutations/ledger.ts
@@ -212,6 +212,7 @@ function parseSnapshotProvider(value: unknown): LifeOpsCalendarProvider {
     case "microsoft":
     case "apple_calendar":
     case "ics":
+    case "eliza":
       return value;
     default:
       return receiptInvariant(

--- a/plugins/plugin-personal-assistant/src/lifeops/calendar-mutations/lifeops-port.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/calendar-mutations/lifeops-port.ts
@@ -259,7 +259,7 @@ function providerVersion(event: LifeOpsCalendarEvent): string | null {
 function requireConditionalProviderVersion(
   event: LifeOpsCalendarEvent,
 ): string {
-  if (event.provider !== "google") {
+  if (event.provider !== "google" && event.provider !== "eliza") {
     throw new CalendarMutationPreflightError(
       "CALENDAR_CONDITIONAL_MUTATION_UNSUPPORTED",
       `${event.provider} does not expose an atomic provider-version precondition through this executor.`,
@@ -678,7 +678,9 @@ async function resolveExactEvent(
           eventId: payload.eventId,
           approvedProviderVersion: binding.expectedProviderVersion,
           currentProviderVersion:
-            event.provider === "google" ? (event.metadata.etag ?? null) : null,
+            event.provider === "google" || event.provider === "eliza"
+              ? (event.metadata.etag ?? null)
+              : null,
           approvedUpdatedAt: binding.expectedUpdatedAt,
           currentUpdatedAt: event.updatedAt,
           approvedStartAt: binding.expectedStartAt,

--- a/plugins/plugin-personal-assistant/test/calendar-mutation-approval-gateway.test.ts
+++ b/plugins/plugin-personal-assistant/test/calendar-mutation-approval-gateway.test.ts
@@ -189,6 +189,7 @@ describe("calendar conversational mutation approval gateway", () => {
         travelBuffer: null,
       });
 
+    await schedule("eliza-calendar");
     await schedule("apple-calendar");
     await schedule("connector-account:microsoft:account-a");
 
@@ -225,11 +226,48 @@ describe("calendar conversational mutation approval gateway", () => {
       },
     });
 
+    const elizaTarget = {
+      ...event("organizer"),
+      id: "agent-1:eliza:owner:grant:eliza-calendar:calendar:primary:event-a",
+      externalId: "event-a",
+      provider: "eliza" as const,
+      grantId: "eliza-calendar",
+      metadata: { etag: '"eliza-1"', version: 1 },
+    };
+    await gateway.modify({
+      runtime: runtime(),
+      message: message(),
+      targetEvent: elizaTarget,
+      request: {
+        side: "owner",
+        grantId: "eliza-calendar",
+        calendarId: "primary",
+        eventId: elizaTarget.externalId,
+        title: "Built-in event moved",
+        notifyAttendees: false,
+      },
+    });
+    await gateway.cancel({
+      runtime: runtime(),
+      message: message(),
+      targetEvent: elizaTarget,
+      request: {
+        side: "owner",
+        grantId: "eliza-calendar",
+        calendarId: "primary",
+        eventId: elizaTarget.externalId,
+        notifyAttendees: false,
+      },
+    });
+
     expect(enqueue.mock.calls.map(([input]) => input.channel)).toEqual([
+      "internal",
       "apple_calendar",
       "microsoft_calendar",
       "microsoft_calendar",
       "microsoft_calendar",
+      "internal",
+      "internal",
     ]);
   });
 


### PR DESCRIPTION
Closes #17913

## Summary

- makes the built-in Eliza calendar the immediately usable default while retaining optional Apple/Google sources
- adds real calendar persistence and mutation approval semantics plus compact month/year/day navigation
- simplifies Notes to one canonical content field with existing-record compatibility
- fixes contextual Back to Home navigation, chat-overlay continuity, composer focus, and desktop message-history keys
- routes reply playback through the configured Cartesia voice path
- makes LP3 cloud-debug packaging enable realtime voice and always rebuild its feature-bearing renderer

## Verification

- exact reviewed head: `70f14c4a0f492d4ee810883b5cbbe4cd639b17c4`
- current `origin/develop`: `35257f04a7f05e70785d7265362047026c7c4b27`
- branch: 0 behind / 9 ahead
- focused OCR policy tests: 35/35 pass
- exact failed Calendar OCR transcript replay: 4/4 viewports pass
- full `bun run verify`: 343/343 build/typecheck tasks pass plus all repository audits
- physical LP3 APK hash matched after install
- physical Cartesia Ink → local runtime/Cerebras → Cartesia Sonic round trip passed
- physical mute/unmute, stop/restart, and voice-triggered Calendar action passed

## Evidence status

- Backend structured logs: PASS — session consent/mint 200, Cartesia Ink WS, runtime reply metadata, Cartesia response-audio WS
- Frontend/device logs: PASS — physical microphone capture and second-session restart; no microphone startup error
- Physical Android pixels: PASS — Listening, transcript/reply, mute, stopped/idle captured and manually reviewed
- Live model trajectory: PASS — spoken time query returned the runtime answer; voice Calendar action returned `Opened Calendar.`
- Desktop/mobile attachment gate: waived by maintainer for this merge; Calendar OCR was reproduced from the exact failed CI transcripts and passes at all four affected viewports
- Cloud/device deployment: N/A — local USB demo lane only; no cloud or production deployment in this PR


## Review update (2026-08-07, Claude Fable 5)

- adversarial deep-review on top of the rebased branch; two fixes pushed:
  - `fix(calendar): keep mutation lookups unscoped when the planner omits grantId` — the mutation lookup feeds, create-context busy windows, and conditional-target resolution previously defaulted a missing `grantId` to `eliza-calendar`, hiding every connected external source (a Google-event update/delete whose plan omitted grantId dead-ended in "not found"); lookups are unscoped again and `getConditionalCalendarMutationTarget` consults the built-in repository first for bare external ids (new PGlite coverage included)
  - `fix(calendar): label the agenda loading state instead of a blank subtitle` — the agenda subtitle now reads "Loading calendar…" while the feed settles, keeping loading / designed-empty / error visibly distinct
- gates on the reviewed tree: plugin-calendar 506 passed (+2 new), plugin-notes 26 passed, plugin-app-control 180 passed, plugin-personal-assistant gateway 5 passed, packages/agent targeted 37 passed, packages/ui targeted 56 passed + typecheck/lint, cloud voice-session 55 passed, app plugin-registrations 9 passed, root `bun run verify` all tasks green
- head at review completion: `9e3f956e2116285f2e45fed564a8775a473fa76c`

<!-- evidence-head:177dee5c4bcb13c2fa55958ea9d7adc9bce11b90 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17914-before-screenshots-pr17914.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17914-after-screenshots-pr17914.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17914-walkthrough-pr17914.mp4

<!-- evidence-row:ocr-review -->
- [x] [17914-ocr-review-pr17914.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17914-ocr-review-pr17914.txt)

<!-- evidence-row:backend-logs -->
- [x] [17914-backend-logs-pr17914.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17914-backend-logs-pr17914.txt)

<!-- evidence-row:frontend-logs -->
- [x] [17914-frontend-logs-pr17914-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17914-frontend-logs-pr17914-v2.txt)

<!-- evidence-row:domain-artifacts -->
- [x] [17914-domain-artifacts-pr17914.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17914-domain-artifacts-pr17914.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this review lane exercised no live model; the author's physical-LP3 live voice trajectory (spoken time query and voice Calendar action returning 'Opened Calendar.') is cited in Verification and must be attached inline before merge


