### PR TITLE
fix(voice): make realtime voice recover from transport loss and token expiry instead of stopping

### DIFF
--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -2114,6 +2114,54 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
     }
   });
 
+  it("parks Talk visibly OFF when a LIVE session dies past the client's recovery budget", async () => {
+    const { result, rerender } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.toggleHandsFree();
+      await Promise.resolve();
+    });
+    expect(realtimeVoiceMock.start).toHaveBeenCalledTimes(1);
+    expect(result.current.handsFree).toBe(true);
+
+    // The session reaches live…
+    await act(async () => {
+      realtimeVoiceMock.state.active = true;
+      realtimeVoiceMock.state.status = "listening";
+      rerender();
+    });
+
+    // …then dies past the client's reconnect budget (a network outage longer
+    // than the recovery window): the hook reports inactive + a transport error.
+    await act(async () => {
+      realtimeVoiceMock.state.active = false;
+      realtimeVoiceMock.state.connecting = false;
+      realtimeVoiceMock.state.status = "idle";
+      realtimeVoiceMock.state.error = {
+        kind: "transport",
+        message: "Voice connection dropped. Tap the mic to try again.",
+        actionable: true,
+      };
+      rerender();
+    });
+
+    // Talk is parked visibly off with the actionable error surfaced…
+    expect(result.current.handsFree).toBe(false);
+    expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+      "Voice connection dropped. Tap the mic to try again.",
+      "error",
+      6000,
+    );
+    // …and the advertised retry tap STARTS a fresh session instead of
+    // toggling the dead one off.
+    await act(async () => {
+      realtimeVoiceMock.state.error = null;
+      result.current.toggleHandsFree();
+      await Promise.resolve();
+    });
+    expect(realtimeVoiceMock.start).toHaveBeenCalledTimes(2);
+  });
+
   it("surfaces a retryable Cartesia error instead of falling back to batch", async () => {
     realtimeVoiceMock.startOutcome = {
       kind: "fallback-to-batch",

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -516,6 +516,10 @@ export function useShellController(): ShellController {
   const realtimeVoiceRef = React.useRef(realtimeVoice);
   realtimeVoiceRef.current = realtimeVoice;
   const realtimeVoiceWantedRef = React.useRef(false);
+  // True once the CURRENT wanted session has reached live; distinguishes a
+  // mid-session death (parked by the effect below startRealtimeVoice) from an
+  // initial start failure (owned by startRealtimeVoice's outcome handling).
+  const realtimeVoiceWasActiveRef = React.useRef(false);
   const startRealtimeVoiceRef = React.useRef<() => void>(() => {});
   const stopRealtimeVoiceRef = React.useRef<() => void>(() => {});
   const [realtimeVoiceBoundaryError, setRealtimeVoiceBoundaryError] =
@@ -1762,6 +1766,7 @@ export function useShellController(): ShellController {
 
   const stopRealtimeVoice = React.useCallback(() => {
     realtimeVoiceWantedRef.current = false;
+    realtimeVoiceWasActiveRef.current = false;
     saveContinuousChatMode(priorContinuousModeRef.current);
     setHandsFree(false);
     handsFreeRef.current = false;
@@ -1784,6 +1789,7 @@ export function useShellController(): ShellController {
     if (prior !== "always-on") priorContinuousModeRef.current = prior;
     saveContinuousChatMode("always-on");
     realtimeVoiceWantedRef.current = true;
+    realtimeVoiceWasActiveRef.current = false;
     setRealtimeVoiceBoundaryError(null);
     setHandsFree(true);
     handsFreeRef.current = true;
@@ -1838,6 +1844,37 @@ export function useShellController(): ShellController {
     void startRealtimeVoice();
   };
   stopRealtimeVoiceRef.current = stopRealtimeVoice;
+
+  // A LIVE Talk session that dies past the client's reconnect budget (network
+  // outage longer than the recovery window, terminal server error) must park
+  // Talk visibly OFF: restore the persisted mode, clear hands-free, and
+  // surface the actionable error. Leaving `wanted` latched would make the
+  // advertised "tap the mic to try again" first toggle the dead session off
+  // and appear to do nothing. Gated on a previously-ACTIVE session so initial
+  // start failures keep their existing outcome-driven handling in
+  // startRealtimeVoice (which also owns the pre-live notice copy).
+  React.useEffect(() => {
+    if (realtimeVoice.active) realtimeVoiceWasActiveRef.current = true;
+  }, [realtimeVoice.active]);
+  React.useEffect(() => {
+    if (!realtimeVoiceEnabled) return;
+    if (!realtimeVoice.error) return;
+    if (realtimeVoice.active || realtimeVoice.connecting) return;
+    if (!realtimeVoiceWasActiveRef.current) return;
+    if (!realtimeVoiceWantedRef.current) return;
+    realtimeVoiceWasActiveRef.current = false;
+    realtimeVoiceWantedRef.current = false;
+    saveContinuousChatMode(priorContinuousModeRef.current);
+    setHandsFree(false);
+    handsFreeRef.current = false;
+    setActionNotice(realtimeVoice.error.message, "error", 6000);
+  }, [
+    realtimeVoiceEnabled,
+    realtimeVoice.error,
+    realtimeVoice.active,
+    realtimeVoice.connecting,
+    setActionNotice,
+  ]);
 
   // Persisted always-on remains one setting across providers, but Cartesia owns
   // its own restoration path. In particular, no batch recorder is opened while

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
@@ -436,8 +436,8 @@ describe("useRealtimeVoiceSession", () => {
     });
   });
 
-  it("does not return a batch fallback after the realtime mic has become live", async () => {
-    const { options, ws } = makeOptions();
+  it("recovers a LIVE session across a transport drop without surfacing an error (no batch fallback)", async () => {
+    const { options, ws, mint } = makeOptions();
     const { result } = renderHook(() => useRealtimeVoiceSession(options));
 
     const startPromise = beginStart(result);
@@ -446,14 +446,29 @@ describe("useRealtimeVoiceSession", () => {
     await waitFor(() => expect(result.current.active).toBe(true));
     await expect(startPromise).resolves.toEqual({ kind: "live" });
 
+    // The wifi-switch class: the live socket dies. The hook must leave the
+    // client's reconnect budget intact (never zero it), so the REAL client
+    // re-mints and reconnects instead of surfacing a transport error.
     await act(async () => {
-      sock.emitClose(1006, "post-ready");
+      sock.emitClose(1006, "post-ready network change");
+      await flushAsync();
+    });
+    await waitFor(() => expect(mint.calls.length).toBe(2));
+    const second = ws.last();
+    expect(second).not.toBe(sock);
+    await act(async () => {
+      second.emitOpen();
+      await flushAsync();
+      second.emitControl({ t: "ready", sessionId: "sess-2", traceId: "T2" });
       await flushAsync();
     });
 
-    await waitFor(() => expect(result.current.error?.kind).toBe("transport"));
-    expect(result.current.active).toBe(false);
+    await waitFor(() => expect(result.current.active).toBe(true));
+    expect(result.current.error).toBeNull();
     expect(result.current.available).toBe(true);
+    await act(async () => {
+      await result.current.stop();
+    });
   });
 
   it("does not arm when the VITE flag is off (batch path owns the mic)", async () => {

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.ts
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.ts
@@ -507,8 +507,16 @@ export function useRealtimeVoiceSession(
     };
 
     const client = createClientRef.current({
+      // The client's own LIVE reconnect budget (with backoff, healthy refill,
+      // and pre-expiry rotation) is the structural answer to transient
+      // transport loss — a wifi switch or the server's 120s token sever must
+      // recover, not end the session. This hook must never zero out
+      // `maxReconnects`. Pre-live is different: a failure before the first
+      // server `ready` hands the SAME mic gesture to the batch path, so the
+      // pre-live budget is 0 — retrying past the gesture would strand the
+      // start outcome.
       ...clientOptionsRef.current,
-      maxReconnects: clientOptionsRef.current?.maxReconnects ?? 0,
+      preLiveMaxReconnects: clientOptionsRef.current?.preLiveMaxReconnects ?? 0,
       agentId: aId,
       conversationId: cId,
       // The client invokes this immediately before every mint/re-mint. Keeping

--- a/packages/ui/src/voice/__tests__/voice-session-client.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-client.test.ts
@@ -27,6 +27,7 @@ interface MintOverrides {
   status?: number;
   malformed?: boolean;
   code?: string;
+  expiresAtMs?: number;
 }
 
 /** A mint fetch that returns the §7.1 shape, tracking each call. */
@@ -52,7 +53,7 @@ function makeMintFetch(overrides: MintOverrides[] = []) {
           sessionId: `sess-${n}`,
           wsUrl: `wss://cloud/api/v1/voice/session/ws?sessionId=sess-${n}`,
           token: o.token ?? `tok-${n}`,
-          expiresAt: Date.now() + 60_000,
+          expiresAt: o.expiresAtMs ?? Date.now() + 60_000,
           uplink: { codecs: o.uplinkCodecs ?? ["pcm16"] },
           downlink: { codecs: o.downlinkCodecs ?? ["pcm16"] },
           iceServers: null,
@@ -1099,3 +1100,311 @@ function floatSpeaking(samples: number): Uint8Array {
   for (let i = 0; i < samples; i += 1) view.setInt16(i * 2, 16384, true);
   return out;
 }
+
+describe("transport-loss recovery (stop-class hardening)", () => {
+  function recoveryClient(
+    mint: ReturnType<typeof makeMintFetch>,
+    ws: ReturnType<typeof makeWsFactory>,
+    overrides: Partial<Parameters<typeof createVoiceSessionClient>[0]> = {},
+  ) {
+    const marks: VoiceTraceMark[] = [];
+    const errors: Error[] = [];
+    const client = createVoiceSessionClient({
+      agentId: "11111111-1111-1111-1111-111111111111",
+      conversationId: "22222222-2222-2222-2222-222222222222",
+      getConsentNonce: async () => `nonce-${mint.calls.length + 1}`,
+      fetch: mint.fetch,
+      webSocketFactory: ws.factory,
+      getUserMedia: fakeGetUserMedia(),
+      createMicAudioContext: () => new FakeMicAudioContext(16_000),
+      createPlaybackAudioContext: () => new FakePlaybackAudioContext(16_000),
+      onTraceMark: (m) => marks.push(m),
+      onError: (e) => errors.push(e),
+      preLiveMaxAttempts: 1,
+      preLiveRetryDelayMs: 0,
+      reconnectBackoffMs: 1,
+      // Rotation is opt-in per test; keep it inert unless a test arms it.
+      rotationLeadMs: 0,
+      ...overrides,
+    });
+    return { client, marks, errors };
+  }
+
+  async function settleTimers(ms = 25): Promise<void> {
+    await new Promise((r) => setTimeout(r, ms));
+    await flush();
+  }
+
+  it("a transport drop MID-UTTERANCE re-mints and returns to listening", async () => {
+    const mint = makeMintFetch([{ token: "A" }, { token: "B" }]);
+    const ws = makeWsFactory();
+    const { client, errors } = recoveryClient(mint, ws);
+    await client.start();
+    await flush();
+    const first = ws.last();
+    first.emitOpen();
+    first.emitControl({ t: "ready", sessionId: "s1", traceId: "T1" });
+    await flush();
+    first.emitControl({ t: "speaking_start", traceId: "T1" });
+    expect(client.state.phase).toBe("speaking");
+
+    // The wifi-switch class: the socket dies while the agent is speaking.
+    first.emitClose(1006, "network change");
+    await settleTimers();
+    expect(mint.calls).toHaveLength(2);
+    const second = ws.last();
+    expect(second).not.toBe(first);
+    second.emitOpen();
+    second.emitControl({ t: "ready", sessionId: "s2", traceId: "T2" });
+    await flush();
+    expect(client.state.phase).toBe("listening");
+    expect(errors).toEqual([]);
+    await client.stop();
+  });
+
+  it("a transient re-mint failure consumes the NEXT budgeted attempt instead of dying", async () => {
+    const mint = makeMintFetch([{}, { status: 500 }, { status: 500 }, {}]);
+    const ws = makeWsFactory();
+    const { client, errors } = recoveryClient(mint, ws, { maxReconnects: 3 });
+    await client.start();
+    await flush();
+    const first = ws.last();
+    first.emitOpen();
+    first.emitControl({ t: "ready", sessionId: "s1", traceId: "T1" });
+    await flush();
+
+    first.emitClose(1006, "network change");
+    // Attempts 2 and 3 wait the (tiny) growing backoff before re-minting.
+    await settleTimers(40);
+    expect(mint.calls).toHaveLength(4);
+    expect(ws.sockets).toHaveLength(2);
+    expect(errors).toEqual([]);
+    await client.stop();
+  });
+
+  it("recovery give-up is transport-shaped, never a mint/consent latch", async () => {
+    const mint = makeMintFetch([{}, { status: 500 }]);
+    const ws = makeWsFactory();
+    const { client, errors } = recoveryClient(mint, ws, { maxReconnects: 1 });
+    await client.start();
+    await flush();
+    const first = ws.last();
+    first.emitOpen();
+    first.emitControl({ t: "ready", sessionId: "s1", traceId: "T1" });
+    await flush();
+
+    first.emitClose(1006, "outage");
+    await settleTimers(40);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/voice session lost/);
+    // The underlying fault is preserved as the cause, not surfaced as the
+    // primary error (a raw mint error would latch realtime off in the hook).
+    expect(errors[0].cause).toBeInstanceOf(VoiceSessionMintError);
+    expect(client.state.phase).toBe("idle");
+    await client.stop();
+  });
+
+  it("a session healthy past the reset window refills the reconnect budget", async () => {
+    const mint = makeMintFetch([{}, {}, {}]);
+    const ws = makeWsFactory();
+    let clock = 0;
+    const { client, errors } = recoveryClient(mint, ws, {
+      maxReconnects: 1,
+      reconnectBudgetResetMs: 1_000,
+      now: () => clock,
+    });
+    await client.start();
+    await flush();
+    ws.last().emitOpen();
+    ws.last().emitControl({ t: "ready", sessionId: "s1", traceId: "T1" });
+    await flush();
+
+    clock = 5_000; // healthy for 5s >= 1s reset window
+    ws.last().emitClose(1006, "drop 1");
+    await settleTimers();
+    ws.last().emitOpen();
+    ws.last().emitControl({ t: "ready", sessionId: "s2", traceId: "T2" });
+    await flush();
+
+    clock = 10_000; // healthy again — the budget must have refilled
+    ws.last().emitClose(1006, "drop 2");
+    await settleTimers();
+    expect(mint.calls).toHaveLength(3);
+    expect(ws.sockets).toHaveLength(3);
+    expect(errors).toEqual([]);
+    await client.stop();
+  });
+
+  it("a connect-die loop does NOT refill the budget and stays bounded", async () => {
+    const mint = makeMintFetch([{}, {}, {}]);
+    const ws = makeWsFactory();
+    let clock = 0;
+    const { client, errors } = recoveryClient(mint, ws, {
+      maxReconnects: 1,
+      reconnectBudgetResetMs: 1_000,
+      now: () => clock,
+    });
+    await client.start();
+    await flush();
+    ws.last().emitOpen();
+    ws.last().emitControl({ t: "ready", sessionId: "s1", traceId: "T1" });
+    await flush();
+
+    clock = 100; // died within the window — no refill
+    ws.last().emitClose(1006, "drop 1");
+    await settleTimers();
+    ws.last().emitOpen();
+    ws.last().emitControl({ t: "ready", sessionId: "s2", traceId: "T2" });
+    await flush();
+
+    clock = 200; // still inside the window
+    ws.last().emitClose(1006, "drop 2");
+    await settleTimers();
+    expect(errors.some((e) => /voice session lost/.test(e.message))).toBe(true);
+    expect(client.state.phase).toBe("idle");
+    expect(mint.calls).toHaveLength(2);
+  });
+
+  it("quota_exhausted is terminal: no re-mint, a typed stop instead", async () => {
+    const mint = makeMintFetch();
+    const ws = makeWsFactory();
+    const { client, errors } = recoveryClient(mint, ws);
+    await client.start();
+    await flush();
+    const sock = ws.last();
+    sock.emitOpen();
+    sock.emitControl({ t: "ready", sessionId: "s1", traceId: "T1" });
+    await flush();
+
+    sock.emitControl({ t: "error", code: "quota_exhausted", retryable: false });
+    await settleTimers();
+    expect(mint.calls).toHaveLength(1);
+    expect(ws.sockets).toHaveLength(1);
+    expect(errors.some((e) => /quota_exhausted/.test(e.message))).toBe(true);
+    expect(client.state.phase).toBe("idle");
+  });
+
+  it("rotates the session before token expiry at a listening boundary without consuming budget", async () => {
+    const mint = makeMintFetch([
+      { token: "A", expiresAtMs: Date.now() + 120 },
+      { token: "B" },
+      { token: "C" },
+    ]);
+    const ws = makeWsFactory();
+    const { client, marks, errors } = recoveryClient(mint, ws, {
+      maxReconnects: 1,
+      rotationLeadMs: 90,
+      rotationRecheckMs: 10,
+      reconnectBudgetResetMs: 1e9,
+    });
+    await client.start();
+    await flush();
+    const first = ws.last();
+    first.emitOpen();
+    first.emitControl({ t: "ready", sessionId: "s1", traceId: "T1" });
+    await flush();
+
+    // Rotation due ~30ms after mint; the session is idle (listening).
+    await settleTimers(70);
+    expect(marks.some((m) => m.name === "token_rotation")).toBe(true);
+    // Clean bye + normal close on the OLD socket — the server sees a
+    // completed session, not an error.
+    expect(first.sentControls().some((c) => c.t === "bye")).toBe(true);
+    expect(first.closed?.code).toBe(1000);
+    expect(mint.calls).toHaveLength(2);
+    const second = ws.last();
+    expect(second).not.toBe(first);
+    second.emitOpen();
+    expect(second.sentControls()[0]).toMatchObject({ t: "hello", token: "B" });
+    second.emitControl({ t: "ready", sessionId: "s2", traceId: "T2" });
+    await flush();
+    expect(client.state.phase).toBe("listening");
+    expect(errors).toEqual([]);
+
+    // The rotation consumed NO budget: a real drop right after still recovers
+    // within maxReconnects: 1.
+    second.emitClose(1006, "drop after rotation");
+    await settleTimers();
+    expect(mint.calls).toHaveLength(3);
+    expect(errors).toEqual([]);
+    await client.stop();
+  });
+
+  it("defers a due rotation while a turn is in flight, then rotates at listening", async () => {
+    const mint = makeMintFetch([
+      { token: "A", expiresAtMs: Date.now() + 2_000 },
+      { token: "B" },
+    ]);
+    const ws = makeWsFactory();
+    const { client, marks, errors } = recoveryClient(mint, ws, {
+      rotationLeadMs: 1_980,
+      rotationRecheckMs: 20,
+    });
+    await client.start();
+    await flush();
+    const first = ws.last();
+    first.emitOpen();
+    first.emitControl({ t: "ready", sessionId: "s1", traceId: "T1" });
+    await flush();
+    first.emitControl({ t: "speaking_start", traceId: "T1" });
+    expect(client.state.phase).toBe("speaking");
+
+    // Rotation comes due while SPEAKING: it must defer, not cut the audio.
+    await settleTimers(80);
+    expect(ws.sockets).toHaveLength(1);
+    expect(marks.some((m) => m.name === "token_rotation_deferred")).toBe(true);
+    expect(marks.some((m) => m.name === "token_rotation")).toBe(false);
+
+    // Turn completes → the deferred rotation fires at the idle boundary.
+    first.emitControl({ t: "speaking_end", traceId: "T1" });
+    expect(client.state.phase).toBe("listening");
+    await settleTimers(80);
+    expect(marks.some((m) => m.name === "token_rotation")).toBe(true);
+    expect(mint.calls).toHaveLength(2);
+    expect(errors).toEqual([]);
+    await client.stop();
+  });
+
+  it("a completed utterance racing a server close recovers instead of double-tearing", async () => {
+    const mint = makeMintFetch([{ token: "A" }, { token: "B" }]);
+    const ws = makeWsFactory();
+    const { client, errors } = recoveryClient(mint, ws);
+    await client.start();
+    await flush();
+    const first = ws.last();
+    first.emitOpen();
+    first.emitControl({ t: "ready", sessionId: "s1", traceId: "T1" });
+    await flush();
+    first.emitControl({ t: "speaking_start", traceId: "T1" });
+    first.emitControl({ t: "speaking_end", traceId: "T1" });
+    // The server severs right on the turn boundary (the 120s expiry class).
+    first.emitClose(1000, "expired");
+    await settleTimers();
+    expect(mint.calls).toHaveLength(2);
+    expect(ws.sockets).toHaveLength(2);
+    expect(errors).toEqual([]);
+    await client.stop();
+  });
+
+  it("a completed utterance racing client stop() stays a clean stop — no re-mint", async () => {
+    const mint = makeMintFetch();
+    const ws = makeWsFactory();
+    const { client, errors } = recoveryClient(mint, ws);
+    await client.start();
+    await flush();
+    const first = ws.last();
+    first.emitOpen();
+    first.emitControl({ t: "ready", sessionId: "s1", traceId: "T1" });
+    await flush();
+    first.emitControl({ t: "speaking_start", traceId: "T1" });
+    first.emitControl({ t: "speaking_end", traceId: "T1" });
+    const stopping = client.stop();
+    first.emitClose(1000, "client bye");
+    await stopping;
+    await settleTimers();
+    expect(mint.calls).toHaveLength(1);
+    expect(ws.sockets).toHaveLength(1);
+    expect(client.state.phase).toBe("idle");
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/ui/src/voice/voice-session-client.ts
+++ b/packages/ui/src/voice/voice-session-client.ts
@@ -11,6 +11,16 @@
  *      per §7.2. Reconnect = RE-MINT (a revoked/expired token can't reconnect).
  *   4. clean `bye` + close.
  *
+ * Transport recovery: any unexpected close, fatal server frame, or failed
+ * re-mint consumes one attempt from a bounded reconnect budget with growing
+ * backoff between attempts, so a network switch that outlives a single mint
+ * still recovers. A session continuously live past `reconnectBudgetResetMs`
+ * refills the budget on its next loss — long sessions tolerate well-separated
+ * drops forever, while a connect-die loop stays bounded. The server hard-severs
+ * at the bootstrap token's exp (<=120s), so the client proactively ROTATES the
+ * session (clean bye + re-mint) shortly before expiry, but only at an idle
+ * `listening` boundary — never mid-turn — making the periodic sever invisible.
+ *
  * The client wires:
  *   - voice-session-mic-capture (getUserMedia → AudioWorklet/ScriptProcessor →
  *     Int16 PCM uplink frames)
@@ -181,11 +191,46 @@ export interface VoiceSessionClientOptions {
   now?: () => number;
 
   /**
-   * Max reconnect (re-mint) attempts on an unexpected close before giving up.
-   * Default 2. A revoked/expired token cannot reconnect — reconnect ALWAYS
-   * re-mints a fresh token, never reuses the old one.
+   * Max reconnect (re-mint) attempts per outage before giving up. Default 5.
+   * A revoked/expired token cannot reconnect — reconnect ALWAYS re-mints a
+   * fresh token, never reuses the old one. The budget refills after the
+   * session has been continuously live for `reconnectBudgetResetMs`.
    */
   maxReconnects?: number;
+  /**
+   * Reconnect budget while the lifecycle has NEVER reached server `ready`.
+   * Defaults to `maxReconnects`. A caller that owns a same-gesture fallback
+   * (the hook hands a pre-live failure to the batch mic) sets 0 so a pre-live
+   * transport fault surfaces immediately instead of retrying past the gesture.
+   */
+  preLiveMaxReconnects?: number;
+  /**
+   * Backoff base between reconnect attempts within one outage: attempt k
+   * (k >= 2) waits base * 2^(k-2); the first attempt is immediate so a
+   * server-side session rotation reconnects with no audible gap. Default 1000.
+   */
+  reconnectBackoffMs?: number;
+  /**
+   * A session continuously live (server `ready` observed) for at least this
+   * long refills the reconnect budget on its next transport loss. Default
+   * 30_000. A session that dies within seconds of connecting never refills,
+   * so a persistent connect-die fault stays bounded.
+   */
+  reconnectBudgetResetMs?: number;
+  /**
+   * Lead time before the minted token's expiry at which an idle (`listening`)
+   * session proactively rotates (clean bye + re-mint) instead of waiting for
+   * the server's hard sever at exp. 0 disables proactive rotation. Default
+   * 10_000.
+   */
+  rotationLeadMs?: number;
+  /** Re-check cadence while a due rotation waits for an idle boundary. Default 1000. */
+  rotationRecheckMs?: number;
+  /**
+   * Epoch clock used only for expiry math against the mint's `expiresAt`;
+   * `now` remains the monotonic trace/health clock. Default Date.now.
+   */
+  epochNow?: () => number;
   /** Bounded attempts for transient failures before the first socket opens. */
   preLiveMaxAttempts?: number;
   /** Backoff base for pre-live retries. Attempt n waits base * n. */
@@ -217,6 +262,28 @@ function nowDefault(): number {
   return typeof performance !== "undefined" ? performance.now() : Date.now();
 }
 
+/**
+ * Server error codes for which re-minting is pointless or would defeat the
+ * server's intent: a fresh session would hit the same quota gate, and a
+ * cross-device revoke means "stop", not "reconnect".
+ */
+const NON_RECOVERABLE_SERVER_ERROR_CODES: ReadonlySet<string> = new Set([
+  "quota_exhausted",
+  "revoked",
+]);
+
+/** Parse the mint `expiresAt` (epoch ms number, epoch seconds, or ISO string). */
+function parseExpiresAtMs(value: number | string | undefined): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > 1e12 ? value : value * 1000;
+  }
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
 export function createVoiceSessionClient(
   options: VoiceSessionClientOptions,
 ): VoiceSessionClient {
@@ -233,7 +300,16 @@ export function createVoiceSessionClient(
     ((url: string) => openNativeVoiceWebSocket(url));
   const preferredUplink = options.uplinkCodec ?? DEFAULT_UPLINK_CODEC;
   const preferredDownlink = options.downlinkCodec ?? DEFAULT_DOWNLINK_CODEC;
-  const maxReconnects = options.maxReconnects ?? 2;
+  const maxReconnects = options.maxReconnects ?? 5;
+  const preLiveMaxReconnects = options.preLiveMaxReconnects ?? maxReconnects;
+  const reconnectBackoffMs = Math.max(0, options.reconnectBackoffMs ?? 1000);
+  const reconnectBudgetResetMs = Math.max(
+    0,
+    options.reconnectBudgetResetMs ?? 30_000,
+  );
+  const rotationLeadMs = Math.max(0, options.rotationLeadMs ?? 10_000);
+  const rotationRecheckMs = Math.max(1, options.rotationRecheckMs ?? 1000);
+  const epochNow = options.epochNow ?? Date.now;
   const preLiveMaxAttempts = Math.max(1, options.preLiveMaxAttempts ?? 3);
   const preLiveRetryDelayMs = Math.max(0, options.preLiveRetryDelayMs ?? 500);
 
@@ -243,6 +319,16 @@ export function createVoiceSessionClient(
   let mic: VoiceMicCapture | null = null;
   let playback: VoiceSessionPlayback | null = null;
   let reconnectsUsed = 0;
+  // Monotonic timestamp of the most recent server `ready`; null while not live
+  // or once a loss has consumed it for the budget-refill decision.
+  let lastLiveAtMs: number | null = null;
+  // Whether THIS lifecycle (since start()) ever reached server `ready` —
+  // selects the pre-live vs live reconnect budget.
+  let everLiveThisLifecycle = false;
+  let rotationTimer: ReturnType<typeof setTimeout> | null = null;
+  // Epoch expiry of the CURRENT minted token; rotation never fires past it
+  // (the server has already severed — the reactive recovery path owns it).
+  let rotationDeadlineMs: number | null = null;
   let disposed = false;
   let lifecycleGeneration = 0;
   let lifecycleAbort: AbortController | null = null;
@@ -298,6 +384,24 @@ export function createVoiceSessionClient(
       setTimeout(resolve, preLiveRetryDelayMs * attempt),
     );
     assertLifecycleCurrent(generation);
+  };
+
+  const waitForReconnectBackoff = async (
+    attempt: number,
+    generation: number,
+  ) => {
+    const delayMs = reconnectBackoffMs * 2 ** (attempt - 2);
+    if (delayMs <= 0) return;
+    mark(`reconnect_backoff(${attempt})`, state.traceId);
+    await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    assertLifecycleCurrent(generation);
+  };
+
+  const clearRotationTimer = (): void => {
+    if (rotationTimer !== null) {
+      clearTimeout(rotationTimer);
+      rotationTimer = null;
+    }
   };
 
   async function mintOnce(
@@ -461,6 +565,10 @@ export function createVoiceSessionClient(
     switch (event.t) {
       case "ready":
         mark("ready", event.traceId);
+        // The server accepted the session: record the health timestamp the
+        // budget-refill decision reads on the next transport loss.
+        lastLiveAtMs = now();
+        everLiveThisLifecycle = true;
         // Client-owned: begin capture, then listening.
         void startCapture(generation, socket);
         break;
@@ -495,6 +603,14 @@ export function createVoiceSessionClient(
         break;
       case "error":
         if (!event.retryable) {
+          if (NON_RECOVERABLE_SERVER_ERROR_CODES.has(event.code)) {
+            // Re-minting cannot help (quota) or would defeat the server's
+            // intent (revoke). Surface the terminal cause and stop cleanly.
+            mark(`not_reached(server_terminal:${event.code})`, state.traceId);
+            emitError(new Error(`voice session ended: ${event.code}`));
+            void stop();
+            break;
+          }
           // Fatal server error: tear down and (unless intentional) re-mint.
           mark("not_reached(server_fatal_error)", state.traceId);
           requestRecovery("server_error", generation, socket);
@@ -642,12 +758,64 @@ export function createVoiceSessionClient(
       // here beyond a trace mark.
       mark("ws_error", state.traceId);
     });
+
+    scheduleRotation(minted, generation);
+  }
+
+  /**
+   * Arm the proactive pre-expiry rotation for the freshly-opened connection.
+   * The server hard-severs at the bootstrap token's exp; rotating first — at an
+   * idle boundary — keeps that sever from ever cutting audible speech.
+   */
+  function scheduleRotation(
+    minted: VoiceSessionMintResponse,
+    generation: number,
+  ): void {
+    clearRotationTimer();
+    rotationDeadlineMs = null;
+    if (rotationLeadMs <= 0) return;
+    const expiresAtMs = parseExpiresAtMs(minted.expiresAt);
+    if (expiresAtMs === null) return;
+    rotationDeadlineMs = expiresAtMs;
+    const delayMs = Math.max(0, expiresAtMs - epochNow() - rotationLeadMs);
+    rotationTimer = setTimeout(() => {
+      rotationTimer = null;
+      attemptRotation(generation);
+    }, delayMs);
+  }
+
+  function attemptRotation(generation: number): void {
+    if (!isLifecycleCurrent(generation) || intentionalClose) return;
+    // A reactive recovery already owns the transport; it re-mints anyway.
+    if (recoveryPromise) return;
+    if (rotationDeadlineMs !== null && epochNow() >= rotationDeadlineMs) {
+      // Token already expired — the server sever + reactive path own recovery.
+      return;
+    }
+    const socket = ws;
+    if (!socket || connPhase !== "open") return;
+    if (state.phase !== "listening") {
+      // Mid-turn: never cut audible speech or an in-flight transcription.
+      // Re-check until the turn completes or the deadline passes.
+      mark("token_rotation_deferred", state.traceId);
+      rotationTimer = setTimeout(() => {
+        rotationTimer = null;
+        attemptRotation(generation);
+      }, rotationRecheckMs);
+      return;
+    }
+    mark("token_rotation", state.traceId);
+    requestRecovery("token_rotation", generation, socket, {
+      budgeted: false,
+      cleanBye: true,
+    });
   }
 
   function requestRecovery(
     reason: string,
     generation: number,
     socket: VoiceWebSocketLike,
+    recoveryOptions?: { budgeted?: boolean; cleanBye?: boolean },
   ): void {
     if (!isLifecycleCurrent(generation) || intentionalClose || ws !== socket) {
       return;
@@ -658,14 +826,30 @@ export function createVoiceSessionClient(
     // consume a second reconnect attempt.
     ws = null;
     connPhase = "closed";
+    clearRotationTimer();
+    if (recoveryOptions?.cleanBye) {
+      try {
+        socket.send(encodeClientControl({ t: "bye" }));
+      } catch (ignoredError) {
+        // error-policy:J6 the bye frame is a courtesy on a socket being rotated away.
+        void ignoredError;
+      }
+    }
     try {
-      socket.close(1012, "re-mint");
+      socket.close(
+        recoveryOptions?.cleanBye ? 1000 : 1012,
+        recoveryOptions?.cleanBye ? "token rotation" : "re-mint",
+      );
     } catch (ignoredError) {
       // error-policy:J6 best-effort close of the dead socket; recovery proceeds regardless.
       void ignoredError;
     }
     if (recoveryPromise) return;
-    const pending = handleTransportLoss(reason, generation);
+    const pending = handleTransportLoss(
+      reason,
+      generation,
+      recoveryOptions?.budgeted ?? true,
+    );
     recoveryPromise = pending;
     void pending.finally(() => {
       if (recoveryPromise === pending) recoveryPromise = null;
@@ -675,31 +859,86 @@ export function createVoiceSessionClient(
   async function handleTransportLoss(
     reason: string,
     generation: number,
+    budgetedInitial: boolean,
   ): Promise<void> {
     if (!isLifecycleCurrent(generation) || intentionalClose) return;
+    clearRotationTimer();
     // Stop capture (a dead socket must not keep the mic hot) but KEEP playback
     // context so an autoplay unlock survives the reconnect.
     await teardownMic();
     if (!isLifecycleCurrent(generation) || intentionalClose) return;
-    if (reconnectsUsed >= maxReconnects) {
-      mark(`not_reached(reconnect_exhausted:${reason})`, state.traceId);
-      emitError(new Error(`voice session lost: ${reason}`));
-      await stop();
-      return;
+
+    // Budget refill: a session that stayed healthy long enough since its last
+    // recovery earns a fresh budget, so a long conversation tolerates
+    // well-separated drops (and 120s server rotations) indefinitely, while a
+    // session that dies within seconds of `ready` still exhausts and surfaces.
+    if (
+      budgetedInitial &&
+      lastLiveAtMs !== null &&
+      now() - lastLiveAtMs >= reconnectBudgetResetMs
+    ) {
+      reconnectsUsed = 0;
     }
-    reconnectsUsed += 1;
-    mark(`reconnect_remint(${reason})`, state.traceId);
-    try {
-      // Reconnect ALWAYS re-mints; the old token is revoked/expired and cannot
-      // reconnect (contract §7.1).
-      const minted = await mint(generation);
-      assertLifecycleCurrent(generation);
-      setState({ ...state, phase: "connecting", lastError: null });
-      await openConnection(minted, generation);
-    } catch (err) {
-      if (!isLifecycleCurrent(generation)) return;
-      emitError(err instanceof Error ? err : new Error(String(err)));
-      await stop();
+    lastLiveAtMs = null;
+
+    const reconnectCap = everLiveThisLifecycle
+      ? maxReconnects
+      : preLiveMaxReconnects;
+    let budgeted = budgetedInitial;
+    let currentReason = reason;
+    let attempt = 0;
+    while (true) {
+      if (budgeted && reconnectsUsed >= reconnectCap) {
+        mark(
+          `not_reached(reconnect_exhausted:${currentReason})`,
+          state.traceId,
+        );
+        emitError(new Error(`voice session lost: ${currentReason}`));
+        await stop();
+        return;
+      }
+      if (budgeted) reconnectsUsed += 1;
+      attempt += 1;
+      mark(`reconnect_remint(${currentReason})`, state.traceId);
+      try {
+        // Show the truthful transport phase for the whole attempt (backoff
+        // included) — the mic is down, so `listening` would be a lie — and
+        // give the caller's connect watchdog a fresh per-attempt arm.
+        setState({ ...state, phase: "connecting", lastError: null });
+        if (attempt > 1) await waitForReconnectBackoff(attempt, generation);
+        // Reconnect ALWAYS re-mints; the old token is revoked/expired and
+        // cannot reconnect (contract §7.1).
+        const minted = await mint(generation);
+        assertLifecycleCurrent(generation);
+        await openConnection(minted, generation);
+        return;
+      } catch (err) {
+        if (!isLifecycleCurrent(generation)) return;
+        if (err instanceof VoiceSessionLifecycleCancelledError) return;
+        const transient =
+          (err instanceof VoiceSessionMintError && err.isTransient) ||
+          err instanceof VoiceSessionConsentError;
+        if (transient) {
+          // A re-mint that failed on a transient fault consumes the NEXT
+          // budgeted attempt (with backoff) instead of killing a recoverable
+          // session — a network switch outlives a single mint by seconds.
+          budgeted = true;
+          currentReason = "remint_failed";
+          if (reconnectsUsed < reconnectCap) continue;
+          mark(
+            `not_reached(reconnect_exhausted:${currentReason})`,
+            state.traceId,
+          );
+        }
+        // Give-up on the recovery path is always transport-shaped: the session
+        // was live, so the caller's mic control must stay armed for retry
+        // rather than latching realtime off on a mint/consent error subtype.
+        emitError(
+          new Error(`voice session lost: ${currentReason}`, { cause: err }),
+        );
+        await stop();
+        return;
+      }
     }
   }
 
@@ -721,6 +960,9 @@ export function createVoiceSessionClient(
     const stoppedGeneration = ++lifecycleGeneration;
     lifecycleAbort?.abort();
     lifecycleAbort = null;
+    clearRotationTimer();
+    rotationDeadlineMs = null;
+    lastLiveAtMs = null;
     // Detach playback before the first await. If a caller reuses this client
     // after the transport reaches `closed`, this stop owns only the old sink
     // and cannot close/null a replacement created by the new lifecycle.
@@ -781,6 +1023,8 @@ export function createVoiceSessionClient(
       disposed = false;
       intentionalClose = false;
       reconnectsUsed = 0;
+      lastLiveAtMs = null;
+      everLiveThisLifecycle = false;
       microphoneMuted = false;
       setState({ ...INITIAL_VOICE_SESSION_STATE, phase: "connecting" });
       // Create playback up front so an early user-gesture unlock is possible and


### PR DESCRIPTION
# Relates to

Closes #17996

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync (verify results in
      Testing below).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low–medium. All changes are in `packages/ui` (voice-session client, realtime
hook, shell controller). The realtime voice path is flag-gated
(`VITE_VOICE_REALTIME_WS` + server `VOICE_REALTIME_WS_ENABLED`); builds with the
flag off are untouched. The pre-live contract (same-gesture batch fallback on a
failure before the first server `ready`) is preserved via a dedicated
`preLiveMaxReconnects: 0` budget and its existing tests still pass unchanged.
The main behavioral change is that a LIVE session now recovers from transport
loss instead of dying — bounded per outage, refilled only after 30 s of
continuous health, so a persistent connect-die fault still surfaces instead of
looping.

# Background

## What does this PR do?

Makes "voice mode randomly stops" structurally impossible-or-recovering for the
realtime (Cartesia) voice path. At current `develop` the stops are
deterministic, four stop-classes:

1. **Reconnect disabled in production wiring** — `useRealtimeVoiceSession.ts`
   created the client with `maxReconnects ?? 0`, so the client's tested
   reconnect-with-re-mint machinery never ran. Any single WS drop (a wifi
   switch is exactly this) ended the session.
2. **Guaranteed stop at ≤120 s** — the server hard-severs every session at the
   bootstrap token's exp (`packages/cloud/api/v1/voice/session/lib/session.ts`,
   TTL ≤120 s per `voice-session/jwt.ts`). The designed recovery is a client
   re-mint (contract §7.1), which (1) disabled — so continuous Talk died ~2
   minutes in, every time, sometimes mid-utterance.
3. **Lifetime-monotonic budget** — `reconnectsUsed` never reset, so even with a
   budget the 120 s rotations would exhaust it within minutes.
4. **Instantly-fatal transient re-mint** — recovery made one re-mint attempt
   (~1.5 s window); a real network switch (3–15 s) killed the session with
   budget remaining, surfacing a mint/consent error that latched realtime off.

Fixes, all client-side (no server changes):

- The hook passes the client's full LIVE reconnect budget (default 5) and
  zeroes only the PRE-live budget (new `preLiveMaxReconnects` option),
  preserving the same-gesture batch-fallback contract for pre-live failures.
- Recovery is a bounded per-outage loop with growing backoff
  (`reconnectBackoffMs`, first attempt immediate); a transient re-mint failure
  consumes the next budgeted attempt instead of dying; give-up is always
  transport-shaped so the mic control stays armed for retry.
- The budget refills after 30 s of continuous live health
  (`reconnectBudgetResetMs`), so long sessions tolerate well-separated drops
  indefinitely while a connect-die loop stays bounded.
- Proactive pre-expiry token rotation: ~10 s before the minted token's
  `expiresAt`, at an idle `listening` boundary (deferring mid-turn), the client
  sends a clean `bye` and re-mints — the server's 120 s sever never cuts
  audible speech, and rotation consumes no reconnect budget.
- `quota_exhausted` / `revoked` are terminal: surfaced typed, never re-minted
  (re-minting cannot help, and reconnect-after-revoke would defeat SEC-6).
- Shell: a LIVE Talk session that dies past the recovery budget parks Talk
  visibly OFF (persisted mode restored, hands-free cleared, actionable notice)
  so the advertised "tap the mic to try again" actually starts a session
  instead of toggling the dead one off.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The behavior
contract is documented in the module headers of `voice-session-client.ts` and
`useRealtimeVoiceSession.ts`.

# Testing

## Where should a reviewer start?

`packages/ui/src/voice/__tests__/voice-session-client.test.ts` — new describe
block `transport-loss recovery (stop-class hardening)` (10 tests, one per
stop-class, driving the REAL client over the suite's fake transports), then
`packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx`
("recovers a LIVE session across a transport drop…" — proves the hook no longer
zeroes the budget, via the real hook + real client) and
`packages/ui/src/components/shell/__tests__/useShellController.test.tsx`
("parks Talk visibly OFF…").

## Detailed testing steps

Automated tests are the proof (headless environment; see Known gaps):

- `bunx vitest run src/voice src/hooks/useRealtimeVoiceSession.test.tsx src/hooks/useRealtimeVoiceMint.test.tsx src/hooks/useContinuousVoiceSession.test.tsx src/components/shell/__tests__/useShellController.test.tsx` — 49 files, 589 passed
- `bunx vitest run src/components/shell/ChatOverlay.test.tsx src/components/shell/useShellVoiceOutput.test.tsx` — 205 passed
- `bun run --cwd packages/ui test` — full package suite (result below)
- `bun run --cwd packages/ui typecheck` — clean
- `bunx biome check` on every touched file — clean
- `bun run verify` — result below

Stop-class → test matrix (all in the new client describe block unless noted):

| Stop-class | Test |
| --- | --- |
| Transport drop mid-utterance | "a transport drop MID-UTTERANCE re-mints and returns to listening" |
| Drop between turns / clean unexpected close | existing "re-mints and tears down a live mic on an unexpected clean close" (kept green) |
| Transient re-mint failure during outage | "a transient re-mint failure consumes the NEXT budgeted attempt instead of dying" |
| Give-up error shape (no realtime latch) | "recovery give-up is transport-shaped, never a mint/consent latch" |
| Budget refill on healthy session | "a session healthy past the reset window refills the reconnect budget" |
| Bounded connect-die loop | "a connect-die loop does NOT refill the budget and stays bounded" |
| Terminal server error frame | "quota_exhausted is terminal: no re-mint, a typed stop instead" |
| 120 s expiry (idle boundary) | "rotates the session before token expiry at a listening boundary without consuming budget" |
| 120 s expiry (mid-turn) | "defers a due rotation while a turn is in flight, then rotates at listening" |
| Completed utterance vs server teardown race | "a completed utterance racing a server close recovers instead of double-tearing" |
| Completed utterance vs client stop race | "a completed utterance racing client stop() stays a clean stop — no re-mint" |
| Hook-level recovery (budget not zeroed) | useRealtimeVoiceSession.test.tsx "recovers a LIVE session across a transport drop without surfacing an error" |
| Shell parks Talk on budget exhaustion | useShellController.test.tsx "parks Talk visibly OFF when a LIVE session dies past the client's recovery budget" |

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:663b46e6265e32e9be2405ae01189c5c2161156c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered visual surface changed: every non-test file in the diff is a `.ts` logic module (client transport lifecycle, hook wiring, controller effect); the only `.tsx` files are test files
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered visual surface changed; the reconnecting state reuses the existing connecting/status surfaces byte-for-byte
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - transport-recovery logic with no new user-visible flow; the environment is a headless server with no audio or display device
<!-- evidence-row:backend-logs -->
- [ ] N/A - no server-side code changed; the client recovery paths are exercised end to end by the deterministic real-client suites whose output is inline below
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no HTTP request/response or rendered state path changed; the WebSocket lifecycle behavior is proven by the deterministic suites inline below
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model handler, action planning, or model output behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduled-task, wallet, generated-media, or audio artifact is produced by this change
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed in this diff

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change; this is client transport
lifecycle code.

## Backend + frontend logs

Deterministic suite output (real client + real hook over fake transports; no
stub of the system under test):

```
$ bunx vitest run src/voice src/hooks/useRealtimeVoiceSession.test.tsx \
    src/hooks/useRealtimeVoiceMint.test.tsx src/hooks/useContinuousVoiceSession.test.tsx \
    src/components/shell/__tests__/useShellController.test.tsx
 Test Files  49 passed (49)
      Tests  589 passed (589)

$ bunx vitest run src/components/shell/ChatOverlay.test.tsx src/components/shell/useShellVoiceOutput.test.tsx
 Test Files  2 passed (2)
      Tests  205 passed (205)

post-rebase onto origin/develop (1fbe2c14da6), same focused sweep:
$ bunx vitest run src/voice/__tests__/voice-session-client.test.ts \
    src/hooks/useRealtimeVoiceSession.test.tsx src/hooks/useContinuousVoiceSession.test.tsx \
    src/components/shell/__tests__/useShellController.test.tsx
      146 voice/shell tests passed, 0 failed
```

```
$ bun run --cwd packages/ui test   (full package suite)
 Test Files  2 failed | 883 passed (885)
      Tests  2 failed | 9231 passed | 7 skipped (9240)
both failures are unrelated to this diff (see Known gaps):
- src/hardcoded-color-ratchet.test.ts — fails identically on current develop tip
  (CloudPairRelay.tsx 11>8, NotificationsHomeCenter.tsx 12>0 — files not touched here)
- src/components/shell/HomeLauncherSurface.test.tsx — load flake; passes in isolation
  (26/26 when run alone)
```

```
$ bun run verify   (repo root)
exit code 0 — all Turbo verify tasks and repository audit gates passed
[anti-larp] scanned 7602 test files — 0 focused, 0 orphaned skip(s); clean

$ bun run --cwd packages/ui typecheck — clean
$ bunx biome check <every touched file> — clean
```

## Screenshots (before / after) + video walkthrough

N/A - no rendered visual surface changed (all changed non-test files are `.ts`
logic modules); headless VPS with no display or audio device.

### Before

N/A - see above.

### After

N/A - see above.

### Walkthrough video

N/A - see above.

## Audio / voice walkthrough

N/A - headless server environment with no audio device; the change alters
transport lifecycle recovery, not synthesis/transcription output. The
stop-classes are each simulated deterministically against the REAL client
(transport drop mid-utterance, drop between turns, provider error frame,
expiry boundary) in the colocated suites listed above. Live desktop
re-verification of the demo scenario is tracked in the linked issue.

## Known gaps / failures

- No live audio round-trip: this environment is a headless VPS without audio
  devices, and the realtime path additionally needs the flag-gated cloud voice
  worker. The proof standard here is the deterministic suites driving the real
  client/hook/controller through every stop-class.
- `packages/ui` full-suite has two failures UNRELATED to this diff:
  `hardcoded-color-ratchet.test.ts` fails identically on the current develop
  tip (color literals above baseline in `CloudPairRelay.tsx` and
  `NotificationsHomeCenter.tsx`, neither touched here), and
  `HomeLauncherSurface.test.tsx` is a load flake that passes 26/26 in
  isolation. Every voice/hook/shell suite touching this change passes.
- Residuals (filed in the linked issue, out of scope): a turn longer than the
  ~10 s rotation lead spanning token exp is still cut by the server sever
  (client now recovers in <1 s, the in-flight turn is lost); the batch
  (non-realtime) voice pipeline was not audited in this pass; mic hardware
  removal mid-session has no explicit capture-layer recovery signal.
