### PR TITLE
fix(core): bare link shares route to web-read, never a coding-agent spawn

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -1356,3 +1356,106 @@ describe("view-surface overlap miss-budget cap (vim-window shape)", () => {
 		expect(routed.plan.requiredToolMissBudget).toBeUndefined();
 	});
 });
+
+describe("bare link shares never commit the turn to coding delegation (link-spawn guard)", () => {
+	const replyAction: Pick<Action, "name" | "similes" | "tags"> = {
+		name: "REPLY",
+		similes: [],
+		tags: [],
+	};
+	const spawnAction: Pick<Action, "name" | "similes" | "tags"> = {
+		name: "TASKS_SPAWN_AGENT",
+		similes: ["SPAWN_AGENT"],
+		tags: ["domain:coding", "coding-delegation"],
+	};
+	const webAction: Pick<Action, "name" | "similes" | "tags"> = {
+		name: "WEB_FETCH",
+		similes: [],
+		tags: [],
+	};
+
+	/** The exact processed-content shape Discord produces for a shared link
+	 * with a rendered preview (raw URL + connector-appended embed block). The
+	 * embed title's workflow-ish words are DERIVED content, not instruction. */
+	const linkShareText = [
+		"https://claude.ai/public/artifacts/abc123",
+		"Embed #1:",
+		"  Title:how the agent decides to message people",
+		"  Description:(none)",
+	].join("\n");
+
+	const fieldResult = (replyText: string) => ({
+		shouldRespond: "RESPOND" as const,
+		contexts: ["general"],
+		intents: [],
+		replyText,
+		candidateActionNames: ["TASKS_SPAWN_AGENT"],
+		facts: [],
+		relationships: [],
+		addressedTo: [],
+	});
+
+	it("a complete reaction to a shared link stays direct even when the model named a spawn candidate", () => {
+		// Live incident shape: bare URL + embed, and the model (mis)committed to
+		// TASKS_SPAWN_AGENT off the embed title. The delegation-commitment
+		// override must NOT stand on a link share — the finished reaction wins.
+		const routed = messageHandlerFromFieldResult(
+			fieldResult(
+				"Neat write-up — it lays out how the agent weighs room context before messaging anyone.",
+			),
+			undefined,
+			{
+				actions: [replyAction, spawnAction, webAction],
+				messageText: linkShareText,
+			},
+		);
+
+		expect(routed.plan.simple).toBe(true);
+		expect(routed.plan.requiresTool).toBe(false);
+		expect(routed.plan.candidateActions ?? []).toEqual([]);
+	});
+
+	it("an explicit build instruction with a URL still commits to delegation", () => {
+		const routed = messageHandlerFromFieldResult(
+			fieldResult("On it — I'll get that page built for you now, one moment."),
+			undefined,
+			{
+				actions: [replyAction, spawnAction, webAction],
+				messageText:
+					"build me a landing page based on this https://example.com/design",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("TASKS_SPAWN_AGENT");
+	});
+
+	it("an unanswered link share escalates to the web-read light path, not a spawn", () => {
+		// Stage 1 acked without reading the page: the deterministic backstop
+		// surfaces the web tools so the planner fetches and reacts to the actual
+		// content (degrading to the embed metadata when unfetchable) instead of
+		// inventing work.
+		const routed = applyDirectCurrentCandidateBackstopToMessageHandler(
+			{
+				processMessage: "RESPOND",
+				thought: "",
+				plan: {
+					contexts: ["simple"],
+					reply: "Taking a look.",
+					simple: true,
+					requiresTool: false,
+				},
+			},
+			{
+				actions: [replyAction, spawnAction, webAction],
+				messageText: linkShareText,
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("WEB_FETCH");
+		expect(routed.plan.candidateActions ?? []).not.toContain(
+			"TASKS_SPAWN_AGENT",
+		);
+	});
+});

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -352,6 +352,7 @@ export {
 	findCodingDelegationActionName,
 	hasActionTags,
 	LEGACY_CODING_DELEGATION_ACTION_NAMES,
+	looksLikeBareLinkShare,
 	normalizeActionIdentifier,
 } from "./services/message/direct-action-heuristics";
 export { sanitizeOutboundText } from "./services/message/outbound-sanitize";

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -334,6 +334,7 @@ import {
 	inferWebSearchQueryFromMessageText,
 	isShellDirectActionName,
 	LEGACY_CODING_DELEGATION_ACTION_NAMES,
+	looksLikeBareLinkShare,
 	looksLikeLocalShellRequest,
 	looksLikeWebSearchRequest,
 	normalizeActionIdentifier,
@@ -9476,6 +9477,13 @@ function looksLikeDelegationExcludedAsk(text: string): boolean {
 			normalized,
 		)
 	) {
+		return true;
+	}
+	// A shared link with no explicit work imperative is content to react to,
+	// not a work order — even when the model itself proposed a spawn candidate
+	// off the embed preview text (observed live: bare URL + embed title →
+	// TASKS_SPAWN_AGENT with an empty derived task → doomed sub-agent).
+	if (looksLikeBareLinkShare(normalized)) {
 		return true;
 	}
 	if (looksLikeActionExplanationRequest(normalized)) {

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -17,9 +17,111 @@ import {
 	inferDirectCurrentRequestCandidateActions,
 	inferDirectCurrentRequestCandidateInference,
 	isShellDirectActionName,
+	looksLikeBareLinkShare,
 	looksLikeLocalShellRequest,
 	looksLikeWebSearchRequest,
 } from "./direct-action-heuristics.ts";
+
+/** The exact processed-content shape Discord produces for a shared link with a
+ * rendered preview: raw URL, then the connector-appended embed block. */
+const DISCORD_LINK_WITH_EMBED = [
+	"https://claude.ai/public/artifacts/abc123",
+	"Embed #1:",
+	"  Title:how the agent decides to message people",
+	"  Description:(none)",
+].join("\n");
+
+describe("looksLikeBareLinkShare", () => {
+	it("fires on a bare URL with no commentary", () => {
+		expect(looksLikeBareLinkShare("https://example.com/some/page")).toBe(true);
+	});
+
+	it("fires on a URL with a connector embed preview — preview text is derived, not instruction", () => {
+		// The embed title contains workflow-ish words ("decides to message
+		// people"); they must not read as user intent.
+		expect(looksLikeBareLinkShare(DISCORD_LINK_WITH_EMBED)).toBe(true);
+	});
+
+	it("fires on a URL with short non-imperative commentary", () => {
+		expect(looksLikeBareLinkShare("check this out https://example.com")).toBe(
+			true,
+		);
+		expect(looksLikeBareLinkShare("https://example.com lol")).toBe(true);
+		expect(looksLikeBareLinkShare("thoughts? https://example.com")).toBe(true);
+	});
+
+	it("does NOT fire when the user's own words carry a work imperative", () => {
+		expect(
+			looksLikeBareLinkShare(
+				"build me a landing page based on this https://example.com/design",
+			),
+		).toBe(false);
+		expect(
+			looksLikeBareLinkShare("fix the bug described here https://example.com"),
+		).toBe(false);
+		// The imperative may live in the residue even with an embed present.
+		expect(
+			looksLikeBareLinkShare(
+				`implement what this describes\n${DISCORD_LINK_WITH_EMBED}`,
+			),
+		).toBe(false);
+	});
+
+	it("does NOT fire without a URL or on substantial commentary", () => {
+		expect(looksLikeBareLinkShare("tell vega to take a break")).toBe(false);
+		expect(looksLikeBareLinkShare("")).toBe(false);
+		const longCommentary = `${"here is a very long analysis of the situation with many words that go on ".repeat(3)}https://example.com`;
+		expect(looksLikeBareLinkShare(longCommentary)).toBe(false);
+	});
+});
+
+describe("bare link share routes to the web-read light path, never coding", () => {
+	const actions = [
+		{ name: "REPLY", similes: [] },
+		{ name: "WEB_FETCH", similes: [] },
+		{ name: "WEB_SEARCH", similes: [] },
+		{ name: "TASKS", similes: [], tags: ["domain:coding"] },
+	] as unknown as ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
+
+	it("a shared link surfaces WEB_FETCH-first web candidates (kind web)", () => {
+		const inference = inferDirectCurrentRequestCandidateInference(
+			actions,
+			DISCORD_LINK_WITH_EMBED,
+			{
+				// A coding hook that would fire on the embed's derived text must
+				// not be consulted before the link-share light path.
+				looksLikeCodingWorkRequest: () => false,
+				findCodingDelegationActionName: () => "TASKS",
+			},
+		);
+		expect(inference.kind).toBe("web");
+		expect(inference.names).toEqual(["WEB_FETCH", "WEB_SEARCH"]);
+	});
+
+	it("an explicit build instruction with a URL still routes to coding", () => {
+		const inference = inferDirectCurrentRequestCandidateInference(
+			actions,
+			"build me a page like this https://example.com/design",
+			{
+				looksLikeCodingWorkRequest: (text) => /\bbuild\b/i.test(text),
+				findCodingDelegationActionName: () => "TASKS",
+			},
+		);
+		expect(inference.kind).toBe("coding");
+		expect(inference.names).toEqual(["TASKS"]);
+	});
+
+	it("with no web backend the link share yields no forced candidate", () => {
+		const inference = inferDirectCurrentRequestCandidateInference(
+			[{ name: "REPLY", similes: [] }] as unknown as ReadonlyArray<
+				Pick<Action, "name" | "similes" | "tags">
+			>,
+			DISCORD_LINK_WITH_EMBED,
+			{},
+		);
+		expect(inference.names).toEqual([]);
+	});
+});
 
 describe("looksLikeLocalShellRequest", () => {
 	it("fires on local inspect-the-repo intent, not on unrelated text", () => {

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -123,6 +123,52 @@ export function looksLikeLocalShellRequest(text: string): boolean {
 	);
 }
 
+const URL_TOKEN_PATTERN = /\bhttps?:\/\/[^\s<>()]+/giu;
+
+/** Connector-appended link-preview blocks (Discord renders shared-link embeds
+ * into the processed text as "Embed #N:\n  Title:…\n  Description:…"). Preview
+ * text is DERIVED from the linked page — it is never a user instruction, so
+ * intent detection must not read it as one. */
+const LINK_EMBED_BLOCK_PATTERN =
+	/(?:^|\n)\s*Embed #\d+:\s*(?:\n[ \t]+[^\n]*)*/giu;
+
+/** Explicit work imperatives in the user's OWN words (outside URLs and embed
+ * previews) that turn a link share into a genuine request. */
+const LINK_SHARE_WORK_IMPERATIVE_PATTERN =
+	/\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|update|verify|deploy|refactor|debug|patch|code|install|run|execute|spawn|delegate)\b/iu;
+
+/**
+ * True when a message is essentially just a shared link: one or more URLs,
+ * optionally with connector-derived embed preview text, and at most a short
+ * remainder that carries no explicit work imperative aimed at the agent.
+ *
+ * A shared link is content, not a work order (observed live: a bare URL whose
+ * embed title happened to contain workflow-ish words spawned a coding
+ * sub-agent with an empty derived task). Link shares route to the web-read
+ * light path — fetch and react to the page, or acknowledge from the embed
+ * metadata when the page is not readable — never to coding delegation.
+ */
+export function looksLikeBareLinkShare(text: string): boolean {
+	const trimmed = text.trim();
+	if (!trimmed) return false;
+	const withoutEmbeds = trimmed.replace(LINK_EMBED_BLOCK_PATTERN, " ");
+	const urls = withoutEmbeds.match(URL_TOKEN_PATTERN);
+	if (!urls || urls.length === 0) return false;
+	let residue = withoutEmbeds;
+	for (const url of urls) {
+		residue = residue.replace(url, " ");
+	}
+	residue = residue
+		.replace(/[|<>*_~`"'()[\]{}.,:;!?@#-]+/gu, " ")
+		.replace(/\s+/gu, " ")
+		.trim();
+	// A substantial remainder means the user actually said something; ordinary
+	// routing applies.
+	if (residue.length > 120) return false;
+	if (residue.length === 0) return true;
+	return !LINK_SHARE_WORK_IMPERATIVE_PATTERN.test(residue);
+}
+
 export function looksLikeWebSearchRequest(text: string): boolean {
 	const normalized = text.toLowerCase();
 	if (!normalized.trim()) {
@@ -494,6 +540,14 @@ export function inferDirectCurrentRequestCandidateInference(
 	if (hooks.looksLikeCodingWorkRequest?.(messageText)) {
 		const codingAction = hooks.findCodingDelegationActionName?.(actions);
 		if (codingAction) return { names: [codingAction], kind: "coding" };
+	}
+	// A bare link share routes to the web-read light path before any view/verb
+	// token in the DERIVED embed preview text can hijack the turn: read the
+	// page and react to it (degrading to the embed metadata already present in
+	// the message when the page is not publicly fetchable) — never spawn work.
+	if (looksLikeBareLinkShare(messageText)) {
+		const lookupActions = findWebLookupActionNames(actions);
+		if (lookupActions.length > 0) return { names: lookupActions, kind: "web" };
 	}
 	if (looksLikeVoiceSettingsWriteRequest(messageText)) {
 		const settingsAction = findSettingsWriteActionName(actions);

--- a/plugins/plugin-agent-orchestrator/src/__tests__/spawn-link-guard.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/spawn-link-guard.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Pre-spawn intent gate: TASKS_SPAWN_AGENT / TASKS_CREATE must refuse — BEFORE
+ * any ACP session exists — when the task prompt is empty or derived only from
+ * a shared link (bare URL + connector embed preview, no explicit instruction
+ * in the user's own words). Live incident: a bare Discord URL whose embed
+ * title contained workflow-ish words spawned a coding sub-agent with
+ * body/instruction/input all empty; the doomed session dead-ended and the
+ * user saw "runtime step failed". Deterministic — drives the REAL tasksAction
+ * handler against a fake ACP service; no live model.
+ */
+
+import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { tasksAction } from "../actions/tasks.ts";
+
+const ROOM = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const MSG = "11111111-1111-4111-8111-111111111111";
+const USER = "22222222-2222-4222-8222-222222222222";
+const AGENT_ID = "00000000-0000-4000-8000-000000000001";
+
+/** The exact processed-content shape Discord produces for a shared link with
+ * a rendered preview: the raw URL plus the connector-appended embed block. */
+const LINK_SHARE_TEXT = [
+  "https://claude.ai/public/artifacts/abc123",
+  "Embed #1:",
+  "  Title:how the agent decides to message people",
+  "  Description:(none)",
+].join("\n");
+
+function makeFakeAcp() {
+  const spawnSession = vi.fn(async (opts: Record<string, unknown>) => ({
+    sessionId: "session-1",
+    agentType: (opts.agentType as string) ?? "codex",
+    workdir: (opts.workdir as string) ?? "/tmp/spawn-test",
+    status: "running",
+  }));
+  const service = {
+    spawnSession,
+    getSession: vi.fn(async () => undefined),
+    getSessions: vi.fn(async () => []),
+    listSessions: vi.fn(async () => []),
+    stopSession: vi.fn(async () => undefined),
+    resolveAgentType: vi.fn(async () => "codex"),
+    onSessionEvent: vi.fn(() => () => undefined),
+  };
+  return { service, spawnSession };
+}
+
+function makeRuntime(acp: ReturnType<typeof makeFakeAcp>["service"]) {
+  return {
+    agentId: AGENT_ID,
+    character: { name: "Tester" },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: () => undefined,
+    getService: (type: string) => {
+      if (type === "ACP_SERVICE" || type === "ACP_SUBPROCESS_SERVICE")
+        return acp;
+      return undefined;
+    },
+    reportError: vi.fn(),
+    emitEvent: vi.fn(async () => undefined),
+    useModel: vi.fn(async () => "{}"),
+  } as unknown as IAgentRuntime;
+}
+
+function messageWithText(text: string): Memory {
+  return {
+    id: MSG,
+    entityId: USER,
+    roomId: ROOM,
+    agentId: AGENT_ID,
+    content: { text, source: "discord" },
+    createdAt: 1,
+  } as unknown as Memory;
+}
+
+async function runOp(
+  runtime: IAgentRuntime,
+  message: Memory,
+  parameters: Record<string, unknown>,
+) {
+  const result = await tasksAction.handler(
+    runtime,
+    message,
+    undefined as unknown as State,
+    { parameters },
+    undefined,
+  );
+  if (!result) throw new Error("handler returned no result");
+  return result;
+}
+
+describe("TASKS spawn gate: bare link shares never spawn", () => {
+  it("spawn_agent with a link-share message and a derived-only task refuses pre-spawn", async () => {
+    const { service, spawnSession } = makeFakeAcp();
+    const runtime = makeRuntime(service);
+    const result = await runOp(runtime, messageWithText(LINK_SHARE_TEXT), {
+      action: "spawn_agent",
+      agentType: "elizaos",
+      // The model derived this from the embed title — not a user instruction.
+      task: "agent-messaging-fix",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("LINK_SHARE_NOT_A_TASK");
+    // The refusal must point the planner at the web-read light path.
+    expect(String(result.text)).toMatch(/WEB_FETCH/);
+    expect(String(result.text)).toMatch(/embed/i);
+    // FAIL FAST: no ACP session may exist for a refused spawn.
+    expect(spawnSession).not.toHaveBeenCalled();
+  });
+
+  it("create with a link-share message refuses pre-spawn too", async () => {
+    const { service, spawnSession } = makeFakeAcp();
+    const runtime = makeRuntime(service);
+    const result = await runOp(runtime, messageWithText(LINK_SHARE_TEXT), {
+      action: "create",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("LINK_SHARE_NOT_A_TASK");
+    expect(spawnSession).not.toHaveBeenCalled();
+  });
+
+  it("an explicit build instruction that includes a URL still spawns", async () => {
+    const { service, spawnSession } = makeFakeAcp();
+    const runtime = makeRuntime(service);
+    const result = await runOp(
+      runtime,
+      messageWithText(
+        "build me a landing page based on this https://example.com/design",
+      ),
+      {
+        action: "spawn_agent",
+        agentType: "elizaos",
+        task: "build a landing page modeled on https://example.com/design",
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(spawnSession).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("TASKS spawn gate: empty task prompts refuse pre-spawn", () => {
+  it("spawn_agent with no task and an empty message refuses before any session exists", async () => {
+    const { service, spawnSession } = makeFakeAcp();
+    const runtime = makeRuntime(service);
+    const result = await runOp(runtime, messageWithText("   "), {
+      action: "spawn_agent",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("EMPTY_TASK_PROMPT");
+    // Clear, planner-usable refusal — not a spawned-then-failed doomed agent.
+    expect(String(result.text)).toMatch(/empty/i);
+    expect(spawnSession).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -23,6 +23,7 @@ import {
   ChannelType,
   logger as coreLogger,
   ElizaError,
+  looksLikeBareLinkShare,
   MESSAGE_SOURCE_SUB_AGENT,
   stringToUuid,
   unwrapUserMessageText,
@@ -221,6 +222,44 @@ function readOp(params: Record<string, unknown>): TaskOp | null {
 function requestText(message: Memory): string {
   if (typeof message.content === "string") return message.content;
   return unwrapUserMessageText(message);
+}
+
+/**
+ * Pre-spawn intent gate — fails fast BEFORE any ACP session exists. A coding
+ * sub-agent must only be spawned on an explicit instruction. Refuses:
+ *
+ * 1. An empty/whitespace task prompt: a session spawned with nothing to do
+ *    dead-ends its planner and surfaces an opaque "runtime step failed" to the
+ *    user (observed live: spawn args with body/instruction/input all empty).
+ * 2. A task derived ONLY from a shared link (bare URL, optionally with the
+ *    connector's embed preview text, and no explicit work imperative in the
+ *    user's own words): a shared link is content to read and react to, not a
+ *    work order. The refusal text points the planner at the web-read light
+ *    path instead.
+ *
+ * Sub-agent re-spawn turns (router-synthesized inbounds) skip the link check —
+ * their root turn was already gated and their task comes from stored metadata.
+ * Refusal text is planner-facing; the model phrases the user-visible reply.
+ */
+function guardSpawnTaskIntent(args: {
+  task: string;
+  originatingText: string;
+  isSubAgentRespawn: boolean;
+}): ActionResult | undefined {
+  if (!args.task.trim()) {
+    return errorResult(
+      "EMPTY_TASK_PROMPT",
+      "Refused to spawn a coding sub-agent: the task prompt is empty, so there is nothing to delegate. No session was created. Ask the user what they actually want built, fixed, or investigated before delegating.",
+    );
+  }
+  if (args.isSubAgentRespawn) return undefined;
+  if (looksLikeBareLinkShare(args.originatingText)) {
+    return errorResult(
+      "LINK_SHARE_NOT_A_TASK",
+      "Refused to spawn a coding sub-agent: the user's message is a shared link with no explicit build/fix/code instruction — the candidate task text was derived from the link's embed preview, not from the user. No session was created. Instead, read the page (WEB_FETCH) and respond about its actual content; if it is not fetchable (private or auth-walled), react using the embed title/description already present in the message and ask whether the user wants anything specific done with it.",
+    );
+  }
+  return undefined;
 }
 
 function taskParts(
@@ -1269,6 +1308,25 @@ async function runCreate(
   content: Record<string, unknown>,
   callback: HandlerCallback | undefined,
 ): Promise<ActionResult> {
+  // Fail fast on empty/derived-only tasks BEFORE any planner or ACP work; this
+  // single gate covers the lane-planner path and every runCreateLegacy fallback.
+  // A missing ACP service still wins (SERVICE_UNAVAILABLE) — capability absence
+  // outranks input validation, and the legacy path owns that refusal.
+  if (getAcpService(runtime)) {
+    const guardFallbackText = requestText(message);
+    const createGuard = guardSpawnTaskIntent({
+      task:
+        taskParts(params, content, guardFallbackText)
+          .find((part) => part.trim())
+          ?.trim() ?? "",
+      originatingText:
+        (await resolveOriginatingRequestText(runtime, message, state)) ||
+        guardFallbackText,
+      isSubAgentRespawn: content.source === MESSAGE_SOURCE_SUB_AGENT,
+    });
+    if (createGuard) return createGuard;
+  }
+
   if (!shouldUseLanePlanner(runtime)) {
     return runCreateLegacy(runtime, message, state, params, content, callback);
   }
@@ -1685,6 +1743,14 @@ async function runSpawnAgent(
       message,
       state,
     );
+    // Fail fast on empty/derived-only tasks BEFORE resolving backends or
+    // creating any ACP session (see guardSpawnTaskIntent).
+    const spawnGuard = guardSpawnTaskIntent({
+      task,
+      originatingText: routingRequest || text,
+      isSubAgentRespawn: content.source === MESSAGE_SOURCE_SUB_AGENT,
+    });
+    if (spawnGuard) return spawnGuard;
     // Backend routing (see resolveCodingBackend): an explicit user ask wins,
     // then declared `character.routing.coding` policy, then the operator pin
     // (ELIZA_ACP_DEFAULT_AGENT), then the planner's heuristic `agentType` guess.


### PR DESCRIPTION
# Relates to

Live over-routing incident on an operator's Discord deployment: a bare shared URL (no instruction) whose embed title contained workflow-ish words spawned a coding sub-agent with `body:"" instruction:"" input:""`; the doomed session dead-ended into "runtime step failed". No public issue; scoped and approved by the repo owner. Companion PR: #18105 (room-first send resolution).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` (112a73c8eec) with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; one unrelated blocker recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from the latest `origin/develop` (112a73c8eec); zero conflicts.
- [x] `bun run verify` run post-sync; the single failure is an unrelated environment blocker documented in **Known gaps / failures**.

# Risks

Medium-low.
- The new `looksLikeBareLinkShare` heuristic is narrow: it requires an actual URL, treats connector embed-preview blocks as derived content, and stands down on any explicit work imperative in the user's own words or any substantial commentary — covered by positive AND negative tests (explicit "build … URL" still routes to coding and still spawns).
- The pre-spawn gate only rejects empty task prompts and bare-link-derived tasks; sub-agent re-spawn turns are exempt (task comes from stored session metadata), and a missing ACP service still wins (`SERVICE_UNAVAILABLE`). Full orchestrator suite (2647 tests) green.

# Background

## What does this PR do?

A shared link is content, not a work order. Defense in depth, both to stop the over-route and to stop the confusing spawned-then-failed session:

1. **`looksLikeBareLinkShare`** (core heuristics): true when a message is essentially just URL(s) — optionally with the connector-appended `Embed #N:` preview block — and the residue in the user's OWN words carries no explicit work imperative.
2. **Web-read light path**: the direct-candidate inference routes a bare link share to the web tools (WEB_FETCH first, then WEB_SEARCH) so the planner reads the page and reacts to its actual content; when the page is not fetchable (private/auth-walled), the embed title/description already present in the message text lets the model degrade to a content-aware acknowledgement instead of an error.
3. **Delegation-commitment exclusion**: a bare link share joins `looksLikeDelegationExcludedAsk`, so a Stage-1 model that (mis)commits to a spawn candidate off the embed preview no longer overrides a finished direct reaction into forced planning.
4. **Pre-spawn intent gate** (plugin-agent-orchestrator): `TASKS create`/`spawn_agent` refuse — with a structured, planner-usable message, BEFORE any ACP session exists — when the task prompt is empty (`EMPTY_TASK_PROMPT`) or derived only from a link share (`LINK_SHARE_NOT_A_TASK`, pointing the planner at the web-read path).

## What kind of change is this?

Bug fix (non-breaking routing + action-gate fix).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/core/src/services/message/direct-action-heuristics.test.ts` — `looksLikeBareLinkShare` + light-path routing suites
- `packages/core/src/__tests__/message-routing-live-regression.test.ts` — "bare link shares never commit the turn to coding delegation"
- `plugins/plugin-agent-orchestrator/src/__tests__/spawn-link-guard.test.ts` — pre-spawn refusals drive the REAL `tasksAction.handler` against a fake ACP service and assert `spawnSession` is never called

## Detailed testing steps

None: automated tests are acceptable — the suites cover the full matrix:

- bare URL / URL+embed / short non-imperative commentary → link share; explicit build/fix wording, no-URL text, substantial commentary → not a link share
- link share surfaces WEB_FETCH-first candidates (kind `web`); explicit "build … URL" still routes to coding; no web backend → no forced candidate
- a complete reaction to a link share stays direct even with a model-named TASKS_SPAWN_AGENT candidate; explicit build+URL still commits to delegation; an unanswered link share escalates to WEB_FETCH, never a spawn
- spawn gate: link-share message + derived-only task → refused pre-spawn, no ACP session; `create` refused too; empty task prompt → refused pre-spawn; explicit build instruction with a URL spawns exactly once

# Evidence Gate

<!-- evidence-head:a8613b16cc37ffd198cb11540f2b8381b3a3f614 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - routing/action-gate change; no rendered UI surface in the diff.
<!-- evidence-row:after-screenshots -->
- [x] N/A - routing/action-gate change; no rendered UI surface in the diff.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible UI flow; behavior is a backend routing contract covered by deterministic suites below.
<!-- evidence-row:backend-logs -->
- [x] Deterministic owning-suite runs (real handlers):

  <details>
  <summary>core + orchestrator suite output</summary>

  ```
  packages/core src/services/message/direct-action-heuristics.test.ts
   Test Files  1 passed (1)
        Tests  47 passed (47)
  packages/core routing regression (message-routing-live-regression, message-runtime-stage1,
                 candidate-action-backstop, message-handler-bogus-candidates)
   Test Files  4 passed (4)
        Tests  222 passed (222)
  packages/core typecheck: tsc --noEmit - clean
  plugins/plugin-agent-orchestrator (FULL suite + typecheck)
   Test Files  232 passed | 5 skipped (237)
        Tests  2647 passed | 8 skipped (2655)
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code modified.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic heuristic/routing/action-gate change (no prompt or model-call change); the deploying operator live-verifies on the real Discord bot before rollout, per the incident workflow.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts (refusal + routing shapes asserted by the suites):

  ```
  link share + derived task:  success=false error=LINK_SHARE_NOT_A_TASK, spawnSession never called (0 ACP sessions)
  empty task prompt:          success=false error=EMPTY_TASK_PROMPT, spawnSession never called
  explicit build + URL:       success=true, spawnSession called exactly once
  bare link routing:          direct candidates = [WEB_FETCH, WEB_SEARCH] (kind web); TASKS_SPAWN_AGENT never injected
  ```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - this change adds deterministic guards around the model (routing exclusion + pre-spawn action gate); no prompt or model-call path changed.

## Backend + frontend logs

Inline in the Evidence Gate backend-logs row above. Frontend: N/A - no frontend code modified.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` in the development worktree fails at `@elizaos/plugin-anthropic#typecheck` with `Module '"@elizaos/core"' has no exported member 'deepToWellFormedUnicode'` — an environment artifact: that plugin's tsconfig path-maps `@elizaos/core` to `../../../packages/core/dist`, which escapes a nested worktree into a sibling checkout's stale dist (predates #18079). Unrelated to this diff; CI's fresh clone resolves correctly.
- No live-model trajectory attached: the deploying operator live-verifies routing changes on the production Discord bot before rollout; this PR's contract is pinned by the deterministic suites above.
- The graceful-degrade reply for an unfetchable link (403/auth-wall) is exercised at the routing seam (WEB_FETCH surfaced + embed metadata present in message text for the model); WEB_FETCH's own fail-soft behavior is an existing separate surface and is unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
