### PR TITLE
fix(ci): make multi-account E2E keychain-independent

### DIFF
--- a/plugins/plugin-agent-orchestrator/scripts/compose-multi-account-e2e.ts
+++ b/plugins/plugin-agent-orchestrator/scripts/compose-multi-account-e2e.ts
@@ -37,6 +37,10 @@ const home = mkdtempSync(path.join(tmpdir(), "ma-compose-e2e-"));
 process.env.ELIZA_HOME = home;
 process.env.ELIZA_STATE_DIR = home;
 process.env.ELIZA_ACP_STATE_DIR = path.join(home, "acp");
+// Keep synthetic credentials independent of both developer keychains and CI
+// host services. This value protects only the disposable state directory.
+process.env.ELIZA_VAULT_DISABLE_KEYCHAIN = "1";
+process.env.ELIZA_VAULT_PASSPHRASE = "not-a-secret-multi-account-e2e-key";
 // Parent creds that MUST be dropped so the selected account authenticates.
 process.env.ANTHROPIC_API_KEY = "sk-ant-api-PARENT-must-drop";
 process.env.OPENAI_API_KEY = "sk-openai-PARENT-must-drop";


### PR DESCRIPTION
## Summary

- force the composed multi-account E2E through the vault passphrase path instead of a host keychain
- use a clearly test-only key that protects only the disposable temporary state directory
- preserve the existing fail-closed production vault behavior and subprocess passphrase deny policy

The failing develop run reached the real composed E2E and then failed before scenario execution because headless Linux has no reachable keychain: https://github.com/elizaOS/eliza/actions/runs/31169791143

Refs #17945

## Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - GitHub workflow skills guided CI inspection and publishing but did not alter the runtime contract.
<!-- attribution-row:status -->
- Attribution status: self-reported

## Validation

- `env -u ELIZA_VAULT_PASSPHRASE ELIZA_VAULT_DISABLE_KEYCHAIN=1 bun run --cwd plugins/plugin-agent-orchestrator test:e2e:multi-account` — 11/11 checks passed
- `bun test plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-env-deny.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts` — 27 passed
- `bun run --cwd plugins/plugin-agent-orchestrator test` — 2,644 passed, 7 intentionally skipped
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`
- `bunx turbo run build --filter=@elizaos/plugin-agent-orchestrator...` — 83/83 tasks
- `bun run verify` on exact head `d75bffb9398a3051b80ed7c7430d4c3be172a961` — 343/343 tasks; all follow-on audits green; 7,590 test files scanned with no focused or orphaned skips

## Evidence

<!-- evidence-head:d75bffb9398a3051b80ed7c7430d4c3be172a961 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend-only deterministic CI harness change; no UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend-only deterministic CI harness change; no UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No user-facing flow or UI changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - The failing live workflow log is linked above; the exact real composed harness passed locally and the live develop lane will be observed after merge.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend or browser path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model, prompt, or LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - The applicable artifact is the 11/11 composed account-selection proof listed in validation; it uses only synthetic credentials and disposable state.