### PR TITLE
feat(cloud): wallet-derived OIDC identity for wallet-only accounts

### DIFF
--- a/packages/cloud/api/__tests__/oidc-provider.test.ts
+++ b/packages/cloud/api/__tests__/oidc-provider.test.ts
@@ -63,6 +63,12 @@ const STEWARD_AUDIENCE = "eliza-cloud-steward";
 const CONSOLE_CLIENT_ID = "eliza-steward-console";
 const CONSOLE_SECRET = "steward-console-secret-value-0123456789";
 const CONSOLE_REDIRECT = "https://console.elizacloud.test/oidc/callback";
+/** The one registration that opts in to wallet-derived identities. */
+const WALLET_CLIENT_ID = "wallet-forge";
+const WALLET_SECRET = "wallet-forge-client-secret-value-0123456789";
+const WALLET_REDIRECT = "https://forge.elizacloud.test/oauth2/callback";
+/** `users.noreply.` + the issuer HOSTNAME; derived, never hardcoded in the Worker. */
+const WALLET_EMAIL_DOMAIN = `users.noreply.${new URL(ISSUER).hostname}`;
 
 /**
  * The gates the two consumers are SHIPPED with. Forgejo's pair comes from
@@ -173,6 +179,19 @@ interface SeedOptions {
   stewardTenantId?: string | null;
   withOrg?: boolean;
   walletAddress?: string;
+  /**
+   * `users.wallet_verified` is notNull with a false default, so `walletAddress`
+   * alone cannot express a wallet that actually proved a signature — and an
+   * unproven address must never produce an identity.
+   */
+  walletVerified?: boolean;
+  /**
+   * Written only by a path that binds a wallet to the account (the SIWE/SIWS
+   * sign-ins, `/api/users/me/wallet/attach`, a Steward wallet claim). Defaults
+   * to `evm` alongside a verified wallet; pass `null` for the row shape a
+   * service bridge produced, which asserts an address with no provenance.
+   */
+  walletChainType?: string | null;
 }
 
 /** Insert a real users/organizations pair and return the ids. */
@@ -218,6 +237,13 @@ async function seedUser(
       is_active: options.isActive ?? true,
       is_anonymous: options.isAnonymous ?? false,
       wallet_address: options.walletAddress ?? null,
+      wallet_verified: options.walletVerified ?? false,
+      wallet_chain_type:
+        options.walletChainType === undefined
+          ? options.walletVerified
+            ? "evm"
+            : null
+          : options.walletChainType,
     })
     .returning();
 
@@ -505,6 +531,26 @@ beforeAll(async () => {
       claims_policy: {
         groups: false,
         roles: true,
+        tenant_id: false,
+        eliza_agents: false,
+      },
+    },
+    {
+      client_id: WALLET_CLIENT_ID,
+      name: "Wallet Forge",
+      client_secret_sha256: sha256Hex(WALLET_SECRET),
+      redirect_uris: [WALLET_REDIRECT],
+      allowed_scopes: ["openid", "email", "profile"],
+      resource_audiences: [],
+      require_pkce: false,
+      // Still requires an identity — the flag widens WHAT counts as one, it does
+      // not turn the gate off.
+      require_verified_email: true,
+      wallet_email_fallback: true,
+      roles_allowlist: [],
+      claims_policy: {
+        groups: false,
+        roles: false,
         tenant_id: false,
         eliza_agents: false,
       },
@@ -1021,6 +1067,44 @@ describe("authorize — subject eligibility", () => {
     );
   });
 
+  test("a wallet-only account is refused by a client that did not opt in", async () => {
+    // The reason string is the byte-identical one this client got before the
+    // feature existed; it reaches the relying party and the audit log.
+    await seedUser({
+      stewardUserId: "u-wallet-refused",
+      email: null,
+      emailVerified: false,
+      walletAddress: "0xaaaa567890abcdef1234567890abcdef1234aaaa",
+      walletVerified: true,
+    });
+    const res = await call(authorizeUrl(), {
+      cookie: await sessionCookie("u-wallet-refused"),
+    });
+    const location = new URL(res.headers.get("location") as string);
+    expect(location.searchParams.get("error_description")).toBe(
+      "email_unverified",
+    );
+  });
+
+  test("an account holding the reserved wallet-email domain cannot buy admission with it", async () => {
+    // The squat: `users.email` is unique and user-settable, and the synthesized
+    // address is computable from a public wallet address. A row carrying one is
+    // read as having NO address, whatever `email_verified` says — that domain
+    // routes no mail, so nothing on it can ever have been verified by delivery.
+    await seedUser({
+      stewardUserId: "u-squatter",
+      email: `wallet-0123456789abcdef0123456789abcdef@${WALLET_EMAIL_DOMAIN}`,
+      emailVerified: true,
+    });
+    const res = await call(authorizeUrl(), {
+      cookie: await sessionCookie("u-squatter"),
+    });
+    const location = new URL(res.headers.get("location") as string);
+    expect(location.searchParams.get("error_description")).toBe(
+      "email_unverified",
+    );
+  });
+
   test("an explicit sign-out blocks a still-unexpired cookie from starting a new login", async () => {
     await seedUser({ stewardUserId: "u-loggedout" });
     const cookie = await sessionCookie("u-loggedout");
@@ -1035,6 +1119,364 @@ describe("authorize — subject eligibility", () => {
     expect(new URL(res.headers.get("location") as string).pathname).toBe(
       "/login",
     );
+  });
+});
+
+/**
+ * The wallet-derived no-reply identity, driven through the real
+ * authorize → token → userinfo legs. `wallet-forge` is the only registration
+ * with `wallet_email_fallback`; every other client in this suite is the
+ * unchanged control.
+ */
+describe("wallet_email_fallback", () => {
+  /** The exact address the digest produces, so a format change fails loudly here. */
+  const ADDRESS_FOR = (local: string): string =>
+    `wallet-${local}@${WALLET_EMAIL_DOMAIN}`;
+
+  function walletAuthorizeUrl(
+    overrides: Record<string, string | undefined> = {},
+  ): string {
+    return authorizeUrl({
+      client_id: WALLET_CLIENT_ID,
+      redirect_uri: WALLET_REDIRECT,
+      scope: "openid email profile",
+      ...overrides,
+    });
+  }
+
+  async function walletLogin(
+    stewardUserId: string,
+  ): Promise<{ idClaims: Record<string, unknown>; accessToken: string }> {
+    const cookie = await sessionCookie(stewardUserId);
+    const res = await call(walletAuthorizeUrl(), { cookie });
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get("location") as string);
+    expect(location.searchParams.get("error_description")).toBeNull();
+    const code = location.searchParams.get("code") as string;
+
+    const tokenRes = await redeem(
+      code,
+      { redirect_uri: WALLET_REDIRECT },
+      WALLET_CLIENT_ID,
+      WALLET_SECRET,
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as TokenResponse;
+    return {
+      idClaims: await verifyLikeConsumer(body.id_token, WALLET_CLIENT_ID),
+      accessToken: body.access_token,
+    };
+  }
+
+  /**
+   * Sign in at `percent-secret-app`, which does NOT require a verified email —
+   * the client any squat would be laundered through, and the one that proves the
+   * guard is unconditional rather than a property of the opted-in registration.
+   */
+  async function percentClaims(
+    stewardUserId: string,
+  ): Promise<Record<string, unknown>> {
+    const res = await call(
+      authorizeUrl({
+        client_id: PERCENT_CLIENT_ID,
+        redirect_uri: PERCENT_REDIRECT,
+        scope: "openid email",
+      }),
+      { cookie: await sessionCookie(stewardUserId) },
+    );
+    expect(res.status).toBe(302);
+    const code = new URL(
+      res.headers.get("location") as string,
+    ).searchParams.get("code") as string;
+    const tokenRes = await redeem(
+      code,
+      { redirect_uri: PERCENT_REDIRECT },
+      PERCENT_CLIENT_ID,
+      PERCENT_SECRET,
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as TokenResponse;
+    return verifyLikeConsumer(body.id_token, PERCENT_CLIENT_ID);
+  }
+
+  test("a wallet-only account signs in and receives a stable synthesized address", async () => {
+    await seedUser({
+      stewardUserId: "u-wallet-ok",
+      email: null,
+      emailVerified: false,
+      nickname: "satoshi",
+      walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
+      walletVerified: true,
+    });
+    const { idClaims, accessToken } = await walletLogin("u-wallet-ok");
+
+    expect(idClaims.email).toBe(
+      ADDRESS_FOR("d4f3c344e6eb25da702fd567072f6ce1"),
+    );
+    // The mailbox does not exist — the domain accepts no mail by construction —
+    // so nobody has ever proven control of it. The wallet assurance travels
+    // under its own name instead of being laundered through this flag.
+    expect(idClaims.email_verified).toBe(false);
+    expect(idClaims.eliza_email_source).toBe("wallet");
+    // The address is not the account name: `preferred_username` is frozen from
+    // the naming policy and is a one-way door.
+    expect(idClaims.preferred_username).toBe("satoshi");
+
+    // Forgejo re-reads /userinfo on every later login. A disagreement here is
+    // how a relying party admits a login and then re-reads it as another account.
+    const infoRes = await call("/api/oidc/userinfo", {
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+    expect(infoRes.status).toBe(200);
+    const info = (await infoRes.json()) as Record<string, unknown>;
+    expect(info.email).toBe(idClaims.email);
+    expect(info.email_verified).toBe(false);
+    expect(info.eliza_email_source).toBe("wallet");
+  });
+
+  test("the address is deterministic across sign-ins", async () => {
+    // Forgejo keys the account on it, so a value that moved between logins
+    // would orphan the account it created on the first one.
+    await seedUser({
+      stewardUserId: "u-wallet-stable",
+      email: null,
+      emailVerified: false,
+      walletAddress: "0xdddd567890abcdef1234567890abcdef1234dddd",
+      walletVerified: true,
+    });
+    const first = await walletLogin("u-wallet-stable");
+    const second = await walletLogin("u-wallet-stable");
+    expect(second.idClaims.email).toBe(first.idClaims.email);
+  });
+
+  test("two different wallets never receive the same address", async () => {
+    // One hex digit apart, which is the closest two distinct rows can be.
+    await seedUser({
+      stewardUserId: "u-wallet-a",
+      email: null,
+      emailVerified: false,
+      walletAddress: "0xeeee567890abcdef1234567890abcdef1234eee0",
+      walletVerified: true,
+    });
+    await seedUser({
+      stewardUserId: "u-wallet-b",
+      email: null,
+      emailVerified: false,
+      walletAddress: "0xeeee567890abcdef1234567890abcdef1234eee1",
+      walletVerified: true,
+    });
+    const a = await walletLogin("u-wallet-a");
+    const b = await walletLogin("u-wallet-b");
+    expect(a.idClaims.email).not.toBe(b.idClaims.email);
+    for (const claims of [a.idClaims, b.idClaims]) {
+      expect(claims.email).toMatch(
+        new RegExp(`^wallet-[0-9a-f]{32}@${WALLET_EMAIL_DOMAIN}$`),
+      );
+    }
+  });
+
+  test("an UNVERIFIED wallet is still refused — an address alone proves nothing", async () => {
+    await seedUser({
+      stewardUserId: "u-wallet-unverified",
+      email: null,
+      emailVerified: false,
+      walletAddress: "0xbbbb567890abcdef1234567890abcdef1234bbbb",
+      walletVerified: false,
+    });
+    const res = await call(walletAuthorizeUrl(), {
+      cookie: await sessionCookie("u-wallet-unverified"),
+    });
+    const location = new URL(res.headers.get("location") as string);
+    expect(location.searchParams.get("error")).toBe("access_denied");
+    expect(location.searchParams.get("error_description")).toBe(
+      "no_verified_identity",
+    );
+  });
+
+  test("a verified flag with no recorded chain type is refused — the service-bridge shape", async () => {
+    // `lib/auth/waifu-bridge.ts` provisioned rows from an address SUBSTRING of a
+    // service token's subject: the holder of the shared service secret picks the
+    // address, including a victim's public one, and nothing in that chain
+    // verifies a signature. It now records `wallet_verified: false`; this asserts
+    // the second, independent lock, because a row whose wallet has no recorded
+    // provenance must not become somebody's permanent git identity even if a
+    // writer sets the flag.
+    await seedUser({
+      stewardUserId: "u-wallet-no-provenance",
+      email: null,
+      emailVerified: false,
+      walletAddress: "0xffff567890abcdef1234567890abcdef1234ffff",
+      walletVerified: true,
+      walletChainType: null,
+    });
+    const res = await call(walletAuthorizeUrl(), {
+      cookie: await sessionCookie("u-wallet-no-provenance"),
+    });
+    const location = new URL(res.headers.get("location") as string);
+    expect(location.searchParams.get("error")).toBe("access_denied");
+    expect(location.searchParams.get("error_description")).toBe(
+      "no_verified_identity",
+    );
+  });
+
+  test("the identity is the wallet's, not the spelling the row happens to hold", async () => {
+    // EVM hex is case-insensitive and the writers disagree about form, so a
+    // digest over the stored bytes would give one wallet two permanent
+    // identities depending on which surface wrote the row last. This row holds
+    // the EIP-55 form of `u-wallet-ok`'s address and must land on the same
+    // address that account already signs in with.
+    await seedUser({
+      stewardUserId: "u-wallet-checksummed",
+      email: null,
+      emailVerified: false,
+      walletAddress: "0x1234567890AbcdEF1234567890aBcdef12345678",
+      walletVerified: true,
+      walletChainType: "evm",
+    });
+    const { idClaims } = await walletLogin("u-wallet-checksummed");
+    expect(idClaims.email).toBe(
+      ADDRESS_FOR("d4f3c344e6eb25da702fd567072f6ce1"),
+    );
+  });
+
+  test("two Solana keys that differ only in case stay two identities", async () => {
+    // base58 is case-SENSITIVE: folding it would merge two distinct wallets onto
+    // one address, which at a relying party keyed on the address is a takeover.
+    const solana = "7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2";
+    await seedUser({
+      stewardUserId: "u-wallet-solana",
+      email: null,
+      emailVerified: false,
+      walletAddress: solana,
+      walletVerified: true,
+      walletChainType: "solana",
+    });
+    await seedUser({
+      stewardUserId: "u-wallet-solana-folded",
+      email: null,
+      emailVerified: false,
+      walletAddress: solana.toLowerCase(),
+      walletVerified: true,
+      walletChainType: "solana",
+    });
+    const verbatim = await walletLogin("u-wallet-solana");
+    const folded = await walletLogin("u-wallet-solana-folded");
+    expect(verbatim.idClaims.email).not.toBe(folded.idClaims.email);
+  });
+
+  test("a user with a real verified email keeps it, wallet or not", async () => {
+    await seedUser({
+      stewardUserId: "u-wallet-and-email",
+      email: "ada@example.com",
+      emailVerified: true,
+      walletAddress: "0xcccc567890abcdef1234567890abcdef1234cccc",
+      walletVerified: true,
+    });
+    const { idClaims } = await walletLogin("u-wallet-and-email");
+    expect(idClaims.email).toBe("ada@example.com");
+    expect(idClaims.email_verified).toBe(true);
+    expect(idClaims).not.toHaveProperty("eliza_email_source");
+  });
+
+  test("an UNCONFIRMED stored address is refused rather than swapped for the wallet", async () => {
+    // Synthesis is for a user who has NO address. Substituting one here would
+    // give this account a different identity at the forge than the row names,
+    // and would do it for a user whose only act was leaving an address
+    // unconfirmed. The client asked for a verified email and this is not one, so
+    // the honest answer is a refusal that says which address to confirm.
+    await seedUser({
+      stewardUserId: "u-wallet-unconfirmed-email",
+      email: "typed@company.example",
+      emailVerified: false,
+      walletAddress: "0xabab567890abcdef1234567890abcdef1234abab",
+      walletVerified: true,
+    });
+    const res = await call(walletAuthorizeUrl(), {
+      cookie: await sessionCookie("u-wallet-unconfirmed-email"),
+    });
+    const location = new URL(res.headers.get("location") as string);
+    expect(location.searchParams.get("error")).toBe("access_denied");
+    expect(location.searchParams.get("error_description")).toBe(
+      "email_unverified",
+    );
+  });
+
+  test("a squatted address on the reserved domain is never emitted as an email", async () => {
+    // `users.email` is unique and user-settable and the synthesized address is
+    // computable from a public wallet address, so without the guard an attacker
+    // could have a relying party create an account holding the victim's
+    // identity — locking them out and authoring public commits as them.
+    // `percent-secret-app` does not require a verified email, which is the
+    // client the attack would have gone through.
+    await seedUser({
+      stewardUserId: "u-squat-emit",
+      email: ADDRESS_FOR("00000000000000000000000000000001"),
+      emailVerified: true,
+    });
+    const cookie = await sessionCookie("u-squat-emit");
+    const res = await call(
+      authorizeUrl({
+        client_id: PERCENT_CLIENT_ID,
+        redirect_uri: PERCENT_REDIRECT,
+        scope: "openid email",
+      }),
+      { cookie },
+    );
+    expect(res.status).toBe(302);
+    const code = new URL(
+      res.headers.get("location") as string,
+    ).searchParams.get("code") as string;
+    const tokenRes = await redeem(
+      code,
+      { redirect_uri: PERCENT_REDIRECT },
+      PERCENT_CLIENT_ID,
+      PERCENT_SECRET,
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as TokenResponse;
+    const claims = await verifyLikeConsumer(body.id_token, PERCENT_CLIENT_ID);
+    expect(claims).not.toHaveProperty("email");
+    expect(claims.eliza_email_source).toBeUndefined();
+    // The scrub clears `email_verified` with the address. Leaving it behind gave
+    // this token a confirmed mailbox it then declined to name — an assertion
+    // with no referent, delivered to a client that opted into nothing.
+    expect(claims.email_verified).toBe(false);
+  });
+
+  test("the squat guard survives the FQDN trailing-dot spelling", async () => {
+    // `…elizacloud.test.` and `…elizacloud.test` are one host to every mail
+    // transport, so a raw string comparison would have read the root-dot form as
+    // an unrelated domain and handed the squatted address straight through.
+    await seedUser({
+      stewardUserId: "u-squat-fqdn",
+      email: `${ADDRESS_FOR("00000000000000000000000000000002")}.`,
+      emailVerified: true,
+    });
+    const claims = await percentClaims("u-squat-fqdn");
+    expect(claims).not.toHaveProperty("email");
+    expect(claims.email_verified).toBe(false);
+  });
+
+  test("an address minted under a PREVIOUS issuer is still reserved", async () => {
+    // The reservation cannot track only the configured domain. Every address
+    // this provider issued stays computable forever and the forge accounts keyed
+    // on them keep existing, so an issuer rotation must not un-reserve them —
+    // and rotating the issuer is what an operator does AFTER an incident.
+    await seedUser({
+      stewardUserId: "u-squat-old-issuer",
+      email:
+        "wallet-00000000000000000000000000000003@users.noreply.old.example",
+      emailVerified: true,
+    });
+    const claims = await percentClaims("u-squat-old-issuer");
+    expect(claims).not.toHaveProperty("email");
+    expect(claims.email_verified).toBe(false);
+  });
+
+  test("the discovery document advertises the claim an RP has to read", async () => {
+    const res = await call("/.well-known/openid-configuration");
+    const metadata = (await res.json()) as { claims_supported: string[] };
+    expect(metadata.claims_supported).toContain("eliza_email_source");
   });
 });
 
@@ -2102,6 +2544,76 @@ describe("issuer configuration", () => {
       pathIssuer,
     );
     expect(authorizeRes.status).toBe(503);
+  });
+
+  test("a refused OIDC_WALLET_EMAIL_DOMAIN turns off one feature, not the provider", async () => {
+    // The variable is optional and governs a single opt-in feature. Collapsing
+    // the config over it 404s discovery and 503s authorize, token, and userinfo
+    // — every relying party loses sign-in, including all the ones that never
+    // asked for a wallet identity. `gmail.com` is the shape of the mistake: an
+    // override the deployment cannot prove it owns.
+    const badDomain = { ...ENV, OIDC_WALLET_EMAIL_DOMAIN: "gmail.com" };
+
+    const discoveryRes = await harness.request(
+      `${ISSUER}/.well-known/openid-configuration`,
+      { headers: { "x-forwarded-for": "10.9.6.5" } },
+      badDomain,
+    );
+    expect(discoveryRes.status).toBe(200);
+    expect(((await discoveryRes.json()) as { issuer: string }).issuer).toBe(
+      ISSUER,
+    );
+
+    // A user with a verified email is entirely unaffected.
+    await seedUser({ stewardUserId: "u-baddomain-email" });
+    const emailRes = await harness.request(
+      `${ISSUER}${authorizeUrl()}`,
+      {
+        headers: {
+          "x-forwarded-for": "10.9.6.4",
+          cookie: await sessionCookie("u-baddomain-email"),
+        },
+        redirect: "manual",
+      },
+      badDomain,
+    );
+    expect(emailRes.status).toBe(302);
+    expect(
+      new URL(emailRes.headers.get("location") as string).searchParams.get(
+        "code",
+      ),
+    ).not.toBeNull();
+
+    // The wallet-only user is the one who loses: refused with a reason, not a
+    // 503, and the operator's mistake is logged beside that refusal.
+    await seedUser({
+      stewardUserId: "u-baddomain-wallet",
+      email: null,
+      emailVerified: false,
+      walletAddress: "0x9999567890abcdef1234567890abcdef12349999",
+      walletVerified: true,
+    });
+    const walletRes = await harness.request(
+      `${ISSUER}${authorizeUrl({
+        client_id: WALLET_CLIENT_ID,
+        redirect_uri: WALLET_REDIRECT,
+        scope: "openid email profile",
+      })}`,
+      {
+        headers: {
+          "x-forwarded-for": "10.9.6.3",
+          cookie: await sessionCookie("u-baddomain-wallet"),
+        },
+        redirect: "manual",
+      },
+      badDomain,
+    );
+    expect(walletRes.status).toBe(302);
+    expect(
+      new URL(walletRes.headers.get("location") as string).searchParams.get(
+        "error_description",
+      ),
+    ).toBe("no_verified_identity");
   });
 
   test("a loopback issuer serves the whole flow over http", async () => {

--- a/packages/cloud/api/auth/siwe/verify/route.ts
+++ b/packages/cloud/api/auth/siwe/verify/route.ts
@@ -56,6 +56,9 @@ app.post("/", async (c) => {
     return c.json({ error: "SIWE verification failed" }, 401);
   }
 
+  // The SIWE message and its nonce were verified and consumed above, so this
+  // caller — unlike topup or agent provisioning, which are handed an address —
+  // may record the wallet as proven.
   const {
     user,
     isNewAccount,
@@ -64,7 +67,7 @@ app.post("/", async (c) => {
     welcomeBonusWithheld,
     welcomeBonusWithheldReason,
     welcomeBonusWithheldMessage,
-  } = await findOrCreateUserByWalletAddress(address);
+  } = await findOrCreateUserByWalletAddress(address, { walletProven: true });
   if (!user.organization_id) {
     return c.json(
       { error: "Organization creation failed - please try again" },

--- a/packages/cloud/api/auth/siws/verify/route.ts
+++ b/packages/cloud/api/auth/siws/verify/route.ts
@@ -55,8 +55,12 @@ app.post("/", async (c) => {
     return c.json({ error: "SIWS verification failed" }, 401);
   }
 
-  const { user, isNewAccount } =
-    await findOrCreateSolanaUserByWalletAddress(address);
+  // The SIWS message and its nonce were just verified and consumed above, so
+  // this caller may mark the wallet proven.
+  const { user, isNewAccount } = await findOrCreateSolanaUserByWalletAddress(
+    address,
+    { walletProven: true },
+  );
   if (!user.organization_id) {
     return c.json(
       { error: "Organization creation failed - please try again" },

--- a/packages/cloud/api/oidc/authorize/route.ts
+++ b/packages/cloud/api/oidc/authorize/route.ts
@@ -539,7 +539,7 @@ async function completeAuthorization(
     return await bounceThroughLogin(c, config, validated);
   }
 
-  const subject = await loadOidcSubject(outcome.session.userId);
+  const subject = await loadOidcSubject(outcome.session.userId, config);
   if (!subject) {
     return redirectError(
       c,
@@ -554,6 +554,11 @@ async function completeAuthorization(
     logger.warn("[oidc] authorization refused", {
       client_id: validated.client.client_id,
       reason: ineligible,
+      // A refused OIDC_WALLET_EMAIL_DOMAIN leaves the provider up and the
+      // feature off, so this refusal is the only place the operator's mistake
+      // becomes observable. Absent unless that variable was rejected.
+      wallet_email_unavailable:
+        config.walletEmailUnavailableReason ?? undefined,
     });
     await emitOidcAudit(c, {
       action: "oidc.authorize.denied",
@@ -568,6 +573,12 @@ async function completeAuthorization(
   // Freeze the username here rather than at redemption, for its side effect:
   // an allocation failure then surfaces on the browser-facing leg, where a
   // human can be shown an error, instead of on the back-channel token call.
+  //
+  // The seed reads `subject.user.email` and must NEVER read
+  // `subject.walletEmail`: the naming policy would derive a `wallet-<hex>` local
+  // part from it and freeze that as `preferred_username`, changing the account
+  // name every wallet user already signs in with today. The username is a
+  // one-way door; the synthesized address is a separate identifier.
   await resolveOidcUsername({
     id: subject.user.id,
     nickname: subject.user.nickname,

--- a/packages/cloud/api/oidc/token/route.ts
+++ b/packages/cloud/api/oidc/token/route.ts
@@ -417,7 +417,7 @@ app.post("/", async (c) => {
 
     // Claims are rebuilt from LIVE rows rather than a snapshot taken at
     // authorize, so a mid-window deactivation fails the exchange.
-    const subject = await loadOidcSubject(grant.userId);
+    const subject = await loadOidcSubject(grant.userId, config);
     if (!subject) return await refuseGrant(c, "subject_missing", bound);
     const ineligible = assertOidcSubjectEligible(subject, client);
     if (ineligible) {
@@ -439,6 +439,7 @@ app.post("/", async (c) => {
       organization: subject.user.organization,
       profile: subject.profile,
       username,
+      walletEmail: subject.walletEmail,
       adminStatus: subject.adminStatus,
       deploymentTenantId:
         typeof c.env.STEWARD_TENANT_ID === "string"

--- a/packages/cloud/api/oidc/userinfo/route.ts
+++ b/packages/cloud/api/oidc/userinfo/route.ts
@@ -168,7 +168,7 @@ async function handleUserInfo(c: AppContext): Promise<Response> {
     if (!client)
       return unauthorized(c, "The access token is invalid or expired.");
 
-    const subject = await loadOidcSubject(verified.subject);
+    const subject = await loadOidcSubject(verified.subject, config);
     if (!subject) return unauthorized(c, "The account is unavailable.");
     if (assertOidcSubjectEligible(subject, client)) {
       return unauthorized(c, "The account is unavailable.");
@@ -186,6 +186,10 @@ async function handleUserInfo(c: AppContext): Promise<Response> {
       organization: subject.user.organization,
       profile: subject.profile,
       username,
+      // Must move with the token route: a `/userinfo` that disagreed with
+      // `/token` about `email` is how a relying party admits a login and then
+      // re-reads it as a different account.
+      walletEmail: subject.walletEmail,
       adminStatus: subject.adminStatus,
       deploymentTenantId:
         typeof c.env.STEWARD_TENANT_ID === "string"

--- a/packages/cloud/api/v1/agents/route.ts
+++ b/packages/cloud/api/v1/agents/route.ts
@@ -225,7 +225,9 @@ app.post("/", async (c) => {
       });
     }
     const walletAccount = p.account?.primaryWalletAddress
-      ? await findOrCreateUserByWalletAddress(p.account.primaryWalletAddress, {
+      ? // No `walletProven`: the address is a provisioning parameter, not a
+        // signature, so the account it opens must not claim a verified wallet.
+        await findOrCreateUserByWalletAddress(p.account.primaryWalletAddress, {
           grantInitialCredits: false,
         })
       : null;

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -327,6 +327,12 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 #                                      empty registry. OIDC_ENABLED / OIDC_ISSUER_URL are
 #                                      committed [vars] below for the same reason inverted:
 #                                      losing them must not silently change the issuer.
+#                                      OIDC_WALLET_EMAIL_DOMAIN is a var for that same
+#                                      reason and is normally UNSET: it defaults to
+#                                      users.noreply.<issuer hostname>, and an override is
+#                                      accepted only as a strict subdomain of that hostname
+#                                      (the rule that makes the domain unregisterable by a
+#                                      user). Set but invalid fails the provider closed.
 #   COINGECKO_API_KEY / BRAVE_SEARCH_API_KEY
 #   TWITTER_BEARER_TOKEN / X_API_KEY / X_API_KEY_SECRET
 #   X402_RECIPIENT_ADDRESS / PINATA_JWT

--- a/packages/cloud/scripts/admin/generate-oidc-keys.ts
+++ b/packages/cloud/scripts/admin/generate-oidc-keys.ts
@@ -18,6 +18,7 @@
  *   --audience         resource servers that must accept the ACCESS token
  *   --constant-claim   a fixed name=value pair for an RP that gates login on one
  *   --map-role/-group  translation into the RP's own roles/groups vocabulary
+ *   --wallet-email-fallback  admit wallet-only accounts and mint a no-reply address
  * The generated entry is run through the Worker's own registry parser before it
  * is printed, so an incoherent combination fails here rather than as a 503.
  *
@@ -187,6 +188,11 @@ if (clientId) {
     resource_audiences: list("audience"),
     require_pkce: hasFlag("require-pkce"),
     require_verified_email: !hasFlag("allow-unverified-email"),
+    // Off unless asked for: it is the only knob that changes what `email` can
+    // hold, and a relying party that wants inbox proof must keep the default. It
+    // WIDENS the verified-email gate, so pairing it with --allow-unverified-email
+    // is refused by the parser below rather than printed.
+    wallet_email_fallback: hasFlag("wallet-email-fallback"),
     roles_allowlist: list("roles-allowlist"),
     claims_policy: {
       groups: true,
@@ -229,6 +235,23 @@ if (clientId) {
   if (parsed.claims_mapping.mode === "replace") {
     console.log(
       "# Native roles/groups are DROPPED; only mapped values are emitted.",
+    );
+  }
+  if (parsed.wallet_email_fallback) {
+    console.log(
+      "# Wallet fallback:  a user with a VERIFIED wallet and NO stored email is admitted",
+    );
+    console.log(
+      "#                   and receives email=wallet-<32 hex>@users.noreply.<issuer hostname>",
+    );
+    console.log(
+      '#                   with email_verified=false and eliza_email_source="wallet".',
+    );
+    console.log(
+      "#                   That address has no mailbox by design; read eliza_email_source,",
+    );
+    console.log(
+      "#                   not email_verified, for identity assurance.",
     );
   }
   console.log(

--- a/packages/cloud/shared/src/lib/auth/waifu-bridge-wallet-claim.test.ts
+++ b/packages/cloud/shared/src/lib/auth/waifu-bridge-wallet-claim.test.ts
@@ -1,0 +1,103 @@
+/**
+ * What a waifu-core service token may assert about a WALLET when it provisions
+ * an eliza-cloud account. Real `authenticateWaifuBridge` and a real HS256 token
+ * signed with the shared secret; only the user/org writers are mocked, so the
+ * assertion is the exact row this path asks for.
+ *
+ * The token is a service credential, not an end-user authentication: its
+ * `userId` is a naming convention, so `waifu:0x<address>` is chosen by whoever
+ * holds `ELIZA_SERVICE_JWT_SECRET` and proves nothing about the address. Cloud
+ * verifies no SIWE/SIWS signature anywhere in this chain. Recording
+ * `wallet_verified: true` here handed that address a permanent no-reply identity
+ * at every relying party with `wallet_email_fallback` — a victim's public wallet
+ * becomes the attacker's git author address at the forge — so the row must
+ * carry the address as a lookup key and nothing more.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { SignJWT } from "jose";
+
+const SECRET = "waifu-bridge-shared-service-secret-0123456789";
+const VICTIM_WALLET = "0xAAaaBBbbCCccDDddEEeeFFff0011223344556677";
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+
+process.env.ELIZA_SERVICE_JWT_SECRET = SECRET;
+process.env.WAIFU_BRIDGE_ORG_ID = ORG_ID;
+
+const createCalls: Array<Record<string, unknown>> = [];
+
+mock.module("../services/users", () => ({
+  usersService: {
+    getByStewardId: async () => undefined,
+    getByWalletAddressWithOrganization: async () => undefined,
+    create: async (data: Record<string, unknown>) => {
+      createCalls.push(data);
+      return { id: "user-waifu" };
+    },
+    getWithOrganization: async () => ({
+      id: "user-waifu",
+      organization_id: ORG_ID,
+      organization: { id: ORG_ID, name: "waifu" },
+    }),
+  },
+}));
+
+mock.module("../services/organizations", () => ({
+  organizationsService: {
+    create: async () => {
+      throw new Error("a pinned WAIFU_BRIDGE_ORG_ID must not create an organization");
+    },
+    getBySlug: async () => undefined,
+  },
+}));
+
+mock.module("../../db/helpers", () => ({
+  dbWrite: {
+    insert: () => ({
+      values: async () => undefined,
+    }),
+  },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} },
+  redact: { id: (v: string) => v, orgId: (v: string) => v, userId: (v: string) => v },
+}));
+
+const { authenticateWaifuBridge } = await import("./waifu-bridge");
+
+async function bridgeRequest(userId: string): Promise<Request> {
+  const token = await new SignJWT({ userId })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(new TextEncoder().encode(SECRET));
+  return new Request("https://api.elizacloud.test/api/waifu/echo", {
+    headers: { authorization: `Bearer ${token}` },
+  });
+}
+
+beforeEach(() => {
+  createCalls.length = 0;
+});
+
+describe("provisioning a user from a service token naming a wallet", () => {
+  test("stores the address but never claims the wallet was verified", async () => {
+    const result = await authenticateWaifuBridge(await bridgeRequest(`waifu:${VICTIM_WALLET}`));
+
+    expect(result?.authMethod).toBe("service_jwt");
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].wallet_address).toBe(VICTIM_WALLET.toLowerCase());
+    // The whole point: nothing in this chain verified a signature over that
+    // address, so the flag the OIDC identity gate reads must stay false.
+    expect(createCalls[0].wallet_verified).toBe(false);
+  });
+
+  test("a token with no wallet in its subject provisions no wallet at all", async () => {
+    await authenticateWaifuBridge(await bridgeRequest("waifu-service-account"));
+
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].wallet_address).toBeUndefined();
+    expect(createCalls[0].wallet_verified).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/auth/waifu-bridge.ts
+++ b/packages/cloud/shared/src/lib/auth/waifu-bridge.ts
@@ -1,5 +1,12 @@
 /**
  * Waifu Bridge Auth — resolves waifu-core service JWTs to eliza-cloud user+org.
+ *
+ * The token is a SERVICE credential: it is signed with the shared
+ * `ELIZA_SERVICE_JWT_SECRET` and its `userId` is a naming convention, so every
+ * value read out of it is chosen by the calling service, not proven by an end
+ * user. That bounds what a row provisioned here may assert — in particular it
+ * may carry a wallet address as a lookup key, but never `wallet_verified`, which
+ * downstream turns into a portable identity (`lib/oidc/subject.ts`).
  */
 
 import crypto from "crypto";
@@ -201,7 +208,14 @@ async function resolveServiceUser(
       email,
       organization_id: orgId,
       wallet_address: walletAddr,
-      wallet_verified: !!walletAddr,
+      // NOT `!!walletAddr`. Nothing in this chain verifies a wallet signature:
+      // `walletAddr` is a substring of the service token's `userId`, so whoever
+      // holds the shared secret names the address — including a victim's public
+      // one. `wallet_verified` is read as control of the wallet and mints a
+      // permanent no-reply identity at any relying party with
+      // `wallet_email_fallback`, so this path must record what it actually
+      // knows, which is nothing.
+      wallet_verified: false,
       is_active: true,
     });
   } catch (err: unknown) {

--- a/packages/cloud/shared/src/lib/auth/wallet-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/wallet-auth.ts
@@ -76,7 +76,11 @@ export async function verifyWalletSignature(
     return cached;
   }
 
-  const { user } = await findOrCreateUserByWalletAddress(walletAddress);
+  // Reached only after the signature over method+path+timestamp verified and the
+  // nonce was claimed, so this request proved control of the address.
+  const { user } = await findOrCreateUserByWalletAddress(walletAddress, {
+    walletProven: true,
+  });
 
   if (!user.is_active) {
     throw new Error("User account is inactive");

--- a/packages/cloud/shared/src/lib/oidc/claims.test.ts
+++ b/packages/cloud/shared/src/lib/oidc/claims.test.ts
@@ -68,6 +68,7 @@ function makeClient(overrides: Partial<OidcClient> = {}): OidcClient {
     resource_audiences: [],
     require_pkce: false,
     require_verified_email: true,
+    wallet_email_fallback: false,
     roles_allowlist: [],
     claims_policy: { groups: true, roles: true, tenant_id: true, eliza_agents: false },
     claims_mapping: { roles: {}, groups: {}, mode: "extend" },
@@ -86,6 +87,7 @@ function build(overrides: Partial<OidcClaimsInput> = {}): Record<string, unknown
     organization: makeOrg(),
     profile: null,
     username: "ada",
+    walletEmail: null,
     adminStatus: NO_ADMIN,
     scopes: ["openid", "email", "profile", "groups"],
     client: makeClient(),
@@ -136,6 +138,117 @@ describe("email and email_verified", () => {
     const claims = build({ scopes: ["openid", "profile"] });
     expect(claims).not.toHaveProperty("email");
     expect(claims).not.toHaveProperty("email_verified");
+  });
+});
+
+/**
+ * The wallet-derived no-reply address. `walletEmail` is non-null only for a
+ * VERIFIED wallet (`loadOidcSubject` enforces that), so these cases are about
+ * what the claim builder does with one once it exists.
+ */
+describe("the wallet-derived email identity", () => {
+  const WALLET_EMAIL = "wallet-d4f3c344e6eb25da702fd567072f6ce1@users.noreply.api.elizacloud.ai";
+  const WALLET_ONLY = makeUser({
+    email: null,
+    email_verified: false,
+    wallet_address: "0x1234567890abcdef1234567890abcdef12345678",
+    wallet_verified: true,
+  });
+  const OPTED_IN = makeClient({ wallet_email_fallback: true });
+
+  test("a client that did not opt in is byte-identical with or without one", () => {
+    // The flag defaults false, so this is what every already-registered client
+    // sees: the address is computed and then simply never reached.
+    const withAddress = build({ user: WALLET_ONLY, walletEmail: WALLET_EMAIL });
+    const without = build({ user: WALLET_ONLY, walletEmail: null });
+    expect(withAddress).toEqual(without);
+    expect(withAddress).not.toHaveProperty("email");
+    expect(withAddress).not.toHaveProperty("eliza_email_source");
+    expect(withAddress.email_verified).toBe(false);
+  });
+
+  test("an opted-in client receives the address for a user who has no email", () => {
+    const claims = build({ user: WALLET_ONLY, walletEmail: WALLET_EMAIL, client: OPTED_IN });
+    expect(claims.email).toBe(WALLET_EMAIL);
+    expect(claims.eliza_email_source).toBe("wallet");
+  });
+
+  test("email_verified is FALSE for the synthesized address — never true, no knob", () => {
+    // The domain accepts no mail by construction, so nobody has ever proven
+    // control of that mailbox. An RP reading `true` would merge federated logins
+    // into local accounts on the strength of it and mail password resets there.
+    const claims = build({ user: WALLET_ONLY, walletEmail: WALLET_EMAIL, client: OPTED_IN });
+    expect(claims.email_verified).toBe(false);
+  });
+
+  test("a real verified email always wins, opted in or not", () => {
+    const verified = build({ user: makeUser(), walletEmail: WALLET_EMAIL, client: OPTED_IN });
+    expect(verified.email).toBe("ada@example.com");
+    expect(verified.email_verified).toBe(true);
+    expect(verified).not.toHaveProperty("eliza_email_source");
+    expect(verified).toEqual(build({ walletEmail: WALLET_EMAIL }));
+  });
+
+  test("a stored address wins even UNVERIFIED — synthesis is for a user who has none", () => {
+    // Substituting the wallet address here would hand this user a different
+    // account at every relying party keyed on the address, for no act of theirs
+    // beyond leaving an address unconfirmed. The unproven-address hazard is
+    // handled by refusing ADMISSION (`hasUsableOidcEmailIdentity`), not by
+    // quietly sending a different identity than the one the row holds.
+    const claims = build({
+      user: makeUser({ email: "ceo@company.example", email_verified: false }),
+      walletEmail: WALLET_EMAIL,
+      client: OPTED_IN,
+    });
+    expect(claims.email).toBe("ceo@company.example");
+    expect(claims.email_verified).toBe(false);
+    expect(claims).not.toHaveProperty("eliza_email_source");
+  });
+
+  test("the scrubbed squatter shape asserts nothing at all", () => {
+    // `loadOidcSubject` clears `email` and `email_verified` together for a row
+    // sitting in the reserved namespace. The result must read as "no address",
+    // not as "a confirmed mailbox this token declines to name" — including for a
+    // client that never opted into any of this.
+    const scrubbed = makeUser({ email: null, email_verified: false });
+    for (const client of [makeClient(), OPTED_IN]) {
+      const claims = build({ user: scrubbed, walletEmail: null, client });
+      expect(claims).not.toHaveProperty("email");
+      expect(claims.email_verified).toBe(false);
+      expect(claims).not.toHaveProperty("eliza_email_source");
+    }
+  });
+
+  test("an opted-in client with no wallet identity falls back to today's behaviour", () => {
+    const claims = build({
+      user: makeUser({ email: "ceo@company.example", email_verified: false }),
+      walletEmail: null,
+      client: OPTED_IN,
+    });
+    expect(claims.email).toBe("ceo@company.example");
+    expect(claims.email_verified).toBe(false);
+    expect(claims).not.toHaveProperty("eliza_email_source");
+  });
+
+  test("nothing is emitted without the email scope, opt-in or not", () => {
+    const claims = build({
+      user: WALLET_ONLY,
+      walletEmail: WALLET_EMAIL,
+      client: OPTED_IN,
+      scopes: ["openid", "profile", "groups"],
+    });
+    expect(claims).not.toHaveProperty("email");
+    expect(claims).not.toHaveProperty("email_verified");
+    expect(claims).not.toHaveProperty("eliza_email_source");
+  });
+
+  test("the synthesized address never becomes the username", () => {
+    // `preferred_username` is frozen at first login and the RP turns it into a
+    // permanent account name, so seeding it from the address would rename every
+    // wallet user who already signs in today.
+    const claims = build({ user: WALLET_ONLY, walletEmail: WALLET_EMAIL, client: OPTED_IN });
+    expect(claims.preferred_username).toBe("ada");
+    expect(claims.nickname).toBe("ada");
   });
 });
 
@@ -355,6 +468,7 @@ describe("tenant_id", () => {
       organization: makeOrg({ steward_tenant_id: null }),
       profile: null,
       username: "ada",
+      walletEmail: null,
       adminStatus: NO_ADMIN,
       deploymentTenantId: "elizacloud",
       scopes: ["openid", "email", "profile", "groups"],

--- a/packages/cloud/shared/src/lib/oidc/claims.ts
+++ b/packages/cloud/shared/src/lib/oidc/claims.ts
@@ -9,6 +9,35 @@
  *   - `email_verified` is read from the row and never fabricated. It is the
  *     gate the relying party uses before auto-creating an account, and
  *     `/authorize` refuses outright when a client requires it.
+ *   - A synthesized wallet address is the one `email` value not read from the
+ *     row, and it is emitted with `email_verified: FALSE`, always, with no
+ *     per-client knob. OpenID Connect Core 1.0 section 5.1 defines the flag as
+ *     "True if the End-User's e-mail address has been verified" — an assertion
+ *     that the End-User controls that MAILBOX, not that the provider controls
+ *     the domain. The mailbox does not exist: the domain accepts no mail by
+ *     construction, which is the whole point of it. `true` would be a claim with
+ *     no referent, and it would poison the one signal an RP uses before merging
+ *     a federated login into an existing local account bearing the same address
+ *     or before sending password-reset mail — linking accounts on an address
+ *     nobody proved, and black-holing every security message into a null route.
+ *     The assurance this deployment actually holds is about the WALLET — bound
+ *     to the account by a signature-verifying sign-in or by the provider that
+ *     issues the session, and admitted by `./subject.ts` — so it is emitted
+ *     truthfully under its own name, `eliza_email_source: "wallet"`, instead of
+ *     being laundered through `email_verified`. Two different questions were being conflated:
+ *     `require_verified_email` is OUR admission policy and is the half that
+ *     widens; `email_verified` is the RP's question about a mailbox and does not
+ *     move.
+ *
+ *     Emitting `false` here rests on a RELYING-PARTY property, so it is named:
+ *     the RP must create and link the account on `sub` and must not refuse or
+ *     defer a login over an unverified address. Forgejo, the RP this was built
+ *     for, does both — `LoginSource`/`ExternalLoginUser` is keyed on the OAuth2
+ *     subject, and its OIDC path has no "email must be verified" gate — and a
+ *     wallet sign-in was driven end to end against it before this shipped. An RP
+ *     that does gate on `email_verified` cannot use `wallet_email_fallback` at
+ *     all; it must not be given `true` instead, because that is the flag such an
+ *     RP would then trust to merge this login into a local account.
  *   - `groups` and `roles` are SYNTHESIZED. There is no `organization_members`
  *     or teams table anywhere in the schema: membership is the single
  *     `users.organization_id` FK plus the scalar `users.role`, so a user
@@ -118,6 +147,13 @@ export interface OidcClaimsInput {
   profile: Pick<OidcUserProfile, "username" | "account_kind" | "actor_id" | "agent_id"> | null;
   /** The frozen username; passed separately so allocation can happen at authorize. */
   username: string;
+  /**
+   * Deterministic no-reply address derived from a VERIFIED wallet, or `null`.
+   * Computed by `loadOidcSubject` because the digest is async and this builder
+   * is sync and pure. Only reached by a client with `wallet_email_fallback`, and
+   * only when the user has no verified email of their own.
+   */
+  walletEmail: string | null;
   adminStatus: OidcAdminStatus;
   /** Deployment-level tenant, used only when the organization carries none. */
   deploymentTenantId?: string | null;
@@ -256,6 +292,58 @@ export function resolveOidcTenantId(input: OidcClaimsInput): string | null {
   return input.organization?.steward_tenant_id ?? input.deploymentTenantId ?? null;
 }
 
+/** Which of the two possible origins the emitted `email` came from. */
+export type OidcEmailSource = "user" | "wallet";
+
+export interface OidcEmailIdentity {
+  /** The address to emit, or `null` when this subject presents none. */
+  email: string | null;
+  /** The value `email_verified` must carry beside it. */
+  emailVerified: boolean;
+  /** `null` exactly when `email` is null. `"wallet"` drives `eliza_email_source`. */
+  source: OidcEmailSource | null;
+}
+
+/**
+ * The single decision about which address a subject presents to one client.
+ *
+ * Both the claim builder here and the admission gate in `./subject.ts` read it,
+ * which is the point: admission and emission answered that question separately
+ * before, and the two answers could disagree — an opted-in client could admit a
+ * subject and then be handed a token with no `email` at all, or with an address
+ * the gate had not considered.
+ *
+ * Precedence is "a stored address wins, whatever its verification state". The
+ * earlier rule keyed the first arm on `email_verified` too, which meant a user
+ * who HAS an address but never confirmed it silently received the wallet-derived
+ * one instead of their own — a different account at every relying party that
+ * keys on the address, for a user who did nothing but leave an address
+ * unconfirmed. Synthesis now happens only where the documented contract says it
+ * does: for a user with genuinely no address. The unverified-address hazard that
+ * motivated the old ordering is handled where it belongs, by refusing ADMISSION
+ * (see `hasUsableOidcEmailIdentity`) rather than by substituting a different
+ * identity behind the relying party's back.
+ *
+ * The final arm keeps a row with no address at all reporting the column's own
+ * `email_verified`. That is pre-existing behaviour for the nullable-plaintext
+ * rows of the field-encryption rollout and is deliberately untouched; the one
+ * place a "verified but unnamed mailbox" must NOT be asserted is the reserved
+ * domain scrub, and `loadOidcSubject` clears both fields together there.
+ */
+export function resolveOidcEmailIdentity(
+  user: Pick<User, "email" | "email_verified">,
+  walletEmail: string | null,
+  client: Pick<OidcClient, "wallet_email_fallback">,
+): OidcEmailIdentity {
+  if (user.email) {
+    return { email: user.email, emailVerified: user.email_verified === true, source: "user" };
+  }
+  if (client.wallet_email_fallback && walletEmail) {
+    return { email: walletEmail, emailVerified: false, source: "wallet" };
+  }
+  return { email: null, emailVerified: user.email_verified === true, source: null };
+}
+
 /**
  * Build the scope-gated, policy-filtered claim set. `sub` is always present;
  * every other claim is omitted rather than emitted as null, so a consumer can
@@ -273,8 +361,12 @@ export function buildOidcClaims(input: OidcClaimsInput): OidcProfileClaims {
   const accountKind = readOidcAccountKind(profile?.account_kind);
 
   if (scopes.has("email")) {
-    if (user.email) claims.email = user.email;
-    claims.email_verified = user.email_verified === true;
+    const identity = resolveOidcEmailIdentity(user, input.walletEmail, client);
+    if (identity.email) claims.email = identity.email;
+    claims.email_verified = identity.emailVerified;
+    // Named only for the synthesized address, so a client reading it can tell
+    // "this is a wallet proof" from "this is a mailbox somebody confirmed".
+    if (identity.source === "wallet") claims.eliza_email_source = "wallet";
   }
 
   if (scopes.has("profile")) {

--- a/packages/cloud/shared/src/lib/oidc/clients.test.ts
+++ b/packages/cloud/shared/src/lib/oidc/clients.test.ts
@@ -50,6 +50,106 @@ describe("defaults", () => {
     expect(client.constant_claims).toEqual({});
     expect(client.resource_audiences).toEqual([]);
   });
+
+  test("wallet_email_fallback defaults OFF, so no registered client changes behavior", () => {
+    // It is the only knob that changes what the `email` claim can hold. Every
+    // entry written before it existed must parse to the strict posture.
+    expect(parseOidcClientEntry(entry()).wallet_email_fallback).toBe(false);
+    expect(
+      parseOidcClientEntry(entry({ require_verified_email: false })).wallet_email_fallback,
+    ).toBe(false);
+    // A non-boolean is the default too, not a truthy read of a JSON string.
+    expect(
+      parseOidcClientEntry(entry({ wallet_email_fallback: "true" })).wallet_email_fallback,
+    ).toBe(false);
+  });
+});
+
+describe("wallet_email_fallback", () => {
+  test("is carried through when set", () => {
+    expect(parseOidcClientEntry(entry({ wallet_email_fallback: true })).wallet_email_fallback).toBe(
+      true,
+    );
+  });
+
+  test("without the email scope that carries the address, the registry refuses to load", () => {
+    // The client would be ADMITTED — the gate widens — and then handed a token
+    // with no address at all, which fails at the relying party's account
+    // creation for a reason nothing here would log.
+    expect(() =>
+      parseOidcClientEntry(
+        entry({
+          wallet_email_fallback: true,
+          allowed_scopes: ["openid", "profile", "groups"],
+        }),
+      ),
+    ).toThrow(/wallet_email_fallback.*email.*scope/is);
+  });
+
+  test("with require_verified_email off, the registry refuses to load", () => {
+    // The flag WIDENS the verified-email gate. With that gate off there is no
+    // gate to widen, and the collision the rule above blocks reopens from the
+    // other side: a user with neither an address nor a verified wallet is
+    // admitted anyway and handed a token carrying no `email`, while the
+    // registration reads as though the flag guaranteed one.
+    expect(() =>
+      parseOidcClientEntry(entry({ wallet_email_fallback: true, require_verified_email: false })),
+    ).toThrow(/wallet_email_fallback.*require_verified_email/is);
+  });
+
+  test("the pair set together is the only accepted shape", () => {
+    const client = parseOidcClientEntry(
+      entry({ wallet_email_fallback: true, require_verified_email: true }),
+    );
+    expect(client.wallet_email_fallback).toBe(true);
+    expect(client.require_verified_email).toBe(true);
+  });
+});
+
+/**
+ * `eliza_email_source` is emitted only beside a wallet-derived address, so it is
+ * reserved only for the clients that can produce one. Reserving it for everybody
+ * would have been a retroactive rule: `RESERVED_CLAIM_NAMES` is spread from
+ * `OIDC_SUPPORTED_CLAIMS`, and one already-deployed entry using the name would
+ * have thrown the WHOLE registry — a 503 for every relying party over a constant
+ * that had been emitted verbatim until the deploy.
+ */
+describe("a constant claim named after a conditionally-emitted provider claim", () => {
+  test("still loads for a client that cannot emit it", () => {
+    const client = parseOidcClientEntry(entry({ constant_claims: { eliza_email_source: "ldap" } }));
+    expect(client.constant_claims.eliza_email_source).toBe("ldap");
+  });
+
+  test("does not take the rest of the registry down with it", () => {
+    // The failure mode being pinned: one legacy entry must not stop the other
+    // relying parties from resolving.
+    loadRegistry([
+      entry({ constant_claims: { eliza_email_source: "ldap" } }),
+      entry({ client_id: "other-app", redirect_uris: ["https://other.example/cb"] }),
+    ]);
+    expect(getOidcClient("elizahub-forgejo")?.constant_claims.eliza_email_source).toBe("ldap");
+    expect(getOidcClient("other-app")).not.toBeNull();
+  });
+
+  test("is refused for a client that DOES emit it, where the constant would be dead", () => {
+    expect(() =>
+      parseOidcClientEntry(
+        entry({
+          wallet_email_fallback: true,
+          require_verified_email: true,
+          constant_claims: { eliza_email_source: "ldap" },
+        }),
+      ),
+    ).toThrow(/eliza_email_source/);
+  });
+
+  test("every unconditional provider claim stays reserved for everybody", () => {
+    for (const name of ["email", "email_verified", "sub", "groups", "eliza_account_kind"]) {
+      expect(() => parseOidcClientEntry(entry({ constant_claims: { [name]: "x" } }))).toThrow(
+        /may not override the provider claim/,
+      );
+    }
+  });
 });
 
 describe("scope and claims_policy must agree", () => {

--- a/packages/cloud/shared/src/lib/oidc/clients.ts
+++ b/packages/cloud/shared/src/lib/oidc/clients.ts
@@ -31,6 +31,15 @@
  * registry. An ID token's `aud` IS the client id, so that registration hands the
  * resource server behind the audience a token its client already holds. It is
  * refused across the whole registry, not per entry.
+ *
+ * `wallet_email_fallback` defaults FALSE and is the only knob that changes what
+ * the `email` claim can hold. It widens the `require_verified_email` gate rather
+ * than replacing it, so the two must be set together: with the requirement OFF
+ * there is no gate to widen, and a user with neither an address nor a verified
+ * wallet is admitted and handed a token carrying no `email` at all — the same
+ * failure the flag exists to prevent, reached from the other side. That
+ * combination is refused here rather than left to surface at the relying party's
+ * account creation.
  */
 
 import { timingSafeEqualSecret } from "../auth/cron";
@@ -78,6 +87,19 @@ export interface OidcClient {
   require_pkce: boolean;
   require_verified_email: boolean;
   /**
+   * Accept a cryptographically verified WALLET in place of a verified email, and
+   * emit the deterministic no-reply address derived from it. Default false, so
+   * every already-registered client keeps byte-identical behaviour.
+   *
+   * Set it only for a relying party that needs an address as an account key —
+   * Forgejo cannot create an account without one, and git cannot author a commit
+   * without one — and that is willing to read `eliza_email_source` rather than
+   * `email_verified` for its identity assurance. A stored `users.email` always
+   * wins; this only ever fills in for a user who has none. Requires
+   * `require_verified_email`, which it widens rather than replaces.
+   */
+  wallet_email_fallback: boolean;
+  /**
    * NATIVE roles this client may see, applied before `claims_mapping`. Empty
    * means "every role this provider knows". Set it for any RP whose
    * authorization decisions branch on `roles`.
@@ -106,10 +128,27 @@ const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
 const CLAIM_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_.-]{0,63}$/;
 
 /**
- * Names `constant_claims` may not take. Everything the provider itself emits is
- * listed, plus the JWT envelope members `stripReservedClaims` removes and the
- * two access-token members `mintOidcAccessToken` writes. A constant claim is
- * spread before the derived ones, so shadowing is already impossible at
+ * Claims the provider emits only for a client that turned a feature on, and
+ * therefore reserves only for that client.
+ *
+ * `RESERVED_CLAIM_NAMES` is derived from `OIDC_SUPPORTED_CLAIMS`, so appending a
+ * name there is NOT the additive change it looks like: it retroactively forbids
+ * that name in `constant_claims`, and one entry using it makes the whole
+ * registry throw — a 503 that takes every relying party down, not just the
+ * misconfigured one, for a value that had been emitted verbatim until the
+ * deploy. `eliza_email_source` is only ever produced beside a wallet-derived
+ * address, so a client without `wallet_email_fallback` cannot collide with it
+ * and keeps whatever it had. `assertClientIsCoherent` refuses the name for the
+ * clients that CAN collide, where the constant would be silently overwritten by
+ * the provider's own value.
+ */
+const CONDITIONAL_CLAIM_NAMES = new Set<string>(["eliza_email_source"]);
+
+/**
+ * Names `constant_claims` may not take. Everything the provider unconditionally
+ * emits is listed, plus the JWT envelope members `stripReservedClaims` removes
+ * and the two access-token members `mintOidcAccessToken` writes. A constant
+ * claim is spread before the derived ones, so shadowing is already impossible at
  * build time; refusing the name here means the operator learns at deploy time
  * that the value would never have been used.
  *
@@ -118,7 +157,7 @@ const CLAIM_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_.-]{0,63}$/;
  * which is the misrepresentation dropping the claim exists to avoid.
  */
 const RESERVED_CLAIM_NAMES = new Set<string>([
-  ...OIDC_SUPPORTED_CLAIMS,
+  ...OIDC_SUPPORTED_CLAIMS.filter((claim) => !CONDITIONAL_CLAIM_NAMES.has(claim)),
   "auth_time",
   "nbf",
   "jti",
@@ -327,6 +366,29 @@ function assertClientIsCoherent(client: OidcClient): void {
       `OIDC_CLIENTS[${id}] must allow the "eliza_agents" scope and set claims_policy.eliza_agents together`,
     );
   }
+  if (client.wallet_email_fallback && !client.allowed_scopes.includes("email")) {
+    throw new Error(
+      `OIDC_CLIENTS[${id}] sets wallet_email_fallback but omits the "email" scope that carries the address, so a wallet-only user would be admitted and then handed no email at all`,
+    );
+  }
+  if (client.wallet_email_fallback && !client.require_verified_email) {
+    // The fallback WIDENS the verified-email gate; with that gate off there is
+    // no gate to widen, and the same collision reopens from the other side. A
+    // user with neither an address nor a verified wallet is admitted and handed
+    // a token with no `email`, which is precisely what the rule above exists to
+    // prevent, and the registration reads as though the flag were guaranteeing
+    // an address it cannot guarantee.
+    throw new Error(
+      `OIDC_CLIENTS[${id}] sets wallet_email_fallback with require_verified_email false; the fallback only widens the verified-email gate, so with the gate off a user with neither an email nor a verified wallet is still admitted and handed a token carrying no address`,
+    );
+  }
+  for (const name of Object.keys(client.constant_claims)) {
+    if (client.wallet_email_fallback && CONDITIONAL_CLAIM_NAMES.has(name)) {
+      throw new Error(
+        `OIDC_CLIENTS[${id}].constant_claims may not set "${name}": this client sets wallet_email_fallback, so the provider emits that claim itself and the constant would never be used`,
+      );
+    }
+  }
   if (client.roles_allowlist.length > 0 && !client.claims_policy.roles) {
     throw new Error(`OIDC_CLIENTS[${id}] sets roles_allowlist but claims_policy denies roles`);
   }
@@ -410,6 +472,7 @@ function parseClient(raw: unknown, index: number): OidcClient {
     resource_audiences: stringList(entry.resource_audiences, "resource_audiences", clientId),
     require_pkce: boolField(entry.require_pkce, false),
     require_verified_email: boolField(entry.require_verified_email, true),
+    wallet_email_fallback: boolField(entry.wallet_email_fallback, false),
     roles_allowlist: stringList(entry.roles_allowlist, "roles_allowlist", clientId),
     claims_policy: parseClaimsPolicy(entry.claims_policy),
     claims_mapping: parseClaimsMapping(entry.claims_mapping, clientId),

--- a/packages/cloud/shared/src/lib/oidc/config.test.ts
+++ b/packages/cloud/shared/src/lib/oidc/config.test.ts
@@ -21,6 +21,7 @@ import { join } from "node:path";
 
 import {
   describeOidcConfigFailure,
+  describeOidcWalletEmailFailure,
   isIssuerHost,
   isLoopbackIssuerHostname,
   isOidcEnabled,
@@ -71,6 +72,75 @@ describe("endpoint derivation", () => {
       "https://elizacloud.ai",
     );
     expect(resolveOidcConfig(env())?.appOrigin).toBe("https://api.elizacloud.ai");
+  });
+});
+
+describe("the wallet-email domain derived from the issuer", () => {
+  test("defaults to users.noreply.<issuer hostname>, which only this deployment can serve", () => {
+    const config = resolveOidcConfig(env());
+    expect(config?.issuerHostname).toBe("api.elizacloud.ai");
+    expect(config?.walletEmailDomain).toBe("users.noreply.api.elizacloud.ai");
+  });
+
+  test("strips the port, because issuerHost is not a legal email domain", () => {
+    // `issuerHost` carries `localhost:8787` for cookie-scope reasons; an email
+    // domain cannot. `localhost` is a reserved TLD that routes nowhere.
+    const config = resolveOidcConfig(env({ OIDC_ISSUER_URL: "http://localhost:8787" }));
+    expect(config?.issuerHost).toBe("localhost:8787");
+    expect(config?.issuerHostname).toBe("localhost");
+    expect(config?.walletEmailDomain).toBe("users.noreply.localhost");
+  });
+
+  test("resolves to null on an IP-literal issuer, leaving the provider otherwise usable", () => {
+    // No DNS subtree exists to own, so there is no honest address to mint. The
+    // rest of the provider still resolves; wallet-only sign-in is what refuses.
+    for (const issuer of ["http://127.0.0.1:8787", "http://[::1]:8787"]) {
+      const config = resolveOidcConfig(env({ OIDC_ISSUER_URL: issuer }));
+      expect(config).not.toBeNull();
+      expect(config?.walletEmailDomain).toBeNull();
+      expect(describeOidcConfigFailure(env({ OIDC_ISSUER_URL: issuer }))).toBe("");
+    }
+  });
+
+  test("an override below the issuer hostname is honored", () => {
+    const config = resolveOidcConfig(
+      env({ OIDC_WALLET_EMAIL_DOMAIN: "noreply.api.elizacloud.ai" }),
+    );
+    expect(config?.walletEmailDomain).toBe("noreply.api.elizacloud.ai");
+  });
+
+  test("an override the deployment cannot own turns the FEATURE off, not the provider", () => {
+    // Collapsing the config over this would 404 discovery and 503 authorize,
+    // token, and userinfo — sign-in gone for every relying party, including all
+    // the ones that never asked for a wallet identity — over one optional
+    // variable governing one opt-in feature. It degrades to the same state an
+    // IP-literal issuer produces, and carries the violated rule as a sentence.
+    for (const override of ["gmail.com", "users.noreply.elizacloud.ai", "api.elizacloud.ai"]) {
+      const config = resolveOidcConfig(env({ OIDC_WALLET_EMAIL_DOMAIN: override }));
+      expect(config).not.toBeNull();
+      expect(config?.issuer).toBe("https://api.elizacloud.ai");
+      expect(config?.tokenUrl).toBe("https://api.elizacloud.ai/api/oidc/token");
+      expect(config?.walletEmailDomain).toBeNull();
+      expect(config?.walletEmailUnavailableReason).toMatch(/OIDC_WALLET_EMAIL_DOMAIN/);
+      // Not a config failure: this string is what a caller logs beside the 404
+      // or 503 it is about to answer, and there is no 404 or 503 here.
+      expect(describeOidcConfigFailure(env({ OIDC_WALLET_EMAIL_DOMAIN: override }))).toBe("");
+      expect(describeOidcWalletEmailFailure(env({ OIDC_WALLET_EMAIL_DOMAIN: override }))).toMatch(
+        /OIDC_WALLET_EMAIL_DOMAIN/,
+      );
+    }
+  });
+
+  test("a working deployment reports no wallet-email reason at all", () => {
+    // The field distinguishes "configured wrong" from "nothing to configure", so
+    // an IP-literal issuer — feature unavailable, but not an operator mistake —
+    // must stay silent rather than manufacture a fixable-looking sentence.
+    expect(resolveOidcConfig(env())?.walletEmailUnavailableReason).toBeNull();
+    expect(describeOidcWalletEmailFailure(env())).toBe("");
+    const literal = env({ OIDC_ISSUER_URL: "http://127.0.0.1:8787" });
+    expect(resolveOidcConfig(literal)?.walletEmailDomain).toBeNull();
+    expect(resolveOidcConfig(literal)?.walletEmailUnavailableReason).toBeNull();
+    expect(describeOidcWalletEmailFailure(literal)).toBe("");
   });
 });
 

--- a/packages/cloud/shared/src/lib/oidc/config.ts
+++ b/packages/cloud/shared/src/lib/oidc/config.ts
@@ -24,7 +24,22 @@
  * `VITE_OIDC_ISSUER_URL`: the SPA sends the signed-out login bounce to the
  * issuer origin, and the two loopback names are separate cookie jars, so a
  * local deployment that mixes them drops the session on the way to `/authorize`.
+ *
+ * The wallet-email domain is derived from the same already-validated URL, which
+ * is why it is resolved here rather than read independently: an address minted
+ * on a domain the issuer does not own would be registerable by somebody else. An
+ * `OIDC_WALLET_EMAIL_DOMAIN` that is SET BUT INVALID does NOT collapse the
+ * config, because that failure is not proportional to its blast radius: the
+ * variable is optional and governs one opt-in feature, while a null config 404s
+ * discovery and 503s authorize, token, and userinfo for every relying party. The
+ * feature degrades to unavailable — `walletEmailDomain: null`, the same state an
+ * IP-literal issuer produces — and the violated rule is carried on
+ * `walletEmailUnavailableReason` and reported by
+ * `describeOidcWalletEmailFailure` so it is a named sentence in a log rather
+ * than a silent refusal.
  */
+
+import { resolveOidcWalletEmailDomain } from "./wallet-email";
 
 export const OIDC_DISCOVERY_PATH = "/.well-known/openid-configuration";
 export const OIDC_JWKS_PATH = "/.well-known/oidc/jwks.json";
@@ -41,6 +56,7 @@ export interface OidcConfigEnv {
   OIDC_ISSUER_URL?: unknown;
   ELIZA_CLOUD_URL?: unknown;
   NEXT_PUBLIC_APP_URL?: unknown;
+  OIDC_WALLET_EMAIL_DOMAIN?: unknown;
 }
 
 export interface OidcConfig {
@@ -48,6 +64,23 @@ export interface OidcConfig {
   issuer: string;
   /** Lowercased host of `issuer`; every endpoint refuses other hosts. */
   issuerHost: string;
+  /** Lowercased HOSTNAME of `issuer` — no port, so it is a legal DNS name. */
+  issuerHostname: string;
+  /**
+   * Provider-controlled domain synthesized wallet identities live on, or `null`
+   * when this deployment cannot host one (an IP-literal issuer). Never a
+   * fallback: a null means wallet-only sign-in is refused, not that some other
+   * domain is used.
+   */
+  walletEmailDomain: string | null;
+  /**
+   * The rule an operator broke in `OIDC_WALLET_EMAIL_DOMAIN`, or `null` when
+   * nothing is wrong. Non-null always accompanies `walletEmailDomain: null` and
+   * is the difference between "this deployment hosts no such domain" and "the
+   * one you configured was refused" — a distinction only a log line can carry,
+   * since both look identical to a refused user.
+   */
+  walletEmailUnavailableReason: string | null;
   /** Origin of the SPA that owns `/login` and `/oidc/continue`. */
   appOrigin: string;
   discoveryUrl: string;
@@ -142,7 +175,31 @@ export function describeOidcConfigFailure(env: OidcConfigEnv): string {
   const raw = readString(env.OIDC_ISSUER_URL);
   if (!raw) return "OIDC_ISSUER_URL is not set";
   const checked = validateOidcIssuer(raw);
-  return checked.ok ? "" : checked.reason;
+  if (!checked.ok) return checked.reason;
+  // A bad OIDC_WALLET_EMAIL_DOMAIN is deliberately NOT reported here. This
+  // string is what a caller logs beside a 404 or a 503, and the provider stays
+  // up for that fault; `describeOidcWalletEmailFailure` carries it instead.
+  return "";
+}
+
+/**
+ * Why wallet-derived identities are unavailable on this deployment, or an empty
+ * string when nothing is wrong.
+ *
+ * Only a REFUSED `OIDC_WALLET_EMAIL_DOMAIN` produces a sentence. An IP-literal
+ * issuer also leaves the feature unavailable, but that is a property of the
+ * deployment rather than a mistake, and there is nothing for an operator to fix.
+ */
+export function describeOidcWalletEmailFailure(env: OidcConfigEnv): string {
+  const raw = readString(env.OIDC_ISSUER_URL);
+  if (!raw) return "";
+  const checked = validateOidcIssuer(raw);
+  if (!checked.ok) return "";
+  const domain = resolveOidcWalletEmailDomain(
+    checked.url.hostname,
+    readString(env.OIDC_WALLET_EMAIL_DOMAIN),
+  );
+  return domain.ok ? "" : domain.reason;
 }
 
 /**
@@ -162,6 +219,16 @@ export function resolveOidcConfig(env: OidcConfigEnv): OidcConfig | null {
   if (!checked.ok) return null;
   const parsed = checked.url;
 
+  const issuerHostname = parsed.hostname.toLowerCase();
+  // A refused override degrades the ONE feature it configures. Returning null
+  // here would 404 discovery and 503 every endpoint — taking down sign-in for
+  // every relying party, including the ones that never asked for a wallet
+  // identity — over an optional variable.
+  const walletEmail = resolveOidcWalletEmailDomain(
+    issuerHostname,
+    readString(env.OIDC_WALLET_EMAIL_DOMAIN),
+  );
+
   const issuer = stripTrailingSlash(raw);
   const appOrigin =
     readString(env.ELIZA_CLOUD_URL) ?? readString(env.NEXT_PUBLIC_APP_URL) ?? parsed.origin;
@@ -169,6 +236,9 @@ export function resolveOidcConfig(env: OidcConfigEnv): OidcConfig | null {
   return {
     issuer,
     issuerHost: parsed.host.toLowerCase(),
+    issuerHostname,
+    walletEmailDomain: walletEmail.ok ? walletEmail.domain : null,
+    walletEmailUnavailableReason: walletEmail.ok ? null : walletEmail.reason,
     appOrigin: stripTrailingSlash(appOrigin),
     discoveryUrl: `${issuer}${OIDC_DISCOVERY_PATH}`,
     jwksUrl: `${issuer}${OIDC_JWKS_PATH}`,

--- a/packages/cloud/shared/src/lib/oidc/metadata.test.ts
+++ b/packages/cloud/shared/src/lib/oidc/metadata.test.ts
@@ -64,6 +64,14 @@ describe("advertised capabilities", () => {
     expect(document.claims_supported).not.toContain("auth_time");
   });
 
+  test("eliza_email_source is advertised, and is therefore reserved from constant_claims", () => {
+    // `clients.ts` builds RESERVED_CLAIM_NAMES from this list, so advertising the
+    // claim is also what stops an operator registering a constant that the
+    // provider would then silently override.
+    const document = buildOidcDiscoveryDocument(config, ["RS256"]);
+    expect(document.claims_supported).toContain("eliza_email_source");
+  });
+
   test("operator-registered constant claims are added once", () => {
     const document = buildOidcDiscoveryDocument(config, ["RS256"], ["tenant", "tenant", "sub"]);
     expect(document.claims_supported.filter((c) => c === "tenant")).toHaveLength(1);

--- a/packages/cloud/shared/src/lib/oidc/metadata.ts
+++ b/packages/cloud/shared/src/lib/oidc/metadata.ts
@@ -63,6 +63,19 @@ export const OIDC_SUPPORTED_SCOPES = [
  * cannot observe when the platform session was established (`./session.ts`).
  * Advertising it would invite a relying party to gate freshness on a number
  * nothing here can source honestly.
+ *
+ * `eliza_email_source` is emitted only when `email` is a wallet-derived no-reply
+ * address, and it is what an RP reads for "this identity is cryptographically
+ * proven" — `email_verified` answers the different question of whether a mailbox
+ * was confirmed, and stays false there.
+ *
+ * Adding a name to this list is not a local edit. `./clients.ts` spreads it into
+ * the set of names `constant_claims` may not take, so a name added here forbids
+ * an operator-chosen constant that had been legal — and one such entry throws
+ * the whole registry, not just its own client. A claim the provider emits only
+ * under a per-client flag therefore belongs in that module's
+ * `CONDITIONAL_CLAIM_NAMES`, which reserves it for the clients that can actually
+ * collide with it.
  */
 export const OIDC_SUPPORTED_CLAIMS = [
   "iss",
@@ -74,6 +87,7 @@ export const OIDC_SUPPORTED_CLAIMS = [
   "azp",
   "email",
   "email_verified",
+  "eliza_email_source",
   "preferred_username",
   "nickname",
   "name",

--- a/packages/cloud/shared/src/lib/oidc/subject.test.ts
+++ b/packages/cloud/shared/src/lib/oidc/subject.test.ts
@@ -1,0 +1,291 @@
+/**
+ * The admission gate for the OpenID Provider: which accounts may become an
+ * identity at a relying party. Real `assertOidcSubjectEligible` against
+ * constructed row literals — pure decision function, no database, no Worker.
+ *
+ * The matrix that matters is verified email / unverified email / verified wallet
+ * / unverified wallet crossed with the per-client opt-in, because each cell is a
+ * different kind of mistake: admitting an unverified wallet would hand out an
+ * identity backed by nothing, and refusing a verified one is the lock-out this
+ * change exists to fix. The last case is the squatting row — a stored address on
+ * the reserved wallet-email domain, which `loadOidcSubject` neutralizes before
+ * this function ever sees it, asserted here through the shape it produces.
+ *
+ * `readVerifiedWalletAddress` is the other half and is tested directly: it
+ * decides which rows are even offered to the gate, and the rows it must refuse
+ * are shapes real writers produce, not hypotheticals.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { UserWithOrganization } from "../../db/repositories/users";
+import { resolveOidcEmailIdentity } from "./claims";
+import type { OidcClient } from "./clients";
+import {
+  assertOidcSubjectEligible,
+  hasUsableOidcEmailIdentity,
+  type OidcSubject,
+  readVerifiedWalletAddress,
+} from "./subject";
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const WALLET_EMAIL = "wallet-d4f3c344e6eb25da702fd567072f6ce1@users.noreply.api.elizacloud.ai";
+
+function makeSubject(overrides: {
+  user?: Partial<UserWithOrganization>;
+  walletEmail?: string | null;
+}): OidcSubject {
+  return {
+    user: {
+      id: USER_ID,
+      email: "ada@example.com",
+      email_verified: true,
+      wallet_address: null,
+      wallet_chain_type: null,
+      wallet_verified: false,
+      is_anonymous: false,
+      is_active: true,
+      deleted_at: null,
+      organization: null,
+      ...overrides.user,
+    } as UserWithOrganization,
+    profile: null,
+    adminStatus: { isAdmin: false, role: null, implicit: false },
+    walletEmail: overrides.walletEmail ?? null,
+  };
+}
+
+function makeClient(overrides: Partial<OidcClient> = {}): OidcClient {
+  return {
+    client_id: "elizahub-forgejo",
+    name: "Eliza Hub",
+    secret_hashes: ["0".repeat(64)],
+    redirect_uris: ["https://hub.example/user/oauth2/elizacloud/callback"],
+    allowed_scopes: ["openid", "email", "profile", "groups"],
+    resource_audiences: [],
+    require_pkce: false,
+    require_verified_email: true,
+    wallet_email_fallback: false,
+    roles_allowlist: [],
+    claims_policy: { groups: true, roles: true, tenant_id: true, eliza_agents: false },
+    claims_mapping: { roles: {}, groups: {}, mode: "extend" },
+    constant_claims: {},
+    id_token_ttl_seconds: 300,
+    access_token_ttl_seconds: 300,
+    ...overrides,
+  };
+}
+
+const WALLET_ONLY = {
+  user: {
+    email: null,
+    email_verified: false,
+    wallet_address: "0xabc",
+    wallet_chain_type: "evm",
+    wallet_verified: true,
+  },
+  walletEmail: WALLET_EMAIL,
+};
+
+describe("the account checks that run before any email rule", () => {
+  test("anonymous, inactive, soft-deleted, and dead-org rows are refused first", () => {
+    const client = makeClient({ wallet_email_fallback: true });
+    expect(assertOidcSubjectEligible(makeSubject({ user: { is_anonymous: true } }), client)).toBe(
+      "user_anonymous",
+    );
+    expect(assertOidcSubjectEligible(makeSubject({ user: { is_active: false } }), client)).toBe(
+      "user_inactive",
+    );
+    expect(
+      assertOidcSubjectEligible(makeSubject({ user: { deleted_at: new Date() } }), client),
+    ).toBe("user_inactive");
+    expect(
+      assertOidcSubjectEligible(
+        makeSubject({ user: { organization: { is_active: false } as never } }),
+        client,
+      ),
+    ).toBe("organization_inactive");
+  });
+
+  test("a verified wallet does not rescue an account that failed one of them", () => {
+    const client = makeClient({ wallet_email_fallback: true });
+    expect(
+      assertOidcSubjectEligible(
+        makeSubject({ ...WALLET_ONLY, user: { ...WALLET_ONLY.user, is_anonymous: true } }),
+        client,
+      ),
+    ).toBe("user_anonymous");
+  });
+});
+
+describe("a client that did not opt in", () => {
+  const client = makeClient();
+
+  test("admits a verified email exactly as before", () => {
+    expect(assertOidcSubjectEligible(makeSubject({}), client)).toBeNull();
+  });
+
+  test("refuses a wallet-only user with the original reason string", () => {
+    // The reason travels to the relying party and into the audit log; changing
+    // it for a registration that did not opt in would be a behaviour change.
+    expect(assertOidcSubjectEligible(makeSubject(WALLET_ONLY), client)).toBe("email_unverified");
+  });
+
+  test("refuses an unverified email exactly as before", () => {
+    expect(
+      assertOidcSubjectEligible(makeSubject({ user: { email_verified: false } }), client),
+    ).toBe("email_unverified");
+  });
+
+  test("does not consider the wallet identity usable at all", () => {
+    expect(hasUsableOidcEmailIdentity(makeSubject(WALLET_ONLY), client)).toBe(false);
+  });
+});
+
+describe("a client with wallet_email_fallback", () => {
+  const client = makeClient({ wallet_email_fallback: true });
+
+  test("admits a wallet-only user whose wallet is verified", () => {
+    expect(assertOidcSubjectEligible(makeSubject(WALLET_ONLY), client)).toBeNull();
+    expect(hasUsableOidcEmailIdentity(makeSubject(WALLET_ONLY), client)).toBe(true);
+  });
+
+  test("still refuses an UNVERIFIED wallet — an address proves nothing on its own", () => {
+    // `loadOidcSubject` produces no walletEmail without `wallet_verified`, which
+    // is what this cell asserts: the gate cannot be reached by storing a string.
+    const subject = makeSubject({
+      user: { email: null, email_verified: false, wallet_address: "0xabc", wallet_verified: false },
+      walletEmail: null,
+    });
+    expect(assertOidcSubjectEligible(subject, client)).toBe("no_verified_identity");
+  });
+
+  test("refuses a user with neither a verified email nor any wallet", () => {
+    const subject = makeSubject({ user: { email: null, email_verified: false } });
+    expect(assertOidcSubjectEligible(subject, client)).toBe("no_verified_identity");
+  });
+
+  test("refuses when the deployment hosts no wallet-email domain", () => {
+    // IP-literal issuer: the wallet is verified but there is no domain to mint
+    // an address on, so there is nothing to admit the user with.
+    const subject = makeSubject({ ...WALLET_ONLY, walletEmail: null });
+    expect(assertOidcSubjectEligible(subject, client)).toBe("no_verified_identity");
+  });
+
+  test("changes nothing for a user who has a real verified email", () => {
+    expect(assertOidcSubjectEligible(makeSubject({}), client)).toBeNull();
+  });
+
+  test("refuses an UNCONFIRMED stored address even when the wallet is verified", () => {
+    // Admission is asked of the identity that will actually be EMITTED, and a
+    // stored address takes precedence over the wallet. Admitting here would hand
+    // a client that demanded a verified email an address nobody proved — the
+    // collision the requirement exists to prevent — because the wallet address
+    // is not what this subject's token would carry.
+    const subject = makeSubject({
+      user: {
+        email: "ada@example.com",
+        email_verified: false,
+        wallet_address: "0xabc",
+        wallet_chain_type: "evm",
+        wallet_verified: true,
+      },
+      walletEmail: WALLET_EMAIL,
+    });
+    expect(hasUsableOidcEmailIdentity(subject, client)).toBe(false);
+    // The address is unconfirmed, and confirming it is the fix — so the reason
+    // is the one that says so, not the one that says there is no identity.
+    expect(assertOidcSubjectEligible(subject, client)).toBe("email_unverified");
+  });
+
+  test("admission implies emission: every admitted subject has an address to send", () => {
+    // The two were separate expressions and could disagree, which is how an
+    // opted-in client came to admit a subject and then receive a token with no
+    // `email` at all. Asserted over the whole matrix rather than a single row.
+    for (const email of [null, "ada@example.com"]) {
+      for (const emailVerified of [true, false]) {
+        for (const walletEmail of [null, WALLET_EMAIL]) {
+          const subject = makeSubject({
+            user: { email, email_verified: emailVerified },
+            walletEmail,
+          });
+          if (!hasUsableOidcEmailIdentity(subject, client)) continue;
+          const identity = resolveOidcEmailIdentity(subject.user, walletEmail, client);
+          expect(identity.email).not.toBeNull();
+        }
+      }
+    }
+  });
+});
+
+describe("which rows carry a wallet identity at all", () => {
+  type WalletRow = Parameters<typeof readVerifiedWalletAddress>[0];
+
+  function row(overrides: Partial<WalletRow> = {}): WalletRow {
+    return {
+      wallet_address: "0x1234567890abcdef1234567890abcdef12345678",
+      wallet_chain_type: "evm",
+      wallet_verified: true,
+      ...overrides,
+    } as WalletRow;
+  }
+
+  test("accepts every chain type a wallet-binding path records", () => {
+    // `evm` from /api/users/me/wallet/attach and the SIWE signup, `solana` from
+    // the SIWS signup and from a Steward claim, `ethereum` from a Steward claim.
+    for (const chain of ["evm", "ethereum", "solana"]) {
+      expect(readVerifiedWalletAddress(row({ wallet_chain_type: chain }))).toBe(
+        "0x1234567890abcdef1234567890abcdef12345678",
+      );
+    }
+  });
+
+  test("refuses a verified flag with NO chain type — the service-bridge shape", () => {
+    // `lib/auth/waifu-bridge.ts` provisioned rows from an address SUBSTRING of a
+    // service token's subject: whoever holds the shared secret picks the
+    // address, including a victim's public one. That path now records
+    // `wallet_verified: false`, and this is the second lock: a row with no
+    // recorded chain type has no recorded provenance, so it is not an identity
+    // even if some later writer flips the flag.
+    expect(readVerifiedWalletAddress(row({ wallet_chain_type: null }))).toBeNull();
+    expect(readVerifiedWalletAddress(row({ wallet_chain_type: "" }))).toBeNull();
+    expect(readVerifiedWalletAddress(row({ wallet_chain_type: "   " }))).toBeNull();
+    expect(readVerifiedWalletAddress(row({ wallet_chain_type: "waifu" }))).toBeNull();
+  });
+
+  test("refuses an unverified wallet whatever else the row says", () => {
+    expect(readVerifiedWalletAddress(row({ wallet_verified: false }))).toBeNull();
+  });
+
+  test("refuses an absent or blank address", () => {
+    expect(readVerifiedWalletAddress(row({ wallet_address: null }))).toBeNull();
+    expect(readVerifiedWalletAddress(row({ wallet_address: "   " }))).toBeNull();
+  });
+
+  test("returns the stored address, leaving canonicalization to the digest", () => {
+    // Base58 is case-sensitive, so nothing here may fold the address; the digest
+    // applies the chain-shaped rule once, in `synthesizeOidcWalletEmail`.
+    const solana = "7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2";
+    expect(
+      readVerifiedWalletAddress(row({ wallet_address: solana, wallet_chain_type: "solana" })),
+    ).toBe(solana);
+  });
+});
+
+describe("a stored email squatting the reserved wallet-email domain", () => {
+  test("counts for nothing, because loadOidcSubject strips it before the gate", () => {
+    // The attacker's row reaches this function with BOTH fields cleared — the
+    // guard is unconditional, so the squat cannot be laundered through a client
+    // that does not require a verified email either. `email_verified` is cleared
+    // beside the address rather than left behind: a lingering `true` would be an
+    // assertion about a mailbox the same token declines to name.
+    const stripped = makeSubject({
+      user: { email: null, email_verified: false, wallet_address: null, wallet_verified: false },
+    });
+    expect(hasUsableOidcEmailIdentity(stripped, makeClient())).toBe(false);
+    expect(assertOidcSubjectEligible(stripped, makeClient())).toBe("email_unverified");
+    expect(assertOidcSubjectEligible(stripped, makeClient({ wallet_email_fallback: true }))).toBe(
+      "no_verified_identity",
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/oidc/subject.ts
+++ b/packages/cloud/shared/src/lib/oidc/subject.ts
@@ -7,42 +7,150 @@
  * `/token` and `/userinfo` must observe a deactivation that happened after the
  * code was issued. `assertOidcSubjectEligible` is the gate: it refuses
  * anonymous, inactive, and soft-deleted rows, and — for a client that requires
- * it — a row without a verified email address.
+ * it — a row with no identity this provider is willing to hand over.
  *
- * That last check is deliberately "verified AND present". The field-level
- * encryption rollout leaves `users.email` nullable while ciphertext columns
- * fill in, and a relying party configured for automatic account creation would
- * otherwise silently start creating accounts with no address. Failing the
- * authorization loudly is the safe direction.
+ * "Identity" is a verified email by default, and that check is deliberately
+ * "verified AND present". The field-level encryption rollout leaves
+ * `users.email` nullable while ciphertext columns fill in, and a relying party
+ * configured for automatic account creation would otherwise silently start
+ * creating accounts with no address. Failing the authorization loudly is the
+ * safe direction.
+ *
+ * A client that sets `wallet_email_fallback` widens that gate — and only that
+ * gate — to also accept a VERIFIED wallet, which `./wallet-email.ts` turns into
+ * a deterministic no-reply address, for a user who has no stored address of
+ * their own. The widening is admission policy; it asserts nothing about a
+ * mailbox, and `email_verified` stays false for the synthesized address (see
+ * `./claims.ts`). An unverified `wallet_address` proves nothing and never
+ * produces an identity.
+ *
+ * The gate reads `resolveOidcEmailIdentity`, the same function that builds the
+ * `email` claim, so admission cannot be granted on the strength of an identity
+ * emission would not produce. That coupling is why a user who holds an
+ * UNCONFIRMED stored address is refused by a client requiring a verified email
+ * even when their wallet is verified: the stored address is what a token would
+ * carry, and it is not one anybody proved. The registry refuses the other half
+ * of the same gap — `wallet_email_fallback` with `require_verified_email` off
+ * (see `./clients.ts`).
+ *
+ * "Verified" is `readVerifiedWalletAddress` below rather than `wallet_verified`
+ * alone, because a boolean cannot say who asserted it. Read off the writers: the
+ * SIWE/SIWS sign-ins, the signed wallet-auth header and
+ * `/api/users/me/wallet/attach` set it from a nonce-bound signature this
+ * deployment checked; `lib/steward-sync.ts` sets it from a claim in the Steward
+ * session token, which is the authority establishing who the browser is for
+ * `/authorize` at all and whose email claim already sets `email_verified` beside
+ * it. Two writers asserted it from an address they were merely handed, and both
+ * are corrected at the source: `lib/services/wallet-signup.ts` now records what
+ * its caller proved (x402 topup and agent provisioning prove nothing), and
+ * `lib/auth/waifu-bridge.ts`, which read the address out of a service token's
+ * subject, records `false`. The chain-type condition below is the second,
+ * independent lock: provenance a row does not record is provenance this provider
+ * does not credit.
+ *
+ * One guard here is unconditional, applying to every client including those with
+ * no flag set: a stored `users.email` in the reserved wallet-email namespace is
+ * treated as ABSENT everywhere downstream — claims, eligibility, and the
+ * username seed. Such a domain routes no mail by construction, so no address on
+ * it can have been verified by delivery; a row carrying one is a squatting
+ * attempt against the synthesized address of whoever owns the matching wallet,
+ * not a user. Making it conditional on the flag would leave the attack open
+ * through any client that does not require a verified email. `email_verified` is
+ * cleared with the address rather than left behind, so the scrub subtracts a
+ * squatted value and adds no assertion of its own.
  */
 
 import { oidcRepository } from "../../db/repositories/oidc";
 import { type UserWithOrganization, usersRepository } from "../../db/repositories/users";
 import type { OidcUserProfile } from "../../db/schemas/oidc";
 import { adminService, isElizaLabsAdminEmail } from "../services/admin";
-import type { OidcAdminStatus } from "./claims";
+import { type OidcAdminStatus, resolveOidcEmailIdentity } from "./claims";
 import type { OidcClient } from "./clients";
+import type { OidcConfig } from "./config";
+import { isOidcWalletEmailAddress, synthesizeOidcWalletEmail } from "./wallet-email";
 
 export interface OidcSubject {
   user: UserWithOrganization;
   profile: OidcUserProfile | null;
   adminStatus: OidcAdminStatus;
+  /**
+   * Deterministic no-reply address derived from a VERIFIED wallet, or `null`
+   * when the wallet is unverified, absent, of unrecorded provenance, or the
+   * deployment hosts no wallet-email domain. Non-null does not mean it will be
+   * emitted: only a client with `wallet_email_fallback` ever sees it.
+   */
+  walletEmail: string | null;
+}
+
+/**
+ * `wallet_chain_type` values that only a wallet-binding path writes, checked
+ * against every writer of the column: `evm` from `/api/users/me/wallet/attach`
+ * and the SIWE branch of `lib/services/wallet-signup.ts`, `solana` from its SIWS
+ * branch and from `lib/steward-sync.ts`, `ethereum` from `lib/steward-sync.ts`.
+ *
+ * Requiring one is the second, independent condition on a wallet identity. A
+ * row can hold `wallet_verified: true` with NO chain type — that is exactly the
+ * shape `lib/auth/waifu-bridge.ts` produced from a self-named address — so the
+ * absence of provenance is treated as absence of a wallet, and the gate stays
+ * closed even if some later writer sets the flag without recording how.
+ */
+const WALLET_PROVING_CHAIN_TYPES: ReadonlySet<string> = new Set(["evm", "ethereum", "solana"]);
+
+/**
+ * The wallet address this account may be identified by, or `null` when nothing
+ * on the row establishes one.
+ *
+ * Returns the STORED address; `synthesizeOidcWalletEmail` canonicalizes it, so
+ * two rows that differ only in EVM letter case cannot become two identities.
+ */
+export function readVerifiedWalletAddress(
+  user: Pick<UserWithOrganization, "wallet_address" | "wallet_verified" | "wallet_chain_type">,
+): string | null {
+  if (user.wallet_verified !== true) return null;
+  const chainType =
+    typeof user.wallet_chain_type === "string" ? user.wallet_chain_type.trim().toLowerCase() : "";
+  if (!WALLET_PROVING_CHAIN_TYPES.has(chainType)) return null;
+  const address = typeof user.wallet_address === "string" ? user.wallet_address.trim() : "";
+  return address.length > 0 ? address : null;
 }
 
 export type OidcIneligibleReason =
   | "user_inactive"
   | "user_anonymous"
   | "email_unverified"
+  | "no_verified_identity"
   | "organization_inactive";
 
-/** Live read of the user, org, OIDC profile, and platform-admin grant. */
-export async function loadOidcSubject(userId: string): Promise<OidcSubject | null> {
-  const user = await usersRepository.findWithOrganization(userId);
-  if (!user) return null;
+/** Live read of the user, org, OIDC profile, platform-admin grant, and wallet identity. */
+export async function loadOidcSubject(
+  userId: string,
+  config: OidcConfig,
+): Promise<OidcSubject | null> {
+  const found = await usersRepository.findWithOrganization(userId);
+  if (!found) return null;
 
-  const [profile, adminStatus] = await Promise.all([
+  const walletEmailDomain = config.walletEmailDomain;
+  // Applied before anything reads the row, so the squatted address cannot reach
+  // the claim builder, the eligibility gate, or the username allocator.
+  //
+  // `email_verified` is cleared WITH the address, never after it. Dropping the
+  // address alone left the row asserting a confirmed mailbox it then declined to
+  // name: `email_verified: true` with no `email`, in every token, for every
+  // client including the ones that never opted into any of this. Clearing both
+  // makes a scrubbed row indistinguishable from a row that simply has no
+  // address, so the guard removes the squatted value and changes nothing else.
+  const user: UserWithOrganization = isOidcWalletEmailAddress(found.email, walletEmailDomain)
+    ? { ...found, email: null, email_verified: false }
+    : found;
+
+  const verifiedWalletAddress = readVerifiedWalletAddress(user);
+
+  const [profile, adminStatus, walletEmail] = await Promise.all([
     oidcRepository.findProfile(user.id),
     adminService.getAdminStatusForUser(user),
+    walletEmailDomain && verifiedWalletAddress
+      ? synthesizeOidcWalletEmail(verifiedWalletAddress, walletEmailDomain)
+      : Promise.resolve(null),
   ]);
 
   return {
@@ -60,7 +168,33 @@ export async function loadOidcSubject(userId: string): Promise<OidcSubject | nul
         user.email_verified === true &&
         !user.wallet_address,
     },
+    walletEmail,
   };
+}
+
+/**
+ * Whether this subject carries an address this client may be handed.
+ *
+ * Asked of `resolveOidcEmailIdentity` — the same function the claim builder uses
+ * — rather than of the row directly, so admission cannot describe a different
+ * identity than emission will produce. Gating them on separate expressions is
+ * how a client came to admit a subject and then receive a token whose `email`
+ * was absent or was an address the gate had never looked at.
+ *
+ * Given a resolved identity the rule is one line: there must be an address, and
+ * it must be one somebody proved. A wallet-derived address qualifies even though
+ * it carries `email_verified: false` — the proof is the signature over the
+ * wallet, which `eliza_email_source` names — while a stored address qualifies
+ * only once the mailbox was confirmed.
+ *
+ * For a client without `wallet_email_fallback` no identity can ever have
+ * `source: "wallet"`, so this reduces to "a present, verified `users.email`",
+ * which is the original expression exactly.
+ */
+export function hasUsableOidcEmailIdentity(subject: OidcSubject, client: OidcClient): boolean {
+  const identity = resolveOidcEmailIdentity(subject.user, subject.walletEmail, client);
+  if (!identity.email) return false;
+  return identity.source === "wallet" || identity.emailVerified;
 }
 
 /** `null` when the subject may authorize; otherwise the refusal reason. */
@@ -72,8 +206,15 @@ export function assertOidcSubjectEligible(
   if (user.is_anonymous) return "user_anonymous";
   if (!user.is_active || user.deleted_at) return "user_inactive";
   if (user.organization && !user.organization.is_active) return "organization_inactive";
-  if (client.require_verified_email && !(user.email_verified === true && user.email)) {
-    return "email_unverified";
+  if (client.require_verified_email && !hasUsableOidcEmailIdentity(subject, client)) {
+    // `no_verified_identity` is for an opted-in client that refused a subject
+    // with nothing to offer at all, which `email_unverified` would misreport as
+    // a problem the user could fix by confirming an address. When the row DOES
+    // hold an unconfirmed address, confirming it is exactly the fix — the stored
+    // address takes precedence over the wallet either way — so the original
+    // reason is the accurate one even for an opted-in client.
+    if (!client.wallet_email_fallback || subject.user.email) return "email_unverified";
+    return "no_verified_identity";
   }
   return null;
 }

--- a/packages/cloud/shared/src/lib/oidc/wallet-email.test.ts
+++ b/packages/cloud/shared/src/lib/oidc/wallet-email.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Derivation rules for the wallet-backed no-reply identity, exercised through
+ * the real functions with literal inputs. Pure, deterministic, no Worker, no
+ * database, real WebCrypto.
+ *
+ * The cases are the ways this can silently produce a WRONG identity rather than
+ * no identity: two distinct wallets folding onto one address (which is an
+ * account takeover at a relying party that keys on the address), a domain the
+ * deployment does not own (which makes the address registerable by somebody
+ * else), and an address that a case-folding or length-limiting consumer would
+ * rewrite on the way in.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  isOidcWalletEmailAddress,
+  OIDC_WALLET_EMAIL_LOCAL_PREFIX,
+  resolveOidcWalletEmailDomain,
+  synthesizeOidcWalletEmail,
+} from "./wallet-email";
+
+const DOMAIN = "users.noreply.api.elizacloud.ai";
+const EVM = "0x1234567890abcdef1234567890abcdef12345678";
+/** The same wallet as `EVM`, in the EIP-55 form some writers store. */
+const EVM_CHECKSUMMED = "0x1234567890AbcdEF1234567890aBcdef12345678";
+/** Solana base58, which is case-SENSITIVE: folding it names a different key. */
+const SOLANA = "7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2";
+
+function localPart(address: string): string {
+  return address.slice(0, address.lastIndexOf("@"));
+}
+
+describe("address derivation", () => {
+  test("is deterministic across calls for the same wallet", async () => {
+    const first = await synthesizeOidcWalletEmail(EVM, DOMAIN);
+    const second = await synthesizeOidcWalletEmail(EVM, DOMAIN);
+    expect(first).toBe(second);
+    // Forgejo turns this into a permanent account identity, so the exact bytes
+    // are the contract — a change here re-identifies every wallet account.
+    expect(first).toBe("wallet-d4f3c344e6eb25da702fd567072f6ce1@users.noreply.api.elizacloud.ai");
+  });
+
+  test("two different wallets never collide", async () => {
+    const addresses = await Promise.all(
+      [EVM, `${EVM.slice(0, -1)}9`, SOLANA, "0x0000000000000000000000000000000000000000"].map(
+        (wallet) => synthesizeOidcWalletEmail(wallet, DOMAIN),
+      ),
+    );
+    expect(new Set(addresses).size).toBe(addresses.length);
+  });
+
+  test("a base58 case difference survives, because folding it would MERGE two wallets", async () => {
+    // `7xKX…AsU` and `7xkx…asu` are different Solana keys. Case-folding the
+    // digest input would map two distinct wallets onto one address, which at a
+    // relying party keyed on the address is an account takeover.
+    const upper = await synthesizeOidcWalletEmail(SOLANA, DOMAIN);
+    const lower = await synthesizeOidcWalletEmail(SOLANA.toLowerCase(), DOMAIN);
+    expect(upper).not.toBe(lower);
+  });
+
+  test("an EVM case difference does NOT survive, because it is one wallet", async () => {
+    // The writers disagree about form: `/api/users/me/wallet/attach` and the
+    // SIWE signup store an EIP-55 address lowercased, a Steward claim arrives in
+    // whatever case Steward sent. Digesting the stored bytes would hand one
+    // wallet two permanent identities depending on which surface wrote the row
+    // last, so the input is canonicalized by the same `normalizeWallet` that
+    // feeds `users.wallet_address_blind_index`.
+    expect(await synthesizeOidcWalletEmail(EVM_CHECKSUMMED, DOMAIN)).toBe(
+      await synthesizeOidcWalletEmail(EVM, DOMAIN),
+    );
+    expect(await synthesizeOidcWalletEmail(EVM.toUpperCase().replace("0X", "0x"), DOMAIN)).toBe(
+      await synthesizeOidcWalletEmail(EVM, DOMAIN),
+    );
+  });
+
+  test("surrounding whitespace is not a second wallet", async () => {
+    expect(await synthesizeOidcWalletEmail(`  ${SOLANA} `, DOMAIN)).toBe(
+      await synthesizeOidcWalletEmail(SOLANA, DOMAIN),
+    );
+  });
+
+  test("the emitted address is a fixed point under case folding", async () => {
+    // Forgejo/Gitea keeps a `lower_email` column for uniqueness, so an address
+    // that was not already lowercase would be rewritten on the way in and stop
+    // matching what this provider emits on the next login.
+    const address = await synthesizeOidcWalletEmail(SOLANA, DOMAIN);
+    expect(address).toBe(address.toLowerCase());
+  });
+
+  test("the local part is prefixed, hex, and inside RFC 5321's 64-octet limit", async () => {
+    const address = await synthesizeOidcWalletEmail(EVM, DOMAIN);
+    const local = localPart(address);
+    expect(local.startsWith(OIDC_WALLET_EMAIL_LOCAL_PREFIX)).toBe(true);
+    expect(local).toMatch(/^wallet-[0-9a-f]{32}$/);
+    expect(local.length).toBeLessThanOrEqual(64);
+    expect(address.length).toBeLessThanOrEqual(254);
+  });
+
+  test("the raw wallet address never appears in the emitted identity", async () => {
+    // Git commit metadata is permanent and public; the address would publish a
+    // wallet-to-commit-history link forever.
+    const address = await synthesizeOidcWalletEmail(EVM, DOMAIN);
+    expect(address).not.toContain(EVM);
+    expect(address.toLowerCase()).not.toContain(EVM.slice(2, 12).toLowerCase());
+  });
+});
+
+describe("the default domain", () => {
+  test("is users.noreply.<issuer hostname>", () => {
+    expect(resolveOidcWalletEmailDomain("api.elizacloud.ai")).toEqual({
+      ok: true,
+      domain: DOMAIN,
+    });
+  });
+
+  test("takes the HOSTNAME, so a loopback port never lands in a domain", () => {
+    // `OidcConfig.issuerHost` carries `localhost:8787`, which is not a legal
+    // email domain. `localhost` is a reserved TLD that routes nowhere, so the
+    // derived name is usable for local development.
+    expect(resolveOidcWalletEmailDomain("localhost")).toEqual({
+      ok: true,
+      domain: "users.noreply.localhost",
+    });
+  });
+
+  test("is unavailable — not wrong — when the issuer is an IP literal", () => {
+    // An address literal has no DNS subtree this deployment can own, so there is
+    // no honest default. `null` refuses every wallet-only sign-in with a reason.
+    for (const host of ["127.0.0.1", "[::1]", "192.168.0.10"]) {
+      expect(resolveOidcWalletEmailDomain(host)).toEqual({ ok: true, domain: null });
+    }
+  });
+});
+
+describe("an OIDC_WALLET_EMAIL_DOMAIN override", () => {
+  test("is accepted only as a strict subdomain of the issuer hostname", () => {
+    expect(resolveOidcWalletEmailDomain("api.elizacloud.ai", "noreply.api.elizacloud.ai")).toEqual({
+      ok: true,
+      domain: "noreply.api.elizacloud.ai",
+    });
+    expect(resolveOidcWalletEmailDomain("api.elizacloud.ai", DOMAIN)).toEqual({
+      ok: true,
+      domain: DOMAIN,
+    });
+  });
+
+  test("refuses a domain the deployment cannot prove it owns", () => {
+    // The whole guarantee is that no user can register a name there. A public
+    // mail domain, a sibling, a parent, and the issuer hostname itself all fail
+    // that test — the parent because the issuer proves nothing about names
+    // ABOVE it, and the hostname itself because it is not a dedicated subtree.
+    for (const override of [
+      "gmail.com",
+      "users.noreply.github.com",
+      "users.noreply.elizacloud.ai",
+      "api.elizacloud.ai",
+      "evil-api.elizacloud.ai",
+      "api.elizacloud.ai.attacker.example",
+    ]) {
+      const checked = resolveOidcWalletEmailDomain("api.elizacloud.ai", override);
+      expect(checked.ok).toBe(false);
+      if (!checked.ok) expect(checked.reason).toMatch(/strict subdomain|unusable DNS label/);
+    }
+  });
+
+  test("refuses a name that is not a bare lowercase DNS domain", () => {
+    for (const override of [
+      "Users.Noreply.api.elizacloud.ai",
+      "https://users.noreply.api.elizacloud.ai",
+      "users noreply.api.elizacloud.ai",
+      "-bad.api.elizacloud.ai",
+      "x@users.noreply.api.elizacloud.ai",
+      `${"a".repeat(210)}.api.elizacloud.ai`,
+    ]) {
+      const checked = resolveOidcWalletEmailDomain("api.elizacloud.ai", override);
+      expect(checked.ok).toBe(false);
+      if (!checked.ok) expect(checked.reason).toContain("OIDC_WALLET_EMAIL_DOMAIN");
+    }
+  });
+
+  test("cannot be a subdomain of an IP-literal issuer either", () => {
+    expect(resolveOidcWalletEmailDomain("127.0.0.1", "users.noreply.127.0.0.1").ok).toBe(false);
+  });
+
+  test("an empty or whitespace value falls back to the derived default", () => {
+    expect(resolveOidcWalletEmailDomain("api.elizacloud.ai", "   ")).toEqual({
+      ok: true,
+      domain: DOMAIN,
+    });
+    expect(resolveOidcWalletEmailDomain("api.elizacloud.ai", null)).toEqual({
+      ok: true,
+      domain: DOMAIN,
+    });
+  });
+});
+
+describe("the reserved-domain guard", () => {
+  test("recognizes a stored email squatting the synthesized domain", async () => {
+    const synthesized = await synthesizeOidcWalletEmail(EVM, DOMAIN);
+    expect(isOidcWalletEmailAddress(synthesized, DOMAIN)).toBe(true);
+    // The attack is not limited to a well-formed synthesized address: any
+    // address on the domain is unverifiable, so any address on it is refused.
+    expect(isOidcWalletEmailAddress("anything@users.noreply.api.elizacloud.ai", DOMAIN)).toBe(true);
+    expect(isOidcWalletEmailAddress("MiXeD@Users.Noreply.API.elizacloud.ai", DOMAIN)).toBe(true);
+    expect(isOidcWalletEmailAddress("a@sub.users.noreply.api.elizacloud.ai", DOMAIN)).toBe(true);
+  });
+
+  test("leaves every real address alone", () => {
+    for (const email of [
+      "ada@example.com",
+      "ada@elizacloud.ai",
+      "ada@api.elizacloud.ai",
+      "users.noreply.api.elizacloud.ai@example.com",
+      "ada@notusers.noreply.api.elizacloud.ai",
+      "wallet-not-a-digest@example.com",
+      "wallet-d4f3c344e6eb25da702fd567072f6ce@example.com",
+      "",
+      null,
+      undefined,
+    ]) {
+      expect(isOidcWalletEmailAddress(email, DOMAIN)).toBe(false);
+    }
+  });
+
+  test("the FQDN trailing dot is the same host, not a way past the guard", () => {
+    // `users.noreply.api.elizacloud.ai.` and `users.noreply.api.elizacloud.ai`
+    // resolve to one mailbox everywhere mail is delivered. Comparing the raw
+    // string would have let the root-dot spelling sit on the reserved domain
+    // while reading here as some unrelated host.
+    expect(isOidcWalletEmailAddress(`squat@${DOMAIN}.`, DOMAIN)).toBe(true);
+    expect(isOidcWalletEmailAddress(`squat@${DOMAIN}..`, DOMAIN)).toBe(true);
+    expect(isOidcWalletEmailAddress(`squat@sub.${DOMAIN}.`, DOMAIN)).toBe(true);
+    expect(isOidcWalletEmailAddress(`  squat@${DOMAIN.toUpperCase()}.  `, DOMAIN)).toBe(true);
+    // And it does not sweep in an address that merely ends with a dot.
+    expect(isOidcWalletEmailAddress("ada@example.com.", DOMAIN)).toBe(false);
+  });
+
+  test("stays reserved after the domain that issued it stops being configured", async () => {
+    // The squat guard cannot depend on the CURRENT configuration. Every address
+    // this provider has issued stays computable forever, and the relying-party
+    // accounts keyed on them keep existing, so an issuer or
+    // OIDC_WALLET_EMAIL_DOMAIN change must not retroactively un-reserve them —
+    // that rotation is the operator action most likely to FOLLOW an incident.
+    const issued = await synthesizeOidcWalletEmail(EVM, DOMAIN);
+    const rotated = "noreply.api2.elizacloud.ai";
+    expect(isOidcWalletEmailAddress(issued, rotated)).toBe(true);
+    expect(isOidcWalletEmailAddress(issued, null)).toBe(true);
+    // The whole `users.noreply.` subtree too, whichever issuer minted it, so an
+    // arbitrary local part on a previous default domain is refused as well.
+    expect(isOidcWalletEmailAddress("anything@users.noreply.api.elizacloud.ai", null)).toBe(true);
+    expect(isOidcWalletEmailAddress("anything@users.noreply.other.example", rotated)).toBe(true);
+    // The synthesized LOCAL PART is reserved wherever it appears: that string is
+    // what an attacker computes, and no human picks it as a mailbox name.
+    expect(
+      isOidcWalletEmailAddress("wallet-d4f3c344e6eb25da702fd567072f6ce1@example.com", null),
+    ).toBe(true);
+    expect(
+      isOidcWalletEmailAddress("WALLET-D4F3C344E6EB25DA702FD567072F6CE1@example.com", DOMAIN),
+    ).toBe(true);
+  });
+
+  test("guards the reserved shape when no domain is configured, and nothing else", () => {
+    // An IP-literal issuer hosts no wallet-email domain, but a row squatting an
+    // address a PREVIOUS issuer minted is still a squat.
+    expect(isOidcWalletEmailAddress("ada@example.com", null)).toBe(false);
+    expect(isOidcWalletEmailAddress("ada@api.elizacloud.ai", null)).toBe(false);
+    expect(isOidcWalletEmailAddress("a@users.noreply.api.elizacloud.ai", null)).toBe(true);
+  });
+});

--- a/packages/cloud/shared/src/lib/oidc/wallet-email.ts
+++ b/packages/cloud/shared/src/lib/oidc/wallet-email.ts
@@ -1,0 +1,312 @@
+/**
+ * Derivation of a no-reply email identity from a cryptographically verified
+ * wallet, for relying parties that cannot create an account without an address.
+ *
+ * Git requires an author email on every commit and Forgejo cannot create an
+ * account without one, but an Eliza Cloud account may be wallet-only:
+ * `users.email` is nullable while `users.wallet_address` is unique and
+ * `users.wallet_verified` marks a wallet that an authenticating path bound to
+ * the account. This module turns that wallet into an address that is syntactically
+ * real, unique, stable, and routes nowhere — the same property GitHub relies on
+ * for `user@users.noreply.github.com`, derived from the configured issuer rather
+ * than hardcoded so a self-hosted deployment cannot emit addresses on a domain
+ * it does not own. WHICH wallets are admissible is `./subject.ts`; this module
+ * only derives, and derives from whatever it is handed.
+ *
+ * The digest input is the address CANONICALIZED by `normalizeWallet`, the same
+ * function that feeds `users.wallet_address_blind_index`, so the identity layer
+ * and the encryption layer answer "is this the same wallet?" with one rule
+ * instead of two that can drift apart. The rule is chain-shaped: a `0x` address
+ * is EVM hex and folds case, anything else is base58 and does not. Both halves
+ * are load-bearing. Folding is required because nothing guarantees which of an
+ * EVM address's two legal spellings a row holds: `/api/users/me/wallet/attach`
+ * and `lib/services/wallet-signup.ts` lowercase the EIP-55 address they were
+ * given, a Steward claim arrives in whatever case Steward sent, and the reader
+ * that finds a row (`findByWalletAddress`) folds case to match any of them. A
+ * digest over the stored bytes would hand one wallet two identities depending on
+ * which surface last wrote the row. NOT folding base58
+ * is equally required: `7xKX…AsU` and `7xkx…asu` are different Solana keys, so
+ * case-folding them would merge two distinct wallets onto one address, which at
+ * a relying party keyed on the address is an account takeover.
+ *
+ * `wallet_chain_type` is deliberately NOT an input, even though `normalizeWallet`
+ * accepts one. It is mutable — a Steward sync rewrites it — and an identity that
+ * moves when a background job rewrites a column is not an identity. Passing it
+ * would change nothing anyway: for every address this provider can be handed the
+ * `0x` test alone decides, because the two writers that record `evm` derive the
+ * address from viem's `getAddress`. The gate in `./subject.ts` still reads the
+ * column, for admission rather than derivation.
+ *
+ * The digest is obfuscation, not secrecy. A wallet address is public, so anyone
+ * holding a candidate list can confirm which address belongs to which wallet. A
+ * keyed HMAC would close that but would make every wallet user's account
+ * identity depend on a secret whose loss rewrites it — disqualifying when the
+ * address IS the identity at the relying party.
+ *
+ * ONE HUMAN MUST OWN ONE ROW, or this derives two identities for them. That is a
+ * property of the wallet LOOKUP paths, not of anything here, and it is fragile
+ * in one specific way: `usersRepository.findByWalletAddress*` and the
+ * `usersService` readers over them lowercase their predicate, which is right for
+ * EVM hex and wrong for base58. A folded base58 lookup misses the row that
+ * already holds the wallet, the caller falls through to account creation, and
+ * the same human acquires a second Cloud account — hence a second permanent git
+ * author address at the forge. The two paths that can create a wallet account
+ * therefore use `findBySolanaWalletAddressWithOrganization` for non-`0x`
+ * addresses (`lib/steward-sync.ts`, `lib/services/wallet-signup.ts`); the folded
+ * readers are reached only from EVM-shaped call sites. A future caller that
+ * hands a base58 address to a folding reader reintroduces the split silently —
+ * nothing fails, there are simply two accounts — so that is the invariant to
+ * check when touching those readers.
+ *
+ * Re-binding a wallet (`/api/users/me/wallet/attach`) changes the derived
+ * address. Forgejo links accounts by `sub` — its `ExternalLoginUser` row is
+ * keyed on the OAuth2 subject, which is why the account survives a changed
+ * address and the address re-syncs on the next login — but a stale row still
+ * holding the old address collides with a later user who binds that wallet:
+ * that fails closed at Forgejo's unique constraint, it does not hand over an
+ * account. Both halves of that (`sub`-keyed linking, and acceptance of
+ * `email_verified: false`) are relying-party properties this provider depends
+ * on; see the header of `./claims.ts`.
+ */
+
+import { normalizeWallet } from "../../db/crypto/field-crypto";
+import { sha256Hex } from "./crypto";
+
+/** Local-part prefix, so a synthesized address is recognizable on sight. */
+export const OIDC_WALLET_EMAIL_LOCAL_PREFIX = "wallet-";
+
+/**
+ * Domain separator with an explicit version tag, so a future format change is
+ * distinguishable from a bare digest and can be migrated deliberately instead of
+ * silently re-identifying every wallet account.
+ */
+export const OIDC_WALLET_EMAIL_DIGEST_CONTEXT = "eliza-oidc/wallet-email/v1\n";
+
+/** Label prepended to the issuer hostname to form the default domain. */
+export const OIDC_WALLET_EMAIL_SUBDOMAIN = "users.noreply";
+
+/**
+ * Hex characters of digest kept in the local part.
+ *
+ * RFC 5321 caps a local part at 64 octets and full SHA-256 hex is 64 characters,
+ * so `wallet-` + the whole digest would be 71. 128 bits keeps second-preimage
+ * work against a NAMED victim at 2^128; the 2^64 birthday bound only lets an
+ * attacker collide two wallets they already own, which gains them nothing.
+ */
+const DIGEST_HEX_LENGTH = 32;
+
+/** `wallet-` + 32 hex characters. Fixed, which is what makes the ceiling below exact. */
+const LOCAL_PART_LENGTH = OIDC_WALLET_EMAIL_LOCAL_PREFIX.length + DIGEST_HEX_LENGTH;
+
+/**
+ * The local part of every address `synthesizeOidcWalletEmail` produces. It is
+ * the half of the reserved shape that does not depend on any configuration, so
+ * matching on it is what keeps a previously issued identity reserved after the
+ * domain it was minted on stops being the configured one.
+ */
+const SYNTHESIZED_LOCAL_PART_RE = new RegExp(
+  `^${OIDC_WALLET_EMAIL_LOCAL_PREFIX}[0-9a-f]{${DIGEST_HEX_LENGTH}}$`,
+);
+
+/**
+ * Longest domain that keeps the whole address inside RFC 5321's 254-octet
+ * ceiling. Tighter than the 253-octet DNS limit because the local part is fixed
+ * length; checking it here means synthesis can never produce an address a strict
+ * relying party would reject.
+ */
+const MAX_DOMAIN_LENGTH = 254 - LOCAL_PART_LENGTH - 1;
+
+const MAX_LABEL_LENGTH = 63;
+const DNS_LABEL_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+const IPV4_LITERAL_RE = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+/**
+ * A resolved wallet-email domain, or the sentence naming the rule an operator
+ * broke. `domain: null` is the third state and is NOT a failure: it means the
+ * deployment cannot host such a domain (an IP-literal issuer), so the feature is
+ * simply unavailable and every wallet-only sign-in is refused with a reason.
+ */
+export type OidcWalletEmailDomainCheck =
+  | { ok: true; domain: string | null }
+  | { ok: false; reason: string };
+
+/** Whether the issuer hostname is an address literal rather than a DNS name. */
+function isIpLiteralHostname(hostname: string): boolean {
+  return hostname.startsWith("[") || IPV4_LITERAL_RE.test(hostname);
+}
+
+/** `null` when the name is a usable lowercase DNS domain, else the violated rule. */
+function describeInvalidDomain(domain: string): string | null {
+  if (domain !== domain.toLowerCase()) {
+    return "must be lowercase (an email domain is compared case-insensitively, and folding it here would change the identity an operator typed)";
+  }
+  if (domain.length > MAX_DOMAIN_LENGTH) {
+    return `must be at most ${MAX_DOMAIN_LENGTH} characters so the ${LOCAL_PART_LENGTH}-character local part keeps the address inside RFC 5321's 254-octet limit`;
+  }
+  const labels = domain.split(".");
+  if (labels.length < 2) {
+    return "must have at least two DNS labels";
+  }
+  for (const label of labels) {
+    if (label.length > MAX_LABEL_LENGTH || !DNS_LABEL_RE.test(label)) {
+      return `has an unusable DNS label "${label}"; labels are 1-${MAX_LABEL_LENGTH} characters of [a-z0-9-] and may not start or end with "-"`;
+    }
+  }
+  return null;
+}
+
+/**
+ * The domain synthesized addresses live on: `users.noreply.<issuer hostname>` by
+ * default, or an `OIDC_WALLET_EMAIL_DOMAIN` override that is a STRICT SUBDOMAIN
+ * of that hostname.
+ *
+ * The subdomain rule is the whole security argument. DNS beneath the issuer
+ * hostname is controlled by whoever controls the host serving the discovery
+ * document, which is provably this deployment, so no user can register a name
+ * there and no synthesized address can collide with one a user owns. Accepting
+ * an arbitrary override would let a misconfiguration mint addresses on
+ * `gmail.com`. The cost is that an operator on `api.example.com` who wants
+ * `users.noreply.example.com` must use one more label instead; the alternative
+ * needs a public-suffix list to be safe.
+ *
+ * Takes the URL HOSTNAME, never `OidcConfig.issuerHost`, which carries the port
+ * for loopback origins and is not a legal email domain.
+ */
+export function resolveOidcWalletEmailDomain(
+  issuerHostname: string,
+  override?: string | null,
+): OidcWalletEmailDomainCheck {
+  const host = issuerHostname.trim().toLowerCase();
+  const configured = typeof override === "string" ? override.trim() : "";
+
+  if (configured) {
+    if (isIpLiteralHostname(host)) {
+      return {
+        ok: false,
+        reason: `OIDC_WALLET_EMAIL_DOMAIN "${configured}" cannot be verified against the issuer hostname "${host}", which is an address literal and owns no DNS subtree`,
+      };
+    }
+    const invalid = describeInvalidDomain(configured);
+    if (invalid) {
+      return { ok: false, reason: `OIDC_WALLET_EMAIL_DOMAIN "${configured}" ${invalid}` };
+    }
+    if (!configured.endsWith(`.${host}`)) {
+      return {
+        ok: false,
+        reason: `OIDC_WALLET_EMAIL_DOMAIN "${configured}" must be a strict subdomain of the issuer hostname "${host}"; only names below the issuer are provably unregisterable by a user`,
+      };
+    }
+    return { ok: true, domain: configured };
+  }
+
+  // An address literal has no subtree this deployment can own, so there is no
+  // honest default. The feature is unavailable rather than misconfigured, and
+  // the eligibility refusal is what surfaces it.
+  if (!host || isIpLiteralHostname(host)) return { ok: true, domain: null };
+
+  const derived = `${OIDC_WALLET_EMAIL_SUBDOMAIN}.${host}`;
+  if (describeInvalidDomain(derived)) return { ok: true, domain: null };
+  return { ok: true, domain: derived };
+}
+
+/**
+ * `wallet-<32 lowercase hex>@<domain>` for a wallet address the caller has
+ * already confirmed is admissible.
+ *
+ * Canonicalization happens HERE rather than at the call site so no future caller
+ * can derive an identity from an uncanonicalized column and hand the same wallet
+ * a second address; `normalizeWallet` is idempotent, so a caller that already
+ * canonicalized loses nothing.
+ *
+ * All-lowercase hex makes the local part a fixed point under case folding, which
+ * matters concretely: Forgejo/Gitea keeps a `lower_email` column for uniqueness,
+ * so an address that was not already lowercase would be folded on the way in and
+ * stop matching what this provider emits.
+ */
+export async function synthesizeOidcWalletEmail(
+  walletAddress: string,
+  domain: string,
+): Promise<string> {
+  const canonical = normalizeWallet(walletAddress);
+  const digest = await sha256Hex(`${OIDC_WALLET_EMAIL_DIGEST_CONTEXT}${canonical}`);
+  return `${OIDC_WALLET_EMAIL_LOCAL_PREFIX}${digest.slice(0, DIGEST_HEX_LENGTH)}@${domain}`;
+}
+
+/**
+ * The host half of an address, in the one spelling every comparison here uses.
+ *
+ * The trailing root dot is the spelling that matters. `users.noreply.api.example.`
+ * and `users.noreply.api.example` are the same DNS name and every mail transport
+ * resolves them to one mailbox, so a raw string comparison would let the FQDN
+ * form sit on the reserved domain while reading as some other host — the guard
+ * below is exactly the code an attacker would aim that at.
+ */
+function canonicalizeEmailHost(raw: string): string {
+  const host = raw.trim().toLowerCase();
+  let end = host.length;
+  while (end > 0 && host[end - 1] === ".") end -= 1;
+  return host.slice(0, end);
+}
+
+/**
+ * Whether a stored address occupies the reserved wallet-email namespace, and
+ * must therefore be treated as absent everywhere in the OIDC layer.
+ *
+ * Without this a squatting attack works: the synthesized address is computable
+ * by anyone who knows the victim's public wallet address, and `users.email` is a
+ * unique, user-settable column. An attacker who writes the victim's synthesized
+ * address into their own row and signs in at any client that does not require a
+ * verified email would have a relying party create an account holding it —
+ * locking the victim out and publishing git commits whose author address
+ * resolves to the victim's wallet.
+ *
+ * Three arms, and the first two exist because a reservation that tracked only
+ * the CURRENTLY configured domain would be undone by the operator action most
+ * likely to follow an incident: changing `OIDC_ISSUER_URL` or
+ * `OIDC_WALLET_EMAIL_DOMAIN`. Every address this provider has already issued
+ * stays computable forever, so a rotation that narrowed the guard would
+ * retroactively un-reserve all of them while the relying-party accounts keyed on
+ * them still exist.
+ *
+ *  1. The synthesized LOCAL PART on any domain. This is the shape an attacker
+ *     can compute, so it is reserved wherever it appears, including on a domain
+ *     this deployment no longer configures.
+ *  2. The `users.noreply.` subtree, whoever the issuer is. That label pair is
+ *     what `resolveOidcWalletEmailDomain` derives for every issuer, so it covers
+ *     an arbitrary local part on a domain a previous issuer minted on.
+ *  3. The configured domain and everything below it, as before.
+ *
+ * Treating such a row as having no address is not a behaviour regression: a
+ * no-reply domain accepts no mail by construction, so no address on one can ever
+ * have been verified by delivery. That reasoning is what makes arms 1 and 2 safe
+ * to apply beyond this deployment's own names — a `users.noreply.` address
+ * issued by somebody else (GitHub's, say) is equally undeliverable and equally
+ * unprovable, and an address in this provider's `wallet-<32 hex>` shape is not
+ * one a human picks. Such a row keeps working everywhere else in Eliza Cloud; it
+ * simply cannot be presented to a relying party as a proven mailbox.
+ */
+export function isOidcWalletEmailAddress(
+  email: string | null | undefined,
+  domain: string | null,
+): boolean {
+  if (!email) return false;
+  const at = email.lastIndexOf("@");
+  if (at < 0) return false;
+  const host = canonicalizeEmailHost(email.slice(at + 1));
+  if (!host) return false;
+
+  // Folded, because every consumer that keys on an address folds it: Forgejo
+  // keeps `lower_email`, so `WALLET-D4F3…` and `wallet-d4f3…` are one account
+  // there and must be one reservation here.
+  const local = email.slice(0, at).trim().toLowerCase();
+  if (SYNTHESIZED_LOCAL_PART_RE.test(local)) return true;
+
+  if (host === OIDC_WALLET_EMAIL_SUBDOMAIN || host.startsWith(`${OIDC_WALLET_EMAIL_SUBDOMAIN}.`)) {
+    return true;
+  }
+
+  if (!domain) return false;
+  const reserved = canonicalizeEmailHost(domain);
+  if (!reserved) return false;
+  return host === reserved || host.endsWith(`.${reserved}`);
+}

--- a/packages/cloud/shared/src/lib/services/__tests__/wallet-signup-proof.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/wallet-signup-proof.test.ts
@@ -1,0 +1,130 @@
+/**
+ * What `users.wallet_verified` means after a wallet signup, against a REAL
+ * PGlite database — no repository mocking.
+ *
+ * `findOrCreate*ByWalletAddress` is shared by callers that PROVED control of the
+ * address (the SIWE/SIWS sign-ins, the signed wallet-auth header) and callers
+ * that were merely handed one in a request body (x402 topup, agent
+ * provisioning). It used to mark every row verified, so naming a stranger's
+ * public wallet opened an account asserting control of it — and the OIDC layer
+ * turns that flag into a permanent no-reply identity at a relying party
+ * (`lib/oidc/subject.ts`). The rule pinned here: the flag follows the caller's
+ * proof, and proof only ever moves upward.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+const PGLITE_TIMEOUT = 120_000;
+
+const NAMED_EVM = `0x${"cd".repeat(20)}`;
+const PROVEN_EVM = `0x${"ef".repeat(20)}`;
+const UPGRADED_EVM = `0x${"1a".repeat(20)}`;
+const NAMED_SOLANA = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
+const PROVEN_SOLANA = "7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2";
+
+let pgliteReady = true;
+let pgliteError: unknown;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let walletSignup: typeof import("../wallet-signup");
+
+beforeAll(async () => {
+  try {
+    const dbClient = await import("../../../db/client");
+    closeDb = dbClient.closeDatabaseConnectionsForTests;
+    const { organizations } = await import("../../../db/schemas/organizations");
+    const { users } = await import("../../../db/schemas/users");
+    const { pushSchema } = await import("../../../db/push-schema-for-tests");
+    const { apply } = await pushSchema(
+      { organizations, users } as never,
+      dbClient.dbWrite as never,
+    );
+    await apply();
+    walletSignup = await import("../wallet-signup");
+  } catch (err) {
+    pgliteReady = false;
+    pgliteError = err;
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDb?.();
+});
+
+describe("what a wallet signup asserts about the wallet", () => {
+  test("PGlite harness is up (fail loudly, never skip silently)", () => {
+    if (!pgliteReady) throw pgliteError;
+    expect(pgliteReady).toBe(true);
+  });
+
+  test(
+    "an address the caller was merely handed creates an UNVERIFIED wallet",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+      const evm = await walletSignup.findOrCreateUserByWalletAddress(NAMED_EVM, {
+        grantInitialCredits: false,
+      });
+      expect(evm.isNewAccount).toBe(true);
+      expect(evm.user.wallet_verified).toBe(false);
+
+      const solana = await walletSignup.findOrCreateSolanaUserByWalletAddress(NAMED_SOLANA, {
+        grantInitialCredits: false,
+      });
+      expect(solana.isNewAccount).toBe(true);
+      expect(solana.user.wallet_verified).toBe(false);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a caller that verified a signature creates a VERIFIED wallet",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+      const evm = await walletSignup.findOrCreateUserByWalletAddress(PROVEN_EVM, {
+        grantInitialCredits: false,
+        walletProven: true,
+      });
+      expect(evm.user.wallet_verified).toBe(true);
+
+      const solana = await walletSignup.findOrCreateSolanaUserByWalletAddress(PROVEN_SOLANA, {
+        grantInitialCredits: false,
+        walletProven: true,
+      });
+      expect(solana.user.wallet_verified).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "proof raises an account opened by a caller that had none, and nothing lowers it",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+      // An x402 topup can be the first thing that ever mentions this wallet.
+      // Without the upgrade the owner would sign a SIWE challenge and still hold
+      // an unverified wallet forever — no identity at any relying party.
+      const named = await walletSignup.findOrCreateUserByWalletAddress(UPGRADED_EVM, {
+        grantInitialCredits: false,
+      });
+      expect(named.user.wallet_verified).toBe(false);
+
+      const proven = await walletSignup.findOrCreateUserByWalletAddress(UPGRADED_EVM, {
+        grantInitialCredits: false,
+        walletProven: true,
+      });
+      expect(proven.isNewAccount).toBe(false);
+      expect(proven.user.id).toBe(named.user.id);
+      expect(proven.user.wallet_verified).toBe(true);
+
+      // A later unproven mention is not evidence against a checked signature.
+      const namedAgain = await walletSignup.findOrCreateUserByWalletAddress(UPGRADED_EVM, {
+        grantInitialCredits: false,
+      });
+      expect(namedAgain.user.wallet_verified).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/topup-handler.ts
+++ b/packages/cloud/shared/src/lib/services/topup-handler.ts
@@ -141,6 +141,9 @@ async function getTopupRecipient(
     throw new Error("walletAddress is required (body or wallet signature headers)");
   }
 
+  // No `walletProven`: this branch is the one with NO wallet signature — the
+  // address came out of the request body, so the account it opens must not
+  // claim the wallet was verified.
   const { user } = await findOrCreateUserByWalletAddress(body.walletAddress, {
     grantInitialCredits: false,
   });

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -209,14 +209,23 @@ export class UsersService {
     return user;
   }
 
+  /**
+   * Both wallet readers key the cache on the LOWERCASED address, because that is
+   * the value the repository actually queries on. Keying on the caller's
+   * spelling gave an EIP-55 address its own entry that `invalidateCache` — which
+   * only knows the stored lowercase form — could never delete, so an update was
+   * invisible to any caller that passed a checksummed address until the TTL
+   * expired.
+   */
   async getByWalletAddress(walletAddress: string): Promise<User | undefined> {
-    const cacheKey = CacheKeys.user.byWalletAddress(walletAddress);
+    const lookupAddress = walletAddress.toLowerCase();
+    const cacheKey = CacheKeys.user.byWalletAddress(lookupAddress);
     const cached = await cache.get<User>(cacheKey);
     if (cached) {
       logger.debug("[UsersService] Cache hit for user byWalletAddress");
       return cached;
     }
-    const user = await usersRepository.findByWalletAddress(walletAddress);
+    const user = await usersRepository.findByWalletAddress(lookupAddress);
     if (user) {
       await cache.set(cacheKey, user, CacheTTL.user.byWalletAddress);
       logger.debug("[UsersService] Cached user data byWalletAddress");
@@ -227,13 +236,14 @@ export class UsersService {
   async getByWalletAddressWithOrganization(
     walletAddress: string,
   ): Promise<UserWithOrganization | undefined> {
-    const cacheKey = CacheKeys.user.byWalletAddressWithOrg(walletAddress);
+    const lookupAddress = walletAddress.toLowerCase();
+    const cacheKey = CacheKeys.user.byWalletAddressWithOrg(lookupAddress);
     const cached = await cache.get<UserWithOrganization>(cacheKey);
     if (cached) {
       logger.debug("[UsersService] Cache hit for user byWalletAddressWithOrg");
       return cached;
     }
-    const user = await usersRepository.findByWalletAddressWithOrganization(walletAddress);
+    const user = await usersRepository.findByWalletAddressWithOrganization(lookupAddress);
     if (user) {
       await cache.set(cacheKey, user, CacheTTL.user.byWalletAddressWithOrg);
       logger.debug("[UsersService] Cached user data byWalletAddressWithOrg");

--- a/packages/cloud/shared/src/lib/services/wallet-signup.ts
+++ b/packages/cloud/shared/src/lib/services/wallet-signup.ts
@@ -41,6 +41,19 @@ export interface FindOrCreateWalletOptions {
   grantInitialCredits?: boolean;
   /** When true, fail signup if the initial free-credit grant cannot be confirmed. */
   requireInitialCredits?: boolean;
+  /**
+   * Whether the caller VERIFIED control of this address — a SIWE/SIWS signature
+   * or the signed wallet-auth header — rather than merely being handed it in a
+   * request body. It lands in `users.wallet_verified`, which the OIDC layer reads
+   * as proof of control and turns into a permanent no-reply identity at a
+   * relying party (`lib/oidc/subject.ts`).
+   *
+   * Defaults to FALSE so a caller that proved nothing cannot assert it by
+   * omission: this helper is shared by the two sign-ins that DO verify a
+   * signature and by x402 topup / agent provisioning, which accept an address
+   * from the request and could otherwise mark a stranger's wallet verified.
+   */
+  walletProven?: boolean;
 }
 
 export interface InitialCreditGrantMetadata {
@@ -211,9 +224,36 @@ async function findSolanaUserForWrite(
 }
 
 /**
+ * Raises `wallet_verified` on a row this caller has just proved control of.
+ *
+ * Proof is monotonic and one-directional: an address can first reach this table
+ * from a path that only NAMED it (x402 topup, agent provisioning), and without
+ * this the account would stay unverified forever even after its owner signs a
+ * SIWE/SIWS challenge — no wallet identity at any relying party. Nothing here
+ * ever lowers the flag, because a later unproven mention is not evidence against
+ * a signature that was already checked.
+ *
+ * Called only outside the signup transaction. A concurrent signup that loses the
+ * insert race returns its winner's row without the upgrade, which the next
+ * sign-in performs; writing to another transaction's just-inserted row from
+ * inside this one is not worth that.
+ */
+async function raiseWalletProof(
+  user: UserWithOrganization,
+  walletProven: boolean,
+): Promise<UserWithOrganization> {
+  if (!walletProven || user.wallet_verified === true) return user;
+  await usersService.update(user.id, { wallet_verified: true });
+  return { ...user, wallet_verified: true };
+}
+
+/**
  * Find user by wallet, or create org + user and return.
  * Address can be any case; stored and slug use lowercase.
  * Used by SIWE, wallet header auth, and x402 topup (with grantInitialCredits: false).
+ *
+ * `walletProven` decides `users.wallet_verified` and defaults to false — see the
+ * option's own note for why the caller must say so explicitly.
  */
 export async function findOrCreateUserByWalletAddress(
   walletAddress: string,
@@ -231,10 +271,11 @@ export async function findOrCreateUserByWalletAddress(
   const normalized = address.toLowerCase();
   const grantInitialCredits = options?.grantInitialCredits !== false;
   const requireInitialCredits = options?.requireInitialCredits === true;
+  const walletProven = options?.walletProven === true;
 
   const existing = await usersService.getByWalletAddressWithOrganization(address);
   if (existing) {
-    return { user: existing, isNewAccount: false };
+    return { user: await raiseWalletProof(existing, walletProven), isNewAccount: false };
   }
 
   /* WHY slug wallet-${normalized}: consistent with topup and SIWE; lowercase for unique indexing. */
@@ -269,7 +310,7 @@ export async function findOrCreateUserByWalletAddress(
           steward_user_id: `wallet:evm:${normalized}`,
           wallet_address: normalized,
           wallet_chain_type: "evm",
-          wallet_verified: true,
+          wallet_verified: walletProven,
           organization_id: org.id,
           // The signup creates this org for the wallet — its creator manages it
           // (matches the anonymous-migration path in session.ts). Without this the
@@ -301,7 +342,7 @@ export async function findOrCreateUserByWalletAddress(
     if (!isUniqueViolation(e)) throw e;
     const raced = await usersService.getByWalletAddressWithOrganization(address);
     if (!raced) throw e;
-    return { user: raced, isNewAccount: false };
+    return { user: await raiseWalletProof(raced, walletProven), isNewAccount: false };
   }
 }
 
@@ -328,10 +369,11 @@ export async function findOrCreateSolanaUserByWalletAddress(
   }
   const grantInitialCredits = options?.grantInitialCredits !== false;
   const requireInitialCredits = options?.requireInitialCredits === true;
+  const walletProven = options?.walletProven === true;
 
   const existing = await usersRepository.findBySolanaWalletAddressWithOrganization(address);
   if (existing) {
-    return { user: existing, isNewAccount: false };
+    return { user: await raiseWalletProof(existing, walletProven), isNewAccount: false };
   }
 
   const slug = `wallet-solana-${address}`;
@@ -365,7 +407,7 @@ export async function findOrCreateSolanaUserByWalletAddress(
           steward_user_id: `wallet:solana:${address}`,
           wallet_address: address,
           wallet_chain_type: "solana",
-          wallet_verified: true,
+          wallet_verified: walletProven,
           organization_id: org.id,
           // Creator of the fresh wallet org manages it — see the EVM path above.
           role: "owner",
@@ -394,6 +436,6 @@ export async function findOrCreateSolanaUserByWalletAddress(
     if (!isUniqueViolation(e)) throw e;
     const raced = await usersRepository.findBySolanaWalletAddressWithOrganization(address);
     if (!raced) throw e;
-    return { user: raced, isNewAccount: false };
+    return { user: await raiseWalletProof(raced, walletProven), isNewAccount: false };
   }
 }

--- a/packages/cloud/shared/src/lib/steward-sync-wallet-canonicalization.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-wallet-canonicalization.test.ts
@@ -1,0 +1,220 @@
+/**
+ * How `syncUserFromSteward` canonicalizes a claimed wallet address and finds the
+ * row that already holds it. Real `syncUserFromSteward` against mocked user
+ * services, so the assertions are the exact values handed to the writers.
+ *
+ * A blanket `.toLowerCase()` is wrong for base58: `7xKX…AsU` and `7xkx…asu` are
+ * different Solana keys, so folding one produces a string that matches no
+ * existing row and is then stored as though it were a second wallet. The
+ * observable damage is a SECOND Cloud account for one human — two rows, two
+ * derived no-reply identities (`lib/oidc/wallet-email.ts`), and a git author
+ * address at the forge that changes with the sign-in surface. EVM hex folds and
+ * must keep folding; every EVM case below is a regression pin, not new behavior.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+/** Solana base58 with both cases present, as `/api/auth/siws/verify` stores it. */
+const SOLANA = "7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2";
+const EVM_CHECKSUMMED = "0x1234567890AbcdEF1234567890aBcdef12345678";
+const EVM_STORED = EVM_CHECKSUMMED.toLowerCase();
+
+interface Call {
+  method: string;
+  args: unknown[];
+}
+
+const calls: Call[] = [];
+const updateCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
+
+let userByStewardId: Record<string, unknown> | undefined;
+let userByWalletFolded: Record<string, unknown> | undefined;
+let userBySolanaWallet: Record<string, unknown> | undefined;
+let userForWrite: Record<string, unknown> | undefined;
+
+function record(method: string, ...args: unknown[]): void {
+  calls.push({ method, args });
+}
+
+function argsFor(method: string): unknown[][] {
+  return calls.filter((call) => call.method === method).map((call) => call.args);
+}
+
+mock.module("./services/users", () => ({
+  usersService: {
+    getByStewardId: async (id: string) => {
+      record("getByStewardId", id);
+      return userByStewardId;
+    },
+    getByStewardIdForWrite: async (id: string) => {
+      record("getByStewardIdForWrite", id);
+      return userForWrite;
+    },
+    getByEmailWithOrganization: async (email: string) => {
+      record("getByEmailWithOrganization", email);
+      return undefined;
+    },
+    getByWalletAddress: async (address: string) => {
+      record("getByWalletAddress", address);
+      return userByWalletFolded;
+    },
+    getByWalletAddressWithOrganization: async (address: string) => {
+      record("getByWalletAddressWithOrganization", address);
+      return userByWalletFolded;
+    },
+    getStewardIdentityForWrite: async () => undefined,
+    create: async (data: unknown) => {
+      record("create", data);
+      throw new Error("a second account must not be created for a wallet that already has one");
+    },
+    update: async (id: string, data: Record<string, unknown>) => {
+      updateCalls.push({ id, data });
+      record("update", id, data);
+      return undefined;
+    },
+    linkStewardId: async (userId: string, stewardUserId: string) => {
+      record("linkStewardId", userId, stewardUserId);
+    },
+    upsertStewardIdentity: async (userId: string, stewardUserId: string) => {
+      record("upsertStewardIdentity", userId, stewardUserId);
+    },
+  },
+}));
+
+mock.module("../db/repositories/users", () => ({
+  usersRepository: {
+    findBySolanaWalletAddressWithOrganization: async (address: string) => {
+      record("findBySolanaWalletAddressWithOrganization", address);
+      return userBySolanaWallet;
+    },
+    delete: async () => undefined,
+  },
+}));
+
+mock.module("./utils/logger", () => ({
+  logger: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} },
+  redact: { id: (v: string) => v, orgId: (v: string) => v, userId: (v: string) => v },
+}));
+
+const { syncUserFromSteward } = await import("./steward-sync");
+
+beforeEach(() => {
+  calls.length = 0;
+  updateCalls.length = 0;
+  userByStewardId = undefined;
+  userByWalletFolded = undefined;
+  userBySolanaWallet = undefined;
+  userForWrite = undefined;
+});
+
+describe("an existing account signing in again (step 1)", () => {
+  test("keeps a Solana address byte-for-byte instead of folding it", async () => {
+    // The row was created by /api/auth/siws/verify and holds the verbatim key.
+    // Rewriting it here would silently re-derive the account's permanent no-reply
+    // identity — the same account, a different git author address.
+    const stored = {
+      id: "user-solana",
+      steward_user_id: "steward-solana",
+      name: "solana-user",
+      email: null,
+      email_verified: false,
+      wallet_address: SOLANA,
+      wallet_chain_type: "solana",
+      wallet_verified: true,
+      organization_id: null,
+    };
+    userByStewardId = stored;
+    userForWrite = stored;
+
+    await syncUserFromSteward({
+      stewardUserId: "steward-solana",
+      walletAddress: SOLANA,
+      walletChainType: "solana",
+      name: "solana-user",
+    });
+
+    // A wallet-only claim always refreshes the profile (the stored email is
+    // `null` and the claim carries none), so this write is the one that decides
+    // what the column holds afterwards.
+    expect(updateCalls.map((call) => call.data.wallet_address)).toEqual([SOLANA]);
+  });
+
+  test("still folds an EVM address, which is one wallet in two spellings", async () => {
+    const stored = {
+      id: "user-evm",
+      steward_user_id: "steward-evm",
+      name: "evm-user",
+      email: null,
+      email_verified: false,
+      wallet_address: EVM_STORED,
+      wallet_chain_type: "ethereum",
+      wallet_verified: true,
+      organization_id: null,
+    };
+    userByStewardId = stored;
+    userForWrite = stored;
+
+    await syncUserFromSteward({
+      stewardUserId: "steward-evm",
+      walletAddress: EVM_CHECKSUMMED,
+      walletChainType: "ethereum",
+      name: "evm-user",
+    });
+
+    expect(updateCalls.map((call) => call.data.wallet_address)).toEqual([EVM_STORED]);
+  });
+});
+
+describe("a wallet-only Steward session for a wallet that already has an account (step 4)", () => {
+  test("finds the Solana row with a case-SENSITIVE lookup and links it", async () => {
+    // The folded lookup cannot see this row: it compares against the lowercased
+    // string, which is a different key. Missing it here is what fell through to
+    // step 5 and created the second account.
+    userBySolanaWallet = {
+      id: "user-solana",
+      steward_user_id: "wallet:solana:" + SOLANA,
+      wallet_address: SOLANA,
+      wallet_chain_type: "solana",
+      wallet_verified: true,
+      organization: null,
+    };
+    userForWrite = { ...userBySolanaWallet, steward_user_id: "steward-new" };
+
+    const synced = await syncUserFromSteward({
+      stewardUserId: "steward-new",
+      walletAddress: SOLANA,
+      walletChainType: "solana",
+    });
+
+    expect(synced.id).toBe("user-solana");
+    expect(argsFor("findBySolanaWalletAddressWithOrganization")).toEqual([[SOLANA]]);
+    expect(argsFor("linkStewardId")).toEqual([["user-solana", "steward-new"]]);
+    // The case-folding lookups must never be asked about a base58 address.
+    expect(argsFor("getByWalletAddress")).toEqual([]);
+    expect(argsFor("getByWalletAddressWithOrganization")).toEqual([]);
+    expect(argsFor("create")).toEqual([]);
+  });
+
+  test("uses the folded lookup for EVM, with the lowercased address", async () => {
+    userByWalletFolded = {
+      id: "user-evm",
+      steward_user_id: "wallet:evm:" + EVM_STORED,
+      wallet_address: EVM_STORED,
+      wallet_chain_type: "ethereum",
+      wallet_verified: true,
+      organization: null,
+    };
+    userForWrite = { ...userByWalletFolded, steward_user_id: "steward-new-evm" };
+
+    const synced = await syncUserFromSteward({
+      stewardUserId: "steward-new-evm",
+      walletAddress: EVM_CHECKSUMMED,
+      walletChainType: "ethereum",
+    });
+
+    expect(synced.id).toBe("user-evm");
+    expect(argsFor("getByWalletAddressWithOrganization")).toEqual([[EVM_STORED]]);
+    expect(argsFor("findBySolanaWalletAddressWithOrganization")).toEqual([]);
+    expect(argsFor("create")).toEqual([]);
+  });
+});

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -6,8 +6,15 @@
  * 1. Steward JWTs contain email/userId/walletAddress directly (no third-party API call)
  * 2. No anonymous user upgrade path (Steward doesn't have anonymous users)
  * 3. Uses steward_user_id as the canonical external auth identity
+ *
+ * A claimed wallet address is canonicalized with `normalizeWallet` — the same
+ * rule as the wallet blind index — so an address matches the row that already
+ * holds it whichever surface wrote that row first. It is chain-shaped on
+ * purpose: EVM hex folds case, base58 does not, because two Solana keys can
+ * differ only in case.
  */
 
+import { normalizeWallet } from "../db/crypto/field-crypto";
 import { organizationInvitesRepository } from "../db/repositories/organization-invites";
 import { usersRepository } from "../db/repositories/users";
 import { getClientIp } from "./runtime/request-context";
@@ -217,6 +224,26 @@ export interface StewardSyncParams {
 }
 
 /**
+ * Finds the row that already holds this wallet, matching the way the address was
+ * STORED.
+ *
+ * `usersRepository.findByWalletAddress*` lowercases its predicate, which is
+ * right for EVM hex and wrong for base58: a Solana row written by
+ * `/api/auth/siws/verify` keeps the case-sensitive key verbatim, so the folded
+ * lookup cannot see it, step 4 falls through to step 5, and the same human ends
+ * up with a second Cloud account — a second wallet identity at every relying
+ * party keyed on it. The discriminator is `normalizeWallet`'s: a `0x` address is
+ * EVM hex, anything else is base58.
+ */
+async function findUserByStoredWalletAddress(
+  walletAddress: string,
+): Promise<UserWithOrganization | undefined> {
+  return walletAddress.startsWith("0x")
+    ? await usersService.getByWalletAddressWithOrganization(walletAddress)
+    : await usersRepository.findBySolanaWalletAddressWithOrganization(walletAddress);
+}
+
+/**
  * Sync a Steward user to the local database.
  * Creates user and organization if they don't exist.
  * Updates user data if it has changed.
@@ -231,7 +258,12 @@ export interface StewardSyncParams {
 export async function syncUserFromSteward(params: StewardSyncParams): Promise<StewardSyncedUser> {
   const { stewardUserId, walletChainType } = params;
   const email = params.email?.toLowerCase().trim();
-  const walletAddress = params.walletAddress?.toLowerCase();
+  // Chain-aware, NOT a blanket lowercase: folding a base58 key produces a string
+  // that is not the user's wallet, matches no existing row, and is then stored
+  // as if it were a second wallet.
+  const walletAddress = params.walletAddress
+    ? normalizeWallet(params.walletAddress, walletChainType)
+    : undefined;
   const resolvedWalletChainType = walletAddress ? (walletChainType ?? "ethereum") : walletChainType;
 
   // Resolve display name with fallbacks
@@ -434,7 +466,7 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
 
   // ── 4. Wallet-only Steward session (SIWE or SIWS) ────────────────────
   if (walletAddress && !email) {
-    const existingByWallet = await usersService.getByWalletAddress(walletAddress);
+    const existingByWallet = await findUserByStoredWalletAddress(walletAddress);
 
     if (existingByWallet && existingByWallet.steward_user_id !== stewardUserId) {
       logger.info(
@@ -599,7 +631,7 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
         }
 
         if (!existingUser && walletAddress) {
-          existingUser = await usersService.getByWalletAddressWithOrganization(walletAddress);
+          existingUser = await findUserByStoredWalletAddress(walletAddress);
         }
 
         if (existingUser) {

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -280,6 +280,22 @@ export interface Bindings {
    * base64-wrapped). Client secrets are stored as sha256 hex only.
    */
   OIDC_CLIENTS?: string;
+  /**
+   * Domain that wallet-derived no-reply identities are minted on, for relying
+   * parties registered with `wallet_email_fallback`. Defaults to
+   * `users.noreply.<OIDC_ISSUER_URL hostname>` and is normally left unset.
+   *
+   * An override is accepted ONLY when it is a strict subdomain of the issuer
+   * hostname — that rule is what proves no user can register a name there, which
+   * is the entire security property of the address. Set but invalid turns the
+   * wallet-identity feature OFF with a named reason (`OidcConfig.
+   * walletEmailUnavailableReason`) and leaves the rest of the provider serving;
+   * it is one optional variable and must not 503 every relying party. A
+   * committed var, not a secret, for the same reason as OIDC_ISSUER_URL: losing
+   * it must not silently rewrite every wallet user's account identity at the
+   * relying party.
+   */
+  OIDC_WALLET_EMAIL_DOMAIN?: string;
 
   RPC_URL?: string;
   CHAIN_ID?: string;


### PR DESCRIPTION
A wallet-only Eliza Cloud account has no email. Git requires an author address on every commit and a relying party needs one to create an account, so a wallet user authenticated at Cloud **successfully** and was then refused — the most confusing possible failure, arriving after a correct login.

This derives a no-reply address from the verified wallet, the same shape GitHub uses for users who withhold an email.

## Design

- Address is a pure function of the **canonicalized** wallet address and the issuer, on a domain no user can register. No migration, no new column, nothing to drift or back out.
- **`email_verified` stays `false`.** OIDC Core defines it as the user controlling that *mailbox*, and the mailbox does not exist by construction. Claiming `true` would poison the one signal a relying party checks before merging a federated login into an existing local account. The assurance that *is* real concerns the wallet, so it is emitted under its own name.
- **Opt-in per client, off by default** — no registered relying party changes behaviour.
- A squat guard reserves the synthesized shape unconditionally, for every client. Without it, an attacker writes a victim's computable address into their own row and collects the victim's identity at any relying party.

## Two pre-existing auth bugs this surfaced

**1. `waifu-bridge.ts` recorded `wallet_verified` from a service token substring.** Nothing in that chain verifies a signature — whoever holds the shared service secret names the address, including a victim's public one. Harmless-ish before; once `wallet_verified` mints a portable identity it becomes account takeover. Now records `false`, with the reasoning in the code.

**2. Steward sync folded Solana base58 to lowercase.** Base58 is case-sensitive, so the same wallet could be stored two ways, be invisible to a case-folding lookup, and create a second user row — and downstream, two permanent identities for one person that can never be merged. Now chain-aware.

## Review

Adversarial review raised **14 issues; all 14 are fixed.** The four high-severity ones: the Solana double-identity above; `wallet_verified` not always meaning a signature; the address not being deterministic per wallet; and the guarantee being enforced against a column that isn't proof on every write path.

Notable narrowings, both deliberate and tested: a client can no longer combine `wallet_email_fallback` with `require_verified_email: false` (that pair admits a user with neither an address nor a proven wallet, then issues an email-less token), and a user with an **unconfirmed** stored email plus a verified wallet is refused rather than silently handed a wallet address — previously they'd get a different account at every relying party for nothing but leaving an email unconfirmed.

## Verification

| Gate | Result |
| --- | --- |
| `packages/cloud/shared` `src/lib/oidc/` | **217 pass**, 0 fail (was 207) |
| `packages/cloud/shared` `src/lib/auth/` | **49 pass**, 0 fail — unchanged |
| `packages/cloud/api` `oidc-provider.test.ts` | **130 pass**, 0 fail (was 126) |
| `packages/cloud/shared` full suite, `--isolate` | **4702 pass / 1 fail** across 464 files |
| typecheck both packages, Biome on 56 files | clean |

The single failure is `AppImageBuilder > propagates a build failure`, a 9.5s timeout in container image building. This diff touches no image-builder file. Note the package's suite **must** run with `--isolate` (per its `CLAUDE.md`) — without it, shared PGlite state produces dozens of unrelated failures.

## Follow-up a human should file

`usersRepository.findByWalletAddress*` and the `usersService` cache keys over them still case-fold. Every current caller is EVM-shaped so they are correct today, but a future base58 caller would silently reintroduce the double-identity bug. The invariant and the two paths that must use the case-sensitive reader are documented in `wallet-email.ts`; the readers themselves were left alone as out of scope.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

---

# Evidence

<!-- evidence-head:c2ed9a7c926c880f96a2e66449e9fc5eb8ee06b6 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface is added or altered; this changes claim derivation in the OIDC provider.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface is added or altered.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow of its own. The sign-in flow it extends was recorded end to end on #17883.`
<!-- evidence-row:backend-logs -->
- [x] Test output across the three suites this changes:

```
packages/cloud/shared  src/lib/oidc/   217 pass  0 fail
packages/cloud/shared  src/lib/auth/    49 pass  0 fail   (unchanged by this PR)
packages/cloud/api     oidc-provider   130 pass  0 fail
packages/cloud/shared  full --isolate  4702 pass  1 fail / 464 files
  only failure: AppImageBuilder > propagates a build failure (9529ms timeout,
  container image building, untouched by this diff)
```

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no browser-observable change. The relying-party redirect chain is unchanged; only the email claim's derivation differs, and only for wallet-only users at an opted-in client.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] The derived identity, and the two existing-auth corrections:

```
address shape:
  wallet-<32 lowercase hex>@users.noreply.<issuer hostname>
  local part = "wallet-" + first 16 bytes of
               SHA-256("eliza-oidc/wallet-email/v1\n" + normalizeWallet(wallet_address))

emitted claims for a wallet-only user at an opted-in client:
  email               wallet-<hex>@users.noreply.api.elizacloud.ai
  email_verified      false            <- never fabricated
  eliza_email_source  "wallet"         <- the assurance that is actually held

existing-auth corrections:
  waifu-bridge.ts   wallet_verified: !!walletAddr  ->  false
  steward-sync.ts   toLowerCase() for every chain  ->  chain-aware normalizeWallet
```

<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)