### PR TITLE
refactor(plugin-wallet): single-source on-chain write subactions

### DIFF
--- a/plugins/plugin-wallet/src/security/__tests__/wallet-context-safety.test.ts
+++ b/plugins/plugin-wallet/src/security/__tests__/wallet-context-safety.test.ts
@@ -10,10 +10,13 @@ import {
   assertEvmTransferRecipientAuthorized,
   assertSolanaTransferRecipientAuthorized,
   assertWalletFinancialActionAllowed,
+  FINANCIAL_WRITE_SUBACTIONS,
   messageAuthorizesEvmRecipient,
   messageAuthorizesSolanaRecipient,
+  ON_CHAIN_WRITE_SUBACTIONS,
   sanitizeWalletDisplayLabel,
 } from "../wallet-context-safety.js";
+import { ON_CHAIN_SUBACTIONS } from "../wallet-financial-confirmation.js";
 
 describe("wallet-context-safety", () => {
   it("blocks injection-flagged governance votes and steward trade orders", () => {
@@ -235,5 +238,21 @@ describe("wallet-context-safety", () => {
         recipient,
       ),
     ).toBe(true);
+  });
+});
+
+describe("ON_CHAIN_WRITE_SUBACTIONS single source", () => {
+  it("FINANCIAL_WRITE_SUBACTIONS contains every ON_CHAIN_SUBACTIONS member plus trade", () => {
+    for (const subaction of ON_CHAIN_SUBACTIONS) {
+      expect(FINANCIAL_WRITE_SUBACTIONS.has(subaction)).toBe(true);
+    }
+    expect(FINANCIAL_WRITE_SUBACTIONS.has("trade")).toBe(true);
+    expect(FINANCIAL_WRITE_SUBACTIONS.size).toBe(ON_CHAIN_SUBACTIONS.size + 1);
+  });
+
+  it("ON_CHAIN_SUBACTIONS equals ON_CHAIN_WRITE_SUBACTIONS", () => {
+    expect([...ON_CHAIN_SUBACTIONS].sort()).toEqual(
+      [...ON_CHAIN_WRITE_SUBACTIONS].sort(),
+    );
   });
 });

--- a/plugins/plugin-wallet/src/security/wallet-context-safety.ts
+++ b/plugins/plugin-wallet/src/security/wallet-context-safety.ts
@@ -20,7 +20,13 @@ import type { Memory } from "@elizaos/core";
 /** GHSA-7qxr-x6cg-r9cc: embedded addresses in token metadata must not become transfer recipients. */
 /** GHSA-gh63-5vpj-39qp: block financial writes on injection-flagged channel messages. */
 
-const FINANCIAL_WRITE_SUBACTIONS = new Set([
+// Single source of truth for on-chain write subactions. Every on-chain write
+// subaction must be in this set: the confirmation gate in
+// wallet-financial-confirmation.ts fires for exactly these subactions, and the
+// injection guard below adds "trade" (which carries its own confirmation
+// prompt in trade-action.ts), so a newly added subaction can never be covered
+// by one gate and missed by the other again.
+export const ON_CHAIN_WRITE_SUBACTIONS: ReadonlySet<string> = new Set([
   "transfer",
   "swap",
   "bridge",
@@ -28,6 +34,10 @@ const FINANCIAL_WRITE_SUBACTIONS = new Set([
   // governance votes/delegations are on-chain writes; an injected message must not
   // drive them any more than it may drive a transfer
   "gov",
+]);
+
+export const FINANCIAL_WRITE_SUBACTIONS: ReadonlySet<string> = new Set([
+  ...ON_CHAIN_WRITE_SUBACTIONS,
   // steward TRADE order submission routes through trade-action.ts, not the wallet
   // router, but is the same class of financial write
   "trade",

--- a/plugins/plugin-wallet/src/security/wallet-financial-confirmation.ts
+++ b/plugins/plugin-wallet/src/security/wallet-financial-confirmation.ts
@@ -21,17 +21,14 @@ import type {
 } from "@elizaos/core";
 import { requireConfirmation } from "@elizaos/core";
 import type { WalletRouterParams } from "../types/wallet-router.js";
+import { ON_CHAIN_WRITE_SUBACTIONS } from "./wallet-context-safety.js";
 
 /** Cache namespace for on-chain wallet writes (GHSA-rqm7-f4jc-84x3). */
 export const WALLET_FINANCIAL_CONFIRM_ACTION = "WALLET_FINANCIAL";
 
-const ON_CHAIN_SUBACTIONS = new Set<WalletRouterParams["subaction"]>([
-  "transfer",
-  "swap",
-  "bridge",
-  "gov",
-  "pump_fun_buy",
-]);
+// Alias of the single source in wallet-context-safety.ts: this gate fires for
+// exactly the on-chain write subactions, so the two gates cannot diverge.
+export const ON_CHAIN_SUBACTIONS = ON_CHAIN_WRITE_SUBACTIONS;
 
 export function requiresWalletFinancialConfirmation(
   params: Pick<WalletRouterParams, "subaction" | "dryRun">,


### PR DESCRIPTION
## Summary

Follow-up to #17775 and #17773, per lalalune's review note.

`FINANCIAL_WRITE_SUBACTIONS` (injection guard, wallet-context-safety.ts) and `ON_CHAIN_SUBACTIONS` (confirmation gate, wallet-financial-confirmation.ts) were hand-maintained lists that diverged: `gov` was in the confirmation gate but missing from the injection guard, which is how the GHSA-gh63 gap opened.

Both now derive from one exported `ON_CHAIN_WRITE_SUBACTIONS` constant (transfer, swap, bridge, pump_fun_buy, gov). `FINANCIAL_WRITE_SUBACTIONS` is the constant plus `trade`, which carries its own confirmation prompt in trade-action.ts. A newly added subaction can no longer be covered by one gate and missed by the other.

## Test plan

* New test asserts `FINANCIAL_WRITE_SUBACTIONS` contains every `ON_CHAIN_SUBACTIONS` member plus trade, and that `ON_CHAIN_SUBACTIONS` equals the constant.
* wallet-context-safety 16/16, trade-action 10/10, wallet-router 10/10, wallet-financial-confirmation suite passes; typecheck and biome clean.

Made with Cursor

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `moonshotai/kimi-k3` (Cursor agent session)
<!-- attribution-row:client -->
- Client / agent tooling: `Cursor`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@4c6b4c3d78269bcbc91aebb3e0ac847e2b95ae57:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - refactor, no rendered surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - refactor, no rendered surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - refactor, no rendered surface

<!-- evidence-row:backend-logs -->
- [x] Vitest: wallet-context-safety 18/18, trade-action 10/10, wallet-router 10/10, wallet-financial-confirmation 3/3 (41/41); typecheck and biome clean

<details>
<summary>vitest output</summary>

```text
RUN  v4.1.5 /private/tmp/elizadev/plugins/plugin-wallet

 Test Files  4 passed (4)
      Tests  41 passed (41)
   Start at  22:27:19
   Duration  3.99s (transform 9.43s, setup 0ms, import 12.52s, tests 31ms, environment 0ms)

Per-file: wallet-context-safety 18 passed, trade-action 10 passed, wallet-router 10 passed, wallet-financial-confirmation 3 passed.
Typecheck: tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.ui.json (exit 0). Biome: Checked 277 files, no fixes applied.
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-path change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifacts

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surface

<!-- evidence-head:4c6b4c3d78269bcbc91aebb3e0ac847e2b95ae57 -->
