### PR TITLE
feat(plugin-google-workspace): wire gmail as a MESSAGE send connector, re-enable new-email send

### DIFF
--- a/plugins/plugin-google-workspace/AGENTS.md
+++ b/plugins/plugin-google-workspace/AGENTS.md
@@ -4,7 +4,7 @@ Google Workspace integration for Gmail, Calendar, Drive, and Meet with account-s
 
 ## Purpose / role
 
-Adds `GoogleWorkspaceService` to an Eliza agent runtime, exposing Gmail, Google Calendar, Google Drive, and Google Meet operations through a single account-scoped OAuth grant. It also exports `GoogleGmailAdapter`, the Gmail-owned message-triage adapter used by assistant plugins such as LifeOps. The plugin is opt-in — load it as `googlePlugin` from this package. It also registers with `ConnectorAccountManager` so the generic connector HTTP routes can manage Google accounts and run OAuth flows automatically.
+Adds `GoogleWorkspaceService` to an Eliza agent runtime, exposing Gmail, Google Calendar, Google Drive, and Google Meet operations through a single account-scoped OAuth grant. It also exports `GoogleGmailAdapter`, the Gmail-owned message-triage adapter used by assistant plugins such as LifeOps. The plugin is opt-in — load it as `googlePlugin` from this package. It also registers with `ConnectorAccountManager` so the generic connector HTTP routes can manage Google accounts and run OAuth flows automatically; that provider registration also mounts the Gmail send `MessageConnector` (`source: "gmail"`, aliases `email`/`mail`) so `MESSAGE op=send` can compose and send email through the connected account.
 
 Google Chat lives here too, as the `src/chat/` module: `GoogleChatService` (service type `"google-chat"`) registers a runtime `MessageConnector` for spaces, DMs, threads, reactions, and attachments, and `GoogleChatWorkflowCredentialProvider` (service type `"workflow_credential_provider"`) supplies `googleChatOAuth2Api` credentials to the workflow plugin. Chat authenticates with a service account (scope `https://www.googleapis.com/auth/chat.bot`), NOT the consolidated Workspace OAuth grant — the two auth models are intentionally separate even though they share this package. The plugin auto-enables when a `connectors.googlechat` block is present and not explicitly disabled (`auto-enable.ts`); the Workspace OAuth side stays opt-in.
 
@@ -13,7 +13,8 @@ Google Chat lives here too, as the `src/chat/` module: `GoogleChatService` (serv
 The plugin object (`googlePlugin`, service name `"google"`) registers:
 
 - **Services:** `GoogleWorkspaceService` — wraps four sub-clients (Gmail, Calendar, Drive, Meet), retrieved via `runtime.getService("google")`; `GoogleChatService` — the Chat connector, retrieved via `runtime.getService("google-chat")`; `GoogleChatWorkflowCredentialProvider` — workflow credential supplier.
-- **Message adapters:** `GoogleGmailAdapter` — Gmail projection into the core message-triage shape for assistant plugins.
+- **Message adapters:** `GoogleGmailAdapter` — Gmail projection into the core message-triage shape for assistant plugins (thread replies and new outbound email).
+- **Message connectors:** the Gmail send connector from `gmail-message-connector.ts`, registered through the Google connector-account provider — routes `MESSAGE op=send source=gmail` / email-literal targets to `GoogleWorkspaceService.sendGmailMessage`.
 - **Actions:** none (empty array).
 - **Providers:** none (registered separately via `ConnectorAccountManager` at init time).
 - **Events:** none.
@@ -63,6 +64,7 @@ src/
   connector-credential-refs.ts   Credential ref persistence helpers (persistConnectorCredentialRefs)
   service.ts                   GoogleWorkspaceService — assembles the four sub-clients
   gmail.ts                     GoogleGmailClient — all Gmail operations
+  gmail-message-connector.ts   Gmail send MessageConnector (MESSAGE op=send source=gmail)
   lifeops-message-adapter.ts   GoogleGmailAdapter for assistant/LifeOps message triage registration
   calendar.ts                  GoogleCalendarClient — Calendar list/CRUD
   drive.ts                     GoogleDriveClient — Drive/Docs/Sheets operations

--- a/plugins/plugin-google-workspace/CLAUDE.md
+++ b/plugins/plugin-google-workspace/CLAUDE.md
@@ -4,7 +4,7 @@ Google Workspace integration for Gmail, Calendar, Drive, and Meet with account-s
 
 ## Purpose / role
 
-Adds `GoogleWorkspaceService` to an Eliza agent runtime, exposing Gmail, Google Calendar, Google Drive, and Google Meet operations through a single account-scoped OAuth grant. It also exports `GoogleGmailAdapter`, the Gmail-owned message-triage adapter used by assistant plugins such as LifeOps. The plugin is opt-in — load it as `googlePlugin` from this package. It also registers with `ConnectorAccountManager` so the generic connector HTTP routes can manage Google accounts and run OAuth flows automatically.
+Adds `GoogleWorkspaceService` to an Eliza agent runtime, exposing Gmail, Google Calendar, Google Drive, and Google Meet operations through a single account-scoped OAuth grant. It also exports `GoogleGmailAdapter`, the Gmail-owned message-triage adapter used by assistant plugins such as LifeOps. The plugin is opt-in — load it as `googlePlugin` from this package. It also registers with `ConnectorAccountManager` so the generic connector HTTP routes can manage Google accounts and run OAuth flows automatically; that provider registration also mounts the Gmail send `MessageConnector` (`source: "gmail"`, aliases `email`/`mail`) so `MESSAGE op=send` can compose and send email through the connected account.
 
 Google Chat lives here too, as the `src/chat/` module: `GoogleChatService` (service type `"google-chat"`) registers a runtime `MessageConnector` for spaces, DMs, threads, reactions, and attachments, and `GoogleChatWorkflowCredentialProvider` (service type `"workflow_credential_provider"`) supplies `googleChatOAuth2Api` credentials to the workflow plugin. Chat authenticates with a service account (scope `https://www.googleapis.com/auth/chat.bot`), NOT the consolidated Workspace OAuth grant — the two auth models are intentionally separate even though they share this package. The plugin auto-enables when a `connectors.googlechat` block is present and not explicitly disabled (`auto-enable.ts`); the Workspace OAuth side stays opt-in.
 
@@ -13,7 +13,8 @@ Google Chat lives here too, as the `src/chat/` module: `GoogleChatService` (serv
 The plugin object (`googlePlugin`, service name `"google"`) registers:
 
 - **Services:** `GoogleWorkspaceService` — wraps four sub-clients (Gmail, Calendar, Drive, Meet), retrieved via `runtime.getService("google")`; `GoogleChatService` — the Chat connector, retrieved via `runtime.getService("google-chat")`; `GoogleChatWorkflowCredentialProvider` — workflow credential supplier.
-- **Message adapters:** `GoogleGmailAdapter` — Gmail projection into the core message-triage shape for assistant plugins.
+- **Message adapters:** `GoogleGmailAdapter` — Gmail projection into the core message-triage shape for assistant plugins (thread replies and new outbound email).
+- **Message connectors:** the Gmail send connector from `gmail-message-connector.ts`, registered through the Google connector-account provider — routes `MESSAGE op=send source=gmail` / email-literal targets to `GoogleWorkspaceService.sendGmailMessage`.
 - **Actions:** none (empty array).
 - **Providers:** none (registered separately via `ConnectorAccountManager` at init time).
 - **Events:** none.
@@ -63,6 +64,7 @@ src/
   connector-credential-refs.ts   Credential ref persistence helpers (persistConnectorCredentialRefs)
   service.ts                   GoogleWorkspaceService — assembles the four sub-clients
   gmail.ts                     GoogleGmailClient — all Gmail operations
+  gmail-message-connector.ts   Gmail send MessageConnector (MESSAGE op=send source=gmail)
   lifeops-message-adapter.ts   GoogleGmailAdapter for assistant/LifeOps message triage registration
   calendar.ts                  GoogleCalendarClient — Calendar list/CRUD
   drive.ts                     GoogleDriveClient — Drive/Docs/Sheets operations

--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -31,6 +31,7 @@ import {
 } from "@elizaos/core";
 import { GOOGLE_OAUTH_PROVIDER_METADATA } from "./auth.js";
 import { persistConnectorCredentialRefs } from "./connector-credential-refs.js";
+import { createGmailMessageConnector } from "./gmail-message-connector.js";
 import {
   GOOGLE_CAPABILITIES,
   GOOGLE_IDENTITY_SCOPES,
@@ -362,6 +363,11 @@ export function createGoogleConnectorAccountProvider(
   return {
     provider: GOOGLE_SERVICE_NAME,
     label: GOOGLE_OAUTH_PROVIDER_METADATA.label,
+
+    // Registering the provider also registers Gmail as a MESSAGE send
+    // connector, so `op=send source=gmail` (aliases "email"/"mail") routes to
+    // Gmail compose+send instead of SOURCE_CONNECTOR_NOT_FOUND.
+    messageConnector: createGmailMessageConnector(runtime),
 
     listAccounts: async (manager: ConnectorAccountManager): Promise<ConnectorAccount[]> => {
       return manager.getStorage().listAccounts(GOOGLE_SERVICE_NAME);

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Unit coverage for the Gmail send MessageConnector: provider wire-up
+ * (registering the Google connector-account provider registers a `gmail` send
+ * connector, closing the SOURCE_CONNECTOR_NOT_FOUND gap), literal-address and
+ * entity-handle recipient resolution, account selection, subject derivation,
+ * and the structural delivery receipt. Mock runtime and Google service stubs —
+ * no live Gmail API, nothing is actually sent.
+ */
+import {
+  CONNECTOR_ACCOUNT_SERVICE_TYPE,
+  type Content,
+  getConnectorAccountManager,
+  type IAgentRuntime,
+  type MessageConnectorRegistration,
+  type SendHandlerOutcome,
+  type TargetInfo,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { createGoogleConnectorAccountProvider } from "./connector-account-provider.js";
+import {
+  createGmailMessageConnector,
+  GMAIL_MESSAGE_SOURCE,
+  isEmailAddress,
+} from "./gmail-message-connector.js";
+
+const SHADOW_ID = "00000000-0000-0000-0000-0000000000e7";
+
+type AccountStub = {
+  id: string;
+  status: string;
+  displayHandle?: string;
+  metadata?: Record<string, unknown>;
+};
+
+function runtimeStub(options: {
+  accounts?: AccountStub[];
+  sendGmailMessage?: ReturnType<typeof vi.fn>;
+  entity?: { id: string; names: string[]; components?: Array<Record<string, unknown>> };
+}): {
+  runtime: IAgentRuntime;
+  sendGmailMessage: ReturnType<typeof vi.fn>;
+} {
+  const sendGmailMessage =
+    options.sendGmailMessage ??
+    vi.fn(async () => ({ messageId: "sent_1", threadId: "thread_1", labelIds: ["SENT"] }));
+  const accountManager = {
+    registerProvider: vi.fn(),
+    evaluatePolicy: vi.fn(),
+    listAccounts: vi.fn(async () => options.accounts ?? []),
+  };
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    getService: vi.fn((serviceType: string) => {
+      if (serviceType === "google") return { sendGmailMessage };
+      if (serviceType === CONNECTOR_ACCOUNT_SERVICE_TYPE) return accountManager;
+      return null;
+    }),
+    getEntityById: vi.fn(async (id: string) =>
+      options.entity && id === options.entity.id ? options.entity : null
+    ),
+  } as unknown as IAgentRuntime;
+  return { runtime, sendGmailMessage };
+}
+
+async function invokeSend(
+  registration: MessageConnectorRegistration,
+  runtime: IAgentRuntime,
+  target: Partial<TargetInfo>,
+  content: Content
+): Promise<SendHandlerOutcome> {
+  if (!registration.sendHandler) throw new Error("sendHandler missing");
+  const result = await registration.sendHandler(
+    runtime,
+    { source: GMAIL_MESSAGE_SOURCE, ...target } as TargetInfo,
+    content
+  );
+  if (!result || !("kind" in result)) {
+    throw new Error("sendHandler must return a structural outcome");
+  }
+  return result as SendHandlerOutcome;
+}
+
+const CONNECTED_ACCOUNT: AccountStub = {
+  id: "acct_google_1",
+  status: "connected",
+  displayHandle: "owner@example.com",
+  metadata: { grantedCapabilities: ["gmail.read", "gmail.send"] },
+};
+
+describe("gmail send connector wire-up", () => {
+  it("registering the Google provider registers gmail as a send-target MessageConnector", () => {
+    const registered: MessageConnectorRegistration[] = [];
+    const managerRuntime = {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      getService: () => null,
+      getMessageConnectors: () => [],
+      getPostConnectors: () => [],
+      registerMessageConnector: (registration: MessageConnectorRegistration) => {
+        registered.push(registration);
+      },
+    } as unknown as IAgentRuntime;
+
+    const provider = createGoogleConnectorAccountProvider(managerRuntime);
+    const result = getConnectorAccountManager(managerRuntime).registerProvider(provider);
+
+    // This is the seam that used to be missing: without a registered gmail
+    // send connector, MESSAGE op=send source=gmail failed with
+    // SOURCE_CONNECTOR_NOT_FOUND before any Gmail code ran.
+    expect(result.messageConnectorRegistered).toBe(true);
+    expect(registered).toHaveLength(1);
+    expect(registered[0].source).toBe(GMAIL_MESSAGE_SOURCE);
+    expect(typeof registered[0].sendHandler).toBe("function");
+
+    // The registration advertises the shapes MESSAGE op=send resolves against:
+    // "email"-kind targets and the email/mail source aliases.
+    expect(registered[0].supportedTargetKinds).toContain("email");
+    expect((registered[0].metadata as { aliases?: string[] } | undefined)?.aliases).toContain(
+      "email"
+    );
+  });
+
+  it("resolveTargets treats a literal email address as an unambiguous target", async () => {
+    const registration = createGmailMessageConnector(runtimeStub({}).runtime);
+    if (!registration.resolveTargets) throw new Error("resolveTargets missing");
+    const context = { runtime: runtimeStub({}).runtime } as never;
+
+    const hits = await registration.resolveTargets("shadow@example.com", context);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      kind: "email",
+      label: "shadow@example.com",
+      target: { source: GMAIL_MESSAGE_SOURCE, channelId: "shadow@example.com" },
+    });
+
+    await expect(registration.resolveTargets("shadow", context)).resolves.toEqual([]);
+  });
+});
+
+describe("gmail send handler", () => {
+  it("sends to a literal address through the sole connected gmail-send account", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com" },
+      { text: "Please stop smoking.", metadata: { subject: "A friendly reminder" } }
+    );
+
+    expect(sendGmailMessage).toHaveBeenCalledWith({
+      accountId: "acct_google_1",
+      to: ["shadow@example.com"],
+      subject: "A friendly reminder",
+      bodyText: "Please stop smoking.",
+    });
+    expect(outcome).toMatchObject({
+      kind: "delivered",
+      receipt: {
+        providerMessageIds: ["sent_1"],
+        persistence: { status: "not_attempted" },
+      },
+    });
+  });
+
+  it("derives the subject from the first body line when none is supplied", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com" },
+      { text: "Stop smoking\nIt is bad for you." }
+    );
+
+    expect(sendGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ subject: "Stop smoking" })
+    );
+  });
+
+  it("resolves an entity-store recipient through stored email handles", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      entity: {
+        id: SHADOW_ID,
+        names: ["Shadow"],
+        components: [
+          { type: "discord", data: { channelId: "dm-1" } },
+          { type: "contact_info", data: { email: "shadow@example.com" } },
+        ],
+      },
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { entityId: SHADOW_ID as TargetInfo["entityId"] },
+      { text: "hello" }
+    );
+
+    expect(outcome.kind).toBe("delivered");
+    expect(sendGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ to: ["shadow@example.com"] })
+    );
+  });
+
+  it("honors an explicit target accountId over account discovery", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({ accounts: [] });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com", accountId: "acct_explicit" },
+      { text: "hello" }
+    );
+
+    expect(outcome.kind).toBe("delivered");
+    expect(sendGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "acct_explicit" })
+    );
+  });
+
+  it("refuses structurally when no connected account can send", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [
+        {
+          id: "acct_readonly",
+          status: "connected",
+          metadata: { grantedCapabilities: ["gmail.read"] },
+        },
+      ],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com" },
+      { text: "hello" }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "not_delivered",
+      code: "GMAIL_ACCOUNT_UNAVAILABLE",
+    });
+    expect(sendGmailMessage).not.toHaveBeenCalled();
+  });
+
+  it("refuses structurally when the account choice is ambiguous", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT, { ...CONNECTED_ACCOUNT, id: "acct_google_2" }],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com" },
+      { text: "hello" }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "not_delivered",
+      code: "GMAIL_ACCOUNT_AMBIGUOUS",
+    });
+    expect(sendGmailMessage).not.toHaveBeenCalled();
+  });
+
+  it("refuses structurally when no recipient email can be resolved", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { entityId: "shadow" as TargetInfo["entityId"] },
+      { text: "hello" }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "not_delivered",
+      code: "GMAIL_RECIPIENT_UNRESOLVED",
+    });
+    expect(sendGmailMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("isEmailAddress", () => {
+  it("accepts literal addresses and rejects names/handles", () => {
+    expect(isEmailAddress("shadow@example.com")).toBe(true);
+    expect(isEmailAddress("  shadow@example.com  ")).toBe(true);
+    expect(isEmailAddress("shadow")).toBe(false);
+    expect(isEmailAddress("@shadow")).toBe(false);
+    expect(isEmailAddress("shadow@localhost")).toBe(false);
+    expect(isEmailAddress(42)).toBe(false);
+  });
+});

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -1,0 +1,259 @@
+/**
+ * Gmail send-target MessageConnector: advertises Gmail as a cross-connector
+ * send surface so `MESSAGE op=send source=gmail` (aliases "email"/"mail") and
+ * email-literal targets resolve to a real transport instead of
+ * SOURCE_CONNECTOR_NOT_FOUND, and routes delivery through
+ * `GoogleWorkspaceService.sendGmailMessage`.
+ *
+ * Recipient resolution: a literal address on the target (channelId or
+ * entityId) is used as-is — a typed address is unambiguous; an entity-store
+ * UUID resolves through the entity's stored email handles (component data).
+ * Account routing is `connector`-scoped: the handler honors an explicit
+ * target accountId, else the sole connected gmail-send-capable Google
+ * account, and refuses with a structural not_delivered when the account
+ * choice is ambiguous or absent. Subject comes from `content.metadata.subject`
+ * when the planner supplies one, else the first line of the body clipped to a
+ * sane header length. Registered by the Google connector-account provider at
+ * plugin init.
+ */
+import {
+  type ConnectorAccount,
+  type Content,
+  getConnectorAccountManager,
+  type IAgentRuntime,
+  type MessageConnectorRegistration,
+  type MessageConnectorTarget,
+  type SendHandlerOutcome,
+  type TargetInfo,
+  type UUID,
+} from "@elizaos/core";
+import { GOOGLE_SERVICE_NAME } from "./types.js";
+
+export const GMAIL_MESSAGE_SOURCE = "gmail";
+
+const EMAIL_ADDRESS_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SUBJECT_MAX_LENGTH = 78;
+const EMAIL_COMPONENT_KEYS = ["email", "emailAddress"] as const;
+
+/** True when the value is a deliverable literal email address. */
+export function isEmailAddress(value: unknown): value is string {
+  return typeof value === "string" && EMAIL_ADDRESS_PATTERN.test(value.trim());
+}
+
+function emailLiteral(value: unknown): string | undefined {
+  return isEmailAddress(value) ? String(value).trim() : undefined;
+}
+
+interface GmailSendCapableService {
+  sendGmailMessage(params: {
+    accountId: string;
+    to: string[];
+    cc?: string[];
+    bcc?: string[];
+    subject: string;
+    bodyText: string;
+  }): Promise<{ messageId: string | null; threadId: string | null }>;
+}
+
+function getGmailSendService(runtime: IAgentRuntime): GmailSendCapableService | null {
+  const service = runtime.getService(GOOGLE_SERVICE_NAME);
+  return service &&
+    typeof service === "object" &&
+    typeof Reflect.get(service, "sendGmailMessage") === "function"
+    ? (service as unknown as GmailSendCapableService)
+    : null;
+}
+
+function accountSupportsGmailSend(account: ConnectorAccount): boolean {
+  if (account.status !== "connected") return false;
+  const granted = account.metadata?.grantedCapabilities;
+  // Accounts predating capability metadata carry no grant list; treat them as
+  // send-capable and let the Gmail API be the authority at call time.
+  if (!Array.isArray(granted)) return true;
+  return granted.some((capability) => capability === "gmail.send");
+}
+
+async function resolveGmailAccountId(
+  runtime: IAgentRuntime,
+  requested: string | undefined
+): Promise<{ accountId: string } | { error: SendHandlerOutcome }> {
+  if (requested?.trim()) {
+    return { accountId: requested.trim() };
+  }
+  const accounts = (
+    await getConnectorAccountManager(runtime).listAccounts(GOOGLE_SERVICE_NAME)
+  ).filter(accountSupportsGmailSend);
+  const sole = accounts.length === 1 ? accounts[0] : undefined;
+  if (sole) {
+    return { accountId: sole.id };
+  }
+  if (accounts.length === 0) {
+    return {
+      error: {
+        kind: "not_delivered",
+        code: "GMAIL_ACCOUNT_UNAVAILABLE",
+        message:
+          "No connected Google account with the gmail.send capability. Connect a Google account (Gmail send scope) before sending email.",
+      },
+    };
+  }
+  return {
+    error: {
+      kind: "not_delivered",
+      code: "GMAIL_ACCOUNT_AMBIGUOUS",
+      message: `Multiple Google accounts can send email (${accounts
+        .map((account) => account.displayHandle ?? account.id)
+        .join(", ")}). Specify accountId to pick one.`,
+    },
+  };
+}
+
+/**
+ * Resolve the recipient address: literal target address first, then the
+ * entity graph's stored email handles for an entity-store UUID.
+ */
+async function resolveRecipientEmail(
+  runtime: IAgentRuntime,
+  target: TargetInfo
+): Promise<string | null> {
+  const literal = emailLiteral(target.channelId) ?? emailLiteral(target.entityId);
+  if (literal) return literal;
+
+  const entityId = String(target.entityId ?? "").trim();
+  if (!UUID_PATTERN.test(entityId) || typeof runtime.getEntityById !== "function") {
+    return null;
+  }
+  const entity = await runtime.getEntityById(entityId as UUID);
+  if (!entity) return null;
+
+  // Prefer explicitly email-named component fields; fall back to any
+  // email-shaped component value (covers rolodex custom fields and handles).
+  let fallback: string | null = null;
+  for (const component of entity.components ?? []) {
+    const data = component.data ?? {};
+    for (const key of EMAIL_COMPONENT_KEYS) {
+      const value = emailLiteral(data[key]);
+      if (value) return value;
+    }
+    if (!fallback) {
+      for (const value of Object.values(data)) {
+        const email = emailLiteral(value);
+        if (email) {
+          fallback = email;
+          break;
+        }
+      }
+    }
+  }
+  return fallback;
+}
+
+function subjectFromContent(content: Content): string {
+  const metadata = content.metadata;
+  const explicit =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>).subject
+      : undefined;
+  if (typeof explicit === "string" && explicit.trim().length > 0) {
+    return explicit.trim();
+  }
+  const firstLine = String(content.text ?? "")
+    .split("\n", 1)[0]
+    .trim();
+  return firstLine.length <= SUBJECT_MAX_LENGTH
+    ? firstLine
+    : `${firstLine.slice(0, SUBJECT_MAX_LENGTH - 3)}...`;
+}
+
+async function sendGmailFromTarget(
+  runtime: IAgentRuntime,
+  target: TargetInfo,
+  content: Content
+): Promise<SendHandlerOutcome> {
+  const service = getGmailSendService(runtime);
+  if (!service) {
+    return {
+      kind: "not_delivered",
+      code: "GMAIL_SERVICE_UNAVAILABLE",
+      message: "The Google Workspace service is not running; Gmail send is unavailable.",
+    };
+  }
+
+  const recipient = await resolveRecipientEmail(runtime, target);
+  if (!recipient) {
+    return {
+      kind: "not_delivered",
+      code: "GMAIL_RECIPIENT_UNRESOLVED",
+      message:
+        "Could not resolve an email address for the recipient. Provide a literal address (name@example.com) or a contact with a stored email.",
+    };
+  }
+
+  const account = await resolveGmailAccountId(runtime, target.accountId);
+  if ("error" in account) {
+    return account.error;
+  }
+
+  const bodyText = String(content.text ?? "");
+  const sent = await service.sendGmailMessage({
+    accountId: account.accountId,
+    to: [recipient],
+    subject: subjectFromContent(content),
+    bodyText,
+  });
+
+  return {
+    kind: "delivered",
+    receipt: {
+      // Gmail returns the created message id on acceptance; the thread id is
+      // the fallback evidence if the id field is ever absent on a 200.
+      providerMessageIds: [
+        sent.messageId ?? sent.threadId ?? `gmail:${account.accountId}:accepted`,
+      ],
+      acceptedAt: Date.now(),
+      persistence: {
+        status: "not_attempted",
+        reason: "MESSAGE op=send owns outbound-memory persistence",
+      },
+    },
+    memories: [],
+  };
+}
+
+/**
+ * Build the Gmail MessageConnector registration. `accountRouting: "connector"`
+ * keeps one unscoped registration valid for every dynamically-connected Google
+ * account; the send handler resolves the concrete account per delivery.
+ */
+export function createGmailMessageConnector(_runtime: IAgentRuntime): MessageConnectorRegistration {
+  return {
+    source: GMAIL_MESSAGE_SOURCE,
+    label: "Gmail",
+    accountRouting: "connector",
+    capabilities: ["send_message"],
+    supportedTargetKinds: ["email", "contact", "user"],
+    contexts: ["email", "connectors"],
+    description:
+      "Send email through the connected Google account. Targets: a literal email address, or a contact with a stored email.",
+    metadata: {
+      aliases: ["email", "mail", "google mail"],
+      service: GOOGLE_SERVICE_NAME,
+    },
+    resolveTargets: async (query): Promise<MessageConnectorTarget[]> => {
+      const literal = emailLiteral(query);
+      if (!literal) return [];
+      return [
+        {
+          target: { source: GMAIL_MESSAGE_SOURCE, channelId: literal },
+          label: literal,
+          kind: "email",
+          score: 0.95,
+          contexts: ["email", "connectors"],
+        },
+      ];
+    },
+    sendHandler: async (handlerRuntime, target, content) =>
+      sendGmailFromTarget(handlerRuntime, target, content),
+  };
+}

--- a/plugins/plugin-google-workspace/src/index.ts
+++ b/plugins/plugin-google-workspace/src/index.ts
@@ -6,9 +6,12 @@
  * `GoogleChatWorkflowCredentialProvider` — service-account auth, MessageConnector
  * messaging). At init it attaches both connector-account providers to the
  * runtime's `ConnectorAccountManager` so the generic connector HTTP routes can
- * manage accounts and drive OAuth. It registers no actions or providers of its
- * own; callers invoke the services directly, and Chat messaging routes through
- * the MessageConnector that `GoogleChatService` registers.
+ * manage accounts and drive OAuth; registering the Google provider also mounts
+ * the Gmail send MessageConnector (`source: "gmail"`, aliases email/mail) so
+ * MESSAGE op=send can compose and send email. It registers no actions or
+ * providers of its own; callers invoke the services directly, and Chat
+ * messaging routes through the MessageConnector that `GoogleChatService`
+ * registers.
  */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { getConnectorAccountManager, logger } from "@elizaos/core";
@@ -36,6 +39,7 @@ export * from "./connector-account-provider.js";
 export * from "./credential-resolver.js";
 export * from "./drive.js";
 export * from "./gmail.js";
+export * from "./gmail-message-connector.js";
 export { GoogleGmailAdapter } from "./lifeops-message-adapter.js";
 export * from "./meet.js";
 export * from "./scopes.js";

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.test.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.test.ts
@@ -23,6 +23,7 @@ function runtimeWithGoogleService(service: Record<string, unknown>): IAgentRunti
     listGmailTriageMessages: vi.fn(async () => []),
     searchGmailMessages: vi.fn(async () => []),
     sendGmailReply: vi.fn(async () => ({})),
+    sendGmailMessage: vi.fn(async () => ({})),
     modifyGmailMessages: vi.fn(async () => undefined),
     createGmailFilterForSender: vi.fn(async () => ({
       filterId: "filter_default",
@@ -149,6 +150,53 @@ describe("GoogleGmailAdapter", () => {
       references: "<root@example.com>",
     });
     expect(sent.externalId).toBe("sent_1");
+  });
+
+  it("advertises new-email send capability alongside reply", () => {
+    expect(new GoogleGmailAdapter().capabilities().send).toEqual({
+      reply: true,
+      new: true,
+      schedule: false,
+    });
+  });
+
+  it("creates and sends a NEW email draft (no inReplyToId) through sendGmailMessage", async () => {
+    const sendGmailMessage = vi.fn(async () => ({
+      messageId: "sent_new_1",
+      threadId: "thread_new_1",
+      labelIds: ["SENT"],
+    }));
+    const runtime = runtimeWithGoogleService({ sendGmailMessage });
+    const adapter = new GoogleGmailAdapter();
+
+    const draft = await adapter.createDraft(runtime, {
+      source: "gmail",
+      to: [{ identifier: "shadow@example.com" }],
+      subject: "Stop smoking",
+      body: "Please stop smoking.",
+      worldId: "acct_google_1",
+    });
+    const sent = await adapter.sendDraft(runtime, draft.draftId);
+
+    expect(draft.preview).toBe("Please stop smoking.");
+    expect(sendGmailMessage).toHaveBeenCalledWith({
+      accountId: "acct_google_1",
+      to: ["shadow@example.com"],
+      subject: "Stop smoking",
+      bodyText: "Please stop smoking.",
+    });
+    expect(sent.externalId).toBe("sent_new_1");
+  });
+
+  it("refuses a new draft without an email-address recipient", async () => {
+    const runtime = runtimeWithGoogleService({});
+    await expect(
+      new GoogleGmailAdapter().createDraft(runtime, {
+        source: "gmail",
+        to: [{ identifier: "not-an-address" }],
+        body: "hello",
+      })
+    ).rejects.toThrow(/email-address recipient/);
   });
 
   it("manages Gmail messages and unsubscribe requests with plugin-google-workspace operations", async () => {

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
@@ -3,10 +3,11 @@
  * shape consumed by assistant plugins such as LifeOps. Maps Gmail triage
  * summaries to `MessageRef`s, translates the generic manage operations
  * (archive/trash/spam/label/mark-read/unsubscribe) into Gmail bulk operations,
- * and implements reply drafting/sending over `GoogleWorkspaceService`'s Gmail
- * methods. Resolves the Google service by name at runtime and no-ops as
- * unavailable when the plugin is not loaded; `accountId` is carried on each
- * `MessageRef` via `worldId` so triage stays multi-account.
+ * and implements draft/send over `GoogleWorkspaceService`'s Gmail methods —
+ * both thread replies (`inReplyToId`) and new outbound email (`to` recipients,
+ * used by draft_followup). Resolves the Google service by name at runtime and
+ * no-ops as unavailable when the plugin is not loaded; `accountId` is carried
+ * on each `MessageRef` via `worldId` so triage stays multi-account.
  */
 import {
   BaseMessageAdapter,
@@ -20,6 +21,7 @@ import {
   type MessageSource,
   type SearchMessagesFilters,
 } from "@elizaos/core/node";
+import { isEmailAddress } from "./gmail-message-connector.js";
 import type {
   GoogleGmailBulkOperation,
   GoogleGmailMessageSummary,
@@ -31,6 +33,7 @@ const GMAIL_ADAPTER_METHODS = [
   "listGmailTriageMessages",
   "searchGmailMessages",
   "sendGmailReply",
+  "sendGmailMessage",
   "modifyGmailMessages",
   "createGmailFilterForSender",
 ] as const satisfies readonly (keyof IGoogleGmailService)[];
@@ -160,6 +163,12 @@ function messageAccountId(message: MessageRef | null | undefined): string {
   return message?.worldId ?? DEFAULT_GOOGLE_ACCOUNT_ID;
 }
 
+function newDraftRecipients(draft: DraftRequest): string[] {
+  return draft.to
+    .map((recipient) => recipient.identifier.trim())
+    .filter((identifier) => isEmailAddress(identifier));
+}
+
 export class GoogleGmailAdapter extends BaseMessageAdapter {
   readonly source: MessageSource = "gmail";
 
@@ -182,7 +191,7 @@ export class GoogleGmailAdapter extends BaseMessageAdapter {
         markRead: true,
         unsubscribe: true,
       },
-      send: { reply: true, new: false, schedule: false },
+      send: { reply: true, new: true, schedule: false },
       worlds: "multi",
       channels: "explicit",
     };
@@ -236,13 +245,23 @@ export class GoogleGmailAdapter extends BaseMessageAdapter {
     runtime: IAgentRuntime,
     draft: DraftRequest
   ): Promise<{ draftId: string; preview: string }> {
+    const preview = clip(draft.body, 240);
     if (!draft.inReplyToId) {
-      throw new Error("[GoogleGmailAdapter] Gmail replies require inReplyToId");
+      // New outbound email (draft_followup): recipients must be literal
+      // addresses — Gmail has no in-thread sender to fall back to.
+      const recipients = newDraftRecipients(draft);
+      if (recipients.length === 0) {
+        throw new Error(
+          "[GoogleGmailAdapter] a new Gmail draft requires at least one email-address recipient"
+        );
+      }
+      const draftId = `gmail-new:${Date.now()}`;
+      this.draftCache.set(draftId, { request: draft, preview });
+      return { draftId, preview };
     }
     await this.ensureMessage(runtime, draft.inReplyToId);
     const messageId = externalMessageId(draft.inReplyToId);
     const draftId = `gmail-draft:${messageId}:${Date.now()}`;
-    const preview = clip(draft.body, 240);
     this.draftCache.set(draftId, { request: draft, preview });
     return { draftId, preview };
   }
@@ -252,16 +271,26 @@ export class GoogleGmailAdapter extends BaseMessageAdapter {
     draftId: string
   ): Promise<{ externalId: string }> {
     const draft = this.draftCache.get(draftId);
-    if (!draft?.request.inReplyToId) {
+    if (!draft) {
       throw new Error(`[GoogleGmailAdapter] no cached draft for ${draftId}`);
     }
-    const message = await this.ensureMessage(runtime, draft.request.inReplyToId);
     const service = this.requireService(runtime);
+    const request = draft.request;
+    if (!request.inReplyToId) {
+      const sent = await service.sendGmailMessage({
+        accountId: request.worldId ?? DEFAULT_GOOGLE_ACCOUNT_ID,
+        to: newDraftRecipients(request),
+        subject: request.subject?.trim() || "",
+        bodyText: request.body,
+      });
+      return { externalId: sent.messageId ?? `gmail-new:${draftId}` };
+    }
+    const message = await this.ensureMessage(runtime, request.inReplyToId);
     const sent = await service.sendGmailReply({
       accountId: messageAccountId(message),
       to: [message.from.identifier],
       subject: message.subject ?? "Re: your message",
-      bodyText: draft.request.body,
+      bodyText: request.body,
       inReplyTo: metadataString(message.metadata ?? {}, "messageIdHeader"),
       references: metadataString(message.metadata ?? {}, "references"),
     });


### PR DESCRIPTION
## What

Re-enables Gmail email **sending** through the messaging surface. The regression shape: Gmail could reply to threads but never originate email — `GoogleGmailAdapter` declared `send: { reply: true, new: false }` (and threw on non-reply drafts), and no `gmail` `MessageConnector` was ever registered, so `MESSAGE op=send source=gmail` died with `SOURCE_CONNECTOR_NOT_FOUND` before any Gmail code ran. The underlying capability has existed the whole time: `GoogleWorkspaceService.sendGmailMessage` → `gmail.users.messages.send` (`plugins/plugin-google-workspace/src/gmail.ts`). Both `new: false` and the missing connector date to the repo's squashed baseline (`f7a6b0fea57`, "elizaOS v2.0.4 — clean baseline"), so this closes a wiring gap rather than reverting a deliberate safety pause — no gating commit exists in history, and core never enforced `send.new` anywhere (only `send.schedule` is consulted, in `triage-service.ts`).

### Gmail as a MESSAGE send connector
New `src/gmail-message-connector.ts`, registered through the Google connector-account provider (`ConnectorAccountProvider.messageConnector`, mounted at plugin init):
- `source: "gmail"`, aliases `email`/`mail`, `supportedTargetKinds: ["email", "contact", "user"]`, `accountRouting: "connector"` (one unscoped registration serves every dynamically-connected Google account).
- **Recipient resolution:** a literal address on the target is used as-is — a typed address is unambiguous, no fuzzy contact match involved; an entity-store UUID resolves through the entity's stored email handles (email-named component fields first, then any email-shaped component value). Anything else refuses with a structural `not_delivered` (`GMAIL_RECIPIENT_UNRESOLVED`) — never a guessed recipient.
- **Account resolution:** explicit `target.accountId` → honored; else the sole connected `gmail.send`-capable Google account; zero or multiple candidates refuse structurally (`GMAIL_ACCOUNT_UNAVAILABLE` / `GMAIL_ACCOUNT_AMBIGUOUS`) with an actionable message.
- **Subject:** `content.metadata.subject` when supplied (the core `subject` param lands in #18111; the fallback works without it), else the first body line clipped to header length.
- **Delivery evidence:** returns a structural `delivered` receipt carrying the Gmail message id; persistence `not_attempted` (MESSAGE op=send owns the outbound record).
- `resolveTargets` surfaces a literal email address as an unambiguous 0.95 `email`-kind candidate.

### Adapter: new-email send re-enabled
`GoogleGmailAdapter` now advertises `send: { reply: true, new: true, schedule: false }` and implements the non-reply draft path used by `draft_followup`: `createDraft` with `to` recipients (requires at least one literal email address), `sendDraft` via `sendGmailMessage` on the draft's account. The reply path is byte-for-byte the old behavior. `schedule` stays false — no Gmail-side scheduled send exists.

### Safety posture
Sending a new email to a typed address is explicit — the recipient is a literal address or a stored contact handle, never a fuzzy name match (unlike the paused by-name DM path). Every unresolvable case is a structural refusal with a reason, not a guess. Nothing here sends without the user driving `MESSAGE op=send` / a confirmed draft.

## Test matrix

New `gmail-message-connector.test.ts` (10 tests) + extended `lifeops-message-adapter.test.ts` (3 new). Gmail is mocked at the service boundary — nothing real is sent:
- provider registration registers the `gmail` connector with a send handler (the exact seam whose absence produced `SOURCE_CONNECTOR_NOT_FOUND`)
- literal-address send through the sole connected account, with explicit subject and first-line subject derivation
- entity-store recipient resolves via stored email handles
- explicit `accountId` honored; no-account and ambiguous-account structural refusals; unresolvable recipient refusal
- `resolveTargets` email-literal candidate; `isEmailAddress` accept/reject table
- adapter advertises `new: true`; new-draft compose+send routes through `sendGmailMessage`; refuses a new draft without an email recipient; reply-path regression (existing test, unchanged expectations)

```
plugins/plugin-google-workspace: vitest    → 11 files, 91 tests passed
plugins/plugin-google-workspace: tsc --noEmit → clean
plugins/plugin-google-workspace: biome check  → clean
```

Docs: plugin `CLAUDE.md`/`AGENTS.md` updated in lockstep (byte-identical).

Operator follow-up: live verification is a test email to the owner's own address after pulling — not exercised from CI by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - plugin/backend-only change (Gmail send connector + triage adapter); no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - plugin/backend-only change; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing UI flow; the send path is a backend connector, exercised by the mocked-boundary suite below. Real-email verification is an operator step after merge (a test email to the owner's own address) — CI must not send real email.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — full owning-suite run through the connector registration, recipient/account resolution, and send dispatch (Gmail mocked at the service boundary):

<details>
<summary>vitest: plugin-google-workspace</summary>

```
$ bun run --cwd plugins/plugin-google-workspace test
 RUN  v4.1.5 plugins/plugin-google-workspace
 ✓ gmail-message-connector.test.ts (10 tests) — provider registration registers the gmail send connector
   (the SOURCE_CONNECTOR_NOT_FOUND seam), literal-address + entity-handle recipient resolution, explicit
   accountId, no-account / ambiguous-account / unresolved-recipient structural refusals, subject derivation,
   delivered receipt with provider message id, resolveTargets email-literal candidate, isEmailAddress table
 ✓ lifeops-message-adapter.test.ts (7 tests) — capabilities advertise send { reply: true, new: true,
   schedule: false }; NEW-email draft create+send routes through sendGmailMessage; refuses a new draft
   without an email recipient; reply draft path regression (unchanged expectations)
 Test Files  11 passed (11)
      Tests  91 passed (91)

$ bun run --cwd plugins/plugin-google-workspace typecheck   # tsc --noEmit, exit 0
$ bun run --cwd plugins/plugin-google-workspace lint:check  # biome, clean
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend surface; the change is a runtime MessageConnector + triage adapter.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no prompt/model surface changes; the connector is deterministic transport wiring behind the existing MESSAGE action. Live verification (a real email to the owner's own address) is deliberately an operator step after merge - CI and tests must not send real email, so the Gmail API is mocked at the service boundary.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the artifact this PR produces is an accepted Gmail send with a provider receipt; asserted structurally at the mocked boundary:

<details>
<summary>delivery receipt + compose assertions (gmail-message-connector.test.ts)</summary>

```
✓ sends to a literal address through the sole connected gmail-send account
  sendGmailMessage({ accountId: "acct_google_1", to: ["shadow@example.com"],
                     subject: "A friendly reminder", bodyText: "Please stop smoking." })
  outcome = { kind: "delivered",
              receipt: { providerMessageIds: ["sent_1"], persistence: { status: "not_attempted" } } }
✓ creates and sends a NEW email draft (no inReplyToId) through sendGmailMessage
  externalId = "sent_new_1"
```

</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface in this change.`

<!-- evidence-head:34fc388f48682101b9468b044debe35400fa0da6 -->

# Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
