### PR TITLE
fix(cloud): pin CACHE_ENABLED in ledger settler tests

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -31,6 +31,7 @@ process.env.DATABASE_URL = "pglite://memory";
 process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS ||= "1";
+process.env.CACHE_ENABLED = "true";
 
 // Stub the non-billing fire-and-forget side-effects the deduct success path kicks
 // off — NOT the code under test. The deduct + guard SQL runs real against PGlite.


### PR DESCRIPTION
## Problem

The two `createLedgerDebitSettler` gate-hint tests added by #17770 (for #17768) fail deterministically on every PR's cloud `unit-tests` lane. The Cloud Tests workflow sets `CACHE_ENABLED: "false"` at workflow level, and `CacheClient.initialize()` honors that flag before the `MOCK_REDIS=1` in-memory opt-in — so every `writeOrgBalanceHint` returns `unavailable`, the warm-hint assertion fails, and the uncollected-debit test dies on its pre-seed write. Develop itself looks green only because busy-trunk pushes cancel the lane (`cancel-in-progress`); every completed PR run containing #17770 is red.

## Fix

One line: pin `process.env.CACHE_ENABLED = "true"` at module top of `inference-billing-ledger.test.ts`, before any import touches the `CacheClient` singleton — the exact established pattern in `inference-billing-fast-path.test.ts` and `inference-auth-cache.test.ts`.

## Verification

Under the exact CI env (`CACHE_ENABLED=false CACHE_BACKEND=wadis MOCK_REDIS=1 NODE_ENV=test`): without the pin the same 2 tests fail 3/3 runs; with the pin 30/30 pass 3/3 runs.

## Evidence

<!-- evidence-head:3aafb4e90d91cd1ac19a87d107bf64c3033d5404 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - test-env pin only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-env pin only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-env pin only; no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Repro + fix verified under the exact CI env:

```
$ CACHE_ENABLED=false CACHE_BACKEND=wadis MOCK_REDIS=1 NODE_ENV=test bun run test src/lib/services/__tests__/inference-billing-ledger.test.ts
(without pin) 2 fail: 'leaves a warm gate hint …' expect(hint).not.toBeNull() received null; 'uncollected debit …' Organization balance hint write was not confirmed: unavailable
(with pin)    30 pass / 0 fail, 3 consecutive runs
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - test-env pin only; no frontend behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM invoked.
<!-- evidence-row:domain-artifacts -->
- [x] The failing PR lanes themselves are the artifact: identical 2-test failure on unrelated PRs #17929/#17930/#17529/#17562/#17427 cloud unit-tests runs.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)