### PR TITLE
fix(openai): demote orphaned tool messages so strict providers stop 400ing tool turns

### DIFF
--- a/plugins/plugin-openai/__tests__/tool-message-pairing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/tool-message-pairing.shape.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Guards the request-time tool/tool_calls pairing invariant OpenAI-strict
+ * providers (Cerebras) enforce: a `role: "tool"` message must immediately
+ * follow an assistant message carrying the matching `tool-call` id, or the
+ * provider rejects the whole request with HTTP 400. `normalizeNativeMessages`
+ * repairs orphaned tool messages (history compaction can drop the assistant
+ * half) by demoting them to plain user messages so content survives without
+ * breaking the wire contract. Well-formed pairs must pass through untouched.
+ */
+import { describe, expect, it } from "vitest";
+import { __INTERNAL_normalizeNativeMessages } from "../models/text.ts";
+
+describe("normalizeNativeMessages tool pairing", () => {
+  it("passes a well-formed assistant/tool pair through untouched", () => {
+    const out = __INTERNAL_normalizeNativeMessages([
+      { role: "system", content: "eval" },
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "tc-1", toolName: "CAL", input: {} },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-1",
+            toolName: "CAL",
+            output: { type: "text", value: "done" },
+          },
+        ],
+      },
+    ]);
+    expect(out?.map((m) => m.role)).toEqual([
+      "system",
+      "user",
+      "assistant",
+      "tool",
+    ]);
+  });
+
+  it("demotes an orphaned tool message to a user message, preserving content", () => {
+    const out = __INTERNAL_normalizeNativeMessages([
+      { role: "system", content: "eval" },
+      { role: "user", content: "hi" },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "missing",
+            toolName: "CAL",
+            output: { type: "text", value: "created event" },
+          },
+        ],
+      },
+    ]);
+    expect(out?.map((m) => m.role)).toEqual(["system", "user", "user"]);
+    expect(JSON.stringify(out?.[2]?.content)).toContain("created event");
+    // No orphaned tool message may reach the wire.
+    expect(out?.some((m) => m.role === "tool")).toBe(false);
+  });
+
+  it("keeps a paired tool message even when an unrelated orphan is also present", () => {
+    const out = __INTERNAL_normalizeNativeMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "tc-2", toolName: "CAL", input: {} },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-2",
+            toolName: "CAL",
+            output: { type: "text", value: "paired" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "orphan",
+            toolName: "CAL",
+            output: { type: "text", value: "orphan" },
+          },
+        ],
+      },
+    ]);
+    expect(out?.map((m) => m.role)).toEqual(["assistant", "tool", "user"]);
+  });
+});

--- a/plugins/plugin-openai/__tests__/tool-message-pairing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/tool-message-pairing.shape.test.ts
@@ -17,9 +17,7 @@ describe("normalizeNativeMessages tool pairing", () => {
       { role: "user", content: "hi" },
       {
         role: "assistant",
-        content: [
-          { type: "tool-call", toolCallId: "tc-1", toolName: "CAL", input: {} },
-        ],
+        content: [{ type: "tool-call", toolCallId: "tc-1", toolName: "CAL", input: {} }],
       },
       {
         role: "tool",
@@ -33,12 +31,7 @@ describe("normalizeNativeMessages tool pairing", () => {
         ],
       },
     ]);
-    expect(out?.map((m) => m.role)).toEqual([
-      "system",
-      "user",
-      "assistant",
-      "tool",
-    ]);
+    expect(out?.map((m) => m.role)).toEqual(["system", "user", "assistant", "tool"]);
   });
 
   it("demotes an orphaned tool message to a user message, preserving content", () => {
@@ -67,9 +60,7 @@ describe("normalizeNativeMessages tool pairing", () => {
     const out = __INTERNAL_normalizeNativeMessages([
       {
         role: "assistant",
-        content: [
-          { type: "tool-call", toolCallId: "tc-2", toolName: "CAL", input: {} },
-        ],
+        content: [{ type: "tool-call", toolCallId: "tc-2", toolName: "CAL", input: {} }],
       },
       {
         role: "tool",

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -765,7 +765,62 @@ function normalizeNativeMessages(messages: unknown): ModelMessage[] | undefined 
     return undefined;
   }
 
-  return messages.map((message) => normalizeNativeMessage(message));
+  return repairToolMessagePairing(
+    messages.map((message) => normalizeNativeMessage(message)),
+  );
+}
+
+/**
+ * OpenAI-strict providers (Cerebras, and the OpenAI API itself) reject any
+ * `role: "tool"` message that is not an immediate response to an assistant
+ * message carrying the matching `tool-call` id — HTTP 400 `Messages with role
+ * 'tool' must be a response to a preceding message with 'tool_calls'`. The
+ * trajectory assembler emits well-formed pairs, but history compaction and
+ * multi-step summarization upstream can drop or separate the assistant half,
+ * leaving an orphaned tool result that poisons the whole request. This is the
+ * request-time structural analog of the unicode guard: a valid message array
+ * passes through untouched; an orphaned tool message is demoted to a plain user
+ * message so its content is preserved on the wire without breaking the
+ * tool-call sequence contract.
+ */
+function repairToolMessagePairing(messages: ModelMessage[]): ModelMessage[] {
+  const availableToolCallIds = new Set<string>();
+  return messages.map((message) => {
+    if (message.role === "assistant" && Array.isArray(message.content)) {
+      for (const part of message.content) {
+        const id = (part as { type?: unknown; toolCallId?: unknown })
+          ?.toolCallId;
+        if (
+          (part as { type?: unknown })?.type === "tool-call" &&
+          typeof id === "string"
+        ) {
+          availableToolCallIds.add(id);
+        }
+      }
+      return message;
+    }
+    if (message.role === "tool" && Array.isArray(message.content)) {
+      const allPaired = message.content.every((part) => {
+        const id = (part as { toolCallId?: unknown })?.toolCallId;
+        return typeof id === "string" && availableToolCallIds.has(id);
+      });
+      if (allPaired) {
+        return message;
+      }
+      const salvaged = message.content
+        .map((part) => {
+          const value = (part as { output?: { value?: unknown } })?.output
+            ?.value;
+          return typeof value === "string" ? value : JSON.stringify(value);
+        })
+        .join("\n");
+      return {
+        role: "user",
+        content: `[tool result]\n${salvaged}`,
+      } as ModelMessage;
+    }
+    return message;
+  });
 }
 
 function normalizeNativeMessage(message: unknown): ModelMessage {

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -765,9 +765,7 @@ function normalizeNativeMessages(messages: unknown): ModelMessage[] | undefined 
     return undefined;
   }
 
-  return repairToolMessagePairing(
-    messages.map((message) => normalizeNativeMessage(message)),
-  );
+  return repairToolMessagePairing(messages.map((message) => normalizeNativeMessage(message)));
 }
 
 /**
@@ -788,12 +786,8 @@ function repairToolMessagePairing(messages: ModelMessage[]): ModelMessage[] {
   return messages.map((message) => {
     if (message.role === "assistant" && Array.isArray(message.content)) {
       for (const part of message.content) {
-        const id = (part as { type?: unknown; toolCallId?: unknown })
-          ?.toolCallId;
-        if (
-          (part as { type?: unknown })?.type === "tool-call" &&
-          typeof id === "string"
-        ) {
+        const id = (part as { type?: unknown; toolCallId?: unknown })?.toolCallId;
+        if ((part as { type?: unknown })?.type === "tool-call" && typeof id === "string") {
           availableToolCallIds.add(id);
         }
       }
@@ -809,8 +803,7 @@ function repairToolMessagePairing(messages: ModelMessage[]): ModelMessage[] {
       }
       const salvaged = message.content
         .map((part) => {
-          const value = (part as { output?: { value?: unknown } })?.output
-            ?.value;
+          const value = (part as { output?: { value?: unknown } })?.output?.value;
           return typeof value === "string" ? value : JSON.stringify(value);
         })
         .join("\n");


### PR DESCRIPTION
## Bug

OpenAI-strict providers (Cerebras) reject any request where a `role: "tool"` message is not an immediate response to an assistant message carrying the matching `tool_calls` id — HTTP 400 `Messages with role 'tool' must be a response to a preceding message with 'tool_calls'`. History compaction / multi-step summarization can drop or separate the assistant half of a pair, leaving an orphaned tool result that poisons the whole request: on the live deployment every tool-executing turn's post-tool evaluator call was failing (unmasked by #18024's provider-error enrichment; the surviving reply was the degrade path's "I hit a provider issue").

## Fix

`normalizeNativeMessages` (plugins/plugin-openai/models/text.ts) now runs `repairToolMessagePairing`: assistant `tool-call` ids are tracked in order; any tool message whose result ids are not all backed by a previously seen tool-call is demoted to a plain user message (`[tool result]` + salvaged text) so its content survives on the wire without breaking the sequence contract. Well-formed pairs pass through byte-identical. This is the structural request-time analog of #18079's unicode guard.

## Evidence

| check | result |
| --- | --- |
| new colocated suite `__tests__/tool-message-pairing.shape.test.ts` | 3/3 pass (pair untouched; orphan demoted with content preserved and zero tool-role leakage; mixed pair+orphan keeps the pair) |
| wire repro against real `@ai-sdk/openai-compatible` + `ai` (generateText with intercepted fetch) | orphan input → wire roles `[system,user,user]`, no orphaned tool message on the wire; paired input → assistant carries `tool_calls`, tool message kept |
| live deployment (operator VPS, running this patch since 2026-08-08 19:3xZ) | previously-failing Gmail/Calendar tool turns now complete: real inbox subject+sender returned, zero `Bad Request` in logs since |
| plugin-openai typecheck | fails only on pre-existing `deepToWellFormedUnicode` dist-lag error from #18079 (present at base, untouched by this diff) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:1d09b687f90518e69995c813812b274451393075 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - provider wire-format repair; no rendered UI surface in the diff

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change with no UI surface in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible flow changed; request normalization is provider-internal

<!-- evidence-row:backend-logs -->
- [ ] N/A - live-deployment result inline above (operator VPS running this patch: previously-failing Gmail/Calendar tool turns complete, zero Bad Request since); deterministic wire-shape suite covers the contract

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/client code in the diff

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no planner behavior change; the repair is transcript normalization before the provider call, pinned by the colocated wire-shape suite

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the wire repro table above (real @ai-sdk/openai-compatible with intercepted fetch) is the domain artifact

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported
