### PR TITLE
fix(agent): exclude models/cache from snapshot stateFiles

### DIFF
--- a/packages/agent/src/services/agent-backup.test.ts
+++ b/packages/agent/src/services/agent-backup.test.ts
@@ -86,6 +86,24 @@ async function writeFixtureState(
     path.join(root, "skills", "active.json"),
     '{"skills":[]}\n',
   );
+  // Re-downloadable model weights / caches must never enter stateFiles (#17920).
+  await fs.mkdir(path.join(root, "models"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "models", "openai.json"),
+    '{"models":[]}\n',
+  );
+  await fs.mkdir(path.join(root, "models", "weights"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "models", "weights", "giant.bin"),
+    "x".repeat(1024),
+  );
+  await fs.mkdir(path.join(root, "tool-cache"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "tool-cache", "web-search.bin"),
+    "cached-tool-result",
+  );
+  await fs.mkdir(path.join(root, "cache"), { recursive: true });
+  await fs.writeFile(path.join(root, "cache", "runtime.tmp"), "volatile-cache");
   await fs.writeFile(path.join(pgliteDir, "pgdata.bin"), "database-bytes");
   await fs.writeFile(
     path.join(pgliteDir, "postmaster.pid"),
@@ -159,6 +177,19 @@ describe("agent backup manifest", () => {
     expect(pgliteFilePaths).not.toContain("pg_stat_tmp/stats.tmp");
     expect(stateFilePaths).toContain("skills/active.json");
     expect(stateFilePaths).not.toContain("pglite/pgdata.bin");
+    // #17920: models + cache trees are excluded from the stateFiles manifest.
+    expect(stateFilePaths).not.toContain("models/openai.json");
+    expect(stateFilePaths).not.toContain("models/weights/giant.bin");
+    expect(stateFilePaths).not.toContain("tool-cache/web-search.bin");
+    expect(stateFilePaths).not.toContain("cache/runtime.tmp");
+    expect(
+      stateFilePaths.every(
+        (filePath) =>
+          !filePath.startsWith("models/") &&
+          !filePath.startsWith("tool-cache/") &&
+          !filePath.startsWith("cache/"),
+      ),
+    ).toBe(true);
 
     await fs.rm(path.join(root, "media"), { recursive: true, force: true });
     await fs.rm(path.join(root, ".vault-pglite"), {

--- a/packages/agent/src/services/agent-backup.ts
+++ b/packages/agent/src/services/agent-backup.ts
@@ -290,13 +290,23 @@ const POSTGRES_CAPTURE_BATCH_ROWS = 500;
 
 const MEDIA_DIR_NAME = "media";
 const BACKUPS_DIR_NAME = "backups";
+/** Per-provider model cache / weights under state-dir (`resolveModelsCacheDir`). */
+const MODELS_DIR_NAME = "models";
+/** Cross-tool on-disk cache root under state-dir (`tools.cache.diskRoot` default). */
+const TOOL_CACHE_DIR_NAME = "tool-cache";
+/**
+ * Generic cache root occasionally used by inference/runtime layers under
+ * state-dir. Re-downloadable; must not bloat upgrade snapshots (#17920).
+ */
+const CACHE_DIR_NAME = "cache";
 const LOCAL_BACKUP_EXTENSION = ".agent-backup.json";
 const LOCAL_BACKUP_FORMAT = "elizaos.agent-backup-file";
 const LOCAL_BACKUP_RETENTION = 10;
 const DEFAULT_PGLITE_DIR_NAME = ".elizadb";
 const VAULT_PGLITE_DIR_NAME = ".vault-pglite";
 const VAULT_AUDIT_DIR_NAME = "audit";
-const VAULT_AUDIT_PATH = path.join("audit", "vault.jsonl");
+// Always posix-style: collectFileSet/normalizeRelativePath compare against `/`.
+const VAULT_AUDIT_PATH = "audit/vault.jsonl";
 const VAULT_JSON_PATH = "vault.json";
 const PGLITE_VOLATILE_ROOT_FILES = new Set([
   "eliza-pglite.lock",
@@ -546,6 +556,9 @@ function baseStateFileInclude(relativePath: string): boolean {
   if (
     first === MEDIA_DIR_NAME ||
     first === BACKUPS_DIR_NAME ||
+    first === MODELS_DIR_NAME ||
+    first === TOOL_CACHE_DIR_NAME ||
+    first === CACHE_DIR_NAME ||
     first === DEFAULT_PGLITE_DIR_NAME ||
     first === VAULT_PGLITE_DIR_NAME ||
     relativePath === VAULT_JSON_PATH ||


### PR DESCRIPTION
# Relates to

Fixes #17920

- [x] Targets develop from latest origin/develop at open time.
- [x] Focused unit tests passed after the change (23/23 agent-backup.test.ts).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.5
<!-- attribution-row:client -->
- Client tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@50e55f2106da2d8205727dcda9159db645b232f5:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branch cut from origin/develop 50e55f210.
- [ ] Full monorepo bun run verify not re-run (see Known gaps).

# Risks

Low. Snapshot include filter only: re-downloadable models/tool-cache/cache trees leave stateFiles; real agent state (db, media, vault, skills, config) unchanged. Posix path constant for vault audit is a Windows correctness fix with no Linux/mac behavior change.

# Background

## What does this PR do?

Excludes re-downloadable model and cache directories from the managed-agent snapshot `stateFiles` manifest (#17920).

Root cause: `baseStateFileInclude` already denylisted media/backups/pglite/vault paths but walked `models/`, `tool-cache/`, and `cache/` under the state dir. Those hold provider model cache files (`resolveModelsCacheDir` → `<state-dir>/models`), tool-call cache, and volatile runtime cache — multi-GB on canary hosts — so upgrade backups ballooned or failed closed.

Fix: denylist those first-segment roots in `baseStateFileInclude`. Regression asserts none of `models/**`, `tool-cache/**`, or `cache/**` land in the stateFiles component while skills and other state still capture.

Also: vault audit path constant used `path.join` (Windows `audit\\vault.jsonl`) while `normalizeRelativePath` always uses `/`, so Windows hosts silently dropped `audit/vault.jsonl` from vault capture. Constant is now the posix form the walker already produces.

## What kind of change is this?

Bug fix (agent backup/snapshot include filter).

# Documentation changes needed?

No documentation change required.

# Testing

## Where should a reviewer start?

Diff `packages/agent/src/services/agent-backup.ts` (`baseStateFileInclude` + `VAULT_AUDIT_PATH`), then `agent-backup.test.ts` fixture exclusions.

## Detailed testing steps

```bash
bun install --frozen-lockfile --ignore-scripts
bun run --cwd packages/core prebuild
bun test packages/agent/src/services/agent-backup.test.ts
```

Expected: 23 pass / 0 fail; stateFiles contain skills but not models/cache/tool-cache paths.

# Evidence Gate

<!-- evidence-head:51af7a5122d7bb66a9c3d1bb69fd89d6fba8d287 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; agent backup unit tests only.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - unit suite 23/23 at head 51af7a5122d7bb66a9c3d1bb69fd89d6fba8d287; models/cache excluded from stateFiles.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM path exercised.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB/wallet domain side effects beyond in-memory snapshot fixtures.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Known gaps / failures

- Full monorepo bun run verify not re-run (change is one include filter + unit regression).
- Outside-collaborator fork CI may sit at action_required until a maintainer approves workflow runs (see #17551).

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@50e55f2106da2d8205727dcda9159db645b232f5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-krutftw]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/eliza@50e55f2106da2d8205727dcda9159db645b232f5:packages/skills/skills/contribute-to-eliza"} -->
