### PR TITLE
fix(test,ci): port zero-key specs to post-#17859 product behavior and pin runner-sensitive lanes (#18014)

### DIFF
--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -424,13 +424,65 @@ jobs:
         run: bunx playwright install --with-deps chromium
 
       - name: Actual app ratcheted keyless browser coverage
-        run: bun run --cwd packages/app test:e2e test/ui-smoke/ai-qa-capture.spec.ts test/ui-smoke/android-system-apps.spec.ts test/ui-smoke/apps-session.spec.ts test/ui-smoke/apps-session-direct-a.spec.ts test/ui-smoke/apps-session-direct-b.spec.ts test/ui-smoke/auth-startup.spec.ts test/ui-smoke/automations.spec.ts test/ui-smoke/browser-workspace.spec.ts test/ui-smoke/character-editor.spec.ts test/ui-smoke/wallet-inventory.spec.ts test/ui-smoke/workflow-editor.spec.ts test/ui-smoke/computer-use.spec.ts test/ui-smoke/connectors.spec.ts test/ui-smoke/first-run-startup.spec.ts test/ui-smoke/model-download-deferral.spec.ts test/ui-smoke/history-navigation.spec.ts test/ui-smoke/orchestrator-gui-workbench.spec.ts test/ui-smoke/reset-returns-to-onboarding.spec.ts test/ui-smoke/tutorial-chat.spec.ts test/ui-smoke/warming-shell-startup.spec.ts test/ui-smoke/runtime-configurability.spec.ts test/ui-smoke/perf-load-kpi.spec.ts test/ui-smoke/perf-interaction-kpi.spec.ts test/ui-smoke/perf-reduced-motion.spec.ts test/ui-smoke/task-coordinator-gui-interactions.spec.ts test/ui-smoke/titlebar-navigation.spec.ts test/ui-smoke/ui-smoke.spec.ts --project=chromium
+        run: bun run --cwd packages/app test:e2e test/ui-smoke/ai-qa-capture.spec.ts test/ui-smoke/android-system-apps.spec.ts test/ui-smoke/apps-session.spec.ts test/ui-smoke/apps-session-direct-a.spec.ts test/ui-smoke/apps-session-direct-b.spec.ts test/ui-smoke/auth-startup.spec.ts test/ui-smoke/automations.spec.ts test/ui-smoke/browser-workspace.spec.ts test/ui-smoke/character-editor.spec.ts test/ui-smoke/wallet-inventory.spec.ts test/ui-smoke/workflow-editor.spec.ts test/ui-smoke/computer-use.spec.ts test/ui-smoke/connectors.spec.ts test/ui-smoke/first-run-startup.spec.ts test/ui-smoke/model-download-deferral.spec.ts test/ui-smoke/history-navigation.spec.ts test/ui-smoke/orchestrator-gui-workbench.spec.ts test/ui-smoke/reset-returns-to-onboarding.spec.ts test/ui-smoke/tutorial-chat.spec.ts test/ui-smoke/warming-shell-startup.spec.ts test/ui-smoke/runtime-configurability.spec.ts test/ui-smoke/perf-load-kpi.spec.ts test/ui-smoke/perf-reduced-motion.spec.ts test/ui-smoke/task-coordinator-gui-interactions.spec.ts test/ui-smoke/titlebar-navigation.spec.ts test/ui-smoke/ui-smoke.spec.ts --project=chromium
 
       - name: Upload app browser ratcheted artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: scenario-pr-app-browser-ratcheted
+          path: |
+            packages/app/playwright-report/
+            packages/app/test-results/
+          if-no-files-found: ignore
+          retention-days: 3
+
+  # Interaction frame-rate KPI (#9141) runs in its own job pinned to
+  # GitHub-hosted ubuntu-24.04, mirroring the client perf gate split (#18022):
+  # the 100ms p95 jank ceiling in perf-interaction-kpi.spec.ts is calibrated
+  # for hosted-runner headless scheduling, and the contended hetzner-robot
+  # fleet breaches it on hardware grounds alone with a lane label that varies
+  # run to run (#18014). Keep this job hosted until the KPI budgets carry
+  # per-runner-class calibration.
+  app-browser-perf-kpi:
+    name: Zero-Key app browser interaction perf KPI
+    needs: changes
+    if: needs.changes.outputs.run_scenario_pr == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --frozen-lockfile --ignore-scripts
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Actual app interaction frame-rate KPI browser coverage
+        run: bun run --cwd packages/app test:e2e test/ui-smoke/perf-interaction-kpi.spec.ts --project=chromium
+
+      - name: Upload app browser perf KPI artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: scenario-pr-app-browser-perf-kpi
           path: |
             packages/app/playwright-report/
             packages/app/test-results/
@@ -660,7 +712,14 @@ jobs:
     name: Zero-Key accounts UI e2e (real API + pool + disk)
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    # Hosted-pinned (#18014, same grounds as the client perf gate in #18022):
+    # this lane drives the REAL production ElizaClient over real loopback HTTP,
+    # and on the contended hetzner-robot fleet those requests exceed the
+    # client's 10s production request timeout (server logs show immediate
+    # 200/400/201 responses while the browser reports "Request timed out after
+    # 10000ms"), failing the run on infrastructure grounds alone. The lane is
+    # green on hosted runners and locally at the same revision.
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -855,6 +914,7 @@ jobs:
       - app-browser-feature-interactions
       - app-browser-cloud-keyless
       - app-browser-ratcheted
+      - app-browser-perf-kpi
       - app-browser-auto-discovered
       - app-browser-touch-dashboard
       - app-browser-touch-mobile
@@ -879,6 +939,7 @@ jobs:
             "app-browser-feature-interactions:${{ needs.app-browser-feature-interactions.result }}" \
             "app-browser-cloud-keyless:${{ needs.app-browser-cloud-keyless.result }}" \
             "app-browser-ratcheted:${{ needs.app-browser-ratcheted.result }}" \
+            "app-browser-perf-kpi:${{ needs.app-browser-perf-kpi.result }}" \
             "app-browser-auto-discovered:${{ needs.app-browser-auto-discovered.result }}" \
             "app-browser-touch-dashboard:${{ needs.app-browser-touch-dashboard.result }}" \
             "app-browser-touch-mobile:${{ needs.app-browser-touch-mobile.result }}" \

--- a/packages/app/test/ui-smoke/chat-message-actions.spec.ts
+++ b/packages/app/test/ui-smoke/chat-message-actions.spec.ts
@@ -178,6 +178,29 @@ function messageRowFor(page: Page, text: string): Locator {
     .locator("xpath=ancestor::*[@data-testid='thread-line'][1]");
 }
 
+/**
+ * Reveal a message row's action lane through the affordance each pointer class
+ * actually ships (#17859 chat-interaction slice): fine pointers reveal on
+ * pointer movement (hover discovery) while a bubble click TOGGLES the row (the
+ * aria-expanded contract locked in by chat-message.hover-reveal.test.tsx
+ * "does not pin a fine-pointer action rail after bubble click"). Playwright
+ * replays a pointer-move before every click, so on desktop a click always
+ * lands as reveal-then-toggle-hidden — hover is the deterministic desktop
+ * path. Coarse-pointer viewports keep tap-to-reveal.
+ */
+async function revealActionRow(
+  row: Locator,
+  text: string,
+  viewportName: "desktop" | "mobile",
+): Promise<void> {
+  const target = row.getByText(text, { exact: true });
+  if (viewportName === "desktop") {
+    await target.hover();
+    return;
+  }
+  await target.click();
+}
+
 async function expectFullyPaintableActionSurface(row: Locator): Promise<void> {
   const actions = row.getByTestId("thread-line-actions");
   const surface = row.getByTestId("thread-line-action-surface");
@@ -257,7 +280,7 @@ for (const viewport of [
     await screenshot(page, `${viewport.name}-chat-open`);
 
     const assistantRow = messageRowFor(page, ASSISTANT_TEXT);
-    await assistantRow.getByText(ASSISTANT_TEXT, { exact: true }).click();
+    await revealActionRow(assistantRow, ASSISTANT_TEXT, viewport.name);
     await expectFullyPaintableActionSurface(assistantRow);
     await expect(assistantRow.getByTestId("thread-line-reply")).toBeVisible();
     await expect(assistantRow.getByTestId("thread-line-copy")).toBeVisible();
@@ -296,15 +319,7 @@ for (const viewport of [
     await expect(page.getByTestId("chat-reply-pill")).toHaveCount(0);
 
     const userRow = messageRowFor(page, USER_TEXT);
-    const userBubble = userRow.getByText(USER_TEXT, { exact: true });
-    await userBubble.click();
-    if (
-      (await userRow
-        .getByTestId("thread-line-actions")
-        .getAttribute("aria-hidden")) !== "false"
-    ) {
-      await userBubble.click();
-    }
+    await revealActionRow(userRow, USER_TEXT, viewport.name);
     await expectFullyPaintableActionSurface(userRow);
     await expect(userRow.getByTestId("thread-line-reply")).toBeVisible();
     await expect(userRow.getByTestId("thread-line-copy")).toBeVisible();

--- a/packages/app/test/ui-smoke/cloud-pair-evidence.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-pair-evidence.spec.ts
@@ -3,13 +3,17 @@
  *
  * Runs the REAL production boot adopter (`applyCloudPairSessionToken` in
  * packages/app/src/main.tsx) and the REAL credential modules (cloud-pair-token,
- * CloudPairRelay, persistence) in headless Chromium against the REAL Vite dev
- * server, with the REAL localStorage/sessionStorage. No jsdom, no module mocks.
+ * CloudPairRelay, persistence) in headless Chromium against the smoke stack's
+ * origin, with the REAL localStorage/sessionStorage. No jsdom, no module mocks.
  *
- * The boot adopter source is extracted from the live main.tsx module graph —
- * the exact extraction the reviewed unit test (`cloud-pair-session-token.test.ts`)
- * performs — and executed in the page with the real module collaborators bound
- * in. This is a browser-real execution of production code, not a reimplementation.
+ * The smoke stack serves the BUILT renderer (there is no dev-server module
+ * graph to dynamic-import from), so the real modules are bundled from their
+ * repo sources with esbuild at spec runtime — the same technique the reviewed
+ * accounts-ui e2e uses — and injected into the page as one script. The boot
+ * adopter source is extracted from the repo's main.tsx — the exact extraction
+ * the reviewed unit test (`cloud-pair-session-token.test.ts`) performs — and
+ * executed in the page with the real module collaborators bound in. This is a
+ * browser-real execution of production code, not a reimplementation.
  *
  * Evidence captured (saved under test-results/cloud-pair-evidence/):
  *   - storage-dump-<phase>.json   full localStorage+sessionStorage key/value dump
@@ -19,15 +23,158 @@
  * Run with:
  *   ELIZA_UI_SMOKE_REUSE_SERVER=1 bun x playwright test cloud-pair-evidence --config playwright.ui-smoke.config.ts
  */
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { builtinModules } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
+import { build, type Plugin as EsbuildPlugin, transform } from "esbuild";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // HERE = packages/app/test/ui-smoke → up 2 = packages/app
 const APP_DIR = resolve(HERE, "..", "..");
+const REPO_ROOT = resolve(APP_DIR, "..", "..");
 const OUT_DIR = resolve(APP_DIR, "test-results", "cloud-pair-evidence");
+
+/**
+ * Bundle the REAL production modules (plus react/react-dom for the render
+ * test) from their repo sources into one browser IIFE exposing
+ * `window.__cloudPairEvidenceModules`. Built once per worker; esbuild only
+ * bundles — the module code under test is the checked-in production source.
+ */
+let evidenceBundlePromise: Promise<string> | null = null;
+function evidenceModulesBundle(): Promise<string> {
+  evidenceBundlePromise ??= (async () => {
+    const ui = join(REPO_ROOT, "packages", "ui", "src");
+    // Node-builtin imports reached through transitive dependency chains become
+    // inert proxies (mirrors the reviewed accounts-ui e2e bundler): the
+    // modules under test are browser storage/auth code and never call them.
+    const nodeBuiltins = new Set([
+      ...builtinModules,
+      ...builtinModules.map((name) => `node:${name}`),
+    ]);
+    // `@elizaos/core` is never imported by the modules under test (verified —
+    // it only enters transitively through i18n/api barrel collaterals), and
+    // its plugin-manager subtree is node-only, so the whole package becomes an
+    // inert proxy as well.
+    const stubElizaCore: EsbuildPlugin = {
+      name: "stub-eliza-core",
+      setup(b) {
+        b.onResolve({ filter: /^@elizaos\/core(\/.*)?$/ }, (args) => ({
+          path: args.path,
+          namespace: "eliza-core-stub",
+        }));
+        b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
+          contents:
+            "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
+          loader: "js",
+        }));
+      },
+    };
+    const stubNodeBuiltins: EsbuildPlugin = {
+      name: "stub-node-builtins",
+      setup(b) {
+        b.onResolve({ filter: /.*/ }, (args) => {
+          const bare = args.path.replace(/^node:/, "").split("/")[0] ?? "";
+          if (
+            args.path.startsWith("node:") ||
+            nodeBuiltins.has(args.path) ||
+            builtinModules.includes(bare)
+          ) {
+            return { path: args.path, namespace: "node-stub" };
+          }
+          return null;
+        });
+        b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
+          contents:
+            "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
+          loader: "js",
+        }));
+      },
+    };
+    const entry = [
+      `export * as relay from ${JSON.stringify(join(ui, "components/auth/CloudPairRelay.tsx"))};`,
+      `export * as tokenState from ${JSON.stringify(join(ui, "state/cloud-pair-token.ts"))};`,
+      `export * as persistence from ${JSON.stringify(join(ui, "state/persistence.ts"))};`,
+      `export * as agentRecovery from ${JSON.stringify(join(ui, "state/agent-session-recovery.ts"))};`,
+      `export * as agentProfiles from ${JSON.stringify(join(ui, "state/agent-profiles.ts"))};`,
+      `export * as cloudAgentBase from ${JSON.stringify(join(ui, "utils/cloud-agent-base.ts"))};`,
+      `export * as realm from ${JSON.stringify(join(ui, "surface-realm-channel.ts"))};`,
+      `export * as react from "react";`,
+      `export * as reactDomClient from "react-dom/client";`,
+    ].join("\n");
+    const result = await build({
+      stdin: {
+        contents: entry,
+        resolveDir: APP_DIR,
+        sourcefile: "cloud-pair-evidence-entry.ts",
+        loader: "ts",
+      },
+      bundle: true,
+      write: false,
+      format: "iife",
+      globalName: "__cloudPairEvidenceModules",
+      platform: "browser",
+      jsx: "automatic",
+      define: { "process.env.NODE_ENV": '"production"' },
+      loader: {
+        ".css": "empty",
+        ".svg": "dataurl",
+        ".png": "dataurl",
+        ".woff": "empty",
+        ".woff2": "empty",
+      },
+      plugins: [stubElizaCore, stubNodeBuiltins],
+      absWorkingDir: REPO_ROOT,
+      logLevel: "silent",
+    });
+    const [output] = result.outputFiles;
+    if (!output) throw new Error("evidence module bundle produced no output");
+    return output.text;
+  })();
+  return evidenceBundlePromise;
+}
+
+/**
+ * Serve a bare same-origin HTML shell instead of the mounted app: the app
+ * boots a view realm whose surface-realm guard (correctly) rejects raw
+ * localStorage writes to the reserved `eliza:` namespace from page context,
+ * so the harness must run BEFORE any view mounts. `stylesheetHrefs` links the
+ * smoke stack's real built app stylesheets so rendered surfaces are the
+ * styled production output, not an unstyled DOM skeleton.
+ */
+async function serveBareShell(
+  page: Page,
+  stylesheetHrefs: readonly string[] = [],
+): Promise<void> {
+  const links = stylesheetHrefs
+    .map((href) => `<link rel="stylesheet" href="${href}">`)
+    .join("");
+  await page.route("**/*", async (route) => {
+    const url = route.request().url();
+    if (url.endsWith("/") || url.endsWith("/index.html")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><head><meta charset="utf-8">${links}</head><body><div id='root'></div></body></html>`,
+      });
+      return;
+    }
+    await route.fallback();
+  });
+}
+
+/** The built app's stylesheet hrefs, read from the served index.html. */
+async function builtStylesheetHrefs(baseURL: string): Promise<string[]> {
+  const response = await fetch(baseURL);
+  if (!response.ok) {
+    throw new Error(`smoke stack index fetch failed: ${response.status}`);
+  }
+  const html = await response.text();
+  return [...html.matchAll(/<link[^>]+rel="stylesheet"[^>]+href="([^"]+)"/g)]
+    .map((match) => match[1])
+    .filter((href): href is string => typeof href === "string");
+}
 
 const AGENT_A = "agent-aaaa";
 const AGENT_B = "agent-bbbb";
@@ -39,10 +186,11 @@ const ACTIVE_SERVER_KEY = "elizaos:active-server";
 const AGENT_A_KEY = `eliza:cloud-pair:api-token:${AGENT_A}`;
 const AGENT_B_KEY = `eliza:cloud-pair:api-token:${AGENT_B}`;
 
-// The in-page runner: dynamic-imports the REAL modules through the Vite module
-// graph, extracts + executes the REAL boot adopter from main.tsx, and runs the
-// full lifecycle. Returns structured phases for assertion + evidence save.
-const IN_PAGE_RUNNER = async () => {
+// The in-page runner: reads the REAL modules from the injected evidence
+// bundle, extracts + executes the REAL boot adopter from the main.tsx source
+// (passed in from the node side, read from the repo), and runs the full
+// lifecycle. Returns structured phases for assertion + evidence save.
+const IN_PAGE_RUNNER = async (mainSource: string) => {
   const agentA = "agent-aaaa";
   const agentB = "agent-bbbb";
   const tokenA = "pair-token-agent-a";
@@ -50,10 +198,6 @@ const IN_PAGE_RUNNER = async () => {
   const legacyToken = "pair-token-legacy";
   const legacyKey = "eliza:cloud-pair:api-token";
   const activeServerKey = "elizaos:active-server";
-
-  const moduleBase = (window as unknown as { __elizaModuleBasePath?: string })
-    .__elizaModuleBasePath;
-  if (!moduleBase) throw new Error("module base path missing");
 
   const snap = () => {
     const read = (store: Storage) => {
@@ -80,36 +224,34 @@ const IN_PAGE_RUNNER = async () => {
   const adopted: string[] = [];
 
   try {
-    // Import the REAL production modules through the Vite dev module graph.
-    const relay = await import(
-      `/@fs${moduleBase}/packages/ui/src/components/auth/CloudPairRelay.tsx`
-    );
-    const tokenState = await import(
-      `/@fs${moduleBase}/packages/ui/src/state/cloud-pair-token.ts`
-    );
-    const persistence = await import(
-      `/@fs${moduleBase}/packages/ui/src/state/persistence.ts`
-    );
-    const agentRecovery = await import(
-      `/@fs${moduleBase}/packages/ui/src/state/agent-session-recovery.ts`
-    );
-    const agentProfiles = await import(
-      `/@fs${moduleBase}/packages/ui/src/state/agent-profiles.ts`
-    );
-    const cloudAgentBase = await import(
-      `/@fs${moduleBase}/packages/ui/src/utils/cloud-agent-base.ts`
-    );
-    const _bootConfig = await import(
-      `/@fs${moduleBase}/packages/ui/src/config/boot-config-store.ts`
-    );
-    const realm = await import(
-      `/@fs${moduleBase}/packages/ui/src/surface-realm-channel.ts`
-    );
+    // The REAL production modules, bundled from repo source and injected by
+    // the node side before this runner executes.
+    const modules = (
+      window as unknown as {
+        __cloudPairEvidenceModules?: {
+          relay: typeof import("../../../ui/src/components/auth/CloudPairRelay");
+          tokenState: typeof import("../../../ui/src/state/cloud-pair-token");
+          persistence: typeof import("../../../ui/src/state/persistence");
+          agentRecovery: typeof import("../../../ui/src/state/agent-session-recovery");
+          agentProfiles: typeof import("../../../ui/src/state/agent-profiles");
+          cloudAgentBase: typeof import("../../../ui/src/utils/cloud-agent-base");
+          realm: typeof import("../../../ui/src/surface-realm-channel");
+        };
+      }
+    ).__cloudPairEvidenceModules;
+    if (!modules) throw new Error("evidence module bundle not injected");
+    const {
+      relay,
+      tokenState,
+      persistence,
+      agentRecovery,
+      agentProfiles,
+      cloudAgentBase,
+      realm,
+    } = modules;
 
-    // Fetch the REAL main.tsx and extract applyCloudPairSessionToken (same
+    // Extract applyCloudPairSessionToken from the REAL main.tsx source (same
     // extraction as the reviewed unit test).
-    const mainResp = await fetch(`/@fs${moduleBase}/packages/app/src/main.tsx`);
-    const mainSource = await mainResp.text();
     const fnStart = mainSource.indexOf("function applyCloudPairSessionToken()");
     const fnEnd = mainSource.indexOf(
       "function shouldEnableElectrobunMacWindowDrag()",
@@ -248,69 +390,45 @@ test.describe("cloud-pair credential lifecycle — real browser evidence", () =>
     baseURL,
   }) => {
     expect(baseURL, "baseURL required").toBeTruthy();
-    await page.addInitScript(
-      (root) => {
-        (
-          window as unknown as { __elizaModuleBasePath?: string }
-        ).__elizaModuleBasePath = root;
-        // Bare shell has no app boot → no Vite process polyfill. Provide the
-        // minimal browser-safe shim some @elizaos/ui module chains read.
-        (window as unknown as Record<string, unknown>).process = {
-          env: {},
-          browser: true,
-          cwd: () => "/",
-          platform: "linux",
-        };
-      },
-      resolve(HERE, "..", "..", "..", ".."),
-    );
-
-    // Serve a bare HTML shell instead of the mounted app: the app boots a view
-    // realm whose surface-realm guard (correctly) rejects raw localStorage
-    // writes to the reserved `eliza:` namespace from page context. The harness
-    // must run BEFORE any view mounts so the REAL modules can write storage
-    // through the same channels production code uses. Same origin → Vite's
-    // /@fs/ module graph (and the REAL main.tsx source) stays reachable.
-    // The @vitejs/plugin-react preamble is required to transform .tsx modules.
-    await page.route("**/*", async (route) => {
-      const url = route.request().url();
-      if (url.endsWith("/") || url.endsWith("/index.html")) {
-        await route.fulfill({
-          status: 200,
-          contentType: "text/html",
-          body: [
-            "<!doctype html><html><body><div id='root'></div>",
-            "<script type='module'>",
-            "import { injectIntoGlobalHook } from '/@react-refresh';",
-            "injectIntoGlobalHook(window);",
-            "window.$RefreshReg$ = () => {};",
-            "window.$RefreshSig$ = () => (type) => type;",
-            "window.__vite_plugin_react_preamble_installed__ = true;",
-            "</script>",
-            "</body></html>",
-          ].join(""),
-        });
-        return;
-      }
-      await route.fallback();
+    await page.addInitScript(() => {
+      // Bare shell has no app boot → no bundler process polyfill. Provide the
+      // minimal browser-safe shim some @elizaos/ui module chains read.
+      (window as unknown as Record<string, unknown>).process = {
+        env: {},
+        browser: true,
+        cwd: () => "/",
+        platform: "linux",
+      };
     });
 
-    // Load the bare shell so the page origin is the Vite server.
+    await serveBareShell(page);
+
+    // Load the bare shell so the page origin is the smoke stack server.
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForTimeout(500);
 
-    // Run the real-lifecycle harness in the page.
+    // Inject the REAL production modules, then run the lifecycle harness.
+    await page.addScriptTag({ content: await evidenceModulesBundle() });
+    // The in-page extraction executes the adopter with `new Function`, so hand
+    // it the type-stripped (but otherwise untouched) main.tsx source — the
+    // same shape the retired dev-server module graph used to serve.
+    const mainSource = (
+      await transform(
+        await readFile(join(APP_DIR, "src", "main.tsx"), "utf8"),
+        { loader: "tsx", jsx: "automatic" },
+      )
+    ).code;
     const result = (await page.evaluate(
-      async (runnerSource) => {
+      async ({ runnerSource, mainSource }) => {
         // runnerSource is the stringified function above; execute it in page.
         // eslint-disable-next-line @typescript-eslint/no-implied-eval
-        const runner = new Function(
-          `return (${runnerSource})`,
-        )() as () => Promise<unknown>;
-        return runner();
+        const runner = new Function(`return (${runnerSource})`)() as (
+          mainSource: string,
+        ) => Promise<unknown>;
+        return runner(mainSource);
       },
       // Serialize the runner function body (avoid TS const capture issues).
-      IN_PAGE_RUNNER.toString(),
+      { runnerSource: IN_PAGE_RUNNER.toString(), mainSource },
     )) as Awaited<ReturnType<typeof IN_PAGE_RUNNER>>;
 
     expect(
@@ -377,9 +495,9 @@ test.describe("cloud-pair credential lifecycle — real browser evidence", () =>
         `Head: ${process.env.GITHUB_SHA ?? "local"} — baseURL ${baseURL}`,
         "",
         "Method: REAL production modules (CloudPairRelay persist, cloud-pair-token clear,",
-        "persistence, agent-profiles, agent-session-recovery) + REAL boot-adopter source",
-        "extracted from main.tsx, executed in headless Chromium with real",
-        "localStorage/sessionStorage against the real Vite dev server. No jsdom, no mocks.",
+        "persistence, agent-profiles, agent-session-recovery) bundled from repo source +",
+        "REAL boot-adopter source extracted from main.tsx, executed in headless Chromium",
+        "with real localStorage/sessionStorage on the smoke stack's origin. No jsdom, no mocks.",
         "",
         "| Phase | Storage dump | Screenshot |",
         "|---|---|---|",
@@ -411,66 +529,32 @@ test.describe("cloud-pair credential lifecycle — real browser evidence", () =>
     // the live session only and render the visibly distinct session-only
     // state instead of silently redirecting as a success.
     expect(baseURL, "baseURL required").toBeTruthy();
-    await page.addInitScript(
-      (root) => {
-        (
-          window as unknown as { __elizaModuleBasePath?: string }
-        ).__elizaModuleBasePath = root;
-        (window as unknown as Record<string, unknown>).process = {
-          env: {},
-          browser: true,
-          cwd: () => "/",
-          platform: "linux",
-        };
-      },
-      resolve(HERE, "..", "..", "..", ".."),
-    );
-    await page.route("**/*", async (route) => {
-      const url = route.request().url();
-      if (url.endsWith("/") || url.endsWith("/index.html")) {
-        await route.fulfill({
-          status: 200,
-          contentType: "text/html",
-          body: [
-            "<!doctype html><html><body><div id='root'></div>",
-            "<script type='module'>",
-            "import { injectIntoGlobalHook } from '/@react-refresh';",
-            "injectIntoGlobalHook(window);",
-            "window.$RefreshReg$ = () => {};",
-            "window.$RefreshSig$ = () => (type) => type;",
-            "window.__vite_plugin_react_preamble_installed__ = true;",
-            "</script>",
-            "</body></html>",
-          ].join(""),
-        });
-        return;
-      }
-      await route.fallback();
+    await page.addInitScript(() => {
+      (window as unknown as Record<string, unknown>).process = {
+        env: {},
+        browser: true,
+        cwd: () => "/",
+        platform: "linux",
+      };
     });
+    // Link the real built app stylesheets so the captured surface is the
+    // styled production render, not an unstyled DOM skeleton.
+    await serveBareShell(page, await builtStylesheetHrefs(baseURL as string));
     await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.addScriptTag({ content: await evidenceModulesBundle() });
 
     await page.evaluate(async () => {
-      const moduleBase = (
-        window as unknown as { __elizaModuleBasePath?: string }
-      ).__elizaModuleBasePath;
-      if (!moduleBase) throw new Error("module base path missing");
-      const relay = await import(
-        `/@fs${moduleBase}/packages/ui/src/components/auth/CloudPairRelay.tsx`
-      );
-      // Pull in the real app stylesheet so the captured surface is the styled
-      // production render, not an unstyled DOM skeleton.
-      await import(`/@fs${moduleBase}/packages/ui/src/styles.ts`);
-      // Bare specifiers resolve through Vite's id-resolution endpoint; a raw
-      // /@fs directory path cannot serve a package entry.
-      const reactModule = await import("/@id/react");
-      const reactDomModule = await import("/@id/react-dom/client");
-      // CJS interop: the pre-bundled dep may hang its API off `default`.
-      const react = reactModule.createElement
-        ? reactModule
-        : reactModule.default;
-      const reactDom = reactDomModule.createRoot
-        ? reactDomModule
-        : reactDomModule.default;
+      const modules = (
+        window as unknown as {
+          __cloudPairEvidenceModules?: {
+            relay: typeof import("../../../ui/src/components/auth/CloudPairRelay");
+            react: typeof import("react");
+            reactDomClient: typeof import("react-dom/client");
+          };
+        }
+      ).__cloudPairEvidenceModules;
+      if (!modules) throw new Error("evidence module bundle not injected");
+      const { relay, react, reactDomClient: reactDom } = modules;
       const rootEl = document.getElementById("root");
       if (!rootEl) throw new Error("root missing");
       const globals = globalThis as Record<string, unknown>;

--- a/packages/app/test/ui-smoke/drag-and-drop.spec.ts
+++ b/packages/app/test/ui-smoke/drag-and-drop.spec.ts
@@ -898,16 +898,30 @@ test.describe("production launcher — curated pages, reorder disabled by design
     await expect(
       grid.locator('[data-testid^="launcher-tile-"]').first(),
     ).toBeVisible({ timeout: 15_000 });
-    // Plugin-backed launcher entries arrive after the shell-owned tiles. Wait
-    // for the current catalog tail before snapshotting order so an asynchronous
-    // Phone Companion registration cannot be mistaken for drag reordering.
-    await expect(grid.getByTestId("launcher-tile-phone-companion")).toBeVisible(
-      {
-        timeout: 15_000,
-      },
-    );
-
-    const initialIds = await launcherTileIds(page);
+    // Plugin-backed launcher entries arrive after the shell-owned tiles. The
+    // curated page contents are owned by launcher-curation.ts and shift as the
+    // product evolves (#17560 dropped the Phone Companion tile from this
+    // harness's grid), so instead of anchoring on one late tile, wait for the
+    // tile catalog to hold stable across a settle window before snapshotting
+    // order — an asynchronous late registration must not be mistaken for drag
+    // reordering.
+    let initialIds = await launcherTileIds(page);
+    await expect
+      .poll(
+        async () => {
+          const previous = initialIds;
+          initialIds = await launcherTileIds(page);
+          return (
+            previous.length > 1 && previous.join("\n") === initialIds.join("\n")
+          );
+        },
+        {
+          message: "launcher tile catalog settles",
+          intervals: [1_000],
+          timeout: 20_000,
+        },
+      )
+      .toBe(true);
     expect(initialIds.length).toBeGreaterThan(1);
 
     // REAL long-press: press and hold well past the 450ms threshold without

--- a/packages/app/test/ui-smoke/plugin-view-agent-bridge-inventory-extended.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-view-agent-bridge-inventory-extended.spec.ts
@@ -73,18 +73,14 @@ const PLUGIN_VIEW_TARGETS: readonly PluginViewTarget[] = [
     label: "Calendar",
     path: "/calendar",
     viewId: "calendar",
-    // The dynamic route mounts CalendarSpatialView, whose spatial `agent`
-    // values are the canonical bridge ids.
-    ready: { text: "Design sync" },
-    requiredIds: [
-      "prev",
-      "today",
-      "next",
-      "new",
-      "mode:day",
-      "mode:week",
-      "mode:month",
-    ],
+    // #17859 swapped the /calendar bundle to the canonical month-grid
+    // SimpleCalendarView: `useAgentElement` day cells (`calendar-day-<date>`,
+    // date-dependent so not pinned here) plus the always-rendered month
+    // navigation. There is no Day/Week/Month mode control or standalone
+    // "new" button anymore — event mutations stay on the chat CALENDAR
+    // action path.
+    ready: { testId: "simple-calendar-view" },
+    requiredIds: ["prev", "today", "next", "month-picker"],
   },
   {
     label: "Inbox",

--- a/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx
@@ -304,6 +304,39 @@ function MonthControls({
   const month = formatMonth(cursor);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerYear, setPickerYear] = useState(cursor.getFullYear());
+  // Month navigation must stay chat/voice-drivable: these ids ("prev",
+  // "today", "next", plus the month-year picker) are the stable agent-bridge
+  // contract the view-inventory smoke asserts, mirroring the retired unified
+  // CalendarView's spatial ids. The labels double as the accessible names.
+  const prevControl = useAgentElement<HTMLButtonElement>({
+    id: "prev",
+    label: `Previous month, ${month}`,
+    role: "button",
+    group: "calendar-nav",
+    onActivate: onPrevious,
+  });
+  const nextControl = useAgentElement<HTMLButtonElement>({
+    id: "next",
+    label: `Next month, ${month}`,
+    role: "button",
+    group: "calendar-nav",
+    onActivate: onNext,
+  });
+  const todayControl = useAgentElement<HTMLButtonElement>({
+    id: "today",
+    label: "Today",
+    role: "button",
+    group: "calendar-nav",
+    onActivate: onToday,
+  });
+  const monthPickerControl = useAgentElement<HTMLButtonElement>({
+    id: "month-picker",
+    label: `Choose month and year. Current month is ${month}`,
+    role: "button",
+    group: "calendar-nav",
+    status: pickerOpen ? "open" : "closed",
+    onActivate: () => setPickerOpen(true),
+  });
   useEffect(() => setPickerYear(cursor.getFullYear()), [cursor]);
   const yearOptions = useMemo(
     () =>
@@ -343,6 +376,8 @@ function MonthControls({
       }}
     >
       <button
+        ref={prevControl.ref}
+        {...prevControl.agentProps}
         type="button"
         aria-label={`Previous month, ${month}`}
         title="Previous month"
@@ -354,6 +389,8 @@ function MonthControls({
       <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
         <PopoverTrigger asChild>
           <button
+            ref={monthPickerControl.ref}
+            {...monthPickerControl.agentProps}
             type="button"
             aria-label={`Choose month and year. Current month is ${month}`}
             style={{
@@ -470,6 +507,8 @@ function MonthControls({
         </PopoverContent>
       </Popover>
       <button
+        ref={nextControl.ref}
+        {...nextControl.agentProps}
         type="button"
         aria-label={`Next month, ${month}`}
         title="Next month"
@@ -479,6 +518,8 @@ function MonthControls({
         <ChevronRight size={19} aria-hidden />
       </button>
       <button
+        ref={todayControl.ref}
+        {...todayControl.agentProps}
         type="button"
         onClick={onToday}
         style={{


### PR DESCRIPTION
# Relates to

Closes the deterministic red groups of #18014 (remaining `scenario-pr.yml` spec fallout from the #17859 rollup). Follows the porting pattern of #18013 and the runner-class pinning precedent of #18022 (#18021).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync (verify exit 0, transcript below).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `55eb734eda5`; zero conflicts.
- [x] `bun run verify` passes post-sync (exit 0).

# Risks

Low.
- Four zero-key ui-smoke specs and one workflow file; no product behavior changes except one additive DOM/agent-registry wiring in `SimpleCalendarView` (nav buttons gain `data-agent-*` attributes and registry entries; accessible names and pixels unchanged).
- Workflow: `perf-interaction-kpi.spec.ts` moves from the fleet-hosted ratcheted job into a new hosted-pinned job (still wired into the Zero-Key Deterministic E2E aggregator), and the accounts-ui e2e job is pinned to `ubuntu-24.04`. Coverage is unchanged; only the runner class moves, per the #18022 precedent.

# Background

## What does this PR do?

Fixes the five deterministic zero-key failures documented in #18014 that have kept `scenario-pr.yml` red on develop since the #17859 rollup:

1. **`plugin-view-agent-bridge-inventory-extended.spec.ts` — Calendar (issue 1a, #17859 fallout + real product gap).** `/calendar` now mounts the canonical month-grid `SimpleCalendarView`, so the old ready-marker ("Design sync" agenda text) and required ids (`mode:day/week/month`, `new`) no longer exist. The spec now anchors on `data-testid="simple-calendar-view"` and requires the month-navigation ids. That exposed a genuine gap: `SimpleCalendarView`'s Previous/Next/Today/month-picker buttons were **not** agent-bridge wired (chat/voice could not navigate the calendar, and the spec's unwired-controls scan would flag them). The view now registers them via `useAgentElement` (`prev`, `today`, `next`, `month-picker`), matching the retired unified view's id vocabulary.
2. **`cloud-pair-evidence.spec.ts` (issue 1b — harness rot, not a product bug).** The smoke stack serves the **built** renderer through a static proxy (`Static asset not found` on `/@fs/...`), so the spec's Vite-dev-server `/@fs` dynamic imports of `CloudPairRelay.tsx` etc. cannot work anymore. `packages/ui/src/components/auth/CloudPairRelay.tsx` exists and is fine. The spec now bundles the same production sources with esbuild at spec runtime (the reviewed accounts-ui e2e technique, including its node-builtin stub), injects them into the bare same-origin shell, and reads the boot-adopter source from the repo's `main.tsx` (type-stripped only). Same browser-real lifecycle, same assertions; test 2 links the real built app stylesheets so the captured surface stays the styled production render.
3. **`chat-message-actions.spec.ts` desktop (issue 1c — deliberate product behavior, spec ported).** The #17859 chat-interaction slice makes fine pointers reveal the action row on pointer movement while a bubble click TOGGLES it (aria-expanded contract, locked in by `chat-message.hover-reveal.test.tsx` "does not pin a fine-pointer action rail after bubble click and pointer leave"). Playwright replays a pointer-move before every click, so a desktop `.click()` always lands as reveal-then-toggle-hidden — the spec now uses hover (the shipped desktop affordance) on desktop and keeps tap-to-reveal on the coarse-pointer viewport.
4. **`drag-and-drop.spec.ts` curated launcher (issue 1d — #17560 fallout).** The curated launcher page no longer carries a `phone-companion` tile. The spec's wait existed only to let late plugin registrations settle before snapshotting tile order; it now polls for tile-catalog stability instead of hand-naming one late tile, so future curation changes cannot re-break it.
5. **`perf-interaction-kpi` ratchet breaches (issue 2 — runner-class, not a regression).** The failing KPI label varies run to run (`chat-to-settings`, `sheet-open-close`, `live-token-stream`) and the same spec passes locally with p95 50–83 ms against the 100 ms ceiling (transcript below). Exactly the #18021/#18022 situation: budgets calibrated for hosted runners, breached by the contended hetzner-robot fleet on hardware grounds. Following #18022, the spec moves into its own `ubuntu-24.04`-pinned job (`app-browser-perf-kpi`), wired into the deterministic aggregator; the ratcheted job keeps every other spec on the fleet.

Additionally (issue 3 in #18014): the **accounts-ui e2e** lane (still red after #18012) is pinned to `ubuntu-24.04`. The CI logs show the API server answering instantly (`GET /api/accounts -> 200`, `POST -> 400`, `POST -> 201`) while the production `ElizaClient` in the fixture browser reports `Request timed out after 10000ms` and the requests arrive at the server in a delayed burst — loopback HTTP latency on the contended fleet exceeding the client's 10 s production request timeout. The identical suite passes locally end-to-end at this revision (17/17 assertions, transcript below).

## What kind of change is this?

Bug fixes (test/CI: re-green the required zero-key lanes without weakening coverage) plus one small product improvement (calendar navigation becomes chat/voice-drivable through the agent bridge).

## Out of scope (left for #18014 follow-ups)

- **Zero-Key scenario runner E2E** (issue 4): intermittent; the latest red run's (`31248488119`, job 93080947669) failed-step log ends mid-`deterministic-agent-skills-actions` after an `AGENT_SKILLS_PLUGIN_LIFECYCLE` "Service commands not found or failed to start" error — needs its own scoped owner; not a spec-port problem.
- **`chat-thread-gestures.spec.ts:380`** (ArrowDown restore-zone) and the **full-walkthrough desktop diagnostics gate** (`slash-commands.catalog Request timed out after 10000ms`): each failed in only one of the two latest develop runs (not deterministic); the walkthrough signature is the same fleet 10 s-timeout class as the accounts lane.
- The infra-flavored `apt` lock / `pip` runner-setup failures visible in run `31245903348` (feature interactions, Pixel-7) — those jobs are green when the runner setup succeeds (#18013 fixed their deterministic spec).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/app/test/ui-smoke/plugin-view-agent-bridge-inventory-extended.spec.ts` (Calendar target) together with `plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx` (new `useAgentElement` wiring).
- `packages/app/test/ui-smoke/cloud-pair-evidence.spec.ts` — the esbuild bundling replaces only the module *delivery*; the in-page lifecycle, boot-adopter extraction, and every assertion are unchanged.
- `.github/workflows/scenario-pr.yml` — new `app-browser-perf-kpi` job, ratcheted spec list minus `perf-interaction-kpi`, accounts job runs-on, aggregator wiring.

## Detailed testing steps

```bash
# per-spec, against the real zero-key smoke stack (mirrors the CI jobs)
bun run --cwd packages/app test:e2e test/ui-smoke/plugin-view-agent-bridge-inventory-extended.spec.ts --project=chromium
bun run --cwd packages/app test:e2e test/ui-smoke/cloud-pair-evidence.spec.ts --project=chromium
bun run --cwd packages/app test:e2e test/ui-smoke/chat-message-actions.spec.ts --project=chromium
bun run --cwd packages/app test:e2e test/ui-smoke/drag-and-drop.spec.ts test/ui-smoke/perf-interaction-kpi.spec.ts --project=chromium
bun run --cwd packages/app test:e2e test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts --project=mobile-chromium
ELIZA_VAULT_PASSPHRASE=accounts-ui-e2e-headless-only bun run --cwd packages/app test:e2e:accounts-ui
bun run --cwd plugins/plugin-calendar test && bun run --cwd plugins/plugin-calendar typecheck
bun run verify
```

# Evidence Gate

<!-- evidence-head:66fdc4b0e0ab0315a4219f65ae6f03a4d87972d4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A for spec/workflow files — the "before" state is the CI failure itself (every develop scenario-pr run since `acf5fe75b`, e.g. [run 31245903348](https://github.com/elizaOS/eliza/actions/runs/31245903348): auto-discovered ✘ ×6, ratcheted ✘, accounts-ui ✘). For the one rendered surface touched (`SimpleCalendarView`), the change adds `data-agent-*` attributes only; before and after render pixel-identical (after captures below stand for both).
<!-- evidence-row:after-screenshots -->
- [x] `/calendar` after-capture, desktop + mobile, from the real zero-key stack with the wired nav controls (`prev`/`month-picker`/`next`/`today` + 42 day cells registered): ![calendar desktop](https://gist.githubusercontent.com/lalalune/a7308d37f691db310cbf55cf17ec6961/raw/calendar-desktop.jpg) ![calendar mobile](https://gist.githubusercontent.com/lalalune/a7308d37f691db310cbf55cf17ec6961/raw/calendar-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test/CI-focused change; Playwright drives the identical interaction paths a video would show (hover/tap reveal, launcher long-press + drag, calendar bridge interact), and the harness records failure videos which are absent from the passing runs below.
<!-- evidence-row:backend-logs -->
- [x] Accounts-ui e2e transcript below includes the real API server structured log (`[accounts-e2e-api] POST /api/accounts/anthropic-api -> 201`, `[auth] Saved …`, `[account-pool] … needs-reauth: invalid_grant`) with the dialog closing and health badges rendering — the exact path that times out on the fleet.
<!-- evidence-row:frontend-logs -->
- [x] The Playwright transcripts below are the frontend evidence: the specs assert on real browser network/storage/agent-bridge state (cloud-pair storage dumps, `list-elements` bridge inventory, launcher tile catalog, KPI rAF samples) and fail on any harness/page error.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model behavior touched; all lanes here run the Zero-Key deterministic stack with no model in the loop.
<!-- evidence-row:domain-artifacts -->
- [x] Cloud-pair evidence artifacts (storage dumps + phase screenshots) are produced by the passing spec under `test-results/cloud-pair-evidence/`; accounts-ui writes 15 evidence screenshots + credential files on disk (asserted by the suite itself: "credential record written to the on-disk store", "deleted account's on-disk credential was removed").
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual change (attribute-only diff on SimpleCalendarView; all other files are specs/workflow).

# Evidence Details

## Real LLM-call trajectory

N/A - zero-key deterministic lanes; no model in the loop.

## Backend + frontend logs

<details><summary>Zero-key auto-discovered spec targets — all green (chromium)</summary>

```
  ✓   1 chat-message-actions.spec.ts:262:3 › chat overlay message action row works on desktop (10.0s)
  ✓   2 chat-message-actions.spec.ts:262:3 › chat overlay message action row works on mobile (8.6s)
  ✓   3 cloud-pair-evidence.spec.ts:388:3 › cloud-pair credential lifecycle — real browser evidence › pair → relaunch → clear → relaunch → offline negative (1.5s)
  ✓   4 cloud-pair-evidence.spec.ts:522:3 › … session-only pairing fallback renders a distinct non-success state (2.7s)
  ✓   5 plugin-view-agent-bridge-inventory-extended.spec.ts:310:3 › Calendar exposes chat/voice-drivable controls through the agent bridge (5.6s)
  ✓   6 … Inbox (5.2s)  ✓ 7 Finances  ✓ 8 Goals  ✓ 9 Todos  ✓ 10 Health
  10 passed (55.8s)
```
</details>

<details><summary>Full drag-and-drop + perf KPI + decomposed calendar (chromium) — 20/20</summary>

```
  ✓  11..19 drag-and-drop.spec.ts (plugin reorder, chat file drop, knowledge drop, curated launcher long-press/drag) — 9 passed
  ✓   1..10 apps-personal-assistant-decomposed-interactions.spec.ts — 10 passed
[perf-interaction-kpi] live-token-stream: 28fps · p95 66.7ms · worst 116.6ms · dropped 38/42 (budget 16.7ms)
[perf-interaction-kpi] transcript-scroll: 38fps · p95 50.0ms · worst 50.1ms
[perf-interaction-kpi] sheet-open-close: 35fps · p95 50.0ms · worst 66.7ms
[perf-interaction-kpi] sheet-drag: 35fps · p95 50.0ms · worst 50.1ms
[perf-interaction-kpi] chat-to-settings: 16fps · p95 83.3ms · worst 83.3ms
  ✓  20 perf-interaction-kpi.spec.ts:244:3 › dashboard shell interaction framerate (20.4s)
  20 passed (2.4m)
```

Every p95 is far under the 100 ms ceiling on non-fleet hardware — the CI breaches (varying lane label per run) are runner-class, matching #18021.
</details>

<details><summary>Pixel-7 lane (mobile-chromium) — 10/10</summary>

```
  ✓   1 calendar decomposed view: day selection and month navigation (6.7s)
  ✓   2 inbox … ✓ 3 finances … ✓ 4 focus … ✓ 5 goals … ✓ 6 health … ✓ 7 todos … ✓ 8 relationships …
  ✓   9 relationships graph: two-finger pinch-out zooms in under REAL touch (6.1s)
  ✓  10 relationships graph: one-finger pan scrolls the zoomed graph under REAL touch (6.5s)
  10 passed (58.4s)
```
</details>

<details><summary>Accounts-ui e2e — full local pass with real API server logs (the lane pinned to ubuntu-24.04)</summary>

```
$ ELIZA_VAULT_PASSPHRASE=accounts-ui-e2e-headless-only bun run --cwd packages/app test:e2e:accounts-ui
fixture bundled (2950047 bytes js, 70114 bytes css)
accounts API server ready at http://127.0.0.1:34110
PASS  empty state renders when no accounts are connected
PASS  invalid API key (<8 chars) surfaces the server's validation error inline ("Too small: expected string to have >=8 characters")
PASS  added account is in the REAL pool (label=Personal)
PASS  credential record written to the on-disk store
PASS  card shows the API-key source badge
PASS  cards render in priority order (Personal #0, Work #1)
PASS  priority swap persisted through PATCH /api/accounts (Work #0, Personal #1)
PASS  strategy PATCH persisted via saveConfig (accountStrategies.anthropic-api=round-robin)
PASS  rate-limited badge shows the reset countdown from healthDetail.until
PASS  needs-reauth badge renders for the invalid-grant account
PASS  pool state matches the rendered badges (rate-limited + needs-reauth)
PASS  disable toggle persisted (enabled=false for "Work")
PASS  deleted account left the pool
PASS  deleted account's on-disk credential was removed
PASS  empty state returns after all accounts are disconnected
PASS  pool is empty on disk too
PASS  zero page errors across the whole flow
ALL ASSERTIONS PASSED — 15 screenshots
```

Contrast with CI job 93075539404 (fleet): the browser reports `Request timed out after 10000ms` while the server logs `POST /api/accounts/anthropic-api -> 201` and `[auth] Saved anthropic-api account …` immediately, and the early GET/POST responses arrive at the server only in a delayed burst — the fixture's requests are stalled on the runner's loopback, not by product code.
</details>

<details><summary>plugin-calendar package gates + repo verify</summary>

```
$ bun run --cwd plugins/plugin-calendar test
 Test Files  56 passed | 1 skipped (57);  Tests  511 passed | 2 skipped (513)
$ bun run --cwd plugins/plugin-calendar typecheck
 tsc --noEmit (clean)
$ bun run verify
 … [anti-larp] clean — no focused tests, no untracked skips.
 verify exit=0
```
</details>

<details><summary>Calendar agent-bridge wiring proof (real zero-key stack, both viewports)</summary>

```
desktop agent ids (nav): [ 'prev', 'month-picker', 'next', 'today' ] day cells: 42
mobile  agent ids (nav): [ 'prev', 'month-picker', 'next', 'today' ] day cells: 42
```
</details>

## Screenshots (before / after) + video walkthrough

See Evidence Gate rows — `/calendar` desktop + mobile after-captures (pixel-identical to before; the diff adds `data-agent-*` attributes and registry entries only).

### Before

Visually identical to After (attribute-only change); the behavioral "before" is the red develop runs linked above.

### After

Linked in the after-screenshots row.

### Walkthrough video

N/A - test/CI change; the Playwright transcripts above drive the full flows.

## Audio / voice walkthrough

N/A - no voice surface touched.

## Known gaps / failures

- The scenario-runner E2E intermittent failure (issue 4 of #18014) and the two single-run flakes (chat-thread-gestures ArrowDown, full-walkthrough desktop diagnostics gate) are documented in "Out of scope" above and remain owned by #18014 — they are not part of this PR's deterministic set and were not reproducible as deterministic failures.
- The fleet-side loopback stall behind the accounts-ui / walkthrough `Request timed out after 10000ms` signatures is worked around by runner pinning here; a root-cause infra investigation on the hetzner pool would allow unpinning both this job and the perf jobs later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
