### PR TITLE
fix(core): resolve connector-account storage lazily so accounts persist across restart

### DIFF
--- a/packages/agent/src/api/connector-account-routes.durable.test.ts
+++ b/packages/agent/src/api/connector-account-routes.durable.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Durability coverage for GET /api/connectors/<provider>/accounts against the
+ * REAL @elizaos/core connector-account manager (unlike the sibling route test,
+ * core is not mocked here). Reproduces the production boot shape where the
+ * manager is constructed during plugin registration before the SQL adapter is
+ * attached to the runtime, then proves the account written after OAuth lands
+ * in the durable adapter and is still listed by the route after a simulated
+ * restart (fresh runtime + manager over the same adapter). Deterministic
+ * harness — core's InMemoryDatabaseAdapter stands in for plugin-sql.
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  getConnectorAccountManager,
+  InMemoryDatabaseAdapter,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ConnectorAccountRouteContext,
+  handleConnectorAccountRoutes,
+} from "./connector-account-routes";
+
+type Captured = { status: number; body: unknown };
+
+function createRuntime(adapter?: InMemoryDatabaseAdapter) {
+  return {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    adapter,
+    getService: vi.fn(() => null),
+    getMessageConnectors: vi.fn(() => []),
+    getPostConnectors: vi.fn(() => []),
+    registerMessageConnector: vi.fn(),
+    registerPostConnector: vi.fn(),
+  };
+}
+
+function createContext(
+  runtime: ReturnType<typeof createRuntime>,
+  pathname: string,
+): { ctx: ConnectorAccountRouteContext; captured: Captured } {
+  const captured: Captured = { status: 200, body: null };
+  const ctx: ConnectorAccountRouteContext = {
+    req: { url: pathname, on: vi.fn() } as unknown as IncomingMessage,
+    res: {
+      statusCode: 200,
+      setHeader: vi.fn(),
+      write: vi.fn(),
+      end: vi.fn(),
+    } as unknown as ServerResponse,
+    method: "GET",
+    pathname,
+    state: { runtime: runtime as never },
+    readJsonBody: (async () => ({})) as never,
+    json: (_res, data, status = 200) => {
+      captured.status = status;
+      captured.body = data;
+    },
+    error: (_res, message, status = 500) => {
+      captured.status = status;
+      captured.body = { error: message };
+    },
+    authorize: vi.fn(async () => true),
+  };
+  return { ctx, captured };
+}
+
+describe("connector account route durability (real core manager)", () => {
+  it("lists an account after a restart even when the manager was constructed before the adapter registered", async () => {
+    // Boot: connector plugin init constructs the manager while
+    // runtime.adapter is still undefined (plugin-sql has not finished).
+    const bootRuntime = createRuntime();
+    const bootManager = getConnectorAccountManager(bootRuntime as never);
+
+    // plugin-sql finishes and attaches the adapter to the runtime.
+    const adapter = new InMemoryDatabaseAdapter();
+    await adapter.initialize();
+    (bootRuntime as { adapter?: InMemoryDatabaseAdapter }).adapter = adapter;
+
+    // OAuth completion writes the connected account through the manager.
+    await bootManager.upsertAccount("google", {
+      id: "3a899cd0-170f-4b3e-932e-46ec68119b35",
+      provider: "google",
+      label: "user@example.com",
+      externalId: "user@example.com",
+      role: "OWNER",
+      purpose: ["automation"],
+      accessGate: "open",
+      status: "connected",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      metadata: {},
+    });
+
+    // The route on the live process sees the account.
+    const live = createContext(bootRuntime, "/api/connectors/google/accounts");
+    await expect(handleConnectorAccountRoutes(live.ctx)).resolves.toBe(true);
+    expect(live.captured.status).toBe(200);
+    expect(
+      (live.captured.body as { accounts: Array<{ status: string }> }).accounts,
+    ).toHaveLength(1);
+
+    // Restart: a brand-new runtime + manager over the same durable adapter.
+    const restartedRuntime = createRuntime(adapter);
+    getConnectorAccountManager(restartedRuntime as never);
+    const restarted = createContext(
+      restartedRuntime,
+      "/api/connectors/google/accounts",
+    );
+    await expect(handleConnectorAccountRoutes(restarted.ctx)).resolves.toBe(
+      true,
+    );
+    expect(restarted.captured.status).toBe(200);
+    const body = restarted.captured.body as {
+      defaultAccountId?: string;
+      accounts: Array<{ provider: string; status: string; label?: string }>;
+    };
+    expect(body.accounts).toHaveLength(1);
+    expect(body.accounts[0]).toMatchObject({
+      provider: "google",
+      status: "connected",
+    });
+    expect(body.defaultAccountId).toBeTruthy();
+  });
+});

--- a/packages/core/src/connectors/account-manager.test.ts
+++ b/packages/core/src/connectors/account-manager.test.ts
@@ -334,3 +334,82 @@ describe("ConnectorAccountManager", () => {
 		expect(exchange).not.toHaveBeenCalled();
 	});
 });
+
+describe("durable storage binding", () => {
+	const GOOGLE_ACCOUNT = {
+		id: "3a899cd0-170f-4b3e-932e-46ec68119b35",
+		provider: "google",
+		label: "user@example.com",
+		externalId: "user@example.com",
+		role: "OWNER" as const,
+		purpose: ["automation" as const],
+		accessGate: "open" as const,
+		status: "connected" as const,
+		createdAt: 10,
+		updatedAt: 20,
+		metadata: {},
+	};
+
+	it("writes through the database adapter even when the manager was constructed before the adapter registered", async () => {
+		// Connector plugins construct the manager during concurrent plugin
+		// registration, before plugin-sql attaches the adapter to the runtime.
+		const runtime = makeRuntime();
+		const manager = getConnectorAccountManager(runtime);
+
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		(runtime as unknown as { adapter?: InMemoryDatabaseAdapter }).adapter =
+			adapter;
+
+		await manager.upsertAccount("google", GOOGLE_ACCOUNT);
+
+		// The row must land in the durable adapter, not a boot-time fallback Map.
+		const record = await adapter.getConnectorAccount({
+			provider: "google",
+			accountKey: "user@example.com",
+		});
+		expect(record).not.toBeNull();
+		expect(record?.status).toBe("connected");
+
+		// Simulated restart: a fresh runtime + manager over the same durable
+		// backing must still see the account.
+		const restartedManager = getConnectorAccountManager(makeRuntime(adapter));
+		const accounts = await restartedManager.listAccounts("google");
+		expect(accounts).toHaveLength(1);
+		expect(accounts[0]).toMatchObject({
+			provider: "google",
+			externalId: "user@example.com",
+			status: "connected",
+		});
+	});
+
+	it("keeps one consistent in-memory fallback while no adapter exists", async () => {
+		const runtime = makeRuntime();
+		const manager = getConnectorAccountManager(runtime);
+		await manager.upsertAccount("google", GOOGLE_ACCOUNT);
+		const accounts = await manager.listAccounts("google");
+		expect(accounts).toHaveLength(1);
+		expect(manager.getStorage()).toBe(manager.getStorage());
+	});
+
+	it("prefers an explicitly injected storage over the runtime adapter", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const runtime = makeRuntime(adapter);
+		const manager = getConnectorAccountManager(runtime);
+		const injected = {
+			listAccounts: vi.fn(async () => []),
+			getAccount: vi.fn(async () => null),
+			upsertAccount: vi.fn(async (account: unknown) => account),
+			deleteAccount: vi.fn(async () => true),
+			createOAuthFlow: vi.fn(),
+			getOAuthFlow: vi.fn(),
+			updateOAuthFlow: vi.fn(),
+			consumeOAuthFlow: vi.fn(),
+			deleteOAuthFlow: vi.fn(),
+		};
+		manager.setStorage(injected as never);
+		await manager.listAccounts("google");
+		expect(injected.listAccounts).toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/connectors/account-manager.ts
+++ b/packages/core/src/connectors/account-manager.ts
@@ -18,6 +18,7 @@
  * process-local map and referenced by an opaque `codeVerifierRef` written to
  * flow metadata, so stored rows never carry the raw secret.
  */
+import { logger } from "../logger";
 import type { Action, ActionParameters } from "../types/components";
 import type {
 	ConnectorAccountAccessGate,
@@ -1135,31 +1136,21 @@ function ownerBindingKey(
 	return `${normalizeProvider(connector)}:${externalId}:${instanceId ?? ""}`;
 }
 
-function resolveStorage(runtime?: IAgentRuntime): ConnectorAccountStorage {
-	if (runtime && typeof runtime.getService === "function") {
-		const service = runtime.getService(CONNECTOR_ACCOUNT_STORAGE_SERVICE_TYPE);
-		if (isConnectorAccountStorage(service)) {
-			return service;
-		}
-		const adapter = (runtime as { adapter?: unknown }).adapter;
-		if (isConnectorAccountDatabaseAdapter(adapter)) {
-			return new DatabaseConnectorAccountStorage(adapter);
-		}
-	}
-	return new InMemoryConnectorAccountStorage();
-}
-
 export class ConnectorAccountManager extends Service {
 	static override serviceType = CONNECTOR_ACCOUNT_SERVICE_TYPE;
 	capabilityDescription =
 		"Manages connector account providers, OAuth flows, and account access policy";
 
 	private providers = new Map<string, ConnectorAccountProvider>();
-	private storage: ConnectorAccountStorage;
+	private explicitStorage?: ConnectorAccountStorage;
+	private databaseStorage?: DatabaseConnectorAccountStorage;
+	private databaseStorageAdapter?: ConnectorAccountDatabaseAdapter;
+	private fallbackStorage?: InMemoryConnectorAccountStorage;
+	private warnedFallback = false;
 
 	constructor(runtime?: IAgentRuntime, storage?: ConnectorAccountStorage) {
 		super(runtime);
-		this.storage = storage ?? resolveStorage(runtime);
+		this.explicitStorage = storage;
 	}
 
 	static override async start(
@@ -1170,12 +1161,57 @@ export class ConnectorAccountManager extends Service {
 
 	async stop(): Promise<void> {}
 
+	/**
+	 * Storage is resolved lazily on every access rather than pinned at
+	 * construction. The manager is typically constructed during concurrent
+	 * plugin registration — often before the SQL adapter is attached to the
+	 * runtime — and it is cached per-runtime for the process lifetime. A
+	 * construction-time binding therefore captured the in-memory fallback
+	 * forever, so connector accounts written after OAuth completion never
+	 * reached the durable connector_accounts table and vanished on restart.
+	 * Precedence: explicitly injected storage (constructor/setStorage) → a
+	 * registered connector_account_storage service → the runtime database
+	 * adapter (memoized per adapter) → one persistent in-memory fallback.
+	 */
+	private get storage(): ConnectorAccountStorage {
+		if (this.explicitStorage) {
+			return this.explicitStorage;
+		}
+		const runtime = this.runtime as IAgentRuntime | undefined;
+		if (runtime && typeof runtime.getService === "function") {
+			const service = runtime.getService(
+				CONNECTOR_ACCOUNT_STORAGE_SERVICE_TYPE,
+			);
+			if (isConnectorAccountStorage(service)) {
+				return service;
+			}
+			const adapter = (runtime as { adapter?: unknown }).adapter;
+			if (isConnectorAccountDatabaseAdapter(adapter)) {
+				if (this.databaseStorageAdapter !== adapter) {
+					this.databaseStorage = new DatabaseConnectorAccountStorage(adapter);
+					this.databaseStorageAdapter = adapter;
+				}
+				return this.databaseStorage as DatabaseConnectorAccountStorage;
+			}
+			if (!this.warnedFallback) {
+				this.warnedFallback = true;
+				logger.warn(
+					"[ConnectorAccountManager] no durable connector-account storage available yet; using in-memory fallback until a database adapter registers",
+				);
+			}
+		}
+		if (!this.fallbackStorage) {
+			this.fallbackStorage = new InMemoryConnectorAccountStorage();
+		}
+		return this.fallbackStorage;
+	}
+
 	getStorage(): ConnectorAccountStorage {
 		return this.storage;
 	}
 
 	setStorage(storage: ConnectorAccountStorage): void {
-		this.storage = storage;
+		this.explicitStorage = storage;
 	}
 
 	registerProvider(

--- a/plugins/plugin-google-workspace/src/connector-credential-refs.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-credential-refs.test.ts
@@ -9,7 +9,13 @@
  * (connector account storage rows and the vault store), exactly what survives
  * a real process restart.
  */
-import type { ConnectorAccount, ConnectorAccountStorage, IAgentRuntime } from "@elizaos/core";
+import {
+  type ConnectorAccount,
+  type ConnectorAccountStorage,
+  getConnectorAccountManager,
+  type IAgentRuntime,
+  InMemoryDatabaseAdapter,
+} from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES,
@@ -315,5 +321,71 @@ describe("accountId 'default' resolution", () => {
     state.accounts.set(ACCOUNT_ID, connectedAccount(ACCOUNT_ID));
     state.accounts.set("second-account", connectedAccount("second-account"));
     await expect(resolveDefault(state, {})).rejects.toThrow(/default was not found/);
+  });
+});
+
+describe("manager-path durability across restart (real core manager + adapter)", () => {
+  function createManagerRuntime(
+    services: Record<string, unknown>,
+    adapter?: InMemoryDatabaseAdapter
+  ): IAgentRuntime {
+    return {
+      agentId: AGENT_ID,
+      adapter,
+      getService: (name: string) => services[name] ?? null,
+      getSetting: (key: string) =>
+        key === "GOOGLE_CLIENT_ID"
+          ? "client-id"
+          : key === "GOOGLE_CLIENT_SECRET"
+            ? "client-secret"
+            : undefined,
+      getMessageConnectors: () => [],
+      getPostConnectors: () => [],
+      registerMessageConnector: () => undefined,
+      registerPostConnector: () => undefined,
+    } as unknown as IAgentRuntime;
+  }
+
+  it("resolves 'default' to the sole connected account after a restart when the account was written before the adapter registered on the boot runtime", async () => {
+    const vaultEntries = new Map<string, string>();
+    const vaultRef = `connector.${AGENT_ID}.google.${ACCOUNT_ID}.oauth_tokens`;
+    vaultEntries.set(vaultRef, TOKENS_JSON);
+
+    // Boot: the manager is constructed during plugin registration, before
+    // plugin-sql attaches the adapter (the exact race that dropped accounts).
+    const bootServices = {
+      connector_credential_store: createDurableStoreService(vaultEntries),
+    };
+    const bootRuntime = createManagerRuntime(bootServices);
+    const bootManager = getConnectorAccountManager(bootRuntime);
+
+    const adapter = new InMemoryDatabaseAdapter();
+    await adapter.initialize();
+    (bootRuntime as unknown as { adapter?: InMemoryDatabaseAdapter }).adapter = adapter;
+
+    // OAuth completion writes the connected account with its credential refs.
+    await bootManager.upsertAccount("google", {
+      ...connectedAccount(ACCOUNT_ID),
+      metadata: { credentialRefs: [{ credentialType: "oauth.tokens", vaultRef }] },
+    });
+
+    // Restart: fresh runtime + manager over the same durable adapter/vault.
+    const restartedRuntime = createManagerRuntime(
+      { connector_credential_store: createDurableStoreService(vaultEntries) },
+      adapter
+    );
+    const resolver = new DefaultGoogleCredentialResolver({ runtime: restartedRuntime });
+    const client = await resolver.getAuthClient({
+      provider: "google",
+      accountId: "default",
+      scopes: [],
+      capabilities: [],
+      reason: "post-restart default resolution",
+    });
+    const credentials = (
+      client as { credentials?: { access_token?: string; refresh_token?: string } }
+    ).credentials;
+    expect(credentials?.access_token).toBe("test-access-token");
+    expect(credentials?.refresh_token).toBe("test-refresh-token");
   });
 });


### PR DESCRIPTION
## Bug

Connecting a Google account works in-process (OAuth completes, Gmail reads work), but after a process restart `GET /api/connectors/google/accounts` returns `accounts: []` — the ConnectorAccount row itself is gone, not just its credentials. 23da5b793f5 made the OAuth **credentials** durable (vault-backed `connector_credential_store` + reader/writer parity) but the account **row** still never reached the database.

## Root cause

`ConnectorAccountManager` pinned its storage backend once, at construction (`this.storage = storage ?? resolveStorage(runtime)`, `packages/core/src/connectors/account-manager.ts`). Connector plugins construct the manager during plugin registration — `getConnectorAccountManager(runtime)` in `plugin-google-workspace/src/index.ts` — and character plugins register concurrently, so the manager is routinely built **before** plugin-sql attaches `runtime.adapter`. `resolveStorage` then fell through to `InMemoryConnectorAccountStorage`, and because the manager is cached per-runtime (WeakMap) that fallback was kept for the whole process lifetime. Additionally, the `connector_account_storage` service branch of `resolveStorage` was dead code: nothing in the repo ever registers a service under that type — every reference is a consumer.

Result: `manager.upsertAccount(...)` after OAuth completion wrote to a process-local `Map`; the durable path (`adapter.upsertConnectorAccount` → `connector_accounts` table, `plugins/plugin-sql/src/base.ts`) was never invoked; restart wiped the Map.

## Fix

Storage is now resolved **lazily on every access** instead of pinned at construction (`account-manager.ts`, `private get storage()`), with precedence:

1. explicitly injected storage (constructor / `setStorage`, test injection unchanged)
2. a registered `connector_account_storage` service (branch now actually reachable at any time, not only at construction)
3. the runtime database adapter, wrapped in `DatabaseConnectorAccountStorage` and memoized per adapter instance
4. one persistent `InMemoryConnectorAccountStorage` for the pre-adapter window (plus a one-time `logger.warn` so a runtime with no durable backend can't silently masquerade as durable)

All internal call sites (`this.storage.*`) route through the getter, so `listAccounts`/`getAccount`/`upsertAccount`/OAuth flow persistence and every `manager.getStorage()` consumer (routes, connector-account providers, credential resolver) automatically upgrade to the durable adapter the moment plugin-sql registers it. Accounts written after OAuth now land in `connector_accounts` and survive restart on a local PGlite deployment. Credentials stay in the credential store/vault — no security-model change.

## Tests

- `packages/core/src/connectors/account-manager.test.ts` — new `durable storage binding` describe:
  - manager constructed **before** the adapter registers still writes through the adapter, and a simulated restart (fresh runtime + manager over the same adapter) lists the account (the exact regression)
  - the pre-adapter in-memory fallback is a single consistent instance
  - explicitly injected storage still wins over the runtime adapter
- `packages/agent/src/api/connector-account-routes.durable.test.ts` — new: real (unmocked) core manager + `InMemoryDatabaseAdapter`; the manager is constructed pre-adapter, an account is written post-OAuth, and `GET /api/connectors/google/accounts` lists it both live and after a simulated restart, with `defaultAccountId` populated.
- `plugins/plugin-google-workspace/src/connector-credential-refs.test.ts` — new: manager-path durability round-trip; after a restart the credential resolver's `"default"` resolution finds the sole connected account through the real manager over the durable adapter and reconstructs the OAuth client from the vault-stored tokens.

## Evidence

- core `src/connectors/account-manager.test.ts`: 10/10 pass
- full `plugin-google-workspace` suite: 78/78 pass
- agent `connector-account-routes*.test.ts`: 12/12 pass
- full `packages/core` suite: pass (see CI)
- `packages/core` typecheck: clean; `plugin-google-workspace` typecheck: clean; biome on touched files: clean
- `packages/agent` typecheck fails only on a pre-existing, unrelated `plugins/plugin-agent-orchestrator` `findLast`/es2023 lib error also present on the base commit

No schema/migration changes — the `connector_accounts` table and adapter bridge already existed; this PR makes the manager actually use them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Live proof (operator VPS, 2026-08-08)

Applied to the running bot (core loads from source) and proven across a real `systemctl --user restart milady.service`:

- **Before restart**: OAuth grant → `GET /api/connectors/google/accounts` → `[{status: connected, handle: n***vault@gmail.com}]`; Gmail read returned a real message (from: notifications@github.com, subject: workflow-run notification).
- **After restart** (the exact scenario that failed pre-fix): account **survived** — `accounts` still lists the connected account; Gmail read returned the same real message again; Calendar read returned a real "nothing tomorrow".
- Pre-fix, the account row was gone after restart (`accounts: []`) because the manager captured the in-memory fallback store at construction.


<!-- evidence-head:6528d6da9e9e4b82312377b388fb7fbaee48f6fa -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend storage-resolution fix; no rendered UI surface in the diff

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change with no UI surface in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible flow changed; connector-account persistence is server-internal

<!-- evidence-row:backend-logs -->
- [ ] N/A - live proof transcript is inline above (operator VPS, real systemctl restart: account row survives, Gmail/Calendar reads succeed post-restart); deterministic suites cover the regression

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/client code in the diff

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/planner behavior change; storage binding only

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the durable row in connector_accounts is proven by the inline live restart transcript and the new adapter-backed tests

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported
