### PR TITLE
fix(a11y): restore 200% browser zoom on hosted web surfaces

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -208,7 +208,7 @@
     })();
   </script>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="viewport" content="__APP_VIEWPORT_CONTENT__" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="mobile-web-app-capable" content="yes" />

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -133,7 +133,7 @@
     "cap:sync:android": "node scripts/ensure-capacitor-platform.mjs android && capacitor sync android",
     "cap:open:ios": "node scripts/ensure-capacitor-platform.mjs ios && capacitor open ios",
     "cap:open:android": "node scripts/ensure-capacitor-platform.mjs android && capacitor open android",
-    "build:web": "ELIZA_WEB_ABSOLUTE_BASE=1 node ../../node_modules/@elizaos/vitest-vite/bin/vite.js build && node scripts/verify-chunk-safety.mjs",
+    "build:web": "ELIZA_WEB_ABSOLUTE_BASE=1 node ../../node_modules/@elizaos/vitest-vite/bin/vite.js build && node scripts/verify-chunk-safety.mjs && node scripts/verify-viewport-meta.mjs",
     "verify:chunks": "node scripts/verify-chunk-safety.mjs",
     "predev": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --concepts --banners --background --background-videos",
     "prebuild": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --concepts --banners --background --background-videos",

--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -153,11 +153,16 @@ export default defineConfig({
       // in the dedicated `chromium-voice-mic` project below, not here. The
       // all-views aesthetic audit runs only via the `audit:app` project; the
       // cloud-surface audit only via `audit:cloud`.
+      // The viewport-zoom spec runs under `mobile-chromium` where the Pixel 7
+      // profile respects viewport-meta zoom caps — Desktop Chrome's CDP
+      // setPageScaleFactor overrides the meta unconditionally, producing a
+      // false positive for both locked and unlocked viewports.
       testIgnore: [
         VOICE_MIC_SPEC,
         AUDIT_APP_SPEC,
         AUDIT_CLOUD_SPEC,
         AUDIT_APP_DROPDOWN_SPEC,
+        /viewport-zoom-visualviewport\.spec\.ts/,
       ],
       use: {
         ...devices["Desktop Chrome"],
@@ -203,7 +208,7 @@ export default defineConfig({
       // so each surface is exercised at the same WebView viewport that ships on
       // Capacitor iOS/Android.
       testMatch:
-        /(apps-personal-assistant-decomposed-interactions|chat-clear-swipe|chat-send-voice-newchat-fuzz|gesture-matrix|input-modality|launcher-gesture-loop)\.spec\.ts/,
+        /(apps-personal-assistant-decomposed-interactions|chat-clear-swipe|chat-send-voice-newchat-fuzz|gesture-matrix|input-modality|launcher-gesture-loop|viewport-zoom-visualviewport)\.spec\.ts/,
       use: { ...devices["Pixel 7"], ...withLaunchOptions() },
     },
     // WebKit cross-engine lane (opt-in). Only added when PLAYWRIGHT_WEBKIT=1 so a

--- a/packages/app/scripts/build.mjs
+++ b/packages/app/scripts/build.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
-// UI build: Capacitor plugins then Vite. Requires prior `bun install` (postinstall).
-// ELIZA_BUILD_FULL_SETUP=1 prepends install --ignore-scripts + run-repo-setup (CI-style).
+/**
+ * Builds the app's plugin and Vite artifacts, stamps their source revision,
+ * verifies emitted shell contracts, and optionally performs CI-style setup.
+ */
 import { execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -29,6 +31,11 @@ const pruneCdnAssetsScript = path.join(
   "app-core",
   "scripts",
   "prune-cdn-local-assets.mjs",
+);
+const viewportMetaVerifier = path.join(
+  appDir,
+  "scripts",
+  "verify-viewport-meta.mjs",
 );
 const bunExecutable = path
   .basename(process.execPath)
@@ -156,6 +163,7 @@ async function main() {
     ["--bun", "vite", "build", "--configLoader", "runner"],
     appDir,
   );
+  await run(process.execPath, [viewportMetaVerifier], appDir);
   if (resolveElizaAssetBaseUrls().appAssetBaseUrl) {
     await run(process.execPath, [pruneCdnAssetsScript], repoRoot);
   }

--- a/packages/app/scripts/verify-viewport-meta.mjs
+++ b/packages/app/scripts/verify-viewport-meta.mjs
@@ -1,0 +1,95 @@
+/**
+ * Verifies the emitted app shell preserves the viewport policy for its target.
+ * Hosted builds must retain 200% browser zoom; Capacitor builds retain the
+ * existing native gesture policy. The check runs after Vite writes dist.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+function viewportContent(html) {
+  const viewportTags = (html.match(/<meta\b[^>]*>/gi) ?? []).filter((tag) =>
+    /\bname=["']viewport["']/i.test(tag),
+  );
+  if (viewportTags.length !== 1) {
+    throw new Error(
+      `expected exactly one viewport meta tag, found ${viewportTags.length}`,
+    );
+  }
+  const content = viewportTags[0].match(/\bcontent=["']([^"']*)["']/i)?.[1];
+  if (!content || content.includes("__APP_")) {
+    throw new Error(
+      "viewport meta content is missing or still contains a token",
+    );
+  }
+  return content;
+}
+
+function directives(content) {
+  const values = new Map();
+  for (const part of content.split(",")) {
+    const [name, ...value] = part.trim().toLowerCase().split("=");
+    if (!name || values.has(name)) {
+      throw new Error(`viewport directive is empty or duplicated: ${name}`);
+    }
+    values.set(name, value.join("="));
+  }
+  return values;
+}
+
+/** Throws when emitted HTML does not match the target's viewport contract. */
+export function assertViewportMetaPolicy(html, capacitorBuildTarget = "") {
+  const content = viewportContent(html);
+  const values = directives(content);
+  if (values.get("width") !== "device-width") {
+    throw new Error("viewport width must be device-width");
+  }
+  if (values.get("initial-scale") !== "1.0") {
+    throw new Error("viewport initial-scale must be 1.0");
+  }
+  if (values.get("viewport-fit") !== "cover") {
+    throw new Error("viewport-fit must remain cover");
+  }
+
+  const native =
+    capacitorBuildTarget === "ios" || capacitorBuildTarget === "android";
+  if (native) {
+    if (
+      values.get("user-scalable") !== "no" ||
+      values.get("maximum-scale") !== "1.0"
+    ) {
+      throw new Error("Capacitor viewport must retain its native zoom policy");
+    }
+  } else {
+    const maximumScale = values.has("maximum-scale")
+      ? Number(values.get("maximum-scale"))
+      : null;
+    if (
+      ["no", "0", "false"].includes(values.get("user-scalable")) ||
+      (maximumScale !== null &&
+        (!Number.isFinite(maximumScale) || maximumScale < 2))
+    ) {
+      throw new Error(
+        "hosted viewport must allow user-agent zoom to at least 200%",
+      );
+    }
+  }
+  return content;
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedPath) {
+  const appDir = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
+  const html = fs.readFileSync(path.join(appDir, "dist", "index.html"), "utf8");
+  const target = process.env.ELIZA_CAPACITOR_BUILD_TARGET ?? "";
+  const content = assertViewportMetaPolicy(html, target);
+  console.log(
+    `[verify-viewport-meta] ${target || "web"} policy verified: ${content}`,
+  );
+}

--- a/packages/app/scripts/verify-viewport-meta.test.mjs
+++ b/packages/app/scripts/verify-viewport-meta.test.mjs
@@ -1,0 +1,60 @@
+/** Tests the emitted viewport verifier with hosted, native, and invalid shells. */
+import { describe, expect, it } from "vitest";
+import { assertViewportMetaPolicy } from "./verify-viewport-meta.mjs";
+
+const shell = (content) =>
+  `<html><head><meta name="viewport" content="${content}" /></head></html>`;
+
+describe("assertViewportMetaPolicy", () => {
+  it("accepts an uncapped hosted viewport", () => {
+    expect(
+      assertViewportMetaPolicy(
+        shell("width=device-width, initial-scale=1.0, viewport-fit=cover"),
+      ),
+    ).not.toContain("maximum-scale");
+  });
+
+  it.each(["ios", "android"])("accepts the %s native viewport", (target) => {
+    expect(() =>
+      assertViewportMetaPolicy(
+        shell(
+          "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover",
+        ),
+        target,
+      ),
+    ).not.toThrow();
+  });
+
+  it.each([
+    "width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover",
+    "width=device-width, initial-scale=1.0, user-scalable=0, viewport-fit=cover",
+    "width=device-width, initial-scale=1.0, user-scalable=false, viewport-fit=cover",
+    "width=device-width, initial-scale=1.0, maximum-scale=1.5, viewport-fit=cover",
+    "width=device-width, initial-scale=1.0, maximum-scale=yes, viewport-fit=cover",
+  ])("rejects a hosted zoom cap: %s", (content) => {
+    expect(() => assertViewportMetaPolicy(shell(content))).toThrow(
+      /allow user-agent zoom/,
+    );
+  });
+
+  it("rejects unresolved, missing, and duplicate viewport metadata", () => {
+    expect(() =>
+      assertViewportMetaPolicy(shell("__APP_VIEWPORT_CONTENT__")),
+    ).toThrow(/token/);
+    expect(() => assertViewportMetaPolicy("<html></html>")).toThrow(
+      /exactly one/,
+    );
+    expect(() =>
+      assertViewportMetaPolicy(
+        `${shell("width=device-width")}${shell("width=device-width")}`,
+      ),
+    ).toThrow(/exactly one/);
+    expect(() =>
+      assertViewportMetaPolicy(
+        shell(
+          "width=device-width, width=device-width, initial-scale=1.0, viewport-fit=cover",
+        ),
+      ),
+    ).toThrow(/duplicated/);
+  });
+});

--- a/packages/app/test/ui-smoke/viewport-zoom-visualviewport.spec.ts
+++ b/packages/app/test/ui-smoke/viewport-zoom-visualviewport.spec.ts
@@ -1,37 +1,53 @@
 /**
  * Browser-level WCAG 2.2 SC 1.4.4 zoom test for the web viewport meta tag.
  *
- * The unit suite proves the build-time transform resolves the token correctly
- * in source and emitted HTML. This spec proves the RESOLVED viewport meta
- * allows a real browser to zoom beyond 100% — the behavior the issue (#18077)
- * explicitly asks for:
+ * This spec runs under the `mobile-chromium` Playwright project (Pixel 7,
+ * hasTouch). On Desktop Chrome, `Emulation.setPageScaleFactor` overrides
+ * the viewport meta unconditionally — the scale change happens even with
+ * `maximum-scale=1.0, user-scalable=no`. Under a genuine mobile/touch
+ * profile the locked meta correctly blocks the scale, so only the mobile
+ * project distinguishes the WCAG-compliant viewport from the lockdown.
  *
- * > "Add [...] a touch-browser test proving a 2× zoom changes
- * > visualViewport.scale on the hosted shell."
+ * The spec serves the resolved index.html (the same
+ * `__APP_VIEWPORT_CONTENT__` → `VIEWPORT_META_WEB` replacement the Vite
+ * build applies) and uses Chromium's CDP `Emulation.setPageScaleFactor` to
+ * simulate a 2× pinch-zoom, then asserts `visualViewport.scale` reaches
+ * 2.0.
  *
- * It serves the actual resolved index.html (the same `__APP_VIEWPORT_CONTENT__`
- * → `VIEWPORT_META_WEB` replacement the Vite build applies) and uses Chromium's
- * CDP `Emulation.setPageScaleFactor` to simulate a 2× pinch-zoom, then asserts
- * `visualViewport.scale` reaches 2.0.
- *
- * A regression guard asserts the OLD lockdown (`maximum-scale=1.0,
- * user-scalable=no`) would BLOCK the zoom — proving the test has teeth.
+ * A negative-control test asserts the OLD lockdown
+ * (`maximum-scale=1.0, user-scalable=no`) would BLOCK the zoom under the
+ * same mobile profile — proving the test has teeth.
  */
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect, test } from "@playwright/test";
 
-const appRoot = join(__dirname, "..");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const appRoot = path.join(__dirname, "..");
+
+const VIEWPORT_CONTENT_WEB =
+  "width=device-width, initial-scale=1.0, viewport-fit=cover";
+const VIEWPORT_CONTENT_LOCKED =
+  "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover";
 
 /**
  * Read the actual index.html source and apply the exact token replacement the
  * Vite build pipeline applies for web builds.
  */
 function resolvedWebIndexHtml(): string {
-  const source = readFileSync(join(appRoot, "index.html"), "utf8");
-  const VIEWPORT_CONTENT_WEB =
-    "width=device-width, initial-scale=1.0, viewport-fit=cover";
+  const source = readFileSync(path.join(appRoot, "index.html"), "utf8");
   return source.replaceAll("__APP_VIEWPORT_CONTENT__", VIEWPORT_CONTENT_WEB);
+}
+
+/**
+ * Read the actual index.html source but apply the OLD lockdown meta — the
+ * negative control proving the spec catches a regression.
+ */
+function lockdownIndexHtml(): string {
+  const source = readFileSync(path.join(appRoot, "index.html"), "utf8");
+  return source.replaceAll("__APP_VIEWPORT_CONTENT__", VIEWPORT_CONTENT_LOCKED);
 }
 
 test.describe("WCAG 2.2 SC 1.4.4 — browser-level zoom (visualViewport.scale)", () => {
@@ -60,8 +76,8 @@ test.describe("WCAG 2.2 SC 1.4.4 — browser-level zoom (visualViewport.scale)",
     // Wait for visualViewport to update.
     await page.waitForTimeout(500);
 
-    // The viewport meta without user-scalable=no and maximum-scale must allow
-    // the scale change.
+    // The WCAG-compliant viewport meta (no user-scalable=no, no
+    // maximum-scale) must allow the scale change under the mobile profile.
     const zoomedScale = await page.evaluate(
       () => window.visualViewport?.scale ?? 1,
     );
@@ -88,5 +104,40 @@ test.describe("WCAG 2.2 SC 1.4.4 — browser-level zoom (visualViewport.scale)",
     expect(viewportMeta).toContain("viewport-fit=cover");
     expect(viewportMeta).not.toMatch(/user-scalable\s*=\s*no/i);
     expect(viewportMeta).not.toMatch(/maximum-scale/i);
+  });
+
+  test("old lockdown meta BLOCKS zoom under mobile profile (negative control)", async ({
+    page,
+  }) => {
+    // Serve the lockdown HTML — this is what a regression would look like
+    // if someone re-introduced maximum-scale=1.0, user-scalable=no.
+    const html = lockdownIndexHtml();
+    await page.route("**/", (route) =>
+      route.fulfill({ status: 200, contentType: "text/html", body: html }),
+    );
+    await page.goto("https://localhost/", { waitUntil: "domcontentloaded" });
+
+    // Baseline: scale should be 1.0 at 100% zoom.
+    const baselineScale = await page.evaluate(
+      () => window.visualViewport?.scale ?? 1,
+    );
+    expect(baselineScale).toBeCloseTo(1, 1);
+
+    // Attempt the same 2× pinch-zoom via CDP.
+    const client = await page.context().newCDPSession(page);
+    await client.send("Emulation.setPageScaleFactor", { pageScaleFactor: 2 });
+
+    // Wait for visualViewport to update.
+    await page.waitForTimeout(500);
+
+    // Under the mobile/touch profile, the locked meta MUST block the scale
+    // change — visualViewport.scale stays at 1.0 (or very close).
+    // This proves the positive test above is not a false positive: if
+    // someone re-introduces the lockdown, this assertion would fail (or
+    // the positive test would fail), catching the regression.
+    const zoomedScale = await page.evaluate(
+      () => window.visualViewport?.scale ?? 1,
+    );
+    expect(zoomedScale).toBeCloseTo(1, 1);
   });
 });

--- a/packages/app/test/ui-smoke/viewport-zoom-visualviewport.spec.ts
+++ b/packages/app/test/ui-smoke/viewport-zoom-visualviewport.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Browser-level WCAG 2.2 SC 1.4.4 zoom test for the web viewport meta tag.
+ *
+ * The unit suite proves the build-time transform resolves the token correctly
+ * in source and emitted HTML. This spec proves the RESOLVED viewport meta
+ * allows a real browser to zoom beyond 100% — the behavior the issue (#18077)
+ * explicitly asks for:
+ *
+ * > "Add [...] a touch-browser test proving a 2× zoom changes
+ * > visualViewport.scale on the hosted shell."
+ *
+ * It serves the actual resolved index.html (the same `__APP_VIEWPORT_CONTENT__`
+ * → `VIEWPORT_META_WEB` replacement the Vite build applies) and uses Chromium's
+ * CDP `Emulation.setPageScaleFactor` to simulate a 2× pinch-zoom, then asserts
+ * `visualViewport.scale` reaches 2.0.
+ *
+ * A regression guard asserts the OLD lockdown (`maximum-scale=1.0,
+ * user-scalable=no`) would BLOCK the zoom — proving the test has teeth.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+
+const appRoot = join(__dirname, "..");
+
+/**
+ * Read the actual index.html source and apply the exact token replacement the
+ * Vite build pipeline applies for web builds.
+ */
+function resolvedWebIndexHtml(): string {
+  const source = readFileSync(join(appRoot, "index.html"), "utf8");
+  const VIEWPORT_CONTENT_WEB =
+    "width=device-width, initial-scale=1.0, viewport-fit=cover";
+  return source.replaceAll("__APP_VIEWPORT_CONTENT__", VIEWPORT_CONTENT_WEB);
+}
+
+test.describe("WCAG 2.2 SC 1.4.4 — browser-level zoom (visualViewport.scale)", () => {
+  test("resolved web viewport allows 2× zoom via visualViewport.scale", async ({
+    page,
+  }) => {
+    // Serve the resolved HTML inline so the browser loads it with the real
+    // WCAG-compliant viewport meta.
+    const html = resolvedWebIndexHtml();
+    await page.route("**/", (route) =>
+      route.fulfill({ status: 200, contentType: "text/html", body: html }),
+    );
+    await page.goto("https://localhost/", { waitUntil: "domcontentloaded" });
+
+    // Baseline: scale should be 1.0 at 100% zoom.
+    const baselineScale = await page.evaluate(
+      () => window.visualViewport?.scale ?? 1,
+    );
+    expect(baselineScale).toBeCloseTo(1, 1);
+
+    // Simulate a 2× pinch-zoom via CDP (the browser equivalent of the
+    // real gesture the issue asks us to test).
+    const client = await page.context().newCDPSession(page);
+    await client.send("Emulation.setPageScaleFactor", { pageScaleFactor: 2 });
+
+    // Wait for visualViewport to update.
+    await page.waitForTimeout(500);
+
+    // The viewport meta without user-scalable=no and maximum-scale must allow
+    // the scale change.
+    const zoomedScale = await page.evaluate(
+      () => window.visualViewport?.scale ?? 1,
+    );
+    expect(zoomedScale).toBeGreaterThan(1.5);
+  });
+
+  test("resolved web viewport meta contains no WCAG-failing directives", async ({
+    page,
+  }) => {
+    const html = resolvedWebIndexHtml();
+    await page.route("**/", (route) =>
+      route.fulfill({ status: 200, contentType: "text/html", body: html }),
+    );
+    await page.goto("https://localhost/", { waitUntil: "domcontentloaded" });
+
+    // Verify the loaded document's viewport meta matches the WCAG-compliant value.
+    const viewportMeta = await page.evaluate(() => {
+      const meta = document.querySelector('meta[name="viewport"]');
+      return meta?.getAttribute("content") ?? "";
+    });
+
+    expect(viewportMeta).toContain("width=device-width");
+    expect(viewportMeta).toContain("initial-scale=1.0");
+    expect(viewportMeta).toContain("viewport-fit=cover");
+    expect(viewportMeta).not.toMatch(/user-scalable\s*=\s*no/i);
+    expect(viewportMeta).not.toMatch(/maximum-scale/i);
+  });
+});

--- a/packages/app/test/ui-smoke/viewport-zoom-visualviewport.spec.ts
+++ b/packages/app/test/ui-smoke/viewport-zoom-visualviewport.spec.ts
@@ -25,7 +25,7 @@ import { expect, test } from "@playwright/test";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const appRoot = path.join(__dirname, "..");
+const appRoot = path.resolve(__dirname, "../..");
 
 const VIEWPORT_CONTENT_WEB =
   "width=device-width, initial-scale=1.0, viewport-fit=cover";

--- a/packages/app/test/ui-smoke/viewport-zoom-visualviewport.spec.ts
+++ b/packages/app/test/ui-smoke/viewport-zoom-visualviewport.spec.ts
@@ -1,99 +1,16 @@
-/**
- * Browser-level WCAG 2.2 SC 1.4.4 zoom test for the web viewport meta tag.
- *
- * This spec runs under the `mobile-chromium` Playwright project (Pixel 7,
- * hasTouch). On Desktop Chrome, `Emulation.setPageScaleFactor` overrides
- * the viewport meta unconditionally — the scale change happens even with
- * `maximum-scale=1.0, user-scalable=no`. Under a genuine mobile/touch
- * profile the locked meta correctly blocks the scale, so only the mobile
- * project distinguishes the WCAG-compliant viewport from the lockdown.
- *
- * The spec serves the resolved index.html (the same
- * `__APP_VIEWPORT_CONTENT__` → `VIEWPORT_META_WEB` replacement the Vite
- * build applies) and uses Chromium's CDP `Emulation.setPageScaleFactor` to
- * simulate a 2× pinch-zoom, then asserts `visualViewport.scale` reaches
- * 2.0.
- *
- * A negative-control test asserts the OLD lockdown
- * (`maximum-scale=1.0, user-scalable=no`) would BLOCK the zoom under the
- * same mobile profile — proving the test has teeth.
- */
-import { readFileSync } from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { expect, test } from "@playwright/test";
+/** Exercises 200% zoom on the real hosted shell with a locked-meta control. */
+import { expect, type Page, test } from "@playwright/test";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const appRoot = path.resolve(__dirname, "../..");
-
-const VIEWPORT_CONTENT_WEB =
-  "width=device-width, initial-scale=1.0, viewport-fit=cover";
-const VIEWPORT_CONTENT_LOCKED =
-  "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover";
-
-/**
- * Read the actual index.html source and apply the exact token replacement the
- * Vite build pipeline applies for web builds.
- */
-function resolvedWebIndexHtml(): string {
-  const source = readFileSync(path.join(appRoot, "index.html"), "utf8");
-  return source.replaceAll("__APP_VIEWPORT_CONTENT__", VIEWPORT_CONTENT_WEB);
+async function pageScale(page: Page) {
+  return page.evaluate(() => ({
+    scale: window.visualViewport?.scale ?? 1,
+    width: window.visualViewport?.width ?? window.innerWidth,
+  }));
 }
 
-/**
- * Read the actual index.html source but apply the OLD lockdown meta — the
- * negative control proving the spec catches a regression.
- */
-function lockdownIndexHtml(): string {
-  const source = readFileSync(path.join(appRoot, "index.html"), "utf8");
-  return source.replaceAll("__APP_VIEWPORT_CONTENT__", VIEWPORT_CONTENT_LOCKED);
-}
-
-test.describe("WCAG 2.2 SC 1.4.4 — browser-level zoom (visualViewport.scale)", () => {
-  test("resolved web viewport allows 2× zoom via visualViewport.scale", async ({
-    page,
-  }) => {
-    // Serve the resolved HTML inline so the browser loads it with the real
-    // WCAG-compliant viewport meta.
-    const html = resolvedWebIndexHtml();
-    await page.route("**/", (route) =>
-      route.fulfill({ status: 200, contentType: "text/html", body: html }),
-    );
-    await page.goto("https://localhost/", { waitUntil: "domcontentloaded" });
-
-    // Baseline: scale should be 1.0 at 100% zoom.
-    const baselineScale = await page.evaluate(
-      () => window.visualViewport?.scale ?? 1,
-    );
-    expect(baselineScale).toBeCloseTo(1, 1);
-
-    // Simulate a 2× pinch-zoom via CDP (the browser equivalent of the
-    // real gesture the issue asks us to test).
-    const client = await page.context().newCDPSession(page);
-    await client.send("Emulation.setPageScaleFactor", { pageScaleFactor: 2 });
-
-    // Wait for visualViewport to update.
-    await page.waitForTimeout(500);
-
-    // The WCAG-compliant viewport meta (no user-scalable=no, no
-    // maximum-scale) must allow the scale change under the mobile profile.
-    const zoomedScale = await page.evaluate(
-      () => window.visualViewport?.scale ?? 1,
-    );
-    expect(zoomedScale).toBeGreaterThan(1.5);
-  });
-
-  test("resolved web viewport meta contains no WCAG-failing directives", async ({
-    page,
-  }) => {
-    const html = resolvedWebIndexHtml();
-    await page.route("**/", (route) =>
-      route.fulfill({ status: 200, contentType: "text/html", body: html }),
-    );
-    await page.goto("https://localhost/", { waitUntil: "domcontentloaded" });
-
-    // Verify the loaded document's viewport meta matches the WCAG-compliant value.
+test.describe("WCAG 2.2 SC 1.4.4 browser zoom", () => {
+  test("the served web shell allows 2× zoom", async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     const viewportMeta = await page.evaluate(() => {
       const meta = document.querySelector('meta[name="viewport"]');
       return meta?.getAttribute("content") ?? "";
@@ -104,40 +21,39 @@ test.describe("WCAG 2.2 SC 1.4.4 — browser-level zoom (visualViewport.scale)",
     expect(viewportMeta).toContain("viewport-fit=cover");
     expect(viewportMeta).not.toMatch(/user-scalable\s*=\s*no/i);
     expect(viewportMeta).not.toMatch(/maximum-scale/i);
-  });
 
-  test("old lockdown meta BLOCKS zoom under mobile profile (negative control)", async ({
-    page,
-  }) => {
-    // Serve the lockdown HTML — this is what a regression would look like
-    // if someone re-introduced maximum-scale=1.0, user-scalable=no.
-    const html = lockdownIndexHtml();
-    await page.route("**/", (route) =>
-      route.fulfill({ status: 200, contentType: "text/html", body: html }),
-    );
-    await page.goto("https://localhost/", { waitUntil: "domcontentloaded" });
+    const baseline = await pageScale(page);
+    expect(baseline.scale).toBeCloseTo(1, 1);
 
-    // Baseline: scale should be 1.0 at 100% zoom.
-    const baselineScale = await page.evaluate(
-      () => window.visualViewport?.scale ?? 1,
-    );
-    expect(baselineScale).toBeCloseTo(1, 1);
-
-    // Attempt the same 2× pinch-zoom via CDP.
     const client = await page.context().newCDPSession(page);
     await client.send("Emulation.setPageScaleFactor", { pageScaleFactor: 2 });
+    await expect
+      .poll(async () => (await pageScale(page)).scale)
+      .toBeGreaterThan(1.5);
 
-    // Wait for visualViewport to update.
-    await page.waitForTimeout(500);
+    const zoomed = await pageScale(page);
+    expect(zoomed.width).toBeLessThan(baseline.width * 0.75);
+    await expect(page.locator("body")).toBeVisible();
+  });
 
-    // Under the mobile/touch profile, the locked meta MUST block the scale
-    // change — visualViewport.scale stays at 1.0 (or very close).
-    // This proves the positive test above is not a false positive: if
-    // someone re-introduces the lockdown, this assertion would fail (or
-    // the positive test would fail), catching the regression.
-    const zoomedScale = await page.evaluate(
-      () => window.visualViewport?.scale ?? 1,
+  test("the previous lockdown blocks the same zoom request", async ({
+    page,
+  }) => {
+    await page.route("**/viewport-lockdown-control", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"><main>Locked control</main>',
+      }),
     );
-    expect(zoomedScale).toBeCloseTo(1, 1);
+    await page.goto("/viewport-lockdown-control", {
+      waitUntil: "domcontentloaded",
+    });
+    expect((await pageScale(page)).scale).toBeCloseTo(1, 1);
+
+    const client = await page.context().newCDPSession(page);
+    await client.send("Emulation.setPageScaleFactor", { pageScaleFactor: 2 });
+    await page.waitForTimeout(500);
+    expect((await pageScale(page)).scale).toBeCloseTo(1, 1);
   });
 });

--- a/packages/app/test/viewport-zoom-a11y.test.ts
+++ b/packages/app/test/viewport-zoom-a11y.test.ts
@@ -1,0 +1,70 @@
+/**
+ * WCAG 2.2 SC 1.4.4 regression guard for the web viewport meta tag.
+ *
+ * The shared index.html uses a build-time token (`__APP_VIEWPORT_CONTENT__`)
+ * that the appShellMetadataPlugin replaces with a platform-specific value.
+ * Web/desktop builds must not disable user zoom; only native Capacitor builds
+ * retain the touch-viewport lockdown. This test asserts the source token is
+ * present (not a hardcoded lockdown) and that the build-time replacement logic
+ * in vite.config.ts produces WCAG-compliant output for non-native targets.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appRoot = join(import.meta.dirname, "..");
+
+function readAppFile(rel: string): string {
+  return readFileSync(join(appRoot, rel), "utf8");
+}
+
+describe("viewport zoom a11y (WCAG 2.2 SC 1.4.4)", () => {
+  it("index.html does not hardcode the zoom lockdown", () => {
+    const html = readAppFile("index.html");
+    // The viewport meta must use the build-time token, not a literal lock.
+    expect(html).toContain(
+      '<meta name="viewport" content="__APP_VIEWPORT_CONTENT__" />',
+    );
+    // The WCAG-failing directives must not appear in the source.
+    expect(html).not.toMatch(/user-scalable\s*=\s*no/);
+    expect(html).not.toMatch(/maximum-scale\s*=\s*1\.0/);
+  });
+
+  it("vite.config resolves the token to a WCAG-compliant viewport for web builds", () => {
+    const viteConfig = readAppFile("vite.config.ts");
+
+    // The web viewport must not contain user-scalable=no or a maximum-scale cap.
+    expect(viteConfig).toMatch(
+      /VIEWPORT_CONTENT_WEB\s*=\s*\n?\s*"width=device-width,\s*initial-scale=1\.0,\s*viewport-fit=cover"/,
+    );
+
+    // The web constant must NOT include user-scalable=no or maximum-scale.
+    const webMatch = viteConfig.match(/VIEWPORT_CONTENT_WEB\s*=\s*"([^"]+)"/s);
+    expect(webMatch).not.toBeNull();
+    const webValue = webMatch?.[1];
+    expect(webValue).not.toMatch(/user-scalable\s*=\s*no/i);
+    expect(webValue).not.toMatch(/maximum-scale/i);
+  });
+
+  it("vite.config keeps the native lockdown for Capacitor mobile builds", () => {
+    const viteConfig = readAppFile("vite.config.ts");
+
+    // The native viewport must retain the lockdown.
+    const nativeMatch = viteConfig.match(
+      /VIEWPORT_CONTENT_NATIVE\s*=\s*\n?\s*"([^"]+)"/s,
+    );
+    expect(nativeMatch).not.toBeNull();
+    const nativeValue = nativeMatch?.[1];
+    expect(nativeValue).toMatch(/user-scalable\s*=\s*no/i);
+    expect(nativeValue).toMatch(/maximum-scale\s*=\s*1\.0/i);
+    expect(nativeValue).toMatch(/viewport-fit\s*=\s*cover/i);
+  });
+
+  it("the token replacement is gated on IS_CAPACITOR_MOBILE_BUILD", () => {
+    const viteConfig = readAppFile("vite.config.ts");
+    // The replacement map must branch on the Capacitor build flag.
+    expect(viteConfig).toMatch(
+      /__APP_VIEWPORT_CONTENT__[\s\S]*IS_CAPACITOR_MOBILE_BUILD/,
+    );
+  });
+});

--- a/packages/app/test/viewport-zoom-a11y.test.ts
+++ b/packages/app/test/viewport-zoom-a11y.test.ts
@@ -1,16 +1,4 @@
-/**
- * WCAG 2.2 SC 1.4.4 regression guard for the web viewport meta tag.
- *
- * Two layers of coverage:
- * 1. Source-level — the shared index.html uses a build-time token
- *    (`__APP_VIEWPORT_CONTENT__`) and the vite.config.ts replacement constants
- *    produce WCAG-compliant output for web and native builds.
- * 2. Build-output — invokes the REAL `appShellMetadataPlugin` exported from
- *    vite.config.ts and feeds the actual source index.html through its
- *    `transformIndexHtml` hook. This proves the plugin's replacement map and
- *    hook registration work end-to-end — a misconfigured map, dropped token,
- *    or unregistered hook would cause the test to fail.
- */
+/** Verifies the real app-shell transform emits the intended viewport per target. */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -21,171 +9,44 @@ import {
 } from "../vite.config";
 
 const appRoot = path.resolve(import.meta.dirname, "..");
+const sourceHtml = readFileSync(path.join(appRoot, "index.html"), "utf8");
 
-function readAppFile(rel: string): string {
-  return readFileSync(path.join(appRoot, rel), "utf8");
-}
-
-/**
- * Invoke the real appShellMetadataPlugin's transformIndexHtml hook on the
- * given source HTML, simulating a non-Capacitor (web) build environment.
- *
- * The plugin reads `process.env.ELIZA_CAPACITOR_BUILD_TARGET` at module load
- * time to determine IS_CAPACITOR_MOBILE_BUILD. Since vite.config.ts is already
- * loaded (defaulting to a web build), the plugin resolves to the web viewport
- * constants. The returned string is the actual output the Vite build pipeline
- * would emit.
- */
-function transformHtmlViaPlugin(sourceHtml: string): string {
-  const plugin = appShellMetadataPlugin();
-  // transformIndexHtml is a synchronous hook on this plugin (no async context
-  // needed), so we can call it directly. If Vite ever wraps it in an object
-  // form ({ handler, order }) we handle that too.
+function transformHtml(capacitorBuildTarget: string): string {
+  const plugin = appShellMetadataPlugin({ capacitorBuildTarget });
   const hook = plugin.transformIndexHtml;
-  if (typeof hook === "function") {
-    return (hook as (html: string) => string | string[])(sourceHtml) as string;
+  if (typeof hook !== "function") {
+    throw new Error("app-shell metadata transform must be a synchronous hook");
   }
-  if (
-    typeof hook === "object" &&
-    hook !== null &&
-    "handler" in hook &&
-    typeof hook.handler === "function"
-  ) {
-    return (hook.handler as (html: string) => string | string[])(
-      sourceHtml,
-    ) as string;
-  }
-  throw new Error(
-    "appShellMetadataPlugin.transformIndexHtml is neither a function nor an object handler",
-  );
+  return (hook as (html: string) => string)(sourceHtml);
 }
 
-describe("viewport zoom a11y — source-level (WCAG 2.2 SC 1.4.4)", () => {
-  it("index.html does not hardcode the zoom lockdown", () => {
-    const html = readAppFile("index.html");
-    // The viewport meta must use the build-time token, not a literal lock.
-    expect(html).toContain(
+describe("viewport zoom a11y", () => {
+  it("keeps the viewport policy at the build boundary", () => {
+    expect(sourceHtml).toContain(
       '<meta name="viewport" content="__APP_VIEWPORT_CONTENT__" />',
     );
-    // The WCAG-failing directives must not appear in the source.
-    expect(html).not.toMatch(/user-scalable\s*=\s*no/);
-    expect(html).not.toMatch(/maximum-scale\s*=\s*1\.0/);
+    expect(sourceHtml.match(/<meta name="viewport"/g)).toHaveLength(1);
   });
 
-  it("vite.config defines a WCAG-compliant viewport constant for web builds", () => {
-    const viteConfig = readAppFile("vite.config.ts");
+  it.each([
+    ["web", "", VIEWPORT_META_WEB],
+    ["iOS", "ios", VIEWPORT_META_NATIVE],
+    ["Android", "android", VIEWPORT_META_NATIVE],
+  ])(
+    "emits the %s viewport through the real transform",
+    (_, target, expected) => {
+      const emittedHtml = transformHtml(target);
+      expect(emittedHtml).toContain(
+        `<meta name="viewport" content="${expected}" />`,
+      );
+      expect(emittedHtml).not.toContain("__APP_");
+    },
+  );
 
-    // The web viewport constant must exist and be WCAG-compliant.
-    expect(viteConfig).toMatch(
-      /VIEWPORT_META_WEB\s*=\s*\n?\s*"width=device-width,\s*initial-scale=1\.0,\s*viewport-fit=cover"/,
-    );
-
-    // The web constant must NOT include user-scalable=no or maximum-scale.
-    const webMatch = viteConfig.match(
-      /VIEWPORT_META_WEB\s*=\s*\n?\s*"([^"]+)"/s,
-    );
-    expect(webMatch).not.toBeNull();
-    const webValue = webMatch?.[1];
-    expect(webValue).not.toMatch(/user-scalable\s*=\s*no/i);
-    expect(webValue).not.toMatch(/maximum-scale/i);
-  });
-
-  it("vite.config keeps the native lockdown for Capacitor mobile builds", () => {
-    const viteConfig = readAppFile("vite.config.ts");
-
-    // The native viewport constant must retain the lockdown.
-    const nativeMatch = viteConfig.match(
-      /VIEWPORT_META_NATIVE\s*=\s*\n?\s*"([^"]+)"/s,
-    );
-    expect(nativeMatch).not.toBeNull();
-    const nativeValue = nativeMatch?.[1];
-    expect(nativeValue).toMatch(/user-scalable\s*=\s*no/i);
-    expect(nativeValue).toMatch(/maximum-scale\s*=\s*1\.0/i);
-    expect(nativeValue).toMatch(/viewport-fit\s*=\s*cover/i);
-  });
-
-  it("the token replacement is gated on IS_CAPACITOR_MOBILE_BUILD", () => {
-    const viteConfig = readAppFile("vite.config.ts");
-    // The replacement map must branch on the Capacitor build flag.
-    expect(viteConfig).toMatch(
-      /__APP_VIEWPORT_CONTENT__[\s\S]*IS_CAPACITOR_MOBILE_BUILD/,
-    );
-  });
-});
-
-describe("viewport zoom a11y — build-output (real plugin transform)", () => {
-  it("real appShellMetadataPlugin resolves the token to the WCAG-compliant web viewport", () => {
-    const sourceHtml = readAppFile("index.html");
-
-    // Run the source through the REAL plugin's transformIndexHtml hook.
-    // Since vite.config.ts loads with ELIZA_CAPACITOR_BUILD_TARGET unset,
-    // IS_CAPACITOR_MOBILE_BUILD is false → web viewport constants apply.
-    const emittedHtml = transformHtmlViaPlugin(sourceHtml);
-
-    // The token MUST be gone — replaced by the real plugin.
-    expect(emittedHtml).not.toContain("__APP_VIEWPORT_CONTENT__");
-
-    // The resolved viewport meta must match the exported VIEWPORT_META_WEB
-    // constant exactly — not a duplicated literal.
-    expect(emittedHtml).toContain(
-      `<meta name="viewport" content="${VIEWPORT_META_WEB}" />`,
-    );
-
-    // The WCAG-failing directives must NOT be present in the emitted HTML.
-    expect(emittedHtml).not.toMatch(/user-scalable\s*=\s*no/);
-    expect(emittedHtml).not.toMatch(/maximum-scale\s*=\s*1\.0/);
-  });
-
-  it("real appShellMetadataPlugin resolves ALL metadata tokens, not just viewport", () => {
-    const sourceHtml = readAppFile("index.html");
-    const emittedHtml = transformHtmlViaPlugin(sourceHtml);
-
-    // No raw tokens should survive the transform — they all must resolve.
-    expect(emittedHtml).not.toContain("__APP_");
-  });
-
-  it("unresolved HTML still contains the raw token (regression guard)", () => {
-    const sourceHtml = readAppFile("index.html");
-
-    // If the transform stopped firing, the token would remain in the output.
-    // This proves the build-output assertions above have teeth: the raw
-    // index.html source still carries the token before the hook runs.
-    expect(sourceHtml).toContain("__APP_VIEWPORT_CONTENT__");
-
-    // And the source must NOT already contain the resolved viewport values
-    // (otherwise the transform would be a no-op and the tests above would
-    // pass even if the hook were removed).
-    expect(sourceHtml).not.toContain(
-      `<meta name="viewport" content="${VIEWPORT_META_WEB}"`,
-    );
-    expect(sourceHtml).not.toMatch(
-      /<meta name="viewport" content="width=device-width, initial-scale=1\.0, maximum-scale=1\.0/,
-    );
-  });
-
-  it("the exported VIEWPORT_META_NATIVE constant retains the lockdown for Capacitor builds", () => {
-    // Verify the exported constant itself carries the lockdown directives.
-    // This is what the Vite build substitutes when
-    // ELIZA_CAPACITOR_BUILD_TARGET is ios or android.
+  it("leaves browser zoom uncapped only on hosted web surfaces", () => {
+    expect(VIEWPORT_META_WEB).not.toMatch(/user-scalable\s*=\s*no/i);
+    expect(VIEWPORT_META_WEB).not.toMatch(/maximum-scale/i);
     expect(VIEWPORT_META_NATIVE).toMatch(/user-scalable\s*=\s*no/i);
-    expect(VIEWPORT_META_NATIVE).toMatch(/maximum-scale\s*=\s*1\.0/i);
-    expect(VIEWPORT_META_NATIVE).toMatch(/viewport-fit\s*=\s*cover/i);
-  });
-
-  it("a misconfigured plugin (token removed from index.html) would fail the transform test", () => {
-    // This is a mutation-test proof: if the token were absent from the source,
-    // the emitted HTML would not contain the resolved viewport meta.
-    const tamperedHtml = readAppFile("index.html").replaceAll(
-      "__APP_VIEWPORT_CONTENT__",
-      "INTENTIONALLY_BROKEN",
-    );
-    const emittedHtml = transformHtmlViaPlugin(tamperedHtml);
-
-    // The plugin has no replacement for INTENTIONALLY_BROKEN, so the
-    // WCAG-compliant viewport is NOT present — proving the test has teeth.
-    expect(emittedHtml).not.toContain(
-      `<meta name="viewport" content="${VIEWPORT_META_WEB}"`,
-    );
-    expect(emittedHtml).toContain("INTENTIONALLY_BROKEN");
+    expect(VIEWPORT_META_NATIVE).toMatch(/maximum-scale\s*=\s*1(?:\.0)?/i);
   });
 });

--- a/packages/app/test/viewport-zoom-a11y.test.ts
+++ b/packages/app/test/viewport-zoom-a11y.test.ts
@@ -5,38 +5,60 @@
  * 1. Source-level — the shared index.html uses a build-time token
  *    (`__APP_VIEWPORT_CONTENT__`) and the vite.config.ts replacement constants
  *    produce WCAG-compliant output for web and native builds.
- * 2. Build-output — the actual `__APP_VIEWPORT_CONTENT__` token in the real
- *    `index.html` is resolved using the exported build-time constants, proving
- *    the emitted HTML would contain the WCAG-compliant viewport — not the raw
- *    token or the source lockdown. This catches regressions where the transform
- *    stops firing, the replacement map is misconfigured, or the token text
- *    in index.html drifts from the replacement key.
+ * 2. Build-output — invokes the REAL `appShellMetadataPlugin` exported from
+ *    vite.config.ts and feeds the actual source index.html through its
+ *    `transformIndexHtml` hook. This proves the plugin's replacement map and
+ *    hook registration work end-to-end — a misconfigured map, dropped token,
+ *    or unregistered hook would cause the test to fail.
  */
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  appShellMetadataPlugin,
+  VIEWPORT_META_NATIVE,
+  VIEWPORT_META_WEB,
+} from "../vite.config";
 
-const appRoot = join(import.meta.dirname, "..");
+const appRoot = path.resolve(import.meta.dirname, "..");
 
 function readAppFile(rel: string): string {
-  return readFileSync(join(appRoot, rel), "utf8");
+  return readFileSync(path.join(appRoot, rel), "utf8");
 }
 
 /**
- * Build-time viewport constants exported from vite.config.ts.
+ * Invoke the real appShellMetadataPlugin's transformIndexHtml hook on the
+ * given source HTML, simulating a non-Capacitor (web) build environment.
  *
- * These are the exact values the appShellMetadataPlugin replacement map uses to
- * resolve `__APP_VIEWPORT_CONTENT__`. Importing them directly avoids string
- * parsing the config source and ties the build-output assertions to the real
- * constants the build pipeline applies.
+ * The plugin reads `process.env.ELIZA_CAPACITOR_BUILD_TARGET` at module load
+ * time to determine IS_CAPACITOR_MOBILE_BUILD. Since vite.config.ts is already
+ * loaded (defaulting to a web build), the plugin resolves to the web viewport
+ * constants. The returned string is the actual output the Vite build pipeline
+ * would emit.
  */
-const VIEWPORT_CONTENT_TOKEN = "__APP_VIEWPORT_CONTENT__";
-
-const VIEWPORT_CONTENT_WEB =
-  "width=device-width, initial-scale=1.0, viewport-fit=cover";
-
-const VIEWPORT_CONTENT_NATIVE =
-  "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover";
+function transformHtmlViaPlugin(sourceHtml: string): string {
+  const plugin = appShellMetadataPlugin();
+  // transformIndexHtml is a synchronous hook on this plugin (no async context
+  // needed), so we can call it directly. If Vite ever wraps it in an object
+  // form ({ handler, order }) we handle that too.
+  const hook = plugin.transformIndexHtml;
+  if (typeof hook === "function") {
+    return (hook as (html: string) => string | string[])(sourceHtml) as string;
+  }
+  if (
+    typeof hook === "object" &&
+    hook !== null &&
+    "handler" in hook &&
+    typeof hook.handler === "function"
+  ) {
+    return (hook.handler as (html: string) => string | string[])(
+      sourceHtml,
+    ) as string;
+  }
+  throw new Error(
+    "appShellMetadataPlugin.transformIndexHtml is neither a function nor an object handler",
+  );
+}
 
 describe("viewport zoom a11y — source-level (WCAG 2.2 SC 1.4.4)", () => {
   it("index.html does not hardcode the zoom lockdown", () => {
@@ -91,22 +113,22 @@ describe("viewport zoom a11y — source-level (WCAG 2.2 SC 1.4.4)", () => {
   });
 });
 
-describe("viewport zoom a11y — build-output (transform resolves the token)", () => {
-  it("resolved HTML for web builds contains the WCAG-compliant viewport, not the token", () => {
+describe("viewport zoom a11y — build-output (real plugin transform)", () => {
+  it("real appShellMetadataPlugin resolves the token to the WCAG-compliant web viewport", () => {
     const sourceHtml = readAppFile("index.html");
 
-    // Simulate the exact replacement the Vite build pipeline applies.
-    const emittedHtml = sourceHtml.replaceAll(
-      VIEWPORT_CONTENT_TOKEN,
-      VIEWPORT_CONTENT_WEB,
-    );
+    // Run the source through the REAL plugin's transformIndexHtml hook.
+    // Since vite.config.ts loads with ELIZA_CAPACITOR_BUILD_TARGET unset,
+    // IS_CAPACITOR_MOBILE_BUILD is false → web viewport constants apply.
+    const emittedHtml = transformHtmlViaPlugin(sourceHtml);
 
-    // The token MUST be gone — replaced with the real value.
-    expect(emittedHtml).not.toContain(VIEWPORT_CONTENT_TOKEN);
+    // The token MUST be gone — replaced by the real plugin.
+    expect(emittedHtml).not.toContain("__APP_VIEWPORT_CONTENT__");
 
-    // The resolved viewport meta must be the WCAG-compliant web value.
+    // The resolved viewport meta must match the exported VIEWPORT_META_WEB
+    // constant exactly — not a duplicated literal.
     expect(emittedHtml).toContain(
-      `<meta name="viewport" content="${VIEWPORT_CONTENT_WEB}" />`,
+      `<meta name="viewport" content="${VIEWPORT_META_WEB}" />`,
     );
 
     // The WCAG-failing directives must NOT be present in the emitted HTML.
@@ -114,21 +136,12 @@ describe("viewport zoom a11y — build-output (transform resolves the token)", (
     expect(emittedHtml).not.toMatch(/maximum-scale\s*=\s*1\.0/);
   });
 
-  it("resolved HTML for native Capacitor builds retains the touch-viewport lockdown", () => {
+  it("real appShellMetadataPlugin resolves ALL metadata tokens, not just viewport", () => {
     const sourceHtml = readAppFile("index.html");
+    const emittedHtml = transformHtmlViaPlugin(sourceHtml);
 
-    // Simulate the replacement for a Capacitor (native) build.
-    const emittedHtml = sourceHtml.replaceAll(
-      VIEWPORT_CONTENT_TOKEN,
-      VIEWPORT_CONTENT_NATIVE,
-    );
-
-    // The token MUST be gone — replaced with the native lockdown.
-    expect(emittedHtml).not.toContain(VIEWPORT_CONTENT_TOKEN);
-
-    // The native viewport MUST retain the lockdown directives.
-    expect(emittedHtml).toMatch(/user-scalable\s*=\s*no/);
-    expect(emittedHtml).toMatch(/maximum-scale\s*=\s*1\.0/);
+    // No raw tokens should survive the transform — they all must resolve.
+    expect(emittedHtml).not.toContain("__APP_");
   });
 
   it("unresolved HTML still contains the raw token (regression guard)", () => {
@@ -137,16 +150,42 @@ describe("viewport zoom a11y — build-output (transform resolves the token)", (
     // If the transform stopped firing, the token would remain in the output.
     // This proves the build-output assertions above have teeth: the raw
     // index.html source still carries the token before the hook runs.
-    expect(sourceHtml).toContain(VIEWPORT_CONTENT_TOKEN);
+    expect(sourceHtml).toContain("__APP_VIEWPORT_CONTENT__");
 
     // And the source must NOT already contain the resolved viewport values
     // (otherwise the transform would be a no-op and the tests above would
     // pass even if the hook were removed).
     expect(sourceHtml).not.toContain(
-      `<meta name="viewport" content="${VIEWPORT_CONTENT_WEB}"`,
+      `<meta name="viewport" content="${VIEWPORT_META_WEB}"`,
     );
     expect(sourceHtml).not.toMatch(
       /<meta name="viewport" content="width=device-width, initial-scale=1\.0, maximum-scale=1\.0/,
     );
+  });
+
+  it("the exported VIEWPORT_META_NATIVE constant retains the lockdown for Capacitor builds", () => {
+    // Verify the exported constant itself carries the lockdown directives.
+    // This is what the Vite build substitutes when
+    // ELIZA_CAPACITOR_BUILD_TARGET is ios or android.
+    expect(VIEWPORT_META_NATIVE).toMatch(/user-scalable\s*=\s*no/i);
+    expect(VIEWPORT_META_NATIVE).toMatch(/maximum-scale\s*=\s*1\.0/i);
+    expect(VIEWPORT_META_NATIVE).toMatch(/viewport-fit\s*=\s*cover/i);
+  });
+
+  it("a misconfigured plugin (token removed from index.html) would fail the transform test", () => {
+    // This is a mutation-test proof: if the token were absent from the source,
+    // the emitted HTML would not contain the resolved viewport meta.
+    const tamperedHtml = readAppFile("index.html").replaceAll(
+      "__APP_VIEWPORT_CONTENT__",
+      "INTENTIONALLY_BROKEN",
+    );
+    const emittedHtml = transformHtmlViaPlugin(tamperedHtml);
+
+    // The plugin has no replacement for INTENTIONALLY_BROKEN, so the
+    // WCAG-compliant viewport is NOT present — proving the test has teeth.
+    expect(emittedHtml).not.toContain(
+      `<meta name="viewport" content="${VIEWPORT_META_WEB}"`,
+    );
+    expect(emittedHtml).toContain("INTENTIONALLY_BROKEN");
   });
 });

--- a/packages/app/test/viewport-zoom-a11y.test.ts
+++ b/packages/app/test/viewport-zoom-a11y.test.ts
@@ -1,12 +1,16 @@
 /**
  * WCAG 2.2 SC 1.4.4 regression guard for the web viewport meta tag.
  *
- * The shared index.html uses a build-time token (`__APP_VIEWPORT_CONTENT__`)
- * that the appShellMetadataPlugin replaces with a platform-specific value.
- * Web/desktop builds must not disable user zoom; only native Capacitor builds
- * retain the touch-viewport lockdown. This test asserts the source token is
- * present (not a hardcoded lockdown) and that the build-time replacement logic
- * in vite.config.ts produces WCAG-compliant output for non-native targets.
+ * Two layers of coverage:
+ * 1. Source-level — the shared index.html uses a build-time token
+ *    (`__APP_VIEWPORT_CONTENT__`) and the vite.config.ts replacement constants
+ *    produce WCAG-compliant output for web and native builds.
+ * 2. Build-output — the actual `__APP_VIEWPORT_CONTENT__` token in the real
+ *    `index.html` is resolved using the exported build-time constants, proving
+ *    the emitted HTML would contain the WCAG-compliant viewport — not the raw
+ *    token or the source lockdown. This catches regressions where the transform
+ *    stops firing, the replacement map is misconfigured, or the token text
+ *    in index.html drifts from the replacement key.
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -18,7 +22,23 @@ function readAppFile(rel: string): string {
   return readFileSync(join(appRoot, rel), "utf8");
 }
 
-describe("viewport zoom a11y (WCAG 2.2 SC 1.4.4)", () => {
+/**
+ * Build-time viewport constants exported from vite.config.ts.
+ *
+ * These are the exact values the appShellMetadataPlugin replacement map uses to
+ * resolve `__APP_VIEWPORT_CONTENT__`. Importing them directly avoids string
+ * parsing the config source and ties the build-output assertions to the real
+ * constants the build pipeline applies.
+ */
+const VIEWPORT_CONTENT_TOKEN = "__APP_VIEWPORT_CONTENT__";
+
+const VIEWPORT_CONTENT_WEB =
+  "width=device-width, initial-scale=1.0, viewport-fit=cover";
+
+const VIEWPORT_CONTENT_NATIVE =
+  "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover";
+
+describe("viewport zoom a11y — source-level (WCAG 2.2 SC 1.4.4)", () => {
   it("index.html does not hardcode the zoom lockdown", () => {
     const html = readAppFile("index.html");
     // The viewport meta must use the build-time token, not a literal lock.
@@ -30,16 +50,18 @@ describe("viewport zoom a11y (WCAG 2.2 SC 1.4.4)", () => {
     expect(html).not.toMatch(/maximum-scale\s*=\s*1\.0/);
   });
 
-  it("vite.config resolves the token to a WCAG-compliant viewport for web builds", () => {
+  it("vite.config defines a WCAG-compliant viewport constant for web builds", () => {
     const viteConfig = readAppFile("vite.config.ts");
 
-    // The web viewport must not contain user-scalable=no or a maximum-scale cap.
+    // The web viewport constant must exist and be WCAG-compliant.
     expect(viteConfig).toMatch(
-      /VIEWPORT_CONTENT_WEB\s*=\s*\n?\s*"width=device-width,\s*initial-scale=1\.0,\s*viewport-fit=cover"/,
+      /VIEWPORT_META_WEB\s*=\s*\n?\s*"width=device-width,\s*initial-scale=1\.0,\s*viewport-fit=cover"/,
     );
 
     // The web constant must NOT include user-scalable=no or maximum-scale.
-    const webMatch = viteConfig.match(/VIEWPORT_CONTENT_WEB\s*=\s*"([^"]+)"/s);
+    const webMatch = viteConfig.match(
+      /VIEWPORT_META_WEB\s*=\s*\n?\s*"([^"]+)"/s,
+    );
     expect(webMatch).not.toBeNull();
     const webValue = webMatch?.[1];
     expect(webValue).not.toMatch(/user-scalable\s*=\s*no/i);
@@ -49,9 +71,9 @@ describe("viewport zoom a11y (WCAG 2.2 SC 1.4.4)", () => {
   it("vite.config keeps the native lockdown for Capacitor mobile builds", () => {
     const viteConfig = readAppFile("vite.config.ts");
 
-    // The native viewport must retain the lockdown.
+    // The native viewport constant must retain the lockdown.
     const nativeMatch = viteConfig.match(
-      /VIEWPORT_CONTENT_NATIVE\s*=\s*\n?\s*"([^"]+)"/s,
+      /VIEWPORT_META_NATIVE\s*=\s*\n?\s*"([^"]+)"/s,
     );
     expect(nativeMatch).not.toBeNull();
     const nativeValue = nativeMatch?.[1];
@@ -65,6 +87,66 @@ describe("viewport zoom a11y (WCAG 2.2 SC 1.4.4)", () => {
     // The replacement map must branch on the Capacitor build flag.
     expect(viteConfig).toMatch(
       /__APP_VIEWPORT_CONTENT__[\s\S]*IS_CAPACITOR_MOBILE_BUILD/,
+    );
+  });
+});
+
+describe("viewport zoom a11y — build-output (transform resolves the token)", () => {
+  it("resolved HTML for web builds contains the WCAG-compliant viewport, not the token", () => {
+    const sourceHtml = readAppFile("index.html");
+
+    // Simulate the exact replacement the Vite build pipeline applies.
+    const emittedHtml = sourceHtml.replaceAll(
+      VIEWPORT_CONTENT_TOKEN,
+      VIEWPORT_CONTENT_WEB,
+    );
+
+    // The token MUST be gone — replaced with the real value.
+    expect(emittedHtml).not.toContain(VIEWPORT_CONTENT_TOKEN);
+
+    // The resolved viewport meta must be the WCAG-compliant web value.
+    expect(emittedHtml).toContain(
+      `<meta name="viewport" content="${VIEWPORT_CONTENT_WEB}" />`,
+    );
+
+    // The WCAG-failing directives must NOT be present in the emitted HTML.
+    expect(emittedHtml).not.toMatch(/user-scalable\s*=\s*no/);
+    expect(emittedHtml).not.toMatch(/maximum-scale\s*=\s*1\.0/);
+  });
+
+  it("resolved HTML for native Capacitor builds retains the touch-viewport lockdown", () => {
+    const sourceHtml = readAppFile("index.html");
+
+    // Simulate the replacement for a Capacitor (native) build.
+    const emittedHtml = sourceHtml.replaceAll(
+      VIEWPORT_CONTENT_TOKEN,
+      VIEWPORT_CONTENT_NATIVE,
+    );
+
+    // The token MUST be gone — replaced with the native lockdown.
+    expect(emittedHtml).not.toContain(VIEWPORT_CONTENT_TOKEN);
+
+    // The native viewport MUST retain the lockdown directives.
+    expect(emittedHtml).toMatch(/user-scalable\s*=\s*no/);
+    expect(emittedHtml).toMatch(/maximum-scale\s*=\s*1\.0/);
+  });
+
+  it("unresolved HTML still contains the raw token (regression guard)", () => {
+    const sourceHtml = readAppFile("index.html");
+
+    // If the transform stopped firing, the token would remain in the output.
+    // This proves the build-output assertions above have teeth: the raw
+    // index.html source still carries the token before the hook runs.
+    expect(sourceHtml).toContain(VIEWPORT_CONTENT_TOKEN);
+
+    // And the source must NOT already contain the resolved viewport values
+    // (otherwise the transform would be a no-op and the tests above would
+    // pass even if the hook were removed).
+    expect(sourceHtml).not.toContain(
+      `<meta name="viewport" content="${VIEWPORT_CONTENT_WEB}"`,
+    );
+    expect(sourceHtml).not.toMatch(
+      /<meta name="viewport" content="width=device-width, initial-scale=1\.0, maximum-scale=1\.0/,
     );
   });
 });

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1000,28 +1000,26 @@ export function resolveAppShellLocalCspSources(
   };
 }
 
-/**
- * Exported WCAG 2.2 SC 1.4.4 viewport constants for the build-time token.
- *
- * Exposed so that build-output regression tests can assert the exact resolved
- * values without reimplementing string parsing of the config source.
- *
- * Web builds: no zoom cap (WCAG-compliant).
- * Native Capacitor builds: full lockdown (captive WebView has no browser
- * chrome; pinch-zoom interferes with in-app interactions).
- */
+/** Viewport policies selected by the app-shell metadata transform. */
 export const VIEWPORT_META_NATIVE =
   "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover";
 export const VIEWPORT_META_WEB =
   "width=device-width, initial-scale=1.0, viewport-fit=cover";
 
-export function appShellMetadataPlugin(): Plugin {
+/** Creates the metadata transform; the target override keeps build-mode tests exact. */
+export function appShellMetadataPlugin(
+  options: { capacitorBuildTarget?: string } = {},
+): Plugin {
+  const capacitorBuildTarget =
+    options.capacitorBuildTarget ?? CAPACITOR_BUILD_TARGET;
+  const isCapacitorMobileBuild =
+    capacitorBuildTarget === "ios" || capacitorBuildTarget === "android";
   const isIosStoreBuild =
-    CAPACITOR_BUILD_TARGET === "ios" &&
+    capacitorBuildTarget === "ios" &&
     (process.env.ELIZA_BUILD_VARIANT === "store" ||
       process.env.ELIZA_RELEASE_AUTHORITY === "apple-app-store");
   const { localHttpSources, localConnectSources } =
-    resolveAppShellLocalCspSources(CAPACITOR_BUILD_TARGET, isIosStoreBuild);
+    resolveAppShellLocalCspSources(capacitorBuildTarget, isIosStoreBuild);
   const manifest = `${JSON.stringify(
     {
       name: APP_SHELL_METADATA.appName,
@@ -1046,13 +1044,6 @@ export function appShellMetadataPlugin(): Plugin {
     2,
   )}\n`;
 
-  // WCAG 2.2 SC 1.4.4: web/desktop builds must not disable user zoom. Native
-  // Capacitor builds keep the touch-viewport lockdown because they run in a
-  // captive WebView with no browser chrome — zoom there is a pinch gesture that
-  // interferes with in-app interactions, not an accessibility mechanism.
-  const VIEWPORT_CONTENT_NATIVE = VIEWPORT_META_NATIVE;
-  const VIEWPORT_CONTENT_WEB = VIEWPORT_META_WEB;
-
   const replacements = new Map<string, string>([
     ["__APP_NAME__", APP_SHELL_METADATA.appName],
     ["__APP_DESCRIPTION__", APP_SHELL_METADATA.description],
@@ -1063,9 +1054,7 @@ export function appShellMetadataPlugin(): Plugin {
     ["__APP_CSP_LOCAL_CONNECT__", localConnectSources],
     [
       "__APP_VIEWPORT_CONTENT__",
-      IS_CAPACITOR_MOBILE_BUILD
-        ? VIEWPORT_CONTENT_NATIVE
-        : VIEWPORT_CONTENT_WEB,
+      isCapacitorMobileBuild ? VIEWPORT_META_NATIVE : VIEWPORT_META_WEB,
     ],
   ]);
 

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1031,6 +1031,15 @@ function appShellMetadataPlugin(): Plugin {
     2,
   )}\n`;
 
+  // WCAG 2.2 SC 1.4.4: web/desktop builds must not disable user zoom. Native
+  // Capacitor builds keep the touch-viewport lockdown because they run in a
+  // captive WebView with no browser chrome — zoom there is a pinch gesture that
+  // interferes with in-app interactions, not an accessibility mechanism.
+  const VIEWPORT_CONTENT_NATIVE =
+    "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover";
+  const VIEWPORT_CONTENT_WEB =
+    "width=device-width, initial-scale=1.0, viewport-fit=cover";
+
   const replacements = new Map<string, string>([
     ["__APP_NAME__", APP_SHELL_METADATA.appName],
     ["__APP_DESCRIPTION__", APP_SHELL_METADATA.description],
@@ -1039,6 +1048,12 @@ function appShellMetadataPlugin(): Plugin {
     ["__APP_THEME_COLOR__", APP_SHELL_METADATA.themeColor],
     ["__APP_CSP_LOCAL_HTTP__", localHttpSources],
     ["__APP_CSP_LOCAL_CONNECT__", localConnectSources],
+    [
+      "__APP_VIEWPORT_CONTENT__",
+      IS_CAPACITOR_MOBILE_BUILD
+        ? VIEWPORT_CONTENT_NATIVE
+        : VIEWPORT_CONTENT_WEB,
+    ],
   ]);
 
   return {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1000,7 +1000,22 @@ export function resolveAppShellLocalCspSources(
   };
 }
 
-function appShellMetadataPlugin(): Plugin {
+/**
+ * Exported WCAG 2.2 SC 1.4.4 viewport constants for the build-time token.
+ *
+ * Exposed so that build-output regression tests can assert the exact resolved
+ * values without reimplementing string parsing of the config source.
+ *
+ * Web builds: no zoom cap (WCAG-compliant).
+ * Native Capacitor builds: full lockdown (captive WebView has no browser
+ * chrome; pinch-zoom interferes with in-app interactions).
+ */
+export const VIEWPORT_META_NATIVE =
+  "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover";
+export const VIEWPORT_META_WEB =
+  "width=device-width, initial-scale=1.0, viewport-fit=cover";
+
+export function appShellMetadataPlugin(): Plugin {
   const isIosStoreBuild =
     CAPACITOR_BUILD_TARGET === "ios" &&
     (process.env.ELIZA_BUILD_VARIANT === "store" ||
@@ -1035,10 +1050,8 @@ function appShellMetadataPlugin(): Plugin {
   // Capacitor builds keep the touch-viewport lockdown because they run in a
   // captive WebView with no browser chrome — zoom there is a pinch gesture that
   // interferes with in-app interactions, not an accessibility mechanism.
-  const VIEWPORT_CONTENT_NATIVE =
-    "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover";
-  const VIEWPORT_CONTENT_WEB =
-    "width=device-width, initial-scale=1.0, viewport-fit=cover";
+  const VIEWPORT_CONTENT_NATIVE = VIEWPORT_META_NATIVE;
+  const VIEWPORT_CONTENT_WEB = VIEWPORT_META_WEB;
 
   const replacements = new Map<string, string>([
     ["__APP_NAME__", APP_SHELL_METADATA.appName],

--- a/packages/elizaos/templates/project/apps/app/index.html
+++ b/packages/elizaos/templates/project/apps/app/index.html
@@ -32,7 +32,7 @@
     }
   </script>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="viewport" content="__APP_VIEWPORT_CONTENT__" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="mobile-web-app-capable" content="yes" />

--- a/packages/elizaos/templates/project/apps/app/package.json
+++ b/packages/elizaos/templates/project/apps/app/package.json
@@ -26,7 +26,7 @@
     "cap:sync:android": "capacitor sync android",
     "cap:open:ios": "capacitor open ios",
     "cap:open:android": "capacitor open android",
-    "build:web": "bun --bun vite build"
+    "build:web": "bun --bun vite build && node scripts/verify-viewport-meta.mjs"
   },
   "dependencies": {
     "@capacitor/android": "^8.0.2",

--- a/packages/elizaos/templates/project/apps/app/scripts/build.mjs
+++ b/packages/elizaos/templates/project/apps/app/scripts/build.mjs
@@ -114,6 +114,11 @@ if (fullSetup) {
 }
 
 await run(bunExecutable, ["--bun", "vite", "build"], appDir);
+await run(
+  process.execPath,
+  [path.join(__dirname, "verify-viewport-meta.mjs")],
+  appDir,
+);
 if (resolveElizaAssetBaseUrls().appAssetBaseUrl) {
   await run(process.execPath, [pruneCdnAssetsScript], repoRoot);
 }

--- a/packages/elizaos/templates/project/apps/app/scripts/verify-viewport-meta.mjs
+++ b/packages/elizaos/templates/project/apps/app/scripts/verify-viewport-meta.mjs
@@ -1,0 +1,93 @@
+/**
+ * Verifies that a generated app's emitted shell preserves its target viewport
+ * policy: hosted surfaces permit 200% zoom and Capacitor keeps native gestures.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+function viewportContent(html) {
+  const tags = (html.match(/<meta\b[^>]*>/gi) ?? []).filter((tag) =>
+    /\bname=["']viewport["']/i.test(tag),
+  );
+  if (tags.length !== 1) {
+    throw new Error(
+      `expected exactly one viewport meta tag, found ${tags.length}`,
+    );
+  }
+  const content = tags[0].match(/\bcontent=["']([^"']*)["']/i)?.[1];
+  if (!content || content.includes("__APP_")) {
+    throw new Error(
+      "viewport meta content is missing or still contains a token",
+    );
+  }
+  return content;
+}
+
+function directives(content) {
+  const values = new Map();
+  for (const part of content.split(",")) {
+    const [name, ...value] = part.trim().toLowerCase().split("=");
+    if (!name || values.has(name)) {
+      throw new Error(`viewport directive is empty or duplicated: ${name}`);
+    }
+    values.set(name, value.join("="));
+  }
+  return values;
+}
+
+export function assertViewportMetaPolicy(html, capacitorBuildTarget = "") {
+  const content = viewportContent(html);
+  const values = directives(content);
+  if (
+    values.get("width") !== "device-width" ||
+    values.get("initial-scale") !== "1.0" ||
+    values.get("viewport-fit") !== "cover"
+  ) {
+    throw new Error(
+      "viewport must preserve device width, initial scale, and cover fit",
+    );
+  }
+
+  const native =
+    capacitorBuildTarget === "ios" || capacitorBuildTarget === "android";
+  if (native) {
+    if (
+      values.get("user-scalable") !== "no" ||
+      values.get("maximum-scale") !== "1.0"
+    ) {
+      throw new Error("Capacitor viewport must retain its native zoom policy");
+    }
+  } else {
+    const maximumScale = values.has("maximum-scale")
+      ? Number(values.get("maximum-scale"))
+      : null;
+    if (
+      ["no", "0", "false"].includes(values.get("user-scalable")) ||
+      (maximumScale !== null &&
+        (!Number.isFinite(maximumScale) || maximumScale < 2))
+    ) {
+      throw new Error(
+        "hosted viewport must allow user-agent zoom to at least 200%",
+      );
+    }
+  }
+  return content;
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedPath) {
+  const appDir = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
+  const html = fs.readFileSync(path.join(appDir, "dist", "index.html"), "utf8");
+  const target = process.env.ELIZA_CAPACITOR_BUILD_TARGET ?? "";
+  const content = assertViewportMetaPolicy(html, target);
+  console.log(
+    `[verify-viewport-meta] ${target || "web"} policy verified: ${content}`,
+  );
+}

--- a/packages/elizaos/templates/project/apps/app/test/viewport-zoom-a11y.test.ts
+++ b/packages/elizaos/templates/project/apps/app/test/viewport-zoom-a11y.test.ts
@@ -1,0 +1,34 @@
+/** Verifies generated apps resolve their viewport policy through the real Vite hook. */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  appShellViewportPlugin,
+  VIEWPORT_META_NATIVE,
+  VIEWPORT_META_WEB,
+} from "../vite.config";
+
+const sourceHtml = readFileSync(
+  path.resolve(import.meta.dirname, "../index.html"),
+  "utf8",
+);
+
+function transform(target: string) {
+  const hook = appShellViewportPlugin(target).transformIndexHtml;
+  if (typeof hook !== "function") {
+    throw new Error("app-shell viewport transform must be synchronous");
+  }
+  return (hook as (html: string) => string)(sourceHtml);
+}
+
+describe("generated app viewport", () => {
+  it.each([
+    ["hosted", "", VIEWPORT_META_WEB],
+    ["iOS", "ios", VIEWPORT_META_NATIVE],
+    ["Android", "android", VIEWPORT_META_NATIVE],
+  ])("emits the %s policy", (_, target, expected) => {
+    const emitted = transform(target);
+    expect(emitted).toContain(`<meta name="viewport" content="${expected}" />`);
+    expect(emitted).not.toContain("__APP_VIEWPORT_CONTENT__");
+  });
+});

--- a/packages/elizaos/templates/project/apps/app/vite.config.ts
+++ b/packages/elizaos/templates/project/apps/app/vite.config.ts
@@ -368,6 +368,28 @@ function resolveNativePluginAliasEntries(): Array<{
 
 const NATIVE_PLUGIN_ALIAS_ENTRIES = resolveNativePluginAliasEntries();
 
+export const VIEWPORT_META_NATIVE =
+  "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover";
+export const VIEWPORT_META_WEB =
+  "width=device-width, initial-scale=1.0, viewport-fit=cover";
+
+/** Resolves the scaffold shell's viewport policy for hosted and native builds. */
+export function appShellViewportPlugin(
+  capacitorBuildTarget = process.env.ELIZA_CAPACITOR_BUILD_TARGET ?? "",
+): Plugin {
+  const native =
+    capacitorBuildTarget === "ios" || capacitorBuildTarget === "android";
+  return {
+    name: "app-shell-viewport",
+    transformIndexHtml(html) {
+      return html.replaceAll(
+        "__APP_VIEWPORT_CONTENT__",
+        native ? VIEWPORT_META_NATIVE : VIEWPORT_META_WEB,
+      );
+    },
+  };
+}
+
 function resolveManualChunk(id: string): string | undefined {
   const normalizedId = id.split(path.sep).join("/");
 
@@ -1058,6 +1080,7 @@ export default defineConfig({
     ),
   },
   plugins: [
+    appShellViewportPlugin(),
     nativeModuleStubPlugin(),
     asyncLocalStoragePatchPlugin(),
     watchWorkspacePackagesPlugin(),


### PR DESCRIPTION
# Relates to

Closes #18077

## Outcome

Hosted elizaOS app surfaces and newly scaffolded web projects now permit browser zoom to at least 200%. Capacitor iOS/Android builds retain the existing native gesture policy. The policy is selected at the real Vite HTML transform boundary and verified again against emitted `dist/index.html`, so a missing hook, unresolved token, duplicated directive, or alternate lock spelling fails the build.

## Root-cause fixes

- Replaced the shared app's hard-coded viewport lock with a target-aware build token.
- Made the real metadata transform directly testable for web, iOS, and Android targets.
- Added a post-build verifier to both app build entry points and the generated-project template.
- Extended the fix to `elizaos create` project scaffolds, which otherwise continued generating the same inaccessible web viewport.
- Replaced source-regex and hand-rewritten-HTML tests with the real transform, real emitted output, and a real served-app Pixel 7 browser test.
- Added a locked-meta negative control proving the browser test fails for the original policy.
- Rejects `user-scalable=no`, `0`, and `false`, finite zoom caps below 2, unresolved tokens, duplicate tags, and duplicate directives.

## Target policy

| Surface | Emitted viewport |
| --- | --- |
| Hosted web / desktop | `width=device-width, initial-scale=1.0, viewport-fit=cover` |
| Capacitor iOS / Android | `width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover` |

The native policy is deliberately unchanged because the captive WebView uses pinch gestures for established full-bleed app interactions; this PR fixes browser/PWA accessibility without silently changing native gesture semantics.

## Exact-head verification

Head: `15ccc755f8b3756196913ceccecced344f7af17c`

- `bun install --frozen-lockfile` — no changes.
- `bun run --cwd packages/app typecheck` — passed.
- `bun run --cwd packages/app lint` — passed, no fixes.
- Focused viewport contract/verifier tests — 14/14 passed.
- Real Pixel 7 Playwright hosted-shell zoom + locked negative control — 2/2 passed.
- `bun run --cwd packages/app build:web` — passed; emitted hosted viewport verified.
- Real iOS-targeted Vite production build — passed; emitted native viewport verified.
- `bun run --cwd packages/app audit:app` — 214/214 passed; broken=0, needs-work=0; OCR broken=0.
- `bun run --cwd packages/elizaos typecheck` — passed.
- `bun run --cwd packages/elizaos lint:check` — passed.
- `bun run --cwd packages/elizaos test` — 93/93 passed.
- `bun run --cwd packages/elizaos test:packaged` — passed after generating and inspecting a packaged project.
- `bun run verify` — passed on exact head; 7,703 test files scanned with zero focused/orphaned skips.

## Risks

Low and bounded to app-shell metadata at build time. No runtime business path, API, database, model, or scheduling behavior changes. Both hosted and native emitted artifacts are hard-gated, and 100% rendering remains pixel-stable under the full app audit.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2; OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent; Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

Evidence matches the exact reviewed commit.
<!-- evidence-head:15ccc755f8b3756196913ceccecced344f7af17c -->

<!-- evidence-row:before-screenshots -->
- [x] [Desktop + mobile at 100%](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18084-viewport-zoom-100pct-desktop-mobile-15ccc755.jpg)

<!-- evidence-row:after-screenshots -->
- [x] [Desktop + mobile at 200%](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18084-viewport-zoom-200pct-desktop-mobile-15ccc755.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] [Mobile 100% → 200% MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18084-viewport-zoom-mobile-15ccc755.mp4) ([desktop MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18084-viewport-zoom-desktop-15ccc755.mp4))

<!-- evidence-row:backend-logs -->
- [ ] N/A - build-time HTML policy and browser interaction only; no backend path changes.

<!-- evidence-row:frontend-logs -->
- [x] [18084-viewport-zoom-frontend-test-log-v2-15ccc755.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18084-viewport-zoom-frontend-test-log-v2-15ccc755.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, provider, model, action, or agent behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] [Exact visualViewport metadata and 1x/2x telemetry](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18084-viewport-evidence-report-15ccc755.json)

<!-- evidence-row:ocr-review -->
- [x] [Desktop/mobile 100%/200% OCR and human review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18084-viewport-zoom-ocr-review-15ccc755.txt)

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: N/A - contribute-to-eliza skill was not available
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"N/A - contribute-to-eliza skill was not available"} -->


