### PR TITLE
fix(cloud): stabilize develop workflow startup gates

### DIFF
--- a/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
@@ -181,6 +181,8 @@ describe("Miniflare Durable Object integration", () => {
     };
   }
 
+  // Match the cloud test lane's budget because Miniflare startup can be delayed
+  // when this integration test runs alongside the rest of the batched suite.
   test("real Durable Object serialization prevents concurrent overspend", async () => {
     expect(
       (
@@ -239,5 +241,5 @@ describe("Miniflare Durable Object integration", () => {
       );
     }
     expect([first.status, second.status].sort()).toEqual([200, 402]);
-  }, 30_000);
+  }, 120_000);
 });

--- a/packages/cloud/scripts/admin/hetzner-e2e/README.md
+++ b/packages/cloud/scripts/admin/hetzner-e2e/README.md
@@ -82,7 +82,8 @@ intend to create a real billable server.
   operator summary rendering
 - `hetzner-e2e-wait-ready.ts` — SSH-poll for cloud-init + Docker
 - `hetzner-e2e-deploy-agent.ts` — create + provision a trivial agent
-- `hetzner-e2e-healthcheck.ts` — single `status.get` bridge ping
+- `hetzner-e2e-healthcheck.ts` — bounded `status.get` bridge polling across
+  explicit Cloud cache-warming responses
 - `hetzner-e2e-chat.ts` — one real `message.send` chat turn, judged by
   `../bridge-reply-verdict.ts` (#15616): the reply must echo the
   per-run proof token within the retry budget and must not be

--- a/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-healthcheck.test.ts
+++ b/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-healthcheck.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Hetzner bridge health polling tests explicit Cloud warming behavior through
+ * deterministic fetch responses without provisioning infrastructure.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { runHealthcheck } from "./hetzner-e2e-healthcheck";
+
+const options = {
+  apiKey: "test-api-key",
+  baseUrl: "https://cloud.example.test",
+  agentId: "agent-test",
+  retryDelayMs: 0,
+};
+
+describe("Hetzner E2E bridge healthcheck", () => {
+  test("retries an explicit warming response until the bridge is ready", async () => {
+    const responses = [
+      new Response(
+        JSON.stringify({
+          success: false,
+          error: "Agent authorization cache is warming. Retry shortly.",
+          retryable: true,
+        }),
+        { status: 503 },
+      ),
+      Response.json({ result: { ready: true } }),
+    ];
+    const delays: number[] = [];
+
+    await runHealthcheck({
+      ...options,
+      maxAttempts: 2,
+      fetchBridge: async () => {
+        const response = responses.shift();
+        if (!response) throw new Error("unexpected fetch");
+        return response;
+      },
+      sleep: async (delayMs) => {
+        delays.push(delayMs);
+      },
+    });
+
+    expect(responses).toHaveLength(0);
+    expect(delays).toEqual([0]);
+  });
+
+  test("fails immediately on a non-retryable HTTP response", async () => {
+    let calls = 0;
+
+    await expect(
+      runHealthcheck({
+        ...options,
+        maxAttempts: 3,
+        fetchBridge: async () => {
+          calls += 1;
+          return Response.json(
+            { success: false, error: "Forbidden", retryable: false },
+            { status: 403 },
+          );
+        },
+        sleep: async () => {
+          throw new Error("non-retryable response must not sleep");
+        },
+      }),
+    ).rejects.toThrow("Healthcheck HTTP 403");
+    expect(calls).toBe(1);
+  });
+
+  test("does not retry a non-warming status even if its body claims retryable", async () => {
+    let calls = 0;
+
+    await expect(
+      runHealthcheck({
+        ...options,
+        maxAttempts: 3,
+        fetchBridge: async () => {
+          calls += 1;
+          return Response.json(
+            { success: false, error: "Unauthorized", retryable: true },
+            { status: 401 },
+          );
+        },
+        sleep: async () => {
+          throw new Error("non-warming status must not sleep");
+        },
+      }),
+    ).rejects.toThrow("Healthcheck HTTP 401");
+    expect(calls).toBe(1);
+  });
+
+  test("fails after the bounded warming retry budget is exhausted", async () => {
+    let calls = 0;
+
+    await expect(
+      runHealthcheck({
+        ...options,
+        maxAttempts: 3,
+        fetchBridge: async () => {
+          calls += 1;
+          return Response.json(
+            { success: false, error: "Still warming", retryable: true },
+            { status: 503 },
+          );
+        },
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow("Healthcheck HTTP 503");
+    expect(calls).toBe(3);
+  });
+
+  test("does not retry a malformed error body", async () => {
+    let calls = 0;
+
+    await expect(
+      runHealthcheck({
+        ...options,
+        maxAttempts: 3,
+        fetchBridge: async () => {
+          calls += 1;
+          return new Response("not-json", { status: 503 });
+        },
+        sleep: async () => {
+          throw new Error("invalid response must not sleep");
+        },
+      }),
+    ).rejects.toThrow("Healthcheck HTTP 503: not-json");
+    expect(calls).toBe(1);
+  });
+
+  test("rejects an invalid retry budget instead of succeeding without a ping", async () => {
+    await expect(
+      runHealthcheck({
+        ...options,
+        maxAttempts: 0,
+        fetchBridge: async () => {
+          throw new Error("invalid budget must fail before fetching");
+        },
+      }),
+    ).rejects.toThrow("Healthcheck maxAttempts must be positive: 0");
+  });
+});

--- a/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-healthcheck.ts
+++ b/packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-healthcheck.ts
@@ -1,12 +1,27 @@
 #!/usr/bin/env bun
 /**
- * One JSON-RPC `status.get` ping against the deployed agent's bridge.
- * Exit 0 = healthy, nonzero = failure.
+ * Poll the deployed agent's JSON-RPC bridge until it is healthy, retrying only
+ * explicit warming responses from the Cloud API. Exit 0 = healthy, nonzero =
+ * failure.
  */
 
 import { readState } from "./state-file";
 
 const DEFAULT_BASE_URL = "https://api-staging.elizacloud.ai";
+const DEFAULT_MAX_ATTEMPTS = 10;
+const DEFAULT_RETRY_DELAY_MS = 2_000;
+
+type FetchBridge = (input: string, init: RequestInit) => Promise<Response>;
+
+interface HealthcheckOptions {
+  apiKey: string;
+  baseUrl: string;
+  agentId: string;
+  fetchBridge?: FetchBridge;
+  sleep?: (delayMs: number) => Promise<void>;
+  maxAttempts?: number;
+  retryDelayMs?: number;
+}
 
 function requireEnv(name: string): string {
   const value = process.env[name];
@@ -15,6 +30,82 @@ function requireEnv(name: string): string {
     process.exit(1);
   }
   return value;
+}
+
+function isRetryableWarmingResponse(text: string): boolean {
+  try {
+    const body = JSON.parse(text) as { retryable?: unknown };
+    return body.retryable === true;
+  } catch {
+    // error-policy:J3 An invalid error body is not evidence that retry is safe.
+    return false;
+  }
+}
+
+export async function runHealthcheck({
+  apiKey,
+  baseUrl,
+  agentId,
+  fetchBridge = fetch,
+  sleep = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)),
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+}: HealthcheckOptions): Promise<void> {
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new Error(`Healthcheck maxAttempts must be positive: ${maxAttempts}`);
+  }
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const response = await fetchBridge(
+      `${baseUrl}/api/v1/eliza/agents/${agentId}/bridge`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+          accept: "application/json",
+          "user-agent": "hetzner-e2e/1.0",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: `health-${Date.now()}`,
+          method: "status.get",
+          params: {},
+        }),
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+    const text = await response.text();
+    if (!response.ok) {
+      const retryable =
+        response.status === 503 && isRetryableWarmingResponse(text);
+      if (retryable && attempt < maxAttempts) {
+        console.log(
+          `[hetzner-e2e-healthcheck] bridge warming; retrying ${attempt}/${maxAttempts}`,
+        );
+        await sleep(retryDelayMs);
+        continue;
+      }
+      throw new Error(
+        `Healthcheck HTTP ${response.status}: ${text.slice(0, 300)}`,
+      );
+    }
+    const body = JSON.parse(text) as {
+      result?: { ready?: boolean };
+      error?: unknown;
+    };
+    if (body.error) {
+      throw new Error(
+        `Healthcheck JSON-RPC error: ${JSON.stringify(body.error).slice(0, 300)}`,
+      );
+    }
+    if (body.result?.ready !== true) {
+      throw new Error(
+        `Healthcheck not ready: ${JSON.stringify(body.result).slice(0, 300)}`,
+      );
+    }
+    console.log(`[hetzner-e2e-healthcheck] agent ${agentId} ready`);
+    return;
+  }
 }
 
 async function main(): Promise<void> {
@@ -31,46 +122,9 @@ async function main(): Promise<void> {
     );
   }
 
-  const response = await fetch(
-    `${baseUrl}/api/v1/eliza/agents/${agentId}/bridge`,
-    {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${apiKey}`,
-        "content-type": "application/json",
-        accept: "application/json",
-        "user-agent": "hetzner-e2e/1.0",
-      },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: `health-${Date.now()}`,
-        method: "status.get",
-        params: {},
-      }),
-      signal: AbortSignal.timeout(30_000),
-    },
-  );
-  const text = await response.text();
-  if (!response.ok) {
-    throw new Error(
-      `Healthcheck HTTP ${response.status}: ${text.slice(0, 300)}`,
-    );
-  }
-  const body = JSON.parse(text) as {
-    result?: { ready?: boolean };
-    error?: unknown;
-  };
-  if (body.error) {
-    throw new Error(
-      `Healthcheck JSON-RPC error: ${JSON.stringify(body.error).slice(0, 300)}`,
-    );
-  }
-  if (body.result?.ready !== true) {
-    throw new Error(
-      `Healthcheck not ready: ${JSON.stringify(body.result).slice(0, 300)}`,
-    );
-  }
-  console.log(`[hetzner-e2e-healthcheck] agent ${agentId} ready`);
+  await runHealthcheck({ apiKey, baseUrl, agentId });
 }
 
-await main();
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
## Summary

- retry only the Hetzner bridge's explicit HTTP 503 `retryable: true` authorization-cache warming response, with a bounded ten-attempt budget
- keep every other healthcheck failure fail-fast, preserve the per-request abort, and make the runner import-safe for deterministic contract tests
- align the Miniflare Durable Object integration timeout with the 120-second budget already used by its owning cloud test lane
- document the healthcheck warm-up behavior and cover success, exhaustion, malformed, non-retryable, and invalid-budget paths

[Hetzner Agent E2E run 31170725011](https://github.com/elizaOS/eliza/actions/runs/31170725011) proved provisioning, readiness, deployment, and teardown on a real host, then received the bridge's documented transient HTTP 503 authorization-cache-warming response during its one-shot healthcheck. [Cloud Tests run 31168758515](https://github.com/elizaOS/eliza/actions/runs/31168758515) separately exposed the Miniflare test's hardcoded 30-second timeout under a saturated batch even though the lane grants 120 seconds.

Refs #17912

## Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - GitHub workflow skills guided review and CI operations but did not author the code change.
<!-- attribution-row:status -->
- Attribution status: self-reported

## Validation

- `bun test packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-healthcheck.test.ts packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-wait-ready.test.ts packages/cloud/scripts/admin/cleanup-helper-resolution.test.ts` — 9 passed
- `bun test packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts --timeout 120000 --isolate` — 5 passed in each of five consecutive runs, plus a final post-format run
- `bunx biome check packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-healthcheck.ts packages/cloud/scripts/admin/hetzner-e2e/hetzner-e2e-healthcheck.test.ts` — clean except the repository's pre-existing `CLOUD_SMOKE_BASE_URL` Turbo declaration warning
- `git diff --check`
- `bun install --frozen-lockfile` — dependency graph remained exact on the workflow-fix branch
- `bun run verify` on exact head `4cb1684b1560d34b8315afb4b6c5c4c366b958e1` — 343/343 tasks; all follow-on audits green; 7,589 test files scanned with no focused or orphaned skips

The branch is rebased on `origin/develop` at `d73ce09909d`. Focused suites, five consecutive isolated Miniflare runs, and the full repository verify all passed on exact head `4cb1684b1560d34b8315afb4b6c5c4c366b958e1`.

## Evidence

<!-- evidence-head:4cb1684b1560d34b8315afb4b6c5c4c366b958e1 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend-only CI healthcheck and test-lane timeout changes; no UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend-only CI healthcheck and test-lane timeout changes; no UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No user-facing flow or UI changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - The triggering live workflow logs are linked above; successful live validation requires the fix on a GitHub workflow runner.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend code or browser path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent behavior, prompt, model, or LLM path changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - The live Hetzner E2E re-run is the applicable artifact and is expected from the PR/develop workflow; deterministic focused tests are listed above.
