### PR TITLE
fix(agent): load scheduling on lean-chat for calendar views

### DIFF
--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -306,6 +306,12 @@ export const LEAN_CHAT_PLUGINS: readonly string[] = [
   "@elizaos/plugin-local-inference", // text + embeddings + voice — required for memory + generation
   "@elizaos/plugin-app-control", // VIEWS navigation in the app chat surface
   "@elizaos/plugin-notes", // managed Cloud Notes data and capabilities
+  // Always-loaded ScheduledTask primitive (CORE keeps this on for every desktop
+  // agent). Lean chat still pulls @elizaos/plugin-calendar via MOBILE_VIEW_PLUGINS
+  // (viewEveryPlatform); calendar declares a hard dependency on scheduling, so
+  // omitting it left calendar without its runner host and produced dead Calendar
+  // tiles / "No view matches calendar" on dedicated cloud agents.
+  "@elizaos/plugin-scheduling",
   "@elizaos/plugin-native-filesystem", // mobile-safe FILE target
   "@elizaos/plugin-agent-skills", // skill execution + enabled-skills provider
   "@elizaos/plugin-commands", // slash commands

--- a/packages/agent/src/runtime/plugin-collector-lean-chat.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-lean-chat.test.ts
@@ -62,6 +62,9 @@ describe("collectPluginNames lean-chat plugin set (#8434)", () => {
     expect(names.has("@elizaos/plugin-notes")).toBe(true);
     expect(names.has("@elizaos/plugin-commands")).toBe(true);
     expect(names.has("@elizaos/plugin-agent-skills")).toBe(true);
+    // Calendar home tile is viewEveryPlatform; scheduling is calendar's hard dep.
+    expect(names.has("@elizaos/plugin-calendar")).toBe(true);
+    expect(names.has("@elizaos/plugin-scheduling")).toBe(true);
 
     // ...and drops every heavy surface, including browser (off until ready).
     for (const heavy of HEAVY) {


### PR DESCRIPTION
## Summary

Dedicated cloud agents boot with `ELIZA_PLUGIN_SET=lean-chat`. Lean chat still loads `@elizaos/plugin-calendar` through `MOBILE_VIEW_PLUGINS` (`viewEveryPlatform: true`) so the Calendar home tile resolves.

Calendar declares a hard dependency on `@elizaos/plugin-scheduling`, and CORE treats scheduling as an always-loaded primitive. Lean chat did **not** seed scheduling, so dedicated agents could show a Calendar tile while the runtime view/capability path failed (`No view matches "calendar"`, trajectory limit on VIEWS).

This PR adds `@elizaos/plugin-scheduling` to `LEAN_CHAT_PLUGINS` and locks the lean-chat collector test to require both calendar and scheduling.

### Related
- Staging RCA: Calendar launcher tile present, VIEWS failed; PLUGIN_TOGGLE 401 on main is #18042
- Connect handoff cards: #18010
- develop already authenticates PLUGIN self-API via `createSelfApiRequestHeaders` (#17633)

## Test plan
- [x] `bunx vitest run src/runtime/plugin-collector-lean-chat.test.ts src/runtime/core-plugins-profile-metadata.test.ts` (20 passed)
- [ ] Deploy lean-chat cloud agent; confirm Calendar view lists under VIEWS and opens without trajectory failure
- [ ] Confirm scheduling plugin is present in boot plugin resolution logs

