### PR TITLE
fix(test): export real core contract tuples from the accounts-ui e2e core stub

### DIFF
--- a/packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs
+++ b/packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs
@@ -88,6 +88,21 @@ const stubNodeBuiltins = {
     }));
   },
 };
+// The core stub keeps the heavy runtime out of the browser bundle, but esbuild
+// compiles named ESM imports from a CJS module to plain property reads that a
+// bare Proxy target cannot answer — they arrive as `undefined`, not as the
+// callable noop. The accounts-response validator (#17617) consumes the
+// LINKED_ACCOUNT_* / SERVICE_ROUTE_* contract tuples and ElizaError at runtime,
+// so those must be the REAL exports: the contracts module is dependency-free
+// data, and the ElizaError shim carries the same code/context/cause surface.
+const coreContractsPath = join(
+  repoRoot,
+  "packages",
+  "core",
+  "src",
+  "contracts",
+  "service-routing-types.ts",
+);
 const stubElizaCore = {
   name: "stub-eliza-core",
   setup(b) {
@@ -97,10 +112,26 @@ const stubElizaCore = {
     }));
     b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
       contents: `
+        const contracts = require(${JSON.stringify(coreContractsPath)});
+        class ElizaError extends Error {
+          constructor(message, options = {}) {
+            super(
+              message,
+              options.cause !== undefined ? { cause: options.cause } : undefined,
+            );
+            this.name = "ElizaError";
+            this.code = options.code;
+            this.context = options.context;
+          }
+        }
         const noop = new Proxy(() => noop, { get: () => noop });
-        module.exports = new Proxy({}, { get: () => noop });
+        module.exports = new Proxy(
+          { ...contracts, ElizaError },
+          { get: (target, key) => (key in target ? target[key] : noop) },
+        );
       `,
       loader: "js",
+      resolveDir: here,
     }));
   },
 };


### PR DESCRIPTION
## Problem

The `Zero-Key accounts UI e2e (real API + pool + disk)` job of `scenario-pr.yml` fails deterministically on every completed develop run since #17617 merged (first red: run 31193006896 on `bf48431dc`, 2026-08-07 15:31; green through `7f52e3925`, 13:51; also red on 31196963039 and 31212796410). The suite dies in scenario 04 waiting for the add-account dialog/`Accounts (1)`.

Root cause: #17617's `parseAccountsListResponse` consumes the `LINKED_ACCOUNT_*` / `SERVICE_ROUTE_ACCOUNT_STRATEGIES` contract tuples and `ElizaError` from `@elizaos/core` **at runtime**. The accounts-ui fixture bundles the real UI but stubs `@elizaos/core` with a bare CJS Proxy — and esbuild compiles named ESM imports from a CJS module into plain property reads that arrive as `undefined`, not as the stub's callable noop. Every `client.listAccounts()` throws `TypeError: Cannot read properties of undefined (reading 'includes')`, `useAccounts` keeps `data` null, and `AccountList` silently renders the designed empty state — so the added account never appears.

## Fix

Harness-only, in `packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs`: the core stub now bundles the REAL `packages/core/src/contracts/service-routing-types.ts` (dependency-free data module) and an `ElizaError` shim with the same `code`/`context`/`cause` surface, keeping the noop proxy for every other core export so the browser bundle still excludes the runtime.

## Verification

- Bisect: full suite passes at `f1c3584da92` (parent of #17617), fails at `d14df1e602f` and at develop HEAD `d72e9e4e759` — same signature as CI.
- Diagnostic (temporary `console.error` in `useAccounts.refresh` catch): `E2E-DIAG refresh failed: TypeError: Cannot read properties of undefined (reading 'includes')` on all three refreshes.
- Interop proof: a minimal esbuild bundle importing `LINKED_ACCOUNT_PROVIDER_IDS`/`ElizaError` through the old stub logs `undefined undefined`; through the new stub logs `object function`.
- With the fix at develop HEAD: `ALL ASSERTIONS PASSED` (17 PASS, 15 screenshots), twice consecutively, under the CI env (`CI=true ELIZA_VAULT_PASSPHRASE=accounts-ui-e2e-headless-only`, empty provider keys).

Note: the CI job logs additionally show every `/api/*` request timing out client-side at 10s (no response logged server-side) — that flavor did not reproduce locally under D-Bus-less and empty-key emulation and looks environmental on the self-hosted runners; the deterministic validator break above is sufficient to keep the lane red on its own and is what this PR fixes. If the lane stays red after this lands, the residual is the runner-side stall, not the fixture.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Panel stuck on "ACCOUNTS (0) / No accounts yet" after a `201` add + two `200` list refreshes (last video frame of the failing run, develop HEAD): the refreshed list is silently dropped by the throwing validator.
<!-- evidence-row:after-screenshots -->
- [x] With the fix, the suite's own evidence dir captures all 15 screenshots including `04-account-added` and the two-account states.
<!-- evidence-row:walkthrough-video -->
- [x] The suite records `accounts-ui-walkthrough.webm` into `test-results/evidence/10722-accounts-ui-e2e/` on every run (before and after available locally).
<!-- evidence-row:backend-logs -->
- [x] Before: `POST /api/accounts/anthropic-api -> 201` + `GET /api/accounts -> 200` ×2, yet UI stays empty. After: identical server log, suite passes:

```
PASS  added account is in the REAL pool (label=Personal)
PASS  credential record written to the on-disk store
...
ALL ASSERTIONS PASSED — 15 screenshots in test-results/evidence/10722-accounts-ui-e2e
```
<!-- evidence-row:frontend-logs -->
- [x] Before (diagnostic build): `[error] E2E-DIAG refresh failed: TypeError: Cannot read properties of undefined (reading 'includes')` ×3. After: `PASS  zero page errors across the whole flow`.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM invoked; deterministic browser e2e harness.
<!-- evidence-row:domain-artifacts -->
- [x] The red develop lane itself: runs 31193006896, 31196963039, 31212796410 all fail this job at the same scenario-04 assertion; green through run 31184674785 (`7f52e3925`).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)