### PR TITLE
feat(registry): add The Syndicate — agent-playable city game with oracle-priced loot

### DIFF
--- a/packages/registry/entries/third-party/plugin-syndicate.json
+++ b/packages/registry/entries/third-party/plugin-syndicate.json
@@ -1,0 +1,49 @@
+{
+  "package": "plugin-syndicate",
+  "repository": "github:sailorpepe/plugin-syndicate",
+  "kind": "app",
+  "description": "Run a crime family in The Syndicate: a deterministic, turn-based city where the loot is real trading cards priced by a live on-chain oracle. Agents and humans share one world and one leaderboard.",
+  "homepage": "https://play.the-undesirables.com",
+  "version": "0.1.0",
+  "tags": [
+    "game",
+    "agent-gameplay",
+    "strategy",
+    "trading-cards",
+    "oracle",
+    "deterministic"
+  ],
+  "app": {
+    "displayName": "The Syndicate",
+    "category": "game",
+    "launchType": "connect",
+    "launchUrl": "https://play.the-undesirables.com",
+    "icon": "https://play.the-undesirables.com/favicon.png",
+    "heroImage": "https://play.the-undesirables.com/og-image.png",
+    "capabilities": [
+      "agent-gameplay",
+      "bounded-autonomy",
+      "spectate-and-steer",
+      "real-market-data",
+      "deterministic-replay"
+    ],
+    "minPlayers": 1,
+    "maxPlayers": null,
+    "runtimePlugin": "plugin-syndicate",
+    "viewer": {
+      "url": "https://play.the-undesirables.com",
+      "postMessageAuth": false,
+      "sandbox": "allow-scripts allow-same-origin allow-popups"
+    },
+    "session": {
+      "mode": "spectate-and-steer",
+      "features": [
+        "commands",
+        "telemetry",
+        "suggestions"
+      ]
+    },
+    "visibleInAppStore": true,
+    "catalogSection": "other"
+  }
+}

--- a/packages/registry/entries/third-party/plugin-syndicate.json
+++ b/packages/registry/entries/third-party/plugin-syndicate.json
@@ -4,7 +4,7 @@
   "kind": "app",
   "description": "Run a crime family in The Syndicate: a deterministic, turn-based city where the loot is real trading cards priced by a live on-chain oracle. Agents and humans share one world and one leaderboard.",
   "homepage": "https://play.the-undesirables.com",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "tags": [
     "game",
     "agent-gameplay",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1580,7 +1580,7 @@
         "repo": "plugin-syndicate",
         "v0": null,
         "v1": null,
-        "v2": "0.1.0"
+        "v2": "0.1.1"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1563,6 +1563,85 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "plugin-syndicate": {
+      "git": {
+        "repo": "sailorpepe/plugin-syndicate",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "plugin-syndicate",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Run a crime family in The Syndicate: a deterministic, turn-based city where the loot is real trading cards priced by a live on-chain oracle. Agents and humans share one world and one leaderboard.",
+      "homepage": "https://play.the-undesirables.com",
+      "topics": [
+        "game",
+        "agent-gameplay",
+        "strategy",
+        "trading-cards",
+        "oracle",
+        "deterministic"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "app",
+      "registryKind": "app",
+      "directory": null,
+      "app": {
+        "displayName": "The Syndicate",
+        "category": "game",
+        "launchType": "connect",
+        "launchUrl": "https://play.the-undesirables.com",
+        "icon": "https://play.the-undesirables.com/favicon.png",
+        "heroImage": "https://play.the-undesirables.com/og-image.png",
+        "capabilities": [
+          "agent-gameplay",
+          "bounded-autonomy",
+          "spectate-and-steer",
+          "real-market-data",
+          "deterministic-replay"
+        ],
+        "minPlayers": 1,
+        "maxPlayers": null,
+        "runtimePlugin": "plugin-syndicate",
+        "viewer": {
+          "url": "https://play.the-undesirables.com",
+          "postMessageAuth": false,
+          "sandbox": "allow-scripts allow-same-origin allow-popups"
+        },
+        "session": {
+          "mode": "spectate-and-steer",
+          "features": [
+            "commands",
+            "telemetry",
+            "suggestions"
+          ]
+        },
+        "visibleInAppStore": true,
+        "catalogSection": "other"
+      }
+    },
     "plugin-wallettriage": {
       "git": {
         "repo": "wallettriage/plugin-wallettriage",


### PR DESCRIPTION
Adds an app entry for **The Syndicate** — a deterministic, turn-based city game that agents play through a public HTTP API, alongside human players, on one shared world and leaderboard. Follows the process in `packages/registry/README.md`.

**Play:** https://play.the-undesirables.com · **Rules for models:** https://play.the-undesirables.com/SKILL.md

## Why it is a real game for agents, not a chat toy

- **Deterministic, server-authoritative engine.** The whole simulation is a pure `resolveDay(state, orders, seed)` over a seeded RNG with per-subsystem substreams. Agents submit order intents; the server resolves them with a seed the client never sees. Every run is replayable.
- **Loot has a real price.** Cards dropped in-game are priced from a live on-chain TCG oracle over a 449K+ card database — not invented numbers.
- **Legible state.** Every response discloses the combat formula, each target's effective defense, which targets are beatable solo vs. with a squad, and which crew member is strongest.
- **One leaderboard.** Humans and agents compete on the same board; agent entries are flagged with their model.

## Runtime plugin

[`plugin-syndicate`](https://www.npmjs.com/package/plugin-syndicate) ([repo](https://github.com/sailorpepe/plugin-syndicate)) — 4 actions (`SYNDICATE_NEW`, `SYNDICATE_STATE`, `SYNDICATE_MOVE`, `SYNDICATE_LEADERBOARD`). The full 25-verb gameplay vocabulary flows through `SYNDICATE_MOVE`'s order batch. No client-side simulation. Verified end-to-end against production: new → state → move → error paths. 13-test suite; 15s timeouts; expired-session recovery; a cached-state context provider (zero extra API calls).

## Verify without installing

The game this entry lists is playable right now from a hosted MCP connector — no auth, no API key: **https://mcp.the-undesirables.com** (`syndicate_state`, `syndicate_move`, `syndicate_leaderboard`), or plain HTTP per [SKILL.md](https://play.the-undesirables.com/SKILL.md). A reviewer can start a session, submit orders, and read the resolved day in under a minute.

## Checklist

- [x] `kind: "app"` with the full `app` block (schema `allOf` rule)
- [x] `session.mode` / `features` use schema enum values only
- [x] `icon` (256×256 PNG) and `heroImage` (1200×630 PNG) both serve HTTP 200
- [x] `runtimePlugin` is honest: installing `plugin-syndicate` actually lets an agent play
- [x] `version` 0.1.1 is [live on npm](https://www.npmjs.com/package/plugin-syndicate/v/0.1.1)
- [x] `bun run --cwd packages/registry validate` — 37 entries validated
- [x] `bun run --cwd packages/registry generate` — `generated-registry.json` regenerated and included

Note: this branch and the plugin-undesirables entry PR each regenerate `generated-registry.json` from `develop`; whichever merges second will be rebased and regenerated.


