### PR TITLE
fix(orchestrator): capture state-lost forensics before the dying session is reclaimed

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-state-lost-diagnostics.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-state-lost-diagnostics.test.ts
@@ -1,0 +1,98 @@
+/**
+ * When a mid-flight sub-agent loses its ACP state (process exited without
+ * persisting), the service must emit a warn diagnostic carrying the session's
+ * identity and the tail of its output buffer BEFORE the buffer is reclaimed —
+ * otherwise the crash leaves no forensic trail. Exercises the real
+ * `logSubAgentStateLost` path with an in-memory store and a captured logger.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { AcpService } from "../services/acp-service.ts";
+import { InMemorySessionStore } from "../services/session-store.ts";
+import type { SessionInfo } from "../services/types.ts";
+
+function makeRuntime(warn: (msg: string, data?: unknown) => void) {
+	return {
+		agentId: "00000000-0000-4000-8000-000000000001",
+		character: { name: "Tester" },
+		getSetting: () => undefined,
+		logger: { debug() {}, info() {}, warn, error() {} },
+		getService: () => null,
+	};
+}
+
+function session(id: string): SessionInfo {
+	const now = new Date(Date.now() - 5 * 60_000);
+	return {
+		id,
+		name: id,
+		agentType: "elizaos",
+		workdir: "/home/x/apps/app-thing",
+		status: "running",
+		approvalPreset: "standard",
+		createdAt: now,
+		lastActivityAt: now,
+		acpxSessionId: "acpx-123",
+		pid: 4242,
+	} as SessionInfo;
+}
+
+describe("AcpService state-lost diagnostics", () => {
+	it("logs the session identity and output tail before reclaim", async () => {
+		const warn = vi.fn();
+		const store = new InMemorySessionStore();
+		const s = session("sess-1");
+		await store.create(s);
+		const svc = new AcpService(makeRuntime(warn) as never, { store });
+
+		// Seed the session's output buffer as a live run would.
+		const buffers = (svc as unknown as { outputBuffers: Map<string, string[]> })
+			.outputBuffers;
+		buffers.set("sess-1", [
+			"installing deps\n",
+			"vite build...\n",
+			"FATAL: heap out of memory\n",
+		]);
+
+		(
+			svc as unknown as {
+				logSubAgentStateLost: (session: SessionInfo, phase: string) => void;
+			}
+		).logSubAgentStateLost(s, "health-check");
+
+		expect(warn).toHaveBeenCalledTimes(1);
+		const [message, data] = warn.mock.calls[0] as [string, Record<string, unknown>];
+		expect(message).toContain("state lost");
+		expect(data).toMatchObject({
+			phase: "health-check",
+			sessionId: "sess-1",
+			acpxSessionId: "acpx-123",
+			agentType: "elizaos",
+			workdir: "/home/x/apps/app-thing",
+			pid: 4242,
+			outputLines: 3,
+		});
+		// The crash reason is preserved in the tail.
+		expect(String(data.tailOutput)).toContain("heap out of memory");
+		// Idle time is computed (~5 min).
+		expect(Number(data.idleMs)).toBeGreaterThan(4 * 60_000);
+	});
+
+	it("reports no buffered output cleanly when the session produced none", async () => {
+		const warn = vi.fn();
+		const store = new InMemorySessionStore();
+		const s = session("sess-2");
+		await store.create(s);
+		const svc = new AcpService(makeRuntime(warn) as never, { store });
+
+		(
+			svc as unknown as {
+				logSubAgentStateLost: (session: SessionInfo, phase: string) => void;
+			}
+		).logSubAgentStateLost(s, "send-prompt");
+
+		const [, data] = warn.mock.calls[0] as [string, Record<string, unknown>];
+		expect(data.phase).toBe("send-prompt");
+		expect(data.outputLines).toBe(0);
+		expect(data.tailOutput).toBe("(no buffered output)");
+	});
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-state-lost-diagnostics.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-state-lost-diagnostics.test.ts
@@ -11,88 +11,181 @@ import { InMemorySessionStore } from "../services/session-store.ts";
 import type { SessionInfo } from "../services/types.ts";
 
 function makeRuntime(warn: (msg: string, data?: unknown) => void) {
-	return {
-		agentId: "00000000-0000-4000-8000-000000000001",
-		character: { name: "Tester" },
-		getSetting: () => undefined,
-		logger: { debug() {}, info() {}, warn, error() {} },
-		getService: () => null,
-	};
+  return {
+    agentId: "00000000-0000-4000-8000-000000000001",
+    character: { name: "Tester" },
+    getSetting: () => undefined,
+    logger: { debug() {}, info() {}, warn, error() {} },
+    getService: () => null,
+  };
 }
 
 function session(id: string): SessionInfo {
-	const now = new Date(Date.now() - 5 * 60_000);
-	return {
-		id,
-		name: id,
-		agentType: "elizaos",
-		workdir: "/home/x/apps/app-thing",
-		status: "running",
-		approvalPreset: "standard",
-		createdAt: now,
-		lastActivityAt: now,
-		acpxSessionId: "acpx-123",
-		pid: 4242,
-	} as SessionInfo;
+  const now = new Date(Date.now() - 5 * 60_000);
+  return {
+    id,
+    name: id,
+    agentType: "elizaos",
+    workdir: "/home/x/apps/app-thing",
+    status: "running",
+    approvalPreset: "standard",
+    createdAt: now,
+    lastActivityAt: now,
+    acpxSessionId: "acpx-123",
+    pid: 4242,
+  } as SessionInfo;
 }
 
 describe("AcpService state-lost diagnostics", () => {
-	it("logs the session identity and output tail before reclaim", async () => {
-		const warn = vi.fn();
-		const store = new InMemorySessionStore();
-		const s = session("sess-1");
-		await store.create(s);
-		const svc = new AcpService(makeRuntime(warn) as never, { store });
+  it("logs the session identity and output tail before reclaim", async () => {
+    const warn = vi.fn();
+    const store = new InMemorySessionStore();
+    const s = session("sess-1");
+    await store.create(s);
+    const svc = new AcpService(makeRuntime(warn) as never, { store });
 
-		// Seed the session's output buffer as a live run would.
-		const buffers = (svc as unknown as { outputBuffers: Map<string, string[]> })
-			.outputBuffers;
-		buffers.set("sess-1", [
-			"installing deps\n",
-			"vite build...\n",
-			"FATAL: heap out of memory\n",
-		]);
+    // Seed the session's output buffer as a live run would.
+    const buffers = (svc as unknown as { outputBuffers: Map<string, string[]> })
+      .outputBuffers;
+    buffers.set("sess-1", [
+      "installing deps\n",
+      "vite build...\n",
+      "FATAL: heap out of memory\n",
+    ]);
 
-		(
-			svc as unknown as {
-				logSubAgentStateLost: (session: SessionInfo, phase: string) => void;
-			}
-		).logSubAgentStateLost(s, "health-check");
+    (
+      svc as unknown as {
+        logSubAgentStateLost: (session: SessionInfo, phase: string) => void;
+      }
+    ).logSubAgentStateLost(s, "health-check");
 
-		expect(warn).toHaveBeenCalledTimes(1);
-		const [message, data] = warn.mock.calls[0] as [string, Record<string, unknown>];
-		expect(message).toContain("state lost");
-		expect(data).toMatchObject({
-			phase: "health-check",
-			sessionId: "sess-1",
-			acpxSessionId: "acpx-123",
-			agentType: "elizaos",
-			workdir: "/home/x/apps/app-thing",
-			pid: 4242,
-			outputLines: 3,
-		});
-		// The crash reason is preserved in the tail.
-		expect(String(data.tailOutput)).toContain("heap out of memory");
-		// Idle time is computed (~5 min).
-		expect(Number(data.idleMs)).toBeGreaterThan(4 * 60_000);
-	});
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message, data] = warn.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(message).toContain("state lost");
+    expect(data).toMatchObject({
+      phase: "health-check",
+      sessionId: "sess-1",
+      acpxSessionId: "acpx-123",
+      agentType: "elizaos",
+      workdir: "/home/x/apps/app-thing",
+      pid: 4242,
+      outputLines: 3,
+    });
+    // The crash reason is preserved in the tail.
+    expect(String(data.tailOutput)).toContain("heap out of memory");
+    // Idle time is computed (~5 min).
+    expect(Number(data.idleMs)).toBeGreaterThan(4 * 60_000);
+  });
 
-	it("reports no buffered output cleanly when the session produced none", async () => {
-		const warn = vi.fn();
-		const store = new InMemorySessionStore();
-		const s = session("sess-2");
-		await store.create(s);
-		const svc = new AcpService(makeRuntime(warn) as never, { store });
+  it("reports no buffered output cleanly when the session produced none", async () => {
+    const warn = vi.fn();
+    const store = new InMemorySessionStore();
+    const s = session("sess-2");
+    await store.create(s);
+    const svc = new AcpService(makeRuntime(warn) as never, { store });
 
-		(
-			svc as unknown as {
-				logSubAgentStateLost: (session: SessionInfo, phase: string) => void;
-			}
-		).logSubAgentStateLost(s, "send-prompt");
+    (
+      svc as unknown as {
+        logSubAgentStateLost: (session: SessionInfo, phase: string) => void;
+      }
+    ).logSubAgentStateLost(s, "send-prompt");
 
-		const [, data] = warn.mock.calls[0] as [string, Record<string, unknown>];
-		expect(data.phase).toBe("send-prompt");
-		expect(data.outputLines).toBe(0);
-		expect(data.tailOutput).toBe("(no buffered output)");
-	});
+    const [, data] = warn.mock.calls[0] as [string, Record<string, unknown>];
+    expect(data.phase).toBe("send-prompt");
+    expect(data.outputLines).toBe(0);
+    expect(data.tailOutput).toBe("(no buffered output)");
+    expect(data.recentEvents).toEqual([]);
+  });
+
+  it("captures the event trail for a mid-tool death with an empty output buffer", async () => {
+    const warn = vi.fn();
+    const store = new InMemorySessionStore();
+    const s = session("sess-3");
+    await store.create(s);
+    const svc = new AcpService(makeRuntime(warn) as never, { store });
+
+    // A hang mid-tool-call is the common death: the buffer only holds
+    // assistant text + terminal tool output, so it stays empty — only the
+    // event trail records what the agent was doing.
+    svc.emitSessionEvent("sess-3", "ready", {});
+    svc.emitSessionEvent("sess-3", "tool_running", {
+      toolCall: { title: "bun install --frozen-lockfile" },
+    });
+    svc.emitSessionEvent("sess-3", "reasoning", {
+      text: "waiting for the install to finish before wiring routes",
+    });
+
+    (
+      svc as unknown as {
+        logSubAgentStateLost: (session: SessionInfo, phase: string) => void;
+      }
+    ).logSubAgentStateLost(s, "health-check");
+
+    const [, data] = warn.mock.calls[0] as [string, Record<string, unknown>];
+    expect(data.tailOutput).toBe("(no buffered output)");
+    const events = data.recentEvents as string[];
+    expect(events).toHaveLength(3);
+    expect(events[0]).toContain("ready");
+    expect(events[1]).toContain("tool_running — bun install --frozen-lockfile");
+    expect(events[2]).toContain("reasoning — waiting for the install");
+  });
+
+  it("ring-caps the trail and degrades hints gracefully on unrecognized payloads", async () => {
+    const warn = vi.fn();
+    const store = new InMemorySessionStore();
+    const s = session("sess-4");
+    await store.create(s);
+    const svc = new AcpService(makeRuntime(warn) as never, { store });
+
+    // Unrecognized payload shapes must not fabricate a hint.
+    svc.emitSessionEvent("sess-4", "message", undefined);
+    svc.emitSessionEvent("sess-4", "message", 42);
+    svc.emitSessionEvent("sess-4", "message", { unrelated: { deep: true } });
+    // Overlong hints are truncated, never dropped.
+    svc.emitSessionEvent("sess-4", "message", { text: "x".repeat(500) });
+    // Push one past the ring cap; only the newest 15 survive.
+    for (let i = 0; i < 12; i++) {
+      svc.emitSessionEvent("sess-4", "message", { text: `chunk-${i}` });
+    }
+
+    (
+      svc as unknown as {
+        logSubAgentStateLost: (session: SessionInfo, phase: string) => void;
+      }
+    ).logSubAgentStateLost(s, "health-check");
+
+    const [, data] = warn.mock.calls[0] as [string, Record<string, unknown>];
+    const events = data.recentEvents as string[];
+    // 16 emitted, cap 15 → the oldest (first hintless) entry fell off.
+    expect(events).toHaveLength(15);
+    expect(events[events.length - 1]).toContain("chunk-11");
+    // Hintless entries render as bare "<iso> <event>" with no fabricated hint.
+    expect(events[0]).toMatch(/ message$/);
+    expect(events[1]).toMatch(/ message$/);
+    // The overlong hint survived, truncated to the cap.
+    const truncated = events[2].split(" — ")[1];
+    expect(truncated).toBe("x".repeat(120));
+  });
+
+  it("computes idleMs as undefined when the session has no lastActivityAt", async () => {
+    const warn = vi.fn();
+    const store = new InMemorySessionStore();
+    const s = session("sess-5");
+    (s as { lastActivityAt?: Date }).lastActivityAt = undefined;
+    await store.create(s);
+    const svc = new AcpService(makeRuntime(warn) as never, { store });
+
+    (
+      svc as unknown as {
+        logSubAgentStateLost: (session: SessionInfo, phase: string) => void;
+      }
+    ).logSubAgentStateLost(s, "health-check");
+
+    const [, data] = warn.mock.calls[0] as [string, Record<string, unknown>];
+    // Absent activity must read as "unknown", never a fabricated 0 or NaN.
+    expect(data.idleMs).toBeUndefined();
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -822,6 +822,12 @@ export class AcpService extends Service {
   // need the exact latest prompt turn so a retry cannot re-consume an older
   // completion proof from the same long-lived ACP session.
   private readonly turnOutputBuffers = new Map<string, string[]>();
+  // Compact per-session trail of the most recent session events. The output
+  // buffer only holds assistant text and *terminal* tool output, so a session
+  // that dies mid-tool-call (the common hang) leaves it empty — the trail is
+  // what still tells the state-lost forensics WHAT the agent was doing when it
+  // died. Recorded at the emitSessionEvent choke point (both transports).
+  private readonly eventTrails = new Map<string, SessionEventTrailEntry[]>();
   // Sessions whose raw stdout has been teed to disk at least once. Drives the
   // `task_complete` stdoutLogPath reference: only sessions that actually wrote a
   // file get the path attached, so the task document never points at a
@@ -1482,20 +1488,31 @@ export class AcpService extends Service {
     const lastActivityMs = session.lastActivityAt
       ? new Date(session.lastActivityAt).getTime()
       : Number.NaN;
-    this.log("warn", "sub-agent state lost; diagnostics captured before reclaim", {
-      phase,
-      sessionId: session.id,
-      acpxSessionId: session.acpxSessionId,
-      agentType: session.agentType,
-      workdir: session.workdir,
-      pid: session.pid,
-      status: session.status,
-      idleMs: Number.isFinite(lastActivityMs)
-        ? Date.now() - lastActivityMs
-        : undefined,
-      outputLines: buffered.length,
-      tailOutput: tail ? tail.slice(-2000) : "(no buffered output)",
-    });
+    this.log(
+      "warn",
+      "sub-agent state lost; diagnostics captured before reclaim",
+      {
+        phase,
+        sessionId: session.id,
+        acpxSessionId: session.acpxSessionId,
+        agentType: session.agentType,
+        workdir: session.workdir,
+        pid: session.pid,
+        status: session.status,
+        idleMs: Number.isFinite(lastActivityMs)
+          ? Date.now() - lastActivityMs
+          : undefined,
+        outputLines: buffered.length,
+        tailOutput: tail ? tail.slice(-2000) : "(no buffered output)",
+        // The buffer only holds assistant text + terminal tool output, so a
+        // mid-tool death leaves it empty; the event trail still shows what the
+        // agent was doing. Render compactly so one warn line reads as a timeline.
+        recentEvents: (this.eventTrails.get(session.id) ?? []).map(
+          (entry) =>
+            `${entry.at} ${entry.event}${entry.hint ? ` — ${entry.hint}` : ""}`,
+        ),
+      },
+    );
   }
 
   private async runHealthCheck(): Promise<void> {
@@ -1597,6 +1614,7 @@ export class AcpService extends Service {
     for (const id of swept) {
       this.outputBuffers.delete(id);
       this.turnOutputBuffers.delete(id);
+      this.eventTrails.delete(id);
       this.changedPathsBySession.delete(id);
       this.orchestratorOwnedArtifactsBySession.delete(id);
       this.nativeClients.delete(id);
@@ -2326,6 +2344,7 @@ export class AcpService extends Service {
     await this.store.delete(sessionId);
     this.outputBuffers.delete(sessionId);
     this.turnOutputBuffers.delete(sessionId);
+    this.eventTrails.delete(sessionId);
     this.changedPathsBySession.delete(sessionId);
     this.orchestratorOwnedArtifactsBySession.delete(sessionId);
     this.persistedStdoutSessions.delete(sessionId);
@@ -3891,6 +3910,7 @@ export class AcpService extends Service {
     event: SessionEventName,
     data: unknown,
   ): void {
+    this.recordEventTrail(sessionId, event, data);
     for (const callback of [...this.sessionCallbacks]) {
       try {
         callback(sessionId, event, data);
@@ -4547,6 +4567,23 @@ export class AcpService extends Service {
     }
   }
 
+  private recordEventTrail(
+    sessionId: string,
+    event: SessionEventName,
+    data: unknown,
+  ): void {
+    const trail = this.eventTrails.get(sessionId) ?? [];
+    trail.push({
+      at: new Date().toISOString(),
+      event,
+      hint: eventTrailHint(data),
+    });
+    if (trail.length > EVENT_TRAIL_MAX_ENTRIES) {
+      trail.splice(0, trail.length - EVENT_TRAIL_MAX_ENTRIES);
+    }
+    this.eventTrails.set(sessionId, trail);
+  }
+
   // Tool-call arg keys that carry a target file path / signal a write.
   private static readonly EDIT_PATH_KEYS = [
     "filePath",
@@ -4782,6 +4819,41 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object"
     ? (value as Record<string, unknown>)
     : undefined;
+}
+
+interface SessionEventTrailEntry {
+  at: string;
+  event: string;
+  hint?: string;
+}
+
+const EVENT_TRAIL_MAX_ENTRIES = 15;
+const EVENT_TRAIL_HINT_MAX_CHARS = 120;
+
+/**
+ * Distills a session-event payload into a one-line forensic hint for the
+ * event trail. Purely structural key probes on the shapes emitSessionEvent
+ * callers actually pass (tool events carry a toolCall with title/name/kind,
+ * text events carry `text`, errors carry `message`/`failureKind`) — an
+ * unrecognized payload yields no hint rather than a guessed one.
+ */
+function eventTrailHint(data: unknown): string | undefined {
+  const record = asRecord(data);
+  if (!record) return undefined;
+  const toolCall = asRecord(record.toolCall);
+  const candidates = [
+    toolCall?.title,
+    toolCall?.name,
+    toolCall?.kind,
+    record.text,
+    record.message,
+    record.failureKind,
+  ];
+  const hint = candidates.find(
+    (candidate): candidate is string =>
+      typeof candidate === "string" && candidate.trim().length > 0,
+  );
+  return hint?.trim().slice(0, EVENT_TRAIL_HINT_MAX_CHARS);
 }
 
 export interface NormalizedUsage {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -1461,6 +1461,43 @@ export class AcpService extends Service {
     await this.cleanOrphanedScratchWorkdirs();
   }
 
+  /**
+   * Capture WHY a mid-flight sub-agent vanished before its output buffer is
+   * reclaimed. A session that "lost state" left no exit code in the store, so
+   * the tail of its ACP output stream is the only breadcrumb for diagnosing the
+   * crash — emit it at warn with the session identity and idle time. Called at
+   * both state-lost sites (the background health-check and the send-prompt
+   * fast-fail); without it a dead sub-agent leaves no forensic trail because the
+   * session self-heals and its buffer is deleted.
+   */
+  private logSubAgentStateLost(
+    session: Pick<
+      SessionInfo,
+      "id" | "acpxSessionId" | "agentType" | "workdir" | "pid" | "status"
+    > & { lastActivityAt?: Date | string },
+    phase: string,
+  ): void {
+    const buffered = this.outputBuffers.get(session.id) ?? [];
+    const tail = buffered.slice(-40).join("");
+    const lastActivityMs = session.lastActivityAt
+      ? new Date(session.lastActivityAt).getTime()
+      : Number.NaN;
+    this.log("warn", "sub-agent state lost; diagnostics captured before reclaim", {
+      phase,
+      sessionId: session.id,
+      acpxSessionId: session.acpxSessionId,
+      agentType: session.agentType,
+      workdir: session.workdir,
+      pid: session.pid,
+      status: session.status,
+      idleMs: Number.isFinite(lastActivityMs)
+        ? Date.now() - lastActivityMs
+        : undefined,
+      outputLines: buffered.length,
+      tailOutput: tail ? tail.slice(-2000) : "(no buffered output)",
+    });
+  }
+
   private async runHealthCheck(): Promise<void> {
     if (!this.started) return;
     let sessions: SessionInfo[];
@@ -1504,6 +1541,7 @@ export class AcpService extends Service {
       if (sessionTransportMode(s, this.transportMode) === "native") continue;
       const { exists } = await this.acpxSessionStateStat(s.acpxSessionId);
       if (!exists) {
+        this.logSubAgentStateLost(s, "health-check");
         // Descriptive status, NOT an imperative. The old text literally said
         // "spawn a fresh sub-agent to continue", which the planner obeyed
         // verbatim every cycle — the load-bearing line of the respawn loop.
@@ -2020,6 +2058,7 @@ export class AcpService extends Service {
     ) {
       const exists = await this.hasAcpxSessionState(session.acpxSessionId);
       if (!exists) {
+        this.logSubAgentStateLost(session, "send-prompt");
         const message =
           "Sub-agent state was lost (process exited without persisting). No automatic action taken.";
         await this.store.updateStatus(sessionId, "errored", message);


### PR DESCRIPTION
When a sub-agent dies without persisting state, the orchestrator's two "state was lost (process exited without persisting)" sites self-heal the session and delete its output buffer — leaving zero trail about why the process died. Live debugging of these deaths currently starts from nothing. This adds forensics captured at the moment of detection, before the buffer is reclaimed.

## What breaks today

- **State-lost is a silent reclaim.** Both the health-check and send-prompt state-lost branches in `acp-service.ts` log a one-line notice, then reclaim the session; the dying session's identity and output tail are gone before anyone can look.
- **Mid-tool deaths leave an empty buffer.** The output buffer only holds assistant text plus terminal tool output, so a sub-agent that dies mid-tool-call — the common hang, proven live with an induced freeze that logged `outputLines: 0` — leaves nothing even when the buffer is dumped.

## Changes

- `services/acp-service.ts` — `logSubAgentStateLost()` dumps the dying session's identity (id, acpx id, agentType, workdir, pid, idle time) and the tail of its output buffer at warn, called from both state-lost branches before buffer reclaim
- `services/acp-service.ts` — a compact ring of the last 15 session events (structural hint probes, no payload parsing) is recorded at the `emitSessionEvent` choke point — shared by both transports and all adapters — and included as `recentEvents` in the state-lost diagnostic; the trail's lifecycle mirrors `outputBuffers` exactly (same two reclaim sites)
- `src/__tests__/acp-state-lost-diagnostics.test.ts` — new suite pinning the diagnostic shape, the event-ring capture, and the reclaim lifecycle

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-4-8, anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:aaedb4db0066816ddb527b306b57cd42b9a7097b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - orchestrator service diagnostics; no rendered UI surface is touched by this diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - orchestrator service diagnostics; nothing user-visible renders differently.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend diagnostics change; behavior is proven by the plugin's suite, not a screen flow.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - local plugin suite run, full verification output at this head.

<details><summary>Verification output at aaedb4db0066816ddb527b306b57cd42b9a7097b</summary>

```text
$ git rebase origin/develop     (onto 35257f04a7f, includes #17923 + #17906)
Successfully rebased and updated refs/heads/fix/orchestrator-state-lost-forensics.

$ bun run typecheck        (plugins/plugin-agent-orchestrator)
$ tsc --noEmit -p tsconfig.json
exit 0

$ bun run test             (plugins/plugin-agent-orchestrator, full suite)
 Test Files  231 passed | 5 skipped (236)
      Tests  2643 passed | 8 skipped (2651)
   Start at  09:43:47
   Duration  104.15s (transform 36.95s, setup 1.91s, import 492.12s, tests 179.44s, environment 33ms)
exit 0

$ bunx @biomejs/biome check --no-errors-on-unmatched \
    src/services/acp-service.ts src/__tests__/acp-state-lost-diagnostics.test.ts
Checked 2 files in 187ms. No fixes applied.
exit 0
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser client participates in the state-lost detection or reclaim paths.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic diagnostics capture pinned by the plugin suite; no live inference is exercised by this diff.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts - isolated local run of the new diagnostics suite at this head, on top of the full-suite pass in the backend-logs row.

<details><summary>Isolated run output of the new diagnostics suite</summary>

```text
$ bunx vitest run --config vitest.config.ts src/__tests__/acp-state-lost-diagnostics.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  09:43:49
   Duration  13.11s (transform 10.00s, setup 41ms, import 12.87s, tests 10ms, environment 0ms)
exit 0
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
