### PR TITLE
fix(orchestrator): launch-check false-fail residuals — phantom dead urls, tasks:create retry valve, verify-failed delivery, digest source routing

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/lane-planner.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/lane-planner.test.ts
@@ -364,9 +364,10 @@ describe("TASKS create lane planner integration", () => {
     expect(taskService.createTask).toHaveBeenCalledTimes(1);
     const spawnMetadata = acp.spawnSession.mock.calls[0]?.[0]?.metadata;
     expect(spawnMetadata).not.toHaveProperty("lane");
-    expect(taskService.createTask.mock.calls[0]?.[0]).not.toHaveProperty(
-      "metadata",
-    );
+    const createMetadata = taskService.createTask.mock.calls[0]?.[0]?.metadata;
+    expect(createMetadata).not.toHaveProperty("lane");
+    expect(createMetadata).not.toHaveProperty("waveId");
+    expect(createMetadata).toHaveProperty("source", "test");
   });
 
   it("spawns one durable create path per lane when the gate is on", async () => {
@@ -758,9 +759,10 @@ describe("TASKS create lane planner integration", () => {
     expect(acp.spawnSession.mock.calls[0]?.[0]?.metadata).not.toHaveProperty(
       "lane",
     );
-    expect(taskService.createTask.mock.calls[0]?.[0]).not.toHaveProperty(
-      "metadata",
-    );
+    const createMetadata = taskService.createTask.mock.calls[0]?.[0]?.metadata;
+    expect(createMetadata).not.toHaveProperty("lane");
+    expect(createMetadata).not.toHaveProperty("waveId");
+    expect(createMetadata).toHaveProperty("source", "test");
   });
 
   it("falls back to legacy single-task behavior when planning fails", async () => {
@@ -788,9 +790,10 @@ describe("TASKS create lane planner integration", () => {
     expect(acp.spawnSession).toHaveBeenCalledTimes(2);
     const spawnMetadata = acp.spawnSession.mock.calls[0]?.[0]?.metadata;
     expect(spawnMetadata).not.toHaveProperty("lane");
-    expect(taskService.createTask.mock.calls[0]?.[0]).not.toHaveProperty(
-      "metadata",
-    );
+    const createMetadata = taskService.createTask.mock.calls[0]?.[0]?.metadata;
+    expect(createMetadata).not.toHaveProperty("lane");
+    expect(createMetadata).not.toHaveProperty("waveId");
+    expect(createMetadata).toHaveProperty("source", "test");
   });
 
   it("preserves the legacy too-many-agents error when requests exceed both caps", async () => {

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -934,14 +934,17 @@ async function runCreateLegacy(
           : {}),
         ...(taskRoomId ? { taskRoomId } : {}),
         acceptanceCriteria,
-        ...(objectValue(extraMetadata.lane)
-          ? {
-              metadata: {
-                waveId: extraMetadata.waveId,
-                lane: extraMetadata.lane,
-              },
-            }
-          : {}),
+        metadata: {
+          // Persist the originating connector source on the durable record so
+          // proactive surfaces (TaskSupervisorService digest) can reach the
+          // origin room through a registered send handler.
+          ...(typeof content.source === "string" && content.source
+            ? { source: content.source }
+            : {}),
+          ...(objectValue(extraMetadata.lane)
+            ? { waveId: extraMetadata.waveId, lane: extraMetadata.lane }
+            : {}),
+        },
       });
       threadId = detail?.id ?? null;
       if (useSmithers && !threadId) {
@@ -1046,6 +1049,14 @@ async function runCreateLegacy(
           userId: message.entityId,
           label,
           source: content.source,
+          // Session-metadata copy of the task (NOT the spawn-option
+          // `initialTask`, which would double-deliver the prompt — this path
+          // delivers via sendPrompt). The router's recovery valves
+          // (retryIncompleteBuild / respawnStateLost) read `meta.initialTask`
+          // to reconstruct the work; without this stamp both silently return
+          // false on every TASKS:create session and a failed verification
+          // posts a failure instead of re-dispatching.
+          initialTask: taskWithRouteHints,
           workdirRouteId: route?.id,
           workdirRoute: route,
           keepAliveAfterComplete,

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -355,6 +355,48 @@ function verifiedUrlsFromMetadata(message: Memory): string[] {
   return stringArrayOf(metadataRecord(message)?.subAgentVerifiedUrls);
 }
 
+// Trailing-slash/hash-insensitive key so a dead-list URL and a route-alias
+// spelling of the same page compare equal.
+function normalizedUrlKey(value: string): string {
+  const parsed = parseUrl(value);
+  if (!parsed) return value.trim();
+  parsed.hash = "";
+  const text = parsed.toString();
+  return text.endsWith("/") ? text.slice(0, -1) : text;
+}
+
+// The router's verification annotation lists each dead probe as
+// `  - <url> → <status>`; that annotation is the only place the dead list
+// reaches this evaluator (completion metadata carries verified URLs only).
+function deadUrlKeysFromCompletionText(text: string): Set<string> {
+  const keys = new Set<string>();
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  const annotationIndex = lines.findIndex((line) =>
+    line.startsWith("[verification:"),
+  );
+  if (annotationIndex < 0) return keys;
+  for (const line of lines.slice(annotationIndex + 1)) {
+    const match = /^\s*-\s+(\S+)\s+→\s/.exec(line);
+    if (match?.[1]) keys.add(normalizedUrlKey(match[1]));
+  }
+  return keys;
+}
+
+// Route-alias expansion can promote a public URL whose DIRECT probe failed
+// into subAgentVerifiedUrls (the router verifies the loopback page live, then
+// expands it to all route aliases). The annotation's dead list is the ground
+// truth for what actually probed dead, so drop those before relaying.
+function verifiedUrlsExcludingDead(
+  message: Memory,
+  completionText: string,
+): string[] {
+  const verified = verifiedUrlsFromMetadata(message);
+  if (verified.length === 0) return verified;
+  const dead = deadUrlKeysFromCompletionText(completionText);
+  if (dead.size === 0) return verified;
+  return verified.filter((url) => !dead.has(normalizedUrlKey(url)));
+}
+
 function deliverableFromMetadata(message: Memory): string | undefined {
   const value = textOf(metadataRecord(message)?.subAgentDeliverable);
   return value.length > 0 ? value : undefined;
@@ -418,7 +460,13 @@ function isSuccessfulSubAgentCompletion(message: Memory): boolean {
   if (source !== SUB_AGENT_SOURCE && metadata.subAgent !== true) return false;
   if (textOf(metadata.subAgentEvent) !== "task_complete") return false;
   if (metadata.subAgentCapExceeded === true) return false;
-  return !completionHasVerificationFailure(textOf(content.text));
+  const text = textOf(content.text);
+  if (!completionHasVerificationFailure(text)) return true;
+  // Verify-failed / retry-exhausted completion that still carries at least
+  // one URL that actually probed live: there IS a deliverable — relay it with
+  // a caveat instead of stepping aside, which leaves delivery to the planner
+  // model volunteering a reply (fine on strong models, silent on weak ones).
+  return verifiedUrlsExcludingDead(message, text).length > 0;
 }
 
 function replyPatchFromCompletion(
@@ -681,11 +729,20 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
   evaluate: async ({ runtime, message, messageHandler }) => {
     const currentReply = textOf(messageHandler.plan.reply);
     const completionText = textOf(contentRecord(message)?.text);
-    const verifiedUrls = verifiedUrlsFromMetadata(message);
+    const verifiedUrls = verifiedUrlsExcludingDead(message, completionText);
     // Durable-task verification state, when the session has a record. Every
     // branch below that relays the completion as a user-facing reply frames it
     // through this view so an unverified claim is never presented as final.
     const verification = await verificationViewFor(runtime, message);
+    // Router URL-verify failure (dead URLs listed in the completion): every
+    // relayed reply below must disclose the gap, so this is computed ABOVE the
+    // first relay branch — the deliverable and degenerate-partial relays
+    // return early and would otherwise skip it.
+    const verificationCaveat = completionHasVerificationFailure(completionText)
+      ? "Note: some resources referenced by the build failed verification — parts of the page may be broken."
+      : undefined;
+    const withVerificationCaveat = (reply: string): string =>
+      verificationCaveat ? `${reply}\n\n${verificationCaveat}` : reply;
     // The deliverable IS the sub-agent's printed/tool output (short, single
     // block; the router stripped it from the narration). Relay it verbatim
     // rather than letting the parent model re-summarize or truncate it.
@@ -697,7 +754,10 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
         setContexts: [SIMPLE_CONTEXT_ID],
         clearCandidateActions: true,
         clearParentActionHints: true,
-        reply: frameReplyWithVerification(deliverable, verification),
+        reply: frameReplyWithVerification(
+          withVerificationCaveat(deliverable),
+          verification,
+        ),
         debug: [
           "verified sub-agent completion carries a captured deliverable; relaying it verbatim",
         ],
@@ -722,7 +782,10 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
           setContexts: [SIMPLE_CONTEXT_ID],
           clearCandidateActions: true,
           clearParentActionHints: true,
-          reply: frameReplyWithVerification(partial, verification),
+          reply: frameReplyWithVerification(
+            withVerificationCaveat(partial),
+            verification,
+          ),
           debug: [
             `sub-agent completion finished with stopReason=${finishReason} (truncated/blocked); relaying best partial once instead of re-spawning the same request`,
           ],
@@ -790,7 +853,10 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
         setContexts: [SIMPLE_CONTEXT_ID],
         clearCandidateActions: true,
         clearParentActionHints: true,
-        reply: frameReplyWithVerification(reply, verification),
+        reply: frameReplyWithVerification(
+          withVerificationCaveat(reply),
+          verification,
+        ),
         debug: [
           "verified sub-agent completion has no concrete follow-up action; using direct reply",
         ],
@@ -835,7 +901,7 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
       };
     }
     const framedReply = reply
-      ? frameReplyWithVerification(reply, verification)
+      ? frameReplyWithVerification(withVerificationCaveat(reply), verification)
       : reply;
     return {
       ...respondIfNeeded(messageHandler),

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -40,6 +40,7 @@ import {
   Service,
   TRACE_ENV,
   type TrajectoryUsageRollup,
+  type UUID,
 } from "@elizaos/core";
 import {
   detectTaskType,
@@ -2998,10 +2999,15 @@ export class OrchestratorTaskService extends Service {
     const roomId = doc?.task.roomId;
     if (!roomId) return null;
     const meta = doc.task.metadata ?? {};
-    const source =
-      typeof meta.source === "string" && meta.source
-        ? meta.source
-        : "orchestrator";
+    let source =
+      typeof meta.source === "string" && meta.source ? meta.source : undefined;
+    if (!source) {
+      // Records that predate the create-time source stamp: the room row knows
+      // which connector created it, and that source is what sendMessageToTarget
+      // needs to select a registered handler.
+      const room = await this.runtime.getRoom?.(roomId as UUID);
+      source = room?.source || "orchestrator";
+    }
     return {
       roomId,
       source,

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -148,6 +148,12 @@ const URL_IN_TEXT_RE = /https?:\/\/[^\s<>"'`)\]*]+/g;
 // hyphen U+2010, non-breaking hyphen U+2011, figure dash U+2012, en dash
 // U+2013, em dash U+2014, horizontal bar U+2015, minus sign U+2212.
 const UNICODE_DASHES_RE = /[\u2010-\u2015\u2212]/g;
+
+// Well-known XML namespace URIs (xmlns values). They are identifiers pasted
+// inside markup, not hyperlinks a sub-agent claimed as live \u2014 probing them
+// can only manufacture a false "dead" for a healthy build.
+const XML_NAMESPACE_URL_RE =
+  /^https?:\/\/(?:www\.)?w3\.org\/(?:2000\/svg|1999\/xhtml|1999\/xlink|2000\/xmlns|XML\/1998\/namespace|1998\/Math\/MathML|2001\/XMLSchema|2005\/Atom)(?:\/|$)/i;
 // A URL (mentioned by a sub-agent, or a page sub-resource) that did not
 // verify as reachable. Shared by the verification pass and the retry path.
 interface DeadUrl {
@@ -192,6 +198,28 @@ function collectVerifiableUrlCandidates(
     // Trimmed only at end-of-token; interior `!`/`?` (query strings, bang
     // routes) are untouched.
     const url = raw.replace(/[.,;:!?]+$/, "");
+    // Phantom candidates can never verify live, and a single one counted
+    // "dead" flips a live build's verdict to failed (and burns the whole
+    // verify-retry budget re-building an app that is up). Drop, structurally:
+    //  - truncated relay links ("http://…") the WHATWG parser rejects;
+    //  - single-label hostnames ("https://fonts") left by mid-token clipping
+    //    — they never resolve publicly, and loopback stays allowed;
+    //  - XML namespace URIs quoted in pasted markup (xmlns="…/2000/svg").
+    let parsedCandidate: URL;
+    try {
+      parsedCandidate = new URL(url);
+    } catch {
+      continue;
+    }
+    const candidateHost = parsedCandidate.hostname;
+    if (
+      !candidateHost.includes(".") &&
+      candidateHost !== "localhost" &&
+      !candidateHost.startsWith("[")
+    ) {
+      continue;
+    }
+    if (XML_NAMESPACE_URL_RE.test(url)) continue;
     // Raw `curl -i` output includes CDN reporting endpoints in `report-to`
     // headers. They are not part of the built app, and letting them into the
     // bounded verifier list crowds out real page/assets.
@@ -2010,12 +2038,19 @@ export class SubAgentRouter extends Service {
     resumeContext?: ResumeContext,
   ): Promise<boolean> {
     const meta = (session.metadata ?? {}) as Record<string, unknown>;
-    // The original task is stashed on metadata by TASKS op=spawn_agent —
+    // The original task is stashed on metadata by the TASKS spawn paths —
     // SessionInfo itself doesn't carry it. Without it we can't reconstruct the
     // work, so surface the failure honestly instead of respawning a blank one.
     const originalTask =
       typeof meta.initialTask === "string" ? meta.initialTask.trim() : "";
-    if (!originalTask) return false;
+    if (!originalTask) {
+      this.log(
+        "warn",
+        "state-lost respawn unavailable: session metadata has no initialTask",
+        { sessionId: session.id, reason },
+      );
+      return false;
+    }
 
     const service =
       this.acp ??
@@ -2307,11 +2342,20 @@ export class SubAgentRouter extends Service {
       return false;
     }
 
-    // The original task is stashed on metadata by TASKS op=spawn_agent —
-    // SessionInfo itself doesn't carry it.
+    // The original task is stashed on metadata by the TASKS spawn paths —
+    // SessionInfo itself doesn't carry it. Log the miss: a session without
+    // the stamp silently loses its verify-retry valve, and that gap has
+    // previously read as "verification posted a failure instead of retrying".
     const originalTask =
       typeof meta.initialTask === "string" ? meta.initialTask.trim() : "";
-    if (!originalTask) return false;
+    if (!originalTask) {
+      this.log(
+        "warn",
+        "verify-retry unavailable: session metadata has no initialTask",
+        { sessionId: session.id },
+      );
+      return false;
+    }
 
     const service =
       this.acp ??


### PR DESCRIPTION
Launch-check verification could fail a build that actually worked, and three recovery/delivery paths silently dropped out when it did. This applies the remaining july fix-plan residuals that develop had not absorbed — all four are structural, none touch prose.

## What breaks today

- **Phantom dead urls.** `collectVerifiableUrlCandidates` forwards candidates that can never verify: truncated links ("http://…"), single-label hostnames ("https://fonts" from a preconnect tag), and well-known xml namespace uris. One phantom 404 flips a live build's verdict and burns the verify-retry budget probing garbage.
- **Dead retry valves on chat-initiated builds.** `retryIncompleteBuild` / `respawnStateLost` recover a build by re-reading `initialTask` from session metadata — but `tasks:create` never stamped it, so both valves silently returned `false` on every chat-initiated build.
- **Verify-failed silence.** When verification failed, the sub-agent-completion evaluator stepped aside entirely; weak planner models then delivered nothing. A completion that still carries live-probed urls now relays the deliverable with an explicit caveat, and route-alias urls whose direct probe died are excluded from the relayed verified set.
- **Digest routing death.** Durable task records did not persist the originating connector source, so supervisor digests tried to send via the literal `"orchestrator"` source — which has no registered send handler — and died. Records now persist the source and `getTaskOriginTarget` falls back to the room's source.

## Changes

- `services/sub-agent-router.ts` — drop unverifiable url candidates before probing; persist originating connector source on durable task records; `getTaskOriginTarget` room-source fallback
- `actions/tasks.ts` — `tasks:create` stamps `initialTask` into session metadata; both recovery valves log when the stamp is missing
- `evaluators/sub-agent-completion.ts` — verify-failed completions with live-probed urls relay with a caveat instead of stepping aside; dead route-alias urls excluded from the verified set
- `services/orchestrator-task-service.ts` — durable record source plumbing
- `src/__tests__/lane-planner.test.ts` — pins updated for the above

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:6cb3a4277cf493724cbe23046cd241b60684496a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - orchestrator service/evaluator logic; no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - orchestrator service/evaluator logic; nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend orchestration change; behavior is proven by the plugin's suite, not a screen flow.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - full plugin verification output at this head.

<details><summary>Verification output at 6cb3a4277cf493724cbe23046cd241b60684496a</summary>

```text
$ bun run typecheck        (plugins/plugin-agent-orchestrator)
$ tsc --noEmit -p tsconfig.json
exit 0

$ bun run test             (plugins/plugin-agent-orchestrator, full suite)
 Test Files  229 passed | 5 skipped (234)
      Tests  2624 passed | 8 skipped (2632)
   Duration  124.11s (transform 58.59s, setup 2.40s, import 573.33s, tests 226.53s)
exit 0

$ bunx @biomejs/biome check --no-errors-on-unmatched \
    src/actions/tasks.ts src/evaluators/sub-agent-completion.ts \
    src/services/orchestrator-task-service.ts src/services/sub-agent-router.ts \
    src/__tests__/lane-planner.test.ts
Checked 5 files in 141ms. No fixes applied.
exit 0
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the orchestrator's verify/relay/digest paths.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic orchestrator routing/verification logic pinned by the plugin suite; no live inference is exercised by this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - flake isolation run: an initial full-suite pass hit the known timing flake in create-task-attaches-sessions (documented pre-existing in #17810); both files pass in isolation and the full-suite re-run above is fully green.

<details><summary>Isolated re-run of the two timing-flavored files</summary>

```text
$ bunx vitest run --config vitest.config.ts \
    __tests__/unit/create-task-attaches-sessions.test.ts \
    __tests__/unit/tasks-regression-lane.test.ts
 Test Files  2 passed (2)
      Tests  110 passed (110)
exit 0
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
