### PR TITLE
fix(ci): repair voice and mobile workflow regressions

### DIFF
--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -196,7 +196,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: fused-lib
-          key: voice-fused-cpu-v1-${{ steps.fork.outputs.commit }}-${{ hashFiles('packages/app-core/scripts/stage-desktop-fused-lib.mjs') }}
+          key: voice-fused-cpu-v2-${{ steps.fork.outputs.commit }}-${{ hashFiles('packages/app-core/scripts/stage-desktop-fused-lib.mjs') }}
 
       - name: Setup Node.js
         if: steps.fused-cache.outputs.cache-hit != 'true'
@@ -225,7 +225,7 @@ jobs:
         run: |
           set -euo pipefail
           node packages/app-core/scripts/stage-desktop-fused-lib.mjs \
-            --variant cpu --out "$GITHUB_WORKSPACE/fused-lib"
+            --variant cpu --portable-cpu --out "$GITHUB_WORKSPACE/fused-lib"
 
       - name: Verify the fused ABI surface
         run: |

--- a/packages/agent/src/runtime/plugin-resolver.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver.test.ts
@@ -6,7 +6,7 @@
  * spanning the blocking/deferred boot split. Deterministic — a real on-disk
  * fixture package under a temp workspace, no live model.
  */
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import fs, { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { logger, type Plugin } from "@elizaos/core";
@@ -101,6 +101,43 @@ describe("resolvePlugins manifest discovery", () => {
         delete process.env.THIRD_PARTY_PLUGIN_ENABLE;
       else process.env.THIRD_PARTY_PLUGIN_ENABLE = previousEnv;
       await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("does not probe filesystem plugin manifests on mobile", async () => {
+    const previousPlatform = process.env.ELIZA_PLATFORM;
+    const { CORE_PLUGINS, MOBILE_CORE_PLUGINS, MOBILE_VIEW_PLUGINS } =
+      await import("./core-plugins");
+    const filesystemProbe = vi.spyOn(fs, "readdir").mockRejectedValue(
+      Object.assign(new Error("filesystem discovery unsupported"), {
+        code: "ENOSYS",
+      }),
+    );
+
+    try {
+      process.env.ELIZA_PLATFORM = "ios";
+      const resolved = await resolvePlugins(
+        {
+          plugins: {
+            allow: [],
+            deny: [
+              ...new Set([
+                ...CORE_PLUGINS,
+                ...MOBILE_CORE_PLUGINS,
+                ...MOBILE_VIEW_PLUGINS,
+              ]),
+            ],
+          },
+        },
+        { quiet: true },
+      );
+
+      expect(resolved).toEqual([]);
+      expect(filesystemProbe).not.toHaveBeenCalled();
+    } finally {
+      filesystemProbe.mockRestore();
+      if (previousPlatform === undefined) delete process.env.ELIZA_PLATFORM;
+      else process.env.ELIZA_PLATFORM = previousPlatform;
     }
   });
 });

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -2051,6 +2051,7 @@ export async function resolvePlugins(
   const failedPlugins: Array<{ name: string; error: string }> = [];
   const repairedInstallRecords = new Set<string>();
   const phase = opts?.phase ?? "all";
+  const mobilePlatform = isMobilePlatform();
 
   if (phase === "blocking") {
     blockingPhaseLoadedPluginNames.clear();
@@ -2069,59 +2070,64 @@ export async function resolvePlugins(
   // Auto-enable is sourced exclusively from per-plugin manifests: walk plugin
   // and app package.json files on disk and run each plugin's
   // autoEnableModule.shouldEnable(ctx). Each plugin owns its own enable
-  // conditions in auto-enable.ts — no central map exists.
+  // conditions in auto-enable.ts — no central map exists. Mobile bundles have
+  // no package tree, so their build-time static registry and typed collector
+  // policy are the complete plugin plan.
   //
   // App-level manifest (host app's package.json `elizaos.app` block) can:
   //   - restrict the candidate list to a curated subset
   //   - prepopulate config.plugins.entries with default { enabled } flags
   //     (user config still wins; defaults only fill keys the user hasn't set)
   const changes: string[] = [];
-  try {
-    const appManifest = await readAppManifest(process.cwd()).catch(() => null);
-    const defaultedEntries = applyAppManifestDefaults(config, appManifest);
-    if (defaultedEntries.length > 0) {
-      logger.info(
-        `[eliza] App manifest defaults applied to entries: ${defaultedEntries.join(", ")}`,
+  if (!mobilePlatform) {
+    try {
+      const appManifest = await readAppManifest(process.cwd()).catch(
+        () => null,
       );
-    }
-    const allCandidates = await discoverPluginCandidates();
-    const candidates = filterCandidatesByAppManifest(
-      allCandidates,
-      appManifest,
-    );
-    if (appManifest?.candidates && candidates.length < allCandidates.length) {
-      logger.info(
-        `[eliza] App manifest restricted candidate set: ${candidates.length}/${allCandidates.length} plugins considered`,
+      const defaultedEntries = applyAppManifestDefaults(config, appManifest);
+      if (defaultedEntries.length > 0) {
+        logger.info(
+          `[eliza] App manifest defaults applied to entries: ${defaultedEntries.join(", ")}`,
+        );
+      }
+      const allCandidates = await discoverPluginCandidates();
+      const candidates = filterCandidatesByAppManifest(
+        allCandidates,
+        appManifest,
       );
-    }
-    const isNativePlatform = isMobilePlatform();
-    const candidateKey = candidates
-      .map((c) => c.packageName)
-      .sort()
-      .join(",");
-    const verdictKey = `${candidateKey}\n${computeVerdictFingerprint(
-      config,
-      isNativePlatform,
-    )}`;
-    let verdicts: PluginManifestVerdict[];
-    if (pluginVerdictCache?.key === verdictKey) {
-      verdicts = pluginVerdictCache.verdicts;
-    } else {
-      verdicts = await evaluatePluginManifests(candidates, {
-        env: process.env,
+      if (appManifest?.candidates && candidates.length < allCandidates.length) {
+        logger.info(
+          `[eliza] App manifest restricted candidate set: ${candidates.length}/${allCandidates.length} plugins considered`,
+        );
+      }
+      const candidateKey = candidates
+        .map((c) => c.packageName)
+        .sort()
+        .join(",");
+      const verdictKey = `${candidateKey}\n${computeVerdictFingerprint(
         config,
-        isNativePlatform,
+        false,
+      )}`;
+      let verdicts: PluginManifestVerdict[];
+      if (pluginVerdictCache?.key === verdictKey) {
+        verdicts = pluginVerdictCache.verdicts;
+      } else {
+        verdicts = await evaluatePluginManifests(candidates, {
+          env: process.env,
+          config,
+          isNativePlatform: false,
+        });
+        pluginVerdictCache = { key: verdictKey, verdicts };
+      }
+      applyPluginManifestVerdicts(config, verdicts, changes);
+    } catch (error) {
+      // error-policy:J2 plugin-plan configuration is a required boot input; do
+      // not continue with a silently incomplete auto-enable result.
+      throw new ElizaError("Plugin manifest evaluation failed", {
+        code: "PLUGIN_MANIFEST_EVALUATION_FAILED",
+        cause: error,
       });
-      pluginVerdictCache = { key: verdictKey, verdicts };
     }
-    applyPluginManifestVerdicts(config, verdicts, changes);
-  } catch (error) {
-    // error-policy:J2 plugin-plan configuration is a required boot input; do
-    // not continue with a silently incomplete auto-enable result.
-    throw new ElizaError("Plugin manifest evaluation failed", {
-      code: "PLUGIN_MANIFEST_EVALUATION_FAILED",
-      cause: error,
-    });
   }
   if (changes.length > 0) {
     logger.debug(`[eliza] Plugin auto-enable: ${changes.join("; ")}`);
@@ -2164,9 +2170,14 @@ export async function resolvePlugins(
   // ── Auto-discover ejected plugins ───────────────────────────────────────
   // Ejected plugins override npm/core versions, so they are tracked
   // separately and consulted first at import time.
-  const ejectedRecords = await scanDropInPlugins(
-    path.join(resolveStateDir(), EJECTED_PLUGINS_DIRNAME),
-  );
+  // Mobile artifacts have no node_modules/workspace plugin tree and load only
+  // modules anchored in STATIC_ELIZA_PLUGINS. Filesystem discovery is both
+  // inapplicable and unsupported by the sealed iOS Bun host.
+  const ejectedRecords: Record<string, PluginInstallRecord> = mobilePlatform
+    ? {}
+    : await scanDropInPlugins(
+        path.join(resolveStateDir(), EJECTED_PLUGINS_DIRNAME),
+      );
   const ejectedPluginNames: string[] = [];
   for (const [name, _record] of Object.entries(ejectedRecords)) {
     if (denyList.has(name)) continue;
@@ -2182,10 +2193,12 @@ export async function resolvePlugins(
 
   // ── Auto-discover drop-in custom plugins ────────────────────────────────
   // Scan well-known dir + any extra dirs from plugins.load.paths (first wins).
-  const scanDirs = [
-    path.join(resolveStateDir(), CUSTOM_PLUGINS_DIRNAME),
-    ...(config.plugins?.load?.paths ?? []).map(resolveUserPath),
-  ];
+  const scanDirs = mobilePlatform
+    ? []
+    : [
+        path.join(resolveStateDir(), CUSTOM_PLUGINS_DIRNAME),
+        ...(config.plugins?.load?.paths ?? []).map(resolveUserPath),
+      ];
   const dropInRecords: Record<string, PluginInstallRecord> = {};
   for (const dir of scanDirs) {
     for (const [name, record] of Object.entries(await scanDropInPlugins(dir))) {
@@ -2312,7 +2325,9 @@ export async function resolvePlugins(
     const isOfficialElizaPlugin = pluginName.startsWith("@elizaos/plugin-");
     const ejectedRecord = ejectedRecords[pluginName];
     const installRecord = installRecords[pluginName];
-    const workspaceOverridePath = getWorkspacePluginOverridePath(pluginName);
+    const workspaceOverridePath = mobilePlatform
+      ? null
+      : getWorkspacePluginOverridePath(pluginName);
     const staticElizaPlugin = await resolveStaticElizaPlugin(pluginName);
     const exportSubpath = runtimePluginExportSubpath(pluginName);
 
@@ -2365,6 +2380,12 @@ export async function resolvePlugins(
         mod = Object.fromEntries(
           Object.entries(loadedModule as Record<string, unknown>),
         ) as PluginModuleShape;
+      } else if (mobilePlatform) {
+        const reason =
+          "not registered in STATIC_ELIZA_PLUGINS (mobile bundle has no filesystem plugin loader)";
+        logger.warn(`[eliza] Cannot load ${pluginName} on mobile: ${reason}`);
+        failedPlugins.push({ name: pluginName, error: reason });
+        return null;
       } else if (workspaceOverridePath) {
         const shouldPreferRepoNodeModules =
           isOfficialElizaPlugin &&
@@ -2454,13 +2475,6 @@ export async function resolvePlugins(
         // (a host-declared mobile plugin with no static registration) — the
         // exact drift that shipped four dead mobile plugins with health
         // reporting failed:0. Surface it; never skip silently.
-        if (isMobilePlatform()) {
-          const reason =
-            "not registered in STATIC_ELIZA_PLUGINS (mobile bundle has no node_modules to import from)";
-          logger.warn(`[eliza] Cannot load ${pluginName} on mobile: ${reason}`);
-          failedPlugins.push({ name: pluginName, error: reason });
-          return null;
-        }
         // Eliza plugins can resolve either from bundled local wrappers
         // under eliza-dist/plugins/* or from packaged node_modules.
         mod = await importOfficialPluginFromNodeModules();

--- a/packages/app-core/scripts/stage-desktop-fused-lib-staleness.test.mjs
+++ b/packages/app-core/scripts/stage-desktop-fused-lib-staleness.test.mjs
@@ -1,7 +1,7 @@
 /** Exercises stage desktop fused lib staleness behavior with deterministic app-core test fixtures. */
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -40,9 +40,9 @@ function currentFork() {
 }
 
 /** Run `--check --out <dir>`; return the process exit code (0 fresh, 2 stale). */
-function checkExitCode(outDir) {
+function checkExitCode(outDir, extraArgs = []) {
   try {
-    execFileSync("node", [script, "--check", "--out", outDir], {
+    execFileSync("node", [script, "--check", "--out", outDir, ...extraArgs], {
       stdio: "ignore",
     });
     return 0;
@@ -139,6 +139,52 @@ test("--check: staged lib whose bytes don't match the stamp hash is STALE → ex
       }),
     );
     assert.equal(checkExitCode(dir), 2);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("--check: a host-native stamp is stale for a portable CPU request", () => {
+  const dir = mkTmp();
+  try {
+    const bytes = Buffer.from("fake-host-native-lib");
+    fs.writeFileSync(path.join(dir, libName), bytes);
+    fs.writeFileSync(
+      path.join(dir, STAMP),
+      JSON.stringify({
+        forkCommit: currentFork(),
+        forkDirty: "",
+        backend: "cpu",
+        cpuNative: true,
+        fusedLib: libName,
+        fusedSha256: createHash("sha256").update(bytes).digest("hex"),
+        builtAt: "now",
+      }),
+    );
+    assert.equal(checkExitCode(dir, ["--portable-cpu"]), 2);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("--check: a portable CPU stamp is fresh for a portable CPU request", () => {
+  const dir = mkTmp();
+  try {
+    const bytes = Buffer.from("fake-portable-lib");
+    fs.writeFileSync(path.join(dir, libName), bytes);
+    fs.writeFileSync(
+      path.join(dir, STAMP),
+      JSON.stringify({
+        forkCommit: currentFork(),
+        forkDirty: "",
+        backend: "cpu",
+        cpuNative: false,
+        fusedLib: libName,
+        fusedSha256: createHash("sha256").update(bytes).digest("hex"),
+        builtAt: "now",
+      }),
+    );
+    assert.equal(checkExitCode(dir, ["--portable-cpu"]), 0);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/app-core/scripts/stage-desktop-fused-lib.mjs
+++ b/packages/app-core/scripts/stage-desktop-fused-lib.mjs
@@ -20,7 +20,8 @@
  *
  * Usage:
  *   node packages/app-core/scripts/stage-desktop-fused-lib.mjs \
- *     [--variant auto|cpu|cuda|vulkan|metal|hip] [--out <dir>] [--jobs N] [--force]
+ *     [--variant auto|cpu|cuda|vulkan|metal|hip] [--out <dir>] [--jobs N]
+ *     [--portable-cpu] [--force]
  *
  * Backend autodetect (--variant auto, the default):
  *   macOS          → Metal (Apple GPU; always present)
@@ -174,6 +175,7 @@ function parseArgs(argv) {
     variant: "auto",
     outDir: null,
     jobs: null,
+    portableCpu: false,
     force: false,
     check: false,
   };
@@ -181,6 +183,7 @@ function parseArgs(argv) {
     if (argv[i] === "--variant") out.variant = argv[++i];
     else if (argv[i] === "--out") out.outDir = argv[++i];
     else if (argv[i] === "--jobs") out.jobs = parseInt(argv[++i], 10);
+    else if (argv[i] === "--portable-cpu") out.portableCpu = true;
     else if (argv[i] === "--force") out.force = true;
     else if (argv[i] === "--check") out.check = true;
     else if (argv[i] === "--ensure") out.ensure = true;
@@ -341,6 +344,7 @@ const {
   variant,
   outDir: outOverride,
   jobs: jobsArg,
+  portableCpu,
   force,
   check,
   ensure,
@@ -367,6 +371,10 @@ function stagedStalenessReasons() {
     reasons.push("fork working tree changed (uncommitted source edits)");
   if (stamp && stagedSha && stamp.fusedSha256 !== stagedSha)
     reasons.push("staged lib hash != stamp (partial copy / tampered)");
+  if (stamp && (stamp.cpuNative ?? true) !== !portableCpu)
+    reasons.push(
+      `CPU portability mode changed (${(stamp.cpuNative ?? true) ? "native" : "portable"} → ${portableCpu ? "portable" : "native"})`,
+    );
   return reasons;
 }
 
@@ -414,10 +422,13 @@ if (!have("cmake")) die("cmake not found on PATH");
 const backend = variant === "auto" ? detectBackend() : variant;
 log(`host: ${process.platform}/${process.arch}`);
 log(
-  `backend: ${backend}${variant === "auto" ? " (autodetected)" : ""} (GGML_CPU always on for fallback)`,
+  `backend: ${backend}${variant === "auto" ? " (autodetected)" : ""} (GGML_CPU fallback: ${portableCpu ? "portable" : "host-native"})`,
 );
 
-const buildDir = path.join(forkSrc, `build-desktop-${backend}`);
+const buildDir = path.join(
+  forkSrc,
+  `build-desktop-${backend}${portableCpu ? "-portable" : ""}`,
+);
 const outDir = stagedOutDir;
 
 // Self-healing clean rebuild: if the existing build dir was produced from a
@@ -455,9 +466,11 @@ const jobs =
 // (so the GPU backend can load the system driver at runtime) and matches the
 // dlopen()-able sibling set the runtime resolves. LLAMA_BUILD_OMNIVOICE +
 // LLAMA_BUILD_MTMD + LLAMA_BUILD_KOKORO are required for the fused
-// `elizainference` SHARED target (TTS + local ASR + Kokoro). GGML_NATIVE=ON tunes
-// the CPU backend to the build host — correct for a local/dev build; a
-// redistributable build should pin explicit CPU features instead.
+// `elizainference` SHARED target (TTS + local ASR + Kokoro). The default
+// GGML_NATIVE=ON tunes the CPU backend to the build host, which is correct for a
+// local/dev build. Cross-runner artifacts pass --portable-cpu so CMake targets
+// the architecture baseline instead of emitting instructions the consumer
+// host may not support.
 run("cmake", [
   "-S",
   forkSrc,
@@ -471,7 +484,7 @@ run("cmake", [
   // NDK toolchain forces PIC globally so never hit this; make it explicit here.
   "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
   "-DGGML_CPU=ON",
-  "-DGGML_NATIVE=ON",
+  `-DGGML_NATIVE=${portableCpu ? "OFF" : "ON"}`,
   "-DLLAMA_BUILD_OMNIVOICE=ON",
   "-DLLAMA_BUILD_MTMD=ON",
   "-DLLAMA_BUILD_KOKORO=ON",
@@ -578,6 +591,7 @@ const buildStamp = JSON.stringify(
     forkCommit: currentFork,
     forkDirty: currentDirty,
     backend,
+    cpuNative: !portableCpu,
     fusedLib: fusedName,
     fusedSha256: sha256File(path.join(outDir, fusedName)),
     builtAt: new Date().toISOString(),

--- a/packages/scripts/__tests__/voice-railway-service-defs.test.ts
+++ b/packages/scripts/__tests__/voice-railway-service-defs.test.ts
@@ -206,4 +206,15 @@ describe("scheduled live contract lane (voice-live-e2e.yml)", () => {
       workflow.on?.workflow_dispatch?.inputs?.run_railway_contract,
     ).toBeDefined();
   });
+
+  test("builds the cross-runner fused CPU artifact in portable mode", () => {
+    const buildJob = workflow.jobs?.["voice-fused-build"];
+    const buildCommand = (buildJob?.steps ?? [])
+      .map((step) => step.run ?? "")
+      .join("\n");
+
+    expect(buildJob?.["runs-on"]).toBe("ubuntu-24.04");
+    expect(buildCommand).toContain("--variant cpu --portable-cpu");
+    expect(read(WORKFLOW_PATH)).toContain("voice-fused-cpu-v2-");
+  });
 });


### PR DESCRIPTION
## Summary

- build Voice Live's cached CPU inference artifact with architecture-baseline flags so a different runner cannot hit `SIGILL`
- make sealed iOS/Android hosts rely on the static plugin registry and skip unsupported workspace, manifest, ejected, and drop-in filesystem discovery
- add regression coverage for both portable staging and sealed-host plugin resolution

These are the repository-owned failures reproduced from the Voice Live E2E and Mobile Build Smoke workflows. The earlier Views Soak and cloud route fixes are already on `develop`, so they are intentionally absent from this rebased diff.

Refs #17912

## Evidence

- `bun install --frozen-lockfile` — pass
- Voice/staging workflow contracts — 24/24 pass
- mobile plugin resolver contract — 7/7 pass
- `actionlint .github/workflows/voice-live-e2e.yml` — pass
- `bun run verify` — 346/346 tasks; no focused or orphaned skips
- `git diff --check` — pass

Exact Voice Live and Mobile Build Smoke workflow runs are being recorded on this head.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

<!-- evidence-head:621b7ef43e5834c85b4f9e2ac6fca9de87327b54 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI source changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI source changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user interaction changed; exact workflow runs exercise the build/runtime paths.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend request behavior changed; exact workflow logs verify build/runtime selection.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, planner, model, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain record or external system changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual source changed.
