### PR TITLE
fix(ci): escape the Bun contract's NUL map-key separators

### DIFF
--- a/packages/scripts/ci-bun-version-contract.mjs
+++ b/packages/scripts/ci-bun-version-contract.mjs
@@ -373,7 +373,7 @@ function analyzeYamlRuntime(text) {
       ) {
         if (origin === "workflow-env") envDecls.workflow = true;
         else if (origin === "job-env") envDecls.job.add(jobId);
-        else envDecls.step.add(`${jobId} ${stepIndex}`);
+        else envDecls.step.add(`${jobId}\u0000${stepIndex}`);
       }
       return;
     }
@@ -473,7 +473,7 @@ function analyzeYamlRuntime(text) {
   const envVisible = (jobId, stepIndex) =>
     (jobId !== null &&
       stepIndex !== null &&
-      envDecls.step.has(`${jobId} ${stepIndex}`)) ||
+      envDecls.step.has(`${jobId}\u0000${stepIndex}`)) ||
     (jobId !== null && envDecls.job.has(jobId)) ||
     envDecls.workflow;
 


### PR DESCRIPTION
Closes the follow-up @lalalune raised in the post-merge verification of #17599.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: Anthropic/claude-opus-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/army@04a50cb094bbf65599c4857e771c9d875bca51be:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

# What this PR does

`packages/scripts/ci-bun-version-contract.mjs` built its jobId/stepIndex map key with a raw U+0000 separator typed as a literal control byte instead of its six-character escape. Git classifies any file containing a NUL as binary, so the whole module stopped producing text diffs.

Replaced both with the escape. Behaviour-identical by construction -- the escape and the raw byte are the same character, so the composed keys are indistinguishable and collide in a single Map slot:

```
escaped === raw: true
codepoint: 0
one map key: true
```

## Why it matters more than a formatting nit

The byte disables exactly the two instruments most likely to catch its neighbours: `git diff` renders "Binary files differ", and ripgrep skips the file silently. The separator predates the review round on #17599 -- it is present at `22ebc4ec`, the head before those fixes -- so every reviewer of that PR was handed no content for this file while reviewing changes to it.

# Testing

- `node packages/scripts/ci-bun-version-contract.mjs` -- PASS, exit 0, 369 sites scanned, canonical 1.3.14
- `bun test packages/scripts/__tests__/ci-bun-version-contract.test.ts` -- 60 pass / 0 fail
- Targeted Biome -- clean
- `git diff --numstat` on the file now reports line counts rather than `-`, confirming git treats it as text again

Verified against `develop@648dddc2` in a worktree branched from it, Bun 1.3.14 / Node 24.15.0.

# Evidence gate

<!-- evidence-head:dadbe63a85d66655632d747a0a8ffdbf8cf16fff -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - build-tooling change with no UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - build-tooling change with no UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-exercisable flow; a two-character source change in a CI contract script
<!-- evidence-row:backend-logs -->
- [x] Backend logs: verbatim contract + suite transcript below
<details><summary>verification transcript (verbatim)</summary>

```
$ node packages/scripts/ci-bun-version-contract.mjs
ci bun version contract passed (canonical 1.3.14; 369 sites scanned; 110 workflow pin(s) in lockstep; 9 gate lane(s) pinned)
$ echo $?
0
$ bun test packages/scripts/__tests__/ci-bun-version-contract.test.ts
 60 pass
 0 fail
 96 expect() calls
```

</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code touched
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider or model behaviour touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - a two-character source escape in a CI contract script; it produces no persistent domain artifact. The escape/raw-byte equivalence proof is in the backend-logs transcript above.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered views changed

---

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@04a50cb094bbf65599c4857e771c9d875bca51be:skills/contribute-to-eliza
Attribution status: self-reported
-- [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"elizaOS/army@04a50cb094bbf65599c4857e771c9d875bca51be:skills/contribute-to-eliza"} -->
