### PR TITLE
test: harden the rotating loaded-runner Server Tests members (#18053)

### DIFF
--- a/packages/agent/src/api/self-api-auth-contract.test.ts
+++ b/packages/agent/src/api/self-api-auth-contract.test.ts
@@ -91,10 +91,10 @@ const expectedProtectedPaths = [
 ] as const;
 
 const localTargetPattern =
-  /127\.0\.0\.1|localhost|loopbackBase|getApiBase|getLocalApiUrls|resolveServerOnlyPort|resolveDesktopApiPort|ELIZA_PORT/;
+  /127\.0\.0\.1|localhost|loopbackBase|getApiBase|getAppControlApiBase|getLocalApiUrls|resolveServerOnlyPort|resolveDesktopApiPort|ELIZA_PORT/;
 const apiPathPattern = /\/api\//;
 const knownSelfApiBasePattern =
-  /loopbackBase|getApiBase|getLocalApiUrls|resolveServerOnlyPort|resolveDesktopApiPort/;
+  /loopbackBase|getApiBase|getAppControlApiBase|getLocalApiUrls|resolveServerOnlyPort|resolveDesktopApiPort/;
 const authPrimitivePattern =
   /\b(?:createSelfApiRequestHeaders|createViewsRequestHeaders)\s*\(/;
 

--- a/packages/agent/test/api/accounts-routes.test.ts
+++ b/packages/agent/test/api/accounts-routes.test.ts
@@ -31,12 +31,25 @@ const poolMock = {
   selectionState: vi.fn(),
 };
 
-vi.mock("@elizaos/auth/account-storage", () => ({
-  deleteAccount: vi.fn(),
-  listAccounts: vi.fn(() => []),
-  loadAccount: vi.fn(() => null),
-  saveAccount: vi.fn(),
-}));
+vi.mock("@elizaos/auth/account-storage", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@elizaos/auth/account-storage")>();
+  return {
+    ...actual,
+    // Storage I/O is mocked; everything else (notably the pure
+    // assertCanonicalAccountId guard from #17464) stays real so id
+    // enforcement remains covered. The policy factory is stubbed because
+    // the real one mkdirs the state root, and every consumer of the policy
+    // object here is one of the mocked storage functions.
+    createRuntimeAccountStoragePolicy: vi.fn(
+      () => ({}) as ReturnType<typeof actual.createRuntimeAccountStoragePolicy>,
+    ),
+    deleteAccount: vi.fn(),
+    listAccounts: vi.fn(() => []),
+    loadAccount: vi.fn(() => null),
+    saveAccount: vi.fn(),
+  };
+});
 
 vi.mock("@elizaos/auth/credentials", async (importOriginal) => {
   const actual =
@@ -226,8 +239,10 @@ describe("accounts routes provider-scoped account resolution", () => {
     expect(poolMock.deleteMetadata.mock.calls).toEqual([
       ["openai-api", "shared-id"],
     ]);
+    // Third argument is the runtime storage policy (#17464); its ownership
+    // semantics are covered by packages/auth, so only its presence matters.
     expect(vi.mocked(deleteAccount).mock.calls).toEqual([
-      ["openai-api", "shared-id"],
+      ["openai-api", "shared-id", expect.anything()],
     ]);
     expect(ctx.body).toEqual({ deleted: true });
   });

--- a/packages/agent/test/api/agent-message-route.test.ts
+++ b/packages/agent/test/api/agent-message-route.test.ts
@@ -28,6 +28,7 @@ import {
   type AgentRuntime,
   ChannelType,
   ModelType,
+  RoomHandlerQueue,
   stringToUuid,
   type UUID,
 } from "@elizaos/core";
@@ -231,6 +232,10 @@ function createRuntime(
     emitEvent: vi.fn(async () => undefined),
     reportError: vi.fn(),
     drainChatPreHandlers: vi.fn(async () => null),
+    // generateChatResponse acquires per-room ownership through the runtime's
+    // real RoomHandlerQueue; a mock without one 500s every turn (and stream
+    // tests then hang waiting for frames that never arrive).
+    roomHandlerQueue: new RoomHandlerQueue(),
     ...overrides,
   };
   return runtime as unknown as AgentRuntime;

--- a/packages/agent/test/api/chat-augmentation-route.test.ts
+++ b/packages/agent/test/api/chat-augmentation-route.test.ts
@@ -24,6 +24,7 @@ import http from "node:http";
 import {
   type AgentRuntime,
   ModelType,
+  RoomHandlerQueue,
   stringToUuid,
   type UUID,
 } from "@elizaos/core";
@@ -190,6 +191,9 @@ function createRuntime(
     emitEvent: vi.fn(async () => undefined),
     drainChatPreHandlers: vi.fn(async () => null),
     useModel: vi.fn(async () => ""),
+    // generateChatResponse acquires per-room ownership through the runtime's
+    // real RoomHandlerQueue; a mock without one 500s every turn.
+    roomHandlerQueue: new RoomHandlerQueue(),
     ...overrides,
   };
   const contractCheckedRuntime: Pick<AgentRuntime, "getParticipantsForRoom"> =

--- a/packages/agent/test/api/chat-routes-usage.test.ts
+++ b/packages/agent/test/api/chat-routes-usage.test.ts
@@ -5,6 +5,7 @@ import {
   createMessageMemory,
   EventType,
   ModelType,
+  RoomHandlerQueue,
   stringToUuid,
 } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
@@ -41,6 +42,9 @@ function createRuntime(overrides: RuntimeOverrides = {}): AgentRuntime {
     getService: vi.fn(() => null),
     getServicesByType: vi.fn(() => []),
     drainChatPreHandlers: vi.fn(async () => null),
+    // generateChatResponse acquires per-room ownership through the runtime's
+    // real RoomHandlerQueue; a mock without one fails every turn.
+    roomHandlerQueue: new RoomHandlerQueue(),
     ...overrides,
   } satisfies Partial<AgentRuntime>;
 
@@ -50,7 +54,12 @@ function createRuntime(overrides: RuntimeOverrides = {}): AgentRuntime {
 function createChatMessage(text: string) {
   return createMessageMemory({
     id: stringToUuid(`message-${text}`),
-    roomId: stringToUuid("room"),
+    // Per-message room: generateChatResponse serializes turns per room via
+    // the RoomHandlerQueue, so the concurrent-isolation test's two in-flight
+    // turns must live in distinct rooms or they deadlock on each other's
+    // start gate. Usage attribution is keyed per request, not per room, so
+    // the isolation contract is unchanged.
+    roomId: stringToUuid(`room-${text}`),
     entityId: stringToUuid("user"),
     content: {
       text,

--- a/packages/app-core/src/services/multi-account-refresh-failover.test.ts
+++ b/packages/app-core/src/services/multi-account-refresh-failover.test.ts
@@ -427,7 +427,11 @@ describe("adoptRotatedCodexTokens (CLI self-refresh sync-back)", () => {
             expect.stringContaining("[AccountPool] keep-alive sweep failed:"),
           );
         },
-        { timeout: 3_000, interval: 10 },
+        // Generous deadline: the sweep runs real filesystem adoption work on
+        // its immediate timer tick, and loaded CI runners can stall the event
+        // loop for seconds. The waitFor returns as soon as the log lands, so
+        // the margin only bounds the genuine-failure case.
+        { timeout: 30_000, interval: 25 },
       );
       expect(
         getDefaultAccountPool().get("codex-work", "openai-codex")?.health,

--- a/packages/core/src/services/message.run-ended-detach.test.ts
+++ b/packages/core/src/services/message.run-ended-detach.test.ts
@@ -75,11 +75,23 @@ describe("DefaultMessageService — RUN_ENDED post-delivery detach", () => {
 
 		expect(result.didRespond).toBe(false);
 		expect(result.mode).toBe("none");
-		// Must not have waited on the gated RUN_ENDED handler.
-		expect(elapsedMs).toBeLessThan(200);
-		expect(runEndedStarted).toBe(true);
+		// Causality: at the moment handleMessage returned, the gated RUN_ENDED
+		// handler cannot have finished — the gate is still closed. This is the
+		// real detach contract; if RUN_ENDED were back on the await path the
+		// handleMessage call above would deadlock on the gate instead.
 		expect(runEndedFinished).toBe(false);
+		// Deadline assertions on loaded CI runners need generous margins: the
+		// worker can lose seconds of wall clock to CPU contention. 5s is still
+		// far below the forever-pending gate a regression would await.
+		expect(elapsedMs).toBeLessThan(5_000);
 		expect(pendingPostDeliveryTaskCount(runtime)).toBeGreaterThan(0);
+		// The detached handler starts on its own microtask; under load it may
+		// not have begun by the time handleMessage returns. Wait for the start
+		// signal instead of asserting it synchronously.
+		await vi.waitFor(() => {
+			expect(runEndedStarted).toBe(true);
+		});
+		expect(runEndedFinished).toBe(false);
 
 		release();
 		await drainPostDeliveryTasks(runtime);

--- a/packages/core/src/services/message/pre-llm-direct-hook-removed.test.ts
+++ b/packages/core/src/services/message/pre-llm-direct-hook-removed.test.ts
@@ -18,6 +18,7 @@ import { ChannelType, type Content, type UUID } from "../../types/primitives";
 import type { IAgentRuntime } from "../../types/runtime";
 import type { State } from "../../types/state";
 import { DefaultMessageService } from "../message";
+import { drainPostDeliveryTasks } from "../post-delivery-task-tracker.ts";
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
 const USER_ID = "00000000-0000-0000-0000-0000000000b1" as UUID;
@@ -223,6 +224,11 @@ describe("message service pre-LLM direct hook removed (#14715)", () => {
 				"RESPONSE_HANDLER_AFTER",
 			]),
 		);
+		// RUN_ENDED rides the detached post-delivery terminal (#17072), so it
+		// may not have fired yet when handleMessage returns — especially on a
+		// loaded runner. Drain the tracker for a deterministic completion
+		// signal before asserting the event was emitted.
+		await drainPostDeliveryTasks(runtime);
 		expect(
 			emitEvent.mock.calls.some(([event]) => event === EventType.RUN_ENDED),
 		).toBe(true);

--- a/packages/vault/test/master-key.test.ts
+++ b/packages/vault/test/master-key.test.ts
@@ -148,13 +148,24 @@ describe("passphraseMasterKeyFromEnv", () => {
 describe("defaultMasterKey — fallback chain", () => {
   let prev: string | undefined;
   let prevDisable: string | undefined;
+  let prevDbus: string | undefined;
   beforeEach(() => {
     prev = process.env.ELIZA_VAULT_PASSPHRASE;
     prevDisable = process.env.ELIZA_VAULT_DISABLE_KEYCHAIN;
+    prevDbus = process.env.DBUS_SESSION_BUS_ADDRESS;
     // Force the keychain "safe" path so the existing tests below
-    // exercise the keychain attempt regardless of host environment
-    // (e.g. headless Linux CI without D-Bus).
+    // exercise the keychain attempt regardless of host environment.
+    // Deleting the disable flag is not enough: on headless Linux CI
+    // without a reachable D-Bus session, isKeychainUnsafe() still takes
+    // the "keychain bypassed: host unsafe" branch. DBUS_SESSION_BUS_ADDRESS
+    // is the production safe-host signal and is checked before any
+    // filesystem probe, so pinning it makes the branch deterministic on
+    // every host. No Linux test in this block calls load() without
+    // ELIZA_VAULT_DISABLE_KEYCHAIN=1 (which wins over the bus address),
+    // so the fake bus address is never dialed.
     delete process.env.ELIZA_VAULT_DISABLE_KEYCHAIN;
+    process.env.DBUS_SESSION_BUS_ADDRESS =
+      "unix:path=/nonexistent/eliza-vault-test-bus";
   });
   afterEach(() => {
     if (prev === undefined) delete process.env.ELIZA_VAULT_PASSPHRASE;
@@ -162,6 +173,8 @@ describe("defaultMasterKey — fallback chain", () => {
     if (prevDisable === undefined)
       delete process.env.ELIZA_VAULT_DISABLE_KEYCHAIN;
     else process.env.ELIZA_VAULT_DISABLE_KEYCHAIN = prevDisable;
+    if (prevDbus === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
+    else process.env.DBUS_SESSION_BUS_ADDRESS = prevDbus;
   });
 
   test.skipIf(process.platform === "linux")(


### PR DESCRIPTION
Hardens the rotating Server Tests members tracked in #18053 — each red on some hetzner-fleet runs, and (as it turned out for the agent package) several red everywhere. Every fix keeps the covered contract strict — ordering/causality assertions unchanged, mutation-checked where feasible — and removes the host- or load-dependence that made the results rotate.

## Per-test changes

| Test | CI failure signature | Root cause | Fix |
| --- | --- | --- | --- |
| `packages/vault/test/master-key.test.ts` — "defaultMasterKey — fallback chain" describe tests | `expected 'passphrase://test (keychain bypassed:…' to contain 'keychain://'` | Deleting `ELIZA_VAULT_DISABLE_KEYCHAIN` does not force the keychain-attempt branch: on headless Linux without D-Bus, `isKeychainUnsafe()` still bypasses the keychain | Pin `DBUS_SESSION_BUS_ADDRESS` (the production safe-host signal, checked before any filesystem probe) in the block's `beforeEach`, restore in `afterEach`. Keychain-less hosts are now a first-class deterministic path; the "keychain bypassed" block already pins the unsafe branch explicitly |
| `packages/core/src/services/message.run-ended-detach.test.ts` | `expected false to be true` (`runEndedStarted`) | `RUN_ENDED` rides a detached post-delivery task (#17072); its handler starts on its own microtask, so a loaded worker can return from `handleMessage` before it begins | Assert the detach contract by causality (the gated handler cannot have finished at return — a regression re-awaiting `RUN_ENDED` deadlocks instead of passing), `vi.waitFor` the start signal, raise the redundant wall-clock deadline 200ms → 5s with a rationale comment |
| `packages/core/src/services/message/pre-llm-direct-hook-removed.test.ts` | `expected false to be true` (`RUN_ENDED` emitted) | Same detached terminal: `RUN_ENDED` may not have fired when `handleMessage` returns | `await drainPostDeliveryTasks(runtime)` — a deterministic completion signal — before asserting the event |
| `packages/core/src/services/notification.test.ts` (backoff family) | `expected 'Service notification failed to start'…` | Already fixed on develop by #18023 (message realignment); the red runs predate it (verified: run 31225309259's head `676f1f5713d` does not contain `a217b70a2b6`) | No change needed; included in the stress runs below, 3/3 green |
| `packages/app-core/src/services/multi-account-refresh-failover.test.ts` — keep-alive timer boundary | `vi.waitFor` timeout | The sweep runs real filesystem adoption work on its immediate timer tick; 3s is too tight on a loaded runner | Raise the `waitFor` deadline 3s → 30s with a rationale comment; assertions unchanged (`waitFor` returns as soon as the log lands, so the margin only bounds the genuine-failure case) |
| `packages/agent/test/api/agent-message-route.test.ts` (11 tests, run 31248488119) | `expected 500 to be 200`, empty streams, 2×120s timeouts | Not timing: deterministic mock-contract gap. `generateChatResponse` now acquires per-room ownership via `runtime.roomHandlerQueue`; the mock runtime had none → `Cannot read properties of undefined (reading 'currentLease')` → 500 on every turn, and stream tests hang awaiting frames. Reproduced locally at develop HEAD (11 failed) | Give the fixture a real `RoomHandlerQueue` from `@elizaos/core` (same pattern as `conversation-message-delete.test.ts`) |
| `packages/agent` — the other 4 red batches behind CI's `[agent-test] 5 batch(es) failed` (`chat-routes-usage`, `chat-augmentation-route`, `accounts-routes`, `self-api-auth-contract`) | batch failures whose vitest detail never reached the visible CI log | All four reproduce deterministically at develop HEAD: the two chat fixtures share the missing `roomHandlerQueue`; `accounts-routes`' `vi.mock` factory predates #17464 and lacks `assertCanonicalAccountId` / `createRuntimeAccountStoragePolicy`; `self-api-auth-contract`'s classifier doesn't know the renamed `getAppControlApiBase()` loopback helper, so `views-show.ts` fell out of the protected inventory | Real `RoomHandlerQueue` in both chat fixtures (the usage-isolation test gets one room per message: same-room turns are now product-serialized, so two gated concurrent same-room turns deadlock by design); `importOriginal`-based mock keeping the pure id guard real while stubbing storage I/O and the mkdir-ing policy factory, plus the new policy argument on `deleteAccount`; add `getAppControlApiBase` to the classifier patterns (the call site already uses `createViewsRequestHeaders`, and the helper returns `http://127.0.0.1:<runtime port>`) |

## Evidence

**Vault — keychain-less host reproduction (pre-fix) and fix (Linux, `env -u DBUS_SESSION_BUS_ADDRESS -u XDG_RUNTIME_DIR`):**

```
pre-fix:  Tests  2 failed | 26 passed | 1 skipped (29)
  AssertionError: expected 'passphrase://test (keychain bypassed:…' to contain 'keychain://'
  AssertionError: expected 'unavailable (keychain bypassed: host …' to contain 'keychain://'
post-fix: Tests  28 passed | 1 skipped (29)
```

**Vault — mutation check (contract still enforced):** with `defaultMasterKey().describe()` mutated to (a) drop the passphrase-fallback surface on safe hosts and (b) report the keychain on bypassed hosts, the suite fails exactly where it should:

```
Tests  3 failed | 25 passed | 1 skipped (29)
  × fallback chain > describe surfaces both paths when passphrase env is set
  × keychain bypassed on unsafe hosts > describe reports passphrase path when bypassed and env is set
  × keychain bypassed on unsafe hosts > describe reports unavailable when bypassed and no passphrase
```

**Core — stress reproduction (pre-fix tests, CPU-loaded harness: 24 busy-loop hogs, run pinned to 2 CPUs at nice 10):** 4/4 iterations reproduce the exact CI signature:

```
FAIL  message.run-ended-detach.test.ts > returns from a self-message exit before a slow RUN_ENDED handler finishes
FAIL  pre-llm-direct-hook-removed.test.ts > routes missed-call owner chat through Stage 1 instead of a canned hook reply
Tests  2 failed (2)   (×4)
```

**Core — hardened tests under the same stress harness (incl. the notification backoff family):** 3/3 iterations green (`Test Files 3 passed / Tests 39 passed` each).

**app-core failover under stress:** `Tests 30 passed (30)` ×3.
**agent route files:** pre-fix `11 failed | 8 passed` (`agent-message-route`), 45 failed (`chat-routes-usage`), 3 failed (`chat-augmentation-route`), 14 failed (`accounts-routes` + `self-api-auth-contract`); post-fix all green, `agent-message-route` also ×2 under the stress harness.

## Gates

- `packages/vault` full suite: `197 passed | 1 skipped`
- `packages/core` full suite: `494/494 files, 4843 passed | 11 skipped`
- `packages/app-core` full suite: `209 files passed | 1 skipped, 1654 passed | 15 skipped`
- `packages/agent` full batched suite: green after the fixes (was `5 batch(es) failed` at develop HEAD, matching CI)
- `tsc --noEmit` clean for all four packages; Biome clean on every changed file (test-only diff; the sole non-test change is the classifier regex inside `self-api-auth-contract.test.ts`)

Frontend evidence rows are N/A — server-lane test files only; no UI surface is touched.

Fixes the Server Tests rotating members of #18053 (the Plugin Tests pglite WASM-fs family is being addressed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
