### PR TITLE
fix(core): resolve message send targets against room participants before the rolodex

### DIFF
--- a/packages/agent/src/actions/contact.search-room-hint.test.ts
+++ b/packages/agent/src/actions/contact.search-room-hint.test.ts
@@ -1,0 +1,122 @@
+/**
+ * CONTACT search honest dead-end: a no-match search must check the CURRENT
+ * room's participants before reporting "not found". "tell vega …" about a
+ * channel participant previously dead-ended at the saved-contacts rolodex
+ * ("couldn't find anyone named vega in the contacts") even though they were
+ * standing in the room. Deterministic runtime stand-in; the relationships
+ * graph is a recording stub; read-only — no send happens.
+ */
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { contactAction } from "./contact.ts";
+
+const AGENT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID;
+const SENDER_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc" as UUID;
+const VEGA_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const ROOM_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd" as UUID;
+
+function makeRuntime(options: {
+  roomEntities: Array<{
+    id: UUID;
+    names: string[];
+    components?: Array<{ data?: Record<string, unknown> }>;
+  }>;
+}): IAgentRuntime {
+  const graph = {
+    getGraphSnapshot: vi.fn(async () => ({ people: [] })),
+    getPersonDetail: vi.fn(async () => null),
+    getCandidateMerges: vi.fn(async () => []),
+    acceptMerge: vi.fn(async () => undefined),
+    rejectMerge: vi.fn(async () => undefined),
+    proposeMerge: vi.fn(async () => null),
+  };
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    getSetting: () => undefined,
+    getService: (type: string) => (type === "relationships" ? graph : null),
+    getSearchCategory: () => {
+      throw new Error("not registered");
+    },
+    registerSearchCategory: () => undefined,
+    getRoom: async () => ({ id: ROOM_ID, source: "discord", name: "#general" }),
+    getEntitiesForRoom: async () =>
+      options.roomEntities.map((entity) => ({
+        agentId: AGENT_ID,
+        metadata: {},
+        components: [],
+        ...entity,
+      })),
+    getEntityById: async () => null,
+    getRelationships: async () => [],
+    reportError: vi.fn(),
+  };
+  return runtime as unknown as IAgentRuntime;
+}
+
+function makeMessage(text: string): Memory {
+  return {
+    id: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee" as UUID,
+    entityId: SENDER_ID,
+    roomId: ROOM_ID,
+    content: { text, source: "discord" },
+  } as Memory;
+}
+
+async function search(runtime: IAgentRuntime, query: string) {
+  const result = await contactAction.handler(
+    runtime,
+    makeMessage(`tell ${query} to take a break`),
+    undefined,
+    { parameters: { action: "search", query } } as never,
+  );
+  if (!result) throw new Error("handler returned no result");
+  return result;
+}
+
+describe("CONTACT search no-match room-participant hint", () => {
+  it("surfaces a matching room participant instead of a bare dead-end", async () => {
+    const runtime = makeRuntime({
+      roomEntities: [
+        { id: VEGA_ID, names: ["Vega"] },
+        { id: AGENT_ID, names: ["Eliza"] },
+      ],
+    });
+    const result = await search(runtime, "vega");
+
+    expect(result.success).toBe(true);
+    expect(result.values).toMatchObject({
+      resultCount: 0,
+      roomParticipantMatchCount: 1,
+    });
+    expect(result.data).toMatchObject({
+      roomParticipantMatches: [{ entityId: VEGA_ID, name: "Vega" }],
+    });
+    // Planner-facing context: not a contact, but present in the channel — an
+    // in-room reply can reach them. The model phrases the user-visible reply.
+    expect(String(result.text)).toMatch(/present in the current room/i);
+    expect(String(result.text)).toMatch(/Vega/);
+  });
+
+  it("never counts the agent itself as a participant match", async () => {
+    const runtime = makeRuntime({
+      roomEntities: [{ id: AGENT_ID, names: ["Eliza"] }],
+    });
+    const result = await search(runtime, "eliza");
+    expect(result.values).toMatchObject({ roomParticipantMatchCount: 0 });
+  });
+
+  it("stays a plain honest no-match when nobody in the room matches", async () => {
+    const runtime = makeRuntime({
+      roomEntities: [{ id: VEGA_ID, names: ["Someone Else"] }],
+    });
+    const result = await search(runtime, "vega");
+
+    expect(result.success).toBe(true);
+    expect(result.values).toMatchObject({
+      resultCount: 0,
+      roomParticipantMatchCount: 0,
+    });
+    expect(String(result.text)).not.toMatch(/present in the current room/i);
+  });
+});

--- a/packages/agent/src/actions/contact.ts
+++ b/packages/agent/src/actions/contact.ts
@@ -54,6 +54,7 @@ import {
   FOLLOW_UP_CAPABLE_ACTION_TAG,
   findEntityByName,
   getConfiguredOwnerEntityIds,
+  getEntityDetails,
   logger,
   ModelType,
   parseJSONObjectFromText,
@@ -469,6 +470,41 @@ export function registerEntitySearchCategory(runtime: IAgentRuntime): void {
 // op:search
 // ---------------------------------------------------------------------------
 
+/**
+ * Deterministic room-participant lookup for the contact-search dead-end: an
+ * exact (case/`@`-insensitive) name match against the people present in the
+ * message's room, excluding the agent itself. Read-only — used to tell the
+ * planner "not a saved contact, but they are in this channel".
+ */
+async function findRoomParticipantMatches(
+  runtime: IAgentRuntime,
+  roomId: UUID,
+  query: string,
+): Promise<Array<{ entityId: string; name: string }>> {
+  const normalize = (value: string): string =>
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/^[@#]+/, "");
+  const target = normalize(query);
+  if (!target) return [];
+  const details = await getEntityDetails({ runtime, roomId });
+  const matches: Array<{ entityId: string; name: string }> = [];
+  for (const entity of details ?? []) {
+    if (!entity.id || entity.id === runtime.agentId) continue;
+    const names = [entity.name, ...(entity.names ?? [])].filter(
+      (name): name is string => typeof name === "string" && name.length > 0,
+    );
+    if (names.some((name) => normalize(name) === target)) {
+      matches.push({
+        entityId: String(entity.id),
+        name: names[0] ?? query,
+      });
+    }
+  }
+  return matches;
+}
+
 async function handleSearch(
   runtime: IAgentRuntime,
   message: Memory,
@@ -519,11 +555,40 @@ async function handleSearch(
     });
 
     if (!snapshot || snapshot.people.length === 0) {
+      // Honest dead-end: before reporting "not found", check whether the name
+      // matches someone PRESENT in the current room. "tell vega …" about a
+      // channel participant must not dead-end at the saved-contacts rolodex —
+      // surface the participant so the planner can offer an in-room reply.
+      // Read-only; no send happens here.
+      const roomParticipants = await findRoomParticipantMatches(
+        runtime,
+        message.roomId,
+        query,
+      );
+      const noMatchText = `No contacts found matching "${query}"${platform ? ` on ${platform}` : ""}.`;
+      const participantHint =
+        roomParticipants.length > 0
+          ? ` However, ${roomParticipants
+              .map((p) => `"${p.name}"`)
+              .join(
+                ", ",
+              )} matching that name is present in the current room/channel (not a saved contact). A plain reply in this channel can address them directly — offer that to the user instead of a DM or contact lookup.`
+          : "";
       return {
-        text: `No contacts found matching "${query}"${platform ? ` on ${platform}` : ""}.`,
+        text: `${noMatchText}${participantHint}`,
         success: true,
-        values: { success: true, resultCount: 0 },
-        data: { actionName: CONTACT_ACTION, op: "search", query, platform },
+        values: {
+          success: true,
+          resultCount: 0,
+          roomParticipantMatchCount: roomParticipants.length,
+        },
+        data: {
+          actionName: CONTACT_ACTION,
+          op: "search",
+          query,
+          platform,
+          roomParticipantMatches: roomParticipants,
+        },
       };
     }
 

--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -733,3 +733,318 @@ describe("inferOp is i18n-safe (#10471)", () => {
 		expect(inferOp({ text: "そのメッセージを削除して" })).toBe("send");
 	});
 });
+
+describe("MESSAGE op=send room-first name resolution (over-routing fix)", () => {
+	const ROOM_ID = "00000000-0000-0000-0000-0000000000bb";
+	const SHADOW_ID = "00000000-0000-0000-0000-0000000000e1";
+	const OTHER_ID = "00000000-0000-0000-0000-0000000000e2";
+
+	function roomFixture() {
+		return {
+			id: ROOM_ID,
+			name: "#general",
+			source: "discord",
+			channelId: "chan-1",
+			serverId: "guild-1",
+		};
+	}
+
+	function harness(options: {
+		roomEntities: Array<{
+			id: string;
+			names: string[];
+			components?: Array<{ data?: Record<string, unknown> }>;
+		}>;
+		hookCandidates?: Array<Record<string, unknown>>;
+		getEntityById?: (id: string) => Promise<unknown>;
+		getRelationships?: () => Promise<unknown[]>;
+	}) {
+		const sends: Array<{ target: Record<string, unknown>; text: string }> = [];
+		const resolveTargets = vi.fn(async () => options.hookCandidates ?? []);
+		const cache = new Map<string, unknown>();
+		const runtime = createMockRuntime({
+			agentId: "00000000-0000-0000-0000-000000000001",
+			logger: { debug() {}, info() {}, warn() {}, error() {} },
+			getMessageConnectors: () => [
+				{
+					source: "discord",
+					label: "Discord",
+					capabilities: [],
+					supportedTargetKinds: ["user", "room", "channel"],
+					contexts: [],
+					resolveTargets,
+				},
+			],
+			getRoom: async () => roomFixture(),
+			getEntitiesForRoom: async () => options.roomEntities,
+			getEntityById: (options.getEntityById ??
+				(async () => null)) as IAgentRuntime["getEntityById"],
+			getRelationships: (options.getRelationships ??
+				(async () => [])) as IAgentRuntime["getRelationships"],
+			getCache: (async (key: string) =>
+				cache.get(key)) as IAgentRuntime["getCache"],
+			setCache: (async (key: string, value: unknown) => {
+				cache.set(key, value);
+				return true;
+			}) as IAgentRuntime["setCache"],
+			deleteCache: (async (key: string) =>
+				cache.delete(key)) as IAgentRuntime["deleteCache"],
+			sendMessageToTarget: async (target, content) => {
+				sends.push({
+					target: target as unknown as Record<string, unknown>,
+					text: String(content.text ?? ""),
+				});
+				return { id: "00000000-0000-0000-0000-0000000000ff" } as Memory;
+			},
+			useModel: async () => {
+				throw new Error(
+					"room-first resolution must be deterministic — no model call",
+				);
+			},
+			reportError: () => undefined,
+		});
+		return { runtime, sends, resolveTargets };
+	}
+
+	async function send(
+		runtime: IAgentRuntime,
+		params: Record<string, unknown>,
+		text = "tell vega to take a break",
+	): Promise<ActionResult> {
+		const result = await messageAction.handler(
+			runtime,
+			{
+				...message,
+				content: { text, source: "discord" },
+			} as Memory,
+			undefined,
+			{ parameters: { action: "send", persist: false, ...params } },
+			undefined,
+			undefined,
+		);
+		if (!result) throw new Error("no result");
+		return result;
+	}
+
+	it("a name matching a room participant resolves to an in-channel utterance, not a DM or contact lookup", async () => {
+		const { runtime, sends, resolveTargets } = harness({
+			roomEntities: [
+				{ id: SHADOW_ID, names: ["Vega"] },
+				{ id: OTHER_ID, names: ["Someone Else"] },
+			],
+			// A guild-wide fuzzy stranger match must never be consulted first.
+			hookCandidates: [
+				{
+					target: { source: "discord", entityId: "555000111" },
+					label: "@vegafox",
+					kind: "user",
+					score: 0.95,
+					contexts: [],
+				},
+			],
+		});
+		const result = await send(runtime, {
+			target: "vega",
+			message: "take a break",
+		});
+
+		expect(result.success).toBe(true);
+		expect(sends).toHaveLength(1);
+		// Delivered IN the originating channel — never as an entity DM.
+		expect(sends[0].target).toMatchObject({
+			source: "discord",
+			roomId: ROOM_ID,
+			channelId: "chan-1",
+		});
+		expect(sends[0].target.entityId).toBeUndefined();
+		// The in-channel utterance addresses the member.
+		expect(sends[0].text).toBe("@Vega take a break");
+		// Room-first short-circuits the connector-wide fuzzy lookup entirely.
+		expect(resolveTargets).not.toHaveBeenCalled();
+	});
+
+	it("does not double-address when the text already names the member", async () => {
+		const { runtime, sends } = harness({
+			roomEntities: [{ id: SHADOW_ID, names: ["Vega"] }],
+		});
+		const result = await send(runtime, {
+			target: "vega",
+			message: "vega, please take a break",
+		});
+		expect(result.success).toBe(true);
+		expect(sends[0].text).toBe("vega, please take a break");
+	});
+
+	it("matches through connector component names (username/displayName)", async () => {
+		const { runtime, sends } = harness({
+			roomEntities: [
+				{
+					id: SHADOW_ID,
+					names: ["Casts No Light"],
+					components: [{ data: { username: "vega" } }],
+				},
+			],
+		});
+		const result = await send(runtime, {
+			target: "@vega",
+			message: "take a break",
+		});
+		expect(result.success).toBe(true);
+		expect(sends[0].target).toMatchObject({ roomId: ROOM_ID });
+	});
+
+	it("two matching room participants stay ambiguous — asks instead of guessing", async () => {
+		const { runtime, sends } = harness({
+			roomEntities: [
+				{ id: SHADOW_ID, names: ["Vega"] },
+				{
+					id: OTHER_ID,
+					names: ["Vega Two"],
+					components: [{ data: { username: "vega" } }],
+				},
+			],
+		});
+		const result = await send(runtime, {
+			target: "vega",
+			message: "take a break",
+		});
+
+		expect(result.success).toBe(false);
+		expect((result.data as { error?: string })?.error).toBe("TARGET_AMBIGUOUS");
+		expect(
+			(result.data as { candidates?: unknown[] })?.candidates,
+		).toHaveLength(2);
+		expect(sends).toHaveLength(0);
+	});
+});
+
+describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM close)", () => {
+	const STRANGER_PLATFORM_ID = "555000111";
+	const KNOWN_PLATFORM_ID = "555000222";
+
+	function harness(options: {
+		known: boolean;
+		roomEntities?: Array<{ id: string; names: string[] }>;
+	}) {
+		const sends: Array<{ target: Record<string, unknown> }> = [];
+		const cache = new Map<string, unknown>();
+		const platformId = options.known ? KNOWN_PLATFORM_ID : STRANGER_PLATFORM_ID;
+		const runtime = createMockRuntime({
+			agentId: "00000000-0000-0000-0000-000000000001",
+			logger: { debug() {}, info() {}, warn() {}, error() {} },
+			getMessageConnectors: () => [
+				{
+					source: "discord",
+					label: "Discord",
+					capabilities: [],
+					supportedTargetKinds: ["user"],
+					contexts: [],
+					resolveTargets: async () => [
+						{
+							target: { source: "discord", entityId: platformId },
+							label: "@fuzzymatch",
+							kind: "user" as const,
+							score: 0.95,
+							contexts: [],
+						},
+					],
+				},
+			],
+			getRoom: async () => null,
+			getEntitiesForRoom: async () => options.roomEntities ?? [],
+			getEntityById: (async (id: string) =>
+				options.known
+					? { id, names: ["Known Friend"] }
+					: null) as IAgentRuntime["getEntityById"],
+			getRelationships: (async () =>
+				options.known
+					? [{ sourceEntityId: "a", targetEntityId: "b" }]
+					: []) as IAgentRuntime["getRelationships"],
+			getCache: (async (key: string) =>
+				cache.get(key)) as IAgentRuntime["getCache"],
+			setCache: (async (key: string, value: unknown) => {
+				cache.set(key, value);
+				return true;
+			}) as IAgentRuntime["setCache"],
+			deleteCache: (async (key: string) =>
+				cache.delete(key)) as IAgentRuntime["deleteCache"],
+			sendMessageToTarget: async (target) => {
+				sends.push({ target: target as unknown as Record<string, unknown> });
+				return { id: "00000000-0000-0000-0000-0000000000ff" } as Memory;
+			},
+			useModel: async () => {
+				throw new Error("gate must be deterministic — no model call");
+			},
+			reportError: () => undefined,
+		});
+		return { runtime, sends };
+	}
+
+	async function send(
+		runtime: IAgentRuntime,
+		text: string,
+	): Promise<ActionResult> {
+		const result = await messageAction.handler(
+			runtime,
+			{ ...message, content: { text, source: "discord" } } as Memory,
+			undefined,
+			{
+				parameters: {
+					action: "send",
+					persist: false,
+					target: "fuzzymatch",
+					targetKind: "user",
+					message: "hey there",
+				},
+			},
+			undefined,
+			undefined,
+		);
+		if (!result) throw new Error("no result");
+		return result;
+	}
+
+	it("a fuzzy connector match to a STRANGER is confirm-gated — nothing is sent", async () => {
+		const { runtime, sends } = harness({ known: false });
+		const result = await send(runtime, "message fuzzymatch saying hey");
+
+		expect(result.success).toBe(true);
+		expect(result.data).toMatchObject({
+			confirmationRequired: true,
+			awaitingUserInput: true,
+		});
+		expect(sends).toHaveLength(0);
+	});
+
+	it("after the user confirms, the send proceeds", async () => {
+		const { runtime, sends } = harness({ known: false });
+		const first = await send(runtime, "message fuzzymatch saying hey");
+		expect(first.data).toMatchObject({ awaitingUserInput: true });
+		expect(sends).toHaveLength(0);
+
+		const second = await send(runtime, "yes");
+		expect(second.success).toBe(true);
+		expect(sends).toHaveLength(1);
+		expect(sends[0].target).toMatchObject({ entityId: STRANGER_PLATFORM_ID });
+	});
+
+	it("a declined confirmation cancels the send", async () => {
+		const { runtime, sends } = harness({ known: false });
+		await send(runtime, "message fuzzymatch saying hey");
+		const second = await send(runtime, "no, don't do that");
+
+		expect(second.success).toBe(false);
+		expect(second.data).toMatchObject({ cancelled: true });
+		expect(sends).toHaveLength(0);
+	});
+
+	it("a relationship-backed recipient still DMs directly (saved-contact path unchanged)", async () => {
+		const { runtime, sends } = harness({ known: true });
+		const result = await send(runtime, "message my friend saying hey");
+
+		expect(result.success).toBe(true);
+		expect(result.data).not.toMatchObject({ confirmationRequired: true });
+		expect(sends).toHaveLength(1);
+		expect(sends[0].target).toMatchObject({ entityId: KNOWN_PLATFORM_ID });
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -13,7 +13,7 @@
 
 import { searchCanonicalConversationMemories } from "../../../access-control/provenance-envelope.ts";
 import { getConnectorAccountManager } from "../../../connectors/account-manager.ts";
-import { findEntityByName } from "../../../entities.ts";
+import { createUniqueUuid, findEntityByName } from "../../../entities.ts";
 import { getActionSpec } from "../../../generated/spec-helpers.ts";
 import { logger } from "../../../logger.ts";
 import { resolveCanonicalOwnerIdForMessage } from "../../../roles.ts";
@@ -50,6 +50,7 @@ import {
 } from "../../../types/index.ts";
 import { MESSAGE_SOURCE_CLIENT_CHAT } from "../../../types/message-source.ts";
 import { hasActionContext } from "../../../utils/action-validation.ts";
+import { requireConfirmation } from "../../../utils/confirmation.ts";
 import { getActiveRoutingContextsForTurn } from "../../../utils/context-routing.ts";
 import { isObjectRecord as isRecord } from "../../../utils/type-guards.ts";
 import { stringToUuid } from "../../../utils.ts";
@@ -823,6 +824,10 @@ type SendCandidate = {
 	description?: string;
 	score: number;
 	reasons: string[];
+	/** When the resolved delivery is an in-room utterance aimed at a specific
+	 * room participant (the room-first name resolution), the member to address
+	 * in the outgoing text. Absent for every other candidate shape. */
+	address?: { entityId: UUID; name: string };
 };
 
 type TargetResolution =
@@ -1418,6 +1423,121 @@ async function currentRoomCandidate(
 	};
 }
 
+/** Component-data keys that carry a person's platform-visible name. Used for
+ * the deterministic room-first name match so "tell vega …" resolves against
+ * how the participant actually appears in the channel, not only the canonical
+ * entity name list. */
+const MEMBER_NAME_COMPONENT_KEYS = [
+	"username",
+	"handle",
+	"displayName",
+	"globalName",
+	"name",
+	"nick",
+	"nickname",
+] as const;
+
+function entityDisplayNames(entity: {
+	names: string[];
+	components?: Array<{ data?: Record<string, unknown> }>;
+}): string[] {
+	const names = [...entity.names];
+	for (const component of entity.components ?? []) {
+		for (const key of MEMBER_NAME_COMPONENT_KEYS) {
+			const value = component.data?.[key];
+			if (typeof value === "string" && value.trim().length > 0) {
+				names.push(value);
+			}
+		}
+	}
+	return names;
+}
+
+/**
+ * Room-first target resolution: a `target` name that exactly matches someone
+ * PRESENT in the current room resolves to an in-room utterance addressing that
+ * member — a surface the agent already speaks in — instead of falling through
+ * to the saved-contacts rolodex or a connector-wide fuzzy user lookup (which
+ * reported room participants as "not in your contacts", or worse, DM'd a
+ * fuzzy-matched stranger). Deterministic exact-name matching only; fuzzy
+ * resolution stays with the entity/connector paths.
+ */
+async function currentRoomMemberCandidates(
+	runtime: IAgentRuntime,
+	message: Memory,
+	state: State | undefined,
+	considered: ConnectorWithHooks[],
+	params: NormalizedSendParams,
+): Promise<SendCandidate[]> {
+	const rawTarget = params.target?.trim();
+	if (!rawTarget) return [];
+	// An explicit field prefix that is not user/contact-shaped pins the target
+	// to a non-person kind; leave it to the explicit-target path.
+	const fieldMatch = rawTarget.match(
+		/^(room|channel|server|entity|user|contact|thread|group|email|phone):(.+)$/i,
+	);
+	if (
+		fieldMatch?.[1] &&
+		!["user", "contact", "entity"].includes(fieldMatch[1].toLowerCase())
+	) {
+		return [];
+	}
+	if (rawTarget.startsWith("#")) return [];
+	if (
+		params.targetKind &&
+		!kindAliases(params.targetKind).has("user") &&
+		!kindAliases(params.targetKind).has("contact")
+	) {
+		return [];
+	}
+	const query = normalizeComparable(
+		stripTargetPrefix(fieldMatch?.[2] ?? rawTarget),
+	);
+	if (!query || isUuidLike(query)) return [];
+
+	const room = state?.data?.room ?? (await runtime.getRoom(message.roomId));
+	const roomSource =
+		typeof room?.source === "string"
+			? room.source
+			: trustedConnectorSource(message);
+	const connector = findConnectorBySource(considered, roomSource);
+	if (!connector) return [];
+
+	const entities = await runtime.getEntitiesForRoom(message.roomId, true);
+	const matches: Array<{ entityId: UUID; name: string }> = [];
+	for (const entity of entities) {
+		if (!entity.id || entity.id === runtime.agentId) continue;
+		const matched = entityDisplayNames(entity).find(
+			(name) => normalizeComparable(name) === query,
+		);
+		if (matched) {
+			matches.push({
+				entityId: entity.id as UUID,
+				name: entity.names[0] ?? matched,
+			});
+		}
+	}
+	if (matches.length === 0) return [];
+
+	const base = await currentRoomCandidate(
+		runtime,
+		message,
+		state,
+		connector,
+		Boolean(params.source),
+		params.accountId,
+	);
+	return matches.map((member) => ({
+		...base,
+		label: `${member.name} (in ${base.label})`,
+		// Deterministic room-participant hit: outranks every fuzzy connector user
+		// candidate (hook base 0.74 + boosts) without an LLM in the loop.
+		score: 0.97,
+		reasons: ["currentRoomMember"],
+		address: member,
+	}));
+}
+
 function dedupeCandidates(candidates: SendCandidate[]): SendCandidate[] {
 	const byKey = new Map<string, SendCandidate>();
 	for (const c of candidates) {
@@ -1568,6 +1688,38 @@ async function resolveSendTarget(
 		const currentSource = trustedConnectorSource(message);
 		const currentConnector = findConnectorBySource(considered, currentSource);
 		if (currentConnector) considered = [currentConnector];
+	}
+
+	// Check the room before the rolodex: someone present in the current room is
+	// the closest, least-surprising referent for a bare name — resolve to an
+	// in-room utterance addressing them before any connector-wide fuzzy lookup
+	// or contact search gets a chance to misroute the send.
+	if (params.target) {
+		const roomMembers = await currentRoomMemberCandidates(
+			runtime,
+			message,
+			state,
+			considered,
+			params,
+		);
+		const soleMember = roomMembers.length === 1 ? roomMembers[0] : undefined;
+		if (soleMember) {
+			return {
+				status: "resolved",
+				candidate: soleMember,
+				sourceResolution: params.source ? params.sourceResolution : "defaulted",
+			};
+		}
+		if (roomMembers.length > 1) {
+			return {
+				status: "ambiguous",
+				text:
+					`MESSAGE op=send matched ${roomMembers.length} people in the current room for "${params.target}". Pick one:\n` +
+					formatCandidates(roomMembers),
+				candidates: roomMembers,
+				sourceResolution: params.source ? params.sourceResolution : "defaulted",
+			};
+		}
 	}
 
 	const candidates: SendCandidate[] = [];
@@ -2069,6 +2221,87 @@ async function ensureSendAccountAllowed(
 	);
 }
 
+/** Candidate origins whose recipient identity is already vetted: the admin
+ * shortcut, the entity path (findEntityByName only surfaces room/relationship
+ * entities), and in-room deliveries (no DM is involved). */
+const RECIPIENT_VETTED_REASONS = new Set([
+	"admin",
+	"entity",
+	"component",
+	"currentRoom",
+	"currentRoomMember",
+]);
+
+/**
+ * True when the selected candidate is a direct-to-person delivery whose
+ * recipient identity came from an UNVETTED source — a connector discovery hook
+ * (e.g. Discord's guild-wide fuzzy member match) or a raw explicit target.
+ * These must be backed by a room-participant/relationship entity or confirmed
+ * by the user before delivery; without this gate, `target="name"` could DM a
+ * fuzzy-matched stranger with no confirmation.
+ */
+function isUnvettedDirectUserCandidate(candidate: SendCandidate): boolean {
+	const entityId = candidate.target.entityId;
+	if (!entityId) return false;
+	// Address-routed deliveries (an explicit channel/room, or phone/email whose
+	// dial string doubles as the channel) are not identity-fuzzy.
+	if (candidate.target.channelId || candidate.target.roomId) return false;
+	// An entity-store UUID is an unambiguous identifier the planner obtained
+	// from a real lookup, not a fuzzy name match.
+	if (isUuidLike(String(entityId))) return false;
+	if (candidate.reasons.some((reason) => RECIPIENT_VETTED_REASONS.has(reason)))
+		return false;
+	if (candidate.kind) {
+		const aliases = kindAliases(candidate.kind);
+		return aliases.has("user") || aliases.has("contact");
+	}
+	// No declared kind: a bare entityId with no routing address is a DM shape.
+	return true;
+}
+
+/**
+ * A recipient is "known" when they participate in the current room or are
+ * relationship-backed in the entity graph. Connector candidates carry raw
+ * platform ids (e.g. Discord snowflakes), so both the raw id and its
+ * agent-scoped entity UUID (`createUniqueUuid`) are checked, plus the room
+ * participants' connector component data. Mere existence of an entity record
+ * is NOT enough — history backfill creates entities for every past chatter.
+ */
+async function recipientIsKnownEntity(
+	runtime: IAgentRuntime,
+	message: Memory,
+	target: TargetInfo,
+): Promise<boolean> {
+	const raw = String(target.entityId ?? "").trim();
+	if (!raw) return false;
+	const candidateIds = new Set<string>([
+		createUniqueUuid(runtime, raw).toLowerCase(),
+	]);
+	if (isUuidLike(raw)) candidateIds.add(raw.toLowerCase());
+
+	const roomEntities = await runtime.getEntitiesForRoom(message.roomId, true);
+	for (const entity of roomEntities) {
+		if (!entity.id) continue;
+		if (candidateIds.has(String(entity.id).toLowerCase())) return true;
+		for (const component of entity.components ?? []) {
+			const values = Object.values(component.data ?? {});
+			if (values.some((value) => typeof value === "string" && value === raw)) {
+				return true;
+			}
+		}
+	}
+
+	for (const id of candidateIds) {
+		const entity = await runtime.getEntityById(id as UUID);
+		if (!entity?.id) continue;
+		const relationships = await runtime.getRelationships({
+			entityIds: [entity.id],
+		});
+		if (relationships.length > 0) return true;
+	}
+	return false;
+}
+
 async function handleSend(
 	runtime: IAgentRuntime,
 	message: Memory,
@@ -2135,9 +2368,57 @@ async function handleSend(
 		return gate;
 	}
 
+	// A direct-to-person delivery resolved from an unvetted source (connector
+	// fuzzy match / raw explicit target) must be a known recipient — present in
+	// this room or relationship-backed — or explicitly confirmed by the user.
+	if (isUnvettedDirectUserCandidate(selected)) {
+		const known = await recipientIsKnownEntity(runtime, message, target);
+		if (!known) {
+			const decision = await requireConfirmation({
+				runtime,
+				message,
+				actionName: "MESSAGE",
+				pendingKey: `send:${selected.connector.source}:${String(target.entityId)}`,
+				prompt: `Send this via ${selected.connector.label} to ${selected.label}? They are not in this room, your contacts, or your relationship graph.`,
+			});
+			if (decision.status !== "confirmed") {
+				const pending = decision.status === "pending";
+				return {
+					success: pending,
+					text: pending
+						? `"${selected.label}" on ${selected.connector.label} is not in this room or the user's relationship graph. Ask the user to confirm sending to this recipient (yes/no) before the message is delivered; nothing was sent.`
+						: "The user declined sending to this recipient; nothing was sent.",
+					data: {
+						actionName: "MESSAGE",
+						operation: "send",
+						confirmationRequired: pending,
+						awaitingUserInput: pending,
+						cancelled: !pending,
+						source: selected.connector.source,
+						targetLabel: selected.label,
+					},
+				};
+			}
+		}
+	}
+
+	// Room-first member delivery: the utterance lands in the shared channel, so
+	// address the intended member by name unless the text already does.
+	const outboundMessage =
+		selected.address &&
+		!normalizeComparable(normalized.message).includes(
+			normalizeComparable(selected.address.name),
+		)
+			? `@${selected.address.name} ${normalized.message}`.trim()
+			: normalized.message;
+
 	const content = applyContentShaping(
 		selected.connector,
-		buildContent({ ...normalized, source: selected.connector.source }),
+		buildContent({
+			...normalized,
+			message: outboundMessage,
+			source: selected.connector.source,
+		}),
 	);
 
 	let persisted: Memory | undefined;

--- a/packages/core/src/features/basic-capabilities/providers/entities.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/entities.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Contract tests for the ENTITIES ("People in the Room") provider. Pins the
+ * context gate: the provider must be visible on messaging turns — not only
+ * contacts/memory — so the planner can see that an addressee is PRESENT in the
+ * room and prefer a plain in-room reply over a contact search or DM lookup
+ * (the "tell <name> …" over-routing family). Deterministic mocked runtime.
+ */
+import { describe, expect, it } from "vitest";
+import { createMockRuntime } from "../../../testing/mock-runtime";
+import type { IAgentRuntime, Memory, UUID } from "../../../types/index.ts";
+import { entitiesProvider } from "./entities.ts";
+
+describe("ENTITIES provider context gate", () => {
+	it("is visible on messaging turns as well as contacts/memory", () => {
+		expect(entitiesProvider.contexts).toContain("messaging");
+		expect(entitiesProvider.contexts).toContain("contacts");
+		expect(entitiesProvider.contexts).toContain("memory");
+		const gate = entitiesProvider.contextGate as { anyOf?: string[] };
+		expect(gate?.anyOf).toContain("messaging");
+	});
+});
+
+describe("ENTITIES provider content", () => {
+	it("lists the people present in the room", async () => {
+		const roomId = "00000000-0000-0000-0000-0000000000bb" as UUID;
+		const runtime = createMockRuntime({
+			agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+			getRoom: (async () => ({
+				id: roomId,
+				source: "discord",
+				name: "#general",
+			})) as IAgentRuntime["getRoom"],
+			getEntitiesForRoom: (async () => [
+				{
+					id: "00000000-0000-0000-0000-0000000000e1" as UUID,
+					agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+					names: ["Vega"],
+					components: [],
+				},
+			]) as IAgentRuntime["getEntitiesForRoom"],
+		});
+		const message = {
+			id: "00000000-0000-0000-0000-0000000000aa",
+			roomId,
+			entityId: "00000000-0000-0000-0000-0000000000cc",
+			content: { text: "tell vega to take a break", source: "discord" },
+		} as unknown as Memory;
+
+		const result = await entitiesProvider.get(runtime, message, {
+			values: {},
+			data: {},
+			text: "",
+		});
+		expect(result.text).toContain("People in the Room");
+		expect(result.text).toContain("Vega");
+	});
+});

--- a/packages/core/src/features/basic-capabilities/providers/entities.ts
+++ b/packages/core/src/features/basic-capabilities/providers/entities.ts
@@ -25,8 +25,12 @@ export const entitiesProvider: Provider = {
 	name: spec.name,
 	description: spec.description,
 	dynamic: spec.dynamic ?? true,
-	contexts: ["contacts", "memory"],
-	contextGate: { anyOf: ["contacts", "memory"] },
+	// "messaging" is deliberately included: on a "tell <name> …" turn the
+	// planner needs to SEE who is present in the room to prefer a plain
+	// in-room reply over a contact search or DM lookup for someone who is
+	// standing right there (the over-routing family, with #17923 semantics).
+	contexts: ["contacts", "memory", "messaging"],
+	contextGate: { anyOf: ["contacts", "memory", "messaging"] },
 	cacheStable: false,
 	cacheScope: "turn",
 	roleGate: { minRole: "USER" },


### PR DESCRIPTION
# Relates to

Live over-routing incidents on an operator's Discord deployment (routing family: "don't over-route ambiguous input"). No public issue; scoped and approved by the repo owner. Companion PR: #18106 (link-share spawn guard).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` (112a73c8eec) with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; one unrelated blocker recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from the latest `origin/develop` (112a73c8eec); zero conflicts.
- [x] `bun run verify` run post-sync; the single failure is an unrelated environment blocker documented in **Known gaps / failures**.

# Risks

Medium. This touches core `MESSAGE op=send` target resolution — the highest-traffic messaging path.
- Room-first resolution is deterministic (exact normalized-name equality only) and short-circuits BEFORE connector fuzzy hooks; UUID targets, `#channel`/field-prefixed targets, and non-person `targetKind`s are excluded, so explicit-target and channel sends are unchanged.
- The new recipient-confirmation gate only fires for direct-to-person candidates whose identity came from an unvetted source (connector fuzzy hook or raw explicit name). Entity-store UUIDs, address-routed (channel/room/phone/email) targets, the admin path, the entity path, and in-room deliveries are exempt — covered by tests.
- ENTITIES provider widening adds one provider render on messaging turns (position/caching unchanged, turn-scoped cache).

# Background

## What does this PR do?

Fixes the "tell &lt;name&gt; …" over-routing family: a name that refers to someone PRESENT in the current channel was routed away from the room — to the saved-contacts rolodex (dead-ending with "couldn't find anyone named &lt;name&gt; in the contacts") or, worse, to a connector-wide fuzzy user match that could DM a stranger without confirmation.

1. **Room before rolodex** — `resolveSendTarget` resolves `target` against the current room's participants (deterministic pass over `getEntitiesForRoom`, including connector component names) before connector discovery hooks. A unique hit becomes an in-room utterance addressing the member (`@Name …`), in the channel the request came from — a surface the agent already speaks in, so no new delivery gate. Multiple hits return `ambiguous` and ask.
2. **Close the stranger-DM edge** — an unvetted direct-to-person candidate must be a room participant or relationship-backed, or delivery is routed through the standard `requireConfirmation` yes/no gate. The deliberately-reverted send pause on `userId`/`username`/`handle` params stays reverted.
3. **Planner visibility** — the ENTITIES ("People in the Room") provider context gate now includes `messaging`, so Stage-1/planner can see the addressee is present and prefer a plain in-room reply.
4. **Honest dead-end** — CONTACT search's no-match tool result appends a read-only room-participant check (structured data + planner-facing text; the model phrases the user-visible reply — no canned reply strings).

## What kind of change is this?

Bug fix (non-breaking behavior fix in core message routing).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/core/src/features/advanced-capabilities/actions/message.test.ts` — "room-first name resolution" + "unvetted-recipient confirmation gate" suites
- `packages/core/src/features/advanced-capabilities/actions/message.ts` — `currentRoomMemberCandidates`, `isUnvettedDirectUserCandidate`, `recipientIsKnownEntity`
- `packages/agent/src/actions/contact.search-room-hint.test.ts`
- `packages/core/src/features/basic-capabilities/providers/entities.test.ts`

## Detailed testing steps

None: automated tests are acceptable — the new suites drive the REAL `messageAction.handler` / `contactAction.handler` / `entitiesProvider.get` against deterministic runtimes and assert the full contract matrix:

- name matches a room participant → in-channel delivery (`roomId`/`channelId` target, no `entityId`), member addressed in text, connector fuzzy hook never consulted
- name matches a saved (relationship-backed) recipient → still DMs directly, no confirmation (unchanged)
- name fuzzy-matches a stranger only → confirmation required, nothing sent; "yes" delivers, "no" cancels
- two matching participants → `TARGET_AMBIGUOUS` with both candidates, nothing sent
- ENTITIES provider visible on messaging turns and lists room members
- CONTACT search no-match surfaces the matching participant (read-only); agent itself never counts; plain no-match unchanged

# Evidence Gate

<!-- evidence-head:715636a66a8d541bfb1b7cc4e882d0e70985c183 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - core message-routing change; no rendered UI surface in the diff.
<!-- evidence-row:after-screenshots -->
- [x] N/A - core message-routing change; no rendered UI surface in the diff.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible UI flow; behavior is a backend routing contract covered by deterministic suites below.
<!-- evidence-row:backend-logs -->
- [x] Deterministic owning-suite runs (real handlers, structured assertions):

  <details>
  <summary>core + agent + plugin-discord suite output</summary>

  ```
  packages/core (messaging surfaces: features/advanced-capabilities, services/message, providers)
   Test Files  56 passed (56)
        Tests  586 passed (586)
  packages/core typecheck: tsc --noEmit - clean
  packages/agent typecheck: tsc --noEmit - clean
  packages/agent src/actions/contact.search-room-hint.test.ts
   Test Files  1 passed (1)
        Tests  3 passed (3)
  plugins/plugin-discord (full suite + typecheck)
   Test Files  72 passed (72)
        Tests  574 passed (574)
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code modified.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic routing/action contract change (no prompt or model-call change); the deploying operator live-verifies on the real Discord bot before rollout, per the incident workflow.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts (resolved send-target shapes asserted by the suites):

  ```
  in-room resolution:   target={source:"discord", roomId:<origin>, channelId:"chan-1"} (no entityId), text="@Vega take a break"
  ambiguous (2 hits):   TARGET_AMBIGUOUS with 2 currentRoomMember candidates, nothing sent
  stranger fuzzy match: confirmationRequired=true awaitingUserInput=true, nothing sent; "yes" -> delivered; "no" -> cancelled
  contact no-match:     values.roomParticipantMatchCount=1, data.roomParticipantMatches=[{entityId, name}]
  ```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - the change removes an LLM from the loop for room-participant resolution (deterministic exact-name matching); no prompt or model-call path changed.

## Backend + frontend logs

<details>
<summary>Owning-suite runs (deterministic, real handlers)</summary>

```
packages/core (messaging surfaces: features/advanced-capabilities, services/message, providers)
 Test Files  56 passed (56)
      Tests  586 passed (586)

packages/core typecheck: tsc --noEmit — clean
packages/agent typecheck: tsc --noEmit — clean

packages/agent src/actions/contact.search-room-hint.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)

plugins/plugin-discord (full suite + typecheck)
 Test Files  72 passed (72)
      Tests  574 passed (574)
```

</details>

Frontend: N/A - no frontend code modified.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` in the development worktree fails at `@elizaos/plugin-anthropic#typecheck` with `Module '"@elizaos/core"' has no exported member 'deepToWellFormedUnicode'` — an environment artifact: that plugin's tsconfig path-maps `@elizaos/core` to `../../../packages/core/dist`, which escapes a nested worktree into a sibling checkout's stale dist (predates #18079). Unrelated to this diff (which only adds core source + tests); CI's fresh clone resolves correctly.
- No live-model trajectory attached: the deploying operator live-verifies routing changes on the production Discord bot before rollout; this PR's contract is pinned by the deterministic suites above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
