### PR TITLE
fix(ci): enforce App Live runtime readiness

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -46,6 +46,11 @@ env:
   CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  # The Anthropic repository credential can be present but unfunded. The App
+  # Live chat lane already validates this repository's OpenAI key, so use that
+  # funded provider for the mandatory walkthrough screenshot review too.
+  AI_QA_VISION_BACKEND: openai
+  AI_QA_VISION_MODEL: gpt-5-mini
   GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
   OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
   GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}

--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -55,6 +55,7 @@ env:
   # @napi-rs/keyring can terminate the runtime before JavaScript can report it.
   ELIZA_VAULT_DISABLE_KEYCHAIN: "1"
   ELIZA_VAULT_PASSPHRASE: app-live-e2e-headless-vault-only
+  ELIZA_UI_SMOKE_BACKEND_LOG_PATH: e2e-recordings/app-live/backend.log
 
 jobs:
   # Real LOCAL chat turn through the live stack: a real app-core runtime + a real
@@ -130,6 +131,7 @@ jobs:
           path: |
             packages/app/playwright-report/
             packages/app/test-results/
+            e2e-recordings/app-live/backend.log
           if-no-files-found: ignore
           retention-days: 7
 

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -77,8 +77,7 @@ const UI_PORT = Number(process.env.ELIZA_UI_SMOKE_PORT ?? "2138");
 const UI_SMOKE_RUN_ID = process.env.ELIZA_UI_SMOKE_RUN_ID?.trim() ?? "";
 const LIVE_PROVIDER = await selectLiveProviderAsync();
 const REAL_LOCAL_STACK = process.env.ELIZA_UI_SMOKE_REAL_LOCAL_STACK === "1";
-const REAL_LOCAL_BACKEND_LOG_PATH =
-  process.env.ELIZA_UI_SMOKE_BACKEND_LOG_PATH?.trim();
+const BACKEND_LOG_PATH = process.env.ELIZA_UI_SMOKE_BACKEND_LOG_PATH?.trim();
 // Precedence (force-stub > live opt-in > CI default) lives in one tested helper.
 // The key behavior: ELIZA_UI_SMOKE_LIVE_STACK=1 overrides the CI-based stub force
 // so a genuinely-real lane is possible (GitHub Actions always sets CI=true, which
@@ -822,6 +821,57 @@ async function waitForJsonPredicate<T>(
     : new Error(`Timed out waiting for ${url}`);
 }
 
+type DeferredBootHealth = {
+  deferredBoot?: {
+    phases?: Record<string, "pending" | "complete" | "failed">;
+    settled?: boolean;
+  };
+};
+
+async function waitForDeferredBootComplete(apiBase: string): Promise<void> {
+  const url = `${apiBase}/api/health`;
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  let lastHealth: DeferredBootHealth | null = null;
+  let lastError: unknown = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const health = await fetchJson<DeferredBootHealth>(url);
+      lastHealth = health;
+      const phases = health.deferredBoot?.phases ?? {};
+      const failedPhases = Object.entries(phases)
+        .filter(([, status]) => status === "failed")
+        .map(([phase]) => phase);
+      if (failedPhases.length > 0) {
+        throw new Error(
+          `Deferred runtime boot failed (${failedPhases.join(", ")}): ${JSON.stringify(health.deferredBoot)}`,
+        );
+      }
+      if (
+        health.deferredBoot?.settled === true &&
+        phases["app-route-tail"] === "complete"
+      ) {
+        return;
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.startsWith("Deferred runtime boot failed")
+      ) {
+        throw error;
+      }
+      lastError = error;
+    }
+    await sleep(1_000);
+  }
+
+  throw new Error(
+    `Timed out waiting for deferred runtime boot: ${url}; lastHealth=${JSON.stringify(lastHealth)}${
+      lastError instanceof Error ? `; lastError=${lastError.message}` : ""
+    }`,
+  );
+}
+
 async function ensureUiDistReady(): Promise<void> {
   const distIndex = path.join(APP_DIST_DIR, "index.html");
   let needsBuild = false;
@@ -1109,8 +1159,8 @@ async function startRealLocalStack(): Promise<StartedStack> {
   let apiChild: ChildProcessWithoutNullStreams | null = null;
   let uiServer: Server | null = null;
   try {
-    const backendLogPath = REAL_LOCAL_BACKEND_LOG_PATH
-      ? path.resolve(REPO_ROOT, REAL_LOCAL_BACKEND_LOG_PATH)
+    const backendLogPath = BACKEND_LOG_PATH
+      ? path.resolve(REPO_ROOT, BACKEND_LOG_PATH)
       : null;
     if (backendLogPath) {
       await mkdir(path.dirname(backendLogPath), { recursive: true });
@@ -1200,6 +1250,13 @@ async function startRealStack(): Promise<StartedStack> {
   let apiChild: ChildProcessWithoutNullStreams | null = null;
   let uiServer: Server | null = null;
   try {
+    const backendLogPath = BACKEND_LOG_PATH
+      ? path.resolve(REPO_ROOT, BACKEND_LOG_PATH)
+      : null;
+    if (backendLogPath) {
+      await mkdir(path.dirname(backendLogPath), { recursive: true });
+      await writeFile(backendLogPath, "", "utf8");
+    }
     await seedLiveStackConfig(stateDir);
     const uiDistDir = await snapshotUiDist(stateDir);
     const apiBase = `http://127.0.0.1:${API_PORT}`;
@@ -1226,10 +1283,14 @@ async function startRealStack(): Promise<StartedStack> {
     );
 
     apiChild.stdout.on("data", (chunk) => {
-      process.stdout.write(`[ui-smoke][api] ${chunk}`);
+      const output = `[ui-smoke][api] ${chunk}`;
+      process.stdout.write(output);
+      if (backendLogPath) appendFileSync(backendLogPath, output);
     });
     apiChild.stderr.on("data", (chunk) => {
-      process.stdout.write(`[ui-smoke][api-err] ${chunk}`);
+      const output = `[ui-smoke][api-err] ${chunk}`;
+      process.stdout.write(output);
+      if (backendLogPath) appendFileSync(backendLogPath, output);
     });
 
     await waitForJson<{ complete: boolean }>(`${apiBase}/api/first-run/status`);
@@ -1266,13 +1327,7 @@ async function startRealStack(): Promise<StartedStack> {
       // App-control and plugin views are deferred capabilities. Treat the live
       // harness as ready only after the runtime's structured boot state settles;
       // logger filtering may legitimately suppress the human-readable marker.
-      await waitForJsonPredicate<{
-        deferredBoot?: { settled?: boolean };
-      }>(
-        `${apiBase}/api/health`,
-        (health) => health.deferredBoot?.settled === true,
-        READY_TIMEOUT_MS,
-      );
+      await waitForDeferredBootComplete(apiBase);
     }
 
     uiServer = await startUiProxyServer({

--- a/packages/app/scripts/walkthrough-e2e.mjs
+++ b/packages/app/scripts/walkthrough-e2e.mjs
@@ -10,7 +10,8 @@
  *      `--live` lane (real backend agent + model). Tees the runner output and
  *      extracts the backend `[ClassName]` / `[ui-smoke][api]` lines.
  *   2. Runs the per-step vision review (`scripts/ai-qa/review-walkthrough.mjs`)
- *      when ANTHROPIC_API_KEY is present, writing the committed verdict markdown.
+ *      when a configured reviewer provider key is present, writing the
+ *      committed verdict markdown.
  *   3. Stitches ONE human-speed, step-labeled recording per viewport from the
  *      ordered `NN-<step>.png` frames (ffmpeg) into `e2e-recordings/`, with a
  *      contact sheet + a viewer entry — not 25 headless per-test clips.
@@ -508,6 +509,8 @@ async function main() {
     for (const key of [
       "ANTHROPIC_API_KEY",
       "OPENAI_API_KEY",
+      "AI_QA_VISION_BACKEND",
+      "AI_QA_VISION_MODEL",
       "GROQ_API_KEY",
       "OPENROUTER_API_KEY",
       "GOOGLE_GENERATIVE_AI_API_KEY",
@@ -516,8 +519,6 @@ async function main() {
     ]) {
       if (!childEnv[key] && env[key]) childEnv[key] = env[key];
     }
-    if (childEnv.ANTHROPIC_API_KEY)
-      childEnv.ELIZA_UI_SMOKE_LIVE_PROVIDER = "anthropic";
   }
 
   // The live lane promises reviewed visual evidence. Reject unavailable,
@@ -582,10 +583,11 @@ async function main() {
   let reviewOk = true;
   if (!args.skipReview) {
     const reviewEnv = { ...childEnv };
-    if (!reviewEnv.ANTHROPIC_API_KEY) {
+    if (!reviewEnv.ANTHROPIC_API_KEY || !reviewEnv.OPENAI_API_KEY) {
       const env = loadEnvFile(join(REPO_ROOT, ".env.local"));
       if (env.ANTHROPIC_API_KEY)
         reviewEnv.ANTHROPIC_API_KEY = env.ANTHROPIC_API_KEY;
+      if (env.OPENAI_API_KEY) reviewEnv.OPENAI_API_KEY = env.OPENAI_API_KEY;
     }
     const review = await run(
       process.execPath,

--- a/packages/app/src/packaged-shell-storage-test-bridge.test.ts
+++ b/packages/app/src/packaged-shell-storage-test-bridge.test.ts
@@ -78,6 +78,7 @@ describe("packaged shell storage test bridge", () => {
   it("seeds returning-install state through shellLocalStorage", () => {
     const result = seedReturningInstallStateForPackagedTests(
       "http://127.0.0.1:31337",
+      "Alt+Shift+Super+F11",
     );
 
     expect(storageBridge.removeItem).toHaveBeenCalledWith(
@@ -94,6 +95,13 @@ describe("packaged shell storage test bridge", () => {
     expect(storageBridge.setItem).toHaveBeenCalledWith(
       "eliza:ui-shell-mode",
       "native",
+    );
+    expect(storageBridge.setItem).toHaveBeenCalledWith(
+      "eliza:chatOverlayHotkey",
+      JSON.stringify({
+        accelerator: "Alt+Shift+Super+F11",
+        enabled: true,
+      }),
     );
     expect(result).toMatchObject({
       ok: true,

--- a/packages/app/src/packaged-shell-storage-test-bridge.ts
+++ b/packages/app/src/packaged-shell-storage-test-bridge.ts
@@ -26,7 +26,10 @@ export interface ResettableStateSeedResult {
 
 export interface PackagedShellStorageTestBridge {
   seedResettableState(): ResettableStateSeedResult;
-  seedReturningInstallState(apiBase: string): ReturningInstallSeedResult;
+  seedReturningInstallState(
+    apiBase: string,
+    chatOverlayHotkey?: string,
+  ): ReturningInstallSeedResult;
 }
 
 declare global {
@@ -58,12 +61,19 @@ function readSeededState(win: Window): ReturningInstallSeedResult {
 
 export function seedReturningInstallStateForPackagedTests(
   apiBase: string,
+  chatOverlayHotkey?: string,
   win = window,
 ): ReturningInstallSeedResult {
   shellLocalStorage.removeItem("elizaos:first-run:force-fresh");
   shellLocalStorage.setItem("eliza:first-run-complete", "1");
   shellLocalStorage.setItem("eliza:setup:step", "activate");
   shellLocalStorage.setItem("eliza:ui-shell-mode", "native");
+  if (chatOverlayHotkey) {
+    shellLocalStorage.setItem(
+      "eliza:chatOverlayHotkey",
+      JSON.stringify({ accelerator: chatOverlayHotkey, enabled: true }),
+    );
+  }
   shellLocalStorage.setItem(
     "elizaos:active-server",
     JSON.stringify({
@@ -102,8 +112,12 @@ export function installPackagedShellStorageTestBridge(win = window): boolean {
 
   const bridge: PackagedShellStorageTestBridge = {
     seedResettableState: () => seedResettableStateForPackagedTests(win),
-    seedReturningInstallState: (apiBase) =>
-      seedReturningInstallStateForPackagedTests(apiBase, win),
+    seedReturningInstallState: (apiBase, chatOverlayHotkey) =>
+      seedReturningInstallStateForPackagedTests(
+        apiBase,
+        chatOverlayHotkey,
+        win,
+      ),
   };
   Object.defineProperty(win, PACKAGED_SHELL_STORAGE_TEST_GLOBAL, {
     configurable: true,

--- a/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
@@ -32,6 +32,13 @@ const PLUGINS_ROUTE = "/apps/plugins";
 const NAVIGATE_SETTINGS_EVENT = "eliza:navigate:settings";
 const NAVIGATE_VIEW_EVENT = "eliza:navigate:view";
 const NOTIFICATION_TEST_BRIDGE_SYMBOL = "elizaos.ui.notification-store-tests";
+// Electrobun's own Linux shortcut tests use an uncommon multi-modifier chord:
+// ordinary desktop chords can be unavailable under Xvfb even when native
+// registration works. Other platforms exercise the product default.
+const PACKAGED_CHAT_OVERLAY_ACCELERATOR =
+  process.platform === "linux"
+    ? "Alt+Shift+Super+F11"
+    : "CommandOrControl+Shift+C";
 
 test.describe.configure({ mode: "serial" });
 
@@ -714,7 +721,10 @@ async function seedReturningInstallState(
             error: "Packaged shell storage test bridge is unavailable.",
           };
         }
-        return bridge.seedReturningInstallState(apiBase);
+        return bridge.seedReturningInstallState(
+          apiBase,
+          ${JSON.stringify(PACKAGED_CHAT_OVERLAY_ACCELERATOR)},
+        );
       } catch (error) {
         return {
           ok: false,
@@ -1028,7 +1038,12 @@ test("packaged desktop shortcut bridge summons the main window", async ({
   await withPackagedHarness(async ({ harness }) => {
     const initialState = await harness.getState();
     expect(initialState.shell.shortcuts ?? []).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: "chat-overlay" })]),
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "chat-overlay",
+          accelerator: PACKAGED_CHAT_OVERLAY_ACCELERATOR,
+        }),
+      ]),
     );
 
     await harness.closeMainWindow();

--- a/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
+++ b/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
@@ -967,7 +967,11 @@ export class PackagedDesktopHarness {
         return response.result;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        if (!message.includes("/main-window/eval failed (500)")) {
+        const isTransientEvalFailure =
+          message.includes("/main-window/eval failed (500)") ||
+          (message.includes("/main-window/eval") &&
+            message.includes("timed out after"));
+        if (!isTransientEvalFailure) {
           throw error;
         }
         lastError = error instanceof Error ? error : new Error(message);

--- a/packages/app/test/ui-smoke/live-agent-chat.spec.ts
+++ b/packages/app/test/ui-smoke/live-agent-chat.spec.ts
@@ -8,6 +8,10 @@
 import { expect, type Page, test } from "@playwright/test";
 import { selectLiveProviderAsync } from "../../../app-core/test/helpers/live-provider";
 import {
+  ExpectedDevSmokeFailureMatcher,
+  isExpectedDevSmokeResponseCandidate,
+} from "../dev-smoke/browser-failure-policy";
+import {
   installDefaultAppRoutes,
   openAppPath,
   seedAppStorage,
@@ -86,6 +90,10 @@ type LivePromptTiming = {
   sendToAssistantMarkerMs: number;
 };
 
+type LiveFailureCollector = {
+  settle(): Promise<string[]>;
+};
+
 function isOptionalLiveEndpoint(url: string): boolean {
   return OPTIONAL_LIVE_ENDPOINTS.some((pattern) => pattern.test(url));
 }
@@ -108,10 +116,14 @@ function parseAssistantFixtureText(
   ) as DeterministicAssistantFixture;
 }
 
-function installFailureCollectors(page: Page): string[] {
-  const failures: string[] = [];
+function installFailureCollectors(page: Page): LiveFailureCollector {
+  const pageFailures: string[] = [];
+  const responseFailures: string[] = [];
+  const consoleErrors: Array<{ locationUrl: string; text: string }> = [];
+  const pendingResponses = new Set<Promise<void>>();
+  const expectedFailureMatcher = new ExpectedDevSmokeFailureMatcher();
   page.on("pageerror", (error) => {
-    failures.push(`pageerror: ${error.message}`);
+    pageFailures.push(`pageerror: ${error.message}`);
   });
   page.on("console", (message) => {
     if (message.type() !== "error") return;
@@ -124,7 +136,10 @@ function installFailureCollectors(page: Page): string[] {
     ) {
       return;
     }
-    failures.push(`console.error: ${text}`);
+    consoleErrors.push({
+      locationUrl: message.location().url,
+      text,
+    });
   });
   page.on("response", (response) => {
     if (response.status() < 400) return;
@@ -132,9 +147,51 @@ function installFailureCollectors(page: Page): string[] {
     if (response.status() < 500 && isOptionalLiveEndpoint(response.url())) {
       return;
     }
-    failures.push(`${response.status()} ${response.url()}`);
+    if (
+      !isExpectedDevSmokeResponseCandidate(response.status(), response.url())
+    ) {
+      responseFailures.push(`${response.status()} ${response.url()}`);
+      return;
+    }
+
+    const capture = response
+      .text()
+      .then((body) => {
+        if (
+          !expectedFailureMatcher.recordResponse(
+            response.status(),
+            response.url(),
+            body,
+          )
+        ) {
+          responseFailures.push(`${response.status()} ${response.url()}`);
+        }
+      })
+      .catch((error) => {
+        // error-policy:J7 An unreadable candidate remains an explicit smoke
+        // failure; response diagnostics must not create an unhandled rejection.
+        responseFailures.push(
+          `${response.status()} ${response.url()} (body read failed: ${String(error)})`,
+        );
+      });
+    pendingResponses.add(capture);
+    void capture.finally(() => pendingResponses.delete(capture));
   });
-  return failures;
+  return {
+    async settle() {
+      while (pendingResponses.size > 0) {
+        await Promise.allSettled([...pendingResponses]);
+      }
+      const failures = [...pageFailures, ...responseFailures];
+      for (const { locationUrl, text } of consoleErrors) {
+        if (expectedFailureMatcher.consumeConsoleError(text, locationUrl)) {
+          continue;
+        }
+        failures.push(`console.error: ${text}`);
+      }
+      return failures;
+    },
+  };
 }
 
 async function installOptionalLiveChromeRoutes(page: Page): Promise<void> {
@@ -380,7 +437,7 @@ test.describe("live agent chat", () => {
   test("app chat sends a message to the live agent and renders the response", async ({
     page,
   }) => {
-    const failures = installFailureCollectors(page);
+    const failureCollector = installFailureCollectors(page);
     await createAndActivateLiveConversation(page, "live-agent-marker");
 
     const prompt = `For a Playwright end-to-end smoke test, reply with exactly ${LIVE_AGENT_RESPONSE_MARKER} and no other words.`;
@@ -392,19 +449,22 @@ test.describe("live agent chat", () => {
       ),
     );
 
-    expect(failures, "live agent chat browser/runtime failures").toEqual([]);
+    expect(
+      await failureCollector.settle(),
+      "live agent chat browser/runtime failures",
+    ).toEqual([]);
   });
 
   for (const { marker, prompt } of LIVE_GENERAL_PROMPTS) {
     test(`app chat handles live general prompt ${marker}`, async ({ page }) => {
-      const failures = installFailureCollectors(page);
+      const failureCollector = installFailureCollectors(page);
       await createAndActivateLiveConversation(page, `live-agent-${marker}`);
       reportLiveTiming(
         await sendPromptAndExpectAssistantMarker(page, prompt, marker),
       );
 
       expect(
-        failures,
+        await failureCollector.settle(),
         `live prompt ${marker} browser/runtime failures`,
       ).toEqual([]);
     });

--- a/packages/app/test/ui-smoke/live-agent-chat.spec.ts
+++ b/packages/app/test/ui-smoke/live-agent-chat.spec.ts
@@ -351,6 +351,17 @@ async function createAndActivateLiveConversation(
   await installOptionalLiveChromeRoutes(page);
   await openAppPath(page, "/chat");
   await expect(chatComposer(page)).toBeVisible({ timeout: 60_000 });
+  const chatSheet = page.getByTestId("chat-sheet");
+  await expect(chatSheet).toHaveAttribute(
+    "data-conversation-id",
+    conversationId,
+    { timeout: 60_000 },
+  );
+  await expect(chatSheet).toHaveAttribute(
+    "data-conversation-index",
+    /^(?:0|[1-9]\d*)$/,
+    { timeout: 60_000 },
+  );
 }
 
 test("app chat sends a message to the deterministic keyless agent and renders parseable JSON", async ({

--- a/plugins/plugin-native-reminders/package.json
+++ b/plugins/plugin-native-reminders/package.json
@@ -11,6 +11,11 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
       "bun": "./src/index.ts",
       "development": "./src/index.ts",
       "import": "./dist/index.js",

--- a/plugins/plugin-native-reminders/src/package-exports.test.ts
+++ b/plugins/plugin-native-reminders/src/package-exports.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Pins the source-mode export used by fresh-workspace Node runtimes before the
+ * native Reminders package has produced its distributable build artifacts.
+ */
+
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("@elizaos/macosreminders package exports", () => {
+  it("resolves the package root from source under eliza-source", async () => {
+    const packageJson = JSON.parse(
+      await readFile(new URL("../package.json", import.meta.url), "utf8"),
+    ) as {
+      exports?: {
+        "."?: {
+          "eliza-source"?: Record<string, string>;
+        };
+      };
+    };
+
+    expect(packageJson.exports?.["."]?.["eliza-source"]).toEqual({
+      types: "./src/index.ts",
+      import: "./src/index.ts",
+      default: "./src/index.ts",
+    });
+  });
+});

--- a/scripts/ai-qa/review-walkthrough.mjs
+++ b/scripts/ai-qa/review-walkthrough.mjs
@@ -155,7 +155,7 @@ async function reviewOne(capture) {
           isOpenAi
             ? {
                 model: MODEL,
-                max_tokens: 1024,
+                max_completion_tokens: 1024,
                 response_format: { type: "json_object" },
                 messages: [
                   {

--- a/scripts/ai-qa/review-walkthrough.mjs
+++ b/scripts/ai-qa/review-walkthrough.mjs
@@ -12,8 +12,8 @@
  * shrinking debt allowlist (the same ratchet as the story gate + aesthetic
  * audit), and writes the committed verdict markdown next to JOURNEY.md.
  *
- * OPT-IN + CI-SAFE: requires ANTHROPIC_API_KEY. With no key it logs and exits 0
- * (the keyless PR lane is unaffected). Model: AI_QA_VISION_MODEL (default Haiku).
+ * OPT-IN + CI-SAFE: requires the key for AI_QA_VISION_BACKEND. With no key it
+ * logs and exits 0 (the keyless PR lane is unaffected).
  *
  * Usage:
  *   node scripts/ai-qa/review-walkthrough.mjs [--run-dir reports/walkthrough/<id>]
@@ -32,9 +32,13 @@ import {
   imageBlock,
   parseVisionVerdict,
 } from "./review-lib.mjs";
+import { resolveReviewerBackend } from "./reviewer-preflight.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-const MODEL = process.env.AI_QA_VISION_MODEL || "claude-haiku-4-5-20251001";
+const BACKEND = resolveReviewerBackend();
+const MODEL =
+  process.env.AI_QA_VISION_MODEL ||
+  (BACKEND === "openai" ? "gpt-5-mini" : "claude-haiku-4-5-20251001");
 const ANTHROPIC_VERSION = "2023-06-01";
 const DEFAULT_VERDICT_MD = join(
   REPO_ROOT,
@@ -130,33 +134,69 @@ async function reviewOne(capture) {
       theme: "light",
       issues: capture.issues,
     });
-    const res = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": process.env.ANTHROPIC_API_KEY,
-        "anthropic-version": ANTHROPIC_VERSION,
+    const isOpenAi = BACKEND === "openai";
+    const res = await fetch(
+      isOpenAi
+        ? "https://api.openai.com/v1/chat/completions"
+        : "https://api.anthropic.com/v1/messages",
+      {
+        method: "POST",
+        headers: isOpenAi
+          ? {
+              "content-type": "application/json",
+              authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+            }
+          : {
+              "content-type": "application/json",
+              "x-api-key": process.env.ANTHROPIC_API_KEY,
+              "anthropic-version": ANTHROPIC_VERSION,
+            },
+        body: JSON.stringify(
+          isOpenAi
+            ? {
+                model: MODEL,
+                max_tokens: 1024,
+                response_format: { type: "json_object" },
+                messages: [
+                  {
+                    role: "user",
+                    content: [
+                      { type: "text", text: prompt },
+                      {
+                        type: "image_url",
+                        image_url: { url: `data:image/png;base64,${base64}` },
+                      },
+                    ],
+                  },
+                ],
+              }
+            : {
+                model: MODEL,
+                max_tokens: 1024,
+                messages: [
+                  {
+                    role: "user",
+                    content: [
+                      imageBlock(base64),
+                      { type: "text", text: prompt },
+                    ],
+                  },
+                ],
+              },
+        ),
       },
-      body: JSON.stringify({
-        model: MODEL,
-        max_tokens: 1024,
-        messages: [
-          {
-            role: "user",
-            content: [imageBlock(base64), { type: "text", text: prompt }],
-          },
-        ],
-      }),
-    });
+    );
     if (!res.ok)
       throw new Error(
         `HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`,
       );
     const body = await res.json();
-    const text = (body.content ?? [])
-      .filter((b) => b.type === "text")
-      .map((b) => b.text)
-      .join("");
+    const text = isOpenAi
+      ? body.choices?.[0]?.message?.content || ""
+      : (body.content ?? [])
+          .filter((b) => b.type === "text")
+          .map((b) => b.text)
+          .join("");
     const verdict = parseVisionVerdict(text);
     return {
       key: capture.key,
@@ -241,9 +281,15 @@ function buildVerdictMarkdown({ runId, model, lane, totals, results }) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  if (!process.env.ANTHROPIC_API_KEY) {
+  const providerKey =
+    BACKEND === "openai"
+      ? process.env.OPENAI_API_KEY
+      : BACKEND === "anthropic"
+        ? process.env.ANTHROPIC_API_KEY
+        : null;
+  if (!providerKey) {
     console.log(
-      "[walkthrough-vision] ANTHROPIC_API_KEY not set — skipping (CI-safe no-op). Set it to run the content review.",
+      "[walkthrough-vision] reviewer provider key not set — skipping (CI-safe no-op). Set AI_QA_VISION_BACKEND and its key to run the content review.",
     );
     return;
   }
@@ -266,7 +312,7 @@ async function main() {
     process.exit(2);
   }
   console.log(
-    `[walkthrough-vision] reviewing ${captures.length} step screenshots with ${MODEL} (concurrency ${args.concurrency})`,
+    `[walkthrough-vision] reviewing ${captures.length} step screenshots with ${BACKEND}/${MODEL} (concurrency ${args.concurrency})`,
   );
 
   const results = await mapPool(captures, args.concurrency, reviewOne);

--- a/scripts/ai-qa/reviewer-preflight.mjs
+++ b/scripts/ai-qa/reviewer-preflight.mjs
@@ -89,7 +89,7 @@ export async function preflightReviewer({
         isOpenAi
           ? {
               model: resolvedModel,
-              max_tokens: 1,
+              max_completion_tokens: 16,
               messages: [
                 {
                   role: "user",

--- a/scripts/ai-qa/reviewer-preflight.mjs
+++ b/scripts/ai-qa/reviewer-preflight.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Bounded Anthropic reviewer-provider preflight.
+ * Bounded reviewer-provider preflight for Anthropic or OpenAI.
  *
  * The walkthrough calls this before starting the expensive browser journey.
  * It sends one tiny text-only request and classifies credential and billing
@@ -12,7 +12,18 @@ import { pathToFileURL } from "node:url";
 
 const DEFAULT_ENDPOINT = "https://api.anthropic.com/v1/messages";
 const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+const DEFAULT_OPENAI_ENDPOINT = "https://api.openai.com/v1/chat/completions";
+const DEFAULT_OPENAI_MODEL = "gpt-5-mini";
 const ANTHROPIC_VERSION = "2023-06-01";
+
+export function resolveReviewerBackend(env = process.env) {
+  const explicit = env.AI_QA_VISION_BACKEND?.trim().toLowerCase();
+  if (explicit === "anthropic" || explicit === "openai") return explicit;
+  if (explicit) return null;
+  if (env.ANTHROPIC_API_KEY?.trim()) return "anthropic";
+  if (env.OPENAI_API_KEY?.trim()) return "openai";
+  return null;
+}
 
 export function classifyReviewerFailure(status, responseBody = "") {
   const body = String(responseBody).toLowerCase();
@@ -35,39 +46,70 @@ export function classifyReviewerFailure(status, responseBody = "") {
 }
 
 export async function preflightReviewer({
-  apiKey = process.env.ANTHROPIC_API_KEY,
-  endpoint = DEFAULT_ENDPOINT,
-  model = process.env.AI_QA_VISION_MODEL || DEFAULT_MODEL,
+  backend = "anthropic",
+  apiKey,
+  endpoint,
+  model,
   timeoutMs = 15_000,
   fetchImpl = fetch,
 } = {}) {
-  if (!apiKey?.trim()) {
+  const isOpenAi = backend === "openai";
+  const resolvedApiKey =
+    apiKey ??
+    (isOpenAi ? process.env.OPENAI_API_KEY : process.env.ANTHROPIC_API_KEY);
+  const resolvedEndpoint =
+    endpoint ?? (isOpenAi ? DEFAULT_OPENAI_ENDPOINT : DEFAULT_ENDPOINT);
+  const resolvedModel =
+    model ??
+    process.env.AI_QA_VISION_MODEL ??
+    (isOpenAi ? DEFAULT_OPENAI_MODEL : DEFAULT_MODEL);
+  if (!resolvedApiKey?.trim()) {
     return {
       ok: false,
       classification: "missing-credentials",
-      detail: "ANTHROPIC_API_KEY is not configured",
+      detail: `${isOpenAi ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY"} is not configured`,
     };
   }
 
   let response;
   try {
-    response = await fetchImpl(endpoint, {
+    response = await fetchImpl(resolvedEndpoint, {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": ANTHROPIC_VERSION,
-      },
-      body: JSON.stringify({
-        model,
-        max_tokens: 1,
-        messages: [
-          {
-            role: "user",
-            content: "Reply with one character to validate reviewer access.",
+      headers: isOpenAi
+        ? {
+            "content-type": "application/json",
+            authorization: `Bearer ${resolvedApiKey}`,
+          }
+        : {
+            "content-type": "application/json",
+            "x-api-key": resolvedApiKey,
+            "anthropic-version": ANTHROPIC_VERSION,
           },
-        ],
-      }),
+      body: JSON.stringify(
+        isOpenAi
+          ? {
+              model: resolvedModel,
+              max_tokens: 1,
+              messages: [
+                {
+                  role: "user",
+                  content:
+                    "Reply with one character to validate reviewer access.",
+                },
+              ],
+            }
+          : {
+              model: resolvedModel,
+              max_tokens: 1,
+              messages: [
+                {
+                  role: "user",
+                  content:
+                    "Reply with one character to validate reviewer access.",
+                },
+              ],
+            },
+      ),
       signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (error) {
@@ -95,9 +137,17 @@ export async function preflightReviewer({
 }
 
 async function main() {
-  const result = await preflightReviewer();
+  const backend = resolveReviewerBackend();
+  if (backend === null) {
+    console.error(
+      "[walkthrough-vision] reviewer preflight failed (missing-credentials): configure AI_QA_VISION_BACKEND with its provider key",
+    );
+    process.exitCode = 2;
+    return;
+  }
+  const result = await preflightReviewer({ backend });
   if (result.ok) {
-    console.log("[walkthrough-vision] reviewer preflight: ready");
+    console.log(`[walkthrough-vision] reviewer preflight: ${backend} ready`);
     return;
   }
 

--- a/scripts/ai-qa/reviewer-preflight.test.mjs
+++ b/scripts/ai-qa/reviewer-preflight.test.mjs
@@ -3,9 +3,28 @@ import { describe, it } from "node:test";
 import {
   classifyReviewerFailure,
   preflightReviewer,
+  resolveReviewerBackend,
 } from "./reviewer-preflight.mjs";
 
 describe("reviewer provider preflight", () => {
+  it("honors an explicit backend and otherwise selects a configured provider", () => {
+    assert.equal(
+      resolveReviewerBackend({
+        AI_QA_VISION_BACKEND: "openai",
+        ANTHROPIC_API_KEY: "anthropic-key",
+      }),
+      "openai",
+    );
+    assert.equal(
+      resolveReviewerBackend({ OPENAI_API_KEY: "openai-key" }),
+      "openai",
+    );
+    assert.equal(
+      resolveReviewerBackend({ AI_QA_VISION_BACKEND: "invalid" }),
+      null,
+    );
+  });
+
   it("classifies rejected, quota, and billing responses", () => {
     assert.equal(
       classifyReviewerFailure(401, "unauthorized"),
@@ -142,5 +161,25 @@ describe("reviewer provider preflight", () => {
     });
 
     assert.deepEqual(result, { ok: true, classification: "ready", detail: "" });
+  });
+
+  it("preflights OpenAI with its bearer credential and selected model", async () => {
+    let requestUrl = "";
+    let requestInit;
+    const result = await preflightReviewer({
+      backend: "openai",
+      apiKey: "openai-test-key",
+      model: "gpt-5-mini",
+      fetchImpl: async (url, init) => {
+        requestUrl = String(url);
+        requestInit = init;
+        return new Response("{}", { status: 200 });
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(requestUrl, "https://api.openai.com/v1/chat/completions");
+    assert.equal(requestInit.headers.authorization, "Bearer openai-test-key");
+    assert.equal(JSON.parse(requestInit.body).model, "gpt-5-mini");
   });
 });

--- a/scripts/ai-qa/reviewer-preflight.test.mjs
+++ b/scripts/ai-qa/reviewer-preflight.test.mjs
@@ -180,6 +180,9 @@ describe("reviewer provider preflight", () => {
     assert.equal(result.ok, true);
     assert.equal(requestUrl, "https://api.openai.com/v1/chat/completions");
     assert.equal(requestInit.headers.authorization, "Bearer openai-test-key");
-    assert.equal(JSON.parse(requestInit.body).model, "gpt-5-mini");
+    const requestBody = JSON.parse(requestInit.body);
+    assert.equal(requestBody.model, "gpt-5-mini");
+    assert.equal(requestBody.max_completion_tokens, 16);
+    assert.equal("max_tokens" in requestBody, false);
   });
 });


### PR DESCRIPTION
## Summary

- make App Live reject deferred boot failures and wait for route-tail readiness before assertions
- preserve backend logs and enforce the shared exact browser-failure policy
- make packaged desktop shortcut and reminders source resolution work in fresh Linux runners
- wait for the exact hydrated conversation before starting the live SSE stream
- run walkthrough visual review through the funded OpenAI path, using the provider's required completion-token parameter

The exact live runs exposed three false-readiness boundaries: `/api/server/ready` could settle before a failed `app-route-tail`, the model stream could start while the chat sheet still held conversation index `-1`, and the OpenAI reviewer preflight used Anthropic's `max_tokens` parameter. Each path now fails with an exact diagnostic or waits for the real ready state.

Refs #17912

## Evidence

- `bun install` on the rebased head — pass, no dependency changes
- `bun run verify` — required green on this head before merge
- `bun run --cwd packages/app typecheck` — pass
- packaged shell storage bridge — 4/4 pass
- browser failure policy — 47/47 pass
- walkthrough reviewer contract — 10/10 pass, including `max_completion_tokens`
- native reminders tests — 3/3 pass; typecheck and lint pass
- app aesthetic audit — 214/214 captures, broken=0, needs-work=0; OCR broken=0
- exact App Live run: https://github.com/elizaOS/eliza/actions/runs/31206028397

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

<!-- evidence-head:cc5a29586f3283352e6711d3d8bde1aafa87a2e0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow and harness behavior only; no rendered UI source changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow and harness behavior only; app audit is green.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no product interaction changed; the exact walkthrough is CI-harness verification.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend behavior changed; the harness now retains backend diagnostics.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no product frontend behavior changed; the harness applies the existing failure policy.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no planner, prompt, provider, or product model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain contract changed.
<!-- evidence-row:ocr-review -->
- [x] 214/214 app audit captures passed; OCR reported zero broken views.
