### PR TITLE
fix(orchestrator): restore read-write key symmetry in multi-account e2e harness

### DIFF
--- a/plugins/plugin-agent-orchestrator/scripts/compose-multi-account-e2e.ts
+++ b/plugins/plugin-agent-orchestrator/scripts/compose-multi-account-e2e.ts
@@ -24,8 +24,12 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+// Runtime (not isolated-test) policy: the default AccountPool reads with a
+// runtime policy, and envelope encryption is keyed per policy owner — an
+// isolated-test write uses an in-memory random key the pool's runtime read
+// can never decrypt, so every account would silently vanish from selection.
 import {
-  createIsolatedAccountStoragePolicy,
+  createRuntimeAccountStoragePolicy,
   saveAccount,
 } from "@elizaos/auth/account-storage";
 // Import the pool from app-core SRC, not the package barrel: app-core has no
@@ -89,7 +93,7 @@ function mkAccount(
       updatedAt: Date.now(),
       ...(organizationId ? { organizationId } : {}),
     },
-    createIsolatedAccountStoragePolicy(home),
+    createRuntimeAccountStoragePolicy(home),
   );
 }
 


### PR DESCRIPTION
## Problem
`Orchestrator multi-account` is red on develop since 15:02Z ([run 31190638619](https://github.com/elizaOS/eliza/actions/runs/31190638619)): every selection check fails with `undefined` right after the three account saves succeed.

#17464 scoped envelope master keys per storage-policy owner: `isolated-test` policies encrypt with an in-memory random key, while the default `AccountPool` reads with a `runtime` policy and the real master key. The composed e2e saved its synthetic accounts with `createIsolatedAccountStoragePolicy`, so every record fails authenticated decryption in the pool (`AUTH_CREDENTIAL_RECORD_CORRUPT: Credential envelope failed authenticated decryption`) and selection sees zero accounts.

Bisect proof: 11/11 checks pass at `deb54363fdd^`, 2/11 at develop head.

## Fix
Save with `createRuntimeAccountStoragePolicy(home)` rooted at the same temp `ELIZA_HOME`, restoring write/read key symmetry with the pool. `ELIZA_VAULT_DISABLE_KEYCHAIN` + `ELIZA_VAULT_PASSPHRASE` already keep the run offline and disposable. Comment added so the asymmetry isn't reintroduced.

## Verification
`bun run --cwd plugins/plugin-agent-orchestrator test:e2e:multi-account` at this commit: **11/11 checks passed** (transcript in evidence).

## Attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Evidence

<!-- evidence-head:7e39ea75af3dfae569d148eace8d22d9dd66a2a0 -->

<!-- evidence-row:before-screenshots -->
N/A - CI e2e harness policy fix; no UI surface involved.

<!-- evidence-row:after-screenshots -->
N/A - CI e2e harness policy fix; no UI surface involved.

<!-- evidence-row:walkthrough-video -->
N/A - headless e2e harness fix; there is no user-visible flow to record.

<!-- evidence-row:backend-logs -->
Local run of the exact CI command at this commit:

<details>
<summary>test:e2e:multi-account — 11/11 passed</summary>

```
Info [auth] Saved anthropic-subscription account "claude-A" (label="claude-A")
Info [auth] Saved anthropic-subscription account "claude-B" (label="claude-B")
Info [auth] Saved openai-codex account "codex-A" (label="codex-A")
Info [coding-account-bridge] claude → anthropic-subscription account "claude-A" (claude-A) via least-used
Info [coding-account-bridge] claude → anthropic-subscription account "claude-B" (claude-B) via least-used
Info [coding-account-bridge] codex → openai-codex account "codex-A" (codex-A) via least-used
PASS  claude spawn 1 selected an account  [claude-A]
PASS  claude spawn 2 selected an account  [claude-B]
PASS  two claude spawns used DISTINCT accounts (round-robin least-used)  [claude-A vs claude-B]
PASS  codex spawn selected the codex account  [codex-A]
PASS  real subprocess received an injected Claude OAuth token  [3 claude invocations]
PASS  the two Claude subprocesses got DISTINCT injected tokens  [oat-AAA, oat-BBB]
PASS  parent ANTHROPIC_API_KEY was DROPPED from claude subprocess env
PASS  Claude follow-up subprocess reused spawn 1's selected account token  [oat-AAA -> oat-AAA]
PASS  codex subprocess received a per-account CODEX_HOME  [.../auth/_codex-home/codex-A/generations/...]
PASS  parent OPENAI_API_KEY was DROPPED from codex subprocess env
PASS  codex auth.json has the selected account's token + account_id
11/11 checks passed
```

</details>

<!-- evidence-row:frontend-logs -->
N/A - no frontend involved; headless subprocess e2e.

<!-- evidence-row:llm-trajectory -->
N/A - no live model involved; the coding-agent binary is the harness's fake acpx.

<!-- evidence-row:domain-artifacts -->
N/A - disposable temp-state credentials only; the artifact is the green Orchestrator multi-account lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
