### PR TITLE
fix(cloud): retain deletion capacity until teardown settles

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-release-proven-absence.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-release-proven-absence.test.ts
@@ -4,7 +4,8 @@
  * The exactly-once CAS is covered elsewhere; what these pin is the policy that
  * decides whether the CAS is reached at all. Two paths must NOT release: a
  * reachable stop failure (the container is still there and the teardown will be
- * retried) and a bounded-timeout abandon (the container may still be running).
+ * retried) and a bounded-timeout or unreachable-node abandon (the container may
+ * still be running).
  * Releasing on either hands a live container's slot back to the scheduler, which
  * then packs a new container onto a node still running the old one — a worse
  * failure than the double-free this feature closes, because it is invisible
@@ -18,7 +19,7 @@
  * stop past `SANDBOX_DELETE_STOP_TIMEOUT_MS` (120s, not env-tunable): that would
  * make the suite two minutes slower and timing-dependent for no added coverage.
  * The timer itself is exercised by the provider suites; what is under test here
- * is what `deleteAgent` DOES with a `timedOut` verdict, which is exactly the
+ * is what `deleteAgent` does with a tagged timeout, which is exactly the
  * branch a future refactor could silently drop.
  */
 
@@ -37,6 +38,12 @@ import { dockerNodes } from "../../../db/schemas/docker-nodes";
 import { organizations } from "../../../db/schemas/organizations";
 import { users } from "../../../db/schemas/users";
 import { apiKeysService } from "../api-keys";
+import { AGENT_ORPHAN_RECONCILER_CONFIG } from "../docker-node-workloads";
+import {
+  type OrphanReconcilerNode,
+  reconcileOrphanContainers,
+} from "../orphan-container-reconciler";
+import type { SandboxDeletionStopOutcome } from "../sandbox-provider-types";
 import { PROVISIONING_JOB_TEST_TABLES } from "./tier-upgrade-pglite-schema";
 
 const PGLITE_TIMEOUT = 60_000;
@@ -138,9 +145,13 @@ async function seedPlacedAgent(): Promise<{
 function scriptProvider(
   service: InstanceType<typeof ElizaSandboxService>,
   stop: () => Promise<void>,
+  outcome: SandboxDeletionStopOutcome = { kind: "not-running-proven" },
 ): void {
   (service as unknown as { _provider: unknown })._provider = {
-    stop,
+    stopForDeletion: async () => {
+      await stop();
+      return outcome;
+    },
     stopForReplacement: stop,
   };
 }
@@ -161,7 +172,7 @@ async function ownership(agentId: string): Promise<boolean | null> {
   return row?.owned ?? null;
 }
 
-describe("deleteAgent releases the node slot only on proven absence", () => {
+describe("deleteAgent releases the node slot only when the workload is proven not running", () => {
   test(
     "a clean teardown releases exactly one slot",
     async () => {
@@ -208,13 +219,84 @@ describe("deleteAgent releases the node slot only on proven absence", () => {
       (
         service as unknown as { runBoundedSandboxStop: () => Promise<unknown> }
       ).runBoundedSandboxStop = async () => ({
+        kind: "stop-timed-out" as const,
         error: new Error("agent-delete stop timed out"),
-        timedOut: true as const,
       });
 
-      await service.deleteAgent(agentId, orgId);
+      const result = await service.deleteAgent(agentId, orgId);
 
+      expect(result).toMatchObject({ success: true, rowDeleted: false });
       expect(await nodeCount(nodeId)).toBe(2);
+      expect(await ownership(agentId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "an unreachable-node abandon completes deletion without releasing its slot",
+    async () => {
+      if (!pgliteReady) return;
+      const { service, agentId, orgId, nodeId } = await seedPlacedAgent();
+      scriptProvider(service, async () => {}, {
+        kind: "not-running-unresolved",
+        reason: "node-unreachable",
+      });
+
+      const result = await service.deleteAgent(agentId, orgId);
+
+      expect(result).toMatchObject({ success: true, rowDeleted: false });
+      expect(await nodeCount(nodeId)).toBe(2);
+      expect(await ownership(agentId)).toBe(true);
+      const retained = await dbWrite.query.agentSandboxes.findFirst({
+        where: eq(agentSandboxes.id, agentId),
+      });
+      expect(retained?.status).toBe("deletion_failed");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "an unresolved tombstone survives until the real orphan reaper releases and retry finalizes it",
+    async () => {
+      if (!pgliteReady) return;
+      const { service, agentId, orgId, nodeId } = await seedPlacedAgent();
+      scriptProvider(service, async () => {}, {
+        kind: "not-running-unresolved",
+        reason: "node-unreachable",
+      });
+      const pending = await service.deleteAgent(agentId, orgId);
+      expect(pending).toMatchObject({ success: true, rowDeleted: false });
+
+      const removed: string[] = [];
+      const node: OrphanReconcilerNode = {
+        node_id: nodeId,
+        hostname: "reaper.test.invalid",
+        status: "healthy",
+        listContainers: async () => [
+          { id: "immutable-container-id", name: `agent-${agentId}`, createdAtMs: 1 },
+        ],
+        removeContainer: async (containerId) => {
+          removed.push(containerId);
+        },
+      };
+      const reaped = await reconcileOrphanContainers([node], {
+        ...AGENT_ORPHAN_RECONCILER_CONFIG,
+        rowlessGraceMs: 0,
+      });
+
+      expect(reaped.reaped).toBe(1);
+      expect(removed).toEqual(["immutable-container-id"]);
+      expect(await nodeCount(nodeId)).toBe(1);
+      expect(await ownership(agentId)).toBe(false);
+
+      scriptProvider(service, async () => {});
+      const finalized = await service.deleteAgent(agentId, orgId);
+      expect(finalized).toMatchObject({ success: true, rowDeleted: true });
+      const row = await dbWrite.query.agentSandboxes.findFirst({
+        where: eq(agentSandboxes.id, agentId),
+      });
+      expect(row).toBeUndefined();
+      expect(await nodeCount(nodeId)).toBe(1);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-stop-no-capacity-mutation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-stop-no-capacity-mutation.test.ts
@@ -81,7 +81,9 @@ describe("provider stop never mutates node capacity", () => {
     const provider = new DockerSandboxProvider();
     seedContainer(provider);
 
-    await expect(provider.stop(SANDBOX_ID)).resolves.toBeUndefined();
+    await expect(provider.stopForDeletion(SANDBOX_ID)).resolves.toEqual({
+      kind: "not-running-proven",
+    });
     expect(decrementSpy).not.toHaveBeenCalled();
   });
 
@@ -95,18 +97,23 @@ describe("provider stop never mutates node capacity", () => {
     const provider = new DockerSandboxProvider();
     seedContainer(provider);
 
-    await expect(provider.stop(SANDBOX_ID)).resolves.toBeUndefined();
+    await expect(provider.stopForDeletion(SANDBOX_ID)).resolves.toEqual({
+      kind: "not-running-proven",
+    });
     expect(decrementSpy).not.toHaveBeenCalled();
   });
 
-  test("an abandoned container on an unreachable node leaks on the box, not in the counter", async () => {
+  test("an unreachable container retains its capacity for reconciliation", async () => {
     execBehavior = async () => {
       throw new Error("[docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms");
     };
     const provider = new DockerSandboxProvider();
     seedContainer(provider);
 
-    await expect(provider.stop(SANDBOX_ID)).resolves.toBeUndefined();
+    await expect(provider.stopForDeletion(SANDBOX_ID)).resolves.toEqual({
+      kind: "not-running-unresolved",
+      reason: "node-unreachable",
+    });
     expect(decrementSpy).not.toHaveBeenCalled();
   });
 
@@ -120,7 +127,7 @@ describe("provider stop never mutates node capacity", () => {
     const provider = new DockerSandboxProvider();
     seedContainer(provider);
 
-    await expect(provider.stop(SANDBOX_ID)).rejects.toThrow(/Failed to stop container/);
+    await expect(provider.stopForDeletion(SANDBOX_ID)).rejects.toThrow(/Failed to stop container/);
     expect(decrementSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-unreachable-terminal.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-unreachable-terminal.test.ts
@@ -3,22 +3,23 @@
  * container stop must be TERMINAL, not retryable.
  *
  * Before the fix, when both `docker stop` and `docker rm -f` failed because the
- * node was unreachable (SSH connect/exec timeout), `DockerSandboxProvider.stop()`
+ * node was unreachable (SSH connect/exec timeout), the deletion stop
  * threw "Failed to stop container ...". That throw propagated up through
  * `deleteAgent` -> `executeDeletion` -> `executeAgentDelete`, which re-queued the
  * job (attempts < 3) and re-ran the ~20-65s stop path every cycle, eventually
  * pushing the worker's work cycle past the 300s watchdog so the liveness
  * heartbeat was withheld and the agents API failed closed.
  *
- * The fix: classify both-legs-unreachable as "container gone" and let `stop()`
- * RESOLVE (after a warn). With stop() resolving, `deleteAgent`'s try succeeds,
- * the row DELETE runs, and the job completes terminally — no re-queue.
+ * The fix: classify both-legs-unreachable as a terminal but unresolved
+ * deletion outcome. The hot queue attempt completes without re-queueing, while
+ * a terminal sandbox tombstone retains capacity ownership until the orphan
+ * reconciler proves the workload is no longer running.
  *
- * This test drives the real `DockerSandboxProvider.stop()` with the SSH client
+ * This test drives the real deletion stop with the SSH client
  * mocked to reject (no real SSH) and the in-memory container pre-seeded so no DB
  * lookup is needed.
  */
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 // Fake SSH client: getClient() returns an object whose exec() rejects with a
 // caller-controlled error. Registered BEFORE importing the provider so the
@@ -37,6 +38,7 @@ mock.module("../docker-ssh", () => ({
   },
 }));
 
+import { dockerNodesRepository } from "../../../db/repositories/docker-nodes";
 import { DockerSandboxProvider } from "../docker-sandbox-provider";
 
 const SANDBOX_ID = "agent-unreachable-test";
@@ -71,23 +73,23 @@ function seedContainer(provider: DockerSandboxProvider): void {
   );
 }
 
-describe("DockerSandboxProvider.stop() terminal policy on unreachable node", () => {
+describe("DockerSandboxProvider deletion policy on unreachable node", () => {
   beforeEach(() => {
     // Headscale deletion is skipped when not configured.
     delete process.env.HEADSCALE_API_KEY;
   });
 
-  test("RESOLVES (no throw) when both stop and rm fail with an SSH timeout", async () => {
+  test("returns unresolved running state when both stop and rm fail with an SSH timeout", async () => {
     nextExecError = new Error(
       "[docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms",
     );
     const provider = new DockerSandboxProvider();
     seedContainer(provider);
 
-    // The fix means this no longer throws: an unreachable node is terminal, so
-    // the caller (deleteAgent) proceeds to the row DELETE and the job completes
-    // instead of re-queuing and re-running the ~20-65s stop path each cycle.
-    await expect(provider.stop(SANDBOX_ID)).resolves.toBeUndefined();
+    await expect(provider.stopForDeletion(SANDBOX_ID)).resolves.toEqual({
+      kind: "not-running-unresolved",
+      reason: "node-unreachable",
+    });
   });
 
   test("replacement stop REJECTS when the node is unreachable", async () => {
@@ -116,8 +118,16 @@ describe("DockerSandboxProvider.stop() terminal policy on unreachable node", () 
     nextExecError = new Error("Error response from daemon: No such container: agent-x");
     const provider = new DockerSandboxProvider();
     seedContainer(provider);
+    const decrement = spyOn(dockerNodesRepository, "decrementAllocated").mockResolvedValue(
+      undefined,
+    );
 
-    await expect(provider.stopForReplacement(SANDBOX_ID)).resolves.toBeUndefined();
+    try {
+      await expect(provider.stopForReplacement(SANDBOX_ID)).resolves.toBeUndefined();
+      expect(decrement).toHaveBeenCalledWith("node-1");
+    } finally {
+      decrement.mockRestore();
+    }
   });
 
   test("still THROWS when both legs fail for a non-unreachable, non-gone reason", async () => {
@@ -129,7 +139,7 @@ describe("DockerSandboxProvider.stop() terminal policy on unreachable node", () 
     const provider = new DockerSandboxProvider();
     seedContainer(provider);
 
-    await expect(provider.stop(SANDBOX_ID)).rejects.toThrow(/Failed to stop container/);
+    await expect(provider.stopForDeletion(SANDBOX_ID)).rejects.toThrow(/Failed to stop container/);
   });
 
   test("still THROWS on a per-command timeout (reachable-but-slow node, NOT terminal)", async () => {
@@ -143,7 +153,7 @@ describe("DockerSandboxProvider.stop() terminal policy on unreachable node", () 
     const provider = new DockerSandboxProvider();
     seedContainer(provider);
 
-    await expect(provider.stop(SANDBOX_ID)).rejects.toThrow(/Failed to stop container/);
+    await expect(provider.stopForDeletion(SANDBOX_ID)).rejects.toThrow(/Failed to stop container/);
   });
 
   test("RESOLVES when the container is already gone (existing behavior preserved)", async () => {
@@ -151,6 +161,8 @@ describe("DockerSandboxProvider.stop() terminal policy on unreachable node", () 
     const provider = new DockerSandboxProvider();
     seedContainer(provider);
 
-    await expect(provider.stop(SANDBOX_ID)).resolves.toBeUndefined();
+    await expect(provider.stopForDeletion(SANDBOX_ID)).resolves.toEqual({
+      kind: "not-running-proven",
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.error-policy.test.ts
@@ -81,7 +81,7 @@ afterAll(() => {
 describe("destroyPoolContainer fail-closed", () => {
   test("a DB error on the final deletePoolEntry PROPAGATES — not swallowed into a phantom leaked row", async () => {
     repo.findById.mockResolvedValue({ id: "p1", organization_id: WARM_POOL_ORG_ID });
-    sandbox.deleteAgent.mockResolvedValue({ success: true });
+    sandbox.deleteAgent.mockResolvedValue({ success: true, rowDeleted: true });
     // The removed slop was `.catch(() => undefined)` here: a genuine DB failure
     // would read as a successful destroy while the pool row leaks. It must throw.
     repo.deletePoolEntry.mockRejectedValue(new Error("connection terminated"));
@@ -92,12 +92,21 @@ describe("destroyPoolContainer fail-closed", () => {
 
   test("row already gone (deletePoolEntry returns false) resolves — a designed idempotent no-op, not a failure", async () => {
     repo.findById.mockResolvedValue({ id: "p2", organization_id: WARM_POOL_ORG_ID });
-    sandbox.deleteAgent.mockResolvedValue({ success: true });
+    sandbox.deleteAgent.mockResolvedValue({ success: true, rowDeleted: true });
     repo.deletePoolEntry.mockResolvedValue(false);
 
     const creator = getHetznerPoolContainerCreator();
     await expect(creator.destroyPoolContainer("p2")).resolves.toBeUndefined();
     expect(repo.deletePoolEntry).toHaveBeenCalledWith("p2");
+  });
+
+  test("unresolved teardown preserves the capacity tombstone", async () => {
+    repo.findById.mockResolvedValue({ id: "p-pending", organization_id: WARM_POOL_ORG_ID });
+    sandbox.deleteAgent.mockResolvedValue({ success: true, rowDeleted: false });
+
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.destroyPoolContainer("p-pending")).resolves.toBeUndefined();
+    expect(repo.deletePoolEntry).not.toHaveBeenCalled();
   });
 
   test("unknown poolId (findById null) is an idempotent no-op — no destroy attempted", async () => {

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.ts
@@ -86,6 +86,10 @@ export class HetznerPoolContainerCreator implements PoolContainerCreator {
     if (!result.success && result.error !== "Agent not found") {
       throw new Error(`pool destroy failed: ${result.error}`);
     }
+    // Unresolved remote teardown retains the row as a capacity-ownership
+    // tombstone. Deleting it here would erase the orphan reaper's exactly-once
+    // release claim, so only clean deletion may run the defensive no-op below.
+    if (result.success && !result.rowDeleted) return;
     // deleteAgent already removes the row, but if it short-circuited (e.g.
     // because the container was never started) the pool row may still exist.
     // deletePoolEntry is a no-op (returns false) when the row is already gone,

--- a/packages/cloud/shared/src/lib/services/docker-node-workload-queries.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workload-queries.ts
@@ -19,20 +19,6 @@ export const TERMINAL_SANDBOX_STATUSES = [
 export const TERMINAL_SANDBOX_STATUS_SET: ReadonlySet<string> = new Set(TERMINAL_SANDBOX_STATUSES);
 
 /**
- * Whether a row still holds one counted slot in `docker_nodes.allocated_count`.
- *
- * Seeds `agent_sandboxes.deletion_allocation_counted` when a deletion generation
- * starts, so it must be evaluated against the PRE-delete lifecycle state, before
- * the row moves to `deletion_pending`.
- *
- * Derived from `TERMINAL_SANDBOX_STATUSES` rather than listing statuses again,
- * because the two rules must not drift: `syncAllocatedCounts` periodically
- * RECOMPUTES `allocated_count` from that same set, so any status this treated as
- * still-counted while the recount treated it as free would be released twice —
- * once by the recount, once by the deletion CAS — which is the exact double-free
- * #17185 exists to close. A row with no `node_id` was never placed at all.
- */
-/**
  * Whether a row is ALREADY inside a deletion generation, so a new delete request
  * continues it rather than establishing a fresh one.
  *
@@ -62,6 +48,20 @@ export function isDeletionContinuation(row: {
   );
 }
 
+/**
+ * Whether a row still holds one counted slot in `docker_nodes.allocated_count`.
+ *
+ * Seeds `agent_sandboxes.deletion_allocation_counted` when a deletion generation
+ * starts, so it must be evaluated against the PRE-delete lifecycle state, before
+ * the row moves to `deletion_pending`.
+ *
+ * Derived from `TERMINAL_SANDBOX_STATUSES` rather than listing statuses again,
+ * because the two rules must not drift: `syncAllocatedCounts` periodically
+ * RECOMPUTES `allocated_count` from that same set, so any status this treated as
+ * still-counted while the recount treated it as free would be released twice —
+ * once by the recount, once by the deletion CAS — which is the exact double-free
+ * #17185 exists to close. A row with no `node_id` was never placed at all.
+ */
 export function holdsCountedNodeSlot(row: { status: string; node_id: string | null }): boolean {
   if (!row.node_id) return false;
   return !TERMINAL_SANDBOX_STATUS_SET.has(row.status);
@@ -92,8 +92,8 @@ export async function countAllocatedWorkloadsOnNodeWithDatabase(
           eq(agentSandboxes.node_id, nodeId),
           // Recorded allocation ownership outranks status. Once a deletion
           // generation has handed its slot back the row stops consuming
-          // capacity immediately, even though it lingers in `deletion_pending`
-          // until the row delete commits; conversely a `deletion_failed` row
+          // capacity immediately, even though it can linger in a deletion
+          // status until final row cleanup; conversely a `deletion_failed` row
           // that still owns its slot genuinely occupies one, which a
           // status-only rule counted as free (#17185).
           //

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
@@ -53,7 +53,7 @@ describe("countAllocatedWorkloadsOnNode — live-slot accounting (#15378)", () =
     where.mockClear();
   });
 
-  test("the agent_sandboxes filter excludes every terminal status, not just stopped/error", async () => {
+  test("the agent_sandboxes filter recognizes every terminal status before ownership override", async () => {
     await countAllocatedWorkloadsOnNode("node-under-test");
 
     // Two queries run (containers + agent_sandboxes); the agent one is the
@@ -63,8 +63,9 @@ describe("countAllocatedWorkloadsOnNode — live-slot accounting (#15378)", () =
       .find((params) => params.includes("sleeping"));
 
     expect(agentParams).toBeDefined();
-    // Regression: the previous filter only excluded stopped/error, so sleeping
-    // and deletion_failed sandboxes kept holding phantom slots.
+    // Regression: the status vocabulary previously omitted sleeping and
+    // deletion_failed. The query's ownership branch may still count a terminal
+    // deletion row when its container has not been proven stopped.
     for (const terminal of ["stopped", "error", "sleeping", "deletion_failed"]) {
       expect(agentParams).toContain(terminal);
     }

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -39,18 +39,16 @@ async function countRows(query: Promise<Array<{ count: number }>>): Promise<numb
   return row.count;
 }
 
-/**
- * agent_sandboxes statuses that mean the container should NOT be running. A
- * container backing a row in one of these states is reapable just like one
- * with no row at all: the lifecycle has decided this agent has no live
- * container, so a leftover Docker process is a leak.
- *
- * `deletion_failed` is included deliberately — that state exists precisely
- * because the delete-time container teardown did not succeed, so reaping it
- * here is the recovery path. `deletion_pending` is NOT terminal: an
- * agent_delete job is actively in flight and owns the teardown; reaping under
- * it would race the worker.
- */
+/** Postgres `undefined_column` — the shape a pre-migration read takes. */
+const UNDEFINED_COLUMN = "42703";
+
+function isUndefinedColumn(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === UNDEFINED_COLUMN
+  );
+}
 
 /**
  * Active compute slots on a Docker node.
@@ -72,17 +70,6 @@ async function countRows(query: Promise<Array<{ count: number }>>): Promise<numb
  * `disconnected` is deliberately NOT excluded: it is non-terminal (the
  * container is up but unreachable) and still occupies the slot.
  */
-/** Postgres `undefined_column` — the shape a pre-migration read takes. */
-const UNDEFINED_COLUMN = "42703";
-
-function isUndefinedColumn(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as { code?: unknown }).code === UNDEFINED_COLUMN
-  );
-}
-
 export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<number> {
   // Repair-on-failure rather than prophylactic DDL. This is the placement hot
   // path (`getAvailableNode`, the autoscaler, `syncAllocatedCounts`, each once
@@ -103,15 +90,32 @@ export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<num
   try {
     return await countAllocatedWorkloadsOnNodeWithDatabase(dbRead, nodeId);
   } catch (error) {
-    // error-policy:J2 context-adding rethrow — the retry is the handling; any
-    // other failure, and any failure of the retry itself, propagates with cause.
-    if (!isUndefinedColumn(error)) throw error;
+    // error-policy:J2 context-adding rethrow — only the known pre-migration
+    // shape is repairable; every other database failure keeps its cause and the
+    // node whose placement count could not be established.
+    if (!isUndefinedColumn(error)) {
+      throw new ElizaError("Failed to count allocated workloads on Docker node", {
+        code: "DOCKER_NODE_WORKLOAD_COUNT_FAILED",
+        context: { nodeId },
+        cause: error,
+      });
+    }
     logger.warn(
       "[docker-node-workloads] Workload count hit a missing column; applying agent-sandbox schema ensure and retrying once",
       { nodeId },
     );
-    await ensureAgentSandboxSchema();
-    return countAllocatedWorkloadsOnNodeWithDatabase(dbRead, nodeId);
+    try {
+      await ensureAgentSandboxSchema();
+      return await countAllocatedWorkloadsOnNodeWithDatabase(dbRead, nodeId);
+    } catch (retryError) {
+      // error-policy:J2 context-adding rethrow — a failed repair must distinguish
+      // the recovery path from an ordinary placement query failure.
+      throw new ElizaError("Failed to repair the Docker workload-count schema", {
+        code: "DOCKER_NODE_WORKLOAD_SCHEMA_REPAIR_FAILED",
+        context: { nodeId },
+        cause: retryError,
+      });
+    }
   }
 }
 
@@ -229,17 +233,11 @@ export async function loadSandboxStatusesByIds(
 }
 
 /**
- * The agent-specific deltas injected into the shared reconciler. Agents are
- * `nodeAware`: a sandbox has exactly one canonical node (`node_id`), so a
- * container found on any OTHER node is a stale twin from a re-provision that
- * moved the workload (#15228). Apps deliberately fan one name across rows and
- * are NOT node-aware.
- */
-/**
- * Exported so a test can drive the REAL wiring rather than a copy: the contract
- * that `keyOf` yields an `agent_sandboxes.id` — which `onReaped` then feeds to a
- * CAS keyed on that column — is an assumption spanning two modules, and a copy
- * of the config in a test would assert nothing about the one production uses.
+ * Agent-specific deltas injected into the shared reconciler. Agents are
+ * `nodeAware`: a sandbox has exactly one canonical node, so a container on any
+ * other node is a stale twin from a moved workload (#15228). Tests consume the
+ * exported production wiring because `keyOf` and the release callback share an
+ * `agent_sandboxes.id` contract that a copied fixture would not verify.
  */
 export const AGENT_ORPHAN_RECONCILER_CONFIG: OrphanReconcilerConfig = {
   prefix: AGENT_CONTAINER_NAME_PREFIX,
@@ -251,8 +249,8 @@ export const AGENT_ORPHAN_RECONCILER_CONFIG: OrphanReconcilerConfig = {
   rowlessGraceMs: DEFAULT_ROWLESS_GRACE_MS,
   nodeMoveGraceMs: DEFAULT_NODE_MOVE_GRACE_MS,
   // Reaping is the only step that PROVES an agent container is gone, so it is
-  // where a deletion generation that could not prove absence finally hands its
-  // node slot back (#17185).
+  // where a deletion generation that could not prove the workload stopped
+  // finally hands its node slot back (#17185).
   onReaped: async (agentId, nodeId) => {
     await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, nodeId);
   },

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -69,6 +69,7 @@ import { DEFAULT_REGISTRATION_TIMEOUT_MS, headscaleIntegration } from "./headsca
 import { buildKeylessOpenAIContainerEnv } from "./managed-eliza-env";
 import type {
   SandboxCreateConfig,
+  SandboxDeletionStopOutcome,
   SandboxHandle,
   SandboxHealthOutcome,
   SandboxProvider,
@@ -571,7 +572,7 @@ const DOCKER_CMD_TIMEOUT_MS = 60_000;
  */
 const STOP_CMD_TIMEOUT_MS = 25_000;
 
-/** Cap on the best-effort headscale VPN cleanup during stop(). */
+/** Cap on best-effort Headscale VPN cleanup during sandbox teardown. */
 const HEADSCALE_CLEANUP_TIMEOUT_MS = 15_000;
 
 /** Autoscaled node readiness polling. */
@@ -2306,12 +2307,13 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
   }
 
-  async stop(sandboxId: string): Promise<void> {
+  async stopForDeletion(sandboxId: string): Promise<SandboxDeletionStopOutcome> {
     // Deletion is the one teardown whose capacity is owned elsewhere: the
     // caller's deletion generation releases the slot exactly once via
     // `tryReleaseDeletionAllocation`, because this path is retryable and
-    // treats "already gone" as success (#17185).
-    await this.stopWithPolicy(sandboxId, true, false);
+    // treats either a successful stop or "already gone" as proof that the
+    // workload no longer consumes compute (#17185).
+    return this.stopWithPolicy(sandboxId, true, false);
   }
 
   /**
@@ -2332,7 +2334,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     sandboxId: string,
     allowUnreachableAbandon: boolean,
     releaseCapacity: boolean,
-  ): Promise<void> {
+  ): Promise<SandboxDeletionStopOutcome> {
     const meta = await this.resolveContainer(sandboxId);
 
     logger.info(
@@ -2376,6 +2378,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       );
     }
 
+    let outcome: SandboxDeletionStopOutcome = { kind: "not-running-proven" };
     if (stopErr && rmErr) {
       const stopMsg = stopErr instanceof Error ? stopErr.message : String(stopErr);
       const rmMsg = rmErr instanceof Error ? rmErr.message : String(rmErr);
@@ -2397,16 +2400,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       // cloud-api fails closed (agents API hangs).
       //
       // TRADE-OFF / HONEST LIMITATION: completing the delete here ABANDONS the
-      // container. There is currently NO automatic reclaimer — no orphan-sweep /
-      // node-reconcile job exists that lists actual containers on a node and
-      // removes ones with no DB row. So if the node later returns, the container
-      // (and its headscale registration, if deletion was skipped) can leak until
-      // such a sweeper is built or it is reclaimed by hand. We accept that leak
-      // to keep the work cycle bounded; the lifecycle/capacity owner should add
-      // a node-reconcile sweep when one lands. Do NOT claim a reconciler already
-      // reclaims it. The abandoned container's node slot is still released once
-      // by the caller's deletion generation — an abandoned container leaks on
-      // the box, not in `allocated_count`.
+      // container. The orphan reconciler retains the deletion generation's
+      // capacity ownership until it can inspect the node and prove the workload
+      // absent. This prevents the scheduler from packing against capacity that
+      // an abandoned container may still consume.
       const unreachable = isNodeUnreachableMessage(stopMsg) && isNodeUnreachableMessage(rmMsg);
       if (!stopIsGone && !rmIsGone && (!unreachable || !allowUnreachableAbandon)) {
         throw new Error(
@@ -2415,10 +2412,10 @@ export class DockerSandboxProvider implements SandboxProvider {
         );
       }
       if (unreachable) {
+        outcome = { kind: "not-running-unresolved", reason: "node-unreachable" };
         logger.warn(
           `[docker-sandbox] Node ${meta.hostname} unreachable during stop of ${meta.containerName}; ` +
-            `completing delete and ABANDONING the container — it will LEAK until reclaimed ` +
-            `(no automatic orphan-sweep / node-reconcile job exists yet) — ` +
+            `completing delete while retaining its capacity until reconciliation — ` +
             `docker stop -> ${stopMsg}; docker rm -f -> ${rmMsg}`,
           { nodeId: meta.nodeId, containerName: meta.containerName },
         );
@@ -2436,6 +2433,8 @@ export class DockerSandboxProvider implements SandboxProvider {
     // times for one allocation and free a live sibling's slot (#17185).
     if (releaseCapacity) {
       await dockerNodesRepository.decrementAllocated(meta.nodeId).catch((err) => {
+        // error-policy:J6 best-effort teardown — the workload is already not
+        // running; the logged overcount is safe and the periodic recount heals it.
         logger.warn(
           `[docker-sandbox] Failed to decrement allocated_count for node ${meta.nodeId}: ${err instanceof Error ? err.message : String(err)}`,
         );
@@ -2463,6 +2462,8 @@ export class DockerSandboxProvider implements SandboxProvider {
       if (cleanup) {
         await withTimeout(cleanup, HEADSCALE_CLEANUP_TIMEOUT_MS, "headscale cleanup").catch(
           (err) => {
+            // error-policy:J6 best-effort teardown — compute teardown is already
+            // complete, so VPN cleanup failure is observable without reviving it.
             logger.warn(
               `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
             );
@@ -2477,6 +2478,7 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // Remove from in-memory registry
     this.containers.delete(meta.containerName);
+    return outcome;
   }
 
   // ------------------------------------------------------------------
@@ -2882,7 +2884,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     };
 
     // Docker handles use the container name as sandboxId, so the refreshed row
-    // updates the same cache key used by create(), stop(), and runCommand().
+    // updates the same cache key used by create, teardown, and runCommand.
     this.containers.set(sandboxId, meta);
     logger.info(
       `[docker-sandbox] Hydrated container "${sandboxId}" from DB -> node ${meta.nodeId} (${meta.hostname})`,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -233,14 +233,21 @@ function expectSameReplacement(
 function replacementAwareProvider<T extends SandboxProvider>(provider: T): T {
   const mutable = provider as T & {
     [replacementAwareProviderMarker]?: true;
+    stop?: (sandboxId: string) => Promise<void>;
   };
   if (mutable[replacementAwareProviderMarker]) return provider;
   mutable[replacementAwareProviderMarker] = true;
   const originalCreate = provider.create.bind(provider);
   if (!provider.stopForReplacement) {
-    provider.stopForReplacement = async (sandboxId) => {
-      await provider.stop(sandboxId);
-    };
+    const legacyFixtureStop = mutable.stop?.bind(provider);
+    provider.stopForReplacement = legacyFixtureStop
+      ? legacyFixtureStop
+      : async (sandboxId) => {
+          const outcome = await provider.stopForDeletion(sandboxId);
+          if (outcome.kind !== "not-running-proven") {
+            throw new Error("Replacement fixture could not prove the sandbox stopped");
+          }
+        };
   }
   provider.create = async (config: SandboxCreateConfig): Promise<SandboxHandle> => {
     let intentCalled = false;
@@ -1214,7 +1221,7 @@ describe("ElizaSandboxService wake", () => {
             webUiPort: 3000,
           },
         })),
-        stop: mock(async () => {}),
+        stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
         checkHealth: mock(async () => true),
       };
       const requests: string[] = [];
@@ -1367,7 +1374,8 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
           webUiPort: 3000,
         },
       })),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
       checkHealth: mock(async () => true),
     };
     globalThis.fetch = mock(async (input: RequestInfo | URL) => {
@@ -1457,7 +1465,7 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
         h.rec.id,
         expect.objectContaining({ status: "error" }),
       );
-      expect(h.provider.stop).toHaveBeenCalled();
+      expect(h.provider.stopForReplacement).toHaveBeenCalled();
     } finally {
       h.restore();
     }
@@ -1523,7 +1531,7 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
         h.rec.id,
         expect.objectContaining({ status: "error" }),
       );
-      expect(h.provider.stop).toHaveBeenCalled();
+      expect(h.provider.stopForReplacement).toHaveBeenCalled();
       expect(h.pruneSpy).not.toHaveBeenCalled();
     } finally {
       h.restore();
@@ -1566,7 +1574,7 @@ describe("ElizaSandboxService shutdown fails closed without a current capture (#
       create: mock(async () => {
         throw new Error("must not create");
       }),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement: mock(async () => {}),
       checkHealth: mock(async () => true),
     };
@@ -1585,7 +1593,7 @@ describe("ElizaSandboxService shutdown fails closed without a current capture (#
       expect(result.success).toBe(false);
       expect(result.error).toContain("Refusing to stop without a current backup");
       expect(result.error).toContain("snapshot endpoint timed out");
-      expect(provider.stop).not.toHaveBeenCalled();
+      expect(provider.stopForDeletion).not.toHaveBeenCalled();
       expect(provider.stopForReplacement).not.toHaveBeenCalled();
     } finally {
       getForWrite.mockRestore();
@@ -1602,7 +1610,7 @@ describe("ElizaSandboxService sleep refuses an unproven fallback backup (#17180 
       create: mock(async () => {
         throw new Error("must not create");
       }),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement: mock(async () => {}),
       checkHealth: mock(async () => true),
     };
@@ -1659,7 +1667,7 @@ describe("ElizaSandboxService sleep refuses an unproven fallback backup (#17180 
       expect(result.success).toBe(false);
       expect(result.containerRemoved).toBe(false);
       expect(result.error).toContain("Refusing to deactivate on an unproven backup");
-      expect(provider.stop).not.toHaveBeenCalled();
+      expect(provider.stopForDeletion).not.toHaveBeenCalled();
       expect(provider.stopForReplacement).not.toHaveBeenCalled();
       expect(updateSpy).not.toHaveBeenCalled();
     } finally {
@@ -1682,7 +1690,8 @@ describe("ElizaSandboxService sleep", () => {
         bridgeUrl: "https://runtime.example",
         healthUrl: "https://runtime.example/health",
       })),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
       checkHealth: mock(async () => true),
     };
     globalThis.fetch = mock(async () => {
@@ -1714,7 +1723,7 @@ describe("ElizaSandboxService sleep", () => {
         error:
           "Unable to create or find a durable backup before deactivation; agent was left running.",
       });
-      expect(provider.stop).not.toHaveBeenCalled();
+      expect(provider.stopForDeletion).not.toHaveBeenCalled();
       expect(createBackupSpy).not.toHaveBeenCalled();
       expect(updateSpy).not.toHaveBeenCalled();
     } finally {
@@ -3073,7 +3082,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       create: mock(async () => {
         throw new Error("must not create");
       }),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement: mock(async () => {
         throw new Error("old node unreachable");
       }),
@@ -3121,7 +3130,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
         error: "Failed to prove the previous sandbox stopped",
       });
       expect(provider.stopForReplacement).toHaveBeenCalledWith(rec.sandbox_id);
-      expect(provider.stop).not.toHaveBeenCalled();
+      expect(provider.stopForDeletion).not.toHaveBeenCalled();
       expect(writes).toHaveLength(0);
       expect(provision).not.toHaveBeenCalled();
     } finally {
@@ -3149,7 +3158,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       create: mock(async () => {
         throw new Error("provision is spied");
       }),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement: mock(async () => {}),
       checkHealth: mock(async () => true),
     };
@@ -3246,7 +3255,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       create: mock(async () => {
         throw new Error("must not create");
       }),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement: mock(async () => {}),
       checkHealth: mock(async () => true),
     };
@@ -3298,7 +3307,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       create: mock(async () => {
         throw new Error("must not create");
       }),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement: mock(async () => {
         throw new Error("old node unreachable");
       }),
@@ -3400,7 +3409,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       create: mock(async () => {
         throw new Error("must not create");
       }),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement: mock(async () => {
         throw new Error("old node unreachable");
       }),
@@ -3432,7 +3441,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
         error: "old node unreachable",
       });
       expect(provider.stopForReplacement).toHaveBeenCalledWith(rec.sandbox_id);
-      expect(provider.stop).not.toHaveBeenCalled();
+      expect(provider.stopForDeletion).not.toHaveBeenCalled();
       expect(tx.writes).toHaveLength(0);
     } finally {
       upgradeTransactionImpl = null;
@@ -3459,7 +3468,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       create: mock(async () => {
         throw new Error("must not create");
       }),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement: mock(async () => {}),
       checkHealth: mock(async () => true),
     };
@@ -3509,7 +3518,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       create: mock(async () => {
         throw new Error("must not create");
       }),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement: mock(async () => {}),
       checkHealth: mock(async () => true),
     };
@@ -3586,6 +3595,7 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
       | { ok: false; error: string }
     >;
     commitAgentRowDelete(agentId: string, orgId: string): Promise<unknown>;
+    commitAgentReconciliationPending(agentId: string, orgId: string): Promise<unknown>;
     runBoundedSandboxStop(sandboxId: string): Promise<unknown>;
   };
 
@@ -3594,7 +3604,7 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     return new ElizaSandboxService() as unknown as Svc;
   }
 
-  test("(a) teardown timeout → delete still proceeds (row deleted) + leak warning, no phantom 'handled'", async () => {
+  test("(a) teardown timeout completes the attempt but retains a reconciliation tombstone", async () => {
     const svc = await makeSvc();
     const deletedSandbox = { ...customSandbox(), id: AGENT, organization_id: ORG };
     const prepare = spyOn(svc, "prepareAgentDelete").mockResolvedValue({
@@ -3603,13 +3613,20 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
       status: "running",
       sourcePoolId: null,
     });
-    // Timed-out teardown is reported as the { error, timedOut } shape.
+    // Timed-out teardown is reported as an explicit tagged outcome.
     const stop = spyOn(svc, "runBoundedSandboxStop").mockResolvedValue({
+      kind: "stop-timed-out",
       error: new Error("agent-delete stop sandbox-e06bb509 timed out after 120000ms"),
-      timedOut: true,
     });
     const commit = spyOn(svc, "commitAgentRowDelete").mockResolvedValue({
       success: true,
+      rowDeleted: true,
+      deletedSandbox,
+    });
+    const retain = spyOn(svc, "commitAgentReconciliationPending").mockResolvedValue({
+      success: true,
+      rowDeleted: false,
+      reconciliationPending: true,
       deletedSandbox,
     });
     const apiKeySpy = spyOn(apiKeysService, "revokeForAgent").mockResolvedValue(undefined as never);
@@ -3618,22 +3635,25 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     try {
       const res = (await svc.deleteAgent(AGENT, ORG)) as {
         success: boolean;
+        rowDeleted?: boolean;
         deletedSandbox?: unknown;
       };
-      // A hang must NOT block the delete — the row is still removed.
+      // A hang does not retry in the hot queue, but its ownership row remains.
       expect(res.success).toBe(true);
+      expect(res.rowDeleted).toBe(false);
       expect(res.deletedSandbox).toEqual(deletedSandbox);
-      expect(commit).toHaveBeenCalledTimes(1);
-      // The warning must flag a real leak — not pretend an orphan got swept.
+      expect(commit).not.toHaveBeenCalled();
+      expect(retain).toHaveBeenCalledTimes(1);
+      // The warning must flag abandonment while preserving capacity accounting.
       const warned = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
       expect(warned).toContain("timed out");
       expect(warned).toContain("ABANDONING");
-      expect(warned).toContain("LEAK");
-      expect(warned).not.toContain("reconciler sweeps");
+      expect(warned).toContain("retaining its capacity");
     } finally {
       prepare.mockRestore();
       stop.mockRestore();
       commit.mockRestore();
+      retain.mockRestore();
       apiKeySpy.mockRestore();
       historySpy.mockRestore();
       warnSpy.mockRestore();
@@ -3650,6 +3670,7 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     });
     // Bounded (non-timeout) failure with a non-ignorable message.
     const stop = spyOn(svc, "runBoundedSandboxStop").mockResolvedValue({
+      kind: "stop-failed",
       error: new Error("docker stop -> daemon hung; docker rm -f -> daemon hung"),
     });
     const commit = spyOn(svc, "commitAgentRowDelete");
@@ -3679,10 +3700,12 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
       sourcePoolId: null,
     });
     const stop = spyOn(svc, "runBoundedSandboxStop").mockResolvedValue({
+      kind: "stop-failed",
       error: new Error("container not found"),
     });
     const commit = spyOn(svc, "commitAgentRowDelete").mockResolvedValue({
       success: true,
+      rowDeleted: true,
       deletedSandbox,
     });
     const apiKeySpy = spyOn(apiKeysService, "revokeForAgent").mockResolvedValue(undefined as never);
@@ -3722,12 +3745,14 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     // points at a node that no longer has a docker_nodes record: the host is
     // gone, so there is nothing left to stop.
     const stop = spyOn(svc, "runBoundedSandboxStop").mockResolvedValue({
+      kind: "stop-failed",
       error: new Error(
         '[docker-sandbox] Missing persisted docker node metadata for node "node-decommissioned"',
       ),
     });
     const commit = spyOn(svc, "commitAgentRowDelete").mockResolvedValue({
       success: true,
+      rowDeleted: true,
       deletedSandbox,
     });
     const apiKeySpy = spyOn(apiKeysService, "revokeForAgent").mockResolvedValue(undefined as never);
@@ -3764,6 +3789,7 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     // A sibling hydrateContainerFromDb failure that does NOT mean the host is
     // gone — the container may still be running, so the delete must escalate.
     const stop = spyOn(svc, "runBoundedSandboxStop").mockResolvedValue({
+      kind: "stop-failed",
       error: new Error(
         '[docker-sandbox] Missing port data for "sandbox-e06bb509": bridge=null, webUi=null',
       ),
@@ -3798,11 +3824,15 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     });
     const stop = spyOn(svc, "runBoundedSandboxStop").mockImplementation(async () => {
       order.push("teardown");
-      return null;
+      return { kind: "not-running-proven" };
     });
     const commit = spyOn(svc, "commitAgentRowDelete").mockImplementation(async () => {
       order.push("commit");
-      return { success: true, deletedSandbox: { ...customSandbox(), id: AGENT } };
+      return {
+        success: true,
+        rowDeleted: true,
+        deletedSandbox: { ...customSandbox(), id: AGENT },
+      };
     });
     const apiKeySpy = spyOn(apiKeysService, "revokeForAgent").mockImplementation(
       async (credentialOwnerId) => {
@@ -3839,7 +3869,9 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
       status: "error",
       sourcePoolId,
     });
-    const stop = spyOn(svc, "runBoundedSandboxStop").mockResolvedValue(null);
+    const stop = spyOn(svc, "runBoundedSandboxStop").mockResolvedValue({
+      kind: "not-running-proven",
+    });
     const commit = spyOn(svc, "commitAgentRowDelete");
     const apiKeySpy = spyOn(apiKeysService, "revokeForAgent")
       .mockResolvedValueOnce(undefined)
@@ -3856,15 +3888,17 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     }
   });
 
-  test("runBoundedSandboxStop returns null on a clean provider stop", async () => {
+  test("runBoundedSandboxStop returns proven absence from a clean provider stop", async () => {
     const svc = await makeSvc();
     const getProvider = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ stop: async () => {} } as unknown as SandboxProvider);
+    ).mockResolvedValue({
+      stopForDeletion: async () => ({ kind: "not-running-proven" as const }),
+    } as unknown as SandboxProvider);
     try {
       const res = await svc.runBoundedSandboxStop(SANDBOX_ID);
-      expect(res).toBeNull();
+      expect(res).toEqual({ kind: "not-running-proven" });
     } finally {
       getProvider.mockRestore();
     }
@@ -3877,54 +3911,49 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
     ).mockResolvedValue({
-      stop: async () => {
+      stopForDeletion: async () => {
         throw boom;
       },
     } as unknown as SandboxProvider);
     try {
       const res = (await svc.runBoundedSandboxStop(SANDBOX_ID)) as {
+        kind: string;
         error: unknown;
-        timedOut?: true;
       };
+      expect(res.kind).toBe("stop-failed");
       expect(res.error).toBe(boom);
-      // A captured error is NOT a timeout — the delete must treat it as a real
-      // failure, not abandon-and-proceed.
-      expect("timedOut" in res).toBe(false);
     } finally {
       getProvider.mockRestore();
     }
   });
 
-  // The whole reason #9066 exists: a provider.stop that genuinely never
+  // The whole reason #9066 exists: a provider stop that genuinely never
   // settles (SSH connect / provider init wedge) must be cut off at the hard
   // cap so a single stuck node can't hang the delete past the job watchdog and
   // wedge the provisioning worker. The two tests above cover clean/error; this
   // one drives the REAL withTimeout branch — a never-settling stop raced under
-  // fake timers — and asserts the abandon-and-proceed { error, timedOut }
-  // shape that deleteAgent keys "ABANDON + LEAK" on.
-  test("runBoundedSandboxStop cuts off a never-settling provider stop with { error, timedOut }", async () => {
+  // fake timers — and asserts the tagged timeout used to preserve capacity.
+  test("runBoundedSandboxStop cuts off a never-settling provider stop", async () => {
     const svc = await makeSvc();
     // Never resolves and never rejects: the only way out is the timeout race.
     const getProvider = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
     ).mockResolvedValue({
-      stop: () => new Promise<void>(() => {}),
+      stopForDeletion: () => new Promise<never>(() => {}),
     } as unknown as SandboxProvider);
     jest.useFakeTimers();
     try {
       const pending = svc.runBoundedSandboxStop(SANDBOX_ID) as Promise<{
+        kind: string;
         error: unknown;
-        timedOut?: true;
       }>;
       // Let getProvider() + the try-body microtasks settle so the timeout
       // timer is actually armed, then blow past the 120s hard cap.
       await Promise.resolve();
       jest.advanceTimersByTime(120_001);
       const res = await pending;
-      // Abandon-and-proceed: a genuine hang is reported as a TIMEOUT, distinct
-      // from a captured provider error (no `timedOut` flag on that path).
-      expect(res.timedOut).toBe(true);
+      expect(res.kind).toBe("stop-timed-out");
       expect(res.error).toBeInstanceOf(Error);
       expect((res.error as Error).message).toContain("timed out after");
     } finally {
@@ -4024,7 +4053,7 @@ describe("failed warm-claim replacement teardown", () => {
     const stopForReplacement = mock(async () => {});
     const provider: SandboxProvider = {
       create,
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement,
       checkHealth: mock(async () => true),
     };
@@ -4121,7 +4150,7 @@ describe("failed warm-claim replacement teardown", () => {
     });
     const provider: SandboxProvider = {
       create,
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement,
       checkHealth: mock(async () => true),
     };
@@ -4255,7 +4284,7 @@ describe("failed warm-claim replacement teardown", () => {
     }));
     const provider: SandboxProvider = {
       create,
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
       stopForReplacement,
       checkHealth: mock(async () => true),
     };
@@ -4506,7 +4535,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const create = mock(async () => providerHandle());
     const provider: SandboxProvider = {
       create,
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
       checkHealth: mock(async () => true),
     };
     try {
@@ -4543,7 +4573,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const create = mock(async () => providerHandle());
     const provider: SandboxProvider = {
       create,
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
       checkHealth: mock(async () => true),
     };
     try {
@@ -4663,7 +4694,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       "getProvider",
     ).mockResolvedValue({
       create,
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
       checkHealth: async () => true,
     } as SandboxProvider);
 
@@ -4725,7 +4757,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       "getProvider",
     ).mockResolvedValue({
       create,
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
       checkHealth: async () => true,
     } as SandboxProvider);
 
@@ -4985,7 +5018,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     });
     const provider: SandboxProvider = {
       create: mock(async () => handle),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
       checkHealth: async () => true,
     };
     const svc = new ElizaSandboxService(provider);
@@ -5041,7 +5075,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     );
     const provider: SandboxProvider = {
       create: mock(async () => providerHandle()),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
       checkHealth: mock(async () => true),
     };
     reactivateBillingSpy.mockClear();
@@ -5116,7 +5151,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       "getProvider",
     ).mockResolvedValue({
       create: mock(async () => providerHandle()),
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
       checkHealth: async () => true,
     } as SandboxProvider);
     try {
@@ -5366,7 +5402,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       "getProvider",
     ).mockResolvedValue({
       create,
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
       checkHealth: async () => true,
     } as SandboxProvider);
     try {
@@ -5702,7 +5739,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       "getProvider",
     ).mockResolvedValue({
       create,
-      stop: mock(async () => {}),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
       checkHealth: async () => true,
     } as SandboxProvider);
     try {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -24,6 +24,7 @@ import * as realHelpersNs from "../../db/helpers";
 import { agentBillingRepository } from "../../db/repositories/agent-billing";
 import type { AgentSandbox, AgentSandboxBackup } from "../../db/repositories/agent-sandboxes";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import { userCharactersRepository } from "../../db/repositories/characters";
 import type { DockerNode } from "../../db/repositories/docker-nodes";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { sharedRuntimeHistoryRepository } from "../../db/repositories/shared-runtime-history";
@@ -3582,6 +3583,15 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
 
   type Svc = {
     deleteAgent(agentId: string, orgId: string): Promise<unknown>;
+    executeDeletion(
+      agentId: string,
+      orgId: string,
+    ): Promise<{
+      success: boolean;
+      containerStopped: boolean;
+      rowDeleted: boolean;
+      error?: string;
+    }>;
     prepareAgentDelete(
       agentId: string,
       orgId: string,
@@ -3603,6 +3613,51 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     return new ElizaSandboxService() as unknown as Svc;
   }
+
+  test("linked character cleanup waits until the reconciliation tombstone is removed", async () => {
+    const svc = await makeSvc();
+    const characterId = "44444444-4444-4444-8444-444444444444";
+    const deletedSandbox = {
+      ...customSandbox(),
+      id: AGENT,
+      organization_id: ORG,
+      character_id: characterId,
+      agent_config: {},
+    };
+    const deletion = spyOn(svc, "deleteAgent")
+      .mockResolvedValueOnce({
+        success: true,
+        rowDeleted: false,
+        reconciliationPending: true,
+        deletedSandbox,
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        rowDeleted: true,
+        deletedSandbox,
+      });
+    const deleteCharacter = spyOn(userCharactersRepository, "delete").mockResolvedValue(undefined);
+
+    try {
+      await expect(svc.executeDeletion(AGENT, ORG)).resolves.toEqual({
+        success: true,
+        containerStopped: false,
+        rowDeleted: false,
+      });
+      expect(deleteCharacter).not.toHaveBeenCalled();
+
+      await expect(svc.executeDeletion(AGENT, ORG)).resolves.toEqual({
+        success: true,
+        containerStopped: true,
+        rowDeleted: true,
+      });
+      expect(deleteCharacter).toHaveBeenCalledTimes(1);
+      expect(deleteCharacter).toHaveBeenCalledWith(characterId);
+    } finally {
+      deletion.mockRestore();
+      deleteCharacter.mockRestore();
+    }
+  });
 
   test("(a) teardown timeout completes the attempt but retains a reconciliation tombstone", async () => {
     const svc = await makeSvc();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -106,7 +106,10 @@ import {
   type SandboxHandle,
   type SandboxProvider,
 } from "./sandbox-provider";
-import { SandboxReplacementCleanupUnresolvedError } from "./sandbox-provider-types";
+import {
+  type SandboxDeletionStopOutcome,
+  SandboxReplacementCleanupUnresolvedError,
+} from "./sandbox-provider-types";
 import { isDedicatedBootstrapWindow } from "./shared-runtime/dedicated-bootstrap";
 import {
   type RunSharedAgentTurnResult,
@@ -380,7 +383,13 @@ export type ProvisionRestoreOverride =
   | { kind: "fresh-boot" };
 
 export type DeleteAgentResult =
-  | { success: true; deletedSandbox: AgentSandbox }
+  | { success: true; rowDeleted: true; deletedSandbox: AgentSandbox }
+  | {
+      success: true;
+      rowDeleted: false;
+      reconciliationPending: true;
+      deletedSandbox: AgentSandbox;
+    }
   | { success: false; error: string };
 
 /**
@@ -393,6 +402,11 @@ export type BoundedSandboxStopResult =
   | null
   | { error: unknown }
   | { error: unknown; timedOut: true };
+
+type BoundedDeletionSandboxStopResult =
+  | SandboxDeletionStopOutcome
+  | { kind: "stop-failed"; error: unknown }
+  | { kind: "stop-timed-out"; error: unknown };
 
 export interface BridgeRequest {
   jsonrpc: "2.0";
@@ -1733,7 +1747,8 @@ export class ElizaSandboxService {
   async deleteAgent(agentId: string, orgId: string): Promise<DeleteAgentResult> {
     // Phase 1 — short transaction: take the lifecycle lock, validate
     // preconditions, and capture the fields needed for teardown. We deliberately
-    // do NOT run the container teardown inside this transaction: provider.stop()
+    // do NOT run the container teardown inside this transaction:
+    // provider.stopForDeletion()
     // can hang on an early SSH connect / provider init, and holding the row lock
     // + write transaction + a pooled connection for the full teardown cap (up to
     // SANDBOX_DELETE_STOP_TIMEOUT_MS) would wedge concurrent lifecycle ops on the
@@ -1750,8 +1765,8 @@ export class ElizaSandboxService {
     });
 
     // Phase 2 — bounded container + VPN teardown, run OUTSIDE the write-lock /
-    // transaction. provider.stop() removes the container and cleans up the
-    // headscale route (each internally bounded), but an EARLY hang (SSH connect /
+    // transaction. provider.stopForDeletion() removes the container and cleans
+    // up the headscale route (each internally bounded), but an EARLY hang (SSH connect /
     // provider init) was unbounded — a single stuck node could hang this delete
     // past the 300s job watchdog and wedge the entire provisioning worker
     // (fail-closed on every provision).
@@ -1760,38 +1775,40 @@ export class ElizaSandboxService {
     // genuine hang. A real stop failure on a REACHABLE node still escalates
     // (returns failure / retry), since the container may still be running; an
     // "already gone" failure is ignorable and we proceed.
-    // Whether the container is PROVEN gone. A bounded timeout completes the
+    // Whether the container is PROVEN not running. A bounded timeout completes the
     // delete but abandons a container that may still be running, so it is not
     // proof — releasing its slot would let the scheduler pack new containers
     // onto a box still running the old ones.
-    let containerProvenGone = true;
+    let containerProvenNotRunning = true;
+    let reconciliationReason: string | null = null;
 
     if (precheck.sandboxId) {
       const sandboxId = precheck.sandboxId;
       const stop = await this.runBoundedSandboxStop(sandboxId);
 
-      if (stop) {
+      if (stop.kind === "stop-timed-out") {
         const errorMessage = stop.error instanceof Error ? stop.error.message : String(stop.error);
-        if ("timedOut" in stop) {
-          // The container may still be running, so this generation keeps its
-          // node slot. The orphan reconciler releases it once it proves the
-          // container is actually absent (#17185).
-          containerProvenGone = false;
-          // HONEST LIMITATION: there is currently NO automatic reclaimer — no
-          // orphan-sweep / node-reconcile job that lists actual containers on a
-          // node and removes ones with no DB row (see docker-sandbox-provider's
-          // unreachable-node path for the same trade-off). We complete the
-          // delete to keep the provisioning work cycle bounded, but on timeout
-          // the container (and its headscale registration) is ABANDONED and will
-          // LEAK until such a sweeper is built or it is reclaimed by hand. Do NOT
-          // claim a reconciler already reclaims it.
-          logger.warn(
-            "[agent-sandbox] Stop during delete timed out; completing delete and ABANDONING the " +
-              "container — it will LEAK until reclaimed (no automatic orphan-sweep / node-reconcile " +
-              "job exists yet)",
-            { sandboxId, status: precheck.status, error: errorMessage },
-          );
-        } else if (this.isIgnorableSandboxStopError(stop.error)) {
+        // The container may still be running, so this generation keeps its
+        // node slot. The orphan reconciler releases it once it proves the
+        // container is actually not running (#17185).
+        containerProvenNotRunning = false;
+        reconciliationReason = `container stop timed out: ${errorMessage}`;
+        logger.warn(
+          "[agent-sandbox] Stop during delete timed out; completing delete and ABANDONING the " +
+            "container while retaining its capacity until reconciliation",
+          { sandboxId, status: precheck.status, error: errorMessage },
+        );
+      } else if (stop.kind === "not-running-unresolved") {
+        containerProvenNotRunning = false;
+        reconciliationReason = stop.reason;
+        logger.warn(
+          "[agent-sandbox] Provider could not prove the container stopped during delete; " +
+            "retaining its capacity until reconciliation",
+          { sandboxId, status: precheck.status, reason: stop.reason },
+        );
+      } else if (stop.kind === "stop-failed") {
+        const errorMessage = stop.error instanceof Error ? stop.error.message : String(stop.error);
+        if (this.isIgnorableSandboxStopError(stop.error)) {
           logger.info("[agent-sandbox] Sandbox already absent during delete cleanup", {
             sandboxId,
             status: precheck.status,
@@ -1808,18 +1825,17 @@ export class ElizaSandboxService {
       }
     }
 
-    // The container is proven gone, so this generation hands its node slot back
+    // The container is proven not running, so this generation hands its node slot back
     // — and does so BEFORE the steps that can still fail below (credential
     // revocation, the row-delete CAS, job-status persistence). Those failures
     // re-run this whole path; the CAS is what makes the second run a no-op
     // instead of a second decrement that frees a live sibling's slot (#17185).
     //
-    // Two paths deliberately skip the release and keep ownership: a reachable
-    // stop FAILURE returns above without reaching here, and a bounded timeout
-    // abandons a container that may still be running. Both leave the slot
-    // counted until something proves absence — the retry that completes the
-    // teardown, or the orphan reconciler that reaps the container.
-    if (containerProvenGone && precheck.nodeId) {
+    // Unresolved teardown deliberately skips the release and keeps ownership.
+    // A reachable stop failure returns above; a timeout or unreachable node
+    // completes deletion but leaves the slot counted until the orphan
+    // reconciler proves the container absent.
+    if (containerProvenNotRunning && precheck.nodeId) {
       const outcome = await agentSandboxesRepository.tryReleaseDeletionAllocation(
         agentId,
         orgId,
@@ -1852,11 +1868,27 @@ export class ElizaSandboxService {
       await apiKeysService.revokeForAgent(credentialOwnerId);
     }
 
-    // Phase 3 — short transaction: re-take the lock, re-validate (a concurrent
-    // provision could have started while teardown ran), then delete the row.
-    const result = await this.commitAgentRowDelete(agentId, orgId, precheck);
+    // The ownership flag lives on the sandbox row, so unresolved teardown must
+    // preserve that row as a terminal tombstone. The orphan reaper consumes the
+    // flag after removing the immutable container ID; a later delete retry then
+    // observes explicit absence and removes the tombstone. Deleting the row here
+    // would erase the only proof that the node counter still includes this slot.
+    let result: DeleteAgentResult;
+    if (containerProvenNotRunning) {
+      result = await this.commitAgentRowDelete(agentId, orgId, precheck);
+    } else {
+      if (!reconciliationReason) {
+        throw new Error("Unresolved deletion is missing its reconciliation reason");
+      }
+      result = await this.commitAgentReconciliationPending(
+        agentId,
+        orgId,
+        precheck,
+        reconciliationReason,
+      );
+    }
 
-    if (result.success) {
+    if (result.success && result.rowDeleted) {
       // Best-effort: drop the shared-runtime (Tier-0) conversation history for
       // this agent. That table is deliberately decoupled from the sandbox row
       // (no FK cascade), so the per-channel history rows would otherwise be
@@ -2037,7 +2069,82 @@ export class ElizaSandboxService {
         .returning();
 
       return deletedSandbox
-        ? ({ success: true, deletedSandbox } as const)
+        ? ({ success: true, rowDeleted: true, deletedSandbox } as const)
+        : ({ success: false, error: "Agent not found" } as const);
+    });
+  }
+
+  /**
+   * Persists unresolved deletion as a terminal tombstone without spending its
+   * capacity ownership. This completes the queue attempt promptly while keeping
+   * the durable row the orphan reaper and low-frequency delete retry require.
+   */
+  private async commitAgentReconciliationPending(
+    agentId: string,
+    orgId: string,
+    ownership: {
+      sandboxId: string | null;
+      environmentRevision: number;
+      lifecycleRevision: number;
+      deletionAttemptId: string;
+    },
+    reason: string,
+  ): Promise<DeleteAgentResult> {
+    return dbWrite.transaction(async (tx) => {
+      await this.lockLifecycle(tx, agentId, orgId);
+
+      const rec = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
+      if (!rec) return { success: false, error: "Agent not found" } as const;
+      if (this.getReplacementCleanupLocator(rec)) {
+        return {
+          success: false,
+          error: "Agent replacement cleanup is still pending",
+        } as const;
+      }
+
+      const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(tx, agentId, orgId);
+      if (
+        rec.status !== "deletion_pending" ||
+        rec.deletion_attempt_id !== ownership.deletionAttemptId ||
+        rec.sandbox_id !== ownership.sandboxId ||
+        rec.environment_revision !== ownership.environmentRevision ||
+        rec.lifecycle_revision !== ownership.lifecycleRevision ||
+        hasActiveProvisionJob
+      ) {
+        return {
+          success: false,
+          error: "Agent deletion ownership changed",
+        } as const;
+      }
+
+      const [pendingSandbox] = await tx
+        .update(agentSandboxes)
+        .set({
+          status: "deletion_failed",
+          error_message: `Deletion is awaiting container reconciliation: ${reason}`,
+          error_count: sql`${agentSandboxes.error_count} + 1`,
+          updated_at: new Date(),
+        })
+        .where(
+          and(
+            eq(agentSandboxes.id, agentId),
+            eq(agentSandboxes.organization_id, orgId),
+            eq(agentSandboxes.status, "deletion_pending"),
+            eq(agentSandboxes.deletion_attempt_id, ownership.deletionAttemptId),
+            sql`${agentSandboxes.sandbox_id} IS NOT DISTINCT FROM ${ownership.sandboxId}`,
+            eq(agentSandboxes.environment_revision, ownership.environmentRevision),
+            eq(agentSandboxes.lifecycle_revision, ownership.lifecycleRevision),
+          ),
+        )
+        .returning();
+
+      return pendingSandbox
+        ? ({
+            success: true,
+            rowDeleted: false,
+            reconciliationPending: true,
+            deletedSandbox: pendingSandbox,
+          } as const)
         : ({ success: false, error: "Agent not found" } as const);
     });
   }
@@ -2045,21 +2152,22 @@ export class ElizaSandboxService {
   /**
    * Phase 2 of `deleteAgent` (see there): the bounded container + VPN teardown.
    * Provider errors are captured as values so `withTimeout` rejects ONLY on a
-   * genuine hang. Returns `null` on success, `{ error }` on a bounded failure,
-   * or `{ error, timedOut: true }` when the teardown hit the hard cap (in which
-   * case the container is abandoned and leaks — there is no reclaimer).
+   * genuine hang. The provider's tagged outcome distinguishes proven absence
+   * from an unreachable workload; failures and timeouts remain distinct so the
+   * deletion workflow can preserve capacity without wedging its worker.
    */
-  private async runBoundedSandboxStop(sandboxId: string): Promise<BoundedSandboxStopResult> {
+  private async runBoundedSandboxStop(
+    sandboxId: string,
+  ): Promise<BoundedDeletionSandboxStopResult> {
     return withTimeout(
-      (async (): Promise<null | { error: unknown }> => {
+      (async (): Promise<SandboxDeletionStopOutcome | { kind: "stop-failed"; error: unknown }> => {
         try {
           const provider = await this.getProvider();
-          await provider.stop(sandboxId);
-          return null;
+          return await provider.stopForDeletion(sandboxId);
         } catch (error) {
           // error-policy:J1 provider boundary translation — deletion records the
           // exact stop failure so the outer workflow can report a structured outcome.
-          return { error };
+          return { kind: "stop-failed", error };
         }
       })(),
       SANDBOX_DELETE_STOP_TIMEOUT_MS,
@@ -2067,7 +2175,7 @@ export class ElizaSandboxService {
     ).catch(
       // error-policy:J1 timeout boundary translation — the deletion workflow
       // distinguishes a bounded timeout from a completed provider failure.
-      (error: unknown) => ({ error, timedOut: true as const }),
+      (error: unknown) => ({ kind: "stop-timed-out" as const, error }),
     );
   }
 
@@ -2115,10 +2223,8 @@ export class ElizaSandboxService {
    * Wraps `deleteAgent` so the SSH/DB sequence stays in one place,
    * but maps the return shape to what the queue handler expects and
    * tracks whether the container actually went down before the row was
-   * removed. The row delete happens iff `stop` either succeeded or the
-   * container was already gone — both are observable in the `deleteAgent`
-   * success path (`isIgnorableSandboxStopError` swallows "no such
-   * container" specifically).
+   * removed. Unresolved teardown is terminal for this queue attempt but keeps a
+   * reconciliation tombstone, so `rowDeleted` remains explicit in the result.
    */
   async executeDeletion(
     agentId: string,
@@ -2126,6 +2232,7 @@ export class ElizaSandboxService {
   ): Promise<{
     success: boolean;
     containerStopped: boolean;
+    rowDeleted: boolean;
     error?: string;
   }> {
     const result = await this.deleteAgent(agentId, orgId);
@@ -2134,11 +2241,12 @@ export class ElizaSandboxService {
       // case where a prior attempt deleted the row but failed before updating
       // the job status to "completed", causing the runner to retry.
       if (result.error === "Agent not found") {
-        return { success: true, containerStopped: true };
+        return { success: true, containerStopped: true, rowDeleted: true };
       }
       return {
         success: false,
         containerStopped: false,
+        rowDeleted: false,
         error: result.error,
       };
     }
@@ -2147,7 +2255,7 @@ export class ElizaSandboxService {
     // delete is async via the queue, the daemon owns this step so orphan
     // characters do not pile up when the deletion completes outside of an
     // HTTP request context. Best-effort: a failure here leaves an orphan
-    // row but does not un-delete the (already gone) sandbox.
+    // character but does not reverse the agent's logical deletion.
     const characterId = result.deletedSandbox.character_id;
     if (characterId && !reusesExistingElizaCharacter(result.deletedSandbox.agent_config)) {
       try {
@@ -2167,11 +2275,8 @@ export class ElizaSandboxService {
 
     return {
       success: true,
-      // If we got past the stop step at all, by the time we returned success
-      // the container was either stopped or was never there. Either way it
-      // is no longer running, which is what the daemon needs to know to
-      // mark the job complete.
-      containerStopped: true,
+      containerStopped: result.rowDeleted,
+      rowDeleted: result.rowDeleted,
     };
   }
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2256,8 +2256,20 @@ export class ElizaSandboxService {
     // characters do not pile up when the deletion completes outside of an
     // HTTP request context. Best-effort: a failure here leaves an orphan
     // character but does not reverse the agent's logical deletion.
+    //
+    // Only once the sandbox row is actually gone. On the `deletion_failed`
+    // tombstone path the row survives for the recovery sweep, and
+    // `agent_sandboxes.character_id` is `onDelete: "set null"` — so deleting
+    // the character here would strip the tombstone's identity while it is
+    // still visible as an agent, leaving the sweep nothing to reconcile
+    // against. Mirrors the shared-runtime history drop above, which already
+    // gates on `result.rowDeleted`.
     const characterId = result.deletedSandbox.character_id;
-    if (characterId && !reusesExistingElizaCharacter(result.deletedSandbox.agent_config)) {
+    if (
+      result.rowDeleted &&
+      characterId &&
+      !reusesExistingElizaCharacter(result.deletedSandbox.agent_config)
+    ) {
       try {
         await userCharactersRepository.delete(characterId);
         logger.info("[agent-sandbox] Cleaned up linked character after delete", {

--- a/packages/cloud/shared/src/lib/services/local-docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/local-docker-sandbox-provider.ts
@@ -27,7 +27,12 @@ import {
   validateEnvKey,
   validateEnvValue,
 } from "./docker-sandbox-utils";
-import type { SandboxCreateConfig, SandboxHandle, SandboxProvider } from "./sandbox-provider-types";
+import type {
+  SandboxCreateConfig,
+  SandboxDeletionStopOutcome,
+  SandboxHandle,
+  SandboxProvider,
+} from "./sandbox-provider-types";
 
 const execFileAsync = promisify(execFile);
 
@@ -384,29 +389,9 @@ export class LocalDockerSandboxProvider implements SandboxProvider {
   // stop
   // ------------------------------------------------------------------
 
-  async stop(sandboxId: string): Promise<void> {
-    validateContainerName(sandboxId);
-    const meta = this.containers.get(sandboxId);
-
-    logger.info(`${LOG_PREFIX} Stopping container ${sandboxId}`);
-
-    await this.execDocker(["stop", "-t", "10", sandboxId]).catch((err: unknown) => {
-      logger.warn(
-        `${LOG_PREFIX} docker stop failed for ${sandboxId}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    });
-
-    await this.execDocker(["rm", "-f", sandboxId]).catch((err: unknown) => {
-      logger.warn(
-        `${LOG_PREFIX} docker rm failed for ${sandboxId}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    });
-
-    if (meta) {
-      this.ports.release(meta.bridgePort);
-      this.ports.release(meta.healthPort);
-      this.containers.delete(sandboxId);
-    }
+  async stopForDeletion(sandboxId: string): Promise<SandboxDeletionStopOutcome> {
+    await this.stopForReplacement(sandboxId);
+    return { kind: "not-running-proven" };
   }
 
   async stopForReplacement(sandboxId: string): Promise<void> {
@@ -525,7 +510,7 @@ export class LocalDockerSandboxProvider implements SandboxProvider {
 
   /** Fully delete the agent: stop + rm + remove host volume directory. */
   async deleteAgent(handle: SandboxHandle): Promise<void> {
-    await this.stop(handle.sandboxId);
+    await this.stopForDeletion(handle.sandboxId);
     const meta = handle.metadata as Partial<LocalDockerSandboxMetadata> | undefined;
     const volumePath = meta?.volumePath;
     if (typeof volumePath === "string" && volumePath.startsWith("/") && existsSync(volumePath)) {

--- a/packages/cloud/shared/src/lib/services/memory-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/memory-sandbox-provider.ts
@@ -4,7 +4,12 @@ import { createServer, type Server } from "node:http";
 import type { Socket } from "node:net";
 import { setTimeout as delay } from "node:timers/promises";
 
-import type { SandboxCreateConfig, SandboxHandle, SandboxProvider } from "./sandbox-provider-types";
+import type {
+  SandboxCreateConfig,
+  SandboxDeletionStopOutcome,
+  SandboxHandle,
+  SandboxProvider,
+} from "./sandbox-provider-types";
 
 interface MemoryAgentState {
   memories: Array<{ role: string; text: string; timestamp: number }>;
@@ -164,9 +169,9 @@ export class MemorySandboxProvider implements SandboxProvider {
     return handle;
   }
 
-  async stop(sandboxId: string): Promise<void> {
+  async stopForDeletion(sandboxId: string): Promise<SandboxDeletionStopOutcome> {
     const sandbox = this.sandboxes.get(sandboxId);
-    if (!sandbox) return;
+    if (!sandbox) return { kind: "not-running-proven" };
     this.sandboxes.delete(sandboxId);
     const close = new Promise<void>((resolve, reject) => {
       sandbox.server.close((error) => {
@@ -179,10 +184,11 @@ export class MemorySandboxProvider implements SandboxProvider {
       socket.destroy();
     }
     await Promise.race([close, delay(2_000)]);
+    return { kind: "not-running-proven" };
   }
 
   async stopForReplacement(sandboxId: string): Promise<void> {
-    await this.stop(sandboxId);
+    await this.stopForDeletion(sandboxId);
   }
 
   async checkHealth(handle: SandboxHandle): Promise<boolean> {

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
@@ -572,10 +572,10 @@ export async function reconcileOrphanContainers(
           // error-policy:J6 best-effort teardown bookkeeping. Not J7: this is not
           // diagnostics — a swallowed failure holds a real node slot. It is
           // survivable only because the retry contract is explicit: the reap is
-          // already counted, the remaining reaps must still run, and the next
-          // sweep re-attempts the release against a CAS that is idempotent by
-          // construction, so a missed release costs one sweep interval of
-          // capacity rather than leaking it permanently.
+          // already counted and the remaining reaps must still run. Agent
+          // deletion keeps a durable terminal tombstone, so its independent
+          // low-frequency delete retry can observe container absence and spend
+          // the idempotent release CAS after a bookkeeping failure here.
           await config.onReaped(orphan.key, node.node_id).catch((error: unknown) => {
             logger.warn(`[${config.logScope}] Post-reap bookkeeping failed`, {
               nodeId: node.node_id,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
@@ -176,7 +176,7 @@ const AGENT_ARMS: Array<{
     type: JOB_TYPES.AGENT_DELETE,
     data: {},
     method: "executeDeletion",
-    success: { success: true, containerStopped: true },
+    success: { success: true, containerStopped: true, rowDeleted: true },
   },
   {
     name: "suspend",
@@ -610,6 +610,32 @@ describe("executeJob dispatch — failure path per job type retries (increments 
 });
 
 describe("executeJob dispatch — type-specific disposition rules", () => {
+  test("an unresolved delete completes the hot queue attempt with rowDeleted false", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_DELETE));
+    stub("executeDeletion", {
+      success: true,
+      containerStopped: false,
+      rowDeleted: false,
+    });
+    try {
+      const res = await run(JOB_TYPES.AGENT_DELETE);
+      expect(res).toMatchObject({ succeeded: 1, failed: 0, retried: 0 });
+      const completed = completedCall(ctx);
+      expect(completed?.[2]?.result).toMatchObject({
+        containerStopped: false,
+        rowDeleted: false,
+      });
+      expect(ctx.incrementSpy).not.toHaveBeenCalled();
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
   test("agent_provision retryable transport → requeued without burning an attempt", async () => {
     const ctx = harness(makeJob(JOB_TYPES.AGENT_PROVISION));
     stub("provision", {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-stuck-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-stuck-reconcile.test.ts
@@ -40,7 +40,7 @@ function providerWithHealth(outcome: { ready: boolean; verdict: string }): Sandb
     create: async () => {
       throw new Error("unused");
     },
-    stop: async () => {},
+    stopForDeletion: async () => ({ kind: "not-running-proven" }),
     checkHealth: async () => outcome.ready,
     checkHealthDetailed: async () => outcome,
   } as unknown as SandboxProvider;
@@ -146,7 +146,7 @@ describe("elizaSandboxService.reconcileStuckProvisioning (service seam)", () => 
       create: async () => {
         throw new Error("unused");
       },
-      stop: async () => {},
+      stopForDeletion: async () => ({ kind: "not-running-proven" }),
       checkHealth: async () => {
         throw new Error("ssh down");
       },

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -1437,7 +1437,7 @@ export class ProvisioningJobService {
       webhookUrl: params.webhookUrl,
       maxAttempts: 3,
       // SSH stop is fast (~10s graceful + ~5s force kill), DB cascade is
-      // sub-second. 30s matches docker-sandbox-provider.stop() timeout.
+      // sub-second. 30s matches the Docker deletion-stop command timeout.
       estimatedDurationMs: 30_000,
       logName: "agent_delete",
       validateSandbox: expectedIdentity
@@ -1456,8 +1456,8 @@ export class ProvisioningJobService {
           }
         : undefined,
       // Flip status so the UI shows "deleting" and concurrent mutations
-      // bail. Actual row removal happens in executeAgentDelete once SSH
-      // stop() succeeds.
+      // bail. Actual row removal happens in executeAgentDelete once the
+      // provider proves the workload is no longer running.
       beforeInsert: async (tx, sandbox) => {
         if (
           sandbox.claimed_at &&
@@ -4759,7 +4759,7 @@ export class ProvisioningJobService {
     const jobResult: AgentDeleteJobResult = {
       cloudAgentId: data.agentId,
       containerStopped: delResult.containerStopped,
-      rowDeleted: true,
+      rowDeleted: delResult.rowDeleted,
     };
 
     await this.settleClaimedExecution(job, "completed", {

--- a/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
+++ b/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
@@ -21,6 +21,16 @@ export interface SandboxHealthOutcome {
   verdict: SandboxHealthVerdict;
 }
 
+/**
+ * Evidence produced by the provider-specific teardown used for agent deletion.
+ * A successful stop is sufficient even when removal fails because stopped
+ * containers do not consume compute slots. Unreachable workloads retain their
+ * capacity until reconciliation proves they are no longer running.
+ */
+export type SandboxDeletionStopOutcome =
+  | { kind: "not-running-proven" }
+  | { kind: "not-running-unresolved"; reason: "node-unreachable" };
+
 export interface SandboxReplacementCleanupLocator {
   sandboxId: string;
   nodeId: string;
@@ -73,7 +83,12 @@ export class SandboxReplacementCleanupUnresolvedError extends Error {
 
 export interface SandboxProvider {
   create(config: SandboxCreateConfig): Promise<SandboxHandle>;
-  stop(sandboxId: string): Promise<void>;
+  /**
+   * Tears down a sandbox for deletion and reports whether the provider proved
+   * the workload is not running. The deletion workflow owns capacity release,
+   * so an unresolved outcome completes deletion without authorizing release.
+   */
+  stopForDeletion(sandboxId: string): Promise<SandboxDeletionStopOutcome>;
   /**
    * Retires a sandbox before a replacement is allowed to start. Unlike the
    * ordinary delete-oriented stop path, this must reject whenever the provider

--- a/packages/cloud/shared/src/lib/services/sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/sandbox-provider.ts
@@ -3,6 +3,7 @@ import type { SandboxProvider } from "./sandbox-provider-types";
 
 export type {
   SandboxCreateConfig,
+  SandboxDeletionStopOutcome,
   SandboxHandle,
   SandboxProvider,
 } from "./sandbox-provider-types";


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

## Summary

Follow-up to #17930. That PR made allocation release idempotent, but its deletion caller still treated an unreachable provider as proof that a container was not running and erased the ownership row after timeout/unreachable outcomes.

This change:

- replaces generic deletion `stop()` with a typed `stopForDeletion()` outcome (`not-running-proven` vs `not-running-unresolved`)
- keeps reachable failures fail-closed and keeps timeout/unreachable capacity counted
- completes the hot queue attempt with a durable `deletion_failed` tombstone instead of deleting the ownership row
- lets the production orphan reconciler reap the immutable container ID and consume the allocation CAS exactly once
- makes a later low-frequency delete retry finalize the row without another decrement
- threads `rowDeleted` through provisioning jobs and prevents warm-pool cleanup from erasing a pending tombstone
- keeps local, memory, and Docker providers on the explicit contract
- adds cause-preserving `ElizaError` context to workload-count schema repair

Fixes #17966.

## Correctness model

A deletion may be logically complete for the user and hot work queue while physical teardown remains unresolved. In that state the row is terminal/reapable, credentials and character cleanup proceed, but the row remains as the durable capacity claim. Only either provider proof that the workload is not running or the orphan reaper's successful immutable-ID removal can spend that claim. Both paths share the same CAS, so races and retries release at most once.

## Verification

All commands were run after rebasing onto `develop`; the final rebase only added non-overlapping scenario/app/CI/homepage commits.

- `deletion-release-proven-absence.test.ts`: 7/7 — real PGlite row/counter lifecycle, real production reaper config, immutable-ID removal, final retry
- `deletion-allocation-ownership.test.ts`: 26/26 — retries, stale generation/node/org fences, concurrency, zero floor, continuation ownership
- Docker deletion/replacement provider suites: 12/12
- full `eliza-sandbox.test.ts`: 169 passed, 6 designed skips (175 total)
- orphan release callback: 4/4
- workload recount: 3/3
- failed-deletion re-enqueue: 7/7
- migration journal registration: 3/3
- warm-pool creator: 13/13
- stuck-job reconciliation: 7/7
- delete-related dispatch cases: 3/3
- `bun x tsc --noEmit -p packages/cloud/shared/tsconfig.json`: pass
- Biome check over all 19 changed TypeScript files: pass
- `bun run --cwd packages/cloud/shared db:check-migrations`: pass
- `git diff --check`: pass

The entire `provisioning-jobs-execute-dispatch.test.ts` file exceeded the local 180s and 300s process bounds without reporter output. Its three delete-related cases pass together; CI remains the required gate for the complete file/lane before merge.

## Evidence matrix

- Backend/domain evidence: real PGlite assertions prove `allocated_count` stays 2 while unresolved, becomes 1 only after the real reaper callback, and remains 1 after final row deletion. The retained row is observed as `deletion_failed` with ownership before reap and absent after final retry.
- Provider boundary: scripted remote outcomes are used for unreachable/timeout because no live failed Hetzner node is available; database, repository CAS, reconciler classification/removal callback, and retry finalization are real.
- UI before/after screenshots (desktop/mobile): N/A — backend lifecycle/accounting only.
- Video walkthrough: N/A — no rendered surface.
- Frontend console/network logs: N/A — no frontend change.
- Live-model trajectory: N/A — no model, prompt, action, or provider behavior in the agent loop.
- Audio/native/platform capture: N/A — no voice or native surface.

<!-- evidence-head:3900839c9e240030775d09ef07e5c0c2a13f1913 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only sandbox deletion and capacity accounting; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only sandbox deletion and capacity accounting; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing interaction or rendered surface changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - the failure mode is an unreachable deleted node; real structured logs cannot be captured locally without that failed infrastructure, and the PGlite integration test exercises the production reconciliation path

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, request flow, or state rendering changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or evaluator behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - real PGlite integration assertions inspect the retained deletion_failed tombstone and allocated_count 2 to 1 transition; the sandbox suite also proves the linked character survives the tombstone and is deleted exactly once after finalization

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed



