### PR TITLE
fix(scenarios): recognize corpus credentials and os requirements in the scenario schema

### DIFF
--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -541,6 +541,14 @@ export type ScenarioRequirements = {
    * Services omitted here are optional even when a required plugin declares them.
    */
   services?: readonly string[];
+  /**
+   * Named credential slots (e.g. `1password:eliza-e2e-autofill`) the live lane
+   * must provision before this scenario is eligible; corpora-specific runners
+   * interpret the slot names.
+   */
+  credentials?: readonly string[];
+  /** Host platform the scenario needs (e.g. `macos`); other platforms defer it. */
+  os?: string;
 };
 
 export type ScenarioDefinition = {

--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -293,18 +293,27 @@ function validateScenarioRequirements(value) {
     Array.isArray(requires)
   ) {
     throw new Error(
-      `scenario "${value?.id ?? "<unknown>"}" has invalid requires; expected { plugins?: string[], services?: string[] }`,
+      `scenario "${value?.id ?? "<unknown>"}" has invalid requires; expected { plugins?: string[], services?: string[], credentials?: string[], os?: string }`,
     );
   }
+  const knownKeys = ["plugins", "services", "credentials", "os"];
   const unknownKeys = Object.keys(requires).filter(
-    (key) => key !== "plugins" && key !== "services",
+    (key) => !knownKeys.includes(key),
   );
   if (unknownKeys.length > 0) {
     throw new Error(
       `scenario "${value?.id ?? "<unknown>"}" has unknown requires field(s): ${unknownKeys.join(", ")}`,
     );
   }
-  for (const key of ["plugins", "services"]) {
+  if (
+    requires.os !== undefined &&
+    (typeof requires.os !== "string" || requires.os.trim().length === 0)
+  ) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" has invalid requires.os; expected a non-empty string`,
+    );
+  }
+  for (const key of ["plugins", "services", "credentials"]) {
     const requirements = requires[key];
     if (requirements === undefined) {
       continue;

--- a/packages/scenario-runner/src/required-services.test.ts
+++ b/packages/scenario-runner/src/required-services.test.ts
@@ -80,6 +80,36 @@ describe("scenario required-service contract", () => {
       } as unknown as ScenarioDefinition),
     ).toThrow("unknown requires field(s): service");
   });
+
+  it("accepts corpus credential and os requirements and rejects malformed ones", () => {
+    const definition = scenario({
+      id: "credential-os-requirements",
+      title: "credential and os requirements",
+      domain: "required-service-preflight",
+      requires: {
+        plugins: ["@elizaos/plugin-agent-skills"],
+        credentials: ["1password:eliza-e2e-autofill"],
+        os: "macos",
+      },
+      turns: [],
+    });
+    expect(resolveRequiredServiceTypes(definition)).toEqual([]);
+
+    expect(() =>
+      scenario({
+        ...definition,
+        id: "malformed-credentials",
+        requires: { credentials: ["1password:eliza-e2e-autofill", ""] },
+      } as unknown as ScenarioDefinition),
+    ).toThrow("invalid requires.credentials");
+    expect(() =>
+      scenario({
+        ...definition,
+        id: "malformed-os",
+        requires: { os: " " },
+      } as unknown as ScenarioDefinition),
+    ).toThrow("invalid requires.os");
+  });
 });
 
 describe("required-service readiness", () => {


### PR DESCRIPTION
# Relates to

Follow-up to #17427. The typed `requires` schema validation it added rejects the pre-existing `requires.credentials` and `requires.os` fields used across the `plugin-personal-assistant` scenario corpus, so every corpus load on develop now throws `unknown requires field(s): credentials` and the plugin-tests lane fails repo-wide.

# What changed

- `packages/scenario-runner/schema/index.js`: `requires` now recognizes `credentials` (non-empty string array) and `os` (non-empty string) alongside `plugins`/`services`; unknown keys still fail closed.
- `packages/scenario-runner/schema/index.d.ts`: `ScenarioRequirements` documents both fields.
- `packages/scenario-runner/src/required-services.test.ts`: regression coverage for accepted and malformed `credentials`/`os` requirements.

# Testing

- `packages/scenario-runner` `vitest run src/required-services.test.ts`: 10 passed, 0 failed.
- `plugins/plugin-personal-assistant` `vitest run test/executive-assistant-scenarios.test.ts` (the exact suite failing on develop): 4 passed, 0 failed.
- Biome on the changed files: clean.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - schema validation fix; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - schema validation fix; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual flow.
<!-- evidence-row:backend-logs -->
- [x] Local run at head `2769935503d`:

  <details>
  <summary>scenario-runner + personal-assistant corpus transcripts</summary>

  ```text
  packages/scenario-runner> vitest run src/required-services.test.ts
   Test Files  1 passed (1)
        Tests  10 passed (10)

  plugins/plugin-personal-assistant> vitest run test/executive-assistant-scenarios.test.ts
   Test Files  1 passed (1)
        Tests  4 passed (4)

  (before the fix the same suite failed all 4 tests with
   "scenario \"1password-autofill.non-whitelisted-refused\" has unknown requires field(s): credentials")
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic schema validation; no model in the changed path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - covered by the loader regression tests above.

# Known gaps / failures

None in the changed path.

<!-- evidence-head:2769935503d88996fdcb231f5cf1d733c963e42e -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - develop regression repaired directly in the elizaOS/eliza checkout without the contribute-to-eliza skill`
<!-- attribution-row:status -->
- Attribution status: `self-reported`
