### PR TITLE
fix(app): track plugin-calendar in the boot view-manifest ratchet

### DIFF
--- a/packages/app/test/route-coverage.test.ts
+++ b/packages/app/test/route-coverage.test.ts
@@ -105,8 +105,6 @@ const NOT_APP_BOOT_LOADED_VIEW_MANIFESTS: Readonly<Record<string, string>> = {
     "View manager routes are built into the app shell and tested through /views; this plugin supplies agent actions plus the manager view declaration.",
   "plugins/plugin-blocker/src/plugin.ts":
     "Focus is a decomposed personal-assistant domain view; it is discoverable through the View Manager but not yet a boot-loaded renderer module.",
-  "plugins/plugin-calendar/src/plugin.ts":
-    "Calendar is a decomposed personal-assistant domain view; it is discoverable through the View Manager but not yet a boot-loaded renderer module.",
   "plugins/plugin-documents/src/plugin.ts":
     "Documents is a decomposed personal-assistant domain view; it is discoverable through the View Manager but not yet a boot-loaded renderer module.",
   "plugins/plugin-elizacloud/src/index.ts":
@@ -130,6 +128,7 @@ const NOT_APP_BOOT_LOADED_VIEW_MANIFESTS: Readonly<Record<string, string>> = {
 };
 
 const BOOT_PLUGIN_VIEW_MANIFEST_BY_MODULE: Record<string, string | null> = {
+  "@elizaos/plugin-calendar": "plugins/plugin-calendar/src/plugin.ts",
   "@elizaos/plugin-contacts": "plugins/plugin-contacts/src/plugin.ts",
   "@elizaos/plugin-native-settings": null,
   // PA no longer declares a view (the LifeOps overview was removed); it is a


### PR DESCRIPTION
## Problem
[Tests run 31181377235](https://github.com/elizaOS/eliza/actions/runs/31181377235/job/92875516258) fails on develop in the Zero-Key `App route + ui-smoke spec coverage gates` step:

```
AssertionError: New compiled app plugin loaders need a view manifest classification: @elizaos/plugin-calendar
```

709a771907f added `elizaos.appRegister: "register"` to `@elizaos/plugin-calendar`, which makes it a compiled app boot side-effect module discovered by `discoverSideEffectAppModules`, but never updated the ratchet in `packages/app/test/route-coverage.test.ts`.

## Fix
- Map `@elizaos/plugin-calendar` → `plugins/plugin-calendar/src/plugin.ts` in `BOOT_PLUGIN_VIEW_MANIFEST_BY_MODULE`.
- Remove the now-stale `NOT_APP_BOOT_LOADED_VIEW_MANIFESTS` entry (the sibling assertion rejects allowlisted manifests that are boot-mapped).

## Verification
Simulated all six ratchet assertions headlessly against origin/develop's tree (boot ids from `main.tsx` dynamic imports + all `elizaos.appRegister`-marked packages under `plugins/` and `packages/`): missingMappings, staleMappings, missingManifestCoverage, unclassified, mappedAllowlist, staleAllowlist all empty with this change. The PR's own Tests run is the authoritative rerun of the failing gate.

## Attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Evidence

<!-- evidence-head:683fe8d22b583f9c2a00517f4a0cd021aea303b3 -->

<!-- evidence-row:before-screenshots -->
N/A - CI coverage-ratchet test data change only; no UI or rendered surface is modified.

<!-- evidence-row:after-screenshots -->
N/A - CI coverage-ratchet test data change only; no UI or rendered surface is modified.

<!-- evidence-row:walkthrough-video -->
N/A - one-file test-ratchet fix; there is no user-visible flow to record.

<!-- evidence-row:backend-logs -->
Failing develop gate this fixes (run 31181377235):

<details>
<summary>Zero-Key coverage gate failure log excerpt</summary>

```
FAIL test/route-coverage.test.ts > app route coverage gate > plugin view manifest ratchet tracks compiled app plugin loaders
AssertionError: New compiled app plugin loaders need a view manifest classification: @elizaos/plugin-calendar: expected [ '@elizaos/plugin-calendar' ] to deeply equal []
 Test Files  1 failed | 2 passed (3)
      Tests  1 failed | 18 passed (19)
error: script "test" exited with code 1
```

</details>

<!-- evidence-row:frontend-logs -->
N/A - no frontend runtime change; the touched file is a Vitest ratchet spec.

<!-- evidence-row:llm-trajectory -->
N/A - no agent/model behavior change; deterministic file-scanning test data only.

<!-- evidence-row:domain-artifacts -->
N/A - no domain data produced; the artifact is the green Tests run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-refresh:2 -->
