### PR TITLE
fix(orchestrator): keep paths, uuids, and disk telemetry out of user-facing chat text

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
@@ -6,6 +6,7 @@ import { promoteSubactionsToActions } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 // SPAWN_AGENT is `TASKS { action: "spawn_agent" }`.
 import { spawnAgentAction } from "../../src/actions/tasks.js";
+import { workspaceDiskBudgetError } from "../../src/services/workspace-registry.js";
 import {
   callback,
   memory,
@@ -477,5 +478,54 @@ describe("TASKS:spawn_agent", () => {
         )
       )?.error,
     ).toBe("INVALID_CREDENTIALS");
+  });
+
+  it("keeps a disk-budget refusal human in text and technical in error data", async () => {
+    const svc = serviceMock({
+      spawnSession: vi.fn(async () => {
+        throw workspaceDiskBudgetError(
+          {
+            allowed: false,
+            reclaimedBytes: 0,
+            reclaimedCount: 0,
+            freeBytes: 753868800,
+            usedBytes: 0,
+            reason: "free-disk-floor",
+          },
+          { capBytes: 21474836480, minFreeBytes: 2147483648 },
+          "/home/user/.eliza/workspaces",
+        );
+      }),
+    });
+
+    const result = await spawnAgentAction.handler(
+      runtimeWith(svc),
+      memory({ task: "x" }),
+      state,
+      spawnOptions,
+      callback(),
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe("WORKSPACE_DISK_BUDGET_EXCEEDED");
+    // Chat-bound text stays human: no byte counts, caps, or fs paths.
+    expect(result?.text).toBe(
+      "Failed to spawn agent: the workspace disk is nearly full, so a new coding workspace cannot be created right now",
+    );
+    expect(result?.text).not.toMatch(/used=|free=|cap=|minFree=/);
+    expect(result?.text).not.toContain("/home/");
+    // The byte-level fields still ride the action's error data for
+    // logs/trajectories and planner diagnostics.
+    expect(result?.data).toMatchObject({
+      errorCode: "WORKSPACE_DISK_BUDGET_EXCEEDED",
+      errorContext: {
+        reason: "free-disk-floor",
+        usedBytes: 0,
+        freeBytes: 753868800,
+        capBytes: 21474836480,
+        minFreeBytes: 2147483648,
+        targetRoot: "/home/user/.eliza/workspaces",
+      },
+    });
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-identity.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-identity.test.ts
@@ -98,6 +98,18 @@ describe("writeWorkspaceIdentity", () => {
     expect(SUB_AGENT_IDENTITY_MD).toMatch(/SOUL\.md/);
   });
 
+  it("bans absolute paths and internal ids from the final message", () => {
+    // The final message is relayed into user chat; internal workspace paths
+    // (task-<uuid> dirs) and session/task ids must stay in logs/trajectories.
+    expect(SUB_AGENT_IDENTITY_MD).toMatch(
+      /NEVER include absolute filesystem paths/,
+    );
+    expect(SUB_AGENT_IDENTITY_MD).toMatch(/workspace\/session ids/);
+    expect(SUB_AGENT_IDENTITY_MD).toMatch(
+      /bare name or workspace-relative path/,
+    );
+  });
+
   it("does NOT clobber a real project's existing AGENTS.md", async () => {
     const original = "# my real project\n";
     writeFileSync(join(dir, "AGENTS.md"), original, "utf8");

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -455,6 +455,38 @@ describe("SubAgentRouter", () => {
     );
   });
 
+  it("keeps the internal workdir out of the task_complete planner header", async () => {
+    session = makeSession({
+      metadata: {
+        label: "fix-bug-42",
+        roomId: ROOM,
+        worldId: WORLD,
+        userId: USER,
+        messageId: PARENT_MSG,
+        source: "telegram",
+      },
+    });
+    acp = makeAcpService(session);
+    const { runtime, handleMessage } = makeRuntime({ acp: acp.service });
+    await SubAgentRouter.start(runtime);
+
+    acp.emit(SESSION_ID, "task_complete", { response: "done" });
+    await new Promise((r) => setImmediate(r));
+
+    const text = String(handleMessage.mock.calls[0]?.[1]?.content?.text);
+    const [headerLine] = text.split("\n");
+    expect(headerLine).toContain("[sub-agent:");
+    expect(headerLine).toContain("task_complete");
+    // The planner echoes header instructions into its user-facing reply — an
+    // absolute internal workspace path in the header gets recited into chat
+    // (observed live). The directive must instead demand a human summary with
+    // no internal paths/ids, while keeping the anti-substitution guidance.
+    expect(headerLine).not.toContain(session.workdir);
+    expect(headerLine).toContain("never repeat absolute filesystem paths");
+    expect(headerLine).toContain("never claim a user-requested path");
+    expect(headerLine).toContain("do NOT start another sub-agent");
+  });
+
   it("dedupes task/worktree swarm rooms when both roles share one room", async () => {
     session = makeSession({
       metadata: {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
@@ -174,8 +174,11 @@ describe("TASKS:history", () => {
     });
     expect(result?.success).toBe(true);
     expect(result?.text).toContain(
-      'The orchestrator task containing session session-older is "Long-running migration" [active].',
+      'The orchestrator task for that session is "Long-running migration" [active].',
     );
+    // The raw session uuid is planner/log detail — user-bound text never
+    // carries it (it stays in data.filters below).
+    expect(result?.text).not.toContain("session-older");
     expect(result?.text).toContain("Latest session: newest-agent");
     expect(result?.text).not.toContain("Unrelated work");
     expect(result?.data?.taskIds).toEqual(["task-target"]);
@@ -212,11 +215,95 @@ describe("TASKS:history", () => {
     expect(taskService.listTasks).not.toHaveBeenCalled();
     expect(result?.success).toBe(true);
     expect(result?.text).toContain(
-      "I did not find any orchestrator task threads matching session session-missing.",
+      "I did not find any orchestrator task threads matching that session.",
     );
+    // The raw session uuid stays out of user-bound text; the structural
+    // filter value remains available in the action data.
+    expect(result?.text).not.toContain("session-missing");
+    expect(result?.data?.filters).toMatchObject({
+      sessionId: "session-missing",
+    });
     expect(result?.data?.count).toBe(0);
     expect(result?.data?.taskIds).toEqual([]);
     expect(historyCallback).not.toHaveBeenCalled();
+  });
+
+  it("names the in-flight task instead of claiming nothing was found when filters exclude a running build", async () => {
+    const tasks = [
+      task({
+        id: "task-building",
+        title: "color-pop",
+        status: "active",
+        activeSessionCount: 1,
+      }),
+    ];
+    const taskService = { listTasks: vi.fn(async () => tasks) };
+
+    const result = await taskHistoryAction.handler(
+      runtimeWithServices({ taskService }),
+      memory({ text: "what did you just change?" }),
+      state,
+      {
+        parameters: {
+          action: "history",
+          metric: "list",
+          statuses: ["done"],
+        },
+      },
+      callback(),
+    );
+
+    expect(result?.success).toBe(true);
+    expect(result?.text).toContain('still working on "color-pop"');
+    expect(result?.text).not.toContain("did not find");
+    expect(result?.data?.count).toBe(0);
+    expect(result?.data?.inFlight).toEqual({ taskId: "task-building" });
+  });
+
+  it("falls back to a running ACP session for the in-flight answer on a session-index miss", async () => {
+    const taskService = {
+      getTaskForSession: vi.fn(async () => null),
+      listTasks: vi.fn(async () => []),
+    };
+    const acpService = serviceMock({
+      listSessions: vi.fn(() => [
+        {
+          id: "01234567-89ab-cdef-0123-456789abcdef",
+          name: "agent-one",
+          agentType: "codex",
+          workdir: "/repo/a",
+          status: "running",
+          approvalPreset: "standard",
+          createdAt: new Date("2026-08-07T10:00:00.000Z"),
+          lastActivityAt: new Date("2026-08-07T10:00:00.000Z"),
+          metadata: { label: "color-pop" },
+        },
+      ]),
+    });
+
+    const result = await taskHistoryAction.handler(
+      runtimeWithServices({ taskService, acpService }),
+      memory({ text: "what did you just change?" }),
+      state,
+      {
+        parameters: {
+          action: "history",
+          sessionId: "session-missing",
+        },
+      },
+      callback(),
+    );
+
+    expect(taskService.listTasks).not.toHaveBeenCalled();
+    expect(result?.success).toBe(true);
+    expect(result?.text).toContain('still working on "color-pop"');
+    // Neither the queried session uuid nor the running session's uuid may
+    // reach user-bound text; the running session id rides the action data.
+    expect(result?.text).not.toContain("session-missing");
+    expect(result?.text).not.toContain("01234567-89ab-cdef");
+    expect(result?.data?.inFlight).toEqual({
+      sessionId: "01234567-89ab-cdef-0123-456789abcdef",
+    });
   });
 
   it("applies the active window before the requested result limit", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-spawn-disk-budget.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-spawn-disk-budget.test.ts
@@ -9,6 +9,7 @@
 import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { ElizaError } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AcpService } from "../services/acp-service.ts";
 import { InMemorySessionStore } from "../services/session-store.ts";
@@ -149,9 +150,30 @@ describe("AcpService spawn disk-budget + registry (#13773)", () => {
     );
     (svc as unknown as { started: boolean }).started = true;
 
-    await expect(
-      svc.spawnSession({ agentType: "opencode", slotClass: "worker" }),
-    ).rejects.toThrow(/disk budget/i);
+    let refusal: unknown;
+    try {
+      await svc.spawnSession({ agentType: "opencode", slotClass: "worker" });
+    } catch (err) {
+      refusal = err;
+    }
+    // The refusal is a structured ElizaError whose MESSAGE is chat-safe (an
+    // action boundary relays it toward the user verbatim): human words, no
+    // byte counts, no filesystem paths. The technical fields ride `context`.
+    expect(refusal).toBeInstanceOf(ElizaError);
+    const budgetError = refusal as ElizaError;
+    expect(budgetError.code).toBe("WORKSPACE_DISK_BUDGET_EXCEEDED");
+    expect(budgetError.message).toBe(
+      "the workspace disk is nearly full, so a new coding workspace cannot be created right now",
+    );
+    expect(budgetError.message).not.toMatch(/\d/);
+    expect(budgetError.message).not.toContain(root);
+    expect(budgetError.context).toMatchObject({
+      reason: "free-disk-floor",
+      minFreeBytes: Number.MAX_SAFE_INTEGER,
+    });
+    expect(typeof budgetError.context?.freeBytes).toBe("number");
+    expect(typeof budgetError.context?.usedBytes).toBe("number");
+    expect(String(budgetError.context?.targetRoot)).toContain(root);
 
     expect(readdirSync(root)).toEqual([]);
   });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
@@ -20,6 +20,7 @@ import {
   resetSharedWorkspaceRegistry,
   resolveDiskBudgetConfig,
   WorkspaceRegistry,
+  workspaceDiskBudgetError,
 } from "../services/workspace-registry.js";
 import { CodingWorkspaceService } from "../services/workspace-service.js";
 
@@ -224,6 +225,42 @@ describe("measureDirBytes", () => {
   it("returns 0 for a missing dir", async () => {
     const total = await measureDirBytes(join(tmpdir(), "does-not-exist-13773"));
     expect(total).toBe(0);
+  });
+});
+
+describe("workspaceDiskBudgetError", () => {
+  it("keeps the message human and the technical fields in context", () => {
+    const error = workspaceDiskBudgetError(
+      {
+        allowed: false,
+        reclaimedBytes: 4096,
+        reclaimedCount: 1,
+        freeBytes: 753868800,
+        usedBytes: 0,
+        reason: "free-disk-floor",
+      },
+      { capBytes: 21474836480, minFreeBytes: 2147483648 },
+      "/home/user/.eliza/workspaces",
+    );
+    expect(error.code).toBe("WORKSPACE_DISK_BUDGET_EXCEEDED");
+    expect(error.severity).toBe("ephemeral");
+    // Chat-safe by construction: an action boundary relays the message
+    // verbatim, so no byte counts, uuids, or filesystem paths may ride in it.
+    expect(error.message).toBe(
+      "the workspace disk is nearly full, so a new coding workspace cannot be created right now",
+    );
+    expect(error.message).not.toMatch(/\d/);
+    expect(error.message).not.toContain("/");
+    expect(error.context).toEqual({
+      reason: "free-disk-floor",
+      usedBytes: 0,
+      freeBytes: 753868800,
+      capBytes: 21474836480,
+      minFreeBytes: 2147483648,
+      reclaimedBytes: 4096,
+      reclaimedCount: 1,
+      targetRoot: "/home/user/.eliza/workspaces",
+    });
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -1965,15 +1965,25 @@ async function runSpawnAgent(
   } catch (error) {
     // error-policy:J1 spawn action boundary → structured failure to the
     // planner; no visible callback (see runSend's catch) — the evaluator
-    // reports the failure in voice instead of a raw canned bubble.
+    // reports the failure in voice instead of a raw canned bubble. The
+    // planner echoes `text` toward chat, so producers must keep their
+    // messages human (ElizaError with technical fields in `context`);
+    // that context is preserved here in the action's error data.
     const messageTextValue = failureMessage(error);
-    const code = isAuthError(error) ? "INVALID_CREDENTIALS" : messageTextValue;
+    const code = isAuthError(error)
+      ? "INVALID_CREDENTIALS"
+      : error instanceof ElizaError
+        ? error.code
+        : messageTextValue;
     return {
       success: false,
       error: code,
       text: isAuthError(error)
         ? "Task-agent credentials are invalid; tell the user the coding agent could not authenticate."
         : `Failed to spawn agent: ${messageTextValue}`,
+      ...(error instanceof ElizaError && error.context
+        ? { data: { errorCode: error.code, errorContext: error.context } }
+        : {}),
       continueChain: false,
     };
   }

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -2623,6 +2623,41 @@ function sessionMatchesTaskStatus(
   return status === taskStatus;
 }
 
+/**
+ * Best-effort probe for the empty-history answer: "I found no task threads"
+ * while a build is visibly running mid-turn reads as a contradiction in chat
+ * (observed live on "what did you just change?" during a build). Prefers the
+ * durable candidates the filters excluded, then falls back to any non-terminal
+ * ACP session. Returns a chat-safe display name (title/label in quotes — never
+ * a raw uuid) plus structural ids for the action data.
+ */
+async function findInFlightWork(
+  runtime: IAgentRuntime,
+  candidates: readonly TaskThreadDto[],
+): Promise<{ name: string; taskId?: string; sessionId?: string } | undefined> {
+  const running = candidates.find(
+    (task) =>
+      !task.paused &&
+      task.activeSessionCount > 0 &&
+      (task.status === "active" || task.status === "open"),
+  );
+  if (running) return { name: `"${running.title}"`, taskId: running.id };
+  const service = getAcpService(runtime);
+  if (!service) return undefined;
+  const active = (await listSessionsWithin(service)).find(
+    (session) => !TERMINAL_SESSION_STATUSES.has(session.status.toLowerCase()),
+  );
+  if (!active) return undefined;
+  const label =
+    typeof active.metadata?.label === "string"
+      ? active.metadata.label
+      : active.name;
+  return {
+    name: label ? `"${label}"` : "a coding task",
+    sessionId: active.id,
+  };
+}
+
 function failureResult(
   actionName: string,
   error: string,
@@ -2708,22 +2743,28 @@ async function runHistory(
         statuses.length > 0 ? `statuses ${statuses.join(", ")}` : undefined,
         search ? `search "${search}"` : undefined,
         projectId ? `project ${projectId}` : undefined,
-        sessionId ? `session ${sessionId}` : undefined,
+        // The raw session uuid is planner/log detail (kept in data.filters);
+        // user-bound text refers to it in plain words.
+        sessionId ? "that session" : undefined,
         includeArchived ? "including archived" : undefined,
       ].filter((part): part is string => Boolean(part));
       const filterSuffix =
         filterParts.length > 0 ? ` matching ${filterParts.join("; ")}` : "";
 
       let responseText = "";
+      let inFlight: Awaited<ReturnType<typeof findInFlightWork>> | undefined;
       if (metric === "count") {
         responseText = `I found ${count} orchestrator task${count === 1 ? "" : "s"}${filterSuffix}.`;
       } else if (tasks.length === 0) {
-        responseText = `I did not find any orchestrator task threads${filterSuffix}.`;
+        inFlight = await findInFlightWork(runtime, taskCandidates);
+        responseText = inFlight
+          ? `Nothing has finished yet — I'm still working on ${inFlight.name}.`
+          : `I did not find any orchestrator task threads${filterSuffix}.`;
       } else if (metric === "detail") {
         const task = tasks[0];
         responseText = [
           sessionId
-            ? `The orchestrator task containing session ${sessionId} is "${task.title}" [${task.status}].`
+            ? `The orchestrator task for that session is "${task.title}" [${task.status}].`
             : `The most recent orchestrator task is "${task.title}" [${task.status}].`,
           `Task id: ${task.id}`,
           `Latest session: ${task.latestSessionLabel ?? task.latestSessionId ?? "none"}`,
@@ -2750,6 +2791,16 @@ async function runHistory(
           actionName: "TASKS:history",
           count,
           taskIds: tasks.map((task) => task.id),
+          ...(inFlight
+            ? {
+                inFlight: {
+                  ...(inFlight.taskId ? { taskId: inFlight.taskId } : {}),
+                  ...(inFlight.sessionId
+                    ? { sessionId: inFlight.sessionId }
+                    : {}),
+                },
+              }
+            : {}),
           filters: {
             metric,
             ...(window ? { window } : {}),

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -138,6 +138,7 @@ import {
   getSharedWorkspaceRegistry,
   resolveDiskBudgetConfig,
   type WorkspaceRegistry,
+  workspaceDiskBudgetError,
 } from "./workspace-registry.js";
 
 export {
@@ -1253,11 +1254,9 @@ export class AcpService extends Service {
       });
     }
     if (!decision.allowed) {
-      throw new Error(
-        `workspace disk budget exceeded (${decision.reason}): ` +
-          `used=${decision.usedBytes} free=${decision.freeBytes} ` +
-          `cap=${config.capBytes} minFree=${config.minFreeBytes} root=${targetRoot}`,
-      );
+      // Human message; byte-level fields ride the error context and the
+      // registry's refusal warn log, never chat-bound prose.
+      throw workspaceDiskBudgetError(decision, config, targetRoot);
     }
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
@@ -149,6 +149,11 @@ the other end, only chat. Make that message the answer itself:
   A script you wrote but never ran is NOT the deliverable — it returns nothing,
   the answer the user asked for is missing, and you force a wasteful re-spawn.
   The value must come from a real execution, not from unexecuted code.
+- NEVER include absolute filesystem paths, workspace/session ids, or other
+  internal identifiers in the final message. Your workspace (and its
+  \`task-<uuid>\` path shape) is internal infrastructure the user cannot see or
+  browse — refer to a file by bare name or workspace-relative path, or omit
+  the path entirely when the deliverable itself is the answer.
 - Do NOT narrate your process. No "I'll load the workspace context first",
   "checking the workspace shape", "rg is not installed so I'll use…", "the file
   already exists, reading it before editing", no step-by-step play-by-play, no

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -3349,9 +3349,16 @@ function composeNarration(
     requestedType !== session.agentType
       ? ` Requested agent type was ${requestedType}; actual agent type was ${session.agentType}.`
       : "";
+  // The header is the planner's operating instruction for this turn, and the
+  // planner echoes what it is told into its user-facing reply. An earlier
+  // revision said "state the actual workdir (<abs path>)" to stop the planner
+  // claiming files landed at a user-requested location — and the planner
+  // obediently recited the absolute internal workspace path into chat. The
+  // directive now bans internal paths/ids outright while keeping the
+  // anti-substitution intent: files by bare name, never a claimed location.
   const header =
     event === "task_complete"
-      ? `[sub-agent: ${label} (${session.agentType}) — task_complete — this delegated task is DONE; the result is below, relay it to the user as the answer, state the actual workdir (${session.workdir}), do NOT substitute or repeat a requested path unless it matches the actual workdir, and do NOT start another sub-agent for it.${agentTypeNote}]`
+      ? `[sub-agent: ${label} (${session.agentType}) — task_complete — this delegated task is DONE; the result is below, relay it to the user as the answer and do NOT start another sub-agent for it. Summarize like a human: never repeat absolute filesystem paths or internal ids (session/task uuids, workspace dirs) in the reply — refer to files by bare name. The files live in the agent's own internal workspace, NOT in any folder the user asked for, so never claim a user-requested path.${agentTypeNote}]`
       : `[sub-agent: ${label} (${session.agentType}) — ${event}]`;
   if (event === QUESTION_FOR_TASK_CREATOR) {
     const message =
@@ -3405,9 +3412,10 @@ function composeNarration(
     // "verified" body line would pollute the completion body that downstream
     // consumers (notification preview, verified-URL fallback, the completion
     // evaluator's reply) read from, regressing existing narration tests. The
-    // authoritative workdir + requested-vs-actual-agent note lives in the
-    // planner-only header (stripped by every `[sub-agent:`-prefix reader), so
-    // it never leaks into the user-facing body.
+    // requested-vs-actual-agent note lives in the planner-only header
+    // (stripped by every `[sub-agent:`-prefix reader), so it never leaks into
+    // the user-facing body; the actual workdir stays out of both header and
+    // body — it is internal infrastructure available in session metadata.
     const missing = artifactVerification?.missingFiles ?? [];
     const unverifiedLine =
       artifactVerification &&
@@ -3424,8 +3432,8 @@ function composeNarration(
     ].filter((line) => typeof line === "string" && line.trim().length > 0);
     return `${header}\n${lines.join("\n")}`;
   }
-  // Genuinely no captured output — keep the explicit note. The workdir lives
-  // in the planner-only header, not the body.
+  // Genuinely no captured output — keep the explicit note. The workdir stays
+  // out of the narration entirely (internal path; session metadata carries it).
   if (response === undefined) {
     return `${header}\nsub-agent reports task complete (no captured output).`;
   }

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-registry.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-registry.ts
@@ -20,6 +20,7 @@
 import type { Dirent } from "node:fs";
 import { readdir, rm, stat, statfs } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { ElizaError } from "@elizaos/core";
 
 export type WorkspaceKind = "acp-scratch" | "git-workspace";
 
@@ -331,6 +332,38 @@ export class WorkspaceRegistry {
       usedBytes: used,
     };
   }
+}
+
+/**
+ * The one place a refused {@link BudgetDecision} becomes a throwable error.
+ * The message is deliberately human — an action-boundary catch relays
+ * `error.message` toward chat, so byte counts, caps, and filesystem paths
+ * must never ride in it. The technical fields live in the structured
+ * `context` (for the action's error data / `reportError`) and are already
+ * warn-logged by `checkDiskBudget` at refusal time.
+ */
+export function workspaceDiskBudgetError(
+  decision: BudgetDecision,
+  config: DiskBudgetConfig,
+  targetRoot: string,
+): ElizaError {
+  return new ElizaError(
+    "the workspace disk is nearly full, so a new coding workspace cannot be created right now",
+    {
+      code: "WORKSPACE_DISK_BUDGET_EXCEEDED",
+      severity: "ephemeral",
+      context: {
+        reason: decision.reason ?? "unknown",
+        usedBytes: decision.usedBytes,
+        freeBytes: decision.freeBytes,
+        capBytes: config.capBytes,
+        minFreeBytes: config.minFreeBytes,
+        reclaimedBytes: decision.reclaimedBytes,
+        reclaimedCount: decision.reclaimedCount,
+        targetRoot,
+      },
+    },
+  );
 }
 
 /**

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -121,6 +121,7 @@ import {
   getSharedWorkspaceRegistry,
   resolveDiskBudgetConfig,
   type WorkspaceRegistry,
+  workspaceDiskBudgetError,
 } from "./workspace-registry.js";
 
 export type {
@@ -797,11 +798,9 @@ export class CodingWorkspaceService {
       );
     }
     if (!decision.allowed) {
-      throw new Error(
-        `workspace disk budget exceeded (${decision.reason}): ` +
-          `used=${decision.usedBytes} free=${decision.freeBytes} ` +
-          `cap=${config.capBytes} minFree=${config.minFreeBytes} root=${targetRoot}`,
-      );
+      // Human message; byte-level fields ride the error context and the
+      // registry's refusal warn log, never chat-bound prose.
+      throw workspaceDiskBudgetError(decision, config, targetRoot);
     }
   }
 


### PR DESCRIPTION
Three orchestrator chat surfaces leaked internal machinery — absolute workspace paths, raw session uuids, and byte-level disk telemetry — verbatim into user-facing text. All three are structural fixes at the seam that produced the string, not regex on the outgoing message.

## What breaks today

- **Completion narration recites the workdir.** The `task_complete` planner header instructed "state the actual workdir (`<abs path>`)", so the planner dutifully recited the internal workspace path (and task/session ids) into chat. Users see `/home/.../.eliza/workspaces/<uuid>` in a "your task is done" message.
- **Disk-budget refusal dumps telemetry.** The workspace disk-budget gate threw a raw `used=/free=/cap=/minFree=/root=` string that action boundaries relayed verbatim into chat as the spawn refusal.
- **Task history answers "found nothing" with a uuid.** `i did not find any orchestrator task threads ... session <uuid>` was a double defect: a raw session uuid in user text, and a "found nothing" claim while a build was visibly running.

## Changes

- `services/sub-agent-router.ts` — the `task_complete` narration directive now bans absolute paths and internal ids while keeping its anti-substitution intent (name the deliverable concretely, never a path or id)
- `services/sub-agent-identity.ts` — the identity scaffold's final-message section forbids absolute paths/internal ids at the source, matching the router directive
- `services/workspace-registry.ts` + `services/workspace-service.ts` + `services/acp-service.ts` — the disk-budget refusal is now a single `ElizaError` (`workspaceDiskBudgetError()`) produced in workspace-registry with a human message; the byte-level fields ride `error.context` (already warn-logged by the registry at refusal time) and the spawn action's error data
- `actions/tasks.ts` — the task-history empty branch now probes durable candidates then non-terminal acp sessions (`findInFlightWork()`) and answers "still working on `<label>`"; session uuids stay in `data.filters` / `data.inFlight`, never in user text
- tests — new pins in `sub-agent-router.test.ts`, `sub-agent-identity.test.ts`, `task-history.test.ts`, `spawn-agent.test.ts`, `acp-spawn-disk-budget.test.ts`, `workspace-registry.test.ts`

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:10b87c3c4883eb2b0aa87da783180aa814346894 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - orchestrator service/action prompt-and-error seams; no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - orchestrator service/action prompt-and-error seams; nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend orchestration change; behavior is proven by the plugin's suite, not a screen flow.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - local plugin suite run, full verification output at this head.

<details><summary>Verification output at 10b87c3c4883eb2b0aa87da783180aa814346894</summary>

```text
$ git rebase origin/develop     (onto 9298cb46af8, #17916)
Successfully rebased and updated refs/heads/fix/humanize-orchestrator-output.

$ bun run typecheck        (plugins/plugin-agent-orchestrator)
$ tsc --noEmit -p tsconfig.json
exit 0

$ bun run test             (plugins/plugin-agent-orchestrator, full suite)
 Test Files  230 passed | 5 skipped (235)
      Tests  2638 passed | 8 skipped (2646)
   Start at  08:54:51
   Duration  114.19s (transform 61.24s, setup 2.65s, import 543.21s, tests 196.50s, environment 30ms)
exit 0

$ bunx @biomejs/biome check --no-errors-on-unmatched \
    src/actions/tasks.ts src/services/acp-service.ts \
    src/services/sub-agent-identity.ts src/services/sub-agent-router.ts \
    src/services/workspace-registry.ts src/services/workspace-service.ts \
    __tests__/unit/spawn-agent.test.ts __tests__/unit/sub-agent-identity.test.ts \
    __tests__/unit/sub-agent-router.test.ts __tests__/unit/task-history.test.ts \
    src/__tests__/acp-spawn-disk-budget.test.ts src/__tests__/workspace-registry.test.ts
Checked 12 files in 172ms. No fixes applied.
exit 0
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the narration/refusal/history paths this diff touches.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic prompt-directive and error-shape changes pinned by the plugin suite; no live inference is exercised by this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - isolated local run of the six touched test suites at this head, on top of the full-suite pass in the backend-logs row.

<details><summary>Isolated run output of the six touched suites</summary>

```text
$ bunx vitest run --config vitest.config.ts \
    __tests__/unit/spawn-agent.test.ts __tests__/unit/sub-agent-identity.test.ts \
    __tests__/unit/sub-agent-router.test.ts __tests__/unit/task-history.test.ts \
    src/__tests__/acp-spawn-disk-budget.test.ts src/__tests__/workspace-registry.test.ts
 Test Files  6 passed (6)
      Tests  154 passed (154)
   Start at  08:58:03
   Duration  21.57s (transform 52.89s, setup 305ms, import 66.22s, tests 10.39s, environment 1ms)
exit 0
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
