### PR TITLE
fix(ci): scope gitleaks PR scan to three-dot merge-base range

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -69,7 +69,12 @@ jobs:
           set -euo pipefail
           RANGE_ARGS=()
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            RANGE_ARGS=(--log-opts "${PR_BASE_SHA}..${PR_HEAD_SHA}")
+            # Three-dot: scan merge-base(base,head)..head, i.e. only what THIS
+            # PR added. `pull_request.base.sha` is the base branch tip at event
+            # time, not the merge base, so a two-dot range also scans commits the
+            # branch merely inherited by merging develop — re-flagging fixtures
+            # the PR never touched (#17971).
+            RANGE_ARGS=(--log-opts "${PR_BASE_SHA}...${PR_HEAD_SHA}")
           elif [[ -n "$BEFORE_SHA" && "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]]; then
             RANGE_ARGS=(--log-opts "${BEFORE_SHA}..${CURRENT_SHA}")
           elif ! git rev-parse -q --verify "${CURRENT_SHA}^" >/dev/null 2>&1; then


### PR DESCRIPTION
# Relates to

Fixes #17971

- [x] Targets develop from latest origin/develop
- [x] Single-line workflow fix matching develop-pr.yml three-dot lesson

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.5
<!-- attribution-row:client -->
- Client tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@38d47c8a378de335ed1a4ad2d1aa4b8215ba73b3:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from current origin/develop
- [ ] Full monorepo verify not re-run (workflow-only change)

# Risks

Low. Changes only the gitleaks pull_request log range from two-dot to three-dot. Push branches unchanged.

# Background

## What does this PR do?

`pull_request.base.sha` is the base tip at event time, not the merge base. `base..head` therefore re-scans commits the branch merely inherited (e.g. after merging develop), which can fail PRs on files they never touched (observed on #17420 vs swe-bench fixtures). Switch the PR arm to `base...head` so gitleaks only scans this PR's commits — same rule as `develop-pr.yml`.

## What kind of change is this?

Bug fix (CI false-positive reduction).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`.github/workflows/gitleaks.yml` PR branch of the `Run gitleaks` step.

## Detailed testing steps

`ash
# three-dot is merge-base..head
git rev-parse "\...\15188a0941ed8f29bbc9cb12f58ed074eb5445ea"
# gitleaks still receives --log-opts with the three-dot form
`

# Evidence Gate

<!-- evidence-head:d235cd1a347fe91bf2fe2dc85ceb7e06e158774b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI workflow only; no UI.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI workflow only; no UI.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CI workflow only; no UI.
<!-- evidence-row:backend-logs -->
- [ ] N/A - workflow range string change only.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface; CI gitleaks range only.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model path.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain side effects.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual surface.

# Evidence Details

## Known gaps / failures

- Cannot run live gitleaks against #17420 historical event without replaying GHA.

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@38d47c8a378de335ed1a4ad2d1aa4b8215ba73b3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-krutftw]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/eliza@38d47c8a378de335ed1a4ad2d1aa4b8215ba73b3:packages/skills/skills/contribute-to-eliza"} -->






