### PR TITLE
fix(cloud): restore dedicated-agent dispatch on the bridge route

### DIFF
--- a/packages/cloud/api/__tests__/agent-bridge-dedicated-dispatch.test.ts
+++ b/packages/cloud/api/__tests__/agent-bridge-dedicated-dispatch.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Pins that the agent bridge route serves BOTH tiers.
+ *
+ * The shared resolver refuses a dedicated agent by design; that refusal is a
+ * routing signal, not a client verdict. #17076 collapsed the branch that read
+ * it, so every dedicated agent 404'd for two weeks and iOS cloud chat broke in
+ * production (#18062). These tests drive the real Hono route with a stubbed
+ * resolver and sandbox service.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realAuth from "@/lib/auth";
+import * as realSandbox from "@/lib/services/eliza-sandbox";
+import * as realResolveSharedAgent from "@/lib/services/shared-runtime/resolve-shared-agent";
+
+const resolveSharedAgent = mock();
+const sandboxBridge = mock();
+const requireAuthOrApiKeyWithOrg = mock();
+
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  ...realResolveSharedAgent,
+  resolveSharedAgent,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  ...realSandbox,
+  elizaSandboxService: {
+    ...realSandbox.elizaSandboxService,
+    bridge: sandboxBridge,
+  },
+}));
+
+mock.module("@/lib/auth", () => ({
+  ...realAuth,
+  requireAuthOrApiKeyWithOrg,
+}));
+
+const route = (await import("../v1/eliza/agents/[agentId]/bridge/route"))
+  .default;
+
+const RPC = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "message.send",
+  params: { text: "hi" },
+};
+
+function post() {
+  // Hono's test helper takes (path, init, Env, executionCtx). The route refuses
+  // with a 503 unless BOTH the Durable Object binding and a real waitUntil are
+  // present, so the executionCtx must be the fourth argument, not an env key.
+  return route.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-API-Key": "eliza_test",
+      },
+      body: JSON.stringify(RPC),
+    },
+    { SHARED_RUNTIME_CONVERSATIONS: { getByName: () => ({}) } },
+    {
+      waitUntil: () => {},
+      passThroughOnException: () => {},
+      props: {},
+    } as unknown as ExecutionContext,
+  );
+}
+
+beforeEach(() => {
+  resolveSharedAgent.mockReset();
+  sandboxBridge.mockReset();
+  requireAuthOrApiKeyWithOrg.mockReset();
+  requireAuthOrApiKeyWithOrg.mockResolvedValue({
+    user: { organization_id: "org-1" },
+  });
+});
+
+describe("agent bridge dispatches both tiers", () => {
+  test("a dedicated agent reaches its sandbox bridge instead of 404ing", async () => {
+    // Exactly what resolveSharedAgent returns for a dedicated agent: a 404 that
+    // carries the typed refusal. Before the fix this fell through to the generic
+    // error branch and the caller got the routing discriminator as a verdict.
+    resolveSharedAgent.mockResolvedValue({
+      error: "Not a shared-runtime agent",
+      status: 404,
+      refusal: "dedicated-agent",
+    });
+    sandboxBridge.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { ok: true },
+    });
+
+    const res = await post();
+
+    expect(res.status).toBe(200);
+    expect(sandboxBridge).toHaveBeenCalledTimes(1);
+    // Org must come from the request's own credential: the shared resolver
+    // refused, so it produced no authorized scope to inherit.
+    const [, orgId] = sandboxBridge.mock.calls[0] as unknown[];
+    expect(orgId).toBe("org-1");
+    expect(await res.json()).toMatchObject({ result: { ok: true } });
+  });
+
+  test("a sleeping dedicated agent answers JSON-RPC, never 404", async () => {
+    resolveSharedAgent.mockResolvedValue({
+      error: "Not a shared-runtime agent",
+      status: 404,
+      refusal: "dedicated-agent",
+    });
+    // What eliza-sandbox returns when findRunningSandbox misses.
+    sandboxBridge.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: -32000, message: "Sandbox is not running" },
+    });
+
+    const res = await post();
+
+    // A deactivated agent is a JSON-RPC-level condition the client can render;
+    // a 404 would be indistinguishable from "this agent does not exist".
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      error: { code: -32000, message: "Sandbox is not running" },
+    });
+  });
+
+  test("a genuine 404 without the refusal stays terminal", async () => {
+    resolveSharedAgent.mockResolvedValue({
+      error: "Agent not found",
+      status: 404,
+    });
+
+    const res = await post();
+
+    // The dispatch must key on the typed refusal, not on "any 404" — an agent
+    // that truly does not exist must not be forwarded to the sandbox.
+    expect(res.status).toBe(404);
+    expect(sandboxBridge).not.toHaveBeenCalled();
+  });
+
+  test("a warming 503 is still retryable and never reaches the sandbox", async () => {
+    resolveSharedAgent.mockResolvedValue({
+      error: "Agent authorization cache is warming. Retry shortly.",
+      status: 503,
+    });
+
+    const res = await post();
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("1");
+    expect(await res.json()).toMatchObject({ retryable: true });
+    expect(sandboxBridge).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts
@@ -1,13 +1,18 @@
 /**
  * Dispatches shared-agent JSON-RPC requests to the conversation Durable Object.
  *
- * Worker bindings and cache-authorized agent scope are mandatory; the route
- * never falls through to a repository-backed sandbox bridge.
+ * Serves BOTH tiers. Shared agents go to the conversation Durable Object; a
+ * dedicated agent — which the shared resolver refuses by design — is dispatched
+ * to its own container bridge. Losing that second branch is what 404'd every
+ * dedicated agent between 2026-07-23 and #18062.
  */
+import type { Context } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import type { AgentSandbox } from "@/db/repositories/agent-sandboxes";
 import { errorToResponse, ValidationError } from "@/lib/api/errors";
+import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import type { BridgeRequest } from "@/lib/services/eliza-sandbox-bridge";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { coordinateSharedBridge } from "@/lib/services/shared-runtime/conversation-coordinator";
@@ -99,6 +104,50 @@ async function __hono_POST(
   }
 }
 
+/**
+ * Forward a JSON-RPC request to a dedicated agent's own container bridge.
+ *
+ * Authorization is re-derived here rather than inherited: the shared resolver
+ * refused this agent, so it produced no authorized scope to reuse.
+ * `elizaSandboxService.bridge` is org-scoped, so the organization must come
+ * from the request's own credential.
+ */
+async function dispatchToDedicatedSandbox(
+  c: Context<AppEnv>,
+  executionCtx: BridgeExecutionContext,
+): Promise<Response> {
+  try {
+    const body = await c.req.raw.json().catch(() => {
+      // error-policy:J3 untrusted request body — malformed JSON becomes a typed 400
+      throw new ValidationError("Invalid JSON body");
+    });
+    const parsed = bridgeRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return applyCorsHeaders(
+        Response.json(
+          {
+            success: false,
+            error: "Invalid JSON-RPC request",
+            details: parsed.error.issues,
+          },
+          { status: 400 },
+        ),
+        CORS_METHODS,
+      );
+    }
+    const { user } = await requireAuthOrApiKeyWithOrg(c.req.raw);
+    const response = await elizaSandboxService.bridge(
+      c.req.param("agentId")!,
+      user.organization_id,
+      parsed.data as BridgeRequest,
+      executionCtx,
+    );
+    return applyCorsHeaders(Response.json(response), CORS_METHODS);
+  } catch (error) {
+    return applyCorsHeaders(errorToResponse(error), CORS_METHODS);
+  }
+}
+
 const __hono_app = new Hono<AppEnv>();
 __hono_app.options("/", () => handleCorsOptions(CORS_METHODS));
 __hono_app.post("/", async (c) => {
@@ -122,6 +171,13 @@ __hono_app.post("/", async (c) => {
     executionCtx: worker.executionCtx,
   });
   if ("error" in scope) {
+    // A dedicated agent is not a client error here — this route serves both
+    // tiers, and the shared resolver refusing it is the signal to take the
+    // sandbox path. #17076 collapsed this branch, so the internal discriminator
+    // escaped to callers as a terminal 404 (#18062).
+    if (scope.refusal === "dedicated-agent") {
+      return dispatchToDedicatedSandbox(c, worker.executionCtx);
+    }
     return applyCorsHeaders(
       Response.json(
         {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
@@ -322,8 +322,14 @@ describe("resolveSharedAgent", () => {
         executionCtx: { waitUntil: (promise) => waited.push(promise) },
       }),
     ).resolves.toEqual({
+      // The refusal is TAGGED, not merely worded. The bridge route dispatches a
+      // dedicated agent to its sandbox on this field; when the distinction lived
+      // only in the message, #17076 read it as a client verdict and every
+      // dedicated agent 404'd for two weeks (#18062). toEqual keeps this exact —
+      // a dropped tag fails here rather than silently reaching production.
       error: "Not a shared-runtime agent",
       status: 404,
+      refusal: "dedicated-agent",
     });
   });
 
@@ -439,6 +445,9 @@ describe("resolveSharedAgent", () => {
     await expect(resolveSharedAgent(apiKeyContext("agent-1") as never)).resolves.toEqual({
       error: "Not a shared-runtime agent",
       status: 404,
+      // A running dedicated agent is refused here and dispatched to its own
+      // container by the bridge route; the tag is what carries that decision.
+      refusal: "dedicated-agent",
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -26,8 +26,28 @@ import { isDedicatedBootstrapWindow } from "./dedicated-bootstrap";
 
 export { type CachedAgentSandbox, rehydrateCachedAgentDates } from "./cached-agent-dates";
 
+/**
+ * Why the refusal, for callers that can act on it.
+ *
+ * `dedicated-agent` is not a client error: the agent exists and the caller is
+ * entitled to it, it simply is not served by the shared runtime. Only the
+ * bridge route acts on this — it owns both tiers and dispatches to the sandbox
+ * instead. Every other caller serves shared agents exclusively and correctly
+ * keeps treating the 404 as terminal.
+ *
+ * This exists because the distinction used to live in the message string
+ * "Not a shared-runtime agent". A routing decision encoded as English is one
+ * refactor away from being read as a client verdict, which is what happened in
+ * #17076 and left every dedicated agent 404ing for two weeks (#18062).
+ */
+export type SharedAgentRefusal = "dedicated-agent";
+
 export type ResolvedSharedAgent =
-  | { error: string; status: 400 | 401 | 403 | 404 | 503 }
+  | {
+      error: string;
+      status: 400 | 401 | 403 | 404 | 503;
+      refusal?: SharedAgentRefusal;
+    }
   | { agent: AgentSandbox; agentId: string; orgId: string; agentName: string };
 
 export interface SharedRuntimeExecutionContext {
@@ -142,6 +162,16 @@ function requiresAuthoritativeResolution(
   return (
     "requiresAuthoritativeResolution" in entry && entry.requiresAuthoritativeResolution === true
   );
+}
+
+/**
+ * Recover the typed refusal an ApiError was tagged with, if any. Kept beside
+ * the status guard so both catch sites convert a thrown authorization failure
+ * into a result the same way.
+ */
+function refusalOf(error: ApiError): { refusal?: SharedAgentRefusal } {
+  const tagged = error.details?.refusal;
+  return tagged === "dedicated-agent" ? { refusal: tagged } : {};
 }
 
 function isSharedAgentResolutionStatus(status: number): status is 400 | 401 | 403 | 404 {
@@ -520,7 +550,11 @@ export async function resolveSharedAgent(
       // by shared-runtime routes, so authoritative client failures retain their
       // exact status without becoming a reusable cache value.
       if (error instanceof ApiError && isSharedAgentResolutionStatus(error.status)) {
-        return { error: error.message, status: error.status };
+        return {
+          error: error.message,
+          status: error.status,
+          ...refusalOf(error),
+        };
       }
       logger.warn("[resolveSharedAgent] scope hydration cache failed; using authoritative path", {
         agentId,
@@ -536,7 +570,11 @@ export async function resolveSharedAgent(
     // error-policy:J1 authoritative auth/scope failures retain their exact
     // client status; the neutral marker is not itself an authorization result.
     if (error instanceof ApiError && isSharedAgentResolutionStatus(error.status)) {
-      return { error: error.message, status: error.status };
+      return {
+        error: error.message,
+        status: error.status,
+        ...refusalOf(error),
+      };
     }
     throw error;
   }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -454,7 +454,11 @@ export async function resolveSharedAgent(
       throw new ApiError(404, "resource_not_found", "Agent not found");
     }
     if (agent.execution_tier !== "shared" && !isDedicatedBootstrapWindow(agent)) {
-      throw new ApiError(404, "resource_not_found", "Not a shared-runtime agent");
+      // Tagged, not merely worded: the bridge route dispatches on this rather
+      // than on the message text (see SharedAgentRefusal).
+      throw new ApiError(404, "resource_not_found", "Not a shared-runtime agent", {
+        refusal: "dedicated-agent" satisfies SharedAgentRefusal,
+      });
     }
     const admissionWarm = import("../inference-admission-snapshot").then(
       ({ warmInferenceAdmissionSnapshot }) => warmInferenceAdmissionSnapshot(user.organization_id),


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

Closes #18062

## What broke

`POST /api/v1/eliza/agents/:agentId/bridge` has returned **404 for every dedicated agent, in every state, since 2026-07-23**.

`ac3639ecca6` (#17076) rewrote this route around the shared-runtime path and removed the dedicated dispatch:

```
-            elizaSandboxService.bridge(
```

Before, the route branched: `resolved ? coordinateSharedBridge(...) : elizaSandboxService.bridge(...)`. The 404 `"Not a shared-runtime agent"` from `resolveSharedAgent` was the route's **internal routing discriminator** — the signal to take the dedicated path. The same commit collapsed `if ("error" in scope && scope.status === 503)` into `if ("error" in scope)`, so that discriminator started escaping to callers as a terminal error.

It is total rather than partial: `isDedicatedBootstrapWindow` returns false once `bridge_url` is set or status is anything but `pending`/`provisioning`, so a *running* dedicated agent takes the 404 exactly like a sleeping one.

**Blast radius.** `packages/ui/src/api/ios-local-agent-kernel.ts:2288` POSTs to this exact path with `apiBase` hardcoded to `https://api.elizacloud.ai` and no execution-tier check anywhere in the file — every shipped iOS build paired to a dedicated agent has thrown `Cloud bridge failed: HTTP 404` on every message. Field builds cannot be re-pointed, so moving callers elsewhere does not substitute for restoring the route. The managed-dedicated canary asserts `[200]` after readiness confirms `running`, so it has been red since the same date.

## The fix

**The refusal is now typed, not worded.** The distinction lived in the English string `"Not a shared-runtime agent"`. A routing decision encoded as prose is one refactor away from being read as a client verdict — which is precisely what happened. `resolveSharedAgent` now carries a `SharedAgentRefusal` tag on the result, and the route dispatches on that.

The field is **additive**: the other thirteen `resolveSharedAgent` call sites serve shared agents exclusively and correctly keep treating the 404 as terminal. I enumerated them before touching the shared resolver rather than trusting the signature.

**Authorization is re-derived, not inherited.** The shared resolver refused this agent, so it produced no authorized scope to reuse; `elizaSandboxService.bridge` is org-scoped, so the organization comes from the request's own credential.

## Evidence

<details>
<summary>Mutation runs — each failure lands in the suite that owns it</summary>

```
BASELINE                                            route[ 4 pass 0 fail ]  resolver[ 37 pass 0 fail ]

M1 dedicated branch removed (= the regression)      route[ 2 pass 2 fail ]  resolver[ 37 pass 0 fail ]
M2 dispatch on any 404, not the typed refusal       route[ 3 pass 1 fail ]  resolver[ 37 pass 0 fail ]
M3 org from the route param, not the credential     route[ 3 pass 1 fail ]  resolver[ 37 pass 0 fail ]
M4 resolver stops tagging the refusal               route[ 4 pass 0 fail ]  resolver[ 35 pass 2 fail ]
M5 refusal dropped in the throw→result converter    route[ 4 pass 0 fail ]  resolver[ 36 pass 1 fail ]

BASELINE restored                                   route[ 4 pass 0 fail ]  resolver[ 37 pass 0 fail ]
```

The two suites run in separate processes: `mock.module` leaks across files in one bun process, and the route stubs would corrupt the resolver suite.

M4 and M5 are why the resolver assertions exist at all. The route tests mock `resolveSharedAgent` entirely, so an early mutation that dropped the tag left every route test green — writing the resolver pins closed that seam, and doing so surfaced a real hole in this change: the `throw` itself was initially never tagged, because the edit targeted a multi-line form the formatter had collapsed.

```
cloud/api full suite     1852 pass  0 fail
typecheck (api, shared)  clean
biome                    clean
```

</details>

`M2` deserves a note for reviewers: dispatching on *any* 404 would be the tempting simplification and it is wrong — an agent that genuinely does not exist would then be forwarded to the sandbox instead of answering 404.

## Not in this PR

A dedicated agent that is *sleeping* should answer `{error:{code:-32000,message:"Sandbox is not running"}}`, which is pinned here at the route level. The end-to-end leg through `deactivate-reactivate-ui.spec.ts` belongs with the e2e suite repair and is tracked separately, so this change stays reviewable on its own.

[stan-cloud]

<!-- evidence-head:8eeb9bb51661716def9c39489372af3826398b38 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - a server-side routing branch; the user-visible symptom is an HTTP 404 from a native client, quoted in the description

<!-- evidence-row:after-screenshots -->
- [ ] N/A - a server-side routing branch; no UI surface in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable behaviour is which backend a request is dispatched to; the mutation runs and the route-level assertions carry it

<!-- evidence-row:backend-logs -->
- [x] [18069-runs-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18069-runs-v2.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed; the affected iOS caller is unmodified and is the reason the route must be restored rather than callers migrated

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call on any path this diff touches

<!-- evidence-row:domain-artifacts -->
- [x] [18069-domain.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18069-domain.txt)



