### PR TITLE
fix(cloud): build gateway-discord from pruned workspace root

### DIFF
--- a/.github/workflows/cloud-gateway-discord.yml
+++ b/.github/workflows/cloud-gateway-discord.yml
@@ -73,10 +73,6 @@ jobs:
       - name: Run messaging gateway preflight
         run: bun run preflight:messaging-gateways
 
-      - name: Install service dependencies
-        working-directory: packages/cloud/services/gateway-discord
-        run: bun install --frozen-lockfile --no-save && git diff --exit-code -- bun.lock
-
       - name: Run service tests
         working-directory: packages/cloud/services/gateway-discord
         run: bun test tests/ --timeout 60000

--- a/packages/cloud/services/gateway-discord/Dockerfile
+++ b/packages/cloud/services/gateway-discord/Dockerfile
@@ -2,14 +2,15 @@
 # Multi-tenant Discord gateway for Eliza Cloud
 #
 # BUILD CONTEXT IS THE REPOSITORY ROOT, not this directory. The service depends
-# on the `@elizaos/cloud-services-common` workspace package, so a package-only
-# context cannot resolve its `workspace:*` dependency.
+# on the `@elizaos/cloud-services-common` workspace package, and `workspace:*`
+# cannot resolve from a context that contains only this package — which is why
+# every build since that dependency landed failed and the deployed image stayed
+# frozen. Matching the gateway-webhook pattern (#17841), the deps stage writes a
+# pruned workspace root containing just this service and the one package it
+# needs, so `bun install` resolves the workspace link without installing the
+# whole monorepo.
 #
 #   docker build -f packages/cloud/services/gateway-discord/Dockerfile .
-#
-# The deps stage creates a pruned workspace containing only this service and
-# the shared Cloud service package. That keeps installs small while preserving
-# Bun's workspace resolution and the runtime node_modules layout.
 
 # BUN_BASE selects the Bun base image. Default targets linux/amd64 + linux/arm64
 # via upstream oven/bun. For linux/riscv64 (no upstream image — oven-sh/bun#6266,
@@ -54,9 +55,18 @@ ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 gateway
 
-# The bundle leaves a few dependencies external at runtime. Bun's package store
-# lives at the workspace root and the member directory holds its links, so both
-# paths must retain their build-stage layout.
+# The bundle still resolves a few dependencies at runtime (ioredis reaches into
+# its own package internals), so the installed tree ships with it. bun's store
+# lives at the workspace root and the member directory holds the links, so both
+# have to keep their original paths.
+#
+# Note: only `${SERVICE_DIR}/node_modules` is copied below, not `${COMMON_DIR}`.
+# The workspace link `node_modules/@elizaos/cloud-services-common` in the
+# service tree therefore points at a directory that is absent from this stage.
+# That is intentional: `bun build` inlines the workspace package (only
+# `zlib-sync` stays external), so nothing resolves that specifier at runtime in
+# this image. Do not "fix" this by copying `${COMMON_DIR}` unless the entrypoint
+# stops bundling the workspace source.
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/${SERVICE_DIR}/node_modules ./${SERVICE_DIR}/node_modules
 COPY --from=builder /app/${SERVICE_DIR}/dist ./${SERVICE_DIR}/dist

--- a/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
@@ -98,14 +98,14 @@ describe("service Dockerfiles can resolve their workspace dependencies", () => {
   }
 
   test("this service builds from the repository root, and says so", () => {
-    const gateway = services.find((s) => s.name === "gateway-webhook");
-    expect(gateway?.workspaceDeps).toContain("@elizaos/cloud-services-common");
-    // The path prefix is what proves the context: a repo-root build addresses
-    // its own files through the full path, a directory-scoped one does not.
-    expect(gateway?.dockerfile).toContain(
-      "packages/cloud/services/gateway-webhook",
-    );
-    expect(gateway?.dockerfile).toContain("packages/cloud/services/_common");
+    for (const expected of ["gateway-webhook", "gateway-discord"]) {
+      const gateway = services.find((s) => s.name === expected);
+      expect(gateway?.workspaceDeps).toContain("@elizaos/cloud-services-common");
+      // The path prefix is what proves the context: a repo-root build addresses
+      // its own files through the full path, a directory-scoped one does not.
+      expect(gateway?.dockerfile).toContain(`packages/cloud/services/${expected}`);
+      expect(gateway?.dockerfile).toContain("packages/cloud/services/_common");
+    }
   });
 
   for (const service of services.filter((s) => s.workspaceDeps.length > 0)) {

--- a/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
@@ -100,10 +100,14 @@ describe("service Dockerfiles can resolve their workspace dependencies", () => {
   test("this service builds from the repository root, and says so", () => {
     for (const expected of ["gateway-webhook", "gateway-discord"]) {
       const gateway = services.find((s) => s.name === expected);
-      expect(gateway?.workspaceDeps).toContain("@elizaos/cloud-services-common");
+      expect(gateway?.workspaceDeps).toContain(
+        "@elizaos/cloud-services-common",
+      );
       // The path prefix is what proves the context: a repo-root build addresses
       // its own files through the full path, a directory-scoped one does not.
-      expect(gateway?.dockerfile).toContain(`packages/cloud/services/${expected}`);
+      expect(gateway?.dockerfile).toContain(
+        `packages/cloud/services/${expected}`,
+      );
       expect(gateway?.dockerfile).toContain("packages/cloud/services/_common");
     }
   });


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: deepseek/deepseek-v4-pro
<!-- attribution-row:client -->
- Client / agent tooling: Hermes Agent
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@64942cd44461ecc24b3ca1421de74900906e9506:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

fix(cloud): build gateway-discord from pruned workspace root

Closes #17840 (the gateway-discord half).

## Problem

`gateway-discord` depends on the `@elizaos/cloud-services-common` workspace
package, but its Dockerfile copied only its own `package.json` and ran
`bun install --frozen-lockfile` against a stale service-local lockfile. Since
`workspace:*` has nothing to resolve against in a context holding only this
package, every build failed — silently, because nothing in CI builds the
image and the deployed image stays frozen on the last build that succeeded.
This is the identical latent defect #17841 fixed for `gateway-webhook`.

## Fix

Mirror the merged `gateway-webhook` pattern (#17841):

- **Dockerfile** now uses the repository root as the build context and writes
  a **pruned workspace root** in the deps stage (this service + `_common`,
  via a minimal `workspaces` manifest), so the `workspace:*` link resolves
  without installing the whole monorepo (270 packages, not several thousand).
  Build: `docker build -f packages/cloud/services/gateway-discord/Dockerfile .`
- **Removed the stale service-local `bun.lock`** — the root lockfile is
  authoritative for a workspace member, and the service-local one was written
  before the workspace dep existed (`--frozen-lockfile` could never install it).
- **CI:** removed the "Install service dependencies" step from
  `cloud-gateway-discord.yml` that assumed a `--frozen-lockfile` lockfile next
  to the service; the root install already provides the workspace member deps.
  Kept the preflight + unit/lib tests that still exercise the service.

## Guard-test coverage

Extended `packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts`:

- `gateway-discord` is removed from the `DOCKERFILE_BROKEN` and `LOCKFILE_BLIND`
  known-broken lists — it now asserts the service copies every workspace
  package and ships no blind lockfile.
- The "builds from the repository root" assertion now covers `gateway-discord`
  alongside `gateway-webhook`.

`agent-server` (6 workspace deps) stays on the known-broken list for a
follow-up, exactly as the guard test intends (fixing one fails until the list
is updated).

## Evidence

<!-- evidence-head:ea50258863010ce5004a3e8761be0b471d746a59 -->

<!-- evidence-row:before-screenshots -->
- N/A - no rendered surface changes; the fix is a Dockerfile/workspace-context change, not UI.

<!-- evidence-row:after-screenshots -->
- N/A - no rendered surface changes; post-fix behavior is verified by the docker build + guard test below.

<!-- evidence-row:walkthrough-video -->
- N/A - no user-visible flow change; this is a build toolchain fix only.

<!-- evidence-row:backend-logs -->
- N/A - no runtime/server behavior change; the image is built identically at runtime.

<!-- evidence-row:frontend-logs -->
- N/A - no frontend/UI code changed by this PR.

<!-- evidence-row:llm-trajectory -->
- N/A - no real-LLM prompt/model/evaluator behavior change; a build-scope fix only.

<!-- evidence-row:domain-artifacts -->
Guard-test + Docker-build transcripts below were captured at `733feba66`; the only later commit is a format-only Biome wrap of two expect lines (https://github.com/elizaOS/eliza/pull/17929/commits/ea50258863010ce5004a3e8761be0b471d746a59). Full lanes at head: https://github.com/elizaOS/eliza/pull/17929/checks
Guard test `dockerfile-workspace-context.test.ts` and the real Docker build, both re-run from the exact PR head commit (<code>733feba66</code>, working tree clean):

```
bun test ./__tests__/dockerfile-workspace-context.test.ts
  (pass) the scan finds the services it is meant to cover
  (pass) gateway-webhook copies every workspace package it depends on
  (pass) gateway-discord copies every workspace package it depends on      <-- no longer known-broken
  (pass) agent-server copies every workspace package it depends on (known broken)
  (pass) this service builds from the repository root, and says so          <-- covers both gateways
  (pass) gateway-webhook does not ship a lockfile blind to its workspace deps
  (pass) gateway-discord does not ship a lockfile blind to its workspace deps
  (pass) agent-server does not ship a lockfile blind to its workspace deps
 8 pass · 0 fail · 14 expect() calls

docker build -f packages/cloud/services/gateway-discord/Dockerfile .   # build context = repo root
  [deps]   pruned workspace root (service + _common) --> "Resolved, downloaded and extracted [270]"
  [builder] bun build src/index.ts --outdir dist --target node --external zlib-sync  # SUCCESS
  [runner] /app/<service>/dist + node_modules copied; image gateway-discord named
  DOCKER_EXIT=0
```

## Out of scope

Nothing yet guards the **deploy** half — a service can still sit months without
a successful build and no signal. Worth a separate check per the issue.

AI provider/model: deepseek / deepseek-v4-pro
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@64942cd44461ecc24b3ca1421de74900906e9506:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sharkwon]
<!-- eliza-computer-attribution:v1 {"provider":"deepseek","model":"deepseek-v4-pro","client":"Hermes Agent","skill_revision":"elizaOS/eliza@64942cd44461ecc24b3ca1421de74900906e9506:packages/skills/skills/contribute-to-eliza"} -->


<!-- gate-rerun-2 -->

