### PR TITLE
fix(google-workspace): make connector oauth credentials survive restarts

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -180,7 +180,11 @@ import {
 import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared/contracts/service-routing";
 import { resolveDefaultVaultDataDir } from "@elizaos/vault";
 import { registerDesktopScreenCaptureBridgeService } from "./desktop-screen-capture-bridge-service.ts";
-import { type AgentHostBridge, getAgentHostBridge } from "./host-bridge.ts";
+import {
+  type AgentHostBridge,
+  getAgentHostBridge,
+  hasDurableHostVault,
+} from "./host-bridge.ts";
 
 // Host capabilities (wallet-key hydration, vault bootstrap/access, account
 // pool, build variant) are INJECTED downward by the app-core host via
@@ -4823,6 +4827,32 @@ export async function startEliza(
     }
   };
 
+  // Durable storage for connector OAuth credential refs. Connector plugins
+  // resolve `connector_credential_store` for BOTH the write at OAuth-callback
+  // time and the read after restart; without this service their token writes
+  // fall through to the in-memory SECRETS global store and die with the
+  // process (the dangling vaultRef then fails every post-restart credential
+  // read). Registered only when the host vault is real — wrapping the no-op
+  // default vault would swallow writes instead.
+  const registerConnectorCredentialStoreService = async (): Promise<void> => {
+    try {
+      if (!hasDurableHostVault()) {
+        logger.debug(
+          "[eliza] ConnectorCredentialStoreService skipped: no durable host vault",
+        );
+        return;
+      }
+      const { ConnectorCredentialStoreService } = await import(
+        "../services/connector-credential-store.ts"
+      );
+      await runtime.registerService(ConnectorCredentialStoreService);
+    } catch (err) {
+      logger.debug(
+        `[eliza] ConnectorCredentialStoreService registration skipped: ${formatError(err)}`,
+      );
+    }
+  };
+
   // Register the hosted-app run reader as a runtime service so the session gate
   // can query it via getService instead of statically importing the plugin
   // (which inverted the host→plugin dependency direction). Dynamic import keeps
@@ -5385,6 +5415,8 @@ export async function startEliza(
   const initializeRuntimeServices = async (): Promise<void> => {
     await registerConnectorSetupService();
     bootTimer.lap("svc:connector-setup");
+    await registerConnectorCredentialStoreService();
+    bootTimer.lap("svc:connector-credential-store");
     await registerAppSessionService();
     bootTimer.lap("svc:app-session");
     await registerRemoteCodingRunner();

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4853,6 +4853,26 @@ export async function startEliza(
     }
   };
 
+  // registerService is lazy — the instance is only created by the ASYNC
+  // service-load path, while connector plugins resolve the credential store
+  // with the SYNCHRONOUS runtime.getService(), which returns null for a
+  // registered-but-never-started service. That null silently demotes every
+  // connector OAuth credential write to the in-memory SECRETS fallback (lost
+  // on restart). Force the start once runtime.initialize() has resolved (the
+  // load path awaits initPromise, so forcing earlier would deadlock boot) and
+  // surface a failure loudly — a missing store is exactly the silent-token-
+  // loss condition this service exists to prevent.
+  const ensureConnectorCredentialStoreStarted = async (): Promise<void> => {
+    if (!hasDurableHostVault()) return;
+    try {
+      await runtime.getServiceLoadPromise("connector_credential_store");
+    } catch (err) {
+      logger.warn(
+        `[eliza] ConnectorCredentialStoreService failed to start; connector OAuth credential writes will fall back to non-durable storage: ${formatError(err)}`,
+      );
+    }
+  };
+
   // Register the hosted-app run reader as a runtime service so the session gate
   // can query it via getService instead of statically importing the plugin
   // (which inverted the host→plugin dependency direction). Dynamic import keeps
@@ -5440,6 +5460,8 @@ export async function startEliza(
 
     await initializeCoreRuntime();
     bootTimer.lap("svc:runtime.initialize");
+    await ensureConnectorCredentialStoreStarted();
+    bootTimer.lap("svc:connector-credential-store-start");
     await registerDesktopScreenCaptureBridgeService(runtime);
     bootTimer.lap("svc:desktop-screen-capture");
   };

--- a/packages/agent/src/runtime/host-bridge.ts
+++ b/packages/agent/src/runtime/host-bridge.ts
@@ -151,6 +151,16 @@ export function getAgentHostBridge(): AgentHostBridge {
   return installedBridge ?? defaultAgentHostBridge;
 }
 
+/**
+ * True when the active bridge supplies a real, durable host vault. The no-op
+ * default vault swallows writes and misses every read, so callers that would
+ * persist secrets through it (for example the connector credential store
+ * service) must treat it as absent rather than silently losing data.
+ */
+export function hasDurableHostVault(): boolean {
+  return getAgentHostBridge().sharedVault() !== noopVault;
+}
+
 /** Test-only: drop any installed bridge so the default is used again. */
 export function _resetAgentHostBridge(): void {
   installedBridge = null;

--- a/packages/agent/src/services/connector-credential-store.runtime.test.ts
+++ b/packages/agent/src/services/connector-credential-store.runtime.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Real-runtime regression coverage for the connector credential store's
+ * start semantics. `runtime.registerService` is LAZY — the instance is only
+ * created by the async service-load path — while connector plugins resolve
+ * the store with the SYNCHRONOUS `runtime.getService()`, which returns null
+ * for a registered-but-never-started service. On the live deployment that
+ * null silently demoted every connector OAuth credential write to the
+ * in-memory SECRETS fallback, and the tokens died with the process. These
+ * tests run against a real `AgentRuntime` with the real `@elizaos/plugin-sql`
+ * adapter (local mode, PGlite) — the same registry shape as the deployment —
+ * so the lazy-start trap cannot regress unnoticed again.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { AgentRuntime, type Plugin } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  _resetAgentHostBridge,
+  defaultAgentHostBridge,
+  setAgentHostBridge,
+} from "../runtime/host-bridge.ts";
+import { ConnectorCredentialStoreService } from "./connector-credential-store.ts";
+
+const SERVICE_TYPE = "connector_credential_store";
+
+function installBridgeWithVault(entries: Map<string, string>): void {
+  setAgentHostBridge({
+    ...defaultAgentHostBridge,
+    sharedVault: () =>
+      ({
+        set: async (key: string, value: string) => {
+          entries.set(key, value);
+        },
+        setIfAbsent: async (key: string, value: string) => {
+          if (entries.has(key)) return false;
+          entries.set(key, value);
+          return true;
+        },
+        setReference: async () => {},
+        get: async (key: string) => {
+          const value = entries.get(key);
+          if (value === undefined) throw new Error(`vault miss: ${key}`);
+          return value;
+        },
+        reveal: async (key: string) => {
+          const value = entries.get(key);
+          if (value === undefined) throw new Error(`vault miss: ${key}`);
+          return value;
+        },
+        has: async (key: string) => entries.has(key),
+        remove: async (key: string) => {
+          entries.delete(key);
+        },
+        quarantineUnreadable: async () => false,
+        list: async () => [],
+        describe: async () => null,
+        stats: async () => ({
+          total: 0,
+          sensitive: 0,
+          nonSensitive: 0,
+          references: 0,
+        }),
+      }) as ReturnType<typeof defaultAgentHostBridge.sharedVault>,
+  });
+}
+
+const activeRuntimes: AgentRuntime[] = [];
+const pgliteDirs: string[] = [];
+const originalPgliteDataDir = process.env.PGLITE_DATA_DIR;
+
+async function bootRuntime(
+  vaultEntries: Map<string, string>,
+): Promise<AgentRuntime> {
+  const pgliteDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-cred-store-"));
+  pgliteDirs.push(pgliteDir);
+  process.env.PGLITE_DATA_DIR = pgliteDir;
+
+  installBridgeWithVault(vaultEntries);
+
+  const runtime = new AgentRuntime({
+    character: { name: "CredStoreRuntime" },
+    plugins: [],
+    logLevel: "fatal",
+    enableAutonomy: false,
+  });
+  activeRuntimes.push(runtime);
+
+  const pluginSqlModule = (await import(
+    ["@elizaos", "plugin-sql"].join("/")
+  )) as {
+    default?: Plugin;
+    elizaPlugin?: Plugin;
+  };
+  const pluginSql = pluginSqlModule.default ?? pluginSqlModule.elizaPlugin;
+  if (!pluginSql) throw new Error("plugin-sql did not export a plugin");
+  await runtime.registerPlugin(pluginSql);
+  await runtime.initialize();
+  return runtime;
+}
+
+afterEach(async () => {
+  for (const runtime of activeRuntimes.splice(0)) {
+    try {
+      await runtime.stop();
+    } catch {
+      // already stopped
+    }
+  }
+  for (const dir of pgliteDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  if (originalPgliteDataDir === undefined) {
+    delete process.env.PGLITE_DATA_DIR;
+  } else {
+    process.env.PGLITE_DATA_DIR = originalPgliteDataDir;
+  }
+  _resetAgentHostBridge();
+});
+
+describe("ConnectorCredentialStoreService start semantics (real runtime)", () => {
+  it("is invisible to the synchronous getService until the load path starts it", async () => {
+    const runtime = await bootRuntime(new Map());
+    await runtime.registerService(ConnectorCredentialStoreService);
+
+    // The lazy-registration trap: registered, never started, sync-invisible.
+    // This exact null is what demoted live OAuth credential writes to the
+    // volatile SECRETS fallback. The boot funnel must force the start.
+    expect(runtime.getService(SERVICE_TYPE)).toBeNull();
+
+    await runtime.getServiceLoadPromise(SERVICE_TYPE);
+    expect(runtime.getService(SERVICE_TYPE)).not.toBeNull();
+  }, 120_000);
+
+  it("round-trips a credential across a full runtime restart via the started store", async () => {
+    const durableVault = new Map<string, string>();
+
+    const first = await bootRuntime(durableVault);
+    await first.registerService(ConnectorCredentialStoreService);
+    await first.getServiceLoadPromise(SERVICE_TYPE);
+    const writer = first.getService(
+      SERVICE_TYPE,
+    ) as ConnectorCredentialStoreService;
+    const vaultRef = await writer.putSecret({
+      agentId: first.agentId,
+      provider: "google",
+      accountId: "acct-restart",
+      credentialType: "oauth.tokens",
+      value: "restart-surviving-material",
+      caller: "runtime-test",
+    });
+    await first.stop();
+
+    // Restart: a brand-new runtime and service instance; only the vault
+    // backing store survives (as the real host vault does on disk).
+    const second = await bootRuntime(durableVault);
+    await second.registerService(ConnectorCredentialStoreService);
+    await second.getServiceLoadPromise(SERVICE_TYPE);
+    const reader = second.getService(
+      SERVICE_TYPE,
+    ) as ConnectorCredentialStoreService;
+    expect(await reader.get(vaultRef, { reveal: true })).toBe(
+      "restart-surviving-material",
+    );
+  }, 240_000);
+});

--- a/packages/agent/src/services/connector-credential-store.test.ts
+++ b/packages/agent/src/services/connector-credential-store.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit coverage for ConnectorCredentialStoreService: the vault-backed
+ * `connector_credential_store` runtime service and the host-bridge durability
+ * gate that decides whether it registers. Deterministic harness — the vault is
+ * an in-memory fake implementing the `@elizaos/vault` surface the service
+ * touches; no keychain or PGlite is involved.
+ */
+import type { Vault } from "@elizaos/vault";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  _resetAgentHostBridge,
+  defaultAgentHostBridge,
+  hasDurableHostVault,
+  setAgentHostBridge,
+} from "../runtime/host-bridge.ts";
+import {
+  buildConnectorCredentialVaultRef,
+  ConnectorCredentialStoreService,
+} from "./connector-credential-store.ts";
+
+function createFakeVault(): Vault & {
+  entries: Map<string, string>;
+  revealCalls: string[];
+} {
+  const entries = new Map<string, string>();
+  const revealCalls: string[] = [];
+  return {
+    entries,
+    revealCalls,
+    set: async (key: string, value: string) => {
+      entries.set(key, value);
+    },
+    setIfAbsent: async (key: string, value: string) => {
+      if (entries.has(key)) return false;
+      entries.set(key, value);
+      return true;
+    },
+    setReference: async () => {},
+    get: async (key: string) => {
+      const value = entries.get(key);
+      if (value === undefined) throw new Error(`vault miss: ${key}`);
+      return value;
+    },
+    reveal: async (key: string, caller?: string) => {
+      revealCalls.push(caller ?? "");
+      const value = entries.get(key);
+      if (value === undefined) throw new Error(`vault miss: ${key}`);
+      return value;
+    },
+    has: async (key: string) => entries.has(key),
+    remove: async (key: string) => {
+      entries.delete(key);
+    },
+    quarantineUnreadable: async () => false,
+    list: async () => [],
+    describe: async () => null,
+    stats: async () => ({
+      total: 0,
+      sensitive: 0,
+      nonSensitive: 0,
+      references: 0,
+    }),
+  } as Vault & { entries: Map<string, string>; revealCalls: string[] };
+}
+
+describe("ConnectorCredentialStoreService", () => {
+  it("round-trips putSecret → get/reveal/has → remove through the vault", async () => {
+    const vault = createFakeVault();
+    const service = new ConnectorCredentialStoreService(undefined, vault);
+
+    const vaultRef = await service.putSecret({
+      agentId: "agent-1",
+      provider: "google",
+      accountId: "acct-1",
+      credentialType: "oauth.tokens",
+      value: "token-material",
+      caller: "test",
+    });
+    expect(vaultRef).toBe("connector.agent-1.google.acct-1.oauth_tokens");
+    expect(await service.get(vaultRef)).toBe("token-material");
+    expect(await service.reveal(vaultRef, "test-reader")).toBe(
+      "token-material",
+    );
+    expect(vault.revealCalls).toContain("test-reader");
+    expect(await service.has(vaultRef)).toBe(true);
+
+    await service.remove(vaultRef);
+    expect(await service.has(vaultRef)).toBe(false);
+    await expect(service.get(vaultRef)).rejects.toThrow(/vault miss/);
+  });
+
+  it("honors an explicit vaultRef instead of deriving one", async () => {
+    const vault = createFakeVault();
+    const service = new ConnectorCredentialStoreService(undefined, vault);
+    const explicit = "connector.a.google.b.oauth_tokens";
+    const vaultRef = await service.putSecret({
+      vaultRef: explicit,
+      agentId: "ignored",
+      provider: "ignored",
+      accountId: "ignored",
+      credentialType: "ignored",
+      value: "v",
+    });
+    expect(vaultRef).toBe(explicit);
+    expect(vault.entries.has(explicit)).toBe(true);
+  });
+
+  it("normalizes vault ref segments deterministically", () => {
+    expect(
+      buildConnectorCredentialVaultRef({
+        agentId: "agent id!",
+        provider: "google",
+        accountId: "acct/1",
+        credentialType: "oauth.tokens",
+      }),
+    ).toBe("connector.agent_id.google.acct_1.oauth_tokens");
+  });
+});
+
+describe("hasDurableHostVault", () => {
+  afterEach(() => {
+    _resetAgentHostBridge();
+  });
+
+  it("is false for the no-op default bridge", () => {
+    _resetAgentHostBridge();
+    expect(hasDurableHostVault()).toBe(false);
+  });
+
+  it("is true when a host installs a bridge with a real vault", () => {
+    const vault = createFakeVault();
+    setAgentHostBridge({ ...defaultAgentHostBridge, sharedVault: () => vault });
+    expect(hasDurableHostVault()).toBe(true);
+  });
+});

--- a/packages/agent/src/services/connector-credential-store.ts
+++ b/packages/agent/src/services/connector-credential-store.ts
@@ -1,0 +1,128 @@
+/**
+ * ConnectorCredentialStoreService — the durable secret store behind connector
+ * OAuth credential refs. Connector plugins (google-workspace, github, slack,
+ * x, microsoft calendar) persist token material through the first runtime
+ * service they find under `connector_credential_store` and read it back
+ * through the same lookup after a restart; until this service existed nothing
+ * registered under that name, so those writes fell through to the core
+ * SECRETS service, whose global storage is process-memory only — every
+ * connector credential silently died with the process while its vaultRef
+ * pointer stayed behind in connector account storage.
+ *
+ * Backed by the host vault (`AgentHostBridge.sharedVault()`), which encrypts
+ * at rest and survives restarts. The boot funnel registers this service only
+ * when `hasDurableHostVault()` is true: wrapping the no-op default vault
+ * would swallow writes and lose credentials immediately, which is strictly
+ * worse than the SECRETS fallback it replaces.
+ *
+ * The read/write surface mirrors the `ConnectorCredentialStore` contract in
+ * `@elizaos/plugin-sql` (`putSecret`/`get`/`has`/`remove`) plus `reveal`,
+ * which credential resolvers probe first when reading refs.
+ */
+
+import { type IAgentRuntime, logger, Service } from "@elizaos/core";
+import type { Vault } from "@elizaos/vault";
+import { getAgentHostBridge } from "../runtime/host-bridge.ts";
+
+export const CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPE =
+  "connector_credential_store";
+
+const CALLER_FALLBACK = "connector-credential-store";
+
+export interface ConnectorCredentialPutSecretParams {
+  vaultRef?: string;
+  agentId: string;
+  provider: string;
+  accountId: string;
+  credentialType: string;
+  value: string;
+  caller?: string;
+}
+
+export class ConnectorCredentialStoreService extends Service {
+  static serviceType = CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPE;
+  capabilityDescription =
+    "Durable, encrypted-at-rest storage for connector OAuth credentials referenced by vaultRef";
+
+  private readonly vault: Vault;
+
+  constructor(runtime?: IAgentRuntime, vault?: Vault) {
+    super(runtime);
+    this.vault = vault ?? getAgentHostBridge().sharedVault();
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<Service> {
+    const instance = new ConnectorCredentialStoreService(runtime);
+    logger.debug("[connector-credential-store] Service started");
+    return instance;
+  }
+
+  async stop(): Promise<void> {}
+
+  /** Write a credential value under its vaultRef; returns the ref used. */
+  async putSecret(params: ConnectorCredentialPutSecretParams): Promise<string> {
+    const vaultRef =
+      params.vaultRef ?? buildConnectorCredentialVaultRef(params);
+    await this.vault.set(vaultRef, params.value, {
+      sensitive: true,
+      caller: params.caller ?? CALLER_FALLBACK,
+    });
+    return vaultRef;
+  }
+
+  /** Read a credential value by vaultRef; throws on a vault miss. */
+  async get(
+    vaultRef: string,
+    options?: { reveal?: boolean; caller?: string },
+  ): Promise<string> {
+    if (options?.reveal && this.vault.reveal) {
+      return this.vault.reveal(vaultRef, options.caller ?? CALLER_FALLBACK);
+    }
+    return this.vault.get(vaultRef);
+  }
+
+  /** Reveal a sensitive credential value by vaultRef (audit-logged). */
+  async reveal(vaultRef: string, caller?: string): Promise<string> {
+    if (this.vault.reveal) {
+      return this.vault.reveal(vaultRef, caller ?? CALLER_FALLBACK);
+    }
+    return this.vault.get(vaultRef);
+  }
+
+  async has(vaultRef: string): Promise<boolean> {
+    return this.vault.has(vaultRef);
+  }
+
+  async remove(vaultRef: string): Promise<void> {
+    await this.vault.remove(vaultRef);
+  }
+}
+
+/**
+ * Deterministic vault key for a connector credential:
+ * `connector.<agentId>.<provider>.<accountId>.<credentialType>`. Mirrors
+ * `buildConnectorCredentialVaultRef` in `@elizaos/plugin-sql` so refs written
+ * by either side resolve identically.
+ */
+export function buildConnectorCredentialVaultRef(params: {
+  agentId: string;
+  provider: string;
+  accountId: string;
+  credentialType: string;
+}): string {
+  return [
+    "connector",
+    normalizeVaultSegment(params.agentId),
+    normalizeVaultSegment(params.provider),
+    normalizeVaultSegment(params.accountId),
+    normalizeVaultSegment(params.credentialType),
+  ].join(".");
+}
+
+function normalizeVaultSegment(value: string): string {
+  const normalized = value
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return (normalized || "unknown").slice(0, 64);
+}

--- a/packages/core/src/connectors/account-manager.test.ts
+++ b/packages/core/src/connectors/account-manager.test.ts
@@ -301,4 +301,36 @@ describe("ConnectorAccountManager", () => {
 			reason: "owner binding has not been verified",
 		});
 	});
+
+	it("fails a flow whose PKCE verifier died with a restart instead of forwarding a doomed exchange", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const runtime = makeRuntime(adapter);
+		const manager = getConnectorAccountManager(runtime);
+		const exchange = vi.fn();
+		manager.registerProvider({
+			provider: "oauth-restart",
+			startOAuth: () => ({ authUrl: "https://auth.example/start" }),
+			completeOAuth: exchange,
+		});
+
+		// Exactly what a restart leaves behind: a durable flow row whose
+		// codeVerifierRef points at a process-local PKCE secret that no longer
+		// exists in this process.
+		await adapter.createOAuthFlowState?.({
+			state: "state-restart-1",
+			provider: "oauth-restart",
+			codeVerifierRef: "connector-oauth-pkce:gone-after-restart",
+			metadata: { status: "pending", flowId: "oauth_restart_1" },
+		});
+
+		const result = await manager.completeOAuth("oauth-restart", {
+			state: "state-restart-1",
+			code: "auth-code-1",
+		});
+		expect(result.flow.status).toBe("failed");
+		expect(result.flow.error).toMatch(/before the agent restarted/i);
+		expect(result.flow.error).toMatch(/start the oauth flow again/i);
+		expect(exchange).not.toHaveBeenCalled();
+	});
 });

--- a/packages/core/src/connectors/account-manager.ts
+++ b/packages/core/src/connectors/account-manager.ts
@@ -1471,6 +1471,26 @@ export class ConnectorAccountManager extends Service {
 			return { flow: failed ?? flow };
 		}
 
+		// PKCE verifiers live only in a process-local map (never persisted, so
+		// stored flow rows carry no raw secret) while flow state itself is
+		// durable. A flow minted before a restart therefore arrives here with a
+		// codeVerifierRef whose verifier no longer exists; exchanging the code
+		// without it can only produce an opaque provider 400 ("invalid code
+		// verifier"). Fail the flow with an explicit re-mint message instead of
+		// forwarding a doomed exchange.
+		const codeVerifierRef = stringMetadataValue(
+			flow.metadata,
+			"codeVerifierRef",
+		);
+		if (codeVerifierRef && !flow.codeVerifier) {
+			const failed = await this.storage.updateOAuthFlow(providerId, flow.id, {
+				status: "failed",
+				error:
+					"This authorization link was created before the agent restarted, so its one-time PKCE secret no longer exists. Start the OAuth flow again and use the fresh link.",
+			});
+			return { flow: failed ?? flow };
+		}
+
 		const registered = this.providers.get(providerId);
 		if (!registered?.completeOAuth) {
 			throw new Error(

--- a/plugins/plugin-google-workspace/src/connector-credential-refs.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-credential-refs.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Writer/reader parity coverage for connector credential persistence: proves
+ * that a credential persisted through `persistConnectorCredentialRefs` is
+ * readable by `DefaultGoogleCredentialResolver` after a simulated process
+ * restart, for every service name the writer can target. Deterministic
+ * harness — the runtime, credential store, vault, and SECRETS services are
+ * in-memory fakes shaped like their production counterparts; "restart" means
+ * new runtime/service instances sharing only the durable backing maps
+ * (connector account storage rows and the vault store), exactly what survives
+ * a real process restart.
+ */
+import type { ConnectorAccount, ConnectorAccountStorage, IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES,
+  CONNECTOR_VAULT_SERVICE_TYPES,
+  persistConnectorCredentialRefs,
+} from "./connector-credential-refs.js";
+import { DefaultGoogleCredentialResolver } from "./credential-resolver.js";
+
+const AGENT_ID = "6f110aa9-c169-0e10-8a4f-b4cca439be25";
+const ACCOUNT_ID = "3a899cd0-170f-4b3e-932e-46ec68119b35";
+const TOKENS_JSON = JSON.stringify({
+  access_token: "test-access-token",
+  refresh_token: "test-refresh-token",
+  token_type: "Bearer",
+  scope: "https://www.googleapis.com/auth/gmail.readonly",
+  expiry_date: Date.now() + 3_600_000,
+});
+
+interface CredentialRefRow {
+  credentialType: string;
+  vaultRef: string;
+  metadata?: Record<string, unknown>;
+  expiresAt?: number;
+}
+
+/** Durable rows that survive a "restart" — stands in for the SQL adapter. */
+interface DurableState {
+  accounts: Map<string, ConnectorAccount>;
+  credentialRefs: Map<string, CredentialRefRow>;
+  vaultEntries: Map<string, string>;
+}
+
+function newDurableState(): DurableState {
+  return { accounts: new Map(), credentialRefs: new Map(), vaultEntries: new Map() };
+}
+
+function connectedAccount(id: string): ConnectorAccount {
+  return {
+    id,
+    provider: "google",
+    role: "OWNER",
+    purpose: ["messaging"],
+    accessGate: "open",
+    status: "connected",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    metadata: {},
+  } as ConnectorAccount;
+}
+
+function createStorage(state: DurableState): ConnectorAccountStorage & {
+  setConnectorAccountCredentialRef(params: CredentialRefRow & { accountId: string }): Promise<void>;
+  listConnectorAccountCredentialRefs(params: { accountId: string }): Promise<CredentialRefRow[]>;
+} {
+  return {
+    async listAccounts() {
+      return [...state.accounts.values()];
+    },
+    async getAccount(_provider: string, accountId: string) {
+      return state.accounts.get(accountId) ?? null;
+    },
+    async upsertAccount(account: ConnectorAccount) {
+      state.accounts.set(account.id, account);
+      return account;
+    },
+    async deleteAccount(_provider: string, accountId: string) {
+      state.accounts.delete(accountId);
+      return true;
+    },
+    async setConnectorAccountCredentialRef(params) {
+      state.credentialRefs.set(`${params.accountId}:${params.credentialType}`, params);
+    },
+    async listConnectorAccountCredentialRefs(params) {
+      return [...state.credentialRefs.entries()]
+        .filter(([key]) => key.startsWith(`${params.accountId}:`))
+        .map(([, row]) => row);
+    },
+  } as ConnectorAccountStorage & {
+    setConnectorAccountCredentialRef(
+      params: CredentialRefRow & { accountId: string }
+    ): Promise<void>;
+    listConnectorAccountCredentialRefs(params: { accountId: string }): Promise<CredentialRefRow[]>;
+  };
+}
+
+/** Store-shaped durable service: the agent's ConnectorCredentialStoreService. */
+function createDurableStoreService(vaultEntries: Map<string, string>) {
+  return {
+    async putSecret(params: { vaultRef?: string; value: string }): Promise<string> {
+      if (!params.vaultRef) throw new Error("test store requires an explicit vaultRef");
+      vaultEntries.set(params.vaultRef, params.value);
+      return params.vaultRef;
+    },
+    async get(vaultRef: string): Promise<string> {
+      const value = vaultEntries.get(vaultRef);
+      if (value === undefined) throw new Error(`vault miss: ${vaultRef}`);
+      return value;
+    },
+    async has(vaultRef: string): Promise<boolean> {
+      return vaultEntries.has(vaultRef);
+    },
+    async remove(vaultRef: string): Promise<void> {
+      vaultEntries.delete(vaultRef);
+    },
+  };
+}
+
+/** Vault-shaped durable service (`set`/`get`), as registered under vault names. */
+function createDurableVaultService(vaultEntries: Map<string, string>) {
+  return {
+    async set(key: string, value: string): Promise<void> {
+      vaultEntries.set(key, value);
+    },
+    async get(key: string): Promise<string> {
+      const value = vaultEntries.get(key);
+      if (value === undefined) throw new Error(`vault miss: ${key}`);
+      return value;
+    },
+  };
+}
+
+/**
+ * Volatile SECRETS fake shaped like core SecretsService global storage: writes
+ * land in an instance-private map that a restart (new instance) wipes.
+ */
+function createVolatileSecretsService() {
+  const entries = new Map<string, string>();
+  return {
+    entries,
+    async setGlobal(key: string, value: string): Promise<boolean> {
+      entries.set(key, value);
+      return true;
+    },
+    async get(key: string): Promise<string | null> {
+      return entries.get(key) ?? null;
+    },
+  };
+}
+
+function createRuntime(
+  storage: ReturnType<typeof createStorage>,
+  services: Record<string, unknown>
+): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    getService: (name: string) => services[name] ?? null,
+    getSetting: (key: string) =>
+      key === "GOOGLE_CLIENT_ID"
+        ? "client-id"
+        : key === "GOOGLE_CLIENT_SECRET"
+          ? "client-secret"
+          : undefined,
+    adapter: storage,
+  } as unknown as IAgentRuntime;
+}
+
+async function persistTokens(runtime: IAgentRuntime): Promise<string> {
+  const result = await persistConnectorCredentialRefs({
+    runtime,
+    provider: "google",
+    accountIdForRef: ACCOUNT_ID,
+    storageAccountId: ACCOUNT_ID,
+    caller: "test",
+    credentials: [{ credentialType: "oauth.tokens", value: TOKENS_JSON }],
+  });
+  expect(result.refs).toHaveLength(1);
+  return result.refs[0].vaultRef;
+}
+
+async function resolveAfterRestart(
+  state: DurableState,
+  services: Record<string, unknown>
+): Promise<{ accessToken?: string | null; refreshToken?: string | null }> {
+  const restartedStorage = createStorage(state);
+  const restartedRuntime = createRuntime(restartedStorage, services);
+  const resolver = new DefaultGoogleCredentialResolver({
+    runtime: restartedRuntime,
+    storage: restartedStorage,
+  });
+  const client = await resolver.getAuthClient({
+    provider: "google",
+    accountId: ACCOUNT_ID,
+    scopes: [],
+    capabilities: [],
+    reason: "round-trip test",
+  });
+  const credentials = (
+    client as { credentials?: { access_token?: string; refresh_token?: string } }
+  ).credentials;
+  return { accessToken: credentials?.access_token, refreshToken: credentials?.refresh_token };
+}
+
+describe("connector credential persist → restart → resolve round-trip", () => {
+  it("persists through the durable connector_credential_store ahead of SECRETS and survives a restart", async () => {
+    const state = newDurableState();
+    state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
+    const storage = createStorage(state);
+    const secrets = createVolatileSecretsService();
+    const services: Record<string, unknown> = {
+      connector_credential_store: createDurableStoreService(state.vaultEntries),
+      SECRETS: secrets,
+    };
+
+    const vaultRef = await persistTokens(createRuntime(storage, services));
+    expect(vaultRef).toBe(`connector.${AGENT_ID}.google.${ACCOUNT_ID}.oauth_tokens`);
+    // Precedence: the durable store wins; nothing lands in volatile SECRETS.
+    expect(state.vaultEntries.get(vaultRef)).toBe(TOKENS_JSON);
+    expect(secrets.entries.size).toBe(0);
+
+    // Restart: fresh SECRETS instance (memory wiped), same durable state.
+    const restarted = await resolveAfterRestart(state, {
+      connector_credential_store: createDurableStoreService(state.vaultEntries),
+      SECRETS: createVolatileSecretsService(),
+    });
+    expect(restarted.accessToken).toBe("test-access-token");
+    expect(restarted.refreshToken).toBe("test-refresh-token");
+  });
+
+  it("reads back a credential written under every writable store and vault service name", async () => {
+    for (const serviceType of [
+      ...CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES,
+      ...CONNECTOR_VAULT_SERVICE_TYPES,
+    ]) {
+      const state = newDurableState();
+      state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
+      const storage = createStorage(state);
+      const durable = (CONNECTOR_VAULT_SERVICE_TYPES as readonly string[]).includes(serviceType)
+        ? createDurableVaultService(state.vaultEntries)
+        : createDurableStoreService(state.vaultEntries);
+      const services: Record<string, unknown> = { [serviceType]: durable };
+
+      await persistTokens(createRuntime(storage, services));
+      expect(state.vaultEntries.size).toBe(1);
+
+      const restarted = await resolveAfterRestart(state, {
+        [serviceType]: (CONNECTOR_VAULT_SERVICE_TYPES as readonly string[]).includes(serviceType)
+          ? createDurableVaultService(state.vaultEntries)
+          : createDurableStoreService(state.vaultEntries),
+      });
+      expect(restarted.accessToken, `service name ${serviceType}`).toBe("test-access-token");
+    }
+  });
+
+  it("documents the SECRETS-only fallback as volatile: the persisted ref dangles after a restart", async () => {
+    const state = newDurableState();
+    state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
+    const storage = createStorage(state);
+    const secrets = createVolatileSecretsService();
+
+    const vaultRef = await persistTokens(createRuntime(storage, { SECRETS: secrets }));
+    expect(secrets.entries.get(vaultRef)).toBe(TOKENS_JSON);
+
+    await expect(
+      resolveAfterRestart(state, { SECRETS: createVolatileSecretsService() })
+    ).rejects.toThrow(/could not be read/);
+  });
+});
+
+describe("accountId 'default' resolution", () => {
+  function refsRow(): CredentialRefRow & { accountId: string } {
+    return {
+      accountId: ACCOUNT_ID,
+      credentialType: "oauth.tokens",
+      vaultRef: `connector.${AGENT_ID}.google.${ACCOUNT_ID}.oauth_tokens`,
+    };
+  }
+
+  async function resolveDefault(state: DurableState, services: Record<string, unknown>) {
+    const storage = createStorage(state);
+    const resolver = new DefaultGoogleCredentialResolver({
+      runtime: createRuntime(storage, services),
+      storage,
+    });
+    return resolver.getAuthClient({
+      provider: "google",
+      accountId: "default",
+      scopes: [],
+      capabilities: [],
+      reason: "default-resolution test",
+    });
+  }
+
+  it("resolves to the sole connected account", async () => {
+    const state = newDurableState();
+    state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
+    state.credentialRefs.set(`${ACCOUNT_ID}:oauth.tokens`, refsRow());
+    state.vaultEntries.set(refsRow().vaultRef, TOKENS_JSON);
+
+    const client = await resolveDefault(state, {
+      connector_credential_store: createDurableStoreService(state.vaultEntries),
+    });
+    const credentials = (client as { credentials?: { access_token?: string } }).credentials;
+    expect(credentials?.access_token).toBe("test-access-token");
+  });
+
+  it("stays not-found with zero connected accounts", async () => {
+    const state = newDurableState();
+    await expect(resolveDefault(state, {})).rejects.toThrow(/default was not found/);
+  });
+
+  it("stays not-found with multiple connected accounts", async () => {
+    const state = newDurableState();
+    state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
+    state.accounts.set("second-account", connectedAccount("second-account"));
+    await expect(resolveDefault(state, {})).rejects.toThrow(/default was not found/);
+  });
+});

--- a/plugins/plugin-google-workspace/src/connector-credential-refs.ts
+++ b/plugins/plugin-google-workspace/src/connector-credential-refs.ts
@@ -25,6 +25,25 @@ type JsonValue =
   | { readonly [key: string]: JsonValue };
 type JsonRecord = Record<string, JsonValue>;
 
+/**
+ * Runtime service names probed, in precedence order, for the durable
+ * connector credential store and the vault. The credential resolver's read
+ * path (`credential-resolver.ts`) resolves EXACTLY this set in this order:
+ * any store a credential can be written to must be findable under the same
+ * name after a restart, or the persisted vaultRef dangles and every
+ * credential read comes back empty.
+ */
+export const CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES = [
+  "connector_credential_store",
+  "CONNECTOR_CREDENTIAL_STORE",
+  "connectorCredentialStore",
+  "credential_store",
+] as const;
+
+export const CONNECTOR_VAULT_SERVICE_TYPES = ["vault", "VAULT"] as const;
+
+export const CORE_SECRETS_SERVICE_TYPE = "SECRETS";
+
 export interface ConnectorCredentialRefMetadata extends JsonRecord {
   credentialType: string;
   vaultRef: string;
@@ -192,12 +211,7 @@ function resolveVaultWriters(
   context: { provider: string; accountId: string; caller: string }
 ): VaultWriter[] {
   const writers: VaultWriter[] = [];
-  const credentialStore = getFirstService(runtime, [
-    "connector_credential_store",
-    "CONNECTOR_CREDENTIAL_STORE",
-    "connectorCredentialStore",
-    "credential_store",
-  ]) as {
+  const credentialStore = getFirstService(runtime, CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES) as {
     putSecret?: (params: {
       vaultRef?: string;
       agentId: string;
@@ -224,7 +238,7 @@ function resolveVaultWriters(
     });
   }
 
-  const vault = getFirstService(runtime, ["vault", "VAULT"]) as {
+  const vault = getFirstService(runtime, CONNECTOR_VAULT_SERVICE_TYPES) as {
     set?: (
       key: string,
       value: string,
@@ -244,7 +258,7 @@ function resolveVaultWriters(
     });
   }
 
-  const secrets = getService(runtime, "SECRETS") as {
+  const secrets = getService(runtime, CORE_SECRETS_SERVICE_TYPE) as {
     setGlobal?: (
       key: string,
       value: string,

--- a/plugins/plugin-google-workspace/src/credential-resolver.ts
+++ b/plugins/plugin-google-workspace/src/credential-resolver.ts
@@ -25,7 +25,12 @@ import { Auth } from "googleapis";
 type Credentials = Auth.Credentials;
 const { OAuth2Client } = Auth;
 
-import { credentialRefRecordsFromMetadata } from "./connector-credential-refs.js";
+import {
+  CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES,
+  CONNECTOR_VAULT_SERVICE_TYPES,
+  CORE_SECRETS_SERVICE_TYPE,
+  credentialRefRecordsFromMetadata,
+} from "./connector-credential-refs.js";
 import type {
   GoogleAuthClient,
   GoogleAuthResolutionRequest,
@@ -36,15 +41,14 @@ import { GOOGLE_SERVICE_NAME } from "./types.js";
 const GOOGLE_CLIENT_ID_SETTING = "GOOGLE_CLIENT_ID";
 const GOOGLE_CLIENT_SECRET_SETTING = "GOOGLE_CLIENT_SECRET";
 const GOOGLE_REDIRECT_URI_SETTING = "GOOGLE_REDIRECT_URI";
-const CORE_SECRETS_SERVICE_TYPE = "SECRETS";
 
-const CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES = [
-  "connector_credential_store",
-  "CONNECTOR_CREDENTIAL_STORE",
-  "connectorCredentialStore",
-  "credential_store",
-  "vault",
-  "secrets_manager",
+// Read-side store resolution mirrors the write side exactly
+// (connector-credential-refs.ts): same service names, same precedence. A
+// name probed by only one side is how a credential gets written to a store
+// the reader can never find again after a restart.
+const SECRET_READER_SERVICE_TYPES = [
+  ...CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES,
+  ...CONNECTOR_VAULT_SERVICE_TYPES,
 ] as const;
 
 const TOKEN_SET_CREDENTIAL_TYPES = ["oauth.tokens", "oauth.token_set", "oauth"] as const;
@@ -235,6 +239,39 @@ export class DefaultGoogleCredentialResolver implements GoogleCredentialResolver
   }
 
   private async getAccount(accountId: string): Promise<ConnectorAccount | null> {
+    const direct = await this.getAccountById(accountId);
+    if (direct) {
+      return direct;
+    }
+    // "default" is the adapter-level placeholder for "the user's Google
+    // account" (lifeops-message-adapter DEFAULT_GOOGLE_ACCOUNT_ID). Accounts
+    // connected through the OAuth flow are stored under manager-assigned ids,
+    // so a literal lookup always misses. Resolve it to the sole connected
+    // account; with zero or multiple connected accounts the miss stands and
+    // the caller's not-found error names the ambiguity honestly.
+    if (accountId === "default") {
+      const accounts = await this.listAccounts();
+      const connected = accounts.filter((account) => account.status === "connected");
+      if (connected.length === 1) {
+        return connected[0];
+      }
+    }
+    return null;
+  }
+
+  /** List Google accounts from the same source precedence `getAccountById` uses. */
+  private async listAccounts(): Promise<ConnectorAccount[]> {
+    if (this.storage) {
+      return (await this.storage.listAccounts(GOOGLE_SERVICE_NAME)) ?? [];
+    }
+    const manager = this.accountManager ?? this.getRuntimeAccountManager();
+    if (manager) {
+      return manager.listAccounts(GOOGLE_SERVICE_NAME);
+    }
+    return (await this.resolveStorage()?.listAccounts?.(GOOGLE_SERVICE_NAME)) ?? [];
+  }
+
+  private async getAccountById(accountId: string): Promise<ConnectorAccount | null> {
     if (this.storage) {
       return this.storage.getAccount(GOOGLE_SERVICE_NAME, accountId);
     }
@@ -438,7 +475,7 @@ export class DefaultGoogleCredentialResolver implements GoogleCredentialResolver
     if (this.vault) readers.push(this.vault);
 
     if (this.runtime?.getService) {
-      for (const serviceType of CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES) {
+      for (const serviceType of SECRET_READER_SERVICE_TYPES) {
         const service = safelyGetService(this.runtime, serviceType);
         if (service) readers.push(service);
       }


### PR DESCRIPTION
# Relates to

Live-debugged production failure (Gmail/Calendar dead after every restart despite a completed OAuth connect); no pre-existing issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` at branch time with zero conflicts.
- [x] Focused verify run: full `plugin-google-workspace` suite (10 files / 73 tests) green, new agent service tests green, both packages typecheck green, biome clean on touched files.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (6b5e323be4); zero conflicts.
- [x] Focused verify (suite + typecheck + lint on touched packages) passes; full `bun run verify` not run — see **Risks**.

# Risks

Low-medium.
- New boot-funnel service registration (`connector_credential_store`): gated on `hasDurableHostVault()`, wrapped in the same try/debug-log pattern as its `ConnectorSetupService` neighbor; a registration failure degrades to today's behavior (SECRETS fallback), never blocks boot.
- Google credential read-path service list changed: `secrets_manager` (a name no writer ever targets and no service in the repo registers) dropped, `VAULT` added for writer parity. Any store a credential can be written to is now readable under the same name.
- `accountId "default"` now resolves to the sole connected Google account; zero/multi-account deployments keep the existing not-found error.

# Background

## What does this PR do?

Makes Google connector OAuth credentials survive process restarts, and fixes the `default` account-id lookup.

**Root cause (live-debugged):** `persistConnectorCredentialRefs` writes token material to the first "durable" vault writer among `connector_credential_store` / `vault` / core `SECRETS`. Nothing in the repo registers a service under the first two names (`createConnectorCredentialStore` in plugin-sql has zero callers), so every deployment falls through to `SECRETS` — whose global storage (`CharacterSettingsStorage`, `packages/core/src/features/secrets/storage/character-store.ts`) mutates `runtime.character.settings.secrets` in process memory and never persists. The write "succeeds", the account is marked connected, the durable ref rows point at a key that stops existing at the next restart, and every credential read comes back empty:

```
Google connector credential oauth.tokens could not be read from connector.<agentId>.google.<accountId>.oauth_tokens.
```

**Fix:**
- `packages/agent`: new `ConnectorCredentialStoreService` (serviceType `connector_credential_store`) wrapping the host vault (`AgentHostBridge.sharedVault()`, PGlite-backed, encrypted at rest), registered in the boot funnel, gated on the new `hasDurableHostVault()` so the no-op default vault is never wrapped. Writer and reader now resolve the same durable store first — for google-workspace and the github/slack/x connector plugins that probe the same names.
- `plugins/plugin-google-workspace`: read-side secret-reader service list now shares one constant with the write side (same names, same precedence; the reader previously missed `VAULT` and probed `secrets_manager` which no writer targets).
- `plugins/plugin-google-workspace`: `accountId "default"` (the lifeops adapter placeholder) resolves to the sole connected account.

**Second and third bugs surfaced by live re-verification on the same deployment:**
- `runtime.registerService` is LAZY — the instance is only created by the async service-load path — while connector plugins resolve the store with the SYNCHRONOUS `runtime.getService()`, which returns null for a registered-but-never-started service. The first deploy still lost tokens to a real restart through exactly this null. The boot funnel now forces the start via `getServiceLoadPromise` once `runtime.initialize()` has resolved (the load path awaits `initPromise`; forcing earlier deadlocks boot).
- OAuth flow state is durable but PKCE verifiers are process-local by design, so an auth link minted before a restart reached the token exchange without its verifier and died as an opaque Google 400 ("Invalid code verifier"). `completeOAuth` now fails such flows with an explicit re-mint message before any exchange is attempted.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-workspace/src/connector-credential-refs.test.ts` — the persist → simulated-restart → resolve round-trip suite. "Restart" = new runtime + fresh service instances where only the DB-shaped rows and the vault backing map survive, mirroring the production service registry (SECRETS present, durable store present/absent).

## Detailed testing steps

- `cd plugins/plugin-google-workspace && bun run test` — 10 files / 73 tests, includes:
  - durable store wins precedence over SECRETS and round-trips across restart;
  - every writable service name is readable after restart (fails on the old reader list for `VAULT`);
  - SECRETS-only fallback documented volatile (persisted ref dangles after restart);
  - `default` resolution: sole-connected resolves; zero/multi stay not-found.
- `cd packages/agent && bunx vitest run src/services/connector-credential-store.test.ts` — vault adapter round-trip + `hasDurableHostVault` gating. 
- `cd packages/agent && bunx vitest run src/services/connector-credential-store.runtime.test.ts` — REAL `AgentRuntime` + real `@elizaos/plugin-sql` (PGlite): a registered-but-unstarted store is sync-invisible (the exact demotion that lost live tokens), and a credential round-trips across a full runtime restart once the boot funnel forces the start.
- `cd packages/core && bunx vitest run src/connectors/account-manager.test.ts` — a flow whose PKCE verifier died with a restart fails with the re-mint message; the exchange is never attempted.

## Live restart proof (production VPS deployment)

This branch is deployed on the live nubilio VPS (`milady.service`, systemd user unit). The full-restart contract was proven end to end on 2026-08-08:

- systemd journal: `Stopping milady.service` 18:05:25Z → `Started milady.service` 18:05:28Z, followed by the post-restart boot with `svc:connector-credential-store` coming up (backend-logs artifact).
- 18:07:30Z — first Gmail read AFTER the restart: probe "whats the newest email in my inbox?" → the MESSAGE tool returned `success: true` with a real inbox item (`from: notifications@github.com`, subject `[RemilioNubilio/milady] Run failed: Rotate E2E Secrets…`) using the persisted OAuth credentials. Full trajectory `tj-8f05be101bc9c4` in the llm-trajectory artifact (third-party identities redacted, Discord ids masked).
- The OAuth grant lives in the fixed store: connector account `3a899cd0-170f-4b3e-932e-46ec68119b35` reports `status: "connected"` with gmail+calendar scopes after the restart (domain artifact; owner handle redacted to `n***vault@gmail.com`).
- Discord-side capture of the same turn: [18027-domain-discord-turn.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18027-domain-discord-turn.json).
- Calendar reads also work live post-restart (real empty-day answer, and the mutation-safety approval gate engages on writes).
- Before/after pair: the same probe shape succeeded pre-restart at ~06:0xZ, and on the pre-fix build the read failed after a restart — exactly the contract this PR fixes.

Note on the visible reply text: during this testing window the user-facing reply surface intermittently answers "something glitched on my end. try again." That is the separate surrogate-reply bug tracked in #18025 (fix in flight), not this PR's scope — the credential-backed tool reads themselves succeed, as the trajectory and logs above show.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d9cc721d7c2663b409895603861f8c57080c2efe -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend connector credential persistence fix; no UI surface touched
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend connector credential persistence fix with no UI in the diff
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - headless connector fix verified via live service restart
<!-- evidence-row:backend-logs -->
- [x] [18027-backend-restart-credential-load.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18027-backend-restart-credential-load.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/client code in the diff
<!-- evidence-row:llm-trajectory -->
- [x] [18027-llm-trajectory-postrestart-gmail.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18027-llm-trajectory-postrestart-gmail.json)
<!-- evidence-row:domain-artifacts -->
- [x] [18027-domain-google-account-connected.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18027-domain-google-account-connected.json)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
