### PR TITLE
fix: close Unicode sanitizer gaps from #18079

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-rendering.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-rendering.test.ts
@@ -151,6 +151,34 @@ describe("truncateToolResultText (pure)", () => {
 			expect(JSON.stringify(out)).not.toMatch(/\\u[dD][89a-fA-F]/);
 		}
 	});
+
+	// #18081: The truncated count must be exact — head + tail + truncated = total.
+	// The old code computed the count from requested head/tail lengths before
+	// surrogate-safe back-off, so the sum was wrong when a surrogate pair was
+	// split.
+	it("reports an exact truncated count for astral-only input (#18081)", () => {
+		const input = "💀".repeat(100); // 200 UTF-16 code units
+		const out = truncateToolResultText(input, 30);
+		expect(out).toMatch(/chars truncated/);
+		const match = out.match(/\[(\d+) chars truncated\]/);
+		expect(match).not.toBeNull();
+		const truncatedCount = Number.parseInt(match?.[1] ?? "0", 10);
+		const preserved = out.replace(/\s\[\d+ chars truncated\]\s/, "");
+		// head + tail + truncated = original length — the invariant.
+		expect(preserved.length + truncatedCount).toBe(input.length);
+	});
+
+	// #18081: Same invariant for mixed-content strings with emoji at cut boundaries.
+	it("reports an exact truncated count for mixed content with emoji boundaries (#18081)", () => {
+		const input = `header ${"💀".repeat(50)} ${"x".repeat(80)} ${"🔥".repeat(50)} footer`;
+		const out = truncateToolResultText(input, 80);
+		expect(out).toMatch(/chars truncated/);
+		const match = out.match(/\[(\d+) chars truncated\]/);
+		expect(match).not.toBeNull();
+		const truncatedCount = Number.parseInt(match?.[1] ?? "0", 10);
+		const preserved = out.replace(/\s\[\d+ chars truncated\]\s/, "");
+		expect(preserved.length + truncatedCount).toBe(input.length);
+	});
 });
 
 describe("trajectoryStepsToMessages — maxToolResultChars option", () => {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -2278,7 +2278,13 @@ function compactText(value: string, maxLength: number): string {
 	}
 	const headLength = Math.max(20, Math.floor(maxLength * 0.65));
 	const tailLength = Math.max(20, maxLength - headLength - 24);
-	return `${truncateWellFormed(text, headLength)} ...[${text.length - headLength - tailLength} chars compacted]... ${tailWellFormed(text, tailLength)}`;
+	// Compute the compacted count from the ACTUAL retained code-unit lengths
+	// after surrogate-safe truncation — truncateWellFormed and tailWellFormed
+	// may back off at surrogate boundaries, so the retained length can differ
+	// from the request (#18081).
+	const head = truncateWellFormed(text, headLength);
+	const tail = tailWellFormed(text, tailLength);
+	return `${head} ...[${text.length - head.length - tail.length} chars compacted]... ${tail}`;
 }
 
 /**

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -76,17 +76,21 @@ export function truncateToolResultText(
 		const tailFloor = preserveBudget >= 20 ? 10 : preserveBudget > 1 ? 1 : 0;
 		const headChars = Math.max(headFloor, Math.floor(preserveBudget * 0.6));
 		const tailChars = Math.max(tailFloor, preserveBudget - headChars);
-		const preservedChars = headChars + tailChars;
-		const truncatedCount = text.length - preservedChars;
+		// Surrogate-safe cuts: a plain slice landing mid-emoji leaves a lone
+		// surrogate that strict provider JSON parsers reject (#18025).
+		const head = truncateWellFormed(text, headChars);
+		const tail = tailWellFormed(text, tailChars);
+		// Compute the truncated count from the ACTUAL retained code-unit
+		// lengths, not the requested head/tail lengths — truncateWellFormed
+		// and tailWellFormed back off at surrogate boundaries, so the actual
+		// retained length may be shorter than the request (#18081).
+		const actualPreserved = head.length + tail.length;
+		const truncatedCount = text.length - actualPreserved;
 		if (truncatedCount <= 0) {
 			return truncateWellFormed(text, limit);
 		}
 		const marker = markerFor(truncatedCount);
-		if (preservedChars + marker.length <= limit) {
-			// Surrogate-safe cuts: a plain slice landing mid-emoji leaves a lone
-			// surrogate that strict provider JSON parsers reject (#18025).
-			const head = truncateWellFormed(text, headChars);
-			const tail = tailWellFormed(text, tailChars);
+		if (actualPreserved + marker.length <= limit) {
 			return `${head}${marker}${tail}`;
 		}
 	}

--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -293,14 +293,20 @@ describe("deepToWellFormedUnicode", () => {
 	it("preserves own __proto__ key as a data member on the function-preservation branch (#18081 review)", () => {
 		// An own __proto__ data key (from JSON.parse) + execute() to select
 		// the function/symbol-preserving copy-on-write branch.
+		// A malformed sibling key ("bad\uD83D") forces `changed = true` so the
+		// clone path actually executes — without it, sanitizeObjectPreservingSymbols
+		// early-returns the original input and the assertions would merely observe
+		// the JSON.parse output, not the clone.
 		const input = JSON.parse(
-			'{"execute":"placeholder","__proto__":{"marker":"kept"}}',
+			'{"execute":"placeholder","__proto__":{"marker":"kept"},"bad\\uD83D":"sibling"}',
 		) as Record<string, unknown>;
 		// Replace the string with a real function to select the special branch.
 		input.execute = () => "ok";
 
 		const output = deepToWellFormedUnicode(input);
 
+		// The clone path ran (the malformed key forced changed = true).
+		expect(output).not.toBe(input);
 		// The own __proto__ key must survive as an enumerable own property.
 		const desc = Object.getOwnPropertyDescriptor(output, "__proto__");
 		expect(desc).toBeDefined();

--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -174,6 +174,7 @@ describe("deepToWellFormedUnicode", () => {
 		expect(serialized).toContain('"marker":"kept"');
 		// The lone surrogate in the sibling value was sanitized.
 		expect((output as Record<string, unknown>).bad).toBe("�");
+		expect(Object.getPrototypeOf(output)).toBe(Object.prototype);
 	});
 
 	// #18081: Two distinct keys that sanitize to the same form should not
@@ -238,6 +239,35 @@ describe("deepToWellFormedUnicode", () => {
 		expect(output).toBe(input);
 	});
 
+	it("preserves non-enumerable callbacks and symbol descriptors when cloning", () => {
+		const callback = () => "execute";
+		const sdkMarker = Symbol("sdk-marker");
+		const input = { "bad\uD83D": "value" } as Record<PropertyKey, unknown>;
+		Object.defineProperty(input, "execute", {
+			value: callback,
+			writable: false,
+			enumerable: false,
+			configurable: false,
+		});
+		Object.defineProperty(input, sdkMarker, {
+			value: 42,
+			writable: false,
+			enumerable: false,
+			configurable: false,
+		});
+
+		const output = deepToWellFormedUnicode(input);
+
+		expect(output).not.toBe(input);
+		expect(Object.getOwnPropertyDescriptor(output, "execute")).toEqual(
+			Object.getOwnPropertyDescriptor(input, "execute"),
+		);
+		expect(Object.getOwnPropertyDescriptor(output, sdkMarker)).toEqual(
+			Object.getOwnPropertyDescriptor(input, sdkMarker),
+		);
+		expect(output.execute).toBe(callback);
+	});
+
 	it("sanitizes string values and keys copy-on-write on objects with function properties (#18081)", () => {
 		const callback = () => "execute";
 		const input = { description: "bad \uD83D", execute: callback } as Record<
@@ -294,7 +324,7 @@ describe("deepToWellFormedUnicode", () => {
 		// An own __proto__ data key (from JSON.parse) + execute() to select
 		// the function/symbol-preserving copy-on-write branch.
 		// A malformed sibling key ("bad\uD83D") forces `changed = true` so the
-		// clone path actually executes — without it, sanitizeObjectPreservingSymbols
+		// clone path actually executes — without it, sanitizeObjectPreservingDescriptors
 		// early-returns the original input and the assertions would merely observe
 		// the JSON.parse output, not the clone.
 		const input = JSON.parse(
@@ -318,6 +348,15 @@ describe("deepToWellFormedUnicode", () => {
 		const serialized = JSON.stringify(output);
 		expect(serialized).toContain('"__proto__"');
 		expect(serialized).toContain('"marker":"kept"');
+		expect(Object.getPrototypeOf(output)).toBe(Object.prototype);
+	});
+
+	it("preserves a null prototype while sanitizing", () => {
+		const input = Object.assign(Object.create(null), { value: "bad \uD83D" });
+		const output = deepToWellFormedUnicode(input);
+		expect(output).not.toBe(input);
+		expect(Object.getPrototypeOf(output)).toBeNull();
+		expect(output.value).toBe("bad �");
 	});
 
 	it("handles normalized-key collisions with first-write-wins on the function-preservation branch (#18081 review)", () => {

--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -283,6 +283,54 @@ describe("deepToWellFormedUnicode", () => {
 		const serialized = JSON.stringify(output);
 		expect(LONE_SURROGATE_ESCAPE.test(serialized)).toBe(false);
 	});
+
+	// #18081 review (2nd CHANGES_REQUESTED): the function/symbol-preserving
+	// copy-on-write branch must use the same safe key-insertion strategy as
+	// the plain-object branch — null-prototype object + defineProperty +
+	// first-write-wins collision guard. Without it, an own `__proto__` data
+	// key is silently lost (prototype mutation) and two keys that normalize
+	// to the same form are last-write-wins instead of first-write-wins.
+	it("preserves own __proto__ key as a data member on the function-preservation branch (#18081 review)", () => {
+		// An own __proto__ data key (from JSON.parse) + execute() to select
+		// the function/symbol-preserving copy-on-write branch.
+		const input = JSON.parse(
+			'{"execute":"placeholder","__proto__":{"marker":"kept"}}',
+		) as Record<string, unknown>;
+		// Replace the string with a real function to select the special branch.
+		input.execute = () => "ok";
+
+		const output = deepToWellFormedUnicode(input);
+
+		// The own __proto__ key must survive as an enumerable own property.
+		const desc = Object.getOwnPropertyDescriptor(output, "__proto__");
+		expect(desc).toBeDefined();
+		expect(desc?.enumerable).toBe(true);
+		expect((desc?.value as { marker: string } | undefined)?.marker).toBe(
+			"kept",
+		);
+		// JSON round-trip must contain __proto__ as a data key.
+		const serialized = JSON.stringify(output);
+		expect(serialized).toContain('"__proto__"');
+		expect(serialized).toContain('"marker":"kept"');
+	});
+
+	it("handles normalized-key collisions with first-write-wins on the function-preservation branch (#18081 review)", () => {
+		// execute() selects the function/symbol-preserving copy-on-write branch.
+		// Both keys contain a lone surrogate that normalizes to U+FFFD, so
+		// both sanitize to "a\uFFFDb".
+		const input = {
+			execute() {
+				return "ok";
+			},
+			"a\uD83Db": 1,
+			"a\uDC80b": 2,
+		} as Record<string, unknown>;
+		const output = deepToWellFormedUnicode(input) as Record<string, unknown>;
+		const keys = Object.keys(output);
+		// Both keys collapse to "a\uFFFDb" — the first one wins (value 1).
+		expect(keys).toEqual(["execute", "a\uFFFDb"]);
+		expect(output["a\uFFFDb"]).toBe(1);
+	});
 });
 
 describe("#18025 wire regression: the captured Cerebras failure shape", () => {

--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -210,28 +210,78 @@ describe("deepToWellFormedUnicode", () => {
 	});
 
 	// #18081: Objects with symbol properties or function values are sanitized
-	// in-place (not cloned) to preserve SDK contract symbols and callbacks.
-	// This must not throw and must sanitize string-valued properties.
-	it("sanitizes string values in-place on objects with symbol properties (#18081)", () => {
+	// copy-on-write (not in-place) to preserve SDK contract symbols and
+	// callbacks without mutating or crashing on frozen inputs. The output is a
+	// new object when sanitizing is needed; the same reference when clean.
+	it("sanitizes string values and keys copy-on-write on objects with symbol properties (#18081)", () => {
 		const sym = Symbol("test");
-		const input = { description: "bad \uD83D", [sym]: 42 };
+		const input = { description: "bad \uD83D", [sym]: 42 } as Record<
+			PropertyKey,
+			unknown
+		>;
 		const output = deepToWellFormedUnicode(input);
-		// Same reference (in-place, not cloned).
-		expect(output).toBe(input);
-		expect((output as Record<string, unknown>).description).toBe("bad �");
-		// Symbol property survives.
-		expect((input as Record<symbol, unknown>)[sym]).toBe(42);
+		// Copy-on-write: output is a new object (input is NOT mutated).
+		expect(output).not.toBe(input);
+		expect((input as Record<string, unknown>).description).toBe("bad \uD83D");
+		expect((output as Record<string, unknown>).description).toBe("bad \uFFFD");
+		// Symbol property survives on the clone.
+		expect((output as Record<symbol, unknown>)[sym]).toBe(42);
 	});
 
-	it("sanitizes string values in-place on objects with function properties (#18081)", () => {
-		const callback = () => "execute";
-		const input = { description: "bad \uD83D", execute: callback };
+	it("returns the same reference for clean objects with symbol properties (#18081)", () => {
+		const sym = Symbol("test");
+		const input = { description: "clean", [sym]: 42 } as Record<
+			PropertyKey,
+			unknown
+		>;
 		const output = deepToWellFormedUnicode(input);
-		// Same reference (in-place, not cloned).
 		expect(output).toBe(input);
-		expect((output as Record<string, unknown>).description).toBe("bad �");
-		// Function property survives.
+	});
+
+	it("sanitizes string values and keys copy-on-write on objects with function properties (#18081)", () => {
+		const callback = () => "execute";
+		const input = { description: "bad \uD83D", execute: callback } as Record<
+			PropertyKey,
+			unknown
+		>;
+		const output = deepToWellFormedUnicode(input);
+		// Copy-on-write: output is a new object (input is NOT mutated).
+		expect(output).not.toBe(input);
+		expect((input as Record<string, unknown>).description).toBe("bad \uD83D");
+		expect((output as Record<string, unknown>).description).toBe("bad \uFFFD");
+		// Function property survives on the clone.
 		expect((output as Record<string, unknown>).execute).toBe(callback);
+	});
+
+	// #18081 review: the function/symbol preservation branch must sanitize
+	// object KEYS, not just values. A key containing a lone surrogate must be
+	// sanitized — not silently passed through.
+	it("sanitizes object keys containing lone surrogates on the function-preservation branch (#18081 review)", () => {
+		const callback = () => "execute";
+		const input = {
+			execute: callback,
+			"bad\uD83D": "ok",
+			nested: { "schema\uD83D": "value" },
+		} as Record<PropertyKey, unknown>;
+		const output = deepToWellFormedUnicode(input);
+		const serialized = JSON.stringify(output);
+		expect(LONE_SURROGATE_ESCAPE.test(serialized)).toBe(false);
+		// Functions preserved by reference.
+		expect((output as Record<string, unknown>).execute).toBe(callback);
+	});
+
+	// #18081 review: frozen objects (e.g. prebuilt SDK tools) must not crash
+	// — the branch is copy-on-write, not in-place mutation.
+	it("does not throw on frozen objects with function properties (#18081 review)", () => {
+		const frozen = Object.freeze({
+			execute() {
+				return "ok";
+			},
+			"bad\uD83D": "value",
+		});
+		const output = deepToWellFormedUnicode(frozen);
+		const serialized = JSON.stringify(output);
+		expect(LONE_SURROGATE_ESCAPE.test(serialized)).toBe(false);
 	});
 });
 

--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -134,6 +134,105 @@ describe("deepToWellFormedUnicode", () => {
 		const input = { a: null, b: 42, c: true, d: undefined };
 		expect(deepToWellFormedUnicode(input)).toBe(input);
 	});
+
+	// #18081: JSON object keys containing lone surrogates must be sanitized.
+	it("sanitizes object keys containing lone surrogates (#18081)", () => {
+		const input = { "bad\uD83D": "ok" };
+		const output = deepToWellFormedUnicode(input);
+		const serialized = JSON.stringify(output);
+		expect(LONE_SURROGATE_ESCAPE.test(serialized)).toBe(false);
+		// The sanitized key should be "bad�"
+		expect(Object.keys(output)).toEqual(["bad�"]);
+	});
+
+	// #18081: An own __proto__ key from a JSON-parsed input must be preserved
+	// as a data member, not collapsed into the clone's prototype chain.
+	it("preserves own __proto__ key as a data member (#18081)", () => {
+		const input = JSON.parse('{"__proto__":{"marker":"kept"},"bad":"clean"}');
+		const output = deepToWellFormedUnicode(input);
+		// The own __proto__ key must survive as an enumerable own property.
+		const desc = Object.getOwnPropertyDescriptor(output, "__proto__");
+		expect(desc).toBeDefined();
+		expect(desc?.enumerable).toBe(true);
+		expect((desc?.value as { marker: string } | undefined)?.marker).toBe(
+			"kept",
+		);
+		// JSON round-trip must contain __proto__ as a data key.
+		const serialized = JSON.stringify(output);
+		expect(serialized).toContain('"__proto__"');
+		expect(serialized).toContain('"marker":"kept"');
+	});
+
+	it("preserves own __proto__ key with a lone surrogate in a sibling value (#18081)", () => {
+		const input = JSON.parse('{"__proto__":{"marker":"kept"},"bad":"\\uD83D"}');
+		const output = deepToWellFormedUnicode(input);
+		const serialized = JSON.stringify(output);
+		// No lone surrogate escapes in the serialized body.
+		expect(LONE_SURROGATE_ESCAPE.test(serialized)).toBe(false);
+		// The __proto__ key survived.
+		expect(serialized).toContain('"__proto__"');
+		expect(serialized).toContain('"marker":"kept"');
+		// The lone surrogate in the sibling value was sanitized.
+		expect((output as Record<string, unknown>).bad).toBe("�");
+	});
+
+	// #18081: Two distinct keys that sanitize to the same form should not
+	// overwrite each other silently — first-write-wins.
+	it("handles key collisions with first-write-wins policy", () => {
+		// Both keys contain a lone surrogate at different positions, but both
+		// surrogates replace to U+FFFD, so both keys sanitize to "a\ufffdb".
+		const input = { "a\uD83Db": 1, "a\uDC80b": 2 };
+		const output = deepToWellFormedUnicode(input);
+		const keys = Object.keys(output);
+		// Both keys sanitize to "a\ufffdb" — the first one wins.
+		expect(keys).toEqual(["a\ufffdb"]);
+		expect((output as Record<string, unknown>)["a\ufffdb"]).toBe(1);
+	});
+
+	// #18081: Dirty plain objects (with surrogates but no own __proto__) must
+	// retain Object.prototype so downstream code that calls hasOwnProperty /
+	// toString still works. The `"__proto__" in value` check is always true
+	// for Object.prototype-backed objects, so this guards against a regression
+	// where setPrototypeOf never fires.
+	it("re-attaches Object.prototype on dirty plain objects without own __proto__ (#18081)", () => {
+		const input = { message: "bad \uD83D" };
+		const output = deepToWellFormedUnicode(input);
+		expect(Object.getPrototypeOf(output)).toBe(Object.prototype);
+		// Verify prototype methods actually work.
+		expect(
+			(
+				Object.prototype.hasOwnProperty.call as (
+					o: unknown,
+					k: string,
+				) => boolean
+			)(output, "message"),
+		).toBe(true);
+	});
+
+	// #18081: Objects with symbol properties or function values are sanitized
+	// in-place (not cloned) to preserve SDK contract symbols and callbacks.
+	// This must not throw and must sanitize string-valued properties.
+	it("sanitizes string values in-place on objects with symbol properties (#18081)", () => {
+		const sym = Symbol("test");
+		const input = { description: "bad \uD83D", [sym]: 42 };
+		const output = deepToWellFormedUnicode(input);
+		// Same reference (in-place, not cloned).
+		expect(output).toBe(input);
+		expect((output as Record<string, unknown>).description).toBe("bad �");
+		// Symbol property survives.
+		expect((input as Record<symbol, unknown>)[sym]).toBe(42);
+	});
+
+	it("sanitizes string values in-place on objects with function properties (#18081)", () => {
+		const callback = () => "execute";
+		const input = { description: "bad \uD83D", execute: callback };
+		const output = deepToWellFormedUnicode(input);
+		// Same reference (in-place, not cloned).
+		expect(output).toBe(input);
+		expect((output as Record<string, unknown>).description).toBe("bad �");
+		// Function property survives.
+		expect((output as Record<string, unknown>).execute).toBe(callback);
+	});
 });
 
 describe("#18025 wire regression: the captured Cerebras failure shape", () => {

--- a/packages/core/src/utils/well-formed.ts
+++ b/packages/core/src/utils/well-formed.ts
@@ -119,6 +119,12 @@ export function tailWellFormed(text: string, maxLength: number): string {
  * properties pass through by reference; nested values are routed through
  * {@link deepToWellFormedUnicode} for the same recursive treatment. Returns
  * the same reference when nothing needed sanitizing.
+ *
+ * Key-safety policy mirrors the plain-object branch: the clone is built on a
+ * null-prototype object with `Object.defineProperty` so an own `__proto__` key
+ * from a JSON-parsed input is preserved as a data member instead of mutating
+ * the clone's prototype chain, and a first-write-wins collision policy prevents
+ * two distinct keys from collapsing onto the same sanitized form (#18081 review).
  */
 function sanitizeObjectPreservingSymbols<T>(value: T): T {
 	if (value === null || typeof value !== "object") {
@@ -136,7 +142,7 @@ function sanitizeObjectPreservingSymbols<T>(value: T): T {
 		return (changed ? next : value) as T;
 	}
 	const source = value as Record<PropertyKey, unknown>;
-	const clone: Record<string, unknown> = {};
+	const clone = Object.create(null) as Record<PropertyKey, unknown>;
 	let changed = false;
 	for (const key of Object.keys(source)) {
 		const sanitizedKey = toWellFormedUnicode(key);
@@ -145,10 +151,24 @@ function sanitizeObjectPreservingSymbols<T>(value: T): T {
 		if (sanitizedKey !== key || sanitizedValue !== entry) {
 			changed = true;
 		}
-		clone[sanitizedKey] = sanitizedValue;
+		if (!(sanitizedKey in clone)) {
+			Object.defineProperty(clone, sanitizedKey, {
+				value: sanitizedValue,
+				writable: true,
+				enumerable: true,
+				configurable: true,
+			});
+		}
 	}
 	for (const sym of Object.getOwnPropertySymbols(source)) {
-		(clone as Record<symbol, unknown>)[sym] = source[sym];
+		clone[sym] = source[sym];
+	}
+	// Re-attach Object.prototype so downstream code that relies on
+	// hasOwnProperty/toString still works — but only if the original input
+	// didn't define an own `__proto__` key. See deepToWellFormedUnicode for
+	// the rationale on Object.hasOwn vs `in`.
+	if (!Object.hasOwn(source, "__proto__")) {
+		Object.setPrototypeOf(clone, Object.prototype);
 	}
 	return (changed ? clone : value) as T;
 }

--- a/packages/core/src/utils/well-formed.ts
+++ b/packages/core/src/utils/well-formed.ts
@@ -110,12 +110,54 @@ export function tailWellFormed(text: string, maxLength: number): string {
 }
 
 /**
+ * Sanitizes string-valued own properties of an object **in-place**, recursing
+ * into nested plain objects and arrays. Used for objects that carry behavior
+ * (function-valued properties such as AI SDK tool schemas or execute callbacks)
+ * and must not be cloned onto a null-prototype object. Returns the same
+ * reference.
+ */
+function sanitizeStringsInPlace<T>(value: T): T {
+	if (value === null || typeof value !== "object") {
+		return value;
+	}
+	if (Array.isArray(value)) {
+		for (let i = 0; i < value.length; i++) {
+			const item = value[i];
+			if (typeof item === "string") {
+				value[i] = toWellFormedUnicode(item) as typeof item;
+			} else {
+				sanitizeStringsInPlace(item);
+			}
+		}
+		return value;
+	}
+	const obj = value as Record<string, unknown>;
+	for (const key of Object.keys(obj)) {
+		const entry = obj[key];
+		if (typeof entry === "string") {
+			obj[key] = toWellFormedUnicode(entry);
+		} else {
+			sanitizeStringsInPlace(entry);
+		}
+	}
+	return value;
+}
+
+/**
  * Recursively applies {@link toWellFormedUnicode} to every string in a
- * JSON-shaped value (strings, arrays, plain objects). Non-plain objects
- * (typed arrays, URLs, class instances such as AI SDK model handles) pass
- * through untouched, and untouched subtrees keep their original references so
- * a clean input returns the same instance. Intended for provider request
- * bodies right before serialization.
+ * JSON-shaped value — including **object keys**, which `Object.entries`
+ * skips by default. A key containing a lone surrogate (e.g.
+ * `{"bad\uD83D": "ok"}`) serializes to the same `\\uD8xx` escape that strict
+ * provider JSON parsers reject.
+ *
+ * The clone is built on a null-prototype object with `Object.defineProperty`
+ * so an own `__proto__` key from a JSON-parsed input is preserved as a data
+ * member instead of mutating the clone's prototype chain. A collision policy
+ * (first-write-wins) prevents two distinct keys from collapsing onto the same
+ * sanitized form. Non-plain objects (typed arrays, URLs, class instances such
+ * as AI SDK model handles) pass through untouched, and untouched subtrees keep
+ * their original references so a clean input returns the same instance.
+ * Intended for provider request bodies right before serialization.
  */
 export function deepToWellFormedUnicode<T>(value: T): T {
 	if (typeof value === "string") {
@@ -137,14 +179,43 @@ export function deepToWellFormedUnicode<T>(value: T): T {
 		if (proto !== Object.prototype && proto !== null) {
 			return value;
 		}
+		// Objects that carry SDK-identifying symbols or function-valued
+		// properties (e.g. AI SDK jsonSchema wrappers, tool execute callbacks)
+		// must not be cloned onto a null-prototype object — cloning drops
+		// non-enumerable symbol properties and breaks SDK contract checks
+		// (asSchema throws "schema is not a function"). Sanitize their
+		// string-valued own properties in-place instead (#18081).
+		if (
+			Object.getOwnPropertySymbols(value).length > 0 ||
+			Object.values(value).some((v) => typeof v === "function")
+		) {
+			return sanitizeStringsInPlace(value);
+		}
 		let changed = false;
-		const next: Record<string, unknown> = {};
+		const next = Object.create(null) as Record<string, unknown>;
 		for (const [key, entry] of Object.entries(value)) {
+			const sanitizedKey = toWellFormedUnicode(key);
 			const sanitized = deepToWellFormedUnicode(entry);
-			if (sanitized !== entry) {
+			if (sanitizedKey !== key || sanitized !== entry) {
 				changed = true;
 			}
-			next[key] = sanitized;
+			if (!(sanitizedKey in next)) {
+				Object.defineProperty(next, sanitizedKey, {
+					value: sanitized,
+					writable: true,
+					enumerable: true,
+					configurable: true,
+				});
+			}
+		}
+		// Re-attach Object.prototype so downstream code that relies on
+		// hasOwnProperty/toString still works — but only if the original
+		// input didn't define an own `__proto__` key. Note: `"__proto__" in
+		// value` is always true for Object.prototype-backed objects (the
+		// property is inherited), so use Object.hasOwn to detect a genuine
+		// own data key.
+		if (!Object.hasOwn(value, "__proto__")) {
+			Object.setPrototypeOf(next, Object.prototype);
 		}
 		return (changed ? next : value) as T;
 	}

--- a/packages/core/src/utils/well-formed.ts
+++ b/packages/core/src/utils/well-formed.ts
@@ -111,22 +111,23 @@ export function tailWellFormed(text: string, maxLength: number): string {
 
 /**
  * Copy-on-write sanitizer for objects that carry SDK-identifying symbols or
- * function-valued properties (AI SDK tool schemas, execute callbacks).
+ * function-valued or accessor properties (AI SDK tool schemas and execute
+ * callbacks).
  *
  * Unlike the plain-object path in {@link deepToWellFormedUnicode}, this builds
  * a NEW object so the caller's input is never mutated — even if frozen. String
- * keys AND values are sanitized; function-valued properties and symbol
- * properties pass through by reference; nested values are routed through
- * {@link deepToWellFormedUnicode} for the same recursive treatment. Returns
- * the same reference when nothing needed sanitizing.
+ * enumerable string keys AND values are sanitized; non-enumerable and symbol
+ * properties retain their original descriptors; nested enumerable values are
+ * routed through {@link deepToWellFormedUnicode} for the same recursive
+ * treatment. Returns the same reference when nothing needed sanitizing.
  *
  * Key-safety policy mirrors the plain-object branch: the clone is built on a
- * null-prototype object with `Object.defineProperty` so an own `__proto__` key
- * from a JSON-parsed input is preserved as a data member instead of mutating
- * the clone's prototype chain, and a first-write-wins collision policy prevents
- * two distinct keys from collapsing onto the same sanitized form (#18081 review).
+ * null-prototype staging object with `Object.defineProperty` so an own
+ * `__proto__` key is preserved as data. The source prototype is restored only
+ * after all keys are defined, and a first-write-wins collision policy prevents
+ * distinct keys from collapsing onto the same sanitized form.
  */
-function sanitizeObjectPreservingSymbols<T>(value: T): T {
+function sanitizeObjectPreservingDescriptors<T>(value: T): T {
 	if (value === null || typeof value !== "object") {
 		return value;
 	}
@@ -144,32 +145,44 @@ function sanitizeObjectPreservingSymbols<T>(value: T): T {
 	const source = value as Record<PropertyKey, unknown>;
 	const clone = Object.create(null) as Record<PropertyKey, unknown>;
 	let changed = false;
-	for (const key of Object.keys(source)) {
+	for (const key of Reflect.ownKeys(source)) {
+		const descriptor = Object.getOwnPropertyDescriptor(source, key);
+		if (!descriptor) {
+			continue;
+		}
+
+		// Symbols and non-enumerable string members do not enter a JSON body.
+		// Preserve them byte-for-byte because SDK identity markers, callbacks,
+		// and lazy metadata commonly live there.
+		if (typeof key === "symbol" || !descriptor.enumerable) {
+			Object.defineProperty(clone, key, descriptor);
+			continue;
+		}
+
 		const sanitizedKey = toWellFormedUnicode(key);
-		const entry = source[key];
+		const entry = "value" in descriptor ? descriptor.value : source[key];
 		const sanitizedValue = deepToWellFormedUnicode(entry);
 		if (sanitizedKey !== key || sanitizedValue !== entry) {
 			changed = true;
 		}
-		if (!(sanitizedKey in clone)) {
+		if (!Object.hasOwn(clone, sanitizedKey)) {
+			const sanitizedDescriptor: PropertyDescriptor =
+				"value" in descriptor
+					? { ...descriptor, value: sanitizedValue }
+					: sanitizedValue === entry
+						? descriptor
+						: {
+								value: sanitizedValue,
+								writable: true,
+								enumerable: descriptor.enumerable,
+								configurable: descriptor.configurable,
+							};
 			Object.defineProperty(clone, sanitizedKey, {
-				value: sanitizedValue,
-				writable: true,
-				enumerable: true,
-				configurable: true,
+				...sanitizedDescriptor,
 			});
 		}
 	}
-	for (const sym of Object.getOwnPropertySymbols(source)) {
-		clone[sym] = source[sym];
-	}
-	// Re-attach Object.prototype so downstream code that relies on
-	// hasOwnProperty/toString still works — but only if the original input
-	// didn't define an own `__proto__` key. See deepToWellFormedUnicode for
-	// the rationale on Object.hasOwn vs `in`.
-	if (!Object.hasOwn(source, "__proto__")) {
-		Object.setPrototypeOf(clone, Object.prototype);
-	}
+	Object.setPrototypeOf(clone, Object.getPrototypeOf(source));
 	return (changed ? clone : value) as T;
 }
 
@@ -209,17 +222,25 @@ export function deepToWellFormedUnicode<T>(value: T): T {
 		if (proto !== Object.prototype && proto !== null) {
 			return value;
 		}
-		// Objects that carry SDK-identifying symbols or function-valued
-		// properties (e.g. AI SDK jsonSchema wrappers, tool execute callbacks)
+		// Objects that carry SDK-identifying symbols, function-valued
+		// properties, or accessors (e.g. AI SDK jsonSchema wrappers and tool
+		// execute callbacks)
 		// must not be cloned onto a null-prototype object — cloning drops
 		// non-enumerable symbol properties and breaks SDK contract checks
 		// (asSchema throws "schema is not a function"). Sanitize their
 		// string-valued own properties in-place instead (#18081).
-		if (
-			Object.getOwnPropertySymbols(value).length > 0 ||
-			Object.values(value).some((v) => typeof v === "function")
-		) {
-			return sanitizeObjectPreservingSymbols(value);
+		const needsDescriptorPreservingClone = Reflect.ownKeys(value).some(
+			(key) => {
+				const descriptor = Object.getOwnPropertyDescriptor(value, key);
+				return (
+					typeof key === "symbol" ||
+					Boolean(descriptor && !("value" in descriptor)) ||
+					typeof descriptor?.value === "function"
+				);
+			},
+		);
+		if (needsDescriptorPreservingClone) {
+			return sanitizeObjectPreservingDescriptors(value);
 		}
 		let changed = false;
 		const next = Object.create(null) as Record<string, unknown>;
@@ -238,15 +259,10 @@ export function deepToWellFormedUnicode<T>(value: T): T {
 				});
 			}
 		}
-		// Re-attach Object.prototype so downstream code that relies on
-		// hasOwnProperty/toString still works — but only if the original
-		// input didn't define an own `__proto__` key. Note: `"__proto__" in
-		// value` is always true for Object.prototype-backed objects (the
-		// property is inherited), so use Object.hasOwn to detect a genuine
-		// own data key.
-		if (!Object.hasOwn(value, "__proto__")) {
-			Object.setPrototypeOf(next, Object.prototype);
-		}
+		// Restore the source prototype after defining every own key. Staging on
+		// a null prototype makes `__proto__` safe; restoring afterward preserves
+		// the caller's Object.prototype/null-prototype contract.
+		Object.setPrototypeOf(next, proto);
 		return (changed ? next : value) as T;
 	}
 	return value;

--- a/packages/core/src/utils/well-formed.ts
+++ b/packages/core/src/utils/well-formed.ts
@@ -110,37 +110,47 @@ export function tailWellFormed(text: string, maxLength: number): string {
 }
 
 /**
- * Sanitizes string-valued own properties of an object **in-place**, recursing
- * into nested plain objects and arrays. Used for objects that carry behavior
- * (function-valued properties such as AI SDK tool schemas or execute callbacks)
- * and must not be cloned onto a null-prototype object. Returns the same
- * reference.
+ * Copy-on-write sanitizer for objects that carry SDK-identifying symbols or
+ * function-valued properties (AI SDK tool schemas, execute callbacks).
+ *
+ * Unlike the plain-object path in {@link deepToWellFormedUnicode}, this builds
+ * a NEW object so the caller's input is never mutated — even if frozen. String
+ * keys AND values are sanitized; function-valued properties and symbol
+ * properties pass through by reference; nested values are routed through
+ * {@link deepToWellFormedUnicode} for the same recursive treatment. Returns
+ * the same reference when nothing needed sanitizing.
  */
-function sanitizeStringsInPlace<T>(value: T): T {
+function sanitizeObjectPreservingSymbols<T>(value: T): T {
 	if (value === null || typeof value !== "object") {
 		return value;
 	}
 	if (Array.isArray(value)) {
-		for (let i = 0; i < value.length; i++) {
-			const item = value[i];
-			if (typeof item === "string") {
-				value[i] = toWellFormedUnicode(item) as typeof item;
-			} else {
-				sanitizeStringsInPlace(item);
+		let changed = false;
+		const next = value.map((item) => {
+			const sanitized = deepToWellFormedUnicode(item);
+			if (sanitized !== item) {
+				changed = true;
 			}
-		}
-		return value;
+			return sanitized;
+		});
+		return (changed ? next : value) as T;
 	}
-	const obj = value as Record<string, unknown>;
-	for (const key of Object.keys(obj)) {
-		const entry = obj[key];
-		if (typeof entry === "string") {
-			obj[key] = toWellFormedUnicode(entry);
-		} else {
-			sanitizeStringsInPlace(entry);
+	const source = value as Record<PropertyKey, unknown>;
+	const clone: Record<string, unknown> = {};
+	let changed = false;
+	for (const key of Object.keys(source)) {
+		const sanitizedKey = toWellFormedUnicode(key);
+		const entry = source[key];
+		const sanitizedValue = deepToWellFormedUnicode(entry);
+		if (sanitizedKey !== key || sanitizedValue !== entry) {
+			changed = true;
 		}
+		clone[sanitizedKey] = sanitizedValue;
 	}
-	return value;
+	for (const sym of Object.getOwnPropertySymbols(source)) {
+		(clone as Record<symbol, unknown>)[sym] = source[sym];
+	}
+	return (changed ? clone : value) as T;
 }
 
 /**
@@ -189,7 +199,7 @@ export function deepToWellFormedUnicode<T>(value: T): T {
 			Object.getOwnPropertySymbols(value).length > 0 ||
 			Object.values(value).some((v) => typeof v === "function")
 		) {
-			return sanitizeStringsInPlace(value);
+			return sanitizeObjectPreservingSymbols(value);
 		}
 		let changed = false;
 		const next = Object.create(null) as Record<string, unknown>;

--- a/plugins/plugin-anthropic/__tests__/wire-well-formed.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/wire-well-formed.shape.test.ts
@@ -100,4 +100,48 @@ describe("#18025: Anthropic request bodies are well-formed strict JSON", () => {
     };
     expect(JSON.stringify(parsed.messages)).toContain("summarize this page �");
   });
+
+  // #18081: Tool descriptions, stop sequences, output schemas, and provider
+  // options must also be sanitized — the original #18079 only sanitized
+  // prompt/messages/system, leaving these fields raw.
+  it("sanitizes a lone surrogate in a stop sequence (#18081)", async () => {
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "hello",
+      stopSequences: ["clean-stop", "bad\uD83D"],
+    } as never);
+    expect(result).toBe("ok");
+
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
+    expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+    const parsed = JSON.parse(body) as { stop_sequences?: string[] };
+    expect(parsed.stop_sequences).toContain("clean-stop");
+    // The lone surrogate in the stop sequence was replaced with U+FFFD.
+    expect(parsed.stop_sequences).toContain("bad�");
+  });
+
+  it("sanitizes a lone surrogate in a tool description (#18081)", async () => {
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "use the tool",
+      tools: {
+        lone_surrogate_tool: {
+          name: "lone_surrogate_tool",
+          description: `bad tool \uD83D`,
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    } as never);
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
+    expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+    const serialized = JSON.stringify(JSON.parse(body));
+    expect(serialized).toContain("bad tool �");
+    expect(LONE_SURROGATE_ESCAPE.test(serialized)).toBe(false);
+  });
 });

--- a/plugins/plugin-anthropic/__tests__/wire-well-formed.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/wire-well-formed.shape.test.ts
@@ -24,15 +24,20 @@ function startCaptureServer(): Promise<string> {
     const chunks: Buffer[] = [];
     request.on("data", (chunk: Buffer) => chunks.push(chunk));
     request.on("end", () => {
-      captured.push(Buffer.concat(chunks));
+      const raw = Buffer.concat(chunks).toString("utf8");
+      captured.push(Buffer.from(raw, "utf8"));
       response.writeHead(200, { "content-type": "application/json" });
+      // When the request includes a structured output schema, the Anthropic
+      // native output parser parses the response as JSON; return valid JSON.
+      const hasStructuredOutput = /response_format|responseSchema|"schema"/.test(raw);
+      const text = hasStructuredOutput ? JSON.stringify({ goodField: "value" }) : "ok";
       response.end(
         JSON.stringify({
           id: "msg-test",
           type: "message",
           role: "assistant",
           model: "claude-test",
-          content: [{ type: "text", text: "ok" }],
+          content: [{ type: "text", text }],
           stop_reason: "end_turn",
           stop_sequence: null,
           usage: { input_tokens: 1, output_tokens: 1 },
@@ -141,7 +146,29 @@ describe("#18025: Anthropic request bodies are well-formed strict JSON", () => {
     const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
     expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
     const serialized = JSON.stringify(JSON.parse(body));
-    expect(serialized).toContain("bad tool �");
+    expect(serialized).toContain("bad tool \uFFFD");
     expect(LONE_SURROGATE_ESCAPE.test(serialized)).toBe(false);
+  });
+
+  // #18081 review: structured-output schemas must also be sanitized. The plain
+  // schema is sanitized before being wrapped in the native output shape, so
+  // schema keys AND values carrying lone surrogates never reach the wire.
+  it("sanitizes a lone surrogate in a response schema key and description (#18081 review)", async () => {
+    await handleTextSmall(buildRuntime(), {
+      prompt: "return structured data",
+      responseSchema: {
+        type: "object",
+        description: `schema desc \uD83D`,
+        properties: {
+          goodField: { type: "string", description: "clean" },
+          [`bad${"\uD83D"}`]: { type: "string", description: `also \uD83D` },
+        },
+      },
+    } as never);
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
+    expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
   });
 });

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -1339,8 +1339,15 @@ async function generateTextWithModel(
   const sanitizedToolChoice = paramsWithAttachments.toolChoice
     ? deepToWellFormedUnicode(paramsWithAttachments.toolChoice)
     : undefined;
-  const sanitizedOutput = paramsWithAttachments.responseSchema
-    ? deepToWellFormedUnicode(buildStructuredOutput(paramsWithAttachments.responseSchema))
+  // Sanitize the plain response schema BEFORE it is wrapped in the native
+  // output shape. Once wrapped, responseFormat is a Promise that defeats the
+  // deepToWellFormedUnicode walk, so schema keys/values carrying lone
+  // surrogates would reach the provider wire untouched (#18081 review).
+  const sanitizedResponseSchema = paramsWithAttachments.responseSchema
+    ? deepToWellFormedUnicode(paramsWithAttachments.responseSchema)
+    : undefined;
+  const sanitizedOutput = sanitizedResponseSchema
+    ? buildStructuredOutput(sanitizedResponseSchema)
     : undefined;
   const sanitizedProviderOptions = anthropicProviderOptions
     ? (deepToWellFormedUnicode(anthropicProviderOptions) as NativeProviderOptions)

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -1320,35 +1320,47 @@ async function generateTextWithModel(
           messages: applyTrajectoryTailCacheBreakpoint(basePromptOrMessages.messages, cacheControl),
         }
       : basePromptOrMessages;
+  // Wire-boundary guarantee: lone UTF-16 surrogates (e.g. from a mid-emoji
+  // slice upstream) serialize as \uD8xx escapes that strict provider JSON
+  // parsers reject (#18025); force EVERY outgoing string — including tool
+  // descriptions/schemas, stop sequences, output schemas, and provider
+  // options — to well-formed Unicode at request build. Deterministic, so
+  // cache-prefix stability holds.
+  const sanitizedStopSequences = deepToWellFormedUnicode(
+    resolved.stopSequences as string[] | undefined
+  );
+  const sanitizedTools = paramsWithAttachments.tools
+    ? deepToWellFormedUnicode(
+        toolsCacheControl
+          ? applyToolsCacheBreakpoint(paramsWithAttachments.tools, toolsCacheControl)
+          : paramsWithAttachments.tools
+      )
+    : undefined;
+  const sanitizedToolChoice = paramsWithAttachments.toolChoice
+    ? deepToWellFormedUnicode(paramsWithAttachments.toolChoice)
+    : undefined;
+  const sanitizedOutput = paramsWithAttachments.responseSchema
+    ? deepToWellFormedUnicode(buildStructuredOutput(paramsWithAttachments.responseSchema))
+    : undefined;
+  const sanitizedProviderOptions = anthropicProviderOptions
+    ? (deepToWellFormedUnicode(anthropicProviderOptions) as NativeProviderOptions)
+    : undefined;
+
   const generateParams: NativeTextParams = {
     model: anthropic(modelName),
-    // Wire-boundary guarantee: lone UTF-16 surrogates (e.g. from a mid-emoji
-    // slice upstream) serialize as \uD8xx escapes that strict provider JSON
-    // parsers reject (#18025); force every outgoing string to well-formed
-    // Unicode at request build. Deterministic, so cache-prefix stability holds.
     ...deepToWellFormedUnicode(promptOrMessages),
     system: system === undefined ? undefined : deepToWellFormedUnicode(system),
     temperature: resolved.temperature,
-    stopSequences: resolved.stopSequences as string[],
+    ...(sanitizedStopSequences ? { stopSequences: sanitizedStopSequences } : {}),
     frequencyPenalty: resolved.frequencyPenalty,
     presencePenalty: resolved.presencePenalty,
     experimental_telemetry: telemetryConfig,
     maxOutputTokens: resolved.maxTokens,
     topP: resolved.topP,
-    ...(paramsWithAttachments.tools
-      ? {
-          tools: toolsCacheControl
-            ? applyToolsCacheBreakpoint(paramsWithAttachments.tools, toolsCacheControl)
-            : paramsWithAttachments.tools,
-        }
-      : {}),
-    ...(paramsWithAttachments.toolChoice ? { toolChoice: paramsWithAttachments.toolChoice } : {}),
-    ...(paramsWithAttachments.responseSchema
-      ? { output: buildStructuredOutput(paramsWithAttachments.responseSchema) }
-      : {}),
-    ...(anthropicProviderOptions
-      ? { providerOptions: anthropicProviderOptions as NativeProviderOptions }
-      : {}),
+    ...(sanitizedTools ? { tools: sanitizedTools } : {}),
+    ...(sanitizedToolChoice ? { toolChoice: sanitizedToolChoice } : {}),
+    ...(sanitizedOutput ? { output: sanitizedOutput } : {}),
+    ...(sanitizedProviderOptions ? { providerOptions: sanitizedProviderOptions } : {}),
   };
 
   const operationName = `${modelType} request using ${modelName}`;

--- a/plugins/plugin-openai/__tests__/wire-well-formed.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/wire-well-formed.shape.test.ts
@@ -31,8 +31,13 @@ function startCaptureServer(): Promise<string> {
     const chunks: Buffer[] = [];
     request.on("data", (chunk: Buffer) => chunks.push(chunk));
     request.on("end", () => {
-      captured.push({ url: request.url ?? "", bytes: Buffer.concat(chunks) });
+      const raw = Buffer.concat(chunks).toString("utf8");
+      captured.push({ url: request.url ?? "", bytes: Buffer.from(raw, "utf8") });
       response.writeHead(200, { "content-type": "application/json" });
+      // When the request includes response_format (structured output), the AI
+      // SDK parses the response content as JSON; return valid JSON for those.
+      const hasStructuredOutput = raw.includes("response_format");
+      const content = hasStructuredOutput ? JSON.stringify({ goodField: "value" }) : "ok";
       response.end(
         JSON.stringify({
           id: "chatcmpl-test",
@@ -42,7 +47,7 @@ function startCaptureServer(): Promise<string> {
           choices: [
             {
               index: 0,
-              message: { role: "assistant", content: "ok" },
+              message: { role: "assistant", content },
               finish_reason: "stop",
             },
           ],
@@ -193,7 +198,30 @@ describe("#18025: request bodies are well-formed strict JSON", () => {
     expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
     const body = assertStrictParseable(captured[0].bytes);
     const serialized = JSON.stringify(body);
-    expect(serialized).toContain("bad tool �");
+    expect(serialized).toContain("bad tool \uFFFD");
+    expect(LONE_SURROGATE_ESCAPE.test(serialized)).toBe(false);
+  });
+
+  // #18081 review: structured-output schemas must also be sanitized. The plain
+  // schema is sanitized before being wrapped in Output.object, so schema keys
+  // AND values carrying lone surrogates never reach the provider wire.
+  it("sanitizes a lone surrogate in a response schema key and description (#18081 review)", async () => {
+    await handleTextSmall(buildRuntime(), {
+      prompt: "return structured data",
+      responseSchema: {
+        type: "object",
+        description: `schema desc \uD83D`,
+        properties: {
+          goodField: { type: "string", description: "clean" },
+          [`bad${"\uD83D"}`]: { type: "string", description: `also \uD83D` },
+        },
+      },
+    } as never);
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].bytes.toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = assertStrictParseable(captured[0].bytes);
+    const serialized = JSON.stringify(body);
     expect(LONE_SURROGATE_ESCAPE.test(serialized)).toBe(false);
   });
 });

--- a/plugins/plugin-openai/__tests__/wire-well-formed.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/wire-well-formed.shape.test.ts
@@ -173,4 +173,27 @@ describe("#18025: request bodies are well-formed strict JSON", () => {
     const messages = body.messages as Array<{ role: string; content: string }>;
     expect(messages.find((message) => message.role === "user")?.content).toBe("tail �");
   });
+
+  // #18081: Tool descriptions, output schemas, and provider options must also
+  // be sanitized — the original #18079 only sanitized prompt/messages/system.
+  it("sanitizes a lone surrogate in a tool description (#18081)", async () => {
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "use the tool",
+      tools: {
+        "lone-surrogate-tool": {
+          description: `bad tool \uD83D`,
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    } as never);
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].bytes.toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = assertStrictParseable(captured[0].bytes);
+    const serialized = JSON.stringify(body);
+    expect(serialized).toContain("bad tool �");
+    expect(LONE_SURROGATE_ESCAPE.test(serialized)).toBe(false);
+  });
 });

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -2067,13 +2067,23 @@ async function generateTextByModelType(
       : {}),
   });
 
+  // Wire-boundary guarantee: no upstream text bug may produce an invalid
+  // request body. A lone UTF-16 surrogate (e.g. from a mid-emoji slice)
+  // serializes as a \uD8xx escape that Cerebras's strict JSON parser 400s
+  // on ("lone leading surrogate in hex escape", wrong_api_format — #18025),
+  // so EVERY outgoing string — including tool descriptions/schemas, output
+  // schemas, and provider options — is forced to well-formed Unicode here.
+  const sanitizedTools = normalizedTools ? deepToWellFormedUnicode(normalizedTools) : undefined;
+  const sanitizedToolChoice = normalizedToolChoice
+    ? deepToWellFormedUnicode(normalizedToolChoice)
+    : undefined;
+  const sanitizedOutput = requestedOutput ? deepToWellFormedUnicode(requestedOutput) : undefined;
+  const sanitizedProviderOptions = providerOptions
+    ? (deepToWellFormedUnicode(providerOptions) as NativeProviderOptions)
+    : undefined;
+
   const generateParams: NativeTextParams = {
     model,
-    // Wire-boundary guarantee: no upstream text bug may produce an invalid
-    // request body. A lone UTF-16 surrogate (e.g. from a mid-emoji slice)
-    // serializes as a \uD8xx escape that Cerebras's strict JSON parser 400s
-    // on ("lone leading surrogate in hex escape", wrong_api_format — #18025),
-    // so every outgoing string is forced to well-formed Unicode here.
     ...deepToWellFormedUnicode(promptOrMessages),
     system: systemPrompt === undefined ? undefined : deepToWellFormedUnicode(systemPrompt),
     allowSystemInMessages: true,
@@ -2083,10 +2093,10 @@ async function generateTextByModelType(
     // model's limit. Other callers keep the 8192 default.
     ...(params.omitMaxTokens ? {} : { maxOutputTokens: params.maxTokens ?? 8192 }),
     experimental_telemetry: telemetryConfig,
-    ...(normalizedTools ? { tools: normalizedTools } : {}),
-    ...(normalizedToolChoice ? { toolChoice: normalizedToolChoice } : {}),
-    ...(requestedOutput ? { output: requestedOutput } : {}),
-    ...(providerOptions ? { providerOptions: providerOptions as NativeProviderOptions } : {}),
+    ...(sanitizedTools ? { tools: sanitizedTools } : {}),
+    ...(sanitizedToolChoice ? { toolChoice: sanitizedToolChoice } : {}),
+    ...(sanitizedOutput ? { output: sanitizedOutput } : {}),
+    ...(sanitizedProviderOptions ? { providerOptions: sanitizedProviderOptions } : {}),
   };
 
   // Handle streaming mode

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -2048,9 +2048,16 @@ async function generateTextByModelType(
           "type" in callerResponseFormat
         ? (callerResponseFormat as { type: string }).type
         : undefined;
+  // Sanitize the plain response schema BEFORE it is wrapped in jsonSchema /
+  // Output.object. Once wrapped, responseFormat is a Promise that defeats the
+  // deepToWellFormedUnicode walk, so schema keys/values carrying lone
+  // surrogates would reach the provider wire untouched (#18081 review).
+  const sanitizedResponseSchema = paramsWithAttachments.responseSchema
+    ? deepToWellFormedUnicode(paramsWithAttachments.responseSchema)
+    : undefined;
   const preparedOutput =
-    paramsWithAttachments.responseSchema && !cerebrasMode
-      ? buildStructuredOutput(paramsWithAttachments.responseSchema, modelType)
+    sanitizedResponseSchema && !cerebrasMode
+      ? buildStructuredOutput(sanitizedResponseSchema, modelType)
       : undefined;
   const requestedOutput: NativeOutput | undefined =
     preparedOutput?.output ?? (responseFormatType === "json_object" ? Output.json() : undefined);


### PR DESCRIPTION
# Relates to

Closes #18081.

- [x] Targets `develop` and is rebased onto `origin/develop@21db52022`.
- [x] `bun install --frozen-lockfile` and `bun run verify` pass on exact head `7b67b5886608aa83866844b97c85c99c48182ac0`.
- [x] Provider-boundary behavior is exercised through loopback HTTP wire captures.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`, `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [x] Full repository verification passes post-sync.

# Risks

Medium-low. This changes the final request-construction boundary for OpenAI and Anthropic and the copy-on-write semantics of the shared sanitizer. The principal risk was breaking AI SDK identity/callback metadata while cleaning wire-visible strings; descriptor and prototype regressions now cover that explicitly.

# Background

The previous sanitizer closed the mid-emoji prompt failure but left several related gaps:

1. malformed object keys, structured-output schemas, tool metadata, provider options, and Anthropic stop sequences could still reach provider JSON;
2. surrogate-safe truncation markers counted requested rather than actually retained UTF-16 units;
3. the first copy-on-write follow-up cleaned wire bytes but could drop non-enumerable SDK callbacks, alter symbol descriptors, or change the source prototype.

This head fixes the entire boundary:

- sanitizes enumerable JSON keys and values recursively with collision-safe `__proto__` handling;
- sanitizes plain response schemas before AI SDK wrappers create promise-backed response formats;
- sanitizes OpenAI and Anthropic tools, tool choice, provider options, output schemas, and stop sequences;
- preserves SDK functions, accessors, symbol/non-enumerable descriptors, and Object/null prototypes during copy-on-write;
- computes truncation counts from actual retained head/tail lengths.

No UI or user-facing documentation changes.

# Testing

Exact-head results:

- core focused sanitizer/rendering: **51/51 pass**
- OpenAI wire suite: **5/5 pass**
- Anthropic wire suite: **4/4 pass**
- OpenAI full package suite: **193/193 pass**
- Anthropic full package suite: **81/81 pass**
- core full package suite: **4,941 pass, 1 skipped, 1 unrelated baseline failure**
- the sole core failure, `message.test.ts > allows a send through a verified owner account`, reproduces unchanged on clean `origin/develop@771f024fe` because `upsertOwnerBindingForTest` is absent
- core, OpenAI, and Anthropic typechecks: pass
- core full Node/browser/edge/testing build: pass
- changed-file Biome and `git diff --check`: pass
- `bun run verify`: **346/346 tasks**, all repository audits pass; focused-test audit scanned **7,695 files**

# Evidence Gate

<!-- evidence-head:7b67b5886608aa83866844b97c85c99c48182ac0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual user flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head provider boundary transcript:
<details><summary>Wire and repository verification</summary>

```text
OpenAI loopback wire capture: 5/5 passed; malformed prompt, tool, post-tool result, and schema bytes contain no lone-surrogate escapes.
Anthropic loopback wire capture: 4/4 passed; malformed prompt, stop sequence, tool, and structured schema bytes contain no lone-surrogate escapes.
Repository verify: 346/346 workspace tasks passed; build/typecheck, dependency, script-inventory, bundle, secret-leak, and focused-test audits passed.
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - request serialization is changed, but model selection, prompts, planner behavior, and model outputs are not; loopback wire captures exercise the changed boundary without a billable live-model call.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this fix produces no persisted domain state; the serialized request bytes are represented by the loopback wire transcript above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual or document surface.

# Known gaps / failures

The full core package lane has one pre-existing owner-binding test failure that reproduces on untouched `develop`; all 4,941 other core tests pass. The required repository `bun run verify` gate passes completely.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: N/A - contribute-to-eliza skill was not available
Attribution status: self-reported
— [maintainer]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"N/A - contribute-to-eliza skill was not available"} -->

