### PR TITLE
fix(cloud): ms-window cutover/recovery job timestamp CAS

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -16,7 +16,7 @@
  * here (the repo cannot be driven against a real DB) — it never silently passes.
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
 
 // This suite drives an ISOLATED in-process PGlite (see docstring). When the
 // ambient DATABASE_URL is a real shared Postgres (e.g. CI's

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -16,7 +16,7 @@
  * here (the repo cannot be driven against a real DB) — it never silently passes.
  */
 
-import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 // This suite drives an ISOLATED in-process PGlite (see docstring). When the
 // ambient DATABASE_URL is a real shared Postgres (e.g. CI's

--- a/packages/cloud/shared/src/db/repositories/job-timestamp-fence.test.ts
+++ b/packages/cloud/shared/src/db/repositories/job-timestamp-fence.test.ts
@@ -4,10 +4,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import { sql } from "drizzle-orm";
-import {
-  cutoverResumeWindowAllows,
-  msWindowTimestampMatch,
-} from "./job-timestamp-fence";
+import { cutoverResumeWindowAllows, msWindowTimestampMatch } from "./job-timestamp-fence";
 
 describe("cutover audit timestamp units (#17919)", () => {
   test("ms-window SQL fragment truncates the column before comparing", () => {

--- a/packages/cloud/shared/src/db/repositories/job-timestamp-fence.test.ts
+++ b/packages/cloud/shared/src/db/repositories/job-timestamp-fence.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit pins for the cutover/recovery timestamp unit fence (#17919).
+ * Leaf module only — no full jobs repository import graph.
+ */
+import { describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import {
+  cutoverResumeWindowAllows,
+  msWindowTimestampMatch,
+} from "./job-timestamp-fence";
+
+describe("cutover audit timestamp units (#17919)", () => {
+  test("ms-window SQL fragment truncates the column before comparing", () => {
+    const expected = new Date("2026-08-06T12:00:00.123Z");
+    const fragment = msWindowTimestampMatch(sql`updated_at`, expected);
+    const shape = fragment.queryChunks
+      .map((chunk) => {
+        if (
+          chunk &&
+          typeof chunk === "object" &&
+          "value" in chunk &&
+          Array.isArray((chunk as { value: unknown }).value)
+        ) {
+          return (chunk as { value: string[] }).value.join("");
+        }
+        return "";
+      })
+      .join("");
+    expect(shape).toContain("date_trunc('milliseconds'");
+    expect(shape).toContain("IS NOT DISTINCT FROM");
+  });
+
+  test("resume window accepts epoch-ms ordering and rejects µs-scale inputs", () => {
+    const cutoverAtMs = Date.parse("2026-08-06T12:00:00.000Z");
+    const rowStartedAtMs = cutoverAtMs + 5_000;
+    const rowUpdatedAtMs = rowStartedAtMs + 1_000;
+    expect(
+      cutoverResumeWindowAllows({
+        cutoverAtMs,
+        rowStartedAtMs,
+        rowUpdatedAtMs,
+      }),
+    ).toBe(true);
+
+    // Same chronology but encoded as microseconds — must fail closed.
+    expect(
+      cutoverResumeWindowAllows({
+        cutoverAtMs: cutoverAtMs * 1000,
+        rowStartedAtMs: rowStartedAtMs * 1000,
+        rowUpdatedAtMs: rowUpdatedAtMs * 1000,
+      }),
+    ).toBe(false);
+
+    expect(
+      cutoverResumeWindowAllows({
+        cutoverAtMs: rowStartedAtMs + 1,
+        rowStartedAtMs,
+        rowUpdatedAtMs,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/job-timestamp-fence.ts
+++ b/packages/cloud/shared/src/db/repositories/job-timestamp-fence.ts
@@ -14,10 +14,7 @@ function normalizedTimestamp(value: Date | string | null): Date | null {
   return value === null ? null : value instanceof Date ? value : new Date(value);
 }
 
-export function msWindowTimestampMatch(
-  column: AnyColumn | SQL,
-  value: Date | string | null,
-): SQL {
+export function msWindowTimestampMatch(column: AnyColumn | SQL, value: Date | string | null): SQL {
   return sql`date_trunc('milliseconds', ${column}) IS NOT DISTINCT FROM ${normalizedTimestamp(value)}`;
 }
 

--- a/packages/cloud/shared/src/db/repositories/job-timestamp-fence.ts
+++ b/packages/cloud/shared/src/db/repositories/job-timestamp-fence.ts
@@ -1,0 +1,52 @@
+/**
+ * Timestamp CAS helpers for the µs/ms truncation boundary (#17919 / #17284 class).
+ *
+ * Claim SQL and other raw writers store `updated_at = NOW()` with microsecond
+ * precision on real Postgres. Typed JS reads (and `Date`/`toISOString`) truncate
+ * to milliseconds, so a plain `column IS NOT DISTINCT FROM $expected` silently
+ * misses for every µs-stored row and cutover/recovery CAS fails closed or never
+ * admits a valid resume. Truncate the column to ms before comparing; JS Date
+ * parsing truncates sub-ms lexically (never rounds), so ms==ms is exact.
+ */
+import { type AnyColumn, type SQL, sql } from "drizzle-orm";
+
+function normalizedTimestamp(value: Date | string | null): Date | null {
+  return value === null ? null : value instanceof Date ? value : new Date(value);
+}
+
+export function msWindowTimestampMatch(
+  column: AnyColumn | SQL,
+  value: Date | string | null,
+): SQL {
+  return sql`date_trunc('milliseconds', ${column}) IS NOT DISTINCT FROM ${normalizedTimestamp(value)}`;
+}
+
+/**
+ * Pure window check used by cutover recovery: all inputs must be epoch ms.
+ * Rejects µs-scale numbers so a unit mix cannot silently pass the window.
+ */
+export function cutoverResumeWindowAllows(params: {
+  cutoverAtMs: number;
+  rowStartedAtMs: number;
+  rowUpdatedAtMs: number;
+}): boolean {
+  const { cutoverAtMs, rowStartedAtMs, rowUpdatedAtMs } = params;
+  if (
+    !Number.isFinite(cutoverAtMs) ||
+    !Number.isFinite(rowStartedAtMs) ||
+    !Number.isFinite(rowUpdatedAtMs)
+  ) {
+    return false;
+  }
+  // Epoch ms for 2001-09-09 is ~1e12; µs for the same instant is ~1e15.
+  // Anything at or above 1e14 is not a plausible JS Date ms value.
+  const MS_EPOCH_CEILING = 1e14;
+  if (
+    cutoverAtMs >= MS_EPOCH_CEILING ||
+    rowStartedAtMs >= MS_EPOCH_CEILING ||
+    rowUpdatedAtMs >= MS_EPOCH_CEILING
+  ) {
+    return false;
+  }
+  return cutoverAtMs <= rowStartedAtMs && rowStartedAtMs <= rowUpdatedAtMs;
+}

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -26,16 +26,13 @@ import { agentSandboxes } from "../schemas/agent-sandboxes";
 import { jobExecutionLeases } from "../schemas/job-execution-leases";
 import type { Job, NewJob } from "../schemas/jobs";
 import { jobs } from "../schemas/jobs";
-import {
-  cutoverResumeWindowAllows,
-  msWindowTimestampMatch,
-} from "./job-timestamp-fence";
+import { cutoverResumeWindowAllows, msWindowTimestampMatch } from "./job-timestamp-fence";
 
-export type { Job, NewJob };
 export {
   cutoverResumeWindowAllows,
   msWindowTimestampMatch,
 } from "./job-timestamp-fence";
+export type { Job, NewJob };
 
 /**
  * Settles the rows that depend on a job the recovery sweep just flipped to
@@ -149,10 +146,6 @@ function timestampMillis(value: Date | string | null): number | null {
 
 function sameTimestamp(left: Date | string | null, right: Date | string | null): boolean {
   return timestampMillis(left) === timestampMillis(right);
-}
-
-function normalizedTimestamp(value: Date | string | null): Date | null {
-  return value === null ? null : value instanceof Date ? value : new Date(value);
 }
 
 function hasValidTimestamp(value: string): boolean {
@@ -1162,10 +1155,7 @@ export class JobsRepository {
             eq(jobs.status, "in_progress"),
             eq(jobs.attempts, params.job.attempts),
             sql`${jobs.execution_generation} IS NOT DISTINCT FROM ${params.job.execution_generation}`,
-            msWindowTimestampMatch(
-              jobs.execution_quiesced_at,
-              params.job.execution_quiesced_at,
-            ),
+            msWindowTimestampMatch(jobs.execution_quiesced_at, params.job.execution_quiesced_at),
             lt(jobs.started_at, params.startedBefore),
             params.recoveryFence,
           ),
@@ -1203,10 +1193,7 @@ export class JobsRepository {
             eq(jobs.status, "in_progress"),
             eq(jobs.attempts, params.job.attempts),
             sql`${jobs.execution_generation} IS NOT DISTINCT FROM ${params.job.execution_generation}`,
-            msWindowTimestampMatch(
-              jobs.execution_quiesced_at,
-              params.job.execution_quiesced_at,
-            ),
+            msWindowTimestampMatch(jobs.execution_quiesced_at, params.job.execution_quiesced_at),
             lt(jobs.started_at, params.startedBefore),
             params.recoveryFence,
             requiresExecutionLease && params.job.execution_generation

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -26,8 +26,16 @@ import { agentSandboxes } from "../schemas/agent-sandboxes";
 import { jobExecutionLeases } from "../schemas/job-execution-leases";
 import type { Job, NewJob } from "../schemas/jobs";
 import { jobs } from "../schemas/jobs";
+import {
+  cutoverResumeWindowAllows,
+  msWindowTimestampMatch,
+} from "./job-timestamp-fence";
 
 export type { Job, NewJob };
+export {
+  cutoverResumeWindowAllows,
+  msWindowTimestampMatch,
+} from "./job-timestamp-fence";
 
 /**
  * Settles the rows that depend on a job the recovery sweep just flipped to
@@ -187,8 +195,11 @@ function hasRecoverableAdminCanaryCutover(job: Job): boolean {
   const resumedCleanupClaim =
     rowStartedAt !== null &&
     rowUpdatedAt !== null &&
-    cutoverAt <= rowStartedAt &&
-    rowStartedAt <= rowUpdatedAt;
+    cutoverResumeWindowAllows({
+      cutoverAtMs: cutoverAt,
+      rowStartedAtMs: rowStartedAt,
+      rowUpdatedAtMs: rowUpdatedAt,
+    });
   return (
     job.organization_id === data.organizationId &&
     job.user_id === data.userId &&
@@ -251,10 +262,10 @@ function retryPayloadFence(job: Job) {
     AND ${jobs.attempts} = ${job.attempts}
     AND ${jobs.max_attempts} = ${job.max_attempts}
     AND ${jobs.execution_generation} IS NOT DISTINCT FROM ${job.execution_generation}
-    AND ${jobs.execution_quiesced_at} IS NOT DISTINCT FROM ${normalizedTimestamp(job.execution_quiesced_at)}
-    AND ${jobs.started_at} IS NOT DISTINCT FROM ${normalizedTimestamp(job.started_at)}
-    AND ${jobs.completed_at} IS NOT DISTINCT FROM ${normalizedTimestamp(job.completed_at)}
-    AND ${jobs.updated_at} IS NOT DISTINCT FROM ${normalizedTimestamp(job.updated_at)}
+    AND ${msWindowTimestampMatch(jobs.execution_quiesced_at, job.execution_quiesced_at)}
+    AND ${msWindowTimestampMatch(jobs.started_at, job.started_at)}
+    AND ${msWindowTimestampMatch(jobs.completed_at, job.completed_at)}
+    AND ${msWindowTimestampMatch(jobs.updated_at, job.updated_at)}
     AND ${jobs.data_storage} = ${job.data_storage}
     AND ${jobs.data_key} IS NOT DISTINCT FROM ${job.data_key}
     AND ${dataFence}
@@ -1151,7 +1162,10 @@ export class JobsRepository {
             eq(jobs.status, "in_progress"),
             eq(jobs.attempts, params.job.attempts),
             sql`${jobs.execution_generation} IS NOT DISTINCT FROM ${params.job.execution_generation}`,
-            sql`${jobs.execution_quiesced_at} IS NOT DISTINCT FROM ${normalizedTimestamp(params.job.execution_quiesced_at)}`,
+            msWindowTimestampMatch(
+              jobs.execution_quiesced_at,
+              params.job.execution_quiesced_at,
+            ),
             lt(jobs.started_at, params.startedBefore),
             params.recoveryFence,
           ),
@@ -1189,7 +1203,10 @@ export class JobsRepository {
             eq(jobs.status, "in_progress"),
             eq(jobs.attempts, params.job.attempts),
             sql`${jobs.execution_generation} IS NOT DISTINCT FROM ${params.job.execution_generation}`,
-            sql`${jobs.execution_quiesced_at} IS NOT DISTINCT FROM ${normalizedTimestamp(params.job.execution_quiesced_at)}`,
+            msWindowTimestampMatch(
+              jobs.execution_quiesced_at,
+              params.job.execution_quiesced_at,
+            ),
             lt(jobs.started_at, params.startedBefore),
             params.recoveryFence,
             requiresExecutionLease && params.job.execution_generation

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -37,6 +37,8 @@ import {
   type JobRecoveryFailure,
   type JobRecoverySweepResult,
   jobsRepository,
+  cutoverResumeWindowAllows,
+  msWindowTimestampMatch,
   type NewJob,
   prepareJobInsertData,
   type RecoveryFailureWritebackBuilder,
@@ -4122,11 +4124,11 @@ export class ProvisioningJobService {
         pendingAudit.startedAt ===
           (snapshot.started_at === null ? "" : jobAuditTimestamp(snapshot.started_at)) &&
         pendingAudit.cutoverAt === jobAuditTimestamp(snapshot.updated_at);
-      const resumedCleanupClaim =
-        Number.isFinite(rowStartedAt) &&
-        Number.isFinite(rowUpdatedAt) &&
-        cutoverAt <= rowStartedAt &&
-        rowStartedAt <= rowUpdatedAt;
+      const resumedCleanupClaim = cutoverResumeWindowAllows({
+        cutoverAtMs: cutoverAt,
+        rowStartedAtMs: rowStartedAt,
+        rowUpdatedAtMs: rowUpdatedAt,
+      });
       return (
         Number.isFinite(auditStartedAt) &&
         Number.isFinite(cutoverAt) &&
@@ -4206,15 +4208,23 @@ export class ProvisioningJobService {
             eq(jobs.max_attempts, snapshot.max_attempts),
             sql`${jobs.execution_generation} IS NOT DISTINCT FROM ${snapshot.execution_generation}`,
             isNull(jobs.execution_quiesced_at),
-            sql`${jobs.started_at} IS NOT DISTINCT FROM ${
-              snapshot.started_at ? new Date(jobAuditTimestamp(snapshot.started_at)) : null
-            }`,
-            sql`${jobs.completed_at} IS NOT DISTINCT FROM ${
-              snapshot.completed_at ? new Date(jobAuditTimestamp(snapshot.completed_at)) : null
-            }`,
-            sql`${jobs.updated_at} IS NOT DISTINCT FROM ${new Date(
-              jobAuditTimestamp(snapshot.updated_at),
-            )}`,
+            // #17919 / #17284 class: ms-window fence so µs-stored NOW() rows match JS reads
+            msWindowTimestampMatch(
+              jobs.started_at,
+              snapshot.started_at
+                ? new Date(jobAuditTimestamp(snapshot.started_at))
+                : null,
+            ),
+            msWindowTimestampMatch(
+              jobs.completed_at,
+              snapshot.completed_at
+                ? new Date(jobAuditTimestamp(snapshot.completed_at))
+                : null,
+            ),
+            msWindowTimestampMatch(
+              jobs.updated_at,
+              new Date(jobAuditTimestamp(snapshot.updated_at)),
+            ),
             sql`${jobs.data_storage} = 'inline'`,
             sql`${jobs.data_key} IS NOT DISTINCT FROM ${snapshot.data_key}`,
             sql`${jobs.data} IS NOT DISTINCT FROM ${JSON.stringify(snapshot.data)}::jsonb`,
@@ -4370,15 +4380,21 @@ export class ProvisioningJobService {
             eq(jobs.max_attempts, job.max_attempts),
             sql`${jobs.execution_generation} IS NOT DISTINCT FROM ${job.execution_generation}`,
             isNull(jobs.execution_quiesced_at),
-            sql`${jobs.started_at} IS NOT DISTINCT FROM ${
-              job.started_at ? new Date(jobAuditTimestamp(job.started_at)) : null
-            }`,
-            sql`${jobs.completed_at} IS NOT DISTINCT FROM ${
-              job.completed_at ? new Date(jobAuditTimestamp(job.completed_at)) : null
-            }`,
-            sql`${jobs.updated_at} IS NOT DISTINCT FROM ${new Date(
-              jobAuditTimestamp(job.updated_at),
-            )}`,
+            // #17919 / #17284 class: ms-window fence so µs-stored NOW() rows match JS reads
+            msWindowTimestampMatch(
+              jobs.started_at,
+              job.started_at ? new Date(jobAuditTimestamp(job.started_at)) : null,
+            ),
+            msWindowTimestampMatch(
+              jobs.completed_at,
+              job.completed_at
+                ? new Date(jobAuditTimestamp(job.completed_at))
+                : null,
+            ),
+            msWindowTimestampMatch(
+              jobs.updated_at,
+              new Date(jobAuditTimestamp(job.updated_at)),
+            ),
             sql`${jobs.data_storage} = 'inline'`,
             sql`${jobs.data_key} IS NOT DISTINCT FROM ${job.data_key}`,
             sql`${jobs.data} IS NOT DISTINCT FROM ${JSON.stringify(job.data)}::jsonb`,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -32,12 +32,12 @@ import { ensureAgentSandboxSchema } from "../../db/ensure-agent-sandbox-schema";
 import { dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import {
+  cutoverResumeWindowAllows,
   hydrateJob,
   type Job,
   type JobRecoveryFailure,
   type JobRecoverySweepResult,
   jobsRepository,
-  cutoverResumeWindowAllows,
   msWindowTimestampMatch,
   type NewJob,
   prepareJobInsertData,
@@ -4211,15 +4211,11 @@ export class ProvisioningJobService {
             // #17919 / #17284 class: ms-window fence so µs-stored NOW() rows match JS reads
             msWindowTimestampMatch(
               jobs.started_at,
-              snapshot.started_at
-                ? new Date(jobAuditTimestamp(snapshot.started_at))
-                : null,
+              snapshot.started_at ? new Date(jobAuditTimestamp(snapshot.started_at)) : null,
             ),
             msWindowTimestampMatch(
               jobs.completed_at,
-              snapshot.completed_at
-                ? new Date(jobAuditTimestamp(snapshot.completed_at))
-                : null,
+              snapshot.completed_at ? new Date(jobAuditTimestamp(snapshot.completed_at)) : null,
             ),
             msWindowTimestampMatch(
               jobs.updated_at,
@@ -4387,14 +4383,9 @@ export class ProvisioningJobService {
             ),
             msWindowTimestampMatch(
               jobs.completed_at,
-              job.completed_at
-                ? new Date(jobAuditTimestamp(job.completed_at))
-                : null,
+              job.completed_at ? new Date(jobAuditTimestamp(job.completed_at)) : null,
             ),
-            msWindowTimestampMatch(
-              jobs.updated_at,
-              new Date(jobAuditTimestamp(job.updated_at)),
-            ),
+            msWindowTimestampMatch(jobs.updated_at, new Date(jobAuditTimestamp(job.updated_at))),
             sql`${jobs.data_storage} = 'inline'`,
             sql`${jobs.data_key} IS NOT DISTINCT FROM ${job.data_key}`,
             sql`${jobs.data} IS NOT DISTINCT FROM ${JSON.stringify(job.data)}::jsonb`,


### PR DESCRIPTION
# Relates to

Fixes #17919

- [x] Targets develop from latest origin/develop at open time.
- [x] Focused unit tests passed after the change (2/2 job-timestamp-fence.test.ts).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.5
<!-- attribution-row:client -->
- Client tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@b49a8e8742df71ee3c98f933da30fc0e74a756ee:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branch cut from origin/develop b49a8e8742df71ee3c98f933da30fc0e74a756ee.
- [ ] Full monorepo bun run verify not re-run (see Known gaps).

# Risks

Medium-low. Changes CAS/recovery fence SQL shape for job timestamps (date_trunc ms) and tightens the cutover resume window to reject µs-scale numbers. Same remedy class as #17284. False negatives on genuine same-ms ABA remain possible but were already true of the previous fence class.

# Background

## What does this PR do?

Closes the µs/ms unit mismatch between job claim SQL timestamps and cutover-audit window/CAS math (#17919).

Root cause: claim/recovery writers store `updated_at = NOW()` with microsecond precision on real Postgres. Typed JS reads and `Date`/`toISOString` truncate to milliseconds, so plain `column IS NOT DISTINCT FROM ` silently misses for every µs-stored row — cutover atomic audit CAS and recovery fences fail closed, and resume-window math can mis-evaluate if units are mixed.

Fix (same class as #17284):
- `msWindowTimestampMatch` applies `date_trunc('milliseconds', column)` before comparing.
- Wired into jobs recovery/retry fences and both admin-canary cutover CAS sites in provisioning-jobs.
- `cutoverResumeWindowAllows` centralizes the resume window and fail-closes on µs-scale inputs.

## What kind of change is this?

Bug fix (cloud jobs cutover/recovery timestamp CAS).

# Documentation changes needed?

No documentation change required.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/db/repositories/job-timestamp-fence.ts` then the CAS call sites in `jobs.ts` / `provisioning-jobs.ts`.

## Detailed testing steps

```bash
bun install --frozen-lockfile --ignore-scripts
bun test packages/cloud/shared/src/db/repositories/job-timestamp-fence.test.ts
```

Expected: 2 pass / 0 fail; SQL shape contains `date_trunc('milliseconds'`; µs-scale resume window rejected.

# Evidence Gate

<!-- evidence-head:fdeca8054b9a9b542f682aff56dfd7ba29be0a6f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; cloud jobs unit tests only.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - unit suite 2/2 at head 1431b40822c6cf721ab2783c25c67aca602a357c; ms-window fence shape + µs reject pinned.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM path exercised.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB side effects beyond SQL fence shape unit pins.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Known gaps / failures

- Full monorepo bun run verify not re-run (change is timestamp CAS helpers + call sites).
- Outside-collaborator fork CI may sit at action_required until a maintainer approves workflow runs (see #17551).

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@b49a8e8742df71ee3c98f933da30fc0e74a756ee:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-krutftw]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/eliza@b49a8e8742df71ee3c98f933da30fc0e74a756ee:packages/skills/skills/contribute-to-eliza"} -->



