### PR TITLE
fix(core): keep current-room context providers readable at the GUEST floor

### DIFF
--- a/packages/agent/src/runtime/plugin-role-gating.guest-history.test.ts
+++ b/packages/agent/src/runtime/plugin-role-gating.guest-history.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Incident contract for GUEST-role conversation coherence (live 2026-08-09,
+ * room e7a58c54: the bot answered "chat's empty" to non-admin senders).
+ * Exercises the REAL basic-capabilities providers through
+ * `applyPluginRoleGating` with the roles module mocked to resolve GUEST:
+ * the current-room transcript (RECENT_MESSAGES), room shape (WORLD), and
+ * room membership (ENTITIES) must flow to a GUEST sender, while
+ * cross-platform recall (recent-conversations, ADMIN-gated) stays withheld.
+ * Deterministic: the runtime is a hand-built stub over an in-memory room.
+ */
+import type {
+  IAgentRuntime,
+  Memory,
+  Plugin,
+  Provider,
+  State,
+  UUID,
+} from "@elizaos/core";
+import { basicProviders } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rolesMock = vi.hoisted(() => ({
+  checkSenderRole: vi.fn(),
+}));
+
+vi.mock("./roles.ts", () => rolesMock);
+
+import { recentConversationsProvider } from "../providers/recent-conversations.ts";
+import { applyPluginRoleGating } from "./plugin-role-gating.ts";
+
+const AGENT_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const ROOM_ID = "44444444-4444-4444-4444-444444444444" as UUID;
+const WORLD_ID = "55555555-5555-5555-5555-555555555555" as UUID;
+const GUEST_ID = "33333333-3333-3333-3333-333333333333" as UUID;
+const OTHER_ID = "66666666-6666-6666-6666-666666666666" as UUID;
+
+function providerByName(name: string): Provider {
+  const provider = basicProviders.find((p) => p.name === name);
+  if (!provider) throw new Error(`basicProviders is missing ${name}`);
+  return provider;
+}
+
+function roomMessage(
+  id: string,
+  entityId: UUID,
+  entityName: string,
+  text: string,
+  createdAt: number,
+): Memory {
+  return {
+    id: id as UUID,
+    entityId,
+    agentId: AGENT_ID,
+    roomId: ROOM_ID,
+    createdAt,
+    content: { text, source: "discord" },
+    metadata: { entityName },
+  } as Memory;
+}
+
+/** Busy multi-speaker channel history the provider must surface for GUESTs. */
+const CHANNEL_HISTORY: Memory[] = [
+  roomMessage(
+    "aaaaaaaa-0000-0000-0000-000000000001",
+    OTHER_ID,
+    "shaw",
+    "new channel, lets keep it high signal",
+    1_000,
+  ),
+  roomMessage(
+    "aaaaaaaa-0000-0000-0000-000000000002",
+    GUEST_ID,
+    "bill",
+    "automated agents contributing daily",
+    2_000,
+  ),
+  roomMessage(
+    "aaaaaaaa-0000-0000-0000-000000000003",
+    OTHER_ID,
+    "shaw",
+    "automate the grind",
+    3_000,
+  ),
+];
+
+function stubRuntime(): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    character: { name: "TestAgent" },
+    getConversationLength: () => 32,
+    getRoom: async (roomId: UUID) =>
+      roomId === ROOM_ID
+        ? { id: ROOM_ID, name: "cozy-dev", type: "GROUP", worldId: WORLD_ID }
+        : null,
+    getWorld: async (worldId: UUID) =>
+      worldId === WORLD_ID ? { id: WORLD_ID, name: "cozy" } : null,
+    getRooms: async () => [
+      { id: ROOM_ID, name: "cozy-dev", type: "GROUP", worldId: WORLD_ID },
+    ],
+    getParticipantsForRoom: async () => [GUEST_ID, OTHER_ID, AGENT_ID],
+    getEntitiesForRoom: async () => [
+      { id: GUEST_ID, agentId: AGENT_ID, names: ["bill"], metadata: {} },
+      { id: OTHER_ID, agentId: AGENT_ID, names: ["shaw"], metadata: {} },
+      { id: AGENT_ID, agentId: AGENT_ID, names: ["TestAgent"], metadata: {} },
+    ],
+    getMemories: async ({ tableName }: { tableName: string }) =>
+      tableName === "messages" ? [...CHANNEL_HISTORY] : [],
+    getEntityById: async () => null,
+    reportError: vi.fn(),
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trace: vi.fn(),
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function guestMessage(text: string): Memory {
+  return {
+    id: "22222222-2222-2222-2222-222222222222" as UUID,
+    entityId: GUEST_ID,
+    agentId: AGENT_ID,
+    roomId: ROOM_ID,
+    createdAt: 4_000,
+    content: { text, source: "discord" },
+    metadata: { entityName: "bill" },
+  } as Memory;
+}
+
+function pluginWith(providers: Provider[]): Plugin {
+  return { name: "test-plugin", providers } as Plugin;
+}
+
+describe("GUEST senders keep current-room conversation context after role gating", () => {
+  beforeEach(() => {
+    rolesMock.checkSenderRole.mockReset();
+    rolesMock.checkSenderRole.mockResolvedValue({
+      role: "GUEST",
+      isOwner: false,
+      isAdmin: false,
+    });
+  });
+
+  it("RECENT_MESSAGES yields the busy room's transcript to a GUEST (addressed turn)", async () => {
+    const provider = providerByName("RECENT_MESSAGES");
+    applyPluginRoleGating([pluginWith([provider])]);
+    // A GUEST-floor gate is non-restricting: the provider must not be wrapped.
+    expect((provider as { __roleGate?: string }).__roleGate).toBeUndefined();
+
+    const result = await provider.get(
+      stubRuntime(),
+      guestMessage("@TestAgent you tell me, look at the history"),
+      { values: {}, data: {}, text: "" } as State,
+    );
+
+    const transcript = result?.text ?? "";
+    expect(transcript).toContain("high signal");
+    expect(transcript).toContain("automate the grind");
+    const recentMessages = (
+      result?.data as { recentMessages?: Memory[] } | undefined
+    )?.recentMessages;
+    expect(Array.isArray(recentMessages)).toBe(true);
+    expect(recentMessages?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("RECENT_MESSAGES yields the same transcript on an ambient (unaddressed) turn", async () => {
+    const provider = providerByName("RECENT_MESSAGES");
+    applyPluginRoleGating([pluginWith([provider])]);
+
+    const result = await provider.get(
+      stubRuntime(),
+      guestMessage("what do you see in this chat then"),
+      { values: {}, data: {}, text: "" } as State,
+    );
+
+    expect(result?.text ?? "").toContain("high signal");
+  });
+
+  it("WORLD and ENTITIES yield room awareness to a GUEST", async () => {
+    const world = providerByName("WORLD");
+    const entities = providerByName("ENTITIES");
+    applyPluginRoleGating([pluginWith([world, entities])]);
+    expect((world as { __roleGate?: string }).__roleGate).toBeUndefined();
+    expect((entities as { __roleGate?: string }).__roleGate).toBeUndefined();
+
+    const runtime = stubRuntime();
+    const message = guestMessage("who is in here?");
+    const worldResult = await world.get(runtime, message, {
+      values: {},
+      data: {},
+      text: "",
+    } as State);
+    const entitiesResult = await entities.get(runtime, message, {
+      values: {},
+      data: {},
+      text: "",
+    } as State);
+
+    expect(worldResult?.text ?? "").not.toBe("");
+    expect(entitiesResult?.text ?? "").toContain("shaw");
+  });
+
+  it("cross-platform recall (recent-conversations, ADMIN) stays withheld from a GUEST", async () => {
+    applyPluginRoleGating([pluginWith([recentConversationsProvider])]);
+    expect(
+      (recentConversationsProvider as { __roleGate?: string }).__roleGate,
+    ).toBe("ADMIN");
+
+    const result = await recentConversationsProvider.get(
+      stubRuntime(),
+      guestMessage("what have we talked about elsewhere?"),
+      { values: {}, data: {}, text: "" } as State,
+    );
+
+    expect(result).toEqual({ text: "" });
+  });
+});

--- a/packages/core/src/features/basic-capabilities/providers/entities.ts
+++ b/packages/core/src/features/basic-capabilities/providers/entities.ts
@@ -33,7 +33,11 @@ export const entitiesProvider: Provider = {
 	contextGate: { anyOf: ["contacts", "memory", "messaging"] },
 	cacheStable: false,
 	cacheScope: "turn",
-	roleGate: { minRole: "USER" },
+	// GUEST floor: who's present in the CURRENT room — the member list every
+	// participant already sees. Gating at USER let the agent-host role gate
+	// blank it for unassigned group-channel senders (GUEST floor), leaving the
+	// bot unable to name who it was talking to.
+	roleGate: { minRole: "GUEST" },
 
 	get: async (runtime: IAgentRuntime, message: Memory) => {
 		const { roomId, entityId } = message;

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -371,7 +371,14 @@ export const recentMessagesProvider: Provider = {
 	// Conversation history is correctness-critical and may span several indexed
 	// reads on remote adapters. Extend its deadline without allowing partial state.
 	timeoutMs: 8_000,
-	roleGate: { minRole: "USER" },
+	// GUEST floor: this is the CURRENT room's transcript — content every
+	// participant can already read in their client. Gating it at USER made the
+	// agent-host role gate (packages/agent plugin-role-gating) withhold the
+	// entire conversation window from unassigned group-channel senders (they
+	// resolve to GUEST), so the bot answered "chat's empty" to anyone who was
+	// not a seeded admin. Cross-room/cross-platform recall stays gated on its
+	// own providers (recent-conversations ADMIN, relevant-conversations USER).
+	roleGate: { minRole: "GUEST" },
 
 	get: async (
 		runtime: IAgentRuntime,

--- a/packages/core/src/features/basic-capabilities/providers/role-gates.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/role-gates.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Declaration contract for current-room context provider role gates.
+ * Deterministic, mock-free: asserts the declared `roleGate` floors directly.
+ *
+ * The agent host (packages/agent plugin-role-gating) withholds a provider's
+ * entire output from senders below its declared `minRole`. Unassigned
+ * group-channel senders resolve to GUEST, so any current-room coherence
+ * provider gated above GUEST goes blank for ordinary channel members — the
+ * live "chat's empty" incident (2026-08-09): RECENT_MESSAGES, WORLD, and
+ * ENTITIES were withheld from every non-admin, leaving Stage 1 with no
+ * transcript at all. These floors are load-bearing; tightening one re-breaks
+ * group conversations for non-admin senders.
+ */
+import { describe, expect, it } from "vitest";
+import { entitiesProvider } from "./entities.ts";
+import { recentMessagesProvider } from "./recentMessages.ts";
+import { worldProvider } from "./world.ts";
+
+describe("current-room context providers stay readable at the GUEST floor", () => {
+	it("RECENT_MESSAGES (the current-room transcript) is not gated above GUEST", () => {
+		expect(recentMessagesProvider.roleGate).toEqual({ minRole: "GUEST" });
+	});
+
+	it("WORLD (current room/world shape) is not gated above GUEST", () => {
+		expect(worldProvider.roleGate).toEqual({ minRole: "GUEST" });
+	});
+
+	it("ENTITIES (who is present in the current room) is not gated above GUEST", () => {
+		expect(entitiesProvider.roleGate).toEqual({ minRole: "GUEST" });
+	});
+});

--- a/packages/core/src/features/basic-capabilities/providers/world.ts
+++ b/packages/core/src/features/basic-capabilities/providers/world.ts
@@ -29,7 +29,10 @@ export const worldProvider: Provider = {
 	contextGate: { anyOf: ["general"] },
 	cacheStable: false,
 	cacheScope: "turn",
-	roleGate: { minRole: "USER" },
+	// GUEST floor: world/channel shape for the room the sender is already in —
+	// visible to every participant, so withholding it from GUEST-role senders
+	// (unassigned group-channel members) only broke conversational coherence.
+	roleGate: { minRole: "GUEST" },
 
 	get: async (runtime: IAgentRuntime, message: Memory, _state: State) => {
 		logger.debug(


### PR DESCRIPTION
<!-- evidence-head:e650829906dd11ca284babb523938227048a40cd -->

## Root cause

The agent host's provider role gate (`packages/agent/src/runtime/plugin-role-gating.ts`) wraps every provider that declares a restricting `roleGate.minRole` and **returns `{ text: "" }` — an empty success — for any sender below that role**. The current-room context providers all declared `minRole: "USER"`:

- `packages/core/src/features/basic-capabilities/providers/recentMessages.ts` (the current-room transcript)
- `.../world.ts` (room/world shape)
- `.../entities.ts` (who is in the room)

Unassigned group-channel senders resolve to **GUEST** (`roles.ts` fail-closed floor), and GUEST < USER — so for every non-admin member of a busy Discord channel the entire core context bundle silently came back empty. Stage 1 then truthfully replied "chat's empty" / "don't see any messages in the recent window."

## Live evidence (agent 6f110aa9, room e7a58c54, 2026-08-09)

- `tj-50feee06bc5621` ("you tell me, look at the history", GUEST sender): Stage-1 prompt had **zero** `prior_message` blocks and **zero** provider blocks; `providerAttributions: []`; renderer emitted only 4 segments. InferenceTiming for the same turn shows composeState ran **14 providers, failed:0** — every gated wrapper resolved the same deduped role check and returned empty at the same instant (all durations ≈28.3–28.7 ms).
- `tj-514431f7418920` ("what the fuck. what do you see in this chat then"): same — the ONLY provider that rendered was `current_view`, the one provider in the set with **no** roleGate.
- Turns from an admin-seeded sender in the same room minutes apart rendered the full transcript (RECENT_MESSAGES ≈2K tokens) and all providers.
- `[ShouldRespondRiskGate] ... (role=GUEST ...)` log lines confirm the sender's resolved role on the affected turns.
- The intermittent "[Recent channel context]" digest some turns carried is the Discord debouncer folding batched messages into the root message text (`plugins/plugin-discord/discord-events.ts` / `debouncer.ts`) — it bypasses providers entirely, which is why ambient batched turns looked "fine" while direct @mentions (single-message flush) had nothing.

## Fix

Set the three current-room providers' floor to `GUEST` (non-restricting — the gate wrapper skips it by design). They only expose what every room participant already sees in their client. Cross-room / cross-platform recall keeps its gates unchanged: `recent-conversations` stays **ADMIN**, `relevant-conversations` stays **USER**.

## Tests

- `packages/agent/src/runtime/plugin-role-gating.guest-history.test.ts` — runs the REAL core providers through `applyPluginRoleGating` with the sender resolving GUEST in a busy multi-speaker room: transcript/world/entities must flow (addressed and ambient turns), ADMIN-gated `recent-conversations` must stay withheld. Fails on the previous gates.
- `packages/core/src/features/basic-capabilities/providers/role-gates.test.ts` — pins the three GUEST floors so a future tightening is a visible, reviewed change.

## Evidence

<!-- evidence-row:before-screenshots -->
**Before screenshots:** N/A - backend-only provider role-gate change; no UI surface is touched and nothing visual changes.

<!-- evidence-row:after-screenshots -->
**After screenshots:** N/A - same backend-only scope; the observable change is prompt context, covered by the trajectory row below.

<!-- evidence-row:walkthrough-video -->
**Walkthrough video:** N/A - non-visual core provider gating fix; behavior is proven by the deterministic test matrix and live trajectory below.

<!-- evidence-row:backend-logs -->
**Backend logs** (live bot, `/var/log/milady/bot.log`, incident turns — composeState ran 14 providers "successfully" yet the prompt rendered none; sender resolved GUEST):

```
[ShouldRespondRiskGate] allowed after adjudication (role=GUEST, score=0.6, ... verdict=allow, reason=a blunt but standard user question about chat visibility in a discord context)
[InferenceTiming] message-turn provider=openai total=9809ms ... composeState=32ms provider:UI_CONTEXT=31.99ms provider:RUNTIME_MODEL_CONTEXT=31.95ms provider:CHANNEL_TOPICS=31.94ms provider:CURRENT_TIME=31.93ms provider:ATTACHMENTS=31.93ms provider:FACTS=31.92ms provider:relevant-conversations=31.89ms provider:RECENT_MESSAGES=31.88ms provider:PLATFORM_CHAT_CONTEXT=31.87ms provider:PLATFORM_USER_CONTEXT=31.86ms
  spans: {"name":"composeState","durationMs":29,"meta":{"providers":14,"reused":0,"failed":0,"degraded":0}}
  every provider span: {"meta":{"outcome":"success"}} — all ended the same instant (the shared deduped role check resolving),
  yet the recorded Stage-1 prompt for the same turn contains zero provider blocks and zero prior_message blocks.
Healthy admin-sender turn in the same room minutes earlier:
[InferenceTiming] message-turn ... composeState=74ms provider:FACTS=72.48ms provider:relevant-conversations=51.03ms provider:RECENT_MESSAGES=48.89ms provider:CURRENT_TIME=22.84ms (varied real work, providers render, RECENT_MESSAGES ≈2084 tokens attributed)
```

<!-- evidence-row:frontend-logs -->
**Frontend console/network logs:** N/A - server-side prompt-composition change only; no frontend code path or network surface is involved.

<!-- evidence-row:llm-trajectory -->
**Real-LLM trajectory** — verbatim excerpt of the live incident trajectory `tj-50feee06bc5621` (RESPONSE_HANDLER on a GUEST @mention turn: 14 providers composed, zero attributed into the prompt, and the model answered that it saw no messages):

```json
{
 "trajectoryId": "tj-50feee06bc5621",
 "roomId": "e7a58c54-78f1-0ede-aea3-f10246312ae8",
 "provider": "cerebras",
 "model": "gemma-4-31b",
 "modelType": "RESPONSE_HANDLER",
 "messages": [
  {
   "role": "system",
   "chars": 24165,
   "content_tail": "t + transcript metadata only; do NOT use prior turns. User-side read; assistant emotion uses inline [happy]/[sad]/[excited] tags in replyText when TTS supports."
  },
  {
   "role": "user",
   "chars": 3102,
   "content": "current_turn_boundary: The prior_message blocks above are context only. If a reply_reference block follows, it is the platform message that the final message:user is replying to; use it only to resolve references such as this/that ...  \u2014 never say you cannot verify a run you can look up.\n\nmessage:user:\nremilio nubilio (@1490833425802854491) you tell me, look at the history"
  }
 ],
 "response": {
  "addressedTo": [
   "1490833425802854491"
  ],
  "candidateActionNames": [],
  "contexts": [
   "simple"
  ],
  "emotion": "none",
  "facts": [],
  "intents": [
   "check chat history"
  ],
  "relationships": [],
  "replyEffectStatus": "none",
  "replyText": "don't see any messages in the recent window.",
  "shouldRespond": "RESPOND",
  "threadOps": [],
  "topics": []
 },
 "providerOrder": [
  "UI_CONTEXT",
  "RUNTIME_MODEL_CONTEXT",
  "CHANNEL_TOPICS",
  "ATTACHMENTS",
  "CURRENT_TIME",
  "FACTS",
  "RECENT_ERRORS",
  "uiWidgets",
  "CODING_SESSION_CHANGES",
  "relevant-conversations",
  "RECENT_MESSAGES",
  "REPLY_CONTEXT",
  "PLATFORM_CHAT_CONTEXT",
  "PLATFORM_USER_CONTEXT"
 ],
 "providerAttributions": [],
 "usage": {
  "promptTokens": 7391,
  "completionTokens": 491,
  "totalTokens": 7882,
  "cacheReadInputTokens": 7296,
  "reasoningTokens": 385
 }
}
```

Contrast, same room, admin-seeded sender (`tj-e12f7c68c9b4e3`): 9 `prior_message` blocks + CHANNEL_TOPICS/ATTACHMENTS/CURRENT_TIME/FACTS/PLATFORM_* rendered; RECENT_MESSAGES attributed at 2084 tokens.

<!-- evidence-row:domain-artifacts -->
**Domain artifacts** (deterministic test matrix on this branch):

```
$ vitest run src/runtime/plugin-role-gating.guest-history.test.ts   # packages/agent
 Test Files  1 passed (1)
      Tests  4 passed (4)   # GUEST gets transcript/world/entities (addressed + ambient); ADMIN-gated recent-conversations stays withheld
$ vitest run src/runtime/plugin-role-gating*.test.ts                # packages/agent, pre-existing suites
 Test Files  3 passed (3)
      Tests  15 passed (15)
$ bun run --cwd packages/core test -- src/features/basic-capabilities/providers/
 Test Files  15 passed (15)
      Tests  83 passed (83)
$ bun run --cwd packages/core test -- src/__tests__/message-runtime-stage1.test.ts
 Test Files  1 passed (1)
      Tests  114 passed (114)
$ bun run --cwd packages/core typecheck   # exit 0
```

`packages/agent` typecheck fails only on pre-existing `plugins/plugin-agent-orchestrator/src/services/smithers-task-integration.ts:258` (`.findLast` lib target), untouched by this PR.

## Contribution attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


