### PR TITLE
fix: reap stuck orchestrator tasks and keep stalled-status out of group digests

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   composeRoomDigest,
+  isSupervisorStalled,
   runSupervisorTick,
   type SupervisorTaskView,
   statusEmoji,
@@ -140,31 +141,11 @@ describe("runSupervisorTick (#8900)", () => {
     expect(first.posted).toEqual([]); // failed, nothing posted
     // A failed digest is REMEMBERED as `undeliverable:<digest>` so the loop does
     // not re-hammer a permanently-dead target every tick (the ~1871 warns/day
-    // storm ebdc4bc fixed). It re-posts only when the digest CHANGES — staleness
-    // bands mutate it within minutes; covered by the escalation test below.
+    // storm ebdc4bc fixed). It re-posts only when the digest CHANGES — i.e. on
+    // a structural transition, not on the passage of idle time.
     expect(seen.get(ROOM_A)?.startsWith("undeliverable:")).toBe(true);
     const second = await runSupervisorTick(views, send, seen);
     expect(second.posted).toEqual([]); // same digest still dead → damped, not retried
-  });
-
-  it("re-posts a STUCK task when its staleness band escalates (not deduped silent)", async () => {
-    const send = vi.fn(async () => undefined);
-    const seen = new Map<string, string>();
-    // First tick: task is fresh (no staleness) → posts.
-    const first = await runSupervisorTick(
-      [view({ id: "t1", status: "active" })],
-      send,
-      seen,
-    );
-    expect(first.posted).toEqual([ROOM_A]);
-    // Same task, same status/sessions, but now idle 8m+ (a stall) → the digest
-    // changes and it RE-POSTS, instead of being deduped into silence.
-    const second = await runSupervisorTick(
-      [view({ id: "t1", status: "active", staleness: "⏳ idle 8m+" })],
-      send,
-      seen,
-    );
-    expect(second.posted).toEqual([ROOM_A]);
   });
 });
 
@@ -183,16 +164,148 @@ describe("supervisorStalenessLabel (#8900)", () => {
     expect(supervisorStalenessLabel(min(25), t0)).toBe("⏳ idle 20m+");
     expect(supervisorStalenessLabel(min(90), t0)).toBe("⚠️ stalled 45m+");
   });
-  it("folds into the digest line", () => {
+  it("isSupervisorStalled trips only at the top (stalled) band", () => {
+    expect(isSupervisorStalled(min(10), t0)).toBe(false);
+    expect(isSupervisorStalled(min(44), t0)).toBe(false);
+    expect(isSupervisorStalled(min(45), t0)).toBe(true);
+    expect(isSupervisorStalled(min(90), t0)).toBe(true);
+    expect(isSupervisorStalled(null, t0)).toBe(false);
+    expect(isSupervisorStalled(0, t0)).toBe(false);
+  });
+  it("never folds idle/stall age into the room digest line", () => {
     const digest = composeRoomDigest([
-      view({
-        id: "t1",
-        label: "grind",
-        status: "active",
-        staleness: "⏳ idle 8m+",
-      }),
+      view({ id: "t1", label: "grind", status: "active" }),
     ]);
-    expect(digest).toContain("grind — active (1 running) ⏳ idle 8m+");
+    expect(digest).toContain("grind — active (1 running)");
+    expect(digest).not.toContain("idle");
+    expect(digest).not.toContain("stalled");
+  });
+});
+
+describe("stalled tasks never re-post to the room; they escalate to the owner", () => {
+  function stalledRuntime(opts: { latestActivityAt: number | null }) {
+    const reportError = vi.fn();
+    const listTasks = vi.fn(async () => [
+      {
+        id: "t-stuck",
+        title: "app-build",
+        status: "active",
+        activeSessionCount: 1,
+        latestSessionLabel: "codex",
+        latestActivityAt: opts.latestActivityAt,
+        createdAt: new Date(Date.now() - 3_600_000).toISOString(),
+      },
+    ]);
+    const runtime = {
+      getService: (type: string) =>
+        type === "ORCHESTRATOR_TASK_SERVICE"
+          ? {
+              listTasks,
+              getTaskOriginTarget: async () => ({
+                roomId: ROOM_A,
+                source: "discord",
+              }),
+            }
+          : undefined,
+      sendMessageToTarget: async () => ({
+        kind: "delivered" as const,
+        receipt: {
+          providerMessageIds: ["digest-1"] as [string],
+          acceptedAt: 1_780_000_000_000,
+          persistence: { status: "persisted" as const, memoryIds: [] },
+        },
+        memories: [],
+      }),
+      getSetting: () => undefined,
+      reportError,
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
+    } as never;
+    return { runtime, reportError, listTasks };
+  }
+
+  it("an idle-timer tick does not re-post the digest (no group-channel stall spam)", async () => {
+    const { runtime, listTasks } = stalledRuntime({
+      latestActivityAt: Date.now() - 4 * 60_000,
+    });
+    const svc = await TaskSupervisorService.start(runtime);
+    const first = await svc.runOnce();
+    expect(first.posted).toEqual([ROOM_A]);
+    // Idle deepens across band boundaries; structure is unchanged → deduped.
+    listTasks.mockResolvedValue([
+      {
+        id: "t-stuck",
+        title: "app-build",
+        status: "active",
+        activeSessionCount: 1,
+        latestSessionLabel: "codex",
+        latestActivityAt: Date.now() - 50 * 60_000,
+        createdAt: new Date(Date.now() - 3_600_000).toISOString(),
+      },
+    ]);
+    const second = await svc.runOnce();
+    expect(second.posted).toEqual([]);
+    expect(second.skipped).toEqual([ROOM_A]);
+    await svc.stop();
+  });
+
+  it("a task crossing the stalled band escalates to the owner ONCE via reportError, not to the room", async () => {
+    const { runtime, reportError } = stalledRuntime({
+      latestActivityAt: Date.now() - 50 * 60_000,
+    });
+    const svc = await TaskSupervisorService.start(runtime);
+    const first = await svc.runOnce();
+    // The first digest for the room may post (structural), but the stall itself
+    // rides reportError — scope + task context, no room target.
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith(
+      "TaskSupervisorService.stalledTask",
+      expect.any(Error),
+      expect.objectContaining({ taskId: "t-stuck", status: "active" }),
+    );
+    // Digest text never carries the stall.
+    expect(first.posted).toEqual([ROOM_A]);
+    // Still stalled next tick → no second escalation, no re-post.
+    const second = await svc.runOnce();
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(second.posted).toEqual([]);
+    await svc.stop();
+  });
+
+  it("a recovered task clears its escalation mark so a later re-stall re-reports", async () => {
+    const { runtime, reportError, listTasks } = stalledRuntime({
+      latestActivityAt: Date.now() - 50 * 60_000,
+    });
+    const svc = await TaskSupervisorService.start(runtime);
+    await svc.runOnce();
+    expect(reportError).toHaveBeenCalledTimes(1);
+    // Fresh activity → recovered → mark cleared.
+    listTasks.mockResolvedValue([
+      {
+        id: "t-stuck",
+        title: "app-build",
+        status: "active",
+        activeSessionCount: 1,
+        latestSessionLabel: "codex",
+        latestActivityAt: Date.now() - 60_000,
+        createdAt: new Date(Date.now() - 3_600_000).toISOString(),
+      },
+    ]);
+    await svc.runOnce();
+    // Stalls again → re-escalates.
+    listTasks.mockResolvedValue([
+      {
+        id: "t-stuck",
+        title: "app-build",
+        status: "active",
+        activeSessionCount: 1,
+        latestSessionLabel: "codex",
+        latestActivityAt: Date.now() - 90 * 60_000,
+        createdAt: new Date(Date.now() - 7_200_000).toISOString(),
+      },
+    ]);
+    await svc.runOnce();
+    expect(reportError).toHaveBeenCalledTimes(2);
+    await svc.stop();
   });
 });
 
@@ -340,16 +453,14 @@ describe("digest damping (uncoordinated-messages burst)", () => {
         status: "active",
         activeSessions: 1,
         sessionLabel: "codex · acct-2",
-        staleness: "⏳ idle 8m+",
         heldAfterCompletion: true,
       }),
     ]);
     expect(digest).toContain(`${statusEmoji("active")} build-app — active`);
     expect(digest).not.toContain("running");
     expect(digest).not.toContain("codex");
-    expect(digest).not.toContain("idle");
-    // Verify-retry churn (new session label, escalating staleness) no longer
-    // mutates the digest, so the tick dedups instead of re-posting.
+    // Verify-retry churn (new session label) no longer mutates the digest, so
+    // the tick dedups instead of re-posting.
     const send = vi.fn(async () => undefined);
     const seen = new Map<string, string>();
     await runSupervisorTick(
@@ -370,7 +481,6 @@ describe("digest damping (uncoordinated-messages burst)", () => {
           id: "t1",
           label: "build-app",
           sessionLabel: "retry-2",
-          staleness: "⏳ idle 3m+",
           heldAfterCompletion: true,
         }),
       ],

--- a/plugins/plugin-agent-orchestrator/src/__tests__/stuck-task-reaper.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/stuck-task-reaper.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Stuck-task lifecycle reconciliation (the 45m+ "stalled" color-pop incident).
+ *
+ * Integration-style with a deterministic in-process ACP stand-in (the same
+ * FakeAcp shape admission-integration.test.ts uses); the
+ * OrchestratorTaskService, its store, the transition table, and the supervisor
+ * digest functions are all real. Proven here:
+ *
+ *  - a session that stops WITHOUT task_complete leaves its task `active` with
+ *    nothing running; the reaper reconciles it to `interrupted` past the idle
+ *    threshold, with an audit event, and the task drops out of the
+ *    supervisor's in-flight digest scan;
+ *  - fresh stops (under the threshold) and genuinely live sessions are never
+ *    reaped;
+ *  - a session that VANISHED from the ACP layer with no terminal event counts
+ *    as dead: the row is repaired to `stopped` and the task reconciled;
+ *  - a teardown `stopped` after `task_complete` no longer stomps the
+ *    `completed` session record, and a `validating` task is left to the
+ *    verification gate (never reaped);
+ *  - `stopTaskAgent` on the task's last live worker interrupts the task
+ *    immediately (no lingering `active` shell);
+ *  - a fresh spawn on a reaped task re-activates it through the `restarted`
+ *    edge (interrupted is recoverable, not a dead end).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../services/acp-service.ts";
+import { OrchestratorTaskService } from "../services/orchestrator-task-service.ts";
+import { OrchestratorTaskStore } from "../services/orchestrator-task-store.ts";
+import {
+  runSupervisorTick,
+  type SupervisorTaskView,
+} from "../services/task-supervisor-service.ts";
+import type {
+  SessionInfo,
+  SpawnOptions,
+  SpawnResult,
+} from "../services/types.ts";
+
+type EventHandler = (sessionId: string, event: string, data: unknown) => void;
+
+const ROOM = "11111111-1111-4111-8111-111111111111";
+
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 3000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error("waitUntil timed out");
+}
+
+/** Minimal deterministic ACP stand-in: tracks sessions, lets the test emit
+ * lifecycle events, and can make a session vanish without any event (the
+ * swept/lost-across-restart case the reaper must catch). */
+class FakeAcp {
+  static serviceType = AcpService.serviceType;
+  private readonly sessions = new Map<string, SessionInfo>();
+  private handler: EventHandler | undefined;
+  private counter = 0;
+
+  async spawnSession(opts: SpawnOptions): Promise<SpawnResult> {
+    const id = `sess-${++this.counter}`;
+    const now = new Date();
+    const session: SessionInfo = {
+      id,
+      name: opts.name ?? id,
+      agentType: opts.agentType ?? "opencode",
+      workdir: opts.workdir ?? "/tmp/work",
+      status: "running",
+      approvalPreset: opts.approvalPreset ?? "standard",
+      createdAt: now,
+      lastActivityAt: now,
+      metadata: { ...(opts.metadata ?? {}) },
+    };
+    this.sessions.set(id, session);
+    return {
+      sessionId: id,
+      id,
+      name: session.name ?? id,
+      agentType: session.agentType,
+      workdir: session.workdir,
+      status: session.status,
+      metadata: session.metadata,
+    };
+  }
+
+  listSessions(): SessionInfo[] {
+    return [...this.sessions.values()];
+  }
+
+  async getCapacity() {
+    const active = [...this.sessions.values()].filter(
+      (s) =>
+        !["stopped", "completed", "error", "errored", "cancelled"].includes(
+          s.status,
+        ),
+    ).length;
+    return {
+      maxSessions: 8,
+      systemHeadroom: 2,
+      activeWorkers: active,
+      activeSystem: 0,
+      freeWorkerSlots: Math.max(0, 8 - active),
+      freeSystemSlots: 2,
+    };
+  }
+
+  async getSession(id: string): Promise<SessionInfo | null> {
+    return this.sessions.get(id) ?? null;
+  }
+
+  async stopSession(id: string): Promise<void> {
+    const s = this.sessions.get(id);
+    if (s) s.status = "stopped";
+    this.handler?.(id, "stopped", {});
+  }
+
+  onSessionEvent(cb: EventHandler): () => void {
+    this.handler = cb;
+    return () => {
+      this.handler = undefined;
+    };
+  }
+
+  getChangedPaths(): string[] {
+    return [];
+  }
+
+  emit(sessionId: string, event: string, data: unknown = {}): void {
+    this.handler?.(sessionId, event, data);
+  }
+
+  /** The session's subprocess/record is simply GONE — no terminal event ever
+   * reached the bridge (host restart without persistence, stale sweep). */
+  vanish(id: string): void {
+    this.sessions.delete(id);
+  }
+}
+
+function makeRuntime(acp: FakeAcp): Record<string, unknown> {
+  return {
+    agentId: "00000000-0000-4000-8000-000000000042",
+    character: { name: "Reaper" },
+    databaseAdapter: undefined,
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: () => undefined,
+    useModel: vi.fn(async () => "{}"),
+    reportError: vi.fn(),
+    getService: (type: string) =>
+      type === AcpService.serviceType ? acp : undefined,
+  };
+}
+
+async function newTask(
+  store: OrchestratorTaskStore,
+  title: string,
+): Promise<string> {
+  const detail = await store.createTask({
+    title,
+    goal: `goal ${title}`,
+    acceptanceCriteria: [],
+    priority: "normal",
+    roomId: ROOM,
+  });
+  return detail.task.id;
+}
+
+/** Build supervisor views straight from the REAL task service (the same shape
+ * runOnce builds), bypassing only the young-task age gate so the scan itself —
+ * LIVE_STATUSES membership — is what the assertion exercises. */
+async function supervisorPosts(
+  service: OrchestratorTaskService,
+): Promise<string[]> {
+  const tasks = await service.listTasks({ includeArchived: false });
+  const views: SupervisorTaskView[] = await Promise.all(
+    tasks.map(async (t) => ({
+      id: t.id,
+      label: t.title,
+      status: t.status,
+      activeSessions: t.activeSessionCount,
+      sessionLabel: t.latestSessionLabel,
+      origin: await service.getTaskOriginTarget(t.id),
+    })),
+  );
+  const posted: string[] = [];
+  await runSupervisorTick(
+    views,
+    async (_target, content) => {
+      posted.push(String(content.text ?? ""));
+    },
+    new Map(),
+  );
+  return posted;
+}
+
+const MIN = 60_000;
+
+describe("stuck-task reaper (stalled color-pop incident)", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of [
+      "ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY",
+      "ELIZA_ACP_ADMISSION_QUEUE",
+      "ELIZA_ORCHESTRATOR_STUCK_TASK_REAPER",
+    ]) {
+      saved[key] = process.env[key];
+    }
+    process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = "0";
+    process.env.ELIZA_ACP_ADMISSION_QUEUE = "1";
+    // The interval timer is exercised implicitly by start(); ticks are driven
+    // explicitly through reapStuckTasks(nowMs) for determinism.
+    process.env.ELIZA_ORCHESTRATOR_STUCK_TASK_REAPER = "0";
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  async function harness() {
+    const acp = new FakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+    return { acp, store, service };
+  }
+
+  it("reconciles an active task whose only session stopped without task_complete, dropping it from the supervisor scan", async () => {
+    const { acp, store, service } = await harness();
+    const taskId = await newTask(store, "color-pop app-build");
+    await service.spawnAgentForTask(taskId);
+    const session = acp.listSessions()[0];
+    acp.emit(session.id, "ready", { sessionId: session.id });
+    await waitUntil(async () => {
+      const doc = await store.getTask(taskId);
+      return (
+        doc?.task.status === "active" && doc.sessions[0]?.status === "ready"
+      );
+    });
+
+    // The incident: the session tears down with a bare `stopped` — no
+    // task_complete ever reaches the bridge. The task is left `active`.
+    await acp.stopSession(session.id);
+    await waitUntil(async () => {
+      const doc = await store.getTask(taskId);
+      return doc?.sessions[0]?.status === "stopped";
+    });
+    expect((await store.getTask(taskId))?.task.status).toBe("active");
+    // Pre-reap, the supervisor's in-flight scan still surfaces it.
+    expect((await supervisorPosts(service)).join("\n")).toContain(
+      "color-pop app-build",
+    );
+
+    // Under the idle threshold nothing is reaped.
+    expect(await service.reapStuckTasks(Date.now() + MIN)).toEqual([]);
+    expect((await store.getTask(taskId))?.task.status).toBe("active");
+
+    // Past the threshold the task reconciles to `interrupted` with an audit
+    // event, and the supervisor scan no longer surfaces it.
+    const reaped = await service.reapStuckTasks(Date.now() + 6 * MIN);
+    expect(reaped).toEqual([taskId]);
+    const doc = await store.getTask(taskId);
+    expect(doc?.task.status).toBe("interrupted");
+    expect(doc?.events.some((e) => e.eventType === "task_stalled_reaped")).toBe(
+      true,
+    );
+    expect(await supervisorPosts(service)).toEqual([]);
+
+    await service.stop();
+  });
+
+  it("never reaps a task with a genuinely live session, regardless of idle time", async () => {
+    const { acp, store, service } = await harness();
+    const taskId = await newTask(store, "long-running build");
+    await service.spawnAgentForTask(taskId);
+    const session = acp.listSessions()[0];
+    acp.emit(session.id, "ready", { sessionId: session.id });
+    await waitUntil(async () => {
+      const doc = await store.getTask(taskId);
+      return (
+        doc?.task.status === "active" && doc.sessions[0]?.status === "ready"
+      );
+    });
+
+    expect(await service.reapStuckTasks(Date.now() + 60 * MIN)).toEqual([]);
+    expect((await store.getTask(taskId))?.task.status).toBe("active");
+
+    await service.stop();
+  });
+
+  it("treats a session that vanished from the ACP layer with no event as dead: repairs the row and reconciles the task", async () => {
+    const { acp, store, service } = await harness();
+    const taskId = await newTask(store, "vanished worker");
+    await service.spawnAgentForTask(taskId);
+    const session = acp.listSessions()[0];
+    acp.emit(session.id, "ready", { sessionId: session.id });
+    await waitUntil(async () => {
+      const doc = await store.getTask(taskId);
+      return (
+        doc?.task.status === "active" && doc.sessions[0]?.status === "ready"
+      );
+    });
+
+    // The subprocess/record is gone; the bridge never saw a terminal event, so
+    // the durable row still LOOKS live.
+    acp.vanish(session.id);
+    expect((await store.getTask(taskId))?.sessions[0]?.status).not.toBe(
+      "stopped",
+    );
+
+    const reaped = await service.reapStuckTasks(Date.now() + 6 * MIN);
+    expect(reaped).toEqual([taskId]);
+    const doc = await store.getTask(taskId);
+    expect(doc?.task.status).toBe("interrupted");
+    expect(doc?.sessions[0]?.status).toBe("stopped");
+
+    await service.stop();
+  });
+
+  it("leaves a validating task to the verification gate: teardown `stopped` never stomps `completed`, and the reaper skips it", async () => {
+    const { acp, store, service } = await harness();
+    const taskId = await newTask(store, "completed then torn down");
+    await service.spawnAgentForTask(taskId);
+    const session = acp.listSessions()[0];
+    acp.emit(session.id, "ready", { sessionId: session.id });
+    await waitUntil(async () => {
+      const doc = await store.getTask(taskId);
+      return (
+        doc?.task.status === "active" && doc.sessions[0]?.status === "ready"
+      );
+    });
+
+    acp.emit(session.id, "task_complete", { response: "done, shipped" });
+    await waitUntil(
+      async () => (await store.getTask(taskId))?.task.status === "validating",
+    );
+    expect((await store.getTask(taskId))?.sessions[0]?.status).toBe(
+      "completed",
+    );
+
+    // KeepAlive teardown after completion: `stopped` must not rewrite the
+    // completed record (the completion pipeline keys off it).
+    acp.emit(session.id, "stopped", {});
+    await new Promise((r) => setTimeout(r, 25));
+    expect((await store.getTask(taskId))?.sessions[0]?.status).toBe(
+      "completed",
+    );
+
+    // And a validating task is the verifier's to settle — never the reaper's.
+    expect(await service.reapStuckTasks(Date.now() + 60 * MIN)).toEqual([]);
+    expect((await store.getTask(taskId))?.task.status).toBe("validating");
+
+    await service.stop();
+  });
+
+  it("stopTaskAgent on the last live worker interrupts the task immediately", async () => {
+    const { acp, store, service } = await harness();
+    const taskId = await newTask(store, "operator-stopped build");
+    await service.spawnAgentForTask(taskId);
+    const session = acp.listSessions()[0];
+    acp.emit(session.id, "ready", { sessionId: session.id });
+    await waitUntil(async () => {
+      const doc = await store.getTask(taskId);
+      return (
+        doc?.task.status === "active" && doc.sessions[0]?.status === "ready"
+      );
+    });
+
+    await expect(service.stopTaskAgent(taskId, session.id)).resolves.toBe(true);
+    await waitUntil(
+      async () => (await store.getTask(taskId))?.task.status === "interrupted",
+    );
+    expect(await supervisorPosts(service)).toEqual([]);
+
+    await service.stop();
+  });
+
+  it("a fresh spawn re-activates a reaped task through the restarted edge", async () => {
+    const { acp, store, service } = await harness();
+    const taskId = await newTask(store, "reaped then respawned");
+    await service.spawnAgentForTask(taskId);
+    const first = acp.listSessions()[0];
+    acp.emit(first.id, "ready", { sessionId: first.id });
+    await waitUntil(async () => {
+      const doc = await store.getTask(taskId);
+      return (
+        doc?.task.status === "active" && doc.sessions[0]?.status === "ready"
+      );
+    });
+    await acp.stopSession(first.id);
+    await waitUntil(async () => {
+      const doc = await store.getTask(taskId);
+      return doc?.sessions[0]?.status === "stopped";
+    });
+    expect(await service.reapStuckTasks(Date.now() + 6 * MIN)).toEqual([
+      taskId,
+    ]);
+    expect((await store.getTask(taskId))?.task.status).toBe("interrupted");
+
+    // A late zombie event alone must NOT resurrect the task…
+    acp.emit(first.id, "ready", { sessionId: first.id });
+    await new Promise((r) => setTimeout(r, 25));
+    expect((await store.getTask(taskId))?.task.status).toBe("interrupted");
+
+    // …but a real new spawn re-engages it (interrupted → restarted → active).
+    await service.spawnAgentForTask(taskId);
+    await waitUntil(
+      async () => (await store.getTask(taskId))?.task.status === "active",
+    );
+
+    await service.stop();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -332,6 +332,20 @@ const ADMISSION_DRAIN_EVENTS: ReadonlySet<string> = new Set([
   "error",
 ]);
 
+/** Stuck-task reaper: an `active` task whose every sub-agent session is
+ * stopped/dead cannot make progress — no event will ever advance it, so it
+ * would sit in the supervisor's in-flight scan (and the digest) forever. The
+ * reaper reconciles such a task to `interrupted` (the lost-session state; an
+ * operator restart re-engages it) once it has been idle past this threshold.
+ * The threshold comfortably exceeds spawn/handoff latency so an in-flight
+ * successor session is never mistaken for a corpse. Overridable via
+ * `ELIZA_ORCHESTRATOR_STUCK_TASK_REAP_MS`; the reaper is on by default and
+ * disabled with `ELIZA_ORCHESTRATOR_STUCK_TASK_REAPER=0`. */
+const STUCK_TASK_REAP_THRESHOLD_MS = 5 * 60_000;
+
+/** Cadence of the stuck-task reaper scan. */
+const STUCK_TASK_REAP_INTERVAL_MS = 60_000;
+
 function independentVerifyTimeoutMs(runtime: {
   getSetting?: (key: string) => unknown;
 }): number {
@@ -1027,6 +1041,9 @@ export class OrchestratorTaskService extends Service {
   // tick can't both dispatch the same parked task. A promise-chain mutex.
   private admissionDrainLock = Promise.resolve();
   private admissionReconcileTimer: NodeJS.Timeout | undefined;
+  private stuckTaskReaperTimer: NodeJS.Timeout | undefined;
+  /** Serializes reaper passes — a slow scan must not overlap the next tick. */
+  private stuckTaskReapInFlight = false;
   private smithersRecoveryInFlight:
     | Promise<{ recovered: number; skipped: number }>
     | undefined;
@@ -1101,6 +1118,15 @@ export class OrchestratorTaskService extends Service {
       }, ADMISSION_RECONCILE_INTERVAL_MS);
       this.admissionReconcileTimer.unref?.();
     }
+    // Stuck-task reaper: reconciles `active` tasks whose sessions are all
+    // stopped/dead to `interrupted` so they drop out of every in-flight scan
+    // (supervisor digest, status rollups) instead of "stalling" forever.
+    if (this.stuckTaskReaperEnabled()) {
+      this.stuckTaskReaperTimer = setInterval(() => {
+        void this.reapStuckTasks();
+      }, STUCK_TASK_REAP_INTERVAL_MS);
+      this.stuckTaskReaperTimer.unref?.();
+    }
     const acp = this.acp();
     if (acp) {
       this.subscribeToAcp(acp);
@@ -1156,6 +1182,10 @@ export class OrchestratorTaskService extends Service {
     if (this.admissionReconcileTimer) {
       clearInterval(this.admissionReconcileTimer);
       this.admissionReconcileTimer = undefined;
+    }
+    if (this.stuckTaskReaperTimer) {
+      clearInterval(this.stuckTaskReaperTimer);
+      this.stuckTaskReaperTimer = undefined;
     }
     this.started = false;
   }
@@ -1737,12 +1767,20 @@ export class OrchestratorTaskService extends Service {
         });
         break;
       }
-      case "stopped":
+      case "stopped": {
+        // A teardown `stopped` for a session that already delivered its result
+        // must not stomp the `completed` record (mirror of the late-`error`
+        // guard above): the completion pipeline — validating status, verify
+        // gate, completion summary — keys off that status, and the keepAlive
+        // subprocess closing AFTER task_complete is normal teardown, not news.
+        const stoppedPrior = (await this.store.findSession(sessionId))?.session;
+        if (stoppedPrior?.status === "completed") break;
         await this.store.updateSession(sessionId, {
           status: "stopped",
           stoppedAt: Date.now(),
         });
         break;
+      }
       case "usage_update": {
         const usage = parseUsage(data);
         if (usage) await this.recordUsage(taskId, sessionId, usage);
@@ -2552,6 +2590,25 @@ export class OrchestratorTaskService extends Service {
     const next = resolveTaskTransition(doc.task.status, trigger);
     if (next === null || next === doc.task.status) return;
     await this.store.updateTask(taskId, { status: next });
+  }
+
+  /**
+   * Promote a task for a genuinely NEW live worker (a real spawn or attach).
+   * A plain `session_active` deliberately has no edge out of `interrupted` —
+   * late zombie events from a dying session must not resurrect a stopped or
+   * reaped task — so recording a fresh worker on an interrupted task routes
+   * through `restarted` (the explicit "run it again" move, legal from every
+   * state), and through the weak `session_active` otherwise. This is also what
+   * lets a resume/rerun spawn self-heal a task the stuck-task reaper
+   * interrupted while the spawn was still in flight.
+   */
+  private async advanceTaskLiveness(taskId: string): Promise<void> {
+    const doc = await this.store.getTask(taskId);
+    if (!doc || doc.task.paused) return;
+    await this.advanceTaskStatus(
+      taskId,
+      doc.task.status === "interrupted" ? "restarted" : "session_active",
+    );
   }
 
   /**
@@ -5095,7 +5152,7 @@ export class OrchestratorTaskService extends Service {
           Boolean(doc.task.boundWorkdir) &&
           doc.task.boundWorkdir !== result.workdir,
       });
-      await this.advanceTaskStatus(taskId, "session_active");
+      await this.advanceTaskLiveness(taskId);
       waveSupervisor?.release(taskId);
       return this.getTask(taskId);
     } catch (err) {
@@ -5279,7 +5336,7 @@ export class OrchestratorTaskService extends Service {
     // indexed for history + future token attribution without falsely promoting
     // task status.
     if (!TERMINAL_TASK_SESSION_STATUSES.has(input.status)) {
-      await this.advanceTaskStatus(taskId, "session_active");
+      await this.advanceTaskLiveness(taskId);
     }
     return true;
   }
@@ -5373,6 +5430,22 @@ export class OrchestratorTaskService extends Service {
       status: "stopped",
       stoppedAt: Date.now(),
     });
+    // An explicit stop of the task's LAST live worker ends its in-flight work:
+    // leave the task `interrupted` (the operator-stop state) rather than
+    // `active`, or it lingers in every in-flight scan — the supervisor digest
+    // would surface it as "active/stalled" forever with nothing running.
+    // Scoped to `active` only: a `validating` task legitimately has no live
+    // worker while the verifier holds it, and stopping its keepAlive session
+    // must not yank the status out from under an in-flight validateTask.
+    const after = await this.store.getTask(taskId);
+    if (
+      after &&
+      after.task.status === "active" &&
+      !after.sessions.some((s) => !TERMINAL_TASK_SESSION_STATUSES.has(s.status))
+    ) {
+      await this.advanceTaskStatus(taskId, "interrupted");
+      this.emitChange(taskId);
+    }
     return true;
   }
 
@@ -5631,6 +5704,130 @@ export class OrchestratorTaskService extends Service {
         }`,
       );
     }
+  }
+
+  // ---- stuck-task reaper -------------------------------------------------
+
+  /** On by default; `ELIZA_ORCHESTRATOR_STUCK_TASK_REAPER=0` disables the
+   * periodic reconcile (the scan is still callable directly). */
+  private stuckTaskReaperEnabled(): boolean {
+    return this.readSetting("ELIZA_ORCHESTRATOR_STUCK_TASK_REAPER") !== "0";
+  }
+
+  private stuckTaskReapThresholdMs(): number {
+    return parsePositiveIntSetting(
+      this.readSetting("ELIZA_ORCHESTRATOR_STUCK_TASK_REAP_MS"),
+      STUCK_TASK_REAP_THRESHOLD_MS,
+    );
+  }
+
+  /**
+   * Reconcile stuck tasks: an `active`, unpaused task whose EVERY sub-agent
+   * session is terminal (or dead at the ACP layer — swept, vanished across a
+   * restart, or terminal there without the bridge ever seeing the event) and
+   * that has been idle past the reap threshold is moved to `interrupted` via
+   * the transition table, with an audit event on its timeline. Nothing can
+   * advance such a task — no session exists to emit an event — so without this
+   * it surfaces in the supervisor's in-flight scan as "active/stalled" forever
+   * (the 45m+ color-pop stall). `interrupted` drops it from every live scan
+   * while staying operator-recoverable (restart/reopen re-engage it).
+   *
+   * Deliberately conservative:
+   *  - only `active` — `open` belongs to the admission queue, `validating` to
+   *    the verification gate, `blocked`/`waiting_on_user` legitimately idle;
+   *  - a live-LOOKING session row is trusted unless the ACP layer positively
+   *    contradicts it (absent or terminal there); no ACP service ⇒ skip;
+   *  - the idle threshold comfortably exceeds spawn latency, and a mid-spawn
+   *    reap is self-healed by advanceTaskLiveness once the session records.
+   *
+   * Returns the reaped taskIds (for tests/observability).
+   */
+  async reapStuckTasks(nowMs = Date.now()): Promise<string[]> {
+    if (this.stuckTaskReapInFlight) return [];
+    this.stuckTaskReapInFlight = true;
+    const reaped: string[] = [];
+    try {
+      const thresholdMs = this.stuckTaskReapThresholdMs();
+      const acp = this.acp();
+      const records = await this.store.listTasks({ includeArchived: false });
+      for (const record of records) {
+        if (record.status !== "active" || record.paused) continue;
+        const doc = await this.store.getTask(record.id);
+        if (doc?.task.status !== "active" || doc.task.paused) continue;
+
+        const liveRows = doc.sessions.filter(
+          (s) => !TERMINAL_TASK_SESSION_STATUSES.has(s.status),
+        );
+        // A row that still looks live only counts as dead when the ACP layer
+        // positively contradicts it. Missing ACP service ⇒ cannot judge ⇒ skip.
+        const deadRows: OrchestratorTaskSession[] = [];
+        let hasLiveSession = false;
+        for (const row of liveRows) {
+          if (!acp) {
+            hasLiveSession = true;
+            break;
+          }
+          const acpSession = await acp.getSession(row.sessionId);
+          if (acpSession && !TERMINAL_SESSION_STATUSES.has(acpSession.status)) {
+            hasLiveSession = true;
+            break;
+          }
+          deadRows.push(row);
+        }
+        if (hasLiveSession) continue;
+
+        const latestActivityMs = Math.max(
+          doc.task.lastActivityAt ?? 0,
+          ...doc.sessions.map((s) =>
+            Math.max(s.lastActivityAt ?? 0, s.stoppedAt ?? 0),
+          ),
+        );
+        // No known activity time ⇒ cannot judge idleness ⇒ leave it alone.
+        if (!(latestActivityMs > 0)) continue;
+        const idleMs = nowMs - latestActivityMs;
+        if (idleMs < thresholdMs) continue;
+
+        // Repair rows the bridge never saw go terminal, so DTOs stop counting
+        // phantom "active" sessions for the interrupted task.
+        for (const row of deadRows) {
+          await this.store.updateSession(row.sessionId, {
+            status: "stopped",
+            stoppedAt: nowMs,
+          });
+        }
+        await this.store.addEvent({
+          id: randomUUID(),
+          taskId: record.id,
+          eventType: "task_stalled_reaped",
+          summary: `No live sub-agent session and no activity for ${Math.round(
+            idleMs / 60_000,
+          )}m; task marked interrupted.`,
+          data: {
+            idleMs,
+            thresholdMs,
+            repairedSessionIds: deadRows.map((row) => row.sessionId),
+          },
+          timestamp: nowMs,
+          createdAt: nowIso(),
+        });
+        await this.advanceTaskStatus(record.id, "interrupted");
+        this.emitChange(record.id);
+        this.log("info", "stuck task reaped to interrupted", {
+          taskId: record.id,
+          idleMs,
+        });
+        reaped.push(record.id);
+      }
+    } catch (err) {
+      // error-policy:J7 background reconcile tick — a store/ACP hiccup is
+      // warned and retried on the next interval; it must not kill the timer.
+      this.log("warn", "stuck-task reap pass failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.stuckTaskReapInFlight = false;
+    }
+    return reaped;
   }
 
   // ---- admission queue (#13772) -----------------------------------------

--- a/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
@@ -17,6 +17,15 @@
  * must not be a second uncoordinated message about the same event), and a task
  * held un-done by a verification gate after reporting completion digests on
  * status transitions only. See noteTaskCompletion for the cross-surface half.
+ *
+ * Stall handling is OWNER-scoped, never room-scoped: a task's idle/stalled
+ * age is deliberately NOT part of the digest, because folding an incrementing
+ * idle timer into the room post turns a single stuck task into a stream of
+ * unprompted "still stalled" messages in a shared channel (completions already
+ * relay; a mere stall is noise there). A task that crosses the STALLED band
+ * instead escalates once through `runtime.reportError`, which feeds the
+ * RECENT_ERRORS ring and the owner-escalation threshold — quiet, owner-facing,
+ * and deduplicated until the task recovers.
  */
 
 import type {
@@ -67,11 +76,6 @@ export interface SupervisorTaskView {
   activeSessions: number;
   /** Latest session label (often "agentType · account"), if any. */
   sessionLabel?: string | null;
-  /** Coarse staleness indicator for a progress-expected task that has gone
-   *  idle (e.g. "⏳ idle 8m+"), or undefined when fresh. Folded into the digest
-   *  line so a genuinely STUCK task changes the digest and re-posts, instead of
-   *  being deduped into silence after the first post. */
-  staleness?: string;
   /** The originating chat target; null tasks (no chat origin) are skipped. */
   origin: { roomId: string; source: string } | null;
   /** True when the task is parked in the admission queue (waiting for a session
@@ -85,17 +89,18 @@ export interface SupervisorTaskView {
   recentlyRelayed?: boolean;
   /** True when this task has reported completion at least once but is still
    *  held un-done by a verification gate (URL-verify retry, residuals). The
-   *  verify-retry respawns churn session labels/counts and the staleness bands
-   *  escalate while the gate holds — each mutation would re-post "still
-   *  active" noise after the user already received the completion relay. The
-   *  digest line freezes to structural status for such tasks; a real status
-   *  transition still changes the digest and posts. */
+   *  verify-retry respawns churn session labels/counts while the gate holds —
+   *  each mutation would re-post "still active" noise after the user already
+   *  received the completion relay. The digest line freezes to structural
+   *  status for such tasks; a real status transition still changes the digest
+   *  and posts. */
   heldAfterCompletion?: boolean;
 }
 
-// Coarse staleness bands (minutes → label), highest first. Bucketed on purpose:
-// steady progress within a band still dedups, but a stall crossing into the
-// next band changes the digest and re-posts, escalating as it worsens.
+// Coarse staleness bands (minutes → label), highest first. These feed the
+// OWNER-scoped stall escalation (and its context text), never the room digest:
+// an incrementing idle timer in the digest would change it every band crossing
+// and re-post "still stalled" noise into a shared channel.
 const SUPERVISOR_STALENESS_BANDS: ReadonlyArray<readonly [number, string]> = [
   [45, "⚠️ stalled 45m+"],
   [20, "⏳ idle 20m+"],
@@ -103,9 +108,13 @@ const SUPERVISOR_STALENESS_BANDS: ReadonlyArray<readonly [number, string]> = [
   [3, "⏳ idle 3m+"],
 ];
 
+/** Idle age (minutes) at which a progress-expected task counts as STALLED and
+ *  escalates to the owner — the top staleness band. */
+const STALLED_BAND_MINUTES = SUPERVISOR_STALENESS_BANDS[0][0];
+
 /** Coarse staleness label for a progress-expected task, or undefined when it is
- *  fresh / has no known activity time. Pure (takes `nowMs`) so the digest stays
- *  deterministic and unit-testable without a clock. */
+ *  fresh / has no known activity time. Pure (takes `nowMs`) so the escalation
+ *  context stays deterministic and unit-testable without a clock. */
 export function supervisorStalenessLabel(
   latestActivityAt: number | null | undefined,
   nowMs: number,
@@ -118,6 +127,18 @@ export function supervisorStalenessLabel(
     if (ageMin >= min) return label;
   }
   return undefined;
+}
+
+/** Whether a progress-expected task has crossed the STALLED band. Pure; an
+ *  unknown activity time is never "stalled" (no false owner escalations). */
+export function isSupervisorStalled(
+  latestActivityAt: number | null | undefined,
+  nowMs: number,
+): boolean {
+  if (typeof latestActivityAt !== "number" || latestActivityAt <= 0) {
+    return false;
+  }
+  return nowMs - latestActivityAt >= STALLED_BAND_MINUTES * 60_000;
 }
 
 /** Statuses where the sub-agent is expected to be MAKING PROGRESS, so a long
@@ -159,16 +180,18 @@ export function composeRoomDigest(views: SupervisorTaskView[]): string {
     .sort((a, b) => a.label.localeCompare(b.label))
     .map((v) => {
       // Post-completion hold: only the structural status may drive a re-post
-      // (see heldAfterCompletion) — session churn and staleness escalation on
-      // a gate-held task are noise, not news.
+      // (see heldAfterCompletion) — session churn on a gate-held task is
+      // noise, not news.
       if (v.heldAfterCompletion) {
         return `${statusEmoji(v.status)} ${v.label} — ${v.status}`;
       }
       const detail = v.sessionLabel ? ` · ${v.sessionLabel}` : "";
       const sessions =
         v.activeSessions > 0 ? ` (${v.activeSessions} running)` : "";
-      const stale = v.staleness ? ` ${v.staleness}` : "";
-      return `${statusEmoji(v.status)} ${v.label} — ${v.status}${sessions}${detail}${stale}`;
+      // Deliberately no idle/staleness suffix: a stall is owner-escalation
+      // material (see escalateStalledTasks), not a room broadcast — and its
+      // ticking age must not mutate the digest into change-driven re-posts.
+      return `${statusEmoji(v.status)} ${v.label} — ${v.status}${sessions}${detail}`;
     });
   if (queuedCount > 0) {
     lines.push(`⏳ ${queuedCount} queued (waiting for a session slot)`);
@@ -251,9 +274,9 @@ export async function runSupervisorTick(
         }`,
       );
       // Permanent-failure damper: remember the digest that failed so the loop
-      // retries only when the digest CHANGES — staleness bands mutate the digest
-      // over time and room pruning resets state on task turnover, so stalled
-      // tasks still re-attempt without warn-looping every tick against a
+      // retries only when the digest CHANGES — structural transitions mutate
+      // the digest and room pruning resets state on task turnover, so live
+      // rooms still re-attempt without warn-looping every tick against a
       // permanently undeliverable target.
       seen.set(roomId, `undeliverable:${digest}`);
     }
@@ -320,6 +343,10 @@ export class TaskSupervisorService extends Service {
    *  verification gate is holding un-done. Pruned each tick against the live
    *  task list. */
   private readonly completionNotes = new Map<string, number>();
+  /** taskIds already escalated to the owner for the CURRENT stall, so a stuck
+   *  task escalates once — not once per tick — and re-escalates only after it
+   *  recovers (or vanishes) and stalls again. */
+  private readonly stallEscalated = new Set<string>();
   private readonly digestSinks = new Map<
     string,
     Set<TaskSupervisorDigestSink>
@@ -457,6 +484,9 @@ export class TaskSupervisorService extends Service {
       for (const taskId of [...this.completionNotes.keys()]) {
         if (!noteEligibleIds.has(taskId)) this.completionNotes.delete(taskId);
       }
+      // A stall never rides the room digest — it escalates to the OWNER, once
+      // per stall, through the reportError → RECENT_ERRORS/escalation path.
+      this.escalateStalledTasks(tasks, now);
       const views: SupervisorTaskView[] = await Promise.all(
         surfaced.map(async (t) => {
           const completionAt = this.completionNotes.get(t.id);
@@ -466,11 +496,6 @@ export class TaskSupervisorService extends Service {
             status: t.status,
             activeSessions: t.activeSessionCount,
             sessionLabel: t.latestSessionLabel,
-            // Surface a stall only for progress-expected statuses; waiting_on_user
-            // / blocked are legitimately idle.
-            staleness: PROGRESS_EXPECTED_STATUSES.has(t.status)
-              ? supervisorStalenessLabel(t.latestActivityAt, now)
-              : undefined,
             origin: await taskSvc.getTaskOriginTarget(t.id),
             queued: t.admission?.state === "queued",
             ...(typeof completionAt === "number"
@@ -506,6 +531,54 @@ export class TaskSupervisorService extends Service {
     }
   }
 
+  /**
+   * Owner-scoped stall surfacing: a progress-expected task (active/validating)
+   * whose last activity crossed the STALLED band is reported ONCE through
+   * `runtime.reportError` — the diagnostic boundary that feeds RECENT_ERRORS
+   * and the owner-escalation threshold — and never posted to the originating
+   * (possibly shared/group) room. The escalation mark clears when the task
+   * recovers or leaves the live set, so a later genuine re-stall re-escalates.
+   */
+  private escalateStalledTasks(
+    tasks: Array<{
+      id: string;
+      title: string;
+      status: OrchestratorTaskStatus;
+      latestActivityAt: number | null;
+    }>,
+    nowMs: number,
+  ): void {
+    const stalledIds = new Set<string>();
+    for (const t of tasks) {
+      if (!PROGRESS_EXPECTED_STATUSES.has(t.status)) continue;
+      if (!isSupervisorStalled(t.latestActivityAt, nowMs)) continue;
+      stalledIds.add(t.id);
+      if (this.stallEscalated.has(t.id)) continue;
+      this.stallEscalated.add(t.id);
+      this.runtime.reportError?.(
+        "TaskSupervisorService.stalledTask",
+        new Error(
+          `Orchestrator task "${t.title}" is ${t.status} with no activity (${
+            supervisorStalenessLabel(t.latestActivityAt, nowMs) ?? "stalled"
+          }) — it may need a restart, a stop, or attention.`,
+        ),
+        {
+          taskId: t.id,
+          status: t.status,
+          idleMs:
+            typeof t.latestActivityAt === "number" && t.latestActivityAt > 0
+              ? nowMs - t.latestActivityAt
+              : null,
+        },
+      );
+    }
+    // Recover-then-re-escalate: drop marks for tasks that are no longer stalled
+    // (fresh activity, terminal status, or gone) so a future stall re-reports.
+    for (const id of [...this.stallEscalated]) {
+      if (!stalledIds.has(id)) this.stallEscalated.delete(id);
+    }
+  }
+
   async stop(): Promise<void> {
     if (this.timer) {
       clearInterval(this.timer);
@@ -513,6 +586,7 @@ export class TaskSupervisorService extends Service {
     }
     this.seen.clear();
     this.completionNotes.clear();
+    this.stallEscalated.clear();
     this.digestSinks.clear();
   }
 }


### PR DESCRIPTION
## Problem

The bot proactively posted `task update. color-pop build active. app-build stalled 45m+.` into a group channel, unprompted. Two structural root causes:

1. **The task record never went terminal.** A color-pop app-build task's ACP session stopped (the app itself built and shipped), but the event bridge's `stopped` handler (`orchestrator-task-service.ts`, `applySessionEvent` case `"stopped"`) only wrote the SESSION record — the TASK was never advanced, so it sat `active`/in-flight in the supervisor scan for 45+ minutes with nothing running, and nothing could ever advance it (no session left to emit an event).
2. **The supervisor digest folded the ticking idle timer into the room post.** The digest is change-driven, and the staleness label (`idle 3m+ → 8m+ → 20m+ → stalled 45m+`) mutated the digest on every band crossing — so one stuck task re-posted "still stalled" into a shared channel repeatedly.

## Fix

### Task lifecycle (problem 1)

- **`stopped` completed-guard** — a teardown `stopped` after `task_complete` no longer stomps the `completed` session record (mirror of the existing late-`error` guard on the same switch).
- **`stopTaskAgent`** — explicitly stopping the task's last live worker now advances the task `active → interrupted` through the transition table instead of leaving an `active` shell.
- **Stuck-task reaper** (new, default-on) — a periodic reconcile moves an `active`, unpaused task to `interrupted` (+ `task_stalled_reaped` audit event) when every session row is terminal — or dead at the ACP layer (vanished / terminal there with no bridge event; such rows are repaired to `stopped`) — and the task has been idle past a threshold (default 5m, `ELIZA_ORCHESTRATOR_STUCK_TASK_REAP_MS`; disable with `ELIZA_ORCHESTRATOR_STUCK_TASK_REAPER=0`). Deliberately conservative: only `active` (`open` belongs to the admission queue, `validating` to the verification gate, `blocked`/`waiting_on_user` are legitimately idle); live-looking rows are trusted unless ACP positively contradicts them; unknown activity times are never judged.
- **`advanceTaskLiveness`** — recording a genuinely NEW worker (spawn/attach) on an `interrupted` task routes through the `restarted` edge (legal from every state), so a reaped task re-engages on a real spawn and a mid-spawn reap self-heals — while a late zombie `ready` from a dead session still cannot resurrect it (no `session_active` edge out of `interrupted`, unchanged).

### Digest scope (problem 2)

- Idle/staleness is removed from the room digest AND from its change-driven dedup key: the digest re-posts only on **structural** change (status transition, session churn, task set). A shared channel never receives an unprompted "still working / stalled" update; completions already relay separately.
- A task crossing the STALLED band (45m+) escalates **once** to the owner via `runtime.reportError("TaskSupervisorService.stalledTask", …)` — the documented diagnostic boundary that feeds RECENT_ERRORS and the owner-escalation threshold — deduped until the task recovers, then re-armed.
- `ELIZA_ORCHESTRATOR_SUPERVISOR=0` still disables the whole service (unchanged).

## Test matrix

| Case | Test |
|---|---|
| session stops w/o `task_complete` → task `interrupted`, drops from supervisor in-flight scan, audit event on timeline | `src/__tests__/stuck-task-reaper.test.ts` |
| under-threshold stop / genuinely live session → never reaped | same |
| session vanished at ACP layer with no event → row repaired to `stopped`, task reconciled | same |
| `stopped` after `task_complete` keeps `completed`; `validating` left to the verifier | same |
| `stopTaskAgent` on last live worker → task `interrupted` immediately | same |
| fresh spawn on reaped task → `restarted` → `active`; zombie `ready` alone does not resurrect | same |
| idle-band escalation no longer re-posts the digest; digest text carries no idle/stall | `__tests__/unit/task-supervisor.test.ts` |
| stalled task escalates once via `reportError`; recover-then-re-stall re-reports | same |
| digest sinks / dedup / undeliverable damper / held-after-completion freeze / age gate (existing) | `src/__tests__/task-supervisor.test.ts`, `__tests__/unit/task-supervisor.test.ts` |
| admission + full concurrency lifecycle regressions (terminal transition table, watchdog, scratch GC) | `src/__tests__/admission-integration.test.ts`, `src/__tests__/concurrency-lifecycle-integration.test.ts` |
| completion pipeline regressions | `src/__tests__/auto-goal-verify.test.ts`, `src/__tests__/task-change-set-mirror.test.ts`, `src/__tests__/verify-retry-busy-session.test.ts`, `src/__tests__/verify-retry-stop-race.test.ts` |

## Evidence

Scoped runs on the touched plugin (VPS shared with sibling agents — package-scoped, not whole-repo):

```
vitest run stuck-task-reaper + supervisor + orchestrator-correctness + admission-integration
  + concurrency-lifecycle-integration + auto-goal-verify + task-change-set-mirror
  + verify-retry-busy-session + verify-retry-stop-race
Test Files  10 passed (10) — Tests  112 passed (112)

vitest run src/__tests__/orchestrator-scenario-logic.test.ts
Test Files  1 passed (1) — Tests  5 passed (5)

bun run --cwd plugins/plugin-agent-orchestrator typecheck  → clean
biome check on the 4 changed files                         → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
