### PR TITLE
fix(core): surface the failed step's human cause in failed-turn replies instead of the canned sentence

### DIFF
--- a/packages/core/src/prompts/evaluator.ts
+++ b/packages/core/src/prompts/evaluator.ts
@@ -27,6 +27,7 @@ rules:
 - Structured chat markers are allowed in messageToUser when they are the actual user-visible interaction payload: [FORM]\\n{json}\\n[/FORM], [CHOICE:scope id=id]\\nvalue=Label\\n[/CHOICE], [FOLLOWUPS id=id]\\nvalue=Label\\n[/FOLLOWUPS], or [TASK:threadId]Title[/TASK]. The JSON inside [FORM] is form data, not a tool attempt; keep JSON inside the marker and do not emit unrelated JSON.
 - messageToUser human teammate voice; no session ids (pty-*), auto task labels, or sub-agent name lists; speak as agent doing work
 - FINISH after tool use => include concise grounded messageToUser
+- FINISH success=false after a failed step => messageToUser states plainly what was attempted and why it did not work, in everyday language; no file paths, internal ids, or raw logs
 - no raw transcripts/banners/logs unless user asked raw output
 - copyToClipboard optional; requires title + content
 - thought internal, not shown

--- a/packages/core/src/runtime/__tests__/planner-loop-honest-failure.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-honest-failure.test.ts
@@ -1,0 +1,487 @@
+/**
+ * Honest failed-turn replies (#17948): a planner turn that ends on a failed
+ * step must ship a model-authored reply naming what failed and why — never
+ * the fixed "runtime step failed" sentence — across every failure shape: exec
+ * failures, thrown timeouts, validation rejects, structural retryable:false
+ * results, and multi-step turns that fail late. Also pins the hygiene of the
+ * prompt context the loop adds (scrubbed causes, no absolute paths or ids)
+ * and the J4 degrade when the synthesis model call itself fails.
+ * Deterministic — `useModel`, `executeToolCall`, and `evaluate` are vitest
+ * mocks; no live model.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { FAILED_TOOL_FALLBACK_MESSAGE, runPlannerLoop } from "../planner-loop";
+
+type MockedMessages = {
+	messages?: Array<{ role?: string; content?: unknown }>;
+};
+
+/** The instruction blocks the loop itself composes (retry / synthesis) — the
+ * surface whose hygiene #17948 governs, as opposed to raw tool-result
+ * messages that already existed in the trajectory rendering. */
+function loopComposedInstructionText(
+	useModel: ReturnType<typeof vi.fn>,
+	callIndex: number,
+	marker: string,
+): string {
+	const params = useModel.mock.calls[callIndex]?.[1] as
+		| MockedMessages
+		| undefined;
+	return (params?.messages ?? [])
+		.map((message) =>
+			typeof message.content === "string" ? message.content : "",
+		)
+		.filter((content) => content.includes(marker))
+		.join("\n");
+}
+
+describe("honest failed-turn replies (#17948)", () => {
+	it("exec failure then REPLY: ships a failure-aware synthesis primed with the scrubbed cause, not the canned sentence", async () => {
+		const useModel = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "call-1",
+						name: "SHELL",
+						arguments: { command: 'git log --since="1 week ago" --oneline' },
+					},
+				],
+			})
+			// Replan after the silent failed FINISH: the model recovers with a
+			// terminal REPLY. The tool-owned failure stays authoritative, so the
+			// loop answers through the failure-aware synthesis pass instead.
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "call-2",
+						name: "REPLY",
+						arguments: { text: "I hit an error while checking the log." },
+					},
+				],
+			})
+			.mockResolvedValueOnce({
+				text: "I tried to check this week's git log, but this workspace repo has no commits yet.",
+				toolCalls: [],
+			});
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: "command_failed: exit 128 in /home/milady/workspace/repo: fatal: your current branch 'master' does not have any commits yet",
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: false,
+			decision: "FINISH" as const,
+			thought: "The step failed.",
+		}));
+
+		const result = await runPlannerLoop({
+			runtime: { useModel },
+			context: { id: "ctx" },
+			tools: [{ name: "SHELL", description: "Run a shell command." }],
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(executeToolCall).toHaveBeenCalledTimes(1);
+		expect(useModel).toHaveBeenCalledTimes(3);
+		expect(result.finalMessage).toBe(
+			"I tried to check this week's git log, but this workspace repo has no commits yet.",
+		);
+		expect(result.finalMessage).not.toBe(FAILED_TOOL_FALLBACK_MESSAGE);
+
+		// The silent-failed-finish retry instruction names the failed tool AND
+		// its human-readable cause, with internal detail scrubbed.
+		const retryInstruction = loopComposedInstructionText(
+			useModel,
+			1,
+			"silent_failed_finish",
+		);
+		expect(retryInstruction).toContain("failed_tool: SHELL");
+		expect(retryInstruction).toContain("failed_tool_cause:");
+		expect(retryInstruction).toContain("does not have any commits yet");
+		expect(retryInstruction).toContain("<path>");
+		expect(retryInstruction).not.toContain("/home/milady");
+
+		// The failure synthesis prompt receives the failed step and cause the
+		// same way — scrubbed, human-shaped, no absolute paths.
+		const synthesisInstruction = loopComposedInstructionText(
+			useModel,
+			2,
+			"Recorded failure cause",
+		);
+		expect(synthesisInstruction).toContain("The SHELL step failed");
+		expect(synthesisInstruction).toContain("does not have any commits yet");
+		expect(synthesisInstruction).toContain("<path>");
+		expect(synthesisInstruction).not.toContain("/home/milady");
+	});
+
+	it("thrown timeout: the evaluator's success:false diagnosis ships directly with no extra model call", async () => {
+		const useModel = vi.fn().mockResolvedValueOnce({
+			text: "",
+			toolCalls: [
+				{
+					id: "call-1",
+					name: "WEB_FETCH",
+					arguments: { url: "https://example.com/report" },
+				},
+			],
+		});
+		const executeToolCall = vi.fn(async () => {
+			throw new Error("WEB_FETCH timed out after 30000ms");
+		});
+		const evaluate = vi.fn(async () => ({
+			success: false,
+			decision: "FINISH" as const,
+			thought: "The fetch timed out.",
+			messageToUser:
+				"I tried to fetch that page, but the request timed out before anything came back.",
+		}));
+
+		const result = await runPlannerLoop({
+			runtime: { useModel },
+			context: { id: "ctx" },
+			tools: [{ name: "WEB_FETCH", description: "Fetch a URL." }],
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(useModel).toHaveBeenCalledTimes(1);
+		expect(result.finalMessage).toBe(
+			"I tried to fetch that page, but the request timed out before anything came back.",
+		);
+	});
+
+	it("validation reject: the producer's human text reaches the retry context and the evaluator's diagnosis ships from the terminal-text path", async () => {
+		const useModel = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "call-1",
+						name: "SCHEDULED_TASKS",
+						arguments: { action: "create", task: "water the plants" },
+					},
+				],
+			})
+			// Replan ends in terminal planner text, exercising the terminal-text
+			// FINISH path's failure acknowledgment.
+			.mockResolvedValueOnce({
+				text: "I couldn't set that up without a schedule trigger.",
+				toolCalls: [],
+			});
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: "I need a trigger (once, cron, or every) before I can schedule that.",
+			data: { error: "MISSING_TRIGGER" },
+		}));
+		const evaluate = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: false,
+				decision: "FINISH" as const,
+				thought: "Validation failed and I have no reply.",
+			})
+			.mockResolvedValueOnce({
+				success: false,
+				decision: "FINISH" as const,
+				thought: "Cannot schedule without a trigger.",
+				messageToUser:
+					"I couldn't schedule that — I still need to know when it should run (once, on a cron, or repeating).",
+			});
+
+		const result = await runPlannerLoop({
+			runtime: { useModel },
+			context: { id: "ctx" },
+			tools: [{ name: "SCHEDULED_TASKS", description: "Manage schedules." }],
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(useModel).toHaveBeenCalledTimes(2);
+		const retryInstruction = loopComposedInstructionText(
+			useModel,
+			1,
+			"silent_failed_finish",
+		);
+		expect(retryInstruction).toContain(
+			"failed_tool_cause: I need a trigger (once, cron, or every)",
+		);
+		expect(result.finalMessage).toBe(
+			"I couldn't schedule that — I still need to know when it should run (once, on a cron, or repeating).",
+		);
+	});
+
+	it("retryable:false structured failure: the synthesis pass receives the structural failure's human text", async () => {
+		const useModel = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "call-1",
+						name: "DEPLOY_APP",
+						arguments: { template: "landing-page" },
+					},
+				],
+			})
+			.mockResolvedValueOnce({
+				text: "Deployment failed.",
+				toolCalls: [],
+			})
+			.mockResolvedValueOnce({
+				text: "I couldn't deploy the app — the template needs a name and I didn't have one to give it.",
+				toolCalls: [],
+			});
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: "The app build failed: the template requires a name and none was provided.",
+			data: { retryable: false },
+		}));
+		const evaluate = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: false,
+				decision: "FINISH" as const,
+				thought: "Build failed silently.",
+			})
+			.mockResolvedValueOnce({
+				success: false,
+				decision: "FINISH" as const,
+				thought: "Nothing more to do.",
+			});
+
+		const result = await runPlannerLoop({
+			runtime: { useModel },
+			context: { id: "ctx" },
+			tools: [{ name: "DEPLOY_APP", description: "Deploy an app." }],
+			executeToolCall,
+			evaluate,
+		});
+
+		// The structural non-retryable failure was never blindly re-executed and
+		// the reply is the model's own synthesis, primed with the failure text.
+		expect(executeToolCall).toHaveBeenCalledTimes(1);
+		expect(useModel).toHaveBeenCalledTimes(3);
+		const synthesisInstruction = loopComposedInstructionText(
+			useModel,
+			2,
+			"Recorded failure cause",
+		);
+		expect(synthesisInstruction).toContain("The DEPLOY_APP step failed");
+		expect(synthesisInstruction).toContain("requires a name");
+		expect(result.finalMessage).toBe(
+			"I couldn't deploy the app — the template needs a name and I didn't have one to give it.",
+		);
+	});
+
+	it("multi-step turn: a late failure after earlier successes ships the evaluator's diagnosis, not the canned sentence", async () => {
+		const useModel = vi.fn().mockResolvedValueOnce({
+			text: "",
+			toolCalls: [
+				{
+					id: "call-1",
+					name: "VIEWS",
+					arguments: { action: "list" },
+				},
+				{
+					id: "call-2",
+					name: "SHELL",
+					arguments: { command: "grep -r missing-pattern ." },
+				},
+			],
+		});
+		const executeToolCall = vi
+			.fn()
+			.mockResolvedValueOnce({ success: true, text: "3 views listed" })
+			.mockResolvedValueOnce({
+				success: false,
+				text: "command_failed: exit 1: grep found no matches",
+			});
+		const evaluate = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: false,
+				decision: "NEXT_RECOMMENDED" as const,
+				thought: "Run the queued search next.",
+				recommendedToolCallId: "call-2",
+			})
+			.mockResolvedValueOnce({
+				success: false,
+				decision: "FINISH" as const,
+				thought: "The search failed after the listing succeeded.",
+				messageToUser:
+					"I pulled the view list, but the follow-up search failed — nothing matched that pattern.",
+			});
+
+		const result = await runPlannerLoop({
+			runtime: { useModel },
+			context: { id: "ctx" },
+			tools: [
+				{ name: "VIEWS", description: "List views." },
+				{ name: "SHELL", description: "Run a shell command." },
+			],
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(executeToolCall).toHaveBeenCalledTimes(2);
+		expect(useModel).toHaveBeenCalledTimes(1);
+		expect(result.finalMessage).toBe(
+			"I pulled the view list, but the follow-up search failed — nothing matched that pattern.",
+		);
+	});
+
+	it("rejects an unsafe evaluator diagnosis and rescues the turn through the synthesis pass", async () => {
+		const useModel = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "call-1",
+						name: "SHELL",
+						arguments: { command: "ls" },
+					},
+				],
+			})
+			.mockResolvedValueOnce({
+				text: "I couldn't read that directory — the command failed with a permissions error.",
+				toolCalls: [],
+			});
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: "command_failed: permission denied",
+		}));
+		// A diagnosis that leaks tool-invocation syntax must not ship even
+		// though the evaluator structurally acknowledged the failure.
+		const evaluate = vi.fn(async () => ({
+			success: false,
+			decision: "FINISH" as const,
+			thought: "Failed.",
+			messageToUser: "We need to call SHELL again with sudo parameters.",
+		}));
+
+		const result = await runPlannerLoop({
+			runtime: { useModel },
+			context: { id: "ctx" },
+			tools: [{ name: "SHELL", description: "Run a shell command." }],
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(useModel).toHaveBeenCalledTimes(2);
+		expect(result.finalMessage).toBe(
+			"I couldn't read that directory — the command failed with a permissions error.",
+		);
+	});
+
+	it("scrubs uuids, hex ids, and absolute paths from the failure cause it adds to prompt context", async () => {
+		const useModel = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "call-1",
+						name: "SHELL",
+						arguments: { command: "git fetch" },
+					},
+				],
+			})
+			.mockResolvedValueOnce({
+				text: "The fetch step failed on a missing workspace reference.",
+				toolCalls: [],
+			});
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: "command_failed: workspace 3f2504e0-4f89-11d3-9a0c-0305e82c3301 at /var/lib/agent/workspaces/repo missing ref deadbeefdeadbeefdeadbeef",
+		}));
+		const evaluate = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: false,
+				decision: "FINISH" as const,
+				thought: "Failed with no reply.",
+			})
+			.mockResolvedValueOnce({
+				success: false,
+				decision: "FINISH" as const,
+				thought: "Cannot fetch.",
+				messageToUser:
+					"I couldn't fetch that — the workspace reference it needs is missing.",
+			});
+
+		const result = await runPlannerLoop({
+			runtime: { useModel },
+			context: { id: "ctx" },
+			tools: [{ name: "SHELL", description: "Run a shell command." }],
+			executeToolCall,
+			evaluate,
+		});
+
+		const retryInstruction = loopComposedInstructionText(
+			useModel,
+			1,
+			"failed_tool_cause",
+		);
+		expect(retryInstruction).toContain("<id>");
+		expect(retryInstruction).toContain("<path>");
+		expect(retryInstruction).not.toContain(
+			"3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+		);
+		expect(retryInstruction).not.toContain("/var/lib");
+		expect(retryInstruction).not.toContain("deadbeef");
+		expect(result.finalMessage).toBe(
+			"I couldn't fetch that — the workspace reference it needs is missing.",
+		);
+	});
+
+	it("keeps the generic failed-step sentence only when the synthesis model call itself fails", async () => {
+		const useModel = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "call-1",
+						name: "SHELL",
+						arguments: { command: "ls" },
+					},
+				],
+			})
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "call-2",
+						name: "REPLY",
+						arguments: { text: "Something went wrong." },
+					},
+				],
+			})
+			.mockRejectedValueOnce(new Error("provider unavailable"));
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: "command_failed: disk io error",
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: false,
+			decision: "FINISH" as const,
+			thought: "Failed.",
+		}));
+
+		const result = await runPlannerLoop({
+			runtime: { useModel },
+			context: { id: "ctx" },
+			tools: [{ name: "SHELL", description: "Run a shell command." }],
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(useModel).toHaveBeenCalledTimes(3);
+		expect(result.finalMessage).toBe(FAILED_TOOL_FALLBACK_MESSAGE);
+	});
+});

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -2379,6 +2379,14 @@ describe("v5 planner loop skeleton", () => {
 							arguments: { command: "curl https://backup.example.com" },
 						},
 					],
+				})
+				// Failure-aware synthesis pass (#17948): the evaluator's
+				// success-claiming reply was discarded by the failure authority, so
+				// the loop asks the model for an honest failure reply instead of
+				// shipping the generic failed-step sentence.
+				.mockResolvedValueOnce({
+					text: "The primary lookup failed on a DNS error; the backup source did return a result.",
+					toolCalls: [],
 				}),
 		};
 		const executeToolCall = vi
@@ -2413,7 +2421,7 @@ describe("v5 planner loop skeleton", () => {
 			evaluate,
 		});
 
-		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+		expect(runtime.useModel).toHaveBeenCalledTimes(3);
 		const retryParams = runtime.useModel.mock.calls[1]?.[1] as {
 			messages?: Array<{ role?: string; content?: string | null }>;
 		};
@@ -2429,8 +2437,21 @@ describe("v5 planner loop skeleton", () => {
 			},
 			expect.objectContaining({ iteration: 2 }),
 		);
+		// The uncorrelated success still cannot launder the failure — but the
+		// reply is now the model's own failure-aware synthesis, primed with the
+		// failed step and its cause, not the fixed canned sentence (#17948).
+		const synthesisParams = runtime.useModel.mock.calls[2]?.[1] as {
+			messages?: Array<{ role?: string; content?: string | null }>;
+		};
+		const synthesisPrompt = (synthesisParams.messages ?? [])
+			.map((message) =>
+				typeof message.content === "string" ? message.content : "",
+			)
+			.join("\n");
+		expect(synthesisPrompt).toContain("The SHELL step failed");
+		expect(synthesisPrompt).toContain("DNS lookup failed");
 		expect(result.finalMessage).toBe(
-			"I tried to complete that, but the available runtime step failed before it produced a usable result.",
+			"The primary lookup failed on a DNS error; the backup source did return a result.",
 		);
 	});
 
@@ -2761,8 +2782,11 @@ describe("v5 planner loop skeleton", () => {
 		});
 
 		expect(executeToolCall).toHaveBeenCalledTimes(2);
+		// A FINISH that declares success:false is a structural failure
+		// acknowledgment, so the evaluator's own diagnosis ships instead of
+		// being replaced by the generic failed-step sentence (#17948).
 		expect(result.finalMessage).toBe(
-			"I tried to complete that, but the available runtime step failed before it produced a usable result.",
+			"I could not retrieve that from the available sources.",
 		);
 	});
 

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -207,20 +207,24 @@ interface RawPlannerOutput {
 }
 
 /**
- * Public planner-loop entry: runs the iteration loop, then enforces the
- * tool-turn reply guarantee — a turn that executed real tool work must end
- * with a user-facing reply, not silence or the generic handled-step
- * placeholder. Read/list-then-summarize turns ended replyless live when the
- * evaluator emitted junk (a tool-call literal, non-JSON) after a successful
- * tool ran; the post-pass converts that into ONE forced no-tools synthesis
- * call grounded in the tool results (#16935). Deliberate silence
- * (STOP/IGNORE, suppressPlannerReply) is flagged by the loop and respected.
+ * Public planner-loop entry: runs the iteration loop, then enforces two reply
+ * guarantees. Failed turns get the honest-failure guarantee — a turn that
+ * would ship the generic failed-step sentence gets ONE forced no-tools
+ * synthesis pass whose instruction names the failed step and its scrubbed
+ * human-readable cause, so the model states what failed and why in its own
+ * voice (#17948). Successful tool turns get the tool-turn reply guarantee —
+ * real tool work must end with a user-facing reply, not silence or the
+ * generic handled-step placeholder; junk evaluator output after a successful
+ * tool converts into ONE forced no-tools synthesis call grounded in the tool
+ * results (#16935). Deliberate silence (STOP/IGNORE, suppressPlannerReply) is
+ * flagged by the loop and respected.
  */
 export async function runPlannerLoop(
 	params: PlannerLoopParams,
 ): Promise<PlannerLoopResult> {
 	const result = await runPlannerLoopIterations(params);
-	return ensureToolTurnFinalMessage(params, result);
+	const honest = await ensureFailedTurnFinalMessage(params, result);
+	return ensureToolTurnFinalMessage(params, honest);
 }
 
 async function runPlannerLoopIterations(
@@ -622,6 +626,12 @@ async function runPlannerLoopIterations(
 										trajectory,
 										evaluator.messageToUser ?? plannerOutput.messageToUser,
 									),
+									// Same structural failure acknowledgment as the post-tool
+									// FINISH path: success:false licenses the evaluator's own
+									// diagnosis over the generic failed-step sentence (#17948).
+									evaluator.success === false
+										? userSafeFailureReport(evaluator.messageToUser, trajectory)
+										: undefined,
 								),
 								trajectory,
 							),
@@ -1255,6 +1265,13 @@ async function runPlannerLoopIterations(
 								? failedToolFallbackMessage(trajectory)
 								: undefined,
 						),
+						// A FINISH that declares success:false is a structural failure
+						// acknowledgment; its messageToUser is the evaluator's diagnosis
+						// of the failed step (it saw the failed result in its context)
+						// and must not be discarded for the generic sentence (#17948).
+						evaluator.success === false
+							? userSafeFailureReport(evaluator.messageToUser, trajectory)
+							: undefined,
 					),
 					trajectory,
 				),
@@ -2698,11 +2715,18 @@ function appendSilentFailedFinishRecoveryEvent(args: {
 	const createdAt = Date.now();
 	const failedStep = latestFailedToolStep(args.trajectory);
 	const failedToolName = failedStep?.toolCall?.name;
+	// Naming the cause (not just the tool) lets the replan pick a genuinely
+	// different approach — and lets a blocker reply state WHY the step failed
+	// instead of degenerating to the generic failed-step sentence (#17948).
+	const failedToolCause = failedStep
+		? failedStepCauseForPrompt(failedStep)
+		: undefined;
 	const content = [
 		"planner_retry_instruction:",
 		"silent_failed_finish: true",
 		failedToolName ? `failed_tool: ${failedToolName}` : null,
-		"The latest tool step failed, and the evaluator finished without a user-visible message. Retry once with a different available approach if possible; otherwise return a concise user-visible blocker instead of ending silently.",
+		failedToolCause ? `failed_tool_cause: ${failedToolCause}` : null,
+		"The latest tool step failed, and the evaluator finished without a user-visible message. Retry once with a different available approach if possible; otherwise return a concise user-visible blocker that states plainly what failed and why, in everyday language without file paths, internal ids, or raw logs.",
 	]
 		.filter((line): line is string => line !== null)
 		.join("\n");
@@ -2717,6 +2741,7 @@ function appendSilentFailedFinishRecoveryEvent(args: {
 			evaluatorDecision: args.evaluator.decision,
 			evaluatorSuccess: args.evaluator.success,
 			failedToolName,
+			failedToolCause,
 		},
 	});
 }
@@ -3311,10 +3336,18 @@ function latestUnresolvedFailedNonTerminalToolStep(
  * failure has been retried with the same operation and succeeded. This keeps
  * unrelated VIEWS/SHELL work from laundering an unhandled failure into a
  * healthy-looking completion.
+ *
+ * `failureReport` is a model-authored diagnosis of the failure whose producing
+ * output STRUCTURALLY declared the turn failed (evaluator `success:false`, or
+ * a synthesis pass explicitly instructed about the failure). It is not
+ * laundering by construction — the deciding output admitted failure — so it
+ * may stand in for the generic fallback when the failed tool owns no
+ * user-safe text of its own (#17948).
  */
 function terminalMessageWithFailureAuthority(
 	trajectory: PlannerTrajectory,
 	candidate: string | undefined,
+	failureReport?: string,
 ): string | undefined {
 	const unresolvedFailure =
 		latestUnresolvedFailedNonTerminalToolStep(trajectory);
@@ -3337,7 +3370,7 @@ function terminalMessageWithFailureAuthority(
 		return pendingInteraction;
 	}
 
-	return groundedFailedToolMessage(unresolvedFailure);
+	return groundedFailedToolMessage(unresolvedFailure, failureReport);
 }
 
 /**
@@ -3536,6 +3569,13 @@ async function finishWithForcedSynthesis(params: {
 	onUsage?: (usage: { promptTokens: number; completionTokens: number }) => void;
 	/** Overrides the repeated-call framing when a caller forces synthesis for a different reason. */
 	instruction?: string;
+	/**
+	 * Marks this synthesis as failure-instructed: the instruction told the
+	 * model the step failed, so its reply is a failure report by construction
+	 * and may stand against the failure authority instead of being replaced
+	 * with the generic failed-step sentence (#17948).
+	 */
+	failureAware?: boolean;
 }): Promise<PlannerLoopResult> {
 	const { loop, config, trajectory, iteration } = params;
 	trajectory.context = appendContextEvent(trajectory.context, {
@@ -3582,7 +3622,13 @@ async function finishWithForcedSynthesis(params: {
 		status: "finished",
 		trajectory,
 		finalMessage: userSafeFinalMessage(
-			terminalMessageWithFailureAuthority(trajectory, finalMessage),
+			terminalMessageWithFailureAuthority(
+				trajectory,
+				finalMessage,
+				params.failureAware
+					? userSafeFailureReport(synthOutput.messageToUser, trajectory)
+					: undefined,
+			),
 			trajectory,
 		),
 	};
@@ -3806,6 +3852,81 @@ async function ensureToolTurnFinalMessage(
 		params.runtime.logger?.warn?.(
 			{ err: err instanceof Error ? err.message : String(err) },
 			"[planner-loop] forced synthesis pass failed; keeping the original planner result",
+		);
+		return result;
+	}
+}
+
+/**
+ * Honest-failure reply guarantee (post-pass of {@link runPlannerLoop}). A
+ * finished turn whose final message is the generic failed-step sentence —
+ * every model-side candidate was discarded or missing and the failed tool
+ * owned no user-safe text — gets ONE forced no-tools synthesis pass whose
+ * instruction names the failed step and its scrubbed human-readable cause.
+ * Context-in, model-out: the model writes the failure reply in its own voice
+ * from that context; the fixed sentence is never post-processed or templated.
+ * Synthesis is best-effort — a model failure here keeps the generic sentence
+ * rather than discarding the finished turn (#17948).
+ */
+async function ensureFailedTurnFinalMessage(
+	params: PlannerLoopParams,
+	result: PlannerLoopResult,
+): Promise<PlannerLoopResult> {
+	if (result.status !== "finished") return result;
+	// Coding/full-surface mode is exempt for the same reason as the tool-turn
+	// guarantee: its result feeds the orchestrator (which owns its own summary
+	// fallback), not a chat user, and an extra model call per failed build
+	// step would be pure overhead there.
+	if (isCodingFullSurfaceMode()) return result;
+	if (result.finalMessage !== FAILED_TOOL_FALLBACK_MESSAGE) return result;
+	const failedStep =
+		latestUnresolvedFailedNonTerminalToolStep(result.trajectory) ??
+		latestFailedToolStep(result.trajectory);
+	if (!failedStep?.toolCall) return result;
+	const cause = failedStepCauseForPrompt(failedStep);
+	const iteration = result.trajectory.steps.length + 1;
+	const instruction = [
+		`The ${failedStep.toolCall.name} step failed and the turn is ending without a usable result.`,
+		cause ? `Recorded failure cause: ${cause}` : null,
+		"Do not call any tool and do not claim the failed step succeeded. " +
+			"Write the final reply to the user now, in your own conversational " +
+			"voice: state plainly what was attempted and why it did not work, " +
+			"and include any genuine results from steps that did succeed. " +
+			"Summarize the cause in everyday terms; never include file paths, " +
+			"internal ids, or raw logs.",
+	]
+		.filter((line): line is string => line !== null)
+		.join(" ");
+	try {
+		const synthesized = await finishWithForcedSynthesis({
+			loop: params,
+			config: mergeChainingLoopConfig(params.config),
+			trajectory: result.trajectory,
+			iteration,
+			instruction,
+			failureAware: true,
+		});
+		const finalMessage = synthesized.finalMessage;
+		const synthesizedUsable =
+			finalMessage !== undefined &&
+			finalMessage.trim() !== "" &&
+			finalMessage !== HANDLED_STEP_FALLBACK_MESSAGE &&
+			finalMessage !== FAILED_TOOL_FALLBACK_MESSAGE;
+		params.runtime.logger?.warn?.(
+			{ iteration, failedTool: failedStep.toolCall.name, synthesizedUsable },
+			"[planner-loop] turn ended on a failed step with no user-safe failure text; forced a failure-aware synthesis pass",
+		);
+		return synthesizedUsable
+			? { ...result, trajectory: synthesized.trajectory, finalMessage }
+			: result;
+	} catch (err) {
+		// error-policy:J4 explicit user-facing degrade — the failure synthesis is
+		// a best-effort upgrade of an already-finished failed turn; a model
+		// failure here must not discard the turn, so the generic failed-step
+		// sentence ships and the synthesis failure is logged for diagnosis.
+		params.runtime.logger?.warn?.(
+			{ err: err instanceof Error ? err.message : String(err) },
+			"[planner-loop] failure-aware synthesis pass failed; keeping the generic failed-step reply",
 		);
 		return result;
 	}
@@ -4327,9 +4448,12 @@ function shouldRecoverSilentFailedFinish(args: {
 
 /**
  * Generic last-resort reply for a turn that ends on a failed tool with no
- * user-safe tool-owned text. Exported so the message service can recognize it
- * and drop it as redundant when the failed tool's own callback already told
- * the user what happened.
+ * user-safe tool-owned text. Since #17948 this ships only when the
+ * failure-aware synthesis pass in `ensureFailedTurnFinalMessage` itself fails
+ * or produces nothing usable — every model-reachable failed turn instead gets
+ * a model-authored reply naming what failed and why. Exported so the message
+ * service can recognize it and drop it as redundant when the failed tool's
+ * own callback already told the user what happened.
  */
 export const FAILED_TOOL_FALLBACK_MESSAGE =
 	"I tried to complete that, but the available runtime step failed before it produced a usable result.";
@@ -4407,6 +4531,58 @@ function diagnosticFailureReason(
 		return dataError.trim();
 	}
 	return undefined;
+}
+
+/** Ceiling for a scrubbed failure cause injected into a synthesis prompt —
+ * enough for a producer's human-shaped sentence, too short for a log dump. */
+const PROMPT_FAILURE_CAUSE_MAX_CHARS = 320;
+
+/**
+ * Internal-detail hygiene for failure text that is about to enter a prompt
+ * WE compose (retry instructions, failure synthesis). Producers fixed under
+ * #17923 emit human-shaped `text`, but older producers and thrown errors can
+ * still carry absolute paths, uuids, session ids, or byte dumps — none of
+ * which belong in context the reply model is told to speak from. Redaction is
+ * token-level (paths/ids/hex → placeholders), never sentence templating: the
+ * surviving prose is still the producer's own words.
+ */
+function scrubFailureCauseForPrompt(text: string): string | undefined {
+	const cleaned = text
+		.replace(
+			/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+			"<id>",
+		)
+		.replace(/\bpty-\d+-[0-9a-z]+\b/gi, "<id>")
+		.replace(/\b[0-9a-f]{16,}\b/gi, "<id>")
+		.replace(/(^|[\s"'`(=:])(?:~\/|\/)[\w.@+-]+(?:\/[\w.@+-]+)+/g, "$1<path>")
+		.replace(/\b[A-Za-z]:\\[\w.\\ +-]+/g, "<path>")
+		.replace(/\s+/g, " ")
+		.trim();
+	if (!cleaned) return undefined;
+	return cleaned.length > PROMPT_FAILURE_CAUSE_MAX_CHARS
+		? `${cleaned.slice(0, PROMPT_FAILURE_CAUSE_MAX_CHARS)}…`
+		: cleaned;
+}
+
+/**
+ * Human-readable cause of a failed step, scrubbed for prompt injection.
+ * Prefers the producer's human-shaped `text` / structured `data.error` (the
+ * `diagnosticFailureReason` order), then the thrown error's message — the only
+ * cause available for exec failures and timeouts that reached the J1 boundary
+ * in `executeQueuedToolCall` as a bare `{ success:false, error }`.
+ */
+function failedStepCauseForPrompt(step: PlannerStep): string | undefined {
+	const result = step.result;
+	if (!result) return undefined;
+	const reason =
+		diagnosticFailureReason(result) ??
+		(typeof result.error === "string" && result.error.trim()
+			? result.error.trim()
+			: result.error instanceof Error && result.error.message.trim()
+				? result.error.message.trim()
+				: undefined);
+	if (!reason) return undefined;
+	return scrubFailureCauseForPrompt(reason);
 }
 
 /**
@@ -4563,7 +4739,10 @@ const TERMINAL_TOOL_CALL_FINISH_THOUGHT =
 const TERMINAL_AFTER_FAILED_TOOL_THOUGHT =
 	"Terminal FINISH: planner ended the loop after a failed tool; the tool-owned failure remains authoritative.";
 
-function groundedFailedToolMessage(step: PlannerStep): string {
+function groundedFailedToolMessage(
+	step: PlannerStep,
+	failureReport?: string,
+): string {
 	const result = step.result;
 	const toolOwnedText =
 		result &&
@@ -4573,7 +4752,31 @@ function groundedFailedToolMessage(step: PlannerStep): string {
 			: result?.userFacingText;
 	const candidate = sanitizePlannerMessage(toolOwnedText);
 	if (candidate && !isUnsafeUserVisibleText(candidate)) return candidate;
+	// The tool owns no user-safe text. A structurally failure-acknowledging
+	// model diagnosis beats the generic fallback: the model saw the failed
+	// result in its context, so its words describe the actual cause (#17948).
+	if (failureReport) return failureReport;
 	return FAILED_TOOL_FALLBACK_MESSAGE;
+}
+
+/**
+ * User-safe projection of a model-authored failure diagnosis. Callers must
+ * only pass messages whose producing output structurally declared failure
+ * (evaluator `success:false`, failure-instructed synthesis) — this helper
+ * enforces the text-safety half of that contract: leaked tool syntax,
+ * meta-narration, and raw-tool-text echoes are rejected so the caller falls
+ * back to the tool-owned message or the generic placeholder.
+ */
+function userSafeFailureReport(
+	message: unknown,
+	trajectory: PlannerTrajectory,
+): string | undefined {
+	const candidate = sanitizePlannerMessage(message);
+	if (!candidate) return undefined;
+	if (isUnsafeUserVisibleText(candidate)) return undefined;
+	if (isToolMetaNarration(candidate)) return undefined;
+	if (isEchoOfPlannerFacingToolText(candidate, trajectory)) return undefined;
+	return candidate;
 }
 
 function terminalToolCallFinish(


### PR DESCRIPTION
# Relates to

Fixes #17948

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and root `bun run verify` were run after sync; verify exits
      0 (transcript excerpt in **Known gaps / failures** below).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`dc189e8df07`); zero conflicts.
- [x] Root `bun run verify` passes post-sync (exit 0; anti-larp clean — no
      focused tests, no untracked skips).

# Risks

Medium (core planner reply path, bounded):

- The failure authority still replaces success-claiming replies on failed turns
  (laundering prevention unchanged); it now accepts a diagnosis only when the
  producing output *structurally* declared failure (evaluator `success:false`,
  or a synthesis pass explicitly instructed about the failure).
- One additional bounded model call (`toolChoice`-none synthesis) fires only on
  turns that previously shipped the canned sentence — strictly the turns whose
  reply was already broken. Coding/full-surface mode is exempt (same reason as
  the existing tool-turn guarantee).
- If the synthesis model call itself fails, the previous canned sentence still
  ships (J4 degrade), so no failed turn can become silent or throw.

# Background

## What does this PR do?

When a planner step failed and the turn ended without a usable result, the user
got a fixed canned sentence from `packages/core/src/runtime/planner-loop.ts`:
"I tried to complete that, but the available runtime step failed before it
produced a usable result." The failure's human-readable cause (the tool
result's `text` / typed error, already human-shaped for producers fixed under
#17923) never reached the reply — see the live repro in #17948 (git log on a
commit-less workspace repo → exit 128 → canned sentence).

Structural fix, context-in / model-out (no string templating of the final user
sentence, no regex post-processing):

1. **Evaluator diagnosis ships.** A FINISH that declares `success:false` is a
   structural failure acknowledgment; its user-safe `messageToUser` (the
   evaluator saw the failed result in its prompt context) now passes the
   failure authority instead of being replaced by the canned sentence. Both
   evaluator FINISH sites (post-tool and terminal-planner-text) thread it.
2. **Cause-primed retry.** The existing silent-failed-finish recovery
   instruction now names the failed tool's human-readable cause (scrubbed:
   absolute paths / uuids / hex ids → placeholders, 320-char cap) so the one
   bounded replan can pick a genuinely different approach or state the blocker.
3. **Honest-failure post-pass.** A finished turn whose reply would still be the
   canned sentence gets ONE forced no-tools synthesis pass whose instruction
   names the failed step and its scrubbed cause; the model writes the failure
   reply in its own voice ("tried to check the git log but my workspace repo
   has no commits"). Mirrors the existing #16935 tool-turn reply guarantee.
4. **Evaluator prompt rule.** Failed finishes are told to state what was
   attempted and why it did not work, in everyday language without paths, ids,
   or raw logs.

Tool-owned `userFacingText` on the failed result remains the top authority
(#17923 doctrine unchanged); the canned constant remains exported and shipped
only as the last-resort degrade when the synthesis model call itself fails, so
the message service's redundant-fallback suppression keeps working.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

## Secondary suggestion from the issue (alternative attempt for repo/VCS queries)

Assessed, not forced: the existing silent-failed-finish valve already grants
exactly one bounded replan after a failed step, and it is now primed with the
failure cause, so the model can already choose a different approach within the
existing budget. A VCS-specific "try another cwd/repo" attempt would need new
policy (which repo/cwd is correct) and carries loop risk, so it is documented
here as follow-up rather than bundled into this fix.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/core/src/runtime/__tests__/planner-loop-honest-failure.test.ts` —
  the #17948 scenario matrix (8 tests, one per failure shape / path).
- `packages/core/src/runtime/planner-loop.ts` — `ensureFailedTurnFinalMessage`,
  `terminalMessageWithFailureAuthority`, `groundedFailedToolMessage`,
  `userSafeFailureReport`, `failedStepCauseForPrompt`,
  `scrubFailureCauseForPrompt`, `appendSilentFailedFinishRecoveryEvent`.

## Detailed testing steps

Automated tests are acceptable:

```bash
bun run --cwd packages/core test        # full core suite
bun run --cwd packages/core typecheck   # tsc --noEmit
bunx biome check packages/core/src/runtime/planner-loop.ts \
  packages/core/src/prompts/evaluator.ts \
  packages/core/src/runtime/__tests__/planner-loop-honest-failure.test.ts \
  packages/core/src/runtime/__tests__/planner-loop.test.ts
```

Scenario matrix covered by the new colocated suite:

| scenario | path exercised | reply shipped |
| --- | --- | --- |
| exec failure (exit-code class) then REPLY | silent-failed-finish retry → terminal-after-failed-tool → failure synthesis | model-authored, cause-primed |
| thrown timeout | evaluator FINISH `success:false` diagnosis via failure authority | evaluator diagnosis, zero extra calls |
| validation reject (`data.error` + human `text`) | retry-context cause line + terminal-planner-text FINISH site | evaluator diagnosis |
| `retryable:false` structural failure (#17884/#17923 shape) | failure synthesis primed with structural failure's human text; no blind re-execution | model-authored |
| multi-step, late failure after earlier success | NEXT_RECOMMENDED → failed second step → FINISH `success:false` | evaluator diagnosis |
| unsafe evaluator diagnosis (leaked tool syntax) | `userSafeFailureReport` rejects → failure synthesis rescues | model-authored |
| prompt-context hygiene | uuid / 16+ hex / absolute path scrubbed to `<id>` / `<path>` in loop-composed instructions | — |
| synthesis model failure | J4 degrade | canned sentence (last resort only) |

Regression guards: the canned-sentence assertions in the two pre-existing
`planner-loop.test.ts` tests were updated to the new honest replies; iteration
caps, required-tool misses, repeated-failure limits, retryable:false dedup
(#17884), unavailable-tool retries (#17916 valves), and failure-correlation
suites all run unchanged and green.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a5c4c081b505bb2bd40967f07d28341b72fc9381 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - core planner reply-path change; no UI surface touched.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - core planner reply-path change; no UI surface touched.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing UI flow; behavior is a chat reply produced by the core planner loop, covered by the deterministic suites below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: structured-logger output from a real `runPlannerLoop` run of
      the issue's exact scenario on this head, attached inline.

<details>
<summary>Backend logs — live repro run of the real code path (structured logger output)</summary>

Harness: drives the real `runPlannerLoop` from this head through issue #17948's
exact failure (SHELL `git log` on a commit-less repo, exit 128) with a scripted
planner sequence and a console-backed structured logger.

```
$ bun .repro-17948.ts   # real runPlannerLoop from this head; issue #17948 scenario
2026-08-07T12:51:04.595Z WARN [planner-loop] turn ended on a failed step with no user-safe failure text; forced a failure-aware synthesis pass {"iteration":3,"failedTool":"SHELL","synthesizedUsable":true}
FINAL_MESSAGE: I tried to pull this week's git log, but the workspace repo I'm in has no commits yet, so there was no history to read.
```

Before this change the same scenario ended with the fixed sentence
"I tried to complete that, but the available runtime step failed before it
produced a usable result." (live trajectory in issue #17948).

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend request/response involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - the motivating live failed-turn trajectory (planner SHELL git-log exit 128 → canned reply, 1 iteration / 1 tool call / FINISH→CONTINUE / 4,956 ms) is documented in issue #17948; this fix is fully exercised by the deterministic mocked-model suites below, which pin the exact prompt context the reply model receives.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: test / typecheck / lint gate transcripts attached inline.

<details>
<summary>Gate output — vitest, tsc, biome (packages/core)</summary>

```
$ bunx vitest run src/runtime/__tests__/planner-loop-honest-failure.test.ts \
    src/runtime/__tests__/planner-loop.test.ts \
    src/runtime/__tests__/planner-loop-failure-correlation.test.ts \
    src/runtime/__tests__/evaluator.test.ts \
    src/runtime/__tests__/action-retrieval.test.ts
 Test Files  5 passed (5)
      Tests  198 passed (198)
   Start at  12:48:36
   Duration  3.48s

$ bun run --cwd packages/core test      # full core suite
 Test Files  1 failed | 483 passed (484)
      Tests  4720 passed | 53 skipped (4773)
   Duration  331.84s
(the 1 failure was environmental: fresh worktree without packages/core dist —
"Failed to resolve entry for package @elizaos/core" from plugin-sql; after
`bun run --cwd packages/core build`:)

$ bunx vitest run src/services/message.side-effect-claim.test.ts
 Test Files  1 passed (1)
      Tests  42 passed (42)

$ bunx tsc --noEmit -p ./tsconfig.json  # packages/core
exit 0

$ bunx biome check packages/core/src/runtime/planner-loop.ts \
    packages/core/src/prompts/evaluator.ts \
    packages/core/src/runtime/__tests__/planner-loop-honest-failure.test.ts \
    packages/core/src/runtime/__tests__/planner-loop.test.ts
Checked 4 files in 101ms. No fixes applied.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - see the llm-trajectory row above: live repro trajectory is captured in
issue #17948; the change is deterministically covered by the mocked-model
suites below.`

## Backend + frontend logs

Backend logs: attached inline on the backend-logs evidence row above (live
`runPlannerLoop` repro of the issue scenario, structured-logger output).

Frontend logs: `N/A - no frontend involved.`

## Screenshots (before / after) + video walkthrough

`N/A - no UI change; the user-visible artifact is chat reply text, asserted
byte-exactly in the suites above.`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT surface touched.`

## Known gaps / failures

- Root `bun run verify` completed clean on this head after the workspace
  builds finished:

  ```
  [anti-larp] scanned 7599 test files — 0 focused, 0 orphaned skip(s)
  [anti-larp] clean — no focused tests, no untracked skips.
  VERIFY_EXIT=0
  ```

- The `message.side-effect-claim.test.ts` failure in the bulk run was a fresh
  worktree artifact-resolution issue (unbuilt `@elizaos/core` dist), not a
  behavioral failure; it passes after building core (output above).
- Follow-up (documented in the issue discussion above): optional VCS-specific
  alternative attempt (different cwd/repo) after a failed repo query — needs
  its own policy decision; the primary fix does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
