### PR TITLE
test(agent): lock PLUGIN toggle self-API auth headers on cloud

### DIFF
--- a/packages/agent/src/actions/plugin-toggle.test.ts
+++ b/packages/agent/src/actions/plugin-toggle.test.ts
@@ -17,6 +17,7 @@ interface CapturedRequest {
   url: string;
   method?: string;
   body: unknown;
+  headers?: HeadersInit;
 }
 
 function stubFetch(response: Record<string, unknown>): {
@@ -30,6 +31,7 @@ function stubFetch(response: Record<string, unknown>): {
       url: String(input),
       method: init?.method,
       body: typeof init?.body === "string" ? JSON.parse(init.body) : init?.body,
+      headers: init?.headers,
     });
     return {
       ok: true,
@@ -148,5 +150,30 @@ describe("PLUGIN action=toggle → PUT /api/plugins/:id", () => {
     expect(result?.success).toBe(false);
     // No network call when the required param is missing.
     expect(captured).toHaveLength(0);
+  });
+
+  it("attaches the process API token so cloud containers do not 401 loopback toggles", async () => {
+    // Cloud-provisioned agents reject tokenless loopback. PLUGIN toggle must
+    // send createSelfApiRequestHeaders() (Authorization: Bearer …) or the
+    // local PUT /api/plugins/:id returns 401 Unauthorized.
+    const previous = process.env.ELIZA_API_TOKEN;
+    process.env.ELIZA_API_TOKEN = "cloud-container-api-token";
+    const { captured, restore } = stubFetch({ success: true });
+    restoreFetch = () => {
+      restore();
+      if (previous === undefined) {
+        delete process.env.ELIZA_API_TOKEN;
+      } else {
+        process.env.ELIZA_API_TOKEN = previous;
+      }
+    };
+
+    await invokeToggle("calendar", true);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].headers).toMatchObject({
+      Authorization: "Bearer cloud-container-api-token",
+      "Content-Type": "application/json",
+    });
   });
 });


### PR DESCRIPTION
## Summary

**Target: develop.**

Locks a regression test so PLUGIN toggle keeps sending self-API auth headers on cloud agents.

### Background
Cloud-provisioned containers reject tokenless loopback. The PLUGIN action calls local PUT /api/plugins/:id; without Authorization Bearer ELIZA_API_TOKEN, chat/voice PLUGIN_TOGGLE gets 401 Unauthorized and cannot enable plugins (calendar / google-workspace / personal-assistant).

### Status on develop
The production fix is already on develop via shared createSelfApiRequestHeaders() (#17633) used by packages/agent/src/actions/plugin.ts.

This PR does not re-implement that helper. It adds an explicit unit test that:
1. Sets ELIZA_API_TOKEN
2. Invokes PLUGIN toggle
3. Asserts the outbound fetch includes Authorization Bearer and Content-Type application/json

So a future refactor cannot drop auth headers from the toggle path without failing CI.

### Conflict resolution
The earlier main-based commit introduced a parallel internalApiHeaders helper and conflicted with develop createSelfApiRequestHeaders. Branch was reset onto latest develop and reduced to the additive test only.

## Test plan
- [x] bunx vitest run src/actions/plugin-toggle.test.ts (includes new cloud auth header case)
- [ ] N/A runtime change — behavior already on develop

## Related
- Calendar connect handoffs: #18010
- Lean-chat scheduling for calendar views: #18043
