### PR TITLE
fix(core): open CURRENT_TIME to GUEST so non-admins get the date

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/currentTime.ts
+++ b/packages/core/src/features/basic-capabilities/providers/currentTime.ts
@@ -89,7 +89,7 @@ export const currentTimeProvider: Provider = {
 	contextGate: { anyOf: ["general"] },
 	cacheStable: false,
 	cacheScope: "turn",
-	roleGate: { minRole: "USER" },
+	roleGate: { minRole: "GUEST" },
 
 	get: async (_runtime: IAgentRuntime, _message: Memory, _state: State) => {
 		const now = new Date();

--- a/packages/core/src/features/basic-capabilities/providers/role-gates.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/role-gates.test.ts
@@ -12,6 +12,7 @@
  * group conversations for non-admin senders.
  */
 import { describe, expect, it } from "vitest";
+import { currentTimeProvider } from "./currentTime.ts";
 import { entitiesProvider } from "./entities.ts";
 import { recentMessagesProvider } from "./recentMessages.ts";
 import { worldProvider } from "./world.ts";
@@ -27,5 +28,11 @@ describe("current-room context providers stay readable at the GUEST floor", () =
 
 	it("ENTITIES (who is present in the current room) is not gated above GUEST", () => {
 		expect(entitiesProvider.roleGate).toEqual({ minRole: "GUEST" });
+	});
+
+	it("CURRENT_TIME (the date/time signal) is not gated above GUEST", () => {
+		// The system prompt promises the time signal; gating it above GUEST left
+		// non-admin senders to hallucinate the date. Time is not sensitive.
+		expect(currentTimeProvider.roleGate).toEqual({ minRole: "GUEST" });
 	});
 });


### PR DESCRIPTION
## Bug

CURRENT_TIME provider was gated `roleGate: { minRole: "USER" }`. Unassigned connector senders resolve to GUEST, and the provider role gate blanks any `minRole: "USER"` provider for GUEST senders — so non-admin users got NO date/time signal and the model hallucinated the date. The provider's own header says it "injects the current date and time into the prompt"; the system prompt promises this signal. The time is not sensitive.

## Fix

CURRENT_TIME now declares `roleGate: { minRole: "GUEST" }` (non-restricting), so every sender gets the date/time. Follow-up to #18115 (which opened RECENT_MESSAGES/WORLD/ENTITIES to GUEST for the same role-gate reason). Sensitive providers (cross-platform recall, contacts, admin surfaces) stay gated.

## Evidence

| check | result |
| --- | --- |
| `role-gates.test.ts` (extended) | 4/4 pass — CURRENT_TIME pinned to GUEST alongside recentMessages/world/entities |
| core typecheck | clean on the change |

evidence-head: 63017487ab0f3ff44580cf9262072da76d387a15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
