### PR TITLE
fix(cloud): resolve Hetzner cleanup helper from workspace

### DIFF
--- a/packages/cloud/scripts/admin/bootstrap-provisioning-worker-host.mjs
+++ b/packages/cloud/scripts/admin/bootstrap-provisioning-worker-host.mjs
@@ -33,7 +33,16 @@ import { warnMissingUpstash as warnMissingUpstashImpl } from "./bootstrap-warn-m
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const cloudRoot = resolve(scriptDir, "..", "..");
 const repoRoot = resolve(cloudRoot, "..");
-const rmRecursiveScript = join(cloudRoot, "rm-path-recursive.mjs");
+// The recursive-delete helper is a workspace-level script under
+// packages/scripts; packages/cloud has never carried its own copy, so
+// resolving it against cloudRoot spawned a missing module and turned every
+// cleanup into a hard failure at the end of a successful provisioning run.
+const rmRecursiveScript = resolve(
+  cloudRoot,
+  "..",
+  "scripts",
+  "rm-path-recursive.mjs",
+);
 
 const { values } = parseArgs({
   options: {

--- a/packages/cloud/scripts/admin/cleanup-helper-resolution.test.ts
+++ b/packages/cloud/scripts/admin/cleanup-helper-resolution.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Repository contract for how `packages/cloud` scripts locate the workspace
+ * recursive-delete helper.
+ *
+ * The helper exists once, at `packages/scripts/rm-path-recursive.mjs`, and each
+ * caller rebuilds the path from its own directory with a hand-counted `..`
+ * chain. A miscount is invisible until cleanup actually runs, because the
+ * failure is a spawned Node process exiting on a missing module at the very end
+ * of an otherwise successful provisioning run — both callers had already
+ * drifted to a `packages/cloud/rm-path-recursive.mjs` that has never existed.
+ * This replays each caller's real declaration chain against the real repository
+ * layout so a miscounted hop fails here instead of on a live Hetzner host.
+ *
+ * Deterministic: reads source from disk and touches the filesystem only to test
+ * for existence. No network, no SSH, no cloud API.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HELPER_FILENAME = "rm-path-recursive.mjs";
+const scriptsRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(scriptsRoot, "..", "..", "..");
+const canonicalHelper = resolve(
+  repoRoot,
+  "packages",
+  "scripts",
+  HELPER_FILENAME,
+);
+
+function sourceFiles(directory: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const full = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...sourceFiles(full));
+      continue;
+    }
+    if (entry.name.endsWith(".test.ts") || entry.name.endsWith(".test.mjs")) {
+      continue;
+    }
+    if (entry.name.endsWith(".ts") || entry.name.endsWith(".mjs")) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+/**
+ * Replay the `const X = resolve(...)` / `join(...)` declarations a script makes,
+ * seeded with the `scriptDir` every caller derives from `import.meta.url`.
+ * A declaration referencing a binding this evaluator cannot supply is skipped
+ * rather than guessed, so an unresolvable caller surfaces as a miss below.
+ */
+function evaluateDeclarations(
+  filePath: string,
+  source: string,
+): Record<string, string> {
+  const scope: Record<string, string> = { scriptDir: dirname(filePath) };
+  const declaration = /const (\w+) = (resolve|join)\(([\s\S]*?)\);/g;
+  for (const [, name, fn, argsSource] of source.matchAll(declaration)) {
+    const args = argsSource
+      .split(",")
+      .map((argument) => argument.trim())
+      .filter((argument) => argument.length > 0)
+      .map((argument) =>
+        argument.startsWith('"') ? JSON.parse(argument) : scope[argument],
+      );
+    if (args.some((argument) => typeof argument !== "string")) continue;
+    scope[name] = fn === "resolve" ? resolve(...args) : join(...args);
+  }
+  return scope;
+}
+
+describe("packages/cloud cleanup-helper resolution", () => {
+  test("the canonical workspace helper exists where callers resolve it", () => {
+    expect(existsSync(canonicalHelper)).toBe(true);
+  });
+
+  test("every cloud script resolves the helper to that same real file", () => {
+    const callers = sourceFiles(scriptsRoot).filter((file) =>
+      readFileSync(file, "utf8").includes(HELPER_FILENAME),
+    );
+
+    // A caller that stops using the helper is fine; zero callers would mean
+    // this contract silently stopped guarding anything.
+    expect(callers.length).toBeGreaterThan(0);
+
+    const fromRepo = (path: string) =>
+      relative(repoRoot, path).replaceAll("\\", "/");
+
+    const offenders = callers.flatMap((caller) => {
+      const scope = evaluateDeclarations(caller, readFileSync(caller, "utf8"));
+      const resolved = Object.values(scope).find((value) =>
+        value.endsWith(HELPER_FILENAME),
+      );
+      if (!resolved) {
+        return [`${fromRepo(caller)} -> (no resolvable helper declaration)`];
+      }
+      if (resolved !== canonicalHelper || !existsSync(resolved)) {
+        return [`${fromRepo(caller)} -> ${fromRepo(resolved)}`];
+      }
+      return [];
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-wait-ready.test.ts
+++ b/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-wait-ready.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Temporary-key cleanup for the Hetzner readiness probe, exercising the real
+ * repository cleanup helper without making SSH or cloud API calls.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rmRecursive } from "./hetzner-e2e-wait-ready";
+
+describe("Hetzner E2E readiness cleanup", () => {
+  test("removes its temporary key directory through the repository helper", () => {
+    const directory = mkdtempSync(join(tmpdir(), "hetzner-wait-ready-test-"));
+    writeFileSync(join(directory, "id_ed25519"), "test-only-key\n", "utf8");
+
+    rmRecursive(directory);
+
+    expect(existsSync(directory)).toBe(false);
+  });
+});

--- a/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-wait-ready.ts
+++ b/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-wait-ready.ts
@@ -18,6 +18,8 @@ const rmRecursiveScript = resolve(
   "..",
   "..",
   "..",
+  "..",
+  "scripts",
   "rm-path-recursive.mjs",
 );
 
@@ -34,7 +36,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function rmRecursive(targetPath: string): void {
+export function rmRecursive(targetPath: string): void {
   const result = spawnSync(process.execPath, [rmRecursiveScript, targetPath], {
     stdio: "inherit",
   });
@@ -104,4 +106,6 @@ async function main(): Promise<void> {
   }
 }
 
-await main();
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
## Summary

- resolve both Cloud callers of the shared recursive cleanup helper to the real `packages/scripts/rm-path-recursive.mjs`
- keep the Hetzner readiness script import-safe so its real cleanup function can be contract-tested
- add a real-helper deletion test plus a repository contract that discovers every Cloud cleanup-helper caller and validates its complete path-resolution chain

This fixes the code failure exposed by [Hetzner Agent E2E run 31157731183](https://github.com/elizaOS/eliza/actions/runs/31157731183), after that run successfully provisioned a real Hetzner host but failed during readiness cleanup. The broader contract also caught the same latent path defect in the provisioning-worker bootstrap.

Refs #17912

## Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - GitHub workflow skills guided review and CI operations but did not author the code change.
<!-- attribution-row:status -->
- Attribution status: self-reported

## Validation

- `bun test packages/cloud/scripts/admin/cleanup-helper-resolution.test.ts packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-wait-ready.test.ts packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-provision.test.ts packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-reaper.test.ts` — 18 passed
- `bunx biome check packages/cloud/scripts/admin/cleanup-helper-resolution.test.ts packages/cloud/scripts/admin/bootstrap-provisioning-worker-host.mjs packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-wait-ready.ts packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-wait-ready.test.ts`
- `git diff --check`
- `bun install --frozen-lockfile && bun run verify` — 343/343 tasks; all follow-on audits green; 7,568 test files scanned with no focused or orphaned skips

The branch is rebased on `origin/develop` at `35257f04a7f05e70785d7265362047026c7c4b27`. The PR changes four Cloud administration files and no runtime product surface.

## Evidence

<!-- evidence-head:a1cd1ee15b84cb777481ef837dd1b575d0acdc74 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend-only CI path-resolution fix; no UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend-only CI path-resolution fix; no UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No user-facing flow or UI changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - The triggering backend workflow log is linked above; the successful live path requires this fix to be merged onto develop first.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend code or browser path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent behavior, prompt, model, or LLM path changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - The live Hetzner E2E can only validate the merged develop workflow; focused real-helper contract tests are listed above.
