### PR TITLE
fix(agent): humanize trigger replies — no iso/cron in chat, one ack per turn

### DIFF
--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -14,6 +14,10 @@
  * receipt for fresh mutations, a replayed no-op for the idempotent
  * already-exists path — so the planned-reply egress verifier can ground a
  * truthful completion claim, while failures stay receipt-less.
+ * Also pins the reply contract: user text carries humanized schedules (no ISO
+ * timestamps, no cron strings — those stay in `data`) and committed mutations
+ * are turnComplete, making the action's ack the turn's single user-facing
+ * message instead of double-speaking alongside the evaluator's prose.
  */
 
 import type {
@@ -257,7 +261,7 @@ describe("TRIGGER create — recurrence wins over sprayed one-shot fields", () =
     expect(trigger?.kind).toBe("prompt");
     expect(trigger?.triggerType).toBe("cron");
     expect(trigger?.cronExpression).toBe("0 8 * * *");
-    expect(result?.text).toContain("cron 0 8 * * *");
+    expect(result?.text).toContain("every morning at 8am");
   });
 
   it("keeps 'every morning at 9am' recurring when the planner sprays every schedule field", async () => {
@@ -281,7 +285,7 @@ describe("TRIGGER create — recurrence wins over sprayed one-shot fields", () =
     expect(trigger?.triggerType).toBe("cron");
     expect(trigger?.cronExpression).toBe("0 9 * * *");
     expect(trigger?.scheduledAtIso).toBeUndefined();
-    expect(result?.text).toContain("cron 0 9 * * *");
+    expect(result?.text).toContain("every morning at 9am");
     expect(result?.text).not.toContain("once at");
   });
 
@@ -556,6 +560,138 @@ describe("TRIGGER handler — silent, planner-voiced acks (#16863)", () => {
   });
 });
 
+describe("TRIGGER replies — humanized schedule, single final message", () => {
+  const ISO_TIMESTAMP = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders a daily cron as human recurrence — no cron string in user text", async () => {
+    const { runtime } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {
+      instructions: "take vitamins",
+      displayName: "take vitamins",
+      cronExpression: "0 8 * * *",
+    });
+    if (!result) throw new Error("expected a result");
+    expect(result.success).toBe(true);
+    expect(result.text).toBe(
+      'Reminder set: "take vitamins" — every morning at 8am.',
+    );
+    expect(result.text).not.toContain("0 8 * * *");
+    expect(result.text).not.toMatch(/cron/i);
+    expect(result.text).not.toMatch(ISO_TIMESTAMP);
+    // Machine detail stays in structured data for the planner/telemetry.
+    expect(result.data?.cronExpression).toBe("0 8 * * *");
+  });
+
+  it("renders a weekly cron as its weekday recurrence", async () => {
+    const { runtime } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {
+      instructions: "review the sprint board",
+      displayName: "sprint review",
+      cronExpression: "0 9 * * 1",
+    });
+    if (!result) throw new Error("expected a result");
+    expect(result.text).toBe(
+      'Reminder set: "sprint review" — every Monday at 9am.',
+    );
+  });
+
+  it("renders a one-shot ISO timestamp as a friendly local time — never the raw ISO", async () => {
+    vi.useFakeTimers();
+    // Local noon: "tomorrow at 8am" is deterministic in any test timezone
+    // because both the action and the expectation use local time.
+    vi.setSystemTime(new Date(2026, 7, 8, 12, 0, 0));
+    try {
+      const { runtime } = makeRuntime({ enableAutonomy: false });
+      const scheduledAtIso = new Date(2026, 7, 9, 8, 0, 0).toISOString();
+      const result = await create(runtime, {
+        instructions: "take vitamins",
+        displayName: "take vitamins",
+        scheduledAtIso,
+      });
+      if (!result) throw new Error("expected a result");
+      expect(result.success).toBe(true);
+      expect(result.text).toBe(
+        'Reminder set: "take vitamins" — tomorrow at 8am.',
+      );
+      expect(result.text).not.toMatch(ISO_TIMESTAMP);
+      expect(result.data?.scheduledAtIso).toBe(scheduledAtIso);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("renders a delay-derived one-shot as a countdown", async () => {
+    const { runtime } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {
+      instructions: "drink water",
+      displayName: "drink water",
+      delayMinutes: 5,
+    });
+    if (!result) throw new Error("expected a result");
+    expect(result.text).toBe('Reminder set: "drink water" — in 5 minutes.');
+    expect(result.text).not.toMatch(ISO_TIMESTAMP);
+  });
+
+  it("strips the internal 'Trigger:' displayName prefix from the reply", async () => {
+    const { runtime } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {
+      instructions: "stretch",
+      delaySeconds: 120,
+    });
+    if (!result) throw new Error("expected a result");
+    expect(result.text).not.toContain("Trigger:");
+    expect(result.text).toContain('"stretch"');
+  });
+
+  it("owns the turn: create is turnComplete so the ack is the single user-facing message", async () => {
+    // Without turnComplete the planner-loop combines the verified action text
+    // with the evaluator's prose — the observed 'Created trigger "…" (once at
+    // 2026-08-09T08:00:00Z). on it. set for 8am every morning.' double-speak.
+    const { runtime } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {
+      instructions: "take vitamins",
+      cronExpression: "0 8 * * *",
+    });
+    if (!result) throw new Error("expected a result");
+    expect(result.turnComplete).toBe(true);
+    expect(result.verifiedUserFacing).toBe(true);
+    expect(result.userFacingText).toBe(result.text);
+  });
+
+  it("owns the turn on the idempotent replay too", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const first = await create(runtime, {
+      instructions: "drink water",
+      delaySeconds: 90,
+    });
+    expect(first?.success).toBe(true);
+    (
+      runtime.getTasks as unknown as { mockResolvedValue: (v: Task[]) => void }
+    ).mockResolvedValue([
+      {
+        id: stringToUuid("existing-task"),
+        name: "TRIGGER_DISPATCH",
+        tags: ["queue", "repeat", "trigger"],
+        metadata: {
+          updatedAt: Date.now(),
+          trigger: createdTasks[0].metadata.trigger,
+        },
+      } as unknown as Task,
+    ]);
+    const replay = await create(runtime, {
+      instructions: "drink water",
+      delaySeconds: 90,
+    });
+    if (!replay) throw new Error("expected a result");
+    expect(replay.turnComplete).toBe(true);
+    expect(replay.userFacingText).toBe("Already set — you're covered.");
+  });
+});
+
 describe("TRIGGER create — workflow triggers", () => {
   it("still requires the autonomy loop for workflow triggers", async () => {
     const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
@@ -736,7 +872,8 @@ describe("TRIGGER update / delete / toggle — lifecycle ops (#16863)", () => {
       intervalMs: 120_000,
     });
     expect(result?.success).toBe(true);
-    expect(result?.text).toBe('Updated trigger "Trigger: hydrate".');
+    expect(result?.text).toBe('Updated "hydrate" — every 2 minutes.');
+    expect(result?.turnComplete).toBe(true);
     expect(updates).toHaveLength(1);
     expect(updates[0].taskId).toBe(LIFECYCLE_TASK_ID);
     expect(updates[0].patch.description).toBe("Trigger: hydrate");
@@ -775,7 +912,8 @@ describe("TRIGGER update / delete / toggle — lifecycle ops (#16863)", () => {
       displayName: "water the plants",
     });
     expect(result?.success).toBe(true);
-    expect(result?.text).toBe('Deleted trigger "Trigger: water the plants".');
+    expect(result?.text).toBe('Deleted "water the plants".');
+    expect(result?.turnComplete).toBe(true);
     expect(deletions).toEqual([LIFECYCLE_TASK_ID]);
   });
 
@@ -800,7 +938,8 @@ describe("TRIGGER update / delete / toggle — lifecycle ops (#16863)", () => {
       taskId: LIFECYCLE_TASK_ID,
     });
     expect(result?.success).toBe(true);
-    expect(result?.text).toBe('Enabled trigger "Trigger: water the plants".');
+    expect(result?.text).toBe('Enabled "water the plants".');
+    expect(result?.turnComplete).toBe(true);
     expect(result?.data?.enabled).toBe(true);
     expect(updates).toHaveLength(1);
     expect(updates[0].patch.metadata?.trigger?.enabled).toBe(true);

--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -39,6 +39,11 @@ import {
 } from "@elizaos/core";
 
 import {
+  describeCronSchedule,
+  describeIntervalMs,
+  describeOnceAt,
+} from "../triggers/humanize.ts";
+import {
   executeTriggerTask,
   readTriggerConfig,
   TRIGGER_TASK_NAME,
@@ -180,13 +185,14 @@ function ok(
   };
 }
 
-// TRIGGER never emits a mid-turn callback (see the handler note below), so the
-// planner's final message is the only user-facing ack — and the planned-reply
-// egress gate refuses any completion claim not bound to a committed effect
-// receipt with exact action-owned text. Every mutating op therefore returns
-// the full receipt contract; a bare {success,text} result made even a genuine
-// "reminder is set" ack structurally unverifiable, so it was replaced with the
-// unverified-effect fallback at egress.
+// TRIGGER never emits a mid-turn callback (see the handler note below), and
+// every committed mutation opts into `turnComplete`, so the action's own
+// humanized ack is the single user-facing message for a single-op turn — and
+// the planned-reply egress gate refuses any completion claim not bound to a
+// committed effect receipt with exact action-owned text. Every mutating op
+// therefore returns the full receipt contract; a bare {success,text} result
+// made even a genuine "reminder is set" ack structurally unverifiable, so it
+// was replaced with the unverified-effect fallback at egress.
 //
 // The receiptId carries a random component: the planner can re-dispatch the
 // identical create within one turn (both invocations landing on the dedupe
@@ -226,7 +232,11 @@ function triggerReceipt(
 }
 
 // Committed-mutation result: binds the canonical text to its receipt so the
-// egress verifier can ground a completion claim on it.
+// egress verifier can ground a completion claim on it. `turnComplete` makes
+// this ack the turn's single user-facing message when the op was the turn's
+// sole tool — without it the planner-loop combines the verified text with the
+// evaluator's prose, double-speaking the same fact ("Created trigger … . on
+// it. set for 8am every morning." observed live).
 function okCommitted(
   op: TriggerOp,
   text: string,
@@ -238,6 +248,7 @@ function okCommitted(
     ...ok(op, text, data, values),
     userFacingText: text,
     verifiedUserFacing: true,
+    turnComplete: true,
     effectReceipts: [receipt],
     userFacingEffectReceiptIds: [receipt.receiptId],
   };
@@ -257,11 +268,31 @@ function dedupeHash(input: string): string {
   return `trigger-${Math.abs(h >>> 0).toString(16)}`;
 }
 
-function describeSchedule(t: TriggerConfig): string {
-  if (t.triggerType === "interval")
-    return `every ${t.intervalMs ?? DEFAULT_INTERVAL_MS}ms`;
-  if (t.triggerType === "once") return `once at ${t.scheduledAtIso ?? "?"}`;
-  return `cron ${t.cronExpression ?? "* * * * *"}`;
+// Chat-facing schedule phrasing. The raw forms (ISO timestamp, cron
+// expression, interval milliseconds) are machine detail: they stay in the
+// ActionResult's `data`, never in user text. Unrecognized shapes degrade to a
+// neutral phrase rather than echoing the raw value.
+function describeSchedule(t: TriggerConfig, nowMs = Date.now()): string {
+  if (t.triggerType === "interval") {
+    return describeIntervalMs(t.intervalMs ?? DEFAULT_INTERVAL_MS);
+  }
+  if (t.triggerType === "once") {
+    const friendly = t.scheduledAtIso
+      ? describeOnceAt(t.scheduledAtIso, nowMs)
+      : null;
+    return friendly ?? "soon";
+  }
+  const friendly = t.cronExpression
+    ? describeCronSchedule(t.cronExpression)
+    : null;
+  return friendly ?? "on a custom schedule";
+}
+
+// The stored displayName defaults to "Trigger: <instructions>" — an internal
+// naming convention, not something to read back at the user.
+function displayLabel(name: string): string {
+  const stripped = name.replace(/^trigger:\s*/i, "").trim();
+  return stripped.length > 0 ? stripped : name;
 }
 
 function triggersDisabled(runtime: IAgentRuntime): boolean {
@@ -641,9 +672,16 @@ async function opCreate(
     metadata,
   });
 
+  // A prompt trigger IS a reminder to the person who asked for it; a workflow
+  // trigger is a scheduled job. Either way the schedule reads as a human
+  // phrase — the machine forms live in `data` below.
+  const schedule = describeSchedule(triggerConfig);
+  const label = displayLabel(displayName);
   return okCommitted(
     "create",
-    `Created trigger "${displayName}" (${describeSchedule(triggerConfig)}).`,
+    triggerConfig.kind === "workflow"
+      ? `Scheduled "${label}" — ${schedule}.`
+      : `Reminder set: "${label}" — ${schedule}.`,
     triggerReceipt("create", String(taskId), { key: dedupeKey }),
     {
       triggerId,
@@ -654,6 +692,9 @@ async function opCreate(
       kind: triggerConfig.kind,
       workflowId,
       workflowName,
+      scheduledAtIso: triggerConfig.scheduledAtIso,
+      cronExpression: triggerConfig.cronExpression,
+      intervalMs: triggerConfig.intervalMs,
     },
     { triggerId, taskId, workflowId },
   );
@@ -725,9 +766,16 @@ async function opUpdate(
   });
   return okCommitted(
     "update",
-    `Updated trigger "${next.displayName}".`,
+    `Updated "${displayLabel(next.displayName)}" — ${describeSchedule(next)}.`,
     triggerReceipt("update", String(task.id), { key: null }),
-    { taskId: String(task.id), triggerId: next.triggerId },
+    {
+      taskId: String(task.id),
+      triggerId: next.triggerId,
+      triggerType: next.triggerType,
+      scheduledAtIso: next.scheduledAtIso,
+      cronExpression: next.cronExpression,
+      intervalMs: next.intervalMs,
+    },
   );
 }
 
@@ -742,7 +790,7 @@ async function opDelete(
   await runtime.deleteTask(loaded.task.id);
   return okCommitted(
     "delete",
-    `Deleted trigger "${loaded.trigger.displayName}".`,
+    `Deleted "${displayLabel(loaded.trigger.displayName)}".`,
     triggerReceipt("delete", String(loaded.task.id), { key: null }),
     { taskId: String(loaded.task.id) },
   );
@@ -766,7 +814,7 @@ async function opRun(
       { triggerId: loaded.trigger.triggerId },
     );
   }
-  return ok("run", `Ran trigger "${loaded.trigger.displayName}".`, {
+  return ok("run", `Ran "${displayLabel(loaded.trigger.displayName)}".`, {
     taskId: String(loaded.task.id),
     triggerId: loaded.trigger.triggerId,
     status: result.status,
@@ -800,7 +848,7 @@ async function opToggle(
   await runtime.updateTask(task.id, { metadata });
   return okCommitted(
     "toggle",
-    `${enabled ? "Enabled" : "Disabled"} trigger "${trigger.displayName}".`,
+    `${enabled ? "Enabled" : "Disabled"} "${displayLabel(trigger.displayName)}".`,
     triggerReceipt("toggle", String(task.id), { key: null }),
     { taskId: String(task.id), triggerId: trigger.triggerId, enabled },
   );
@@ -851,10 +899,12 @@ export const triggerAction: Action = {
     const op: TriggerOp = opRaw;
 
     // The handler never emits user-visible text itself: every outcome reaches
-    // the planner through the ActionResult, and the planner's final message is
-    // the single user-facing ack. A mid-turn callback here double-posts — the
-    // mechanical `Created trigger "…" (once at …)` line landed seconds before
-    // the planner's own confirmation of the same fact.
+    // the planner through the ActionResult. A mid-turn callback here
+    // double-posts — the mechanical create line landed seconds before the
+    // planner's own confirmation of the same fact. For committed mutations
+    // the ActionResult additionally sets `turnComplete`, making the action's
+    // humanized ack the turn's single final message instead of being merged
+    // with the evaluator's restatement of it.
     switch (op) {
       case "create":
         return opCreate(runtime, message, params);
@@ -980,7 +1030,7 @@ export const triggerAction: Action = {
       {
         name: "{{agent}}",
         content: {
-          text: 'Created trigger "Trigger: review open PRs" (every 43200000ms).',
+          text: 'Reminder set: "review open PRs" — every 12 hours.',
           action: TRIGGER_ACTION,
         },
       },
@@ -995,7 +1045,7 @@ export const triggerAction: Action = {
       {
         name: "{{agent}}",
         content: {
-          text: 'Created trigger "take vitamins" (cron 0 8 * * *).',
+          text: 'Reminder set: "take vitamins" — every morning at 8am.',
           action: TRIGGER_ACTION,
         },
       },
@@ -1008,7 +1058,7 @@ export const triggerAction: Action = {
       {
         name: "{{agent}}",
         content: {
-          text: 'Disabled trigger "Trigger: review open PRs".',
+          text: 'Disabled "review open PRs".',
           action: TRIGGER_ACTION,
         },
       },

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -454,6 +454,7 @@ export * from "./services/tee-runtime-config.ts";
 export * from "./services/tee-sealed-volume.ts";
 export * from "./services/tee-signer-backend.ts";
 export { resolveDefaultAgentWorkspaceDir } from "./shared/workspace-resolution.ts";
+export * from "./triggers/humanize.ts";
 export * from "./triggers/runtime.ts";
 export * from "./triggers/scheduling.ts";
 export * from "./triggers/types.ts";

--- a/packages/agent/src/triggers/humanize.test.ts
+++ b/packages/agent/src/triggers/humanize.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Deterministic unit tests for the trigger-schedule humanizers: cron
+ * recurrence phrasing, one-shot friendly times, and interval descriptions.
+ * Time-relative cases pin "now" and build targets with the local-time Date
+ * constructor so expectations hold in any test-runner timezone.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  describeCronSchedule,
+  describeIntervalMs,
+  describeOnceAt,
+} from "./humanize.ts";
+
+describe("describeCronSchedule", () => {
+  it("maps daily crons onto time-of-day nouns", () => {
+    expect(describeCronSchedule("0 8 * * *")).toBe("every morning at 8am");
+    expect(describeCronSchedule("30 14 * * *")).toBe(
+      "every afternoon at 2:30pm",
+    );
+    expect(describeCronSchedule("0 19 * * *")).toBe("every evening at 7pm");
+    // Small hours have no natural noun; plain daily phrasing instead.
+    expect(describeCronSchedule("0 2 * * *")).toBe("every day at 2am");
+    expect(describeCronSchedule("0 0 * * *")).toBe("every day at 12am");
+  });
+
+  it("describes weekday, weekend, and single-day recurrences", () => {
+    expect(describeCronSchedule("0 9 * * 1-5")).toBe("every weekday at 9am");
+    expect(describeCronSchedule("0 10 * * 0,6")).toBe("every weekend at 10am");
+    expect(describeCronSchedule("0 9 * * 1")).toBe("every Monday at 9am");
+    // POSIX Sunday alias.
+    expect(describeCronSchedule("0 9 * * 7")).toBe("every Sunday at 9am");
+  });
+
+  it("describes minute/hour and day-of-month shapes", () => {
+    expect(describeCronSchedule("*/15 * * * *")).toBe("every 15 minutes");
+    expect(describeCronSchedule("*/1 * * * *")).toBe("every minute");
+    expect(describeCronSchedule("0 * * * *")).toBe("every hour");
+    expect(describeCronSchedule("0 9 1 * *")).toBe(
+      "on the 1st of every month at 9am",
+    );
+    expect(describeCronSchedule("0 9 22 * *")).toBe(
+      "on the 22nd of every month at 9am",
+    );
+  });
+
+  it("returns null for shapes outside the reminder vocabulary", () => {
+    // Ranges/lists in minute or hour would misread as a single fire time.
+    expect(describeCronSchedule("0 9-17 * * *")).toBeNull();
+    expect(describeCronSchedule("0,30 9 * * *")).toBeNull();
+    // Restricted month, malformed, out-of-range.
+    expect(describeCronSchedule("0 9 * 1 *")).toBeNull();
+    expect(describeCronSchedule("not a cron")).toBeNull();
+    expect(describeCronSchedule("0 25 * * *")).toBeNull();
+    expect(describeCronSchedule("0 9 32 * *")).toBeNull();
+  });
+});
+
+describe("describeOnceAt", () => {
+  const NOW = new Date(2026, 7, 8, 12, 0, 0);
+
+  const iso = (d: Date) => d.toISOString();
+
+  it("renders near-term fires as a countdown", () => {
+    expect(
+      describeOnceAt(iso(new Date(NOW.getTime() + 30_000)), NOW.getTime()),
+    ).toBe("in under a minute");
+    expect(
+      describeOnceAt(iso(new Date(NOW.getTime() + 90_000)), NOW.getTime()),
+    ).toBe("in 2 minutes");
+    expect(
+      describeOnceAt(iso(new Date(NOW.getTime() + 5 * 60_000)), NOW.getTime()),
+    ).toBe("in 5 minutes");
+  });
+
+  it("renders same-day, next-day, and same-week fires as local clock times", () => {
+    expect(
+      describeOnceAt(iso(new Date(2026, 7, 8, 15, 30, 0)), NOW.getTime()),
+    ).toBe("today at 3:30pm");
+    expect(
+      describeOnceAt(iso(new Date(2026, 7, 9, 8, 0, 0)), NOW.getTime()),
+    ).toBe("tomorrow at 8am");
+    // 2026-08-12 is a Wednesday.
+    expect(
+      describeOnceAt(iso(new Date(2026, 7, 12, 8, 0, 0)), NOW.getTime()),
+    ).toBe("on Wednesday at 8am");
+  });
+
+  it("renders far-out fires as dates, with the year only when it differs", () => {
+    expect(
+      describeOnceAt(iso(new Date(2026, 7, 20, 8, 0, 0)), NOW.getTime()),
+    ).toBe("on Aug 20 at 8am");
+    expect(
+      describeOnceAt(iso(new Date(2027, 0, 2, 9, 0, 0)), NOW.getTime()),
+    ).toBe("on Jan 2, 2027 at 9am");
+  });
+
+  it("returns null for an unparseable timestamp", () => {
+    expect(describeOnceAt("not a timestamp", NOW.getTime())).toBeNull();
+  });
+});
+
+describe("describeIntervalMs", () => {
+  it("picks the largest evenly-dividing unit", () => {
+    expect(describeIntervalMs(24 * 60 * 60 * 1000)).toBe("every day");
+    expect(describeIntervalMs(2 * 24 * 60 * 60 * 1000)).toBe("every 2 days");
+    expect(describeIntervalMs(12 * 60 * 60 * 1000)).toBe("every 12 hours");
+    expect(describeIntervalMs(60 * 60 * 1000)).toBe("every hour");
+    expect(describeIntervalMs(90 * 60 * 1000)).toBe("every 90 minutes");
+    expect(describeIntervalMs(60 * 1000)).toBe("every minute");
+    expect(describeIntervalMs(45 * 1000)).toBe("every 45 seconds");
+  });
+
+  it("never emits raw milliseconds", () => {
+    expect(describeIntervalMs(1500)).toBe("every 2 seconds");
+    expect(describeIntervalMs(10)).toBe("every second");
+  });
+});

--- a/packages/agent/src/triggers/humanize.ts
+++ b/packages/agent/src/triggers/humanize.ts
@@ -1,0 +1,178 @@
+/**
+ * Human phrasing for trigger schedules in chat replies. Machine forms — ISO
+ * timestamps, cron expressions, raw millisecond intervals — must never reach
+ * the user's message; the TRIGGER action renders schedules through these
+ * helpers and keeps the machine detail in its structured `data` payload.
+ * Clock times render in the process-local timezone: the local-first
+ * deployment runs the agent on the user's own machine, so local time is the
+ * user's time. Cron fields are echoed as written (the scheduler interprets
+ * them in the trigger's own timezone), so no conversion applies there.
+ */
+
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+const MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+/** Below this lead time a one-shot reads as a countdown ("in 20 minutes"). */
+const RELATIVE_CUTOFF_MS = 45 * MINUTE_MS;
+
+function formatClockTime(hour: number, minute: number): string {
+  const h12 = hour % 12 === 0 ? 12 : hour % 12;
+  const suffix = hour < 12 ? "am" : "pm";
+  if (minute === 0) return `${h12}${suffix}`;
+  return `${h12}:${String(minute).padStart(2, "0")}${suffix}`;
+}
+
+// "every morning at 8am" reads the way people ask for it; hours without a
+// natural noun (late night / small hours) fall back to "every day at …".
+function timeOfDayNoun(hour: number): string | null {
+  if (hour >= 5 && hour <= 11) return "morning";
+  if (hour >= 12 && hour <= 16) return "afternoon";
+  if (hour >= 17 && hour <= 21) return "evening";
+  return null;
+}
+
+function ordinal(n: number): string {
+  const rem100 = n % 100;
+  if (rem100 >= 11 && rem100 <= 13) return `${n}th`;
+  const rem10 = n % 10;
+  if (rem10 === 1) return `${n}st`;
+  if (rem10 === 2) return `${n}nd`;
+  if (rem10 === 3) return `${n}rd`;
+  return `${n}th`;
+}
+
+/**
+ * Describe a 5-field cron expression as human recurrence ("every morning at
+ * 8am", "every Monday at 9am"). Returns null for shapes outside the common
+ * reminder vocabulary — callers fall back to a neutral phrase, never the raw
+ * expression.
+ */
+export function describeCronSchedule(expression: string): string | null {
+  const parts = expression.trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+  const [minPart, hourPart, domPart, monthPart, dowPart] = parts;
+  if (monthPart !== "*") return null;
+
+  const everyN = minPart.match(/^\*\/(\d+)$/);
+  if (everyN && hourPart === "*" && domPart === "*" && dowPart === "*") {
+    const n = Number.parseInt(everyN[1], 10);
+    if (n <= 0) return null;
+    return n === 1 ? "every minute" : `every ${n} minutes`;
+  }
+  if (
+    minPart === "0" &&
+    hourPart === "*" &&
+    domPart === "*" &&
+    dowPart === "*"
+  ) {
+    return "every hour";
+  }
+
+  // Single-integer minute and hour only: parsing the first number out of a
+  // range/list would confidently describe a multi-fire schedule as one time.
+  if (!/^\d+$/.test(minPart) || !/^\d+$/.test(hourPart)) return null;
+  const minute = Number.parseInt(minPart, 10);
+  const hour = Number.parseInt(hourPart, 10);
+  if (minute > 59 || hour > 23) return null;
+  const time = formatClockTime(hour, minute);
+
+  if (domPart === "*" && dowPart === "*") {
+    const noun = timeOfDayNoun(hour);
+    return noun ? `every ${noun} at ${time}` : `every day at ${time}`;
+  }
+  if (domPart === "*" && dowPart === "1-5") return `every weekday at ${time}`;
+  if (domPart === "*" && (dowPart === "0,6" || dowPart === "6,0")) {
+    return `every weekend at ${time}`;
+  }
+  if (domPart === "*" && /^[0-7]$/.test(dowPart)) {
+    // POSIX alias: 7 is Sunday.
+    const dow = Number.parseInt(dowPart, 10) % 7;
+    return `every ${DAY_NAMES[dow]} at ${time}`;
+  }
+  if (dowPart === "*" && /^\d+$/.test(domPart)) {
+    const dom = Number.parseInt(domPart, 10);
+    if (dom < 1 || dom > 31) return null;
+    return `on the ${ordinal(dom)} of every month at ${time}`;
+  }
+  return null;
+}
+
+/**
+ * Describe a one-shot fire time relative to now: a countdown for near-term
+ * fires ("in 5 minutes"), then local clock forms ("today at 3pm", "tomorrow
+ * at 8am", "on Saturday at 8am", "on Aug 20 at 8am"). Returns null only for
+ * an unparseable timestamp.
+ */
+export function describeOnceAt(
+  scheduledAtIso: string,
+  nowMs: number,
+): string | null {
+  const atMs = Date.parse(scheduledAtIso);
+  if (Number.isNaN(atMs)) return null;
+  const delta = atMs - nowMs;
+  if (delta > 0 && delta < MINUTE_MS) return "in under a minute";
+  if (delta > 0 && delta < RELATIVE_CUTOFF_MS) {
+    const minutes = Math.round(delta / MINUTE_MS);
+    return minutes <= 1 ? "in a minute" : `in ${minutes} minutes`;
+  }
+
+  const at = new Date(atMs);
+  const now = new Date(nowMs);
+  const time = formatClockTime(at.getHours(), at.getMinutes());
+  const startOfDay = (d: Date) =>
+    new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  const dayDiff = Math.round((startOfDay(at) - startOfDay(now)) / DAY_MS);
+  if (dayDiff === 0) return `today at ${time}`;
+  if (dayDiff === 1) return `tomorrow at ${time}`;
+  if (dayDiff > 1 && dayDiff < 7) {
+    return `on ${DAY_NAMES[at.getDay()]} at ${time}`;
+  }
+  const year =
+    at.getFullYear() === now.getFullYear() ? "" : `, ${at.getFullYear()}`;
+  return `on ${MONTH_NAMES[at.getMonth()]} ${at.getDate()}${year} at ${time}`;
+}
+
+/**
+ * Describe a repeat interval ("every 12 hours", "every 90 minutes"). Picks
+ * the largest unit that divides evenly; sub-second remainders round to
+ * seconds so raw millisecond counts never surface.
+ */
+export function describeIntervalMs(intervalMs: number): string {
+  const every = (n: number, unit: string) =>
+    n === 1 ? `every ${unit}` : `every ${n} ${unit}s`;
+  if (intervalMs >= DAY_MS && intervalMs % DAY_MS === 0) {
+    return every(intervalMs / DAY_MS, "day");
+  }
+  if (intervalMs >= HOUR_MS && intervalMs % HOUR_MS === 0) {
+    return every(intervalMs / HOUR_MS, "hour");
+  }
+  if (intervalMs >= MINUTE_MS && intervalMs % MINUTE_MS === 0) {
+    return every(intervalMs / MINUTE_MS, "minute");
+  }
+  return every(Math.max(1, Math.round(intervalMs / 1000)), "second");
+}


### PR DESCRIPTION
# Problem

Live reminder acks read as machine output, twice over. Observed:

```
Created trigger "take vitamins" (once at 2026-08-09T08:00:00Z). on it. set for 8am every morning.
```

Three defects in one reply:

1. **Raw ISO timestamp (and cron / interval-ms) in chat.** `describeSchedule` in `packages/agent/src/actions/trigger.ts` rendered `once at ${scheduledAtIso}`, `cron ${cronExpression}`, and `every ${intervalMs}ms` straight into the user-facing ack.
2. **Double-speak.** The action returned `verifiedUserFacing` text without `turnComplete`, so the planner-loop's `combinedVerifiedToolTextAndProse` glued the mechanical line to the evaluator's restatement of the same fact — the same class #17975 fixed at the voice seam.
3. Sibling ops (update / delete / toggle / run) echoed the internal `Trigger: …` displayName convention back at the user.

Complementary to #18026 (recurrence correctness): that fixed WHAT gets scheduled; this fixes what the user READS.

# Fix

- **New `packages/agent/src/triggers/humanize.ts`** — schedule phrasing for chat: cron → human recurrence (`every morning at 8am` for `0 8 * * *`, `every Monday at 9am`, `every weekday at 9am`, `every 15 minutes`, `on the 1st of every month at 9am`); one-shots → countdown or friendly local time (`in 5 minutes`, `today at 3:30pm`, `tomorrow at 8am`, `on Wednesday at 8am`, `on Aug 20 at 8am`); intervals → largest evenly-dividing unit (`every 12 hours`). Unrecognized shapes degrade to a neutral phrase (`on a custom schedule`) — never the raw value. Clock times render process-local: the local-first deployment runs the agent on the user's own machine.
- **`TRIGGER` replies humanized** (`trigger.ts`): create / update / delete / toggle / run use those phrases and strip the `Trigger:` prefix. The machine detail moves into the ActionResult's structured `data` (`scheduledAtIso`, `cronExpression`, `intervalMs`) where the planner and telemetry can still read it.
- **One ack per turn.** Committed mutations (create / update / delete / toggle, including the idempotent already-exists replay) now set `turnComplete: true` — the same action-owned contract `LOGS` and `CONTACT` use, and the seam the #17975 voice dedupe keys on. Under the planner-loop's gated-FINISH contract the action's verified humanized ack is the turn's single user-facing message; the evaluator no longer restates it.

## Before / after

| op | before | after |
| --- | --- | --- |
| create (cron `0 8 * * *`) | `Created trigger "take vitamins" (cron 0 8 * * *).` + evaluator prose appended | `Reminder set: "take vitamins" — every morning at 8am.` (sole message) |
| create (once, ISO) | `Created trigger "take vitamins" (once at 2026-08-09T08:00:00Z). on it. set for 8am every morning.` | `Reminder set: "take vitamins" — tomorrow at 8am.` |
| create (delay 5m) | `Created trigger "Trigger: drink water" (once at 2026-…Z).` | `Reminder set: "drink water" — in 5 minutes.` |
| create (interval) | `Created trigger "Trigger: review open PRs" (every 43200000ms).` | `Reminder set: "review open PRs" — every 12 hours.` |
| create (workflow kind) | `Created trigger "…" (cron …).` | `Scheduled "Report" — every weekday at 9am.` |
| update | `Updated trigger "Trigger: hydrate".` | `Updated "hydrate" — every 2 minutes.` |
| delete | `Deleted trigger "Trigger: water the plants".` | `Deleted "water the plants".` |
| toggle | `Enabled trigger "Trigger: water the plants".` | `Enabled "water the plants".` |
| run | `Ran trigger "Trigger: …".` | `Ran "…".` |

# Tests

New `TRIGGER replies — humanized schedule, single final message` block in `trigger.test.ts` pins the reply contract:

- daily cron → exact humanized ack, **no ISO timestamp, no cron string** in user text; the cron asserted present in `data.cronExpression`
- weekly cron → `every Monday at 9am`
- explicit ISO one-shot (pinned clock, local-time target so it holds in any TZ) → `tomorrow at 8am`, raw ISO only in `data.scheduledAtIso`
- delay-derived one-shot → `in 5 minutes`
- `Trigger:` prefix stripped from replies
- `turnComplete` + `verifiedUserFacing` + `userFacingText === text` on create AND on the idempotent replay — the single-message proof
- lifecycle suite extended: update / delete / toggle assert the new humanized text and `turnComplete`

New `packages/agent/src/triggers/humanize.test.ts` covers the formatters deterministically: time-of-day nouns, weekday/weekend/single-day/day-of-month crons, null for shapes outside the vocabulary (ranges/lists that would misread as a single fire time), countdown vs today/tomorrow/weekday/date boundaries, year suffix only when it differs, interval unit selection, no raw milliseconds.

Repo-wide sweep: no other consumer pinned the old strings (only comments and unrelated DB/e2e log lines).

# Gates

- `packages/agent` focused suites at head `165f4331b21`: `trigger.test.ts` (52) + `humanize.test.ts` (10) + `triggers/runtime.test.ts` + `triggers/workbench-migration.test.ts` — **89/89** (fresh run attached in evidence)
- `bun run --cwd packages/agent typecheck` — clean (exit 0)
- `bun run --cwd packages/agent lint:check` — 859 files, no diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:165f4331b216c48530967f44d259a8e45a8fb1d4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only agent action-reply change; no rendered UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only agent action-reply change with no UI surface in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no client flow changed; the delta is server-side reply text and turn ownership

<!-- evidence-row:backend-logs -->
- [x] [18094-trigger-humanize-suites-165f433.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18094-trigger-humanize-suites-165f433.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/client code in the diff

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-path or prompt change; the reply text is action-owned and deterministic, pinned end to end by the contract suites in backend logs, and `turnComplete` is the already-live gated-FINISH contract exercised by planner-loop suites

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - stored trigger task shape unchanged; the delta is reply text and result metadata, covered by the deterministic suites

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported
