### PR TITLE
fix(i18n): add missing browser native-surface keys to the source catalog

### DIFF
--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -8188,5 +8188,7 @@
   "cloud.redemptions.copyPayoutAddress": "Copy payout address",
   "cloud.redemptions.copyUserId": "Copy user ID",
   "cloud.security.metaTitle": "Security · Eliza Cloud",
-  "cloud.security.pluginPermissionsLink": "Plugin permissions →"
+  "cloud.security.pluginPermissionsLink": "Plugin permissions →",
+  "browserworkspace.NativeSurfaceUnavailable": "Browser view unavailable",
+  "browserworkspace.NativeSurfaceUnavailableDescription": "The secure browser surface could not connect. Retry without losing your tabs."
 }


### PR DESCRIPTION
## Problem

Develop's `Tests / Classify changed paths` job (i18n contract check from #17606) fails: `en.json missing 2 key(s) used in source` — `browserworkspace.NativeSurfaceUnavailable` and `browserworkspace.NativeSurfaceUnavailableDescription`, referenced by `packages/ui/src/components/pages/BrowserWorkspaceView.tsx:2578/2583` (native-mobile-webview error state), which merged without catalog entries.

## Fix

Add both keys to `packages/ui/src/i18n/locales/en.json` with the component's `defaultValue` strings. Translated-locale gaps remain warnings by the checker's contract.

## Verification

At develop tip the checker exits 1 with exactly those 2 keys; with this change `node packages/app-core/scripts/check-i18n.mjs` exits 0 (4440 literal keys scanned); biome check clean on the file.

## Evidence

<!-- evidence-head:f8ba3c9bdf9da0dcc9cf3a28b282cdfdfad1741d -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - catalog data only; UI already renders these strings via defaultValue.
<!-- evidence-row:after-screenshots -->
- [x] N/A - catalog data only; no visual change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - catalog data only.
<!-- evidence-row:backend-logs -->
- [x] Checker transcript: develop tip → exit 1 (`en.json missing 2 key(s) used in source: browserworkspace.NativeSurfaceUnavailable, browserworkspace.NativeSurfaceUnavailableDescription`); with fix → exit 0 (`[i18n] OK — 4440 literal keys …`).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior change (defaultValue already displayed).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM invoked.
<!-- evidence-row:domain-artifacts -->
- [x] The two added catalog entries in this diff are the artifacts; values byte-match the component's defaultValue props.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)