### PR TITLE
fix(agent): scope the injected token to this backend, not any stored server

### DIFF
--- a/packages/agent/src/api/static-file-server.test.ts
+++ b/packages/agent/src/api/static-file-server.test.ts
@@ -124,11 +124,16 @@ describe("injectApiBaseIntoHtml token embedding", () => {
       label: "This device",
       accessToken: TOKEN,
     });
-    expect(store.get("eliza:first-run-complete")).toBe("1");
+    // Onboarding state is not ours to decide — ELIZA_FORCE_INJECT_TOKEN says
+    // the operator accepts HTML token injection, not that setup finished.
+    expect(store.get("eliza:first-run-complete")).toBeUndefined();
   });
 
-  // A pre-existing record must keep its own identity — only the token is ours.
-  it("preserves an existing active-server record and only sets the token", () => {
+  // The persisted record can point anywhere the user has previously connected.
+  // Startup restore sends `accessToken` to that record's `apiBase`, so merging
+  // our token into a remote/cloud record would hand this agent's
+  // full-capability token to an unrelated host.
+  function runInjectedScript(stored?: unknown) {
     const out = injectApiBaseIntoHtml(Buffer.from(html), undefined, {
       apiToken: TOKEN,
     }).toString("utf-8");
@@ -136,17 +141,71 @@ describe("injectApiBaseIntoHtml token embedding", () => {
       out.indexOf("<script>") + "<script>".length,
       out.indexOf("</script>"),
     );
+    const store = new Map<string, string>();
+    if (stored !== undefined) {
+      store.set("elizaos:active-server", JSON.stringify(stored));
+    }
+    const localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+    };
+    new Function("window", "localStorage", script)({}, localStorage);
+    return store;
+  }
 
+  it("never attaches the token to a persisted remote server", () => {
+    const remote = {
+      id: "remote:https://box.lan",
+      kind: "remote",
+      label: "box.lan",
+      apiBase: "https://box.lan",
+    };
+    const store = runInjectedScript(remote);
+    expect(JSON.parse(store.get("elizaos:active-server") ?? "{}")).toEqual(
+      remote,
+    );
+  });
+
+  it("never attaches the token to a persisted cloud server", () => {
+    const cloud = {
+      id: "cloud:https://elizacloud.ai",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: "https://elizacloud.ai",
+    };
+    const store = runInjectedScript(cloud);
+    expect(JSON.parse(store.get("elizaos:active-server") ?? "{}")).toEqual(
+      cloud,
+    );
+  });
+
+  it("refreshes the token on this device's own local record", () => {
+    const store = runInjectedScript({
+      id: "local:embedded",
+      kind: "local",
+      label: "This device",
+      accessToken: "stale-token",
+    });
+    expect(JSON.parse(store.get("elizaos:active-server") ?? "{}")).toEqual({
+      id: "local:embedded",
+      kind: "local",
+      label: "This device",
+      accessToken: TOKEN,
+    });
+  });
+
+  it("seeds a local record when a corrupt one is stored", () => {
+    const out = injectApiBaseIntoHtml(Buffer.from(html), undefined, {
+      apiToken: TOKEN,
+    }).toString("utf-8");
+    const script = out.slice(
+      out.indexOf("<script>") + "<script>".length,
+      out.indexOf("</script>"),
+    );
     const store = new Map<string, string>([
-      [
-        "elizaos:active-server",
-        JSON.stringify({
-          id: "remote:https://box.lan",
-          kind: "remote",
-          label: "box.lan",
-          apiBase: "https://box.lan",
-        }),
-      ],
+      ["elizaos:active-server", "{not json"],
     ]);
     const localStorage = {
       getItem: (k: string) => store.get(k) ?? null,
@@ -155,14 +214,40 @@ describe("injectApiBaseIntoHtml token embedding", () => {
       },
     };
     new Function("window", "localStorage", script)({}, localStorage);
-
     expect(JSON.parse(store.get("elizaos:active-server") ?? "{}")).toEqual({
-      id: "remote:https://box.lan",
-      kind: "remote",
-      label: "box.lan",
-      apiBase: "https://box.lan",
+      id: "local:embedded",
+      kind: "local",
+      label: "This device",
       accessToken: TOKEN,
     });
+  });
+
+  // Private-mode Safari throws on localStorage access. The boot-config and
+  // window sinks must still land; only the persistence sink degrades.
+  it("still seeds the in-memory sinks when localStorage throws", () => {
+    const out = injectApiBaseIntoHtml(Buffer.from(html), undefined, {
+      apiToken: TOKEN,
+    }).toString("utf-8");
+    const script = out.slice(
+      out.indexOf("<script>") + "<script>".length,
+      out.indexOf("</script>"),
+    );
+    const hostile = {
+      getItem: () => {
+        throw new Error("SecurityError");
+      },
+      setItem: () => {
+        throw new Error("SecurityError");
+      },
+    };
+    const win: Record<PropertyKey, unknown> = {};
+    expect(() =>
+      new Function("window", "localStorage", script)(win, hostile),
+    ).not.toThrow();
+    expect(
+      (win.__ELIZAOS_APP_BOOT_CONFIG__ as { apiToken?: string }).apiToken,
+    ).toBe(TOKEN);
+    expect(win.__ELIZA_API_TOKEN__).toBe(TOKEN);
   });
 
   it("never leaks a token into the HTML when none is injected", () => {

--- a/packages/agent/src/api/static-file-server.ts
+++ b/packages/agent/src/api/static-file-server.ts
@@ -189,13 +189,22 @@ export function injectApiBaseIntoHtml(
     //    re-authenticates after a hard reload without re-pairing, for LAN
     //    clients (e.g. iPad Safari) that cannot paste a token by hand.
     //
-    // `eliza:first-run-complete` is set alongside because this token is only
-    // injected into an already-provisioned deployment (cloud container, or an
-    // explicit `ELIZA_FORCE_INJECT_TOKEN` opt-in behind the operator's own auth
-    // gate) — the character and provider are configured already, so the
-    // first-run wizard has nothing left to ask.
+    // Sink 3 is scoped to THIS backend, and that scoping is the security
+    // boundary. The persisted record can point at any host the user has
+    // previously connected to; startup restore sends `accessToken` to that
+    // record's `apiBase`. Merging our token into a `remote`/`cloud` record
+    // would hand this agent's full-capability token to an unrelated LAN or
+    // Tailscale host. So: seed a fresh `local:embedded` record when none
+    // exists, refresh the token when the stored record is already this
+    // device's local backend, and otherwise leave the record untouched.
+    //
+    // `eliza:first-run-complete` is deliberately NOT written here.
+    // `ELIZA_FORCE_INJECT_TOKEN` only attests that the operator accepts HTML
+    // token injection; it does not prove character/provider setup finished, so
+    // suppressing onboarding off the back of it would strand a partially
+    // configured self-hosted deployment.
     parts.push(
-      `(function(){var t=${JSON.stringify(trimmedToken)},k=Symbol.for("elizaos.app.boot-config"),w=window,prev=w.__ELIZAOS_APP_BOOT_CONFIG__||(w[k]&&w[k].current)||{},next=Object.assign({},prev,{apiToken:t});w.__ELIZAOS_APP_BOOT_CONFIG__=next;w[k]={current:next};w.__ELIZA_API_TOKEN__=t;try{localStorage.setItem("eliza:first-run-complete","1");var sk="elizaos:active-server",sp={};try{sp=JSON.parse(localStorage.getItem(sk)||"{}")||{};}catch(e){}localStorage.setItem(sk,JSON.stringify(Object.assign({id:"local:embedded",kind:"local",label:"This device"},sp,{accessToken:t})));}catch(e){}})();`,
+      `(function(){var t=${JSON.stringify(trimmedToken)},k=Symbol.for("elizaos.app.boot-config"),w=window,prev=w.__ELIZAOS_APP_BOOT_CONFIG__||(w[k]&&w[k].current)||{},next=Object.assign({},prev,{apiToken:t});w.__ELIZAOS_APP_BOOT_CONFIG__=next;w[k]={current:next};w.__ELIZA_API_TOKEN__=t;try{var sk="elizaos:active-server",sp=null;try{sp=JSON.parse(localStorage.getItem(sk)||"null");}catch(e){sp=null;}if(!sp||typeof sp!=="object"){localStorage.setItem(sk,JSON.stringify({id:"local:embedded",kind:"local",label:"This device",accessToken:t}));}else if(sp.kind==="local"){localStorage.setItem(sk,JSON.stringify(Object.assign({},sp,{accessToken:t})));}}catch(e){}})();`,
     );
   }
   const injection = Buffer.from(`<script>${parts.join("")}</script>`);


### PR DESCRIPTION
# Relates to

Follow-up to #17893, which merged before this review point could be addressed.

# Contribution provenance

Declare the actual assistance used for implementation and review.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code (claude.ai/code)`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Risks

Low — narrows what the injected boot script writes. No new surface; the local
seed path is unchanged.

# Background

## What does this PR do?

#17893 seeded the injected API token into `elizaos:active-server` so LAN
clients re-authenticate after a hard reload. It merged the token into
**whatever** record was already stored:

```js
Object.assign({id:"local:embedded",kind:"local",label:"This device"}, sp, {accessToken:t})
```

`sp` is the persisted record, which can be a `remote` or `cloud` target
pointing at any host the user has previously connected to. Startup restore
(`startup-phase-restore.ts`) then sends `accessToken` to that record's
`apiBase` — so a stale record for another LAN or Tailscale host would receive
this agent's full-capability token.

Scope the write to this backend:

- no record stored, or a corrupt one → seed a fresh `local:embedded` record
- record already `kind: "local"` → refresh its token
- `remote` / `cloud` record → leave untouched, no token attached

Also drops the `eliza:first-run-complete` write. `ELIZA_FORCE_INJECT_TOKEN`
attests only that the operator accepts HTML token injection; it does not prove
character/provider setup finished, so suppressing onboarding off the back of it
can strand a partially configured self-hosted deployment.

Credit to the reviewer on #17893 who identified both — the original test suite
asserted the leaking behaviour as correct, so it locked the defect in rather
than catching it.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Testing

## Where should a reviewer start?

`packages/agent/src/api/static-file-server.ts` — the token branch of
`injectApiBaseIntoHtml`.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:cbdf34a4c57b88245182c7867d23919e575760e2 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - injected boot script; no rendered UI surface in the diff`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - injected boot script; no rendered UI surface in the diff`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no interactive surface; the script is asserted by execution below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — the injected script executed against stubbed browser globals.
<details>
<summary>static-file-server token injection suite</summary>

```
 RUN  v4.1.5 .../packages/agent

 + token embedding > never attaches the token to a persisted remote server
 + token embedding > never attaches the token to a persisted cloud server
 + token embedding > refreshes the token on this device's own local record
 + token embedding > seeds a local record when a corrupt one is stored
 + token embedding > still seeds the in-memory sinks when localStorage throws
 + token embedding > executes cleanly and populates every token sink a reader consults
 + token embedding > keeps seeding the window token global the native web shims read
 + token embedding > never leaks a token into the HTML when none is injected

 Test Files  1 passed (1)
      Tests  17 passed (17)
```

The remote and cloud cases run the emitted script via
new Function("window","localStorage",script) and assert the stored record comes
back byte-identical — no accessToken key added.

```
$ bunx @biomejs/biome check packages/agent/src/api/static-file-server.ts packages/agent/src/api/static-file-server.test.ts
 Checked 2 files. No fixes applied.
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - no client-side module changed; the injected script is asserted by execution above`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no agent, action, provider, prompt, or model path changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - browser localStorage seed only; no server-side rows or generated files`.
<!-- evidence-row:ocr-review -->
- [x] OCR review `N/A - backend-only change has no rendered visual surface`.
