### PR TITLE
fix(voice): single utterance per turn — action acks no longer double-speak over the reply

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-streaming.test.ts
@@ -267,12 +267,14 @@ describe("chat route helper coverage", () => {
       legacy.res,
       "A",
       "A",
+      undefined,
     );
     expect(deps.writeChatTokenSse).toHaveBeenNthCalledWith(
       2,
       legacy.res,
       "AB",
       "AB",
+      undefined,
     );
 
     const deltaDeps = {
@@ -752,6 +754,62 @@ describe("generateChatResponse token streaming", () => {
     expect(snapshots).toEqual([text]);
     expect(result.text).toBe(text);
     expect(result.transcriptVisibility).toBeUndefined();
+  });
+
+  // Voice double-speak fix: the PERSONALITY-style turn delivers TWO texts
+  // through the same HandlerCallback — the action's own ack (with actionName)
+  // and the reply handler's terminal delivery (no actionName). The ack must be
+  // emitted with origin "action_callback" (→ provisional wire frames a voice
+  // client holds) and the reply with origin "model"; the returned final text
+  // is the reply only.
+  it("marks the action ack as action_callback origin and the reply delivery as model origin", async () => {
+    const ack = "Set tone=warm for you.";
+    const reply = "okay i changed personality to warm";
+    const service: MessageService = {
+      async handleMessage(_runtime, _message, callback) {
+        // The action's own callback — provisional status text.
+        await callback?.(
+          { text: ack, actions: ["PERSONALITY"] },
+          "PERSONALITY",
+        );
+        // The reply handler's terminal delivery (mode "simple") — the turn's
+        // actual reply, delivered with no actionName.
+        await callback?.({ text: reply });
+        return {
+          didRespond: true,
+          responseContent: { text: reply },
+          responseMessages: [],
+        };
+      },
+      shouldRespond: () => ({
+        shouldRespond: true,
+        skipEvaluation: true,
+        reason: "double-speak-origin-test",
+      }),
+      deleteMessage: async () => undefined,
+      clearChannel: async () => undefined,
+    };
+    const runtime = createRuntime({ messageService: service });
+
+    const chunks: Array<{ text: string; origin?: string }> = [];
+    const snapshots: Array<{ text: string; origin?: string }> = [];
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("change your personality to warm"),
+      "Streaming Agent",
+      {
+        onChunk: (chunk, origin) => chunks.push({ text: chunk, origin }),
+        onSnapshot: (text, origin) => snapshots.push({ text, origin }),
+      },
+    );
+
+    expect(chunks).toEqual([]);
+    expect(snapshots).toEqual([
+      { text: ack, origin: "action_callback" },
+      { text: reply, origin: "model" },
+    ]);
+    // The reply wins the turn's final text — exactly one final message.
+    expect(result.text).toBe(reply);
   });
 
   it("uses authoritative accumulated text for an in-place stream revision", async () => {

--- a/packages/agent/src/api/__tests__/sse-wire-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/sse-wire-streaming.test.ts
@@ -336,6 +336,37 @@ describe("delta-v2 chat token stream writer", () => {
     });
   });
 
+  // Voice double-speak fix: action-callback text rides the wire marked
+  // `provisional: true` so a voice client holds it (speech cannot be
+  // retracted); the reply frames stay unmarked. Non-provisional frames must
+  // remain byte-identical to the pre-fix wire.
+  it("marks provisional frames on both writers and leaves normal frames untouched", () => {
+    for (const protocol of ["legacy", "delta-v2"] as const) {
+      const mock = createMockResponse();
+      const writer = createChatTokenStreamWriter(protocol, streamWriterDeps);
+
+      writer.writeSnapshot(mock.res, "Set tone=warm for you.", {
+        provisional: true,
+      });
+      writer.writeChunk(mock.res, "ok", "ok", { provisional: true });
+      writer.writeSnapshot(mock.res, "okay i changed personality to warm");
+      writer.writeChunk(mock.res, " done", "okay… done");
+
+      const frames = parseFrames(mock.writes);
+      expect(frames).toHaveLength(4);
+      expect(frames[0].payload.provisional).toBe(true);
+      expect(frames[0].payload.fullText).toBe("Set tone=warm for you.");
+      expect(frames[1].payload.provisional).toBe(true);
+      // The reply snapshot and later deltas carry NO provisional key at all —
+      // the field is additive and absent on the unchanged wire.
+      expect(frames[2].payload).not.toHaveProperty("provisional");
+      expect(frames[2].payload.fullText).toBe(
+        "okay i changed personality to warm",
+      );
+      expect(frames[3].payload).not.toHaveProperty("provisional");
+    }
+  });
+
   it("carries linear (O(N)) bytes vs the legacy writer's quadratic wire", () => {
     const chunkText = "x".repeat(8);
     const chunkCount = 500;

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -944,9 +944,19 @@ export interface ChatActionResultSummary {
   values?: Record<string, unknown>;
 }
 
+/**
+ * Where a streamed text emission originated. `"model"` text is (or extends)
+ * the turn's final reply; `"action_callback"` text is an in-flight action
+ * status delivery that the turn's final reply may replace entirely. Voice
+ * clients must not synthesize `"action_callback"` text until the terminal
+ * frame confirms it — speech, unlike a chat bubble, cannot be retracted
+ * (the "double-speak" defect: ack spoken, then the reply spoken again).
+ */
+export type ChatStreamTextOrigin = "model" | "action_callback";
+
 export interface ChatGenerateOptions {
-  onChunk?: (chunk: string) => void;
-  onSnapshot?: (text: string) => void;
+  onChunk?: (chunk: string, origin?: ChatStreamTextOrigin) => void;
+  onSnapshot?: (text: string, origin?: ChatStreamTextOrigin) => void;
   /**
    * In-flight phase changes for the rich status indicator. Emitted additively
    * alongside `onChunk`/`onSnapshot` — `thinking` before the first visible
@@ -2378,8 +2388,14 @@ export function writeChatTokenSse(
   res: http.ServerResponse,
   text: string,
   fullText: string,
+  options?: ChatTokenWriteOptions,
 ): void {
-  writeSse(res, { type: "token", text, fullText });
+  writeSse(res, {
+    type: "token",
+    text,
+    fullText,
+    ...(options?.provisional ? { provisional: true } : {}),
+  });
 }
 
 export { DELTA_STREAM_PROTOCOL };
@@ -2406,25 +2422,48 @@ export interface ChatTokenStreamWriterDeps {
  * legacy O(N²) (every token re-serialized its whole prefix). The protocol is
  * negotiated per request (see `readChatRequestPayload`).
  */
+/**
+ * Per-write options for the token wire. `provisional: true` marks the carried
+ * text as an in-flight action-callback delivery the turn's final reply may
+ * replace — voice clients must not synthesize it until the terminal `done`
+ * frame (or a later non-provisional frame) confirms it, because speech cannot
+ * be retracted the way a re-rendered chat bubble can (the "double-speak"
+ * defect). Text bubbles may render it exactly as before.
+ */
+export interface ChatTokenWriteOptions {
+  provisional?: boolean;
+}
+
 export interface ChatTokenStreamWriter {
   /** An incremental streamed chunk. `fullText` is the accumulated text so far. */
-  writeChunk(res: http.ServerResponse, chunk: string, fullText: string): void;
+  writeChunk(
+    res: http.ServerResponse,
+    chunk: string,
+    fullText: string,
+    options?: ChatTokenWriteOptions,
+  ): void;
   /** An authoritative full-text replace (structured-field rewrite, single-frame
    *  reply). The client treats the carried `fullText` as the new buffer. */
-  writeSnapshot(res: http.ServerResponse, fullText: string): void;
+  writeSnapshot(
+    res: http.ServerResponse,
+    fullText: string,
+    options?: ChatTokenWriteOptions,
+  ): void;
 }
 
 export function createChatTokenStreamWriter(
   protocol: ChatTokenStreamProtocol,
   deps: ChatTokenStreamWriterDeps,
 ): ChatTokenStreamWriter {
+  const provisionalField = (options?: ChatTokenWriteOptions) =>
+    options?.provisional ? { provisional: true as const } : {};
   if (protocol === "legacy") {
     return {
-      writeChunk(res, chunk, fullText) {
-        deps.writeChatTokenSse(res, chunk, fullText);
+      writeChunk(res, chunk, fullText, options) {
+        deps.writeChatTokenSse(res, chunk, fullText, options);
       },
-      writeSnapshot(res, fullText) {
-        deps.writeChatTokenSse(res, fullText, fullText);
+      writeSnapshot(res, fullText, options) {
+        deps.writeChatTokenSse(res, fullText, fullText, options);
       },
     };
   }
@@ -2439,20 +2478,33 @@ export function createChatTokenStreamWriter(
   let bytesSinceSnapshot = 0;
   let lengthAtLastSnapshot = 0;
   return {
-    writeChunk(res, chunk, fullText) {
+    writeChunk(res, chunk, fullText, options) {
       bytesSinceSnapshot += chunk.length;
       if (bytesSinceSnapshot >= Math.max(2048, lengthAtLastSnapshot)) {
-        deps.writeSse(res, { type: "token", text: chunk, fullText });
+        deps.writeSse(res, {
+          type: "token",
+          text: chunk,
+          fullText,
+          ...provisionalField(options),
+        });
         bytesSinceSnapshot = 0;
         lengthAtLastSnapshot = fullText.length;
       } else {
-        deps.writeSse(res, { type: "token", text: chunk });
+        deps.writeSse(res, {
+          type: "token",
+          text: chunk,
+          ...provisionalField(options),
+        });
       }
     },
-    writeSnapshot(res, fullText) {
+    writeSnapshot(res, fullText, options) {
       // No `text` field: the client reads `fullText` as an authoritative
       // replace rather than an append.
-      deps.writeSse(res, { type: "token", fullText });
+      deps.writeSse(res, {
+        type: "token",
+        fullText,
+        ...provisionalField(options),
+      });
       bytesSinceSnapshot = 0;
       lengthAtLastSnapshot = fullText.length;
     },
@@ -3106,16 +3158,22 @@ async function generateChatResponseWithTiming(
       firstVisibleReplyMarked = true;
       markInference(INFERENCE_MARKS.firstVisibleReply);
     };
-    const emitChunk = (chunk: string): void => {
+    const emitChunk = (
+      chunk: string,
+      origin: ChatStreamTextOrigin = "model",
+    ): void => {
       if (!chunk) return;
       markFirstVisibleReply();
       responseText += chunk;
       if (opts?.onChunk) {
-        opts.onChunk(chunk);
+        opts.onChunk(chunk, origin);
         appendOnlyText += chunk;
       }
     };
-    const emitSnapshot = (text: string): void => {
+    const emitSnapshot = (
+      text: string,
+      origin: ChatStreamTextOrigin = "model",
+    ): void => {
       if (!text) return;
       // Skip when the snapshot matches the current responseText exactly:
       // re-emitting the same fullText forces clients to re-render an identical
@@ -3124,7 +3182,7 @@ async function generateChatResponseWithTiming(
       responseText = text;
       if (opts?.onSnapshot) {
         markFirstVisibleReply();
-        opts.onSnapshot(text);
+        opts.onSnapshot(text, origin);
       }
     };
     const claimStreamSource = (
@@ -3140,22 +3198,26 @@ async function generateChatResponseWithTiming(
       }
       return activeStreamSource === source;
     };
-    const appendIncomingText = (chunk: string, accumulated?: string): void => {
+    const appendIncomingText = (
+      chunk: string,
+      accumulated?: string,
+      origin: ChatStreamTextOrigin = "model",
+    ): void => {
       // StreamChunkCallback defines `chunk` as a delta. Structured extractors
       // additionally provide their authoritative accumulation, which lets this
       // boundary recover an actual upstream rewrite without guessing from text
       // overlap. Applying overlap deduplication to genuine deltas corrupts valid
       // boundaries such as "Fast " + "streaming " and repeated tokens.
       if (accumulated === undefined) {
-        emitChunk(chunk);
+        emitChunk(chunk, origin);
         return;
       }
       if (accumulated === responseText) return;
       if (accumulated.startsWith(responseText)) {
-        emitChunk(accumulated.slice(responseText.length));
+        emitChunk(accumulated.slice(responseText.length), origin);
         return;
       }
-      emitSnapshot(accumulated);
+      emitSnapshot(accumulated, origin);
     };
     const captureCallbackBaseline = (): void => {
       if (preCallbackText === null) {
@@ -3163,7 +3225,10 @@ async function generateChatResponseWithTiming(
       }
     };
     /** Latest action callback wins: replaces prior callback text, keeps LLM prefix. */
-    const replaceCallbackText = (incoming: string): void => {
+    const replaceCallbackText = (
+      incoming: string,
+      origin: ChatStreamTextOrigin = "action_callback",
+    ): void => {
       captureCallbackBaseline();
       const baseline = preCallbackText ?? "";
       const separator = baseline.length > 0 ? "\n\n" : "";
@@ -3181,24 +3246,25 @@ async function generateChatResponseWithTiming(
         (opts?.onSnapshot || appendOnlyText === responseText)
       ) {
         const delta = nextText.slice(responseText.length);
-        emitChunk(delta);
+        emitChunk(delta, origin);
         // emitChunk already advanced responseText; re-emit snapshot for
         // legacy clients that only handle fullText updates.
-        opts?.onSnapshot?.(nextText);
+        opts?.onSnapshot?.(nextText, origin);
         return;
       }
-      emitSnapshot(nextText);
+      emitSnapshot(nextText, origin);
     };
     const applyCallbackTextUpdate = (
       content: Content,
       incoming: string,
+      origin: ChatStreamTextOrigin = "action_callback",
     ): void => {
       captureCallbackBaseline();
       if (resolveCallbackMergeMode(content) === "append") {
-        appendIncomingText(incoming);
+        appendIncomingText(incoming, undefined, origin);
         return;
       }
-      replaceCallbackText(incoming);
+      replaceCallbackText(incoming, origin);
     };
 
     // Inbound event consumers may persist correlation state or apply
@@ -3542,7 +3608,18 @@ async function generateChatResponseWithTiming(
                     if (!progressCallback) {
                       visibleCallbackDeliveries += 1;
                     }
-                    applyCallbackTextUpdate(content, visibleChunk);
+                    // Origin discriminates the two deliveries that ride this
+                    // one callback: an ACTION's own callback carries its
+                    // actionName (provisional status text the final reply may
+                    // replace), while the reply handler's terminal delivery
+                    // carries none (it IS the turn's reply). Voice clients key
+                    // single-utterance behavior off this (see
+                    // ChatStreamTextOrigin).
+                    applyCallbackTextUpdate(
+                      content,
+                      visibleChunk,
+                      attributedActionName ? "action_callback" : "model",
+                    );
                     if (attributedActionName) {
                       recordActionCallback(
                         attributedActionName,
@@ -3749,7 +3826,8 @@ async function generateChatResponseWithTiming(
                   runtime,
                   message,
                   selfControlFallbackActions,
-                  appendIncomingText,
+                  (incoming: string) =>
+                    appendIncomingText(incoming, undefined, "action_callback"),
                   recordActionCallback,
                   {
                     abortSignal: generationAbortController.signal,

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -3163,7 +3163,7 @@ export async function handleConversationRoutes(
             }
             writeChatToolSse(res, event);
           },
-          onChunk: (chunk) => {
+          onChunk: (chunk, origin) => {
             if (!chunk) return;
             if (
               disconnectTracker.isAborted() ||
@@ -3172,9 +3172,15 @@ export async function handleConversationRoutes(
               return;
             }
             streamedText += chunk;
-            tokenWriter.writeChunk(res, chunk, streamedText);
+            // Action-callback text is provisional on the wire: the final reply
+            // may replace it wholesale, and a voice client must not speak text
+            // it cannot retract (the double-speak defect). Text rendering is
+            // unaffected.
+            tokenWriter.writeChunk(res, chunk, streamedText, {
+              provisional: origin === "action_callback",
+            });
           },
-          onSnapshot: (text) => {
+          onSnapshot: (text, origin) => {
             if (!text) return;
             if (
               disconnectTracker.isAborted() ||
@@ -3197,7 +3203,9 @@ export async function handleConversationRoutes(
               return;
             }
             streamedText = text;
-            tokenWriter.writeSnapshot(res, streamedText);
+            tokenWriter.writeSnapshot(res, streamedText, {
+              provisional: origin === "action_callback",
+            });
           },
           resolveNoResponseText: () =>
             resolveNoResponseFallback(state.logBuffer, runtime),

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
@@ -93,12 +93,25 @@ describe("personalityAction — subactions write structured state", () => {
 	});
 
 	test("set_trait user-scope writes user slot only", async () => {
-		const { result } = await run(fake, "be terse with me", "set_trait", {
+		const { result, calls } = await run(fake, "be terse with me", "set_trait", {
 			scope: "user",
 			trait: "verbosity",
 			value: "terse",
 		});
 		expect(result.success).toBe(true);
+		// #17923 humanization: the ack is a human sentence, not settings-speak
+		// ("Set verbosity=terse for you."). Machine detail rides in values/data.
+		expect(calls[0].text).toBe("Okay — I'll be terse with you from here on.");
+		expect(calls[0].text).not.toContain("=");
+		expect(result.values).toMatchObject({
+			scope: "user",
+			trait: "verbosity",
+			value: "terse",
+		});
+		expect(
+			(result.data as { after?: { verbosity?: string | null } }).after
+				?.verbosity,
+		).toBe("terse");
 		const userSlot = fake.store.getSlot(
 			"00000000-0000-4000-8000-0000000000ff" as never,
 		);
@@ -195,7 +208,13 @@ describe("personalityAction — subactions write structured state", () => {
 			scope: "user",
 		});
 		expect(result.success).toBe(true);
-		expect(calls[0].text).toContain("verbosity=terse");
+		// Humanized summary — no key=value settings-speak in the spoken line; the
+		// raw slot stays available as machine detail in data.slot.
+		expect(calls[0].text).toContain("verbosity terse");
+		expect(calls[0].text).not.toContain("=");
+		expect(
+			(result.data as { slot?: { verbosity?: string | null } }).slot?.verbosity,
+		).toBe("terse");
 	});
 });
 

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-echo.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-echo.test.ts
@@ -65,7 +65,7 @@ describe("personalityAction — blob-safe param echoes", () => {
 		});
 		expect(result.success).toBe(false);
 		expect(calls[0].text).toBe(
-			"No profile named that profile. Try list_profiles.",
+			"I don't have a profile named that profile saved — ask me to list the profiles.",
 		);
 		expect(calls[0].text).not.toContain("EXTERNAL_UNTRUSTED_CONTENT");
 		expect(calls[0].text).not.toContain("SECURITY NOTICE");
@@ -76,7 +76,7 @@ describe("personalityAction — blob-safe param echoes", () => {
 			name: "mystery-profile-name",
 		});
 		expect(calls[0].text).toBe(
-			'No profile named "mystery-profile-name". Try list_profiles.',
+			'I don\'t have a profile named "mystery-profile-name" saved — ask me to list the profiles.',
 		);
 	});
 
@@ -98,7 +98,9 @@ describe("personalityAction — blob-safe param echoes", () => {
 			value: ENVELOPE_BLOB,
 		});
 		expect(result.success).toBe(false);
-		expect(calls[0].text).toBe("Invalid value that value for trait 'tone'.");
+		expect(calls[0].text).toBe(
+			"I can't set tone to that value — that's not one of the options.",
+		);
 		expect(calls[0].text).not.toContain("EXTERNAL_UNTRUSTED_CONTENT");
 		expect(calls[0].text).not.toContain("SECURITY NOTICE");
 	});

--- a/packages/core/src/features/advanced-capabilities/personality/actions/personality.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/personality.ts
@@ -195,15 +195,29 @@ function clarifyScopeResult(op: PersonalityOp): ActionResult {
 	};
 }
 
+/** Render a slot as a human sentence fragment (#17923: user-facing text stays
+ * human; the raw slot rides in `data.slot` for planner/log consumers). */
 function summarizeSlot(slot: PersonalitySlot): string {
-	const parts = [
-		`verbosity=${slot.verbosity ?? "—"}`,
-		`tone=${slot.tone ?? "—"}`,
-		`formality=${slot.formality ?? "—"}`,
-		`reply_gate=${slot.reply_gate ?? "—"}`,
-		`directives=${slot.custom_directives.length}`,
-	];
-	return parts.join(" ");
+	const traits = [
+		slot.verbosity ? `verbosity ${slot.verbosity}` : null,
+		slot.tone ? `tone ${slot.tone}` : null,
+		slot.formality ? `formality ${slot.formality}` : null,
+	].filter((part): part is string => part !== null);
+	const traitPart = traits.length > 0 ? traits.join(", ") : "no traits pinned";
+	const gate =
+		slot.reply_gate === "never_until_lift"
+			? "staying silent until told otherwise"
+			: slot.reply_gate === "on_mention"
+				? "replying only when mentioned"
+				: "replying normally";
+	const count = slot.custom_directives.length;
+	const directives =
+		count === 0
+			? "no custom directives"
+			: count === 1
+				? "one custom directive"
+				: `${count} custom directives`;
+	return `${traitPart}; ${gate}; ${directives}`;
 }
 
 export const personalityAction: Action = {
@@ -310,13 +324,16 @@ export const personalityAction: Action = {
 		const rawOp = params.op ?? params.action ?? params.subaction;
 		const op = isPersonalityOp(rawOp) ? rawOp : null;
 		if (!op) {
-			const text = `PERSONALITY requires an op: ${PERSONALITY_OPS.join(", ")}.`;
+			const text =
+				"Tell me what to change — a trait (verbosity, tone, formality), the reply gate, a directive, or a saved profile.";
 			await callback?.({ text, thought: "Missing or invalid op" });
 			return {
 				text,
 				success: false,
 				values: { error: "INVALID_OP" },
-				data: { action: "PERSONALITY" },
+				// Machine detail (the op vocabulary) stays out of the user-facing
+				// text (#17923) and rides here for the planner instead.
+				data: { action: "PERSONALITY", ops: [...PERSONALITY_OPS] },
 			};
 		}
 
@@ -339,7 +356,7 @@ export const personalityAction: Action = {
 		if (ADMIN_ONLY_OPS.has(op) && !isAdmin) {
 			return denyResult(
 				op,
-				`Permission denied: only admins or the owner may run ${op}.`,
+				"Only admins or the owner can manage saved personality profiles.",
 			);
 		}
 
@@ -548,18 +565,18 @@ async function runSetTrait(
 	const trait = args.params.trait;
 	const value = args.params.value;
 	if (!trait || !(TRAIT_VALUES as readonly string[]).includes(trait)) {
-		const text = `set_trait requires a trait: ${TRAIT_VALUES.join(", ")}.`;
+		const text = "Which trait should I change — verbosity, tone, or formality?";
 		await args.callback?.({ text, thought: "Missing trait" });
 		return paramError("set_trait", text);
 	}
 	if (typeof value !== "string" || value.length === 0) {
-		const text = "set_trait requires a value.";
+		const text = "What should I set it to? (e.g. terse, warm, casual.)";
 		await args.callback?.({ text, thought: "Missing value" });
 		return paramError("set_trait", text);
 	}
 	if (!isValidTraitValue(trait as "verbosity" | "tone" | "formality", value)) {
 		// Blob-safe rendering rationale lives in utils/reference-echo.ts.
-		const text = `Invalid value ${describeUserReference(value, "that value")} for trait '${trait}'.`;
+		const text = `I can't set ${trait} to ${describeUserReference(value, "that value")} — that's not one of the options.`;
 		await args.callback?.({ text, thought: "Invalid value" });
 		return paramError("set_trait", text);
 	}
@@ -582,10 +599,12 @@ async function runSetTrait(
 		after,
 	);
 
+	// Human ack (#17923): the trait/value pair is machine detail and already
+	// rides in `values` + `data.after`; the spoken/rendered line stays plain.
 	const text =
 		args.scope === "user"
-			? `Set ${trait}=${value} for you.`
-			: `Set ${trait}=${value} globally.`;
+			? `Okay — I'll be ${value} with you from here on.`
+			: `Okay — I'll be ${value} with everyone from now on.`;
 	await args.callback?.({
 		text,
 		thought: `Personality trait updated: ${trait}=${value} (${args.scope})`,
@@ -607,7 +626,7 @@ async function runClearTrait(
 ): Promise<ActionResult> {
 	const trait = args.params.trait;
 	if (!trait || !(TRAIT_VALUES as readonly string[]).includes(trait)) {
-		const text = `clear_trait requires a trait: ${TRAIT_VALUES.join(", ")}.`;
+		const text = "Which trait should I clear — verbosity, tone, or formality?";
 		await args.callback?.({ text, thought: "Missing trait" });
 		return paramError("clear_trait", text);
 	}
@@ -648,7 +667,8 @@ async function runSetReplyGate(
 ): Promise<ActionResult> {
 	const mode = args.params.mode;
 	if (!mode || !(REPLY_GATE_VALUES as readonly string[]).includes(mode)) {
-		const text = `set_reply_gate requires mode: ${REPLY_GATE_VALUES.join(", ")}.`;
+		const text =
+			"Should I always reply, reply only when mentioned, or stay silent until told otherwise?";
 		await args.callback?.({ text, thought: "Missing mode" });
 		return paramError("set_reply_gate", text);
 	}
@@ -735,18 +755,19 @@ async function runAddDirective(
 	},
 ): Promise<ActionResult> {
 	if (args.scope !== "user") {
-		const text = "add_directive only supports scope='user' in this release.";
+		const text =
+			"Custom directives are per-person right now — I can only add that for you specifically.";
 		await args.callback?.({ text, thought: "Unsupported scope" });
 		return paramError("add_directive", text);
 	}
 	const directive = args.params.directive?.trim();
 	if (!directive) {
-		const text = "add_directive requires a directive string.";
+		const text = "What should I keep in mind? Give me the directive text.";
 		await args.callback?.({ text, thought: "Missing directive" });
 		return paramError("add_directive", text);
 	}
 	if (directive.length > MAX_DIRECTIVE_CHARS) {
-		const text = `Directive too long (max ${MAX_DIRECTIVE_CHARS} chars).`;
+		const text = `That directive is too long — keep it under ${MAX_DIRECTIVE_CHARS} characters.`;
 		await args.callback?.({ text, thought: "Directive too long" });
 		return paramError("add_directive", text);
 	}
@@ -825,14 +846,14 @@ async function runLoadProfile(args: {
 }): Promise<ActionResult> {
 	const name = args.params.name?.trim();
 	if (!name) {
-		const text = "load_profile requires `name`.";
+		const text = "Which profile should I load?";
 		await args.callback?.({ text, thought: "Missing name" });
 		return paramError("load_profile", text);
 	}
 	const profile = args.store.getProfile(name);
 	if (!profile) {
 		// Blob-safe rendering rationale lives in utils/reference-echo.ts.
-		const text = `No profile named ${describeUserReference(name, "that profile")}. Try list_profiles.`;
+		const text = `I don't have a profile named ${describeUserReference(name, "that profile")} saved — ask me to list the profiles.`;
 		await args.callback?.({ text, thought: "Unknown profile" });
 		return paramError("load_profile", text);
 	}
@@ -872,7 +893,7 @@ async function runSaveProfile(args: {
 	// re-broadcast wholesale on every later list_profiles render.
 	const name = userReferenceLogView(args.params.name?.trim() ?? "");
 	if (!name) {
-		const text = "save_profile requires `name`.";
+		const text = "What should I call this profile?";
 		await args.callback?.({ text, thought: "Missing name" });
 		return paramError("save_profile", text);
 	}
@@ -896,9 +917,12 @@ async function runListProfiles(args: {
 	callback?: HandlerCallback;
 }): Promise<ActionResult> {
 	const profiles = args.store.listProfiles();
-	const text = profiles
-		.map((profile) => `• ${profile.name}: ${profile.description}`)
-		.join("\n");
+	const text =
+		profiles.length === 0
+			? "No saved profiles yet."
+			: profiles
+					.map((profile) => `• ${profile.name}: ${profile.description}`)
+					.join("\n");
 	await args.callback?.({ text, actions: ["PERSONALITY"] });
 	return {
 		text,
@@ -919,7 +943,10 @@ async function runShowState(args: {
 		args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId;
 	const slot = args.store.getSlot(target, args.agentId);
 	const recent = args.store.getRecentAudit(10);
-	const text = `Current ${args.scope} personality — ${summarizeSlot(slot)}`;
+	const text =
+		args.scope === "user"
+			? `Here's how I'm tuned for you: ${summarizeSlot(slot)}.`
+			: `Here's how I'm tuned for everyone: ${summarizeSlot(slot)}.`;
 	await args.callback?.({ text, actions: ["PERSONALITY"] });
 	return {
 		text,

--- a/packages/ui/src/api/client-agent-stream.test.ts
+++ b/packages/ui/src/api/client-agent-stream.test.ts
@@ -46,7 +46,7 @@ describe("ElizaClient agent streaming transport", () => {
       messageId: "assistant-db-id",
       userMessageId: "user-db-id",
     });
-    expect(onToken).toHaveBeenCalledWith("hi", "hi");
+    expect(onToken).toHaveBeenCalledWith("hi", "hi", false);
     expect(read).toHaveBeenCalledTimes(1);
     expect(cancel).toHaveBeenCalledWith("elizaos-sse-terminal-done");
   });
@@ -307,7 +307,9 @@ describe("ElizaClient agent streaming transport", () => {
     );
 
     // Token 'a' must surface while the 2nd chunk is still pending.
-    await vi.waitFor(() => expect(onToken).toHaveBeenCalledWith("a", "a"));
+    await vi.waitFor(() =>
+      expect(onToken).toHaveBeenCalledWith("a", "a", false),
+    );
     expect(onToken).toHaveBeenCalledTimes(1);
 
     // Release the 2nd chunk (token 'b'); the stream then completes on the done event.
@@ -319,7 +321,7 @@ describe("ElizaClient agent streaming transport", () => {
     });
 
     const result = await resultPromise;
-    expect(onToken).toHaveBeenNthCalledWith(2, "b", "ab");
+    expect(onToken).toHaveBeenNthCalledWith(2, "b", "ab", false);
     expect(result).toEqual({ text: "ab", agentName: "Eliza", completed: true });
   });
 
@@ -360,7 +362,7 @@ describe("ElizaClient agent streaming transport", () => {
 
     // Exactly one well-formed token — no partial/malformed emission from chunk-1.
     expect(onToken).toHaveBeenCalledTimes(1);
-    expect(onToken).toHaveBeenCalledWith("hi", "hi");
+    expect(onToken).toHaveBeenCalledWith("hi", "hi", false);
     expect(result).toEqual({ text: "hi", agentName: "Eliza", completed: true });
   });
 
@@ -456,7 +458,7 @@ describe("ElizaClient chat-turn status SSE (#8813)", () => {
     // The reply still streams + completes — status is purely additive.
     expect(result.text).toBe("Done.");
     expect(result.completed).toBe(true);
-    expect(onToken).toHaveBeenCalledWith("Done.", "Done.");
+    expect(onToken).toHaveBeenCalledWith("Done.", "Done.", false);
     // Every status event surfaced, in order, with action detail preserved.
     expect(onStatus.mock.calls.map((c) => c[0])).toEqual([
       { kind: "thinking" },
@@ -577,7 +579,7 @@ describe("ElizaClient chat-turn status SSE (#8813)", () => {
       agentName: "Eliza",
       completed: true,
     });
-    expect(onToken).toHaveBeenCalledWith("hi", "hi");
+    expect(onToken).toHaveBeenCalledWith("hi", "hi", false);
   });
 
   it("keeps partial text when the stream transport rejects without fabricating a provider error", async () => {

--- a/packages/ui/src/api/client-base-delta-stream.test.ts
+++ b/packages/ui/src/api/client-base-delta-stream.test.ts
@@ -150,8 +150,38 @@ describe("delta-v2 chat stream client reducer", () => {
     );
 
     // Mid-stream the buffer was "par"; the authoritative done text replaces it.
-    expect(onToken).toHaveBeenCalledWith("par", "par");
+    expect(onToken).toHaveBeenCalledWith("par", "par", false);
     expect(result.text).toBe("partial complete");
     expect(result.completed).toBe(true);
+  });
+
+  // Voice double-speak fix: the server marks in-flight action-callback text
+  // `provisional: true` on its token frames. The client must surface that flag
+  // to onToken (voice output holds provisional text) and default it to false
+  // on ordinary frames.
+  it("surfaces the provisional flag on action-callback frames to onToken", async () => {
+    const { client } = streamFromSse(
+      'data: {"type":"token","fullText":"Set tone=warm for you.","provisional":true}\n\n' +
+        'data: {"type":"token","fullText":"okay i changed personality to warm"}\n\n' +
+        'data: {"type":"done","fullText":"okay i changed personality to warm","agentName":"Eliza"}\n\n',
+    );
+    const calls: Array<[string, string | undefined, boolean | undefined]> = [];
+    const onToken = vi.fn(
+      (token: string, accumulated?: string, provisional?: boolean) => {
+        calls.push([token, accumulated, provisional]);
+      },
+    );
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "change your personality to warm",
+      onToken,
+    );
+
+    expect(calls).toEqual([
+      ["", "Set tone=warm for you.", true],
+      ["", "okay i changed personality to warm", false],
+    ]);
+    expect(result.text).toBe("okay i changed personality to warm");
   });
 });

--- a/packages/ui/src/api/client-base-stream-abort.test.ts
+++ b/packages/ui/src/api/client-base-stream-abort.test.ts
@@ -55,7 +55,7 @@ describe("streamChatEndpoint client abort", () => {
 
     // The partial that streamed before the stop is preserved and returned as an
     // interrupted (completed:false) turn.
-    expect(onToken).toHaveBeenCalledWith("partial", "partial");
+    expect(onToken).toHaveBeenCalledWith("partial", "partial", false);
     expect(result.text).toBe("partial");
     expect(result.completed).toBe(false);
     // The read loop stopped consuming: the reader was cancelled with the client

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -86,6 +86,14 @@ type StreamChatEvent = {
   type?: string;
   text?: string;
   fullText?: string;
+  /**
+   * `type: "token"` only — the carried text is an in-flight action-callback
+   * delivery the turn's final reply may replace wholesale. Text bubbles render
+   * it exactly like any streamed text; voice output must NOT synthesize it
+   * until the terminal frame confirms it (speech cannot be retracted — the
+   * voice "double-speak" defect).
+   */
+  provisional?: boolean;
   transcriptVisibility?: "internal";
   agentName?: string;
   messageId?: string;
@@ -304,7 +312,11 @@ function parseStreamChatDataLine(line: string): StreamChatEvent | null {
 function applyStreamChatTokenEvent(
   parsed: StreamChatEvent,
   state: StreamChatState,
-  onToken: (token: string, accumulatedText?: string) => void,
+  onToken: (
+    token: string,
+    accumulatedText?: string,
+    provisional?: boolean,
+  ) => void,
 ): boolean {
   const chunk = parsed.text ?? "";
   const nextFullText =
@@ -323,7 +335,7 @@ function applyStreamChatTokenEvent(
         : state.fullText;
   if (nextFullText === state.fullText) return false;
   state.fullText = nextFullText;
-  onToken(chunk, state.fullText);
+  onToken(chunk, state.fullText, parsed.provisional === true);
   return false;
 }
 
@@ -383,7 +395,11 @@ function applyStreamChatDoneEvent(
 function applyStreamChatDataLine(
   line: string,
   state: StreamChatState,
-  onToken: (token: string, accumulatedText?: string) => void,
+  onToken: (
+    token: string,
+    accumulatedText?: string,
+    provisional?: boolean,
+  ) => void,
   onStatus?: (status: ChatTurnStatus) => void,
   onToolEvent?: (event: ChatToolCallEvent) => void,
 ): boolean {
@@ -1869,7 +1885,14 @@ export class ElizaClient {
   async streamChatEndpoint(
     path: string,
     text: string,
-    onToken: (token: string, accumulatedText?: string) => void,
+    onToken: (
+      token: string,
+      accumulatedText?: string,
+      /** True when this text state is an in-flight action-callback delivery
+       *  the final reply may replace — voice output must hold it (see
+       *  StreamChatEvent.provisional). */
+      provisional?: boolean,
+    ) => void,
     channelType: ConversationChannelType = "DM",
     signal?: AbortSignal,
     images?: ImageAttachment[],

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -499,7 +499,13 @@ declare module "./client-base" {
     sendConversationMessageStream(
       id: string,
       text: string,
-      onToken: (token: string, accumulatedText?: string) => void,
+      onToken: (
+        token: string,
+        accumulatedText?: string,
+        /** True for in-flight action-callback text the final reply may
+         *  replace — voice output must hold it until the turn completes. */
+        provisional?: boolean,
+      ) => void,
       channelType?: ConversationChannelType,
       signal?: AbortSignal,
       images?: ImageAttachment[],

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -350,6 +350,15 @@ export interface ConversationMessage {
   /** True when the SSE stream was interrupted before receiving a "done" event. */
   interrupted?: boolean;
   /**
+   * True while this in-flight assistant turn's visible text is an action-
+   * callback delivery the turn's final reply may replace wholesale (server
+   * marks those stream frames `provisional`). Text rendering treats it like
+   * any streamed text; VOICE OUTPUT MUST NOT SPEAK IT — speech cannot be
+   * retracted, and speaking the callback ack plus the final reply is the
+   * voice "double-speak" defect. Cleared by the terminal reconciliation.
+   */
+  provisional?: boolean;
+  /**
    * UI-local assistant reply with no durable server row. It remains visible so
    * the user can read the terminal failure, then retires when the next user turn
    * begins instead of surviving beneath a successful retry.

--- a/packages/ui/src/components/pages/chat-view-hooks.ts
+++ b/packages/ui/src/components/pages/chat-view-hooks.ts
@@ -632,6 +632,12 @@ export function useChatVoiceController(options: {
     }
     const latestAssistant = findLatestAssistantMessage(conversationMessages);
     if (!latestAssistant) return;
+    // Single utterance per turn: provisional text is an in-flight action
+    // callback the turn's final reply may replace — speech cannot be
+    // retracted, so speaking it plus the reply is the voice "double-speak"
+    // defect. Hold until a non-provisional frame or terminal reconciliation
+    // delivers the turn's final message (see useShellVoiceOutput).
+    if (latestAssistant.provisional) return;
     const suppressed = suppressedAssistantSpeechRef.current;
     if (
       suppressed &&

--- a/packages/ui/src/components/shell/useShellVoiceOutput.test.tsx
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.test.tsx
@@ -73,6 +73,10 @@ function proactiveMsg(id: string, text: string): ConversationMessage {
     source: "proactive-interaction",
   };
 }
+/** In-flight action-callback text (server-marked provisional stream frames). */
+function provisionalMsg(id: string, text: string): ConversationMessage {
+  return { id, role: "assistant", text, timestamp: 2, provisional: true };
+}
 
 const BASE: ShellVoiceOutputOptions = {
   conversationMessages: [],
@@ -389,6 +393,121 @@ describe("useShellVoiceOutput", () => {
     hoisted.cfg.voiceConfig = { provider: "local-inference" };
     const { result } = render(BASE);
     expect(result.current.asrProvider).toBeUndefined();
+  });
+
+  // Voice double-speak fix: a turn that runs an action streams the action's
+  // callback ack ("Set tone=warm for you.") as PROVISIONAL text, then the
+  // model's reply replaces it. Exactly ONE utterance may reach TTS — the
+  // turn's final message — because speech, unlike a chat bubble, cannot be
+  // retracted once spoken.
+  describe("single utterance per turn (action ack + reply)", () => {
+    it("holds the provisional action ack and speaks only the final reply", () => {
+      const user = userMsg("u1", "change your personality to warm");
+      const { rerender } = render({
+        ...BASE,
+        lastTurnVoice: true,
+        chatSending: true,
+        conversationMessages: [user],
+      });
+
+      // Mid-turn: the PERSONALITY callback snapshot lands as provisional text.
+      rerender({
+        ...BASE,
+        lastTurnVoice: true,
+        chatSending: true,
+        conversationMessages: [
+          user,
+          provisionalMsg("temp-1", "Set tone=warm for you."),
+        ],
+      });
+      expect(hoisted.queueAssistantSpeech).not.toHaveBeenCalled();
+
+      // Terminal reconciliation: the reply replaces the ack and the bubble is
+      // rekeyed to the persisted id. This is the turn's single utterance.
+      rerender({
+        ...BASE,
+        lastTurnVoice: true,
+        chatSending: false,
+        conversationMessages: [
+          user,
+          assistantMsg("server-1", "okay i changed personality to warm"),
+        ],
+      });
+      expect(hoisted.queueAssistantSpeech).toHaveBeenCalledTimes(1);
+      expect(hoisted.queueAssistantSpeech).toHaveBeenCalledWith(
+        "server-1",
+        "okay i changed personality to warm",
+        true,
+        { replace: true },
+      );
+    });
+
+    it("speaks a turnComplete-style ack exactly once, at terminal confirmation", () => {
+      const user = userMsg("u1", "list my cloud apps");
+      const { rerender } = render({
+        ...BASE,
+        lastTurnVoice: true,
+        chatSending: true,
+        conversationMessages: [
+          user,
+          provisionalMsg("temp-1", "You have two cloud apps."),
+        ],
+      });
+      // Provisional while in flight — held.
+      expect(hoisted.queueAssistantSpeech).not.toHaveBeenCalled();
+
+      // The action opted into turnComplete: its ack IS the turn's final
+      // message. The terminal frame confirms the same text (rekeyed id).
+      rerender({
+        ...BASE,
+        lastTurnVoice: true,
+        chatSending: false,
+        conversationMessages: [
+          user,
+          assistantMsg("server-1", "You have two cloud apps."),
+        ],
+      });
+      expect(hoisted.queueAssistantSpeech).toHaveBeenCalledTimes(1);
+      expect(hoisted.queueAssistantSpeech).toHaveBeenCalledWith(
+        "server-1",
+        "You have two cloud apps.",
+        true,
+        { replace: true },
+      );
+    });
+
+    it("speaks the reply as soon as a non-provisional frame replaces the ack mid-turn", () => {
+      const user = userMsg("u1", "change your personality to warm");
+      const { rerender } = render({
+        ...BASE,
+        lastTurnVoice: true,
+        chatSending: true,
+        conversationMessages: [
+          user,
+          provisionalMsg("temp-1", "Set tone=warm for you."),
+        ],
+      });
+      expect(hoisted.queueAssistantSpeech).not.toHaveBeenCalled();
+
+      // The reply handler's delivery is NOT provisional — voice may start on
+      // it immediately (still mid-turn), and it is the only utterance.
+      rerender({
+        ...BASE,
+        lastTurnVoice: true,
+        chatSending: true,
+        conversationMessages: [
+          user,
+          assistantMsg("temp-1", "okay i changed personality to warm"),
+        ],
+      });
+      expect(hoisted.queueAssistantSpeech).toHaveBeenCalledTimes(1);
+      expect(hoisted.queueAssistantSpeech).toHaveBeenCalledWith(
+        "temp-1",
+        "okay i changed personality to warm",
+        false,
+        { replace: true },
+      );
+    });
   });
 
   // #8792: proactive interaction comments are text-only by default.

--- a/packages/ui/src/components/shell/useShellVoiceOutput.ts
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.ts
@@ -11,13 +11,21 @@ import { useVoiceConfig } from "../../voice/useVoiceConfig";
 /** `useVoiceChat` requires a transcript sink; the overlay owns input elsewhere. */
 const NOOP_TRANSCRIPT = (): void => {};
 
-function findLatestAssistantText(
-  messages: readonly ConversationMessage[],
-): { id: string; text: string; source?: string } | null {
+function findLatestAssistantText(messages: readonly ConversationMessage[]): {
+  id: string;
+  text: string;
+  source?: string;
+  provisional?: boolean;
+} | null {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (message && message.role === "assistant" && message.text.trim()) {
-      return { id: message.id, text: message.text, source: message.source };
+      return {
+        id: message.id,
+        text: message.text,
+        source: message.source,
+        provisional: message.provisional,
+      };
     }
   }
   return null;
@@ -160,6 +168,17 @@ export function useShellVoiceOutput(
       if (!lastTurnVoiceRef.current) return;
       voiceReplyIdsRef.current.add(latest.id);
     }
+
+    // Single utterance per turn: provisional text is an in-flight action
+    // callback the turn's final reply may replace wholesale ("Set tone=warm
+    // for you." → "okay i changed personality to warm"). A chat bubble can be
+    // re-rendered; speech cannot be retracted — speaking it here and then the
+    // reply is the voice "double-speak" defect. Hold until a non-provisional
+    // frame or the terminal reconciliation confirms the turn's final message
+    // (a turnComplete-style action ack IS that final message and is spoken
+    // then, exactly once). spokenRef is deliberately not advanced, so the
+    // final text is treated as never-spoken and voiced in full.
+    if (latest.provisional) return;
 
     const previous = spokenRef.current;
     if (

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -565,6 +565,9 @@ export function useChatSend(deps: UseChatSendDeps) {
     conversationId: string | null;
     messageId: string;
     pendingText: string | null;
+    /** Whether the parked text is action-callback (provisional) text — the
+     *  latest frame wins, mirroring `pendingText` (double-speak fix). */
+    pendingTextProvisional: boolean;
     pendingStatus: ChatTurnStatus | null | typeof NO_PENDING_STATUS;
     pendingToolEvents: ChatToolCallEvent[];
     flushScheduled: boolean;
@@ -575,6 +578,7 @@ export function useChatSend(deps: UseChatSendDeps) {
     conversationId: null,
     messageId: "",
     pendingText: null,
+    pendingTextProvisional: false,
     pendingStatus: NO_PENDING_STATUS,
     pendingToolEvents: [],
     flushScheduled: false,
@@ -751,11 +755,14 @@ export function useChatSend(deps: UseChatSendDeps) {
     let committed = false;
     if (buffer.pendingText !== null) {
       const fullText = buffer.pendingText;
+      const provisional = buffer.pendingTextProvisional;
       buffer.pendingText = null;
+      buffer.pendingTextProvisional = false;
       applyStreamingTextModification(setConversationMessages, {
         messageId: buffer.messageId,
         mode: "replace",
         fullText,
+        provisional,
       });
       committed = true;
     }
@@ -819,6 +826,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       buffer.conversationId = conversationId;
       buffer.messageId = messageId;
       buffer.pendingText = null;
+      buffer.pendingTextProvisional = false;
       buffer.pendingStatus = NO_PENDING_STATUS;
       buffer.pendingToolEvents = [];
       buffer.flushScheduled = false;
@@ -854,9 +862,15 @@ export function useChatSend(deps: UseChatSendDeps) {
   // Park the latest cumulative text for `messageId`. Synchronous callbacks from
   // one decoded SSE batch overwrite the parked value and commit together.
   const scheduleStreamingText = useCallback(
-    (conversationId: string, messageId: string, fullText: string) => {
+    (
+      conversationId: string,
+      messageId: string,
+      fullText: string,
+      provisional = false,
+    ) => {
       startStreamingTurn(conversationId, messageId);
       streamingFlushRef.current.pendingText = fullText;
+      streamingFlushRef.current.pendingTextProvisional = provisional;
       ensureStreamingFlush();
     },
     [startStreamingTurn, ensureStreamingFlush],
@@ -902,6 +916,7 @@ export function useChatSend(deps: UseChatSendDeps) {
         buffer.flushTimer = null;
       }
       buffer.pendingText = null;
+      buffer.pendingTextProvisional = false;
       buffer.conversationId = null;
       buffer.pendingStatus = NO_PENDING_STATUS;
       buffer.pendingToolEvents = [];
@@ -1573,7 +1588,7 @@ export function useChatSend(deps: UseChatSendDeps) {
         const data = await client.sendConversationMessageStream(
           convId,
           text,
-          (token, accumulatedText) => {
+          (token, accumulatedText, provisional) => {
             const nextText =
               typeof accumulatedText === "string"
                 ? accumulatedText
@@ -1585,7 +1600,15 @@ export function useChatSend(deps: UseChatSendDeps) {
             }
             // Coalesce tokens delivered in one transport burst into a microtask;
             // the parked text is flushed synchronously before terminal changes.
-            scheduleStreamingText(convId, assistantMsgId, nextText);
+            // Provisional (action-callback) text is stamped on the message so
+            // voice output holds it until the final reply confirms or replaces
+            // it (double-speak fix).
+            scheduleStreamingText(
+              convId,
+              assistantMsgId,
+              nextText,
+              provisional === true,
+            );
           },
           channelType,
           controller.signal,
@@ -1846,7 +1869,7 @@ export function useChatSend(deps: UseChatSendDeps) {
             const retryData = await client.sendConversationMessageStream(
               conversation.id,
               text,
-              (token, accumulatedText) => {
+              (token, accumulatedText, provisional) => {
                 const nextText =
                   typeof accumulatedText === "string"
                     ? accumulatedText
@@ -1860,6 +1883,7 @@ export function useChatSend(deps: UseChatSendDeps) {
                   conversation.id,
                   replayAssistantId,
                   nextText,
+                  provisional === true,
                 );
               },
               channelType,
@@ -2400,7 +2424,7 @@ export function useChatSend(deps: UseChatSendDeps) {
           const data = await client.sendConversationMessageStream(
             convId,
             trimmed,
-            (token, accumulatedText) => {
+            (token, accumulatedText, provisional) => {
               const nextText =
                 typeof accumulatedText === "string"
                   ? accumulatedText
@@ -2412,7 +2436,12 @@ export function useChatSend(deps: UseChatSendDeps) {
               }
               // Coalesce tokens delivered in one transport burst into a microtask;
               // flush synchronously before terminal changes.
-              scheduleStreamingText(convId, assistantMsgId, nextText);
+              scheduleStreamingText(
+                convId,
+                assistantMsgId,
+                nextText,
+                provisional === true,
+              );
             },
             "DM",
             controller.signal,

--- a/packages/ui/src/state/useStreamingText.provisional.test.ts
+++ b/packages/ui/src/state/useStreamingText.provisional.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Behaviour proof for the `provisional` marker on streaming-text
+ * modifications: action-callback text is stamped provisional on the in-flight
+ * assistant turn (voice output holds it — the double-speak fix), the latest
+ * frame is authoritative (a non-provisional frame clears it), and terminal
+ * reconciliation always clears it. Drives the real reducer seam
+ * (`applyStreamingTextModification`) deterministically; no mocks.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { ConversationMessage } from "../api";
+import { applyStreamingTextModification } from "./useStreamingText";
+
+function collect(initial: ConversationMessage[]) {
+  let state = initial;
+  const setter = (
+    updater:
+      | ConversationMessage[]
+      | ((prev: ConversationMessage[]) => ConversationMessage[]),
+  ) => {
+    state = typeof updater === "function" ? updater(state) : updater;
+  };
+  return {
+    apply: (mod: Parameters<typeof applyStreamingTextModification>[1]) =>
+      applyStreamingTextModification(setter, mod),
+    get: () => state,
+  };
+}
+
+function assistant(text = ""): ConversationMessage {
+  return { id: "m1", role: "assistant", text, timestamp: 0 };
+}
+
+describe("applyStreamingTextModification provisional marker", () => {
+  it("stamps provisional on a replace snapshot (action callback ack)", () => {
+    const store = collect([assistant()]);
+    store.apply({
+      messageId: "m1",
+      mode: "replace",
+      fullText: "Set tone=warm for you.",
+      provisional: true,
+    });
+    const msg = store.get()[0];
+    expect(msg.text).toBe("Set tone=warm for you.");
+    expect(msg.provisional).toBe(true);
+  });
+
+  it("clears provisional when a non-provisional replace supersedes the ack", () => {
+    const store = collect([assistant()]);
+    store.apply({
+      messageId: "m1",
+      mode: "replace",
+      fullText: "Set tone=warm for you.",
+      provisional: true,
+    });
+    // The reply handler's delivery replaces the ack — the latest frame wins.
+    store.apply({
+      messageId: "m1",
+      mode: "replace",
+      fullText: "okay i changed personality to warm",
+      provisional: false,
+    });
+    const msg = store.get()[0];
+    expect(msg.text).toBe("okay i changed personality to warm");
+    expect(msg.provisional).toBeUndefined();
+  });
+
+  it("stamps provisional on an append delta (append-mode callback)", () => {
+    const store = collect([assistant("streamed prefix. ")]);
+    store.apply({
+      messageId: "m1",
+      mode: "append",
+      token: "Working on it.",
+      provisional: true,
+    });
+    const msg = store.get()[0];
+    expect(msg.text).toBe("streamed prefix. Working on it.");
+    expect(msg.provisional).toBe(true);
+  });
+
+  it("terminal complete clears provisional even when the text is unchanged", () => {
+    const store = collect([assistant()]);
+    store.apply({
+      messageId: "m1",
+      mode: "replace",
+      fullText: "You have two cloud apps.",
+      provisional: true,
+    });
+    // turnComplete-style action: the ack IS the final message. The complete
+    // frame confirms the same text — provisional must still clear so voice
+    // can speak it (exactly once).
+    store.apply({
+      messageId: "m1",
+      mode: "complete",
+      fullText: "You have two cloud apps.",
+      persistedMessageId: "server-1",
+    });
+    const msg = store.get()[0];
+    expect(msg.id).toBe("server-1");
+    expect(msg.text).toBe("You have two cloud apps.");
+    expect(msg.provisional).toBeUndefined();
+  });
+
+  it("plain streamed replies never gain the marker (byte-identical behavior)", () => {
+    const store = collect([assistant()]);
+    store.apply({ messageId: "m1", mode: "replace", fullText: "Hello wor" });
+    store.apply({ messageId: "m1", mode: "append", token: "ld." });
+    const msg = store.get()[0];
+    expect(msg.text).toBe("Hello world.");
+    expect("provisional" in msg).toBe(false);
+  });
+});

--- a/packages/ui/src/state/useStreamingText.ts
+++ b/packages/ui/src/state/useStreamingText.ts
@@ -52,12 +52,18 @@ export type StreamingTextModification =
       mode: "append";
       /** Raw delta token from the SSE stream. */
       token: string;
+      /** The delta is action-callback text the final reply may replace —
+       *  stamped on the message so voice output holds it (double-speak fix). */
+      provisional?: boolean;
     }
   | {
       messageId: string;
       mode: "replace";
       /** Cumulative snapshot text from the SSE stream. */
       fullText: string;
+      /** The snapshot is action-callback text the final reply may replace —
+       *  stamped on the message so voice output holds it (double-speak fix). */
+      provisional?: boolean;
     }
   | {
       messageId: string;
@@ -107,6 +113,24 @@ export type StreamingTextModification =
     };
 
 /**
+ * Stamp or clear the `provisional` marker (action-callback text the final
+ * reply may replace — held back from voice output). The latest frame is
+ * authoritative: a non-provisional frame clears the marker so the reply can
+ * be spoken the moment it lands.
+ */
+function withProvisional(
+  message: ConversationMessage,
+  provisional: boolean,
+): ConversationMessage {
+  if (provisional) {
+    message.provisional = true;
+    return message;
+  }
+  if (message.provisional !== undefined) delete message.provisional;
+  return message;
+}
+
+/**
  * Compute the patched message for a single modification, or return `null`
  * if the modification produces no observable change.
  */
@@ -117,12 +141,26 @@ function computeNextMessage(
   switch (mod.mode) {
     case "append": {
       const nextText = mergeStreamingText(message.text, mod.token);
-      if (nextText === message.text) return null;
-      return { ...message, text: nextText };
+      if (
+        nextText === message.text &&
+        !mod.provisional === !message.provisional
+      )
+        return null;
+      return withProvisional(
+        { ...message, text: nextText },
+        mod.provisional === true,
+      );
     }
     case "replace": {
-      if (mod.fullText === message.text) return null;
-      return { ...message, text: mod.fullText };
+      if (
+        mod.fullText === message.text &&
+        !mod.provisional === !message.provisional
+      )
+        return null;
+      return withProvisional(
+        { ...message, text: mod.fullText },
+        mod.provisional === true,
+      );
     }
     case "complete": {
       const sameText = message.text === mod.fullText;
@@ -141,15 +179,21 @@ function computeNextMessage(
         sameAccountConnect &&
         sameReasoning &&
         sameAssistantEphemeral &&
-        sameId
+        sameId &&
+        message.provisional === undefined
       ) {
         return null;
       }
-      const next: ConversationMessage = {
-        ...message,
-        ...(mod.persistedMessageId ? { id: mod.persistedMessageId } : {}),
-        text: mod.fullText,
-      };
+      const next: ConversationMessage = withProvisional(
+        {
+          ...message,
+          ...(mod.persistedMessageId ? { id: mod.persistedMessageId } : {}),
+          text: mod.fullText,
+        },
+        // Terminal reconciliation: the text is now the turn's final message —
+        // never provisional, so voice output may speak it.
+        false,
+      );
       if (mod.failureKind) {
         next.failureKind = mod.failureKind;
       } else if (message.failureKind !== undefined) {


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# fix(voice): single utterance per turn — action acks no longer double-speak over the reply

## Defect

Live voice demo: "change your personality to warm" produced TWO spoken utterances — first the PERSONALITY action's mechanical ack ("Set tone=warm for you."), then the model's reply ("okay i changed personality to warm"). Text mode shows ONE message for the same turn.

## Root cause

The stream route emits the action callback's text as a token/snapshot frame (`packages/agent/src/api/chat-routes.ts` `replaceCallbackText` → `emitSnapshot`), and later the reply handler's terminal delivery replaces it (second snapshot / `done` frame). A text bubble converges by replacement — the intermediate ack is simply overwritten. The voice output surfaces (`packages/ui/src/components/shell/useShellVoiceOutput.ts`, `packages/ui/src/components/pages/chat-view-hooks.ts` auto-speak) fed EVERY visible text state of the streaming assistant message into `queueAssistantSpeech`. Speech cannot be retracted: the ack was spoken at its sentence boundary, then the reply arrived as a different text under a rekeyed message id → not a streaming continuation → spoken in full. Two utterances.

Nothing client-side can distinguish the provisional ack from reply text at arrival time — only the server knows which emission came from an action callback. That information was dropped at the wire.

## Fix (structural, at the seam — no text-similarity heuristics)

Propagate the emission's origin end to end and let voice honor the same single-final-message contract text already has (the `turnComplete` contract):

1. **Server** (`packages/agent/src/api/chat-routes.ts`): `generateChatResponse`'s `onChunk`/`onSnapshot` now carry `origin: "model" | "action_callback"`. The one `HandlerCallback` that delivers both texts discriminates by `actionName` presence — the action's own callback carries its actionName (→ `action_callback`), the reply handler's terminal delivery carries none (→ `model`).
2. **Wire** (`chat-routes.ts` writers + `conversation-routes.ts` stream route): frames carrying action-callback text gain `provisional: true` (both legacy and delta-v2 writers). Non-provisional frames are byte-identical to before.
3. **Client** (`packages/ui/src/api/client-base.ts`, `useChatSend.ts`, `useStreamingText.ts`, `client-types-chat.ts`): the flag rides `onToken` → the streaming coalescer → a `provisional` marker on the in-flight `ConversationMessage`. The latest frame is authoritative; terminal reconciliation always clears it.
4. **Voice output** (`useShellVoiceOutput.ts`, `chat-view-hooks.ts`): provisional text is never queued for TTS. The turn's final message — the model reply, or the ack itself when the action opted into `turnComplete` (then the ack IS the final text) — is spoken exactly once via the existing prefix/continuation dedupe.

Plain streamed replies (no actions) never gain the marker: token-by-token streaming TTS is unchanged. The desktop Electrobun voice path already speaks only the terminal `fullText` and is unaffected.

This also fixes the silent dual of the bug: a same-id mid-turn replacement previously made `remainderAfter` return `""`, so the reply was never spoken at all.

## PERSONALITY ack humanization (#17923 convention)

`packages/core/src/features/advanced-capabilities/personality/actions/personality.ts` — user-facing text human, machine detail in `values`/`data`:

- `Set tone=warm for you.` → `Okay — I'll be warm with you from here on.` (trait/value stay in `values` + `data.after`)
- `Current user personality — verbosity=terse tone=— …` → `Here's how I'm tuned for you: verbosity terse; replying normally; no custom directives.` (raw slot stays in `data.slot`)
- op-name/param leakage (`PERSONALITY requires an op: set_trait, …`, `Try list_profiles.`, `` load_profile requires `name`. ``, `add_directive only supports scope='user' …`, …) reworded to plain questions/answers; the op vocabulary moved to `data.ops`.
- Blob-safety (`describeUserReference` neutral-noun substitution) preserved in every reworded string; `personality-echo` regression suite updated and green.

Sweep result: repo-wide grep confirms the four personality.ts sites were the only `key=value` settings-speak acks in production text. (`settings-actions.ts` has a different class of op-name leakage — out of this pattern's scope, noted for follow-up.)

## Test matrix

| Layer | Test | Proves |
| --- | --- | --- |
| server emission | `packages/agent/src/api/__tests__/conversation-streaming.test.ts` "marks the action ack as action_callback origin…" | ack → `action_callback`, reply delivery → `model`, final text = reply |
| wire | `packages/agent/src/api/__tests__/sse-wire-streaming.test.ts` "marks provisional frames on both writers…" | `provisional: true` on marked frames, byte-identical wire otherwise (legacy + delta-v2) |
| client parse | `packages/ui/src/api/client-base-delta-stream.test.ts` "surfaces the provisional flag…" | flag reaches `onToken`; defaults false |
| message state | `packages/ui/src/state/useStreamingText.provisional.test.ts` (5 cases) | stamp on replace/append, clear on non-provisional frame, clear on terminal complete (same-text turnComplete shape), plain replies untouched |
| voice output (the defect) | `packages/ui/src/components/shell/useShellVoiceOutput.test.tsx` "single utterance per turn" (3 cases) | ack held + reply spoken once; turnComplete ack spoken once at confirmation; reply spoken immediately when a non-provisional frame supersedes the ack mid-turn |
| humanization | `packages/core/.../personality-action.test.ts`, `personality-echo.test.ts` | human ack text, machine detail in `values`/`data`, blob-safety intact |

Gates run locally: `packages/ui` tests + typecheck + lint, `packages/agent` tests + typecheck + lint, `packages/core` personality suites + typecheck + lint.

## Evidence notes

- Audio capture: N/A in this environment — the proof standard is the emission-path trace above (wire frames → message state → the single `queueAssistantSpeech` call asserted in tests).
- Screenshots/MP4: N/A — no visual change; text bubbles render provisional text exactly as before.
- Full `packages/ui` suite: 9244 passed / 1 failed — the failure is `src/hardcoded-color-ratchet.test.ts` (`CloudPairRelay.tsx` 11 vs baseline 8, `NotificationsHomeCenter.tsx` 12 vs baseline 0), reproducible on the clean `origin/develop` tip with this branch's commit reverted; neither file is touched here. Pre-existing develop breakage, not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:541cf85d87827ae45031b2508358bfa81216ed6b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no visual change: voice/TTS emission-path fix; chat bubbles render streamed text identically before and after (only speech behavior changes)

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no visual change: voice/TTS emission-path fix; chat bubbles render streamed text identically before and after (only speech behavior changes)

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - audio-only defect (double TTS utterance); no capturable UI flow. Proof standard: wire-frame trace + single-queueAssistantSpeech assertions in domain-artifacts and test logs

<!-- evidence-row:backend-logs -->
- [x] [17975-voice-backend-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17975-voice-backend-tests.log)

<!-- evidence-row:frontend-logs -->
- [x] [17975-voice-frontend-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17975-voice-frontend-tests.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-behavior change: deterministic stream-plumbing + callback-text fix; turn semantics and prompts untouched, no live-LLM path in this environment

<!-- evidence-row:domain-artifacts -->
- [x] [17975-voice-frame-trace.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17975-voice-frame-trace.log)

