### PR TITLE
fix(cloud): quarantine IO-starved nodes from agent placement

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-placement-fallback.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-placement-fallback.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Verifies that database-backed Docker placement cannot bypass an unavailable
+ * or quarantined fleet by reusing the initial environment seed list.
+ */
+
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+import { dockerNodesRepository } from "../../../db/repositories/docker-nodes";
+import type { DockerNode } from "../../../db/schemas/docker-nodes";
+import { dockerNodeManager } from "../docker-node-manager";
+import { DockerSandboxProvider } from "../docker-sandbox-provider";
+import { DockerSSHClient } from "../docker-ssh";
+
+const REGISTERED_NODE: DockerNode = {
+  id: "11111111-1111-4111-8111-111111111111",
+  node_id: "node-quarantined",
+  hostname: "192.0.2.42",
+  ssh_port: 22,
+  capacity: 8,
+  enabled: true,
+  status: "healthy",
+  allocated_count: 2,
+  last_health_check: null,
+  ssh_user: "root",
+  host_key_fingerprint: "SHA256:placement-node",
+  metadata: {},
+  created_at: new Date("2026-08-07T00:00:00.000Z"),
+  updated_at: new Date("2026-08-07T00:00:00.000Z"),
+};
+
+type PlacementInternals = {
+  provisionAutoscaledNodeForAgent: (input: {
+    image: string;
+    platform?: string;
+  }) => Promise<DockerNode | null>;
+};
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("DockerSandboxProvider placement fallback", () => {
+  test("refuses the seed list when registered nodes exist but none are selectable", async () => {
+    const savedSeedNodes = process.env.CONTAINERS_DOCKER_NODES;
+    process.env.CONTAINERS_DOCKER_NODES = "node-quarantined:192.0.2.42:8";
+    const provider = new DockerSandboxProvider();
+    const autoscale = spyOn(
+      provider as unknown as PlacementInternals,
+      "provisionAutoscaledNodeForAgent",
+    ).mockResolvedValue(null);
+    const selectNode = spyOn(dockerNodeManager, "getAvailableNode").mockResolvedValue(null);
+    const findAll = spyOn(dockerNodesRepository, "findAll").mockResolvedValue([REGISTERED_NODE]);
+    const getSshClient = spyOn(DockerSSHClient, "getClient");
+
+    try {
+      const failure = await provider
+        .create({
+          agentId: "22222222-2222-4222-8222-222222222222",
+          agentName: "Placement breaker regression",
+          environmentVars: {},
+        })
+        .catch((error: unknown) => error);
+
+      expect(failure).toBeInstanceOf(ElizaError);
+      expect(failure).toMatchObject({
+        code: "DOCKER_PLACEMENT_UNAVAILABLE",
+        context: {
+          registeredNodeCount: 1,
+        },
+        severity: "ephemeral",
+      });
+      expect((failure as Error).message).toContain(
+        "Registered Docker nodes exist but none are available for placement; refusing CONTAINERS_DOCKER_NODES seed fallback",
+      );
+    } finally {
+      if (savedSeedNodes === undefined) {
+        delete process.env.CONTAINERS_DOCKER_NODES;
+      } else {
+        process.env.CONTAINERS_DOCKER_NODES = savedSeedNodes;
+      }
+    }
+
+    expect(selectNode).toHaveBeenCalledTimes(1);
+    expect(autoscale).toHaveBeenCalledTimes(1);
+    expect(findAll).toHaveBeenCalledTimes(1);
+    expect(getSshClient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-provider-lane.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-provider-lane.test.ts
@@ -11,6 +11,7 @@ import "./docker-sandbox-already-gone.test.ts";
 import "./docker-sandbox-headscale-route.test.ts";
 import "./docker-sandbox-health-fallback.test.ts";
 import "./docker-sandbox-health-stale-node.test.ts";
+import "./docker-sandbox-placement-fallback.test.ts";
 import "./docker-sandbox-probe-transport.test.ts";
 import "./docker-sandbox-replacement-cleanup.test.ts";
 import "./docker-sandbox-unreachable-terminal.test.ts";

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Placement circuit-breaker and IO-pressure readiness tests (#17880).
+ *
+ * The outage these pin: a node that is alive but IO-starved passes the
+ * `docker info` liveness probe, gets selected for every provision (it is the
+ * only node with free slots precisely when the fleet is saturated), and then
+ * times out every `docker create`. These tests drive the REAL manager with a
+ * stubbed SSH client + repository and assert that (1) measured docker-command
+ * timeouts quarantine a node out of selection, and (2) a node reporting
+ * pathological /proc/pressure/io is refused at readiness time.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as realDockerNodesNs from "../../db/repositories/docker-nodes";
+import type { DockerNode } from "../../db/schemas/docker-nodes";
+import * as realDockerNodeWorkloadsNs from "./docker-node-workloads";
+import * as realDockerSshNs from "./docker-ssh";
+
+const realDockerNodes = { ...realDockerNodesNs };
+const realDockerNodeWorkloads = { ...realDockerNodeWorkloadsNs };
+const realDockerSsh = { ...realDockerSshNs };
+
+const repoCalls = {
+  updateStatus: [] as Array<{ nodeId: string; status: string }>,
+};
+
+let enabledNodes: DockerNode[] = [];
+
+const sshMock = {
+  connect: mock(),
+  exec: mock(),
+};
+
+mock.module("../../db/repositories/docker-nodes", () => ({
+  dockerNodesRepository: {
+    findEnabled: () => Promise.resolve(enabledNodes),
+    updateStatus: (nodeId: string, status: string) => {
+      repoCalls.updateStatus.push({ nodeId, status });
+      return Promise.resolve();
+    },
+    setHostKeyFingerprint: () => Promise.resolve(),
+  },
+}));
+
+mock.module("./docker-node-workloads", () => ({
+  countAllocatedWorkloadsOnNode: () => Promise.resolve(0),
+}));
+
+mock.module("./docker-ssh", () => ({
+  DockerSSHClient: {
+    getClient: () => sshMock,
+  },
+}));
+
+afterAll(() => {
+  mock.module("../../db/repositories/docker-nodes", () => realDockerNodes);
+  mock.module("./docker-node-workloads", () => realDockerNodeWorkloads);
+  mock.module("./docker-ssh", () => realDockerSsh);
+});
+
+import {
+  __resetPlacementTimeoutStateForTests,
+  clearPlacementCommandFailures,
+  DockerNodeManager,
+  isNodePlacementQuarantined,
+  notePlacementCommandFailure,
+  parseIoPressureFullAvg10,
+} from "./docker-node-manager";
+
+function node(nodeId: string): DockerNode {
+  return {
+    id: `${nodeId}-uuid`,
+    node_id: nodeId,
+    hostname: `${nodeId}.example.test`,
+    ssh_port: 22,
+    capacity: 4,
+    enabled: true,
+    status: "healthy",
+    allocated_count: 0,
+    last_health_check: null,
+    ssh_user: "root",
+    host_key_fingerprint: "SHA256:test",
+    metadata: {},
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    updated_at: new Date("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+const TIMEOUT_ERROR = new Error(
+  "[docker-sandbox] Failed to create container on node-a: [docker-ssh] Command timed out after 60000ms on 88.99.66.168: docker [redacted]",
+);
+
+/** Verbatim /proc/pressure/io captured on the #17880 outage node. */
+const OUTAGE_PSI = [
+  "some avg10=75.21 avg60=82.04 avg300=82.69 total=493046940717",
+  "full avg10=72.89 avg60=78.50 avg300=78.61 total=450805502651",
+].join("\n");
+
+const HEALTHY_PSI = [
+  "some avg10=0.00 avg60=0.31 avg300=0.12 total=1093046940",
+  "full avg10=0.00 avg60=0.24 avg300=0.09 total=450805502",
+].join("\n");
+
+function probeOutput(psi: string | null): string {
+  const sections = ["docker-id-1|x86_64", "---IO-PRESSURE---"];
+  if (psi !== null) sections.push(psi);
+  return sections.join("\n");
+}
+
+const T0 = 1_700_000_000_000;
+const MINUTE = 60 * 1000;
+
+beforeEach(() => {
+  __resetPlacementTimeoutStateForTests();
+  repoCalls.updateStatus = [];
+  enabledNodes = [];
+  sshMock.connect.mockReset();
+  sshMock.exec.mockReset();
+});
+
+describe("parseIoPressureFullAvg10", () => {
+  test("reads full avg10 from real /proc/pressure/io content", () => {
+    expect(parseIoPressureFullAvg10(OUTAGE_PSI)).toBe(72.89);
+    expect(parseIoPressureFullAvg10(HEALTHY_PSI)).toBe(0);
+  });
+
+  test("returns null when the signal is absent or malformed — never a fake zero", () => {
+    expect(parseIoPressureFullAvg10("")).toBeNull();
+    expect(
+      parseIoPressureFullAvg10("cat: /proc/pressure/io: No such file"),
+    ).toBeNull();
+    // A "some" line alone must not satisfy the "full" gate.
+    expect(
+      parseIoPressureFullAvg10(
+        "some avg10=75.21 avg60=82.04 avg300=82.69 total=1",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("placement circuit breaker", () => {
+  test("quarantines a node at the third docker timeout inside the window", () => {
+    notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0);
+    notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0 + MINUTE);
+    expect(isNodePlacementQuarantined("node-a", T0 + MINUTE)).toBe(false);
+
+    notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0 + 2 * MINUTE);
+    expect(isNodePlacementQuarantined("node-a", T0 + 2 * MINUTE)).toBe(true);
+  });
+
+  test("non-timeout failures never open the breaker", () => {
+    const otherError = new Error(
+      "pull access denied for ghcr.io/elizaos/eliza",
+    );
+    for (let attempt = 0; attempt < 5; attempt++) {
+      notePlacementCommandFailure("node-a", otherError, T0 + attempt * MINUTE);
+    }
+    expect(isNodePlacementQuarantined("node-a", T0 + 5 * MINUTE)).toBe(false);
+  });
+
+  test("timeouts older than the window do not count toward the threshold", () => {
+    notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0);
+    notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0 + MINUTE);
+    // Third timeout lands after the first two fell out of the 10-minute window.
+    notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0 + 15 * MINUTE);
+    expect(isNodePlacementQuarantined("node-a", T0 + 15 * MINUTE)).toBe(false);
+  });
+
+  test("quarantine expires after its cooldown", () => {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0);
+    }
+    expect(isNodePlacementQuarantined("node-a", T0 + 14 * MINUTE)).toBe(true);
+    expect(isNodePlacementQuarantined("node-a", T0 + 15 * MINUTE + 1)).toBe(
+      false,
+    );
+  });
+
+  test("a successful container operation clears the accumulated history", () => {
+    notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0);
+    notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0);
+    clearPlacementCommandFailures("node-a");
+    notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0 + MINUTE);
+    expect(isNodePlacementQuarantined("node-a", T0 + MINUTE)).toBe(false);
+  });
+});
+
+describe("getAvailableNode under quarantine", () => {
+  test("skips a quarantined node and selects the next candidate", async () => {
+    const manager = DockerNodeManager.getInstance();
+    enabledNodes = [node("node-quarantined"), node("node-ok")];
+    for (let attempt = 0; attempt < 3; attempt++) {
+      notePlacementCommandFailure("node-quarantined", TIMEOUT_ERROR);
+    }
+    sshMock.exec.mockResolvedValue(probeOutput(HEALTHY_PSI));
+
+    const selected = await manager.getAvailableNode();
+
+    expect(selected?.node_id).toBe("node-ok");
+  });
+
+  test("returns null when every capacity-bearing node is quarantined, without probing them", async () => {
+    const manager = DockerNodeManager.getInstance();
+    enabledNodes = [node("node-quarantined")];
+    for (let attempt = 0; attempt < 3; attempt++) {
+      notePlacementCommandFailure("node-quarantined", TIMEOUT_ERROR);
+    }
+
+    const selected = await manager.getAvailableNode();
+
+    expect(selected).toBeNull();
+    // Quarantine is decided before the SSH probe — a drowning node must not
+    // receive even probe traffic from selection.
+    expect(sshMock.exec).not.toHaveBeenCalled();
+  });
+});
+
+describe("ensureNodeReady IO-pressure gate", () => {
+  test("refuses an IO-starved node and does not mark it healthy", async () => {
+    const manager = DockerNodeManager.getInstance();
+    sshMock.exec.mockResolvedValue(probeOutput(OUTAGE_PSI));
+
+    const ready = await manager.ensureNodeReady(node("node-starved"));
+
+    expect(ready).toBe(false);
+    expect(repoCalls.updateStatus).toEqual([]);
+  });
+
+  test("accepts a node with healthy IO pressure", async () => {
+    const manager = DockerNodeManager.getInstance();
+    sshMock.exec.mockResolvedValue(probeOutput(HEALTHY_PSI));
+
+    const ready = await manager.ensureNodeReady(node("node-ok"));
+
+    expect(ready).toBe(true);
+    expect(repoCalls.updateStatus).toEqual([
+      { nodeId: "node-ok", status: "healthy" },
+    ]);
+  });
+
+  test("a missing PSI signal never blocks placement", async () => {
+    const manager = DockerNodeManager.getInstance();
+    sshMock.exec.mockResolvedValue(probeOutput(null));
+
+    const ready = await manager.ensureNodeReady(node("node-old-kernel"));
+
+    expect(ready).toBe(true);
+    expect(repoCalls.updateStatus).toEqual([
+      { nodeId: "node-old-kernel", status: "healthy" },
+    ]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
@@ -6,8 +6,9 @@
  * only node with free slots precisely when the fleet is saturated), and then
  * times out every `docker create`. These tests drive the REAL manager with a
  * stubbed SSH client + repository and assert that (1) measured docker-command
- * timeouts quarantine a node out of selection, and (2) a node reporting
- * pathological /proc/pressure/io is refused at readiness time.
+ * timeouts quarantine a node out of selection with an all-quarantined escape
+ * hatch, and (2) pathological /proc/pressure/io blocks only new placement,
+ * never sticky stateful routing or autoscaler liveness checks.
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -226,38 +227,75 @@ describe("getAvailableNode under quarantine", () => {
     expect(selected?.node_id).toBe("node-ok");
   });
 
-  test("returns null when every capacity-bearing node is quarantined, without probing them", async () => {
+  test("overrides the oldest quarantine when every capacity-bearing node is quarantined", async () => {
     const manager = DockerNodeManager.getInstance();
-    enabledNodes = [node("node-quarantined")];
+    enabledNodes = [node("node-newer"), node("node-older")];
+    const nowMs = Date.now();
     for (let attempt = 0; attempt < 3; attempt++) {
-      notePlacementCommandFailure("node-quarantined", TIMEOUT_ERROR);
+      notePlacementCommandFailure("node-older", TIMEOUT_ERROR, nowMs - MINUTE);
+      notePlacementCommandFailure("node-newer", TIMEOUT_ERROR, nowMs);
     }
+    sshMock.exec.mockResolvedValue(probeOutput(HEALTHY_PSI));
+
+    const selected = await manager.getAvailableNode();
+
+    expect(selected?.node_id).toBe("node-older");
+    expect(sshMock.exec).toHaveBeenCalledTimes(1);
+  });
+
+  test("an incompatible available node cannot suppress a compatible quarantine fallback", async () => {
+    const manager = DockerNodeManager.getInstance();
+    const incompatible = node("node-arm64");
+    incompatible.metadata = { architecture: "arm64" };
+    enabledNodes = [incompatible, node("node-amd64-quarantined")];
+    const nowMs = Date.now();
+    for (let attempt = 0; attempt < 3; attempt++) {
+      notePlacementCommandFailure("node-amd64-quarantined", TIMEOUT_ERROR, nowMs);
+    }
+    sshMock.exec.mockResolvedValue(probeOutput(HEALTHY_PSI));
+
+    const selected = await manager.getAvailableNode({
+      requiredPlatform: "linux/amd64",
+    });
+
+    expect(selected?.node_id).toBe("node-amd64-quarantined");
+    expect(sshMock.exec).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("placement-scoped IO-pressure gate", () => {
+  test("refuses an IO-starved node during new placement", async () => {
+    const manager = DockerNodeManager.getInstance();
+    enabledNodes = [node("node-starved")];
+    sshMock.exec.mockResolvedValue(probeOutput(OUTAGE_PSI));
 
     const selected = await manager.getAvailableNode();
 
     expect(selected).toBeNull();
-    // Quarantine is decided before the SSH probe — a drowning node must not
-    // receive even probe traffic from selection.
-    expect(sshMock.exec).not.toHaveBeenCalled();
-  });
-});
-
-describe("ensureNodeReady IO-pressure gate", () => {
-  test("refuses an IO-starved node and does not mark it healthy", async () => {
-    const manager = DockerNodeManager.getInstance();
-    sshMock.exec.mockResolvedValue(probeOutput(OUTAGE_PSI));
-
-    const ready = await manager.ensureNodeReady(node("node-starved"));
-
-    expect(ready).toBe(false);
     expect(repoCalls.updateStatus).toEqual([]);
+  });
+
+  test("does not apply placement pressure policy to a direct liveness probe", async () => {
+    const manager = DockerNodeManager.getInstance();
+    sshMock.exec.mockResolvedValue("docker-id-1|x86_64");
+
+    const ready = await manager.ensureNodeReady(node("node-sticky"));
+
+    expect(ready).toBe(true);
+    expect(sshMock.exec).toHaveBeenCalledWith(
+      "docker info --format '{{.ID}}|{{.Architecture}}'",
+      10_000,
+    );
+    expect(repoCalls.updateStatus).toEqual([{ nodeId: "node-sticky", status: "healthy" }]);
   });
 
   test("accepts a node with healthy IO pressure", async () => {
     const manager = DockerNodeManager.getInstance();
     sshMock.exec.mockResolvedValue(probeOutput(HEALTHY_PSI));
 
-    const ready = await manager.ensureNodeReady(node("node-ok"));
+    const ready = await manager.ensureNodeReady(node("node-ok"), {
+      enforcePlacementIoPressure: true,
+    });
 
     expect(ready).toBe(true);
     expect(repoCalls.updateStatus).toEqual([{ nodeId: "node-ok", status: "healthy" }]);
@@ -269,7 +307,9 @@ describe("ensureNodeReady IO-pressure gate", () => {
     const manager = DockerNodeManager.getInstance();
     sshMock.exec.mockResolvedValue(probeOutput(HEALTHY_BUSY_PSI));
 
-    const ready = await manager.ensureNodeReady(node("node-busy"));
+    const ready = await manager.ensureNodeReady(node("node-busy"), {
+      enforcePlacementIoPressure: true,
+    });
 
     expect(ready).toBe(true);
     expect(repoCalls.updateStatus).toEqual([{ nodeId: "node-busy", status: "healthy" }]);
@@ -279,7 +319,9 @@ describe("ensureNodeReady IO-pressure gate", () => {
     const manager = DockerNodeManager.getInstance();
     sshMock.exec.mockResolvedValue(probeOutput(null));
 
-    const ready = await manager.ensureNodeReady(node("node-old-kernel"));
+    const ready = await manager.ensureNodeReady(node("node-old-kernel"), {
+      enforcePlacementIoPressure: true,
+    });
 
     expect(ready).toBe(true);
     expect(repoCalls.updateStatus).toEqual([{ nodeId: "node-old-kernel", status: "healthy" }]);

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
@@ -126,14 +126,10 @@ describe("parseIoPressureFullAvg10", () => {
 
   test("returns null when the signal is absent or malformed — never a fake zero", () => {
     expect(parseIoPressureFullAvg10("")).toBeNull();
-    expect(
-      parseIoPressureFullAvg10("cat: /proc/pressure/io: No such file"),
-    ).toBeNull();
+    expect(parseIoPressureFullAvg10("cat: /proc/pressure/io: No such file")).toBeNull();
     // A "some" line alone must not satisfy the "full" gate.
     expect(
-      parseIoPressureFullAvg10(
-        "some avg10=75.21 avg60=82.04 avg300=82.69 total=1",
-      ),
+      parseIoPressureFullAvg10("some avg10=75.21 avg60=82.04 avg300=82.69 total=1"),
     ).toBeNull();
   });
 });
@@ -149,9 +145,7 @@ describe("placement circuit breaker", () => {
   });
 
   test("non-timeout failures never open the breaker", () => {
-    const otherError = new Error(
-      "pull access denied for ghcr.io/elizaos/eliza",
-    );
+    const otherError = new Error("pull access denied for ghcr.io/elizaos/eliza");
     for (let attempt = 0; attempt < 5; attempt++) {
       notePlacementCommandFailure("node-a", otherError, T0 + attempt * MINUTE);
     }
@@ -171,9 +165,7 @@ describe("placement circuit breaker", () => {
       notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0);
     }
     expect(isNodePlacementQuarantined("node-a", T0 + 14 * MINUTE)).toBe(true);
-    expect(isNodePlacementQuarantined("node-a", T0 + 15 * MINUTE + 1)).toBe(
-      false,
-    );
+    expect(isNodePlacementQuarantined("node-a", T0 + 15 * MINUTE + 1)).toBe(false);
   });
 
   test("a successful container operation clears the accumulated history", () => {
@@ -233,9 +225,7 @@ describe("ensureNodeReady IO-pressure gate", () => {
     const ready = await manager.ensureNodeReady(node("node-ok"));
 
     expect(ready).toBe(true);
-    expect(repoCalls.updateStatus).toEqual([
-      { nodeId: "node-ok", status: "healthy" },
-    ]);
+    expect(repoCalls.updateStatus).toEqual([{ nodeId: "node-ok", status: "healthy" }]);
   });
 
   test("a missing PSI signal never blocks placement", async () => {
@@ -245,8 +235,6 @@ describe("ensureNodeReady IO-pressure gate", () => {
     const ready = await manager.ensureNodeReady(node("node-old-kernel"));
 
     expect(ready).toBe(true);
-    expect(repoCalls.updateStatus).toEqual([
-      { nodeId: "node-old-kernel", status: "healthy" },
-    ]);
+    expect(repoCalls.updateStatus).toEqual([{ nodeId: "node-old-kernel", status: "healthy" }]);
   });
 });

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
@@ -167,6 +167,26 @@ describe("placement circuit breaker", () => {
     expect(isNodePlacementQuarantined("node-a", T0 + 5 * MINUTE)).toBe(false);
   });
 
+  test("application output mentioning a generic timeout never opens the breaker", () => {
+    const misleadingError = new Error(
+      "[docker-ssh] Command exited with code 1 on node-a: worker said Command timed out after retry",
+    );
+    for (let attempt = 0; attempt < 5; attempt++) {
+      notePlacementCommandFailure("node-a", misleadingError, T0 + attempt * MINUTE);
+    }
+    expect(isNodePlacementQuarantined("node-a", T0 + 5 * MINUTE)).toBe(false);
+  });
+
+  test("non-Docker SSH command timeouts never open the breaker", () => {
+    const stewardTimeout = new Error(
+      "[docker-ssh] Command timed out after 30000ms on node-a: curl [redacted]",
+    );
+    for (let attempt = 0; attempt < 5; attempt++) {
+      notePlacementCommandFailure("node-a", stewardTimeout, T0 + attempt * MINUTE);
+    }
+    expect(isNodePlacementQuarantined("node-a", T0 + 5 * MINUTE)).toBe(false);
+  });
+
   test("timeouts older than the window do not count toward the threshold", () => {
     notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0);
     notePlacementCommandFailure("node-a", TIMEOUT_ERROR, T0 + MINUTE);

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
@@ -64,7 +64,7 @@ import {
   DockerNodeManager,
   isNodePlacementQuarantined,
   notePlacementCommandFailure,
-  parseIoPressureFullAvg10,
+  parseIoPressureFullAvg60,
 } from "./docker-node-manager";
 
 function node(nodeId: string): DockerNode {
@@ -90,10 +90,22 @@ const TIMEOUT_ERROR = new Error(
   "[docker-sandbox] Failed to create container on node-a: [docker-ssh] Command timed out after 60000ms on 88.99.66.168: docker [redacted]",
 );
 
-/** Verbatim /proc/pressure/io captured on the #17880 outage node. */
+/** Verbatim /proc/pressure/io from node 88.99.66.168 during the #17880 outage. */
 const OUTAGE_PSI = [
   "some avg10=75.21 avg60=82.04 avg300=82.69 total=493046940717",
   "full avg10=72.89 avg60=78.50 avg300=78.61 total=450805502651",
+].join("\n");
+
+/**
+ * The SAME node once CI drained and it was completing provisions in ~36s.
+ * Verbatim samples 3 and 5 of the calibration run: both carry an avg10 ABOVE
+ * 40 while avg60 stays ~35 — the reason the gate reads avg60. Pinning these
+ * exact readings keeps a future threshold tweak from re-introducing the
+ * false refusal of a working node.
+ */
+const HEALTHY_BUSY_PSI = [
+  "some avg10=41.02 avg60=36.19 avg300=36.44 total=499893023295",
+  "full avg10=40.87 avg60=36.37 avg300=35.81 total=457451749125",
 ].join("\n");
 
 const HEALTHY_PSI = [
@@ -118,19 +130,22 @@ beforeEach(() => {
   sshMock.exec.mockReset();
 });
 
-describe("parseIoPressureFullAvg10", () => {
-  test("reads full avg10 from real /proc/pressure/io content", () => {
-    expect(parseIoPressureFullAvg10(OUTAGE_PSI)).toBe(72.89);
-    expect(parseIoPressureFullAvg10(HEALTHY_PSI)).toBe(0);
+describe("parseIoPressureFullAvg60", () => {
+  test("reads the full line's avg60, not avg10, from real content", () => {
+    expect(parseIoPressureFullAvg60(OUTAGE_PSI)).toBe(78.5);
+    expect(parseIoPressureFullAvg60(HEALTHY_BUSY_PSI)).toBe(36.37);
+    expect(parseIoPressureFullAvg60(HEALTHY_PSI)).toBe(0.24);
   });
 
   test("returns null when the signal is absent or malformed — never a fake zero", () => {
-    expect(parseIoPressureFullAvg10("")).toBeNull();
-    expect(parseIoPressureFullAvg10("cat: /proc/pressure/io: No such file")).toBeNull();
+    expect(parseIoPressureFullAvg60("")).toBeNull();
+    expect(parseIoPressureFullAvg60("cat: /proc/pressure/io: No such file")).toBeNull();
     // A "some" line alone must not satisfy the "full" gate.
     expect(
-      parseIoPressureFullAvg10("some avg10=75.21 avg60=82.04 avg300=82.69 total=1"),
+      parseIoPressureFullAvg60("some avg10=75.21 avg60=82.04 avg300=82.69 total=1"),
     ).toBeNull();
+    // A "full" line truncated before avg60 has no usable value.
+    expect(parseIoPressureFullAvg60("full avg10=72.89")).toBeNull();
   });
 });
 
@@ -226,6 +241,18 @@ describe("ensureNodeReady IO-pressure gate", () => {
 
     expect(ready).toBe(true);
     expect(repoCalls.updateStatus).toEqual([{ nodeId: "node-ok", status: "healthy" }]);
+  });
+
+  test("accepts a busy-but-working node whose avg10 spikes past 40", async () => {
+    // The regression this guards: gating on avg10 refused THIS node — measured
+    // healthy, provisioning in ~36s — in 2 of 8 consecutive samples.
+    const manager = DockerNodeManager.getInstance();
+    sshMock.exec.mockResolvedValue(probeOutput(HEALTHY_BUSY_PSI));
+
+    const ready = await manager.ensureNodeReady(node("node-busy"));
+
+    expect(ready).toBe(true);
+    expect(repoCalls.updateStatus).toEqual([{ nodeId: "node-busy", status: "healthy" }]);
   });
 
   test("a missing PSI signal never blocks placement", async () => {

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-prepull-self-heal.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-prepull-self-heal.test.ts
@@ -11,7 +11,7 @@ import {
   buildPrePullSelfHealRecoverCommand,
   buildTrackedPrePullCommand,
   DockerNodeManager,
-  isPrePullTimeoutError,
+  isDockerSshCommandTimeoutError,
 } from "./docker-node-manager";
 
 const IMAGE = "ghcr.io/elizaos/eliza:test-prepull";
@@ -69,16 +69,23 @@ afterEach(() => {
 describe("pre-pull timeout classification", () => {
   test("recovers only DockerSSHClient timeout failures", () => {
     expect(
-      isPrePullTimeoutError(
+      isDockerSshCommandTimeoutError(
         new Error("[docker-ssh] Command timed out after 300000ms on node: sh [redacted]"),
       ),
     ).toBe(true);
     expect(
-      isPrePullTimeoutError(
+      isDockerSshCommandTimeoutError(
+        new Error("pre-pull wrapper", {
+          cause: new Error("[docker-ssh] Command timed out after 300000ms on node: sh [redacted]"),
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isDockerSshCommandTimeoutError(
         new Error("[docker-ssh] Command exited with code 1 on node: manifest unknown"),
       ),
     ).toBe(false);
-    expect(isPrePullTimeoutError(new Error("pull access denied"))).toBe(false);
+    expect(isDockerSshCommandTimeoutError(new Error("pull access denied"))).toBe(false);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -165,24 +165,31 @@ export function isNodePlacementQuarantined(nodeId: string, nowMs = Date.now()): 
 // ---------------------------------------------------------------------------
 
 /**
- * Refuse placement above this /proc/pressure/io `full avg10` percentage. A
- * healthy node sits near 0–5; the #17880 outage node measured 72–78 while
- * `docker create` could not finish inside its 60s timeout. 40 refuses nodes
- * already stalling on IO for most of each second while tolerating the bursts a
- * large image extract causes on a working node.
+ * Refuse placement above this /proc/pressure/io `full avg60` percentage.
+ *
+ * Both ends are measured on the same production node (88.99.66.168):
+ * while healthy and completing provisions in ~36s it reports avg60 33.6–36.4,
+ * and during the #17880 outage — every `docker create` timing out at 60s — it
+ * reported avg60 78.50. 60 leaves ~24 points of margin below the healthy
+ * ceiling and ~18 above the outage floor.
+ *
+ * avg60, not avg10: on that same healthy node avg10 swings 30.5–40.9, so a
+ * gate anywhere near the working range refuses a working node on a transient
+ * spike (an image extract is enough) and manufactures the "no nodes available"
+ * outage this is meant to prevent. avg60 spans 2.8 points over the same window.
  */
-const PLACEMENT_MAX_IO_PRESSURE_FULL_AVG10 = 40;
+const PLACEMENT_MAX_IO_PRESSURE_FULL_AVG60 = 60;
 
 /** Separates docker-info output from the PSI section in the readiness probe. */
 const READINESS_PROBE_PSI_MARKER = "---IO-PRESSURE---";
 
 /**
- * Parse `full avg10=` out of /proc/pressure/io content. Returns null when the
+ * Parse `full avg60=` out of /proc/pressure/io content. Returns null when the
  * signal is absent (pre-4.20 kernel, CONFIG_PSI off, unreadable) — absence
  * must not block placement; the circuit breaker still protects that node.
  */
-export function parseIoPressureFullAvg10(section: string): number | null {
-  const match = section.match(/^full\s+avg10=(\d+(?:\.\d+)?)/m);
+export function parseIoPressureFullAvg60(section: string): number | null {
+  const match = section.match(/^full\s+avg10=[\d.]+\s+avg60=(\d+(?:\.\d+)?)/m);
   if (!match) return null;
   const value = Number.parseFloat(match[1]!);
   return Number.isFinite(value) ? value : null;
@@ -716,15 +723,15 @@ export class DockerNodeManager {
           });
           return false;
         }
-        const ioPressure = parseIoPressureFullAvg10(psiSection);
-        if (ioPressure !== null && ioPressure >= PLACEMENT_MAX_IO_PRESSURE_FULL_AVG10) {
+        const ioPressure = parseIoPressureFullAvg60(psiSection);
+        if (ioPressure !== null && ioPressure >= PLACEMENT_MAX_IO_PRESSURE_FULL_AVG60) {
           // No DB status write: IO overload is transient and node-status flips
           // are reserved for dead/unreachable daemons (see the canonical-node
           // protection below).
           logger.warn("[docker-node-manager] Node refused for placement: IO-starved", {
             nodeId: node.node_id,
-            ioPressureFullAvg10: ioPressure,
-            max: PLACEMENT_MAX_IO_PRESSURE_FULL_AVG10,
+            ioPressureFullAvg60: ioPressure,
+            max: PLACEMENT_MAX_IO_PRESSURE_FULL_AVG60,
           });
           return false;
         }

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -9,7 +9,10 @@
 
 import crypto from "node:crypto";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
-import type { DockerNode, DockerNodeStatus } from "../../db/schemas/docker-nodes";
+import type {
+  DockerNode,
+  DockerNodeStatus,
+} from "../../db/schemas/docker-nodes";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
 import {
@@ -29,7 +32,11 @@ import {
   shellQuote,
 } from "./docker-sandbox-utils";
 import { DockerSSHClient } from "./docker-ssh";
-import { type DiskHealthVerdict, diskHealthVerdict, probeNodeDiskUsage } from "./node-disk-manager";
+import {
+  type DiskHealthVerdict,
+  diskHealthVerdict,
+  probeNodeDiskUsage,
+} from "./node-disk-manager";
 
 // ---------------------------------------------------------------------------
 // Pre-pull self-heal bookkeeping (see recoverAfterTimedOutPrePull)
@@ -76,6 +83,124 @@ const nodeHealthFailureState = new Map<string, number>();
 
 export function __resetNodeHealthFailureStateForTests(): void {
   nodeHealthFailureState.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Placement circuit breaker (docker-command timeouts feed back into selection)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-node docker-command timeout timestamps + quarantine deadline. In-memory
+ * for the same reason as the health/pre-pull state above: the provisioning
+ * worker is a single long-lived process and a restart is a clean slate.
+ *
+ * Why this exists (#17880): capacity accounting and the `docker info`
+ * readiness probe are both blind to a node that is alive but drowning in IO —
+ * `docker info` answers from daemon memory while `docker create` needs journal
+ * flushes, so an overloaded node passes selection and then times out every
+ * provision. Timeouts recorded here quarantine the node from selection instead
+ * of letting it be re-picked for every subsequent provision.
+ */
+const placementTimeoutState = new Map<
+  string,
+  { timeoutsMs: number[]; quarantinedUntilMs: number }
+>();
+/** Docker-command timeouts on a node within the window before quarantine. */
+const PLACEMENT_TIMEOUT_THRESHOLD = 3;
+/** Sliding window in which timeouts count toward the threshold. */
+const PLACEMENT_TIMEOUT_WINDOW_MS = 10 * 60 * 1000;
+/**
+ * How long a quarantined node is excluded from selection. Longer than the
+ * window, so a node coming out of quarantine starts from a drained window and
+ * gets the full threshold of fresh attempts before re-quarantining.
+ */
+const PLACEMENT_QUARANTINE_MS = 15 * 60 * 1000;
+
+export function __resetPlacementTimeoutStateForTests(): void {
+  placementTimeoutState.clear();
+}
+
+/** Matches the docker-ssh timeout signature anywhere in a message/cause chain. */
+export function isDockerCommandTimeoutError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("Command timed out after");
+}
+
+/**
+ * Feed a container-operation failure on a node back into placement. Only
+ * docker-command timeouts count — they are the overload signature; every other
+ * failure mode (bad image, auth, node absent) has its own handling and says
+ * nothing about the node's ability to take work.
+ */
+export function notePlacementCommandFailure(
+  nodeId: string,
+  error: unknown,
+  nowMs = Date.now(),
+): void {
+  if (!isDockerCommandTimeoutError(error)) return;
+  const state = placementTimeoutState.get(nodeId) ?? {
+    timeoutsMs: [],
+    quarantinedUntilMs: 0,
+  };
+  state.timeoutsMs = state.timeoutsMs.filter(
+    (ts) => nowMs - ts < PLACEMENT_TIMEOUT_WINDOW_MS,
+  );
+  state.timeoutsMs.push(nowMs);
+  if (state.timeoutsMs.length >= PLACEMENT_TIMEOUT_THRESHOLD) {
+    state.quarantinedUntilMs = nowMs + PLACEMENT_QUARANTINE_MS;
+    state.timeoutsMs = [];
+    logger.warn(
+      "[docker-node-manager] Node quarantined from placement after docker timeouts",
+      {
+        nodeId,
+        threshold: PLACEMENT_TIMEOUT_THRESHOLD,
+        windowMs: PLACEMENT_TIMEOUT_WINDOW_MS,
+        quarantineMs: PLACEMENT_QUARANTINE_MS,
+      },
+    );
+  }
+  placementTimeoutState.set(nodeId, state);
+}
+
+/** A successful container operation proves the node can take work again. */
+export function clearPlacementCommandFailures(nodeId: string): void {
+  placementTimeoutState.delete(nodeId);
+}
+
+export function isNodePlacementQuarantined(
+  nodeId: string,
+  nowMs = Date.now(),
+): boolean {
+  const state = placementTimeoutState.get(nodeId);
+  return !!state && state.quarantinedUntilMs > nowMs;
+}
+
+// ---------------------------------------------------------------------------
+// IO-pressure readiness signal
+// ---------------------------------------------------------------------------
+
+/**
+ * Refuse placement above this /proc/pressure/io `full avg10` percentage. A
+ * healthy node sits near 0–5; the #17880 outage node measured 72–78 while
+ * `docker create` could not finish inside its 60s timeout. 40 refuses nodes
+ * already stalling on IO for most of each second while tolerating the bursts a
+ * large image extract causes on a working node.
+ */
+const PLACEMENT_MAX_IO_PRESSURE_FULL_AVG10 = 40;
+
+/** Separates docker-info output from the PSI section in the readiness probe. */
+const READINESS_PROBE_PSI_MARKER = "---IO-PRESSURE---";
+
+/**
+ * Parse `full avg10=` out of /proc/pressure/io content. Returns null when the
+ * signal is absent (pre-4.20 kernel, CONFIG_PSI off, unreadable) — absence
+ * must not block placement; the circuit breaker still protects that node.
+ */
+export function parseIoPressureFullAvg10(section: string): number | null {
+  const match = section.match(/^full\s+avg10=(\d+(?:\.\d+)?)/m);
+  if (!match) return null;
+  const value = Number.parseFloat(match[1]!);
+  return Number.isFinite(value) ? value : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -174,7 +299,11 @@ export function buildTrackedPrePullCommand(
   marker = crypto.randomUUID(),
 ): { command: string; pidFile: string } {
   const pidFile = prePullPidFile(marker);
-  const pullCommand = ["docker pull", ...dockerPlatformFlag(platform), shellQuote(image)].join(" ");
+  const pullCommand = [
+    "docker pull",
+    ...dockerPlatformFlag(platform),
+    shellQuote(image),
+  ].join(" ");
   const script = [
     `pidfile=${shellQuote(pidFile)}`,
     'rm -f "$pidfile"',
@@ -193,7 +322,10 @@ export function buildTrackedPrePullCommand(
   return { command: `sh -c ${shellQuote(script)}`, pidFile };
 }
 
-export function buildPrePullReapCommand(pidFile: string, image: string): string {
+export function buildPrePullReapCommand(
+  pidFile: string,
+  image: string,
+): string {
   const quotedImage = shellQuote(image);
   const script = [
     `pidfile=${shellQuote(pidFile)}`,
@@ -249,7 +381,9 @@ export class DockerNodeManager {
    * Find the least-loaded healthy node with available capacity.
    * Returns null if no capacity is available.
    */
-  async getAvailableNode(options: NodeSelectionOptions = {}): Promise<DockerNode | null> {
+  async getAvailableNode(
+    options: NodeSelectionOptions = {},
+  ): Promise<DockerNode | null> {
     const nodes = await dockerNodesRepository.findEnabled();
     const candidates = (
       await Promise.all(
@@ -259,7 +393,9 @@ export class DockerNodeManager {
           return {
             node,
             allocated,
-            available: canProbeForCapacity ? Math.max(0, node.capacity - allocated) : 0,
+            available: canProbeForCapacity
+              ? Math.max(0, node.capacity - allocated)
+              : 0,
           };
         }),
       )
@@ -268,13 +404,31 @@ export class DockerNodeManager {
       .filter((candidate) => candidate.node.node_id !== options.excludeNodeId)
       .sort((a, b) => b.available - a.available);
 
-    for (const candidate of candidates) {
+    const quarantined = candidates.filter((candidate) =>
+      isNodePlacementQuarantined(candidate.node.node_id),
+    );
+    if (quarantined.length > 0) {
+      logger.warn(
+        "[docker-node-manager] Skipping quarantined nodes during selection",
+        {
+          nodeIds: quarantined.map((candidate) => candidate.node.node_id),
+        },
+      );
+    }
+    const selectable = candidates.filter(
+      (candidate) => !isNodePlacementQuarantined(candidate.node.node_id),
+    );
+
+    for (const candidate of selectable) {
       if (!isNodeMetadataCompatible(candidate.node, options.requiredPlatform)) {
-        logger.warn("[docker-node-manager] Skipping node with incompatible architecture", {
-          nodeId: candidate.node.node_id,
-          requiredPlatform: options.requiredPlatform,
-          metadata: candidate.node.metadata,
-        });
+        logger.warn(
+          "[docker-node-manager] Skipping node with incompatible architecture",
+          {
+            nodeId: candidate.node.node_id,
+            requiredPlatform: options.requiredPlatform,
+            metadata: candidate.node.metadata,
+          },
+        );
         continue;
       }
       if (!(await this.ensureNodeReady(candidate.node, options))) {
@@ -286,7 +440,9 @@ export class DockerNodeManager {
       return { ...candidate.node, allocated_count: candidate.allocated };
     }
 
-    logger.warn("[docker-node-manager] No reachable healthy nodes with capacity");
+    logger.warn(
+      "[docker-node-manager] No reachable healthy nodes with capacity",
+    );
     return null;
   }
 
@@ -316,7 +472,10 @@ export class DockerNodeManager {
       node.host_key_fingerprint
         ? undefined
         : async (hostname, fingerprint) => {
-            await dockerNodesRepository.setHostKeyFingerprint(node.node_id, fingerprint);
+            await dockerNodesRepository.setHostKeyFingerprint(
+              node.node_id,
+              fingerprint,
+            );
             logger.warn(
               `[docker-node-manager] TOFU-pinned host key for node ${node.node_id} (${hostname}): SHA256:${fingerprint}`,
             );
@@ -358,7 +517,10 @@ export class DockerNodeManager {
       try {
         const ssh = this.sshClientForNode(node);
         await ssh.connect();
-        const dockerId = await ssh.exec("docker info --format '{{.ID}}'", 10_000);
+        const dockerId = await ssh.exec(
+          "docker info --format '{{.ID}}'",
+          10_000,
+        );
 
         if (dockerId.trim()) {
           // Disk-aware verdict: a node whose Docker daemon answers but whose
@@ -383,7 +545,10 @@ export class DockerNodeManager {
               logger.warn(
                 `[docker-node-manager] Node ${node.node_id} (${node.hostname}) is reachable but disk is critically full; marking degraded so it drains/replaces instead of taking new work.`,
               );
-              await dockerNodesRepository.updateStatus(node.node_id, "degraded");
+              await dockerNodesRepository.updateStatus(
+                node.node_id,
+                "degraded",
+              );
               return "degraded";
             }
             logger.warn(
@@ -420,7 +585,9 @@ export class DockerNodeManager {
     logger.warn(
       `[docker-node-manager] Health check failed for ${node.node_id} after ${MAX_RETRIES} attempts: ${lastError}`,
     );
-    const status: DockerNodeStatus = lastError.includes("empty ID") ? "degraded" : "offline";
+    const status: DockerNodeStatus = lastError.includes("empty ID")
+      ? "degraded"
+      : "offline";
 
     // A `degraded` verdict means the daemon ANSWERED but returned no ID — the
     // node is reachable, just unhealthy. Persist it and let the disk-clean /
@@ -478,13 +645,19 @@ export class DockerNodeManager {
   async diskHealthStatus(node: DockerNode): Promise<DiskHealthVerdict> {
     try {
       const usedPercent = await probeNodeDiskUsage(node);
-      return diskHealthVerdict(usedPercent, containersEnv.nodeDiskUnhealthyThresholdPct());
+      return diskHealthVerdict(
+        usedPercent,
+        containersEnv.nodeDiskUnhealthyThresholdPct(),
+      );
     } catch (error) {
-      logger.warn("[docker-node-manager] Disk health probe failed; treating as ok", {
-        nodeId: node.node_id,
-        hostname: node.hostname,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[docker-node-manager] Disk health probe failed; treating as ok",
+        {
+          nodeId: node.node_id,
+          hostname: node.hostname,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return "ok";
     }
   }
@@ -503,21 +676,34 @@ export class DockerNodeManager {
    * of the health check: like the disk sub-probe, the sidecar never owns
    * reachability — the docker-info probe does.
    */
-  async embeddingSidecarHealth(node: DockerNode, ssh: DockerSSHClient): Promise<void> {
+  async embeddingSidecarHealth(
+    node: DockerNode,
+    ssh: DockerSSHClient,
+  ): Promise<void> {
     try {
       let status = await this.probeEmbeddingSidecar(ssh);
       if (status === null) return;
 
-      if (status !== "running" && containersEnv.embeddingSidecarSelfHealEnabled()) {
-        const lastAttempt = embeddingSidecarSelfHealState.get(node.node_id) ?? 0;
-        if (Date.now() - lastAttempt >= EMBEDDING_SIDECAR_SELF_HEAL_COOLDOWN_MS) {
+      if (
+        status !== "running" &&
+        containersEnv.embeddingSidecarSelfHealEnabled()
+      ) {
+        const lastAttempt =
+          embeddingSidecarSelfHealState.get(node.node_id) ?? 0;
+        if (
+          Date.now() - lastAttempt >=
+          EMBEDDING_SIDECAR_SELF_HEAL_COOLDOWN_MS
+        ) {
           // Stamp BEFORE the attempt so a hanging/failing ensure still honors
           // the cooldown next cycle instead of re-pulling the image every tick.
           embeddingSidecarSelfHealState.set(node.node_id, Date.now());
           logger.warn(
             `[docker-node-manager] Embedding sidecar ${status} on node ${node.node_id} (${node.hostname}); attempting self-heal install`,
           );
-          await ssh.exec(buildEnsureEmbeddingSidecarCmd(), EMBEDDING_SIDECAR_ENSURE_TIMEOUT_MS);
+          await ssh.exec(
+            buildEnsureEmbeddingSidecarCmd(),
+            EMBEDDING_SIDECAR_ENSURE_TIMEOUT_MS,
+          );
           status = (await this.probeEmbeddingSidecar(ssh)) ?? status;
         }
       }
@@ -527,19 +713,29 @@ export class DockerNodeManager {
       } else {
         logger.error(
           `[docker-node-manager] Embedding sidecar ${status} on node ${node.node_id} (${node.hostname}) — agents on this node cannot reach local embeddings. Self-heal ${containersEnv.embeddingSidecarSelfHealEnabled() ? "will retry after cooldown" : "is disabled"}.`,
-          { nodeId: node.node_id, hostname: node.hostname, embeddingSidecar: status },
+          {
+            nodeId: node.node_id,
+            hostname: node.hostname,
+            embeddingSidecar: status,
+          },
         );
       }
-      await dockerNodesRepository.setEmbeddingSidecarHealth(node.node_id, status);
+      await dockerNodesRepository.setEmbeddingSidecarHealth(
+        node.node_id,
+        status,
+      );
     } catch (error) {
       // error-policy:J7 the sidecar sub-probe/self-heal is diagnostics on the
       // health loop; a thrown SSH/exec failure is logged loudly here and must
       // not take down the reachability verdict the loop exists to produce.
-      logger.warn("[docker-node-manager] Embedding sidecar probe/self-heal failed", {
-        nodeId: node.node_id,
-        hostname: node.hostname,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[docker-node-manager] Embedding sidecar probe/self-heal failed",
+        {
+          nodeId: node.node_id,
+          hostname: node.hostname,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
     }
   }
 
@@ -550,9 +746,12 @@ export class DockerNodeManager {
     const output = await ssh.exec(buildEmbeddingSidecarProbeCmd(), 20_000);
     const status = parseEmbeddingSidecarProbe(output);
     if (status === null) {
-      logger.warn("[docker-node-manager] Embedding sidecar probe returned no status token", {
-        output: output.slice(0, 200),
-      });
+      logger.warn(
+        "[docker-node-manager] Embedding sidecar probe returned no status token",
+        {
+          output: output.slice(0, 200),
+        },
+      );
     }
     return status;
   }
@@ -562,22 +761,61 @@ export class DockerNodeManager {
    * healthy rows from receiving new work when SSH credentials or the Docker
    * daemon are no longer valid.
    */
-  async ensureNodeReady(node: DockerNode, options: NodeSelectionOptions = {}): Promise<boolean> {
+  async ensureNodeReady(
+    node: DockerNode,
+    options: NodeSelectionOptions = {},
+  ): Promise<boolean> {
     try {
       const ssh = this.sshClientForNode(node);
       await ssh.connect();
-      const dockerInfo = await ssh.exec("docker info --format '{{.ID}}|{{.Architecture}}'", 10_000);
-      const { dockerId, architecture } = parseDockerInfoProbe(dockerInfo);
+      // PSI is read in the same round trip: `docker info` answers from daemon
+      // memory even on a node too IO-starved to finish a `docker create`
+      // (#17880), so daemon liveness alone cannot green-light placement. The
+      // `&&` keeps a failing `docker info` rejecting exec with its own exit
+      // code (the unreachable/catch path below), exactly as the pre-PSI probe
+      // did; the PSI read is only appended to a successful probe.
+      const probeOutput = await ssh.exec(
+        `docker info --format '{{.ID}}|{{.Architecture}}' && { echo '${READINESS_PROBE_PSI_MARKER}'; cat /proc/pressure/io 2>/dev/null || true; }`,
+        10_000,
+      );
+      const [dockerSection = "", psiSection = ""] = probeOutput.split(
+        READINESS_PROBE_PSI_MARKER,
+      );
+      const { dockerId, architecture } = parseDockerInfoProbe(dockerSection);
       if (dockerId.trim()) {
         if (
-          !isArchitectureCompatibleWithPlatform(architecture, options.requiredPlatform) &&
+          !isArchitectureCompatibleWithPlatform(
+            architecture,
+            options.requiredPlatform,
+          ) &&
           requiredArchitectureForPlatform(options.requiredPlatform)
         ) {
-          logger.warn("[docker-node-manager] Node is reachable but incompatible with image", {
-            nodeId: node.node_id,
-            architecture,
-            requiredPlatform: options.requiredPlatform,
-          });
+          logger.warn(
+            "[docker-node-manager] Node is reachable but incompatible with image",
+            {
+              nodeId: node.node_id,
+              architecture,
+              requiredPlatform: options.requiredPlatform,
+            },
+          );
+          return false;
+        }
+        const ioPressure = parseIoPressureFullAvg10(psiSection);
+        if (
+          ioPressure !== null &&
+          ioPressure >= PLACEMENT_MAX_IO_PRESSURE_FULL_AVG10
+        ) {
+          // No DB status write: IO overload is transient and node-status flips
+          // are reserved for dead/unreachable daemons (see the canonical-node
+          // protection below).
+          logger.warn(
+            "[docker-node-manager] Node refused for placement: IO-starved",
+            {
+              nodeId: node.node_id,
+              ioPressureFullAvg10: ioPressure,
+              max: PLACEMENT_MAX_IO_PRESSURE_FULL_AVG10,
+            },
+          );
           return false;
         }
         await dockerNodesRepository.updateStatus(node.node_id, "healthy");
@@ -590,25 +828,34 @@ export class DockerNodeManager {
           `[docker-node-manager] Suppressed degraded mark for canonical node ${node.node_id} (${node.hostname}); Docker probe returned empty ID`,
         );
       }
-      logger.warn(`[docker-node-manager] Node ${node.node_id} Docker probe returned empty ID`);
+      logger.warn(
+        `[docker-node-manager] Node ${node.node_id} Docker probe returned empty ID`,
+      );
       return false;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       // See healthCheckNode for rationale: canonical nodes are never marked
       // offline from a transient ssh failure during scheduling.
       if (isAutoscaledNode(node)) {
-        await dockerNodesRepository.updateStatus(node.node_id, "offline").catch((updateError) => {
-          logger.warn("[docker-node-manager] Failed to mark node offline", {
-            nodeId: node.node_id,
-            error: updateError instanceof Error ? updateError.message : String(updateError),
+        await dockerNodesRepository
+          .updateStatus(node.node_id, "offline")
+          .catch((updateError) => {
+            logger.warn("[docker-node-manager] Failed to mark node offline", {
+              nodeId: node.node_id,
+              error:
+                updateError instanceof Error
+                  ? updateError.message
+                  : String(updateError),
+            });
           });
-        });
       } else {
         logger.warn(
           `[docker-node-manager] Suppressed offline mark for canonical node ${node.node_id} (${node.hostname}): ${message}`,
         );
       }
-      logger.warn(`[docker-node-manager] Node ${node.node_id} is not reachable: ${message}`);
+      logger.warn(
+        `[docker-node-manager] Node ${node.node_id} is not reachable: ${message}`,
+      );
       return false;
     }
   }
@@ -624,7 +871,10 @@ export class DockerNodeManager {
       await Promise.all(
         nodes.map(
           async (node) =>
-            [node.node_id, await countAllocatedWorkloadsOnNode(node.node_id)] as const,
+            [
+              node.node_id,
+              await countAllocatedWorkloadsOnNode(node.node_id),
+            ] as const,
         ),
       ),
     );
@@ -636,7 +886,11 @@ export class DockerNodeManager {
       allocated: allocatedByNode.get(node.node_id) ?? node.allocated_count,
       available:
         node.enabled && node.status === "healthy"
-          ? Math.max(0, node.capacity - (allocatedByNode.get(node.node_id) ?? node.allocated_count))
+          ? Math.max(
+              0,
+              node.capacity -
+                (allocatedByNode.get(node.node_id) ?? node.allocated_count),
+            )
           : 0,
       status: node.status,
       enabled: node.enabled,
@@ -644,7 +898,9 @@ export class DockerNodeManager {
       embeddingSidecar: embeddingSidecarStatusFromMetadata(node.metadata),
     }));
 
-    const enabledNodes = nodeReports.filter((n) => n.enabled && n.status === "healthy");
+    const enabledNodes = nodeReports.filter(
+      (n) => n.enabled && n.status === "healthy",
+    );
 
     return {
       totalCapacity: enabledNodes.reduce((sum, n) => sum + n.capacity, 0),
@@ -664,7 +920,9 @@ export class DockerNodeManager {
    * `agent_sandboxes`; both must be counted or the scheduler can overfill a
    * node or drain a node that still has agent workloads.
    */
-  async syncAllocatedCounts(): Promise<Map<string, { before: number; after: number }>> {
+  async syncAllocatedCounts(): Promise<
+    Map<string, { before: number; after: number }>
+  > {
     const nodes = await dockerNodesRepository.findEnabled();
     const changes = new Map<string, { before: number; after: number }>();
 
@@ -675,7 +933,10 @@ export class DockerNodeManager {
         logger.info(
           `[docker-node-manager] Sync ${node.node_id}: allocated_count ${node.allocated_count} → ${actualCount}`,
         );
-        await dockerNodesRepository.setAllocatedCount(node.node_id, actualCount);
+        await dockerNodesRepository.setAllocatedCount(
+          node.node_id,
+          actualCount,
+        );
         changes.set(node.node_id, {
           before: node.allocated_count,
           after: actualCount,
@@ -684,7 +945,9 @@ export class DockerNodeManager {
     }
 
     if (changes.size > 0) {
-      logger.info(`[docker-node-manager] Synced allocated counts for ${changes.size} node(s)`);
+      logger.info(
+        `[docker-node-manager] Synced allocated counts for ${changes.size} node(s)`,
+      );
     }
 
     return changes;
@@ -758,7 +1021,8 @@ export class DockerNodeManager {
             status: "pulled" as const,
           };
         } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
+          const message =
+            error instanceof Error ? error.message : String(error);
           logger.warn("[docker-node-manager] Agent image pre-pull failed", {
             nodeId: node.node_id,
             image,
@@ -770,7 +1034,12 @@ export class DockerNodeManager {
             // pull` ignores), so it can keep running. The tracked wrapper leaves
             // a PID file only for this pre-pull, so recovery does not kill
             // unrelated deployment pulls on the same node.
-            await this.recoverAfterTimedOutPrePull(ssh, node, prePull.pidFile, image);
+            await this.recoverAfterTimedOutPrePull(
+              ssh,
+              node,
+              prePull.pidFile,
+              image,
+            );
           } else {
             prePullFailureState.delete(node.node_id);
           }
@@ -811,7 +1080,8 @@ export class DockerNodeManager {
         "[docker-node-manager] Failed to reap orphaned docker pull after pre-pull failure",
         {
           nodeId: node.node_id,
-          error: killError instanceof Error ? killError.message : String(killError),
+          error:
+            killError instanceof Error ? killError.message : String(killError),
         },
       );
     }
@@ -826,7 +1096,8 @@ export class DockerNodeManager {
 
     if (!containersEnv.prePullSelfHealRestartEnabled()) return;
     if (state.consecutiveFailures < PREPULL_SELF_HEAL_FAILURE_THRESHOLD) return;
-    if (Date.now() - state.lastSelfHealMs < PREPULL_SELF_HEAL_COOLDOWN_MS) return;
+    if (Date.now() - state.lastSelfHealMs < PREPULL_SELF_HEAL_COOLDOWN_MS)
+      return;
 
     logger.error(
       "[docker-node-manager] Pre-pull wedged repeatedly; auto-restarting docker to self-heal",
@@ -851,7 +1122,10 @@ export class DockerNodeManager {
       // and the cooldown/threshold state lets a later cycle retry.
       logger.error("[docker-node-manager] Self-heal docker restart failed", {
         nodeId: node.node_id,
-        error: restartError instanceof Error ? restartError.message : String(restartError),
+        error:
+          restartError instanceof Error
+            ? restartError.message
+            : String(restartError),
       });
     }
   }
@@ -864,7 +1138,9 @@ export class DockerNodeManager {
    */
   async getRuntimeContainers(
     node: DockerNode,
-  ): Promise<{ name: string; id: string; state: string; status: string }[] | null> {
+  ): Promise<
+    { name: string; id: string; state: string; status: string }[] | null
+  > {
     try {
       const ssh = this.sshClientForNode(node);
       await ssh.connect();
@@ -884,7 +1160,9 @@ export class DockerNodeManager {
         });
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
-      logger.warn(`[docker-node-manager] Failed to list containers on ${node.node_id}: ${msg}`);
+      logger.warn(
+        `[docker-node-manager] Failed to list containers on ${node.node_id}: ${msg}`,
+      );
       return null;
     }
   }

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -113,10 +113,24 @@ export function __resetPlacementTimeoutStateForTests(): void {
   placementTimeoutState.clear();
 }
 
-/** Matches the docker-ssh timeout signature anywhere in a message/cause chain. */
+/** Matches only the docker-ssh timeout signature in an error or its causes. */
 export function isDockerCommandTimeoutError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("Command timed out after");
+  const visited = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current !== undefined && current !== null && !visited.has(current)) {
+    visited.add(current);
+    const message = current instanceof Error ? current.message : String(current);
+    if (
+      message.includes("[docker-ssh] Command timed out after") &&
+      message.endsWith(": docker [redacted]")
+    ) {
+      return true;
+    }
+    current = current instanceof Error ? current.cause : undefined;
+  }
+
+  return false;
 }
 
 /**

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -9,10 +9,7 @@
 
 import crypto from "node:crypto";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
-import type {
-  DockerNode,
-  DockerNodeStatus,
-} from "../../db/schemas/docker-nodes";
+import type { DockerNode, DockerNodeStatus } from "../../db/schemas/docker-nodes";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
 import {
@@ -32,11 +29,7 @@ import {
   shellQuote,
 } from "./docker-sandbox-utils";
 import { DockerSSHClient } from "./docker-ssh";
-import {
-  type DiskHealthVerdict,
-  diskHealthVerdict,
-  probeNodeDiskUsage,
-} from "./node-disk-manager";
+import { type DiskHealthVerdict, diskHealthVerdict, probeNodeDiskUsage } from "./node-disk-manager";
 
 // ---------------------------------------------------------------------------
 // Pre-pull self-heal bookkeeping (see recoverAfterTimedOutPrePull)
@@ -142,22 +135,17 @@ export function notePlacementCommandFailure(
     timeoutsMs: [],
     quarantinedUntilMs: 0,
   };
-  state.timeoutsMs = state.timeoutsMs.filter(
-    (ts) => nowMs - ts < PLACEMENT_TIMEOUT_WINDOW_MS,
-  );
+  state.timeoutsMs = state.timeoutsMs.filter((ts) => nowMs - ts < PLACEMENT_TIMEOUT_WINDOW_MS);
   state.timeoutsMs.push(nowMs);
   if (state.timeoutsMs.length >= PLACEMENT_TIMEOUT_THRESHOLD) {
     state.quarantinedUntilMs = nowMs + PLACEMENT_QUARANTINE_MS;
     state.timeoutsMs = [];
-    logger.warn(
-      "[docker-node-manager] Node quarantined from placement after docker timeouts",
-      {
-        nodeId,
-        threshold: PLACEMENT_TIMEOUT_THRESHOLD,
-        windowMs: PLACEMENT_TIMEOUT_WINDOW_MS,
-        quarantineMs: PLACEMENT_QUARANTINE_MS,
-      },
-    );
+    logger.warn("[docker-node-manager] Node quarantined from placement after docker timeouts", {
+      nodeId,
+      threshold: PLACEMENT_TIMEOUT_THRESHOLD,
+      windowMs: PLACEMENT_TIMEOUT_WINDOW_MS,
+      quarantineMs: PLACEMENT_QUARANTINE_MS,
+    });
   }
   placementTimeoutState.set(nodeId, state);
 }
@@ -167,10 +155,7 @@ export function clearPlacementCommandFailures(nodeId: string): void {
   placementTimeoutState.delete(nodeId);
 }
 
-export function isNodePlacementQuarantined(
-  nodeId: string,
-  nowMs = Date.now(),
-): boolean {
+export function isNodePlacementQuarantined(nodeId: string, nowMs = Date.now()): boolean {
   const state = placementTimeoutState.get(nodeId);
   return !!state && state.quarantinedUntilMs > nowMs;
 }
@@ -299,11 +284,7 @@ export function buildTrackedPrePullCommand(
   marker = crypto.randomUUID(),
 ): { command: string; pidFile: string } {
   const pidFile = prePullPidFile(marker);
-  const pullCommand = [
-    "docker pull",
-    ...dockerPlatformFlag(platform),
-    shellQuote(image),
-  ].join(" ");
+  const pullCommand = ["docker pull", ...dockerPlatformFlag(platform), shellQuote(image)].join(" ");
   const script = [
     `pidfile=${shellQuote(pidFile)}`,
     'rm -f "$pidfile"',
@@ -322,10 +303,7 @@ export function buildTrackedPrePullCommand(
   return { command: `sh -c ${shellQuote(script)}`, pidFile };
 }
 
-export function buildPrePullReapCommand(
-  pidFile: string,
-  image: string,
-): string {
+export function buildPrePullReapCommand(pidFile: string, image: string): string {
   const quotedImage = shellQuote(image);
   const script = [
     `pidfile=${shellQuote(pidFile)}`,
@@ -381,9 +359,7 @@ export class DockerNodeManager {
    * Find the least-loaded healthy node with available capacity.
    * Returns null if no capacity is available.
    */
-  async getAvailableNode(
-    options: NodeSelectionOptions = {},
-  ): Promise<DockerNode | null> {
+  async getAvailableNode(options: NodeSelectionOptions = {}): Promise<DockerNode | null> {
     const nodes = await dockerNodesRepository.findEnabled();
     const candidates = (
       await Promise.all(
@@ -393,9 +369,7 @@ export class DockerNodeManager {
           return {
             node,
             allocated,
-            available: canProbeForCapacity
-              ? Math.max(0, node.capacity - allocated)
-              : 0,
+            available: canProbeForCapacity ? Math.max(0, node.capacity - allocated) : 0,
           };
         }),
       )
@@ -408,12 +382,9 @@ export class DockerNodeManager {
       isNodePlacementQuarantined(candidate.node.node_id),
     );
     if (quarantined.length > 0) {
-      logger.warn(
-        "[docker-node-manager] Skipping quarantined nodes during selection",
-        {
-          nodeIds: quarantined.map((candidate) => candidate.node.node_id),
-        },
-      );
+      logger.warn("[docker-node-manager] Skipping quarantined nodes during selection", {
+        nodeIds: quarantined.map((candidate) => candidate.node.node_id),
+      });
     }
     const selectable = candidates.filter(
       (candidate) => !isNodePlacementQuarantined(candidate.node.node_id),
@@ -421,14 +392,11 @@ export class DockerNodeManager {
 
     for (const candidate of selectable) {
       if (!isNodeMetadataCompatible(candidate.node, options.requiredPlatform)) {
-        logger.warn(
-          "[docker-node-manager] Skipping node with incompatible architecture",
-          {
-            nodeId: candidate.node.node_id,
-            requiredPlatform: options.requiredPlatform,
-            metadata: candidate.node.metadata,
-          },
-        );
+        logger.warn("[docker-node-manager] Skipping node with incompatible architecture", {
+          nodeId: candidate.node.node_id,
+          requiredPlatform: options.requiredPlatform,
+          metadata: candidate.node.metadata,
+        });
         continue;
       }
       if (!(await this.ensureNodeReady(candidate.node, options))) {
@@ -440,9 +408,7 @@ export class DockerNodeManager {
       return { ...candidate.node, allocated_count: candidate.allocated };
     }
 
-    logger.warn(
-      "[docker-node-manager] No reachable healthy nodes with capacity",
-    );
+    logger.warn("[docker-node-manager] No reachable healthy nodes with capacity");
     return null;
   }
 
@@ -472,10 +438,7 @@ export class DockerNodeManager {
       node.host_key_fingerprint
         ? undefined
         : async (hostname, fingerprint) => {
-            await dockerNodesRepository.setHostKeyFingerprint(
-              node.node_id,
-              fingerprint,
-            );
+            await dockerNodesRepository.setHostKeyFingerprint(node.node_id, fingerprint);
             logger.warn(
               `[docker-node-manager] TOFU-pinned host key for node ${node.node_id} (${hostname}): SHA256:${fingerprint}`,
             );
@@ -517,10 +480,7 @@ export class DockerNodeManager {
       try {
         const ssh = this.sshClientForNode(node);
         await ssh.connect();
-        const dockerId = await ssh.exec(
-          "docker info --format '{{.ID}}'",
-          10_000,
-        );
+        const dockerId = await ssh.exec("docker info --format '{{.ID}}'", 10_000);
 
         if (dockerId.trim()) {
           // Disk-aware verdict: a node whose Docker daemon answers but whose
@@ -545,10 +505,7 @@ export class DockerNodeManager {
               logger.warn(
                 `[docker-node-manager] Node ${node.node_id} (${node.hostname}) is reachable but disk is critically full; marking degraded so it drains/replaces instead of taking new work.`,
               );
-              await dockerNodesRepository.updateStatus(
-                node.node_id,
-                "degraded",
-              );
+              await dockerNodesRepository.updateStatus(node.node_id, "degraded");
               return "degraded";
             }
             logger.warn(
@@ -585,9 +542,7 @@ export class DockerNodeManager {
     logger.warn(
       `[docker-node-manager] Health check failed for ${node.node_id} after ${MAX_RETRIES} attempts: ${lastError}`,
     );
-    const status: DockerNodeStatus = lastError.includes("empty ID")
-      ? "degraded"
-      : "offline";
+    const status: DockerNodeStatus = lastError.includes("empty ID") ? "degraded" : "offline";
 
     // A `degraded` verdict means the daemon ANSWERED but returned no ID — the
     // node is reachable, just unhealthy. Persist it and let the disk-clean /
@@ -645,19 +600,13 @@ export class DockerNodeManager {
   async diskHealthStatus(node: DockerNode): Promise<DiskHealthVerdict> {
     try {
       const usedPercent = await probeNodeDiskUsage(node);
-      return diskHealthVerdict(
-        usedPercent,
-        containersEnv.nodeDiskUnhealthyThresholdPct(),
-      );
+      return diskHealthVerdict(usedPercent, containersEnv.nodeDiskUnhealthyThresholdPct());
     } catch (error) {
-      logger.warn(
-        "[docker-node-manager] Disk health probe failed; treating as ok",
-        {
-          nodeId: node.node_id,
-          hostname: node.hostname,
-          error: error instanceof Error ? error.message : String(error),
-        },
-      );
+      logger.warn("[docker-node-manager] Disk health probe failed; treating as ok", {
+        nodeId: node.node_id,
+        hostname: node.hostname,
+        error: error instanceof Error ? error.message : String(error),
+      });
       return "ok";
     }
   }
@@ -676,34 +625,21 @@ export class DockerNodeManager {
    * of the health check: like the disk sub-probe, the sidecar never owns
    * reachability — the docker-info probe does.
    */
-  async embeddingSidecarHealth(
-    node: DockerNode,
-    ssh: DockerSSHClient,
-  ): Promise<void> {
+  async embeddingSidecarHealth(node: DockerNode, ssh: DockerSSHClient): Promise<void> {
     try {
       let status = await this.probeEmbeddingSidecar(ssh);
       if (status === null) return;
 
-      if (
-        status !== "running" &&
-        containersEnv.embeddingSidecarSelfHealEnabled()
-      ) {
-        const lastAttempt =
-          embeddingSidecarSelfHealState.get(node.node_id) ?? 0;
-        if (
-          Date.now() - lastAttempt >=
-          EMBEDDING_SIDECAR_SELF_HEAL_COOLDOWN_MS
-        ) {
+      if (status !== "running" && containersEnv.embeddingSidecarSelfHealEnabled()) {
+        const lastAttempt = embeddingSidecarSelfHealState.get(node.node_id) ?? 0;
+        if (Date.now() - lastAttempt >= EMBEDDING_SIDECAR_SELF_HEAL_COOLDOWN_MS) {
           // Stamp BEFORE the attempt so a hanging/failing ensure still honors
           // the cooldown next cycle instead of re-pulling the image every tick.
           embeddingSidecarSelfHealState.set(node.node_id, Date.now());
           logger.warn(
             `[docker-node-manager] Embedding sidecar ${status} on node ${node.node_id} (${node.hostname}); attempting self-heal install`,
           );
-          await ssh.exec(
-            buildEnsureEmbeddingSidecarCmd(),
-            EMBEDDING_SIDECAR_ENSURE_TIMEOUT_MS,
-          );
+          await ssh.exec(buildEnsureEmbeddingSidecarCmd(), EMBEDDING_SIDECAR_ENSURE_TIMEOUT_MS);
           status = (await this.probeEmbeddingSidecar(ssh)) ?? status;
         }
       }
@@ -720,22 +656,16 @@ export class DockerNodeManager {
           },
         );
       }
-      await dockerNodesRepository.setEmbeddingSidecarHealth(
-        node.node_id,
-        status,
-      );
+      await dockerNodesRepository.setEmbeddingSidecarHealth(node.node_id, status);
     } catch (error) {
       // error-policy:J7 the sidecar sub-probe/self-heal is diagnostics on the
       // health loop; a thrown SSH/exec failure is logged loudly here and must
       // not take down the reachability verdict the loop exists to produce.
-      logger.warn(
-        "[docker-node-manager] Embedding sidecar probe/self-heal failed",
-        {
-          nodeId: node.node_id,
-          hostname: node.hostname,
-          error: error instanceof Error ? error.message : String(error),
-        },
-      );
+      logger.warn("[docker-node-manager] Embedding sidecar probe/self-heal failed", {
+        nodeId: node.node_id,
+        hostname: node.hostname,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
@@ -746,12 +676,9 @@ export class DockerNodeManager {
     const output = await ssh.exec(buildEmbeddingSidecarProbeCmd(), 20_000);
     const status = parseEmbeddingSidecarProbe(output);
     if (status === null) {
-      logger.warn(
-        "[docker-node-manager] Embedding sidecar probe returned no status token",
-        {
-          output: output.slice(0, 200),
-        },
-      );
+      logger.warn("[docker-node-manager] Embedding sidecar probe returned no status token", {
+        output: output.slice(0, 200),
+      });
     }
     return status;
   }
@@ -761,10 +688,7 @@ export class DockerNodeManager {
    * healthy rows from receiving new work when SSH credentials or the Docker
    * daemon are no longer valid.
    */
-  async ensureNodeReady(
-    node: DockerNode,
-    options: NodeSelectionOptions = {},
-  ): Promise<boolean> {
+  async ensureNodeReady(node: DockerNode, options: NodeSelectionOptions = {}): Promise<boolean> {
     try {
       const ssh = this.sshClientForNode(node);
       await ssh.connect();
@@ -778,44 +702,30 @@ export class DockerNodeManager {
         `docker info --format '{{.ID}}|{{.Architecture}}' && { echo '${READINESS_PROBE_PSI_MARKER}'; cat /proc/pressure/io 2>/dev/null || true; }`,
         10_000,
       );
-      const [dockerSection = "", psiSection = ""] = probeOutput.split(
-        READINESS_PROBE_PSI_MARKER,
-      );
+      const [dockerSection = "", psiSection = ""] = probeOutput.split(READINESS_PROBE_PSI_MARKER);
       const { dockerId, architecture } = parseDockerInfoProbe(dockerSection);
       if (dockerId.trim()) {
         if (
-          !isArchitectureCompatibleWithPlatform(
-            architecture,
-            options.requiredPlatform,
-          ) &&
+          !isArchitectureCompatibleWithPlatform(architecture, options.requiredPlatform) &&
           requiredArchitectureForPlatform(options.requiredPlatform)
         ) {
-          logger.warn(
-            "[docker-node-manager] Node is reachable but incompatible with image",
-            {
-              nodeId: node.node_id,
-              architecture,
-              requiredPlatform: options.requiredPlatform,
-            },
-          );
+          logger.warn("[docker-node-manager] Node is reachable but incompatible with image", {
+            nodeId: node.node_id,
+            architecture,
+            requiredPlatform: options.requiredPlatform,
+          });
           return false;
         }
         const ioPressure = parseIoPressureFullAvg10(psiSection);
-        if (
-          ioPressure !== null &&
-          ioPressure >= PLACEMENT_MAX_IO_PRESSURE_FULL_AVG10
-        ) {
+        if (ioPressure !== null && ioPressure >= PLACEMENT_MAX_IO_PRESSURE_FULL_AVG10) {
           // No DB status write: IO overload is transient and node-status flips
           // are reserved for dead/unreachable daemons (see the canonical-node
           // protection below).
-          logger.warn(
-            "[docker-node-manager] Node refused for placement: IO-starved",
-            {
-              nodeId: node.node_id,
-              ioPressureFullAvg10: ioPressure,
-              max: PLACEMENT_MAX_IO_PRESSURE_FULL_AVG10,
-            },
-          );
+          logger.warn("[docker-node-manager] Node refused for placement: IO-starved", {
+            nodeId: node.node_id,
+            ioPressureFullAvg10: ioPressure,
+            max: PLACEMENT_MAX_IO_PRESSURE_FULL_AVG10,
+          });
           return false;
         }
         await dockerNodesRepository.updateStatus(node.node_id, "healthy");
@@ -828,34 +738,25 @@ export class DockerNodeManager {
           `[docker-node-manager] Suppressed degraded mark for canonical node ${node.node_id} (${node.hostname}); Docker probe returned empty ID`,
         );
       }
-      logger.warn(
-        `[docker-node-manager] Node ${node.node_id} Docker probe returned empty ID`,
-      );
+      logger.warn(`[docker-node-manager] Node ${node.node_id} Docker probe returned empty ID`);
       return false;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       // See healthCheckNode for rationale: canonical nodes are never marked
       // offline from a transient ssh failure during scheduling.
       if (isAutoscaledNode(node)) {
-        await dockerNodesRepository
-          .updateStatus(node.node_id, "offline")
-          .catch((updateError) => {
-            logger.warn("[docker-node-manager] Failed to mark node offline", {
-              nodeId: node.node_id,
-              error:
-                updateError instanceof Error
-                  ? updateError.message
-                  : String(updateError),
-            });
+        await dockerNodesRepository.updateStatus(node.node_id, "offline").catch((updateError) => {
+          logger.warn("[docker-node-manager] Failed to mark node offline", {
+            nodeId: node.node_id,
+            error: updateError instanceof Error ? updateError.message : String(updateError),
           });
+        });
       } else {
         logger.warn(
           `[docker-node-manager] Suppressed offline mark for canonical node ${node.node_id} (${node.hostname}): ${message}`,
         );
       }
-      logger.warn(
-        `[docker-node-manager] Node ${node.node_id} is not reachable: ${message}`,
-      );
+      logger.warn(`[docker-node-manager] Node ${node.node_id} is not reachable: ${message}`);
       return false;
     }
   }
@@ -871,10 +772,7 @@ export class DockerNodeManager {
       await Promise.all(
         nodes.map(
           async (node) =>
-            [
-              node.node_id,
-              await countAllocatedWorkloadsOnNode(node.node_id),
-            ] as const,
+            [node.node_id, await countAllocatedWorkloadsOnNode(node.node_id)] as const,
         ),
       ),
     );
@@ -886,11 +784,7 @@ export class DockerNodeManager {
       allocated: allocatedByNode.get(node.node_id) ?? node.allocated_count,
       available:
         node.enabled && node.status === "healthy"
-          ? Math.max(
-              0,
-              node.capacity -
-                (allocatedByNode.get(node.node_id) ?? node.allocated_count),
-            )
+          ? Math.max(0, node.capacity - (allocatedByNode.get(node.node_id) ?? node.allocated_count))
           : 0,
       status: node.status,
       enabled: node.enabled,
@@ -898,9 +792,7 @@ export class DockerNodeManager {
       embeddingSidecar: embeddingSidecarStatusFromMetadata(node.metadata),
     }));
 
-    const enabledNodes = nodeReports.filter(
-      (n) => n.enabled && n.status === "healthy",
-    );
+    const enabledNodes = nodeReports.filter((n) => n.enabled && n.status === "healthy");
 
     return {
       totalCapacity: enabledNodes.reduce((sum, n) => sum + n.capacity, 0),
@@ -920,9 +812,7 @@ export class DockerNodeManager {
    * `agent_sandboxes`; both must be counted or the scheduler can overfill a
    * node or drain a node that still has agent workloads.
    */
-  async syncAllocatedCounts(): Promise<
-    Map<string, { before: number; after: number }>
-  > {
+  async syncAllocatedCounts(): Promise<Map<string, { before: number; after: number }>> {
     const nodes = await dockerNodesRepository.findEnabled();
     const changes = new Map<string, { before: number; after: number }>();
 
@@ -933,10 +823,7 @@ export class DockerNodeManager {
         logger.info(
           `[docker-node-manager] Sync ${node.node_id}: allocated_count ${node.allocated_count} → ${actualCount}`,
         );
-        await dockerNodesRepository.setAllocatedCount(
-          node.node_id,
-          actualCount,
-        );
+        await dockerNodesRepository.setAllocatedCount(node.node_id, actualCount);
         changes.set(node.node_id, {
           before: node.allocated_count,
           after: actualCount,
@@ -945,9 +832,7 @@ export class DockerNodeManager {
     }
 
     if (changes.size > 0) {
-      logger.info(
-        `[docker-node-manager] Synced allocated counts for ${changes.size} node(s)`,
-      );
+      logger.info(`[docker-node-manager] Synced allocated counts for ${changes.size} node(s)`);
     }
 
     return changes;
@@ -1021,8 +906,7 @@ export class DockerNodeManager {
             status: "pulled" as const,
           };
         } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
+          const message = error instanceof Error ? error.message : String(error);
           logger.warn("[docker-node-manager] Agent image pre-pull failed", {
             nodeId: node.node_id,
             image,
@@ -1034,12 +918,7 @@ export class DockerNodeManager {
             // pull` ignores), so it can keep running. The tracked wrapper leaves
             // a PID file only for this pre-pull, so recovery does not kill
             // unrelated deployment pulls on the same node.
-            await this.recoverAfterTimedOutPrePull(
-              ssh,
-              node,
-              prePull.pidFile,
-              image,
-            );
+            await this.recoverAfterTimedOutPrePull(ssh, node, prePull.pidFile, image);
           } else {
             prePullFailureState.delete(node.node_id);
           }
@@ -1080,8 +959,7 @@ export class DockerNodeManager {
         "[docker-node-manager] Failed to reap orphaned docker pull after pre-pull failure",
         {
           nodeId: node.node_id,
-          error:
-            killError instanceof Error ? killError.message : String(killError),
+          error: killError instanceof Error ? killError.message : String(killError),
         },
       );
     }
@@ -1096,8 +974,7 @@ export class DockerNodeManager {
 
     if (!containersEnv.prePullSelfHealRestartEnabled()) return;
     if (state.consecutiveFailures < PREPULL_SELF_HEAL_FAILURE_THRESHOLD) return;
-    if (Date.now() - state.lastSelfHealMs < PREPULL_SELF_HEAL_COOLDOWN_MS)
-      return;
+    if (Date.now() - state.lastSelfHealMs < PREPULL_SELF_HEAL_COOLDOWN_MS) return;
 
     logger.error(
       "[docker-node-manager] Pre-pull wedged repeatedly; auto-restarting docker to self-heal",
@@ -1122,10 +999,7 @@ export class DockerNodeManager {
       // and the cooldown/threshold state lets a later cycle retry.
       logger.error("[docker-node-manager] Self-heal docker restart failed", {
         nodeId: node.node_id,
-        error:
-          restartError instanceof Error
-            ? restartError.message
-            : String(restartError),
+        error: restartError instanceof Error ? restartError.message : String(restartError),
       });
     }
   }
@@ -1138,9 +1012,7 @@ export class DockerNodeManager {
    */
   async getRuntimeContainers(
     node: DockerNode,
-  ): Promise<
-    { name: string; id: string; state: string; status: string }[] | null
-  > {
+  ): Promise<{ name: string; id: string; state: string; status: string }[] | null> {
     try {
       const ssh = this.sshClientForNode(node);
       await ssh.connect();
@@ -1160,9 +1032,7 @@ export class DockerNodeManager {
         });
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
-      logger.warn(
-        `[docker-node-manager] Failed to list containers on ${node.node_id}: ${msg}`,
-      );
+      logger.warn(`[docker-node-manager] Failed to list containers on ${node.node_id}: ${msg}`);
       return null;
     }
   }

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -114,16 +114,20 @@ export function __resetPlacementTimeoutStateForTests(): void {
 }
 
 /** Matches only the docker-ssh timeout signature in an error or its causes. */
-export function isDockerCommandTimeoutError(error: unknown): boolean {
+export function isDockerSshCommandTimeoutError(
+  error: unknown,
+  commandFirstToken?: string,
+): boolean {
   const visited = new Set<unknown>();
   let current: unknown = error;
 
   while (current !== undefined && current !== null && !visited.has(current)) {
     visited.add(current);
     const message = current instanceof Error ? current.message : String(current);
+    const commandSuffix = commandFirstToken ? `: ${commandFirstToken} [redacted]` : " [redacted]";
     if (
       message.includes("[docker-ssh] Command timed out after") &&
-      message.endsWith(": docker [redacted]")
+      message.endsWith(commandSuffix)
     ) {
       return true;
     }
@@ -144,7 +148,7 @@ export function notePlacementCommandFailure(
   error: unknown,
   nowMs = Date.now(),
 ): void {
-  if (!isDockerCommandTimeoutError(error)) return;
+  if (!isDockerSshCommandTimeoutError(error, "docker")) return;
   const state = placementTimeoutState.get(nodeId) ?? {
     timeoutsMs: [],
     quarantinedUntilMs: 0,
@@ -269,6 +273,11 @@ export interface NodeSelectionOptions {
    * if the blue landed on the same node as the old.
    */
   excludeNodeId?: string;
+  /**
+   * Refuse transient IO pressure only while selecting new placement. Sticky
+   * stateful routing and autoscaler readiness must remain liveness-only.
+   */
+  enforcePlacementIoPressure?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -292,11 +301,6 @@ function isAutoscaledNode(node: DockerNode): boolean {
 
 function prePullPidFile(marker: string): string {
   return `${PREPULL_PID_DIR}/eliza-prepull-${marker}.pid`;
-}
-
-export function isPrePullTimeoutError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("Command timed out after");
 }
 
 export function buildTrackedPrePullCommand(
@@ -399,28 +403,59 @@ export class DockerNodeManager {
       .filter((candidate) => candidate.node.node_id !== options.excludeNodeId)
       .sort((a, b) => b.available - a.available);
 
-    const quarantined = candidates.filter((candidate) =>
-      isNodePlacementQuarantined(candidate.node.node_id),
-    );
+    const compatibleCandidates = candidates.filter((candidate) => {
+      if (isNodeMetadataCompatible(candidate.node, options.requiredPlatform)) {
+        return true;
+      }
+      logger.warn("[docker-node-manager] Skipping node with incompatible architecture", {
+        nodeId: candidate.node.node_id,
+        requiredPlatform: options.requiredPlatform,
+        metadata: candidate.node.metadata,
+      });
+      return false;
+    });
+    const nowMs = Date.now();
+    const selectable: typeof compatibleCandidates = [];
+    const quarantined: Array<{
+      candidate: (typeof compatibleCandidates)[number];
+      quarantinedUntilMs: number;
+    }> = [];
+    for (const candidate of compatibleCandidates) {
+      const quarantinedUntilMs =
+        placementTimeoutState.get(candidate.node.node_id)?.quarantinedUntilMs ?? 0;
+      if (quarantinedUntilMs > nowMs) {
+        quarantined.push({ candidate, quarantinedUntilMs });
+      } else {
+        selectable.push(candidate);
+      }
+    }
     if (quarantined.length > 0) {
       logger.warn("[docker-node-manager] Skipping quarantined nodes during selection", {
-        nodeIds: quarantined.map((candidate) => candidate.node.node_id),
+        nodeIds: quarantined.map(({ candidate }) => candidate.node.node_id),
       });
     }
-    const selectable = candidates.filter(
-      (candidate) => !isNodePlacementQuarantined(candidate.node.node_id),
-    );
+
+    if (selectable.length === 0 && quarantined.length > 0) {
+      const fallback = quarantined.reduce((oldest, current) =>
+        current.quarantinedUntilMs < oldest.quarantinedUntilMs ? current : oldest,
+      );
+      selectable.push(fallback.candidate);
+      logger.warn(
+        "[docker-node-manager] Overriding placement quarantine because every capacity-bearing node is quarantined",
+        {
+          nodeId: fallback.candidate.node.node_id,
+          quarantinedUntilMs: fallback.quarantinedUntilMs,
+        },
+      );
+    }
 
     for (const candidate of selectable) {
-      if (!isNodeMetadataCompatible(candidate.node, options.requiredPlatform)) {
-        logger.warn("[docker-node-manager] Skipping node with incompatible architecture", {
-          nodeId: candidate.node.node_id,
-          requiredPlatform: options.requiredPlatform,
-          metadata: candidate.node.metadata,
-        });
-        continue;
-      }
-      if (!(await this.ensureNodeReady(candidate.node, options))) {
+      if (
+        !(await this.ensureNodeReady(candidate.node, {
+          ...options,
+          enforcePlacementIoPressure: true,
+        }))
+      ) {
         continue;
       }
       logger.info(
@@ -713,16 +748,16 @@ export class DockerNodeManager {
     try {
       const ssh = this.sshClientForNode(node);
       await ssh.connect();
-      // PSI is read in the same round trip: `docker info` answers from daemon
-      // memory even on a node too IO-starved to finish a `docker create`
-      // (#17880), so daemon liveness alone cannot green-light placement. The
-      // `&&` keeps a failing `docker info` rejecting exec with its own exit
-      // code (the unreachable/catch path below), exactly as the pre-PSI probe
-      // did; the PSI read is only appended to a successful probe.
-      const probeOutput = await ssh.exec(
-        `docker info --format '{{.ID}}|{{.Architecture}}' && { echo '${READINESS_PROBE_PSI_MARKER}'; cat /proc/pressure/io 2>/dev/null || true; }`,
-        10_000,
-      );
+      const dockerInfoCommand = "docker info --format '{{.ID}}|{{.Architecture}}'";
+      // Placement reads PSI in the same round trip because `docker info`
+      // answers from daemon memory even when IO stalls `docker create`. Other
+      // callers use this method as a liveness probe for sticky stateful routing
+      // and autoscaler bootstrap, where transient pressure must not reroute or
+      // reject the node.
+      const probeCommand = options.enforcePlacementIoPressure
+        ? `${dockerInfoCommand} && { echo '${READINESS_PROBE_PSI_MARKER}'; cat /proc/pressure/io 2>/dev/null || true; }`
+        : dockerInfoCommand;
+      const probeOutput = await ssh.exec(probeCommand, 10_000);
       const [dockerSection = "", psiSection = ""] = probeOutput.split(READINESS_PROBE_PSI_MARKER);
       const { dockerId, architecture } = parseDockerInfoProbe(dockerSection);
       if (dockerId.trim()) {
@@ -737,7 +772,9 @@ export class DockerNodeManager {
           });
           return false;
         }
-        const ioPressure = parseIoPressureFullAvg60(psiSection);
+        const ioPressure = options.enforcePlacementIoPressure
+          ? parseIoPressureFullAvg60(psiSection)
+          : null;
         if (ioPressure !== null && ioPressure >= PLACEMENT_MAX_IO_PRESSURE_FULL_AVG60) {
           // No DB status write: IO overload is transient and node-status flips
           // are reserved for dead/unreachable daemons (see the canonical-node
@@ -933,7 +970,7 @@ export class DockerNodeManager {
             image,
             error: message,
           });
-          if (isPrePullTimeoutError(error)) {
+          if (isDockerSshCommandTimeoutError(error)) {
             // A timed-out `docker pull` is NOT stopped by DockerSSHClient's
             // channel-close (that only sends SIGHUP, which a detached `docker
             // pull` ignores), so it can keep running. The tracked wrapper leaves

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -13,10 +13,7 @@ import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes"
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { WARM_POOL_ORG_ID } from "../../db/schemas/agent-sandboxes";
 import type { DockerNode } from "../../db/schemas/docker-nodes";
-import {
-  isAgentTokenSigningConfigured,
-  mintAgentToken,
-} from "../auth/agent-token";
+import { isAgentTokenSigningConfigured, mintAgentToken } from "../auth/agent-token";
 import { containersEnv } from "../config/containers-env";
 import { getAgentBaseDomain } from "../eliza-agent-web-ui";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
@@ -67,10 +64,7 @@ import {
 } from "./docker-sandbox-utils";
 import { classifyDockerSshProbeError, DockerSSHClient } from "./docker-ssh";
 import { headscaleClient } from "./headscale-client";
-import {
-  DEFAULT_REGISTRATION_TIMEOUT_MS,
-  headscaleIntegration,
-} from "./headscale-integration";
+import { DEFAULT_REGISTRATION_TIMEOUT_MS, headscaleIntegration } from "./headscale-integration";
 import { buildKeylessOpenAIContainerEnv } from "./managed-eliza-env";
 import type {
   SandboxCreateConfig,
@@ -199,10 +193,7 @@ export async function createDockerContainerAfterReplacementIntent<T>({
 }
 
 function dockerContainerIdsMatch(expected: string, actual: string): boolean {
-  if (
-    !/^[a-f0-9]{12,64}$/i.test(expected) ||
-    !/^[a-f0-9]{12,64}$/i.test(actual)
-  ) {
+  if (!/^[a-f0-9]{12,64}$/i.test(expected) || !/^[a-f0-9]{12,64}$/i.test(actual)) {
     return false;
   }
   return expected.startsWith(actual) || actual.startsWith(expected);
@@ -220,10 +211,7 @@ function resolveStewardHostUrl(): string {
 
 function resolveStewardContainerEnvUrl(): string {
   const env = getCloudAwareEnv();
-  return resolveStewardContainerUrl(
-    resolveStewardHostUrl(),
-    env.STEWARD_CONTAINER_URL,
-  );
+  return resolveStewardContainerUrl(resolveStewardHostUrl(), env.STEWARD_CONTAINER_URL);
 }
 
 const STEWARD_JWT_FILE = "/app/data/steward.jwt";
@@ -239,8 +227,7 @@ export function buildManagedElizaRuntimeConfig(
   allEnv: Record<string, string | undefined>,
 ): Record<string, unknown> {
   const apiKey = allEnv.ELIZAOS_CLOUD_API_KEY || "";
-  const agentId =
-    allEnv.ELIZA_CLOUD_AGENT_ID || allEnv.WAIFU_ELIZA_CLOUD_AGENT_ID;
+  const agentId = allEnv.ELIZA_CLOUD_AGENT_ID || allEnv.WAIFU_ELIZA_CLOUD_AGENT_ID;
 
   return {
     logging: { level: "info" },
@@ -299,10 +286,7 @@ function resolveElizaCloudPublicUrl(): string {
 
 function resolveStewardRefreshUrl(): string {
   const env = getCloudAwareEnv();
-  if (
-    typeof env.STEWARD_REFRESH_URL === "string" &&
-    env.STEWARD_REFRESH_URL.trim()
-  ) {
+  if (typeof env.STEWARD_REFRESH_URL === "string" && env.STEWARD_REFRESH_URL.trim()) {
     return env.STEWARD_REFRESH_URL.trim();
   }
   return `${resolveElizaCloudPublicUrl()}/v1/agent-tokens`;
@@ -310,12 +294,8 @@ function resolveStewardRefreshUrl(): string {
 
 function resolveStewardRefreshServiceToken(): string {
   const env = getCloudAwareEnv();
-  for (const candidate of [
-    env.ELIZA_CLOUD_SERVICE_TOKEN,
-    env.AGENT_TOKEN_SERVICE_TOKEN,
-  ]) {
-    if (typeof candidate === "string" && candidate.trim())
-      return candidate.trim();
+  for (const candidate of [env.ELIZA_CLOUD_SERVICE_TOKEN, env.AGENT_TOKEN_SERVICE_TOKEN]) {
+    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
   }
   return "";
 }
@@ -332,14 +312,9 @@ function resolveStewardRefreshServiceToken(): string {
  * Persona + connector POLICY fields (dmPolicy, messagePrefix, enabled, etc.)
  * are preserved so the runtime still loads the right character + behaviour.
  */
-function redactCharacterSecrets(
-  character: Record<string, unknown>,
-): Record<string, unknown> {
+function redactCharacterSecrets(character: Record<string, unknown>): Record<string, unknown> {
   // Deep clone so we never mutate the caller's DB-derived object.
-  const clone = JSON.parse(JSON.stringify(character)) as Record<
-    string,
-    unknown
-  >;
+  const clone = JSON.parse(JSON.stringify(character)) as Record<string, unknown>;
   delete clone.secrets;
   if (clone.settings && typeof clone.settings === "object") {
     delete (clone.settings as Record<string, unknown>).secrets;
@@ -419,8 +394,7 @@ type HeadscaleRouteEnv = Partial<
 function currentHeadscaleRouteEnv(): HeadscaleRouteEnv {
   const cloudEnv = getCloudAwareEnv();
   return {
-    AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK:
-      cloudEnv.AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK,
+    AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK: cloudEnv.AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK,
     CONTAINERS_PUBLIC_BASE_DOMAIN: cloudEnv.CONTAINERS_PUBLIC_BASE_DOMAIN,
     ELIZA_CLOUD_AGENT_BASE_DOMAIN: cloudEnv.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
     ENVIRONMENT: cloudEnv.ENVIRONMENT,
@@ -480,10 +454,7 @@ export function requiresHeadscaleRoute(
  * meant to bypass on nodes that aren't on the mesh.
  */
 export function headscaleVpnEnabled(env: HeadscaleRouteEnv): boolean {
-  return (
-    hasConfiguredValue(env.HEADSCALE_API_KEY) &&
-    !isBridgeHostFallbackEnabled(env)
-  );
+  return hasConfiguredValue(env.HEADSCALE_API_KEY) && !isBridgeHostFallbackEnabled(env);
 }
 
 export function shouldCleanupHeadscaleVpn(
@@ -537,9 +508,7 @@ function buildStewardPluginInstallCommand(containerName: string): string {
  * (the proxy listens on the docker host). Returns an empty object when
  * proxy mode is disabled so callers can spread it unconditionally.
  */
-export function buildStewardProxyEnv(
-  env: NodeJS.ProcessEnv = process.env,
-): Record<string, string> {
+export function buildStewardProxyEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
   if (env.USE_STEWARD_PROXY !== "true") return {};
   const base = "http://host.docker.internal:8080";
   return {
@@ -610,9 +579,7 @@ const AUTOSCALED_NODE_READY_POLL_MS = 10_000;
 
 function getDockerHealthCmd(port: string, path = "/api/health"): string {
   if (!/^\d+$/.test(port)) {
-    throw new Error(
-      `[docker-sandbox] Invalid port "${port}": must be a numeric string.`,
-    );
+    throw new Error(`[docker-sandbox] Invalid port "${port}": must be a numeric string.`);
   }
   if (!/^\/[A-Za-z0-9._~/-]*$/.test(path)) {
     throw new Error(`[docker-sandbox] Invalid health check path "${path}".`);
@@ -624,8 +591,7 @@ function getDockerHealthCmd(port: string, path = "/api/health"): string {
 
 export function resolveContainerPort(config: SandboxCreateConfig): string {
   const requested =
-    typeof config.environmentVars.PORT === "string" &&
-    config.environmentVars.PORT.trim()
+    typeof config.environmentVars.PORT === "string" && config.environmentVars.PORT.trim()
       ? config.environmentVars.PORT.trim()
       : typeof config.environmentVars.HTTP_PORT === "string" &&
           config.environmentVars.HTTP_PORT.trim()
@@ -683,9 +649,7 @@ export function resolveSandboxRegistryEnv(
 function extractStewardToken(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
-    throw new Error(
-      "[docker-sandbox] Steward token endpoint returned an empty response",
-    );
+    throw new Error("[docker-sandbox] Steward token endpoint returned an empty response");
   }
 
   try {
@@ -743,9 +707,7 @@ function warnMissingStewardTenantApiKey(apiKey?: string) {
   );
 }
 
-function resolveStewardRequestSigningSecret(
-  apiKey?: string,
-): string | undefined {
+function resolveStewardRequestSigningSecret(apiKey?: string): string | undefined {
   const env = getCloudAwareEnv();
   const explicit = env.STEWARD_REQUEST_SIGNING_SECRET?.trim();
   if (explicit) {
@@ -788,14 +750,10 @@ async function buildSignedDeleteAgentCurl(
   const path = buildPlatformAgentPath(stewardTenant.tenantId, agentId);
   const url = `${resolveStewardHostUrl()}${path}`;
   const platformKey = resolveStewardPlatformKey();
-  const signingSecret = resolveStewardRequestSigningSecret(
-    stewardTenant.apiKey,
-  );
+  const signingSecret = resolveStewardRequestSigningSecret(stewardTenant.apiKey);
   const flags = [
     `-H ${shellQuote(`X-Steward-Tenant: ${stewardTenant.tenantId}`)}`,
-    ...(platformKey
-      ? [`-H ${shellQuote(`X-Steward-Platform-Key: ${platformKey}`)}`]
-      : []),
+    ...(platformKey ? [`-H ${shellQuote(`X-Steward-Platform-Key: ${platformKey}`)}`] : []),
   ];
   if (signingSecret !== undefined) {
     const signed = await buildStewardSignedHeaders({
@@ -961,9 +919,7 @@ export class DockerSandboxProvider implements SandboxProvider {
    * (Docker self-hosting) it persists across requests.
    */
   private containers = new Map<string, ContainerMeta>();
-  private readonly replacementVpnSettleDelay: (
-    milliseconds: number,
-  ) => Promise<void>;
+  private readonly replacementVpnSettleDelay: (milliseconds: number) => Promise<void>;
   private readonly now: () => number;
 
   constructor(options?: {
@@ -972,8 +928,7 @@ export class DockerSandboxProvider implements SandboxProvider {
   }) {
     this.replacementVpnSettleDelay =
       options?.replacementVpnSettleDelay ??
-      ((milliseconds) =>
-        new Promise((resolve) => setTimeout(resolve, milliseconds)));
+      ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
     this.now = options?.now ?? Date.now;
   }
 
@@ -1031,10 +986,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     // Unreachable, but satisfies the compiler
-    throw (
-      lastError ??
-      new Error("[docker-sandbox] create exhausted all retry attempts")
-    );
+    throw lastError ?? new Error("[docker-sandbox] create exhausted all retry attempts");
   }
 
   /**
@@ -1045,17 +997,9 @@ export class DockerSandboxProvider implements SandboxProvider {
    * sandboxes, so a duplicate will fail at INSERT time. The public `create()`
    * method wraps this in a retry loop to handle port collisions automatically.
    */
-  private async _createOnce(
-    config: SandboxCreateConfig,
-  ): Promise<SandboxHandle> {
-    const {
-      agentId,
-      agentName,
-      environmentVars,
-      organizationId,
-      agentConfig,
-      routeAgentId,
-    } = config;
+  private async _createOnce(config: SandboxCreateConfig): Promise<SandboxHandle> {
+    const { agentId, agentName, environmentVars, organizationId, agentConfig, routeAgentId } =
+      config;
 
     // Resolve Docker image: per-agent DB override > operator env override > hardcoded default.
     // Keep the fallback out of DOCKER_IMAGE_OVERRIDE so per-agent flavor/image
@@ -1163,11 +1107,7 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // 3. Allocate ports (check DB for existing assignments to avoid collisions)
     const usedPorts = await getUsedDockerHostPorts(nodeId);
-    const bridgePort = allocatePort(
-      BRIDGE_PORT_MIN,
-      BRIDGE_PORT_MAX,
-      usedPorts,
-    );
+    const bridgePort = allocatePort(BRIDGE_PORT_MIN, BRIDGE_PORT_MAX, usedPorts);
     // No need to add bridgePort to exclusion set — web UI port range [20000,25000)
     // never overlaps bridge range [18790,19790)
     const webUiPort = allocatePort(WEBUI_PORT_MIN, WEBUI_PORT_MAX, usedPorts);
@@ -1211,13 +1151,11 @@ export class DockerSandboxProvider implements SandboxProvider {
       } catch (err) {
         if (headscaleRouteRequired) {
           if (dbNode && providerManagesCapacity) {
-            await dockerNodesRepository
-              .decrementAllocated(nodeId)
-              .catch((rollbackErr) => {
-                logger.warn(
-                  `[docker-sandbox] Failed to decrement allocated_count after Headscale preparation failure for node ${nodeId}: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
-                );
-              });
+            await dockerNodesRepository.decrementAllocated(nodeId).catch((rollbackErr) => {
+              logger.warn(
+                `[docker-sandbox] Failed to decrement allocated_count after Headscale preparation failure for node ${nodeId}: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
+              );
+            });
           }
           throw err;
         }
@@ -1256,8 +1194,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       kmsEnv.ELIZA_KMS_BACKEND = backend;
       if (backend === "local") {
         const rootKey =
-          environmentVars.ELIZA_LOCAL_ROOT_KEY?.trim() ||
-          process.env.ELIZA_LOCAL_ROOT_KEY?.trim();
+          environmentVars.ELIZA_LOCAL_ROOT_KEY?.trim() || process.env.ELIZA_LOCAL_ROOT_KEY?.trim();
         if (rootKey) kmsEnv.ELIZA_LOCAL_ROOT_KEY = rootKey;
       }
     }
@@ -1280,9 +1217,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       // no agent_config (the runtime keeps its default-character behaviour).
       ...(agentConfig && typeof agentConfig === "object"
         ? {
-            ELIZA_AGENT_CHARACTER_JSON: JSON.stringify(
-              redactCharacterSecrets(agentConfig),
-            ),
+            ELIZA_AGENT_CHARACTER_JSON: JSON.stringify(redactCharacterSecrets(agentConfig)),
           }
         : {}),
       STEWARD_API_URL: stewardContainerUrl,
@@ -1314,12 +1249,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 6. SSH to node, ensure volume dir, pull image, register in Steward,
     // then create/start the container. Pass hostKeyFingerprint so pooled
     // clients pin the key when available.
-    const ssh = DockerSSHClient.getClient(
-      hostname,
-      sshPort,
-      hostKeyFingerprint,
-      sshUser,
-    );
+    const ssh = DockerSSHClient.getClient(hostname, sshPort, hostKeyFingerprint, sshUser);
     const cleanupNode: DockerNodeConnection = {
       node_id: nodeId,
       hostname,
@@ -1339,15 +1269,11 @@ export class DockerSandboxProvider implements SandboxProvider {
 
       // Pull image (may take a while on first run). Log in when registry
       // credentials are configured; otherwise rely on anonymous public pulls.
-      logger.info(
-        `[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`,
-      );
+      logger.info(`[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`);
       try {
         await ensureRegistryAccess(ssh, resolvedImage);
         await ssh.exec(
-          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(
-            " ",
-          ),
+          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(" "),
           PULL_TIMEOUT_MS,
         );
         logger.info(`[docker-sandbox] Image pulled successfully on ${nodeId}`);
@@ -1441,8 +1367,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         // (no D-Bus keychain). Generate one per container — the vault state
         // lives only in the per-container PGlite, so a unique per-launch key
         // is fine.
-        ELIZA_VAULT_PASSPHRASE:
-          environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
+        ELIZA_VAULT_PASSPHRASE: environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
         // Gateway service discovery — see SandboxRegistry in app-core.
         // SANDBOX_PUBLIC_URL targets the public Docker host (not the headscale
         // VPN IP set later at line ~653) because the gateways on Railway can't
@@ -1451,16 +1376,12 @@ export class DockerSandboxProvider implements SandboxProvider {
           ? {
               SANDBOX_REGISTRY_REDIS_URL: registryRedisUrl,
               // Only the REST transport needs a token; a redis:// URL omits it.
-              ...(registryRedisToken
-                ? { SANDBOX_REGISTRY_REDIS_TOKEN: registryRedisToken }
-                : {}),
+              ...(registryRedisToken ? { SANDBOX_REGISTRY_REDIS_TOKEN: registryRedisToken } : {}),
               SANDBOX_AGENT_ID: agentId,
               // The gateways route by the platform character_id, so the
               // container must register under (and answer as) that id, not
               // the sandbox id. Injected only when the caller provides it.
-              ...(routeAgentId?.trim()
-                ? { SANDBOX_ROUTE_AGENT_ID: routeAgentId.trim() }
-                : {}),
+              ...(routeAgentId?.trim() ? { SANDBOX_ROUTE_AGENT_ID: routeAgentId.trim() } : {}),
               SANDBOX_SERVER_NAME: `sandbox-${agentId}-${crypto.randomUUID()}`,
               SANDBOX_PUBLIC_URL: `http://${hostname}:${bridgePort}/api`,
             }
@@ -1496,8 +1417,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         `--label ${shellQuote(`${REPLACEMENT_ATTEMPT_LABEL}=${replacementAttemptId}`)}`,
         "--restart unless-stopped",
         `--network ${shellQuote(DOCKER_NETWORK)}`,
-        ...(requiresDockerHostGateway(stewardContainerUrl) ||
-        Object.keys(proxyEnv).length > 0
+        ...(requiresDockerHostGateway(stewardContainerUrl) || Object.keys(proxyEnv).length > 0
           ? ["--add-host host.docker.internal:host-gateway"]
           : []),
         `--health-cmd ${shellQuote(getDockerHealthCmd(allEnv.PORT || containerPort, healthCheckPath))}`,
@@ -1534,17 +1454,12 @@ export class DockerSandboxProvider implements SandboxProvider {
       // run the cloud-init bootstrap; the network can also be pruned away).
       // Without this, `docker create --network` below fails with an opaque
       // "network not found" and the provision retries forever.
-      await ssh.exec(
-        buildEnsureNetworkCmd(DOCKER_NETWORK),
-        DOCKER_CMD_TIMEOUT_MS,
-      );
+      await ssh.exec(buildEnsureNetworkCmd(DOCKER_NETWORK), DOCKER_CMD_TIMEOUT_MS);
 
       // This clock starts the durable uncertainty window. Keep it adjacent to
       // intent/create rather than tenant setup or image pull so recovery does
       // not widen correlation with unrelated old Headscale registrations.
-      vpnRegistrationStartedAt = headscaleEnabled
-        ? new Date(this.now()).toISOString()
-        : undefined;
+      vpnRegistrationStartedAt = headscaleEnabled ? new Date(this.now()).toISOString() : undefined;
       const containerId = extractDockerCreateContainerId(
         await createDockerContainerAfterReplacementIntent({
           persistIntent: persistReplacementIntent
@@ -1580,8 +1495,7 @@ export class DockerSandboxProvider implements SandboxProvider {
                 }
               }
             : undefined,
-          createContainer: () =>
-            ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),
+          createContainer: () => ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),
         }),
       );
       createdContainerId = containerId;
@@ -1632,37 +1546,25 @@ export class DockerSandboxProvider implements SandboxProvider {
             )} | base64 -d > ${shellQuote(`${volumePath}/eliza/eliza.json`)}`,
             DOCKER_CMD_TIMEOUT_MS,
           );
-          logger.info(
-            `[docker-sandbox] Pre-seeded eliza.json on host volume for ${containerName}`,
-          );
+          logger.info(`[docker-sandbox] Pre-seeded eliza.json on host volume for ${containerName}`);
         }
       } catch (preSeedErr) {
         logger.warn(
           `[docker-sandbox] Failed to pre-seed eliza.json (post-start write will retry): ${
-            preSeedErr instanceof Error
-              ? preSeedErr.message
-              : String(preSeedErr)
+            preSeedErr instanceof Error ? preSeedErr.message : String(preSeedErr)
           }`,
         );
       }
 
-      await ssh.exec(
-        `docker start ${shellQuote(containerName)}`,
-        DOCKER_CMD_TIMEOUT_MS,
-      );
+      await ssh.exec(`docker start ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
       logger.info(
         `[docker-sandbox] Container created on ${nodeId}: ${containerId} (${containerName})`,
       );
 
       if (shouldInstallStewardPlugin(agentId, environmentVars)) {
         try {
-          await ssh.exec(
-            buildStewardPluginInstallCommand(containerName),
-            PULL_TIMEOUT_MS,
-          );
-          logger.info(
-            `[docker-sandbox] Steward Eliza plugin installed in ${containerName}`,
-          );
+          await ssh.exec(buildStewardPluginInstallCommand(containerName), PULL_TIMEOUT_MS);
+          logger.info(`[docker-sandbox] Steward Eliza plugin installed in ${containerName}`);
         } catch (pluginErr) {
           logger.warn(
             `[docker-sandbox] Failed to install Steward Eliza plugin in ${containerName}: ${pluginErr instanceof Error ? pluginErr.message : String(pluginErr)}`,
@@ -1673,16 +1575,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       if (stewardJwt && stewardRefreshServiceToken) {
         try {
           await ssh.exec(
-            buildStewardRefreshCommand(
-              containerName,
-              agentId,
-              stewardRefreshServiceToken,
-            ),
+            buildStewardRefreshCommand(containerName, agentId, stewardRefreshServiceToken),
             DOCKER_CMD_TIMEOUT_MS,
           );
-          logger.info(
-            `[docker-sandbox] Steward JWT refresh sidecar started in ${containerName}`,
-          );
+          logger.info(`[docker-sandbox] Steward JWT refresh sidecar started in ${containerName}`);
         } catch (refreshErr) {
           logger.warn(
             `[docker-sandbox] Failed to start Steward JWT refresh sidecar in ${containerName}: ${refreshErr instanceof Error ? refreshErr.message : String(refreshErr)}`,
@@ -1704,22 +1600,16 @@ export class DockerSandboxProvider implements SandboxProvider {
               "https://api-staging.elizacloud.ai/api/v1 for staging, https://api.elizacloud.ai/api/v1 for prod).",
           );
         }
-        const elizaConfig = JSON.stringify(
-          buildManagedElizaRuntimeConfig(allEnv),
-        );
+        const elizaConfig = JSON.stringify(buildManagedElizaRuntimeConfig(allEnv));
         // Base64-encode the JSON before passing it through the shell so an
         // apiKey/baseUrl containing single quotes can't break out of the
         // outer sh -c quoting or inject commands on the remote host.
-        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString(
-          "base64",
-        );
+        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString("base64");
         const writeCmd = `docker exec ${shellQuote(containerName)} sh -c ${shellQuote(
           `mkdir -p /root/.eliza && printf %s ${shellQuote(encodedConfig)} | base64 -d > /root/.eliza/eliza.json`,
         )}`;
         await ssh.exec(writeCmd, DOCKER_CMD_TIMEOUT_MS);
-        logger.info(
-          `[docker-sandbox] Cloud config written to eliza.json in ${containerName}`,
-        );
+        logger.info(`[docker-sandbox] Cloud config written to eliza.json in ${containerName}`);
       } catch (configErr) {
         logger.warn(
           `[docker-sandbox] Failed to write eliza.json: ${configErr instanceof Error ? configErr.message : String(configErr)}`,
@@ -1736,9 +1626,7 @@ export class DockerSandboxProvider implements SandboxProvider {
           await buildSignedDeleteAgentCurl(agentId, stewardTenant),
           DOCKER_CMD_TIMEOUT_MS,
         );
-        logger.info(
-          `[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`,
-        );
+        logger.info(`[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`);
       } catch (cleanupErr) {
         logger.warn(
           `[docker-sandbox] Failed to cleanup Steward agent ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
@@ -1754,9 +1642,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         vpnNodeId,
         // Before the adjacent timestamp is captured, the container has not
         // been created and therefore cannot have committed a VPN registration.
-        vpnNodeName: vpnRegistrationStartedAt
-          ? vpnEnvVars.TS_HOSTNAME
-          : undefined,
+        vpnNodeName: vpnRegistrationStartedAt ? vpnEnvVars.TS_HOSTNAME : undefined,
         previousVpnNodeId,
         vpnRegistrationStartedAt,
         allocationCounted: Boolean(dbNode),
@@ -1769,33 +1655,25 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
 
       try {
-        await this.retireReplacementCandidateOnNode(
-          cleanupLocator,
-          cleanupNode,
-        );
+        await this.retireReplacementCandidateOnNode(cleanupLocator, cleanupNode);
       } catch (cleanupError) {
         // error-policy:J2 context-adding rethrow — replacement identity is retained
         // so the durable reconciler can retry the exact unresolved cleanup.
         if (cleanupError instanceof SandboxReplacementCleanupUnresolvedError) {
           throw cleanupError;
         }
-        throw new SandboxReplacementCleanupUnresolvedError(
-          cleanupLocator,
-          cleanupError,
-        );
+        throw new SandboxReplacementCleanupUnresolvedError(cleanupLocator, cleanupError);
       }
 
       // Releasing capacity is safe only after the exact candidate and its known
       // VPN identity are absent. An unresolved cleanup retains the allocation
       // and escapes above with a durable locator.
       if (dbNode && providerManagesCapacity) {
-        await dockerNodesRepository
-          .decrementAllocated(nodeId)
-          .catch((rollbackErr) => {
-            logger.error(
-              `[docker-sandbox] Failed to roll back allocation for node ${nodeId}; capacity slot leaked: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
-            );
-          });
+        await dockerNodesRepository.decrementAllocated(nodeId).catch((rollbackErr) => {
+          logger.error(
+            `[docker-sandbox] Failed to roll back allocation for node ${nodeId}; capacity slot leaked: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
+          );
+        });
       }
       throw new Error(
         `[docker-sandbox] Failed to create container on ${nodeId}: ${err instanceof Error ? err.message : String(err)}`,
@@ -1926,10 +1804,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         nodeId,
       });
       await ssh
-        .exec(
-          await buildSignedDeleteAgentCurl(agentId, stewardTenant),
-          DOCKER_CMD_TIMEOUT_MS,
-        )
+        .exec(await buildSignedDeleteAgentCurl(agentId, stewardTenant), DOCKER_CMD_TIMEOUT_MS)
         .then(() => {
           logger.info(
             `[docker-sandbox] Cleaned up Steward agent ${agentId} after missing Headscale registration`,
@@ -1979,15 +1854,13 @@ export class DockerSandboxProvider implements SandboxProvider {
       await this.retireReplacementCandidateOnNode(cleanupLocator, cleanupNode);
       this.containers.delete(containerName);
       if (dbNode && providerManagesCapacity) {
-        await dockerNodesRepository
-          .decrementAllocated(nodeId)
-          .catch((rollbackError) => {
-            // error-policy:J6 best-effort teardown — the candidate is already absent;
-            // capacity reconciliation remains observable while the original failure surfaces.
-            logger.error(
-              `[docker-sandbox] Failed to roll back allocation for node ${nodeId} after unroutable candidate cleanup: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
-            );
-          });
+        await dockerNodesRepository.decrementAllocated(nodeId).catch((rollbackError) => {
+          // error-policy:J6 best-effort teardown — the candidate is already absent;
+          // capacity reconciliation remains observable while the original failure surfaces.
+          logger.error(
+            `[docker-sandbox] Failed to roll back allocation for node ${nodeId} after unroutable candidate cleanup: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+          );
+        });
       }
       throw new Error(errorMessage);
     }
@@ -2054,24 +1927,18 @@ export class DockerSandboxProvider implements SandboxProvider {
     const hcloudToken = containersEnv.hetznerCloudToken();
     const publicKey = env.CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY?.trim();
     if (!hcloudToken || !publicKey) {
-      logger.warn(
-        "[docker-sandbox] No Docker capacity and autoscale is not configured",
-        {
-          hasHcloudToken: Boolean(hcloudToken),
-          hasPublicKey: Boolean(publicKey),
-        },
-      );
+      logger.warn("[docker-sandbox] No Docker capacity and autoscale is not configured", {
+        hasHcloudToken: Boolean(hcloudToken),
+        hasPublicKey: Boolean(publicKey),
+      });
       return null;
     }
 
     try {
-      logger.info(
-        "[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node",
-        {
-          image,
-          platform,
-        },
-      );
+      logger.info("[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node", {
+        image,
+        platform,
+      });
       const provisioned = await getNodeAutoscaler().provisionNode(
         {
           prePullImages: [image],
@@ -2086,9 +1953,7 @@ export class DockerSandboxProvider implements SandboxProvider {
 
       const deadline = Date.now() + AUTOSCALED_NODE_READY_TIMEOUT_MS;
       while (Date.now() < deadline) {
-        const node = await dockerNodesRepository.findByNodeId(
-          provisioned.nodeId,
-        );
+        const node = await dockerNodesRepository.findByNodeId(provisioned.nodeId);
         if (
           node &&
           (await dockerNodeManager.ensureNodeReady(node, {
@@ -2101,26 +1966,18 @@ export class DockerSandboxProvider implements SandboxProvider {
           });
           return node;
         }
-        await new Promise((resolve) =>
-          setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS),
-        );
+        await new Promise((resolve) => setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS));
       }
 
-      logger.warn(
-        "[docker-sandbox] Autoscaled Docker node did not become ready before timeout",
-        {
-          nodeId: provisioned.nodeId,
-          hostname: provisioned.hostname,
-        },
-      );
+      logger.warn("[docker-sandbox] Autoscaled Docker node did not become ready before timeout", {
+        nodeId: provisioned.nodeId,
+        hostname: provisioned.hostname,
+      });
       return null;
     } catch (error) {
-      logger.warn(
-        "[docker-sandbox] Autoscaled Docker node provisioning failed",
-        {
-          error: error instanceof Error ? error.message : String(error),
-        },
-      );
+      logger.warn("[docker-sandbox] Autoscaled Docker node provisioning failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
       return null;
     }
   }
@@ -2148,13 +2005,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     containerName: string,
     gracefulSeconds = 30,
   ): Promise<void> {
-    await this.stopOnSpecificNodeWithPolicy(
-      node,
-      containerName,
-      gracefulSeconds,
-      true,
-      true,
-    );
+    await this.stopOnSpecificNodeWithPolicy(node, containerName, gracefulSeconds, true, true);
   }
 
   async stopOnSpecificNodeForReplacement(
@@ -2213,10 +2064,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
     }
     try {
-      await ssh.exec(
-        `docker rm -f ${shellQuote(containerName)}`,
-        DOCKER_CMD_TIMEOUT_MS,
-      );
+      await ssh.exec(`docker rm -f ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
     } catch (err) {
       rmErr = err;
       const msg = err instanceof Error ? err.message : String(err);
@@ -2234,18 +2082,14 @@ export class DockerSandboxProvider implements SandboxProvider {
     if (!allowUnreachableAbandon && rmErr) {
       const rmMsg = rmErr instanceof Error ? rmErr.message : String(rmErr);
       if (!isContainerAbsentMessage(rmMsg)) {
-        const stopMsg =
-          stopErr instanceof Error
-            ? stopErr.message
-            : String(stopErr ?? "succeeded");
+        const stopMsg = stopErr instanceof Error ? stopErr.message : String(stopErr ?? "succeeded");
         throw new Error(
           `[docker-sandbox] Cannot prove ${containerName} absent on ${node.node_id}: ` +
             `docker stop -> ${stopMsg}; docker rm -f -> ${rmMsg}`,
         );
       }
     } else if (stopErr && rmErr) {
-      const stopMsg =
-        stopErr instanceof Error ? stopErr.message : String(stopErr);
+      const stopMsg = stopErr instanceof Error ? stopErr.message : String(stopErr);
       const rmMsg = rmErr instanceof Error ? rmErr.message : String(rmErr);
       const stopIsGone = isAlreadyGoneMessage(stopMsg);
       const rmIsGone = isAlreadyGoneMessage(rmMsg);
@@ -2258,15 +2102,13 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     if (releaseCapacity) {
-      await dockerNodesRepository
-        .decrementAllocated(node.node_id)
-        .catch((err) => {
-          // error-policy:J6 best-effort teardown — remote absence is already proven,
-          // so a bookkeeping failure is logged for reconciliation rather than reviving it.
-          logger.warn(
-            `[docker-sandbox] stopOnSpecificNode: decrement allocated_count failed for ${node.node_id}: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        });
+      await dockerNodesRepository.decrementAllocated(node.node_id).catch((err) => {
+        // error-policy:J6 best-effort teardown — remote absence is already proven,
+        // so a bookkeeping failure is logged for reconciliation rather than reviving it.
+        logger.warn(
+          `[docker-sandbox] stopOnSpecificNode: decrement allocated_count failed for ${node.node_id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
     }
   }
 
@@ -2279,13 +2121,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         ? await this.resolveReplacementContainerForCleanup(locator, node)
         : locator.containerName;
       if (cleanupTarget) {
-        await this.stopOnSpecificNodeWithPolicy(
-          node,
-          cleanupTarget,
-          10,
-          false,
-          false,
-        );
+        await this.stopOnSpecificNodeWithPolicy(node, cleanupTarget, 10, false, false);
       }
       if (locator.vpnNodeId) {
         await withTimeout(
@@ -2357,10 +2193,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         `[docker-sandbox] Replacement attempt label mismatch for ${locator.containerName}`,
       );
     }
-    if (
-      locator.containerId &&
-      !dockerContainerIdsMatch(locator.containerId, containerId)
-    ) {
+    if (locator.containerId && !dockerContainerIdsMatch(locator.containerId, containerId)) {
       throw new Error(
         `[docker-sandbox] Replacement container id mismatch for ${locator.containerName}`,
       );
@@ -2389,9 +2222,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       );
     }
     const registrationDeadline =
-      startedAt +
-      DEFAULT_REGISTRATION_TIMEOUT_MS +
-      REPLACEMENT_VPN_CLOCK_SKEW_ALLOWANCE_MS;
+      startedAt + DEFAULT_REGISTRATION_TIMEOUT_MS + REPLACEMENT_VPN_CLOCK_SKEW_ALLOWANCE_MS;
     if (this.now() < registrationDeadline) {
       throw new Error(
         `[docker-sandbox] VPN registration window remains open for ${locator.containerName} until ${new Date(registrationDeadline).toISOString()}`,
@@ -2399,11 +2230,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     let consecutiveEmptyObservations = 0;
-    for (
-      let observation = 0;
-      observation < REPLACEMENT_VPN_SETTLE_OBSERVATIONS;
-      observation += 1
-    ) {
+    for (let observation = 0; observation < REPLACEMENT_VPN_SETTLE_OBSERVATIONS; observation += 1) {
       const nodes = await withTimeout(
         headscaleClient.listNodesStrict(),
         HEADSCALE_CLEANUP_TIMEOUT_MS,
@@ -2417,8 +2244,7 @@ export class DockerSandboxProvider implements SandboxProvider {
           ? node.name.slice(baseName.length + 1)
           : null;
         const nameMatches =
-          node.name === baseName ||
-          (suffix !== null && /^[a-z0-9]{8}$/.test(suffix));
+          node.name === baseName || (suffix !== null && /^[a-z0-9]{8}$/.test(suffix));
         if (!nameMatches) {
           return false;
         }
@@ -2452,9 +2278,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
 
       if (observation < REPLACEMENT_VPN_SETTLE_OBSERVATIONS - 1) {
-        await this.replacementVpnSettleDelay(
-          REPLACEMENT_VPN_SETTLE_INTERVAL_MS,
-        );
+        await this.replacementVpnSettleDelay(REPLACEMENT_VPN_SETTLE_INTERVAL_MS);
       }
     }
 
@@ -2478,10 +2302,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     await this.stopWithPolicy(sandboxId, false);
   }
 
-  private async stopWithPolicy(
-    sandboxId: string,
-    allowUnreachableAbandon: boolean,
-  ): Promise<void> {
+  private async stopWithPolicy(sandboxId: string, allowUnreachableAbandon: boolean): Promise<void> {
     const meta = await this.resolveContainer(sandboxId);
 
     logger.info(
@@ -2506,10 +2327,7 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     try {
       // Graceful stop with 10s timeout, then force-remove
-      await ssh.exec(
-        `docker stop -t 10 ${shellQuote(meta.containerName)}`,
-        STOP_CMD_TIMEOUT_MS,
-      );
+      await ssh.exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, STOP_CMD_TIMEOUT_MS);
       logger.info(`[docker-sandbox] Container stopped: ${meta.containerName}`);
     } catch (err) {
       stopErr = err;
@@ -2519,10 +2337,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     try {
-      await ssh.exec(
-        `docker rm -f ${shellQuote(meta.containerName)}`,
-        STOP_CMD_TIMEOUT_MS,
-      );
+      await ssh.exec(`docker rm -f ${shellQuote(meta.containerName)}`, STOP_CMD_TIMEOUT_MS);
       logger.info(`[docker-sandbox] Container removed: ${meta.containerName}`);
     } catch (err) {
       rmErr = err;
@@ -2532,8 +2347,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     if (stopErr && rmErr) {
-      const stopMsg =
-        stopErr instanceof Error ? stopErr.message : String(stopErr);
+      const stopMsg = stopErr instanceof Error ? stopErr.message : String(stopErr);
       const rmMsg = rmErr instanceof Error ? rmErr.message : String(rmErr);
       // "No such container" from either call means the container was
       // already gone — that is a success, not a failure. We only escalate
@@ -2561,13 +2375,8 @@ export class DockerSandboxProvider implements SandboxProvider {
       // to keep the work cycle bounded; the lifecycle/capacity owner should add
       // a node-reconcile sweep (and revisit the allocated_count decrement below)
       // when one lands. Do NOT claim a reconciler already reclaims it.
-      const unreachable =
-        isNodeUnreachableMessage(stopMsg) && isNodeUnreachableMessage(rmMsg);
-      if (
-        !stopIsGone &&
-        !rmIsGone &&
-        (!unreachable || !allowUnreachableAbandon)
-      ) {
+      const unreachable = isNodeUnreachableMessage(stopMsg) && isNodeUnreachableMessage(rmMsg);
+      if (!stopIsGone && !rmIsGone && (!unreachable || !allowUnreachableAbandon)) {
         throw new Error(
           `Failed to stop container ${meta.containerName} on ${meta.hostname}: ` +
             `docker stop -> ${stopMsg}; docker rm -f -> ${rmMsg}`,
@@ -2614,15 +2423,13 @@ export class DockerSandboxProvider implements SandboxProvider {
             ? headscaleIntegration.cleanupContainerVPN(registeredNodeName)
             : null;
       if (cleanup) {
-        await withTimeout(
-          cleanup,
-          HEADSCALE_CLEANUP_TIMEOUT_MS,
-          "headscale cleanup",
-        ).catch((err) => {
-          logger.warn(
-            `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        });
+        await withTimeout(cleanup, HEADSCALE_CLEANUP_TIMEOUT_MS, "headscale cleanup").catch(
+          (err) => {
+            logger.warn(
+              `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          },
+        );
       } else {
         logger.info(
           `[docker-sandbox] Skipping Headscale cleanup for ${meta.agentId}: preserved live node holds the hostname and this container never registered`,
@@ -2704,9 +2511,7 @@ export class DockerSandboxProvider implements SandboxProvider {
    * reached the container as RETRYABLE rather than a terminal failure. See
    * {@link SandboxHealthVerdict}.
    */
-  async checkHealthDetailed(
-    handle: SandboxHandle,
-  ): Promise<SandboxHealthOutcome> {
+  async checkHealthDetailed(handle: SandboxHandle): Promise<SandboxHealthOutcome> {
     const meta = await this.resolveContainer(handle.sandboxId);
     const deadline = Date.now() + HEALTH_CHECK_TIMEOUT_MS;
 
@@ -2718,9 +2523,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     // let the first racing tailnet fetch tear the agent down despite it being
     // healthy.
     const headscaleIp =
-      typeof handle.metadata?.headscaleIp === "string"
-        ? handle.metadata.headscaleIp
-        : undefined;
+      typeof handle.metadata?.headscaleIp === "string" ? handle.metadata.headscaleIp : undefined;
     if (headscaleIp) {
       if (await this.pollTailnetHealth(handle, meta, deadline)) {
         return { ready: true, verdict: "ready" };
@@ -2733,10 +2536,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       // provision time it is enough evidence to avoid tearing down a container
       // the node can prove is up. A container that fails BOTH probes still
       // reports unhealthy, so a dead provision still times out and self-heals.
-      return this.pollSshDockerHealth(
-        meta,
-        Date.now() + HEALTH_CHECK_SSH_FALLBACK_TIMEOUT_MS,
-      );
+      return this.pollSshDockerHealth(meta, Date.now() + HEALTH_CHECK_SSH_FALLBACK_TIMEOUT_MS);
     }
 
     return this.pollSshDockerHealth(meta, deadline);
@@ -2769,9 +2569,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     // would falsely condemn a container the probe never even reached.
     let reachedContainer = false;
 
-    const runOneProbe = async (): Promise<
-      "ready" | "not_ready" | "transport"
-    > => {
+    const runOneProbe = async (): Promise<"ready" | "not_ready" | "transport"> => {
       // Placement-affecting jobs can overlap the health wait, so each probe
       // reads the current node before dialing docker on that host.
       current = await this.refreshNodeMeta(current);
@@ -2848,14 +2646,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       // Wait before retrying (but don't overshoot the deadline)
       const remaining = deadline - Date.now();
       if (remaining > HEALTH_CHECK_POLL_INTERVAL_MS) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS),
-        );
+        await new Promise((resolve) => setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS));
       } else if (remaining > 0) {
         // One last attempt after a short wait
-        await new Promise((resolve) =>
-          setTimeout(resolve, Math.min(remaining, 1000)),
-        );
+        await new Promise((resolve) => setTimeout(resolve, Math.min(remaining, 1000)));
       } else {
         break;
       }
@@ -2880,9 +2674,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         if (reachedContainer) break;
         const remaining = retryDeadline - Date.now();
         if (remaining <= 0) break;
-        await new Promise((resolve) =>
-          setTimeout(resolve, Math.min(backoff, remaining)),
-        );
+        await new Promise((resolve) => setTimeout(resolve, Math.min(backoff, remaining)));
         backoff = Math.min(backoff * 2, HEALTH_CHECK_TRANSPORT_RETRY_MAX_MS);
       }
 
@@ -2921,16 +2713,11 @@ export class DockerSandboxProvider implements SandboxProvider {
         diagnostics: diagnostics.slice(-12_000),
       });
     } catch (diagnosticsError) {
-      logger.warn(
-        "[docker-sandbox] Failed to collect health timeout diagnostics",
-        {
-          containerName: current.containerName,
-          error:
-            diagnosticsError instanceof Error
-              ? diagnosticsError.message
-              : String(diagnosticsError),
-        },
-      );
+      logger.warn("[docker-sandbox] Failed to collect health timeout diagnostics", {
+        containerName: current.containerName,
+        error:
+          diagnosticsError instanceof Error ? diagnosticsError.message : String(diagnosticsError),
+      });
     }
     // We reached the container at least once but it never answered healthy — a
     // genuine not-ready verdict (terminal), not a transport false-negative.
@@ -2941,19 +2728,12 @@ export class DockerSandboxProvider implements SandboxProvider {
   // runCommand
   // ------------------------------------------------------------------
 
-  async runCommand(
-    sandboxId: string,
-    cmd: string,
-    args?: string[],
-  ): Promise<string> {
+  async runCommand(sandboxId: string, cmd: string, args?: string[]): Promise<string> {
     const meta = await this.resolveContainer(sandboxId);
 
     // Shell-escape each argument to prevent command injection
-    const escapedArgs =
-      args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
-    const fullCmd = escapedArgs
-      ? `${shellQuote(cmd)} ${escapedArgs}`
-      : shellQuote(cmd);
+    const escapedArgs = args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
+    const fullCmd = escapedArgs ? `${shellQuote(cmd)} ${escapedArgs}` : shellQuote(cmd);
 
     logger.info(
       `[docker-sandbox] Executing command in ${meta.containerName}: ${cmd} ${(args ?? []).join(" ").slice(0, 80)}`,
@@ -3031,9 +2811,7 @@ export class DockerSandboxProvider implements SandboxProvider {
    * refresh the cache. Returns null only when there is no usable sandbox row;
    * repository and configuration failures propagate to the caller.
    */
-  private async hydrateContainerFromDb(
-    sandboxId: string,
-  ): Promise<ContainerMeta | null> {
+  private async hydrateContainerFromDb(sandboxId: string): Promise<ContainerMeta | null> {
     const sandbox = await agentSandboxesRepository.findBySandboxId(sandboxId);
     if (!sandbox || !sandbox.node_id || !sandbox.container_name) return null;
 
@@ -3044,9 +2822,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       );
     }
     if (!dbNode.hostname) {
-      throw new Error(
-        `[docker-sandbox] Docker node "${sandbox.node_id}" is missing hostname`,
-      );
+      throw new Error(`[docker-sandbox] Docker node "${sandbox.node_id}" is missing hostname`);
     }
 
     if (!sandbox.bridge_port || !sandbox.web_ui_port) {
@@ -3084,9 +2860,7 @@ export class DockerSandboxProvider implements SandboxProvider {
    * job start. Returning the last-known node on a refresh failure keeps a DB
    * blip from turning an otherwise-valid liveness probe into a failed provision.
    */
-  private async refreshNodeMeta(
-    previous: ContainerMeta,
-  ): Promise<ContainerMeta> {
+  private async refreshNodeMeta(previous: ContainerMeta): Promise<ContainerMeta> {
     let fresh: ContainerMeta | null;
     try {
       fresh = await this.hydrateContainerFromDb(previous.containerName);
@@ -3101,10 +2875,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     if (!fresh) return previous;
-    if (
-      fresh.nodeId !== previous.nodeId ||
-      fresh.hostname !== previous.hostname
-    ) {
+    if (fresh.nodeId !== previous.nodeId || fresh.hostname !== previous.hostname) {
       logger.info(
         `[docker-sandbox] ${previous.containerName} re-placed mid health-wait: node ${previous.nodeId} (${previous.hostname}) -> ${fresh.nodeId} (${fresh.hostname}); following the new node`,
       );

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -8,6 +8,7 @@
  * Reference: eliza-cloud/backend/services/container-orchestrator.ts
  */
 
+import { ElizaError } from "@elizaos/core";
 import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared/contracts/service-routing";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
@@ -1076,6 +1077,22 @@ export class DockerSandboxProvider implements SandboxProvider {
         await dockerNodesRepository.incrementAllocated(nodeId);
       }
     } else {
+      const registeredNodes = await dockerNodesRepository.findAll();
+      if (registeredNodes.length > 0) {
+        throw new ElizaError(
+          "[docker-sandbox] Registered Docker nodes exist but none are available for placement; refusing CONTAINERS_DOCKER_NODES seed fallback",
+          {
+            code: "DOCKER_PLACEMENT_UNAVAILABLE",
+            context: {
+              registeredNodeCount: registeredNodes.length,
+              excludedNodeId: config.excludeNodeId ?? null,
+              requiredPlatform: imagePlatform ?? null,
+            },
+            severity: "ephemeral",
+          },
+        );
+      }
+
       // Fallback: seed-only path for initial setup before nodes are registered via Admin API.
       // Uses random selection (no least-loaded placement or capacity checks).
       // Operators should register nodes via POST /admin/docker-nodes for production use.

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -13,7 +13,10 @@ import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes"
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { WARM_POOL_ORG_ID } from "../../db/schemas/agent-sandboxes";
 import type { DockerNode } from "../../db/schemas/docker-nodes";
-import { isAgentTokenSigningConfigured, mintAgentToken } from "../auth/agent-token";
+import {
+  isAgentTokenSigningConfigured,
+  mintAgentToken,
+} from "../auth/agent-token";
 import { containersEnv } from "../config/containers-env";
 import { getAgentBaseDomain } from "../eliza-agent-web-ui";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
@@ -33,7 +36,11 @@ import {
   isContainerAbsentMessage,
   isNodeUnreachableMessage,
 } from "./docker-error-classifier";
-import { dockerNodeManager } from "./docker-node-manager";
+import {
+  clearPlacementCommandFailures,
+  dockerNodeManager,
+  notePlacementCommandFailure,
+} from "./docker-node-manager";
 import { getUsedDockerHostPorts } from "./docker-port-allocation";
 import {
   allocatePort,
@@ -60,7 +67,10 @@ import {
 } from "./docker-sandbox-utils";
 import { classifyDockerSshProbeError, DockerSSHClient } from "./docker-ssh";
 import { headscaleClient } from "./headscale-client";
-import { DEFAULT_REGISTRATION_TIMEOUT_MS, headscaleIntegration } from "./headscale-integration";
+import {
+  DEFAULT_REGISTRATION_TIMEOUT_MS,
+  headscaleIntegration,
+} from "./headscale-integration";
 import { buildKeylessOpenAIContainerEnv } from "./managed-eliza-env";
 import type {
   SandboxCreateConfig,
@@ -163,7 +173,9 @@ const REPLACEMENT_VPN_CLOCK_SKEW_ALLOWANCE_MS = 30_000;
 
 class ReplacementPlacementPersistenceError extends Error {
   constructor(cause: unknown) {
-    super("[docker-sandbox] Failed to persist replacement placement", { cause });
+    super("[docker-sandbox] Failed to persist replacement placement", {
+      cause,
+    });
     this.name = "ReplacementPlacementPersistenceError";
   }
 }
@@ -187,7 +199,10 @@ export async function createDockerContainerAfterReplacementIntent<T>({
 }
 
 function dockerContainerIdsMatch(expected: string, actual: string): boolean {
-  if (!/^[a-f0-9]{12,64}$/i.test(expected) || !/^[a-f0-9]{12,64}$/i.test(actual)) {
+  if (
+    !/^[a-f0-9]{12,64}$/i.test(expected) ||
+    !/^[a-f0-9]{12,64}$/i.test(actual)
+  ) {
     return false;
   }
   return expected.startsWith(actual) || actual.startsWith(expected);
@@ -205,7 +220,10 @@ function resolveStewardHostUrl(): string {
 
 function resolveStewardContainerEnvUrl(): string {
   const env = getCloudAwareEnv();
-  return resolveStewardContainerUrl(resolveStewardHostUrl(), env.STEWARD_CONTAINER_URL);
+  return resolveStewardContainerUrl(
+    resolveStewardHostUrl(),
+    env.STEWARD_CONTAINER_URL,
+  );
 }
 
 const STEWARD_JWT_FILE = "/app/data/steward.jwt";
@@ -221,7 +239,8 @@ export function buildManagedElizaRuntimeConfig(
   allEnv: Record<string, string | undefined>,
 ): Record<string, unknown> {
   const apiKey = allEnv.ELIZAOS_CLOUD_API_KEY || "";
-  const agentId = allEnv.ELIZA_CLOUD_AGENT_ID || allEnv.WAIFU_ELIZA_CLOUD_AGENT_ID;
+  const agentId =
+    allEnv.ELIZA_CLOUD_AGENT_ID || allEnv.WAIFU_ELIZA_CLOUD_AGENT_ID;
 
   return {
     logging: { level: "info" },
@@ -280,7 +299,10 @@ function resolveElizaCloudPublicUrl(): string {
 
 function resolveStewardRefreshUrl(): string {
   const env = getCloudAwareEnv();
-  if (typeof env.STEWARD_REFRESH_URL === "string" && env.STEWARD_REFRESH_URL.trim()) {
+  if (
+    typeof env.STEWARD_REFRESH_URL === "string" &&
+    env.STEWARD_REFRESH_URL.trim()
+  ) {
     return env.STEWARD_REFRESH_URL.trim();
   }
   return `${resolveElizaCloudPublicUrl()}/v1/agent-tokens`;
@@ -288,8 +310,12 @@ function resolveStewardRefreshUrl(): string {
 
 function resolveStewardRefreshServiceToken(): string {
   const env = getCloudAwareEnv();
-  for (const candidate of [env.ELIZA_CLOUD_SERVICE_TOKEN, env.AGENT_TOKEN_SERVICE_TOKEN]) {
-    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+  for (const candidate of [
+    env.ELIZA_CLOUD_SERVICE_TOKEN,
+    env.AGENT_TOKEN_SERVICE_TOKEN,
+  ]) {
+    if (typeof candidate === "string" && candidate.trim())
+      return candidate.trim();
   }
   return "";
 }
@@ -306,9 +332,14 @@ function resolveStewardRefreshServiceToken(): string {
  * Persona + connector POLICY fields (dmPolicy, messagePrefix, enabled, etc.)
  * are preserved so the runtime still loads the right character + behaviour.
  */
-function redactCharacterSecrets(character: Record<string, unknown>): Record<string, unknown> {
+function redactCharacterSecrets(
+  character: Record<string, unknown>,
+): Record<string, unknown> {
   // Deep clone so we never mutate the caller's DB-derived object.
-  const clone = JSON.parse(JSON.stringify(character)) as Record<string, unknown>;
+  const clone = JSON.parse(JSON.stringify(character)) as Record<
+    string,
+    unknown
+  >;
   delete clone.secrets;
   if (clone.settings && typeof clone.settings === "object") {
     delete (clone.settings as Record<string, unknown>).secrets;
@@ -388,7 +419,8 @@ type HeadscaleRouteEnv = Partial<
 function currentHeadscaleRouteEnv(): HeadscaleRouteEnv {
   const cloudEnv = getCloudAwareEnv();
   return {
-    AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK: cloudEnv.AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK,
+    AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK:
+      cloudEnv.AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK,
     CONTAINERS_PUBLIC_BASE_DOMAIN: cloudEnv.CONTAINERS_PUBLIC_BASE_DOMAIN,
     ELIZA_CLOUD_AGENT_BASE_DOMAIN: cloudEnv.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
     ENVIRONMENT: cloudEnv.ENVIRONMENT,
@@ -448,7 +480,10 @@ export function requiresHeadscaleRoute(
  * meant to bypass on nodes that aren't on the mesh.
  */
 export function headscaleVpnEnabled(env: HeadscaleRouteEnv): boolean {
-  return hasConfiguredValue(env.HEADSCALE_API_KEY) && !isBridgeHostFallbackEnabled(env);
+  return (
+    hasConfiguredValue(env.HEADSCALE_API_KEY) &&
+    !isBridgeHostFallbackEnabled(env)
+  );
 }
 
 export function shouldCleanupHeadscaleVpn(
@@ -502,7 +537,9 @@ function buildStewardPluginInstallCommand(containerName: string): string {
  * (the proxy listens on the docker host). Returns an empty object when
  * proxy mode is disabled so callers can spread it unconditionally.
  */
-export function buildStewardProxyEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+export function buildStewardProxyEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
   if (env.USE_STEWARD_PROXY !== "true") return {};
   const base = "http://host.docker.internal:8080";
   return {
@@ -573,7 +610,9 @@ const AUTOSCALED_NODE_READY_POLL_MS = 10_000;
 
 function getDockerHealthCmd(port: string, path = "/api/health"): string {
   if (!/^\d+$/.test(port)) {
-    throw new Error(`[docker-sandbox] Invalid port "${port}": must be a numeric string.`);
+    throw new Error(
+      `[docker-sandbox] Invalid port "${port}": must be a numeric string.`,
+    );
   }
   if (!/^\/[A-Za-z0-9._~/-]*$/.test(path)) {
     throw new Error(`[docker-sandbox] Invalid health check path "${path}".`);
@@ -585,7 +624,8 @@ function getDockerHealthCmd(port: string, path = "/api/health"): string {
 
 export function resolveContainerPort(config: SandboxCreateConfig): string {
   const requested =
-    typeof config.environmentVars.PORT === "string" && config.environmentVars.PORT.trim()
+    typeof config.environmentVars.PORT === "string" &&
+    config.environmentVars.PORT.trim()
       ? config.environmentVars.PORT.trim()
       : typeof config.environmentVars.HTTP_PORT === "string" &&
           config.environmentVars.HTTP_PORT.trim()
@@ -643,7 +683,9 @@ export function resolveSandboxRegistryEnv(
 function extractStewardToken(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
-    throw new Error("[docker-sandbox] Steward token endpoint returned an empty response");
+    throw new Error(
+      "[docker-sandbox] Steward token endpoint returned an empty response",
+    );
   }
 
   try {
@@ -701,7 +743,9 @@ function warnMissingStewardTenantApiKey(apiKey?: string) {
   );
 }
 
-function resolveStewardRequestSigningSecret(apiKey?: string): string | undefined {
+function resolveStewardRequestSigningSecret(
+  apiKey?: string,
+): string | undefined {
   const env = getCloudAwareEnv();
   const explicit = env.STEWARD_REQUEST_SIGNING_SECRET?.trim();
   if (explicit) {
@@ -744,10 +788,14 @@ async function buildSignedDeleteAgentCurl(
   const path = buildPlatformAgentPath(stewardTenant.tenantId, agentId);
   const url = `${resolveStewardHostUrl()}${path}`;
   const platformKey = resolveStewardPlatformKey();
-  const signingSecret = resolveStewardRequestSigningSecret(stewardTenant.apiKey);
+  const signingSecret = resolveStewardRequestSigningSecret(
+    stewardTenant.apiKey,
+  );
   const flags = [
     `-H ${shellQuote(`X-Steward-Tenant: ${stewardTenant.tenantId}`)}`,
-    ...(platformKey ? [`-H ${shellQuote(`X-Steward-Platform-Key: ${platformKey}`)}`] : []),
+    ...(platformKey
+      ? [`-H ${shellQuote(`X-Steward-Platform-Key: ${platformKey}`)}`]
+      : []),
   ];
   if (signingSecret !== undefined) {
     const signed = await buildStewardSignedHeaders({
@@ -913,7 +961,9 @@ export class DockerSandboxProvider implements SandboxProvider {
    * (Docker self-hosting) it persists across requests.
    */
   private containers = new Map<string, ContainerMeta>();
-  private readonly replacementVpnSettleDelay: (milliseconds: number) => Promise<void>;
+  private readonly replacementVpnSettleDelay: (
+    milliseconds: number,
+  ) => Promise<void>;
   private readonly now: () => number;
 
   constructor(options?: {
@@ -922,7 +972,8 @@ export class DockerSandboxProvider implements SandboxProvider {
   }) {
     this.replacementVpnSettleDelay =
       options?.replacementVpnSettleDelay ??
-      ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+      ((milliseconds) =>
+        new Promise((resolve) => setTimeout(resolve, milliseconds)));
     this.now = options?.now ?? Date.now;
   }
 
@@ -980,7 +1031,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     // Unreachable, but satisfies the compiler
-    throw lastError ?? new Error("[docker-sandbox] create exhausted all retry attempts");
+    throw (
+      lastError ??
+      new Error("[docker-sandbox] create exhausted all retry attempts")
+    );
   }
 
   /**
@@ -991,9 +1045,17 @@ export class DockerSandboxProvider implements SandboxProvider {
    * sandboxes, so a duplicate will fail at INSERT time. The public `create()`
    * method wraps this in a retry loop to handle port collisions automatically.
    */
-  private async _createOnce(config: SandboxCreateConfig): Promise<SandboxHandle> {
-    const { agentId, agentName, environmentVars, organizationId, agentConfig, routeAgentId } =
-      config;
+  private async _createOnce(
+    config: SandboxCreateConfig,
+  ): Promise<SandboxHandle> {
+    const {
+      agentId,
+      agentName,
+      environmentVars,
+      organizationId,
+      agentConfig,
+      routeAgentId,
+    } = config;
 
     // Resolve Docker image: per-agent DB override > operator env override > hardcoded default.
     // Keep the fallback out of DOCKER_IMAGE_OVERRIDE so per-agent flavor/image
@@ -1101,7 +1163,11 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // 3. Allocate ports (check DB for existing assignments to avoid collisions)
     const usedPorts = await getUsedDockerHostPorts(nodeId);
-    const bridgePort = allocatePort(BRIDGE_PORT_MIN, BRIDGE_PORT_MAX, usedPorts);
+    const bridgePort = allocatePort(
+      BRIDGE_PORT_MIN,
+      BRIDGE_PORT_MAX,
+      usedPorts,
+    );
     // No need to add bridgePort to exclusion set — web UI port range [20000,25000)
     // never overlaps bridge range [18790,19790)
     const webUiPort = allocatePort(WEBUI_PORT_MIN, WEBUI_PORT_MAX, usedPorts);
@@ -1145,11 +1211,13 @@ export class DockerSandboxProvider implements SandboxProvider {
       } catch (err) {
         if (headscaleRouteRequired) {
           if (dbNode && providerManagesCapacity) {
-            await dockerNodesRepository.decrementAllocated(nodeId).catch((rollbackErr) => {
-              logger.warn(
-                `[docker-sandbox] Failed to decrement allocated_count after Headscale preparation failure for node ${nodeId}: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
-              );
-            });
+            await dockerNodesRepository
+              .decrementAllocated(nodeId)
+              .catch((rollbackErr) => {
+                logger.warn(
+                  `[docker-sandbox] Failed to decrement allocated_count after Headscale preparation failure for node ${nodeId}: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
+                );
+              });
           }
           throw err;
         }
@@ -1188,7 +1256,8 @@ export class DockerSandboxProvider implements SandboxProvider {
       kmsEnv.ELIZA_KMS_BACKEND = backend;
       if (backend === "local") {
         const rootKey =
-          environmentVars.ELIZA_LOCAL_ROOT_KEY?.trim() || process.env.ELIZA_LOCAL_ROOT_KEY?.trim();
+          environmentVars.ELIZA_LOCAL_ROOT_KEY?.trim() ||
+          process.env.ELIZA_LOCAL_ROOT_KEY?.trim();
         if (rootKey) kmsEnv.ELIZA_LOCAL_ROOT_KEY = rootKey;
       }
     }
@@ -1211,7 +1280,9 @@ export class DockerSandboxProvider implements SandboxProvider {
       // no agent_config (the runtime keeps its default-character behaviour).
       ...(agentConfig && typeof agentConfig === "object"
         ? {
-            ELIZA_AGENT_CHARACTER_JSON: JSON.stringify(redactCharacterSecrets(agentConfig)),
+            ELIZA_AGENT_CHARACTER_JSON: JSON.stringify(
+              redactCharacterSecrets(agentConfig),
+            ),
           }
         : {}),
       STEWARD_API_URL: stewardContainerUrl,
@@ -1243,7 +1314,12 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 6. SSH to node, ensure volume dir, pull image, register in Steward,
     // then create/start the container. Pass hostKeyFingerprint so pooled
     // clients pin the key when available.
-    const ssh = DockerSSHClient.getClient(hostname, sshPort, hostKeyFingerprint, sshUser);
+    const ssh = DockerSSHClient.getClient(
+      hostname,
+      sshPort,
+      hostKeyFingerprint,
+      sshUser,
+    );
     const cleanupNode: DockerNodeConnection = {
       node_id: nodeId,
       hostname,
@@ -1263,11 +1339,15 @@ export class DockerSandboxProvider implements SandboxProvider {
 
       // Pull image (may take a while on first run). Log in when registry
       // credentials are configured; otherwise rely on anonymous public pulls.
-      logger.info(`[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`);
+      logger.info(
+        `[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`,
+      );
       try {
         await ensureRegistryAccess(ssh, resolvedImage);
         await ssh.exec(
-          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(" "),
+          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(
+            " ",
+          ),
           PULL_TIMEOUT_MS,
         );
         logger.info(`[docker-sandbox] Image pulled successfully on ${nodeId}`);
@@ -1361,7 +1441,8 @@ export class DockerSandboxProvider implements SandboxProvider {
         // (no D-Bus keychain). Generate one per container — the vault state
         // lives only in the per-container PGlite, so a unique per-launch key
         // is fine.
-        ELIZA_VAULT_PASSPHRASE: environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
+        ELIZA_VAULT_PASSPHRASE:
+          environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
         // Gateway service discovery — see SandboxRegistry in app-core.
         // SANDBOX_PUBLIC_URL targets the public Docker host (not the headscale
         // VPN IP set later at line ~653) because the gateways on Railway can't
@@ -1370,12 +1451,16 @@ export class DockerSandboxProvider implements SandboxProvider {
           ? {
               SANDBOX_REGISTRY_REDIS_URL: registryRedisUrl,
               // Only the REST transport needs a token; a redis:// URL omits it.
-              ...(registryRedisToken ? { SANDBOX_REGISTRY_REDIS_TOKEN: registryRedisToken } : {}),
+              ...(registryRedisToken
+                ? { SANDBOX_REGISTRY_REDIS_TOKEN: registryRedisToken }
+                : {}),
               SANDBOX_AGENT_ID: agentId,
               // The gateways route by the platform character_id, so the
               // container must register under (and answer as) that id, not
               // the sandbox id. Injected only when the caller provides it.
-              ...(routeAgentId?.trim() ? { SANDBOX_ROUTE_AGENT_ID: routeAgentId.trim() } : {}),
+              ...(routeAgentId?.trim()
+                ? { SANDBOX_ROUTE_AGENT_ID: routeAgentId.trim() }
+                : {}),
               SANDBOX_SERVER_NAME: `sandbox-${agentId}-${crypto.randomUUID()}`,
               SANDBOX_PUBLIC_URL: `http://${hostname}:${bridgePort}/api`,
             }
@@ -1411,7 +1496,8 @@ export class DockerSandboxProvider implements SandboxProvider {
         `--label ${shellQuote(`${REPLACEMENT_ATTEMPT_LABEL}=${replacementAttemptId}`)}`,
         "--restart unless-stopped",
         `--network ${shellQuote(DOCKER_NETWORK)}`,
-        ...(requiresDockerHostGateway(stewardContainerUrl) || Object.keys(proxyEnv).length > 0
+        ...(requiresDockerHostGateway(stewardContainerUrl) ||
+        Object.keys(proxyEnv).length > 0
           ? ["--add-host host.docker.internal:host-gateway"]
           : []),
         `--health-cmd ${shellQuote(getDockerHealthCmd(allEnv.PORT || containerPort, healthCheckPath))}`,
@@ -1448,12 +1534,17 @@ export class DockerSandboxProvider implements SandboxProvider {
       // run the cloud-init bootstrap; the network can also be pruned away).
       // Without this, `docker create --network` below fails with an opaque
       // "network not found" and the provision retries forever.
-      await ssh.exec(buildEnsureNetworkCmd(DOCKER_NETWORK), DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        buildEnsureNetworkCmd(DOCKER_NETWORK),
+        DOCKER_CMD_TIMEOUT_MS,
+      );
 
       // This clock starts the durable uncertainty window. Keep it adjacent to
       // intent/create rather than tenant setup or image pull so recovery does
       // not widen correlation with unrelated old Headscale registrations.
-      vpnRegistrationStartedAt = headscaleEnabled ? new Date(this.now()).toISOString() : undefined;
+      vpnRegistrationStartedAt = headscaleEnabled
+        ? new Date(this.now()).toISOString()
+        : undefined;
       const containerId = extractDockerCreateContainerId(
         await createDockerContainerAfterReplacementIntent({
           persistIntent: persistReplacementIntent
@@ -1489,7 +1580,8 @@ export class DockerSandboxProvider implements SandboxProvider {
                 }
               }
             : undefined,
-          createContainer: () => ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),
+          createContainer: () =>
+            ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),
         }),
       );
       createdContainerId = containerId;
@@ -1540,25 +1632,37 @@ export class DockerSandboxProvider implements SandboxProvider {
             )} | base64 -d > ${shellQuote(`${volumePath}/eliza/eliza.json`)}`,
             DOCKER_CMD_TIMEOUT_MS,
           );
-          logger.info(`[docker-sandbox] Pre-seeded eliza.json on host volume for ${containerName}`);
+          logger.info(
+            `[docker-sandbox] Pre-seeded eliza.json on host volume for ${containerName}`,
+          );
         }
       } catch (preSeedErr) {
         logger.warn(
           `[docker-sandbox] Failed to pre-seed eliza.json (post-start write will retry): ${
-            preSeedErr instanceof Error ? preSeedErr.message : String(preSeedErr)
+            preSeedErr instanceof Error
+              ? preSeedErr.message
+              : String(preSeedErr)
           }`,
         );
       }
 
-      await ssh.exec(`docker start ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker start ${shellQuote(containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
       logger.info(
         `[docker-sandbox] Container created on ${nodeId}: ${containerId} (${containerName})`,
       );
 
       if (shouldInstallStewardPlugin(agentId, environmentVars)) {
         try {
-          await ssh.exec(buildStewardPluginInstallCommand(containerName), PULL_TIMEOUT_MS);
-          logger.info(`[docker-sandbox] Steward Eliza plugin installed in ${containerName}`);
+          await ssh.exec(
+            buildStewardPluginInstallCommand(containerName),
+            PULL_TIMEOUT_MS,
+          );
+          logger.info(
+            `[docker-sandbox] Steward Eliza plugin installed in ${containerName}`,
+          );
         } catch (pluginErr) {
           logger.warn(
             `[docker-sandbox] Failed to install Steward Eliza plugin in ${containerName}: ${pluginErr instanceof Error ? pluginErr.message : String(pluginErr)}`,
@@ -1569,10 +1673,16 @@ export class DockerSandboxProvider implements SandboxProvider {
       if (stewardJwt && stewardRefreshServiceToken) {
         try {
           await ssh.exec(
-            buildStewardRefreshCommand(containerName, agentId, stewardRefreshServiceToken),
+            buildStewardRefreshCommand(
+              containerName,
+              agentId,
+              stewardRefreshServiceToken,
+            ),
             DOCKER_CMD_TIMEOUT_MS,
           );
-          logger.info(`[docker-sandbox] Steward JWT refresh sidecar started in ${containerName}`);
+          logger.info(
+            `[docker-sandbox] Steward JWT refresh sidecar started in ${containerName}`,
+          );
         } catch (refreshErr) {
           logger.warn(
             `[docker-sandbox] Failed to start Steward JWT refresh sidecar in ${containerName}: ${refreshErr instanceof Error ? refreshErr.message : String(refreshErr)}`,
@@ -1594,22 +1704,31 @@ export class DockerSandboxProvider implements SandboxProvider {
               "https://api-staging.elizacloud.ai/api/v1 for staging, https://api.elizacloud.ai/api/v1 for prod).",
           );
         }
-        const elizaConfig = JSON.stringify(buildManagedElizaRuntimeConfig(allEnv));
+        const elizaConfig = JSON.stringify(
+          buildManagedElizaRuntimeConfig(allEnv),
+        );
         // Base64-encode the JSON before passing it through the shell so an
         // apiKey/baseUrl containing single quotes can't break out of the
         // outer sh -c quoting or inject commands on the remote host.
-        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString("base64");
+        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString(
+          "base64",
+        );
         const writeCmd = `docker exec ${shellQuote(containerName)} sh -c ${shellQuote(
           `mkdir -p /root/.eliza && printf %s ${shellQuote(encodedConfig)} | base64 -d > /root/.eliza/eliza.json`,
         )}`;
         await ssh.exec(writeCmd, DOCKER_CMD_TIMEOUT_MS);
-        logger.info(`[docker-sandbox] Cloud config written to eliza.json in ${containerName}`);
+        logger.info(
+          `[docker-sandbox] Cloud config written to eliza.json in ${containerName}`,
+        );
       } catch (configErr) {
         logger.warn(
           `[docker-sandbox] Failed to write eliza.json: ${configErr instanceof Error ? configErr.message : String(configErr)}`,
         );
       }
     } catch (err) {
+      // Recorded before any rethrow branching below so every failure shape on
+      // this node feeds the placement breaker (only timeouts count inside).
+      notePlacementCommandFailure(nodeId, err);
       // Best-effort Steward deregistration — the agent was registered but the
       // container failed to start, so the Steward record is deleted here.
       try {
@@ -1617,7 +1736,9 @@ export class DockerSandboxProvider implements SandboxProvider {
           await buildSignedDeleteAgentCurl(agentId, stewardTenant),
           DOCKER_CMD_TIMEOUT_MS,
         );
-        logger.info(`[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`);
+        logger.info(
+          `[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`,
+        );
       } catch (cleanupErr) {
         logger.warn(
           `[docker-sandbox] Failed to cleanup Steward agent ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
@@ -1633,7 +1754,9 @@ export class DockerSandboxProvider implements SandboxProvider {
         vpnNodeId,
         // Before the adjacent timestamp is captured, the container has not
         // been created and therefore cannot have committed a VPN registration.
-        vpnNodeName: vpnRegistrationStartedAt ? vpnEnvVars.TS_HOSTNAME : undefined,
+        vpnNodeName: vpnRegistrationStartedAt
+          ? vpnEnvVars.TS_HOSTNAME
+          : undefined,
         previousVpnNodeId,
         vpnRegistrationStartedAt,
         allocationCounted: Boolean(dbNode),
@@ -1646,25 +1769,33 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
 
       try {
-        await this.retireReplacementCandidateOnNode(cleanupLocator, cleanupNode);
+        await this.retireReplacementCandidateOnNode(
+          cleanupLocator,
+          cleanupNode,
+        );
       } catch (cleanupError) {
         // error-policy:J2 context-adding rethrow — replacement identity is retained
         // so the durable reconciler can retry the exact unresolved cleanup.
         if (cleanupError instanceof SandboxReplacementCleanupUnresolvedError) {
           throw cleanupError;
         }
-        throw new SandboxReplacementCleanupUnresolvedError(cleanupLocator, cleanupError);
+        throw new SandboxReplacementCleanupUnresolvedError(
+          cleanupLocator,
+          cleanupError,
+        );
       }
 
       // Releasing capacity is safe only after the exact candidate and its known
       // VPN identity are absent. An unresolved cleanup retains the allocation
       // and escapes above with a durable locator.
       if (dbNode && providerManagesCapacity) {
-        await dockerNodesRepository.decrementAllocated(nodeId).catch((rollbackErr) => {
-          logger.error(
-            `[docker-sandbox] Failed to roll back allocation for node ${nodeId}; capacity slot leaked: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
-          );
-        });
+        await dockerNodesRepository
+          .decrementAllocated(nodeId)
+          .catch((rollbackErr) => {
+            logger.error(
+              `[docker-sandbox] Failed to roll back allocation for node ${nodeId}; capacity slot leaked: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
+            );
+          });
       }
       throw new Error(
         `[docker-sandbox] Failed to create container on ${nodeId}: ${err instanceof Error ? err.message : String(err)}`,
@@ -1688,6 +1819,9 @@ export class DockerSandboxProvider implements SandboxProvider {
       hostKeyFingerprint,
     };
     this.containers.set(containerName, meta);
+    // The container exists on the node — clear its breaker history so a
+    // recovered node is not one stale timeout away from re-quarantine.
+    clearPlacementCommandFailures(nodeId);
 
     // 8. Wait for Headscale VPN registration if enabled
     if (headscaleEnabled) {
@@ -1792,7 +1926,10 @@ export class DockerSandboxProvider implements SandboxProvider {
         nodeId,
       });
       await ssh
-        .exec(await buildSignedDeleteAgentCurl(agentId, stewardTenant), DOCKER_CMD_TIMEOUT_MS)
+        .exec(
+          await buildSignedDeleteAgentCurl(agentId, stewardTenant),
+          DOCKER_CMD_TIMEOUT_MS,
+        )
         .then(() => {
           logger.info(
             `[docker-sandbox] Cleaned up Steward agent ${agentId} after missing Headscale registration`,
@@ -1842,13 +1979,15 @@ export class DockerSandboxProvider implements SandboxProvider {
       await this.retireReplacementCandidateOnNode(cleanupLocator, cleanupNode);
       this.containers.delete(containerName);
       if (dbNode && providerManagesCapacity) {
-        await dockerNodesRepository.decrementAllocated(nodeId).catch((rollbackError) => {
-          // error-policy:J6 best-effort teardown — the candidate is already absent;
-          // capacity reconciliation remains observable while the original failure surfaces.
-          logger.error(
-            `[docker-sandbox] Failed to roll back allocation for node ${nodeId} after unroutable candidate cleanup: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
-          );
-        });
+        await dockerNodesRepository
+          .decrementAllocated(nodeId)
+          .catch((rollbackError) => {
+            // error-policy:J6 best-effort teardown — the candidate is already absent;
+            // capacity reconciliation remains observable while the original failure surfaces.
+            logger.error(
+              `[docker-sandbox] Failed to roll back allocation for node ${nodeId} after unroutable candidate cleanup: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+            );
+          });
       }
       throw new Error(errorMessage);
     }
@@ -1915,18 +2054,24 @@ export class DockerSandboxProvider implements SandboxProvider {
     const hcloudToken = containersEnv.hetznerCloudToken();
     const publicKey = env.CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY?.trim();
     if (!hcloudToken || !publicKey) {
-      logger.warn("[docker-sandbox] No Docker capacity and autoscale is not configured", {
-        hasHcloudToken: Boolean(hcloudToken),
-        hasPublicKey: Boolean(publicKey),
-      });
+      logger.warn(
+        "[docker-sandbox] No Docker capacity and autoscale is not configured",
+        {
+          hasHcloudToken: Boolean(hcloudToken),
+          hasPublicKey: Boolean(publicKey),
+        },
+      );
       return null;
     }
 
     try {
-      logger.info("[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node", {
-        image,
-        platform,
-      });
+      logger.info(
+        "[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node",
+        {
+          image,
+          platform,
+        },
+      );
       const provisioned = await getNodeAutoscaler().provisionNode(
         {
           prePullImages: [image],
@@ -1941,7 +2086,9 @@ export class DockerSandboxProvider implements SandboxProvider {
 
       const deadline = Date.now() + AUTOSCALED_NODE_READY_TIMEOUT_MS;
       while (Date.now() < deadline) {
-        const node = await dockerNodesRepository.findByNodeId(provisioned.nodeId);
+        const node = await dockerNodesRepository.findByNodeId(
+          provisioned.nodeId,
+        );
         if (
           node &&
           (await dockerNodeManager.ensureNodeReady(node, {
@@ -1954,18 +2101,26 @@ export class DockerSandboxProvider implements SandboxProvider {
           });
           return node;
         }
-        await new Promise((resolve) => setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS));
+        await new Promise((resolve) =>
+          setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS),
+        );
       }
 
-      logger.warn("[docker-sandbox] Autoscaled Docker node did not become ready before timeout", {
-        nodeId: provisioned.nodeId,
-        hostname: provisioned.hostname,
-      });
+      logger.warn(
+        "[docker-sandbox] Autoscaled Docker node did not become ready before timeout",
+        {
+          nodeId: provisioned.nodeId,
+          hostname: provisioned.hostname,
+        },
+      );
       return null;
     } catch (error) {
-      logger.warn("[docker-sandbox] Autoscaled Docker node provisioning failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[docker-sandbox] Autoscaled Docker node provisioning failed",
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return null;
     }
   }
@@ -1993,7 +2148,13 @@ export class DockerSandboxProvider implements SandboxProvider {
     containerName: string,
     gracefulSeconds = 30,
   ): Promise<void> {
-    await this.stopOnSpecificNodeWithPolicy(node, containerName, gracefulSeconds, true, true);
+    await this.stopOnSpecificNodeWithPolicy(
+      node,
+      containerName,
+      gracefulSeconds,
+      true,
+      true,
+    );
   }
 
   async stopOnSpecificNodeForReplacement(
@@ -2052,7 +2213,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
     }
     try {
-      await ssh.exec(`docker rm -f ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker rm -f ${shellQuote(containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
     } catch (err) {
       rmErr = err;
       const msg = err instanceof Error ? err.message : String(err);
@@ -2070,14 +2234,18 @@ export class DockerSandboxProvider implements SandboxProvider {
     if (!allowUnreachableAbandon && rmErr) {
       const rmMsg = rmErr instanceof Error ? rmErr.message : String(rmErr);
       if (!isContainerAbsentMessage(rmMsg)) {
-        const stopMsg = stopErr instanceof Error ? stopErr.message : String(stopErr ?? "succeeded");
+        const stopMsg =
+          stopErr instanceof Error
+            ? stopErr.message
+            : String(stopErr ?? "succeeded");
         throw new Error(
           `[docker-sandbox] Cannot prove ${containerName} absent on ${node.node_id}: ` +
             `docker stop -> ${stopMsg}; docker rm -f -> ${rmMsg}`,
         );
       }
     } else if (stopErr && rmErr) {
-      const stopMsg = stopErr instanceof Error ? stopErr.message : String(stopErr);
+      const stopMsg =
+        stopErr instanceof Error ? stopErr.message : String(stopErr);
       const rmMsg = rmErr instanceof Error ? rmErr.message : String(rmErr);
       const stopIsGone = isAlreadyGoneMessage(stopMsg);
       const rmIsGone = isAlreadyGoneMessage(rmMsg);
@@ -2090,13 +2258,15 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     if (releaseCapacity) {
-      await dockerNodesRepository.decrementAllocated(node.node_id).catch((err) => {
-        // error-policy:J6 best-effort teardown — remote absence is already proven,
-        // so a bookkeeping failure is logged for reconciliation rather than reviving it.
-        logger.warn(
-          `[docker-sandbox] stopOnSpecificNode: decrement allocated_count failed for ${node.node_id}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
+      await dockerNodesRepository
+        .decrementAllocated(node.node_id)
+        .catch((err) => {
+          // error-policy:J6 best-effort teardown — remote absence is already proven,
+          // so a bookkeeping failure is logged for reconciliation rather than reviving it.
+          logger.warn(
+            `[docker-sandbox] stopOnSpecificNode: decrement allocated_count failed for ${node.node_id}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
     }
   }
 
@@ -2109,7 +2279,13 @@ export class DockerSandboxProvider implements SandboxProvider {
         ? await this.resolveReplacementContainerForCleanup(locator, node)
         : locator.containerName;
       if (cleanupTarget) {
-        await this.stopOnSpecificNodeWithPolicy(node, cleanupTarget, 10, false, false);
+        await this.stopOnSpecificNodeWithPolicy(
+          node,
+          cleanupTarget,
+          10,
+          false,
+          false,
+        );
       }
       if (locator.vpnNodeId) {
         await withTimeout(
@@ -2181,7 +2357,10 @@ export class DockerSandboxProvider implements SandboxProvider {
         `[docker-sandbox] Replacement attempt label mismatch for ${locator.containerName}`,
       );
     }
-    if (locator.containerId && !dockerContainerIdsMatch(locator.containerId, containerId)) {
+    if (
+      locator.containerId &&
+      !dockerContainerIdsMatch(locator.containerId, containerId)
+    ) {
       throw new Error(
         `[docker-sandbox] Replacement container id mismatch for ${locator.containerName}`,
       );
@@ -2210,7 +2389,9 @@ export class DockerSandboxProvider implements SandboxProvider {
       );
     }
     const registrationDeadline =
-      startedAt + DEFAULT_REGISTRATION_TIMEOUT_MS + REPLACEMENT_VPN_CLOCK_SKEW_ALLOWANCE_MS;
+      startedAt +
+      DEFAULT_REGISTRATION_TIMEOUT_MS +
+      REPLACEMENT_VPN_CLOCK_SKEW_ALLOWANCE_MS;
     if (this.now() < registrationDeadline) {
       throw new Error(
         `[docker-sandbox] VPN registration window remains open for ${locator.containerName} until ${new Date(registrationDeadline).toISOString()}`,
@@ -2218,7 +2399,11 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     let consecutiveEmptyObservations = 0;
-    for (let observation = 0; observation < REPLACEMENT_VPN_SETTLE_OBSERVATIONS; observation += 1) {
+    for (
+      let observation = 0;
+      observation < REPLACEMENT_VPN_SETTLE_OBSERVATIONS;
+      observation += 1
+    ) {
       const nodes = await withTimeout(
         headscaleClient.listNodesStrict(),
         HEADSCALE_CLEANUP_TIMEOUT_MS,
@@ -2232,7 +2417,8 @@ export class DockerSandboxProvider implements SandboxProvider {
           ? node.name.slice(baseName.length + 1)
           : null;
         const nameMatches =
-          node.name === baseName || (suffix !== null && /^[a-z0-9]{8}$/.test(suffix));
+          node.name === baseName ||
+          (suffix !== null && /^[a-z0-9]{8}$/.test(suffix));
         if (!nameMatches) {
           return false;
         }
@@ -2266,7 +2452,9 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
 
       if (observation < REPLACEMENT_VPN_SETTLE_OBSERVATIONS - 1) {
-        await this.replacementVpnSettleDelay(REPLACEMENT_VPN_SETTLE_INTERVAL_MS);
+        await this.replacementVpnSettleDelay(
+          REPLACEMENT_VPN_SETTLE_INTERVAL_MS,
+        );
       }
     }
 
@@ -2290,7 +2478,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     await this.stopWithPolicy(sandboxId, false);
   }
 
-  private async stopWithPolicy(sandboxId: string, allowUnreachableAbandon: boolean): Promise<void> {
+  private async stopWithPolicy(
+    sandboxId: string,
+    allowUnreachableAbandon: boolean,
+  ): Promise<void> {
     const meta = await this.resolveContainer(sandboxId);
 
     logger.info(
@@ -2315,7 +2506,10 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     try {
       // Graceful stop with 10s timeout, then force-remove
-      await ssh.exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, STOP_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker stop -t 10 ${shellQuote(meta.containerName)}`,
+        STOP_CMD_TIMEOUT_MS,
+      );
       logger.info(`[docker-sandbox] Container stopped: ${meta.containerName}`);
     } catch (err) {
       stopErr = err;
@@ -2325,7 +2519,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     try {
-      await ssh.exec(`docker rm -f ${shellQuote(meta.containerName)}`, STOP_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker rm -f ${shellQuote(meta.containerName)}`,
+        STOP_CMD_TIMEOUT_MS,
+      );
       logger.info(`[docker-sandbox] Container removed: ${meta.containerName}`);
     } catch (err) {
       rmErr = err;
@@ -2335,7 +2532,8 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     if (stopErr && rmErr) {
-      const stopMsg = stopErr instanceof Error ? stopErr.message : String(stopErr);
+      const stopMsg =
+        stopErr instanceof Error ? stopErr.message : String(stopErr);
       const rmMsg = rmErr instanceof Error ? rmErr.message : String(rmErr);
       // "No such container" from either call means the container was
       // already gone — that is a success, not a failure. We only escalate
@@ -2363,8 +2561,13 @@ export class DockerSandboxProvider implements SandboxProvider {
       // to keep the work cycle bounded; the lifecycle/capacity owner should add
       // a node-reconcile sweep (and revisit the allocated_count decrement below)
       // when one lands. Do NOT claim a reconciler already reclaims it.
-      const unreachable = isNodeUnreachableMessage(stopMsg) && isNodeUnreachableMessage(rmMsg);
-      if (!stopIsGone && !rmIsGone && (!unreachable || !allowUnreachableAbandon)) {
+      const unreachable =
+        isNodeUnreachableMessage(stopMsg) && isNodeUnreachableMessage(rmMsg);
+      if (
+        !stopIsGone &&
+        !rmIsGone &&
+        (!unreachable || !allowUnreachableAbandon)
+      ) {
         throw new Error(
           `Failed to stop container ${meta.containerName} on ${meta.hostname}: ` +
             `docker stop -> ${stopMsg}; docker rm -f -> ${rmMsg}`,
@@ -2411,13 +2614,15 @@ export class DockerSandboxProvider implements SandboxProvider {
             ? headscaleIntegration.cleanupContainerVPN(registeredNodeName)
             : null;
       if (cleanup) {
-        await withTimeout(cleanup, HEADSCALE_CLEANUP_TIMEOUT_MS, "headscale cleanup").catch(
-          (err) => {
-            logger.warn(
-              `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          },
-        );
+        await withTimeout(
+          cleanup,
+          HEADSCALE_CLEANUP_TIMEOUT_MS,
+          "headscale cleanup",
+        ).catch((err) => {
+          logger.warn(
+            `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
       } else {
         logger.info(
           `[docker-sandbox] Skipping Headscale cleanup for ${meta.agentId}: preserved live node holds the hostname and this container never registered`,
@@ -2499,7 +2704,9 @@ export class DockerSandboxProvider implements SandboxProvider {
    * reached the container as RETRYABLE rather than a terminal failure. See
    * {@link SandboxHealthVerdict}.
    */
-  async checkHealthDetailed(handle: SandboxHandle): Promise<SandboxHealthOutcome> {
+  async checkHealthDetailed(
+    handle: SandboxHandle,
+  ): Promise<SandboxHealthOutcome> {
     const meta = await this.resolveContainer(handle.sandboxId);
     const deadline = Date.now() + HEALTH_CHECK_TIMEOUT_MS;
 
@@ -2511,7 +2718,9 @@ export class DockerSandboxProvider implements SandboxProvider {
     // let the first racing tailnet fetch tear the agent down despite it being
     // healthy.
     const headscaleIp =
-      typeof handle.metadata?.headscaleIp === "string" ? handle.metadata.headscaleIp : undefined;
+      typeof handle.metadata?.headscaleIp === "string"
+        ? handle.metadata.headscaleIp
+        : undefined;
     if (headscaleIp) {
       if (await this.pollTailnetHealth(handle, meta, deadline)) {
         return { ready: true, verdict: "ready" };
@@ -2524,7 +2733,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       // provision time it is enough evidence to avoid tearing down a container
       // the node can prove is up. A container that fails BOTH probes still
       // reports unhealthy, so a dead provision still times out and self-heals.
-      return this.pollSshDockerHealth(meta, Date.now() + HEALTH_CHECK_SSH_FALLBACK_TIMEOUT_MS);
+      return this.pollSshDockerHealth(
+        meta,
+        Date.now() + HEALTH_CHECK_SSH_FALLBACK_TIMEOUT_MS,
+      );
     }
 
     return this.pollSshDockerHealth(meta, deadline);
@@ -2557,7 +2769,9 @@ export class DockerSandboxProvider implements SandboxProvider {
     // would falsely condemn a container the probe never even reached.
     let reachedContainer = false;
 
-    const runOneProbe = async (): Promise<"ready" | "not_ready" | "transport"> => {
+    const runOneProbe = async (): Promise<
+      "ready" | "not_ready" | "transport"
+    > => {
       // Placement-affecting jobs can overlap the health wait, so each probe
       // reads the current node before dialing docker on that host.
       current = await this.refreshNodeMeta(current);
@@ -2634,10 +2848,14 @@ export class DockerSandboxProvider implements SandboxProvider {
       // Wait before retrying (but don't overshoot the deadline)
       const remaining = deadline - Date.now();
       if (remaining > HEALTH_CHECK_POLL_INTERVAL_MS) {
-        await new Promise((resolve) => setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS));
+        await new Promise((resolve) =>
+          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS),
+        );
       } else if (remaining > 0) {
         // One last attempt after a short wait
-        await new Promise((resolve) => setTimeout(resolve, Math.min(remaining, 1000)));
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.min(remaining, 1000)),
+        );
       } else {
         break;
       }
@@ -2662,7 +2880,9 @@ export class DockerSandboxProvider implements SandboxProvider {
         if (reachedContainer) break;
         const remaining = retryDeadline - Date.now();
         if (remaining <= 0) break;
-        await new Promise((resolve) => setTimeout(resolve, Math.min(backoff, remaining)));
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.min(backoff, remaining)),
+        );
         backoff = Math.min(backoff * 2, HEALTH_CHECK_TRANSPORT_RETRY_MAX_MS);
       }
 
@@ -2701,11 +2921,16 @@ export class DockerSandboxProvider implements SandboxProvider {
         diagnostics: diagnostics.slice(-12_000),
       });
     } catch (diagnosticsError) {
-      logger.warn("[docker-sandbox] Failed to collect health timeout diagnostics", {
-        containerName: current.containerName,
-        error:
-          diagnosticsError instanceof Error ? diagnosticsError.message : String(diagnosticsError),
-      });
+      logger.warn(
+        "[docker-sandbox] Failed to collect health timeout diagnostics",
+        {
+          containerName: current.containerName,
+          error:
+            diagnosticsError instanceof Error
+              ? diagnosticsError.message
+              : String(diagnosticsError),
+        },
+      );
     }
     // We reached the container at least once but it never answered healthy — a
     // genuine not-ready verdict (terminal), not a transport false-negative.
@@ -2716,12 +2941,19 @@ export class DockerSandboxProvider implements SandboxProvider {
   // runCommand
   // ------------------------------------------------------------------
 
-  async runCommand(sandboxId: string, cmd: string, args?: string[]): Promise<string> {
+  async runCommand(
+    sandboxId: string,
+    cmd: string,
+    args?: string[],
+  ): Promise<string> {
     const meta = await this.resolveContainer(sandboxId);
 
     // Shell-escape each argument to prevent command injection
-    const escapedArgs = args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
-    const fullCmd = escapedArgs ? `${shellQuote(cmd)} ${escapedArgs}` : shellQuote(cmd);
+    const escapedArgs =
+      args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
+    const fullCmd = escapedArgs
+      ? `${shellQuote(cmd)} ${escapedArgs}`
+      : shellQuote(cmd);
 
     logger.info(
       `[docker-sandbox] Executing command in ${meta.containerName}: ${cmd} ${(args ?? []).join(" ").slice(0, 80)}`,
@@ -2799,7 +3031,9 @@ export class DockerSandboxProvider implements SandboxProvider {
    * refresh the cache. Returns null only when there is no usable sandbox row;
    * repository and configuration failures propagate to the caller.
    */
-  private async hydrateContainerFromDb(sandboxId: string): Promise<ContainerMeta | null> {
+  private async hydrateContainerFromDb(
+    sandboxId: string,
+  ): Promise<ContainerMeta | null> {
     const sandbox = await agentSandboxesRepository.findBySandboxId(sandboxId);
     if (!sandbox || !sandbox.node_id || !sandbox.container_name) return null;
 
@@ -2810,7 +3044,9 @@ export class DockerSandboxProvider implements SandboxProvider {
       );
     }
     if (!dbNode.hostname) {
-      throw new Error(`[docker-sandbox] Docker node "${sandbox.node_id}" is missing hostname`);
+      throw new Error(
+        `[docker-sandbox] Docker node "${sandbox.node_id}" is missing hostname`,
+      );
     }
 
     if (!sandbox.bridge_port || !sandbox.web_ui_port) {
@@ -2848,7 +3084,9 @@ export class DockerSandboxProvider implements SandboxProvider {
    * job start. Returning the last-known node on a refresh failure keeps a DB
    * blip from turning an otherwise-valid liveness probe into a failed provision.
    */
-  private async refreshNodeMeta(previous: ContainerMeta): Promise<ContainerMeta> {
+  private async refreshNodeMeta(
+    previous: ContainerMeta,
+  ): Promise<ContainerMeta> {
     let fresh: ContainerMeta | null;
     try {
       fresh = await this.hydrateContainerFromDb(previous.containerName);
@@ -2863,7 +3101,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     if (!fresh) return previous;
-    if (fresh.nodeId !== previous.nodeId || fresh.hostname !== previous.hostname) {
+    if (
+      fresh.nodeId !== previous.nodeId ||
+      fresh.hostname !== previous.hostname
+    ) {
       logger.info(
         `[docker-sandbox] ${previous.containerName} re-placed mid health-wait: node ${previous.nodeId} (${previous.hostname}) -> ${fresh.nodeId} (${fresh.hostname}); following the new node`,
       );


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

Closes #17880

## What happened

Between 2026-08-06 11:41 and 2026-08-07 01:05 UTC **no new agent provisioned anywhere on the fleet**. 8 `agent_provision` jobs hard-failed (`Job timed out 3 times - max attempts reached`); users were left on "your container is provisioning" indefinitely. Existing agents were unaffected — heartbeats stayed green fleet-wide, which is why nothing alerted.

The node carrying the work (`eliza-core-prod-1`) also hosts the self-hosted Actions farm. CI concurrency saturated its disks, and `docker create` — which needs journal flushes — stopped completing inside the provisioner's 60s timeout:

```
load average 451.39   /proc/pressure/io full avg60=78.50
366 processes in D-state:  224 runc:[2:INIT] + 116 runc  on flush_workqueue
                            10 tar           on jbd2_log_do_checkpoint
```

Two blind spots let this become fleet-wide rather than one bad node:

1. **The readiness probe measures the wrong thing.** `docker info` answers from daemon memory, so it returned promptly on a box too IO-starved to create a container. The node passed selection every time.
2. **Failures never fed back into selection.** Each provision started from a clean slate, saw "2 free slots, docker info OK", and re-picked the same node. Every other node was over its declared capacity (#17866), so the drowning node was the *only* candidate — precisely when it was least able to serve.

The node recovered on its own once CI drained (01:05 onward, provisions completing in 36–80s). This PR is about not needing that luck.

## The fix

**Circuit breaker on measured failures.** Docker-command timeouts are counted per node in a 10-minute sliding window; at the third, the node is quarantined from selection for 15 minutes. Only timeouts count — a bad image or auth failure says nothing about a node's ability to take work. Quarantine is evaluated *before* the SSH probe, so a drowning node stops receiving even probe traffic. A successful container create clears the history.

**IO pressure at readiness.** `/proc/pressure/io` is read in the same round trip as `docker info` (joined with `&&`, so a failing `docker info` still rejects through the existing unreachable path). A node above the threshold is refused for placement — without a DB status write, since IO overload is transient and status flips are reserved for dead daemons.

The two layers are deliberately different in kind: the probe is predictive and avoids the first failure; the breaker is reactive and bounds the damage when prediction misses. A missing PSI signal (old kernel, `CONFIG_PSI` off) never blocks placement — the breaker still covers that node.

## Threshold calibration — measured, not guessed

My first implementation gated on `full avg10 >= 40`. Sampling the **real node while healthy** disproved it:

| state | `full avg10` | `full avg60` |
|---|---|---|
| healthy, provisioning in ~36s | **30.53 – 40.87** (spread 10.3) | **33.56 – 36.37** (spread 2.8) |
| #17880 outage | 72.89 | 78.50 |

An avg10 gate at 40 would have refused this **working** node in 2 of 8 consecutive samples — manufacturing the "no nodes available" outage it exists to prevent. The gate reads `avg60` at **60**: ~24 points below the measured healthy ceiling, ~18 above the outage floor. Both healthy samples that spike past 40 on avg10 are pinned verbatim as a regression fixture.

## Evidence

<details>
<summary>Mutation runs — every pin verified to go red</summary>

| mutation | result |
|---|---|
| M1 selection iterates all candidates, ignoring quarantine | 2 fail |
| M2 classifier widened: every failure counts, not just timeouts | 1 fail |
| M3 sliding window removed: timeouts accumulate forever | 1 fail |
| M4 PSI gate removed: an IO-starved node is accepted | 1 fail |
| M5 quarantine never expires | 1 fail |
| M6 parser reads avg10 instead of avg60 | 2 fail |
| M7 missing PSI treated as zero instead of null | 1 fail |
| M8 threshold lowered into the healthy band | 1 fail |

```
this suite                     13 pass  0 fail   (baseline before AND after every mutation)
cloud/shared full package    6158 pass  0 fail   exit 0
typecheck + biome                              clean
```

The harness aborts if a mutation fails to apply, so a no-op can't be reported as a false red.

</details>

## Maintainer review verification

The maintainer review found and corrected two edge cases before merge:

- When registered database nodes existed but were all unavailable or quarantined, the provider could reuse the initial CONTAINERS_DOCKER_NODES seed and immediately select the sick node. The seed path is now restricted to an actually empty registry and the unavailable state is a typed DOCKER_PLACEMENT_UNAVAILABLE error.
- The timeout classifier could count generic application output or non-Docker SSH timeouts. It now accepts only the redacted docker command timeout signature while safely traversing error causes.

Verification on ca4b2c8f9032f63eb097072e351955628205a0d7 after rebasing onto develop at f38b671f975781cbc73beff91ceb6a4f3a2c0ee5:

- focused circuit-breaker and placement-fallback tests: 16 passed
- composite Docker sandbox provider lane: 109 passed\n- container memory-cap regression lane: 17 passed\n- bun run verify: 343/343 workspace tasks passed; all repository audits passed

## Scope

This does not create capacity, and it is not a substitute for #17881 (getting the CI farm off production agent nodes) or #17866 (fleet over declared capacity). It stops one sick node from absorbing every provision attempt and makes the failure legible in the logs instead of silent.

[stan-cloud]

<!-- evidence-head:5171fe05bb4440da8c57f430c4242fb7b73ba425 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - node placement logic in a background provisioning daemon, no UI surface in the diff

<!-- evidence-row:after-screenshots -->
- [ ] N/A - node placement logic in a background provisioning daemon, no UI surface in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable behaviour is a node being skipped during selection; the production incident timeline and the verbatim mutation runs carry it

<!-- evidence-row:backend-logs -->
- [x] [17925-breaker-runs-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17925-breaker-runs-v2.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call on any path this diff touches

<!-- evidence-row:domain-artifacts -->
- [x] [17925-breaker-domain.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17925-breaker-domain.txt)

