### PR TITLE
fix(agent): keep the local-inference boot hook installable without the registry

### DIFF
--- a/packages/agent/src/runtime/boot-hooks.test.ts
+++ b/packages/agent/src/runtime/boot-hooks.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Contract for the registry-driven boot-hook channel, with the registry and
+ * logger stubbed and no real plugin installed.
+ *
+ * Guards the two designed absences that leave voice dead if they regress: a
+ * packaged build whose registry is empty must still install the local-inference
+ * hook, and a host that ships without that plugin must skip it rather than
+ * abort startup — while a genuinely broken hook module still fails the boot.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type BootHookDeclaration,
+  resolveBootHookContributors,
+} from "./boot-hooks";
+
+const LOCAL_INFERENCE_ID = "@elizaos/plugin-local-inference";
+
+describe("boot-hook contributors", () => {
+  it("installs the local-inference hook when the registry is empty", () => {
+    // The packaged-build case: loadRegistry() degrades to [] by design, so an
+    // empty declaration list must not mean "no local model handlers".
+    const contributors = resolveBootHookContributors([]);
+    expect(contributors.map((c) => c.id)).toContain(LOCAL_INFERENCE_ID);
+  });
+
+  it("lets a registry declaration win over the fallback for the same id", () => {
+    const declared: BootHookDeclaration = {
+      id: LOCAL_INFERENCE_ID,
+      specifier: "@elizaos/plugin-local-inference/runtime",
+      exportName: "registerLocalInferenceBoot",
+    };
+    const contributors = resolveBootHookContributors([declared]);
+    const matching = contributors.filter((c) => c.id === LOCAL_INFERENCE_ID);
+    expect(matching).toHaveLength(1);
+  });
+
+  it("skips a hook whose own module is not installed", async () => {
+    const contributors = resolveBootHookContributors([
+      {
+        id: "absent-plugin",
+        specifier: "@elizaos/definitely-not-installed/runtime",
+        exportName: "register",
+      },
+    ]);
+    const contributor = contributors.find((c) => c.id === "absent-plugin");
+    expect(contributor).toBeDefined();
+    // A supported deployment without the optional plugin: skip, do not throw.
+    await expect(contributor?.invoke({} as never)).resolves.toBeUndefined();
+  });
+});

--- a/packages/agent/src/runtime/boot-hooks.ts
+++ b/packages/agent/src/runtime/boot-hooks.ts
@@ -2,9 +2,19 @@
  * Registry-driven pre-ready boot hooks shared by every agent host. The registry
  * declares optional hook modules; this module resolves and invokes them without
  * coupling startup to any specific plugin.
+ *
+ * Two absences are designed rather than exceptional, and both are load-bearing
+ * for voice. A packaged bundle that does not stage `generated.json` makes
+ * `loadRegistry()` return an empty set on purpose
+ * (`packages/registry/src/first-party/index.ts` marks that `error-policy:J4`), so
+ * the registry alone cannot be the only source of the local-inference hook —
+ * nothing else installs the local TEXT/EMBEDDING/TRANSCRIPTION/TTS handlers, and
+ * without them voice reports not-ready with no failure at the boot site. And a
+ * host may legitimately ship without the optional plugin at all, which must skip
+ * rather than abort startup.
  */
 
-import type { AgentRuntime } from "@elizaos/core";
+import { type AgentRuntime, logger } from "@elizaos/core";
 import {
   getApps,
   getPlugins,
@@ -25,13 +35,56 @@ export interface BootHookContributor {
 type BootHookModule = Record<string, unknown>;
 type BootHook = (runtime: AgentRuntime) => void | Promise<void>;
 
+/**
+ * Host-owned declarations appended when the registry does not supply one for the
+ * same id. These are not a duplicate source of truth: a registry declaration
+ * always wins, and this only covers the packaged-build case where the registry
+ * is empty by design.
+ */
+const FALLBACK_BOOT_HOOK_DECLARATIONS: readonly BootHookDeclaration[] = [
+  {
+    id: "@elizaos/plugin-local-inference",
+    specifier: "@elizaos/plugin-local-inference/runtime",
+    exportName: "registerLocalInferenceBoot",
+  },
+];
+
+/**
+ * True only when `specifier` itself could not be resolved — not when the hook
+ * module loaded and one of *its* imports was missing. Skipping on the latter
+ * would turn a genuinely broken plugin into a silent no-op.
+ */
+function isMissingModule(error: unknown, specifier: string): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as { code?: unknown }).code;
+  if (code !== "ERR_MODULE_NOT_FOUND" && code !== "MODULE_NOT_FOUND") {
+    return false;
+  }
+  const message = (error as { message?: unknown }).message;
+  return typeof message === "string" && message.includes(specifier);
+}
+
 async function loadAndInvokeBootHook(
   declaration: BootHookDeclaration,
   runtime: AgentRuntime,
 ): Promise<void> {
-  const module = (await import(
-    /* webpackIgnore: true */ declaration.specifier
-  )) as BootHookModule;
+  let module: BootHookModule;
+  try {
+    module = (await import(
+      /* webpackIgnore: true */ declaration.specifier
+    )) as BootHookModule;
+  } catch (error) {
+    // error-policy:J4 a host that ships without an optional hook module is a
+    // supported deployment, so its absence degrades to "no hook". Anything else,
+    // including a broken import inside the hook module, still fails the boot.
+    if (isMissingModule(error, declaration.specifier)) {
+      logger.debug(
+        `[eliza] boot hook ${declaration.id} not installed (${declaration.specifier}); skipping`,
+      );
+      return;
+    }
+    throw error;
+  }
   const hook = module[declaration.exportName];
   if (typeof hook !== "function") {
     throw new Error(
@@ -46,7 +99,11 @@ export function resolveBootHookContributors(
   declarations: BootHookDeclaration[],
 ): BootHookContributor[] {
   const contributors = new Map<string, BootHookContributor>();
-  for (const declaration of declarations) {
+  for (const declaration of [
+    ...declarations,
+    ...FALLBACK_BOOT_HOOK_DECLARATIONS,
+  ]) {
+    if (contributors.has(declaration.id)) continue;
     contributors.set(declaration.id, {
       id: declaration.id,
       invoke: (runtime) => loadAndInvokeBootHook(declaration, runtime),


### PR DESCRIPTION
Follow-up to #17954, which merged at 13:51 UTC. That PR moved the boot-hook channel from app-core to `@elizaos/agent` — the right direction — but the move dropped two guarantees the old app-core implementation carried, and both are load-bearing for voice.

## What breaks today on develop

`packages/agent/src/runtime/boot-hooks.ts` sources hook declarations exclusively from `loadRegistry()`. But an empty registry is a **designed, supported state**, not an error: `packages/registry/src/first-party/index.ts:130-136` warns `[registry] generated.json missing` and returns `[]` under an explicit `// error-policy:J4 explicit designed degrade`, precisely for packaged builds that do not stage the file.

`registerLocalInferenceBoot` has no other install site anywhere in the tree (`git grep registerLocalInferenceBoot origin/develop` finds only tests and the registry declaration itself). So on a packaged build:

`loadRegistry()` → `[]` → `runBootHooks()` is a silent no-op → local TEXT / EMBEDDING / TRANSCRIPTION / TTS handlers are never installed → voice and ASR report `ready:false`, with nothing failing at the boot site to say why.

The second gap: `loadAndInvokeBootHook` did a bare `await import(...)` with no module-not-found branch, and `drainBootHookContributors` no longer skipped an unavailable optional plugin. A deployment that genuinely ships without local-inference — supported before — now fails `startEliza` outright.

## The fix

**Host-owned fallback declaration.** `resolveBootHookContributors` appends a declaration for `@elizaos/plugin-local-inference/runtime` when the registry supplied none for that id. This is not a second source of truth: a registry declaration for the same id always wins (first-wins on the id key), so it only covers the case where the registry is empty by design.

**Precise absent-module tolerance.** `isMissingModule(error, specifier)` returns true only when the failure names the declaration's *own* specifier. A `MODULE_NOT_FOUND` raised by an import *inside* a hook module still propagates and fails the boot — skipping there would turn a genuinely broken plugin into a silent no-op, which is the same class of bug as the one being fixed.

## Verification

Ran the new suite against both implementations in an isolated harness with the registry and logger stubbed:

```
RED  (develop's boot-hooks.ts):  1 pass, 2 fail
       ✗ installs the local-inference hook when the registry is empty
       ✗ skips a hook whose own module is not installed
GREEN (this branch):             3 pass, 0 fail
```

Both files clean under `biome check`.

The third case — a registry declaration overriding the fallback for the same id — passes on both, and is there so the fallback cannot silently shadow a real declaration later.

<!-- evidence-head:9a07dca84a2b4a6f33b6e5b03309a0d6fb08e1fb -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - runtime boot path, no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - runtime boot path, no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-operated UI flow changed
<!-- evidence-row:backend-logs -->
- [x] Isolated harness stubbing `@elizaos/registry/first-party` to an empty registry and `@elizaos/core` to a no-op logger, reproducing the packaged-build shape with no plugin installed:

```
$ bun test boot-hooks.test.ts        # develop's packages/agent/src/runtime/boot-hooks.ts
(fail) boot-hook contributors > installs the local-inference hook when the registry is empty [1.42ms]
(fail) boot-hook contributors > skips a hook whose own module is not installed [2.42ms]
 1 pass
 2 fail
Ran 3 tests across 1 file. [595.00ms]

$ bun test boot-hooks.test.ts        # this branch
 3 pass
 0 fail
 4 expect() calls
Ran 3 tests across 1 file. [1.92s]
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend renderer or network path changed
<!-- evidence-row:llm-trajectory -->
- [x] N/A - boot-hook resolution does not invoke a model
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no generated artifact; the change is hook resolution and error classification

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`
