### PR TITLE
fix(cloud): let an organization re-provision after its agent dies

### DIFF
--- a/packages/cloud/e2e/tests/onboarding-reprovision.spec.ts
+++ b/packages/cloud/e2e/tests/onboarding-reprovision.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Covers the eliza-app onboarding re-provision path against the real local
+ * stack: an organization whose only sandbox has died must be able to get a new
+ * container by talking to the onboarding chat, and must not be able to storm
+ * the fleet by talking to it repeatedly.
+ *
+ * Real cloud-shared services and the real jobs table; only the container
+ * infrastructure is mock-backed (in-memory sandbox provider).
+ */
+import { expect, test } from "../src/helpers/test-fixtures";
+
+const DEAD_ERROR_MESSAGE =
+  "Provisioning permanently failed after 3 attempts: Job timed out 3 times - max attempts reached";
+
+async function repositories() {
+  const { agentSandboxesRepository } =
+    await import("@elizaos/cloud-shared/db/repositories/agent-sandboxes");
+  const { jobsRepository } =
+    await import("@elizaos/cloud-shared/db/repositories/jobs");
+  const { ensureElizaAppProvisioning } =
+    await import("@elizaos/cloud-shared/lib/services/eliza-app/provisioning");
+  return {
+    agentSandboxesRepository,
+    jobsRepository,
+    ensureElizaAppProvisioning,
+  };
+}
+
+async function countProvisionJobs(
+  jobsRepository: {
+    findByFilters: (f: Record<string, unknown>) => Promise<unknown[]>;
+  },
+  organizationId: string,
+): Promise<number> {
+  const rows = await jobsRepository.findByFilters({
+    type: "agent_provision",
+    organizationId,
+    limit: 100,
+  });
+  return rows.length;
+}
+
+test.describe("eliza-app onboarding re-provisions a dead sandbox", () => {
+  test("a terminal row is re-armed once, and repeat turns do not queue more work", async ({
+    seededUser,
+  }) => {
+    const {
+      agentSandboxesRepository,
+      jobsRepository,
+      ensureElizaAppProvisioning,
+    } = await repositories();
+
+    // The state the reaper leaves behind after a provision exhausts its retries.
+    // Before the fix this row made the organization permanently unable to get an
+    // agent from the onboarding chat, with no self-service escape.
+    const past = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const dead = await agentSandboxesRepository.create({
+      organization_id: seededUser.organizationId,
+      user_id: seededUser.userId,
+      sandbox_id: `dead-${Date.now()}`,
+      status: "error",
+      agent_name: "reprovision-e2e-agent",
+      error_message: DEAD_ERROR_MESSAGE,
+      database_status: "none",
+      environment_vars: {},
+      created_at: past,
+      updated_at: past,
+    });
+
+    const before = await countProvisionJobs(
+      jobsRepository,
+      seededUser.organizationId,
+    );
+
+    const first = await ensureElizaAppProvisioning({
+      organizationId: seededUser.organizationId,
+      userId: seededUser.userId,
+    });
+
+    // Same row, not a second agent: minting a new one would orphan the first and
+    // leave the organization holding two.
+    expect(first.agentId).toBe(dead.id);
+    // Still `error` — only the daemon claiming the job moves it to
+    // `provisioning`. Reporting progress here would invent a state the database
+    // does not have, and the stuck-provisioning reaper would never sweep it.
+    expect(first.status).toBe("error");
+
+    const afterFirst = await countProvisionJobs(
+      jobsRepository,
+      seededUser.organizationId,
+    );
+    expect(afterFirst).toBe(before + 1);
+
+    const second = await ensureElizaAppProvisioning({
+      organizationId: seededUser.organizationId,
+      userId: seededUser.userId,
+    });
+
+    // A user who keeps typing must not keep queueing container builds. The
+    // pending job dedup covers this turn; the cooldown covers the turn after
+    // the job settles.
+    expect(second.agentId).toBe(dead.id);
+    const afterSecond = await countProvisionJobs(
+      jobsRepository,
+      seededUser.organizationId,
+    );
+    expect(afterSecond).toBe(afterFirst);
+
+    const persisted = await agentSandboxesRepository.findByIdAndOrg(
+      dead.id,
+      seededUser.organizationId,
+    );
+    expect(persisted?.status).toBe("error");
+  });
+
+  test("a healthy sandbox is reused, never re-armed", async ({
+    seededUser,
+  }) => {
+    const {
+      agentSandboxesRepository,
+      jobsRepository,
+      ensureElizaAppProvisioning,
+    } = await repositories();
+
+    const live = await agentSandboxesRepository.create({
+      organization_id: seededUser.organizationId,
+      user_id: seededUser.userId,
+      sandbox_id: `live-${Date.now()}`,
+      status: "running",
+      agent_name: "reuse-e2e-agent",
+      bridge_url: "http://127.0.0.1:65535",
+      health_url: "http://127.0.0.1:65535/health",
+      database_status: "ready",
+      environment_vars: {},
+    });
+
+    const before = await countProvisionJobs(
+      jobsRepository,
+      seededUser.organizationId,
+    );
+
+    const result = await ensureElizaAppProvisioning({
+      organizationId: seededUser.organizationId,
+      userId: seededUser.userId,
+    });
+
+    expect(result.agentId).toBe(live.id);
+    expect(result.status).toBe("running");
+    // The whole point of the guard: a working agent costs no new work.
+    expect(
+      await countProvisionJobs(jobsRepository, seededUser.organizationId),
+    ).toBe(before);
+  });
+});

--- a/packages/cloud/e2e/tsconfig.json
+++ b/packages/cloud/e2e/tsconfig.json
@@ -18,7 +18,11 @@
       "@elizaos/plugin-sql": ["../../../plugins/plugin-sql/src/index.ts"],
       "@elizaos/plugin-sql/*": ["../../../plugins/plugin-sql/src/*"]
     },
-    "lib": ["ES2022", "DOM"]
+    // Matches the repository base. This package typechecks cloud-shared through
+    // the path mappings above, and that code targets a newer library than
+    // ES2022 (Array.prototype.toReversed is ES2023), so pinning lower here fails
+    // on its dependency's source rather than on anything in this package.
+    "lib": ["ES2024", "DOM", "DOM.Iterable"]
   },
   "include": ["src", "tests", "scripts", "playwright.config.ts"]
 }

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -447,9 +447,19 @@ async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
         }
       : {}),
     ...(result
-      ? { result: result.value, result_storage: result.storage, result_key: result.key }
+      ? {
+          result: result.value,
+          result_storage: result.storage,
+          result_key: result.key,
+        }
       : {}),
-    ...(error ? { error: error.value, error_storage: error.storage, error_key: error.key } : {}),
+    ...(error
+      ? {
+          error: error.value,
+          error_storage: error.storage,
+          error_key: error.key,
+        }
+      : {}),
   };
 }
 
@@ -587,6 +597,38 @@ export class JobsRepository {
       .limit(filters.limit || 1000)
       .orderBy(filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at);
     return await Promise.all(rows.map(hydrateJob));
+  }
+
+  /**
+   * Most recent lifecycle job for one agent, whatever its status.
+   *
+   * `findByFilters` cannot express this: it has no `agent_id` predicate, and
+   * widening it would change a reader many callers share. Callers use this to
+   * decide whether enough time has passed since the last attempt — so the row
+   * must be the latest attempt, not the latest *failed* one, or a retry that
+   * is still running would look like an opportunity to start another.
+   *
+   * Served by `jobs_org_type_agent_created_idx` on
+   * (organization_id, type, agent_id, created_at) WHERE agent_id IS NOT NULL.
+   */
+  async findLatestAgentLifecycleJob(filters: {
+    type: ProvisioningJobType;
+    organizationId: string;
+    agentId: string;
+  }): Promise<Job | null> {
+    const [row] = await dbRead
+      .select()
+      .from(jobs)
+      .where(
+        and(
+          eq(jobs.organization_id, filters.organizationId),
+          eq(jobs.type, filters.type),
+          eq(jobs.agent_id, filters.agentId),
+        ),
+      )
+      .orderBy(desc(jobs.created_at))
+      .limit(1);
+    return row ? await hydrateJob(row) : null;
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -589,7 +589,10 @@ describe("runOnboardingChat", () => {
         message: "My name is Eve",
         platform: "twilio",
         platformUserId: "+15550002222",
-        authenticatedUser: { userId: "attacker-user", organizationId: "attacker-org" },
+        authenticatedUser: {
+          userId: "attacker-user",
+          organizationId: "attacker-org",
+        },
       });
       expect(withSessionId.session.id).toMatch(UUID_PATTERN);
       expect(sessionCache.has(cacheKey("platform:twilio:+15550002222"))).toBe(false);
@@ -598,7 +601,10 @@ describe("runOnboardingChat", () => {
         message: "My name is Eve",
         platform: "twilio",
         platformUserId: "+15550003333",
-        authenticatedUser: { userId: "attacker-user", organizationId: "attacker-org" },
+        authenticatedUser: {
+          userId: "attacker-user",
+          organizationId: "attacker-org",
+        },
       });
       expect(withoutSessionId.session.id).toMatch(UUID_PATTERN);
       expect(sessionCache.has(cacheKey("platform:twilio:+15550003333"))).toBe(false);
@@ -614,7 +620,10 @@ describe("runOnboardingChat", () => {
 
       const attacker = await runOnboardingChat({
         sessionId: PLATFORM_SESSION,
-        authenticatedUser: { userId: "attacker-user", organizationId: "attacker-org" },
+        authenticatedUser: {
+          userId: "attacker-user",
+          organizationId: "attacker-org",
+        },
       });
 
       expect(attacker.session.id).not.toBe(PLATFORM_SESSION);
@@ -640,14 +649,20 @@ describe("runOnboardingChat", () => {
       const victimBound = await runOnboardingChat({
         sessionId: continuationToken(victim),
         platform: "blooio",
-        authenticatedUser: { userId: "victim-user", organizationId: "victim-org" },
+        authenticatedUser: {
+          userId: "victim-user",
+          organizationId: "victim-org",
+        },
       });
       expect(victimBound.session.id).toBe(PLATFORM_SESSION);
       expect(victimBound.session.userId).toBe("victim-user");
 
       const attacker = await runOnboardingChat({
         sessionId: PLATFORM_SESSION,
-        authenticatedUser: { userId: "attacker-user", organizationId: "attacker-org" },
+        authenticatedUser: {
+          userId: "attacker-user",
+          organizationId: "attacker-org",
+        },
       });
 
       expect(attacker.session.id).not.toBe(PLATFORM_SESSION);
@@ -872,7 +887,7 @@ describe("runOnboardingChat", () => {
   });
 
   describe("provisioning-state replies without an LLM", () => {
-    test("provisioning error reply points at the control panel and never claims the agent is live", async () => {
+    test("provisioning error reply promises the queued retry and never claims the agent is live", async () => {
       ensureElizaAppProvisioning.mockResolvedValue({
         status: "error",
         agentId: "agent-1",
@@ -889,7 +904,13 @@ describe("runOnboardingChat", () => {
       });
       expect(result.provisioning.status).toBe("error");
       expect(result.handoffComplete).toBe(false);
-      expect(result.reply).toContain("dashboard");
+      // The retry is queued automatically now (#17924), so the reply must say
+      // so rather than send the user to a dashboard that has no button to fix
+      // this — that instruction was a dead end for every stranded org.
+      expect(result.reply.toLowerCase()).toContain("queued");
+      expect(result.reply.toLowerCase()).not.toContain("dashboard");
+      // Still must not overclaim: the row is `error` at this instant and only
+      // becomes `provisioning` when the daemon claims the job.
       expect(result.reply).not.toContain("agent is live");
       expect(result.reply.toLowerCase()).not.toContain("running");
     });
@@ -958,11 +979,18 @@ describe("runOnboardingChat", () => {
           status: "running",
           agentId: "agent-1",
           bridgeUrl: "https://agent-1.example",
-          sandbox: { id: "agent-1", status: "running", bridge_url: "https://agent-1.example" },
+          sandbox: {
+            id: "agent-1",
+            status: "running",
+            bridge_url: "https://agent-1.example",
+          },
         });
         launchManagedElizaAgent.mockResolvedValue({
           appUrl: "https://app.elizacloud.ai/dashboard/agents/agent-1",
-          connection: { apiBase: "https://agent-1.example", token: "agent-token" },
+          connection: {
+            apiBase: "https://agent-1.example",
+            token: "agent-token",
+          },
         });
 
         const first = await runOnboardingChat({
@@ -1019,11 +1047,18 @@ describe("runOnboardingChat", () => {
           status: "running",
           agentId: "agent-1",
           bridgeUrl: "https://agent-1.example",
-          sandbox: { id: "agent-1", status: "running", bridge_url: "https://agent-1.example" },
+          sandbox: {
+            id: "agent-1",
+            status: "running",
+            bridge_url: "https://agent-1.example",
+          },
         });
         launchManagedElizaAgent.mockResolvedValue({
           appUrl: "https://app.elizacloud.ai/dashboard/agents/agent-1",
-          connection: { apiBase: "https://agent-1.example", token: "agent-token" },
+          connection: {
+            apiBase: "https://agent-1.example",
+            token: "agent-token",
+          },
         });
 
         const result = await runOnboardingChat({

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -552,7 +552,10 @@ function fallbackReply(args: {
     return `almost there, ${name}. finishing setup now.`;
   }
   if (args.provisioning.status === "error") {
-    return `hit a snag on my end, ${name}. your dashboard has the details and the team is on it.`;
+    // The row is still `error` at this instant — the retry only flips it once
+    // the daemon claims the job — so this promises a retry, not progress, and
+    // sends nobody to a dashboard that has no button to fix it.
+    return `last attempt failed, ${name}. I've queued another one, nothing for you to do. keep chatting here.`;
   }
   if (args.provisioning.status === "insufficient_credits") {
     return `you're out of credits, ${name}. top up at ${onboardingAppPath("/dashboard/billing")} and I'll get your agent going.`;

--- a/packages/cloud/shared/src/lib/services/eliza-app/provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/provisioning.test.ts
@@ -1,6 +1,8 @@
 // Exercises provisioning behavior with deterministic cloud-shared lib fixtures.
 import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { agentSandboxesRepository } from "../../../db/repositories/agent-sandboxes";
+import { jobsRepository } from "../../../db/repositories/jobs";
+import { ApiError } from "../../api/cloud-worker-errors";
 import { containersEnv as actualContainersEnv } from "../../config/containers-env";
 import { elizaSandboxService } from "../eliza-sandbox";
 
@@ -80,10 +82,17 @@ mock.module("../agent-billing-gate", () => ({
   checkAgentCreditGate,
 }));
 
+const findLatestAgentLifecycleJob = mock();
+const findLatestAgentLifecycleJobSpy = spyOn(
+  jobsRepository,
+  "findLatestAgentLifecycleJob",
+).mockImplementation((...args) => findLatestAgentLifecycleJob(...args) as never);
+
 afterAll(() => {
   listByOrganizationSpy.mockRestore();
   createAgentSpy.mockRestore();
   deleteSandboxSpy.mockRestore();
+  findLatestAgentLifecycleJobSpy.mockRestore();
 });
 
 const { ensureElizaAppProvisioning } = await import(
@@ -99,6 +108,7 @@ describe("ensureElizaAppProvisioning", () => {
     hasElizaAppInitialFreeCredits.mockReset();
     addCredits.mockReset();
     checkAgentCreditGate.mockReset();
+    findLatestAgentLifecycleJob.mockReset();
   });
 
   test("grants starter credits before provisioning a new Eliza App agent", async () => {
@@ -256,5 +266,191 @@ describe("ensureElizaAppProvisioning", () => {
       bridgeUrl: null,
       sandbox: null,
     });
+  });
+});
+
+describe("a dead sandbox no longer locks the organization out (#17924)", () => {
+  // Sibling describes do not inherit the suite above's beforeEach, and these
+  // assertions count calls — without this the counts accumulate across tests.
+  beforeEach(() => {
+    listByOrganization.mockReset();
+    createAgent.mockReset();
+    enqueueAgentProvision.mockReset();
+    deleteSandbox.mockReset();
+    hasElizaAppInitialFreeCredits.mockReset();
+    addCredits.mockReset();
+    checkAgentCreditGate.mockReset();
+    findLatestAgentLifecycleJob.mockReset();
+  });
+
+  const DEAD_ROW = {
+    id: "agent-dead",
+    organization_id: "org-1",
+    status: "error",
+    bridge_url: null,
+  };
+  const HOUR_AGO = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+  function orgWithNewestRow(row: Record<string, unknown>) {
+    hasElizaAppInitialFreeCredits.mockResolvedValue(true);
+    checkAgentCreditGate.mockResolvedValue({ allowed: true, balance: 5 });
+    listByOrganization.mockResolvedValue([row]);
+  }
+
+  test("an errored row is re-armed in place: same agent id, no second agent minted", async () => {
+    orgWithNewestRow(DEAD_ROW);
+    findLatestAgentLifecycleJob.mockResolvedValue({ completed_at: HOUR_AGO });
+    enqueueAgentProvision.mockResolvedValue({ id: "job-1" });
+
+    const result = await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    expect(enqueueAgentProvision).toHaveBeenCalledWith({
+      agentId: "agent-dead",
+      organizationId: "org-1",
+      userId: "user-1",
+      agentName: "Eliza",
+    });
+    // Minting a second row would leave the org with two agents and orphan the
+    // first — the reuse path exists precisely to keep one row per org.
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(result.agentId).toBe("agent-dead");
+  });
+
+  test("the reported status stays error — the row only moves when the daemon claims the job", async () => {
+    orgWithNewestRow(DEAD_ROW);
+    findLatestAgentLifecycleJob.mockResolvedValue({ completed_at: HOUR_AGO });
+    enqueueAgentProvision.mockResolvedValue({ id: "job-1" });
+
+    const result = await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    // Claiming "provisioning" here would be a state the database does not have,
+    // and the stuck-provisioning reaper would never sweep it back.
+    expect(result.status).toBe("error");
+  });
+
+  test("a second message inside the cooldown does not enqueue again", async () => {
+    orgWithNewestRow(DEAD_ROW);
+    findLatestAgentLifecycleJob.mockResolvedValue({
+      completed_at: new Date(Date.now() - 60 * 1000).toISOString(),
+    });
+
+    const result = await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(result.status).toBe("error");
+  });
+
+  test("the cooldown is measured from the JOB, so row writes cannot push it out forever", async () => {
+    // updated_at on the sandbox is bumped by heartbeat/reconciler/billing; if the
+    // cooldown keyed on it, those writers would re-create the permanent lockout.
+    orgWithNewestRow({ ...DEAD_ROW, updated_at: new Date().toISOString() });
+    findLatestAgentLifecycleJob.mockResolvedValue({ completed_at: HOUR_AGO });
+    enqueueAgentProvision.mockResolvedValue({ id: "job-1" });
+
+    await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
+  });
+
+  test("a row with no prior job is re-armed immediately", async () => {
+    orgWithNewestRow(DEAD_ROW);
+    findLatestAgentLifecycleJob.mockResolvedValue(null);
+    enqueueAgentProvision.mockResolvedValue({ id: "job-1" });
+
+    await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
+  });
+
+  test("a drained organization is still refused before any compute is minted", async () => {
+    orgWithNewestRow(DEAD_ROW);
+    checkAgentCreditGate.mockResolvedValue({ allowed: false, balance: 0 });
+    findLatestAgentLifecycleJob.mockResolvedValue({ completed_at: HOUR_AGO });
+
+    const result = await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(result.status).toBe("insufficient_credits");
+  });
+
+  test("a lifecycle conflict is absorbed, not surfaced as a 500", async () => {
+    orgWithNewestRow(DEAD_ROW);
+    findLatestAgentLifecycleJob.mockResolvedValue({ completed_at: HOUR_AGO });
+    enqueueAgentProvision.mockRejectedValue(
+      new ApiError(409, "session_not_ready", "Agent agent-dead has unresolved replacement cleanup"),
+    );
+
+    const result = await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    // runOnboardingChat has no enclosing try/catch: an escaping 409 would 500
+    // the user's whole turn over a condition that resolves itself.
+    expect(result.status).toBe("error");
+  });
+
+  test("a non-conflict enqueue failure still escapes", async () => {
+    orgWithNewestRow(DEAD_ROW);
+    findLatestAgentLifecycleJob.mockResolvedValue({ completed_at: HOUR_AGO });
+    enqueueAgentProvision.mockRejectedValue(new Error("database is on fire"));
+
+    await expect(
+      ensureElizaAppProvisioning({ organizationId: "org-1", userId: "user-1" }),
+    ).rejects.toThrow("database is on fire");
+  });
+
+  test("a row being deleted gets a NEW agent, never a revival", async () => {
+    orgWithNewestRow({ ...DEAD_ROW, status: "deletion_pending" });
+    createAgent.mockResolvedValue({
+      agent: { id: "agent-fresh", status: "pending", bridge_url: null },
+      idempotent: false,
+    });
+    enqueueAgentProvision.mockResolvedValue({ id: "job-2" });
+
+    const result = await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    // Re-arming mid-teardown would race the deletion for the same container.
+    expect(createAgent).toHaveBeenCalled();
+    expect(result.agentId).toBe("agent-fresh");
+  });
+
+  test("a healthy row still short-circuits — no job, no new agent", async () => {
+    orgWithNewestRow({
+      ...DEAD_ROW,
+      status: "running",
+      bridge_url: "https://a.test",
+    });
+
+    const result = await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(result.status).toBe("running");
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-app/provisioning.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/provisioning.ts
@@ -1,7 +1,9 @@
 // Coordinates cloud service provisioning behavior behind route handlers.
 import { agentSandboxesRepository } from "../../../db/repositories/agent-sandboxes";
 import { creditTransactionsRepository } from "../../../db/repositories/credit-transactions";
-import type { AgentSandbox } from "../../../db/schemas/agent-sandboxes";
+import { jobsRepository } from "../../../db/repositories/jobs";
+import type { AgentSandbox, AgentSandboxStatus } from "../../../db/schemas/agent-sandboxes";
+import { ApiError } from "../../api/cloud-worker-errors";
 import { containersEnv } from "../../config/containers-env";
 import { logger } from "../../utils/logger";
 import { checkAgentCreditGate } from "../agent-billing-gate";
@@ -16,6 +18,82 @@ const DEFAULT_AGENT_NAME = "Eliza";
 // docker.io, producing an "unauthorized" / "pull access denied" error.
 const DEFAULT_DOCKER_IMAGE = containersEnv.defaultAgentImage();
 const ELIZA_APP_INITIAL_CREDITS = 5.0;
+
+/**
+ * Minimum gap between two onboarding-driven provision attempts for one sandbox.
+ *
+ * Without it, an organization whose provisioning is genuinely broken would
+ * enqueue a fresh attempt on every inbound message, turning one stuck user into
+ * a container-build storm against the shared fleet. Measured against the last
+ * attempt's own terminal timestamp, so a node outage costs at most one build
+ * per window per organization.
+ */
+const ELIZA_APP_REPROVISION_COOLDOWN_MS = 15 * 60 * 1000;
+
+/**
+ * What the onboarding path should do with the organization's newest sandbox.
+ *
+ * `reuse` covers every state that is already heading toward a working agent.
+ * `reprovision` covers states where the row is still the user's agent but its
+ * compute is gone, so the same row is re-armed with a new provision job.
+ * `replace` covers rows being torn down, where a NEW row is the only correct
+ * answer — reviving one mid-deletion would race the teardown.
+ */
+type ElizaAppSandboxDisposition = "reuse" | "reprovision" | "replace";
+
+export function classifyElizaAppSandbox(status: AgentSandboxStatus): ElizaAppSandboxDisposition {
+  // Exhaustive by design, with no `default`: a tenth status must fail the build
+  // here rather than silently inherit whichever branch happens to be last. The
+  // old guard's bug was exactly this kind of silent catch-all.
+  switch (status) {
+    case "pending":
+    case "provisioning":
+    case "running":
+    case "stopped":
+    case "sleeping":
+      return "reuse";
+    case "error":
+    case "disconnected":
+      return "reprovision";
+    case "deletion_pending":
+    case "deletion_failed":
+      return "replace";
+  }
+}
+
+/**
+ * A 409 from the enqueue means another lifecycle operation owns this agent —
+ * a deletion in flight, or an unresolved replacement-cleanup fence. Re-arming
+ * has to stand down and let that finish; it is a state of the world, not a
+ * fault. Anything else is a real failure and must escape.
+ */
+function isLifecycleConflict(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 409;
+}
+
+/**
+ * Whether enough time has passed since this sandbox's last provision attempt.
+ *
+ * Keyed on the JOB's terminal timestamp, never `sandbox.updated_at`: heartbeat,
+ * reconciler and billing writers all bump the row, and any of them would keep
+ * pushing the deadline outward — re-creating the permanent lockout this whole
+ * change exists to remove. No prior job means nothing has been attempted for
+ * this row, so the caller may proceed.
+ */
+async function elizaAppReprovisionCooldownElapsed(
+  sandbox: AgentSandbox,
+  nowMs: number,
+): Promise<boolean> {
+  const last = await jobsRepository.findLatestAgentLifecycleJob({
+    type: "agent_provision",
+    organizationId: sandbox.organization_id,
+    agentId: sandbox.id,
+  });
+  if (!last) return true;
+  const settledAt = last.completed_at ?? last.updated_at;
+  if (!settledAt) return false;
+  return nowMs - new Date(settledAt).getTime() >= ELIZA_APP_REPROVISION_COOLDOWN_MS;
+}
 
 export interface ElizaAppProvisioningStatus {
   status: string;
@@ -90,17 +168,22 @@ export async function ensureElizaAppProvisioning(params: {
   await ensureElizaAppStarterCredits(params);
 
   const existing = await getElizaAppProvisioningStatus(params.organizationId);
-  if (existing.sandbox) {
+  // Only a sandbox still heading toward a working agent short-circuits here.
+  // Testing the ROW'S EXISTENCE instead of its state is what stranded every
+  // organization whose newest row had died: the reaper marks a wedged row
+  // `error` precisely so the user can re-provision, and this guard was what
+  // stopped them (#17924).
+  const disposition = existing.sandbox ? classifyElizaAppSandbox(existing.sandbox.status) : null;
+  if (existing.sandbox && disposition === "reuse") {
     return existing;
   }
 
-  // Every other create/provision/resume path runs the credit gate before
-  // createAgent; this onboarding entry point must too. Fresh orgs just
-  // received the starter grant above so they pass, and an org with a live
-  // sandbox already returned early — the gate only blocks NEW provisioning
-  // for a drained returning org. Return a non-provisioning status instead of
-  // throwing: runOnboardingChat has no enclosing try/catch, so a throw here
-  // would 500 the whole onboarding turn.
+  // Every create/provision/resume path runs the credit gate before minting
+  // compute; this onboarding entry point must too. It now covers BOTH
+  // remaining branches — re-arming a dead row builds a container just as a
+  // fresh row does, so neither may skip it. Return a non-provisioning status
+  // instead of throwing: runOnboardingChat has no enclosing try/catch, so a
+  // throw here would 500 the whole onboarding turn.
   const creditGate = await checkAgentCreditGate(params.organizationId);
   if (!creditGate.allowed) {
     logger.warn("[eliza-app provisioning] Credit gate blocked provisioning", {
@@ -113,6 +196,45 @@ export async function ensureElizaAppProvisioning(params: {
       bridgeUrl: null,
       sandbox: null,
     };
+  }
+
+  if (existing.sandbox && disposition === "reprovision") {
+    const sandbox = existing.sandbox;
+    if (!(await elizaAppReprovisionCooldownElapsed(sandbox, Date.now()))) {
+      logger.info("[eliza-app provisioning] Re-provision held by cooldown", {
+        agentId: sandbox.id,
+        orgId: params.organizationId,
+      });
+      return existing;
+    }
+
+    try {
+      await provisioningJobService.enqueueAgentProvision({
+        agentId: sandbox.id,
+        organizationId: params.organizationId,
+        userId: params.userId,
+        agentName: DEFAULT_AGENT_NAME,
+      });
+      logger.info("[eliza-app provisioning] Re-armed a dead sandbox", {
+        agentId: sandbox.id,
+        orgId: params.organizationId,
+        fromStatus: sandbox.status,
+      });
+    } catch (err) {
+      // error-policy:J4 the enqueue refuses while a lifecycle job already owns
+      // this agent; that is the dedup working, not a failure, and the caller
+      // has no try/catch. Any other error is a real fault and must escape.
+      if (!isLifecycleConflict(err)) throw err;
+      logger.info("[eliza-app provisioning] Re-provision already queued", {
+        agentId: sandbox.id,
+        orgId: params.organizationId,
+      });
+    }
+
+    // Returned unchanged, still `error`: the row only becomes `provisioning`
+    // when the daemon claims the job and calls trySetProvisioning. Reporting
+    // progress here would invent a state the database does not have.
+    return toElizaAppProvisioningStatus(sandbox);
   }
 
   const { agent: sandbox, idempotent } = await elizaSandboxService.createAgent({


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

Closes #17924

## The defect

The onboarding guard tested whether a sandbox row **exists**, not whether it is still heading toward a working agent:

```ts
const existing = await getElizaAppProvisioningStatus(params.organizationId);
if (existing.sandbox) { return existing; }
```

`getElizaAppProvisioningStatus` takes `sandboxes[0]` from `listByOrganization`, which orders `created_at DESC` with no status predicate. So an organization whose newest row is terminal never reaches `createAgent` — even though `createAgent` is already written with `reuseExistingNonTerminal: true` and would mint a fresh row correctly.

The cruel part: the `cleanup-stuck-provisioning` reaper marks a wedged row `error` *specifically so the user can re-provision*. This guard is what stopped them. There was no self-service escape either — the control-panel delete hits the same wall when a replacement-cleanup fence is stranded.

Measured on production while writing this:

```
organizations with any sandbox                     268
newest-row status: running 195 | error 50 | stopped 8
                   deleted 8 | deletion_failed 6 | sleeping 1
terminal-newest AND no live sandbox anywhere        69   (was 60 fifteen hours earlier)
```

It is growing, because every provisioning failure adds one. Fourteen of them get a permanent **false-progress** reply — "your agent is spinning up now" — forever.

## The fix

**Classification, exhaustive and without a `default`.** A tenth status must fail the build rather than silently inherit whichever branch happens to be last — the old guard's bug was exactly that kind of catch-all.

| disposition | statuses | why |
|---|---|---|
| `reuse` | pending, provisioning, running, stopped, sleeping | already heading toward a working agent |
| `reprovision` | error, disconnected | still the user's agent, but its compute is gone |
| `replace` | deletion_pending, deletion_failed | mid-teardown; reviving one would race the deletion |

**The credit gate now covers both remaining branches.** Re-arming a dead row builds a container exactly as creating one does, so neither may skip it.

**A 15-minute cooldown, keyed on the JOB's terminal timestamp — never on the sandbox row.** Heartbeat, reconciler and billing writers all bump `updated_at`; keying there would let them push the deadline outward and re-create the permanent lockout this change removes. Without the cooldown, an organization whose provisioning is genuinely broken turns every inbound message into a container build.

**The row is returned unchanged, still `error`.** It only becomes `provisioning` when the daemon claims the job and calls `trySetProvisioning`. Reporting progress here would invent a state the database does not have — and `markStuckProvisioningWithoutActiveJobAsError` would then never sweep it, because a pending job counts as a status owner.

That makes the copy load-bearing rather than cosmetic: it now promises the retry it actually queued, instead of sending the user to a dashboard that has no button for this.

**One narrow `error-policy:J4` catch** for a 409 `session_not_ready` — a deletion in flight or an unresolved replacement-cleanup fence owns the agent, which is a state of the world, not a fault. `runOnboardingChat` has no enclosing try/catch, so an escaping 409 would 500 the user's whole turn. Everything else escapes.

## Evidence

<details>
<summary>Mutation runs — unit and full-stack, every mutation verified to apply</summary>

```
BASELINE                                              unit: 15 pass 0 fail   e2e: 2 passed
M1 revert to the existence guard (= the bug)          unit:  9 pass 6 fail   e2e: 1 failed 1 passed
M2 treat a terminal row as reusable                   unit: 10 pass 5 fail   e2e: 1 failed 1 passed
M3 cooldown keyed on the sandbox row, not the job     unit: 11 pass 4 fail
M4 cooldown removed entirely                          unit: 14 pass 1 fail
M5 catch widened to swallow every enqueue failure     unit: 14 pass 1 fail
M6 credit gate skipped for the re-arm branch          unit: 12 pass 3 fail
M7 rows mid-teardown revived instead of replaced      unit: 14 pass 1 fail
BASELINE restored                                     unit: 15 pass 0 fail   e2e: 2 passed
```

The harness aborts if a mutation fails to apply, so a no-op cannot be reported as a red.

</details>

The full-stack spec (`packages/cloud/e2e/tests/onboarding-reprovision.spec.ts`) runs against the real local stack — real cloud-shared services, real `jobs` table, in-memory sandbox provider — as `packages/cloud/CLAUDE.md` requires for provisioning changes. It seeds the exact row the reaper leaves behind, drives an onboarding turn, and asserts the same row is re-armed with exactly one new job, still `error`; a second turn adds none.

```
cloud/shared typecheck + biome    clean
```

## Deploy note

The production provisioning daemon is currently pinned to an older commit, so the *execution* half will only reach users once it is redeployed. That does not change this fix's ordering — it is the precondition: no daemon redeploy, however clean, helps those 69 organizations while the guard stands, because they never enqueue anything for the daemon to claim.

[stan-cloud]

<!-- evidence-head:cb5f6adf96094ddef8f5e604d2682c4ba0c3b922 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - a server-side provisioning guard; the only user-visible surface is chat copy, quoted in the description

<!-- evidence-row:after-screenshots -->
- [ ] N/A - a server-side provisioning guard; the only user-visible surface is chat copy, quoted in the description

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable behaviour is a row being re-armed with a job; the full-stack spec and the mutation runs carry it

<!-- evidence-row:backend-logs -->
- [x] [18044-runs-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18044-runs-v2.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call on any path this diff touches

<!-- evidence-row:domain-artifacts -->
- [x] [18044-domain.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18044-domain.txt)

