### PR TITLE
fix(ci): pin the client perf gate to its calibrated runner class

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -288,6 +288,39 @@ jobs:
       - name: Remote capability UI smoke
         run: bun run test:remote-capabilities:ui
 
+  # Perf gate (#9954) runs in its own job pinned to GitHub-hosted ubuntu-24.04:
+  # FRAME_GATE_RELAYOUT budgets are calibrated to that runner class, and the
+  # contended hetzner-robot fleet breaches them on hardware grounds alone
+  # (#18021). Keep this job hosted until the budgets carry per-runner-class
+  # calibration.
+  client-perf-gate:
+    name: Client Perf Gate
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.client == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Install Playwright Chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
+
       # Perf gate (#9954): drive REAL overlay thread-scroll + pull-to-maximize /
       # top-pull-restore in headless chromium, feed REAL rAF/longtask/layout-shift
       # entries through the shared frame-budget + layout-stability detectors,
@@ -1279,6 +1312,7 @@ jobs:
       - merge-quality-gate
       - server-tests
       - client-tests
+      - client-perf-gate
       - plugin-tests-status
       - integration-tests
       - desktop-contract
@@ -1303,6 +1337,7 @@ jobs:
           echo "merge-quality-gate:${{ needs.merge-quality-gate.result }}"
           echo "server-tests:     ${{ needs.server-tests.result }}"
           echo "client-tests:     ${{ needs.client-tests.result }}"
+          echo "client-perf-gate: ${{ needs.client-perf-gate.result }}"
           echo "plugin-tests:     ${{ needs.plugin-tests-status.result }}"
           echo "integration-tests:${{ needs.integration-tests.result }}"
           echo "desktop-contract: ${{ needs.desktop-contract.result }}"
@@ -1320,6 +1355,7 @@ jobs:
             "merge-quality-gate:${{ needs.merge-quality-gate.result }}" \
             "server-tests:${{ needs.server-tests.result }}" \
             "client-tests:${{ needs.client-tests.result }}" \
+            "client-perf-gate:${{ needs.client-perf-gate.result }}" \
             "plugin-tests:${{ needs.plugin-tests-status.result }}" \
             "integration-tests:${{ needs.integration-tests.result }}" \
             "desktop-contract:${{ needs.desktop-contract.result }}" \


### PR DESCRIPTION
## Problem

The Perf gate e2e (#9954) step inside Client Tests fails on every develop `test.yml` run since the `HETZNER_FLEET_ONLINE` flip: `[maximize-restore] median p95 66.7ms ≤ 41.7ms, dropped 41% < 35%`. Investigation in #18021 showed this is runner-class miscalibration, not a code regression: the `FRAME_GATE_RELAYOUT` budgets are explicitly calibrated to GitHub-hosted `ubuntu-24.04` (every green execution ever ran there), the gate had never executed on hetzner-robot hardware before Aug 7, and a local A/B at last-green vs tip passes both comfortably (p95 33.4ms). `overlay-scroll` stays perfect on the robots — only the whole-panel re-layout gesture doubles in cost on the contended fleet.

## Fix

Split the perf-gate step (and its artifact upload) out of Client Tests into a new `client-perf-gate` job pinned to `ubuntu-24.04`, same path gating (`changes.outputs.client`), wired into `ci-ok`'s needs/echo/results loop. No budget was changed — the gate keeps its teeth on the hardware it was calibrated against, per option 2 of #18021. Client Tests keeps its Playwright install (the remote-capability UI smoke uses it).

## Evidence

<!-- evidence-head:ef209f78dad13e91b8c40982e4a7793977876501 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow topology change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow topology change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - CI workflow topology change; no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Attribution evidence in #18021: last-green run 30918919172 (ubuntu-24.04, Aug 4); first-ever hetzner execution run 31221532988 failed immediately; rerun 31225309259 failed identically on a different robot; local A/B at last-green 32085063148 vs tip 676f1f5713d both PASS (p95 33.4ms, dropped 17-24%).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM invoked.
<!-- evidence-row:domain-artifacts -->
- [x] The gate step itself is unchanged (same run command, same artifact upload); `python3 yaml.safe_load` validates the workflow parses. The develop run on this merge will exercise the new job for real.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes

Refs #18021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)