### PR TITLE
fix(ci): stop PR template labels from invalidating army attribution

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,17 +24,25 @@ prompts containing secrets, tokens, private session IDs, or hidden reasoning.
 Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
 enough. Human-only work must say so explicitly.
 
+The row labels below must **not** reuse the terminal eliza.army footer labels
+(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
+`Attribution status`). Duplicating those strings makes the scoring validator
+reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
+markers; only the human-readable prefixes changed. After filling these rows,
+append the standard footer once at the end of the PR body (do not repeat the
+visible footer lines here).
+
 <!-- contribution-attribution:v1 -->
 <!-- attribution-row:ai-assistance -->
 - AI assistance: `yes` / `no - human-only contribution`
 <!-- attribution-row:models -->
 - Model(s) used: `provider/model-id` / `None - human-only contribution`
 <!-- attribution-row:client -->
-- Client / agent tooling: `client-name` / `None - human-only contribution`
+- Agent tooling: `client-name` / `None - human-only contribution`
 <!-- attribution-row:skill-revision -->
-- Skill revision: `owner/repo@full-commit-sha:path` / `N/A - no contribution skill used`
+- Skill path: `owner/repo@full-commit-sha:path` / `N/A - no contribution skill used`
 <!-- attribution-row:status -->
-- Attribution status: `self-reported`
+- Provenance status: `self-reported`
 
 # Sync with develop
 

--- a/packages/skills/skills/contribute-to-eliza/SKILL.md
+++ b/packages/skills/skills/contribute-to-eliza/SKILL.md
@@ -55,7 +55,12 @@ put secrets, prompts, session identifiers, or hidden reasoning in the footer.
 In an issue body, complete the visible provenance rows once, then append only
 the lane signature and marker at the end. In a PR body, complete every stable
 contribution-attribution row in the repository template and append this footer
-after the template.
+after the template. The template row labels are deliberately different from the
+footer labels (see #17855): do **not** reword template rows to match
+`Client / agent tooling`, `Skill revision` / `Contribution skill revision`, or
+`Attribution status`, and do **not** paste a second copy of those footer lines
+into the provenance block — the army scorer requires exactly one of each footer
+label in the whole body.
 
 Resolve the skill revision before posting:
 

--- a/scripts/check-pr-agent-attribution.test.mjs
+++ b/scripts/check-pr-agent-attribution.test.mjs
@@ -47,17 +47,19 @@ function body({
   revision = "`elizaOS/eliza@0123456789abcdef0123456789abcdef01234567:packages/skills/skills/contribute-to-eliza`",
   status = "self-reported",
 } = {}) {
+  // Labels match .github/pull_request_template.md (#17855): they must not reuse
+  // the terminal army footer labels or the scorer drops the machine marker.
   return `<!-- contribution-attribution:v1 -->
 <!-- attribution-row:ai-assistance -->
 - AI assistance: ${assistance}
 <!-- attribution-row:models -->
 - Model(s) used: ${models}
 <!-- attribution-row:client -->
-- Client / agent tooling: ${client}
+- Agent tooling: ${client}
 <!-- attribution-row:skill-revision -->
-- Skill revision: ${revision}
+- Skill path: ${revision}
 <!-- attribution-row:status -->
-- Attribution status: ${status}`;
+- Provenance status: ${status}`;
 }
 
 function workflowSource(workflowPath) {
@@ -209,8 +211,8 @@ describe("PR agent attribution", () => {
 
     const mixed = evaluatePrAttribution(
       deterministicBody.replace(
-        "Client / agent tooling: None - deterministic workflow",
-        "Client / agent tooling: None - human-only contribution",
+        "Agent tooling: None - deterministic workflow",
+        "Agent tooling: None - human-only contribution",
       ),
     );
     assert.equal(mixed.ok, false);
@@ -386,9 +388,11 @@ describe("PR agent attribution", () => {
 
   it("still drops a human label, including one containing a slash", () => {
     // The strip exists for the documented template, so refusing to run past a
-    // value's colon must not stop it removing a genuine label. `Client / agent
-    // tooling:` is the repository's own, and it carries a slash.
-    const labelled = evaluatePrAttribution(body());
+    // value's colon must not stop it removing a genuine label. Legacy
+    // `Client / agent tooling:` still works when present and carries a slash.
+    const labelled = evaluatePrAttribution(
+      body().replace("Agent tooling:", "Client / agent tooling:"),
+    );
     assert.equal(labelled.ok, true);
     assert.equal(labelled.attribution.client, "Codex Desktop");
     assert.equal(
@@ -397,6 +401,70 @@ describe("PR agent attribution", () => {
       "a labelled status row must still reduce to the bare keyword",
     );
     assert.deepEqual(labelled.attribution.modelIds, ["openai/gpt-5.6-sol"]);
+  });
+
+  it("keeps PR template labels free of army terminal-footer collisions (#17855)", () => {
+    const templatePath = path.join(
+      repositoryRoot,
+      ".github",
+      "pull_request_template.md",
+    );
+    const template = readFileSync(templatePath, "utf8");
+    // Reserved by elizaOS/army leaderboard.ts attributionLineValues for the
+    // terminal footer — if the template reuses them, filling the template and
+    // appending the skill footer yields count=2 and drops the machine marker.
+    const reserved = [
+      /^-\s*Client \/ agent tooling\s*:/im,
+      /^-\s*Skill revision\s*:/im,
+      /^-\s*Contribution skill revision\s*:/im,
+      /^-\s*Attribution status\s*:/im,
+    ];
+    for (const pattern of reserved) {
+      assert.equal(
+        pattern.test(template),
+        false,
+        `PR template must not use reserved footer label matching ${pattern}`,
+      );
+    }
+    assert.match(template, /<!-- attribution-row:client -->/);
+    assert.match(template, /Agent tooling:/);
+    assert.match(template, /Skill path:/);
+    assert.match(template, /Provenance status:/);
+
+    // Filled template rows + full terminal footer must still pass the CI gate.
+    const filled = template
+      .replace(
+        /`yes` \/ `no - human-only contribution`/,
+        "yes",
+      )
+      .replace(
+        /`provider\/model-id` \/ `None - human-only contribution`/,
+        "`xai/grok-4.5`",
+      )
+      .replace(
+        /`client-name` \/ `None - human-only contribution`/,
+        "grok",
+      )
+      .replace(
+        /`owner\/repo@full-commit-sha:path` \/ `N\/A - no contribution skill used`/,
+        "`elizaOS/eliza@0123456789abcdef0123456789abcdef01234567:packages/skills/skills/contribute-to-eliza`",
+      )
+      .replace(/`self-reported`/, "self-reported");
+    const withFooter = `${filled}
+
+AI provider/model: xai / grok-4.5
+Client / agent tooling: grok
+Contribution skill revision: elizaOS/eliza@0123456789abcdef0123456789abcdef01234567:packages/skills/skills/contribute-to-eliza
+Attribution status: self-reported
+— [grok-krutftw]
+<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/eliza@0123456789abcdef0123456789abcdef01234567:packages/skills/skills/contribute-to-eliza"} -->
+`;
+    const result = evaluatePrAttribution(withFooter);
+    assert.equal(
+      result.ok,
+      true,
+      result.findings.map((finding) => finding.message).join("; "),
+    );
   });
 
   it("rejects missing markers and rows even when prose names a model", () => {


### PR DESCRIPTION
# Relates to

Fixes #17855

- [x] Targets develop from latest origin/develop at open time.
- [x] Focused unit tests passed after the change (21/21 check-pr-agent-attribution.test.mjs).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.5
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@561a817b1641d4dd83b04727e59635221fde564d:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branch cut from origin/develop 561a817b1641d4dd83b04727e59635221fde564d.
- [ ] Full monorepo bun run verify not re-run (see Known gaps).

# Risks

Low. Template label wording and skill guidance only; HTML attribution-row markers and CI value extraction are unchanged. Legacy bodies that still use the old labels remain valid for the PR gate.

# Background

## What does this PR do?

Stops the PR template provenance labels from colliding with the terminal eliza.army footer labels (#17855).

Root cause: filling the template (required by CI) and appending the skill footer (required by the skill / army) put `Client / agent tooling`, `Skill revision` / `Contribution skill revision`, and `Attribution status` in the body twice. Army's `attributionLineValues` counts labels across the **whole** body and rejects the machine marker when each is not exactly once — coverage drops to partial and `client`/`skill_revision` are lost.

Fix (issue candidate Fix 2; army is not a scored target repo, so the scorer change is out of scope here):
- Relabel template rows to `Agent tooling`, `Skill path`, `Provenance status` (`<!-- attribution-row:* -->` markers unchanged).
- Document the non-collision rule in contribute-to-eliza.
- Regression: template must not contain reserved footer labels; filled template + full footer still passes the PR attribution CI gate.

## What kind of change is this?

Bug fix (contribution provenance template / skill docs / gate tests).

# Documentation changes needed?

No separate docs package change; skill + PR template carry the guidance.

# Testing

## Where should a reviewer start?

`.github/pull_request_template.md` provenance block, then `scripts/check-pr-agent-attribution.test.mjs` (#17855 case).

## Detailed testing steps

```bash
node --test scripts/check-pr-agent-attribution.test.mjs
```

Expected: 21 pass / 0 fail, including `keeps PR template labels free of army terminal-footer collisions (#17855)`.

# Evidence Gate

<!-- evidence-head:1857bdff1792fc8781a936d7c69feae2119b55a3 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; PR template + attribution unit tests only.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - unit suite 21/21 at head 1857bdff1792fc8781a936d7c69feae2119b55a3; reserved-label + template+footer CI-gate pins.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM path exercised.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB/wallet domain side effects.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Known gaps / failures

- Full monorepo bun run verify not re-run (change is template labels + skill note + unit test).
- Preferred Fix 1 (army scorer scoping) remains valuable but lives in elizaOS/army (not a scored target).
- Outside-collaborator fork CI may sit at action_required until a maintainer approves workflow runs (see #17551).

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@561a817b1641d4dd83b04727e59635221fde564d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-krutftw]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/eliza@561a817b1641d4dd83b04727e59635221fde564d:packages/skills/skills/contribute-to-eliza"} -->
