### PR TITLE
fix: keep Cloud login handoff on one surface

### DIFF
--- a/packages/ui/src/cloud/auth/cloud-auth-complete-signal.test.ts
+++ b/packages/ui/src/cloud/auth/cloud-auth-complete-signal.test.ts
@@ -1,0 +1,86 @@
+/** Verifies cloud-auth-complete-signal message matching and handoff surface detection. */
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isCloudAuthCompleteMessage,
+  isCloudAuthHandoffSurface,
+  publishCloudAuthComplete,
+  subscribeCloudAuthComplete,
+} from "./cloud-auth-complete-signal";
+
+let originalName = "";
+let originalOpener: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  originalName = window.name;
+  originalOpener = Object.getOwnPropertyDescriptor(window, "opener");
+});
+
+afterEach(() => {
+  window.name = originalName;
+  if (originalOpener) {
+    Object.defineProperty(window, "opener", originalOpener);
+  } else {
+    delete (window as { opener?: unknown }).opener;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("isCloudAuthCompleteMessage", () => {
+  it("accepts a well-formed complete payload", () => {
+    expect(
+      isCloudAuthCompleteMessage({
+        type: "eliza-cloud-auth-complete",
+        sessionId: "sess-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects mismatched session when filtered", () => {
+    expect(
+      isCloudAuthCompleteMessage(
+        { type: "eliza-cloud-auth-complete", sessionId: "sess-1" },
+        "other",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects garbage", () => {
+    expect(isCloudAuthCompleteMessage(null)).toBe(false);
+    expect(isCloudAuthCompleteMessage({ type: "nope" })).toBe(false);
+  });
+});
+
+describe("isCloudAuthHandoffSurface", () => {
+  it("is true for the named cloud-login popup", () => {
+    window.name = "eliza-cloud-auth";
+    expect(isCloudAuthHandoffSurface()).toBe(true);
+  });
+
+  it("is true when a live opener exists", () => {
+    window.name = "";
+    Object.defineProperty(window, "opener", {
+      configurable: true,
+      value: { closed: false },
+    });
+    expect(isCloudAuthHandoffSurface()).toBe(true);
+  });
+
+  it("is false for a plain top-level tab", () => {
+    window.name = "";
+    Object.defineProperty(window, "opener", {
+      configurable: true,
+      value: null,
+    });
+    expect(isCloudAuthHandoffSurface()).toBe(false);
+  });
+});
+
+describe("publish / subscribe", () => {
+  it("publish and subscribe are safe no-ops or callable without throw", () => {
+    const unsub = subscribeCloudAuthComplete(() => {});
+    expect(() => publishCloudAuthComplete("sess-bc")).not.toThrow();
+    expect(() => unsub()).not.toThrow();
+  });
+});

--- a/packages/ui/src/cloud/auth/cloud-auth-complete-signal.ts
+++ b/packages/ui/src/cloud/auth/cloud-auth-complete-signal.ts
@@ -1,0 +1,115 @@
+/**
+ * Cross-tab signal when a device-code / CLI Cloud login session finishes.
+ *
+ * The opener (local first-run or hosted shell) polls until authenticated; the
+ * auth surface (popup or tab on elizacloud) may also complete via
+ * `/auth/cli-login`. Orphaned intermediate tabs (e.g. Steward `/login` left
+ * open after nested OAuth) do not share `window.opener`, so `postMessage` alone
+ * cannot dismiss them. BroadcastChannel reaches every same-origin Cloud tab so
+ * they can show a terminal "done" state instead of a live sign-in form.
+ *
+ * Localhost openers do not share origin with Cloud, so they still rely on
+ * polling + `window.opener` postMessage; this channel is for Cloud-origin
+ * surfaces talking to each other.
+ */
+
+export const CLOUD_AUTH_COMPLETE_MESSAGE_TYPE = "eliza-cloud-auth-complete";
+
+export const CLOUD_AUTH_COMPLETE_CHANNEL = "eliza-cloud-auth-complete";
+
+export type CloudAuthCompleteMessage = {
+  type: typeof CLOUD_AUTH_COMPLETE_MESSAGE_TYPE;
+  sessionId: string;
+};
+
+export function isCloudAuthCompleteMessage(
+  data: unknown,
+  sessionId?: string,
+): data is CloudAuthCompleteMessage {
+  if (!data || typeof data !== "object") return false;
+  const message = data as { type?: unknown; sessionId?: unknown };
+  if (message.type !== CLOUD_AUTH_COMPLETE_MESSAGE_TYPE) return false;
+  if (typeof message.sessionId !== "string" || !message.sessionId.trim()) {
+    return false;
+  }
+  if (sessionId !== undefined && message.sessionId !== sessionId) return false;
+  return true;
+}
+
+export function publishCloudAuthComplete(sessionId: string): void {
+  const trimmed = sessionId.trim();
+  if (!trimmed || typeof window === "undefined") return;
+  const payload: CloudAuthCompleteMessage = {
+    type: CLOUD_AUTH_COMPLETE_MESSAGE_TYPE,
+    sessionId: trimmed,
+  };
+  try {
+    if (typeof BroadcastChannel === "undefined") return;
+    const channel = new BroadcastChannel(CLOUD_AUTH_COMPLETE_CHANNEL);
+    channel.postMessage(payload);
+    channel.close();
+  } catch (error) {
+    void error;
+    // error-policy:J6 broadcast is best-effort; opener poll still completes login.
+  }
+}
+
+/**
+ * Subscribe to same-origin Cloud auth completion. Returns an unsubscribe fn.
+ * No-ops when BroadcastChannel is unavailable (SSR / old engines).
+ */
+export function subscribeCloudAuthComplete(
+  onComplete: (message: CloudAuthCompleteMessage) => void,
+): () => void {
+  if (typeof window === "undefined" || typeof BroadcastChannel === "undefined") {
+    return () => {};
+  }
+  let channel: BroadcastChannel;
+  try {
+    channel = new BroadcastChannel(CLOUD_AUTH_COMPLETE_CHANNEL);
+  } catch (error) {
+    void error;
+    return () => {};
+  }
+  const handler = (event: MessageEvent) => {
+    if (!isCloudAuthCompleteMessage(event.data)) return;
+    onComplete(event.data);
+  };
+  channel.addEventListener("message", handler);
+  return () => {
+    try {
+      channel.removeEventListener("message", handler);
+      channel.close();
+    } catch (error) {
+      void error;
+      // error-policy:J6 teardown only.
+    }
+  };
+}
+
+/**
+ * True when this browsing context is already the device-code auth surface
+ * (named popup or opened from the app). Nested OAuth must stay same-tab so we
+ * do not leave the Steward sign-in form stranded in a sibling tab.
+ *
+ * `popupName` defaults to the Cloud login popup name (`eliza-cloud-auth`);
+ * callers may pass {@link CLOUD_LOGIN_POPUP_NAME} explicitly to avoid a
+ * packages-layer import cycle.
+ */
+export function isCloudAuthHandoffSurface(
+  popupName = "eliza-cloud-auth",
+): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    if (window.name === popupName) return true;
+  } catch (error) {
+    void error;
+  }
+  try {
+    const opener = window.opener as Window | null;
+    if (opener && !opener.closed) return true;
+  } catch (error) {
+    void error;
+  }
+  return false;
+}

--- a/packages/ui/src/cloud/auth/cloud-auth-complete-signal.ts
+++ b/packages/ui/src/cloud/auth/cloud-auth-complete-signal.ts
@@ -61,7 +61,10 @@ export function publishCloudAuthComplete(sessionId: string): void {
 export function subscribeCloudAuthComplete(
   onComplete: (message: CloudAuthCompleteMessage) => void,
 ): () => void {
-  if (typeof window === "undefined" || typeof BroadcastChannel === "undefined") {
+  if (
+    typeof window === "undefined" ||
+    typeof BroadcastChannel === "undefined"
+  ) {
     return () => {};
   }
   let channel: BroadcastChannel;

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
@@ -170,8 +170,9 @@ describe("CliLoginPage", () => {
       json: async () => ({ keyPrefix: "ek_live_abc" }),
     });
     const postMessage = vi.fn();
+    // No live opener — terminal success UI (manual close), not auto-close.
     Object.defineProperty(window, "opener", {
-      value: { postMessage },
+      value: null,
       configurable: true,
     });
     const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
@@ -185,10 +186,7 @@ describe("CliLoginPage", () => {
       "/api/auth/cli-session/sess-1/complete",
       expect.objectContaining({ method: "POST" }),
     );
-    expect(postMessage).toHaveBeenCalledWith(
-      { type: "eliza-cloud-auth-complete", sessionId: "sess-1" },
-      window.location.origin,
-    );
+    expect(postMessage).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "Close window" })).toBeTruthy();
     expect(
       screen.queryByRole("link", { name: "Continue to dashboard" }),
@@ -199,7 +197,7 @@ describe("CliLoginPage", () => {
     expect(closeSpy).not.toHaveBeenCalled();
   });
 
-  it("redirects authenticated app-launched sessions back to the sanitized returnTo", async () => {
+  it("with a live opener, notifies and closes without navigating returnTo (no second app shell)", async () => {
     searchParamsRef.current = new URLSearchParams({
       session: "sess-1",
       returnTo: "http://localhost:2138/chat?firstRun=1",
@@ -214,9 +212,41 @@ describe("CliLoginPage", () => {
     });
     const postMessage = vi.fn();
     Object.defineProperty(window, "opener", {
-      value: { postMessage },
+      value: { postMessage, closed: false },
       configurable: true,
     });
+    const replace = stubLocationReplace();
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+
+    render(<CliLoginPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Authentication Complete!")).toBeTruthy(),
+    );
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: "eliza-cloud-auth-complete", sessionId: "sess-1" },
+      "http://localhost:2138",
+    );
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    // Opener owns continuation — returnTo must not load a second localhost.
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.queryByText("Returning to app")).toBeNull();
+  });
+
+  it("without an opener, redirects authenticated app-launched sessions to sanitized returnTo", async () => {
+    searchParamsRef.current = new URLSearchParams({
+      session: "sess-1",
+      returnTo: "http://localhost:2138/chat?firstRun=1",
+    });
+    sessionAuthRef.current = {
+      ready: true,
+      authenticated: true,
+      user: { id: "u1", email: "a@b.co" },
+    };
+    apiFetchMock.mockResolvedValue({
+      json: async () => ({ keyPrefix: "ek_live_abc" }),
+    });
+    delete (window as { opener?: unknown }).opener;
     const replace = stubLocationReplace();
     const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
 
@@ -226,10 +256,6 @@ describe("CliLoginPage", () => {
       expect(replace).toHaveBeenCalledWith(
         "http://localhost:2138/chat?firstRun=1",
       ),
-    );
-    expect(postMessage).toHaveBeenCalledWith(
-      { type: "eliza-cloud-auth-complete", sessionId: "sess-1" },
-      "http://localhost:2138",
     );
     expect(closeSpy).toHaveBeenCalledTimes(1);
     expect(screen.getByText("Returning to app")).toBeTruthy();

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
@@ -233,6 +233,44 @@ describe("CliLoginPage", () => {
     expect(screen.queryByText("Returning to app")).toBeNull();
   });
 
+  it("named cloud-auth popup without opener stays terminal (no returnTo second shell)", async () => {
+    // COOP / opener closed mid-flight: window.name still identifies the handoff
+    // surface, but hasLiveOpener would be false. Must not location.replace.
+    searchParamsRef.current = new URLSearchParams({
+      session: "sess-1",
+      returnTo: "http://localhost:2138/chat?firstRun=1",
+    });
+    sessionAuthRef.current = {
+      ready: true,
+      authenticated: true,
+      user: { id: "u1", email: "a@b.co" },
+    };
+    apiFetchMock.mockResolvedValue({
+      json: async () => ({ keyPrefix: "ek_live_abc" }),
+    });
+    Object.defineProperty(window, "opener", {
+      value: null,
+      configurable: true,
+    });
+    const originalName = window.name;
+    window.name = "eliza-cloud-auth";
+    const replace = stubLocationReplace();
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+
+    try {
+      render(<CliLoginPage />);
+
+      await waitFor(() =>
+        expect(screen.getByText("Authentication Complete!")).toBeTruthy(),
+      );
+      expect(replace).not.toHaveBeenCalled();
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+      expect(screen.queryByText("Returning to app")).toBeNull();
+    } finally {
+      window.name = originalName;
+    }
+  });
+
   it("without an opener, redirects authenticated app-launched sessions to sanitized returnTo", async () => {
     searchParamsRef.current = new URLSearchParams({
       session: "sess-1",

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
@@ -8,11 +8,11 @@ import { AlertCircle, CheckCircle2, Key, Loader2 } from "lucide-react";
 import type { ComponentType, ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { Button } from "../../../../components/primitives";
 import {
   publishCloudAuthComplete,
   subscribeCloudAuthComplete,
 } from "../../../auth/cloud-auth-complete-signal";
-import { Button } from "../../../../components/primitives";
 import { ApiError, apiFetch } from "../../../lib/api-client";
 import { useSessionAuth } from "../../../lib/use-session-auth";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
@@ -246,6 +246,7 @@ export default function CliLoginPage() {
     if (!sessionId || !ready || !authenticated) return;
     if (completionFiredRef.current) return;
     completionFiredRef.current = true;
+    const activeSessionId = sessionId;
 
     const abort = new AbortController();
     const timeout = setTimeout(() => abort.abort(), COMPLETE_TIMEOUT_MS);
@@ -254,11 +255,11 @@ export default function CliLoginPage() {
       setCompletion({ status: "completing" });
       try {
         const response = await apiFetch(
-          `/api/auth/cli-session/${sessionId}/complete`,
+          `/api/auth/cli-session/${activeSessionId}/complete`,
           { method: "POST", json: {}, signal: abort.signal },
         );
         const data = (await response.json()) as { keyPrefix: string };
-        notifyCliLoginComplete(sessionId, launchReturnTo);
+        notifyCliLoginComplete(activeSessionId, launchReturnTo);
 
         // Live opener: the app tab owns continuation (poll / postMessage).
         // Close this surface and never navigate returnTo — that would open a

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
@@ -8,6 +8,10 @@ import { AlertCircle, CheckCircle2, Key, Loader2 } from "lucide-react";
 import type { ComponentType, ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import {
+  publishCloudAuthComplete,
+  subscribeCloudAuthComplete,
+} from "../../../auth/cloud-auth-complete-signal";
 import { Button } from "../../../../components/primitives";
 import { ApiError, apiFetch } from "../../../lib/api-client";
 import { useSessionAuth } from "../../../lib/use-session-auth";
@@ -84,6 +88,43 @@ function resolveCliLoginMessageTargetOrigin(returnTo: string | null): string {
   if (typeof window === "undefined") return "https://elizacloud.ai";
   if (!returnTo) return window.location.origin;
   return new URL(returnTo).origin;
+}
+
+function hasLiveOpener(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const opener = window.opener as Window | null;
+    return Boolean(opener && !opener.closed);
+  } catch (error) {
+    void error;
+    return false;
+  }
+}
+
+function notifyCliLoginComplete(
+  sessionId: string,
+  launchReturnTo: string | null,
+): void {
+  const targetOrigin = resolveCliLoginMessageTargetOrigin(launchReturnTo);
+  try {
+    window.opener?.postMessage(
+      { type: "eliza-cloud-auth-complete", sessionId },
+      targetOrigin,
+    );
+  } catch (error) {
+    void error;
+    // error-policy:J6 cross-origin opener policies can reject postMessage.
+  }
+  publishCloudAuthComplete(sessionId);
+}
+
+function tryCloseAuthWindow(): void {
+  try {
+    window.close();
+  } catch (error) {
+    void error;
+    // Some browsers reject script-close for normal tabs; success UI remains.
+  }
 }
 
 function getPageState({
@@ -186,6 +227,21 @@ export default function CliLoginPage() {
     setCompletion({ status: "idle" });
   }, [sessionId]);
 
+  // Another Cloud tab already finished this session — stop showing a live
+  // sign-in / completing state on this orphan surface. Ignore events after
+  // this tab has already started completion (avoids same-tab BroadcastChannel
+  // self-echo double-close).
+  useEffect(() => {
+    if (!sessionId) return;
+    return subscribeCloudAuthComplete((message) => {
+      if (message.sessionId !== sessionId) return;
+      if (completionFiredRef.current) return;
+      completionFiredRef.current = true;
+      setCompletion({ status: "success", apiKeyPrefix: "" });
+      tryCloseAuthWindow();
+    });
+  }, [sessionId]);
+
   useEffect(() => {
     if (!sessionId || !ready || !authenticated) return;
     if (completionFiredRef.current) return;
@@ -202,19 +258,20 @@ export default function CliLoginPage() {
           { method: "POST", json: {}, signal: abort.signal },
         );
         const data = (await response.json()) as { keyPrefix: string };
-        window.opener?.postMessage(
-          { type: "eliza-cloud-auth-complete", sessionId },
-          resolveCliLoginMessageTargetOrigin(launchReturnTo),
-        );
+        notifyCliLoginComplete(sessionId, launchReturnTo);
+
+        // Live opener: the app tab owns continuation (poll / postMessage).
+        // Close this surface and never navigate returnTo — that would open a
+        // second app shell when window.close() is ignored (#18001).
+        if (hasLiveOpener()) {
+          tryCloseAuthWindow();
+          setCompletion({ status: "success", apiKeyPrefix: data.keyPrefix });
+          return;
+        }
+
         if (launchReturnTo) {
           setCompletion({ status: "redirecting" });
-          try {
-            window.close();
-          } catch (error) {
-            void error;
-            // Some browsers reject script-close for normal tabs; redirect below
-            // still lands the user back in the app that started sign-in.
-          }
+          tryCloseAuthWindow();
           window.location.replace(launchReturnTo);
           return;
         }

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "../../../../components/primitives";
 import {
+  isCloudAuthHandoffSurface,
   publishCloudAuthComplete,
   subscribeCloudAuthComplete,
 } from "../../../auth/cloud-auth-complete-signal";
@@ -88,17 +89,6 @@ function resolveCliLoginMessageTargetOrigin(returnTo: string | null): string {
   if (typeof window === "undefined") return "https://elizacloud.ai";
   if (!returnTo) return window.location.origin;
   return new URL(returnTo).origin;
-}
-
-function hasLiveOpener(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    const opener = window.opener as Window | null;
-    return Boolean(opener && !opener.closed);
-  } catch (error) {
-    void error;
-    return false;
-  }
 }
 
 function notifyCliLoginComplete(
@@ -261,10 +251,11 @@ export default function CliLoginPage() {
         const data = (await response.json()) as { keyPrefix: string };
         notifyCliLoginComplete(activeSessionId, launchReturnTo);
 
-        // Live opener: the app tab owns continuation (poll / postMessage).
-        // Close this surface and never navigate returnTo — that would open a
-        // second app shell when window.close() is ignored (#18001).
-        if (hasLiveOpener()) {
+        // Handoff surface (live opener OR named cloud-auth popup): the opener
+        // poll / BroadcastChannel owns continuation. Never navigate returnTo —
+        // that loads a second app shell when opener is severed by COOP or the
+        // opener tab closed while auth was in flight (#18001).
+        if (isCloudAuthHandoffSurface()) {
           tryCloseAuthWindow();
           setCompletion({ status: "success", apiKeyPrefix: data.keyPrefix });
           return;

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -1,11 +1,16 @@
 /**
  * Login page (public) — Steward is the sole auth provider. Renders the lazy
- * Steward login section with the terms/privacy links.
+ * Steward login section with the terms/privacy links. Listens for device-code
+ * auth completion on same-origin tabs so an orphaned sign-in form does not
+ * stay live after the session already finished (#18001).
  */
 
 import { BRAND_PATHS, LOGO_FILES } from "@elizaos/shared/brand";
-import { lazy, Suspense } from "react";
-import { Link } from "react-router-dom";
+import { CheckCircle2 } from "lucide-react";
+import { lazy, Suspense, useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { subscribeCloudAuthComplete } from "../../../auth/cloud-auth-complete-signal";
+import { Button } from "../../../../components/primitives";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import { usePageTitle } from "../../lib/use-page-title";
 
@@ -68,11 +73,79 @@ function LoginBackground({ children }: { children: React.ReactNode }) {
   );
 }
 
+function sessionIdFromLoginReturnTo(returnTo: string | null): string | null {
+  if (!returnTo?.trim()) return null;
+  try {
+    const url = new URL(returnTo, window.location.origin);
+    if (!url.pathname.includes("/auth/cli-login")) return null;
+    const session = url.searchParams.get("session")?.trim();
+    return session || null;
+  } catch (error) {
+    void error;
+    return null;
+  }
+}
+
 export default function LoginPage() {
   const t = useCloudT();
+  const [searchParams] = useSearchParams();
+  const handoffSessionId = sessionIdFromLoginReturnTo(
+    searchParams.get("returnTo"),
+  );
+  const [handoffComplete, setHandoffComplete] = useState(false);
+
   usePageTitle(
     t("cloud.login.metaTitle", { defaultValue: "Sign In | Eliza Cloud" }),
   );
+
+  useEffect(() => {
+    if (!handoffSessionId) return;
+    return subscribeCloudAuthComplete((message) => {
+      if (message.sessionId !== handoffSessionId) return;
+      setHandoffComplete(true);
+      try {
+        window.close();
+      } catch (error) {
+        void error;
+      }
+    });
+  }, [handoffSessionId]);
+
+  if (handoffComplete) {
+    return (
+      <LoginBackground>
+        <div className="space-y-6 text-center">
+          <CheckCircle2 className="mx-auto h-10 w-10 text-status-success" />
+          <div className="space-y-1.5">
+            <h1 className="font-sans text-2xl font-semibold tracking-tight text-txt-strong">
+              {t("cloud.login.handoffCompleteTitle", {
+                defaultValue: "You're signed in",
+              })}
+            </h1>
+            <p className="text-sm text-muted">
+              {t("cloud.login.handoffCompleteBody", {
+                defaultValue:
+                  "Return to the Eliza app tab to continue. You can close this window.",
+              })}
+            </p>
+          </div>
+          <Button
+            className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
+            onClick={() => {
+              try {
+                window.close();
+              } catch (error) {
+                void error;
+              }
+            }}
+          >
+            {t("cloud.login.closeWindow", { defaultValue: "Close window" })}
+          </Button>
+        </div>
+      </LoginBackground>
+    );
+  }
+
   return (
     <LoginBackground>
       <div className="space-y-8">

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -9,8 +9,8 @@ import { BRAND_PATHS, LOGO_FILES } from "@elizaos/shared/brand";
 import { CheckCircle2 } from "lucide-react";
 import { lazy, Suspense, useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import { subscribeCloudAuthComplete } from "../../../auth/cloud-auth-complete-signal";
 import { Button } from "../../../../components/primitives";
+import { subscribeCloudAuthComplete } from "../../../auth/cloud-auth-complete-signal";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import { usePageTitle } from "../../lib/use-page-title";
 

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -38,6 +38,7 @@ import { DiscordIcon } from "../../../../cloud-ui/components/icons";
 import { Alert, AlertDescription } from "../../../../components/primitives";
 import { Button } from "../../../../components/ui/button";
 import { Input } from "../../../../components/ui/input";
+import { isCloudAuthHandoffSurface } from "../../../auth/cloud-auth-complete-signal";
 import {
   canNavigateSameTabForBlockedPopup,
   preOpenCloudLoginWindow,
@@ -773,7 +774,17 @@ export default function StewardLoginSection() {
     // PKCE challenge is asynchronous, so opening after it resolves is blocked
     // by browsers. Touch-primary browsers intentionally return null here and
     // continue in the current tab.
-    const authWindow = preOpenCloudLoginWindow();
+    //
+    // When this /login is already the device-code handoff surface (named
+    // popup or opened from local first-run), never nest a second OAuth
+    // window — that left the Steward sign-in form stranded while auth
+    // finished elsewhere (#18001). Stay same-tab instead.
+    // Popup name matches CLOUD_LOGIN_POPUP_NAME ("eliza-cloud-auth") — keep
+    // the default argument so partial mocks of cloud-login-launch still work.
+    const alreadyHandoffSurface = isCloudAuthHandoffSurface();
+    const authWindow = alreadyHandoffSurface
+      ? null
+      : preOpenCloudLoginWindow();
     setLoading(provider);
     setError(null);
     const host = window.location.hostname.toLowerCase();
@@ -804,7 +815,10 @@ export default function StewardLoginSection() {
       stewardTenantId: STEWARD_TENANT_ID,
       codeChallenge,
     });
-    if (authWindow && !authWindow.closed) {
+    if (alreadyHandoffSurface) {
+      // Stay in this tab so nested OAuth does not orphan the Steward form.
+      window.location.href = authorizeUrl;
+    } else if (authWindow && !authWindow.closed) {
       navigatePreOpenedWindow(authWindow, authorizeUrl);
     } else if (canNavigateSameTabForBlockedPopup()) {
       // Plain web can safely preserve the sign-in round trip in this tab.

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -38,12 +38,12 @@ import { DiscordIcon } from "../../../../cloud-ui/components/icons";
 import { Alert, AlertDescription } from "../../../../components/primitives";
 import { Button } from "../../../../components/ui/button";
 import { Input } from "../../../../components/ui/input";
-import { isCloudAuthHandoffSurface } from "../../../auth/cloud-auth-complete-signal";
 import {
   canNavigateSameTabForBlockedPopup,
   preOpenCloudLoginWindow,
 } from "../../../../state/cloud-login-launch";
 import { navigatePreOpenedWindow } from "../../../../utils/openExternalUrl";
+import { isCloudAuthHandoffSurface } from "../../../auth/cloud-auth-complete-signal";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import {
   configuredStewardTenantId,
@@ -782,9 +782,7 @@ export default function StewardLoginSection() {
     // Popup name matches CLOUD_LOGIN_POPUP_NAME ("eliza-cloud-auth") — keep
     // the default argument so partial mocks of cloud-login-launch still work.
     const alreadyHandoffSurface = isCloudAuthHandoffSurface();
-    const authWindow = alreadyHandoffSurface
-      ? null
-      : preOpenCloudLoginWindow();
+    const authWindow = alreadyHandoffSurface ? null : preOpenCloudLoginWindow();
     setLoading(provider);
     setError(null);
     const host = window.location.hostname.toLowerCase();

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -794,6 +794,14 @@ export function useFirstRunConductor(): void {
   // ── Flow launchers (shared by the action handler + the auto-resume) ──────
   const startCloudProvisionFlow = React.useCallback(() => {
     busyRef.current = true;
+    // Explicit waiting state on the opener while Cloud auth runs in the
+    // popup/tab — the sign-in CTA must not look idle (#18001).
+    seedTurn(
+      makeTurn(
+        "first-run:cloud-login-waiting",
+        "Waiting for sign-in in the window we opened… Finish there, then this tab will continue. If nothing opened, use the link in Settings → Cloud or tap Sign in again.",
+      ),
+    );
     // Pre-open the cloud-login popup synchronously NOW — the action handler is
     // still inside the user gesture, but the provision flow below awaits
     // several network round-trips before reaching the (async) interactive login
@@ -826,7 +834,7 @@ export function useFirstRunConductor(): void {
         // leave the gesture-claimed about:blank window open.
         releaseClaimedCloudLoginWindow();
       });
-  }, [handleOutcome, seedError]);
+  }, [handleOutcome, seedError, seedTurn]);
 
   const startProviderFinish = React.useCallback(() => {
     busyRef.current = true;

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -34,6 +34,7 @@ import {
   invokeDesktopBridgeRequestWithTimeout,
   isElectrobunRuntime,
 } from "../bridge";
+import { publishCloudAuthComplete } from "../cloud/auth/cloud-auth-complete-signal";
 import { clearStaleStewardSession } from "../cloud/shell/StewardProviderShared";
 import { getBootConfig, setBootConfig } from "../config/boot-config";
 import { dispatchElizaCloudStatusUpdated } from "../events";
@@ -145,6 +146,8 @@ function isMatchingCloudAuthCompleteMessage(
   data: unknown,
   sessionId: string,
 ): boolean {
+  // Keep the message contract aligned with cloud-auth-complete-signal.ts
+  // (BroadcastChannel + postMessage share the same payload shape).
   if (!sessionId || typeof data !== "object" || data === null) return false;
   const message = data as { type?: unknown; sessionId?: unknown };
   return (
@@ -1033,6 +1036,17 @@ export function useCloudState({
 
               closePrePoppedWindow();
               void closeExternalBrowser();
+              // Same-origin Cloud auth tabs (orphaned /login) dismiss via BC.
+              // Cross-origin openers already advanced via this poll.
+              if (sessionId) {
+                publishCloudAuthComplete(sessionId);
+              }
+              try {
+                window.focus();
+              } catch (error) {
+                void error;
+                // error-policy:J6 focus is best-effort after auth return.
+              }
 
               stopCloudLoginPolling();
               setElizaCloudConnected(true);


### PR DESCRIPTION
# Relates to

Closes #18001.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused UI package tests for the changed surface pass after sync (transcript below); full workspace `bun run verify` deferred to CI after fork workflow approval.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4`
<!-- attribution-row:client -->
- Agent tooling: `Grok Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop` at head `5a2a9cd1fb09c2c8d8a8240cf42df781c3ab40f9`; zero conflicts.
- [x] Focused tests pass post-rebase (see Testing / frontend-logs).

# Risks

Low–medium.
- Auth handoff path only (`packages/ui` Cloud public pages + first-run conductor + `useCloudState` poll).
- Named-popup + opener-severed path always terminal (no `returnTo` navigation) — covers COOP/opener-closed mid-flight.
- Regular non-popup tabs with a sanitized `returnTo` still redirect as before.

# Background

## What does this PR do?

Fixes the local first-run Cloud sign-in handoff where a new Cloud tab stayed on **Sign in to Eliza Cloud** (or became a second primary surface) while localhost was already connected.

1. **`CliLoginPage`** — if this is a Cloud auth handoff surface (live opener **or** named `eliza-cloud-auth` popup), notify + close and show success; **do not** `location.replace(returnTo)` (avoids a second app shell even when opener is null/closed).
2. **Steward OAuth** — when already on the device-code auth surface (named popup / opener), keep OAuth **same-tab** instead of nesting another window that orphans `/login`.
3. **BroadcastChannel** (`cloud-auth-complete-signal`) — orphan same-origin Cloud tabs dismiss to a terminal "You're signed in" state.
4. **Opener first-run** — seed an explicit **Waiting for sign-in…** turn while Cloud auth runs.
5. **`useCloudState`** — on poll success, publish the complete signal and attempt `window.focus()`.

## What kind of change is this?

Bug fix (non-breaking) for Cloud login multi-surface handoff.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx` — completion branch uses `isCloudAuthHandoffSurface()`.
- `packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx` — live opener + named-popup-without-opener cases.
- `packages/ui/src/cloud/auth/cloud-auth-complete-signal.ts` — BroadcastChannel + handoff predicate.

## Detailed testing steps

```bash
bun run --cwd packages/ui test -- \
  src/cloud/auth/cloud-auth-complete-signal.test.ts \
  src/cloud/public-pages/pages/auth/cli-login-page.test.tsx \
  src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
```

Local after fix (`cli-login-page` + signal) at head `5a2a9cd1fb09c2c8d8a8240cf42df781c3ab40f9`: **20 passed** (13 + 7).

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:5a2a9cd1fb09c2c8d8a8240cf42df781c3ab40f9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before (orphaned **Sign in to Eliza Cloud** primary surface) desktop + mobile: ![before desktop](https://github.com/user-attachments/assets/28209981-262f-4ef7-ac46-d0f3a994eb05) · ![before mobile](https://github.com/user-attachments/assets/99da0a44-1691-46fd-9684-81358a5a35d2)
<!-- evidence-row:after-screenshots -->
- [x] After CliLogin success (handoff surface — no second shell) + LoginPage BroadcastChannel terminal: ![after cli desktop](https://github.com/user-attachments/assets/b462c32a-6266-412f-8ee2-37eae13b7485) · ![after cli mobile](https://github.com/user-attachments/assets/3b49740d-99b8-4c2c-93ed-42fdea6ce7c4) · ![after login desktop](https://github.com/user-attachments/assets/dff7c7cc-9b63-463f-965b-a12141b4d1fa) · ![after login mobile](https://github.com/user-attachments/assets/6bdaefda-9305-46fc-946b-7cb94b519d4e)
<!-- evidence-row:walkthrough-video -->
- [x] Before → CliLogin success → LoginPage handoff terminal walkthrough: https://github.com/user-attachments/assets/fd83a412-8762-42ab-b298-6472bdc0ea12
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend/API route or server runtime files changed; handoff is pure client surface orchestration.
<!-- evidence-row:frontend-logs -->
- [x] Frontend control-flow evidence from real package vitest (jsdom) at head `5a2a9cd1fb09c2c8d8a8240cf42df781c3ab40f9`:

<details><summary>Focused UI handoff tests — 20 passed</summary>

```
$ bun run --cwd packages/ui test -- \
  src/cloud/auth/cloud-auth-complete-signal.test.ts \
  src/cloud/public-pages/pages/auth/cli-login-page.test.tsx

 RUN  v4.1.5 packages/ui
 ✓ src/cloud/auth/cloud-auth-complete-signal.test.ts (7 tests) 3ms
 ✓ src/cloud/public-pages/pages/auth/cli-login-page.test.tsx (13 tests) 115ms
   including:
   - with a live opener, notifies and closes without navigating returnTo
   - named cloud-auth popup without opener stays terminal (no returnTo second shell)
   - without an opener, redirects authenticated app-launched sessions to sanitized returnTo
 Test Files  2 passed (2)
      Tests  20 passed (20)
```

</details>
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or agent-loop behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, wallet, scheduled-task, or on-disk domain artifact path; change is browser-tab handoff only.
<!-- evidence-row:ocr-review -->
- [x] tesseract OCR text readout + manual visual review of the three terminal surfaces: [ocr-manual-review.md](https://github.com/user-attachments/files/30863968/18004-ocr-manual-review.md) · [before desktop OCR](https://github.com/user-attachments/files/30863970/18004-before-desktop-ocr.txt) · [after cli OCR](https://github.com/user-attachments/files/30863971/18004-after-cli-desktop-ocr.txt) · [after login OCR](https://github.com/user-attachments/files/30863972/18004-after-login-desktop-ocr.txt) · [before mobile OCR](https://github.com/user-attachments/files/30863973/18004-before-mobile-ocr.txt) · [after cli mobile OCR](https://github.com/user-attachments/files/30863974/18004-after-cli-mobile-ocr.txt) · [after login mobile OCR](https://github.com/user-attachments/files/30863975/18004-after-login-mobile-ocr.txt)

# Evidence Details

## Screenshots (before / after) + video walkthrough

Captures use headless Chromium with the exact product copy from `login-page.tsx` / `cli-login-page.tsx` terminal states (before = orphaned sign-in; after = Authentication Complete / You're signed in). Full multi-origin live Steward OAuth needs Cloud + localhost credentials in this environment; unit tests assert the real control flow (opener notify/close, named-popup without opener, BroadcastChannel shape). Artifacts also mirrored in [this PR comment](https://github.com/elizaOS/eliza/pull/18004).

### Before
![before desktop](https://github.com/user-attachments/assets/28209981-262f-4ef7-ac46-d0f3a994eb05)

### After
![after cli](https://github.com/user-attachments/assets/b462c32a-6266-412f-8ee2-37eae13b7485)
![after login handoff](https://github.com/user-attachments/assets/dff7c7cc-9b63-463f-965b-a12141b4d1fa)

### Walkthrough video
https://github.com/user-attachments/assets/fd83a412-8762-42ab-b298-6472bdc0ea12

## Known gaps / failures

1. **Live two-window OAuth with real Steward credentials** was not available in the babysit environment; control-flow coverage is the 20 focused unit tests including the named-popup-without-opener regression.
2. **Fork workflow approval:** Develop PR Gate / Security Advisory Gate may still need maintainer "Approve and run workflows" on first-time fork runs — not a code failure.
3. Full `bun run verify` not re-run end-to-end in this cycle after develop rebase; focused UI tests pass at `5a2a9cd1fb09c2c8d8a8240cf42df781c3ab40f9`.

# Review follow-ups addressed

- Named popup without live opener no longer `location.replace(returnTo)` — uses `isCloudAuthHandoffSurface()` (`5a2a9cd1fb09c2c8d8a8240cf42df781c3ab40f9`).
- Evidence head + trusted `user-attachments` screenshots/video/OCR attached for gate.
- Contribution-attribution:v1 complete.
