### PR TITLE
fix(ui): allocate ephemeral ports in the frontend-hosting e2e harness

### DIFF
--- a/packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs
+++ b/packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs
@@ -39,11 +39,27 @@ const outDir = join(here, "output-frontend-hosting");
 await rm(outDir, { recursive: true, force: true });
 await mkdir(outDir, { recursive: true });
 
-// Leg-3 port range (363xx).
-const API_PORT = 36313;
-const PAGE_PORT = 36314;
+// Ephemeral ports: a fixed port lets a zombie cloud-api from a previous run
+// on a persistent self-hosted runner answer the health check with its stale
+// DB (app create then 409s on the reused fixture name). A kernel-assigned
+// free port guarantees this run talks only to the server it just booted.
+import { createServer as createNetServer } from "node:net";
+async function freePort() {
+  return new Promise((res, rej) => {
+    const srv = createNetServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close((err) => (err ? rej(err) : res(port)));
+    });
+    srv.on("error", rej);
+  });
+}
+const API_PORT = await freePort();
+const PAGE_PORT = await freePort();
 const API_BASE = `http://127.0.0.1:${API_PORT}`;
-const DEAD_API_BASE = "http://127.0.0.1:36399"; // nothing listens here
+// A port we allocated and immediately released, then never listen on: requests
+// must fail, which is exactly the cloud-inactive state under test.
+const DEAD_API_BASE = `http://127.0.0.1:${await freePort()}`;
 
 let failures = 0;
 function assert(cond, msg) {


### PR DESCRIPTION
## Problem
`UI Core Fixture E2E` on develop fails intermittently in the `Frontend hosting e2e` step with:

```
== boot cloud-api ==
== SIWE signup ==
error: app create failed: 409
```

The harness binds fixed leg-3 ports (`API_PORT = 36313`). On the persistent self-hosted runner, a zombie `cloud-api` process from a previous run can still hold that port; the health check then passes against the stale server, and creating the fixed-name fixture app (`w3-hosting-e2e`) 409s because it already exists in the zombie's PGlite DB. Failing example: [run 31187958054](https://github.com/elizaOS/eliza/actions/runs/31187958054); the very next run on a clean runner passed, matching the zombie-port signature (this repo has hit the same pattern in the CF-deploy lanes before).

## Fix
Allocate kernel-assigned ephemeral ports (`net.createServer().listen(0)`) for `API_PORT`, `PAGE_PORT`, and `DEAD_API_BASE` so each run can only ever reach the server it just booted. The dead-API port stays an allocated-then-released port that nothing listens on, preserving the cloud-inactive state under test.

## Attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Evidence

<!-- evidence-head:4d71fec154017405aba6195fe205f01b7736623f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - flake fix in the e2e harness bootstrap; the surface under test is unchanged, so before/after pixels are identical. After-captures from the patched run are attached.

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17974-03-desktop-v1-live.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17974-walkthrough.mp4

<!-- evidence-row:backend-logs -->
Failing lane this fixes (run 31187958054):

<details>
<summary>Frontend hosting e2e failure log excerpt</summary>

```
== migrate PGlite ==
== boot cloud-api ==
== SIWE signup ==
148 | if (!APP_ID) throw new Error(`app create failed: ${app.s}`);
error: app create failed: 409
error: script "test:frontend-hosting-e2e" exited with code 1
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime change; harness port allocation only. Playwright console output is in the backend-logs transcript.

<!-- evidence-row:llm-trajectory -->
N/A - no agent/model behavior change; deterministic port allocation only.

<!-- evidence-row:domain-artifacts -->
N/A - no domain data produced; the artifact is the green UI Core Fixture E2E lane rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

