### PR TITLE
fix(testing): default PGlite test runtimes to in-memory storage (#18053 pglite-fault axis)

### DIFF
--- a/packages/app-core/test/helpers/pglite-runtime.ts
+++ b/packages/app-core/test/helpers/pglite-runtime.ts
@@ -1,11 +1,14 @@
 /** Builds a real AgentRuntime backed by an in-process PGLite database. */
 
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { Plugin } from "@elizaos/core";
 import { AgentRuntime, createCharacter, logger } from "@elizaos/core";
+import {
+  createTestPgliteDataDir,
+  isInMemoryPgliteDataDir,
+} from "@elizaos/core/testing";
 
 const helperDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -14,7 +17,11 @@ export interface TestRuntimeOptions {
   characterName?: string;
   /** Additional plugins to register (plugin-sql is always included). */
   plugins?: Plugin[];
-  /** Reuse an existing PGLite data directory instead of creating a temp one. */
+  /**
+   * Reuse an existing PGLite data directory instead of the default per-call
+   * in-memory database. Pass a real directory only when the test proves
+   * restart persistence.
+   */
   pgliteDir?: string;
   /**
    * Remove the PGLite data directory during cleanup.
@@ -108,10 +115,10 @@ export async function createTestRuntime(
   options?: TestRuntimeOptions,
 ): Promise<TestRuntimeResult> {
   const pgliteDir =
-    options?.pgliteDir ??
-    fs.mkdtempSync(path.join(os.tmpdir(), "eliza-test-pglite-"));
+    options?.pgliteDir ?? createTestPgliteDataDir("eliza-test-pglite-");
   const removePgliteDirOnCleanup =
-    options?.removePgliteDirOnCleanup ?? options?.pgliteDir === undefined;
+    options?.removePgliteDirOnCleanup ??
+    (options?.pgliteDir === undefined && !isInMemoryPgliteDataDir(pgliteDir));
 
   const prevPgliteDir = process.env.PGLITE_DATA_DIR;
   process.env.PGLITE_DATA_DIR = pgliteDir;

--- a/packages/app-core/test/helpers/real-runtime.ts
+++ b/packages/app-core/test/helpers/real-runtime.ts
@@ -11,6 +11,10 @@ import {
   DEFAULT_CEREBRAS_TEXT_MODEL,
   logger,
 } from "@elizaos/core";
+import {
+  createTestPgliteDataDir,
+  isInMemoryPgliteDataDir,
+} from "@elizaos/core/testing";
 import { configureLocalEmbeddingPlugin } from "../../../agent/src/runtime/eliza";
 import type { LiveProviderConfig, LiveProviderName } from "./live-provider";
 
@@ -282,10 +286,10 @@ export async function createRealTestRuntime(
   options?: RealTestRuntimeOptions,
 ): Promise<RealTestRuntimeResult> {
   const pgliteDir =
-    options?.pgliteDir ??
-    fs.mkdtempSync(path.join(os.tmpdir(), "eliza-real-test-"));
+    options?.pgliteDir ?? createTestPgliteDataDir("eliza-real-test-");
   const removePgliteDirOnCleanup =
-    options?.removePgliteDirOnCleanup ?? options?.pgliteDir === undefined;
+    options?.removePgliteDirOnCleanup ??
+    (options?.pgliteDir === undefined && !isInMemoryPgliteDataDir(pgliteDir));
   const restoreWindow = suppressWindowDuringNodeRuntime();
   let selfControlTempDir: string | null = null;
 

--- a/packages/core/src/access-control/canonical-memory-pglite.integration.test.ts
+++ b/packages/core/src/access-control/canonical-memory-pglite.integration.test.ts
@@ -5,6 +5,8 @@
  * permission from the trusted delivery-audience gate against live room state.
  */
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createMessageMemory } from "../memory";
 import {
@@ -78,8 +80,14 @@ describe("canonical connector memory recall on AgentRuntime + PGlite", () => {
 	let testRuntime: TestRuntimeResult | undefined;
 
 	beforeEach(async () => {
+		// The restart case below reopens the same data dir with a second
+		// runtime, so this suite needs a real on-disk store rather than the
+		// helper's default in-memory database.
 		testRuntime = await createTestRuntime({
 			characterName: "CanonicalMemoryAgent",
+			pgliteDir: fs.mkdtempSync(
+				path.join(os.tmpdir(), "eliza-canonical-memory-"),
+			),
 			removePgliteDirOnCleanup: false,
 		});
 		testRuntime.runtime.character.settings = {

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -114,6 +114,13 @@ export {
 	type TestRuntimeOptions,
 	type TestRuntimeResult,
 } from "./pglite-runtime";
+// PGLite storage-mode policy (in-memory by default; disk via env or explicit dir)
+export {
+	createTestPgliteDataDir,
+	isInMemoryPgliteDataDir,
+	type TestPgliteStorageMode,
+	testPgliteStorageMode,
+} from "./pglite-storage";
 // React test-renderer helpers
 export { findButtonByText, flush, text, textOf } from "./react-test";
 // Real connector helpers (Discord, Telegram)

--- a/packages/core/src/testing/pglite-runtime.ts
+++ b/packages/core/src/testing/pglite-runtime.ts
@@ -19,12 +19,14 @@
  */
 
 import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { createCharacter } from "../character";
 import { logger } from "../logger";
 import { AgentRuntime } from "../runtime";
 import type { Plugin } from "../types";
+import {
+	createTestPgliteDataDir,
+	isInMemoryPgliteDataDir,
+} from "./pglite-storage";
 
 export interface TestRuntimeOptions {
 	/** Name for the test agent character. Defaults to "TestAgent". */
@@ -33,7 +35,12 @@ export interface TestRuntimeOptions {
 	plugins?: Plugin[];
 	/** Embedding width shared by the database vector schema and model provider. */
 	embeddingDimensions?: number;
-	/** Reuse an existing PGLite data directory instead of creating a temp one. */
+	/**
+	 * Reuse an existing PGLite data directory instead of the default per-call
+	 * in-memory database. Pass a real directory when the test proves restart
+	 * persistence; otherwise omit it and the runtime gets a unique `memory://`
+	 * store (see ./pglite-storage).
+	 */
 	pgliteDir?: string;
 	/**
 	 * Remove the PGLite data directory during cleanup.
@@ -52,6 +59,7 @@ export interface TestRuntimeOptions {
 
 export interface TestRuntimeResult {
 	runtime: AgentRuntime;
+	/** Data dir backing the runtime: a `memory://` URL unless the caller passed a directory. */
 	pgliteDir: string;
 	/** Stops the runtime and removes the temp PGLite directory. */
 	cleanup: () => Promise<void>;
@@ -104,10 +112,10 @@ export async function createTestRuntime(
 	options?: TestRuntimeOptions,
 ): Promise<TestRuntimeResult> {
 	const pgliteDir =
-		options?.pgliteDir ??
-		fs.mkdtempSync(path.join(os.tmpdir(), "eliza-test-pglite-"));
+		options?.pgliteDir ?? createTestPgliteDataDir("eliza-test-pglite-");
 	const removePgliteDirOnCleanup =
-		options?.removePgliteDirOnCleanup ?? options?.pgliteDir === undefined;
+		options?.removePgliteDirOnCleanup ??
+		(options?.pgliteDir === undefined && !isInMemoryPgliteDataDir(pgliteDir));
 
 	const prevPgliteDir = process.env.PGLITE_DATA_DIR;
 	const prevEmbeddingDimension = process.env.EMBEDDING_DIMENSION;

--- a/packages/core/src/testing/pglite-storage.ts
+++ b/packages/core/src/testing/pglite-storage.ts
@@ -1,0 +1,53 @@
+/**
+ * Storage-mode policy for PGlite-backed test runtimes. In-memory WASM storage
+ * (a `memory://` data dir) is the default: it exercises the same Postgres
+ * engine, extensions, and schema migrations as a disk data dir while avoiding
+ * Emscripten NODEFS writes to the host tmp filesystem, which fault mid-suite
+ * on loaded CI runners (WASI EBADF/ENOENT, `could not seek to end of file`,
+ * elizaOS/eliza#18053). Suites that prove restart persistence create a real
+ * directory themselves and pass it explicitly; setting
+ * `ELIZA_TEST_PGLITE_STORAGE=disk` forces temp-directory storage everywhere
+ * as a diagnostic escape hatch.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export type TestPgliteStorageMode = "memory" | "disk";
+
+let memoryDataDirSequence = 0;
+
+/** Resolves the storage mode from `ELIZA_TEST_PGLITE_STORAGE` (default: memory). */
+export function testPgliteStorageMode(): TestPgliteStorageMode {
+	const mode = process.env.ELIZA_TEST_PGLITE_STORAGE;
+	if (mode === undefined || mode === "" || mode === "memory") {
+		return "memory";
+	}
+	if (mode === "disk") {
+		return "disk";
+	}
+	throw new Error(
+		`ELIZA_TEST_PGLITE_STORAGE must be "memory" or "disk", got "${mode}"`,
+	);
+}
+
+/** True when the data dir is PGlite's in-memory URL form (no host filesystem). */
+export function isInMemoryPgliteDataDir(dataDir: string): boolean {
+	return dataDir.startsWith("memory://");
+}
+
+/**
+ * Allocates a PGlite data dir for one test runtime: a unique `memory://` URL
+ * in memory mode, or a fresh temp directory in disk mode. Uniqueness matters
+ * even in memory mode — plugin-sql caches managers per (dataDir, agentId), so
+ * a shared URL would alias two concurrently open runtimes onto one database.
+ * Disk-mode callers own removal of the returned directory.
+ */
+export function createTestPgliteDataDir(prefix: string): string {
+	if (testPgliteStorageMode() === "memory") {
+		memoryDataDirSequence += 1;
+		return `memory://${prefix}${process.pid}-${memoryDataDirSequence}`;
+	}
+	return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}

--- a/packages/core/src/testing/real-runtime.ts
+++ b/packages/core/src/testing/real-runtime.ts
@@ -18,8 +18,6 @@
  */
 
 import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { createCharacter } from "../character";
 import { logger } from "../logger";
 import { AgentRuntime } from "../runtime";
@@ -33,6 +31,10 @@ import {
 	type LiveProviderName,
 	selectLiveProvider,
 } from "./live-provider";
+import {
+	createTestPgliteDataDir,
+	isInMemoryPgliteDataDir,
+} from "./pglite-storage";
 
 export interface RealTestRuntimeOptions {
 	/** Name for the test agent character. Defaults to "TestAgent". */
@@ -47,7 +49,11 @@ export interface RealTestRuntimeOptions {
 	withDiscord?: boolean;
 	/** Register Telegram plugin if TELEGRAM_BOT_TOKEN is available. Default: false. */
 	withTelegram?: boolean;
-	/** Reuse an existing PGLite data directory. */
+	/**
+	 * Reuse an existing PGLite data directory instead of the default per-call
+	 * in-memory database. Pass a real directory when the test proves restart
+	 * persistence (see ../testing/pglite-storage).
+	 */
 	pgliteDir?: string;
 	/** Remove PGLite dir on cleanup. Defaults to true when dir is auto-created. */
 	removePgliteDirOnCleanup?: boolean;
@@ -138,10 +144,10 @@ export async function createRealTestRuntime(
 	options?: RealTestRuntimeOptions,
 ): Promise<RealTestRuntimeResult> {
 	const pgliteDir =
-		options?.pgliteDir ??
-		fs.mkdtempSync(path.join(os.tmpdir(), "eliza-real-test-"));
+		options?.pgliteDir ?? createTestPgliteDataDir("eliza-real-test-");
 	const removePgliteDirOnCleanup =
-		options?.removePgliteDirOnCleanup ?? options?.pgliteDir === undefined;
+		options?.removePgliteDirOnCleanup ??
+		(options?.pgliteDir === undefined && !isInMemoryPgliteDataDir(pgliteDir));
 
 	const prevPgliteDir = process.env.PGLITE_DATA_DIR;
 	process.env.PGLITE_DATA_DIR = pgliteDir;

--- a/plugins/plugin-personal-assistant/src/lifeops/school/school-source-facts.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/school/school-source-facts.integration.test.ts
@@ -3,6 +3,9 @@
  * reconciliation, child ambiguity, prompt-injection safety, and C/P/E/M edges.
  */
 import { randomUUID } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   type EntityStore,
   type RelationshipStore,
@@ -1082,11 +1085,14 @@ describe("school source facts — real PGlite", () => {
 
   it("recovers source facts, correction state, and action bundles after a real PGlite runtime restart", async () => {
     const characterName = `SchoolRestart-${randomUUID()}`;
+    // Restart persistence needs an on-disk store: the helper's default
+    // in-memory database cannot be reopened by the second runtime.
+    const pgliteDir = mkdtempSync(join(tmpdir(), "lifeops-school-restart-"));
     const firstRuntimeResult = await createLifeOpsTestRuntime({
       characterName,
+      pgliteDir,
       removePgliteDirOnCleanup: false,
     });
-    const pgliteDir = firstRuntimeResult.pgliteDir;
     let secondRuntimeResult: RealTestRuntimeResult | null = null;
     try {
       const firstRuntime = firstRuntimeResult.runtime;

--- a/plugins/plugin-workflow/__tests__/integration/embedded-harness.ts
+++ b/plugins/plugin-workflow/__tests__/integration/embedded-harness.ts
@@ -2,9 +2,6 @@
  * Shared PGlite-backed AgentRuntime harness for workflow integration suites.
  * Core tasks and services use the real runtime; only external systems are absent.
  */
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import { AgentRuntime, createCharacter, stringToUuid } from '@elizaos/core';
 import { drizzle } from 'drizzle-orm/pglite';
@@ -14,6 +11,7 @@ import {
   EMBEDDED_WORKFLOW_SERVICE_TYPE,
   EmbeddedWorkflowService,
 } from '../../src/services/embedded-workflow-service';
+import { makeWorkflowPgliteStore } from '../pglite-test-store';
 
 export interface EmbeddedHarness {
   runtime: AgentRuntime;
@@ -25,8 +23,8 @@ export async function makeEmbeddedHarness(
   agentSeed: string,
   options: { seedDefaults?: boolean } = {}
 ): Promise<EmbeddedHarness> {
-  const dir = await mkdtemp(join(tmpdir(), 'workflow-e2e-'));
-  const client = new PGlite({ dataDir: join(dir, 'pglite') });
+  const store = makeWorkflowPgliteStore('workflow-e2e-');
+  const client = new PGlite({ dataDir: store.dataDir });
   const db = drizzle(client, { schema: dbSchema });
   const adapter = new InMemoryDatabaseAdapter();
   Reflect.set(adapter, 'db', db);
@@ -61,7 +59,7 @@ export async function makeEmbeddedHarness(
       await runtime.stop();
       await runtime.close();
       await client.close();
-      await rm(dir, { recursive: true, force: true });
+      await store.cleanup();
     },
   };
 }

--- a/plugins/plugin-workflow/__tests__/integration/tenant-isolation.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/tenant-isolation.test.ts
@@ -3,9 +3,6 @@
  * Two AgentRuntime-shaped services share storage without sharing domain rows.
  */
 import { afterEach, describe, expect, setDefaultTimeout, test } from 'bun:test';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import { type IAgentRuntime, stringToUuid, type Task, type UUID } from '@elizaos/core';
 import { and, eq } from 'drizzle-orm';
@@ -16,6 +13,7 @@ import { EmbeddedWorkflowService } from '../../src/services/embedded-workflow-se
 import { WorkflowCredentialStore } from '../../src/services/workflow-credential-store';
 import type { WorkflowDefinition } from '../../src/types/index';
 import { getUserTagName } from '../../src/utils/context';
+import { makeWorkflowPgliteStore } from '../pglite-test-store';
 
 setDefaultTimeout(120_000);
 
@@ -39,8 +37,8 @@ afterEach(async () => {
 });
 
 async function makeSharedHarness(): Promise<SharedHarness> {
-  const dir = await mkdtemp(join(tmpdir(), 'workflow-tenant-isolation-'));
-  const client = new PGlite({ dataDir: join(dir, 'pglite') });
+  const store = makeWorkflowPgliteStore('workflow-tenant-isolation-');
+  const client = new PGlite({ dataDir: store.dataDir });
   const db = drizzle(client, { schema: dbSchema });
   const tasks: StoredTask[] = [];
   let taskSequence = 0;
@@ -86,7 +84,7 @@ async function makeSharedHarness(): Promise<SharedHarness> {
       if (closed) return;
       closed = true;
       await client.close();
-      await rm(dir, { recursive: true, force: true });
+      await store.cleanup();
     },
   };
   openHarnesses.push(harness);

--- a/plugins/plugin-workflow/__tests__/integration/trigger-dispatch-e2e.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/trigger-dispatch-e2e.test.ts
@@ -28,9 +28,6 @@
  */
 
 import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import type { IAgentRuntime, Task, TaskWorker, UUID } from '@elizaos/core';
 import { stringToUuid } from '@elizaos/core';
@@ -89,6 +86,7 @@ import {
   registerWorkflowDispatchService,
   WORKFLOW_DISPATCH_SERVICE_TYPE,
 } from '../../src/services/workflow-dispatch';
+import { makeWorkflowPgliteStore } from '../pglite-test-store';
 
 setDefaultTimeout(60_000);
 
@@ -111,8 +109,8 @@ interface Harness {
  * WORKFLOW_DISPATCH all run for real against it.
  */
 async function makeHarness(): Promise<Harness> {
-  const dir = await mkdtemp(join(tmpdir(), 'wi6-trigger-'));
-  const client = new PGlite({ dataDir: join(dir, 'pglite') });
+  const store = makeWorkflowPgliteStore('wi6-trigger-');
+  const client = new PGlite({ dataDir: store.dataDir });
   const db = drizzle(client, { schema: dbSchema });
 
   const tasks = new Map<UUID, Task>();
@@ -185,7 +183,7 @@ async function makeHarness(): Promise<Harness> {
     async close() {
       await taskService.stop();
       await client.close();
-      await rm(dir, { recursive: true, force: true });
+      await store.cleanup();
     },
   };
 }

--- a/plugins/plugin-workflow/__tests__/integration/workflow-crash-recovery.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/workflow-crash-recovery.test.ts
@@ -5,10 +5,8 @@
  * issuing that HTTP request again.
  */
 import { expect, test } from 'bun:test';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { rm } from 'node:fs/promises';
 import { createServer } from 'node:http';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import { stringToUuid } from '@elizaos/core';
 import { drizzle } from 'drizzle-orm/pglite';
@@ -20,6 +18,7 @@ import {
   type SmithersExecutionPlan,
 } from '../../src/services/smithers-runtime';
 import type { WorkflowDefinition, WorkflowExecution } from '../../src/types/index';
+import { makeWorkflowPgliteStore } from '../pglite-test-store';
 
 async function waitForFinishedExecution(
   service: EmbeddedWorkflowService,
@@ -35,10 +34,10 @@ async function waitForFinishedExecution(
 }
 
 test('startup resumes a killed execution without duplicating its persisted side effect', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'workflow-crash-recovery-'));
-  const client = new PGlite({ dataDir: join(root, 'pglite') });
+  const store = makeWorkflowPgliteStore('workflow-crash-recovery-');
+  const client = new PGlite({ dataDir: store.dataDir });
   const db = drizzle(client, { schema: dbSchema });
-  const agentId = stringToUuid(`workflow-crash-recovery-${root}`);
+  const agentId = stringToUuid(`workflow-crash-recovery-${store.dataDir}`);
   const runtime = {
     agentId,
     character: { settings: { WORKFLOW_SEED_DEFAULTS: 'false' } },
@@ -206,7 +205,7 @@ test('startup resumes a killed execution without duplicating its persisted side 
     server.closeAllConnections?.();
     await new Promise<void>((resolve) => server.close(() => resolve()));
     await client.close();
-    await rm(root, { recursive: true, force: true });
+    await store.cleanup();
     await Promise.all([
       rm(smithersDbPath, { force: true }),
       rm(`${smithersDbPath}-wal`, { force: true }),

--- a/plugins/plugin-workflow/__tests__/integration/workflow-service-startup.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/workflow-service-startup.test.ts
@@ -3,10 +3,7 @@
  * Boots the production plugin with default seeding and the real service implementations.
  */
 import { expect, setDefaultTimeout, spyOn, test } from 'bun:test';
-import { mkdtemp, rm } from 'node:fs/promises';
 import http from 'node:http';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import { AgentRuntime, createCharacter, stringToUuid } from '@elizaos/core';
 import { and, eq } from 'drizzle-orm';
@@ -20,6 +17,7 @@ import {
   EmbeddedWorkflowService,
 } from '../../src/services/embedded-workflow-service';
 import { WORKFLOW_SERVICE_TYPE, WorkflowService } from '../../src/services/workflow-service';
+import { makeWorkflowPgliteStore } from '../pglite-test-store';
 
 setDefaultTimeout(120_000);
 
@@ -67,8 +65,8 @@ async function readWorkflowStatus(runtime: AgentRuntime): Promise<Record<string,
 }
 
 test('full plugin boot shares one embedded engine and exposes a runnable ready workflow service', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'workflow-service-startup-'));
-  const client = new PGlite({ dataDir: join(dir, 'pglite') });
+  const store = makeWorkflowPgliteStore('workflow-service-startup-');
+  const client = new PGlite({ dataDir: store.dataDir });
   const db = drizzle(client, { schema: dbSchema });
   const adapter = new InMemoryDatabaseAdapter();
   Reflect.set(adapter, 'db', db);
@@ -153,6 +151,6 @@ test('full plugin boot shares one embedded engine and exposes a runnable ready w
     await runtime.stop();
     await runtime.close();
     await client.close();
-    await rm(dir, { recursive: true, force: true });
+    await store.cleanup();
   }
 });

--- a/plugins/plugin-workflow/__tests__/pglite-test-store.ts
+++ b/plugins/plugin-workflow/__tests__/pglite-test-store.ts
@@ -1,0 +1,38 @@
+/**
+ * Per-test PGlite storage allocation for the workflow suites. Delegates the
+ * memory-vs-disk decision to core's shared test policy (in-memory `memory://`
+ * by default; `ELIZA_TEST_PGLITE_STORAGE=disk` restores temp directories),
+ * so these suites stop writing WASM filesystem pages to host tmp — the
+ * NODEFS path faults mid-suite on loaded CI runners (elizaOS/eliza#18053).
+ * Suites that prove restart persistence keep constructing their own on-disk
+ * data dirs and must not use this helper.
+ */
+import { rm } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import {
+  createTestPgliteDataDir,
+  isInMemoryPgliteDataDir,
+} from '../../../packages/core/src/testing/pglite-storage.ts';
+
+export interface WorkflowPgliteStore {
+  /** Value for `new PGlite({ dataDir })`: a `memory://` URL or a temp path. */
+  dataDir: string;
+  /** Removes the on-disk store if one was created; no-op for memory stores. */
+  cleanup: () => Promise<void>;
+}
+
+export function makeWorkflowPgliteStore(prefix: string): WorkflowPgliteStore {
+  const allocated = createTestPgliteDataDir(prefix);
+  if (isInMemoryPgliteDataDir(allocated)) {
+    return { dataDir: allocated, cleanup: async () => {} };
+  }
+  // Disk mode: keep the historical layout of a `pglite/` dir inside the temp
+  // root so the whole mkdtemp root is removed on cleanup.
+  const dataDir = `${allocated}/pglite`;
+  return {
+    dataDir,
+    cleanup: async () => {
+      await rm(dirname(dataDir), { recursive: true, force: true });
+    },
+  };
+}

--- a/plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts
@@ -10,6 +10,7 @@ import { drizzle } from 'drizzle-orm/pglite';
 import * as dbSchema from '../../src/db/schema';
 import { EmbeddedWorkflowService } from '../../src/services/embedded-workflow-service';
 import { WorkflowService } from '../../src/services/workflow-service';
+import { makeWorkflowPgliteStore } from '../pglite-test-store';
 
 function runtime(
   settings: Record<string, unknown> = {},
@@ -35,14 +36,14 @@ async function persistentRuntime(
   settings: Record<string, unknown> = {},
   services: Record<string, unknown> = {}
 ) {
-  const dir = await mkdtemp(join(tmpdir(), 'embedded-workflow-service-'));
-  const client = new PGlite({ dataDir: join(dir, 'pglite') });
+  const store = makeWorkflowPgliteStore('embedded-workflow-service-');
+  const client = new PGlite({ dataDir: store.dataDir });
   const db = drizzle(client, { schema: dbSchema });
   return {
     runtime: runtime({ WORKFLOW_SEED_DEFAULTS: false, ...settings }, services, db),
     async close() {
       await client.close();
-      await rm(dir, { recursive: true, force: true });
+      await store.cleanup();
     },
   };
 }
@@ -56,8 +57,8 @@ async function persistentRuntime(
  * against the SAME db + cache, simulating a process reboot.
  */
 async function seedingHarness(settings: Record<string, unknown> = {}) {
-  const dir = await mkdtemp(join(tmpdir(), 'embedded-workflow-seed-'));
-  const client = new PGlite({ dataDir: join(dir, 'pglite') });
+  const store = makeWorkflowPgliteStore('embedded-workflow-seed-');
+  const client = new PGlite({ dataDir: store.dataDir });
   const db = drizzle(client, { schema: dbSchema });
   const tasks: Array<Record<string, unknown>> = [];
   const cache = new Map<string, unknown>();
@@ -154,7 +155,7 @@ async function seedingHarness(settings: Record<string, unknown> = {}) {
     },
     async close() {
       await client.close();
-      await rm(dir, { recursive: true, force: true });
+      await store.cleanup();
     },
   };
 }
@@ -580,15 +581,11 @@ describe('EmbeddedWorkflowService', () => {
   test('runs a schedule -> HTTP Request -> Set workflow in a child process', async () => {
     const pluginRoot = join(import.meta.dir, '../..');
     const script = `
-      import { mkdtemp, rm } from 'node:fs/promises';
-      import { tmpdir } from 'node:os';
-      import { join } from 'node:path';
       import { PGlite } from '@electric-sql/pglite';
       import { drizzle } from 'drizzle-orm/pglite';
       import { EmbeddedWorkflowService } from './src/services/embedded-workflow-service.ts';
       import * as dbSchema from './src/db/schema.ts';
-      const dir = await mkdtemp(join(tmpdir(), 'embedded-workflows-child-'));
-      const client = new PGlite({ dataDir: join(dir, 'pglite') });
+      const client = new PGlite();
       const db = drizzle(client, { schema: dbSchema });
       const runtime = {
         agentId: 'agent-test',
@@ -628,7 +625,6 @@ describe('EmbeddedWorkflowService', () => {
       } finally {
         await service.stop();
         await client.close();
-        await rm(dir, { recursive: true, force: true });
       }
     `;
 
@@ -745,15 +741,12 @@ describe('EmbeddedWorkflowService', () => {
     const resultDir = await mkdtemp(join(tmpdir(), 'embedded-workflows-code-result-'));
     const resultPath = join(resultDir, 'result.json');
     const script = `
-      import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-      import { tmpdir } from 'node:os';
-      import { join } from 'node:path';
+      import { writeFile } from 'node:fs/promises';
       import { PGlite } from '@electric-sql/pglite';
       import { drizzle } from 'drizzle-orm/pglite';
       import { EmbeddedWorkflowService } from './src/services/embedded-workflow-service.ts';
       import * as dbSchema from './src/db/schema.ts';
-      const dir = await mkdtemp(join(tmpdir(), 'embedded-workflows-code-'));
-      const client = new PGlite({ dataDir: join(dir, 'pglite') });
+      const client = new PGlite();
       const db = drizzle(client, { schema: dbSchema });
       const runtime = {
         agentId: 'agent-test',
@@ -787,7 +780,6 @@ describe('EmbeddedWorkflowService', () => {
       } finally {
         await service.stop();
         await client.close();
-        await rm(dir, { recursive: true, force: true });
       }
     `;
 
@@ -872,16 +864,13 @@ describe('EmbeddedWorkflowService', () => {
     const resultPath = join(resultDir, 'result.json');
     const script = `
       import { Database } from 'bun:sqlite';
-      import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-      import { tmpdir } from 'node:os';
-      import { join } from 'node:path';
+      import { rm, writeFile } from 'node:fs/promises';
       import { PGlite } from '@electric-sql/pglite';
       import { drizzle } from 'drizzle-orm/pglite';
       import { EmbeddedWorkflowService } from './src/services/embedded-workflow-service.ts';
       import { resolveSmithersDbPath } from './src/services/smithers-runtime.ts';
       import * as dbSchema from './src/db/schema.ts';
-      const dir = await mkdtemp(join(tmpdir(), 'embedded-workflows-smithers-'));
-      const client = new PGlite({ dataDir: join(dir, 'pglite') });
+      const client = new PGlite();
       const db = drizzle(client, { schema: dbSchema });
       const runtime = {
         agentId: 'agent-test',
@@ -937,7 +926,6 @@ describe('EmbeddedWorkflowService', () => {
       } finally {
         await service.stop();
         await client.close();
-        await rm(dir, { recursive: true, force: true });
         if (smithersDbPath) {
           await Promise.all([
             rm(smithersDbPath, { force: true }),
@@ -991,15 +979,12 @@ describe('EmbeddedWorkflowService', () => {
     const resultDir = await mkdtemp(join(tmpdir(), 'embedded-workflows-webhook-result-'));
     const resultPath = join(resultDir, 'result.json');
     const script = `
-      import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-      import { tmpdir } from 'node:os';
-      import { join } from 'node:path';
+      import { writeFile } from 'node:fs/promises';
       import { PGlite } from '@electric-sql/pglite';
       import { drizzle } from 'drizzle-orm/pglite';
       import { EmbeddedWorkflowService } from './src/services/embedded-workflow-service.ts';
       import * as dbSchema from './src/db/schema.ts';
-      const dir = await mkdtemp(join(tmpdir(), 'embedded-workflows-webhook-'));
-      const client = new PGlite({ dataDir: join(dir, 'pglite') });
+      const client = new PGlite();
       const db = drizzle(client, { schema: dbSchema });
       const runtime = {
         agentId: 'agent-test',
@@ -1031,7 +1016,6 @@ describe('EmbeddedWorkflowService', () => {
       } finally {
         await service.stop();
         await client.close();
-        await rm(dir, { recursive: true, force: true });
       }
     `;
     try {

--- a/plugins/plugin-workflow/__tests__/unit/respond-to-event.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/respond-to-event.test.ts
@@ -1,14 +1,12 @@
 /** Unit tests for EmbeddedWorkflowService event-triggered runs against a real PGlite-backed store, capturing emitted memories. */
 import { describe, expect, mock, test } from 'bun:test';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import type { IAgentRuntime, UUID } from '@elizaos/core';
 import { drizzle } from 'drizzle-orm/pglite';
 import defaultNodes from '../../src/data/defaultNodes.json';
 import * as dbSchema from '../../src/db/schema';
 import { EmbeddedWorkflowService } from '../../src/services/embedded-workflow-service';
+import { makeWorkflowPgliteStore } from '../pglite-test-store';
 
 interface CapturedMemory {
   entityId: string;
@@ -101,8 +99,8 @@ interface PersistentHarness {
 }
 
 async function persistentRuntime(options: RuntimeMockOptions = {}): Promise<PersistentHarness> {
-  const dir = await mkdtemp(join(tmpdir(), 'respond-to-event-'));
-  const client = new PGlite({ dataDir: join(dir, 'pglite') });
+  const store = makeWorkflowPgliteStore('respond-to-event-');
+  const client = new PGlite({ dataDir: store.dataDir });
   const db = drizzle(client, { schema: dbSchema });
   const built = buildRuntime({ ...options, db });
   return {
@@ -111,7 +109,7 @@ async function persistentRuntime(options: RuntimeMockOptions = {}): Promise<Pers
     warnings: built.warnings,
     async close() {
       await client.close();
-      await rm(dir, { recursive: true, force: true });
+      await store.cleanup();
     },
   };
 }

--- a/plugins/plugin-workflow/__tests__/unit/workflow-task-worker.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-task-worker.test.ts
@@ -1,8 +1,5 @@
 /** Unit tests for the workflow trigger task worker firing scheduled runs against a real PGlite-backed EmbeddedWorkflowService. */
 import { describe, expect, setDefaultTimeout, test } from 'bun:test';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import type { IAgentRuntime, Task, TaskWorker } from '@elizaos/core';
 import { drizzle } from 'drizzle-orm/pglite';
@@ -12,6 +9,7 @@ import {
   TRIGGER_TASK_NAME,
   WORKFLOW_TASK_KIND,
 } from '../../src/services/embedded-workflow-service';
+import { makeWorkflowPgliteStore } from '../pglite-test-store';
 
 setDefaultTimeout(30_000);
 
@@ -23,8 +21,8 @@ interface TestRuntimeContext {
 }
 
 async function makeRuntime(): Promise<TestRuntimeContext> {
-  const dir = await mkdtemp(join(tmpdir(), 'workflow-task-worker-'));
-  const client = new PGlite({ dataDir: join(dir, 'pglite') });
+  const store = makeWorkflowPgliteStore('workflow-task-worker-');
+  const client = new PGlite({ dataDir: store.dataDir });
   const db = drizzle(client, { schema: dbSchema });
 
   const workers = new Map<string, TaskWorker>();
@@ -64,7 +62,7 @@ async function makeRuntime(): Promise<TestRuntimeContext> {
     tasks,
     async close() {
       await client.close();
-      await rm(dir, { recursive: true, force: true });
+      await store.cleanup();
     },
   };
 }


### PR DESCRIPTION
## What

Develop's Plugin Tests shards (and sometimes Server Tests) go red on the self-hosted hetzner fleet with rotating PGlite WASM-filesystem faults — `could not seek to end of file "base/5/16489": Bad file descriptor`, `XX000`/`_mdnblocks`, `ErrnoError { errno: 8 }` (WASI EBADF) and `errno: 44` (WASI ENOENT) — while the same suites are green locally at the same commits (#18053, runs 31221532988 / 31248488119). This PR removes the host filesystem from the test-database path: PGlite-backed test runtimes now default to PGlite's real in-memory storage (`memory://`), and only suites that actually prove restart persistence keep an on-disk data dir.

## Root cause

Every PGlite-backed test helper provisioned an **on-disk** data dir under `os.tmpdir()` (`fs.mkdtempSync(...)` → `PGLITE_DATA_DIR` / `new PGlite({ dataDir })`). On disk, PGlite runs Postgres on Emscripten's NODEFS, which keeps long-lived fds and synchronous seek/read/write cycles against host tmp. The hetzner fleet runs multiple shards and other jobs on shared persistent hosts; when host tmp is disturbed under load (tmp churn/cleanup by co-tenant jobs — the failing runs' logs show foreign `/tmp/cerebras-eval-runner-*` state leaking into our shards — plus fd pressure), NODEFS surfaces exactly this fault family mid-suite: WASI `EBADF`(8)/`ENOENT`(44), `could not seek to end of file`, `_mdnblocks` `XX000`. Which suite happened to be mid-write when the host misbehaved rotates per run — matching the observed rotation (plugin-workflow, plugin-sql electric-sync stderr, core suites).

None of the faulting suites need a disk at all: each creates a fresh throwaway dir and removes it in cleanup. The storage was on-disk only by default, not by contract.

## Fix

- **`packages/core/src/testing/pglite-storage.ts` (new)** — single storage-mode policy for test runtimes: default `memory://` (unique URL per runtime so plugin-sql's per-`(dataDir, agentId)` manager cache never aliases two live runtimes); `ELIZA_TEST_PGLITE_STORAGE=disk` restores temp-dir provisioning as a diagnostic escape hatch; unknown values throw.
- **`createTestRuntime` / `createRealTestRuntime`** (core `./testing`, mirrored app-core helpers) — allocate through the policy when the caller does not pass `pgliteDir`; an explicit `pgliteDir` keeps on-disk semantics and caller-owned cleanup, exactly as before.
- **plugin-workflow suites** — new `__tests__/pglite-test-store.ts` delegating to the core policy; all harness/unit/integration `mkdtemp` + `new PGlite({ dataDir })` sites converted. The child-process smoke scripts inside `embeddedWorkflowService.test.ts` now use plain in-memory `new PGlite()`.
- **Restart-persistence suites keep disk, explicitly** — `canonical-memory-pglite.integration.test.ts` (core), `school-source-facts.integration.test.ts` (personal-assistant), and plugin-workflow's `persists workflows across embedded service restarts` / `orphaned-schedule-reconciliation` keep real directories, now allocated explicitly, because reopening the same data dir is the thing they prove. `plugin-sql`'s own file-backed manager/lock suites are intentionally untouched — file-backed storage is their subject.

What the tests prove is unchanged: `memory://` runs the same WASM Postgres engine, extensions (vector/pg_trgm/fuzzystrmatch), plugin-sql migrations, and RLS paths — only the Emscripten FS backend differs. The plugin-sql "never a silent skip" migration guards still execute against a real database.

## Reproduction / evidence

Controlled reproduction of the fault class (script in PR discussion): a PGlite instance on a NODEFS temp dir, with the data dir disturbed externally mid-run (the shared-runner tmp-churn model), faults with the exact CI signature; an in-memory instance under identical interference survives:

```text
on-disk NODEFS: FAULTED name=error errno=undefined msg=could not create file "pg_logical/replorigin_checkpoint.tmp": No such file or directory
memory://     : SURVIVED, rows=200
```

CI-observed signature this maps to (run 31248488119, Plugin Tests 2/4, `providers.test.ts > reports status and a real persisted execution`):

```text
ErrnoError { name: "ErrnoError", errno: 8 }
(fail) workflow providers with real runtime services > reports status and a real persisted execution
```

## Tests

- plugin-workflow: full suite A/B on the same host — memory mode (new default) 434 pass / 0 fail; `ELIZA_TEST_PGLITE_STORAGE=disk` 434 pass / 0 fail. Converted suites also green in isolation — `providers` + `workflow-crash-recovery` + `tenant-isolation` (18/18), `embeddedWorkflowService` + `workflow-service-startup` + `trigger-dispatch-e2e` (29/29), `respond-to-event` (5/5), `workflow-task-worker` in `ELIZA_TEST_PGLITE_STORAGE=disk` escape-hatch mode (2/2).
- core: `canonical-memory-pglite.integration.test.ts` (restart persistence on explicit disk dir) + `message.side-effect-claim.test.ts` — 46/46; `service-authorization.real.test.ts` + `trace-correlation-db.real.test.ts` (post-merge lane) — 12/12.
- personal-assistant: `school-source-facts.integration.test.ts` restart test green with its explicit disk dir.
- app-core: `agent-reset-route.real.e2e.test.ts` (helper path, explicit dir) green.
- In-memory mode verified to create no `/tmp` state; `bun run verify` exit 0; `typecheck` green for core, app-core, plugin-workflow, plugin-personal-assistant.

Fixes the Plugin Tests / Server Tests pglite-fault axis of #18053 (the loaded-runner timing-tolerance and vault keychain axes are tracked there separately).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code CLI
<!-- attribution-row:skill-revision -->
- Skill revision: N/A - no contribution skill used
<!-- attribution-row:status -->
- Attribution status: self-reported

# Evidence Gate

<!-- evidence-head:0fa8adc49cb35ce6667deec9b03ea5d7b52866c6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI test-infrastructure change; no rendered UI surface is touched.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI change.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend/test-infrastructure change with no on-screen flow.

<!-- evidence-row:backend-logs -->
- [x] Backend logs - CI fault signatures from the failing runs and the controlled reproduction are quoted above; full suite outputs in collapsible blocks below.

<details><summary>Controlled fault reproduction (on-disk NODEFS vs memory://)</summary>

```text
on-disk NODEFS: FAULTED name=error errno=undefined msg=could not create file "pg_logical/replorigin_checkpoint.tmp": No such file or directory
memory://     : SURVIVED, rows=200
```

</details>

<details><summary>Converted plugin-workflow suites (memory mode)</summary>

```text
providers.test.ts + workflow-crash-recovery.test.ts + tenant-isolation.test.ts
 18 pass / 0 fail (104 expect() calls)

embeddedWorkflowService.test.ts + workflow-service-startup.test.ts + trigger-dispatch-e2e.test.ts
 29 pass / 0 fail (124 expect() calls)

respond-to-event.test.ts
 5 pass / 0 fail
```

</details>

<details><summary>Core + personal-assistant + app-core suites</summary>

```text
core: canonical-memory-pglite.integration.test.ts + message.side-effect-claim.test.ts
 Test Files  2 passed (2) / Tests  46 passed (46)

core (VITEST_LANE=post-merge): service-authorization.real.test.ts + trace-correlation-db.real.test.ts
 Test Files  2 passed (2) / Tests  12 passed (12)

personal-assistant: school-source-facts.integration.test.ts -t restart
 Test Files  1 passed (1) / Tests  1 passed | 11 skipped

app-core: agent-reset-route.real.e2e.test.ts
 Test Files  1 passed (1) / Tests  1 passed (1)
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
