### PR TITLE
fix(ci): admit Dependabot uv-ecosystem refs to the body normalizer

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -160,7 +160,7 @@ jobs:
             exit 1
           fi
           case "$HEAD_REF" in
-            dependabot/npm_and_yarn/*|dependabot/github_actions/*) ;;
+            dependabot/npm_and_yarn/*|dependabot/github_actions/*|dependabot/uv/*) ;;
             *)
               echo "::error::unexpected Dependabot ecosystem ref: $HEAD_REF"
               exit 1


### PR DESCRIPTION
# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:fe99118d799d7e6bf97a68ce6a1be4fe21657af0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - one-line CI workflow allowlist change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - CI-only change with no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] Failing gate output from the live Dependabot uv PR this fixes:

```
normalize-dependabot-body (PR #17983, run 31195...):
##[error]unexpected Dependabot ecosystem ref: dependabot/uv/packages/training/uv-71e320eebf
##[error]Process completed with exit code 1.
downstream: check-pr-evidence FAIL (untemplated dependabot body), Develop PR Gate FAIL
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model path touched.
<!-- evidence-row:domain-artifacts -->
- [x] The case-pattern change is the artifact; the same shell case statement evaluated against the live ref:

```
$ HEAD_REF=dependabot/uv/packages/training/uv-71e320eebf
$ case "$HEAD_REF" in dependabot/npm_and_yarn/*|dependabot/github_actions/*|dependabot/uv/*) echo admitted;; *) echo rejected;; esac
admitted
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels.

Unblocks #17983 (uv group bump), whose normalize-dependabot-body job refused the uv ecosystem ref, cascading into check-pr-evidence and the Develop PR Gate.
