### PR TITLE
fix(homepage): judge capture stability with the snapshot comparator's pixelmatch tolerance

### DIFF
--- a/packages/homepage/tests/e2e/screenshot-quality.ts
+++ b/packages/homepage/tests/e2e/screenshot-quality.ts
@@ -128,8 +128,44 @@ interface FrameDelta {
   byteDelta: number;
 }
 
-/** Per-channel delta below this is anti-aliasing noise, not real change. */
-const CHANNEL_NOISE_THRESHOLD = 3;
+// Per-pixel tolerance mirrors the comparator the snapshot assertion itself
+// uses: Playwright's toMatchSnapshot diffs PNGs with pixelmatch at threshold
+// 0.2, which treats two pixels as equal while their weighted-YIQ color
+// distance stays within 35215 * threshold^2. The stability gate must judge
+// consecutive frames by the same metric — a stricter one (small per-channel
+// deltas) fails pages whose WebGL/video/shader dither the snapshot diff
+// happily tolerates, which is exactly what red-flagged every homepage route
+// in CI while the golden comparison itself was green.
+const PIXELMATCH_THRESHOLD = 0.2;
+const MAX_YIQ_DELTA = 35215 * PIXELMATCH_THRESHOLD ** 2;
+
+/** Composite a channel over white by its alpha, as pixelmatch does. */
+function blendOverWhite(channel: number, alpha: number): number {
+  return 255 + (channel - 255) * alpha;
+}
+
+/**
+ * Whether two RGBA pixels differ perceptibly, using pixelmatch's weighted
+ * YIQ color-distance formula and coefficients at PIXELMATCH_THRESHOLD.
+ */
+function pixelsDiffer(a: Uint8Array, b: Uint8Array, i: number): boolean {
+  const alphaA = a[i + 3] / 255;
+  const alphaB = b[i + 3] / 255;
+  const rA = blendOverWhite(a[i], alphaA);
+  const gA = blendOverWhite(a[i + 1], alphaA);
+  const bA = blendOverWhite(a[i + 2], alphaA);
+  const rB = blendOverWhite(b[i], alphaB);
+  const gB = blendOverWhite(b[i + 1], alphaB);
+  const bB = blendOverWhite(b[i + 2], alphaB);
+  const dy =
+    (rA - rB) * 0.29889531 + (gA - gB) * 0.58662247 + (bA - bB) * 0.11448223;
+  const di =
+    (rA - rB) * 0.59597799 - (gA - gB) * 0.2741761 - (bA - bB) * 0.32180189;
+  const dq =
+    (rA - rB) * 0.21147017 - (gA - gB) * 0.52261711 + (bA - bB) * 0.31114694;
+  const delta = 0.5053 * dy * dy + 0.299 * di * di + 0.1957 * dq * dq;
+  return delta > MAX_YIQ_DELTA;
+}
 
 /**
  * Pixel-level delta between two consecutive PNG captures. Byte-identical
@@ -158,12 +194,7 @@ async function compareFrames(a: Buffer, b: Buffer): Promise<FrameDelta> {
   }
   let differingPixels = 0;
   for (let i = 0; i < rawA.data.length; i += 4) {
-    if (
-      Math.abs(rawA.data[i] - rawB.data[i]) > CHANNEL_NOISE_THRESHOLD ||
-      Math.abs(rawA.data[i + 1] - rawB.data[i + 1]) > CHANNEL_NOISE_THRESHOLD ||
-      Math.abs(rawA.data[i + 2] - rawB.data[i + 2]) > CHANNEL_NOISE_THRESHOLD ||
-      Math.abs(rawA.data[i + 3] - rawB.data[i + 3]) > CHANNEL_NOISE_THRESHOLD
-    ) {
+    if (pixelsDiffer(rawA.data, rawB.data, i)) {
       differingPixels += 1;
     }
   }

--- a/packages/homepage/tests/screenshot-stability.node.test.mjs
+++ b/packages/homepage/tests/screenshot-stability.node.test.mjs
@@ -54,6 +54,26 @@ async function perturbedPng(seed, pixels) {
     .toBuffer();
 }
 
+/**
+ * Variant of colorfulPng(seed) with every channel of every pixel nudged by
+ * `amount` — whole-frame dither below pixelmatch's perceptual threshold,
+ * the shape WebGL/video compositing noise takes in real captures.
+ */
+async function ditheredPng(seed, amount) {
+  const raw = Buffer.alloc(SIZE * SIZE * 3);
+  for (let y = 0; y < SIZE; y += 1) {
+    for (let x = 0; x < SIZE; x += 1) {
+      const i = (y * SIZE + x) * 3;
+      raw[i] = Math.min(255, ((x * 8 + seed * 37) % 256) + amount);
+      raw[i + 1] = Math.min(255, ((y * 8 + seed * 53) % 256) + amount);
+      raw[i + 2] = Math.min(255, ((x * y + seed) % 256) + amount);
+    }
+  }
+  return sharp(raw, { raw: { width: SIZE, height: SIZE, channels: 3 } })
+    .png()
+    .toBuffer();
+}
+
 /** Single-color PNG that must fail the blank/quality gate. */
 async function blankPng() {
   return sharp({
@@ -113,6 +133,25 @@ test("consecutive frames within the pixel tolerance count as stable", async () =
     retry,
   );
   assert.ok(result.equals(nearA));
+  assert.equal(callCount(), 2);
+});
+
+test("whole-frame dither below the perceptual threshold counts as stable", async () => {
+  // Every pixel's every channel differs by 6 — far past any per-channel
+  // noise cutoff on 100% of the frame, yet imperceptible under the
+  // pixelmatch YIQ metric the snapshot comparison judges captures by.
+  // This is the compositing noise real WebGL/video pages produce between
+  // consecutive captures while the golden diff itself stays green.
+  const a = await colorfulPng(7);
+  const jittered = await ditheredPng(7, 6);
+  const { page, callCount } = fakePage([a, jittered]);
+  const result = await captureScreenshotWithQualityRetry(
+    page,
+    "dither",
+    {},
+    retry,
+  );
+  assert.ok(result.equals(jittered));
   assert.equal(callCount(), 2);
 });
 


### PR DESCRIPTION
# Relates to

Red `Quality (Extended)` on develop: the "Homepage Build (PR smoke) / Test homepage" job fails all 10 visual-regression specs with `ScreenshotUnstableError` since #17915 landed (first failing completed run [31200316094](https://github.com/elizaOS/eliza/actions/runs/31200316094), latest [31212796926](https://github.com/elizaOS/eliza/actions/runs/31212796926)).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Risks

Low, confined to the homepage visual-suite capture gate. The 2% stability frame ratio, the 2% golden `maxDiffPixelRatio`, snapshot names, masking, and attempt budget are unchanged. Only the **per-pixel** "does this pixel differ" predicate changes, from an ad-hoc per-channel cutoff to the exact metric the snapshot comparison itself diffs with.

# Background

## What does this PR do?

Root cause of the red: the stability gate #17915 added to `captureScreenshotWithQualityRetry` counts a pixel as differing when any channel delta exceeds `CHANNEL_NOISE_THRESHOLD = 3`. Playwright's `toMatchSnapshot` diffs with pixelmatch at threshold `0.2`, which tolerates a weighted-YIQ color distance of `35215 * 0.2^2 ≈ 1409` — roughly per-channel deltas up to ~50 in luma. The gate was therefore ~30x stricter per pixel than the comparison it guards. WebGL / video / shader compositing dither of 4–20 per channel — invisible to the golden diff (which was green at 2%) — covers 13–43% of consecutive frames on the homepage routes, so the gate red-flagged every route (`landing`, `login`, `connected`, `get-started`, `leaderboard`, desktop and mobile) while `toMatchSnapshot` would have passed.

Fix: `compareFrames` now judges pixel pairs with pixelmatch's weighted-YIQ color-distance formula (same coefficients, same alpha-over-white blend) at the same `0.2` threshold, so a buffer the gate returns is settled to exactly the precision the snapshot diff judges it by — the stated intent of `stabilityMaxDiffRatio` ("the same ratio the snapshot comparison uses") now holds per pixel too. No thresholds were loosened beyond that alignment: real color changes (the scripted unstable-frame sequences in the behavior tests) still trip the gate, and a new behavior test proves whole-frame sub-perceptual dither counts as stable.

### Attribution of the develop red (for the record)

- Aug 6 ~23:32Z → Aug 7 ~06:14Z: Homepage Build failed on the snapshot-baseline inventory guard (`Missing/Unexpected homepage snapshot baseline`) — different, since-resolved signature.
- Aug 7 08:30Z–09:33Z (e.g. run 31166421871): failed only `route-coverage.spec.ts`; **all visual specs passed** (62 passed). Fixed by #17739's route-coverage update.
- Aug 7 17:01Z onward: `ScreenshotUnstableError` on all 10 visual specs — introduced by **#17915** (merged 14:18Z), not by #17739 (13:17Z), whose diff touches no capture code.

## What kind of change is this?

Bug fix (test-harness correction).

# Documentation changes needed?

No. `tests/VISUAL-REGRESSION.md` describes the gate at the ratio level, which is unchanged.

# Testing

## Where should a reviewer start?

`packages/homepage/tests/e2e/screenshot-quality.ts` (`pixelsDiffer` + `compareFrames`), then the new case in `tests/screenshot-stability.node.test.mjs`.

## Detailed testing steps

<!-- evidence-head:550a9be3c3194853860dc7df022e08582fba1c5f -->

<!-- evidence-row:before-screenshots -->
- [x] Before: on unmodified `origin/develop@d72e9e4e759` (Linux, chromium), the visual suite reproduces CI exactly — `login/connected/get-started/landing/leaderboard` fail on both viewports while `downloads/not-found/profile-edit` pass; CI run [31212796926](https://github.com/elizaOS/eliza/actions/runs/31212796926) shows the same 10 failures, e.g. `ScreenshotUnstableError: landing desktop: … last two captures differ by ~43% of the frame`. Single-spec repro on the develop harness (`ScreenshotUnstableError: login desktop: … differ by 46293 pixels (5% of the frame)`): [before-login-desktop-unstable.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18007-before-login-desktop-unstable.png) — the last capture Playwright saved when the gate gave up. The full local repro transcript is in the frontend-logs row.

<!-- evidence-row:after-screenshots -->
- [x] After: same machine, fix applied — `ScreenshotUnstableError` count is 0; 14/16 visual specs pass including every previously-unstable route on desktop (`landing` 23.6s, `leaderboard` 25.4s, `login`, `connected`, `get-started`) and mobile `login/connected/get-started`. The settled capture the fixed gate returned for the WebGL/video-heavy landing route: [landing-mobile-actual.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18007-landing-mobile-actual.png) (deterministic across retries). The two remaining local failures are `landing (mobile)` / `leaderboard (mobile)` golden mismatches at a deterministic 13037 px (0.04) across retries — a local font-fallback difference in the canvas chat demo (text wraps differently than the CI-minted baseline; see the expected/diff artifacts in the domain-artifacts row), not instability; CI renders with the font stack the baselines were minted on. The PR's own Homepage Build job is the arbiter. Full after transcript is in the frontend-logs row.

<!-- evidence-row:walkthrough-video -->
- [x] N/A — test-harness-only change; no user-facing UI flow to walk through.

<!-- evidence-row:backend-logs -->
- [x] N/A — no server/runtime code in scope; the Playwright web server output is embedded in the attached run transcripts.

<!-- evidence-row:frontend-logs -->
- [x] Playwright list-reporter transcript of the fixed run: [fixed-run.log.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18007-fixed-run.log.txt) (`14 passed`, zero `ScreenshotUnstableError`) and of the develop-harness repro: [develop-repro-partial.log.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18007-develop-repro-partial.log.txt). Behavior lane: `bun run --cwd packages/homepage test` → 57 pass / 0 fail (includes the 8 stability-loop behavior tests, one new). `typecheck` clean, `lint:check` clean.

<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model-facing behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Comparison artifacts for the residual local mobile mismatch: [landing-mobile-expected.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18007-landing-mobile-expected.png) (CI-minted baseline) and [landing-mobile-diff.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18007-landing-mobile-diff.png), demonstrating the residual delta is font-metric text wrap in the canvas chat demo, not compositing motion (the settled actual capture is in the after-screenshots row).

<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered-text content changed; text differences visible in the diff artifact are pre-existing local font fallback, analyzed in the after-screenshots row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
