### PR TITLE
fix(core): unmask provider 400 bodies and persist the failing model request

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -324,7 +324,11 @@ import {
 } from "./utils/context-routing";
 import { buildDeterministicSeed, shortStringHash } from "./utils/deterministic";
 import { getNumberEnv } from "./utils/environment";
-import { getErrorMessage, isTransientModelError } from "./utils/model-errors";
+import {
+	getErrorMessage,
+	isTransientModelError,
+	modelProviderErrorDetail,
+} from "./utils/model-errors";
 import { captureModelLookupCaller } from "./utils/model-lookup-caller";
 import { PromptBatcher, PromptDispatcher } from "./utils/prompt-batcher";
 import { getOptimizationRootDir } from "./utils/state-dir";
@@ -7736,7 +7740,26 @@ export class AgentRuntime implements IAgentRuntime {
 			// Mark the response as a sanitized failure, not a success payload, so
 			// downstream readers/agents can distinguish billed-but-failed attempts
 			// from real outputs. Secrets are stripped to keep the trajectory safe.
-			const sanitizedMessage = this.redactSecrets(errorMessage);
+			// The provider's own diagnostic (status + body message) is appended:
+			// SDK error messages degrade to the bare statusText for providers with
+			// non-OpenAI error envelopes, and without the body detail a failed
+			// attempt reads as an uninvestigable "Bad Request".
+			const providerDetail = modelProviderErrorDetail(args.error);
+			const detailSuffix = providerDetail
+				? `${
+						providerDetail.providerMessage &&
+						!errorMessage.includes(providerDetail.providerMessage)
+							? ` | provider: ${providerDetail.providerMessage}`
+							: ""
+					}${
+						providerDetail.status !== undefined
+							? ` | status: ${providerDetail.status}`
+							: ""
+					}`
+				: "";
+			const sanitizedMessage = this.redactSecrets(
+				`${errorMessage}${detailSuffix}`,
+			);
 			const activeTrace = this.getActiveTrace(this.getCurrentRunId());
 			trajLogger.logLlmCall({
 				stepId,
@@ -7749,7 +7772,13 @@ export class AgentRuntime implements IAgentRuntime {
 					typeof paramsRecord.prompt === "string"
 						? paramsRecord.prompt
 						: userPrompt,
-				messages: undefined,
+				// The failed request's messages ARE the evidence: without them a
+				// provider rejection (schema, shape, encoding) cannot be replayed or
+				// diagnosed from the trajectory. Same privacy surface as the
+				// successful-call record, which already persists messages.
+				messages: Array.isArray(paramsRecord.messages)
+					? (paramsRecord.messages as unknown[])
+					: undefined,
 				tools: paramsRecord.tools,
 				toolChoice: paramsRecord.toolChoice,
 				responseSchema: paramsRecord.responseSchema,

--- a/packages/core/src/runtime/__tests__/evaluator-errored-stage.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator-errored-stage.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Covers the evaluator's errored-stage evidence contract: when the post-tool
+ * evaluator MODEL CALL itself throws (the live failure mode is an intermittent
+ * provider 400 whose request was previously persisted nowhere), runEvaluator
+ * must record an `evaluation` stage carrying the REQUEST messages and the
+ * provider's real error detail before rethrowing. Deterministic — mocked
+ * useModel/recorder, no live model.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { runEvaluator } from "../evaluator";
+import type { RecordedStage } from "../trajectory-recorder";
+
+function providerBadRequest(): Error {
+	return Object.assign(new Error("Bad Request"), {
+		statusCode: 400,
+		responseBody:
+			'{"message":"Encountered a server error, please try again","type":"server_error"}',
+		url: "https://api.cerebras.ai/v1/chat/completions",
+	});
+}
+
+const CONTEXT = {
+	id: "ctx",
+	staticPrefix: {
+		characterPrompt: { content: "agent_name: Eliza", stable: true },
+	},
+	events: [
+		{
+			id: "msg",
+			type: "message",
+			message: { role: "user", content: { text: "remember my color." } },
+		},
+	],
+};
+
+const TRAJECTORY = {
+	context: { id: "ctx" },
+	steps: [
+		{
+			iteration: 1,
+			thought: "",
+			toolCall: {
+				id: "tool-1-0",
+				name: "MEMORY_CREATE",
+				params: { text: "favorite color is teal" },
+			},
+			result: { success: true, text: "Stored memory abc." },
+		},
+	],
+	archivedSteps: [],
+	plannedQueue: [],
+	evaluatorOutputs: [],
+};
+
+describe("runEvaluator — errored evaluation stage evidence", () => {
+	it("records the request messages and provider detail, then rethrows", async () => {
+		const recorded: Array<{ trajectoryId: string; stage: RecordedStage }> = [];
+		const recorder = {
+			recordStage: vi.fn(async (trajectoryId: string, stage: RecordedStage) => {
+				recorded.push({ trajectoryId, stage });
+			}),
+		};
+		const runtime = {
+			useModel: vi.fn(async () => {
+				throw providerBadRequest();
+			}),
+		};
+
+		await expect(
+			runEvaluator({
+				runtime,
+				recorder: recorder as never,
+				trajectoryId: "tj-test",
+				iteration: 1,
+				context: CONTEXT,
+				trajectory: TRAJECTORY,
+				effects: {},
+			}),
+		).rejects.toThrow("Bad Request");
+
+		expect(recorded).toHaveLength(1);
+		const stage = recorded[0]?.stage;
+		expect(recorded[0]?.trajectoryId).toBe("tj-test");
+		expect(stage?.kind).toBe("evaluation");
+		// The REQUEST is the evidence: system/user context plus the
+		// assistant/tool step pair the failing call carried.
+		const messages = stage?.model?.messages ?? [];
+		expect(messages.length).toBeGreaterThanOrEqual(4);
+		expect(messages[0]?.role).toBe("system");
+		const roles = messages.map((m) => m.role);
+		expect(roles).toContain("assistant");
+		expect(roles).toContain("tool");
+		// The provider's real diagnostic (recovered from responseBody) is on the
+		// recorded response, not just the masked statusText.
+		expect(String(stage?.model?.response ?? "")).toContain(
+			"evaluator model call failed",
+		);
+		expect(String(stage?.model?.response ?? "")).toContain("please try again");
+		expect(String(stage?.model?.response ?? "")).toContain("400");
+		// The failure is marked as a non-decision so downstream consumers cannot
+		// mistake it for a model verdict.
+		expect(stage?.evaluation?.protocolFailure).toBe(true);
+	});
+
+	it("does not swallow the model error when no recorder is attached", async () => {
+		const runtime = {
+			useModel: vi.fn(async () => {
+				throw providerBadRequest();
+			}),
+		};
+		await expect(
+			runEvaluator({
+				runtime,
+				context: CONTEXT,
+				trajectory: TRAJECTORY,
+				effects: {},
+			}),
+		).rejects.toThrow("Bad Request");
+	});
+});

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -17,6 +17,7 @@ import {
 	ModelType,
 	type PromptSegment,
 } from "../types/model";
+import { modelProviderErrorDetail } from "../utils/model-errors";
 import { computePrefixHashes } from "./context-hash";
 import {
 	buildStageChatMessages,
@@ -123,26 +124,67 @@ export async function runEvaluator(
 	};
 	const startedAt = Date.now();
 	const modelType = params.modelType ?? ModelType.RESPONSE_HANDLER;
-	const raw = await runWithStreamingContext(
-		streamingContext
-			? {
-					...streamingContext,
-					onStreamChunk: async () => undefined,
-				}
-			: undefined,
-		() =>
-			params.runtime.useModel(
-				modelType,
-				{
-					messages: renderedInput.messages,
-					maxTokens: DEFAULT_EVALUATOR_MAX_TOKENS,
-					responseSchema: evaluatorSchema,
-					promptSegments: renderedInput.promptSegments,
-					providerOptions,
-				},
-				params.provider,
-			),
-	);
+	let raw: Awaited<ReturnType<EvaluatorRuntime["useModel"]>>;
+	try {
+		raw = await runWithStreamingContext(
+			streamingContext
+				? {
+						...streamingContext,
+						onStreamChunk: async () => undefined,
+					}
+				: undefined,
+			() =>
+				params.runtime.useModel(
+					modelType,
+					{
+						messages: renderedInput.messages,
+						maxTokens: DEFAULT_EVALUATOR_MAX_TOKENS,
+						responseSchema: evaluatorSchema,
+						promptSegments: renderedInput.promptSegments,
+						providerOptions,
+					},
+					params.provider,
+				),
+		);
+	} catch (error) {
+		// error-policy:J2 context-adding rethrow — the evaluator model call is
+		// the one whose REQUEST is otherwise never persisted: on success the
+		// stage records below, but a provider failure (e.g. an intermittent
+		// Cerebras 400) used to leave the trajectory with no evaluation stage at
+		// all, making the failing request undiagnosable. Record the errored
+		// stage WITH the request messages and the provider's real error detail,
+		// then rethrow for the planner-loop's degrade/propagate policy.
+		const detail = modelProviderErrorDetail(error);
+		await recordEvaluationStage({
+			runtime: params.runtime,
+			recorder: params.recorder,
+			trajectoryId: params.trajectoryId,
+			parentStageId: params.parentStageId,
+			iteration: params.iteration ?? 1,
+			modelType: String(modelType),
+			provider: params.provider,
+			messages: renderedInput.messages,
+			providerOptions,
+			raw: `[evaluator model call failed] ${
+				error instanceof Error ? error.message : String(error)
+			}${detail?.providerMessage ? ` | provider: ${detail.providerMessage}` : ""}${
+				detail?.status !== undefined ? ` | status: ${detail.status}` : ""
+			}`,
+			output: {
+				success: false,
+				decision: "CONTINUE",
+				thought: "Evaluator model call failed before producing output.",
+				protocolFailure: true,
+				raw: {},
+			},
+			startedAt,
+			endedAt: Date.now(),
+			segmentHashes: prefixHashes.map((entry) => entry.segmentHash),
+			prefixHash,
+			logger: params.runtime.logger,
+		});
+		throw error;
+	}
 	const endedAt = Date.now();
 	const output = sanitizeOutputMessage(
 		repairFinishedToolTurnWithoutUserMessage(

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -40,7 +40,10 @@ import {
 	type ToolChoice,
 	type ToolDefinition,
 } from "../types/model";
-import { isModelProviderError } from "../utils/model-errors";
+import {
+	isModelProviderError,
+	modelProviderErrorDetail,
+} from "../utils/model-errors";
 import { resolveStateDir } from "../utils/state-dir";
 import { isPlainObject } from "../utils/type-guards";
 import { computePrefixHashes, stableJsonStringify } from "./context-hash";
@@ -1201,7 +1204,13 @@ async function runPlannerLoopIterations(
 			const relay = deterministicSuccessfulToolRelay(trajectory);
 			if (!relay) throw err;
 			params.runtime.logger?.warn?.(
-				{ iteration, err: err instanceof Error ? err.message : String(err) },
+				{
+					iteration,
+					err: err instanceof Error ? err.message : String(err),
+					...(modelProviderErrorDetail(err)
+						? { providerErrorDetail: modelProviderErrorDetail(err) }
+						: {}),
+				},
 				"[planner-loop] post-tool evaluator model call failed; relaying the completed tool result instead of discarding the turn",
 			);
 			return {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -308,6 +308,7 @@ import {
 	getUserMessageText,
 	stripAugmentationForPersistence,
 } from "../utils/message-text";
+import { modelProviderErrorDetail } from "../utils/model-errors";
 import { readEnv } from "../utils/read-env";
 import {
 	extractFirstSentence,
@@ -11707,18 +11708,27 @@ export class DefaultMessageService implements IMessageService {
 				}
 				const errMsg = error instanceof Error ? error.message : String(error);
 				const errStack = error instanceof Error ? error.stack : undefined;
+				// Provider failures often surface with a masked statusText message
+				// ("Bad Request") while the actionable cause lives on the AI SDK
+				// error's responseBody — carry it so the failure is diagnosable
+				// from logs and RECENT_ERRORS without a wire capture.
+				const providerErrorDetail = modelProviderErrorDetail(error);
 				runtime.logger.warn(
 					{
 						src: "service:message",
 						agentId: runtime.agentId,
 						error: errMsg,
 						stack: errStack,
+						...(providerErrorDetail ? { providerErrorDetail } : {}),
 					},
 					"v5 message runtime failed",
 				);
 				runtime.reportError("MessageService.v5Runtime", error, {
 					entityId: message.entityId,
 					roomId: message.roomId,
+					...(providerErrorDetail
+						? { providerError: providerErrorDetail as JsonValue }
+						: {}),
 				});
 				// Mirror to process.stderr so bench / orchestrator runs can see
 				// the underlying cause when runtime.logger output is buffered or

--- a/packages/core/src/utils/model-errors.test.ts
+++ b/packages/core/src/utils/model-errors.test.ts
@@ -4,7 +4,11 @@
  * Deterministic — plain constructed error shapes, no live model.
  */
 import { describe, expect, it } from "vitest";
-import { isModelProviderError, modelProviderErrorStatus } from "./model-errors";
+import {
+	isModelProviderError,
+	modelProviderErrorDetail,
+	modelProviderErrorStatus,
+} from "./model-errors";
 
 function withStatus(status: number, message = "err"): Error {
 	const err = new Error(message) as Error & { statusCode: number };
@@ -89,5 +93,80 @@ describe("isModelProviderError", () => {
 
 	it("is FALSE for a sub-400 status", () => {
 		expect(isModelProviderError(withStatus(200))).toBe(false);
+	});
+});
+
+describe("modelProviderErrorDetail", () => {
+	function apiCallError(args: {
+		message?: string;
+		statusCode?: number;
+		responseBody?: string;
+		url?: string;
+	}): Error {
+		return Object.assign(new Error(args.message ?? "Bad Request"), {
+			statusCode: args.statusCode,
+			responseBody: args.responseBody,
+			url: args.url,
+		});
+	}
+
+	it("recovers the FLAT Cerebras error shape the AI SDK masks to statusText", () => {
+		// Live signature: Cerebras returns {"message","type","param","code"} with
+		// no OpenAI {"error":{...}} wrapper, so APICallError.message is the bare
+		// "Bad Request" while the actionable cause sits on responseBody.
+		const detail = modelProviderErrorDetail(
+			apiCallError({
+				statusCode: 400,
+				responseBody:
+					'{"message":": Invalid JSON: lone leading surrogate in hex escape at line 1 column 135","type":"invalid_request_error","param":"validation_error","code":"wrong_api_format"}',
+				url: "https://api.cerebras.ai/v1/chat/completions",
+			}),
+		);
+		expect(detail).toBeDefined();
+		expect(detail?.status).toBe(400);
+		expect(detail?.providerMessage).toContain("lone leading surrogate");
+		expect(detail?.responseBodyExcerpt).toContain("wrong_api_format");
+		expect(detail?.url).toContain("cerebras");
+	});
+
+	it("recovers the OpenAI error envelope shape", () => {
+		const detail = modelProviderErrorDetail(
+			apiCallError({
+				statusCode: 400,
+				responseBody:
+					'{"error":{"message":"context_length_exceeded: reduce your prompt","type":"invalid_request_error"}}',
+			}),
+		);
+		expect(detail?.providerMessage).toContain("context_length_exceeded");
+	});
+
+	it("keeps a bounded excerpt of a non-JSON body instead of dropping it", () => {
+		const detail = modelProviderErrorDetail(
+			apiCallError({
+				statusCode: 400,
+				responseBody: `<html>upstream gateway rejected ${"x".repeat(1000)}</html>`,
+			}),
+		);
+		expect(detail?.providerMessage).toBeUndefined();
+		expect(detail?.responseBodyExcerpt).toContain("upstream gateway rejected");
+		expect(detail?.responseBodyExcerpt?.length).toBeLessThanOrEqual(400);
+	});
+
+	it("walks the RetryError/cause chain for the body", () => {
+		const retry = new Error("retries exhausted") as Error & {
+			lastError: unknown;
+		};
+		retry.lastError = apiCallError({
+			statusCode: 400,
+			responseBody: '{"message":"please try again"}',
+		});
+		expect(modelProviderErrorDetail(retry)?.providerMessage).toBe(
+			"please try again",
+		);
+	});
+
+	it("is undefined when the chain carries neither status nor body", () => {
+		expect(modelProviderErrorDetail(new Error("plain"))).toBeUndefined();
+		expect(modelProviderErrorDetail(undefined)).toBeUndefined();
 	});
 });

--- a/packages/core/src/utils/model-errors.ts
+++ b/packages/core/src/utils/model-errors.ts
@@ -109,6 +109,100 @@ export function modelProviderErrorStatus(error: unknown): number | undefined {
 }
 
 /**
+ * Structured diagnostic detail for a model/provider failure: the HTTP status,
+ * the provider's own error message parsed out of the response body, and a
+ * bounded excerpt of that body. The AI SDK keeps the raw body on
+ * `APICallError.responseBody` but derives `error.message` from the OpenAI
+ * `{"error": {...}}` envelope only — providers that return a FLAT error shape
+ * (Cerebras: `{"message", "type", "param", "code"}`) surface as a bare
+ * statusText ("Bad Request") with the real cause silently dropped. This
+ * extractor recovers that cause so reportError context, logs, and trajectory
+ * records can carry it.
+ */
+export interface ModelProviderErrorDetail {
+	status?: number;
+	providerMessage?: string;
+	responseBodyExcerpt?: string;
+	url?: string;
+}
+
+const RESPONSE_BODY_EXCERPT_MAX_CHARS = 400;
+
+function providerMessageFromBody(body: string): string | undefined {
+	try {
+		const parsed = JSON.parse(body) as {
+			message?: unknown;
+			error?: { message?: unknown } | string;
+			detail?: unknown;
+		};
+		if (typeof parsed !== "object" || parsed === null) return undefined;
+		const candidates = [
+			parsed.message,
+			typeof parsed.error === "object" && parsed.error !== null
+				? parsed.error.message
+				: parsed.error,
+			parsed.detail,
+		];
+		for (const candidate of candidates) {
+			if (typeof candidate === "string" && candidate.trim().length > 0) {
+				return candidate.trim();
+			}
+		}
+		return undefined;
+	} catch {
+		// error-policy:J3 untrusted-input sanitizing — a non-JSON body has no
+		// structured message; the caller falls back to the raw excerpt.
+		return undefined;
+	}
+}
+
+/**
+ * Best-effort extraction of {@link ModelProviderErrorDetail} from a thrown
+ * model-call error, walking the same bounded `.cause`/`RetryError` graph as
+ * {@link modelProviderErrorStatus}. Returns undefined when the chain carries
+ * neither a status nor a response body, so callers can spread it into context
+ * objects without manufacturing empty fields.
+ */
+export function modelProviderErrorDetail(
+	error: unknown,
+): ModelProviderErrorDetail | undefined {
+	let status: number | undefined;
+	let providerMessage: string | undefined;
+	let responseBodyExcerpt: string | undefined;
+	let url: string | undefined;
+	for (const node of modelErrorChain(error)) {
+		status ??= readHttpStatus(node);
+		if (responseBodyExcerpt === undefined) {
+			const body = (node as { responseBody?: unknown }).responseBody;
+			if (typeof body === "string" && body.trim().length > 0) {
+				responseBodyExcerpt = body
+					.replace(/\s+/g, " ")
+					.trim()
+					.slice(0, RESPONSE_BODY_EXCERPT_MAX_CHARS);
+				providerMessage = providerMessageFromBody(body);
+			}
+		}
+		if (url === undefined) {
+			const rawUrl = (node as { url?: unknown }).url;
+			if (typeof rawUrl === "string" && rawUrl.length > 0) url = rawUrl;
+		}
+	}
+	if (
+		status === undefined &&
+		providerMessage === undefined &&
+		responseBodyExcerpt === undefined
+	) {
+		return undefined;
+	}
+	return {
+		...(status !== undefined ? { status } : {}),
+		...(providerMessage !== undefined ? { providerMessage } : {}),
+		...(responseBodyExcerpt !== undefined ? { responseBodyExcerpt } : {}),
+		...(url !== undefined ? { url } : {}),
+	};
+}
+
+/**
  * True when a thrown model-call error is an EXPECTED provider/transport failure
  * — the provider returned an HTTP error status (>= 400) or the request failed
  * at the network layer — as opposed to a programmer or schema-validation error

--- a/plugins/plugin-openai/__tests__/provider-error-enrichment.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/provider-error-enrichment.shape.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Shape tests for provider-error body recovery: `providerErrorBodyMessage` /
+ * `enrichProviderCallError` (unmasking the AI SDK's statusText-only message
+ * for providers with non-OpenAI error envelopes, e.g. Cerebras's flat
+ * `{"message","type","param","code"}` shape) and the transient-400 retry
+ * classifier reading the response body. Deterministic — constructed error
+ * objects, no live provider.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  __INTERNAL_enrichProviderCallError,
+  __INTERNAL_isTransientProviderError,
+  __INTERNAL_providerErrorBodyMessage,
+} from "../models/text";
+
+function apiCallError(args: {
+  message?: string;
+  statusCode?: number;
+  responseBody?: string;
+}): Error & { statusCode?: number; responseBody?: string } {
+  return Object.assign(new Error(args.message ?? "Bad Request"), {
+    statusCode: args.statusCode,
+    responseBody: args.responseBody,
+  });
+}
+
+const CEREBRAS_FLAT_400 =
+  '{"message":": Invalid JSON: lone leading surrogate in hex escape at line 1 column 135","type":"invalid_request_error","param":"validation_error","code":"wrong_api_format"}';
+
+describe("providerErrorBodyMessage", () => {
+  it("parses the flat Cerebras error shape", () => {
+    const error = apiCallError({ statusCode: 400, responseBody: CEREBRAS_FLAT_400 });
+    expect(__INTERNAL_providerErrorBodyMessage(error)).toContain("lone leading surrogate");
+  });
+
+  it("parses the OpenAI error envelope", () => {
+    const error = apiCallError({
+      statusCode: 400,
+      responseBody: '{"error":{"message":"model_not_found"}}',
+    });
+    expect(__INTERNAL_providerErrorBodyMessage(error)).toBe("model_not_found");
+  });
+
+  it("returns a bounded excerpt for a non-JSON body", () => {
+    const error = apiCallError({
+      statusCode: 400,
+      responseBody: `gateway says no ${"y".repeat(1000)}`,
+    });
+    const message = __INTERNAL_providerErrorBodyMessage(error);
+    expect(message).toContain("gateway says no");
+    expect((message ?? "").length).toBeLessThanOrEqual(300);
+  });
+
+  it("walks the cause chain", () => {
+    const wrapped = new Error("outer", {
+      cause: apiCallError({ statusCode: 400, responseBody: '{"message":"inner detail"}' }),
+    });
+    expect(__INTERNAL_providerErrorBodyMessage(wrapped)).toBe("inner detail");
+  });
+
+  it("is undefined without a body", () => {
+    expect(__INTERNAL_providerErrorBodyMessage(apiCallError({ statusCode: 400 }))).toBeUndefined();
+    expect(__INTERNAL_providerErrorBodyMessage(undefined)).toBeUndefined();
+  });
+});
+
+describe("enrichProviderCallError", () => {
+  it("appends the body message to a masked statusText message in place", () => {
+    const error = apiCallError({ statusCode: 400, responseBody: CEREBRAS_FLAT_400 });
+    const enriched = __INTERNAL_enrichProviderCallError(error) as Error;
+    expect(enriched).toBe(error);
+    expect(enriched.message).toContain("Bad Request");
+    expect(enriched.message).toContain("lone leading surrogate");
+  });
+
+  it("is idempotent — enriching twice does not duplicate the detail", () => {
+    const error = apiCallError({ statusCode: 400, responseBody: '{"message":"only once"}' });
+    __INTERNAL_enrichProviderCallError(error);
+    __INTERNAL_enrichProviderCallError(error);
+    expect(error.message.match(/only once/g)?.length).toBe(1);
+  });
+
+  it("leaves errors without a recoverable body untouched", () => {
+    const error = apiCallError({ statusCode: 400 });
+    expect((__INTERNAL_enrichProviderCallError(error) as Error).message).toBe("Bad Request");
+  });
+
+  it("passes through non-object errors", () => {
+    expect(__INTERNAL_enrichProviderCallError("boom")).toBe("boom");
+    expect(__INTERNAL_enrichProviderCallError(undefined)).toBeUndefined();
+  });
+});
+
+describe("isTransientProviderError with response bodies", () => {
+  it("classifies a Cerebras overload 400 as transient even when the message is masked", () => {
+    // The live failure signature: message is the bare statusText because the
+    // SDK could not parse the flat error shape; the transient wording lives
+    // only in the body. Before body-reading, this returned false and the
+    // documented transient-400 retry lane never engaged.
+    const error = apiCallError({
+      statusCode: 400,
+      responseBody:
+        '{"message":"Encountered a server error, please try again","type":"server_error"}',
+    });
+    expect(__INTERNAL_isTransientProviderError(error)).toBe(true);
+  });
+
+  it("keeps a genuine validation 400 non-transient (no retry masking)", () => {
+    const error = apiCallError({ statusCode: 400, responseBody: CEREBRAS_FLAT_400 });
+    expect(__INTERNAL_isTransientProviderError(error)).toBe(false);
+  });
+
+  it("keeps a body-less masked 400 non-transient", () => {
+    expect(__INTERNAL_isTransientProviderError(apiCallError({ statusCode: 400 }))).toBe(false);
+  });
+});

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -1607,6 +1607,75 @@ function applyUsageToDetails(
 // ============================================================================
 
 /**
+ * Recover the provider's own error message from a failed call's response body.
+ *
+ * The AI SDK's openai error handler only understands the OpenAI error
+ * envelope (`{"error": {"message": ...}}`). Cerebras's OpenAI-compatible
+ * endpoint returns a FLAT shape — `{"message", "type", "param", "code"}` — so
+ * `APICallError.message` degrades to the bare HTTP statusText ("Bad Request")
+ * while the actionable cause (e.g. `Invalid JSON: lone leading surrogate...`,
+ * `please try again`) survives only on `error.responseBody`. Walks the error
+ * and a bounded `.cause` chain for the first parseable body message; falls
+ * back to a bounded raw-body excerpt so even a non-JSON body is not lost.
+ */
+function providerErrorBodyMessage(error: unknown): string | undefined {
+  const seen = new Set<unknown>();
+  let node: unknown = error;
+  for (let depth = 0; depth < 5 && node && typeof node === "object" && !seen.has(node); depth++) {
+    seen.add(node);
+    const record = node as { responseBody?: unknown; cause?: unknown };
+    const body = typeof record.responseBody === "string" ? record.responseBody : undefined;
+    if (body && body.trim().length > 0) {
+      try {
+        const parsed = JSON.parse(body) as {
+          message?: unknown;
+          error?: { message?: unknown } | string;
+        };
+        const candidates = [
+          parsed?.message,
+          typeof parsed?.error === "object" && parsed.error !== null
+            ? parsed.error.message
+            : parsed?.error,
+        ];
+        for (const candidate of candidates) {
+          if (typeof candidate === "string" && candidate.trim().length > 0) {
+            return candidate.trim();
+          }
+        }
+      } catch {
+        // error-policy:J3 untrusted-input sanitizing — a non-JSON error body is
+        // still diagnostic; return a bounded excerpt instead of dropping it.
+      }
+      return body.replace(/\s+/g, " ").trim().slice(0, 300);
+    }
+    node = record.cause;
+  }
+  return undefined;
+}
+
+/**
+ * Append the provider's real error message (recovered from the response body)
+ * to a masked provider error IN PLACE, preserving the error's identity, stack,
+ * and AI SDK marker fields. Idempotent: a message that already carries the
+ * body text is left untouched. Every plugin-openai throw boundary funnels
+ * through this so "Bad Request" is never the only diagnostic that escapes.
+ */
+function enrichProviderCallError(error: unknown): unknown {
+  if (!error || typeof error !== "object") return error;
+  const record = error as { message?: unknown };
+  if (typeof record.message !== "string") return error;
+  const bodyMessage = providerErrorBodyMessage(error);
+  if (!bodyMessage || record.message.includes(bodyMessage)) return error;
+  try {
+    (error as { message: string }).message = `${record.message}: ${bodyMessage}`;
+  } catch {
+    // error-policy:J6 best-effort enrichment — a frozen error object keeps its
+    // original message; the body remains readable via responseBody.
+  }
+  return error;
+}
+
+/**
  * Whether a thrown model-call error is a transient provider hiccup that is
  * worth retrying. The AI SDK already retries clear-cut retryables (408/409/429/
  * 5xx) via its own `maxRetries`, but Cerebras under load returns its transient
@@ -1626,9 +1695,13 @@ function isTransientProviderError(error: unknown): boolean {
   const status = e.statusCode ?? e.status;
   if (status === 408 || status === 409 || status === 429) return true;
   if (typeof status === "number" && status >= 500 && status < 600) return true;
+  // Include the raw response body: the AI SDK derives `message` from the
+  // OpenAI `{"error":{...}}` envelope only, so a provider that reports its
+  // transient overload in a FLAT body (Cerebras) otherwise reads as a bare
+  // "Bad Request" here and the transient-400 lane below can never match.
   const msg = `${e.message ?? ""} ${JSON.stringify(e.data ?? "")} ${
     (e as { type?: string }).type ?? ""
-  }`.toLowerCase();
+  } ${providerErrorBodyMessage(error) ?? ""}`.toLowerCase();
   // No HTTP status: either a network-level failure OR a provider that returns
   // its transient error as a bare object (Cerebras passes
   // `{message:"Encountered a server error, please try again", type:"server_error"}`
@@ -1750,10 +1823,12 @@ async function generateTextWithTransientRetry(
         generateParams as Parameters<typeof generateText>[0]
         // biome-ignore lint/suspicious/noExplicitAny: see above.
       )) as any;
-    } catch (error) {
+    } catch (rawError) {
       // error-policy:J2 context-adding rethrow — terminal, retry-exhausted, or
-      // cancelled errors rethrow unchanged; only bounded transient provider
-      // errors on a still-live request retry.
+      // cancelled errors rethrow enriched with the provider's real body
+      // message; only bounded transient provider errors on a still-live
+      // request retry.
+      const error = enrichProviderCallError(rawError);
       if (attempt >= maxRetries || signal?.aborted || !isTransientProviderError(error)) {
         throw error;
       }
@@ -1828,10 +1903,12 @@ async function consumeStreamWithTransientRetry(
       const finishReason = (await result.finishReason) as string | undefined;
       if (capturedError) throw capturedError;
       return { text, toolCalls, usage, finishReason };
-    } catch (error) {
+    } catch (rawError) {
       // error-policy:J2 context-adding rethrow — terminal, retry-exhausted, or
-      // cancelled errors rethrow unchanged; only bounded transient provider
-      // errors on a still-live request retry.
+      // cancelled errors rethrow enriched with the provider's real body
+      // message; only bounded transient provider errors on a still-live
+      // request retry.
+      const error = enrichProviderCallError(rawError);
       if (attempt >= maxRetries || signal?.aborted || !isTransientProviderError(error)) {
         throw error;
       }
@@ -2107,6 +2184,10 @@ async function generateTextByModelType(
       // check here plus the abort-aware backoff below guarantee no attempt
       // starts after cancellation.
       const abortSignal = retryAbortSignal(generateParams);
+      // Enrich BEFORE classifying: a Cerebras transient 400 arrives with the
+      // masked "Bad Request" message, and only the response body carries the
+      // wording the transient classifier matches on.
+      capturedStreamError = enrichProviderCallError(capturedStreamError);
       if (
         !failedBeforeFirstToken ||
         attempt >= 5 ||
@@ -2264,11 +2345,11 @@ async function generateTextByModelType(
         } finally {
           await finalizeStreamingTelemetry();
         }
-        const streamError = streamIterationError ?? capturedStreamError ?? companionStreamError;
+        const streamError = enrichProviderCallError(
+          streamIterationError ?? capturedStreamError ?? companionStreamError
+        );
         settleStructuredText(streamError);
-        if (streamIterationError) throw streamIterationError;
-        if (capturedStreamError) throw capturedStreamError;
-        if (companionStreamError) throw companionStreamError;
+        if (streamError) throw streamError;
       })(),
       text: textPromise,
       ...(shouldReturnNativeResult ? { toolCalls: restoredToolCallsPromise } : {}),
@@ -2431,3 +2512,9 @@ export const __INTERNAL_normalizeNativeTools = normalizeNativeTools;
 export const __INTERNAL_normalizeNativeToolsForCall = normalizeNativeToolsForCall;
 /** @internal — exported for unit tests only. */
 export const __INTERNAL_restoreRecordArgToolCalls = restoreRecordArgToolCalls;
+/** @internal — exported for unit tests only. */
+export const __INTERNAL_providerErrorBodyMessage = providerErrorBodyMessage;
+/** @internal — exported for unit tests only. */
+export const __INTERNAL_enrichProviderCallError = enrichProviderCallError;
+/** @internal — exported for unit tests only. */
+export const __INTERNAL_isTransientProviderError = isTransientProviderError;


### PR DESCRIPTION
## Incident

On the nubilio deployment (cerebras openai-compat brain), ~30% of live tool-turns were dying with `finalDecision=error` — the user sees "something glitched. try again." Every failure was the **post-tool evaluator model call** rejected with HTTP 400 in 77–281 ms (attempt 1, `model:RESPONSE_HANDLER outcome:error` inside `evaluators:planner`), while the stage-1 and planner calls on the same turn succeeded. Reproduced on demand live (a single "remember that my favorite color is teal" probe errored the same way).

The error surfaced **everywhere** as a bare `AI_APICallError: Bad Request` — logs, `reportError`, trajectories — with no response body anywhere, which is what made the incident undiagnosable for a full day.

## Root cause of the missing diagnostics (this PR)

Two structural gaps:

1. **The AI SDK masks non-OpenAI error envelopes.** `@ai-sdk/openai`'s failed-response handler only parses `{"error": {...}}`. Cerebras returns a **flat** shape — `{"message", "type", "param", "code"}` — so `APICallError.message` degrades to the HTTP statusText (`"Bad Request"`) and the real cause survives only on `error.responseBody`, which nothing read. Verified live against api.cerebras.ai: a controlled invalid request returns `{"message":": Invalid JSON: lone leading surrogate in hex escape…","code":"wrong_api_format"}` and the SDK surfaces it as bare `Bad Request` (mock-server repro below).
   **Consequence:** plugin-openai's transient-400 retry lanes — built *specifically* for cerebras's documented under-load 400s ("Encountered a server error, please try again") — classify by `error.message`/`error.data` and could never match, so every such 400 hard-failed the turn on the first attempt instead of retrying.

2. **The failing request was persisted nowhere.** The evaluator records its trajectory stage only on success, and `recordFailedModelTrajectory` deliberately dropped `messages`. An errored turn's trajectory shows the successful planner + tool stages and then… nothing.

## Fix

**plugin-openai (`models/text.ts`)**
- `providerErrorBodyMessage()` / `enrichProviderCallError()`: recover the provider's real message from `responseBody` (flat + OpenAI envelope + bounded raw excerpt; walks the cause chain) and append it to the error message **in place** at every throw boundary — generate, buffered-stream, and live-stream lanes.
- `isTransientProviderError()` now also reads the response body, so transient-shaped 400s engage the existing typed-backoff retry lanes while validation-shaped 400s (`invalid`/`unsupported`/`schema`…) still surface immediately. No blanket retry-on-400.

**core**
- `utils/model-errors.ts`: `modelProviderErrorDetail()` — status / provider message / bounded body excerpt / url from the bounded error chain.
- `runtime/evaluator.ts`: a failed evaluator model call now records the **errored evaluation stage with the request messages** and provider detail before rethrowing — the next occurrence of this failure class is fully replayable from the trajectory file.
- `runtime.ts` `recordFailedModelTrajectory`: keeps `params.messages` (same privacy surface as the successful-call record) and appends the provider detail to the sanitized response.
- `services/message.ts` (v5Runtime catch) + `runtime/planner-loop.ts` (post-tool evaluator catch): attach `providerErrorDetail` to the warn + `reportError` context, so RECENT_ERRORS and logs name the real cause.

## Evidence

**Masking repro (mock server returning the exact cerebras flat 400 body), before → after:**
```
BEFORE (current develop / live build):
  ERROR name: AI_APICallError
  ERROR message: "Bad Request"            <- only diagnostic that escapes

AFTER (this branch):
  ERROR message: "Bad Request: : Invalid JSON: lone leading surrogate in hex escape at line 1 column 135"
  responseBody: {"message":"...","type":"invalid_request_error","param":"validation_error","code":"wrong_api_format"}
```

**Transient-400 recovery (mock flapping twice with cerebras's transient wording, then recovering) — the live-stream lane previously hard-failed on attempt 1, now:**
```
Warn [OpenAI] transient stream-start error, retrying (lane=stream-start, attempt=1, maxRetries=5, backoffMs=306, model=gemma-4-31b, reason=Bad Request: Encountered a server error, please try again)
Warn [OpenAI] transient stream-start error, retrying (lane=stream-start, attempt=2, maxRetries=5, backoffMs=759, ...)
ok recovered
```

**Ruled out while root-causing** (full replay harness against api.cerebras.ai with the live key + the recorded trajectories): request content (yesterday's + same-day errored turns replay 200 byte-faithfully, incl. via the real `trajectoryStepsToMessages`/`evaluatorTemplate` builders and the real plugin wire conversion), message shape (`content: null` + `tool_calls` + tool role without `tools` param replays 200), `stream`/`stream_options`/`prompt_cache_key`/`max_tokens`/`reasoning_effort`, AI SDK version drift (identical 6.0.174/3.0.58), and 8-way concurrency bursts. The provider rejection only manifests inside the live process — which is precisely why this PR makes the failing request and the provider's body land in the trajectory and error report: the next occurrence names itself.

## Tests

- `packages/core/src/utils/model-errors.test.ts` — `modelProviderErrorDetail` (flat cerebras shape, OpenAI envelope, non-JSON excerpt bounding, RetryError chain, undefined cases).
- `packages/core/src/runtime/__tests__/evaluator-errored-stage.test.ts` — errored evaluation stage records the request messages + provider detail and rethrows; no swallow without a recorder.
- `plugins/plugin-openai/__tests__/provider-error-enrichment.shape.test.ts` — body recovery, in-place idempotent enrichment, and transient classification from the body (transient wording ⇒ retry; `wrong_api_format` validation ⇒ no retry).
- Full plugin-openai unit suite (185 passed) + affected core suites (evaluator, planner-loop, planner-loop post-tool failure, honest-failure, message-failure-reply — 173 passed) + typecheck green on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:fa84458f68b1e5eea3ac69376494ae3ce169c949 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change (core error handling + plugin-openai provider boundary); no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change; no user-visible flow to walk through

<!-- evidence-row:backend-logs -->
- [x] [18024-backend-logs-18024.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18024-backend-logs-18024.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/client code in the diff

<!-- evidence-row:llm-trajectory -->
- [x] [18024-llm-trajectory-18024.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18024-llm-trajectory-18024.json)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain assets; deterministic unit tests cover the enrichment and errored-stage contracts



<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported
