### PR TITLE
fix(cloud): keep app-mode entry inside the agent app when no agent is running

### DIFF
--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
@@ -240,14 +240,25 @@ describe("AppModeEntryRoute — routing table", () => {
     expect(fetchLog).toContain("POST /api/v1/eliza/agents/fresh/pairing-token");
   });
 
-  it("dedicated agents exist but none running → the Instances view (resume from there)", async () => {
+  it("dedicated agents exist but none running → the same-origin chat app (never the console)", async () => {
     signIn();
     stubNetwork({
       agents: agentsOk([agent({ id: "agent-1", status: "stopped" })]),
     });
     renderEntry();
 
-    expect(await screen.findByTestId("instances-page")).toBeTruthy();
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
+    expect(assignedUrls).toEqual([]);
+  });
+
+  it("an errored dedicated agent (failed provision) → the same-origin chat app, not a dashboard bounce", async () => {
+    signIn();
+    stubNetwork({
+      agents: agentsOk([agent({ id: "agent-1", status: "error" })]),
+    });
+    renderEntry();
+
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
     expect(assignedUrls).toEqual([]);
   });
 
@@ -270,13 +281,13 @@ describe("AppModeEntryRoute — routing table", () => {
     expect(assignedUrls).toEqual([]);
   });
 
-  it("agents fetch failure → graceful fallback to the Instances view", async () => {
+  it("agents fetch failure → graceful fallback to the same-origin chat app", async () => {
     signIn();
     stubNetwork({
       agents: () => jsonResponse(500, { error: "backend down" }),
     });
     renderEntry();
 
-    expect(await screen.findByTestId("instances-page")).toBeTruthy();
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
   });
 });

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
@@ -9,9 +9,10 @@
  * agents and routes per `decideAppModeRoute`: one running dedicated agent →
  * full-page pairing redirect into its web UI (202 "must resume" and pairing
  * failures degrade to the Instances console); several → a minimal chooser;
- * dedicated-but-stopped → Instances; shared-tier-only orgs fall through to the
- * same-origin chat app unchanged; no agents at all → the `/join`
- * deploy-first-agent flow. Unauthenticated visitors first get one shot at the
+ * no pairing target (shared-tier-only orgs AND dedicated agents that are not
+ * running) → the same-origin chat app unchanged — on the app hosts the entry
+ * must stay inside the app, never bounce to the console because an agent is
+ * stopped or errored; no agents at all → the `/join` deploy-first-agent flow. Unauthenticated visitors first get one shot at the
  * cross-host SSO bridge (`../sso-bridge/sso-bridge` — only when the
  * domain-wide session marker says the dashboard pair holds a live session and
  * the user did not explicitly sign out here), then the normal login flow, and
@@ -140,9 +141,11 @@ export function AppModeEntryRoute({
   }
 
   if (agentsQuery.isError) {
-    // Never a blank screen: the Instances console owns the failure surface
-    // (skeleton / error state / retry) for the same list.
-    return <Navigate to={APP_MODE_INSTANCES_PATH} replace />;
+    // Never a blank screen — and never the console either: the same-origin
+    // chat app is the app host's own degraded surface (its pre-app-mode
+    // behavior), so a control-plane hiccup on the agents list keeps the
+    // visitor in the product instead of evicting them to the dashboard.
+    return <>{appElement}</>;
   }
 
   if (!route) {
@@ -170,7 +173,6 @@ export function AppModeEntryRoute({
     case "choose-agent":
       return <AgentChooser running={route.running} />;
 
-    case "resume":
     case "create":
       return <Navigate to={route.to} replace />;
 

--- a/packages/ui/src/cloud/app-mode/app-mode.test.ts
+++ b/packages/ui/src/cloud/app-mode/app-mode.test.ts
@@ -4,7 +4,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   APP_MODE_CREATE_PATH,
-  APP_MODE_INSTANCES_PATH,
   type AppModeAgent,
   appModeNavigation,
   decideAppModeRoute,
@@ -132,19 +131,24 @@ describe("decideAppModeRoute — decision table", () => {
     });
   });
 
-  it("dedicated agents exist but none running → Instances resume", () => {
+  it("dedicated agents exist but none running → chat-home (the app stays home; never the console)", () => {
     const route = decideAppModeRoute([
       agent({ id: "d1", status: "stopped" }),
       agent({ id: "d2", status: "sleeping" }),
     ]);
-    expect(route).toEqual({ kind: "resume", to: APP_MODE_INSTANCES_PATH });
+    expect(route).toEqual({ kind: "chat-home" });
   });
 
-  it("deletion_pending is not running → Instances resume", () => {
+  it("an errored dedicated agent (failed provision) → chat-home, not a dashboard bounce", () => {
+    const route = decideAppModeRoute([agent({ id: "d1", status: "error" })]);
+    expect(route).toEqual({ kind: "chat-home" });
+  });
+
+  it("deletion_pending is not running → chat-home", () => {
     const route = decideAppModeRoute([
       agent({ id: "d1", status: "deletion_pending" }),
     ]);
-    expect(route).toEqual({ kind: "resume", to: APP_MODE_INSTANCES_PATH });
+    expect(route).toEqual({ kind: "chat-home" });
   });
 
   it("shared-tier-only org → chat-home (the same-origin chat app, unchanged)", () => {

--- a/packages/ui/src/cloud/app-mode/app-mode.ts
+++ b/packages/ui/src/cloud/app-mode/app-mode.ts
@@ -67,8 +67,13 @@ export interface AppModeAgent {
   updatedAt: IsoDateString;
 }
 
-/** Where the instances console lives — the resume / manage surface. A
- * registered cloud route, reachable on every host. */
+/** Where the instances console lives — the manage surface an explicit user
+ * action (the "Go to your instances" escape, the 202 wake-progress landing)
+ * may navigate to. A registered cloud route, reachable on every host. Entry
+ * routing itself never lands here: the app host is the product, and evicting
+ * a visitor to the console because their agent is stopped or errored buries
+ * the app under the dashboard (the exact app-staging regression this
+ * distinction exists for). */
 export const APP_MODE_INSTANCES_PATH = "/dashboard/agents";
 /** The deploy-first-agent flow: `/join` select-or-provisions a Cloud agent and
  * drops the user straight into chat. */
@@ -79,12 +84,14 @@ export type AppModeRoute =
   | { kind: "enter-agent"; agent: AppModeAgent }
   /** Several running dedicated agents — minimal chooser, most recent first. */
   | { kind: "choose-agent"; running: AppModeAgent[] }
-  /** Dedicated agents exist but none running — Instances, resume from there. */
-  | { kind: "resume"; to: string }
   /** No agents at all — the `/join` deploy-first-agent flow. */
   | { kind: "create"; to: string }
-  /** Only shared-tier agents (no per-agent web UI to pair into) — the existing
-   * same-origin chat app stays their home, exactly as before app-mode. */
+  /** No pairing target right now (shared-tier-only org, or dedicated agents
+   * that are stopped/errored/starting) — the existing same-origin chat app
+   * stays home, exactly as before app-mode. On the app hosts the entry must
+   * stay INSIDE the app: bouncing to the console instances page here is what
+   * made app-staging "redirect to the dashboard" whenever an org's only
+   * dedicated agent wasn't running. */
   | { kind: "chat-home" };
 
 function activityStamp(agent: AppModeAgent): number {
@@ -99,6 +106,14 @@ function activityStamp(agent: AppModeAgent): number {
  * REST adapter and have no per-agent subdomain to redirect into, so a
  * shared-only org keeps the same-origin chat app ({@link AppModeRoute}
  * `chat-home`) instead of a pairing call that cannot succeed.
+ *
+ * Dedicated agents that are NOT running (stopped, sleeping, errored,
+ * provisioning-failed) also resolve to `chat-home`: there is no web UI to
+ * pair into yet, and the same-origin chat app — the app host's pre-app-mode
+ * behavior — degrades gracefully, while a `/dashboard/agents` navigation
+ * would replace the product with the console. Managing/resuming instances
+ * remains an explicit action (the chooser, the error escape button, the
+ * dashboard origin itself), never the silent entry default.
  */
 export function decideAppModeRoute(
   agents: readonly AppModeAgent[],
@@ -110,8 +125,6 @@ export function decideAppModeRoute(
 
   if (running.length === 1) return { kind: "enter-agent", agent: running[0] };
   if (running.length > 1) return { kind: "choose-agent", running };
-  if (dedicated.length > 0)
-    return { kind: "resume", to: APP_MODE_INSTANCES_PATH };
   if (agents.length > 0) return { kind: "chat-home" };
   return { kind: "create", to: APP_MODE_CREATE_PATH };
 }


### PR DESCRIPTION
## The regression

Shadow's report (2026-08-07): **app-staging.elizacloud.ai redirects to the dashboard instead of just taking you to the Agent app.** It worked before, regressed this week.

Root cause is client-side, introduced by #17752 (app-mode entry gate, merged Aug 5). `decideAppModeRoute` sends any org whose dedicated agents exist but are **not running** to `/dashboard/agents` — the cloud console. On staging, Shadow's org's only dedicated agent is in `status=error` (provisioning failed: "Sandbox health check timed out", job `02875846`, 19:31Z today), so opening app-staging deterministically bounced to the dashboard. The `agents` fetch-error branch had the same console bounce.

The serving path is fine: `app-staging` worker route → `develop.eliza-app.pages.dev` serves the correct current bundle (commit d72e9e4e7, verified byte-identical, `/api/health` → `environment: staging`), zero HTTP redirects. The "redirect" is this gate.

## The fix

On the app hosts the entry must become the product; the console is never a valid entry destination.

- `decideAppModeRoute`: drop the `resume` route kind. Dedicated-but-not-running (stopped / sleeping / **error** / deletion_pending) resolves to `chat-home` — the same-origin chat app, which was exactly these hosts' behavior before app-mode. Managing/resuming instances stays an explicit action: the chooser, the pairing-error "Go to your instances" escape, and the 202 wake landing are all unchanged.
- `AppModeEntryRoute`: the agents-list fetch failure also degrades to the chat app instead of evicting the visitor to the console.

Unchanged: pairing redirect for one running dedicated agent, multi-agent chooser, `/join` for empty orgs, 202 resume landing, every apex console behavior, the SSO bridge.

Design note for @NubsCarson: this deliberately reverses the `resume → Instances` decision from #17752. Reasoning: an entry-time console navigation turns any provisioning failure or stopped agent into "the app is gone, here's the dashboard", which reads as a broken PWA — especially bad while app.elizacloud.ai is the add-to-homescreen path pending the iOS app. Happy to iterate if you want an in-app resume affordance instead; the chat app is the safe floor either way.

## Evidence

Regression (staging, before):
- `GET https://app-staging.elizacloud.ai/` → 200, correct app bundle, then client gate navigates to `/dashboard/agents` (org `7b3519e4`, one dedicated agent `d944feab` in `status=error`)
- decision table: `dedicated.length > 0 && running.length === 0 → { kind: \"resume\", to: \"/dashboard/agents\" }`

After (this branch):
- same state → `{ kind: \"chat-home\" }` → the agent app renders
- `packages/ui` app-mode suite: 3 files, 47 tests pass, including new pins for the exact regression shape (`status=error` dedicated agent → chat app, no navigation; fetch failure → chat app)
- `CloudRouterShell.test.tsx` 16/16 pass (apex guard untouched)
- `tsc --noEmit` clean, biome clean

Note: app.elizacloud.ai (prod) carries the same #17752 behavior via the Aug 6 promote, so prod users with a stopped dedicated agent currently get the same dashboard bounce. This fix covers it on the next promote.

# Evidence Gate

<!-- evidence-head:aed63172f48b0162636fec439933dc5a9ab88d8c -->

<!-- evidence-row:before-screenshots -->
- [x] Before (develop tip `d72e9e4e759`, the post-#17752 gate, extracted verbatim and mounted in real Chromium against the regressing org state: 1 dedicated agent, `status=error`, 0 running) — entry navigates to `/dashboard/agents`: desktop ![before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18005-before-desktop.jpg) mobile ![before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18005-before-mobile.jpg)

<!-- evidence-row:after-screenshots -->
- [x] After (this head) — the same org state resolves to `chat-home`, the agent app renders, router stays on `/`: desktop ![after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18005-after-desktop.jpg) mobile ![after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18005-after-mobile.jpg) plus the fixed agents-fetch-failure branch ![after fetch error](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18005-after-fetch-error-desktop.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] before (console bounce) → after (chat app) → after with agents fetch 500 (chat app), real-browser render of the real gate component both sides: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18005-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend-only routing change; no server code path is touched by this diff (same scope as #17752 which introduced the gate).

<!-- evidence-row:frontend-logs -->
- [x] [18005-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18005-frontend-logs.txt) — console + network trace of every capture: the `/api/v1/eliza/agents` 200 (`status=error` agent) and 500 variants, the router-location line per variant, and 12/12 in-page assertions (before navigates to `/dashboard/agents`; after stays on `/` and renders the app element).

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - client-side entry routing only; no model, prompt, provider, action, or inference behavior participates in this diff.

<!-- evidence-row:domain-artifacts -->
- [x] [18005-unit-suite.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18005-unit-suite.txt) — the full app-mode + router-shell unit run at this head: 63/63 pass (`app-mode.test.ts` 31, `AppModeEntryRoute.test.tsx` 11 incl. the new `status=error` and fetch-failure pins, SSO 5, `CloudRouterShell.test.tsx` 16 apex guard).

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review — tesseract 5.3.4 text readout of all five attached captures, checked against the intended copy of each state (before: `DASHBOARD / INSTANCES CONSOLE` + `router location: /dashboard/agents`; after + fetch-error: `SAME-ORIGIN CHAT APP` + `router location: /`): [18005-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18005-ocr-review.txt)

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `moltbot`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
