### PR TITLE
fix(i18n): add cloud.apps.signInRequired to the en catalog

### DIFF
--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -1194,6 +1194,7 @@
   "cloud.apps.overview.statusActive": "Active",
   "cloud.apps.overview.statusInactive": "Inactive",
   "cloud.apps.stat.activeApps": "Active Apps",
+  "cloud.apps.signInRequired": "Sign in to Eliza Cloud to manage Cloud Apps.",
   "cloud.apps.stat.totalApps": "Total Apps",
   "cloud.apps.stat.totalRequests": "Total Requests",
   "cloud.apps.stat.totalUsers": "Total Users",


### PR DESCRIPTION
## Problem
The `Tests` workflow fails on develop in `Classify changed paths → Validate i18n source catalog contract` ([run 31189426666](https://github.com/elizaOS/eliza/actions/runs/31189426666)), which then skips every downstream lane and reds `ci-ok`:

```
[i18n] en.json missing 1 key(s) used in source:
  - cloud.apps.signInRequired   (packages/ui/src/cloud/applications/ApplicationsPage.tsx:42)
```

#17420 (41b916d3407) introduced `t("cloud.apps.signInRequired", …)` without adding the key to the en catalog.

## Fix
Add `cloud.apps.signInRequired` to `packages/ui/src/i18n/locales/en.json`, using the component's existing `defaultValue` string. Other locales fall back to en at runtime, matching the validator's warning-only policy for translation gaps.

## Verification
Ran `packages/app-core/scripts/check-i18n.mjs` at this commit:

```
[i18n] OK — 4439 literal keys, 6 wildcard prefixes, 75 dynamic sites, 84 indirect-only keys; 8190 source keys × 8 locales
```

## Attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Evidence

<!-- evidence-head:31b8f149f03f92f9665ca260c64594e9b8330b66 -->

<!-- evidence-row:before-screenshots -->
N/A - catalog-only key addition; the rendered string is unchanged (it was already shown via defaultValue fallback).

<!-- evidence-row:after-screenshots -->
N/A - catalog-only key addition; the rendered string is unchanged (it was already shown via defaultValue fallback).

<!-- evidence-row:walkthrough-video -->
N/A - one-line locale catalog fix; no user-visible flow changes.

<!-- evidence-row:backend-logs -->
Failing gate this fixes (run 31189426666) and local validator proof at this head:

<details>
<summary>i18n contract failure + fixed validator output</summary>

```
[i18n] en.json missing 1 key(s) used in source:
  - cloud.apps.signInRequired   (packages/ui/src/cloud/applications/ApplicationsPage.tsx:42)
##[error]Process completed with exit code 1.
--- with this commit ---
[i18n] OK — 4439 literal keys, 6 wildcard prefixes, 75 dynamic sites, 84 indirect-only keys; 8190 source keys × 8 locales
```

</details>

<!-- evidence-row:frontend-logs -->
N/A - no frontend runtime behavior change; key resolves to the identical string previously supplied inline.

<!-- evidence-row:llm-trajectory -->
N/A - no agent/model behavior change.

<!-- evidence-row:domain-artifacts -->
N/A - no domain data produced; the artifact is the green Tests lane on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
