### PR TITLE
fix(cloud): turn the inference flags on in the base wrangler vars

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -205,7 +205,7 @@ REDIS_RATE_LIMITING = "false"
 # misses warm and retry instead of joining an authoritative database fallback.
 # SAFE_BALANCE_THRESHOLD remains a non-Worker compatibility control; exact
 # Durable Object admission does not impose a minimum account-balance floor.
-INFERENCE_OPTIMISTIC_BILLING = "false"
+INFERENCE_OPTIMISTIC_BILLING = "true"
 # Thin chat-only bootstrap. Keep production off until staging parity/latency soak passes.
 THIN_INFERENCE_ENTRY_ENABLED = "false"
 SAFE_BALANCE_THRESHOLD = ""
@@ -214,7 +214,7 @@ SAFE_BALANCE_THRESHOLD = ""
 INFERENCE_BILLING_LEDGER = "db"
 # Required for the Worker cache-only path. The only pre-provider write is the
 # per-organization Durable Object lease; Postgres accounting starts afterward.
-INFERENCE_DEFERRED_ADMISSION = "false"
+INFERENCE_DEFERRED_ADMISSION = "true"
 # Enables local decision memos in front of shared revisioned caches. Exact
 # organization rate and spend decisions remain in the Durable Object.
 INFERENCE_HOT_PATH_CACHES = "false"


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## What

Two flags in the base `[vars]` block of `packages/cloud/api/wrangler.toml` go `"false"` → `"true"`:

```
INFERENCE_OPTIMISTIC_BILLING
INFERENCE_DEFERRED_ADMISSION
```

## Why this is a two-line diff and still worth its own PR

**No deployed environment changes.** Wrangler does not inherit top-level `[vars]` into named environments, and both `[env.staging.vars]` and `[env.production.vars]` already set these to `"true"`. Deployed blast radius is zero — which is precisely why it went unnoticed.

**Every local run reads the base block.** With the inference surface off, the shared tier cannot complete a single turn: `bun run cloud:mock` and `dev-all` are unusable as shipped, and one cloud e2e spec (`shared-to-dedicated-upgrade`) fails for this reason alone.

The comments sitting directly above both flags already describe them as enabled, so the config contradicted its own documentation.

This is split out of the e2e suite repair deliberately. It is a product configuration change, and bundling it with thirteen test-file edits is how a consequential flag flip gets approved without being read.

## How it was found

While diagnosing why thirteen cloud e2e specs were red on `develop`, one turned out not to be a test defect at all. Tracing `shared-to-dedicated-upgrade` down to the Worker showed the inference routes returning unavailable locally regardless of test setup, because the flags they gate on were off in the only block a local run consults.

## Verification

The dependent e2e spec passes with this change and fails without it; that run is evidence on the companion PR, which declares this one as a prerequisite. Nothing else in the repository reads these two variables outside the inference admission path.

[stan-cloud]


<!-- evidence-head:a4bb6b33d8049a15a32bc12f7c94c2c6096fb630 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - two-line Worker config flag flip; no rendered UI surface in the diff

<!-- evidence-row:after-screenshots -->
- [ ] N/A - config-only change with no UI surface in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible flow changed; local-dev wrangler [vars] alignment only

<!-- evidence-row:backend-logs -->
- [ ] N/A - deployed environments already carry these values; the dependent cloud e2e spec run (pass with / fail without this flip) is attached to the companion e2e-suite PR that declares this one as prerequisite

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/client code in the diff

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent behavior change; configuration gate for the inference admission path only

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the artifact is the wrangler.toml diff itself; base [vars] now matches env.staging.vars and env.production.vars
