### PR TITLE
fix(cloud): app-mode entry always lands in the same-origin chat app (chat floor, no cold-start pairing dead end)

### DIFF
--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
@@ -1,15 +1,9 @@
-/** Verifies the AppModeEntryRoute gate — auth gating, the agents-driven routing table, and the pairing redirect outcomes (200 / 202 / error) — through the package's configured test harness (jsdom, real render, hand-rolled fetch stub; no Steward provider mounted, sessions come from the persisted localStorage JWT). */
+/** Verifies the AppModeEntryRoute gate — auth gating and the chat-floor routing table (any agents → the same-origin chat app with ZERO pairing traffic; empty org → /join) — through the package's configured test harness (jsdom, real render, hand-rolled fetch stub; no Steward provider mounted, sessions come from the persisted localStorage JWT). */
 // @vitest-environment jsdom
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
 import { AppModeEntryRoute } from "./AppModeEntryRoute";
@@ -56,8 +50,6 @@ function agent(
 interface StubRoutes {
   /** Response for GET /api/v1/eliza/agents. */
   agents: () => Response;
-  /** Response for POST /api/v1/eliza/agents/:id/pairing-token. */
-  pairing?: (agentId: string) => Response;
 }
 
 const realFetch = globalThis.fetch;
@@ -71,12 +63,6 @@ function stubNetwork(routes: StubRoutes): void {
   globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     fetchLog.push(`${init?.method ?? "GET"} ${url}`);
-    const pairing = /^\/api\/v1\/eliza\/agents\/([^/]+)\/pairing-token$/.exec(
-      url,
-    );
-    if (pairing && routes.pairing) {
-      return Promise.resolve(routes.pairing(pairing[1]));
-    }
     if (url === "/api/v1/eliza/agents") {
       return Promise.resolve(routes.agents());
     }
@@ -88,8 +74,8 @@ function stubNetwork(routes: StubRoutes): void {
     );
   }) as typeof fetch;
   assignedUrls = [];
-  // Both seams feed one log: automatic entry replaces history, an explicit
-  // chooser pick pushes; the replace-vs-assign split is pinned in app-mode.test.ts.
+  // Any full-page navigation (the old pairing redirect used these seams) is a
+  // chat-floor violation at entry; the suite pins that the log stays empty.
   appModeNavigation.assign = (url: string) => {
     assignedUrls.push(url);
   };
@@ -170,74 +156,41 @@ describe("AppModeEntryRoute — auth gating", () => {
   });
 });
 
-describe("AppModeEntryRoute — routing table", () => {
-  it("exactly one running dedicated agent → full-page pairing redirect into its web UI", async () => {
+describe("AppModeEntryRoute — chat-floor routing table", () => {
+  it("one running dedicated agent → the same-origin chat app; NO pairing token is minted, NO redirect fires", async () => {
+    // The cold-start dead-end pin. `status: "running"` in the control plane
+    // does not mean the container is warm: the previous gate POSTed
+    // /pairing-token here (one-time, 60s TTL) and full-page-redirected into
+    // `<agentId>.…/pair?token=…`; a cold-starting agent cannot consume the
+    // token inside the TTL, so every cold start dead-ended on the agent's
+    // "Sign-in link expired" page. Entry must render the chat app instead and
+    // issue zero pairing traffic.
     signIn();
-    const redirectUrl = "https://agent-1.elizacloud.ai/pair?token=tok";
-    stubNetwork({
-      agents: agentsOk([agent({ id: "agent-1" })]),
-      pairing: () => jsonResponse(200, { data: { redirectUrl } }),
-    });
+    stubNetwork({ agents: agentsOk([agent({ id: "agent-1" })]) });
     renderEntry();
 
-    await waitFor(() => expect(assignedUrls).toEqual([redirectUrl]));
-    expect(fetchLog).toContain(
-      "POST /api/v1/eliza/agents/agent-1/pairing-token",
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
+    expect(fetchLog.filter((line) => line.includes("pairing-token"))).toEqual(
+      [],
     );
-    expect(screen.queryByTestId("agent-app")).toBeNull();
-  });
-
-  it("pairing 202 (agent must resume) → lands on the Instances view", async () => {
-    signIn();
-    stubNetwork({
-      agents: agentsOk([agent({ id: "agent-1" })]),
-      pairing: () => jsonResponse(202, { data: { status: "starting" } }),
-    });
-    renderEntry();
-
-    expect(await screen.findByTestId("instances-page")).toBeTruthy();
     expect(assignedUrls).toEqual([]);
   });
 
-  it("pairing failure → visible error state with an escape to Instances, never a blank screen", async () => {
+  it("several running dedicated agents → still the chat app (no chooser interstitial at entry)", async () => {
     signIn();
-    stubNetwork({
-      agents: agentsOk([agent({ id: "agent-1" })]),
-      pairing: () => jsonResponse(503, { error: "agent not reachable" }),
-    });
-    renderEntry();
-
-    expect(await screen.findByText("agent not reachable")).toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Go to your instances" }),
-    );
-    expect(await screen.findByTestId("instances-page")).toBeTruthy();
-  });
-
-  it("several running dedicated agents → chooser (most recently active first), rows pair on demand", async () => {
-    signIn();
-    const redirectUrl = "https://fresh.elizacloud.ai/pair?token=tok";
     stubNetwork({
       agents: agentsOk([
         agent({ id: "stale", lastHeartbeatAt: "2026-08-01T00:00:00.000Z" }),
         agent({ id: "fresh", lastHeartbeatAt: "2026-08-05T00:00:00.000Z" }),
       ]),
-      pairing: (agentId) =>
-        agentId === "fresh"
-          ? jsonResponse(200, { data: { redirectUrl } })
-          : jsonResponse(503, { error: "wrong agent" }),
     });
     renderEntry();
 
-    const rows = await screen.findAllByRole("button", { name: /Open/ });
-    expect(rows.map((row) => row.textContent)).toEqual([
-      "freshOpen",
-      "staleOpen",
-    ]);
-
-    fireEvent.click(rows[0]);
-    await waitFor(() => expect(assignedUrls).toEqual([redirectUrl]));
-    expect(fetchLog).toContain("POST /api/v1/eliza/agents/fresh/pairing-token");
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
+    expect(assignedUrls).toEqual([]);
+    expect(fetchLog.filter((line) => line.includes("pairing-token"))).toEqual(
+      [],
+    );
   });
 
   it("dedicated agents exist but none running → the same-origin chat app (never the console)", async () => {
@@ -259,6 +212,20 @@ describe("AppModeEntryRoute — routing table", () => {
     renderEntry();
 
     expect(await screen.findByTestId("agent-app")).toBeTruthy();
+    expect(assignedUrls).toEqual([]);
+  });
+
+  it("a provisioning (cold-starting) dedicated agent → the chat app, no doomed pairing hop", async () => {
+    signIn();
+    stubNetwork({
+      agents: agentsOk([agent({ id: "agent-1", status: "provisioning" })]),
+    });
+    renderEntry();
+
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
+    expect(fetchLog.filter((line) => line.includes("pairing-token"))).toEqual(
+      [],
+    );
     expect(assignedUrls).toEqual([]);
   });
 
@@ -289,5 +256,22 @@ describe("AppModeEntryRoute — routing table", () => {
     renderEntry();
 
     expect(await screen.findByTestId("agent-app")).toBeTruthy();
+  });
+
+  it("never renders the instances console from entry, in any state", async () => {
+    signIn();
+    stubNetwork({
+      agents: agentsOk([
+        agent({ id: "e1", status: "error" }),
+        agent({ id: "r1", status: "running" }),
+        agent({ id: "s1", status: "stopped" }),
+      ]),
+    });
+    renderEntry();
+
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.queryByTestId("instances-page")).toBeNull(),
+    );
   });
 });

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
@@ -6,13 +6,11 @@
  * match before the catch-all and stay reachable.
  *
  * After the existing Steward session auth resolves, the gate fetches the org's
- * agents and routes per `decideAppModeRoute`: one running dedicated agent →
- * full-page pairing redirect into its web UI (202 "must resume" and pairing
- * failures degrade to the Instances console); several → a minimal chooser;
- * no pairing target (shared-tier-only orgs AND dedicated agents that are not
- * running) → the same-origin chat app unchanged — on the app hosts the entry
- * must stay inside the app, never bounce to the console because an agent is
- * stopped or errored; no agents at all → the `/join` deploy-first-agent flow. Unauthenticated visitors first get one shot at the
+ * agents and routes per `decideAppModeRoute`: any agents → the same-origin
+ * chat app (the chat floor — entry never pairing-redirects into a per-agent
+ * web UI and never bounces to the console; see `./app-mode` for why the
+ * entry-time pairing redirect was removed); no agents at all → the `/join`
+ * deploy-first-agent flow. Unauthenticated visitors first get one shot at the
  * cross-host SSO bridge (`../sso-bridge/sso-bridge` — only when the
  * domain-wide session marker says the dashboard pair holds a live session and
  * the user did not explicitly sign out here), then the normal login flow, and
@@ -22,8 +20,7 @@
  */
 
 import { type ReactNode, useEffect, useRef, useState } from "react";
-import { Navigate, useLocation, useNavigate } from "react-router-dom";
-import { Button } from "../../components/ui/button";
+import { Navigate, useLocation } from "react-router-dom";
 import { useAgents } from "../instances/lib/data/eliza-agents";
 import { useSessionAuth } from "../lib/use-session-auth";
 import {
@@ -31,12 +28,7 @@ import {
   redirectToSsoBridge,
   shouldAutoBridgeToSso,
 } from "../sso-bridge/sso-bridge";
-import {
-  APP_MODE_INSTANCES_PATH,
-  type AppModeAgent,
-  decideAppModeRoute,
-  redirectToAgentWebUI,
-} from "./app-mode";
+import { decideAppModeRoute } from "./app-mode";
 
 function EntryNotice({
   label,
@@ -62,11 +54,7 @@ export function AppModeEntryRoute({
 }): React.JSX.Element {
   const { ready, authenticated } = useSessionAuth();
   const location = useLocation();
-  const navigate = useNavigate();
   const agentsQuery = useAgents();
-
-  const redirectStartedRef = useRef(false);
-  const [redirectError, setRedirectError] = useState<string | null>(null);
 
   // Unauthenticated visits may ride the cross-host SSO bridge instead of the
   // local login: when the domain-wide session marker says the dashboard pair
@@ -97,30 +85,6 @@ export function AppModeEntryRoute({
     );
   }, [ready, authenticated, location]);
 
-  const route =
-    authenticated && agentsQuery.data !== undefined
-      ? decideAppModeRoute(agentsQuery.data)
-      : null;
-  const entryAgent = route?.kind === "enter-agent" ? route.agent : null;
-
-  // Exactly one running dedicated agent → full-page redirect into its web UI.
-  // The ref makes the pairing POST once-per-mount: the agents query repolls and
-  // re-derives `route`, and a second POST would burn another one-time token.
-  useEffect(() => {
-    if (!entryAgent || redirectStartedRef.current) return;
-    redirectStartedRef.current = true;
-    void redirectToAgentWebUI(entryAgent.id).then((result) => {
-      if (result.ok) return;
-      if (result.starting) {
-        // 202 — the server queued a resume; land on Instances where the agent's
-        // status and wake progress are visible.
-        navigate(APP_MODE_INSTANCES_PATH, { replace: true });
-        return;
-      }
-      setRedirectError(result.error);
-    });
-  }, [entryAgent, navigate]);
-
   if (!ready) {
     return <EntryNotice label="Loading" />;
   }
@@ -142,99 +106,20 @@ export function AppModeEntryRoute({
 
   if (agentsQuery.isError) {
     // Never a blank screen — and never the console either: the same-origin
-    // chat app is the app host's own degraded surface (its pre-app-mode
-    // behavior), so a control-plane hiccup on the agents list keeps the
-    // visitor in the product instead of evicting them to the dashboard.
+    // chat app is the app host's own surface, so a control-plane hiccup on
+    // the agents list keeps the visitor in the product.
     return <>{appElement}</>;
   }
 
-  if (!route) {
+  if (agentsQuery.data === undefined) {
     return <EntryNotice label="Loading your agent" />;
   }
 
-  switch (route.kind) {
-    case "enter-agent":
-      if (redirectError) {
-        return (
-          <EntryNotice label="Connection failed">
-            <p className="max-w-sm text-sm text-white/62">{redirectError}</p>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => navigate(APP_MODE_INSTANCES_PATH)}
-            >
-              Go to your instances
-            </Button>
-          </EntryNotice>
-        );
-      }
-      return <EntryNotice label="Connecting to your agent" />;
-
-    case "choose-agent":
-      return <AgentChooser running={route.running} />;
-
-    case "create":
-      return <Navigate to={route.to} replace />;
-
-    case "chat-home":
-      return <>{appElement}</>;
+  const route = decideAppModeRoute(agentsQuery.data);
+  if (route.kind === "create") {
+    return <Navigate to={route.to} replace />;
   }
-}
-
-/** Minimal chooser for orgs with several running dedicated agents; each row
- * deep-links through the same pairing redirect as automatic entry. */
-function AgentChooser({
-  running,
-}: {
-  running: AppModeAgent[];
-}): React.JSX.Element {
-  const navigate = useNavigate();
-  const [pendingId, setPendingId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  async function openAgent(agentId: string): Promise<void> {
-    setPendingId(agentId);
-    setError(null);
-    const result = await redirectToAgentWebUI(agentId, "user-initiated");
-    if (!result.ok) {
-      setPendingId(null);
-      setError(
-        result.starting
-          ? "Agent is still starting — try again shortly."
-          : result.error,
-      );
-    }
-  }
-
-  return (
-    <EntryNotice label="Pick your agent">
-      <div className="w-full max-w-sm space-y-2 text-left">
-        {running.map((agent) => (
-          <button
-            key={agent.id}
-            type="button"
-            disabled={pendingId !== null}
-            onClick={() => void openAgent(agent.id)}
-            className="flex w-full items-center justify-between border border-white/15 bg-white/5 px-4 py-3 text-sm text-white transition-colors hover:bg-white/10 disabled:opacity-50"
-          >
-            <span className="truncate">{agent.agentName ?? agent.id}</span>
-            <span className="ml-3 shrink-0 font-mono text-[11px] uppercase tracking-widest text-white/62">
-              {pendingId === agent.id ? "Connecting…" : "Open"}
-            </span>
-          </button>
-        ))}
-      </div>
-      {error ? <p className="max-w-sm text-sm text-red-400">{error}</p> : null}
-      <Button
-        type="button"
-        variant="link"
-        className="text-xs text-white/62"
-        onClick={() => navigate(APP_MODE_INSTANCES_PATH)}
-      >
-        Manage all instances
-      </Button>
-    </EntryNotice>
-  );
+  return <>{appElement}</>;
 }
 
 export default AppModeEntryRoute;

--- a/packages/ui/src/cloud/app-mode/app-mode.test.ts
+++ b/packages/ui/src/cloud/app-mode/app-mode.test.ts
@@ -1,14 +1,12 @@
-/** Verifies the app-mode hostname matrix, entry-routing decision table, and pairing redirect through the package's configured test harness (jsdom, hand-rolled fetch stub — no module mocks). */
+/** Verifies the app-mode hostname matrix and the entry-routing decision table (chat floor: any agents → chat-home, none → /join; never a pairing redirect, never a console bounce) through the package's configured test harness (jsdom, no module mocks). */
 // @vitest-environment jsdom
 
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   APP_MODE_CREATE_PATH,
   type AppModeAgent,
-  appModeNavigation,
   decideAppModeRoute,
   isAppModeHostname,
-  redirectToAgentWebUI,
 } from "./app-mode";
 
 function agent(
@@ -65,7 +63,7 @@ describe("isAppModeHostname — hostname matrix", () => {
   });
 });
 
-describe("decideAppModeRoute — decision table", () => {
+describe("decideAppModeRoute — decision table (chat floor)", () => {
   it("no agents at all → the /join deploy-first-agent flow", () => {
     expect(decideAppModeRoute([])).toEqual({
       kind: "create",
@@ -73,62 +71,24 @@ describe("decideAppModeRoute — decision table", () => {
     });
   });
 
-  it("exactly one running dedicated agent → enter-agent", () => {
-    const a = agent({ id: "a1" });
-    expect(decideAppModeRoute([a])).toEqual({ kind: "enter-agent", agent: a });
+  it("a running dedicated agent → chat-home, NEVER an entry-time pairing redirect", () => {
+    // The cold-start regression pin: `status === "running"` in the DB does not
+    // mean the container is serving. The old gate minted a one-time 60s
+    // pairing token and full-page-redirected here; a cold container cannot
+    // consume the token inside its TTL, so entry dead-ended on the agent's
+    // "Sign-in link expired" page. Entry must land in the same-origin chat
+    // app; entering the agent web UI is an explicit action elsewhere.
+    expect(decideAppModeRoute([agent({ id: "a1" })])).toEqual({
+      kind: "chat-home",
+    });
   });
 
-  it("a running dedicated agent wins over running shared + stopped dedicated noise", () => {
-    const winner = agent({ id: "ded-1" });
+  it("several running dedicated agents → still chat-home (no chooser at entry)", () => {
     const route = decideAppModeRoute([
-      agent({ id: "shared-1", executionTier: "shared" }),
-      agent({ id: "ded-stopped", status: "stopped" }),
-      winner,
+      agent({ id: "a1", lastHeartbeatAt: "2026-08-01T00:00:00.000Z" }),
+      agent({ id: "a2", lastHeartbeatAt: "2026-08-05T00:00:00.000Z" }),
     ]);
-    expect(route).toEqual({ kind: "enter-agent", agent: winner });
-  });
-
-  it("several running dedicated agents → chooser ordered most-recently-active first (lastHeartbeatAt ?? updatedAt)", () => {
-    const stale = agent({
-      id: "stale",
-      lastHeartbeatAt: "2026-08-01T00:00:00.000Z",
-    });
-    const fresh = agent({
-      id: "fresh",
-      lastHeartbeatAt: "2026-08-05T00:00:00.000Z",
-    });
-    const heartbeatless = agent({
-      id: "no-heartbeat",
-      lastHeartbeatAt: null,
-      updatedAt: "2026-08-03T00:00:00.000Z",
-    });
-    const route = decideAppModeRoute([stale, heartbeatless, fresh]);
-    expect(route.kind).toBe("choose-agent");
-    if (route.kind !== "choose-agent") throw new Error("unreachable");
-    expect(route.running.map((a) => a.id)).toEqual([
-      "fresh",
-      "no-heartbeat",
-      "stale",
-    ]);
-  });
-
-  it("unparseable activity stamps sort last instead of throwing", () => {
-    const broken = agent({ id: "broken", lastHeartbeatAt: "not-a-date" });
-    const fresh = agent({
-      id: "fresh",
-      lastHeartbeatAt: "2026-08-05T00:00:00.000Z",
-    });
-    const route = decideAppModeRoute([broken, fresh]);
-    if (route.kind !== "choose-agent") throw new Error("expected chooser");
-    expect(route.running.map((a) => a.id)).toEqual(["fresh", "broken"]);
-  });
-
-  it("custom-tier agents are pairing candidates (per-container tier)", () => {
-    const custom = agent({ id: "c1", executionTier: "custom" });
-    expect(decideAppModeRoute([custom])).toEqual({
-      kind: "enter-agent",
-      agent: custom,
-    });
+    expect(route).toEqual({ kind: "chat-home" });
   });
 
   it("dedicated agents exist but none running → chat-home (the app stays home; never the console)", () => {
@@ -144,7 +104,15 @@ describe("decideAppModeRoute — decision table", () => {
     expect(route).toEqual({ kind: "chat-home" });
   });
 
-  it("deletion_pending is not running → chat-home", () => {
+  it("provisioning / pending dedicated agents (cold start in progress) → chat-home", () => {
+    const route = decideAppModeRoute([
+      agent({ id: "d1", status: "provisioning" }),
+      agent({ id: "d2", status: "pending" }),
+    ]);
+    expect(route).toEqual({ kind: "chat-home" });
+  });
+
+  it("deletion_pending is not a create-worthy empty org → chat-home", () => {
     const route = decideAppModeRoute([
       agent({ id: "d1", status: "deletion_pending" }),
     ]);
@@ -158,150 +126,12 @@ describe("decideAppModeRoute — decision table", () => {
     ]);
     expect(route).toEqual({ kind: "chat-home" });
   });
-});
 
-describe("redirectToAgentWebUI — pairing redirect", () => {
-  const realFetch = globalThis.fetch;
-  const realAssign = appModeNavigation.assign;
-  const realReplace = appModeNavigation.replace;
-  let fetchCalls: Array<{ url: string; method: string | undefined }>;
-  let assignedUrls: string[];
-
-  function stubFetch(respond: () => Response | Promise<Response>): void {
-    fetchCalls = [];
-    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-      fetchCalls.push({ url: String(input), method: init?.method });
-      return Promise.resolve(respond());
-    }) as typeof fetch;
-  }
-
-  function captureAssign(): void {
-    assignedUrls = [];
-    // Both seams feed one log: automatic entry replaces history, an explicit
-    // pick pushes; the distinction is asserted in its own test below.
-    appModeNavigation.assign = (url: string) => {
-      assignedUrls.push(url);
-    };
-    appModeNavigation.replace = (url: string) => {
-      assignedUrls.push(url);
-    };
-  }
-
-  afterEach(() => {
-    globalThis.fetch = realFetch;
-    appModeNavigation.assign = realAssign;
-    appModeNavigation.replace = realReplace;
-  });
-
-  function jsonResponse(status: number, body: unknown): Response {
-    return new Response(JSON.stringify(body), {
-      status,
-      headers: { "content-type": "application/json" },
-    });
-  }
-
-  it("200 with a redirectUrl → full-page navigation to the agent's /pair URL", async () => {
-    const redirectUrl = "https://agent-1.elizacloud.ai/pair?token=tok";
-    stubFetch(() => jsonResponse(200, { data: { redirectUrl } }));
-    captureAssign();
-
-    const result = await redirectToAgentWebUI("agent-1");
-
-    expect(result).toEqual({ ok: true, redirectUrl });
-    expect(assignedUrls).toEqual([redirectUrl]);
-    expect(fetchCalls).toEqual([
-      { url: "/api/v1/eliza/agents/agent-1/pairing-token", method: "POST" },
+  it("mixed shared + dedicated org → chat-home", () => {
+    const route = decideAppModeRoute([
+      agent({ id: "s1", executionTier: "shared" }),
+      agent({ id: "d1" }),
     ]);
-  });
-
-  it("automatic entry REPLACES history; an explicit pick pushes", async () => {
-    // The gate is a transient "connecting" screen. Left in history, Back from
-    // the agent UI re-enters it, mints another one-time pairing token, and
-    // bounces forward — trapping the user. An explicit chooser pick is a real
-    // navigation the user should be able to back out of.
-    const redirectUrl = "https://agent-1.elizacloud.ai/pair?token=tok";
-    const seen: Array<"assign" | "replace"> = [];
-    appModeNavigation.assign = () => {
-      seen.push("assign");
-    };
-    appModeNavigation.replace = () => {
-      seen.push("replace");
-    };
-
-    stubFetch(() => jsonResponse(200, { data: { redirectUrl } }));
-    await redirectToAgentWebUI("agent-1");
-    expect(seen).toEqual(["replace"]);
-
-    stubFetch(() => jsonResponse(200, { data: { redirectUrl } }));
-    await redirectToAgentWebUI("agent-1", "user-initiated");
-    expect(seen).toEqual(["replace", "assign"]);
-  });
-
-  it("202 (agent must resume first) → starting result, no navigation", async () => {
-    stubFetch(() =>
-      jsonResponse(202, { data: { status: "starting", retryAfterMs: 5000 } }),
-    );
-    captureAssign();
-
-    const result = await redirectToAgentWebUI("agent-1");
-
-    expect(result).toEqual({ ok: false, starting: true });
-    expect(assignedUrls).toEqual([]);
-  });
-
-  it("error status → the server's error message, no navigation", async () => {
-    stubFetch(() => jsonResponse(503, { error: "agent not reachable" }));
-    captureAssign();
-
-    const result = await redirectToAgentWebUI("agent-1");
-
-    expect(result).toEqual({
-      ok: false,
-      starting: false,
-      error: "agent not reachable",
-    });
-    expect(assignedUrls).toEqual([]);
-  });
-
-  it("non-JSON error body → HTTP-status fallback message", async () => {
-    stubFetch(() => new Response("<html>bad gateway</html>", { status: 502 }));
-    captureAssign();
-
-    const result = await redirectToAgentWebUI("agent-1");
-
-    expect(result).toEqual({
-      ok: false,
-      starting: false,
-      error: "Failed to generate pairing token (HTTP 502)",
-    });
-    expect(assignedUrls).toEqual([]);
-  });
-
-  it("200 without a redirectUrl → explicit error, no navigation", async () => {
-    stubFetch(() => jsonResponse(200, { data: {} }));
-    captureAssign();
-
-    const result = await redirectToAgentWebUI("agent-1");
-
-    expect(result.ok).toBe(false);
-    if (result.ok || result.starting) throw new Error("expected error result");
-    expect(result.error).toMatch(/no redirect url/i);
-    expect(assignedUrls).toEqual([]);
-  });
-
-  it("transport failure → error result, never a throw", async () => {
-    fetchCalls = [];
-    globalThis.fetch = (() =>
-      Promise.reject(new Error("network down"))) as typeof fetch;
-    captureAssign();
-
-    const result = await redirectToAgentWebUI("agent-1");
-
-    expect(result).toEqual({
-      ok: false,
-      starting: false,
-      error: "network down",
-    });
-    expect(assignedUrls).toEqual([]);
+    expect(route).toEqual({ kind: "chat-home" });
   });
 });

--- a/packages/ui/src/cloud/app-mode/app-mode.ts
+++ b/packages/ui/src/cloud/app-mode/app-mode.ts
@@ -1,10 +1,23 @@
 /**
  * App-mode: hostname detection and entry-routing decisions for the Eliza app
  * hosts (app.elizacloud.ai / app-staging.elizacloud.ai). The same packages/app
- * bundle serves the apex console AND the app hosts; on the app hosts the entry
- * must BECOME the product — a signed-in visitor is routed straight into their
- * dedicated agent's own web UI via the pairing-token flow instead of landing in
- * the generic same-origin shell.
+ * bundle serves the apex console AND the app hosts; on the app hosts the
+ * same-origin chat app IS the product, so entry always lands there (the
+ * "chat floor"): signed-in visitors get the chat app immediately, and the only
+ * entry navigation left is the `/join` deploy-first-agent flow for an org with
+ * no agents at all.
+ *
+ * Entry deliberately performs NO pairing redirect into a per-agent web UI.
+ * The previous entry gate minted a one-time pairing token (60s TTL) and
+ * full-page-redirected into `<agentId>.elizacloud.ai/pair?token=…` whenever the
+ * org had a running dedicated agent. A dedicated container that is cold
+ * starting (or `running` in the DB but not yet serving) cannot consume the
+ * token inside its TTL, so entry dead-ended on the agent's "Sign-in link
+ * expired" page — a guaranteed trap on every cold start. Until pairing is
+ * re-introduced as a health-gated background hop (probe the agent, mint the
+ * token only once the agent is confirmed consuming), entering a dedicated
+ * agent's own web UI stays an explicit user action (the Instances console's
+ * "Open Web UI"), never an entry-time redirect.
  *
  * Every app-mode hostname check lives here (mirroring `../shell/apex-host.ts`
  * for the apex set); never scatter `window.location.hostname` comparisons —
@@ -18,7 +31,6 @@ import type {
   AgentSandboxStatus,
   IsoDateString,
 } from "@elizaos/cloud-shared/lib/types/cloud-api";
-import { apiWithStatus } from "../lib/api-client";
 
 /** Production + staging Eliza app hosts (the staging Pages deploy serves the
  * identical bundle on `app-staging.*`, so staging must mirror prod behavior). */
@@ -57,7 +69,9 @@ export function isAppModeHost(): boolean {
 }
 
 /** Minimal structural slice of `AgentListItemDto` the routing decision needs
- * (assignable from the full DTO; test fixtures stay small). */
+ * (assignable from the full DTO; test fixtures stay small). The lifecycle
+ * fields are retained for the planned health-gated background pairing layer;
+ * the entry decision itself only branches on org emptiness. */
 export interface AppModeAgent {
   id: string;
   agentName: string | null;
@@ -67,71 +81,44 @@ export interface AppModeAgent {
   updatedAt: IsoDateString;
 }
 
-/** Where the instances console lives — the manage surface an explicit user
- * action (the "Go to your instances" escape, the 202 wake-progress landing)
- * may navigate to. A registered cloud route, reachable on every host. Entry
- * routing itself never lands here: the app host is the product, and evicting
- * a visitor to the console because their agent is stopped or errored buries
- * the app under the dashboard (the exact app-staging regression this
- * distinction exists for). */
-export const APP_MODE_INSTANCES_PATH = "/dashboard/agents";
 /** The deploy-first-agent flow: `/join` select-or-provisions a Cloud agent and
  * drops the user straight into chat. */
 export const APP_MODE_CREATE_PATH = "/join";
 
 export type AppModeRoute =
-  /** Exactly one running dedicated agent — straight into its web UI via pairing. */
-  | { kind: "enter-agent"; agent: AppModeAgent }
-  /** Several running dedicated agents — minimal chooser, most recent first. */
-  | { kind: "choose-agent"; running: AppModeAgent[] }
   /** No agents at all — the `/join` deploy-first-agent flow. */
   | { kind: "create"; to: string }
-  /** No pairing target right now (shared-tier-only org, or dedicated agents
-   * that are stopped/errored/starting) — the existing same-origin chat app
-   * stays home, exactly as before app-mode. On the app hosts the entry must
-   * stay INSIDE the app: bouncing to the console instances page here is what
-   * made app-staging "redirect to the dashboard" whenever an org's only
-   * dedicated agent wasn't running. */
+  /** The org has agents (any tier, any lifecycle state) — the same-origin
+   * chat app is home. This is the chat floor: entry never bounces to the
+   * console and never pairing-redirects into a per-agent web UI, because a
+   * cold-starting agent cannot consume a 60s one-time pairing token and the
+   * redirect dead-ends on "Sign-in link expired" (the app-staging cold-start
+   * regression this floor exists for). */
   | { kind: "chat-home" };
-
-function activityStamp(agent: AppModeAgent): number {
-  const stamp = Date.parse(agent.lastHeartbeatAt ?? agent.updatedAt);
-  return Number.isNaN(stamp) ? 0 : stamp;
-}
 
 /**
  * Given the org's agents (GET /api/v1/eliza/agents), decide where app-mode
- * entry lands. Only dedicated-capable tiers (everything but `"shared"`) are
- * pairing candidates: shared-tier agents serve chat through the control-plane
- * REST adapter and have no per-agent subdomain to redirect into, so a
- * shared-only org keeps the same-origin chat app ({@link AppModeRoute}
- * `chat-home`) instead of a pairing call that cannot succeed.
+ * entry lands: any agents → the same-origin chat app; none → `/join`.
  *
- * Dedicated agents that are NOT running (stopped, sleeping, errored,
- * provisioning-failed) also resolve to `chat-home`: there is no web UI to
- * pair into yet, and the same-origin chat app — the app host's pre-app-mode
- * behavior — degrades gracefully, while a `/dashboard/agents` navigation
- * would replace the product with the console. Managing/resuming instances
- * remains an explicit action (the chooser, the error escape button, the
- * dashboard origin itself), never the silent entry default.
+ * The chat app serves every tier the same way at entry. Shared-tier agents
+ * chat through the control-plane REST adapter; dedicated agents chat through
+ * the same-origin surface too, regardless of whether their container is
+ * running, starting, stopped, or errored — a non-running container has no
+ * reachable web UI, and a "running" one may still be cold, so no lifecycle
+ * state makes an entry-time redirect safe. Entering the per-agent web UI is
+ * an explicit user action from the Instances console.
  */
 export function decideAppModeRoute(
   agents: readonly AppModeAgent[],
 ): AppModeRoute {
-  const dedicated = agents.filter((a) => a.executionTier !== "shared");
-  const running = dedicated
-    .filter((a) => a.status === "running")
-    .sort((a, b) => activityStamp(b) - activityStamp(a));
-
-  if (running.length === 1) return { kind: "enter-agent", agent: running[0] };
-  if (running.length > 1) return { kind: "choose-agent", running };
   if (agents.length > 0) return { kind: "chat-home" };
   return { kind: "create", to: APP_MODE_CREATE_PATH };
 }
 
 /**
- * Indirection over `window.location.assign` so tests can observe the redirect
- * (jsdom forbids stubbing `location.assign` directly).
+ * Indirection over `window.location.assign` so tests can observe redirects
+ * (jsdom forbids stubbing `location.assign` directly). Used by the SSO bridge
+ * (`../sso-bridge/sso-bridge`) for its full-page bounce.
  */
 export const appModeNavigation = {
   assign(url: string): void {
@@ -141,88 +128,3 @@ export const appModeNavigation = {
     window.location.replace(url);
   },
 };
-
-export type PairingRedirectResult =
-  | { ok: true; redirectUrl: string }
-  /** 202 — the agent must resume first; the server has queued the wake. */
-  | { ok: false; starting: true }
-  | { ok: false; starting: false; error: string };
-
-function pairingErrorMessage(payload: unknown, status: number): string {
-  if (typeof payload === "object" && payload !== null) {
-    const body = payload as { error?: unknown; message?: unknown };
-    if (typeof body.error === "string" && body.error) return body.error;
-    if (typeof body.message === "string" && body.message) return body.message;
-  }
-  return `Failed to generate pairing token (HTTP ${status})`;
-}
-
-/**
- * Send the user INTO a dedicated agent's web UI with a FULL-PAGE redirect.
- *
- * Same pairing-token endpoint as `openWebUIWithPairing`
- * (`../instances/lib/open-web-ui.ts`) but via `window.location.assign` instead
- * of a popup: automatic entry runs outside a click handler, where popups are
- * blocked and full-page navigation is not. Rides {@link apiWithStatus} — the
- * canonical status-branching transport for endpoints whose HTTP status IS the
- * protocol (202 = "agent must resume first") — so auth (steward cookie +
- * Bearer) matches every other cloud call.
- */
-export async function redirectToAgentWebUI(
-  agentId: string,
-  /**
-   * Automatic entry replaces the gate in history: the gate page is a
-   * transient "connecting" state, and leaving it in history traps the user
-   * (Back from the agent UI re-enters the gate, which mints another one-time
-   * pairing token and bounces forward again). An explicit chooser click is a
-   * real navigation the user should be able to back out of.
-   */
-  navigation: "automatic" | "user-initiated" = "automatic",
-): Promise<PairingRedirectResult> {
-  try {
-    const { status, data } = await apiWithStatus<unknown>(
-      `/api/v1/eliza/agents/${encodeURIComponent(agentId)}/pairing-token`,
-      { method: "POST" },
-    );
-
-    if (status === 202) {
-      return { ok: false, starting: true };
-    }
-
-    if (status < 200 || status >= 300) {
-      return {
-        ok: false,
-        starting: false,
-        error: pairingErrorMessage(data, status),
-      };
-    }
-
-    const redirectUrl =
-      typeof data === "object" && data !== null
-        ? (data as { data?: { redirectUrl?: unknown } }).data?.redirectUrl
-        : undefined;
-    if (typeof redirectUrl !== "string" || !redirectUrl) {
-      return {
-        ok: false,
-        starting: false,
-        error: "No redirect URL returned from the pairing endpoint",
-      };
-    }
-
-    if (navigation === "automatic") {
-      appModeNavigation.replace(redirectUrl);
-    } else {
-      appModeNavigation.assign(redirectUrl);
-    }
-    return { ok: true, redirectUrl };
-  } catch (err) {
-    // error-policy:J4 network/transport failure becomes the gate's visibly
-    // distinct "connection failed" state with an escape to Instances — the
-    // entry must degrade to a navigable screen, never rethrow into a blank one.
-    return {
-      ok: false,
-      starting: false,
-      error: err instanceof Error ? err.message : String(err),
-    };
-  }
-}

--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -2,7 +2,7 @@
 // @vitest-environment jsdom
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
 import { appModeNavigation } from "../app-mode/app-mode";
@@ -273,16 +273,14 @@ describe("CloudRouterShell app-mode catch-all (app.elizacloud.ai)", () => {
     expect(screen.queryByTestId("agent-app")).toBeNull();
   });
 
-  it("routes a signed-in app-host visitor with one running dedicated agent into its web UI via pairing", async () => {
+  it("keeps a signed-in app-host visitor with one running dedicated agent in the same-origin chat app (chat floor: no pairing token, no redirect)", async () => {
+    // Regression pin for the cold-start dead-end: the previous gate minted a
+    // one-time 60s pairing token here and full-page-redirected into the
+    // per-agent /pair URL; a cold-starting container cannot consume the token
+    // inside its TTL, so entry dead-ended on "Sign-in link expired". Entry
+    // must render the chat app and issue zero pairing traffic.
     setHostname("app.elizacloud.ai");
-    const redirectUrl = "https://agent-1.elizacloud.ai/pair?token=tok";
     installFetchRecorder((url, init) => {
-      if (url === "/api/v1/eliza/agents/agent-1/pairing-token") {
-        return new Response(JSON.stringify({ data: { redirectUrl } }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
-      }
       if (url === "/api/v1/eliza/agents" && (init?.method ?? "GET") === "GET") {
         return new Response(
           JSON.stringify({
@@ -307,8 +305,6 @@ describe("CloudRouterShell app-mode catch-all (app.elizacloud.ai)", () => {
       });
     });
     assignedUrls = [];
-    // Both seams feed one log: automatic entry replaces history, an explicit
-    // chooser pick pushes; the split itself is pinned in app-mode.test.ts.
     appModeNavigation.assign = (url: string) => {
       assignedUrls.push(url);
     };
@@ -318,11 +314,11 @@ describe("CloudRouterShell app-mode catch-all (app.elizacloud.ai)", () => {
     localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken(FUTURE_EXP));
     renderCatchAllWithAppModeMarkers();
 
-    await waitFor(() => expect(assignedUrls).toEqual([redirectUrl]));
-    expect(fetchLog).toContain(
-      "POST /api/v1/eliza/agents/agent-1/pairing-token",
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
+    expect(fetchLog.filter((line) => line.includes("pairing-token"))).toEqual(
+      [],
     );
-    expect(screen.queryByTestId("agent-app")).toBeNull();
+    expect(assignedUrls).toEqual([]);
   });
 
   it("app-staging.elizacloud.ai is an app-mode host too (staging mirrors prod)", async () => {

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -279,10 +279,11 @@ const APEX_AUTHENTICATED_HOME = "/dashboard";
  *
  * On the Eliza APP hosts (app.elizacloud.ai / app-staging — checked AFTER the
  * apex branch, so apex behavior is untouched) the catch-all renders the
- * app-mode entry gate instead: signed-in visitors are routed into their
- * dedicated agent via the pairing flow (see `../app-mode/AppModeEntryRoute`),
- * and only its `chat-home` decision falls through to the agent app. The gate
- * chunk is lazy so no app-mode code loads on any other host.
+ * app-mode entry gate instead: signed-in visitors land in the same-origin
+ * chat app (the chat floor — see `../app-mode/AppModeEntryRoute`; entry never
+ * pairing-redirects into a per-agent web UI), and an org with no agents at
+ * all is sent to the `/join` deploy-first-agent flow. The gate chunk is lazy
+ * so no app-mode code loads on any other host.
  *
  * Every other host (per-agent subdomains, localhost) is untouched: chat stays
  * home.


### PR DESCRIPTION
## The regression (the next one in the same entry gate)

Shadow QA'd app-staging after #18005 and hit the next dead end in the same entry flow: signing in on app-staging showed "cold start, take some time", then the entry gate pairing-redirected to `<agentId>.staging.elizacloud.ai/pair?token=…`, which rendered **"Sign-in link expired: Pairing links are single-use and only valid for a minute."** Dead end, every time the agent is not warm.

Root cause: the entry gate redirects the moment the control plane says the dedicated agent's row is `running` — but `running` in the DB does not mean the container is serving. The pairing token is one-time with a 60s TTL (`packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts` → `expiresIn: 60`), and the agent-side `/pair` exchange (`packages/agent/src/api/cloud-pair-route.ts`) can only run once the container is actually up and can reach the cloud API. A cold-starting container cannot consume the token inside the TTL, so the entry redirect is a guaranteed trap on every cold start. #18005 fixed the dedicated-but-not-running bounce; this closes the running-but-cold one.

## The fix (per operator direction: the chat floor)

Entry on the app hosts now ALWAYS lands signed-in visitors in the same-origin chat app — the pre-#17752 behavior, restored as the guaranteed floor:

- `decideAppModeRoute` collapses to two outcomes: **any agents → `chat-home`** (the same-origin chat app renders immediately, whatever the lifecycle state — running, cold, stopped, errored), **no agents → `/join`** (unchanged).
- The entry-time pairing redirect, the multi-agent chooser interstitial, and `redirectToAgentWebUI` are removed from the entry path entirely. Zero pairing tokens are minted at entry, so no token can expire uncomsumed.
- Entering a dedicated agent's own web UI remains an explicit user action (the Instances console "Open Web UI" flow, `../instances/lib/open-web-ui.ts`, untouched).
- Auth gating, the SSO auto-bridge, `returnTo` login round-trip, and every apex-console behavior are unchanged.

Design note for @NubsCarson: this is the third iteration on your #17752 entry gate, and it implements Shadow's explicit direction after QA ("entry must just work like before"). Your app-mode vision — warm agent means the visitor lands straight in their agent — is right, and we're keeping it: the follow-up PR layers pairing back on top of this floor as a **health-gated background hop** (render chat first, probe the agent's actual health in the background, mint the token only once the agent is confirmed able to consume it, then do the `location.replace` hop with your history hygiene; cold agents get a "waking up" affordance in-app instead of a doomed redirect). This PR is deliberately the minimal shippable floor so staging QA is unblocked tonight; happy to pair on the health-gated layer.

## Bidirectional proof

The new `AppModeEntryRoute.test.tsx` suite run against the develop-tip gate (the exact files from `origin/develop`, imports rewired, same fixtures): **3 failed / 8 passed** — the running-agent tests fail on develop because the old gate mints the pairing token and redirects. Against this head: **11/11 pass**. Full log attached in the evidence rows (`chatfloor-bidirectional-before.txt` inside frontend logs bundle).

Local QA at this head: `packages/ui` app-mode + router-shell suites 55/55 pass, `tsc --noEmit` clean, biome clean.

# Evidence Gate

<!-- evidence-head:c3052ffc8991d0f3dff6a0e6831209bf7c7baf51 -->

<!-- evidence-row:before-screenshots -->
- [x] Before (develop tip gate, the exact `app-mode.ts`/`AppModeEntryRoute.tsx` from `origin/develop` extracted verbatim and mounted in real Chromium against the cold-start org state: 1 dedicated agent, control-plane row `running`, container cold) — entry mints the one-time 60s pairing token and redirects into the per-agent `/pair` URL, dead-ending on "Sign-in link expired": desktop ![before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18016-chatfloor-before-desktop.jpg) mobile ![before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18016-chatfloor-before-mobile.jpg)

<!-- evidence-row:after-screenshots -->
- [x] After (this head) — same org state: zero pairing tokens minted, zero redirects, the same-origin chat app renders and the router stays on `/`: desktop ![after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18016-chatfloor-after-desktop.jpg) mobile ![after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18016-chatfloor-after-mobile.jpg) plus the intact empty-org `/join` branch ![after empty org](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18016-chatfloor-after-empty-org-desktop.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] before (pairing redirect → expired dead end) → after (chat floor) → after with empty org (/join), real-browser render of the real gate component both sides: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18016-chatfloor-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend-only routing change; no server code path is touched by this diff (the pairing-token endpoint and agent-side /pair route are unmodified — entry simply no longer calls them).

<!-- evidence-row:frontend-logs -->
- [x] [18016-chatfloor-frontend-logs-combined.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18016-chatfloor-frontend-logs-combined.txt) — the bidirectional unit run (this PR's suite vs the develop-tip gate: 3 failed / 8 passed; the running-agent pins fail on develop because it mints the token and redirects) plus the real-Chromium console + network trace of every capture (agents 200 with the cold `running` agent, the before-side `pairing-token MINTED (#1) — one-time, 60s TTL` line, the redirect capture, and 18/18 in-page assertions including the mint-count checks).

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - client-side entry routing only; no model, prompt, provider, action, or inference behavior participates in this diff.

<!-- evidence-row:domain-artifacts -->
- [x] [18016-chatfloor-unit-suite.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18016-chatfloor-unit-suite.txt) — the full app-mode + router-shell unit run at this head: 55/55 pass (`app-mode.test.ts` 23, `AppModeEntryRoute.test.tsx` 11 incl. the running-but-cold zero-pairing pins, SSO 5, `CloudRouterShell.test.tsx` 16 apex guard). Plus the develop-side failing run: [18016-chatfloor-bidirectional-before.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18016-chatfloor-bidirectional-before.txt)

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review — tesseract 5.3.4 text readout of all five attached captures checked against the intended copy of each state (before: the agent-side "Sign-in link expired" page verbatim; after: `SAME-ORIGIN CHAT APP` + `router location: /`; empty org: `/JOIN`): [18016-chatfloor-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18016-chatfloor-ocr-review.txt)

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `moltbot`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
