### PR TITLE
fix(core): prewarm relationships graph at boot for cold rolodex

### DIFF
--- a/packages/core/src/services/relationships-graph-builder.ts
+++ b/packages/core/src/services/relationships-graph-builder.ts
@@ -229,6 +229,13 @@ export type RelationshipsGraphService = {
 		entityB: UUID,
 		evidence: RelationshipsMergeProposalEvidence,
 	) => Promise<UUID>;
+	/**
+	 * Kick a background graph-model build so the first user turn after boot
+	 * can hit the stale-while-revalidate cache instead of awaiting a cold
+	 * CPU-bound rebuild that pins the event loop past the 3s rolodex budget
+	 * (#17932). Safe to call multiple times; builds are single-flighted.
+	 */
+	prewarmGraphModel: () => void;
 };
 
 type RelationshipsContactLike = {
@@ -2324,6 +2331,15 @@ export function createNativeRelationshipsGraphService(
 		modelBuildPromise = null;
 	}
 
+	/**
+	 * Fire-and-forget first-build of the graph model. Does not await; errors
+	 * are already observed by the shared getCachedModel catch handler.
+	 */
+	function prewarmGraphModel(): void {
+		if (modelCache || modelBuildPromise) return;
+		void getCachedModel();
+	}
+
 	function applyOwnerName(
 		summaries: RelationshipsPersonSummary[],
 		ownerName: string | null,
@@ -2335,6 +2351,7 @@ export function createNativeRelationshipsGraphService(
 	}
 
 	return {
+		prewarmGraphModel,
 		async getGraphSnapshot(query = {}): Promise<RelationshipsGraphSnapshot> {
 			const [model, ownerName] = await Promise.all([
 				getCachedModel(),

--- a/packages/core/src/services/relationships-graph-prewarm.test.ts
+++ b/packages/core/src/services/relationships-graph-prewarm.test.ts
@@ -1,0 +1,101 @@
+/**
+ * #17932: boot-time graph prewarm so cold rolodex turns hit the
+ * stale-while-revalidate cache instead of awaiting a first-build that pins
+ * the event loop past the 3s provider deadline.
+ */
+import { describe, expect, test } from "bun:test";
+import type { IAgentRuntime } from "../types/index";
+import { createNativeRelationshipsGraphService } from "./relationships-graph-builder";
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function mockRuntime(options: {
+	onWorlds: () => void;
+}): IAgentRuntime {
+	let worldsCalls = 0;
+	return {
+		agentId: "11111111-1111-4111-8111-111111111111",
+		async getAllWorlds() {
+			worldsCalls += 1;
+			options.onWorlds();
+			// Simulate a non-trivial first build without needing a real store.
+			await sleep(30);
+			return [];
+		},
+		async getRoomsByWorlds() {
+			return [];
+		},
+		async getEntitiesForRoom() {
+			return [];
+		},
+		async getRelationships() {
+			return [];
+		},
+		async getEntityById() {
+			return null;
+		},
+		getService() {
+			return null;
+		},
+		_worldsCalls: () => worldsCalls,
+	} as unknown as IAgentRuntime & { _worldsCalls: () => number };
+}
+
+describe("relationships graph prewarm (#17932)", () => {
+	test("prewarmGraphModel starts a single-flight build shared with getGraphSnapshot", async () => {
+		let worldsCalls = 0;
+		const runtime = mockRuntime({
+			onWorlds: () => {
+				worldsCalls += 1;
+			},
+		});
+		const service = createNativeRelationshipsGraphService(runtime, {
+			async searchContacts() {
+				return [];
+			},
+			async getCandidateMerges() {
+				return [];
+			},
+		});
+
+		// Kick background prewarm — must not throw and must not await.
+		expect(() => service.prewarmGraphModel()).not.toThrow();
+		// Second prewarm is a no-op while the build (or cache) is live.
+		service.prewarmGraphModel();
+
+		// Concurrent snapshot must share the single-flight build, not start a second.
+		const snapshot = await service.getGraphSnapshot({ limit: 10 });
+		expect(snapshot.people).toEqual([]);
+		expect(worldsCalls).toBe(1);
+
+		// Warm hit: no additional build.
+		await service.getGraphSnapshot({ limit: 10 });
+		expect(worldsCalls).toBe(1);
+	});
+
+	test("prewarm is a no-op once the model cache is populated", async () => {
+		let worldsCalls = 0;
+		const runtime = mockRuntime({
+			onWorlds: () => {
+				worldsCalls += 1;
+			},
+		});
+		const service = createNativeRelationshipsGraphService(runtime, {
+			async searchContacts() {
+				return [];
+			},
+			async getCandidateMerges() {
+				return [];
+			},
+		});
+
+		await service.getGraphSnapshot({ limit: 5 });
+		expect(worldsCalls).toBe(1);
+		service.prewarmGraphModel();
+		service.prewarmGraphModel();
+		await sleep(10);
+		expect(worldsCalls).toBe(1);
+	});
+});

--- a/packages/core/src/services/relationships-graph-prewarm.test.ts
+++ b/packages/core/src/services/relationships-graph-prewarm.test.ts
@@ -11,9 +11,7 @@ function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function mockRuntime(options: {
-	onWorlds: () => void;
-}): IAgentRuntime {
+function mockRuntime(options: { onWorlds: () => void }): IAgentRuntime {
 	let worldsCalls = 0;
 	return {
 		agentId: "11111111-1111-4111-8111-111111111111",

--- a/packages/core/src/services/relationships.ts
+++ b/packages/core/src/services/relationships.ts
@@ -746,6 +746,10 @@ export class RelationshipsService extends Service {
 		// Load existing contact info from components
 		await this.loadContactInfoFromComponents();
 
+		// Best-effort cold-start prewarm with default resolvers. Agent code that
+		// later calls setGraphResolvers will re-prewarm with owner wiring (#17932).
+		this.prewarmGraphModel();
+
 		logger.info("[RelationshipsService] Initialized successfully");
 	}
 
@@ -2324,6 +2328,28 @@ export class RelationshipsService extends Service {
 	setGraphResolvers(resolvers: GraphResolvers): void {
 		this.graphResolvers = resolvers;
 		this.graphServiceInstance = null;
+		// Resolvers are agent-wired after service start; prewarm only once they
+		// are set so the first-build owner/name path matches live turns (#17932).
+		this.prewarmGraphModel();
+	}
+
+	/**
+	 * Kick a background relationships-graph build so cold rolodex turns after
+	 * restart hit the stale-while-revalidate cache instead of blocking the
+	 * event loop past the 3s provider deadline (#17932).
+	 */
+	prewarmGraphModel(): void {
+		if (!this.runtime) return;
+		try {
+			this.getGraphServiceInstance().prewarmGraphModel();
+		} catch (err) {
+			// error-policy:J5 Prewarm is best-effort; live turns still cold-build.
+			logger.warn(
+				`[RelationshipsService] Graph prewarm failed to start: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
 	}
 
 	private getGraphServiceInstance(): RelationshipsGraphService {


### PR DESCRIPTION
# Relates to

Fixes #17932

- [x] Targets develop from latest origin/develop at open time.
- [x] Focused unit tests passed after the change (2/2 relationships-graph-prewarm.test.ts).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.5
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@140bf552ff84e72bab812f9ba91a34179321c39a:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branch cut from origin/develop 140bf552ff84e72bab812f9ba91a34179321c39a.
- [ ] Full monorepo bun run verify not re-run (see Known gaps).

# Risks

Low-medium. Background graph build at service init and after setGraphResolvers. Single-flighted with existing cache; errors already handled by the rebuild catch. Extra CPU shortly after boot; no user-turn path change when cache is already warm.

# Background

## What does this PR do?

Boot-time prewarm of the relationships graph model so the first post-restart rolodex turn hits the stale-while-revalidate cache (#17932).

Root cause: after #17876, steady-state rolodex is ~29ms from cache, but the first turn after process restart has no snapshot and awaits `buildGraphModel`. That build's synchronous stretches pin the event loop, so the 3s `withProviderDeadline` timer cannot fire until the build finishes (live-measured ~20s composeState).

Fix (issue option 1):
- `prewarmGraphModel()` kicks a fire-and-forget single-flight `getCachedModel()`.
- Called from `RelationshipsService.initialize` (default resolvers) and again from `setGraphResolvers` when the agent wires owner resolvers (invalidates and re-prewarms so the live path matches).

## What kind of change is this?

Bug fix / performance (relationships graph cold-start).

# Documentation changes needed?

No documentation change required.

# Testing

## Where should a reviewer start?

`packages/core/src/services/relationships-graph-builder.ts` (`prewarmGraphModel`), then `relationships.ts` call sites.

## Detailed testing steps

```bash
bun install --frozen-lockfile --ignore-scripts
bun test packages/core/src/services/relationships-graph-prewarm.test.ts
```

Expected: 2 pass / 0 fail; single-flight shared with getGraphSnapshot; prewarm no-op when warm.

# Evidence Gate

<!-- evidence-head:a53343d91101d2ab48e399cd809b53919570d5a0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; relationships graph unit tests only.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - unit suite 2/2 at head a53343d91101d2ab48e399cd809b53919570d5a0; single-flight prewarm pin.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM path exercised.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB/wallet domain side effects beyond in-memory graph mocks.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Known gaps / failures

- Full monorepo bun run verify not re-run.
- Live post-restart timing (20s cold → ~1s warm) not re-measured on this machine; unit pins the single-flight prewarm contract.
- Outside-collaborator fork CI may sit at action_required until a maintainer approves workflow runs (see #17551).

AI provider/model: xai / grok-4.5
Client / agent tooling: grok
Contribution skill revision: elizaOS/eliza@140bf552ff84e72bab812f9ba91a34179321c39a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [grok-krutftw]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"grok","skill_revision":"elizaOS/eliza@140bf552ff84e72bab812f9ba91a34179321c39a:packages/skills/skills/contribute-to-eliza"} -->





<!-- evidence re-verify a53343d91101d2ab48e399cd809b53919570d5a0 -->

