### PR TITLE
fix(plugin-wallet): honor confirmed slippage in EVM swap/bridge execution

### DIFF
--- a/plugins/plugin-wallet/src/chains/__tests__/wallet-bridge-recipient.test.ts
+++ b/plugins/plugin-wallet/src/chains/__tests__/wallet-bridge-recipient.test.ts
@@ -284,7 +284,9 @@ describe("wallet bridge recipient guard", () => {
 
     expect(first?.data?.requiresConfirmation).toBe(true);
     const prompt = prompts.join("\n");
-    expect(prompt).toContain("Bridge 0.5 ETH from base to arbitrum?");
+    expect(prompt).toContain(
+      "Bridge 0.5 ETH from base to arbitrum with default slippage?",
+    );
     expect(prompt).not.toContain("undefined");
     expect(base.execute).not.toHaveBeenCalled();
   });

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/slippage-threading.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/slippage-threading.test.ts
@@ -6,34 +6,40 @@
  * regardless of the confirmed value) and both `routeEvmBridge` quote sites
  * hardcoded `DEFAULT_SLIPPAGE_PERCENT`. These tests pin the confirmed value
  * reaching the Li.Fi quote layer and the defaults holding when no slippage
- * was stated. Network boundaries (Li.Fi `getRoutes`, bebop/kyberswap fetch)
- * are mocked; the routing and slippage math under test is the real
- * production code. Also covers the registry swap path forwarding and the
- * parse-layer contract: `SwapParamsSchema`/`BridgeParamsSchema` must accept
- * and bounds-check `slippageBps` so the field cannot be silently stripped
- * between the router boundary and execution.
+ * was stated. It also proves that an explicitly bounded swap cannot select a
+ * Bebop quote whose request has no enforceable tolerance, and that Li.Fi's
+ * exchange-rate refresh hook fails closed instead of widening a confirmed
+ * bridge tolerance. Network boundaries (Li.Fi `getRoutes`/`executeRoute`,
+ * Bebop/KyberSwap fetch) are mocked; the routing and slippage math under test
+ * is the real production code. Also covers the registry swap path forwarding
+ * and the parse-layer contract: `SwapParamsSchema`/`BridgeParamsSchema` must
+ * accept and bounds-check `slippageBps` so the field cannot be silently
+ * stripped between the router boundary and execution.
  */
+
 import type { IAgentRuntime } from "@elizaos/core";
+import type { ExecutionOptions } from "@lifi/sdk";
 import { arbitrum, base } from "viem/chains";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WalletBackendService } from "../../../../services/wallet-backend-service.js";
 import type { WalletChainHandler, WalletRouterContext } from "../../../../types/wallet-router.js";
 import { registerDefaultWalletChainHandlers } from "../../../registry";
 import { SwapAction } from "../../actions/swap";
-import { routeEvmBridge } from "../../bridge-router";
+import { BridgeAction, routeEvmBridge } from "../../bridge-router";
 import { createEvmWalletChainHandler } from "../../chain-handler";
 import { NATIVE_TOKEN_ADDRESS } from "../../constants";
 import type { WalletProvider } from "../../providers/wallet";
 import { parseBridgeParams, parseSwapParams } from "../../types";
 
-const { getRoutesMock, initWalletProviderMock } = vi.hoisted(() => ({
+const { executeRouteMock, getRoutesMock, initWalletProviderMock } = vi.hoisted(() => ({
+  executeRouteMock: vi.fn(),
   getRoutesMock: vi.fn(),
   initWalletProviderMock: vi.fn(),
 }));
 
 vi.mock("@lifi/sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@lifi/sdk")>();
-  return { ...actual, getRoutes: getRoutesMock };
+  return { ...actual, executeRoute: executeRouteMock, getRoutes: getRoutesMock };
 });
 
 vi.mock("../../providers/wallet", async (importOriginal) => {
@@ -75,7 +81,12 @@ function quotedSlippages(): number[] {
   );
 }
 
+function requestedUrls(): string[] {
+  return vi.mocked(fetch).mock.calls.map(([url]) => String(url));
+}
+
 beforeEach(() => {
+  executeRouteMock.mockReset();
   getRoutesMock.mockReset();
   getRoutesMock.mockResolvedValue({ routes: [] });
   initWalletProviderMock.mockReset();
@@ -146,6 +157,7 @@ describe("EVM confirmed slippage threading", () => {
     ).rejects.toThrow("No routes found");
 
     expect(quotedSlippages()).toEqual([0.001]);
+    expect(requestedUrls().some((url) => url.includes("api.bebop.xyz"))).toBe(false);
   });
 
   it("keeps the default 1% first quote when no swap slippage was stated", async () => {
@@ -161,6 +173,72 @@ describe("EVM confirmed slippage threading", () => {
     ).rejects.toThrow("No routes found");
 
     expect(quotedSlippages()).toEqual([0.01]);
+    expect(requestedUrls().some((url) => url.includes("api.bebop.xyz"))).toBe(true);
+  });
+
+  it("rejects a Li.Fi bridge rate refresh when the user confirmed an explicit tolerance", async () => {
+    let executionOptions: ExecutionOptions | undefined;
+    getRoutesMock.mockResolvedValue({
+      routes: [{ steps: [{ tool: "lifi" }] }],
+    });
+    executeRouteMock.mockImplementation(async (_route: unknown, options: ExecutionOptions) => {
+      executionOptions = options;
+      throw new Error("stop after capturing execution options");
+    });
+
+    const action = new BridgeAction(createFakeWalletProvider());
+    await expect(
+      action.bridge({
+        fromChain: "base",
+        toChain: "arbitrum",
+        fromToken: NATIVE_TOKEN_ADDRESS,
+        toToken: NATIVE_TOKEN_ADDRESS,
+        amount: "0.5",
+        slippageBps: 10,
+      })
+    ).rejects.toThrow("stop after capturing execution options");
+
+    const hook = executionOptions?.acceptExchangeRateUpdateHook;
+    if (!hook) throw new Error("acceptExchangeRateUpdateHook was not configured");
+    await expect(
+      hook({
+        oldToAmount: "1000000",
+        newToAmount: "990000",
+        toToken: { decimals: 6, symbol: "USDC" },
+      })
+    ).resolves.toBe(false);
+  });
+
+  it("preserves the existing rate-refresh policy when bridge slippage was not explicit", async () => {
+    let executionOptions: ExecutionOptions | undefined;
+    getRoutesMock.mockResolvedValue({
+      routes: [{ steps: [{ tool: "lifi" }] }],
+    });
+    executeRouteMock.mockImplementation(async (_route: unknown, options: ExecutionOptions) => {
+      executionOptions = options;
+      throw new Error("stop after capturing execution options");
+    });
+
+    const action = new BridgeAction(createFakeWalletProvider());
+    await expect(
+      action.bridge({
+        fromChain: "base",
+        toChain: "arbitrum",
+        fromToken: NATIVE_TOKEN_ADDRESS,
+        toToken: NATIVE_TOKEN_ADDRESS,
+        amount: "0.5",
+      })
+    ).rejects.toThrow("stop after capturing execution options");
+
+    const hook = executionOptions?.acceptExchangeRateUpdateHook;
+    if (!hook) throw new Error("acceptExchangeRateUpdateHook was not configured");
+    await expect(
+      hook({
+        oldToAmount: "1000000",
+        newToAmount: "990000",
+        toToken: { decimals: 6, symbol: "USDC" },
+      })
+    ).resolves.toBe(true);
   });
 
   it("quotes the bridge at exactly the confirmed slippage (50 bps -> 0.005)", async () => {

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/slippage-threading.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/slippage-threading.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Regression tests for confirmed-slippage threading on the EVM swap and
+ * bridge paths. The wallet router binds `slippageBps` into the confirmation
+ * pending key, but the EVM execution path dropped it: `executeSwap` called
+ * `SwapAction.swap` without it (so quotes escalated 1% -> 1.5% -> 2%
+ * regardless of the confirmed value) and both `routeEvmBridge` quote sites
+ * hardcoded `DEFAULT_SLIPPAGE_PERCENT`. These tests pin the confirmed value
+ * reaching the Li.Fi quote layer and the defaults holding when no slippage
+ * was stated. Network boundaries (Li.Fi `getRoutes`, bebop/kyberswap fetch)
+ * are mocked; the routing and slippage math under test is the real
+ * production code.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { arbitrum, base } from "viem/chains";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WalletRouterContext } from "../../../../types/wallet-router.js";
+import { SwapAction } from "../../actions/swap";
+import { routeEvmBridge } from "../../bridge-router";
+import { createEvmWalletChainHandler } from "../../chain-handler";
+import { NATIVE_TOKEN_ADDRESS } from "../../constants";
+import type { WalletProvider } from "../../providers/wallet";
+
+const { getRoutesMock, initWalletProviderMock } = vi.hoisted(() => ({
+  getRoutesMock: vi.fn(),
+  initWalletProviderMock: vi.fn(),
+}));
+
+vi.mock("@lifi/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lifi/sdk")>();
+  return { ...actual, getRoutes: getRoutesMock };
+});
+
+vi.mock("../../providers/wallet", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../providers/wallet")>();
+  return { ...actual, initWalletProvider: initWalletProviderMock };
+});
+
+const ACCOUNT = "0x1111111111111111111111111111111111111111";
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const HASH = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+function createFakeWalletProvider(): WalletProvider {
+  return {
+    chains: { base, arbitrum },
+    getSupportedChains: () => ["base", "arbitrum"],
+    getChainConfigs: (name: string) => (name === "arbitrum" ? arbitrum : base),
+    getWalletClient: () => ({
+      account: { address: ACCOUNT },
+      getAddresses: async () => [ACCOUNT],
+      sendTransaction: vi.fn(async () => HASH),
+    }),
+    getPublicClient: () => ({
+      readContract: vi.fn(async () => 6),
+    }),
+  } as unknown as WalletProvider;
+}
+
+const context = {
+  runtime: {} as IAgentRuntime,
+  walletBackend: null,
+  walletServices: [],
+  tokenDataService: null,
+} satisfies WalletRouterContext;
+
+/** Slippage fraction seen by each Li.Fi `getRoutes` call, in call order. */
+function quotedSlippages(): number[] {
+  return getRoutesMock.mock.calls.map(
+    (call: unknown[]) => (call[0] as { options?: { slippage?: number } }).options?.slippage ?? -1
+  );
+}
+
+beforeEach(() => {
+  getRoutesMock.mockReset();
+  getRoutesMock.mockResolvedValue({ routes: [] });
+  initWalletProviderMock.mockReset();
+  initWalletProviderMock.mockImplementation(async () => createFakeWalletProvider());
+  // Bebop/KyberSwap quote fetches fail fast; the Li.Fi quote path (mocked
+  // getRoutes) is the slippage witness for both swap and bridge.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: false, status: 500, statusText: "stubbed" }))
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("EVM confirmed slippage threading", () => {
+  it("forwards confirmed slippageBps from the wallet router to SwapAction.swap", async () => {
+    const swapSpy = vi.spyOn(SwapAction.prototype, "swap").mockResolvedValue({
+      hash: HASH,
+      from: ACCOUNT,
+      to: USDC,
+      value: 0n,
+      data: "0x",
+      chainId: base.id,
+    });
+    const handler = createEvmWalletChainHandler("base", base, {
+      walletProvider: createFakeWalletProvider(),
+    });
+
+    await handler.executeSwap(
+      {
+        subaction: "swap",
+        chain: "base",
+        fromToken: "ETH",
+        toToken: USDC,
+        amount: "1",
+        slippageBps: 10,
+        mode: "execute",
+        dryRun: false,
+      },
+      context
+    );
+
+    expect(swapSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chain: "base",
+        fromToken: NATIVE_TOKEN_ADDRESS,
+        toToken: USDC,
+        amount: "1",
+        slippageBps: 10,
+      })
+    );
+  });
+
+  it("quotes the swap at exactly the confirmed slippage (10 bps -> 0.001)", async () => {
+    const action = new SwapAction(createFakeWalletProvider());
+
+    await expect(
+      action.swap({
+        chain: "base",
+        fromToken: NATIVE_TOKEN_ADDRESS,
+        toToken: USDC,
+        amount: "1",
+        slippageBps: 10,
+      })
+    ).rejects.toThrow("No routes found");
+
+    expect(quotedSlippages()).toEqual([0.001]);
+  });
+
+  it("keeps the default 1% first quote when no swap slippage was stated", async () => {
+    const action = new SwapAction(createFakeWalletProvider());
+
+    await expect(
+      action.swap({
+        chain: "base",
+        fromToken: NATIVE_TOKEN_ADDRESS,
+        toToken: USDC,
+        amount: "1",
+      })
+    ).rejects.toThrow("No routes found");
+
+    expect(quotedSlippages()).toEqual([0.01]);
+  });
+
+  it("quotes the bridge at exactly the confirmed slippage (50 bps -> 0.005)", async () => {
+    await expect(
+      routeEvmBridge(
+        {
+          subaction: "bridge",
+          chain: "base",
+          toChain: "arbitrum",
+          fromToken: NATIVE_TOKEN_ADDRESS,
+          toToken: NATIVE_TOKEN_ADDRESS,
+          amount: "0.5",
+          slippageBps: 50,
+          mode: "execute",
+          dryRun: false,
+        },
+        context,
+        "base",
+        base
+      )
+    ).rejects.toThrow("No bridge routes found");
+
+    expect(quotedSlippages()).toEqual([0.005]);
+  });
+
+  it("keeps the default bridge slippage when none was stated", async () => {
+    await expect(
+      routeEvmBridge(
+        {
+          subaction: "bridge",
+          chain: "base",
+          toChain: "arbitrum",
+          fromToken: NATIVE_TOKEN_ADDRESS,
+          toToken: NATIVE_TOKEN_ADDRESS,
+          amount: "0.5",
+          mode: "execute",
+          dryRun: false,
+        },
+        context,
+        "base",
+        base
+      )
+    ).rejects.toThrow("No bridge routes found");
+
+    expect(quotedSlippages()).toEqual([0.01]);
+  });
+
+  it("threads confirmed slippage through the prepare-mode bridge quote", async () => {
+    const result = await routeEvmBridge(
+      {
+        subaction: "bridge",
+        chain: "base",
+        toChain: "arbitrum",
+        fromToken: NATIVE_TOKEN_ADDRESS,
+        toToken: NATIVE_TOKEN_ADDRESS,
+        amount: "0.5",
+        slippageBps: 50,
+        mode: "prepare",
+        dryRun: false,
+      },
+      context,
+      "base",
+      base
+    );
+
+    expect(result.status).toBe("prepared");
+    expect(quotedSlippages()).toEqual([0.005]);
+  });
+});

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/slippage-threading.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/slippage-threading.test.ts
@@ -8,17 +8,23 @@
  * reaching the Li.Fi quote layer and the defaults holding when no slippage
  * was stated. Network boundaries (Li.Fi `getRoutes`, bebop/kyberswap fetch)
  * are mocked; the routing and slippage math under test is the real
- * production code.
+ * production code. Also covers the registry swap path forwarding and the
+ * parse-layer contract: `SwapParamsSchema`/`BridgeParamsSchema` must accept
+ * and bounds-check `slippageBps` so the field cannot be silently stripped
+ * between the router boundary and execution.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { arbitrum, base } from "viem/chains";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { WalletRouterContext } from "../../../../types/wallet-router.js";
+import type { WalletBackendService } from "../../../../services/wallet-backend-service.js";
+import type { WalletChainHandler, WalletRouterContext } from "../../../../types/wallet-router.js";
+import { registerDefaultWalletChainHandlers } from "../../../registry";
 import { SwapAction } from "../../actions/swap";
 import { routeEvmBridge } from "../../bridge-router";
 import { createEvmWalletChainHandler } from "../../chain-handler";
 import { NATIVE_TOKEN_ADDRESS } from "../../constants";
 import type { WalletProvider } from "../../providers/wallet";
+import { parseBridgeParams, parseSwapParams } from "../../types";
 
 const { getRoutesMock, initWalletProviderMock } = vi.hoisted(() => ({
   getRoutesMock: vi.fn(),
@@ -222,5 +228,80 @@ describe("EVM confirmed slippage threading", () => {
 
     expect(result.status).toBe("prepared");
     expect(quotedSlippages()).toEqual([0.005]);
+  });
+
+  it("forwards confirmed slippageBps through the registry EVM swap path", async () => {
+    const swapSpy = vi.spyOn(SwapAction.prototype, "swap").mockResolvedValue({
+      hash: HASH,
+      from: ACCOUNT,
+      to: USDC,
+      value: 0n,
+      data: "0x",
+      chainId: base.id,
+    });
+    const handlers = new Map<string, WalletChainHandler>();
+    const service = {
+      registerChainHandler: (handler: WalletChainHandler) => handlers.set(handler.chain, handler),
+    } as unknown as WalletBackendService;
+    const runtime = {
+      character: { settings: { chains: { evm: ["base"] } } },
+      getSetting: (key: string) => (key === "SOLANA_NO_ACTIONS" ? "true" : undefined),
+    } as unknown as IAgentRuntime;
+
+    registerDefaultWalletChainHandlers(service, runtime);
+    const handler = handlers.get("base");
+    if (!handler) throw new Error("base handler was not registered");
+
+    await handler.execute(
+      {
+        subaction: "swap",
+        chain: "base",
+        fromToken: "ETH",
+        toToken: USDC,
+        amount: "1",
+        slippageBps: 25,
+        mode: "execute",
+        dryRun: false,
+      },
+      context
+    );
+
+    expect(swapSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chain: "base",
+        fromToken: NATIVE_TOKEN_ADDRESS,
+        toToken: USDC,
+        amount: "1",
+        slippageBps: 25,
+      })
+    );
+  });
+});
+
+describe("slippageBps parse-layer acceptance", () => {
+  const swapInput = {
+    chain: "base",
+    fromToken: NATIVE_TOKEN_ADDRESS,
+    toToken: USDC,
+    amount: "1",
+  };
+  const bridgeInput = {
+    fromChain: "base",
+    toChain: "arbitrum",
+    fromToken: NATIVE_TOKEN_ADDRESS,
+    toToken: NATIVE_TOKEN_ADDRESS,
+    amount: "0.5",
+  };
+
+  it("preserves a valid slippageBps through parseSwapParams and parseBridgeParams", () => {
+    expect(parseSwapParams({ ...swapInput, slippageBps: 50 }).slippageBps).toBe(50);
+    expect(parseBridgeParams({ ...bridgeInput, slippageBps: 50 }).slippageBps).toBe(50);
+  });
+
+  it("rejects negative, fractional, and over-limit slippageBps", () => {
+    for (const bad of [-1, 10.5, 10_001]) {
+      expect(() => parseSwapParams({ ...swapInput, slippageBps: bad })).toThrow();
+      expect(() => parseBridgeParams({ ...bridgeInput, slippageBps: bad })).toThrow();
+    }
   });
 });

--- a/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
@@ -163,7 +163,10 @@ export class SwapAction {
       toToken: resolvedToToken as Address,
     };
 
-    const slippageLevels = [0.01, 0.015, 0.02];
+    // A confirmed slippageBps is the tolerance the user approved, so quote at
+    // exactly that level; only the unstated case escalates through the ladder.
+    const slippageLevels =
+      params.slippageBps === undefined ? [0.01, 0.015, 0.02] : [params.slippageBps / 10000];
     let lastError: Error | undefined;
     let attemptCount = 0;
 

--- a/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
@@ -260,7 +260,12 @@ export class SwapAction {
 
     const quotesPromises: Promise<SwapQuote | undefined>[] = [
       this.getLifiQuote(fromAddress, params, fromTokenDecimals, slippage),
-      this.getBebopQuote(fromAddress, params, fromTokenDecimals),
+      // The current Bebop request does not carry an enforceable slippage
+      // bound. Keep it available for the legacy default path, but never let
+      // it win a quote the user confirmed with an explicit tolerance.
+      ...(params.slippageBps === undefined
+        ? [this.getBebopQuote(fromAddress, params, fromTokenDecimals)]
+        : []),
       this.getKyberSwapQuote(fromAddress, params, fromTokenDecimals, slippage),
     ];
 

--- a/plugins/plugin-wallet/src/chains/evm/bridge-router.ts
+++ b/plugins/plugin-wallet/src/chains/evm/bridge-router.ts
@@ -198,7 +198,10 @@ export class BridgeAction {
     return Number(decimals);
   }
 
-  private createExecutionOptions(routeId: string): ExecutionOptions {
+  private createExecutionOptions(
+    routeId: string,
+    confirmedSlippageBps?: number,
+  ): ExecutionOptions {
     return {
       updateTransactionRequestHook: async (txRequest) => {
         if (txRequest.gas) {
@@ -216,6 +219,12 @@ export class BridgeAction {
         oldToAmount: string;
         newToAmount: string;
       }) => {
+        // Li.Fi invokes this hook after a refreshed step has already exceeded
+        // the route's slippage. Accepting it would widen an explicit tolerance
+        // after confirmation, so that path must fail closed.
+        if (confirmedSlippageBps !== undefined) {
+          return false;
+        }
         const priceChange =
           ((Number(params.newToAmount) - Number(params.oldToAmount)) /
             Number(params.oldToAmount)) *
@@ -445,7 +454,10 @@ export class BridgeAction {
       .slice(2, 11)}`;
 
     try {
-      const executionOptions = this.createExecutionOptions(routeId);
+      const executionOptions = this.createExecutionOptions(
+        routeId,
+        params.slippageBps,
+      );
       const executedRoute = await executeRoute(selectedRoute, executionOptions);
 
       const sourceSteps = executedRoute.steps.filter((step) =>

--- a/plugins/plugin-wallet/src/chains/evm/bridge-router.ts
+++ b/plugins/plugin-wallet/src/chains/evm/bridge-router.ts
@@ -384,7 +384,10 @@ export class BridgeAction {
       toAddress: params.toAddress ?? fromAddress,
       options: {
         order: "RECOMMENDED",
-        slippage: DEFAULT_SLIPPAGE_PERCENT,
+        slippage:
+          params.slippageBps === undefined
+            ? DEFAULT_SLIPPAGE_PERCENT
+            : params.slippageBps / 10000,
         maxPriceImpact: MAX_PRICE_IMPACT,
         allowSwitchChain: true,
       },
@@ -586,6 +589,7 @@ export async function routeEvmBridge(
         toToken: (params.toToken ?? params.fromToken) as Address,
         amount: params.amount as string,
         toAddress: params.recipient as Address | undefined,
+        slippageBps: params.slippageBps,
       });
 
       const topRoute = quote.routes[0];
@@ -639,6 +643,7 @@ export async function routeEvmBridge(
     toToken: (params.toToken ?? params.fromToken) as Address,
     amount: params.amount as string,
     toAddress: params.recipient as Address | undefined,
+    slippageBps: params.slippageBps,
   });
 
   logger.debug(

--- a/plugins/plugin-wallet/src/chains/evm/chain-handler.ts
+++ b/plugins/plugin-wallet/src/chains/evm/chain-handler.ts
@@ -391,6 +391,7 @@ export class EvmWalletChainHandler implements WalletChainHandler {
       fromToken,
       toToken,
       amount,
+      slippageBps: params.slippageBps,
     });
     return transactionToExecution(
       {

--- a/plugins/plugin-wallet/src/chains/evm/types/index.ts
+++ b/plugins/plugin-wallet/src/chains/evm/types/index.ts
@@ -148,6 +148,7 @@ export interface SwapParams {
   readonly fromToken: Address;
   readonly toToken: Address;
   readonly amount: string;
+  readonly slippageBps?: number;
 }
 
 export const SwapParamsSchema = z.object({
@@ -196,6 +197,7 @@ export interface BridgeParams {
   readonly toToken: Address;
   readonly amount: string;
   readonly toAddress?: Address;
+  readonly slippageBps?: number;
 }
 
 export const BridgeParamsSchema = z.object({

--- a/plugins/plugin-wallet/src/chains/evm/types/index.ts
+++ b/plugins/plugin-wallet/src/chains/evm/types/index.ts
@@ -156,6 +156,7 @@ export const SwapParamsSchema = z.object({
   fromToken: z.union([AddressSchema, z.string().min(1)]),
   toToken: z.union([AddressSchema, z.string().min(1)]),
   amount: AmountSchema,
+  slippageBps: z.coerce.number().int().min(0).max(10_000).optional(),
 });
 
 export function parseSwapParams(input: unknown): SwapParams {
@@ -207,6 +208,7 @@ export const BridgeParamsSchema = z.object({
   toToken: z.union([AddressSchema, z.string().min(1)]),
   amount: AmountSchema,
   toAddress: AddressSchema.optional(),
+  slippageBps: z.coerce.number().int().min(0).max(10_000).optional(),
 });
 
 export function parseBridgeParams(input: unknown): BridgeParams {

--- a/plugins/plugin-wallet/src/chains/registry.ts
+++ b/plugins/plugin-wallet/src/chains/registry.ts
@@ -318,6 +318,7 @@ async function executeEvmSwap(
     fromToken,
     toToken,
     amount: params.amount ?? "",
+    slippageBps: params.slippageBps,
   });
   return transactionToExecution(
     {

--- a/plugins/plugin-wallet/src/security/__tests__/wallet-financial-confirmation.test.ts
+++ b/plugins/plugin-wallet/src/security/__tests__/wallet-financial-confirmation.test.ts
@@ -11,6 +11,7 @@ import { isConfirmed } from "../../chains/evm/actions/helpers.js";
 import {
   gateWalletFinancialExecution,
   walletFinancialPendingKey,
+  walletFinancialPreview,
 } from "../wallet-financial-confirmation.js";
 
 function runtimeWithCache(): IAgentRuntime {
@@ -91,5 +92,65 @@ describe("wallet-financial-confirmation", () => {
       dryRun: false,
     });
     expect(keyA).toBe(keyB);
+  });
+
+  it("binds different slippageBps values into different pending keys", () => {
+    const base = {
+      subaction: "swap" as const,
+      chain: "base",
+      fromToken: "ETH",
+      toToken: "USDC",
+      amount: "1",
+      mode: "execute" as const,
+      dryRun: false,
+    };
+    expect(walletFinancialPendingKey({ ...base, slippageBps: 10 })).not.toBe(
+      walletFinancialPendingKey({ ...base, slippageBps: 10_000 }),
+    );
+  });
+
+  it("shows the authorized slippage in swap and bridge previews", () => {
+    const shared = {
+      subaction: "swap" as const,
+      chain: "base",
+      fromToken: "ETH",
+      toToken: "USDC",
+      amount: "1",
+    };
+    const tight = walletFinancialPreview({ ...shared, slippageBps: 10 });
+    const loose = walletFinancialPreview({ ...shared, slippageBps: 10_000 });
+
+    // A 10 bps and a 10,000 bps confirmation must never read identically.
+    expect(tight).not.toBe(loose);
+    expect(tight).toContain("0.1% slippage (10 bps)");
+    expect(loose).toContain("100% slippage (10000 bps)");
+
+    const bridge = walletFinancialPreview({
+      subaction: "bridge",
+      chain: "base",
+      toChain: "arbitrum",
+      amount: "0.5",
+      slippageBps: 50,
+    });
+    expect(bridge).toContain("0.5% slippage (50 bps)");
+  });
+
+  it("labels the slippage as default in previews when none was stated", () => {
+    const swap = walletFinancialPreview({
+      subaction: "swap",
+      chain: "base",
+      fromToken: "ETH",
+      toToken: "USDC",
+      amount: "1",
+    });
+    expect(swap).toContain("default slippage");
+
+    const bridge = walletFinancialPreview({
+      subaction: "bridge",
+      chain: "base",
+      toChain: "arbitrum",
+      amount: "0.5",
+    });
+    expect(bridge).toContain("default slippage");
   });
 });

--- a/plugins/plugin-wallet/src/security/__tests__/wallet-financial-confirmation.test.ts
+++ b/plugins/plugin-wallet/src/security/__tests__/wallet-financial-confirmation.test.ts
@@ -125,14 +125,21 @@ describe("wallet-financial-confirmation", () => {
     expect(tight).toContain("0.1% slippage (10 bps)");
     expect(loose).toContain("100% slippage (10000 bps)");
 
+    const destination = "0x00000000000000000000000000000000deadbeef";
     const bridge = walletFinancialPreview({
       subaction: "bridge",
       chain: "base",
       toChain: "arbitrum",
+      fromToken: "ETH",
       amount: "0.5",
+      recipient: destination,
       slippageBps: 50,
     });
     expect(bridge).toContain("0.5% slippage (50 bps)");
+    // Destination disclosure from the bridge-recipient guard must survive
+    // alongside the slippage clause.
+    expect(bridge).toContain(destination);
+    expect(bridge).toContain("ETH");
   });
 
   it("labels the slippage as default in previews when none was stated", () => {
@@ -152,5 +159,6 @@ describe("wallet-financial-confirmation", () => {
       amount: "0.5",
     });
     expect(bridge).toContain("default slippage");
+    expect(bridge).not.toContain("undefined");
   });
 });

--- a/plugins/plugin-wallet/src/security/wallet-financial-confirmation.ts
+++ b/plugins/plugin-wallet/src/security/wallet-financial-confirmation.ts
@@ -151,6 +151,18 @@ export function walletFinancialPendingKey(
   return entries.map(([key, value]) => `${key}=${value}`).join("|");
 }
 
+// The authorized slippage is part of what the user confirms, so the prompt
+// must disclose it: without it a 10 bps and a 10,000 bps swap read
+// identically. The unstated default is not a single chain-agnostic number
+// (EVM swaps escalate 1% -> 1.5% -> 2%, bridges hold 1%, Solana uses dynamic
+// slippage), so it is labeled rather than numbered.
+function slippagePreviewClause(slippageBps: number | undefined): string {
+  if (slippageBps === undefined) {
+    return " with default slippage";
+  }
+  return ` with up to ${slippageBps / 100}% slippage (${slippageBps} bps)`;
+}
+
 export function walletFinancialPreview(
   params: Pick<
     WalletFinancialWriteParams,
@@ -161,6 +173,7 @@ export function walletFinancialPreview(
     | "recipient"
     | "fromToken"
     | "toToken"
+    | "slippageBps"
     | "op"
     | "pool"
     | "position"
@@ -183,17 +196,18 @@ export function walletFinancialPreview(
     const key = walletFinancialRangeKey(params.range);
     return key ? ` range ${key}` : "";
   })();
+  const slippage = slippagePreviewClause(params.slippageBps);
   switch (params.subaction) {
     case "transfer":
       return `Transfer ${params.amount ?? "?"} ${params.fromToken ?? "tokens"} to ${params.recipient ?? "?"} on ${chainLabel}? Reply yes to submit or no to cancel.`;
     case "swap":
-      return `Swap ${params.amount ?? "?"} ${params.fromToken ?? "?"} to ${params.toToken ?? "?"} on ${chainLabel}? Reply yes to submit or no to cancel.`;
+      return `Swap ${params.amount ?? "?"} ${params.fromToken ?? "?"} to ${params.toToken ?? "?"} on ${chainLabel}${slippage}? Reply yes to submit or no to cancel.`;
     case "bridge": {
       // params.recipient becomes the Li.Fi destination toAddress, so the user
       // must see it before confirming; with no recipient the bridge returns
       // funds to the sender on the destination chain.
       const destination = params.recipient ? ` to ${params.recipient}` : "";
-      return `Bridge ${params.amount ?? "?"} ${params.fromToken ?? "?"} from ${params.chain ?? "?"} to ${params.toChain ?? "?"}${destination}? Reply yes to submit or no to cancel.`;
+      return `Bridge ${params.amount ?? "?"} ${params.fromToken ?? "?"} from ${params.chain ?? "?"} to ${params.toChain ?? "?"}${destination}${slippage}? Reply yes to submit or no to cancel.`;
     }
     case "gov":
       return `Governance ${params.op ?? "operation"} on ${chainLabel}? Reply yes to submit or no to cancel.`;


### PR DESCRIPTION
## Summary

A swap you confirmed at 0.1% slippage could still execute at 2%: the EVM swap and bridge paths accepted `slippageBps` at the wallet router, bound it into the confirmation pending key, and then silently dropped it before quoting.

Three drop points lined up:

1. `executeSwap` (both the chain-handler and registry EVM paths) called `SwapAction.swap` without `params.slippageBps`, so `SwapAction` always walked its 1% -> 1.5% -> 2% escalation ladder. A user who confirmed tighter than 2% could still execute at 2% (20x for a 0.1% confirmation).
2. Both `routeEvmBridge` call sites (prepare quote and execute) reach `BridgeAction.getQuote`, which hardcoded `DEFAULT_SLIPPAGE_PERCENT` (1%) regardless of the confirmed value.
3. `slippageBps` has been bound in `walletFinancialPendingKey` all along, so the confirm turn promised parameter integrity that the execution layer did not deliver. Severity is bounded (max 2% on swap, fixed 1% on bridge), but it is a confirm-vs-execute integrity break in the same class the pending key was built to prevent.

Sibling of #18003 and #18006 (same wallet confirmation-integrity pass).

## Fix

- `chains/evm/types`: `SwapParams` and `BridgeParams` gain optional `slippageBps`.
- `chains/evm/chain-handler.ts` and `chains/registry.ts`: both EVM swap execution sites forward `params.slippageBps` to `SwapAction.swap`.
- `chains/evm/actions/swap.ts`: when `slippageBps` is set, the quote ladder collapses to exactly that tolerance (`slippageBps / 10000` as the Li.Fi slippage fraction); the 1% -> 1.5% -> 2% escalation now runs only when no slippage was stated, so a confirmed value is never exceeded.
- `chains/evm/bridge-router.ts`: `BridgeAction.getQuote` converts confirmed `slippageBps` to the Li.Fi slippage fraction and keeps `DEFAULT_SLIPPAGE_PERCENT` as the unstated fallback; `routeEvmBridge` forwards the param on both the prepare quote and the execute call.
- `security/wallet-financial-confirmation.ts`: `walletFinancialPreview` now discloses the authorized slippage in swap and bridge confirmation prompts (`Swap 1 ETH to USDC on base with up to 0.1% slippage (10 bps)?`), so a 10 bps and a 10,000 bps confirmation no longer read identically. Prompts with no stated slippage are labeled `with default slippage`: the unstated default is not one chain-agnostic number (EVM swaps escalate 1% -> 1.5% -> 2%, bridges hold 1%, Solana is dynamic). (Review follow-up, thanks @HomunculusLabs.)
- `chains/evm/types`: `SwapParamsSchema` and `BridgeParamsSchema` now accept and bounds-check optional `slippageBps` (`z.coerce.number().int().min(0).max(10_000)`, mirroring the wallet-router boundary), closing the latent parse-layer drop point where the field was silently stripped.

Unchanged because it already works: the Solana swap path honors `params.slippageBps` end to end.

## Test plan

- [x] Maintainer exact-head validation (`2680a2d`): 11/11 regression tests; full wallet suite 260 passed / 1 skipped; plugin-wallet and app-core typechecks pass; root verify 346/346 tasks plus all audits.
- [x] New regression suite `plugins/plugin-wallet/src/chains/evm/__tests__/unit/slippage-threading.test.ts` (6 tests): the router forwards confirmed `slippageBps` to `SwapAction.swap`; swap quotes at exactly 10 bps (0.001) when confirmed; swap keeps the 1% default first quote when unstated; bridge execute quotes at exactly 50 bps (0.005) when confirmed; bridge keeps the 1% default when unstated; the prepare-mode bridge quote threads the confirmed value too.
- [x] Red run from parent-commit source (`d72e9e4`): 4 failed, 2 passed (the two default-preservation tests pass on both sides, as designed).
- [x] Green run with the fix: 6 passed.
- [x] Review follow-up coverage (commit `00ebd9b`): registry EVM swap forwarding test; preview disclosure tests (10 bps vs 10,000 bps prompts differ, bridge shows the value, unstated prompts say `default slippage`); parse-layer acceptance (`parseSwapParams`/`parseBridgeParams` preserve `slippageBps: 50`) and negative-input tests (negative, fractional, over-limit rejected); pending-key distinctness check. Red run against pre-fix branch source: 4 failed, 11 passed (registry forwarding and pending-key tests pass on both sides, as designed). Green run: 15 passed across both suites.
- [x] Full plugin-wallet suite: 239 passed, 1 skipped. `src/ui/InventoryView.test.tsx` fails identically on pristine parent source (unresolved `@elizaos/ui` workspace import, a collection error with zero assertions run; same pre-existing failure noted in #17773 and #18006).
- [x] `bunx @biomejs/biome check .` in `plugins/plugin-wallet`: 278 files, no fixes applied.
- [x] Typecheck: `bun run typecheck` error list is identical between parent and branch (34 pre-existing `src/ui/*` errors from the unbuilt `@elizaos/ui` workspace package); zero errors in the changed files.

Made with Cursor

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `moonshotai/kimi-k3`
<!-- attribution-row:client -->
- Agent tooling: `Cursor`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@00ebd9b9faeed3d841e320cb32c7c67deda78343:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

<!-- evidence-head:2680a2d2e01f38e587240bd027489216f6b3d5d4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - execution-parameter threading change, no rendered surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - execution-parameter threading change, no rendered surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - execution-parameter threading change, no rendered surface

<!-- evidence-row:backend-logs -->
- [x] Vitest red/green pair for the new regression suite plus the full plugin-wallet suite, run locally against the real routing and quoting code with only the network boundary mocked (no live chain, model, or API).

<details>
<summary>RED run: regression tests against parent-commit source (4 failed, 2 passed)</summary>

```text
$ bunx vitest run --config ./vitest.config.ts src/chains/evm/__tests__/unit/slippage-threading.test.ts

 ❯ src/chains/evm/__tests__/unit/slippage-threading.test.ts (6 tests | 4 failed) 11ms
     × forwards confirmed slippageBps from the wallet router to SwapAction.swap 4ms
     × quotes the swap at exactly the confirmed slippage (10 bps -> 0.001) 4ms
     × quotes the bridge at exactly the confirmed slippage (50 bps -> 0.005) 1ms
     × threads confirmed slippage through the prepare-mode bridge quote 0ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  slippage-threading.test.ts > EVM confirmed slippage threading > forwards confirmed slippageBps from the wallet router to SwapAction.swap
AssertionError: expected "swap" to be called with arguments: [ ObjectContaining{…} ]
  1st swap call received { chain: "base", fromToken: "0x0000000000000000000000000000000000000000",
    toToken: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", amount: "1" } with no slippageBps
 FAIL  slippage-threading.test.ts > EVM confirmed slippage threading > quotes the swap at exactly the confirmed slippage (10 bps -> 0.001)
AssertionError: expected [ 0.01 ] to deeply equal [ 0.001 ]
  (parent logs "Attempting swap with 1.0% slippage...", the first rung of the escalation ladder)
 FAIL  slippage-threading.test.ts > EVM confirmed slippage threading > quotes the bridge at exactly the confirmed slippage (50 bps -> 0.005)
AssertionError: expected [ 0.01 ] to deeply equal [ 0.005 ]
 FAIL  slippage-threading.test.ts > EVM confirmed slippage threading > threads confirmed slippage through the prepare-mode bridge quote
AssertionError: expected [ 0.01 ] to deeply equal [ 0.005 ]

 Test Files  1 failed (1)
      Tests  4 failed | 2 passed (6)
   Duration  2.82s
```

</details>

<details>
<summary>GREEN run: same tests with the fix (6 passed), then full plugin-wallet suite (233 passed, 1 skipped)</summary>

```text
$ bunx vitest run --config ./vitest.config.ts --reporter=verbose src/chains/evm/__tests__/unit/slippage-threading.test.ts

 ✓ slippage-threading.test.ts > EVM confirmed slippage threading > forwards confirmed slippageBps from the wallet router to SwapAction.swap 2ms
 ✓ slippage-threading.test.ts > EVM confirmed slippage threading > quotes the swap at exactly the confirmed slippage (10 bps -> 0.001) 3ms
 ✓ slippage-threading.test.ts > EVM confirmed slippage threading > keeps the default 1% first quote when no swap slippage was stated 1ms
 ✓ slippage-threading.test.ts > EVM confirmed slippage threading > quotes the bridge at exactly the confirmed slippage (50 bps -> 0.005) 1ms
 ✓ slippage-threading.test.ts > EVM confirmed slippage threading > keeps the default bridge slippage when none was stated 0ms
 ✓ slippage-threading.test.ts > EVM confirmed slippage threading > threads confirmed slippage through the prepare-mode bridge quote 0ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  2.67s

$ bunx vitest run --config ./vitest.config.ts

 Test Files  1 failed | 42 passed | 1 skipped (44)
      Tests  233 passed | 1 skipped (234)
   Duration  5.05s

The 1 failed file is a collection error that fails identically on pristine parent source
(parent run: 1 failed | 41 passed | 1 skipped, 227 passed): src/ui/InventoryView.test.tsx,
an unresolved @elizaos/ui workspace import where no test assertions ran or failed.
All 233 executed tests pass.
Typecheck: bun run typecheck error list is identical between parent and branch (34
pre-existing src/ui/* errors from the unbuilt @elizaos/ui workspace package); zero errors
in changed files.
Biome: bunx @biomejs/biome check . in plugins/plugin-wallet: Checked 278 files, no fixes applied.
```

</details>

<details>
<summary>Review-follow-up pair (commit 00ebd9b): RED against pre-fix branch source (4 failed, 11 passed), GREEN with the fix (15 passed), full suite 239 passed</summary>

```text
$ bunx vitest run --config ./vitest.config.ts --reporter=verbose \
    src/security/__tests__/wallet-financial-confirmation.test.ts \
    src/chains/evm/__tests__/unit/slippage-threading.test.ts

RED (tests added, source unmodified):
 × shows the authorized slippage in swap and bridge previews
   (10 bps and 10,000 bps prompts were byte-identical:
    "Swap 1 ETH to USDC on base? Reply yes to submit or no to cancel.")
 × labels the slippage as default in previews when none was stated
 × preserves a valid slippageBps through parseSwapParams and parseBridgeParams
   (parseSwapParams({...slippageBps: 50}).slippageBps === undefined: stripped)
 × rejects negative, fractional, and over-limit slippageBps
 4 failed | 11 passed (registry forwarding and pending-key distinctness pass
 on both sides, as designed: those paths already worked)

GREEN (same tests, fix applied): 15 passed (2 files)

Full plugin-wallet suite: 239 passed, 1 skipped; the single failed file is the
pre-existing src/ui/InventoryView.test.tsx collection error (unresolved
@elizaos/ui workspace import, zero assertions run, fails identically on
pristine parent source). Typecheck: same 34 pre-existing src/ui/* errors as
parent, zero in changed files. Biome: Checked 278 files, no fixes applied.
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-path change; the fix is deterministic parameter threading

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifacts; tests run locally with no chain access

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surface



