### PR TITLE
chore(cloud): enable the OIDC provider on production

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -612,7 +612,7 @@ ELIZA_CLOUD_AGENT_BASE_DOMAIN = "elizacloud.ai"
 # secrets. Flip OIDC_ENABLED to "true" only after OIDC_SIGNING_JWKS and
 # OIDC_CLIENTS are pushed; changing OIDC_ISSUER_URL afterwards invalidates every
 # relying-party account link.
-OIDC_ENABLED = "false"
+OIDC_ENABLED = "true"
 OIDC_ISSUER_URL = "https://api.elizacloud.ai"
 # Pin the prod Steward tenant explicitly instead of leaning on the implicit
 # DEFAULT_STEWARD_TENANT_ID ("elizacloud") in steward-tenant-config.ts. That


### PR DESCRIPTION
Flips `OIDC_ENABLED` to `"true"` in `[env.production.vars]`. One line.

**This does not change how anyone signs in to Eliza.** It adds the ability for a registered relying party to use Eliza Cloud as an identity provider. Existing session, social, and wallet flows are untouched — the provider reuses them rather than replacing them.

## Prerequisites are in place

`OIDC_SIGNING_JWKS` (a dedicated RS256 ring, separate from the internal-service and agent keys so rotation is independent) and `OIDC_CLIENTS` (one entry: Eliza Hub) are set as secrets on `eliza-cloud-api-prod`. `OIDC_ISSUER_URL` was already `https://api.elizacloud.ai`.

## Staging has been serving this since #17940

```
$ curl -s https://api-staging.elizacloud.ai/.well-known/openid-configuration
issuer:                    https://api-staging.elizacloud.ai
authorization_endpoint:    .../api/oidc/authorize
token_endpoint:            .../api/oidc/token
userinfo_endpoint:         .../api/oidc/userinfo
jwks_uri:                  .../.well-known/oidc/jwks.json
response_types_supported:  ["code"]
id_token_signing_alg_values_supported: ["RS256"]

$ curl -s .../.well-known/oidc/jwks.json  ->  1 key, RS256, no private components
```

Eliza Hub (`git.eliza.army`) has an `elizacloud` auth source pointed at the staging issuer, renders **Sign in with elizacloud**, and completes the handshake: the hub redirects to `/api/oidc/authorize`, which parks the request and bounces to the Cloud login with an `rid`. A full browser sign-in against a throwaway Forgejo was recorded on #17883, including the required-claim gate passing and failing in both directions, code-replay rejection, and the issuer-host pin.

## Why production, and why now

The hub currently authenticates against **staging**. Staging is reset and redeployed as normal practice, and each of those is a login outage for the forge. Pointing a real relying party at a staging issuer is the wrong long-term shape; this is the switch that lets the hub use `api.elizacloud.ai` instead.

`config.test.ts` — which fails if the issuer and the console build drift — passes 15/15.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

---

# Evidence

<!-- evidence-head:88a2157e11d067275cf0417edb12508684a9a488 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - configuration-only change; no UI surface is added or altered.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - configuration-only change; no UI surface is added or altered.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - configuration-only change. The sign-in flow it unblocks was recorded end to end on #17883.`
<!-- evidence-row:backend-logs -->
- [x] Production currently refuses to serve the provider, which is exactly what this flips, while the Worker itself is healthy:

```
$ curl -s https://api.elizacloud.ai/.well-known/openid-configuration
{"error":"not_found"}        <- isOidcEnabled() false, every OIDC route 404s

$ curl -s https://api-staging.elizacloud.ai/.well-known/openid-configuration
{"issuer":"https://api-staging.elizacloud.ai", ...}   <- same code, flag on
```

<!-- evidence-row:frontend-logs -->
- [x] The hub's redirect handshake against the staging issuer, observed in a real browser:

```
GET https://git.eliza.army/user/login                 200  renders "Sign in with elizacloud"
GET /user/oauth2/elizacloud                           302 -> api-staging.elizacloud.ai/api/oidc/authorize
GET /api/oidc/authorize                               302 -> staging.elizacloud.ai/login?returnTo=/oidc/continue?rid=eoq_...
```

<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] The single line changed, and the discovery document the flag governs:

```
packages/cloud/api/wrangler.toml
  [env.production.vars]  line 615:  OIDC_ENABLED = "true"   <- changed
  [env.staging.vars]     line 402:  OIDC_ENABLED = "true"   <- already true (#17940)

Secrets on eliza-cloud-api-prod: OIDC_SIGNING_JWKS, OIDC_CLIENTS  (set, values never printed)
config.test.ts: 15 pass, 0 fail
```

<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface is added or changed.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)