### PR TITLE
fix: never emit lone utf-16 surrogates in provider request bodies

### DIFF
--- a/packages/agent/src/providers/relevant-conversations.ts
+++ b/packages/agent/src/providers/relevant-conversations.ts
@@ -31,6 +31,7 @@ import {
   revalidateOwnerExclusiveDisclosure,
   searchCanonicalConversationMemories,
   stringToUuid,
+  truncateWellFormed,
 } from "@elizaos/core";
 import { getValidationKeywordTerms } from "@elizaos/shared";
 import {
@@ -289,7 +290,7 @@ export const relevantConversationsProvider: Provider = {
           source === HASH_MEMORY_SOURCE
             ? HASH_MEMORY_SNIPPET_LENGTH
             : RELEVANT_SNIPPET_LENGTH;
-        const msgText = memoryText(mem).slice(0, snippetLength);
+        const msgText = truncateWellFormed(memoryText(mem), snippetLength);
         lines.push(`${tag} (${ts}) ${speaker}: ${msgText}`);
       }
 

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -33,6 +33,7 @@ import {
 import * as utils from "./utils";
 import { stableStringify } from "./utils/deterministic";
 import { isObjectRecord as isRecord } from "./utils/type-guards";
+import { truncateWellFormed } from "./utils/well-formed";
 
 type EntityDetailsRecord = Pick<
 	Entity,
@@ -658,7 +659,7 @@ function truncateEntityMetadata(metadata: unknown): string {
 	if (rendered.length <= MAX_ENTITY_METADATA_CHARS) {
 		return rendered;
 	}
-	return `${rendered.slice(0, MAX_ENTITY_METADATA_CHARS)}... (truncated)`;
+	return `${truncateWellFormed(rendered, MAX_ENTITY_METADATA_CHARS)}... (truncated)`;
 }
 
 export function formatEntities({ entities }: { entities: Entity[] }) {

--- a/packages/core/src/features/autonomy/providers.ts
+++ b/packages/core/src/features/autonomy/providers.ts
@@ -12,6 +12,7 @@ import type {
 	State,
 } from "../../types";
 import { stringToUuid } from "../../utils";
+import { truncateWellFormed } from "../../utils/well-formed";
 import { AUTONOMY_SERVICE_TYPE, type AutonomyService } from "./service";
 
 const MAX_ADMIN_HISTORY_MESSAGES = 10;
@@ -109,7 +110,7 @@ export const adminChatProvider: Provider = {
 					const rawText = msg.content.text || "[No text content]";
 					const text =
 						rawText.length > MAX_ADMIN_MESSAGE_LENGTH
-							? `${rawText.slice(0, MAX_ADMIN_MESSAGE_LENGTH)}...`
+							? `${truncateWellFormed(rawText, MAX_ADMIN_MESSAGE_LENGTH)}...`
 							: rawText;
 					const timestamp = new Date(msg.createdAt || 0).toLocaleTimeString();
 
@@ -130,7 +131,7 @@ export const adminChatProvider: Provider = {
 			const lastAdminMessageText = lastAdminMessage?.content.text || "";
 			const adminMoodContext =
 				recentAdminMessages.length > 0
-					? `Last admin message: "${lastAdminMessageText.slice(0, MAX_ADMIN_MESSAGE_LENGTH) || "N/A"}"`
+					? `Last admin message: "${truncateWellFormed(lastAdminMessageText, MAX_ADMIN_MESSAGE_LENGTH) || "N/A"}"`
 					: "No recent admin messages";
 			const now = Date.now();
 

--- a/packages/core/src/features/autonomy/service.ts
+++ b/packages/core/src/features/autonomy/service.ts
@@ -29,6 +29,7 @@ import {
 } from "../../types";
 import { Service } from "../../types/service";
 import { stringToUuid } from "../../utils";
+import { truncateWellFormed } from "../../utils/well-formed";
 import { runAutonomyPostResponse } from "./execution-facade";
 import type { AutonomyStatus } from "./types";
 
@@ -359,7 +360,7 @@ export class AutonomyService extends Service {
 			}
 			seen.add(normalized);
 			const marker = new Date(memory.createdAt ?? Date.now()).toISOString();
-			importantLines.push(`- ${marker}: ${text.slice(0, 500)}`);
+			importantLines.push(`- ${marker}: ${truncateWellFormed(text, 500)}`);
 		}
 
 		const header = `Compacted ${memories.length} prior autonomous thoughts. Preserve standing goals, unresolved blockers, commitments, and recently discovered facts:`;

--- a/packages/core/src/features/basic-capabilities/evaluators/link-extraction.ts
+++ b/packages/core/src/features/basic-capabilities/evaluators/link-extraction.ts
@@ -22,6 +22,7 @@ import type {
 	Memory,
 } from "../../../types/index.ts";
 import { asUUID, MemoryType, ModelType } from "../../../types/index.ts";
+import { truncateWellFormed } from "../../../utils/well-formed.ts";
 
 const EVALUATOR_NAME = "linkExtraction";
 const EVALUATOR_SOURCE = "link_extraction_evaluator";
@@ -112,16 +113,16 @@ function hasUrl(message: Memory): boolean {
 function extractTitle(html: string): string {
 	const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
 	if (titleMatch?.[1]) {
-		return decodeHtmlEntities(titleMatch[1])
-			.replace(/\s+/g, " ")
-			.trim()
-			.slice(0, 200);
+		return truncateWellFormed(
+			decodeHtmlEntities(titleMatch[1]).replace(/\s+/g, " ").trim(),
+			200,
+		);
 	}
 	const ogMatch = html.match(
 		/<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']+)["']/i,
 	);
 	if (ogMatch?.[1]) {
-		return decodeHtmlEntities(ogMatch[1]).trim().slice(0, 200);
+		return truncateWellFormed(decodeHtmlEntities(ogMatch[1]).trim(), 200);
 	}
 	return "";
 }
@@ -196,9 +197,12 @@ async function fetchLinkPreview(
 		if (!/text\/html|application\/xhtml/i.test(contentType)) {
 			return null;
 		}
-		const html = (await response.text()).slice(0, 200_000);
+		const html = truncateWellFormed(await response.text(), 200_000);
 		const title = extractTitle(html);
-		const bodyChunk = stripTags(html).slice(0, SUMMARY_MAX_INPUT_CHARS);
+		const bodyChunk = truncateWellFormed(
+			stripTags(html),
+			SUMMARY_MAX_INPUT_CHARS,
+		);
 		return { title, bodyChunk };
 	} catch {
 		// error-policy:J4 link previews are optional enrichments; blocked,
@@ -228,7 +232,7 @@ ${bodyChunk}
 Summary:`;
 	const response = await runtime.useModel(ModelType.TEXT_SMALL, { prompt });
 	if (typeof response === "string") {
-		return response.trim().slice(0, 1_000);
+		return truncateWellFormed(response.trim(), 1_000);
 	}
 	return "";
 }

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -40,6 +40,7 @@ import type {
 	UUID,
 } from "../../../types/index.ts";
 import { ChannelType } from "../../../types/index.ts";
+import { truncateWellFormed } from "../../../utils/well-formed.ts";
 import {
 	addHeader,
 	conversationMessagesHeader,
@@ -515,7 +516,7 @@ export const recentMessagesProvider: Provider = {
 				? addHeader(
 						"# Conversation Compact Ledger",
 						compactLedger.length > MAX_COMPACT_LEDGER_CHARS
-							? `${compactLedger.slice(0, MAX_COMPACT_LEDGER_CHARS)}...`
+							? `${truncateWellFormed(compactLedger, MAX_COMPACT_LEDGER_CHARS)}...`
 							: compactLedger,
 					)
 				: "";

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -239,6 +239,7 @@ export * from "./utils/read-env";
 export * from "./utils/resolve-setting";
 export * from "./utils/streaming";
 export { ResponseSkeletonStreamExtractor } from "./utils/streaming";
+export * from "./utils/well-formed";
 // Validation helpers (validateActionKeywords / validateActionRegex /
 // secret-format validators) are pure functions with no Node-only deps,
 // so they're safe in the browser bundle. Several plugin browser dists

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -106,6 +106,7 @@ export * from "./utils/prompt-compression";
 export * from "./utils/read-env";
 export * from "./utils/resolve-setting";
 export * from "./utils/streaming";
+export * from "./utils/well-formed";
 export * from "./validation";
 
 export const isBrowser = false;

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -490,6 +490,7 @@ export * from "./utils/state-dir";
 // Export streaming utilities
 export * from "./utils/streaming";
 export { ResponseSkeletonStreamExtractor } from "./utils/streaming";
+export * from "./utils/well-formed";
 // User-chosen workspace folder persisted in <stateDir>/workspace-folder.json,
 // shared between the Electrobun renderer (writes via desktop RPC) and the
 // agent runtime (reads at boot to seed ELIZA_WORKSPACE_DIR for store builds).

--- a/packages/core/src/runtime/__tests__/planner-rendering.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-rendering.test.ts
@@ -137,6 +137,20 @@ describe("truncateToolResultText (pure)", () => {
 		expect(out.length).toBeLessThanOrEqual(80);
 		expect(out).toMatch(/chars truncated/);
 	});
+
+	it("never splits a surrogate pair at the head or tail cut (#18025)", () => {
+		// All-astral content: any odd cut index lands mid-emoji, which used to
+		// leave a lone surrogate that strict provider JSON parsers reject
+		// ("lone leading surrogate in hex escape", wrong_api_format).
+		const emoji = "💀🔥🤖🎉😀".repeat(2_000);
+		for (const maxChars of [101, 202, 333, 1_000, 2_048]) {
+			const out = truncateToolResultText(emoji, maxChars);
+			expect(
+				(out as unknown as { isWellFormed(): boolean }).isWellFormed(),
+			).toBe(true);
+			expect(JSON.stringify(out)).not.toMatch(/\\u[dD][89a-fA-F]/);
+		}
+	});
 });
 
 describe("trajectoryStepsToMessages — maxToolResultChars option", () => {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -46,6 +46,7 @@ import {
 } from "../utils/model-errors";
 import { resolveStateDir } from "../utils/state-dir";
 import { isPlainObject } from "../utils/type-guards";
+import { tailWellFormed, truncateWellFormed } from "../utils/well-formed";
 import { computePrefixHashes, stableJsonStringify } from "./context-hash";
 import { appendContextEvent } from "./context-object";
 import {
@@ -2277,7 +2278,7 @@ function compactText(value: string, maxLength: number): string {
 	}
 	const headLength = Math.max(20, Math.floor(maxLength * 0.65));
 	const tailLength = Math.max(20, maxLength - headLength - 24);
-	return `${text.slice(0, headLength)} ...[${text.length - headLength - tailLength} chars compacted]... ${text.slice(-tailLength)}`;
+	return `${truncateWellFormed(text, headLength)} ...[${text.length - headLength - tailLength} chars compacted]... ${tailWellFormed(text, tailLength)}`;
 }
 
 /**
@@ -4569,7 +4570,7 @@ function scrubFailureCauseForPrompt(text: string): string | undefined {
 		.trim();
 	if (!cleaned) return undefined;
 	return cleaned.length > PROMPT_FAILURE_CAUSE_MAX_CHARS
-		? `${cleaned.slice(0, PROMPT_FAILURE_CAUSE_MAX_CHARS)}…`
+		? `${truncateWellFormed(cleaned, PROMPT_FAILURE_CAUSE_MAX_CHARS)}…`
 		: cleaned;
 }
 

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -6,6 +6,7 @@
  */
 import type { ChatMessage, ChatMessageContentPart } from "../types/model";
 import type { JsonValue } from "../types/primitives.ts";
+import { tailWellFormed, truncateWellFormed } from "../utils/well-formed";
 import { stringifyForModel } from "./json-output";
 import type { PlannerStep, PlannerToolResult } from "./planner-types";
 import {
@@ -78,17 +79,19 @@ export function truncateToolResultText(
 		const preservedChars = headChars + tailChars;
 		const truncatedCount = text.length - preservedChars;
 		if (truncatedCount <= 0) {
-			return text.slice(0, limit);
+			return truncateWellFormed(text, limit);
 		}
 		const marker = markerFor(truncatedCount);
 		if (preservedChars + marker.length <= limit) {
-			const head = text.slice(0, headChars);
-			const tail = text.slice(text.length - tailChars);
+			// Surrogate-safe cuts: a plain slice landing mid-emoji leaves a lone
+			// surrogate that strict provider JSON parsers reject (#18025).
+			const head = truncateWellFormed(text, headChars);
+			const tail = tailWellFormed(text, tailChars);
 			return `${head}${marker}${tail}`;
 		}
 	}
 
-	return text.slice(0, limit);
+	return truncateWellFormed(text, limit);
 }
 
 /**

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -317,6 +317,7 @@ import {
 	hasFirstSentence,
 } from "../utils/text-splitting";
 import { isObjectRecord as isRecord } from "../utils/type-guards";
+import { truncateWellFormed } from "../utils/well-formed";
 import { maybeHandleAnalysisActivation } from "./analysis-mode-handler";
 import { ChannelTopicsService } from "./channel-topics";
 import { runPostTurnEvaluators } from "./evaluator";
@@ -6308,7 +6309,7 @@ const SUB_STEP_SUMMARY_MAX_CHARS = 400;
 function truncateSubStepText(text: string): string {
 	const trimmed = text.trim();
 	if (trimmed.length <= SUB_STEP_SUMMARY_MAX_CHARS) return trimmed;
-	return `${trimmed.slice(0, SUB_STEP_SUMMARY_MAX_CHARS)}...`;
+	return `${truncateWellFormed(trimmed, SUB_STEP_SUMMARY_MAX_CHARS)}...`;
 }
 
 function collectSubPlannerSubSteps(

--- a/packages/core/src/services/message/bot-noise-triage.ts
+++ b/packages/core/src/services/message/bot-noise-triage.ts
@@ -29,6 +29,7 @@ import {
 	ModelType,
 } from "../../types/model";
 import type { IAgentRuntime } from "../../types/runtime";
+import { truncateWellFormed } from "../../utils/well-formed";
 import { stripReasoningBlocks } from "./fallback-reply";
 import { getV5ModelText } from "./generate-text-result";
 import { isUnaddressedTextGroupTurn } from "./stage1-prompt-tier";
@@ -115,7 +116,7 @@ function senderNameOf(message: Memory): string {
 function clip(text: string, maxChars: number): string {
 	const collapsed = text.replace(/\s+/g, " ").trim();
 	return collapsed.length > maxChars
-		? `${collapsed.slice(0, maxChars)}…`
+		? `${truncateWellFormed(collapsed, maxChars)}…`
 		: collapsed;
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -38,6 +38,7 @@ import {
 import { extractAndParseJSONObjectFromText } from "./utils/json-llm";
 import { RecursiveCharacterTextSplitter } from "./utils/recursive-character-text-splitter";
 import { formatTimestamp as formatTimestampBase } from "./utils/time-format";
+import { truncateWellFormed } from "./utils/well-formed";
 
 // Token / embedding budget constants
 export const DEFAULT_MAX_CONVERSATION_TOKENS = 50_000;
@@ -982,8 +983,8 @@ export function truncateToCompleteSentence(
 		}
 	}
 
-	// Fallback: Hard truncate and add ellipsis
-	const hardTruncated = text.slice(0, maxLength - 3).trim();
+	// Fallback: Hard truncate (surrogate-safe) and add ellipsis
+	const hardTruncated = truncateWellFormed(text, maxLength - 3).trim();
 	return `${hardTruncated}...`;
 }
 

--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Deterministic unit coverage for the well-formed Unicode helpers: truncation
+ * must never split a surrogate pair (the #18025 failure mode — a mid-emoji
+ * slice produced a lone leading surrogate that Cerebras's strict JSON parser
+ * rejected with `wrong_api_format`), and the sanitizers must turn any lone
+ * surrogate into U+FFFD so a serialized request body never carries a bare
+ * \uD8xx escape.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	deepToWellFormedUnicode,
+	tailWellFormed,
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "./well-formed";
+
+/** JSON.stringify escapes ONLY lone surrogates as \ud8xx..\udfff; well-formed
+ * astral characters are emitted raw. A strict parser (serde_json, Cerebras)
+ * rejects those escapes, so their absence is the wire-safety invariant. */
+const LONE_SURROGATE_ESCAPE = /\\u[dD][89a-fA-F][0-9a-fA-F]{2}/;
+
+function isWellFormed(text: string): boolean {
+	return (text as unknown as { isWellFormed: () => boolean }).isWellFormed();
+}
+
+describe("truncateWellFormed", () => {
+	it("backs the boundary off by one when the cut lands mid-emoji", () => {
+		const text = "abc💀def"; // 💀 = 💀 at index 3..4
+		const cut = truncateWellFormed(text, 4);
+		expect(cut).toBe("abc");
+		expect(isWellFormed(cut)).toBe(true);
+	});
+
+	it("keeps a complete emoji that fits exactly", () => {
+		expect(truncateWellFormed("abc💀def", 5)).toBe("abc💀");
+	});
+
+	it("produces well-formed output at every possible boundary", () => {
+		const text = "hi 👩‍👩‍👧‍👦 mixed 🇺🇸 text 💀🔥 end";
+		for (let n = 0; n <= text.length + 1; n++) {
+			const cut = truncateWellFormed(text, n);
+			expect(isWellFormed(cut)).toBe(true);
+			expect(cut.length).toBeLessThanOrEqual(Math.max(0, n));
+			expect(text.startsWith(cut)).toBe(true);
+		}
+	});
+
+	it("returns short input unchanged (same reference)", () => {
+		const text = "short 💀";
+		expect(truncateWellFormed(text, 100)).toBe(text);
+	});
+
+	it("returns empty string for non-positive budgets", () => {
+		expect(truncateWellFormed("abc", 0)).toBe("");
+		expect(truncateWellFormed("abc", -1)).toBe("");
+	});
+
+	it("preserves a pre-existing lone surrogate (sanitizing is not its job)", () => {
+		const malformed = `x\uD83D`;
+		expect(truncateWellFormed(`${malformed}yz`, 2)).toBe(malformed);
+	});
+});
+
+describe("tailWellFormed", () => {
+	it("advances past a split pair so the tail never starts on a low surrogate", () => {
+		const text = "abc💀def"; // low half \uDC80 at index 4
+		const tail = tailWellFormed(text, 4);
+		expect(tail).toBe("def");
+		expect(isWellFormed(tail)).toBe(true);
+	});
+
+	it("produces well-formed output at every possible boundary", () => {
+		const text = "hi 👩‍👩‍👧‍👦 mixed 🇺🇸 text 💀🔥 end";
+		for (let n = 0; n <= text.length + 1; n++) {
+			const tail = tailWellFormed(text, n);
+			expect(isWellFormed(tail)).toBe(true);
+			expect(text.endsWith(tail)).toBe(true);
+		}
+	});
+
+	it("returns short input unchanged and empty for non-positive budgets", () => {
+		expect(tailWellFormed("💀", 5)).toBe("💀");
+		expect(tailWellFormed("abc", 0)).toBe("");
+	});
+});
+
+describe("toWellFormedUnicode", () => {
+	it("replaces lone leading (high) surrogates with U+FFFD", () => {
+		expect(toWellFormedUnicode("bad \uD83D end")).toBe("bad � end");
+	});
+
+	it("replaces lone trailing (low) surrogates with U+FFFD", () => {
+		expect(toWellFormedUnicode("bad \uDC80 end")).toBe("bad � end");
+	});
+
+	it("preserves valid pairs, including adjacent emoji and ZWJ sequences", () => {
+		const text = "ok 💀🔥 👩‍👩‍👧‍👦 🇺🇸";
+		expect(toWellFormedUnicode(text)).toBe(text);
+	});
+
+	it("handles a trailing lone high surrogate (the mid-emoji slice shape)", () => {
+		expect(toWellFormedUnicode("truncated 💀".slice(0, 11))).toBe(
+			"truncated �",
+		);
+	});
+});
+
+describe("deepToWellFormedUnicode", () => {
+	it("sanitizes strings nested in arrays and plain objects", () => {
+		const input = {
+			messages: [
+				{ role: "tool", content: [{ type: "text", text: `oops \uD83D` }] },
+			],
+		};
+		const output = deepToWellFormedUnicode(input);
+		expect(output.messages[0].content[0].text).toBe("oops �");
+	});
+
+	it("returns the same reference when nothing needs sanitizing", () => {
+		const input = { a: ["clean 💀", { b: "fine" }] };
+		expect(deepToWellFormedUnicode(input)).toBe(input);
+	});
+
+	it("passes non-plain objects through untouched", () => {
+		const bytes = new Uint8Array([1, 2, 3]);
+		const input = { data: bytes, url: new URL("https://example.com/") };
+		const output = deepToWellFormedUnicode(input);
+		expect(output.data).toBe(bytes);
+		expect(output.url).toBe(input.url);
+	});
+
+	it("preserves null, numbers, and booleans", () => {
+		const input = { a: null, b: 42, c: true, d: undefined };
+		expect(deepToWellFormedUnicode(input)).toBe(input);
+	});
+});
+
+describe("#18025 wire regression: the captured Cerebras failure shape", () => {
+	// The live 400 body was {"message":": Invalid JSON: lone leading surrogate
+	// in hex escape...","code":"wrong_api_format"} — produced when a mid-emoji
+	// slice left a lone \uD8xx code unit that JSON.stringify emitted as a bare
+	// surrogate escape.
+	it("a mid-emoji slice serializes to a body a strict parser rejects; the sanitized body is clean", () => {
+		const toolResult = `web page title 🤖 with emoji`.slice(0, 16); // splits 🤖
+		const rawBody = JSON.stringify({
+			messages: [{ role: "tool", content: toolResult }],
+		});
+		expect(LONE_SURROGATE_ESCAPE.test(rawBody)).toBe(true); // the bug
+
+		const sanitizedBody = JSON.stringify(
+			deepToWellFormedUnicode({
+				messages: [{ role: "tool", content: toolResult }],
+			}),
+		);
+		expect(LONE_SURROGATE_ESCAPE.test(sanitizedBody)).toBe(false);
+		expect(isWellFormed(sanitizedBody)).toBe(true);
+		// Round-trips through a strict UTF-8 encode/decode (TextEncoder would
+		// have replaced lone surrogates; a clean body is byte-stable).
+		const bytes = new TextEncoder().encode(sanitizedBody);
+		const decoded = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+		expect(decoded).toBe(sanitizedBody);
+		expect(JSON.parse(decoded)).toEqual({
+			messages: [{ role: "tool", content: "web page title �" }],
+		});
+	});
+
+	it("truncateWellFormed prevents the escape from ever forming", () => {
+		const safe = truncateWellFormed("web page title 🤖 with emoji", 16);
+		const body = JSON.stringify({
+			messages: [{ role: "tool", content: safe }],
+		});
+		expect(LONE_SURROGATE_ESCAPE.test(body)).toBe(false);
+	});
+});

--- a/packages/core/src/utils/well-formed.ts
+++ b/packages/core/src/utils/well-formed.ts
@@ -1,0 +1,152 @@
+/**
+ * Well-formed Unicode guarantees for text that is truncated at an arbitrary
+ * UTF-16 index or serialized into a provider request body. A `.slice()` that
+ * lands mid-emoji leaves a lone surrogate; `JSON.stringify` emits it as a
+ * `\uD8xx` escape that strict JSON parsers (Cerebras/serde: "lone leading
+ * surrogate in hex escape", code `wrong_api_format`) reject with HTTP 400.
+ * Truncation helpers here never create a lone surrogate, and the sanitizers
+ * replace any pre-existing lone surrogate with U+FFFD so a wire request is
+ * always well-formed regardless of upstream text handling.
+ */
+
+const HIGH_SURROGATE_START = 0xd800;
+const HIGH_SURROGATE_END = 0xdbff;
+const LOW_SURROGATE_START = 0xdc00;
+const LOW_SURROGATE_END = 0xdfff;
+const REPLACEMENT_CHARACTER = "�";
+
+function isHighSurrogate(code: number): boolean {
+	return code >= HIGH_SURROGATE_START && code <= HIGH_SURROGATE_END;
+}
+
+function isLowSurrogate(code: number): boolean {
+	return code >= LOW_SURROGATE_START && code <= LOW_SURROGATE_END;
+}
+
+// ES2024 natives; typed locally because some package tsconfigs pin lib < ES2024.
+const nativeToWellFormed = (
+	String.prototype as { toWellFormed?: (this: string) => string }
+).toWellFormed;
+const nativeIsWellFormed = (
+	String.prototype as { isWellFormed?: (this: string) => boolean }
+).isWellFormed;
+
+function replaceLoneSurrogates(text: string): string {
+	let out = "";
+	for (let i = 0; i < text.length; i++) {
+		const code = text.charCodeAt(i);
+		if (isHighSurrogate(code)) {
+			if (i + 1 < text.length && isLowSurrogate(text.charCodeAt(i + 1))) {
+				out += text[i] + text[i + 1];
+				i++;
+			} else {
+				out += REPLACEMENT_CHARACTER;
+			}
+		} else if (isLowSurrogate(code)) {
+			out += REPLACEMENT_CHARACTER;
+		} else {
+			out += text[i];
+		}
+	}
+	return out;
+}
+
+/**
+ * Returns `text` with every lone surrogate replaced by U+FFFD. Well-formed
+ * input is returned as the same string instance (the native fast path scans
+ * without allocating).
+ */
+export function toWellFormedUnicode(text: string): string {
+	if (nativeToWellFormed) {
+		return nativeToWellFormed.call(text);
+	}
+	if (nativeIsWellFormed?.call(text)) {
+		return text;
+	}
+	return replaceLoneSurrogates(text);
+}
+
+/**
+ * `text.slice(0, maxLength)` that never splits a surrogate pair: when the cut
+ * would end on a high surrogate (the lead half of an emoji), the boundary
+ * backs off by one code unit. Pre-existing lone surrogates are preserved —
+ * sanitizing malformed input is {@link toWellFormedUnicode}'s job.
+ */
+export function truncateWellFormed(text: string, maxLength: number): string {
+	if (maxLength <= 0) {
+		return "";
+	}
+	if (text.length <= maxLength) {
+		return text;
+	}
+	const end =
+		isHighSurrogate(text.charCodeAt(maxLength - 1)) &&
+		isLowSurrogate(text.charCodeAt(maxLength))
+			? maxLength - 1
+			: maxLength;
+	return text.slice(0, end);
+}
+
+/**
+ * Keeps the LAST `maxLength` code units of `text` without starting on the low
+ * half of a split surrogate pair (the tail-side dual of
+ * {@link truncateWellFormed}).
+ */
+export function tailWellFormed(text: string, maxLength: number): string {
+	if (maxLength <= 0) {
+		return "";
+	}
+	if (text.length <= maxLength) {
+		return text;
+	}
+	let start = text.length - maxLength;
+	if (
+		isLowSurrogate(text.charCodeAt(start)) &&
+		isHighSurrogate(text.charCodeAt(start - 1))
+	) {
+		start++;
+	}
+	return text.slice(start);
+}
+
+/**
+ * Recursively applies {@link toWellFormedUnicode} to every string in a
+ * JSON-shaped value (strings, arrays, plain objects). Non-plain objects
+ * (typed arrays, URLs, class instances such as AI SDK model handles) pass
+ * through untouched, and untouched subtrees keep their original references so
+ * a clean input returns the same instance. Intended for provider request
+ * bodies right before serialization.
+ */
+export function deepToWellFormedUnicode<T>(value: T): T {
+	if (typeof value === "string") {
+		return toWellFormedUnicode(value) as unknown as T;
+	}
+	if (Array.isArray(value)) {
+		let changed = false;
+		const next = value.map((item) => {
+			const sanitized = deepToWellFormedUnicode(item);
+			if (sanitized !== item) {
+				changed = true;
+			}
+			return sanitized;
+		});
+		return (changed ? next : value) as T;
+	}
+	if (value !== null && typeof value === "object") {
+		const proto = Object.getPrototypeOf(value);
+		if (proto !== Object.prototype && proto !== null) {
+			return value;
+		}
+		let changed = false;
+		const next: Record<string, unknown> = {};
+		for (const [key, entry] of Object.entries(value)) {
+			const sanitized = deepToWellFormedUnicode(entry);
+			if (sanitized !== entry) {
+				changed = true;
+			}
+			next[key] = sanitized;
+		}
+		return (changed ? next : value) as T;
+	}
+	return value;
+}

--- a/plugins/plugin-anthropic/__tests__/wire-well-formed.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/wire-well-formed.shape.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Wire-boundary regression for #18025 on the Anthropic path: request bodies
+ * built by the text handler must serialize to well-formed strict JSON even
+ * when upstream text carries lone UTF-16 surrogates (a mid-emoji `.slice()`
+ * leaves a lone leading surrogate that `JSON.stringify` emits as a bare
+ * `\uD8xx` escape strict provider parsers reject). Real `@ai-sdk/anthropic`
+ * client against a loopback Messages API server capturing raw request bytes.
+ */
+import { createServer, type Server } from "node:http";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleTextSmall } from "../models";
+
+/** JSON.stringify only escapes surrogate code units when they are lone; a
+ * well-formed body therefore contains no \ud800-\udfff escape at all. */
+const LONE_SURROGATE_ESCAPE = /\\u[dD][89a-fA-F][0-9a-fA-F]{2}/;
+
+const captured: Buffer[] = [];
+let server: Server;
+let baseUrl: string;
+
+function startCaptureServer(): Promise<string> {
+  server = createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      captured.push(Buffer.concat(chunks));
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          id: "msg-test",
+          type: "message",
+          role: "assistant",
+          model: "claude-test",
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        })
+      );
+    });
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("capture server did not bind a TCP port"));
+        return;
+      }
+      resolve(`http://127.0.0.1:${address.port}/v1`);
+    });
+  });
+}
+
+function buildRuntime(): IAgentRuntime {
+  const settings: Record<string, string> = {
+    ANTHROPIC_API_KEY: "test-key",
+    ANTHROPIC_AUTH_MODE: "apikey",
+    ANTHROPIC_BASE_URL: baseUrl,
+    ANTHROPIC_SMALL_MODEL: "claude-test",
+  };
+  return {
+    getSetting: vi.fn((key: string) => settings[key]),
+    character: { name: "Ada" },
+    emitEvent: vi.fn(),
+    getService: vi.fn(() => null),
+    getServicesByType: vi.fn(() => []),
+  } as unknown as IAgentRuntime;
+}
+
+beforeAll(async () => {
+  baseUrl = await startCaptureServer();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+beforeEach(() => {
+  captured.length = 0;
+  vi.stubEnv("ANTHROPIC_AUTH_MODE", "apikey");
+  vi.stubEnv("ELIZA_TRAJECTORY_STRICT", undefined);
+});
+
+describe("#18025: Anthropic request bodies are well-formed strict JSON", () => {
+  it("sanitizes a prompt truncated mid-emoji (lone leading surrogate)", async () => {
+    const brokenPrompt = "summarize this page 🤖 please".slice(0, 21); // splits 🤖
+    expect(LONE_SURROGATE_ESCAPE.test(JSON.stringify(brokenPrompt))).toBe(true);
+
+    const result = await handleTextSmall(buildRuntime(), { prompt: brokenPrompt } as never);
+    expect(result).toBe("ok");
+
+    expect(captured).toHaveLength(1);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
+    expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+    expect(LONE_SURROGATE_ESCAPE.test(body)).toBe(false);
+    const parsed = JSON.parse(body) as {
+      messages: Array<{ role: string; content: unknown }>;
+    };
+    expect(JSON.stringify(parsed.messages)).toContain("summarize this page �");
+  });
+});

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -25,6 +25,7 @@ import type {
 } from "@elizaos/core";
 import {
   buildCanonicalSystemPrompt,
+  deepToWellFormedUnicode,
   dropDuplicateLeadingSystemMessage,
   logger,
   ModelType,
@@ -1321,8 +1322,12 @@ async function generateTextWithModel(
       : basePromptOrMessages;
   const generateParams: NativeTextParams = {
     model: anthropic(modelName),
-    ...promptOrMessages,
-    system,
+    // Wire-boundary guarantee: lone UTF-16 surrogates (e.g. from a mid-emoji
+    // slice upstream) serialize as \uD8xx escapes that strict provider JSON
+    // parsers reject (#18025); force every outgoing string to well-formed
+    // Unicode at request build. Deterministic, so cache-prefix stability holds.
+    ...deepToWellFormedUnicode(promptOrMessages),
+    system: system === undefined ? undefined : deepToWellFormedUnicode(system),
     temperature: resolved.temperature,
     stopSequences: resolved.stopSequences as string[],
     frequencyPenalty: resolved.frequencyPenalty,

--- a/plugins/plugin-openai/__tests__/wire-well-formed.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/wire-well-formed.shape.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Wire-boundary regression for #18025: requests built by the text handlers
+ * must serialize to well-formed strict JSON even when upstream text carries
+ * lone UTF-16 surrogates (a mid-emoji `.slice()` leaves a lone leading
+ * surrogate that `JSON.stringify` emits as a bare `\uD8xx` escape — Cerebras
+ * rejects that body with `{"message":": Invalid JSON: lone leading surrogate
+ * in hex escape...","code":"wrong_api_format"}`). Real `ai` SDK and real
+ * client factory against a loopback chat-completions server that captures the
+ * raw request bytes; the assertions replay a strict parser's view of the body.
+ */
+import { createServer, type Server } from "node:http";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleTextSmall } from "../models";
+
+/** JSON.stringify only escapes surrogate code units when they are lone; a
+ * well-formed body therefore contains no \ud800-\udfff escape at all. */
+const LONE_SURROGATE_ESCAPE = /\\u[dD][89a-fA-F][0-9a-fA-F]{2}/;
+
+interface CapturedRequest {
+  url: string;
+  bytes: Buffer;
+}
+
+const captured: CapturedRequest[] = [];
+let server: Server;
+let baseUrl: string;
+
+function startCaptureServer(): Promise<string> {
+  server = createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      captured.push({ url: request.url ?? "", bytes: Buffer.concat(chunks) });
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          id: "chatcmpl-test",
+          object: "chat.completion",
+          created: 0,
+          model: "test-model",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "ok" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        })
+      );
+    });
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("capture server did not bind a TCP port"));
+        return;
+      }
+      resolve(`http://127.0.0.1:${address.port}/v1`);
+    });
+  });
+}
+
+function buildRuntime(): IAgentRuntime {
+  return {
+    // Fall through to the stubbed env for every setting.
+    getSetting: vi.fn(() => undefined),
+    character: { name: "Ada", system: "You are Ada \uD83D" },
+    emitEvent: vi.fn(),
+    getService: vi.fn(() => null),
+    getServicesByType: vi.fn(() => []),
+  } as unknown as IAgentRuntime;
+}
+
+/** Strict-parser view of the captured body: fatal UTF-8 decode, full-body
+ * well-formedness, no lone-surrogate escapes, and a successful JSON.parse. */
+function assertStrictParseable(bytes: Buffer): Record<string, unknown> {
+  const body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+  expect(LONE_SURROGATE_ESCAPE.test(body)).toBe(false);
+  return JSON.parse(body) as Record<string, unknown>;
+}
+
+beforeAll(async () => {
+  baseUrl = await startCaptureServer();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+beforeEach(() => {
+  captured.length = 0;
+  vi.stubEnv("OPENAI_API_KEY", "test-key");
+  vi.stubEnv("OPENAI_BASE_URL", baseUrl);
+  vi.stubEnv("OPENAI_SMALL_MODEL", "test-model");
+  vi.stubEnv("CEREBRAS_API_KEY", undefined);
+  vi.stubEnv("ELIZA_PROVIDER", undefined);
+  vi.stubEnv("ELIZA_TRAJECTORY_STRICT", undefined);
+});
+
+describe("#18025: request bodies are well-formed strict JSON", () => {
+  it("sanitizes a prompt truncated mid-emoji (lone leading surrogate)", async () => {
+    const brokenPrompt = "summarize this page 🤖 please".slice(0, 21); // splits 🤖
+    expect(LONE_SURROGATE_ESCAPE.test(JSON.stringify(brokenPrompt))).toBe(true);
+
+    const result = await handleTextSmall(buildRuntime(), { prompt: brokenPrompt } as never);
+    expect(result).toBe("ok");
+
+    expect(captured).toHaveLength(1);
+    const body = assertStrictParseable(captured[0].bytes);
+    const messages = body.messages as Array<{ role: string; content: string }>;
+    const user = messages.find((message) => message.role === "user");
+    expect(user?.content).toBe("summarize this page �");
+    // The lone surrogate in the character's system prompt is sanitized too.
+    const system = messages.find((message) => message.role === "system");
+    expect(system?.content).toContain("You are Ada �");
+  });
+
+  it("sanitizes the post-tool evaluator shape: assistant tool_calls + tool result content", async () => {
+    const loneInToolResult = `fetched: emoji heavy 💀🔥 page…`.slice(0, 22); // splits 💀
+    const loneInToolArgs = "🔥".slice(0, 1);
+
+    const result = await handleTextSmall(buildRuntime(), {
+      messages: [
+        { role: "system", content: "evaluate the tool turn" },
+        { role: "user", content: "look this up 🤖" },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              toolCallId: "tool-1-0",
+              toolName: "WEB_FETCH",
+              input: { url: "https://example.com", note: loneInToolArgs },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          toolCallId: "tool-1-0",
+          toolName: "WEB_FETCH",
+          content: loneInToolResult,
+        },
+      ],
+    } as never);
+    // Native params (messages/tools) return the structured result object.
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+
+    expect(captured).toHaveLength(1);
+    const body = assertStrictParseable(captured[0].bytes);
+    const serialized = JSON.stringify(body);
+    // Well-formed emoji from the user message survives untouched...
+    expect(serialized).toContain("🤖");
+    // ...while both injected lone surrogates were replaced.
+    expect(serialized).toContain("fetched: emoji heavy �");
+  });
+
+  it("round-trips the exact captured failure signature safely", async () => {
+    // The live 400: {"message":": Invalid JSON: lone leading surrogate in hex
+    // escape...","code":"wrong_api_format"} — triggered by any \uD8xx escape.
+    // Feed a raw lone leading surrogate straight through the handler and
+    // assert the wire never carries the escape a strict parser rejects.
+    await handleTextSmall(buildRuntime(), { prompt: "tail \uD83D" } as never);
+
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].bytes.toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = assertStrictParseable(captured[0].bytes);
+    const messages = body.messages as Array<{ role: string; content: string }>;
+    expect(messages.find((message) => message.role === "user")?.content).toBe("tail �");
+  });
+});

--- a/plugins/plugin-openai/models/embedding.ts
+++ b/plugins/plugin-openai/models/embedding.ts
@@ -6,7 +6,13 @@
  * real embedding server is reachable.
  */
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
-import { logger, ModelType, VECTOR_DIMS } from "@elizaos/core";
+import {
+  logger,
+  ModelType,
+  toWellFormedUnicode,
+  truncateWellFormed,
+  VECTOR_DIMS,
+} from "@elizaos/core";
 
 import type { OpenAIEmbeddingResponse } from "../types";
 import {
@@ -135,8 +141,11 @@ export async function handleTextEmbedding(
     logger.warn(
       `[OpenAI] Embedding input too long (~${Math.ceil(trimmedText.length / 4)} tokens), truncating to ~8000 tokens`
     );
-    trimmedText = trimmedText.slice(0, maxChars);
+    trimmedText = truncateWellFormed(trimmedText, maxChars);
   }
+  // Wire-boundary guarantee: lone surrogates in the JSON body 400 on strict
+  // provider parsers (#18025).
+  trimmedText = toWellFormedUnicode(trimmedText);
 
   if (shouldUseLocalEmbeddingFallback(runtime)) {
     logger.debug("[OpenAI] Using deterministic local embedding fallback for Cerebras mode");

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -15,6 +15,7 @@ import {
   assertActiveTrajectoryForLlmCall,
   attestLlmInputSubstring,
   buildCanonicalSystemPrompt,
+  deepToWellFormedUnicode,
   dropDuplicateLeadingSystemMessage,
   ElizaError,
   logActiveTrajectoryLlmCall,
@@ -2020,8 +2021,13 @@ async function generateTextByModelType(
 
   const generateParams: NativeTextParams = {
     model,
-    ...promptOrMessages,
-    system: systemPrompt,
+    // Wire-boundary guarantee: no upstream text bug may produce an invalid
+    // request body. A lone UTF-16 surrogate (e.g. from a mid-emoji slice)
+    // serializes as a \uD8xx escape that Cerebras's strict JSON parser 400s
+    // on ("lone leading surrogate in hex escape", wrong_api_format — #18025),
+    // so every outgoing string is forced to well-formed Unicode here.
+    ...deepToWellFormedUnicode(promptOrMessages),
+    system: systemPrompt === undefined ? undefined : deepToWellFormedUnicode(systemPrompt),
     allowSystemInMessages: true,
     ...(params.signal ? { abortSignal: params.signal } : {}),
     // Omit the cap when the caller opted out (direct-channel Stage-1) so the


### PR DESCRIPTION
## What

Kills the root cause of #18025 at both layers: intermittent Cerebras HTTP 400s (`{"message":": Invalid JSON: lone leading surrogate in hex escape…","code":"wrong_api_format"}`) that surfaced to users as canned failure replies on tool-turns.

**Mechanism:** JS `.slice()/.substring()` on UTF-16 strings can split a surrogate pair (emoji), leaving a lone surrogate. `JSON.stringify` emits it as a bare `\uD8xx` escape — technically-valid JSON that strict parsers (serde/Cerebras) reject. A truncation boundary landing mid-emoji in any prompt-fed snippet poisoned every model call carrying it: deterministic per-content, intermittent across turns (~30% of tool-turns in batteries), and invisible to replay because trajectory persistence normalizes the lone surrogate — exactly the "live process 400s, byte-faithful replays succeed" signature in the issue.

### Layer 1 — wire-boundary guarantee (load-bearing)

No upstream text bug may produce an invalid wire request. At request build:

- `plugins/plugin-openai/models/text.ts` — the single `generateParams` choke point (all text lanes: generate, live-stream, buffered-stream) deep-sanitizes `prompt`/`messages`/`system` to well-formed Unicode.
- `plugins/plugin-openai/models/embedding.ts` — embedding input sanitized before `JSON.stringify` (and its 32k-char cap is now surrogate-safe).
- `plugins/plugin-anthropic/models/text.ts` — same choke-point sanitize on `promptOrMessages` + `system` (deterministic, so prompt-cache prefix stability holds).

### Layer 2 — truncation-site hygiene

New shared utils in `@elizaos/core` (`packages/core/src/utils/well-formed.ts`, exported from node/browser/edge barrels):

- `truncateWellFormed(text, n)` — `slice(0, n)` that backs off one code unit when the cut lands on the lead half of a pair (cheap: one charCode check).
- `tailWellFormed(text, n)` — the tail-side dual for head+tail compactors.
- `toWellFormedUnicode(text)` / `deepToWellFormedUnicode(value)` — lone surrogates → U+FFFD; native `String.prototype.toWellFormed` fast path, reference-preserving deep walk for request bodies.

Prompt-feeding truncation sites switched (display-only slicing untouched):

| Site | File |
|---|---|
| Planner tool-result rendering (head/tail/limit cuts) — **the post-tool evaluator path from the issue** | `packages/core/src/runtime/planner-rendering.ts` (`truncateToolResultText`) |
| Planner compaction head/tail + failure-cause scrub | `packages/core/src/runtime/planner-loop.ts` |
| Sub-step tool summaries | `packages/core/src/services/message.ts` |
| Recent-messages compact ledger | `packages/core/src/features/basic-capabilities/providers/recentMessages.ts` |
| Relevant-conversations snippets (`HASH_MEMORY_SNIPPET_LENGTH` / `RELEVANT_SNIPPET_LENGTH`) | `packages/agent/src/providers/relevant-conversations.ts` |
| Entity metadata render | `packages/core/src/entities.ts` |
| Autonomy admin-message / thought snippets | `packages/core/src/features/autonomy/{providers,service}.ts` |
| Bot-noise triage clip | `packages/core/src/services/message/bot-noise-triage.ts` |
| Link-extraction title/body/summary previews | `packages/core/src/features/basic-capabilities/evaluators/link-extraction.ts` |
| `truncateToCompleteSentence` hard fallback | `packages/core/src/utils.ts` |

## Evidence

- **Unit (core):** `packages/core/src/utils/well-formed.test.ts` — full boundary sweep over emoji/ZWJ/flag content proving every cut is well-formed; the exact captured failure shape (mid-emoji slice → `\uD8xx` escape) shown failing raw and round-tripping safely after sanitize (strict `TextDecoder(fatal)` + `JSON.parse` + no-escape scan). `planner-rendering.test.ts` gains an all-astral sweep over `truncateToolResultText`.
- **Wire (both plugins):** `plugins/plugin-openai/__tests__/wire-well-formed.shape.test.ts` and `plugins/plugin-anthropic/__tests__/wire-well-formed.shape.test.ts` — real AI SDK + real client factory against a loopback capture server; raw HTTP body bytes asserted strict-parseable with zero lone-surrogate escapes for (a) a mid-emoji-truncated prompt, (b) the issue's post-tool evaluator shape (`system + user + assistant(tool_calls) + tool`), (c) a raw lone leading surrogate. Well-formed emoji passes through untouched.
- **Regression:** plugin-openai full suite 188/188, plugin-anthropic full suite 78/78, owning core suites (planner-rendering, planner-loop lanes, utils.parsing, recentMessages, entities-format, autonomy, bot-noise-triage, link-extraction) all green, agent relevant-conversations suites 16/16. Typecheck green for core + both plugins; `packages/agent` typecheck failures are pre-existing on the base (verified byte-identical error profile with the change reverted). Biome lint green on all four packages.

Complements #18024 (unmasked provider error bodies + transient-400 retries): that made the failure diagnosable and retried the under-load 400s; this removes the validation 400s at the source.

Fixes #18025

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:b607317fcb7e726e7df29e429ba0b5f7bc83ff14 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only provider/runtime fix; no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only; no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only; no UI flow to record

<!-- evidence-row:backend-logs -->
- [x] [18079-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18079-backend-logs.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code in the diff

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic wire-level proof via loopback capture of real AI SDK request bytes; live-bot trajectory pickup handled by operator (do-not-live-test constraint)

<!-- evidence-row:domain-artifacts -->
- [x] [18079-domain-artifacts.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18079-domain-artifacts.txt)


# Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
