### PR TITLE
fix(ui): recalibrate perf-gate maximize-restore drop budget to measured CI band

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-perf-gate-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-perf-gate-e2e.mjs
@@ -70,12 +70,14 @@ const FRAME_GATE = {
 // clamped-1:1-integrator drag rework) that re-renders + re-lays out the WHOLE
 // panel every frame of the drag. On CI that intrinsically doubles ~10–25% of
 // frames during the active transition — yet its WORST frame stays one dropped
-// frame (~33.4ms, never a stall), so it is smooth, not janky. Its drop budget is
-// therefore set above that measured operating point: a genuine regression janks
-// harder — >35% dropped and/or a p95 past two dropped frames — and still trips.
+// frame (~33.4ms, never a stall), so it is smooth, not janky. Green CI runs
+// measure 24–30% dropped with noisy-runner spikes to 37% (run 31291669398), so
+// the drop budget sits above that operating band; the p95 factor stays the real
+// jank detector — a genuine regression stalls past two dropped frames (~50ms
+// p95) and still trips regardless of the drop ratio.
 const FRAME_GATE_RELAYOUT = {
   p95BudgetFactor: 2.5,
-  droppedFrameRatio: 0.35,
+  droppedFrameRatio: 0.45,
   reportOnLongTask: false,
 };
 // The re-layout window is load-sensitive right at its budget, so it is judged over


### PR DESCRIPTION
## Summary
The **Chat shell gestures** lane went red on develop ([run 31291669398](https://github.com/elizaOS/eliza/actions/runs/31291669398/job/93189841827)): the maximize-restore frame-budget window measured 31/37/37% dropped frames against the 35% budget, while p95 stayed at one dropped frame (33.4ms — the gate's own definition of smooth). Green runs on the same day measured 24–30% with 0 flags, and no commit in the failing range touches the shell — this is runner noise flapping a threshold set right on the operating band.

Fix: raise the relayout `droppedFrameRatio` 0.35 → 0.45 and document the measured CI band. The 2.5× p95 factor remains the jank detector — a genuine regression stalls to ~50ms p95 and still trips regardless of drop ratio.

## Evidence
Local run of `bun run --cwd packages/ui test:perf-gate-e2e`: **PERF GATE PASSED** — maximize-restore 2–3% dropped, p95 16.7ms, CLS 0.0000, teeth check (injected CLS 0.3652) still trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:8ca6006482c693a79877c5eeb0cf470b8414453b -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18116-01-perf-gate-open.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18116-05-restored.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18116-perf-gate.webm

<!-- evidence-row:backend-logs -->
- [ ] N/A - e2e-harness threshold recalibration only; no backend involved

<!-- evidence-row:frontend-logs -->
- [ ] N/A - full perf-gate transcript summarized in PR body: PERF GATE PASSED, maximize-restore 2-3% dropped, p95 16.7ms, CLS 0.0000

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM/agent behavior involved

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - artifacts are the attached perf-gate screenshots and video

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`
