### PR TITLE
chore(cloud): enable the OIDC provider on staging

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -399,7 +399,7 @@ ELIZA_CLOUD_URL = "https://staging.elizacloud.ai"
 # VITE_OIDC_ISSUER_URL or signed-out relying-party logins cannot resume; the
 # `build:web` env blocks in .github/workflows/cloud-cf-deploy.yml carry it, and
 # `packages/cloud/shared/src/lib/oidc/config.test.ts` fails if the two drift.
-OIDC_ENABLED = "false"
+OIDC_ENABLED = "true"
 OIDC_ISSUER_URL = "https://api-staging.elizacloud.ai"
 # Per-tenant `magicLinkBaseUrl` (set in Steward Neon `tenant_configs.email_config`)
 # redirects email magic-link callbacks to staging.elizacloud.ai instead of the


### PR DESCRIPTION
Flips `OIDC_ENABLED` to `"true"` in `[env.staging.vars]` only. **Production stays `"false"`.**

The prerequisites the comment in `wrangler.toml` calls for are in place: `OIDC_SIGNING_JWKS` (a dedicated RS256 ring) and `OIDC_CLIENTS` (one entry, the Eliza Hub relying party) are set as secrets on `eliza-cloud-api-staging`. The client is registered with `tenant=eliza` as a constant claim and group/role mappings onto the vocabulary the hub's Merge Steward is configured to require, so the required-claim gate and the admin/restricted groups both resolve.

Once this deploys, staging serves discovery at `https://api-staging.elizacloud.ai/.well-known/openid-configuration`. I will then point a Forgejo at it and drive a real browser sign-in before anyone proposes touching production.

Enabling in **production** is deliberately not part of this: that is the moment real users' login path changes, and it deserves a human looking at it rather than a config flip riding along in an unrelated PR.

`config.test.ts` (which fails if the issuer and the console build drift) passes: 15/15.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Evidence

<!-- evidence-head:0ffbbe08f81df4f38fe464643b12143dc79c9686 -->

This changes one configuration value: `OIDC_ENABLED` from `"false"` to `"true"` inside `[env.staging.vars]`. No source, no UI, no schema.

<!-- evidence-row:before-screenshots -->
- [x] `N/A - configuration-only change; no UI surface is added or altered.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - configuration-only change; no UI surface is added or altered.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - configuration-only change with no user-facing flow of its own. The sign-in flow this unblocks was recorded end to end on #17883.`
<!-- evidence-row:backend-logs -->
- [x] Staging currently refuses to serve the provider, which is the behaviour this flips:

```
$ curl -s https://api-staging.elizacloud.ai/.well-known/openid-configuration
{"error":"not_found"}          <- isOidcEnabled() is false, so every OIDC route 404s

$ curl -s -o /dev/null -w '%{http_code}' https://api-staging.elizacloud.ai/
200                            <- the Worker itself is healthy and serving
```

Prerequisites named in the `wrangler.toml` comment are already in place on `eliza-cloud-api-staging`: `OIDC_SIGNING_JWKS` and `OIDC_CLIENTS` are set as Worker secrets (values never printed). After deploy, discovery is expected to return 200 with `issuer` byte-equal to `https://api-staging.elizacloud.ai`.

<!-- evidence-row:frontend-logs -->
- [x] `N/A - configuration-only change; no browser-observable behaviour changes until a relying party is pointed at the issuer, which is out of scope for this PR.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] The single line changed, and the production value proven untouched:

```
packages/cloud/api/wrangler.toml

  [env.staging.vars]      line 402:  OIDC_ENABLED = "true"     <- changed
  [env.production.vars]   line 615:  OIDC_ENABLED = "false"    <- unchanged

config.test.ts (fails if the issuer and console build drift): 15 pass, 0 fail
```

<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface is added or changed.`
