### PR TITLE
fix(scenarios): port deterministic-browser-actions to the #17999 Opened-destination reply contract

### DIFF
--- a/packages/scenario-runner/test/scenarios/deterministic-browser-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-browser-actions.scenario.ts
@@ -65,7 +65,7 @@ const strictBrowserRoutes = [
     args: { url: "about:blank" },
     contextIds: ["browser", "web"],
     input: "Open another browser tab",
-    messageToUser: "open completed in web mode.\nNew Tab\nabout:blank",
+    messageToUser: "Opened about:blank.",
   },
   {
     actionName: "BROWSER_LIST_TABS",
@@ -451,7 +451,7 @@ export default scenario({
           url: "https://scenario.test/form",
         },
       },
-      responseIncludesAll: ["navigate completed", "https://scenario.test/form"],
+      responseIncludesAll: ["Opened scenario.test/form."],
       assertTurn: expectRestoreFormTurn,
     },
     {
@@ -559,12 +559,12 @@ export default scenario({
       kind: "message",
       name: "open an additional browser tab",
       text: "Open another browser tab",
-      responseIncludesAny: ["open completed in web mode"],
+      responseIncludesAny: ["Opened about:blank."],
       assertTurn: (execution) =>
         expectActionTurn(execution, {
           actionName: "BROWSER_OPEN",
           parameters: { url: "about:blank" },
-          responseText: "open completed in web mode.\nNew Tab\nabout:blank",
+          responseText: "Opened about:blank.",
           resultFields: {
             "values.mode": "web",
             "values.subaction": "open",

--- a/plugins/plugin-browser/src/actions/browser.ts
+++ b/plugins/plugin-browser/src/actions/browser.ts
@@ -1005,7 +1005,7 @@ export const browserAction: Action = {
       {
         name: "{{agentName}}",
         content: {
-          text: "open completed in desktop mode.\nelizaOS\nhttps://elizaos.ai",
+          text: "Opened elizaos.ai.",
         },
       },
     ],


### PR DESCRIPTION
# Relates to

Fixes the "Zero-Key scenario runner" red streak tracked as group 4 ("Zero-Key scenario runner E2E") in #18014.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run after sync; scoped gates recorded below (diff is two
      expectation strings plus one prompt-example string; no runtime behavior
      change).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# What actually broke (triage correction for #18014)

Every completed `develop` Tests run since 2026-08-08T05:48Z fails the
"Zero-Key scenario runner" job in the `Zero-cost scenario e2e` step with the
same single scenario failure:

```
| deterministic-browser-actions | failed | responseIncludesAll: expected response to
  include all of [navigate completed,https://scenario.test/form] ... |
Totals: 37 passed, 1 failed, 0 skipped of 38
```

Verified stable across three runs: 31248488119 and 31250634054 (tip `55eb734eda5`) and 31263574537 (tip `ac43b67db01`, which already contains #18064). The uploaded `tests-zero-key-e2e-report` artifacts pin the exact deltas:

```
responseIncludesAll: expected response to include all of
  [navigate completed,https://scenario.test/form],
  missing [navigate completed,https://scenario.test/form],
  saw "Opened scenario.test/form."

assertTurn: expected BROWSER_OPEN result.text="open completed in web mode.\nNew Tab\nabout:blank",
  saw responseText="Opened about:blank.\n\nopen completed in web mode.\nNew Tab\nabout:blank",
  result.text="Opened about:blank."
```

**Root cause:** #17999 (`69ecac0eacc`, merged 2026-08-08T05:48Z) deliberately
changed `formatBrowserSessionResult` in
`plugins/plugin-browser/src/actions/browser.ts` so `open`/`navigate` return
`Opened <destination>.` (scheme stripped via `formatBrowserDestination`) and
marked the text `verifiedUserFacing`. The
`deterministic-browser-actions` scenario still asserted the pre-#17999
phrasing. The last green "Zero-Key scenario runner" job on develop is run
31225309259 (`676f1f571`, pre-#17999); every completed run after the merge is
red with this signature. This PR ports the scenario (and the one stale
few-shot example left in the action prompt) to the landed product contract —
the #17999 phrasing is the intentional behavior, so the spec moves, not the
product.

**Note for the #18014 signature that named `AGENT_SKILLS_PLUGIN_LIFECYCLE`:**
that service-start error is real but non-fatal noise, present in green runs'
logs too: the scenario simulated profile registers
`@elizaos/plugin-agent-skills` without its declared dependency
`@elizaos/plugin-commands` (`packages/scenario-runner/src/runtime-factory.ts`),
so `AgentSkillsPluginLifecycleService.start` cannot bind the `commands`
service. `deterministic-agent-skills-actions` itself passes (25s) in every
triaged run; the log merely *appears* to end mid-scenario because `gh run view
--log` truncates — the raw job log (`actions/jobs/<id>/logs`) contains the full
run and the real failure table.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# How to test

```bash
cd packages/scenario-runner
SCENARIO_USE_DETERMINISTIC_MODEL=1 bun --conditions eliza-source \
  --tsconfig-override ../../tsconfig.json src/cli.ts run test/scenarios \
  --scenario deterministic-browser-actions --lane pr-deterministic \
  --report-dir /tmp/sc-report --run-dir /tmp/sc-run
```

On `origin/develop` this fails with exactly the CI signature; with this PR it
passes, and the full CI lane (`bun run test:deterministic:e2e`) is green.

# Evidence Gate

<!-- evidence-head:a8132505d87bd6657a3fe595d252e7a1352d408c -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - headless scenario-runner lane; no UI surface. Red transcript attached below.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - headless scenario-runner lane; no UI surface. Green transcript attached below.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - non-UI CI-lane fix; complete before/after runner transcripts attached instead.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: attached below (local red-then-green scenario-runner transcripts plus CI artifact excerpts).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - the pr-deterministic lane is the zero-key deterministic-model lane by design (SCENARIO_USE_DETERMINISTIC_MODEL=1); no prompt/model behavior changed, only spec expectations ported to the landed #17999 reply contract, plus one few-shot example string aligned to what the action actually returns.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: scenario-runner `matrix.json` verdicts attached below (CI artifacts of failing runs + local red and green runs).
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## CI red (two independent develop runs, artifact `tests-zero-key-e2e-report`)

Run 31248488119 (`55eb734eda5`) and run 31263574537 (`ac43b67db01`) both contain, in `pr-deterministic/matrix.json`:

```json
[
  {
    "detail": "responseIncludesAll: expected response to include all of [navigate completed,https://scenario.test/form], missing [navigate completed,https://scenario.test/form], saw \"Opened scenario.test/form.\"",
    "label": "restore seeded browser form after callback"
  },
  {
    "detail": "assertTurn: expected BROWSER_OPEN result.text=\"open completed in web mode.\\nNew Tab\\nabout:blank\", saw responseText=\"Opened about:blank.\\n\\nopen completed in web mode.\\nNew Tab\\nabout:blank\", result.text=\"Opened about:blank.\"",
    "label": "open an additional browser tab"
  }
]
```

## Local red (unmodified origin/develop `fdecf676fb2`, real harness)

```
Scenario run 2767b658-2472-4e27-a4aa-6f6fab7300e4 | provider=deterministic-model-provider | profile=simulated
| deterministic-browser-actions | failed | 30663ms | responseIncludesAll: expected response to include all of [navigate completed,https: |
Totals: 0 passed, 1 failed, 0 skipped of 1
```

`matrix.json` failedAssertions identical to CI (same two `saw` strings).

## Local green (this PR)

Single scenario:

```
Scenario run 18aa4167-a0af-48a3-b836-fd93f0d5dc3a | provider=deterministic-model-provider | profile=simulated
| deterministic-browser-actions | passed | 29213ms |  |
Totals: 1 passed, 0 failed, 0 skipped of 1
```

Full CI lane (`bun run test:deterministic:e2e`, all 38 in-lane scenarios):

```
Totals: 38 passed, 0 failed, 0 skipped of 38
(providers=deterministic-model-provider, profile=simulated; run in
/home/shaw/wt worktree at develop fdecf676fb2 + this commit)
```

## Package gates

- `bun run --cwd plugins/plugin-browser test` — 26 files, 152 tests passed.
- `bun run --cwd plugins/plugin-browser typecheck` — clean.
- `bun run --cwd plugins/plugin-browser lint` (biome) — clean.
- `bun run --cwd packages/scenario-runner typecheck` — clean.
- scenario-runner has no package lint task; `biome check` on the touched
  scenario reports only a pre-existing import-order assist finding that is
  byte-identical on `origin/develop` (verified by stashing the diff).

# Risks

Low. The diff changes two spec expectation strings in a runner-owned
deterministic scenario and one few-shot example string in the BROWSER action
prompt (aligning it with the reply text the action actually produces since
#17999). No runtime logic changes.

# Known gaps / failures

- The `Zero-Key Deterministic E2E` derived job and the other red groups in
  #18014 (app-browser specs, orchestrator lanes) are separate signatures and
  remain owned by that issue; this PR greens the "Zero-Key scenario runner"
  job's `Zero-cost scenario e2e` step.
- The non-fatal `AGENT_SKILLS_PLUGIN_LIFECYCLE` startup error described above
  predates this failure, does not fail any scenario today, and is worth a
  follow-up (register `@elizaos/plugin-commands` in the simulated profile or
  degrade the lifecycle service cleanly), tracked via #18014 discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
