### PR TITLE
fix(agent): take semantic recall off the reply critical path structurally

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -38,6 +38,7 @@
     "build:ios-bun": "bun run scripts/build-mobile-bundle.mjs --target=ios",
     "build:ios-jsc": "bun run scripts/build-mobile-bundle.mjs --target=ios-jsc",
     "perf:cerebras-chat": "bun --conditions=eliza-source scripts/cerebras-chat-flow-latency.ts",
+    "perf:relevant-conversations": "bun --conditions=eliza-source scripts/bench-relevant-conversations.ts",
     "verify:mobile-workspace-resolution": "bun run scripts/build-mobile-bundle.mjs --verify-workspace-resolution",
     "build:docker-dist": "bun run build:dist",
     "typecheck": "tsc --noEmit -p tsconfig.json",

--- a/packages/agent/scripts/bench-relevant-conversations.ts
+++ b/packages/agent/scripts/bench-relevant-conversations.ts
@@ -1,0 +1,506 @@
+/**
+ * Stage-decomposition micro-bench for the relevant-conversations provider's
+ * recall pipeline against a real PGlite-backed AgentRuntime. Seeds a local
+ * corpus (message memories with HNSW-indexed embeddings across many rooms plus
+ * a hash-memory room), then times each pipeline stage independently — current
+ * room fetch, access-context build, hash-memory scan + BM25 rank, recall
+ * embed, semantic vector search (threshold-in-SQL vs threshold-post-filter
+ * query shapes, with EXPLAIN ANALYZE), room resolution (sequential getRoom vs
+ * one batched getRoomsByIds), and the provider end-to-end — so critical-path
+ * fixes attack measured dominators instead of guesses.
+ *
+ * Run from the repo root:
+ *   bun packages/agent/scripts/bench-relevant-conversations.ts \
+ *     [--vectors=8000] [--hash=2000] [--rooms=64] [--reps=5] [--embed-ms=0]
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import {
+  AgentRuntime,
+  buildAccessContext,
+  embedRecallQuery,
+  ModelType,
+  type Plugin,
+  type Room,
+  type State,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import { HASH_MEMORY_SOURCE, rankByKeyword } from "../src/api/memory-routes.ts";
+import { relevantConversationsProvider } from "../src/providers/relevant-conversations.ts";
+import {
+  executeRawSql,
+  extractRows,
+} from "../src/runtime/trajectory-internals.ts";
+
+interface BenchArgs {
+  vectors: number;
+  hash: number;
+  rooms: number;
+  reps: number;
+  embedMs: number;
+}
+
+function parseArgs(): BenchArgs {
+  const defaults: BenchArgs = {
+    vectors: 8000,
+    hash: 2000,
+    rooms: 64,
+    reps: 5,
+    embedMs: 0,
+  };
+  for (const arg of process.argv.slice(2)) {
+    const match = /^--([a-z-]+)=(\d+)$/.exec(arg);
+    if (!match) continue;
+    const value = Number(match[2]);
+    if (match[1] === "vectors") defaults.vectors = value;
+    if (match[1] === "hash") defaults.hash = value;
+    if (match[1] === "rooms") defaults.rooms = value;
+    if (match[1] === "reps") defaults.reps = value;
+    if (match[1] === "embed-ms") defaults.embedMs = value;
+  }
+  return defaults;
+}
+
+/** Deterministic PRNG so every run seeds the identical corpus. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const DIM = 384;
+
+function normalize(vec: number[]): number[] {
+  let norm = 0;
+  for (const v of vec) norm += v * v;
+  norm = Math.sqrt(norm) || 1;
+  return vec.map((v) => Number((v / norm).toFixed(6)));
+}
+
+function randomVector(rand: () => number): number[] {
+  return Array.from({ length: DIM }, () => rand() * 2 - 1);
+}
+
+/** Deterministic text -> unit vector (stands in for the embedding model). */
+function textToVector(text: string): number[] {
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return normalize(randomVector(mulberry32(hash >>> 0)));
+}
+
+/** Cluster around a topic center so the corpus geometry resembles real text
+ * embeddings (unrelated docs at moderate similarity, not near-orthogonal). */
+function clusteredVector(center: number[], rand: () => number, closeness: number): number[] {
+  const noise = randomVector(rand);
+  return normalize(center.map((c, i) => closeness * c + (1 - closeness) * noise[i]));
+}
+
+function vectorLiteral(vec: number[]): string {
+  return `[${vec.map((v) => v.toFixed(6)).join(",")}]`;
+}
+
+function quantile(sorted: number[], q: number): number {
+  const idx = Math.min(sorted.length - 1, Math.floor(q * sorted.length));
+  return sorted[idx];
+}
+
+interface StageResult {
+  label: string;
+  median: number;
+  min: number;
+  max: number;
+}
+
+const results: StageResult[] = [];
+
+async function timeStage(
+  label: string,
+  reps: number,
+  fn: () => Promise<unknown>,
+): Promise<StageResult> {
+  const samples: number[] = [];
+  for (let i = 0; i < reps; i++) {
+    const start = performance.now();
+    await fn();
+    samples.push(performance.now() - start);
+  }
+  samples.sort((a, b) => a - b);
+  const stage: StageResult = {
+    label,
+    median: quantile(samples, 0.5),
+    min: samples[0],
+    max: samples[samples.length - 1],
+  };
+  results.push(stage);
+  process.stdout.write(
+    `  ${label.padEnd(58)} median=${stage.median.toFixed(1)}ms min=${stage.min.toFixed(1)}ms max=${stage.max.toFixed(1)}ms\n`,
+  );
+  return stage;
+}
+
+const HASH_SENTENCES = [
+  "the launch window for the connector rollout is the first week of the month",
+  "billing reconciliation runs nightly and posts a ledger summary to the ops room",
+  "the staging canary needs a manual promote before the prod deploy can start",
+  "remember that the vector index rebuild happens on the first boot after upgrade",
+  "the desktop shell pins the api port registry under the state directory",
+  "trajectory captures drain their write queue before the viewer reads them",
+  "the media store is content addressed by sha256 and garbage collected weekly",
+  "scheduling conflicts resolve through the shared task service clock",
+];
+
+function hashMemoryText(rand: () => number, index: number): string {
+  const base = HASH_SENTENCES[index % HASH_SENTENCES.length];
+  const filler = Math.floor(rand() * 3) + 1;
+  return `${base} (note ${index}, detail level ${filler})`;
+}
+
+const SCARCE_QUERY =
+  "did we ever settle the question about the quarterly hardware budget approval flow";
+const MATCH_QUERY =
+  "what did we decide about the launch date for the connector rollout";
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  process.stdout.write(
+    `relevant-conversations stage bench — vectors=${args.vectors} hash=${args.hash} rooms=${args.rooms} reps=${args.reps} embed-ms=${args.embedMs}\n`,
+  );
+
+  const prevPgliteDir = process.env.PGLITE_DATA_DIR;
+  const pgliteDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-recall-bench-"));
+  process.env.PGLITE_DATA_DIR = pgliteDir;
+
+  const runtime = new AgentRuntime({
+    character: { name: "Eliza" },
+    plugins: [],
+    logLevel: "error",
+    enableAutonomy: false,
+  });
+
+  const pluginSqlModule = (await import(["@elizaos", "plugin-sql"].join("/"))) as {
+    default?: Plugin;
+    plugin?: Plugin;
+  };
+  const pluginSql = pluginSqlModule.default ?? pluginSqlModule.plugin;
+  if (!pluginSql) throw new Error("plugin-sql did not export a plugin");
+  await runtime.registerPlugin(pluginSql);
+  await runtime.initialize();
+
+  try {
+    await run(runtime, args);
+  } finally {
+    await runtime.stop();
+    if (prevPgliteDir === undefined) {
+      delete process.env.PGLITE_DATA_DIR;
+    } else {
+      process.env.PGLITE_DATA_DIR = prevPgliteDir;
+    }
+    fs.rmSync(pgliteDir, { recursive: true, force: true });
+  }
+}
+
+async function run(runtime: AgentRuntime, args: BenchArgs): Promise<void> {
+  const rand = mulberry32(0xe11a);
+  const agentId = runtime.agentId;
+  const worldId = stringToUuid("bench-world") as UUID;
+  const userEntityId = stringToUuid("bench-user") as UUID;
+  const currentRoomId = stringToUuid("bench-current-room") as UUID;
+  const hashRoomId = stringToUuid("Eliza-hash-memory-room") as UUID;
+
+  await runtime.createWorld({
+    id: worldId,
+    name: "bench world",
+    agentId,
+    messageServerId: stringToUuid("bench-server") as UUID,
+  });
+  await runtime.createEntity({
+    id: userEntityId,
+    names: ["Bench User"],
+    agentId,
+  });
+
+  const roomIds: UUID[] = [];
+  const roomRows: Room[] = [];
+  for (let i = 0; i < args.rooms; i++) {
+    const id = stringToUuid(`bench-room-${i}`) as UUID;
+    roomIds.push(id);
+    roomRows.push({
+      id,
+      name: `bench room ${i}`,
+      agentId,
+      source: "discord",
+      type: "GROUP" as Room["type"],
+      worldId,
+    });
+  }
+  roomRows.push(
+    {
+      id: currentRoomId,
+      name: "current room",
+      agentId,
+      source: "discord",
+      type: "GROUP" as Room["type"],
+      worldId,
+    },
+    {
+      id: hashRoomId,
+      name: "hash memory room",
+      agentId,
+      source: "agent",
+      type: "GROUP" as Room["type"],
+      worldId,
+    },
+  );
+  await runtime.createRooms(roomRows);
+
+  // ---- Seed corpus via chunked multi-row inserts (fast on PGlite) ----
+  process.stdout.write("seeding corpus...\n");
+  const seedStart = performance.now();
+
+  const centers = Array.from({ length: 32 }, () => normalize(randomVector(rand)));
+  const matchVector = textToVector(MATCH_QUERY);
+
+  const CHUNK = 250;
+  let seeded = 0;
+  while (seeded < args.vectors) {
+    const batch = Math.min(CHUNK, args.vectors - seeded);
+    const memoryValues: string[] = [];
+    const embeddingValues: string[] = [];
+    for (let i = 0; i < batch; i++) {
+      const index = seeded + i;
+      const id = stringToUuid(`bench-memory-${index}`) as UUID;
+      const roomId = roomIds[index % roomIds.length];
+      const entityId = index % 3 === 0 ? agentId : userEntityId;
+      // The first 24 docs sit near the match query so the plentiful-match path
+      // has real hits; everything else clusters around topic centers.
+      const vec =
+        index < 24
+          ? clusteredVector(matchVector, rand, 0.92)
+          : clusteredVector(centers[index % centers.length], rand, 0.55);
+      const text = `seed message ${index} about topic ${index % centers.length} in room ${index % roomIds.length}`;
+      const createdAt = new Date(Date.now() - index * 60_000).toISOString();
+      memoryValues.push(
+        `('${id}', 'messages', '${createdAt}', ` +
+          `'${JSON.stringify({ text, source: "discord" })}'::jsonb, ` +
+          `'${entityId}', '${agentId}', '${roomId}', '${worldId}', true, '{}'::jsonb)`,
+      );
+      embeddingValues.push(
+        `(gen_random_uuid(), '${id}', now(), '${vectorLiteral(vec)}'::vector)`,
+      );
+    }
+    await executeRawSql(
+      runtime,
+      `INSERT INTO memories (id, type, created_at, content, entity_id, agent_id, room_id, world_id, "unique", metadata) VALUES ${memoryValues.join(",")}`,
+    );
+    await executeRawSql(
+      runtime,
+      `INSERT INTO embeddings (id, memory_id, created_at, dim_384) VALUES ${embeddingValues.join(",")}`,
+    );
+    seeded += batch;
+  }
+
+  let hashSeeded = 0;
+  while (hashSeeded < args.hash) {
+    const batch = Math.min(CHUNK, args.hash - hashSeeded);
+    const values: string[] = [];
+    for (let i = 0; i < batch; i++) {
+      const index = hashSeeded + i;
+      const id = stringToUuid(`bench-hash-${index}`) as UUID;
+      const text = hashMemoryText(rand, index);
+      const createdAt = new Date(Date.now() - index * 30_000).toISOString();
+      values.push(
+        `('${id}', 'messages', '${createdAt}', ` +
+          `'${JSON.stringify({ text, source: HASH_MEMORY_SOURCE })}'::jsonb, ` +
+          `'${agentId}', '${agentId}', '${hashRoomId}', '${worldId}', true, '{}'::jsonb)`,
+      );
+    }
+    await executeRawSql(
+      runtime,
+      `INSERT INTO memories (id, type, created_at, content, entity_id, agent_id, room_id, world_id, "unique", metadata) VALUES ${values.join(",")}`,
+    );
+    hashSeeded += batch;
+  }
+
+  // Register the deterministic embedding model, then build the HNSW index over
+  // the seeded corpus in one pass (the adapter creates it during the dimension
+  // ensure) and refresh planner stats.
+  const embedMs = args.embedMs;
+  runtime.registerModel(
+    ModelType.TEXT_EMBEDDING,
+    async (_runtime, params) => {
+      if (embedMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, embedMs));
+      }
+      // The dimension probe may call with null/absent params; any input maps
+      // to a deterministic 384-wide vector.
+      const text =
+        params !== null &&
+        typeof params === "object" &&
+        typeof (params as { text?: unknown }).text === "string"
+          ? ((params as { text: string }).text)
+          : "dimension probe";
+      return textToVector(text);
+    },
+    "bench",
+    1000,
+  );
+  await runtime.ensureEmbeddingDimension();
+  await executeRawSql(runtime, "ANALYZE memories");
+  await executeRawSql(runtime, "ANALYZE embeddings");
+  process.stdout.write(
+    `seeded ${args.vectors} vectors + ${args.hash} hash rows in ${((performance.now() - seedStart) / 1000).toFixed(1)}s\n\n`,
+  );
+
+  const message = {
+    id: stringToUuid("bench-message") as UUID,
+    entityId: userEntityId,
+    agentId,
+    roomId: currentRoomId,
+    content: { text: SCARCE_QUERY, source: "discord" },
+    createdAt: Date.now(),
+  };
+  const matchMessage = {
+    ...message,
+    id: stringToUuid("bench-message-match") as UUID,
+    content: { text: MATCH_QUERY, source: "discord" },
+  };
+  const emptyState: State = { values: {}, data: {}, text: "" };
+  const scarceVector = textToVector(SCARCE_QUERY);
+  const accessContext = await buildAccessContext(runtime, message);
+
+  // ---- EXPLAIN ANALYZE both semantic-search query shapes ----
+  const oldShape = (vec: number[]) =>
+    `SELECT m.id, 1 - (e.dim_384 <=> '${vectorLiteral(vec)}'::vector) AS similarity ` +
+    `FROM embeddings e JOIN memories m ON m.id = e.memory_id ` +
+    `WHERE e.dim_384 IS NOT NULL AND m.type = 'messages' AND m.agent_id = '${agentId}' ` +
+    `AND 1 - (e.dim_384 <=> '${vectorLiteral(vec)}'::vector) >= 0.7 ` +
+    `ORDER BY e.dim_384 <=> '${vectorLiteral(vec)}'::vector ASC LIMIT 15`;
+  const newShape = (vec: number[]) =>
+    `SELECT m.id, 1 - (e.dim_384 <=> '${vectorLiteral(vec)}'::vector) AS similarity ` +
+    `FROM embeddings e JOIN memories m ON m.id = e.memory_id ` +
+    `WHERE e.dim_384 IS NOT NULL AND m.type = 'messages' AND m.agent_id = '${agentId}' ` +
+    `ORDER BY e.dim_384 <=> '${vectorLiteral(vec)}'::vector ASC LIMIT 15`;
+
+  for (const [label, sqlText] of [
+    ["threshold-in-SQL (current adapter shape), scarce-match query", oldShape(scarceVector)],
+    ["no-threshold top-K (post-filter shape), scarce-match query", newShape(scarceVector)],
+  ] as const) {
+    const explain = await executeRawSql(runtime, `EXPLAIN ANALYZE ${sqlText}`);
+    process.stdout.write(`EXPLAIN ANALYZE — ${label}\n`);
+    for (const row of extractRows(explain)) {
+      const record = row as Record<string, unknown>;
+      process.stdout.write(`  ${String(record["QUERY PLAN"])}\n`);
+    }
+    process.stdout.write("\n");
+  }
+
+  // ---- Stage timings ----
+  process.stdout.write("stage timings:\n");
+  const reps = args.reps;
+
+  await timeStage("getRoom(current) — cold adapter read", reps, () =>
+    runtime.getRoomsByIds([currentRoomId]),
+  );
+  await timeStage("buildAccessContext", reps, () =>
+    buildAccessContext(runtime, message),
+  );
+
+  let hashRows: Awaited<ReturnType<typeof runtime.getMemories>> = [];
+  await timeStage(
+    `hash-memory getMemories (limit 2000, ${args.hash} rows)`,
+    reps,
+    async () => {
+      hashRows = await runtime.getMemories({
+        roomId: hashRoomId,
+        tableName: "messages",
+        limit: 2000,
+        includeEmbedding: false,
+        accessContext,
+      });
+    },
+  );
+  await timeStage(`BM25 rankByKeyword over ${hashRows.length} rows`, reps, async () =>
+    rankByKeyword(SCARCE_QUERY, hashRows, (m) =>
+      typeof m.content.text === "string" ? m.content.text : "",
+    ),
+  );
+  await timeStage(`embedRecallQuery (simulated ${args.embedMs}ms model)`, reps, () =>
+    embedRecallQuery(runtime, SCARCE_QUERY),
+  );
+
+  await timeStage(
+    "runtime.searchMemories (checked-out adapter), scarce-match query",
+    reps,
+    () =>
+      runtime.searchMemories({
+        embedding: scarceVector,
+        tableName: "messages",
+        match_threshold: 0.7,
+        limit: 15,
+        accessContext,
+      }),
+  );
+  await timeStage(
+    "runtime.searchMemories (checked-out adapter), plentiful-match query",
+    reps,
+    () =>
+      runtime.searchMemories({
+        embedding: textToVector(MATCH_QUERY),
+        tableName: "messages",
+        match_threshold: 0.7,
+        limit: 15,
+        accessContext,
+      }),
+  );
+  await timeStage("raw SQL threshold-in-SQL shape, scarce-match query", reps, () =>
+    executeRawSql(runtime, oldShape(scarceVector)),
+  );
+  await timeStage("raw SQL no-threshold top-K shape, scarce-match query", reps, () =>
+    executeRawSql(runtime, newShape(scarceVector)),
+  );
+  await timeStage("raw SQL threshold-in-SQL shape, plentiful-match query", reps, () =>
+    executeRawSql(runtime, oldShape(textToVector(MATCH_QUERY))),
+  );
+  await timeStage("raw SQL no-threshold top-K shape, plentiful-match query", reps, () =>
+    executeRawSql(runtime, newShape(textToVector(MATCH_QUERY))),
+  );
+
+  const resultRooms = roomIds.slice(0, 10);
+  await timeStage("room resolve — 10x sequential getRoomsByIds([id])", reps, async () => {
+    for (const id of resultRooms) {
+      await runtime.getRoomsByIds([id]);
+    }
+  });
+  await timeStage("room resolve — 1x batched getRoomsByIds(ids)", reps, () =>
+    runtime.getRoomsByIds(resultRooms),
+  );
+
+  await timeStage("provider.get end-to-end, scarce-match query", reps, () =>
+    relevantConversationsProvider.get(runtime, message, emptyState),
+  );
+  await timeStage("provider.get end-to-end, plentiful-match query", reps, () =>
+    relevantConversationsProvider.get(runtime, matchMessage, emptyState),
+  );
+
+  process.stdout.write("\nsummary (median ms):\n");
+  for (const stage of results) {
+    process.stdout.write(`  ${stage.label.padEnd(58)} ${stage.median.toFixed(1)}\n`);
+  }
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`bench failed: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`);
+  process.exit(1);
+});

--- a/packages/agent/src/providers/relevant-conversations.test.ts
+++ b/packages/agent/src/providers/relevant-conversations.test.ts
@@ -2,10 +2,13 @@
  * Coverage for relevantConversationsProvider's recall paths: the shared per-turn
  * embed (embedRecallQuery) failing open to `null` (no vector search issued,
  * empty result), resolving to a vector (drives searchMemories), lexical
- * hash-memory recall surfacing even when the embed fails open, and short
- * messages short-circuiting before any embed. Deterministic: @elizaos/core is
- * partially mocked to drive embedRecallQuery, and the runtime's
- * searchMemories / getMemories are in-memory vi fakes.
+ * hash-memory recall surfacing even when the embed fails open, short messages
+ * short-circuiting before any embed, the hash scan overlapping the semantic
+ * branch instead of serializing, and result-room tags resolving through one
+ * batched getRoomsByIds read (degrading to untagged on failure). Deterministic:
+ * @elizaos/core is partially mocked to drive embedRecallQuery, and the
+ * runtime's searchMemories / getMemories / getRoomsByIds are in-memory vi
+ * fakes.
  */
 import type { IAgentRuntime, Memory, Room, State } from "@elizaos/core";
 import { createMockRuntime } from "@elizaos/core/testing";
@@ -51,9 +54,12 @@ function makeRuntime(overrides: Partial<IAgentRuntime> = {}): {
   ]);
   const runtime = createMockRuntime({
     getRoom: vi.fn(async () => ({ id: ROOM_ID }) as unknown as Room),
-    // Lexical hash-memory scan runs before the semantic embed; default to no
-    // hash memories so these tests isolate the embed path.
+    // Lexical hash-memory scan runs concurrently with the semantic embed;
+    // default to no hash memories so these tests isolate the embed path.
     getMemories: vi.fn(async () => []),
+    // Recall-result room tags resolve through one batched read; default to no
+    // rooms (tags degrade to "[unknown]").
+    getRoomsByIds: vi.fn(async () => []),
     searchMemories,
     reportError: vi.fn(),
     ...overrides,
@@ -208,6 +214,99 @@ describe("relevantConversationsProvider — shared recall embed fail-open", () =
 
     expect(result.text).toContain("shared launch note");
     expect(result.text).not.toContain("owner pendant canary");
+  });
+
+  it("resolves recall-result room tags with one batched getRoomsByIds read", async () => {
+    embedRecallQuery.mockResolvedValue([0.1, 0.2, 0.3]);
+    const THIRD_ROOM = "00000000-0000-0000-0000-0000000000c3" as Room["id"];
+    const searchMemories = vi.fn(async () => [
+      {
+        id: "00000000-0000-0000-0000-0000000000m1",
+        roomId: OTHER_ROOM,
+        entityId: "00000000-0000-0000-0000-0000000000e1",
+        content: { text: "first relevant message" },
+        createdAt: 3,
+      } as unknown as Memory,
+      {
+        id: "00000000-0000-0000-0000-0000000000m2",
+        roomId: THIRD_ROOM,
+        entityId: "00000000-0000-0000-0000-0000000000e2",
+        content: { text: "second relevant message" },
+        createdAt: 2,
+      } as unknown as Memory,
+      {
+        id: "00000000-0000-0000-0000-0000000000m3",
+        roomId: OTHER_ROOM,
+        entityId: "00000000-0000-0000-0000-0000000000e1",
+        content: { text: "third relevant message" },
+        createdAt: 1,
+      } as unknown as Memory,
+    ]);
+    const getRoomsByIds = vi.fn(async () => [
+      { id: OTHER_ROOM, source: "discord", name: "general" } as unknown as Room,
+      { id: THIRD_ROOM, source: "slack", name: "ops" } as unknown as Room,
+    ]);
+    const { runtime } = makeRuntime({ searchMemories, getRoomsByIds });
+
+    const result = await relevantConversationsProvider.get(
+      runtime,
+      makeMessage("what did we decide about the launch date"),
+      EMPTY_STATE,
+    );
+
+    // One batched read over the distinct result rooms — never one call per row.
+    expect(getRoomsByIds).toHaveBeenCalledTimes(1);
+    expect(getRoomsByIds).toHaveBeenCalledWith([OTHER_ROOM, THIRD_ROOM]);
+    expect(result.text).toContain("[discord] general");
+    expect(result.text).toContain("[slack] ops");
+  });
+
+  it("degrades room tags to [unknown] when the batched room read fails, keeping the recall text", async () => {
+    embedRecallQuery.mockResolvedValue([0.1, 0.2, 0.3]);
+    const getRoomsByIds = vi.fn(async () => {
+      throw new Error("room store unavailable");
+    });
+    const reportError = vi.fn();
+    const { runtime } = makeRuntime({ getRoomsByIds, reportError });
+
+    const result = await relevantConversationsProvider.get(
+      runtime,
+      makeMessage("what did we decide about the launch date"),
+      EMPTY_STATE,
+    );
+
+    // Cosmetic tag degrade, not a recall failure: text survives untagged and
+    // nothing is reported as a broken pipeline.
+    expect(result.text).toContain("Relevant past conversations:");
+    expect(result.text).toContain("[unknown]");
+    expect(result.text).toContain("earlier relevant message");
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("overlaps the lexical hash scan with the semantic embed+search instead of serializing them", async () => {
+    embedRecallQuery.mockResolvedValue([0.1, 0.2, 0.3]);
+    let releaseHashScan: ((memories: Memory[]) => void) | undefined;
+    const hashScan = new Promise<Memory[]>((resolve) => {
+      releaseHashScan = resolve;
+    });
+    const getMemories = vi.fn(() => hashScan);
+    const { runtime, searchMemories } = makeRuntime({ getMemories });
+
+    const pending = relevantConversationsProvider.get(
+      runtime,
+      makeMessage("what did we decide about the launch date"),
+      EMPTY_STATE,
+    );
+
+    // The semantic branch must reach searchMemories while the hash scan is
+    // still in flight — a serial pipeline would block on getMemories first.
+    await vi.waitFor(() => expect(searchMemories).toHaveBeenCalledTimes(1));
+    expect(getMemories).toHaveBeenCalledTimes(1);
+    releaseHashScan?.([]);
+
+    const result = await pending;
+    expect(result.text).toContain("Relevant past conversations:");
+    expect(result.text).toContain("earlier relevant message");
   });
 
   it("allows the authenticated owner to recall owner-private pendant memory", async () => {

--- a/packages/agent/src/providers/relevant-conversations.ts
+++ b/packages/agent/src/providers/relevant-conversations.ts
@@ -4,8 +4,11 @@
  * "hash memory" scan (mirroring the /api/memory/remember writer, so recall works
  * even when no embedding model is registered) with semantic search over the
  * shared per-turn recall-query embed; on embed failure it fails open to the
- * lexical hits alone. Current-room messages are filtered out to avoid echo, and
- * hash-memory hits win on id overlap. Gated to USER.
+ * lexical hits alone. The two sources are independent and run concurrently, and
+ * result-room tags resolve through one batched room read — this provider sits
+ * on the composeState critical path of every reply, so it must not serialize
+ * independent round-trips. Current-room messages are filtered out to avoid
+ * echo, and hash-memory hits win on id overlap. Gated to USER.
  */
 import type {
   AccessContext,
@@ -152,26 +155,33 @@ export const relevantConversationsProvider: Provider = {
         accessContext = { requesterEntityId: message.entityId };
       }
 
-      // Lexical hash-memory recall mirrors the /api/memory/remember writer and
-      // works even when no TEXT_EMBEDDING model is registered.
-      const hashMemories = await loadHashMemories(runtime, text, accessContext);
-
-      // Embed the current message for semantic search. Routes through the one
-      // shared per-turn recall-query embed so this provider, document recall, and
-      // experience recall reuse a single embed round-trip per turn. `null` means
-      // the embed timed out/failed (or no embedding model) — fail open and rely
-      // on lexical hash memories alone.
-      const embedding = await embedRecallQuery(runtime, text);
-      const results: Memory[] =
-        embedding && embedding.length > 0
-          ? await runtime.searchMemories({
-              embedding,
-              tableName: "messages",
-              match_threshold: MATCH_THRESHOLD,
-              limit: MAX_RELEVANT_RESULTS + 5, // fetch extra to filter current room
-              accessContext,
-            })
-          : [];
+      // The two recall sources are independent, so they run concurrently
+      // instead of serially: the lexical hash-memory scan (which mirrors the
+      // /api/memory/remember writer and works even when no TEXT_EMBEDDING
+      // model is registered) overlaps the embed await + semantic search
+      // instead of adding to the compose critical path. A failure in either
+      // branch rejects into the outer catch — the same wholesale degrade the
+      // serial form had.
+      //
+      // Semantic branch: routes through the one shared per-turn recall-query
+      // embed so this provider, document recall, and experience recall reuse
+      // a single embed round-trip per turn. `null` means the embed timed
+      // out/failed (or no embedding model) — fail open and rely on lexical
+      // hash memories alone.
+      const [hashMemories, results] = await Promise.all([
+        loadHashMemories(runtime, text, accessContext),
+        (async (): Promise<Memory[]> => {
+          const embedding = await embedRecallQuery(runtime, text);
+          if (!embedding || embedding.length === 0) return [];
+          return runtime.searchMemories({
+            embedding,
+            tableName: "messages",
+            match_threshold: MATCH_THRESHOLD,
+            limit: MAX_RELEVANT_RESULTS + 5, // fetch extra to filter current room
+            accessContext,
+          });
+        })(),
+      ]);
 
       // Filter out messages from the current conversation to avoid echo, dedupe
       // by id (hash memories prepended so they win on overlap), then cap.
@@ -194,20 +204,26 @@ export const relevantConversationsProvider: Provider = {
         return { text: "", values: {}, data: {} };
       }
 
-      // Resolve room details
+      // Resolve room details for source tags in ONE batched read. The
+      // per-result getRoom loop this replaces paid one adapter round-trip per
+      // distinct room every turn (the runtime's room memo TTL is shorter than
+      // a turn gap), serially on the compose critical path.
       const roomCache = new Map<string, Room | null>();
+      const roomIds: UUID[] = [];
       for (const mem of filtered) {
-        const rid = mem.roomId;
-        if (rid && !roomCache.has(rid)) {
-          try {
-            roomCache.set(rid, await runtime.getRoom(rid));
-          } catch {
-            // error-policy:J4 one room's source tag degrades to untagged; the
-            // outer catch reports a wholesale recall failure, this per-room miss
-            // is cosmetic and must not abort the whole provider.
-            roomCache.set(rid, null);
-          }
+        if (mem.roomId && !roomCache.has(mem.roomId)) {
+          roomCache.set(mem.roomId, null);
+          roomIds.push(mem.roomId);
         }
+      }
+      try {
+        for (const room of await runtime.getRoomsByIds(roomIds)) {
+          if (room.id) roomCache.set(room.id, room);
+        }
+      } catch {
+        // error-policy:J4 room source tags degrade to untagged; the outer
+        // catch reports a wholesale recall failure, this lookup miss is
+        // cosmetic and must not abort the whole provider.
       }
 
       const lines: string[] = ["Relevant past conversations:"];

--- a/plugins/plugin-sql/src/__tests__/integration/memory-search-threshold-postfilter.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-search-threshold-postfilter.real.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Integration proof that `searchMemoriesByEmbedding`'s post-LIMIT similarity
+ * threshold returns the byte-identical result set (ids, order, similarity) as
+ * the previous threshold-in-WHERE query shape, against a real isolated
+ * PGlite/Postgres adapter. The threshold predicate is monotone in the ORDER BY
+ * key (similarity >= T is distance <= 1 - T), so every passing row is a prefix
+ * of the distance-ordered eligible sequence — filtering the top K after the
+ * LIMIT can neither drop nor add a row. The in-WHERE form is replayed here as
+ * raw SQL to pin that equivalence for plentiful, sparse, and no-match corpora,
+ * plus the unchanged scope-in-WHERE and zero/absent-threshold contracts.
+ */
+import { ChannelType, type Memory, type Room, type UUID, type World } from "@elizaos/core";
+import { sql } from "drizzle-orm";
+import { v4 } from "uuid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { PgDatabaseAdapter } from "../../pg/adapter";
+import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { getDb } from "../../types";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+const DIMS = 384;
+const TABLE = "threshold-postfilter";
+
+/** Unit vector at an exact cosine similarity to the query axis `e0`. */
+function vectorAtSimilarity(similarity: number): number[] {
+  const rest = Math.sqrt(Math.max(0, 1 - similarity * similarity));
+  return Array.from({ length: DIMS }, (_, i) => {
+    if (i === 0) return similarity;
+    if (i === 1) return rest;
+    return 0;
+  });
+}
+
+const QUERY = vectorAtSimilarity(1);
+
+/** Exact cosine similarities seeded into the corpus (all distinct, so both
+ * query shapes have one deterministic order). Six rows sit at or above 0.7. */
+const SEEDED_SIMILARITIES = [0.98, 0.95, 0.9, 0.85, 0.8, 0.72, 0.65, 0.6, 0.5, 0.35, 0.2, 0.05];
+
+describe("searchMemoriesByEmbedding threshold post-filter (query-shape identity)", () => {
+  let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
+  let cleanup: () => Promise<void>;
+  let testAgentId: UUID;
+  let roomId: UUID;
+  let entityId: UUID;
+  const idBySimilarity = new Map<number, UUID>();
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("threshold_postfilter");
+    adapter = setup.adapter;
+    cleanup = setup.cleanup;
+    testAgentId = setup.testAgentId;
+
+    const worldId = v4() as UUID;
+    roomId = v4() as UUID;
+    entityId = v4() as UUID;
+    await adapter.createWorld({
+      id: worldId,
+      agentId: testAgentId,
+      name: "Threshold World",
+      serverId: "threshold-server",
+    } as World);
+    await adapter.createRooms([
+      {
+        id: roomId,
+        agentId: testAgentId,
+        worldId,
+        name: "Threshold Room",
+        source: "test",
+        type: ChannelType.GROUP,
+      } as Room,
+    ]);
+    await adapter.createEntities([
+      { id: entityId, agentId: testAgentId, names: ["Threshold Entity"] },
+    ]);
+
+    for (const similarity of SEEDED_SIMILARITIES) {
+      const id = v4() as UUID;
+      idBySimilarity.set(similarity, id);
+      await adapter.createMemory(
+        {
+          id,
+          content: { text: `corpus row at similarity ${similarity}` },
+          createdAt: Date.now(),
+          embedding: vectorAtSimilarity(similarity),
+          agentId: testAgentId,
+          roomId,
+          entityId,
+          unique: false,
+        } as Memory,
+        TABLE
+      );
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  /** The previous adapter query shape — similarity floor inside the WHERE of
+   * the ordered scan — replayed verbatim as the baseline oracle. */
+  async function baselineThresholdInWhere(
+    threshold: number,
+    limit: number
+  ): Promise<Array<{ id: string; similarity: number }>> {
+    const vec = `[${QUERY.join(",")}]`;
+    const result = await getDb(adapter).execute(
+      sql.raw(
+        `SELECT m.id AS id, 1 - (e.dim_384 <=> '${vec}'::vector) AS similarity ` +
+          `FROM embeddings e JOIN memories m ON m.id = e.memory_id ` +
+          `WHERE e.dim_384 IS NOT NULL AND m.type = '${TABLE}' AND m.agent_id = '${testAgentId}' ` +
+          `AND 1 - (e.dim_384 <=> '${vec}'::vector) >= ${threshold} ` +
+          `ORDER BY e.dim_384 <=> '${vec}'::vector ASC LIMIT ${limit}`
+      )
+    );
+    const rows = Array.isArray(result) ? result : (result.rows ?? []);
+    return rows.map((row) => {
+      const record = row as { id: string; similarity: number | string };
+      return { id: record.id, similarity: Number(record.similarity) };
+    });
+  }
+
+  async function searchWithThreshold(threshold: number | undefined, limit: number) {
+    return adapter.searchMemoriesByEmbedding(QUERY, {
+      tableName: TABLE,
+      count: limit,
+      ...(threshold === undefined ? {} : { match_threshold: threshold }),
+    });
+  }
+
+  it("matches the threshold-in-WHERE baseline when more rows pass than the limit (plentiful)", async () => {
+    const limit = 4;
+    const current = await searchWithThreshold(0.7, limit);
+    const baseline = await baselineThresholdInWhere(0.7, limit);
+
+    expect(current.map((m) => m.id)).toEqual(baseline.map((row) => row.id));
+    expect(current).toHaveLength(limit);
+    current.forEach((memory, i) => {
+      expect(memory.similarity ?? 0).toBeCloseTo(baseline[i].similarity, 10);
+    });
+  });
+
+  it("matches the baseline when fewer rows pass than the limit (sparse)", async () => {
+    const limit = 10;
+    const current = await searchWithThreshold(0.7, limit);
+    const baseline = await baselineThresholdInWhere(0.7, limit);
+
+    // Exactly the six seeded rows at similarity >= 0.7, in descending order.
+    expect(current.map((m) => m.id)).toEqual(baseline.map((row) => row.id));
+    expect(current.map((m) => m.id)).toEqual(
+      [0.98, 0.95, 0.9, 0.85, 0.8, 0.72].map((s) => idBySimilarity.get(s))
+    );
+    for (const memory of current) {
+      expect(memory.similarity ?? 0).toBeGreaterThanOrEqual(0.7);
+    }
+  });
+
+  it("matches the baseline when nothing passes the threshold (no-match turn)", async () => {
+    const current = await searchWithThreshold(0.99, 10);
+    const baseline = await baselineThresholdInWhere(0.99, 10);
+
+    expect(current).toEqual([]);
+    expect(baseline).toEqual([]);
+  });
+
+  it("applies no similarity floor when match_threshold is absent or zero (unchanged truthiness contract)", async () => {
+    const absent = await searchWithThreshold(undefined, SEEDED_SIMILARITIES.length);
+    expect(absent).toHaveLength(SEEDED_SIMILARITIES.length);
+
+    const zero = await searchWithThreshold(0, SEEDED_SIMILARITIES.length);
+    expect(zero.map((m) => m.id)).toEqual(absent.map((m) => m.id));
+  });
+
+  it("keeps scope predicates inside the ordered scan (no starvation from closer out-of-scope rows)", async () => {
+    // Plant closer vectors in ANOTHER room; a room-scoped search must still
+    // surface this room's row rather than starving on the global top-K.
+    const otherRoomId = v4() as UUID;
+    await adapter.createRooms([
+      {
+        id: otherRoomId,
+        agentId: testAgentId,
+        name: "Other Room",
+        source: "test",
+        type: ChannelType.GROUP,
+      } as Room,
+    ]);
+    for (let i = 0; i < 20; i++) {
+      await adapter.createMemory(
+        {
+          id: v4() as UUID,
+          content: { text: `closer out-of-scope ${i}` },
+          createdAt: Date.now(),
+          embedding: vectorAtSimilarity(0.999),
+          agentId: testAgentId,
+          roomId: otherRoomId,
+          entityId,
+          unique: false,
+        } as Memory,
+        TABLE
+      );
+    }
+
+    const scoped = await adapter.searchMemoriesByEmbedding(QUERY, {
+      tableName: TABLE,
+      roomId,
+      count: 1,
+      match_threshold: 0.7,
+    });
+    expect(scoped.map((m) => m.id)).toEqual([idBySimilarity.get(0.98)]);
+  });
+});

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -3416,19 +3416,29 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       const activeColumn = embeddingTable[this.embeddingDimension];
       const count = params.count ?? 10;
 
-      // Eligibility lives INSIDE the ordered scan: every scope predicate
-      // (type, agent, room, world, entity, uniqueness, threshold) is part of
-      // the WHERE of the same query that orders by the raw distance operator.
-      // The contract is "top K among eligible memories" — a two-stage form
-      // that takes a global top-K first and filters afterwards silently drops
-      // eligible matches whenever closer out-of-scope vectors outnumber the
-      // candidate pool (multi-agent and room-scoped recall starve first).
-      // Ordering by `asc(cosineDistance(...))` — not by the derived
-      // similarity — is the shape the HNSW index (ensureEmbeddingVectorIndex)
-      // can serve; `hnsw.iterative_scan = strict_order` keeps a filtered
-      // index scan refilling until the LIMIT is satisfied, and when the
-      // planner prefers a non-index plan for a selective scope the result is
-      // identical, just unaccelerated.
+      // SCOPE eligibility lives INSIDE the ordered scan: every scope predicate
+      // (type, agent, room, world, entity, uniqueness) is part of the WHERE of
+      // the same query that orders by the raw distance operator. The contract
+      // is "top K among eligible memories" — a two-stage form that takes a
+      // global top-K first and filters afterwards silently drops eligible
+      // matches whenever closer out-of-scope vectors outnumber the candidate
+      // pool (multi-agent and room-scoped recall starve first). Ordering by
+      // `asc(cosineDistance(...))` — not by the derived similarity — is the
+      // shape the HNSW index (ensureEmbeddingVectorIndex) can serve;
+      // `hnsw.iterative_scan = strict_order` keeps a scope-filtered index scan
+      // refilling until the LIMIT is satisfied, and when the planner prefers a
+      // non-index plan for a selective scope the result is identical, just
+      // unaccelerated.
+      //
+      // The THRESHOLD is deliberately NOT in the WHERE. Unlike the scope
+      // predicates it is monotone in the ORDER BY key (similarity >= T is
+      // distance <= 1 - T), so every row passing it is a prefix of the
+      // distance-ordered scope-eligible sequence and filtering the top K
+      // after the LIMIT returns the identical result set. Inside the WHERE it
+      // is a starvation predicate instead: on a no-close-match query (most
+      // turns) nothing passes, and the strict_order iterative scan chews
+      // through the index up to hnsw.max_scan_tuples computing distances for
+      // rows it will discard — measured as the dominant composeState cost.
       const distance = cosineDistance(activeColumn, cleanVector);
       const similarity = sql<number>`1 - (${distance})`;
       const conditions = [
@@ -3449,11 +3459,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       if (params.entityId) {
         conditions.push(eq(memoryTable.entityId, params.entityId));
       }
-      if (params.match_threshold) {
-        conditions.push(gte(similarity, params.match_threshold));
-      }
 
-      const results = await this.db
+      const candidates = await this.db
         .select({
           memory: memoryTable,
           similarity,
@@ -3464,6 +3471,13 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .where(and(...conditions))
         .orderBy(asc(distance))
         .limit(count);
+
+      // Same truthiness contract as the removed WHERE predicate: an absent or
+      // zero threshold applies no similarity floor.
+      const matchThreshold = params.match_threshold;
+      const results = matchThreshold
+        ? candidates.filter((row) => row.similarity >= matchThreshold)
+        : candidates;
 
       return results.map((row) => ({
         id: row.memory.id as UUID,


### PR DESCRIPTION
## Problem

The `relevant-conversations` provider dominates the reply critical path. Live `InferenceTiming` on a routine turn: `provider:relevant-conversations=1738ms` inside `composeState=1739ms`, on a turn whose reply model call was ~816ms — recall costs more than the answer, on nearly every message.

Per prior review direction this is a root-cause fix, not a timeout: the provider's `timeoutMs`/`timeoutMode` are untouched and no stage got a deadline.

## Instrumentation first

New stage-decomposition bench: `packages/agent/scripts/bench-relevant-conversations.ts` (`bun run --cwd packages/agent perf:relevant-conversations`). It boots a real PGlite-backed `AgentRuntime` + `plugin-sql`, seeds a deterministic local corpus (message memories with HNSW-indexed 384-dim embeddings across 64 rooms + 2,000 hash-memory rows), and times every pipeline stage independently, including `EXPLAIN ANALYZE` on both vector-query shapes.

Measured decomposition at 8,000 vectors (medians, 5 reps, this VPS):

| stage (serial in the old provider) | old | new |
|---|---|---|
| getRoom(current) | 3.5ms | 0.7ms |
| buildAccessContext | 1.1ms | 0.7ms |
| hash-memory getMemories (2,000 rows) | 62.5ms | 46.1ms (now overlaps semantic branch) |
| BM25 rank over 2,000 rows | 47.7ms | 40.4ms |
| shared recall embed | prefetched (#17879 seam) | unchanged |
| semantic searchMemories, no-close-match query | **51.9ms** | **7.8ms** |
| room tags for results (10 rooms) | 7.5ms (10 sequential reads) | 1.0ms (1 batched read) |
| **provider end-to-end, no-close-match query** | **143.3ms** | **90.6ms** |
| provider end-to-end, close-match query | 98.0ms | 80.7ms |

## Root cause 1: the vector query shape defeats HNSW termination (the corpus-scaling dominator)

`searchMemoriesByEmbedding` put the similarity floor **inside the WHERE** of the distance-ordered scan. On a no-close-match turn (most turns) nothing passes the floor, so the `hnsw.iterative_scan = strict_order` index scan keeps refilling — computing distances for rows it will discard — until `hnsw.max_scan_tuples`. `EXPLAIN ANALYZE` from the bench at 20,000 vectors:

```
threshold-in-WHERE (old shape), no-close-match query:
  Index Scan using idx_embeddings_dim_384_hnsw_cosine ... rows=0
        Rows Removed by Filter: 19454
  Execution Time: 107.5 ms          (grows linearly with corpus size)

no-threshold top-K + post-filter (new shape), same query:
  Index Scan using idx_embeddings_dim_384_hnsw_cosine ... rows=15
  Execution Time: 8.6 ms            (flat: O(K) tuples regardless of corpus)
```

Corpus scaling measured (raw SQL, no-close-match query): 2K vectors 15.6ms → 8K 58.6ms → 20K 107.5ms for the old shape; 5.1ms → 5.9ms → 8.6ms for the new shape. The live bot sits at ~60K vectors with wider embeddings on a single-threaded PGlite connection shared by every compose-time provider — this scan is the 1.7s.

**Fix (structural, in the adapter):** the similarity floor is *monotone in the ORDER BY key* (`similarity >= T` ⇔ `distance <= 1 - T`), so every row passing it is a prefix of the distance-ordered eligible sequence — filtering the top-K **after** the LIMIT returns the identical result set. The floor moves out of the WHERE; every **scope** predicate (type, agent, room, world, entity, uniqueness) deliberately stays inside the ordered scan (non-monotone — moving those would starve scoped recall, which the existing crowding tests pin). Every `searchMemories` caller benefits, including the `createMemory` uniqueness probe (threshold 0.95, which paid the same exhausted scan on most memory writes).

## Root cause 2: independent stages serialized

The lexical hash-memory scan and the embed→vector-search branch are independent; the provider ran them serially. They now run concurrently, so the hash scan overlaps the embed round-trip (and, on multi-connection Postgres, the search itself). Failure of either branch rejects into the same outer catch as before — identical wholesale degrade.

## Root cause 3: N sequential room reads per turn

Result-room source tags issued one `getRoom` per distinct room, serially (the runtime's room memo TTL is 1s — shorter than a turn gap, so every turn re-paid them). Replaced by one batched `getRoomsByIds` read: 7.5ms → 1.0ms for 10 rooms, degrading to untagged rooms on failure exactly as the old per-room catch did.

## Recall results provably unchanged

- `plugins/plugin-sql/src/__tests__/integration/memory-search-threshold-postfilter.real.test.ts` replays the old threshold-in-WHERE query verbatim as a raw-SQL oracle against a real isolated PGlite adapter and asserts the new adapter output is identical (ids, order, similarity) for plentiful-match, sparse-match, and no-match corpora at exact seeded cosine similarities; plus the unchanged zero/absent-threshold truthiness contract and the scope-starvation guard.
- Existing `memory.real.test.ts` (38 tests, incl. the out-of-scope crowding suite and the threshold case) passes unchanged.
- Provider tests pin the batched room read (one call, distinct ids), the hash∥semantic concurrency, tag degrade on room-read failure, and the untouched fail-open/report-and-degrade paths (`relevant-conversations.fastfail.test.ts` unchanged and green).

## Evidence

| check | result |
|---|---|
| local corpus bench, stage decomposition + before/after | table + EXPLAIN above; full output reproducible via `bun run --cwd packages/agent perf:relevant-conversations` |
| plugin-sql query-shape identity suite (real PGlite) | 5/5 pass |
| plugin-sql `memory.real.test.ts` (real PGlite) | 38/38 pass |
| plugin-sql default test lane | 18 files, 109 tests pass |
| agent provider suites + chat-augmentation | 15 files, 104 tests pass |
| agent `database.search-vectors` action test | 1/1 pass |
| plugin-sql typecheck + lint | pass |
| agent lint | pass |
| agent typecheck | fails on develop baseline too (`TS2550 findLast` in `plugin-agent-orchestrator/src/services/smithers-task-integration.ts`, ES2022 lib) — verified identical with this diff fully reverted; unrelated pre-existing failure |
| UI screenshots / video / frontend logs | N/A — server-side provider + SQL adapter change, no UI surface |

<details>
<summary>plugin-sql identity suite output</summary>

```
✓ __tests__/integration/memory-search-threshold-postfilter.real.test.ts (5 tests) 6327ms
  ✓ matches the threshold-in-WHERE baseline when more rows pass than the limit (plentiful)
  ✓ matches the baseline when fewer rows pass than the limit (sparse)
  ✓ matches the baseline when nothing passes the threshold (no-match turn)
  ✓ applies no similarity floor when match_threshold is absent or zero (unchanged truthiness contract)
  ✓ keeps scope predicates inside the ordered scan (no starvation from closer out-of-scope rows)
Test Files  1 passed (1)   Tests  5 passed (5)
```
</details>

<details>
<summary>existing real memory suite output</summary>

```
✓ __tests__/integration/memory.real.test.ts (38 tests) — incl.
  ✓ finds the eligible memory when 300 nearer vectors live in another table
  ✓ finds the eligible memory when 300 nearer vectors live in another room
  ✓ finds the eligible memory when 300 nearer vectors belong to another agent
Test Files  1 passed (1)   Tests  38 passed (38)
```
</details>

<details>
<summary>agent provider suites output</summary>

```
bunx vitest run src/providers/ src/api/chat-augmentation.test.ts
Test Files  15 passed (15)   Tests  104 passed (104)
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:439d4be1af5459b8fa9dc938917f5a0c56a44026 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server-side provider and SQL adapter change; no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - server-side provider and SQL adapter change; no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - server-side provider and SQL adapter change; no UI surface

<!-- evidence-row:backend-logs -->
- [x] [17921-local-corpus-bench-stage-decomposition.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17921-local-corpus-bench-stage-decomposition.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface in this change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-call behavior change; recall output proven identical by the query-shape identity suite; the shared recall-embed path is untouched

<!-- evidence-row:domain-artifacts -->
- [x] [17921-recall-identity-suite-real-pglite.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17921-recall-identity-suite-real-pglite.log)


<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`
