### PR TITLE
fix: add readAliasedEnv import + generation_timeout to ChatFailureKind

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -65,6 +65,7 @@ import {
   extractAssistantReplyText,
   isLinkedAccountProviderId,
   normalizeCharacterLanguage,
+  readAliasedEnv,
   resolveStreamingUpdate,
 } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";

--- a/packages/shared/src/contracts/chat.ts
+++ b/packages/shared/src/contracts/chat.ts
@@ -80,4 +80,5 @@ export type ChatFailureKind =
   | "no_provider"
   | "provider_issue"
   | "rate_limited"
-  | "local_inference";
+  | "local_inference"
+  | "generation_timeout";


### PR DESCRIPTION
Fixes 3 blocking type errors from HomunculusLabs review on #17891:

1. **readAliasedEnv not imported** - Added to @elizaos/shared value imports in chat-routes.ts (was causing ReferenceError at runtime)
2. **generation_timeout not in ChatFailureKind** - Added to union in packages/shared/src/contracts/chat.ts  
3. **generation_timeout not in SyntheticChatFailureKind** - Inherits from ChatFailureKind automatically

Tests pass: chat-failure-classification.test.ts (2/2)