### PR TITLE
fix(core): smart channel routing for MESSAGE op=send

### DIFF
--- a/packages/core/src/features/advanced-capabilities/actions/message.send-routing.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.send-routing.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Covers MESSAGE op=send smart routing: the exact-beats-prefix confidence
+ * tier, the unresolved-recipient upfront clarify, the last-delivered-channel
+ * preference (write + read), and the admin/owner shortcut over the current /
+ * internal transport. Deterministic mock runtime and connectors — no live
+ * model, no DB.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createMockRuntime } from "../../../testing/mock-runtime";
+import type {
+	ActionResult,
+	Component,
+	IAgentRuntime,
+	Memory,
+} from "../../../types/index.ts";
+import { messageAction } from "./message.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+const ROOM_ID = "00000000-0000-0000-0000-0000000000bb";
+const SENDER_ID = "00000000-0000-0000-0000-0000000000cc";
+const SHADOW_ID = "00000000-0000-0000-0000-0000000000e7";
+
+const baseMessage = {
+	id: "00000000-0000-0000-0000-0000000000aa",
+	roomId: ROOM_ID,
+	entityId: SENDER_ID,
+	agentId: AGENT_ID,
+	content: { text: "tell shadow to stop smoking", source: "discord" },
+	createdAt: 1,
+} as unknown as Memory;
+
+type SentMessage = {
+	target: Record<string, unknown>;
+	text: string;
+	metadata?: Record<string, unknown>;
+};
+
+async function send(
+	runtime: IAgentRuntime,
+	params: Record<string, unknown>,
+	message: Memory = baseMessage,
+): Promise<ActionResult> {
+	const result = await messageAction.handler(
+		runtime,
+		message,
+		undefined,
+		{ parameters: { action: "send", persist: false, ...params } },
+		undefined,
+		undefined,
+	);
+	if (!result) throw new Error("handler returned no result");
+	return result;
+}
+
+describe("MESSAGE op=send exact-beats-prefix tier (ambiguity over-fire fix)", () => {
+	function harness(hookCandidates: Array<Record<string, unknown>>) {
+		const sends: SentMessage[] = [];
+		const resolveTargets = vi.fn(async () => hookCandidates);
+		const runtime = createMockRuntime({
+			agentId: AGENT_ID,
+			logger: { debug() {}, info() {}, warn() {}, error() {} },
+			getMessageConnectors: () => [
+				{
+					source: "discord",
+					label: "Discord",
+					capabilities: [],
+					supportedTargetKinds: ["user", "room", "channel"],
+					contexts: [],
+					resolveTargets,
+				},
+			],
+			getRoom: async () => null,
+			getEntitiesForRoom: async () => [],
+			getEntityById: (async () => null) as IAgentRuntime["getEntityById"],
+			getRelationships: (async () => []) as IAgentRuntime["getRelationships"],
+			sendMessageToTarget: async (target, content) => {
+				sends.push({
+					target: target as unknown as Record<string, unknown>,
+					text: String(content.text ?? ""),
+				});
+				return { id: "00000000-0000-0000-0000-0000000000ff" } as Memory;
+			},
+			useModel: async () => {
+				throw new Error("resolution must be deterministic — no model call");
+			},
+			reportError: () => undefined,
+		});
+		return { runtime, sends, resolveTargets };
+	}
+
+	it("an exact label match beats a prefix match instead of tripping the ambiguity brake", async () => {
+		const { runtime, sends } = harness([
+			{
+				target: { source: "discord", channelId: "dm-shadow", entityId: "111" },
+				label: "shadow",
+				kind: "user",
+				score: 0.95,
+				contexts: [],
+			},
+			{
+				target: {
+					source: "discord",
+					channelId: "dm-shadowfax",
+					entityId: "222",
+				},
+				label: "shadowfax",
+				kind: "user",
+				score: 0.85,
+				contexts: [],
+			},
+		]);
+		const result = await send(runtime, {
+			target: "shadow",
+			targetKind: "user",
+			message: "stop smoking",
+		});
+
+		expect(result.success).toBe(true);
+		expect(sends).toHaveLength(1);
+		expect(sends[0].target).toMatchObject({ channelId: "dm-shadow" });
+	});
+
+	it("two exact matches remain genuinely ambiguous — asks instead of guessing", async () => {
+		const { runtime, sends } = harness([
+			{
+				target: {
+					source: "discord",
+					channelId: "dm-shadow-1",
+					entityId: "111",
+				},
+				label: "shadow",
+				kind: "user",
+				score: 0.95,
+				contexts: [],
+			},
+			{
+				target: {
+					source: "discord",
+					channelId: "dm-shadow-2",
+					entityId: "222",
+				},
+				label: "shadow",
+				kind: "user",
+				score: 0.95,
+				contexts: [],
+			},
+		]);
+		const result = await send(runtime, {
+			target: "shadow",
+			targetKind: "user",
+			message: "stop smoking",
+		});
+
+		expect(result.success).toBe(false);
+		expect((result.data as { error?: string })?.error).toBe("TARGET_AMBIGUOUS");
+		expect(sends).toHaveLength(0);
+	});
+});
+
+describe("MESSAGE op=send unresolved recipient asks upfront (no doomed send)", () => {
+	function harness() {
+		const sends: SentMessage[] = [];
+		const cache = new Map<string, unknown>();
+		const runtime = createMockRuntime({
+			getCache: (async (key: string) =>
+				cache.get(key)) as IAgentRuntime["getCache"],
+			setCache: (async (key: string, value: unknown) => {
+				cache.set(key, value);
+				return true;
+			}) as IAgentRuntime["setCache"],
+			deleteCache: (async (key: string) =>
+				cache.delete(key)) as IAgentRuntime["deleteCache"],
+			agentId: AGENT_ID,
+			logger: { debug() {}, info() {}, warn() {}, error() {} },
+			getMessageConnectors: () => [
+				{
+					source: "discord",
+					label: "Discord",
+					capabilities: [],
+					supportedTargetKinds: ["user", "room", "channel", "email"],
+					contexts: [],
+					resolveTargets: async () => [],
+				},
+			],
+			getRoom: async () => null,
+			getEntitiesForRoom: async () => [],
+			getEntityById: (async () => null) as IAgentRuntime["getEntityById"],
+			getRelationships: (async () => []) as IAgentRuntime["getRelationships"],
+			sendMessageToTarget: async (target, content) => {
+				sends.push({
+					target: target as unknown as Record<string, unknown>,
+					text: String(content.text ?? ""),
+					metadata: content.metadata as Record<string, unknown>,
+				});
+				return { id: "00000000-0000-0000-0000-0000000000ff" } as Memory;
+			},
+			useModel: async () => {
+				throw new Error("resolution must be deterministic — no model call");
+			},
+			reportError: () => undefined,
+		});
+		return { runtime, sends };
+	}
+
+	it("an unresolvable bare name fails fast with a clarify, not a shipped send", async () => {
+		const { runtime, sends } = harness();
+		const result = await send(runtime, {
+			target: "shadow",
+			message: "stop smoking",
+		});
+
+		expect(result.success).toBe(false);
+		expect((result.data as { error?: string })?.error).toBe(
+			"TARGET_UNRESOLVED_RECIPIENT",
+		);
+		expect(result.text).toContain('"shadow"');
+		expect(result.data).not.toMatchObject({ confirmationRequired: true });
+		expect(sends).toHaveLength(0);
+	});
+
+	it("a literal email address is address-routed and delivers without a contact lookup", async () => {
+		const { runtime, sends } = harness();
+		const result = await send(runtime, {
+			target: "shadow@example.com",
+			message: "stop smoking",
+			subject: "A friendly reminder",
+		});
+
+		expect(result.success).toBe(true);
+		expect(sends).toHaveLength(1);
+		expect(sends[0].target).toMatchObject({
+			channelId: "shadow@example.com",
+		});
+		expect(sends[0].metadata).toMatchObject({
+			subject: "A friendly reminder",
+		});
+	});
+
+	it("a numeric platform id stays on the explicit path (not treated as an unknown name)", async () => {
+		const { runtime } = harness();
+		const result = await send(runtime, {
+			target: "555000111222333",
+			targetKind: "user",
+			message: "hey",
+		});
+
+		// The raw platform id proceeds to the recipient gate (confirmation),
+		// never the unresolved-name clarify.
+		expect((result.data as { error?: string })?.error).not.toBe(
+			"TARGET_UNRESOLVED_RECIPIENT",
+		);
+	});
+});
+
+describe("MESSAGE op=send last-delivered-channel preference", () => {
+	function shadowEntity(withPreference: boolean) {
+		const components: Array<{
+			id: string;
+			type: string;
+			sourceEntityId: string;
+			data: Record<string, unknown>;
+		}> = [
+			{
+				id: "00000000-0000-0000-0000-0000000000c1",
+				type: "discord",
+				sourceEntityId: AGENT_ID,
+				data: { channelId: "dm-discord" },
+			},
+			{
+				id: "00000000-0000-0000-0000-0000000000c2",
+				type: "telegram",
+				sourceEntityId: AGENT_ID,
+				data: { channelId: "dm-telegram" },
+			},
+		];
+		if (withPreference) {
+			components.push({
+				id: "00000000-0000-0000-0000-0000000000c3",
+				type: "message_delivery_preference",
+				sourceEntityId: AGENT_ID,
+				data: { source: "telegram" },
+			});
+		}
+		return {
+			id: SHADOW_ID,
+			names: ["Shadow"],
+			agentId: AGENT_ID,
+			components,
+		};
+	}
+
+	function harness(options: { withPreference: boolean }) {
+		const sends: SentMessage[] = [];
+		const upserts: Component[] = [];
+		const entity = shadowEntity(options.withPreference);
+		const runtime = createMockRuntime({
+			agentId: AGENT_ID,
+			logger: { debug() {}, info() {}, warn() {}, error() {} },
+			getMessageConnectors: () => [
+				{
+					source: "discord",
+					label: "Discord",
+					capabilities: [],
+					supportedTargetKinds: ["user", "contact"],
+					contexts: [],
+				},
+				{
+					source: "telegram",
+					label: "Telegram",
+					capabilities: [],
+					supportedTargetKinds: ["user", "contact"],
+					contexts: [],
+				},
+			],
+			// The room's source has no registered connector, so the room-first
+			// member path stays out of the way and the entity path is exercised.
+			getRoom: async () => ({ id: ROOM_ID, name: "app", source: "app" }),
+			getEntitiesForRoom: async () => [entity],
+			getWorld: (async () => null) as IAgentRuntime["getWorld"],
+			getEntityById: (async (id: string) =>
+				id === SHADOW_ID ? entity : null) as IAgentRuntime["getEntityById"],
+			getRelationships: (async () => []) as IAgentRuntime["getRelationships"],
+			getMemories: (async () => []) as IAgentRuntime["getMemories"],
+			sendMessageToTarget: async (target, content) => {
+				sends.push({
+					target: target as unknown as Record<string, unknown>,
+					text: String(content.text ?? ""),
+				});
+				return { id: "00000000-0000-0000-0000-0000000000ff" } as Memory;
+			},
+			upsertComponent: (async (component: Component) => {
+				upserts.push(component);
+			}) as IAgentRuntime["upsertComponent"],
+			// findEntityByName degrades to its sole-candidate heuristic on
+			// unparseable model output — resolution stays deterministic.
+			useModel: (async () => "not-json") as IAgentRuntime["useModel"],
+			reportError: () => undefined,
+		});
+		return { runtime, sends, upserts };
+	}
+
+	it("without a recorded preference, two stored handles stay ambiguous (baseline)", async () => {
+		const { runtime, sends } = harness({ withPreference: false });
+		const message = {
+			...baseMessage,
+			content: { text: "tell shadow to stop smoking", source: "app" },
+		} as Memory;
+		const result = await send(
+			runtime,
+			{ target: "shadow", message: "stop smoking" },
+			message,
+		);
+
+		expect(result.success).toBe(false);
+		expect((result.data as { error?: string })?.error).toBe("TARGET_AMBIGUOUS");
+		expect(sends).toHaveLength(0);
+	});
+
+	it("prefers the channel the person was last reached on", async () => {
+		const { runtime, sends } = harness({ withPreference: true });
+		const message = {
+			...baseMessage,
+			content: { text: "tell shadow to stop smoking", source: "app" },
+		} as Memory;
+		const result = await send(
+			runtime,
+			{ target: "shadow", message: "stop smoking" },
+			message,
+		);
+
+		expect(result.success).toBe(true);
+		expect(sends).toHaveLength(1);
+		expect(sends[0].target).toMatchObject({
+			source: "telegram",
+			channelId: "dm-telegram",
+		});
+		expect(
+			(result.data as { resolutionReasons?: string[] })?.resolutionReasons,
+		).toContain("lastChannel");
+	});
+
+	it("a successful entity delivery records the channel for next time", async () => {
+		const { runtime, upserts } = harness({ withPreference: true });
+		const message = {
+			...baseMessage,
+			content: { text: "tell shadow to stop smoking", source: "app" },
+		} as Memory;
+		const result = await send(
+			runtime,
+			{ target: "shadow", message: "stop smoking" },
+			message,
+		);
+
+		expect(result.success).toBe(true);
+		expect(upserts).toHaveLength(1);
+		expect(upserts[0]).toMatchObject({
+			entityId: SHADOW_ID,
+			type: "message_delivery_preference",
+			data: { source: "telegram" },
+		});
+	});
+});
+
+describe("MESSAGE op=send admin/owner target (app + connector transports)", () => {
+	it("resolves 'owner' through the internal client_chat transport when no connector is registered", async () => {
+		const sends: SentMessage[] = [];
+		const runtime = createMockRuntime({
+			agentId: AGENT_ID,
+			logger: { debug() {}, info() {}, warn() {}, error() {} },
+			getMessageConnectors: () => [],
+			getRoom: async () => null,
+			getSetting: (() => undefined) as IAgentRuntime["getSetting"],
+			sendMessageToTarget: async (target, content) => {
+				sends.push({
+					target: target as unknown as Record<string, unknown>,
+					text: String(content.text ?? ""),
+				});
+				return { id: "00000000-0000-0000-0000-0000000000ff" } as Memory;
+			},
+			useModel: async () => {
+				throw new Error("admin resolution must be deterministic");
+			},
+			reportError: () => undefined,
+		});
+		(
+			runtime as unknown as { sendHandlers: Map<string, unknown> }
+		).sendHandlers = new Map([["client_chat", async () => undefined]]);
+
+		const message = {
+			...baseMessage,
+			content: {
+				text: "message the owner that I'm done",
+				source: "client_chat",
+			},
+		} as Memory;
+		const result = await send(
+			runtime,
+			{ target: "owner", message: "the report is done" },
+			message,
+		);
+
+		expect(result.success).toBe(true);
+		expect(sends).toHaveLength(1);
+		expect(sends[0].target).toMatchObject({
+			source: "client_chat",
+			roomId: ROOM_ID,
+		});
+	});
+
+	it("resolves 'admin' over the current conversation's connector, never a fuzzy user match", async () => {
+		const sends: SentMessage[] = [];
+		const resolveTargets = vi.fn(async () => [
+			{
+				target: { source: "discord", entityId: "999" },
+				label: "@adminlarper",
+				kind: "user" as const,
+				score: 0.95,
+				contexts: [],
+			},
+		]);
+		const runtime = createMockRuntime({
+			agentId: AGENT_ID,
+			logger: { debug() {}, info() {}, warn() {}, error() {} },
+			getMessageConnectors: () => [
+				{
+					source: "discord",
+					label: "Discord",
+					capabilities: [],
+					supportedTargetKinds: ["user", "room", "channel"],
+					contexts: [],
+					resolveTargets,
+				},
+			],
+			getRoom: async () => null,
+			getSetting: (() => undefined) as IAgentRuntime["getSetting"],
+			sendMessageToTarget: async (target, content) => {
+				sends.push({
+					target: target as unknown as Record<string, unknown>,
+					text: String(content.text ?? ""),
+				});
+				return { id: "00000000-0000-0000-0000-0000000000ff" } as Memory;
+			},
+			useModel: async () => {
+				throw new Error("admin resolution must be deterministic");
+			},
+			reportError: () => undefined,
+		});
+
+		const result = await send(runtime, {
+			target: "admin",
+			message: "task finished",
+		});
+
+		expect(result.success).toBe(true);
+		expect(sends).toHaveLength(1);
+		expect(sends[0].target).toMatchObject({ source: "discord" });
+		expect(sends[0].target.entityId).toBeDefined();
+		expect(resolveTargets).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -320,10 +320,13 @@ describe("MESSAGE op=send owner-binding gate", () => {
 		accessGate: "open" | "owner_binding",
 		hasBinding: boolean,
 	): Promise<{ runtime: IAgentRuntime; sent: { called: boolean } }> {
-		const { ConnectorAccountManager } = await import(
-			"../../../connectors/account-manager.ts"
-		);
-		const manager = new ConnectorAccountManager();
+		const { ConnectorAccountManager, InMemoryConnectorAccountStorage } =
+			await import("../../../connectors/account-manager.ts");
+		// getStorage() returns the lazy-resolving facade since #18095, which
+		// carries only the ConnectorAccountStorage contract — seed bindings on an
+		// explicitly injected in-memory backend instead.
+		const storage = new InMemoryConnectorAccountStorage();
+		const manager = new ConnectorAccountManager(undefined, storage);
 		manager.registerProvider({
 			provider: "matrix",
 			listAccounts: () => [
@@ -343,11 +346,7 @@ describe("MESSAGE op=send owner-binding gate", () => {
 			],
 		});
 		if (hasBinding) {
-			(
-				manager.getStorage() as {
-					upsertOwnerBindingForTest(b: unknown): void;
-				}
-			).upsertOwnerBindingForTest({
+			storage.upsertOwnerBindingForTest({
 				id: "binding-1",
 				identityId: "00000000-0000-0000-0000-0000000000cc",
 				connector: "matrix",

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -802,6 +802,24 @@ const VALID_URGENCIES = new Set(["normal", "important", "urgent"]);
 const AMBIGUITY_DELTA = 0.12;
 const AMBIGUITY_SCORE = 0.68;
 
+/** Entity component recording the connector a message to this person last
+ * successfully went out on. Written by handleSend after confirmed delivery and
+ * read back by collectEntityCandidates as a scoring bonus, so a bare
+ * "tell shadow …" prefers the channel shadow was actually last reached on
+ * instead of guessing between platforms. */
+const DELIVERY_PREFERENCE_COMPONENT_TYPE = "message_delivery_preference";
+
+/** Last-channel preference bonus. Must exceed AMBIGUITY_DELTA: two connectors
+ * that both hold stored handles for the same entity tie at the same base
+ * score, and a bonus inside the ambiguity window would still trip the
+ * multiple-plausible-targets brake instead of expressing the preference. It
+ * stays a bonus, not an override — an explicit source/targetKind scopes the
+ * candidate set before this is ever applied. */
+const LAST_CHANNEL_BONUS = 0.15;
+
+/** Email literal: an address-routed target that needs no contact resolution. */
+const EMAIL_LITERAL = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
 type SourceResolution = "exact" | "inferred" | "defaulted";
 
 type NormalizedSendParams = {
@@ -811,6 +829,7 @@ type NormalizedSendParams = {
 	sourceResolution: SourceResolution;
 	targetKind?: MessageTargetKind;
 	message: string;
+	subject?: string;
 	thread?: string;
 	attachments?: Media[];
 	urgency: string;
@@ -824,6 +843,10 @@ type SendCandidate = {
 	description?: string;
 	score: number;
 	reasons: string[];
+	/** True when the candidate's label/handle matches the query exactly (not a
+	 * prefix/substring hit). Exact hits form a higher confidence tier: they win
+	 * equal-score sorting and are not held ambiguous against partial matches. */
+	exact?: boolean;
 	/** When the resolved delivery is an in-room utterance aimed at a specific
 	 * room participant (the room-first name resolution), the member to address
 	 * in the outgoing text. Absent for every other candidate shape. */
@@ -1042,6 +1065,7 @@ function normalizeSendParams(
 		sourceResolution,
 		targetKind,
 		message: messageText,
+		subject: textParam(raw.subject),
 		thread: textParam(raw.thread),
 		attachments: normalizeAttachments(raw.attachments),
 		urgency: textParam(raw.urgency) ?? "normal",
@@ -1099,6 +1123,16 @@ function scoreHookCandidate(
 	return Math.max(0, Math.min(1, score));
 }
 
+function labelMatchesQuery(
+	label: string | undefined,
+	query: string | undefined,
+): boolean {
+	if (!label || !query) return false;
+	return (
+		normalizeComparable(label) === normalizeComparable(stripTargetPrefix(query))
+	);
+}
+
 function normalizeHookCandidate(
 	connector: ConnectorWithHooks,
 	raw: MessageConnectorTarget,
@@ -1116,10 +1150,16 @@ function normalizeHookCandidate(
 		source: raw.target.source || connector.source,
 		accountId: raw.target.accountId ?? connector.accountId ?? accountId,
 	} as TargetInfo;
+	const label = raw.label ?? targetLabel(target);
+	const exact =
+		labelMatchesQuery(label, query) ||
+		[raw.target.channelId, raw.target.entityId]
+			.filter((value): value is string => typeof value === "string")
+			.some((value) => labelMatchesQuery(value, query));
 	return {
 		connector,
 		target,
-		label: raw.label ?? targetLabel(target),
+		label,
 		kind: raw.kind ?? targetKind,
 		description: raw.description,
 		score: scoreHookCandidate(
@@ -1131,6 +1171,7 @@ function normalizeHookCandidate(
 			reasons,
 		),
 		reasons,
+		exact,
 	};
 }
 
@@ -1290,6 +1331,12 @@ function explicitSendTarget(
 	} else if (isUuidLike(value)) {
 		kind = "room";
 		target.roomId = value;
+	} else if (EMAIL_LITERAL.test(value)) {
+		// A literal email address is an unambiguous, address-routed target: it
+		// needs no contact lookup and no recipient confirmation to deliver.
+		kind = "email";
+		target.entityId = value as UUID;
+		target.channelId = value;
 	} else {
 		kind = targetKind ?? "contact";
 		target.entityId = stripped as UUID;
@@ -1303,6 +1350,41 @@ function explicitSendTarget(
 		score: sourceWasExact ? 0.64 : 0.52,
 		reasons: ["explicitTarget"],
 	};
+}
+
+/** Values deliverable without a name lookup — numeric platform ids, phone dial
+ * strings, email addresses. These stay on the explicit-target path instead of
+ * being treated as an unresolved human name. */
+function isAddressShaped(value: string): boolean {
+	return (
+		/^\d{6,}$/.test(value) ||
+		/^\+?\d[\d\s().-]{5,}$/.test(value) ||
+		EMAIL_LITERAL.test(value)
+	);
+}
+
+/**
+ * True when the top candidate is nothing but the raw-string person fallback —
+ * no room member, entity, or connector hook corroborated the name. Shipping it
+ * anyway just fails downstream at the connector ("could not resolve user")
+ * after a wasted confirmation round, so resolution converts it into an upfront
+ * question instead.
+ */
+function isUnresolvedPersonFallback(candidate: SendCandidate): boolean {
+	if (
+		candidate.reasons.length === 0 ||
+		!candidate.reasons.every((reason) => reason === "explicitTarget")
+	) {
+		return false;
+	}
+	if (candidate.target.channelId || candidate.target.roomId) return false;
+	const entityId = String(candidate.target.entityId ?? "").trim();
+	if (!entityId || isUuidLike(entityId) || isAddressShaped(entityId)) {
+		return false;
+	}
+	if (!candidate.kind) return true;
+	const aliases = kindAliases(candidate.kind);
+	return aliases.has("user") || aliases.has("contact");
 }
 
 function componentString(
@@ -1352,6 +1434,10 @@ async function collectEntityCandidates(
 	if (!entity?.id) return [];
 
 	const label = entity.names[0] ?? query;
+	const preferredSource = preferredDeliverySource(entity);
+	const exact = entityDisplayNames(entity).some((name) =>
+		labelMatchesQuery(name, query),
+	);
 	const candidates: SendCandidate[] = [];
 	for (const connector of connectors) {
 		if (!connectorSupportsKind(connector, targetKind ?? "contact")) continue;
@@ -1379,16 +1465,41 @@ async function collectEntityCandidates(
 			const serverId = componentString(matchingComponent, ["serverId"]);
 			if (serverId) target.serverId = serverId;
 		}
+		const lastChannel =
+			preferredSource !== undefined &&
+			normalizeComparable(connector.source) ===
+				normalizeComparable(preferredSource);
+		const reasons = matchingComponent ? ["entity", "component"] : ["entity"];
+		if (lastChannel) reasons.push("lastChannel");
 		candidates.push({
 			connector,
 			target,
 			label,
 			kind: targetKind ?? "contact",
-			score: matchingComponent ? 0.78 : sourceWasExact ? 0.66 : 0.56,
-			reasons: matchingComponent ? ["entity", "component"] : ["entity"],
+			score:
+				(matchingComponent ? 0.78 : sourceWasExact ? 0.66 : 0.56) +
+				(lastChannel ? LAST_CHANNEL_BONUS : 0),
+			reasons,
+			exact,
 		});
 	}
 	return candidates;
+}
+
+/** The connector this entity was last successfully reached on, if recorded.
+ * Read from the entity's already-loaded components — no extra lookup. */
+function preferredDeliverySource(entity: {
+	components?: Array<{ type?: string; data?: Record<string, unknown> }>;
+}): string | undefined {
+	const component = entity.components?.find(
+		(c) =>
+			normalizeComparable(c.type) ===
+			normalizeComparable(DELIVERY_PREFERENCE_COMPONENT_TYPE),
+	);
+	const source = component?.data?.source;
+	return typeof source === "string" && source.trim().length > 0
+		? source.trim()
+		: undefined;
 }
 
 async function currentRoomCandidate(
@@ -1534,6 +1645,7 @@ async function currentRoomMemberCandidates(
 		// candidate (hook base 0.74 + boosts) without an LLM in the loop.
 		score: 0.97,
 		reasons: ["currentRoomMember"],
+		exact: true,
 		address: member,
 	}));
 }
@@ -1551,10 +1663,22 @@ function dedupeCandidates(candidates: SendCandidate[]): SendCandidate[] {
 			c.target.threadId,
 		].join("|");
 		const existing = byKey.get(key);
-		if (!existing || c.score > existing.score) byKey.set(key, c);
+		if (
+			!existing ||
+			c.score > existing.score ||
+			(c.score === existing.score &&
+				c.exact === true &&
+				existing.exact !== true)
+		)
+			byKey.set(key, c);
 	}
 	return Array.from(byKey.values()).sort((l, r) => {
 		if (r.score !== l.score) return r.score - l.score;
+		// The 1.0 clamp saturates exact and prefix hits into the same score, so
+		// tier before the alphabetical fallback can promote the wrong candidate.
+		const lExact = l.exact === true ? 1 : 0;
+		const rExact = r.exact === true ? 1 : 0;
+		if (rExact !== lExact) return rExact - lExact;
 		return l.label.localeCompare(r.label);
 	});
 }
@@ -1569,6 +1693,39 @@ function formatCandidates(candidates: SendCandidate[]): string {
 		.join("\n");
 }
 
+/**
+ * Resolve a runtime-internal send transport (e.g. the dashboard's
+ * `client_chat` handler) that registers a send handler without advertising a
+ * user-selectable MessageConnector. Only the admin/owner shortcut consults
+ * this; ordinary target resolution must never route arbitrary sends through
+ * internal transports.
+ */
+function internalSendConnector(
+	runtime: IAgentRuntime,
+	source: string,
+): ConnectorWithHooks | null {
+	const sendHandlers = (runtime as RuntimeWithLegacySendHandlers).sendHandlers;
+	if (!(sendHandlers instanceof Map) || !sendHandlers.has(source)) return null;
+	return {
+		source,
+		label: source
+			.replace(/[_-]+/g, " ")
+			.replace(/\b\w/g, (c) => c.toUpperCase()),
+		capabilities: ["send_message"],
+		supportedTargetKinds: [],
+		contexts: [],
+	};
+}
+
+/**
+ * "Message the owner/admin" resolves to the canonical owner over the transport
+ * the request arrived on. Source preference: an explicit `source` param, then
+ * the current conversation's connector, then the internal dashboard transport
+ * (`client_chat`) — which is a registered send handler but deliberately not a
+ * MessageConnector, so it needs the sendHandlers fallback here. Without that
+ * fallback the literal word "admin" fell through to connector-wide fuzzy user
+ * matching.
+ */
 async function resolveAdminTarget(
 	runtime: IAgentRuntime,
 	message: Memory,
@@ -1577,19 +1734,41 @@ async function resolveAdminTarget(
 ): Promise<SendCandidate | null> {
 	if (!params.target || !ADMIN_TARGETS.has(params.target.toLowerCase()))
 		return null;
-	const source = params.source ?? MESSAGE_SOURCE_CLIENT_CHAT;
-	const connector = findConnectorBySource(connectors, source);
+	const envelopeSource = trustedConnectorSource(message);
+	const source = params.source ?? envelopeSource ?? MESSAGE_SOURCE_CLIENT_CHAT;
+	const accountId =
+		params.accountId ??
+		(!params.source && source === envelopeSource
+			? trustedConnectorAccountId(message)
+			: undefined);
+	const sourceMatches = connectors.filter((connector) =>
+		connectorAliases(connector).some(
+			(alias) => normalizeComparable(alias) === normalizeComparable(source),
+		),
+	);
+	const scoped = selectAccountConnectors(sourceMatches, accountId);
+	// More than one account on the resolved source is a genuine account choice;
+	// fall through so the generic account scoping surfaces it to the user.
+	if (scoped.length > 1) return null;
+	const registered = scoped[0];
+	const connector = registered ?? internalSendConnector(runtime, source);
 	if (!connector) return null;
 	const ownerId =
 		(await resolveCanonicalOwnerIdForMessage(runtime, message)) ??
 		stringToUuid(`${runtime.character.name ?? runtime.agentId}-admin-entity`);
+	const target = {
+		source: connector.source,
+		accountId: connector.accountId ?? accountId,
+		entityId: ownerId as UUID,
+	} as TargetInfo;
+	if (!registered) {
+		// Internal transports route by conversation room, not entity id: pin the
+		// originating room so delivery lands in the user's active conversation.
+		target.roomId = message.roomId;
+	}
 	return {
 		connector,
-		target: {
-			source: connector.source,
-			accountId: connector.accountId ?? params.accountId,
-			entityId: ownerId as UUID,
-		} as TargetInfo,
+		target,
 		label: params.target,
 		kind: "contact",
 		score: 1,
@@ -1604,6 +1783,23 @@ async function resolveSendTarget(
 	connectors: ConnectorWithHooks[],
 	params: NormalizedSendParams,
 ): Promise<TargetResolution> {
+	// The admin/owner shortcut resolves before connector scoping: it must work
+	// even when zero user-selectable connectors are registered (app-only
+	// installs deliver through the internal client_chat transport).
+	const adminCandidate = await resolveAdminTarget(
+		runtime,
+		message,
+		connectors,
+		params,
+	);
+	if (adminCandidate) {
+		return {
+			status: "resolved",
+			candidate: adminCandidate,
+			sourceResolution: params.source ? params.sourceResolution : "defaulted",
+		};
+	}
+
 	if (connectors.length === 0) {
 		return {
 			status: "missing_connector",
@@ -1656,20 +1852,6 @@ async function resolveSendTarget(
 	}
 	const exact =
 		params.source && accountScoped.length === 1 ? accountScoped[0] : undefined;
-
-	const adminCandidate = await resolveAdminTarget(
-		runtime,
-		message,
-		accountScoped,
-		params,
-	);
-	if (adminCandidate) {
-		return {
-			status: "resolved",
-			candidate: adminCandidate,
-			sourceResolution: params.source ? params.sourceResolution : "defaulted",
-		};
-	}
 
 	const sourceWasExact = Boolean(params.source && exact);
 	let considered = exact
@@ -1806,8 +1988,28 @@ async function resolveSendTarget(
 			sourceResolution: params.sourceResolution,
 		};
 	}
+	// A raw-name fallback that nothing corroborated is not a deliverable
+	// recipient — turn it into an upfront question instead of a doomed send.
+	if (isUnresolvedPersonFallback(top)) {
+		return {
+			status: "missing_target",
+			text:
+				`MESSAGE op=send could not find "${params.target}" in the current room, saved contacts, or connector lookups. ` +
+				`Ask the user who "${params.target}" is — a contact name, @handle, #channel, or literal address — before retrying.`,
+			error: "TARGET_UNRESOLVED_RECIPIENT",
+			sourceResolution: params.sourceResolution,
+		};
+	}
+
 	const ambiguous = sorted.filter(
-		(c) => c !== top && Math.abs(top.score - c.score) <= AMBIGUITY_DELTA,
+		(c) =>
+			c !== top &&
+			Math.abs(top.score - c.score) <= AMBIGUITY_DELTA &&
+			// An exact name/label hit is a higher confidence tier than the prefix/
+			// substring matches sharing its score band (both clamp to 1.0):
+			// "shadow" is not ambiguous against "shadowfax". Two exact hits remain
+			// genuinely ambiguous.
+			(top.exact !== true || c.exact === true),
 	);
 	if (
 		ambiguous.length > 0 &&
@@ -1859,10 +2061,65 @@ function buildContent(params: NormalizedSendParams): Content {
 			urgency: params.urgency,
 			targetKind: params.targetKind,
 			accountId: params.accountId,
+			...(params.subject ? { subject: params.subject } : {}),
 		},
 	};
 	if (params.attachments) content.attachments = params.attachments;
 	return content;
+}
+
+/**
+ * Remember the channel a person was last successfully reached on. Stored as an
+ * entity component and read back by collectEntityCandidates as a scoring
+ * bonus, so the next bare "tell <name> …" prefers the connector that actually
+ * reached them. Recorded only for entity-backed recipients (room members and
+ * rolodex contacts) — raw platform ids carry no entity to attach it to.
+ */
+async function recordDeliveryPreference(
+	runtime: IAgentRuntime,
+	message: Memory,
+	candidate: SendCandidate,
+	target: TargetInfo,
+): Promise<void> {
+	const entityIdRaw = String(target.entityId ?? "").trim();
+	const entityId =
+		candidate.address?.entityId ??
+		(isUuidLike(entityIdRaw) ? (entityIdRaw as UUID) : undefined);
+	if (
+		!entityId ||
+		entityId === runtime.agentId ||
+		typeof runtime.upsertComponent !== "function"
+	) {
+		return;
+	}
+	try {
+		await runtime.upsertComponent({
+			id: stringToUuid(
+				`delivery-preference-${entityId}-${runtime.agentId}`,
+			) as UUID,
+			entityId,
+			agentId: runtime.agentId,
+			roomId: message.roomId,
+			worldId:
+				message.worldId ??
+				(stringToUuid(`${runtime.agentId}:delivery-preference-world`) as UUID),
+			sourceEntityId: runtime.agentId,
+			type: DELIVERY_PREFERENCE_COMPONENT_TYPE,
+			createdAt: Date.now(),
+			data: {
+				source: candidate.connector.source,
+				...(target.accountId ? { accountId: target.accountId } : {}),
+				lastDeliveredAtMs: Date.now(),
+			},
+		});
+	} catch (error) {
+		// error-policy:J7 preference recording is delivery telemetry; a failed
+		// write must not turn an already-delivered send into a failure.
+		runtime.reportError("MESSAGE.recordDeliveryPreference", error, {
+			source: candidate.connector.source,
+			entityId,
+		});
+	}
 }
 
 function applyContentShaping(
@@ -2616,6 +2873,7 @@ async function handleSend(
 					? persistedMetadata.messageIdFull
 					: undefined;
 	}
+	await recordDeliveryPreference(runtime, message, selected, target);
 	await persistCurrentChatMemory({
 		runtime,
 		message,
@@ -4345,9 +4603,9 @@ export const MESSAGE_PARAMETERS: ActionParameter[] = [
 	},
 	{
 		name: "subject",
-		description: "Subject for email-like draft operations.",
+		description: "Subject for email-like sends and draft operations.",
 		required: false,
-		subactions: ["draft_followup", "send_draft"],
+		subactions: ["send", "draft_followup", "send_draft"],
 		schema: { type: "string" },
 	},
 	{


### PR DESCRIPTION
## What

Four structural fixes to `MESSAGE op=send` target resolution in `packages/core/src/features/advanced-capabilities/actions/message.ts`, plus a small send-surface addition (`subject` param, email-literal targets) and a repair for the owner-binding test harness broken on develop by #18095.

### 1. Remember the last channel per person
A successful entity-backed delivery now upserts a `message_delivery_preference` component on the recipient entity (`recordDeliveryPreference`, called from the `handleSend` success path). `collectEntityCandidates` reads it back and gives the last-used connector a `LAST_CHANNEL_BONUS` (0.15, deliberately > `AMBIGUITY_DELTA` so it actually breaks the two-stored-handles tie instead of still tripping the ambiguity brake). It is a bonus, not an override: an explicit `source`/`targetKind` scopes the candidate set before the bonus is ever applied, so "email shadow" still wins over shadow's discord preference. Applied candidates carry a `lastChannel` resolution reason for observability.

### 2. Exact match no longer trips the ambiguity brake
The 1.0 score clamp saturated exact (0.95 + bonuses) and prefix (0.85 + bonuses) hook hits into the same score, so "shadow" tied "shadowfax", sort order fell to the alphabetical tiebreak, and the ambiguity brake fired on an obvious exact match. Candidates now carry an `exact` tier (label/handle equals the query after normalization): exact wins equal-score dedupe and sorting, and a lower-tier candidate inside the score window no longer counts as ambiguity. Two exact hits still ask.

### 3. Unknown names ask upfront instead of failing at delivery
A raw-string person fallback that nothing corroborated (no room member, no entity, no connector hook) scored 0.52 — above the 0.5 send floor — so an unresolvable "shadow" shipped to the connector, burned a confirmation round, and then failed with the connector's "could not resolve user". Resolution now returns `TARGET_UNRESOLVED_RECIPIENT` with a clarify prompt before anything ships. Address-shaped values (email literals, phone dial strings, numeric platform ids) are exempt and stay deliverable.

### 4. "Message the owner/admin" works from the app
`resolveAdminTarget` defaulted to `client_chat`, which is a registered send handler but deliberately not a `MessageConnector`, so it returned null and the literal word "admin" fell through to connector-wide fuzzy user matching. It now resolves: explicit `source` param → the current conversation's connector (envelope-account scoped) → the internal `client_chat` transport (send-handler fallback, target pinned to the originating room). The admin path also runs before connector scoping, so it works on app-only installs with zero registered connectors.

### Also
- `MESSAGE op=send` accepts an optional `subject` param, carried as `content.metadata.subject` for email-like connectors (spec entry extended, additive).
- A bare email-literal `target` is recognized as an address-routed `email` kind (channelId = address) instead of a fuzzy contact guess.
- Test-harness repair: `getStorage()` returns the lazy-resolving facade since #18095 (no `upsertOwnerBindingForTest`), which broke the owner-binding suite on develop tip. The harness now injects an explicit `InMemoryConnectorAccountStorage` via the constructor seam.

## Test matrix

New `message.send-routing.test.ts` (10 tests, deterministic, no live model/DB):
- exact-beats-prefix resolves "shadow" over "shadowfax"; two exact "shadow"s stay `TARGET_AMBIGUOUS`
- unresolvable bare name → `TARGET_UNRESOLVED_RECIPIENT`, nothing sent, no confirmation round
- email literal delivers address-routed with `metadata.subject`; numeric platform id stays on the explicit path
- two stored handles tie → ambiguous (baseline); with a recorded preference the last channel wins and carries the `lastChannel` reason; successful delivery records the preference component
- "owner" from the app (zero connectors) delivers via the internal `client_chat` transport pinned to the originating room; "admin" from a connector room resolves over that connector without any fuzzy `resolveTargets` call

```
packages/core: vitest src/features/advanced-capabilities/ src/features/messaging/  → 36 files, 298 tests passed (pre-harness-fix baseline)
packages/core: vitest src/features/advanced-capabilities/actions/                  → 7 files, 73 tests passed (incl. 10 new)
packages/core: tsc --noEmit                                                        → clean
biome check (changed files)                                                        → clean
```

No public type changes: `SendCandidate` is file-local; the `subject` spec entry and the new error code are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - core-only messaging change (packages/core action resolution); no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - core-only messaging change; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing UI flow; the behavior is a backend action path, exercised end to end by the deterministic suite below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — full owning-suite run through the real `messageAction.handler` path (resolution → gates → transport dispatch → persistence hooks):

<details>
<summary>vitest: core advanced-capabilities + messaging suites</summary>

```
$ cd packages/core && bunx vitest run src/features/advanced-capabilities/ src/features/messaging/
 RUN  v4.1.5 packages/core
 Test Files  36 passed (36)
      Tests  298 passed (298)

$ cd packages/core && bunx vitest run src/features/advanced-capabilities/actions/
 ✓ message.send-routing.test.ts  (10 tests) — exact-beats-prefix, unresolved-recipient clarify,
   last-channel preference (read + write), admin/owner via internal client_chat + connector transport
 ✓ message.test.ts               (29 tests) — list_connections, owner-binding gate, delivery evidence,
   room-first resolution, stranger-DM confirmation gate, i18n op inference
 ✓ message.list-muted.test.ts    (7 tests)
 Test Files  7 passed (7)
      Tests  73 passed (73)

$ cd packages/core && bunx tsc --noEmit -p tsconfig.json   # exit 0
$ bunx biome check src/features/advanced-capabilities/actions/message.ts \
    src/features/advanced-capabilities/actions/message.send-routing.test.ts \
    src/features/advanced-capabilities/actions/message.test.ts             # clean
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend surface; the change is entirely inside the core MESSAGE action.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - the changed resolution paths are deliberately deterministic (the new tests assert no model call is made: useModel throws in every routing harness). No prompt/model surface changes beyond one additive optional 'subject' parameter. Live-bot verification is deferred to the operator by design — CI must not send real messages, and the running bot is not restarted from PRs.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the persisted delivery-preference component (the new DB-backed artifact this PR introduces) is asserted structurally:

<details>
<summary>component upsert assertion (message.send-routing.test.ts)</summary>

```
✓ a successful entity delivery records the channel for next time
  expect(upserts[0]).toMatchObject({
    entityId: SHADOW_ID,
    type: "message_delivery_preference",
    data: { source: "telegram" },
  })
✓ prefers the channel the person was last reached on
  resolutionReasons contains "lastChannel"; delivery target = { source: "telegram", channelId: "dm-telegram" }
```

</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface in this change.`

<!-- evidence-head:8e3b1344399fb87d6e85144ad89027207d9518b3 -->

# Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
