### PR TITLE
fix(core): character-modify survives classifier flake; gated character asks decline in voice

### DIFF
--- a/packages/core/src/features/advanced-capabilities/index.ts
+++ b/packages/core/src/features/advanced-capabilities/index.ts
@@ -28,6 +28,7 @@ import { experiencePatternEvaluator } from "./experience/evaluators/experience-i
 import { experienceProvider } from "./experience/providers/experienceProvider.ts";
 import { characterAction } from "./personality/actions/character.ts";
 import { personalityAction } from "./personality/actions/personality.ts";
+import { characterGateNoticeProvider } from "./personality/providers/character-gate-notice.ts";
 import { userPersonalityProvider } from "./personality/providers/user-personality.ts";
 
 // Re-export action, provider, and post-message-action modules
@@ -81,6 +82,7 @@ export const advancedProviders = [
 	settingsProvider,
 	experienceProvider,
 	userPersonalityProvider,
+	characterGateNoticeProvider,
 ];
 
 /**

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/character-gate-notice.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/character-gate-notice.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Covers the CHARACTER_GATE_NOTICE provider against the in-memory FakeRuntime
+ * with the real characterAction gate metadata and real hasRoleAccess (no live
+ * model, no DB): a below-gate sender's explicit character-modification ask
+ * produces a model-visible notice, an owner's ask and non-asks stay silent, and
+ * an ACTION_ROLE_POLICY loosening suppresses the notice entirely.
+ */
+import { afterEach, describe, expect, test } from "vitest";
+import { _resetActionRolePolicyCacheForTests } from "../../../../runtime/action-role-policy.ts";
+import type { IAgentRuntime, Memory, UUID } from "../../../../types/index.ts";
+import { characterAction } from "../actions/character.ts";
+import { characterGateNoticeProvider } from "../providers/character-gate-notice.ts";
+import { makeFakeRuntime, makeMessage } from "./test-helpers.ts";
+
+const OWNER = "00000000-0000-4000-8000-0000000000aa" as UUID;
+const GUEST = "00000000-0000-4000-8000-0000000000bb" as UUID;
+
+const EXPLICIT_ASK = "change your personality to never say bet";
+
+function gateRuntime(): IAgentRuntime {
+	const fake = makeFakeRuntime({ owner: OWNER });
+	const runtimeMutable = fake.runtime as unknown as {
+		actions: unknown[];
+		reportError: () => void;
+	};
+	runtimeMutable.actions = [characterAction];
+	runtimeMutable.reportError = () => {};
+	return fake.runtime;
+}
+
+function connectorMessage(
+	runtime: IAgentRuntime,
+	args: {
+		entityId: UUID;
+		text: string;
+	},
+): Memory {
+	const message = makeMessage({
+		entityId: args.entityId,
+		agentId: runtime.agentId,
+		text: args.text,
+	});
+	// A connector source keeps the unresolved-role floor at GUEST (roles.ts),
+	// matching the live Discord turn this notice exists for.
+	message.content.source = "discord";
+	return message;
+}
+
+afterEach(() => {
+	delete process.env.ACTION_ROLE_POLICY;
+	_resetActionRolePolicyCacheForTests();
+});
+
+describe("CHARACTER_GATE_NOTICE", () => {
+	test("a GUEST's explicit character-change ask surfaces the gated-capability notice", async () => {
+		const runtime = gateRuntime();
+		const result = await characterGateNoticeProvider.get(
+			runtime,
+			connectorMessage(runtime, { entityId: GUEST, text: EXPLICIT_ASK }),
+		);
+		expect(result.text).toContain("Character modification access notice");
+		expect(result.text).toContain("ADMIN");
+		expect(result.text).toContain("Do not promise");
+		expect(result.values?.characterModificationGated).toBe(true);
+		expect(result.values?.requiredRole).toBe("ADMIN");
+	});
+
+	test("the owner's identical ask produces no notice", async () => {
+		const runtime = gateRuntime();
+		const result = await characterGateNoticeProvider.get(
+			runtime,
+			connectorMessage(runtime, { entityId: OWNER, text: EXPLICIT_ASK }),
+		);
+		expect(result.text).toBe("");
+		expect(result.values?.characterModificationGated).toBeUndefined();
+	});
+
+	test("a GUEST's unrelated message produces no notice", async () => {
+		const runtime = gateRuntime();
+		const result = await characterGateNoticeProvider.get(
+			runtime,
+			connectorMessage(runtime, {
+				entityId: GUEST,
+				text: "what's the weather today",
+			}),
+		);
+		expect(result.text).toBe("");
+	});
+
+	test("an inconclusive character mention produces no notice", async () => {
+		const runtime = gateRuntime();
+		const result = await characterGateNoticeProvider.get(
+			runtime,
+			connectorMessage(runtime, {
+				entityId: GUEST,
+				text: "hmm your personality could probably improve somehow",
+			}),
+		);
+		expect(result.text).toBe("");
+	});
+
+	test("an ACTION_ROLE_POLICY loosening to GUEST suppresses the notice", async () => {
+		process.env.ACTION_ROLE_POLICY = '{"CHARACTER":"GUEST"}';
+		_resetActionRolePolicyCacheForTests();
+		const runtime = gateRuntime();
+		const result = await characterGateNoticeProvider.get(
+			runtime,
+			connectorMessage(runtime, { entityId: GUEST, text: EXPLICIT_ASK }),
+		);
+		expect(result.text).toBe("");
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/character-modify-intent.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/character-modify-intent.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Covers CHARACTER.modify intent classification against the in-memory
+ * FakeRuntime with scripted model stubs (no live model): the deterministic rule
+ * fast path — including the exact live-miss shapes from tj-4c9e654fec50ea — the
+ * tolerant-parse + single-reroll model path, and the actionable failure surface
+ * when classification stays inconclusive. Role access runs the real
+ * hasRoleAccess against an owner-seeded runtime.
+ */
+import { describe, expect, test } from "vitest";
+import type {
+	ActionResult,
+	HandlerCallback,
+	IAgentRuntime,
+	UUID,
+} from "../../../../types/index.ts";
+import {
+	characterAction,
+	detectModificationIntentByRules,
+} from "../actions/character.ts";
+import { PersonalityServiceType } from "../types.ts";
+import { makeFakeRuntime, makeMessage } from "./test-helpers.ts";
+
+const SENDER = "00000000-0000-4000-8000-0000000000aa" as UUID;
+
+/** The exact planner-authored request that killed the live action. */
+const LIVE_PARAMETER_REQUEST =
+	"add a strict rule to my personality: never say 'bet' under any circumstances.";
+/** The exact raw owner message from the live turn. */
+const LIVE_RAW_MESSAGE = "change your personality to never say bet";
+
+const INTENT_PROMPT_MARKER = "character modification intent";
+const PARSE_PROMPT_MARKER = "structured global character update";
+const SAFETY_PROMPT_MARKER = "safety and appropriateness";
+
+type ScriptedRuntime = {
+	fake: ReturnType<typeof makeFakeRuntime>;
+	prompts: string[];
+	intentPrompts: string[];
+};
+
+/**
+ * Owner-seeded runtime with a scripted `useModel`: `intentResponses` are served
+ * in order to intent-classifier prompts; parse/safety prompts get canned valid
+ * output so the modify pipeline can complete after a fast-path or model-path
+ * classification.
+ */
+function scriptedRuntime(intentResponses: readonly string[]): ScriptedRuntime {
+	const fake = makeFakeRuntime({ owner: SENDER });
+	const prompts: string[] = [];
+	const intentPrompts: string[] = [];
+	let intentCall = 0;
+	const runtimeMutable = fake.runtime as unknown as {
+		useModel: (
+			modelType: string,
+			params: { prompt: string },
+		) => Promise<string>;
+		reportError: () => void;
+	};
+	runtimeMutable.reportError = () => {};
+	runtimeMutable.useModel = async (_modelType, params) => {
+		prompts.push(params.prompt);
+		if (params.prompt.includes(INTENT_PROMPT_MARKER)) {
+			intentPrompts.push(params.prompt);
+			const response = intentResponses[intentCall] ?? intentResponses.at(-1);
+			intentCall += 1;
+			if (response === undefined) {
+				throw new Error("no scripted intent response left");
+			}
+			return response;
+		}
+		if (params.prompt.includes(PARSE_PROMPT_MARKER)) {
+			return '{"apply": true, "style_all": ["never say bet under any circumstances"]}';
+		}
+		if (params.prompt.includes(SAFETY_PROMPT_MARKER)) {
+			return '{"isAppropriate": true, "concerns": [], "reasoning": "style-only change"}';
+		}
+		throw new Error(`unexpected model prompt: ${params.prompt.slice(0, 80)}`);
+	};
+	fake.runtime.registerService(PersonalityServiceType.CHARACTER_MANAGEMENT, {
+		validateModification: () => ({ valid: true, errors: [] }),
+		applyModification: async () => ({ success: true }),
+	});
+	return { fake, prompts, intentPrompts };
+}
+
+async function runModify(
+	scripted: ScriptedRuntime,
+	messageText: string,
+	request?: string,
+): Promise<ActionResult> {
+	const message = makeMessage({
+		entityId: SENDER,
+		agentId: scripted.fake.runtime.agentId,
+		text: messageText,
+	});
+	return (await characterAction.handler?.(
+		scripted.fake.runtime as IAgentRuntime,
+		message,
+		undefined,
+		{
+			parameters: {
+				action: "modify",
+				...(request !== undefined ? { request } : {}),
+			},
+		} as Record<string, unknown>,
+		(async () => []) as HandlerCallback,
+	)) as ActionResult;
+}
+
+describe("detectModificationIntentByRules — fast-path shapes", () => {
+	const explicitShapes = [
+		LIVE_RAW_MESSAGE,
+		LIVE_PARAMETER_REQUEST,
+		// the live raw message shape as delivered, mention prefix and all
+		"agent name (@1234567890123456789) change your personality to never say bet",
+		"never say bet",
+		"stop saying bet",
+		"don't say bro anymore",
+		"never ever say bet again",
+		"be more skeptical",
+		"be less verbose",
+		"act more formal",
+	];
+	for (const shape of explicitShapes) {
+		test(`classifies "${shape}" as definitive explicit`, () => {
+			const result = detectModificationIntentByRules(shape);
+			expect(result.definitive).toBe(true);
+			expect(result.intent.isModificationRequest).toBe(true);
+			expect(result.intent.requestType).toBe("explicit");
+		});
+	}
+
+	test("unrelated text is definitively not a modification request", () => {
+		const result = detectModificationIntentByRules("what's the weather today");
+		expect(result.definitive).toBe(true);
+		expect(result.intent.isModificationRequest).toBe(false);
+	});
+
+	test("ambiguous character talk stays inconclusive for the model path", () => {
+		const result = detectModificationIntentByRules(
+			"hmm your personality could probably improve somehow",
+		);
+		expect(result.definitive).toBe(false);
+		expect(result.potentialRequest).toBe(true);
+	});
+});
+
+describe("CHARACTER.modify — rule fast path skips the intent model call", () => {
+	test("the exact live planner request applies without an intent round-trip", async () => {
+		const scripted = scriptedRuntime([]);
+		const result = await runModify(
+			scripted,
+			LIVE_RAW_MESSAGE,
+			LIVE_PARAMETER_REQUEST,
+		);
+		expect(result.success).toBe(true);
+		expect(result.values?.modificationsApplied).toBe(true);
+		expect(scripted.intentPrompts).toHaveLength(0);
+		// parse + safety only
+		expect(scripted.prompts).toHaveLength(2);
+	});
+
+	test("the exact raw owner message applies without an intent round-trip", async () => {
+		const scripted = scriptedRuntime([]);
+		const result = await runModify(scripted, LIVE_RAW_MESSAGE);
+		expect(result.success).toBe(true);
+		expect(scripted.intentPrompts).toHaveLength(0);
+	});
+});
+
+describe("CHARACTER.modify — model path retry and tolerant parsing", () => {
+	const AMBIGUOUS = "hmm your personality could probably improve somehow";
+
+	test("a flaky first response is retried once and the valid retry is used", async () => {
+		const scripted = scriptedRuntime([
+			"I think this is asking about personality but I cannot answer in JSON",
+			'{"isModificationRequest": false, "requestType": "none", "confidence": 0.9}',
+		]);
+		const result = await runModify(scripted, AMBIGUOUS);
+		expect(scripted.intentPrompts).toHaveLength(2);
+		// intent=none with no pending evolution suggestion → honest no-op result
+		expect(result.success).toBe(false);
+		expect(result.values?.error).toBe("no_modification_found");
+	});
+
+	test("fenced JSON is accepted on the first attempt", async () => {
+		const scripted = scriptedRuntime([
+			'```json\n{"isModificationRequest": false, "requestType": "none", "confidence": 0.95}\n```',
+		]);
+		const result = await runModify(scripted, AMBIGUOUS);
+		expect(scripted.intentPrompts).toHaveLength(1);
+		expect(result.values?.error).toBe("no_modification_found");
+	});
+
+	test("still-invalid after the reroll fails with actionable guidance", async () => {
+		const scripted = scriptedRuntime([
+			"no json here at all",
+			"still no json here",
+		]);
+		const result = await runModify(scripted, AMBIGUOUS);
+		expect(scripted.intentPrompts).toHaveLength(2);
+		expect(result.success).toBe(false);
+		expect(result.data?.errorType).toBe("intent_classification_failed");
+		expect(result.text).toContain('"change your personality to ..."');
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/personality/actions/character.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/character.ts
@@ -20,7 +20,10 @@
 import { ElizaError } from "../../../../errors.ts";
 import { logger } from "../../../../logger.ts";
 import { hasRoleAccess } from "../../../../roles.ts";
-import { stringifyForModel } from "../../../../runtime/json-output.ts";
+import {
+	parseJsonObject,
+	stringifyForModel,
+} from "../../../../runtime/json-output.ts";
 import type { Character } from "../../../../types/agent.ts";
 import type {
 	Action,
@@ -138,11 +141,12 @@ export const characterAction: Action = {
 	// Coarse floor; per-op requirements (update_identity → OWNER) in CHARACTER_OP_ACCESS.
 	roleGate: { minRole: "ADMIN" },
 	similes: [
-		// Old leaf action names
+		// Old leaf action names. UPDATE_OWNER_NAME deliberately absent: it names
+		// the OWNER's profile name (SETTINGS territory, see the provider-context
+		// catalog), and a double claim drops the simile from routing as ambiguous.
 		"MODIFY_CHARACTER",
 		"PERSIST_CHARACTER",
 		"UPDATE_IDENTITY",
-		"UPDATE_OWNER_NAME",
 		// Identity / naming aliases
 		"IDENTITY",
 		"SET_IDENTITY",
@@ -809,15 +813,23 @@ async function runModify(
 			{ error: error instanceof Error ? error.message : String(error) },
 			"Error in CHARACTER.modify",
 		);
-		const text =
-			"Character modification failed with an unexpected error; tell the user it didn't go through and they can try again.";
+		const intentClassificationFailed =
+			error instanceof ElizaError &&
+			error.code === "CHARACTER_INTENT_CLASSIFICATION_FAILED";
+		// A classification failure is a phrasing problem, not a glitch: tell the
+		// planner what wording works so the user gets an actionable retry.
+		const text = intentClassificationFailed
+			? 'Couldn\'t work out what the user wants changed about the character; ask them to rephrase it concretely, like "change your personality to ...", and try again.'
+			: "Character modification failed with an unexpected error; tell the user it didn't go through and they can try again.";
 		return {
 			text,
 			values: { success: false, error: (error as Error).message },
 			data: {
 				action: "CHARACTER",
 				op: "modify",
-				errorType: "character_modification_error",
+				errorType: intentClassificationFailed
+					? "intent_classification_failed"
+					: "character_modification_error",
 				errorDetails: (error as Error).stack,
 			},
 			success: false,
@@ -828,14 +840,14 @@ async function runModify(
 function parseStructuredRecord(
 	response: string,
 ): Record<string, unknown> | null {
-	try {
-		const parsed = JSON.parse(response.trim()) as unknown;
-		return isRecord(parsed) ? parsed : null;
-	} catch {
-		// error-policy:J3 character model output is untrusted input; malformed
-		// JSON is an explicit invalid response.
-		return null;
-	}
+	// Tolerant of fenced / prose-wrapped output: small hosted models routinely
+	// decorate strict-JSON asks, and a bare JSON.parse here was failing whole
+	// CHARACTER operations on recoverable responses. parseJsonObject is the
+	// same recovery layer runtime/validated-model-call.ts uses for remote
+	// structured output; it returns null (never a fake-valid default) when no
+	// object can be extracted.
+	const parsed = parseJsonObject<Record<string, unknown>>(response);
+	return parsed && isRecord(parsed) ? parsed : null;
 }
 
 function normalizeBoolean(value: unknown): boolean | undefined {
@@ -924,7 +936,7 @@ function buildModificationFromStructuredRecord(
 	return Object.keys(modification).length > 0 ? modification : null;
 }
 
-function detectModificationIntentByRules(messageText: string): {
+export function detectModificationIntentByRules(messageText: string): {
 	intent: ModificationIntentAnalysis;
 	definitive: boolean;
 	potentialRequest: boolean;
@@ -944,7 +956,21 @@ function detectModificationIntentByRules(messageText: string): {
 
 	const characterKeyword =
 		/\b(personality|character|tone|style|voice|behavior|response(?:\s+style|\s+format)?|interaction(?:\s+style)?|preferences?|bio|topics?|name|language)\b/i;
-	const directChangeVerb = /\b(change|update|modify|adjust|set|rename|call)\b/i;
+	// "add a rule to your personality" / "remove X from your topics" are as
+	// direct as "change your personality" — the additive verbs cost nothing
+	// because a character keyword must co-occur (live miss: tj-4c9e654fec50ea).
+	const directChangeVerb =
+		/\b(change|update|modify|adjust|set|rename|call|add|remove|drop)\b/i;
+	// A speech rule addressed to the agent ("never say bet", "stop saying bro",
+	// "don't use emoji") is an explicit behavior modification on its own — this
+	// handler only classifies text already routed to CHARACTER, so a plain
+	// imperative needs no character keyword and no model round-trip.
+	const speechRule =
+		/\b(?:never|always|stop|start|don't|do not|avoid|quit)\s+(?:ever\s+)?(?:say|saying|use|using|mention|mentioning)\b/i;
+	// "be more skeptical" / "act less formal" with an arbitrary trait — the
+	// styleCue list below can't enumerate every adjective.
+	const degreeDirective =
+		/^(?:please\s+)?(?:be|act|sound)\s+(?:a\s+(?:bit|little)\s+|way\s+|much\s+|far\s+)?(?:more|less)\s+\S/i;
 	const stylisticAdjustment =
 		/\b(be|sound|act|respond|reply|talk|speak)\b[\s\S]{0,80}\b(more|less|warmer|cooler|friendlier|formal|casual|direct|verbose|concise|skeptical|encouraging|supportive|detailed|brief|professional|polite)\b/i;
 	const interactionScope =
@@ -965,6 +991,8 @@ function detectModificationIntentByRules(messageText: string): {
 	if (
 		resetPreference.test(normalized) ||
 		(directChangeVerb.test(normalized) && characterKeyword.test(normalized)) ||
+		speechRule.test(normalized) ||
+		degreeDirective.test(normalized) ||
 		soundLikeMe.test(normalized) ||
 		respondInLanguage.test(normalized) ||
 		(interactionScope.test(normalized) &&
@@ -1041,47 +1069,56 @@ Example:
   "confidence": 0.93
 }`;
 
-	try {
-		const response = await runtime.useModel(ModelType.TEXT_SMALL, {
-			prompt: intentPrompt,
-			temperature: 0.2,
-			maxTokens: 150,
-		});
-		const raw = parseStructuredRecord(response);
-		if (!raw) {
-			throw new ElizaError("Character intent model returned invalid JSON", {
-				code: "CHARACTER_INTENT_INVALID",
+	// One reroll on an invalid response: the TEXT_SMALL tier on live deployments
+	// flakes on strict-JSON asks often enough that a single-shot failure was
+	// killing the whole action (tj-4c9e654fec50ea). Mirrors the remote reroll in
+	// runtime/validated-model-call.ts, capped at one because the heuristic above
+	// already resolved every unambiguous shape.
+	let lastFailure: unknown;
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		try {
+			const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+				prompt: intentPrompt,
+				temperature: 0.2,
+				maxTokens: 150,
 			});
-		}
+			const raw = parseStructuredRecord(response);
+			if (!raw) {
+				throw new ElizaError("Character intent model returned invalid JSON", {
+					code: "CHARACTER_INTENT_INVALID",
+				});
+			}
 
-		const confidence = normalizeNumber(raw.confidence);
-		const isModificationRequest = normalizeBoolean(raw.isModificationRequest);
-		const requestType = raw.requestType;
-		if (
-			confidence === undefined ||
-			isModificationRequest === undefined ||
-			(requestType !== "explicit" &&
-				requestType !== "suggestion" &&
-				requestType !== "none")
-		) {
-			throw new ElizaError("Character intent model returned invalid fields", {
-				code: "CHARACTER_INTENT_INVALID",
-			});
+			const confidence = normalizeNumber(raw.confidence);
+			const isModificationRequest = normalizeBoolean(raw.isModificationRequest);
+			const requestType = raw.requestType;
+			if (
+				confidence === undefined ||
+				isModificationRequest === undefined ||
+				(requestType !== "explicit" &&
+					requestType !== "suggestion" &&
+					requestType !== "none")
+			) {
+				throw new ElizaError("Character intent model returned invalid fields", {
+					code: "CHARACTER_INTENT_INVALID",
+				});
+			}
+			return {
+				isModificationRequest: isModificationRequest && confidence > 0.5,
+				requestType: requestType as "explicit" | "suggestion" | "none",
+				confidence,
+			};
+		} catch (error) {
+			// error-policy:J2 hold the failure for the single reroll; the terminal
+			// wrapper below rethrows at the classification boundary with the last
+			// cause preserved — an inconclusive rule result is never fabricated.
+			lastFailure = error;
 		}
-		const llmResult = {
-			isModificationRequest: isModificationRequest && confidence > 0.5,
-			requestType: requestType as "explicit" | "suggestion" | "none",
-			confidence,
-		};
-		return llmResult;
-	} catch (error) {
-		// error-policy:J2 preserve the model failure while identifying the intent
-		// classification boundary; an inconclusive rule result is not fabricated.
-		throw new ElizaError("Failed to classify character modification intent", {
-			code: "CHARACTER_INTENT_CLASSIFICATION_FAILED",
-			cause: error,
-		});
 	}
+	throw new ElizaError("Failed to classify character modification intent", {
+		code: "CHARACTER_INTENT_CLASSIFICATION_FAILED",
+		cause: lastFailure,
+	});
 }
 
 async function buildRecentConversationContext(

--- a/packages/core/src/features/advanced-capabilities/personality/index.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/index.ts
@@ -5,6 +5,7 @@
 export { characterAction } from "./actions/character.ts";
 export { personalityAction } from "./actions/personality.ts";
 export { defaultProfiles } from "./profiles/index.ts";
+export { characterGateNoticeProvider } from "./providers/character-gate-notice.ts";
 export { userPersonalityProvider } from "./providers/user-personality.ts";
 export * from "./reply-gate.ts";
 // CharacterFileManager + PersonalityStore are lazy-loaded in advancedServices
@@ -25,10 +26,12 @@ import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // when a consumer dereferences a re-exported binding at runtime.
 import { characterAction as _bs_1_characterAction } from "./actions/character.ts";
 import { personalityAction as _bs_3_personalityAction } from "./actions/personality.ts";
+import { characterGateNoticeProvider as _bs_4_characterGateNoticeProvider } from "./providers/character-gate-notice.ts";
 import { userPersonalityProvider as _bs_2_userPersonalityProvider } from "./providers/user-personality.ts";
 
 anchorBundleSafety("FEATURES_ADVANCED_CAPABILITIES_PERSONALITY_INDEX", [
 	_bs_1_characterAction,
 	_bs_2_userPersonalityProvider,
 	_bs_3_personalityAction,
+	_bs_4_characterGateNoticeProvider,
 ]);

--- a/packages/core/src/features/advanced-capabilities/personality/providers/character-gate-notice.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/providers/character-gate-notice.ts
@@ -1,0 +1,108 @@
+/**
+ * Surfaces an explicit character-modification ask from a sender below the
+ * CHARACTER action's role gate as a model-visible notice. Role gating drops the
+ * CHARACTER tools from the planner surface silently, so without this signal the
+ * reply model acks the request ("on it.") and the sender never learns the
+ * refusal was a permissions matter (live: shaw as GUEST, 2026-08-08). Follows
+ * the owner-exclusive suppression-note pattern (security/trusted-delivery-
+ * audience.ts): context in, model out — the model phrases the in-voice decline;
+ * no reply string is hardcoded here.
+ *
+ * Fires only when the deterministic rule classifier (the same fast path the
+ * CHARACTER action uses) marks the current message as a definitive modification
+ * request AND the sender fails the action's effective role gate, honoring any
+ * ACTION_ROLE_POLICY override so deployments that loosen the gate never emit a
+ * false refusal hint. Always-on: the sender roles this notice exists for are
+ * exactly the ones whose turns are not routed to the settings context.
+ */
+import { hasRoleAccess, type RoleName } from "../../../../roles.ts";
+import { resolveActionRolePolicyRole } from "../../../../runtime/action-role-policy.ts";
+import type { RoleGateRole } from "../../../../types/contexts.ts";
+import type {
+	IAgentRuntime,
+	Memory,
+	Provider,
+	ProviderResult,
+} from "../../../../types/index.ts";
+import { detectModificationIntentByRules } from "../actions/character.ts";
+
+const EMPTY_RESULT: ProviderResult = {
+	data: {},
+	values: {},
+	text: "",
+};
+
+/**
+ * Maps a gate tier to the role hierarchy `hasRoleAccess` checks. NONE/GUEST
+ * gates admit every sender, so no notice can ever be warranted for them.
+ */
+function accessRoleForGate(minRole: RoleGateRole): RoleName | null {
+	switch (minRole) {
+		case "OWNER":
+		case "ADMIN":
+			return minRole;
+		case "MEMBER":
+		case "USER":
+			return "USER";
+		default:
+			return null;
+	}
+}
+
+export const characterGateNoticeProvider: Provider = {
+	name: "CHARACTER_GATE_NOTICE",
+	description:
+		"Flags an explicit character-modification ask from a sender below the CHARACTER action's role gate so the reply declines in voice instead of implying the change happened",
+	dynamic: true,
+	// The turns that need this notice are exactly the ones context routing
+	// cannot reach: role filtering strips the settings context for low-role
+	// senders before providers are selected. Free on the happy path — it
+	// renders nothing unless the rule classifier fires.
+	alwaysInResponseState: true,
+
+	get: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+	): Promise<ProviderResult> => {
+		const text =
+			typeof message.content?.text === "string" ? message.content.text : "";
+		if (!text.trim()) return EMPTY_RESULT;
+
+		const heuristic = detectModificationIntentByRules(text);
+		if (!heuristic.definitive || !heuristic.intent.isModificationRequest) {
+			return EMPTY_RESULT;
+		}
+
+		const characterAction = (runtime.actions ?? []).find(
+			(action) => action.name === "CHARACTER",
+		);
+		if (!characterAction) return EMPTY_RESULT;
+
+		// Same precedence as the shared action gate: an ACTION_ROLE_POLICY entry
+		// replaces the declared gates; otherwise the declared roleGate (and the
+		// contextGate's role term) is the floor.
+		const minRole =
+			resolveActionRolePolicyRole(characterAction) ??
+			characterAction.roleGate?.minRole ??
+			characterAction.contextGate?.roleGate?.minRole;
+		if (!minRole) return EMPTY_RESULT;
+		const accessRole = accessRoleForGate(minRole);
+		if (!accessRole) return EMPTY_RESULT;
+
+		if (await hasRoleAccess(runtime, message, accessRole)) {
+			return EMPTY_RESULT;
+		}
+
+		const noticeText = [
+			"# Character modification access notice",
+			`The current message reads as asking to change the agent's persistent character, personality, or behavior, but that capability requires the ${minRole} role and this sender does not have it. The character tools are not available on this turn.`,
+			"Do not promise, imply, or claim any persistent change was or will be applied. Acknowledge in your own voice that only your owner/admins can change how you are configured.",
+			"If the message is merely an in-conversation request (like keeping something quiet in this chat), respond to it naturally instead — this notice covers only persistent configuration changes.",
+		].join("\n");
+		return {
+			data: { characterGateNotice: { requiredRole: minRole } },
+			values: { characterModificationGated: true, requiredRole: minRole },
+			text: noticeText,
+		};
+	},
+};


### PR DESCRIPTION
## What

Fixes two defects exposed by a live owner test of character modification (2026-08-08, Discord deployment; sanitized trajectories attached).

### 1 — CHARACTER.modify died on a single classifier flake

Live: the owner asked for a character change; the planner routed `CHARACTER_MODIFY` with `request: "add a strict rule to my personality: never say 'bet' under any circumstances."`; `detectModificationIntent` threw `ElizaError: Failed to classify character modification intent` (character.ts:1080) and the whole action failed with a generic glitch line. Root cause: that request shape slipped past the rule heuristic's definitive branch ("add" was not a change verb, "never say X" was not a recognized speech rule), fell to the ONE strict-JSON `TEXT_SMALL` call, and the deployment's small model flaked on it — one bad parse killed the action closed.

Structural fixes in `packages/core/src/features/advanced-capabilities/personality/actions/character.ts`:

- **Rule fast path covers the live shapes.** `detectModificationIntentByRules` now classifies definitively, with no model round-trip: speech-rule imperatives (`never say X`, `stop saying X`, `don't say X`), additive asks (`add a rule to my personality: ...`, `remove X from your topics`), and degree directives (`be more X`, `act less X`). The exact live request and the exact raw owner message both hit the fast path.
- **Tolerant parsing + one reroll on the model path.** `parseStructuredRecord` now uses `parseJsonObject` (the same recovery layer as `runtime/validated-model-call.ts`: fenced/prose-wrapped/embedded objects recovered, never a fake-valid default), and the intent call rerolls once on an invalid response — mirroring validated-model-call's remote reroll, capped at one because the heuristic already resolves every unambiguous shape. The tolerant parser also hardens the parse/safety/identity call sites that share the helper.
- **Actionable failure surface.** If classification still fails after the reroll, the planner-facing result says what phrasing works (`ask them to rephrase it concretely, like "change your personality to ..."`) instead of the generic unexpected-error line, with `errorType: intent_classification_failed`.

### 2 — owner-gated character asks from non-owners were silently ignored

Live: a GUEST-role sender issued the same command directly. Role gating correctly excludes `CHARACTER` (roleGate ADMIN floor) from the planner surface — but the turn ended Stage-1-only with the reply "on it." and zero planner iterations. The sender was promised a change that silently never ran, with no indication it was a permissions matter.

Structural fix, following the existing gate-feedback pattern (`ownerExclusiveSuppressionNote` in `security/trusted-delivery-audience.ts` — context in, model out, no hardcoded reply strings):

- **New `CHARACTER_GATE_NOTICE` provider** (`personality/providers/character-gate-notice.ts`, registered in `advancedProviders`, `alwaysInResponseState` so it reaches Stage 1 even when role filtering strips the settings context for exactly these senders). When the deterministic rule classifier marks the current message as a definitive character-modification ask AND the sender fails the CHARACTER action's effective role gate (ACTION_ROLE_POLICY override honored — a deployment that loosens the gate never emits a false refusal hint), it injects a model-visible notice: the capability is role-gated, do not promise or imply the change, decline in your own voice. The model phrases the refusal; no reply string is hardcoded.

### 3 — routing double-claim (one-liner)

Live startup warning: `simile claimed by multiple parents — dropped from routing as ambiguous (simile=UPDATE_OWNER_NAME, parents=["CHARACTER","SETTINGS"])`. `UPDATE_OWNER_NAME` names the owner's profile name — SETTINGS territory (`packages/agent/src/actions/settings-actions.ts` claims it; the provider-context catalog maps it to `settings`). Dropped the stale claim from CHARACTER's similes so the simile routes again.

## Tests

`packages/core/.../personality/__tests__/character-modify-intent.test.ts` (17) and `character-gate-notice.test.ts` (5), real handlers/provider against the in-memory FakeRuntime, real `hasRoleAccess`, scripted model stubs:

| Case | Result |
|---|---|
| Rule fast path: exact live planner request, exact raw owner message (bare + mention-prefixed), `never say X`, `stop saying X`, `don't say X`, `be more/less X`, `act more X` → definitive explicit | pass |
| Unrelated text → definitive non-request; ambiguous character talk → inconclusive (model path) | pass |
| Fast path end-to-end: live request applies with zero intent-classifier calls (parse + safety only) | pass |
| Model path: flaky-then-valid → one reroll, valid retry used | pass |
| Model path: fenced JSON accepted on first attempt (tolerant parse) | pass |
| Still-invalid after reroll → `intent_classification_failed` + actionable phrasing guidance | pass |
| GUEST explicit ask → gate notice with required role; owner identical ask → no notice; unrelated/ambiguous GUEST messages → no notice; `ACTION_ROLE_POLICY` loosened to GUEST → no notice | pass |

Owning suites green: full personality feature suite + `character.test.ts` per-op gating + `action-role-policy.test.ts` + `action-retrieval.test.ts` (multi-parent simile drop) — 123 tests. Stage-1/provider-surface suites green (`compose-state-provider-purity`, `message-runtime-stage1`, `message-stable-prefix`, `tiered-action-surface`, `message-stage1-context-catalog`). `packages/core` typecheck + biome lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:f48d32b6e75bc265883864cc6d7dc9d105a45eed -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core runtime/action fix; no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core runtime/action fix; no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI flow to record

<!-- evidence-row:backend-logs -->
- [x] [18091-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18091-backend-logs.txt)

<!-- evidence-row:llm-trajectory -->
- [x] [18091-llm-trajectory.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18091-llm-trajectory.json) — sanitized live trajectories: the classifier-flake action failure and the GUEST turn that ended Stage-1-only with "on it."

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code in the diff

<!-- evidence-row:domain-artifacts -->
- [x] [18091-domain-artifacts.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18091-domain-artifacts.txt) — verbose per-test matrix for the two new suites (22 tests)


# Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
