### PR TITLE
test(app): deflake the cloud-login popup ui-smoke spec

### DIFF
--- a/packages/app/test/ui-smoke/cloud-login-callsite-popup.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-login-callsite-popup.spec.ts
@@ -72,24 +72,28 @@ async function installCloudLoginRoutes(page: Page): Promise<void> {
       body: JSON.stringify({
         ok: true,
         sessionId: "ui-smoke-callsite-session",
-        browserUrl: "https://www.elizacloud.ai/device/ui-smoke-callsite-session",
+        browserUrl:
+          "https://www.elizacloud.ai/device/ui-smoke-callsite-session",
       }),
     });
   });
   // Serve a real-ish device page so the popup renders content instead of a
-  // network error (sandbox has no outbound network). The interactive flow
-  // navigates the pre-opened popup to the cli-login/device URL on the direct
-  // cloud base (https://elizacloud.ai/...), not www.
-  await page.route("https://elizacloud.ai/**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "text/html",
-      body: `<!doctype html><html><head><title>Eliza Cloud login (ui-smoke stub)</title></head>
+  // network error (sandbox has no outbound network). The flow navigates the
+  // pre-opened popup to the login/device URL, which the stubbed /api/cloud/login
+  // response addresses on the www host. Context-scoped: page routes do not
+  // apply to the popup, which is a separate Page.
+  await page
+    .context()
+    .route(/^https:\/\/(www\.)?elizacloud\.ai\//, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><head><title>Eliza Cloud login (ui-smoke stub)</title></head>
 <body style="font-family:system-ui;background:#0f1115;color:#e6e6e6;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
 <div style="text-align:center"><h1>Eliza Cloud</h1><p>Device login (ui-smoke evidence stub)</p>
 <p style="color:#8b949e;font-size:12px">window.name = eliza-cloud-auth</p></div></body></html>`,
+      });
     });
-  });
 }
 
 async function bootCloudSettings(
@@ -118,9 +122,7 @@ test.describe("cloud login callsite — interactive popup opens from the real Se
       const consoleLogs: string[] = [];
       const networkLogs: string[] = [];
       page.on("console", (message) => {
-        consoleLogs.push(
-          `[${message.type()}] ${message.text()}`,
-        );
+        consoleLogs.push(`[${message.type()}] ${message.text()}`);
       });
       page.on("pageerror", (error) => {
         consoleLogs.push(`[pageerror] ${error.message}`);
@@ -153,14 +155,11 @@ test.describe("cloud login callsite — interactive popup opens from the real Se
         .click();
       const popup = await popupPromise;
 
-      // window.open("about:blank", "eliza-cloud-auth") — assert the name.
-      await popup.waitForLoadState("domcontentloaded").catch(() => {});
-      const popupName = await popup.evaluate(() => window.name);
-      expect(popupName).toBe(CLOUD_LOGIN_POPUP_NAME);
-
       // The popup navigates to the device-login URL on the direct cloud base
       // (stubbed above) — proving the interactive path drives the popup to the
-      // real login URL instead of falling back to same-tab.
+      // real login URL instead of falling back to same-tab. Settle this FIRST:
+      // evaluating during the about:blank → device-URL navigation races the
+      // context teardown ("Execution context was destroyed").
       await expect
         .poll(
           async () => {
@@ -170,6 +169,23 @@ test.describe("cloud login callsite — interactive popup opens from the real Se
           { timeout: 15_000 },
         )
         .not.toBe("");
+      // window.open("about:blank", "eliza-cloud-auth") — assert the name,
+      // which persists across navigations on the same window. Poll with a
+      // swallowed evaluate: any still-committing navigation destroys the
+      // execution context mid-call, and the poll simply retries on the next
+      // stable document.
+      let popupName: string | null = null;
+      await expect
+        .poll(
+          async () => {
+            popupName = await popup
+              .evaluate(() => window.name)
+              .catch(() => null);
+            return popupName;
+          },
+          { timeout: 15_000 },
+        )
+        .toBe(CLOUD_LOGIN_POPUP_NAME);
       await popup.screenshot({
         path: testInfo.outputPath(`${viewport.name}-popup-device-login.png`),
         type: "png",
@@ -182,7 +198,9 @@ test.describe("cloud login callsite — interactive popup opens from the real Se
       await screenshot(page, testInfo, `${viewport.name}-2-after-popup-opened`);
 
       // Raw console + network logs as reviewable artifacts.
-      const logsPath = testInfo.outputPath(`${viewport.name}-console-network.log`);
+      const logsPath = testInfo.outputPath(
+        `${viewport.name}-console-network.log`,
+      );
       await mkdir(testInfo.outputDir, { recursive: true });
       await writeFile(
         logsPath,


### PR DESCRIPTION
# Relates to

Follow-up to #17572 (#17129 call-site contract). The merged ui-smoke spec `cloud-login-callsite-popup.spec.ts` was racy and its popup rendered the wrong document; this deflakes it.

Definition of Done:
- [x] Targets `develop`, branched from current `origin/develop` (308ea8de4cf), zero conflicts.
- [x] Focused spec run recorded below; test-only change (one Playwright spec).
- [x] Reviewer can confirm from the attached run output and screenshots.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` at 308ea8de4cf; zero conflicts.
- [x] Test-only change; the focused spec run and `biome check` on the file pass. No production code is touched, so the full `bun run verify` sweep is not re-run for this one spec file.

# Risks

Low: one Playwright ui-smoke spec; no production code.

# Background

## What does this PR do?

Deflakes the cloud-login popup ui-smoke spec merged in #17572:

1. `popup.evaluate(() => window.name)` raced the popup's `about:blank` → device-URL navigation ("Execution context was destroyed") and failed 2/2 on first local run. The spec now settles the navigation first and polls the evaluate with a swallowed context-destroyed retry.
2. The device-page stub was installed with `page.route`, which never applies to the popup (a separate `Page`), and matched only the bare `elizacloud.ai` host while the stubbed `/api/cloud/login` response addresses `www.elizacloud.ai`. The popup therefore rendered the app shell instead of the stub. The route is now context-scoped and matches both hosts, so the popup screenshot actually shows the device-login stub.

## What kind of change is this?

Bug fix (test-only, non-breaking).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

packages/app/test/ui-smoke/cloud-login-callsite-popup.spec.ts

## Detailed testing steps

From `packages/app`: `E2E_RECORD=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=chromium test/ui-smoke/cloud-login-callsite-popup.spec.ts` — both desktop and mobile pass; before this change the name-evaluate raced (2/2 failures on the first run) and the popup screenshot showed the app boot screen.

# Evidence Gate

<!-- evidence-head:55d807091fa625cff2ed11a30b8209202171b7ab -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only Playwright spec change; no product UI surface is modified. The "before" defect is the spec failure itself, recorded in the transcript below.
<!-- evidence-row:after-screenshots -->
- [x] The spec's own desktop and mobile captures at this head, including the popup now rendering the device-login stub instead of the app shell:
  ![desktop after popup opened](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17963-desktop-2-after-popup-opened.jpg)
  ![desktop popup device login stub](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17963-desktop-popup-device-login.png)
  ![mobile after popup opened](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17963-mobile-2-after-popup-opened.jpg)
  ![mobile popup device login stub](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17963-mobile-popup-device-login.png)
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed; the spec's recorded walkthrough artifact is regenerated on every run and reviewed via the attached captures.
<!-- evidence-row:backend-logs -->
- [x] Focused spec run at head 55d807091fa:

  <details><summary>playwright run @ 55d807091fa (desktop + mobile pass)</summary>

  ```text
  Running 2 tests using 1 worker
  ✓ 1 [chromium] › test/ui-smoke/cloud-login-callsite-popup.spec.ts:119:5 › cloud login callsite — interactive popup opens from the real Settings CTA (#17129) › clicking the connect CTA opens the eliza-cloud-auth popup on desktop
  ✓ 2 [chromium] › test/ui-smoke/cloud-login-callsite-popup.spec.ts:119:5 › cloud login callsite — interactive popup opens from the real Settings CTA (#17129) › clicking the connect CTA opens the eliza-cloud-auth popup on mobile
  2 passed

  Pre-fix failure mode (same spec, prior revision):
  Error: page.evaluate: Execution context was destroyed, most likely because of a navigation
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] Per-viewport console/network logs are produced by the spec on every run; desktop capture from the run at this head:

  <details><summary>desktop-console-network.log @ 55d807091fa</summary>

  ```text
  === console (13) ===
  [info] [shell] window shell mode: main (search="")
  [info] [SW] Registered, scope: http://127.0.0.1:33963/
  [info] [renderer-build] e1d479cd8389 built 2026-08-07T13:52:15.731Z (variant=?, target=web/desktop)
  [info] [startup-coordinator] phase=restoring-session
  [info] [startup-coordinator] phase=ready
  [info] [ViewLifecycle] "settings" mounted → active (show)

  === cloud network (6) ===
  REQ GET http://127.0.0.1:33963/api/cloud/status
  RES 200 http://127.0.0.1:33963/api/cloud/status
  REQ POST http://127.0.0.1:33963/api/cloud/login
  RES 200 http://127.0.0.1:33963/api/cloud/login
  ```

  </details>
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model call in this spec.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, task, or external domain record involved; the spec's assertions are the artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no product visual surface changed; the attached captures document spec behavior only.

# Known gaps / failures

None. Test-only change; the spec passes deterministically across repeated local runs after the fix.
