### PR TITLE
fix(ui): drop stale cloud agent binding on agent-gone 404

### DIFF
--- a/packages/cloud/scripts/admin/daemons/agent-router.test.ts
+++ b/packages/cloud/scripts/admin/daemons/agent-router.test.ts
@@ -249,23 +249,31 @@ describe("buildUnresolvedAgentResponse — CORS-bearing failure (#15347)", () =>
     expect(body.code).toBe("agent_unroutable");
   });
 
-  it("no such agent (undefined) → 404 not-found, still CORS-bearing", async () => {
+  it("no such agent (undefined) → 404 agent_not_found, still CORS-bearing", async () => {
     const res = buildUnresolvedAgentResponse(undefined, ORIGIN);
     expect(res.status).toBe(404);
     expect(res.headers.get("access-control-allow-origin")).toBe(ORIGIN);
     expect(res.headers.get("retry-after")).toBeNull();
     const body = (await res.json()) as { error?: string; code?: string };
     expect(body.error).toBe("agent not found or not running");
-    expect(body.code).toBeUndefined();
+    expect(body.code).toBe("agent_not_found");
   });
 
-  it("non-running row (pending/stopped) with empty ip → 404, NOT 503 (only running is 'unroutable')", () => {
+  it("non-running row (pending/stopped) → 503 agent_not_running (recoverable, not deleted)", async () => {
     for (const status of ["pending", "stopped", "disconnected"]) {
       const res = buildUnresolvedAgentResponse(
         { status, headscale_ip: "", web_ui_port: 20001 },
         ORIGIN,
       );
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as {
+        error?: string;
+        code?: string;
+        status?: string;
+      };
+      expect(body.code).toBe("agent_not_running");
+      expect(body.status).toBe(status);
+      expect(res.headers.get("retry-after")).toBe("5");
     }
   });
 

--- a/packages/cloud/scripts/admin/daemons/agent-router.ts
+++ b/packages/cloud/scripts/admin/daemons/agent-router.ts
@@ -354,9 +354,32 @@ export function buildUnresolvedAgentResponse(
       },
     );
   }
+  // Distinguish a missing row (deleted / never existed) from a row that is
+  // merely non-running (pending/stopped/disconnected). Clients may destructively
+  // drop a binding only on the definitive not-found code — not on recoverable
+  // cold/stopped states that share the old 404 body (#18048 / #18070 review).
+  if (!sandbox) {
+    return Response.json(
+      {
+        error: "agent not found or not running",
+        code: "agent_not_found",
+      },
+      { status: 404, headers: corsHeaders(origin) },
+    );
+  }
   return Response.json(
-    { error: "agent not found or not running" },
-    { status: 404, headers: corsHeaders(origin) },
+    {
+      error: "agent not running",
+      code: "agent_not_running",
+      status: sandbox.status,
+    },
+    {
+      status: 503,
+      headers: {
+        ...corsHeaders(origin),
+        "retry-after": String(UNROUTABLE_RETRY_AFTER_SECONDS),
+      },
+    },
   );
 }
 

--- a/packages/ui/src/api/client-base-stale-agent-binding.test.ts
+++ b/packages/ui/src/api/client-base-stale-agent-binding.test.ts
@@ -22,6 +22,8 @@ import type { AgentRequestTransport } from "./transport";
 
 const DEAD_AGENT_BASE =
   "https://85a07f11-a3dc-4394-b1f2-318e22338afd.staging.elizacloud.ai";
+const LIVE_AGENT_BASE =
+  "https://aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.staging.elizacloud.ai";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -60,6 +62,13 @@ describe("ElizaClient stale cloud-agent binding release", () => {
           apiBase: DEAD_AGENT_BASE,
           createdAt: new Date().toISOString(),
         },
+        {
+          id: "profile-other",
+          label: "Other",
+          kind: "cloud",
+          apiBase: LIVE_AGENT_BASE,
+          createdAt: new Date().toISOString(),
+        },
       ],
     });
 
@@ -83,8 +92,94 @@ describe("ElizaClient stale cloud-agent binding release", () => {
     expect(isCloudAgentGoneLike(caught)).toBe(true);
     expect(client.getBaseUrl()).toBe("");
     expect(loadPersistedActiveServer()).toBeNull();
-    expect(loadAgentProfileRegistry().profiles).toEqual([]);
+    const registry = loadAgentProfileRegistry();
+    // Survivor stays catalogued but is NOT auto-activated (no live connection).
+    expect(registry.profiles.map((p) => p.id)).toEqual(["profile-other"]);
+    expect(registry.activeProfileId).toBeNull();
     expect(localStorage.getItem("elizaos_api_base")).toBeNull();
+  });
+
+  it("releases on allowNonOk probes (health poll path)", async () => {
+    savePersistedActiveServer({
+      id: "cloud:dead",
+      kind: "cloud",
+      label: "Dead",
+      apiBase: DEAD_AGENT_BASE,
+    });
+
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValue(
+        jsonResponse(404, { error: "agent not found or not running" }),
+      );
+
+    const client = new ElizaClient(DEAD_AGENT_BASE, "token");
+    client.setRequestTransport({ request });
+
+    const res = await client.rawRequest("/api/status", undefined, {
+      allowNonOk: true,
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({
+      error: "agent not found or not running",
+    });
+    expect(client.getBaseUrl()).toBe("");
+    expect(loadPersistedActiveServer()).toBeNull();
+  });
+
+  it("does not clear a newly selected binding when a stale response arrives late", async () => {
+    savePersistedActiveServer({
+      id: "cloud:live",
+      kind: "cloud",
+      label: "Live",
+      apiBase: LIVE_AGENT_BASE,
+    });
+    saveAgentProfileRegistry({
+      version: 1,
+      activeProfileId: "profile-live",
+      profiles: [
+        {
+          id: "profile-live",
+          label: "Live",
+          kind: "cloud",
+          apiBase: LIVE_AGENT_BASE,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    let resolveDead!: (value: Response) => void;
+    const deadResponse = new Promise<Response>((resolve) => {
+      resolveDead = resolve;
+    });
+    const request = vi.fn<AgentRequestTransport["request"]>(async (url) => {
+      if (String(url).startsWith(DEAD_AGENT_BASE)) {
+        return deadResponse;
+      }
+      return jsonResponse(200, { ok: true });
+    });
+
+    const client = new ElizaClient(DEAD_AGENT_BASE, "token");
+    client.setRequestTransport({ request });
+
+    const pending = client.fetch("/api/lifeops/activity-signals", {
+      method: "POST",
+    });
+    // User switches to a healthy agent while the dead request is in flight.
+    client.setBaseUrl(LIVE_AGENT_BASE);
+    savePersistedActiveServer({
+      id: "cloud:live",
+      kind: "cloud",
+      label: "Live",
+      apiBase: LIVE_AGENT_BASE,
+    });
+
+    resolveDead(jsonResponse(404, { error: "agent not found or not running" }));
+    await expect(pending).rejects.toBeInstanceOf(ApiError);
+
+    expect(client.getBaseUrl()).toBe(LIVE_AGENT_BASE);
+    expect(loadPersistedActiveServer()?.apiBase).toBe(LIVE_AGENT_BASE);
+    expect(loadAgentProfileRegistry().activeProfileId).toBe("profile-live");
   });
 
   it("does not clear a local agent binding on an unrelated 404", async () => {

--- a/packages/ui/src/api/client-base-stale-agent-binding.test.ts
+++ b/packages/ui/src/api/client-base-stale-agent-binding.test.ts
@@ -1,0 +1,142 @@
+/**
+ * ElizaClient choke-point recovery when a bound cloud agent is deleted.
+ * Transport is stubbed; localStorage holds the stale active-server binding
+ * under a jsdom harness.
+ */
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+import {
+  loadAgentProfileRegistry,
+  saveAgentProfileRegistry,
+} from "../state/agent-profiles";
+import {
+  clearPersistedActiveServer,
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "../state/persistence";
+import { ElizaClient } from "./client-base";
+import { ApiError } from "./client-types";
+import type { AgentRequestTransport } from "./transport";
+
+const DEAD_AGENT_BASE =
+  "https://85a07f11-a3dc-4394-b1f2-318e22338afd.staging.elizacloud.ai";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("ElizaClient stale cloud-agent binding release", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+    localStorage.clear();
+    clearPersistedActiveServer();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    clearPersistedActiveServer();
+  });
+
+  it("clears the live base + persisted binding on agent-gone 404", async () => {
+    savePersistedActiveServer({
+      id: "cloud:85a07f11-a3dc-4394-b1f2-318e22338afd",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: DEAD_AGENT_BASE,
+    });
+    saveAgentProfileRegistry({
+      version: 1,
+      activeProfileId: "profile-dead",
+      profiles: [
+        {
+          id: "profile-dead",
+          label: "Eliza Cloud",
+          kind: "cloud",
+          apiBase: DEAD_AGENT_BASE,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValue(
+        jsonResponse(404, { error: "agent not found or not running" }),
+      );
+
+    const client = new ElizaClient(DEAD_AGENT_BASE, "token");
+    client.setRequestTransport({ request });
+
+    let caught: unknown;
+    try {
+      await client.fetch("/api/lifeops/activity-signals", { method: "POST" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ApiError);
+    expect(isCloudAgentGoneLike(caught)).toBe(true);
+    expect(client.getBaseUrl()).toBe("");
+    expect(loadPersistedActiveServer()).toBeNull();
+    expect(loadAgentProfileRegistry().profiles).toEqual([]);
+    expect(localStorage.getItem("elizaos_api_base")).toBeNull();
+  });
+
+  it("does not clear a local agent binding on an unrelated 404", async () => {
+    savePersistedActiveServer({
+      id: "local",
+      kind: "local",
+      label: "Local",
+      apiBase: "http://127.0.0.1:3000",
+    });
+
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValue(jsonResponse(404, { error: "route missing" }));
+
+    const client = new ElizaClient("http://127.0.0.1:3000", "token");
+    client.setRequestTransport({ request });
+
+    await expect(client.fetch("/api/missing")).rejects.toBeInstanceOf(ApiError);
+    expect(client.getBaseUrl()).toBe("http://127.0.0.1:3000");
+    expect(loadPersistedActiveServer()?.apiBase).toBe("http://127.0.0.1:3000");
+  });
+
+  it("releases only once per dead base (idempotent under concurrent posts)", async () => {
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValue(
+        jsonResponse(404, { error: "agent not found or not running" }),
+      );
+
+    const client = new ElizaClient(DEAD_AGENT_BASE, "token");
+    client.setRequestTransport({ request });
+    savePersistedActiveServer({
+      id: "cloud:dead",
+      kind: "cloud",
+      label: "Dead",
+      apiBase: DEAD_AGENT_BASE,
+    });
+
+    await Promise.allSettled([
+      client.fetch("/api/lifeops/activity-signals", { method: "POST" }),
+      client.fetch("/api/lifeops/activity-signals", { method: "POST" }),
+    ]);
+
+    expect(client.getBaseUrl()).toBe("");
+    expect(loadPersistedActiveServer()).toBeNull();
+  });
+});
+
+function isCloudAgentGoneLike(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    error.status === 404 &&
+    error.message.includes("agent not found or not running")
+  );
+}

--- a/packages/ui/src/api/client-base-stale-agent-binding.test.ts
+++ b/packages/ui/src/api/client-base-stale-agent-binding.test.ts
@@ -75,7 +75,7 @@ describe("ElizaClient stale cloud-agent binding release", () => {
     const request = vi
       .fn<AgentRequestTransport["request"]>()
       .mockResolvedValue(
-        jsonResponse(404, { error: "agent not found or not running" }),
+        jsonResponse(404, { error: "agent not found or not running", code: "agent_not_found" }),
       );
 
     const client = new ElizaClient(DEAD_AGENT_BASE, "token");
@@ -110,7 +110,7 @@ describe("ElizaClient stale cloud-agent binding release", () => {
     const request = vi
       .fn<AgentRequestTransport["request"]>()
       .mockResolvedValue(
-        jsonResponse(404, { error: "agent not found or not running" }),
+        jsonResponse(404, { error: "agent not found or not running", code: "agent_not_found" }),
       );
 
     const client = new ElizaClient(DEAD_AGENT_BASE, "token");
@@ -122,9 +122,34 @@ describe("ElizaClient stale cloud-agent binding release", () => {
     expect(res.status).toBe(404);
     expect(await res.json()).toEqual({
       error: "agent not found or not running",
+      code: "agent_not_found",
     });
     expect(client.getBaseUrl()).toBe("");
     expect(loadPersistedActiveServer()).toBeNull();
+  });
+
+  it("does not clear on recoverable agent_not_running (stopped/cold)", async () => {
+    savePersistedActiveServer({
+      id: "cloud:cold",
+      kind: "cloud",
+      label: "Cold",
+      apiBase: DEAD_AGENT_BASE,
+    });
+
+    const request = vi.fn<AgentRequestTransport["request"]>().mockResolvedValue(
+      jsonResponse(503, {
+        error: "agent not running",
+        code: "agent_not_running",
+        status: "stopped",
+      }),
+    );
+
+    const client = new ElizaClient(DEAD_AGENT_BASE, "token");
+    client.setRequestTransport({ request });
+
+    await expect(client.fetch("/api/status")).rejects.toBeInstanceOf(ApiError);
+    expect(client.getBaseUrl()).toBe(DEAD_AGENT_BASE);
+    expect(loadPersistedActiveServer()?.apiBase).toBe(DEAD_AGENT_BASE);
   });
 
   it("does not clear a newly selected binding when a stale response arrives late", async () => {
@@ -174,7 +199,7 @@ describe("ElizaClient stale cloud-agent binding release", () => {
       apiBase: LIVE_AGENT_BASE,
     });
 
-    resolveDead(jsonResponse(404, { error: "agent not found or not running" }));
+    resolveDead(jsonResponse(404, { error: "agent not found or not running", code: "agent_not_found" }));
     await expect(pending).rejects.toBeInstanceOf(ApiError);
 
     expect(client.getBaseUrl()).toBe(LIVE_AGENT_BASE);
@@ -206,7 +231,7 @@ describe("ElizaClient stale cloud-agent binding release", () => {
     const request = vi
       .fn<AgentRequestTransport["request"]>()
       .mockResolvedValue(
-        jsonResponse(404, { error: "agent not found or not running" }),
+        jsonResponse(404, { error: "agent not found or not running", code: "agent_not_found" }),
       );
 
     const client = new ElizaClient(DEAD_AGENT_BASE, "token");

--- a/packages/ui/src/api/client-base-stale-agent-binding.test.ts
+++ b/packages/ui/src/api/client-base-stale-agent-binding.test.ts
@@ -17,7 +17,7 @@ import {
   savePersistedActiveServer,
 } from "../state/persistence";
 import { ElizaClient } from "./client-base";
-import { ApiError } from "./client-types";
+import { ApiError, isCloudAgentGoneError } from "./client-types";
 import type { AgentRequestTransport } from "./transport";
 
 const DEAD_AGENT_BASE =
@@ -72,11 +72,12 @@ describe("ElizaClient stale cloud-agent binding release", () => {
       ],
     });
 
-    const request = vi
-      .fn<AgentRequestTransport["request"]>()
-      .mockResolvedValue(
-        jsonResponse(404, { error: "agent not found or not running", code: "agent_not_found" }),
-      );
+    const request = vi.fn<AgentRequestTransport["request"]>().mockResolvedValue(
+      jsonResponse(404, {
+        error: "agent not found or not running",
+        code: "agent_not_found",
+      }),
+    );
 
     const client = new ElizaClient(DEAD_AGENT_BASE, "token");
     client.setRequestTransport({ request });
@@ -89,7 +90,7 @@ describe("ElizaClient stale cloud-agent binding release", () => {
     }
 
     expect(caught).toBeInstanceOf(ApiError);
-    expect(isCloudAgentGoneLike(caught)).toBe(true);
+    expect(isCloudAgentGoneError(caught)).toBe(true);
     expect(client.getBaseUrl()).toBe("");
     expect(loadPersistedActiveServer()).toBeNull();
     const registry = loadAgentProfileRegistry();
@@ -107,11 +108,12 @@ describe("ElizaClient stale cloud-agent binding release", () => {
       apiBase: DEAD_AGENT_BASE,
     });
 
-    const request = vi
-      .fn<AgentRequestTransport["request"]>()
-      .mockResolvedValue(
-        jsonResponse(404, { error: "agent not found or not running", code: "agent_not_found" }),
-      );
+    const request = vi.fn<AgentRequestTransport["request"]>().mockResolvedValue(
+      jsonResponse(404, {
+        error: "agent not found or not running",
+        code: "agent_not_found",
+      }),
+    );
 
     const client = new ElizaClient(DEAD_AGENT_BASE, "token");
     client.setRequestTransport({ request });
@@ -150,6 +152,53 @@ describe("ElizaClient stale cloud-agent binding release", () => {
     await expect(client.fetch("/api/status")).rejects.toBeInstanceOf(ApiError);
     expect(client.getBaseUrl()).toBe(DEAD_AGENT_BASE);
     expect(loadPersistedActiveServer()?.apiBase).toBe(DEAD_AGENT_BASE);
+  });
+
+  it("does not clear on code-less legacy 404 (ambiguous pre-change router)", async () => {
+    // Pre-change agent-router emitted the same 404 body for missing rows and
+    // for pending/stopped/disconnected rows. A UI-first mixed rollout must
+    // not treat that shape as definitive deletion.
+    savePersistedActiveServer({
+      id: "cloud:legacy",
+      kind: "cloud",
+      label: "Legacy",
+      apiBase: DEAD_AGENT_BASE,
+    });
+    saveAgentProfileRegistry({
+      version: 1,
+      activeProfileId: "profile-legacy",
+      profiles: [
+        {
+          id: "profile-legacy",
+          label: "Legacy",
+          kind: "cloud",
+          apiBase: DEAD_AGENT_BASE,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValue(
+        jsonResponse(404, { error: "agent not found or not running" }),
+      );
+
+    const client = new ElizaClient(DEAD_AGENT_BASE, "token");
+    client.setRequestTransport({ request });
+
+    let caught: unknown;
+    try {
+      await client.fetch("/api/status");
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ApiError);
+    expect(isCloudAgentGoneError(caught)).toBe(false);
+    expect(client.getBaseUrl()).toBe(DEAD_AGENT_BASE);
+    expect(loadPersistedActiveServer()?.apiBase).toBe(DEAD_AGENT_BASE);
+    expect(loadAgentProfileRegistry().activeProfileId).toBe("profile-legacy");
   });
 
   it("does not clear a newly selected binding when a stale response arrives late", async () => {
@@ -199,7 +248,12 @@ describe("ElizaClient stale cloud-agent binding release", () => {
       apiBase: LIVE_AGENT_BASE,
     });
 
-    resolveDead(jsonResponse(404, { error: "agent not found or not running", code: "agent_not_found" }));
+    resolveDead(
+      jsonResponse(404, {
+        error: "agent not found or not running",
+        code: "agent_not_found",
+      }),
+    );
     await expect(pending).rejects.toBeInstanceOf(ApiError);
 
     expect(client.getBaseUrl()).toBe(LIVE_AGENT_BASE);
@@ -228,11 +282,12 @@ describe("ElizaClient stale cloud-agent binding release", () => {
   });
 
   it("releases only once per dead base (idempotent under concurrent posts)", async () => {
-    const request = vi
-      .fn<AgentRequestTransport["request"]>()
-      .mockResolvedValue(
-        jsonResponse(404, { error: "agent not found or not running", code: "agent_not_found" }),
-      );
+    const request = vi.fn<AgentRequestTransport["request"]>().mockResolvedValue(
+      jsonResponse(404, {
+        error: "agent not found or not running",
+        code: "agent_not_found",
+      }),
+    );
 
     const client = new ElizaClient(DEAD_AGENT_BASE, "token");
     client.setRequestTransport({ request });
@@ -252,11 +307,3 @@ describe("ElizaClient stale cloud-agent binding release", () => {
     expect(loadPersistedActiveServer()).toBeNull();
   });
 });
-
-function isCloudAgentGoneLike(error: unknown): boolean {
-  return (
-    error instanceof ApiError &&
-    error.status === 404 &&
-    error.message.includes("agent not found or not running")
-  );
-}

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -18,6 +18,11 @@ import {
 import { hydrateAndroidLocalAgentTokenForUrl } from "../first-run/local-agent-token";
 import { isMobileLocalAgentIpcUrl } from "../first-run/mobile-runtime-mode";
 import { isAndroidLocalSideloadBuild } from "../platform/android-runtime";
+import {
+  loadAgentProfileRegistry,
+  removeAgentProfile,
+} from "../state/agent-profiles";
+import { clearPersistedActiveServer } from "../state/persistence";
 import { isTrustedRestoreApiBaseUrl } from "../state/runtime-url-trust";
 import { shellLocalStorage } from "../surface-realm-channel";
 import {
@@ -45,7 +50,7 @@ import type {
   WebSocketConnectionState,
   WsEventHandler,
 } from "./client-types";
-import { ApiError } from "./client-types";
+import { ApiError, isCloudAgentGoneError } from "./client-types";
 import { desktopHttpTransportForUrl } from "./desktop-http-transport";
 import { desktopLocalAgentTransportForUrl } from "./desktop-local-agent-transport";
 import {
@@ -704,6 +709,8 @@ export class ElizaClient {
   private _baseUrl: string;
   private _userSetBase: boolean;
   private _token: string | null;
+  /** Last cloud agent base released after an agent-gone 404 (idempotency). */
+  private _releasedGoneAgentBase: string | null = null;
   private readonly clientId: string;
   private requestTransport: AgentRequestTransport = fetchAgentTransport;
   private ws: WebSocket | null = null;
@@ -1098,7 +1105,7 @@ export class ElizaClient {
           ? rawBodyRetryAfter
           : undefined;
       const retryAfter = bodyRetryAfter ?? headerRetryAfter;
-      throw new ApiError({
+      const error = new ApiError({
         kind: "http",
         path,
         status: res.status,
@@ -1106,8 +1113,55 @@ export class ElizaClient {
         code,
         retryAfter,
       });
+      // Structural agent-gone from a bound cloud agent host: drop the dead
+      // binding at the request choke point so background callers (lifeops
+      // activity-signals, status probes, …) stop hammering a deleted agent
+      // forever. Join-flow recovery alone only covered the selection path
+      // (#17837); login-page background posts were still bound (#18048).
+      this.releaseStaleCloudAgentBindingIfGone(error);
+      throw error;
     }
     return res;
+  }
+
+  /**
+   * When a cloud agent host answers the unambiguous "agent not found or not
+   * running" 404, clear the live base + persisted active-server / matching
+   * agent profile so subsequent requests stop targeting the corpse. No-ops for
+   * local agents, control-plane hosts, and non-agent-gone errors. Idempotent
+   * per base URL for the life of this client instance.
+   */
+  private releaseStaleCloudAgentBindingIfGone(error: ApiError): void {
+    if (!isCloudAgentGoneError(error)) return;
+    const base = this.baseUrl;
+    if (!base) return;
+    if (
+      !isDedicatedCloudAgentBase(base) &&
+      !isSharedRuntimeRestAdapterBase(base)
+    ) {
+      return;
+    }
+    if (this._releasedGoneAgentBase === base) return;
+    this._releasedGoneAgentBase = base;
+
+    try {
+      clearPersistedActiveServer();
+      const normalizedBase = normalizeBaseUrl(base).replace(/\/+$/, "");
+      const registry = loadAgentProfileRegistry();
+      for (const profile of [...registry.profiles]) {
+        const profileBase = normalizeBaseUrl(profile.apiBase ?? "").replace(
+          /\/+$/,
+          "",
+        );
+        if (profileBase && profileBase === normalizedBase) {
+          removeAgentProfile(profile.id);
+        }
+      }
+      this.setBaseUrl(null);
+    } catch {
+      // error-policy:J6 best-effort binding teardown must not mask the original
+      // agent-gone error the caller still needs to handle.
+    }
   }
 
   private rawRequestUrl(path: string): string {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -5,6 +5,7 @@
  * without circular dependency issues.
  */
 
+import { logger } from "@elizaos/logger";
 import {
   extractAssistantReplyText,
   SHELL_NAVIGATE_VIEW_WS_EVENT,
@@ -20,9 +21,12 @@ import { isMobileLocalAgentIpcUrl } from "../first-run/mobile-runtime-mode";
 import { isAndroidLocalSideloadBuild } from "../platform/android-runtime";
 import {
   loadAgentProfileRegistry,
-  removeAgentProfile,
+  saveAgentProfileRegistry,
 } from "../state/agent-profiles";
-import { clearPersistedActiveServer } from "../state/persistence";
+import {
+  clearPersistedActiveServer,
+  loadPersistedActiveServer,
+} from "../state/persistence";
 import { isTrustedRestoreApiBaseUrl } from "../state/runtime-url-trust";
 import { shellLocalStorage } from "../surface-realm-channel";
 import {
@@ -1022,6 +1026,9 @@ export class ElizaClient {
         message: "API not available (no HTTP origin)",
       });
     }
+    // Capture the base this request was issued against so a concurrent
+    // setBaseUrl cannot attribute another host's 404 to the new binding.
+    const requestBase = this.baseUrl;
     const requestUrl = this.rawRequestUrl(path);
     const token =
       this.apiToken ?? (await hydrateAndroidLocalAgentTokenForUrl(requestUrl));
@@ -1075,20 +1082,32 @@ export class ElizaClient {
         retryAfter: resumeRetryDelayMs(res) / 1000,
       });
     }
-    if (!res.ok && !options?.allowNonOk) {
-      const body = (await this.readBodyText(res, path, options?.timeoutMs, init)
-        .then((text) => JSON.parse(text) as Record<string, unknown>)
-        .catch(() => ({ error: res.statusText }))) as Record<
-        string,
-        unknown
-      > | null;
+    if (!res.ok) {
+      const rawText = await this.readBodyText(
+        res,
+        path,
+        options?.timeoutMs,
+        init,
+      ).catch(() => "");
+      let body: Record<string, unknown> | null = null;
+      if (rawText) {
+        try {
+          body = JSON.parse(rawText) as Record<string, unknown>;
+        } catch {
+          // error-policy:J3 untrusted error body stays an explicit null parse.
+          body = null;
+        }
+      }
+      if (!body) {
+        body = { error: res.statusText || `HTTP ${res.status}` };
+      }
       const message =
-        typeof body?.error === "string"
+        typeof body.error === "string"
           ? body.error
-          : typeof body?.message === "string"
+          : typeof body.message === "string"
             ? body.message
             : `HTTP ${res.status}`;
-      const code = typeof body?.code === "string" ? body.code : undefined;
+      const code = typeof body.code === "string" ? body.code : undefined;
       // `Number(null) === 0` and `Number(undefined) === NaN`, so we must guard
       // each source before coercing — otherwise an absent `Retry-After` header
       // produces a spurious `retryAfter = 0` on every non-rate-limit error
@@ -1098,7 +1117,7 @@ export class ElizaClient {
         headerValue !== null && Number.isFinite(Number(headerValue))
           ? Number(headerValue)
           : undefined;
-      const rawBodyRetryAfter = body?.retryAfter;
+      const rawBodyRetryAfter = body.retryAfter;
       const bodyRetryAfter =
         typeof rawBodyRetryAfter === "number" &&
         Number.isFinite(rawBodyRetryAfter)
@@ -1115,11 +1134,21 @@ export class ElizaClient {
       });
       // Structural agent-gone from a bound cloud agent host: drop the dead
       // binding at the request choke point so background callers (lifeops
-      // activity-signals, status probes, …) stop hammering a deleted agent
-      // forever. Join-flow recovery alone only covered the selection path
-      // (#17837); login-page background posts were still bound (#18048).
-      this.releaseStaleCloudAgentBindingIfGone(error);
-      throw error;
+      // activity-signals, status probes with allowNonOk, …) stop hammering a
+      // deleted agent forever. Join-flow recovery alone only covered the
+      // selection path (#17837); login-page background posts were still bound
+      // (#18048). Uses the request-time base so a concurrent setBaseUrl cannot
+      // attribute this 404 to a newly selected agent.
+      this.releaseStaleCloudAgentBindingIfGone(error, requestBase);
+      if (!options?.allowNonOk) {
+        throw error;
+      }
+      // allowNonOk callers still need a Response whose body is unread.
+      return new Response(rawText, {
+        status: res.status,
+        statusText: res.statusText,
+        headers: res.headers,
+      });
     }
     return res;
   }
@@ -1127,13 +1156,17 @@ export class ElizaClient {
   /**
    * When a cloud agent host answers the unambiguous "agent not found or not
    * running" 404, clear the live base + persisted active-server / matching
-   * agent profile so subsequent requests stop targeting the corpse. No-ops for
-   * local agents, control-plane hosts, and non-agent-gone errors. Idempotent
-   * per base URL for the life of this client instance.
+   * agent profiles so subsequent requests stop targeting the corpse. No-ops for
+   * local agents, control-plane hosts, non-agent-gone errors, and requests
+   * whose base no longer matches the live client (concurrent switch). Marks a
+   * base released only after teardown succeeds so a partial failure can retry.
    */
-  private releaseStaleCloudAgentBindingIfGone(error: ApiError): void {
+  private releaseStaleCloudAgentBindingIfGone(
+    error: ApiError,
+    requestBase: string,
+  ): void {
     if (!isCloudAgentGoneError(error)) return;
-    const base = this.baseUrl;
+    const base = normalizeBaseUrl(requestBase);
     if (!base) return;
     if (
       !isDedicatedCloudAgentBase(base) &&
@@ -1142,25 +1175,56 @@ export class ElizaClient {
       return;
     }
     if (this._releasedGoneAgentBase === base) return;
-    this._releasedGoneAgentBase = base;
+
+    // A concurrent switch may have already moved the live client off this
+    // corpse — never tear down the new binding because of a stale response.
+    const liveBase = normalizeBaseUrl(this.baseUrl);
+    if (liveBase && liveBase !== base) return;
 
     try {
-      clearPersistedActiveServer();
-      const normalizedBase = normalizeBaseUrl(base).replace(/\/+$/, "");
-      const registry = loadAgentProfileRegistry();
-      for (const profile of [...registry.profiles]) {
-        const profileBase = normalizeBaseUrl(profile.apiBase ?? "").replace(
-          /\/+$/,
-          "",
-        );
-        if (profileBase && profileBase === normalizedBase) {
-          removeAgentProfile(profile.id);
-        }
+      const persisted = loadPersistedActiveServer();
+      const persistedBase = normalizeBaseUrl(persisted?.apiBase);
+      if (!persisted || persistedBase === base) {
+        clearPersistedActiveServer();
       }
-      this.setBaseUrl(null);
-    } catch {
+
+      // One registry write: drop matching profiles and leave activeProfileId
+      // null rather than auto-activating an unconnected survivor (removeAgentProfile
+      // would promote profiles[0]).
+      const registry = loadAgentProfileRegistry();
+      const remaining = registry.profiles.filter((profile) => {
+        const profileBase = normalizeBaseUrl(profile.apiBase);
+        return !profileBase || profileBase !== base;
+      });
+      if (remaining.length !== registry.profiles.length) {
+        const activeStillPresent = remaining.some(
+          (profile) => profile.id === registry.activeProfileId,
+        );
+        saveAgentProfileRegistry({
+          version: 1,
+          activeProfileId: activeStillPresent ? registry.activeProfileId : null,
+          profiles: remaining,
+        });
+      }
+
+      if (!liveBase || liveBase === base) {
+        this.setBaseUrl(null);
+      }
+      this._releasedGoneAgentBase = base;
+    } catch (teardownError) {
       // error-policy:J6 best-effort binding teardown must not mask the original
-      // agent-gone error the caller still needs to handle.
+      // agent-gone error; leave _releasedGoneAgentBase unset so a later 404 can
+      // retry incomplete cleanup.
+      logger.warn(
+        {
+          requestBase: base,
+          error:
+            teardownError instanceof Error
+              ? teardownError.message
+              : String(teardownError),
+        },
+        "[ElizaClient] failed to release stale cloud agent binding after agent-gone 404",
+      );
     }
   }
 

--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -334,11 +334,12 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
   it("keeps the structural agent-gone shape on the cause chain of a failed lookup", async () => {
     const { client, getCloudCompatAgents } = fakeClient();
     // What a stale binding produces: the deleted agent's origin answers the
-    // compat agent list with the cloud router's 404 shape.
+    // compat agent list with the structured agent_not_found 404.
     getCloudCompatAgents.mockRejectedValue(
       Object.assign(new Error("agent not found or not running"), {
         kind: "http",
         status: 404,
+        code: "agent_not_found",
         path: "/api/cloud/compat/agents",
       }),
     );
@@ -356,6 +357,17 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(
       isCloudAgentGoneError(
         Object.assign(new Error("unauthorized"), { status: 401 }),
+      ),
+    ).toBe(false);
+    // Pre-change router used this code-less body for both deleted and
+    // stopped/cold rows — must not classify as gone (mixed-version safety).
+    expect(
+      isCloudAgentGoneError(
+        Object.assign(new Error("agent not found or not running"), {
+          kind: "http",
+          status: 404,
+          path: "/api/cloud/compat/agents",
+        }),
       ),
     ).toBe(false);
   });

--- a/packages/ui/src/api/client-types-core.ts
+++ b/packages/ui/src/api/client-types-core.ts
@@ -527,12 +527,13 @@ export function isRateLimitedError(value: unknown): value is ApiError {
 
 /**
  * Definitive "this agent row is gone" shape used for destructive binding
- * cleanup. Prefer the structured `agent_not_found` code (agent-router emits it
- * only when no sandbox row exists). Do **not** treat recoverable cold/stopped
- * states (`agent_not_running` / 503) as gone — those must keep the binding and
- * resume. Legacy code-less 404 bodies with the historical message are still
- * accepted for older routers. Walks the `cause` chain so wrapped selection
- * errors classify.
+ * cleanup and join stale-binding recovery. Requires the structured
+ * `agent_not_found` code that agent-router emits only when no sandbox row
+ * exists. Do **not** treat recoverable cold/stopped states
+ * (`agent_not_running` / 503) or code-less legacy 404 bodies as gone — the
+ * pre-change router emitted the same message for missing and non-running
+ * rows, so a mixed UI/router rollout would otherwise erase legitimate
+ * bindings. Walks the `cause` chain so wrapped selection errors classify.
  */
 export function isCloudAgentGoneError(error: unknown): boolean {
   let current: unknown = error;
@@ -545,13 +546,9 @@ export function isCloudAgentGoneError(error: unknown): boolean {
       current = (current as Error & { cause?: unknown }).cause;
       continue;
     }
-    if (code === "agent_not_found" && (status === 404 || status === undefined)) {
-      return true;
-    }
     if (
-      status === 404 &&
-      (code === undefined || code === null || code === "") &&
-      current.message.includes("agent not found or not running")
+      code === "agent_not_found" &&
+      (status === 404 || status === undefined)
     ) {
       return true;
     }

--- a/packages/ui/src/api/client-types-core.ts
+++ b/packages/ui/src/api/client-types-core.ts
@@ -526,13 +526,13 @@ export function isRateLimitedError(value: unknown): value is ApiError {
 }
 
 /**
- * The Cloud's structural "agent gone" shape: an HTTP 404 carrying the
- * `agent_not_found` code (code-carrying cloud routes) or the agent router's
- * code-less body `{ error: "agent not found or not running" }` — what every
- * request through a bound agent origin gets once that agent has been deleted.
- * Distinct from transport failure (network down produces no HTTP status), so
- * callers can treat a stale binding as invalid without masking real outages.
- * Walks the `cause` chain so wrapped selection/provisioning errors classify.
+ * Definitive "this agent row is gone" shape used for destructive binding
+ * cleanup. Prefer the structured `agent_not_found` code (agent-router emits it
+ * only when no sandbox row exists). Do **not** treat recoverable cold/stopped
+ * states (`agent_not_running` / 503) as gone — those must keep the binding and
+ * resume. Legacy code-less 404 bodies with the historical message are still
+ * accepted for older routers. Walks the `cause` chain so wrapped selection
+ * errors classify.
  */
 export function isCloudAgentGoneError(error: unknown): boolean {
   let current: unknown = error;
@@ -541,10 +541,17 @@ export function isCloudAgentGoneError(error: unknown): boolean {
       status?: unknown;
       code?: unknown;
     };
+    if (code === "agent_not_running") {
+      current = (current as Error & { cause?: unknown }).cause;
+      continue;
+    }
+    if (code === "agent_not_found" && (status === 404 || status === undefined)) {
+      return true;
+    }
     if (
       status === 404 &&
-      (code === "agent_not_found" ||
-        current.message.includes("agent not found or not running"))
+      (code === undefined || code === null || code === "") &&
+      current.message.includes("agent not found or not running")
     ) {
       return true;
     }

--- a/packages/ui/src/cloud/join/lib/run-join-flow.test.ts
+++ b/packages/ui/src/cloud/join/lib/run-join-flow.test.ts
@@ -61,12 +61,13 @@ function makeEffects(): {
 
 /** The wrapped list-lookup failure `selectOrProvisionCloudAgent` throws when
  * the bound (deleted) agent's origin answers the agent list with the cloud
- * router's structural agent-gone shape. */
+ * router's structural agent-gone shape (`agent_not_found` code). */
 function agentGoneError(): Error {
   return new Error("agent not found or not running", {
     cause: Object.assign(new Error("agent not found or not running"), {
       kind: "http",
       status: 404,
+      code: "agent_not_found",
       path: "/api/cloud/compat/agents",
     }),
   });

--- a/packages/ui/src/cloud/join/lib/run-join-flow.ts
+++ b/packages/ui/src/cloud/join/lib/run-join-flow.ts
@@ -157,15 +157,16 @@ export async function runJoinFlow(
     });
   } catch (error) {
     // error-policy:J4 only the structural agent-gone shape (404 +
-    // agent_not_found code / the router's known body) from a remembered
-    // binding is recovered here. A stale persisted binding keeps the live
-    // client pointed at a DELETED agent's origin, so the selection lookup
-    // misroutes through that dead origin and 404s forever — retrying can
-    // never succeed. Drop the binding, reset the client to the fresh-visit
-    // state (empty base → control-plane resolution), and re-run selection:
-    // existing agents are picked normally, zero agents fall through to the
-    // provisioning path. Transport failures of a valid binding (and every
-    // other shape) still rethrow into the terminal error state.
+    // `agent_not_found` code) from a remembered binding is recovered here.
+    // Code-less legacy 404 bodies are intentionally excluded: older routers
+    // used the same message for stopped/cold rows. A stale persisted binding
+    // keeps the live client pointed at a DELETED agent's origin, so the
+    // selection lookup misroutes through that dead origin and 404s forever —
+    // retrying can never succeed. Drop the binding, reset the client to the
+    // fresh-visit state (empty base → control-plane resolution), and re-run
+    // selection: existing agents are picked normally, zero agents fall
+    // through to the provisioning path. Transport failures of a valid binding
+    // (and every other shape) still rethrow into the terminal error state.
     if (!preferAgentId || !isCloudAgentGoneError(error)) throw error;
     effects.clearPersistedActiveServer();
     client.setBaseUrl(null);


### PR DESCRIPTION
## Summary

Fixes #18048.

A deleted cloud agent left `elizaos_api_base` / `elizaos:active-server` / matching `elizaos:agent-profiles` intact. Background callers (notably `POST /api/lifeops/activity-signals` on the login page) kept hammering the dead host forever.

#17837 already recovered the **join selection** path via `isCloudAgentGoneError` + `clearPersistedActiveServer`. This PR puts the same structural signal at the **request choke point** so every client caller benefits, and makes the agent-router emit an unambiguous deleted vs recoverable-non-running distinction.

### Behavior
On `ElizaClient.rawRequest` HTTP error / allowNonOk non-OK:
1. Classify with shared `isCloudAgentGoneError` — **only** structured `code === "agent_not_found"` (404). Code-less legacy 404 bodies and `agent_not_running` (503) do **not** destroy bindings.
2. Only if the request-time base is a **dedicated** or **shared-runtime agent** host (not local, not control-plane)
3. Compare-and-clear only when live + persisted binding still point at that same request base; drop matching agent profiles by `apiBase` without auto-activating survivors; `setBaseUrl(null)` (also clears `elizaos_api_base`)
4. Idempotent per base for the client instance; mark released only after teardown succeeds
5. Teardown failures are best-effort and never mask the original error

Agent-router (`buildUnresolvedAgentResponse`):
- Missing sandbox row → `404` + `code: "agent_not_found"`
- Existing non-running row (pending/stopped/disconnected) → `503` + `code: "agent_not_running"` + `retry-after`

Does **not** clear `steward_session_token` (control-plane session ≠ agent binding).

## Tests
- [x] `bun run --cwd packages/ui test src/api/client-base-stale-agent-binding.test.ts` (7, includes race + legacy-404 negative)
- [x] `bun run --cwd packages/ui test src/api/client-cloud-select-or-provision.test.ts` + `src/cloud/join/lib/run-join-flow.test.ts` (40 total with the above)
- [x] `bun test packages/cloud/scripts/admin/daemons/agent-router.test.ts` (19)
- [x] Biome check clean on changed UI files

## Evidence matrix
- [x] Frontend/network: unit + classifier coverage; code-less legacy 404 rejected for destructive cleanup; race switch-while-in-flight covered
- [ ] MP4/JPG: N/A — DOM/API contract covered by automated tests; no visual surface change
- [ ] Real-LLM trajectory: N/A — no model path
- [ ] Domain artifacts: N/A — no account/DB mutation in this PR

## Contribution provenance
- AI assistance: yes
- AI provider/model: Anthropic / Claude (pi agent) + OpenAI Codex review + PR babysitter
- Client / agent tooling: pi + codex review + grok pr-babysitter
- Contribution skill revision: N/A - contribute-to-eliza skill was not available in this environment
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude","client":"pi+pr-babysitter","skill_revision":"N/A - contribute-to-eliza skill was not available"} -->

<!-- evidence-head:625d99cbcdc21e1d0c8115f4c576e771709225ff -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no visual surface change; stale cloud agent binding cleanup is API/client-base contract only (covered by unit tests)

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no visual surface change; binding clear is opaque client-side state, not a rendered page

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible interaction path; destructive cleanup is gated on agent_not_found API code

<!-- evidence-row:backend-logs -->
- [ ] N/A - daemon/router unit coverage in agent-router.test.ts asserts gone-agent 404 path; no live server log required for pure client+router contract

<!-- evidence-row:frontend-logs -->
- [ ] N/A - client-base-stale-agent-binding.test.ts and client-cloud-select-or-provision.test.ts cover clear-on-404; no browser console path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/runtime agent path in this PR

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no account/DB mutation beyond clearing a stale local agent binding reference

