### PR TITLE
fix(cloud): recover rejected app sessions

### DIFF
--- a/packages/ui/src/cloud/public-pages/lib/steward-session.recovery.test.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.recovery.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Verifies login-page cookie-session recovery without reading HttpOnly tokens:
+ * one rejected refresh may lose a rotation race, while two rejected refreshes
+ * clear the stale server session before the user starts a new login.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  recoverStewardSessionViaCookie,
+  refreshStewardSessionViaCookie,
+} from "./steward-session";
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("recoverStewardSessionViaCookie", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns the first healthy refresh without clearing the session", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse({ ok: true, token: "fresh-token" }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(recoverStewardSessionViaCookie()).resolves.toEqual({
+      ok: true,
+      token: "fresh-token",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ method: "POST" });
+  });
+
+  it("retries once when another tab may have won refresh-token rotation", async () => {
+    const fetchMock = vi
+      .fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse({ ok: true }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { error: "Refresh token rejected", code: "invalid_token" },
+          401,
+        ),
+      )
+      .mockResolvedValueOnce(jsonResponse({ ok: true, token: "winner-token" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(recoverStewardSessionViaCookie()).resolves.toEqual({
+      ok: true,
+      token: "winner-token",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      fetchMock.mock.calls.every(([, init]) => init?.method === "POST"),
+    ).toBe(true);
+  });
+
+  it("clears a dead cookie session after two rejected refreshes", async () => {
+    const rejected = () =>
+      jsonResponse(
+        { error: "Refresh token rejected", code: "invalid_token" },
+        401,
+      );
+    const fetchMock = vi
+      .fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse({ ok: true }),
+      )
+      .mockResolvedValueOnce(rejected())
+      .mockResolvedValueOnce(rejected())
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(recoverStewardSessionViaCookie()).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2]?.[1]).toMatchObject({
+      method: "DELETE",
+      credentials: "include",
+    });
+  });
+
+  it("preserves non-auth refresh failures for the login boundary", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse(
+          { error: "Steward upstream unavailable", code: "internal_error" },
+          502,
+        ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(recoverStewardSessionViaCookie()).rejects.toThrow(
+      "Steward upstream unavailable",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("refreshStewardSessionViaCookie", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("still exposes a rejected token as a typed failure to non-recovery callers", async () => {
+    globalThis.fetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse(
+          { error: "Refresh token rejected", code: "invalid_token" },
+          401,
+        ),
+    ) as unknown as typeof fetch;
+
+    await expect(refreshStewardSessionViaCookie()).rejects.toMatchObject({
+      status: 401,
+      code: "invalid_token",
+    });
+  });
+});

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  clearStoredStewardToken,
   STEWARD_NONCE_EXCHANGE_ENDPOINT,
   STEWARD_REFRESH_ENDPOINT,
   STEWARD_SESSION_ENDPOINT,
@@ -28,9 +29,10 @@ export function resolveStewardAuthEndpoint(
 async function postAuthJson(
   path: string,
   body?: Record<string, unknown>,
+  method: "POST" | "DELETE" = "POST",
 ): Promise<Response> {
   return fetch(resolveStewardAuthEndpoint(path), {
-    method: "POST",
+    method,
     credentials: "include",
     headers: { "Content-Type": "application/json" },
     ...(body ? { body: JSON.stringify(body) } : {}),
@@ -227,4 +229,63 @@ export async function refreshStewardSessionViaCookie(): Promise<{
     expiresIn?: number;
     token?: string;
   };
+}
+
+const DEAD_SESSION_RETRY_DELAY_MS = 100;
+
+function isRejectedCookieSession(error: unknown): boolean {
+  return (
+    error instanceof StewardSessionError &&
+    error.status === 401 &&
+    (error.code === "invalid_token" || error.code === "missing_token")
+  );
+}
+
+async function clearRejectedCookieSession(): Promise<void> {
+  const response = await postAuthJson(
+    STEWARD_SESSION_ENDPOINT,
+    undefined,
+    "DELETE",
+  );
+  if (!response.ok) {
+    const body = await readSessionError(response);
+    throw new StewardSessionError(
+      body.error || "Could not reset the expired Eliza Cloud session.",
+      response.status,
+      body.code ?? null,
+    );
+  }
+  clearStoredStewardToken();
+}
+
+/**
+ * Restore the cookie session when the login page has only the non-HttpOnly
+ * `steward-authed` marker. A refresh token is single-use, so one 401 can be the
+ * losing side of another tab's successful rotation. Retry once after that
+ * response settles; a second auth rejection proves the cookie is stale enough
+ * to clear before rendering a clean sign-in form.
+ */
+export async function recoverStewardSessionViaCookie(): Promise<{
+  ok: true;
+  expiresAt?: number;
+  expiresIn?: number;
+  token?: string;
+} | null> {
+  try {
+    return await refreshStewardSessionViaCookie();
+  } catch (error) {
+    if (!isRejectedCookieSession(error)) throw error;
+  }
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, DEAD_SESSION_RETRY_DELAY_MS);
+  });
+
+  try {
+    return await refreshStewardSessionViaCookie();
+  } catch (error) {
+    if (!isRejectedCookieSession(error)) throw error;
+    await clearRejectedCookieSession();
+    return null;
+  }
 }

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.callback-state.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.callback-state.test.tsx
@@ -28,6 +28,7 @@ vi.mock("../../lib/steward-session", () => ({
   consumeStewardCodeFromQuery: () => "callback-code",
   consumeStewardTokensFromHash: () => null,
   exchangeStewardCodeViaApi: () => callbackState.exchange(),
+  recoverStewardSessionViaCookie: () => Promise.resolve(null),
   refreshStewardSessionViaCookie: () => Promise.resolve({ ok: true as const }),
   syncStewardSessionCookie: () => Promise.resolve(),
 }));

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.email-login.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.email-login.test.tsx
@@ -92,6 +92,7 @@ vi.mock("../../lib/steward-session", () => ({
   consumeStewardCodeFromQuery: () => null,
   consumeStewardTokensFromHash: () => null,
   exchangeStewardCodeViaApi: vi.fn(),
+  recoverStewardSessionViaCookie: vi.fn(),
   refreshStewardSessionViaCookie: vi.fn(),
   syncStewardSessionCookie: sessionSpies.sync,
 }));

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
@@ -75,6 +75,7 @@ vi.mock("../../lib/steward-session", () => ({
   consumeStewardCodeFromQuery: () => null,
   consumeStewardTokensFromHash: () => null,
   exchangeStewardCodeViaApi: () => Promise.resolve({}),
+  recoverStewardSessionViaCookie: () => Promise.resolve(null),
   refreshStewardSessionViaCookie: () => Promise.resolve({ ok: true as const }),
   syncStewardSessionCookie: () => Promise.resolve(),
 }));

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
@@ -42,6 +42,22 @@ const emailLoginSpies = vi.hoisted(() => ({
   poll: vi.fn(),
 }));
 
+const sessionSpies = vi.hoisted(() => ({
+  recover: vi.fn(),
+  hasCookie: false,
+}));
+
+vi.mock("@elizaos/shared/steward-session-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@elizaos/shared/steward-session-client")
+    >();
+  return {
+    ...actual,
+    hasStewardAuthedCookie: () => sessionSpies.hasCookie,
+  };
+});
+
 vi.mock("@stwd/sdk", () => ({
   StewardAuth: class {
     getProviders = stewardAuthSpies.getProviders;
@@ -89,6 +105,7 @@ vi.mock("../../lib/steward-session", () => ({
   consumeStewardCodeFromQuery: () => null,
   consumeStewardTokensFromHash: () => null,
   exchangeStewardCodeViaApi: vi.fn(),
+  recoverStewardSessionViaCookie: sessionSpies.recover,
   refreshStewardSessionViaCookie: vi.fn(),
   syncStewardSessionCookie: vi.fn(() => Promise.resolve()),
 }));
@@ -144,11 +161,23 @@ describe("StewardLoginSection passkey capability gating", () => {
       token: "session-token",
       refreshToken: null,
     });
+    sessionSpies.recover.mockResolvedValue(null);
+    sessionSpies.hasCookie = false;
   });
 
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+  });
+
+  it("cleans a rejected cookie-only session and leaves a usable sign-in form", async () => {
+    sessionSpies.hasCookie = true;
+
+    renderSection();
+
+    await waitFor(() => expect(sessionSpies.recover).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole("button", { name: /Google/i })).toBeTruthy();
+    expect(screen.queryByText("Refresh token rejected")).toBeNull();
   });
 
   it("hides passkey, omits webauthn autocomplete, and routes Enter to Magic Link when unsupported", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -76,6 +76,7 @@ import {
   consumeStewardTokensFromHash,
   exchangeStewardCodeViaApi,
   hasStewardOAuthCallbackInUrl,
+  recoverStewardSessionViaCookie,
   refreshStewardSessionViaCookie,
   syncStewardSessionCookie,
 } from "../../lib/steward-session";
@@ -496,7 +497,7 @@ export default function StewardLoginSection() {
 
         const storedToken = readStoredStewardToken();
         if (!storedToken && hasStewardAuthedCookie()) {
-          const refreshed = await refreshStewardSessionViaCookie();
+          const refreshed = await recoverStewardSessionViaCookie();
           if (cancelled) return;
           if (refreshed?.token) {
             writeStoredStewardToken(refreshed.token);

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet.test.tsx
@@ -44,6 +44,7 @@ vi.mock("../../lib/steward-session", () => ({
   consumeStewardCodeFromQuery: () => null,
   consumeStewardTokensFromHash: () => null,
   exchangeStewardCodeViaApi: () => Promise.resolve({}),
+  recoverStewardSessionViaCookie: () => Promise.resolve(null),
   refreshStewardSessionViaCookie: () => Promise.resolve({ ok: true as const }),
   syncStewardSessionCookie: () => Promise.resolve(),
 }));

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
@@ -687,6 +687,19 @@ describe("startLifeOpsActivitySignalCapture", () => {
     consoleError.mockRestore();
   });
 
+  it("treats a 403 status-probe response as the expected signed-out state", async () => {
+    h.isApiError.mockImplementation(
+      (error) => typeof error === "object" && error !== null && "kind" in error,
+    );
+    h.getStatus.mockRejectedValue({ kind: "http", status: 403 });
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await settle();
+
+    expect(h.captureLifeOpsActivitySignal).not.toHaveBeenCalled();
+    expect(h.dispatchStatus).not.toHaveBeenCalled();
+  });
+
   it("swallows a 401 on the capture endpoint as the signed-out state (session expired mid-capture)", async () => {
     h.isApiError.mockImplementation(
       (error) => typeof error === "object" && error !== null && "kind" in error,
@@ -703,6 +716,11 @@ describe("startLifeOpsActivitySignalCapture", () => {
     expect(h.dispatchStatus).not.toHaveBeenCalledWith(
       expect.objectContaining({ status: "capture_error" }),
     );
+
+    h.captureLifeOpsActivitySignal.mockClear();
+    window.dispatchEvent(new Event("blur"));
+    await settle();
+    expect(h.captureLifeOpsActivitySignal).not.toHaveBeenCalled();
   });
 
   it("treats a structural agent-gone status probe (stale binding to a deleted agent) as an expected stand-down", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
@@ -239,22 +239,24 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
   const isExpectedTransientError = (error: unknown): boolean =>
     isApiError(error) && (error.kind === "network" || error.kind === "timeout");
 
-  // A 401 is the designed signed-out state, not a capture defect: every
+  // A 401/403 is the designed signed-out state, not a capture defect: every
   // capture endpoint sits behind session auth, so anonymous pages (pre
   // sign-in, post sign-out) reject each probe and signal. The ready poll
   // keeps checking quietly and the capture engages on the first poll after a
   // session exists — no console noise in between.
-  const isUnauthenticatedError = (error: unknown): boolean =>
-    isApiError(error) && error.kind === "http" && error.status === 401;
+  const isSessionUnavailableError = (error: unknown): boolean =>
+    isApiError(error) &&
+    error.kind === "http" &&
+    (error.status === 401 || error.status === 403);
 
   const reportCaptureError = (error: unknown): void => {
-    if (isRuntimeUnavailableError(error)) {
+    if (isRuntimeUnavailableError(error) || isSessionUnavailableError(error)) {
       standDownActivitySignals();
       return;
     }
     if (
       isExpectedTransientError(error) ||
-      isUnauthenticatedError(error) ||
+      isSessionUnavailableError(error) ||
       isCloudAgentGoneError(error)
     ) {
       return;
@@ -269,14 +271,14 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
     });
   };
 
-  // Runtime not up yet (boot, restart), signed-out (401), and a stale binding
+  // Runtime not up yet (boot, restart), signed-out (401/403), and a stale binding
   // to a deleted agent (structural agent-gone 404) are the designed
   // stand-down states; only those plus transport loss and the 503 "runtime
   // starting" shape count. Anything else coming out of the status probe
   // (persistent 500s included) is a real defect and must surface, not read as
   // "not ready" forever (#16504).
   const isExpectedProbeFailure = (error: unknown): boolean =>
-    isUnauthenticatedError(error) ||
+    isSessionUnavailableError(error) ||
     isCloudAgentGoneError(error) ||
     (isApiError(error) &&
       (error.kind === "network" ||
@@ -329,7 +331,10 @@ export function startLifeOpsActivitySignalCapture(enabled = true): () => void {
       return persisted;
     } catch (error) {
       lastSent.delete(dedupeKey);
-      if (isRuntimeUnavailableError(error)) {
+      if (
+        isRuntimeUnavailableError(error) ||
+        isSessionUnavailableError(error)
+      ) {
         standDownActivitySignals();
         return null;
       }


### PR DESCRIPTION
## Summary

- retry cookie refresh once to tolerate cross-tab refresh-token rotation
- clear a definitively rejected cookie session and return to a usable sign-in form
- stand activity-signal capture down after 401/403 responses so signed-out pages stop repeating requests

## Root cause

The app trusted the non-HttpOnly `steward-authed` marker after its refresh cookie had expired or been revoked. The login page surfaced the raw refresh rejection instead of clearing the dead server session. Separately, activity capture remained runtime-ready after an authenticated post was rejected, so lifecycle events continued issuing requests.

## Validation

- 28 focused Steward login/session tests pass
- 31 activity-signal capture tests pass
- `packages/ui` typecheck and lint pass
- `plugin-personal-assistant` typecheck and lint pass
- production web build and chunk-safety verification pass

Agent: OpenAI Codex (GPT-5)