### PR TITLE
fix(app): keep Cloud Apps inside the view shell

### DIFF
--- a/packages/app/scripts/audit-views-soak-navigation.test.mjs
+++ b/packages/app/scripts/audit-views-soak-navigation.test.mjs
@@ -25,6 +25,17 @@ test("cleanup navigates through the shell event instead of raw History", () => {
   expect(source).not.toContain("window.history.replaceState");
 });
 
+test("navigation uses an independent cold-load timeout with target diagnostics", () => {
+  expect(source).toContain(
+    "const NAV_TIMEOUT_MS = Number(process.env.NAV_TIMEOUT_MS || 10_000);",
+  );
+  expect(source).toContain(
+    "{ timeout: Math.max(NAV_TIMEOUT_MS, NAV_WAIT_MS * 3) }",
+  );
+  expect(source).toContain("navigation to view");
+  expect(source).toContain("did not reach");
+});
+
 test("context teardown owns video finalization without swallowed failures", () => {
   expect(source).not.toContain("ctx.close().catch");
   expect(source).not.toContain("await page.close()");

--- a/packages/app/scripts/audit-views-soak.mjs
+++ b/packages/app/scripts/audit-views-soak.mjs
@@ -35,6 +35,7 @@ const UI = process.env.UI || "http://127.0.0.1:2138";
 const API = process.env.API || "http://127.0.0.1:31337";
 const ROUNDS = Number(process.env.ROUNDS || 6);
 const NAV_WAIT_MS = Number(process.env.NAV_WAIT_MS || 700);
+const NAV_TIMEOUT_MS = Number(process.env.NAV_TIMEOUT_MS || 10_000);
 const VIDEO = process.env.VIDEO !== "0";
 const SETUP_FIRST_RUN = process.env.SETUP_FIRST_RUN !== "0";
 const OUT =
@@ -620,15 +621,25 @@ async function main() {
     const targetPath = normalizePath(view.path);
     const beforePath = await page.evaluate(() => window.location.pathname);
     await dispatchShellNavigation(view);
-    await page.waitForFunction(
-      (target) => {
-        const path = window.location.pathname;
-        const normalized = path.length > 1 ? path.replace(/\/+$/, "") : path;
-        return normalized === target;
-      },
-      targetPath,
-      { timeout: Math.max(1000, NAV_WAIT_MS * 3) },
-    );
+    try {
+      await page.waitForFunction(
+        (target) => {
+          const path = window.location.pathname;
+          const normalized = path.length > 1 ? path.replace(/\/+$/, "") : path;
+          return normalized === target;
+        },
+        targetPath,
+        { timeout: Math.max(NAV_TIMEOUT_MS, NAV_WAIT_MS * 3) },
+      );
+    } catch (cause) {
+      // error-policy:J2 Preserve Playwright's timeout while identifying the
+      // exact registered view and route that failed the hard navigation gate.
+      const currentPath = await page.evaluate(() => window.location.pathname);
+      throw new Error(
+        `navigation to view "${view.id}" timed out: ${normalizePath(currentPath)} did not reach ${targetPath}`,
+        { cause },
+      );
+    }
     await page.waitForTimeout(NAV_WAIT_MS);
     const afterPath = await page.evaluate(() => window.location.pathname);
     const firstRunBlocking = await isFirstRunBlocking(page);

--- a/packages/app/src/cloud-apps-view.test.ts
+++ b/packages/app/src/cloud-apps-view.test.ts
@@ -1,19 +1,23 @@
 /**
- * Native Cloud Apps destination registration against the real app-shell registry.
+ * Cloud Apps destination registration against the real app-shell registry.
  */
 
 import { listAppShellPages } from "@elizaos/ui/app-shell-registry";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { cloudAppsStudioKind } from "./cloud-apps-view";
 
 vi.mock("@elizaos/ui/platform", () => ({
   getFrontendPlatform: () => "ios",
 }));
 
-beforeAll(async () => {
-  await import("./cloud-apps-view");
-});
+describe("Cloud Apps destination", () => {
+  it("uses the host-aware studio wrapper", () => {
+    expect(cloudAppsStudioKind("web")).toBe("web");
+    expect(cloudAppsStudioKind("ios")).toBe("native");
+    expect(cloudAppsStudioKind("android")).toBe("native");
+    expect(cloudAppsStudioKind("desktop")).toBe("native");
+  });
 
-describe("Cloud Apps native destination", () => {
   it("registers a bundled app-shell page at the path emitted by VIEWS", () => {
     const page = listAppShellPages().find((entry) => entry.id === "cloud-apps");
 

--- a/packages/app/src/cloud-apps-view.ts
+++ b/packages/app/src/cloud-apps-view.ts
@@ -1,20 +1,16 @@
 /**
  * In-process app-shell registration for the Eliza Cloud **Applications**
- * dashboard on native runtimes (iOS / Android / Electrobun desktop).
+ * dashboard across web and native runtimes.
  *
- * On the web build the Applications surfaces are served by the top-level
- * `CloudRouterShell` `<BrowserRouter>` (mounted only when `__ELIZA_WEB_SHELL__`
- * is true). Native runtimes never mount that shell — the renderer boots the
- * tab/view `App` directly — so the same Applications components are surfaced
- * here as an in-process app-shell page that mounts the self-contained
- * `NativeAppsStudio` (a `MemoryRouter` + cloud providers + native Steward auth
- * context; see `@elizaos/ui/cloud/applications/NativeAppsStudio`).
+ * The web build keeps this route inside the tab/view `App`, where the shared
+ * navigate-view listener remains mounted while Cloud Apps is active. Its
+ * `WebAppsStudio` inherits the top-level cloud providers. Native runtimes use
+ * the self-contained `NativeAppsStudio` with its own router and providers.
  *
  * This uses the in-process app-shell registration mechanism (the same one
- * `orchestrator` / `wallet.inventory` use). It is gated to non-web platforms so
- * it never competes with the web shell's route, and the import stays **lazy**
- * (the studio chunk — and the whole applications domain it pulls — loads only
- * when the studio is opened), preserving the native bundle's tree-shake.
+ * `orchestrator` / `wallet.inventory` use). The platform-specific import stays
+ * **lazy** so the studio chunk and its Applications domain load only when the
+ * studio is opened.
  *
  * The page id is `cloud-apps` (the local installed-`AppsView` owns `apps`), the
  * route is `/cloud-apps`, and the label is "Cloud Apps". The page is NOT a
@@ -26,19 +22,24 @@
 import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
 import { getFrontendPlatform } from "@elizaos/ui/platform";
 
-// "web" → served by CloudRouterShell; every other platform (ios / android /
-// desktop) boots the tab/view app directly and needs this in-process mount.
-if (getFrontendPlatform() !== "web") {
-  registerAppShellPage({
-    id: "cloud-apps",
-    viewKind: "release",
-    pluginId: "@elizaos/app",
-    label: "Cloud Apps",
-    icon: "Grid3x3",
-    path: "/cloud-apps",
-    loader: () =>
-      import("@elizaos/ui/cloud/applications/NativeAppsStudio").then((m) => ({
-        default: m.default,
-      })),
-  });
+/** Choose the provider/router wrapper owned by the current host platform. */
+export function cloudAppsStudioKind(platform: string): "web" | "native" {
+  return platform === "web" ? "web" : "native";
 }
+
+const studioKind = cloudAppsStudioKind(getFrontendPlatform());
+const loadCloudAppsStudio =
+  studioKind === "web"
+    ? () => import("@elizaos/ui/cloud/applications/WebAppsStudio")
+    : () => import("@elizaos/ui/cloud/applications/NativeAppsStudio");
+
+registerAppShellPage({
+  id: "cloud-apps",
+  viewKind: "release",
+  pluginId: "@elizaos/app",
+  label: "Cloud Apps",
+  icon: "Grid3x3",
+  path: "/cloud-apps",
+  loader: () =>
+    loadCloudAppsStudio().then((module) => ({ default: module.default })),
+});

--- a/packages/ui/src/cloud/applications/WebAppsStudio.tsx
+++ b/packages/ui/src/cloud/applications/WebAppsStudio.tsx
@@ -1,0 +1,15 @@
+/**
+ * Web app-shell mount for Cloud Applications that preserves the host's
+ * navigate-view lifecycle while supplying the cloud surface theme.
+ */
+
+import ApplicationsPage from "./ApplicationsPage";
+
+/** Render the Applications list inside the web tab/view app catch-all. */
+export default function WebAppsStudio(): React.JSX.Element {
+  return (
+    <div className="theme-cloud flex h-full min-h-0 w-full flex-col overflow-y-auto bg-surface text-txt">
+      <ApplicationsPage />
+    </div>
+  );
+}

--- a/packages/ui/src/cloud/register-all.test.ts
+++ b/packages/ui/src/cloud/register-all.test.ts
@@ -39,7 +39,6 @@ describe("registerAllCloudSurfaces", () => {
       "dashboard/connectors",
       "dashboard/organization",
       "dashboard/api-explorer",
-      "cloud-apps",
       "dashboard/apps",
       "dashboard/admin",
       "approve/:approvalId",
@@ -55,16 +54,13 @@ describe("registerAllCloudSurfaces", () => {
     }
   });
 
-  it("keeps the web Cloud Apps handoff on the live Applications surface", () => {
+  it("leaves the web Cloud Apps handoff in the tab/view app", () => {
     registerAllCloudSurfaces();
     const cloudApps = getCloudRoute("cloud-apps");
-    const retiredConsoleApps = getCloudRoute("dashboard/apps");
 
-    expect(cloudApps).toMatchObject({
-      path: "cloud-apps",
-      group: "dashboard",
-    });
-    expect(cloudApps?.element).not.toBe(retiredConsoleApps?.element);
+    // Registering this as a top-level cloud route unmounts App and therefore
+    // its navigate-view listener, stranding the user on the handoff surface.
+    expect(cloudApps).toBeUndefined();
   });
 
   it("keeps legacy-only spellings as redirects, not routes", () => {

--- a/packages/ui/src/cloud/register-all.ts
+++ b/packages/ui/src/cloud/register-all.ts
@@ -67,14 +67,8 @@ export function registerAllCloudSurfaces(): void {
   // 40's `import "./applications"` chain), but the console no longer surfaces
   // Apps — management moved into the Eliza app. Override both paths (later
   // same-path registration wins) so a stale /dashboard/apps link redirects to
-  // the dashboard. The applications components stay for the native eliza app.
+  // the dashboard. The Applications components stay in the tab/view app.
   const AppsMovedRoute = lazy(() => import("./applications/AppsMovedRoute"));
-  const CloudAppsRoute = lazy(() => import("./applications/ApplicationsPage"));
-  registerCloudRoute({
-    path: "cloud-apps",
-    element: CloudAppsRoute,
-    group: "dashboard",
-  });
   registerCloudRoute({
     path: APPLICATIONS_LIST_ROUTE_PATH,
     element: AppsMovedRoute,


### PR DESCRIPTION
## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - GitHub workflow skills were operational review tools from a local plugin cache, not a repository contribution skill with a source revision.`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Summary

- keep the web Cloud Apps destination registered in the shared app/view shell instead of mounting a separate top-level router
- add a lightweight web studio wrapper while preserving the native Cloud Apps studio
- harden the real view-soak navigation timeout and surface target/current-path diagnostics on failure

## Root cause

The Cloud Apps route was registered as a top-level `CloudRouterShell` destination. Navigating there unmounted the tab/view `App` and its shared navigate-view listener; signed-out sessions could also be redirected to `/login` before `ApplicationsPage` rendered its explicit signed-out state. The scheduled and manual Views Soak runs therefore timed out or became stranded on `/cloud-apps`.

## Verification

Exact head: `4f628e3c7385ac0215d8ab9d550cc124288e1a19`

- `bun run verify` — 346/346 tasks passed; repository audits and anti-larp gate clean
- focused app/UI tests — 17/17 passed
- app and UI package typechecks — passed
- Biome on all seven changed files — passed
- real API + renderer soak (`ROUNDS=1`) — 24/24 registered paths, zero page errors, zero unexpected console/network failures, heap 1.00x
- `bun run --cwd packages/app audit:app` — 214/214 tests, 212 captures: 196 good, 16 needs-eyeball, 0 broken, 0 needs-work; OCR 192 verified, 20 needs-eyeball, 0 broken
- merge-tree against current `origin/develop` — clean; exactly the seven intended files

## Evidence matrix

- Before screenshot/video: N/A — this corrects route ownership and navigation lifecycle; the failing behavior is captured by the prior scheduled/manual Views Soak runs on #17912.
- After screenshots: the app audit generated the complete 212-capture desktop/mobile matrix with no broken or needs-work verdicts; CI will upload its own exact-head artifacts.
- Walkthrough: the real-stack soak exercised every registered route and produced deterministic JSON evidence.
- Backend/frontend logs: local soak recorded zero page errors and zero unexpected console/network failures.
- Live-model trajectories: N/A — no model behavior changed.
- Native/device proof: N/A — native continues to use the existing `NativeAppsStudio`; the changed failing path is web shell routing.

Closes #17912

<!-- evidence-head:4f628e3c7385ac0215d8ab9d550cc124288e1a19 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17991-before-desktop-mobile.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17991-after-desktop-mobile.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17991-audit-views-soak.mp4

<!-- evidence-row:backend-logs -->
- [x] [17991-pr17991-walkthrough-dev.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17991-pr17991-walkthrough-dev.log)

<!-- evidence-row:frontend-logs -->
- [x] [17991-audit-views-scorecard.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17991-audit-views-scorecard.md)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent, action, provider, prompt, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No database, memory, scheduled-task, wallet, audio, or generated-domain artifact changed.

<!-- evidence-row:ocr-review -->
- [x] [17991-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/17991-ocr-triage.json)