### PR TITLE
fix(calendar): pin connect handoffs as verified user-facing cards

### DIFF
--- a/plugins/plugin-calendar/src/actions/calendar-sources.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-sources.test.ts
@@ -259,6 +259,27 @@ describe("CALENDAR_SOURCES action", () => {
     });
   });
 
+  it("claims natural-language Google calendar connect intents over CONNECTOR", () => {
+    // Planner selection uses similes/routingHint/examples; without these
+    // CONNECT_GOOGLE on CONNECTOR steals "connect google calendar" and drops
+    // the verified [CONFIG:…] handoff path.
+    expect(calendarSourcesAction.similes).toEqual(
+      expect.arrayContaining([
+        "CONNECT_GOOGLE_CALENDAR",
+        "CONNECT_CALENDAR",
+        "LINK_GOOGLE_CALENDAR",
+      ]),
+    );
+    expect(calendarSourcesAction.routingHint).toMatch(/not CONNECTOR/i);
+    expect(calendarSourcesAction.routingHint).toMatch(/CALENDAR_SOURCES/i);
+    const exampleTexts = (calendarSourcesAction.examples ?? [])
+      .flat()
+      .map((turn) => turn.content?.text ?? "")
+      .join("\n")
+      .toLowerCase();
+    expect(exampleTexts).toContain("connect google calendar");
+  });
+
   it("rejects reconnect when the grant and account identities disagree", async () => {
     const { runtime, manager } = runtimeFixture();
     const startOAuth = vi.fn(async () => ({

--- a/plugins/plugin-calendar/src/actions/calendar-sources.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-sources.test.ts
@@ -193,6 +193,8 @@ describe("CALENDAR_SOURCES action", () => {
       awaitingUserAction: true,
       awaitingUserInput: true,
     });
+    expect(result?.verifiedUserFacing).toBe(true);
+    expect(result?.userFacingText).toContain("not connected until");
     expect(result?.text).toContain("not connected until");
     expect(result?.effectReceipts).toEqual([
       expect.objectContaining({
@@ -246,6 +248,15 @@ describe("CALENDAR_SOURCES action", () => {
       reason: "microsoft OAuth is not registered in this runtime.",
       completion: "configuration_required",
     });
+    // Card marker + verified handoff so the planner cannot paraphrase away
+    // [CONFIG:microsoft] into a vague authentication error.
+    expect(result?.verifiedUserFacing).toBe(true);
+    expect(result?.userFacingText).toContain("[CONFIG:microsoft]");
+    expect(result?.text).toContain("[CONFIG:microsoft]");
+    expect(result?.data).toMatchObject({
+      awaitingUserAction: true,
+      awaitingUserInput: true,
+    });
   });
 
   it("rejects reconnect when the grant and account identities disagree", async () => {
@@ -296,6 +307,10 @@ describe("CALENDAR_SOURCES action", () => {
     });
     expect(result?.success).toBe(false);
     expect(result?.text).toContain('"action":"permission_request"');
+    // Permission JSON must be verified user-facing so voice rewrite cannot
+    // strip the card marker into plain prose.
+    expect(result?.verifiedUserFacing).toBe(true);
+    expect(result?.userFacingText).toContain('"action":"permission_request"');
   });
 
   it("offers no URL parameter on the agent surface", () => {

--- a/plugins/plugin-calendar/src/actions/calendar-sources.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-sources.ts
@@ -863,9 +863,12 @@ function connectionEffectReceipts(
 }
 
 function connectionAwaitsUser(intent: CalendarSourceConnectionIntent): boolean {
+  // configuration_required also needs an owner next step (plugin config card),
+  // so mark it the same as OAuth/permission handoffs for planner preservation.
   return (
     intent.state === "authorization_required" ||
-    intent.state === "permission_required"
+    intent.state === "permission_required" ||
+    intent.state === "configuration_required"
   );
 }
 
@@ -873,10 +876,13 @@ async function resultWithCallback(
   result: ActionResult,
   callback: Parameters<NonNullable<Action["handler"]>>[4],
 ): Promise<ActionResult> {
+  // agentVoiced skips ACTION_CALLBACK_VOICE_REWRITE so card markers
+  // ([CONFIG:…], permission_request JSON) and OAuth URLs stay byte-exact.
   await callback?.({
     text: result.text,
     source: "action",
     action: ACTION_NAME,
+    ...(result.verifiedUserFacing === true ? { agentVoiced: true } : {}),
   });
   return result;
 }
@@ -1025,14 +1031,19 @@ export function createCalendarSourcesAction(
           appliedReceiptIds.length > 0
             ? appliedReceiptIds
             : effectReceipts.map((receipt) => receipt.receiptId);
+        // Always pin connect handoffs as verified user-facing text so the
+        // planner echoes [CONFIG:…], permission_request JSON, and OAuth URLs
+        // instead of paraphrasing them into vague "auth error" prose.
+        // Only attach effectReceipts when present — an empty array would make
+        // the verified-path proof check fail.
         return resultWithCallback(
           {
             success: connectionSucceeded(intent),
             text,
+            userFacingText: text,
+            verifiedUserFacing: true,
             ...(effectReceipts.length > 0
               ? {
-                  userFacingText: text,
-                  verifiedUserFacing: true,
                   effectReceipts,
                   userFacingEffectReceiptIds,
                 }

--- a/plugins/plugin-calendar/src/actions/calendar-sources.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-sources.ts
@@ -917,11 +917,22 @@ export function createCalendarSourcesAction(
       "CONNECT_CALENDAR_SOURCE",
       "RECONNECT_CALENDAR_SOURCE",
       "MANAGE_CALENDAR_SOURCES",
+      // Natural-language connect intents must win over CONNECTOR.CONNECT_GOOGLE
+      // so Google/Microsoft/Apple calendar handoffs emit [CONFIG:…] / OAuth /
+      // permission_request cards instead of generic account-connect prose.
+      "CONNECT_CALENDAR",
+      "CONNECT_GOOGLE_CALENDAR",
+      "CONNECT_MICROSOFT_CALENDAR",
+      "CONNECT_APPLE_CALENDAR",
+      "LINK_CALENDAR",
+      "LINK_GOOGLE_CALENDAR",
+      "ADD_GOOGLE_CALENDAR",
+      "SETUP_GOOGLE_CALENDAR",
     ],
     description:
-      "Read and change which calendar sources feed the owner's calendar, across Google, Microsoft, Apple, and ICS. select and deselect are writes: they durably include or exclude a source from the combined feed, and are the way to act on a source. Call list before select/deselect; echo provider, grantId, connectorAccountId, calendarId, and version exactly. Connect/reconnect returns OAuth, device-permission, configuration, or verified ICS states and never implies authorization is complete. New ICS/webcal subscriptions are added by the owner in the source-manager UI; subscription URLs never pass through this action.",
+      "Read and change which calendar sources feed the owner's calendar, across Google, Microsoft, Apple, and ICS. Prefer this action for any 'connect/link/add my calendar' request (including 'connect Google Calendar') — do not use CONNECTOR or PLUGIN for calendar feed authorization. select and deselect are writes: they durably include or exclude a source from the combined feed, and are the way to act on a source. Call list before select/deselect; echo provider, grantId, connectorAccountId, calendarId, and version exactly. Connect/reconnect returns OAuth, device-permission, configuration ([CONFIG:…]), or verified ICS states and never implies authorization is complete. New ICS/webcal subscriptions are added by the owner in the source-manager UI; subscription URLs never pass through this action.",
     descriptionCompressed:
-      "calendar sources: list reads; select|deselect WRITE feed inclusion; connect|reconnect start owner auth; exact identity + version; ics create=owner UI only",
+      "calendar sources: list; select|deselect WRITE feed; connect|reconnect owner auth + [CONFIG] cards; prefer over CONNECTOR for calendar; ics create=owner UI",
     tags: [
       "domain:calendar",
       "capability:read",
@@ -932,7 +943,7 @@ export function createCalendarSourcesAction(
     contexts: ["general", "calendar", "connectors"],
     roleGate: { minRole: "OWNER" },
     routingHint:
-      "calendar source connection, reconnection, health, or including/excluding a calendar from the feed (a durable write, not just a report) -> CALENDAR_SOURCES; calendar event reads/writes -> CALENDAR",
+      "connect/link/add/setup Google|Microsoft|Apple calendar, reconnect calendar source, calendar source health, or include/exclude a calendar from the feed -> CALENDAR_SOURCES (not CONNECTOR, not PLUGIN); calendar event CRUD -> CALENDAR; Gmail/Drive account without calendar wording -> CONNECTOR",
     suppressPostActionContinuation: true,
     validate: authorize,
     handler: async (runtime, message, _state, options, callback) => {
@@ -1168,6 +1179,32 @@ export function createCalendarSourcesAction(
           name: "{{agentName}}",
           content: {
             text: "I’ll start least-privilege Google Calendar authorization. I won’t claim it is connected until authorization completes.",
+            actions: [ACTION_NAME],
+          },
+        },
+      ],
+      [
+        {
+          name: "{{name1}}",
+          content: { text: "connect google calendar" },
+        },
+        {
+          name: "{{agentName}}",
+          content: {
+            text: "I’ll start Google Calendar source connection and surface the owner handoff card or OAuth URL.",
+            actions: [ACTION_NAME],
+          },
+        },
+      ],
+      [
+        {
+          name: "{{name1}}",
+          content: { text: "can u do it now; connect google cal" },
+        },
+        {
+          name: "{{agentName}}",
+          content: {
+            text: "Starting Google Calendar source connect via CALENDAR_SOURCES.",
             actions: [ACTION_NAME],
           },
         },

--- a/plugins/plugin-personal-assistant/src/actions/connector.ts
+++ b/plugins/plugin-personal-assistant/src/actions/connector.ts
@@ -380,27 +380,71 @@ async function dispatchGoogle(
   const side = normalizeSide(params.side) ?? "owner";
   switch (subaction) {
     case "connect": {
-      const response = await service.startGoogleConnector(
-        {
-          side,
-          mode: params.mode,
-          capabilities: params.capabilities,
-          redirectUrl: params.redirectUrl,
-        },
-        INTERNAL_URL,
-      );
-      return {
-        success: true,
-        text: response.authUrl
+      // Pin OAuth URLs and missing-plugin config cards as verified user-facing
+      // text so the planner cannot paraphrase them into vague "401" prose and
+      // drop the handoff (same contract as CALENDAR_SOURCES connect).
+      try {
+        const response = await service.startGoogleConnector(
+          {
+            side,
+            mode: params.mode,
+            capabilities: params.capabilities,
+            redirectUrl: params.redirectUrl,
+          },
+          INTERNAL_URL,
+        );
+        const text = response.authUrl
           ? `Open this URL to finish Google connect: ${response.authUrl}`
-          : `Google connector started for side=${side}, mode=${response.mode}.`,
-        data: {
-          actionName: ACTION_NAME,
-          connector: "google",
-          subaction,
-          response,
-        },
-      };
+          : `Google connector started for side=${side}, mode=${response.mode}.`;
+        return {
+          success: true,
+          text,
+          userFacingText: text,
+          // OAuth URL must stay byte-exact; mode-only ack is still final.
+          verifiedUserFacing: true,
+          data: {
+            actionName: ACTION_NAME,
+            connector: "google",
+            subaction,
+            response,
+            ...(response.authUrl
+              ? { awaitingUserAction: true, awaitingUserInput: true }
+              : {}),
+          },
+        };
+      } catch (error) {
+        // error-policy:J1 Boundary: expected LifeOps failures become owner
+        // handoffs; unexpected errors rethrow into the planner.
+        if (error instanceof LifeOpsServiceError) {
+          const needsConfig =
+            error.status === 503 ||
+            /plugin-google-workspace|OAuth is not registered|required before starting/i.test(
+              error.message,
+            );
+          // Same short id as CALENDAR_SOURCES configuration_required ([CONFIG:google])
+          // so the chat widget resolves one consistent Google setup surface.
+          const text = needsConfig
+            ? withConfigCard(error.message, "google")
+            : error.message;
+          return {
+            success: false,
+            text,
+            userFacingText: text,
+            verifiedUserFacing: true,
+            data: {
+              actionName: ACTION_NAME,
+              connector: "google",
+              subaction,
+              status: error.status,
+              error: error.code ?? "GOOGLE_CONNECT_FAILED",
+              ...(needsConfig
+                ? { awaitingUserAction: true, awaitingUserInput: true }
+                : {}),
+            },
+          };
+        }
+        throw error;
+      }
     }
     case "disconnect": {
       const status = await service.disconnectGoogleConnector(
@@ -1368,6 +1412,10 @@ export const connectorAction: Action & {
 } = {
   name: ACTION_NAME,
   similes: [
+    // Prefer CONNECT_GOOGLE_ACCOUNT for account-level Google OAuth. Calendar
+    // feed connect phrases ("connect google calendar") must route to
+    // CALENDAR_SOURCES — CONNECT_GOOGLE remains as a legacy alias only.
+    "CONNECT_GOOGLE_ACCOUNT",
     "CONNECT_GOOGLE",
     "CONNECT_TELEGRAM",
     "CONNECT_DISCORD",
@@ -1391,15 +1439,15 @@ export const connectorAction: Action & {
   description:
     "Installed connector account state: connect, disconnect, verify, status, list. " +
     `Actions: ${VALID_SUBACTIONS.join(", ")}. ` +
-    "External accounts: Google, Telegram, Discord, Slack, etc. " +
+    "External accounts: Google (Gmail/Drive package OAuth), Telegram, Discord, Slack, etc. " +
+    "Do NOT use this for 'connect Google Calendar' / calendar feed authorization — use CALENDAR_SOURCES. " +
     "Connector kinds from runtime ConnectorRegistry; verify active upstream API probe. " +
     "Plugin install/uninstall/configure -> use PLUGIN.",
   descriptionCompressed:
-    "CONNECTOR accounts: connect|disconnect|verify|status|list; plugin install/config -> PLUGIN",
+    "CONNECTOR accounts: connect|disconnect|verify|status|list; calendar feed connect -> CALENDAR_SOURCES; plugin install -> PLUGIN",
   contexts: [
     "connectors",
     "settings",
-    "calendar",
     "email",
     "messaging",
     "contacts",
@@ -1407,6 +1455,8 @@ export const connectorAction: Action & {
     "browser",
   ],
   roleGate: { minRole: "OWNER" },
+  routingHint:
+    "connect/link Google Calendar or any calendar source/feed authorization -> CALENDAR_SOURCES; Gmail/Drive/account Google OAuth without calendar-feed wording -> CONNECTOR; package install/config -> PLUGIN",
   suppressPostActionContinuation: true,
 
   validate: async () => true,

--- a/plugins/plugin-personal-assistant/test/connector-config-card.test.ts
+++ b/plugins/plugin-personal-assistant/test/connector-config-card.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   extractActionParamsViaLlm: vi.fn(),
   hasLifeOpsAccess: vi.fn(async () => true),
   connected: { value: false },
+  startGoogleConnector: vi.fn(),
 }));
 
 vi.mock("@elizaos/agent", () => ({
@@ -47,6 +48,16 @@ vi.mock("../src/lifeops/connectors/index.js", () => ({
 // same shape, which is all the connect dispatchers read.
 vi.mock("../src/lifeops/service.js", () => {
   const status = () => ({ connected: mocks.connected.value });
+  class LifeOpsServiceError extends Error {
+    status: number;
+    code?: string;
+    constructor(status: number, message: string, code?: string) {
+      super(message);
+      this.name = "LifeOpsServiceError";
+      this.status = status;
+      this.code = code;
+    }
+  }
   return {
     LifeOpsService: class LifeOpsService {
       getDiscordConnectorStatus = vi.fn(async () => status());
@@ -54,10 +65,9 @@ vi.mock("../src/lifeops/service.js", () => {
       getSignalConnectorStatus = vi.fn(async () => status());
       getIMessageConnectorStatus = vi.fn(async () => status());
       getWhatsAppConnectorStatus = vi.fn(async () => status());
+      startGoogleConnector = mocks.startGoogleConnector;
     },
-    LifeOpsServiceError: class LifeOpsServiceError extends Error {
-      status = 500;
-    },
+    LifeOpsServiceError,
   };
 });
 
@@ -108,6 +118,54 @@ beforeEach(() => {
   mocks.extractActionParamsViaLlm.mockReset();
   mocks.hasLifeOpsAccess.mockReset().mockResolvedValue(true);
   mocks.connected.value = false;
+  mocks.startGoogleConnector.mockReset();
+});
+
+describe("CONNECTOR Google connect handoff cards", () => {
+  it("pins OAuth URLs as verified user-facing text", async () => {
+    mocks.startGoogleConnector.mockResolvedValue({
+      authUrl: "https://accounts.example.test/oauth",
+      mode: "local",
+      side: "owner",
+    });
+    const result = await connect("google");
+    expect(result.success).toBe(true);
+    expect(result.verifiedUserFacing).toBe(true);
+    expect(result.userFacingText).toContain(
+      "https://accounts.example.test/oauth",
+    );
+    expect(result.text).toContain("https://accounts.example.test/oauth");
+    expect(result.data).toMatchObject({
+      awaitingUserAction: true,
+      awaitingUserInput: true,
+    });
+  });
+
+  it("emits a verified [CONFIG:google] card when OAuth cannot start", async () => {
+    const { LifeOpsServiceError } = await import("../src/lifeops/service.js");
+    mocks.startGoogleConnector.mockRejectedValue(
+      new LifeOpsServiceError(
+        503,
+        "@elizaos/plugin-google-workspace is required before starting Google OAuth.",
+      ),
+    );
+    const result = await connect("google");
+    expect(result.success).toBe(false);
+    expect(result.verifiedUserFacing).toBe(true);
+    expect(result.text).toContain("[CONFIG:google]");
+    expect(result.userFacingText).toContain("[CONFIG:google]");
+    expect(result.data).toMatchObject({
+      awaitingUserAction: true,
+      status: 503,
+    });
+  });
+
+  it("routes calendar-feed connect away from CONNECTOR in metadata", () => {
+    expect(connectorAction.routingHint).toMatch(/CALENDAR_SOURCES/);
+    expect(connectorAction.routingHint).toMatch(/calendar/i);
+    expect(connectorAction.description).toMatch(/CALENDAR_SOURCES/);
+    expect(connectorAction.contexts).not.toContain("calendar");
+  });
 });
 
 describe("CONNECTOR connect emits the setup-card marker", () => {


### PR DESCRIPTION
## Summary

Stops calendar connect from getting paraphrased into vague “auth error / try logging in again” chat.

When the owner asks to connect Google/Microsoft/Apple calendar, two things were going wrong:

1. **Wrong action** — natural language like “connect google calendar” often hit `CONNECTOR.CONNECT_GOOGLE` instead of `CALENDAR_SOURCES`, so the calendar source handoff (`[CONFIG:…]`, OAuth URL, Apple `permission_request`) never ran.
2. **Planner rewrite** — even when `CALENDAR_SOURCES` returned the right handoff text, missing `verifiedUserFacing` / `awaitingUserInput` / `agentVoiced` let the planner and callback voice rewrite strip card markers into soft prose.

This PR pins those handoffs as verified user-facing text and steers calendar-feed connect away from `CONNECTOR`.

## Why this is useful

Without it, a correct backend state (`configuration_required`, missing Google Workspace plugin, Apple permission needed, OAuth URL ready) still looks like a generic failure in chat. The product already has config cards and permission UI; this makes the agent **preserve the handoff** so the owner can act.

This is independent of “plugin not loaded / PLUGIN_TOGGLE 401” (#18042, #18043). Those are about *getting* calendar running. This PR is about what the user sees **once connect runs**.

## Changes

### `CALENDAR_SOURCES` (`plugin-calendar`)
- Always set `userFacingText` + `verifiedUserFacing: true` on connect/reconnect handoffs (not only when effect receipts exist).
- Treat `configuration_required` as `awaitingUserInput` (same as OAuth / permission).
- Set `agentVoiced: true` on verified callbacks so voice rewrite cannot drop `[CONFIG:…]` / permission JSON / OAuth URLs.
- Add similes + examples + routingHint so “connect google calendar” prefers `CALENDAR_SOURCES` over `CONNECTOR`.

### `CONNECTOR` (`plugin-personal-assistant`)
- Pin Google connect OAuth URL (and missing-plugin failures) as verified user-facing text; emit `[CONFIG:google]` on 503 / unregistered OAuth.
- Explicit routing: calendar feed connect → `CALENDAR_SOURCES`; Gmail/Drive account OAuth without calendar wording → `CONNECTOR`.
- Drop `calendar` from CONNECTOR contexts; add `CONNECT_GOOGLE_ACCOUNT` simile; keep `CONNECT_GOOGLE` as legacy alias.

## Out of scope
- Enabling calendar / google-workspace on lean-chat cloud agents
- Cloud loopback `PLUGIN_TOGGLE` 401 on main (#18042)
- Lean-chat missing `plugin-scheduling` under calendar (#18043)
- Registering Google OAuth client credentials in the environment

## Test plan
- [x] `bun run --cwd plugins/plugin-calendar test`
- [x] Unit: verified handoffs for `configuration_required`, Apple `permission_request`, similes/routing
- [x] Unit: CONNECTOR Google OAuth URL + `[CONFIG:google]` on missing workspace plugin
- [ ] Manual: Google workspace inactive → “connect google calendar” → `[CONFIG:google]` card (not “log in again”)
- [ ] Manual: Apple calendar connect → `permission_request` card, not paraphrased prose
- [ ] Manual: “connect my Gmail” still routes to CONNECTOR account OAuth, not calendar sources

## Ship notes
CI gate failures on fork PRs have been **workflow approval holds**, not product test failures. Pair with #18042/#18043 if validating on main-line lean-chat staging images.
