### PR TITLE
fix(plugins): read actions that already answered stop the model's second reply

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -5459,6 +5459,244 @@ describe("runV5MessageRuntimeStage1", () => {
 	});
 });
 
+// A read action that already spoke to the user must be the turn's single final
+// message. Live incident: a calendar read's callback posted "clear tomorrow.",
+// then the evaluator — unaware of the delivery — authored "you're clear
+// tomorrow.", a semantic paraphrase the byte-level dedupe correctly refuses to
+// touch, so one question produced two bubbles. The structural contract under
+// test: a verified callback-delivered answer declares `turnComplete`, the
+// gated evaluator path skips the paraphrase-capable model call entirely, and
+// the provenance suppression drops the byte-equal finalMessage as already
+// delivered. Side-effect turns without a verified answer keep their model
+// reply, and byte-identical echoes stay deduped without `turnComplete`.
+describe("verified read actions own the turn's single user-facing message", () => {
+	const CALENDAR_ANSWER = "clear tomorrow.";
+
+	function makeCalendarReadAction(handler: Action["handler"]): Action {
+		return {
+			name: "CALENDAR",
+			similes: [],
+			tags: ["domain:calendar", "capability:read"],
+			description: "Read the owner's live calendar.",
+			contexts: ["calendar"],
+			suppressPostActionContinuation: true,
+			parameters: [
+				{
+					name: "intent",
+					description: "Natural-language calendar request.",
+					schema: { type: "string" },
+				},
+			],
+			validate: async () => true,
+			handler,
+		} as Action;
+	}
+
+	function calendarPlannerResponses(): unknown[] {
+		return [
+			stage1Response({
+				contexts: ["calendar"],
+				candidateActionNames: ["CALENDAR"],
+				replyText: "",
+				extra: { requiresTool: true },
+			}),
+			{
+				thought: "Read tomorrow's calendar.",
+				toolCalls: [
+					{
+						id: "calendar-1",
+						name: "CALENDAR",
+						args: { intent: "whats on my calendar tomorrow" },
+					},
+				],
+			},
+		];
+	}
+
+	it("delivers a turnComplete verified read answer exactly once with no model paraphrase", async () => {
+		const runtime = makeRuntime(calendarPlannerResponses());
+		const calendarHandler = vi.fn(
+			async (_runtime, _message, _state, _options, callback) => {
+				await callback?.({
+					text: CALENDAR_ANSWER,
+					source: "action",
+					action: "CALENDAR",
+				});
+				return {
+					success: true,
+					text: CALENDAR_ANSWER,
+					userFacingText: CALENDAR_ANSWER,
+					verifiedUserFacing: true,
+					turnComplete: true,
+				};
+			},
+		);
+		runtime.actions = [makeCalendarReadAction(calendarHandler)] as never;
+		const deliveredVisibleTexts = new Set<string>();
+		const delivered: string[] = [];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "whats on my calendar tomorrow" }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+			deliveredVisibleTexts,
+			callback: async (content) => {
+				if (content.text) {
+					delivered.push(content.text);
+					deliveredVisibleTexts.add(content.text.toLowerCase());
+				}
+				return [];
+			},
+		});
+
+		expect(calendarHandler).toHaveBeenCalledTimes(1);
+		// The action's own delivery is the turn's only user-facing message.
+		expect(delivered).toEqual([CALENDAR_ANSWER]);
+		// The gated evaluator skips the paraphrase-capable model call outright:
+		// Stage 1 + planner only, no in-loop evaluator call remains queued.
+		expect(useModelCalls(runtime).map((call) => call[0])).toEqual([
+			ModelType.RESPONSE_HANDLER,
+			ModelType.ACTION_PLANNER,
+		]);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent).toBeNull();
+			expect(result.result.responseMessages).toEqual([]);
+		}
+	});
+
+	it("keeps the model reply for a side-effect action without a verified answer", async () => {
+		const modelReply = "Sunny out — nothing to reschedule.";
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["general"],
+				candidateActionNames: ["WEB_SEARCH"],
+				replyText: "",
+				extra: { requiresTool: true },
+			}),
+			{
+				thought: "Check the demo weather.",
+				toolCalls: [
+					{
+						id: "search-1",
+						name: "WEB_SEARCH",
+						args: { query: "demo weather" },
+					},
+				],
+			},
+			JSON.stringify({
+				success: true,
+				decision: "FINISH",
+				thought: "Summarize the result.",
+				messageToUser: modelReply,
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "WEB_SEARCH",
+				similes: [],
+				tags: ["resource:web", "capability:read"],
+				description: "Read current public information.",
+				contexts: ["general", "web"],
+				parameters: [
+					{
+						name: "query",
+						description: "Search query",
+						required: true,
+						schema: { type: "string" },
+					},
+				],
+				validate: async () => true,
+				handler: async () => ({
+					success: true,
+					text: "Sunny.",
+					data: { query: "demo weather" },
+				}),
+			},
+		] as never;
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "Search for the demo weather." }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		// No verified user-facing answer was delivered by the action, so the
+		// evaluator still runs and its reply still ships.
+		expect(useModelCalls(runtime).map((call) => call[0])).toEqual([
+			ModelType.RESPONSE_HANDLER,
+			ModelType.ACTION_PLANNER,
+			ModelType.RESPONSE_HANDLER,
+		]);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(modelReply);
+		}
+	});
+
+	it("still dedupes a byte-identical model echo of a delivered answer without turnComplete", async () => {
+		const runtime = makeRuntime([
+			...calendarPlannerResponses(),
+			JSON.stringify({
+				success: true,
+				decision: "FINISH",
+				thought: "Relay the calendar answer.",
+				messageToUser: CALENDAR_ANSWER,
+			}),
+		]);
+		const calendarHandler = vi.fn(
+			async (_runtime, _message, _state, _options, callback) => {
+				await callback?.({
+					text: CALENDAR_ANSWER,
+					source: "action",
+					action: "CALENDAR",
+				});
+				return {
+					success: true,
+					text: CALENDAR_ANSWER,
+					userFacingText: CALENDAR_ANSWER,
+					verifiedUserFacing: true,
+				};
+			},
+		);
+		runtime.actions = [makeCalendarReadAction(calendarHandler)] as never;
+		const deliveredVisibleTexts = new Set<string>();
+		const delivered: string[] = [];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "whats on my calendar tomorrow" }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+			deliveredVisibleTexts,
+			callback: async (content) => {
+				if (content.text) {
+					delivered.push(content.text);
+					deliveredVisibleTexts.add(content.text.toLowerCase());
+				}
+				return [];
+			},
+		});
+
+		// Without turnComplete the evaluator still runs, but its byte-identical
+		// echo of the delivered answer is suppressed (regression guard for the
+		// pre-existing dedupe).
+		expect(useModelCalls(runtime).map((call) => call[0])).toEqual([
+			ModelType.RESPONSE_HANDLER,
+			ModelType.ACTION_PLANNER,
+			ModelType.RESPONSE_HANDLER,
+		]);
+		expect(delivered).toEqual([CALENDAR_ANSWER]);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent).toBeNull();
+			expect(result.result.responseMessages).toEqual([]);
+		}
+	});
+});
+
 // A sub-agent completion relay's envelope echoes the ORIGINAL task text
 // ("[sub-agent: Build and deploy…]"), so the direct-candidate injection
 // backstop used to read a FINISHED task as fresh task intent: it forced

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -3768,6 +3768,14 @@ const calendarAction: CalendarHandlerAction = {
         text,
         userFacingText: text,
         verifiedUserFacing: true,
+        // The callback above already delivered this exact text, and the action
+        // description promises the final grounded reply. A successful calendar
+        // operation is a single-operation turn whose delivered text IS the
+        // answer, so declare it complete — the gated-evaluator skip keeps the
+        // model from re-rendering the delivery as a second message ("clear
+        // tomorrow." followed by "you're clear tomorrow."). Failures stay
+        // un-gated so the evaluator may still add recovery guidance.
+        ...(payload.success ? { turnComplete: true } : {}),
         effectReceipts: [effectReceipt],
         userFacingEffectReceiptIds: [effectReceipt.receiptId],
         ...(payload.data !== undefined ? { data: payload.data } : {}),

--- a/plugins/plugin-calendar/src/actions/calendar-sources.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-sources.test.ts
@@ -567,6 +567,9 @@ describe("CALENDAR_SOURCES action", () => {
     expect(result).toMatchObject({
       success: true,
       verifiedUserFacing: true,
+      // The delivered source list IS the turn's answer: declaring the turn
+      // complete keeps the evaluator from paraphrasing it as a second message.
+      turnComplete: true,
       data: {
         operation: "list",
         snapshot: {

--- a/plugins/plugin-calendar/src/actions/calendar-sources.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-sources.ts
@@ -1001,7 +1001,14 @@ async function resultWithCallback(
     action: ACTION_NAME,
     ...(result.verifiedUserFacing === true ? { agentVoiced: true } : {}),
   });
-  return result;
+  // The callback above is the turn's single visible delivery of this text. A
+  // successful verified result is therefore the complete answer: declaring the
+  // turn complete (unless explicitly disclaimed) opts into the gated-evaluator
+  // skip so the model cannot paraphrase the already-delivered source list as a
+  // second message. Failures and unverified results stay un-gated.
+  return result.success === true && result.verifiedUserFacing === true
+    ? { ...result, turnComplete: result.turnComplete ?? true }
+    : result;
 }
 
 function defaultAuthorize(

--- a/plugins/plugin-calendar/test/calendar-action-effect-receipts.test.ts
+++ b/plugins/plugin-calendar/test/calendar-action-effect-receipts.test.ts
@@ -203,6 +203,10 @@ describe("CALENDAR effect receipt settlement", () => {
     expect(result, JSON.stringify(result)).toMatchObject({
       success: true,
       verifiedUserFacing: true,
+      // The delivered feed text IS the turn's answer: the read declares the
+      // turn complete so the evaluator cannot paraphrase it into a second
+      // user-facing message (the "clear tomorrow." double-speak).
+      turnComplete: true,
       effectReceipts: [
         {
           operation: "calendar.feed.read",
@@ -724,6 +728,9 @@ describe("CALENDAR effect receipt settlement", () => {
         },
       ],
     });
+    // Failures never declare the turn complete: the evaluator may still add
+    // recovery guidance after the action's own failure text.
+    expect(result.turnComplete).toBeUndefined();
     expectBoundDelivery(delivered, result);
   });
 });

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-account-actions.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-account-actions.test.ts
@@ -63,6 +63,10 @@ describe("CLOUD_ACCOUNT_STATUS", () => {
     expect(result.success).toBe(true);
     expect(replies[0]?.text).toContain("$12.34");
     expect(result.data).toMatchObject({ balance: 12.34, low: false, critical: false });
+    // The delivered balance IS the answer: turnComplete opts into the gated
+    // evaluator skip so the model cannot paraphrase it as a second message.
+    expect(result.verifiedUserFacing).toBe(true);
+    expect(result.turnComplete).toBe(true);
   });
 
   it("warns and links the top-up page on a critical balance", async () => {
@@ -128,6 +132,10 @@ describe("CLOUD_LIST_AGENTS", () => {
     expect(replies[0]?.text).toContain("2 agents hosted on Eliza Cloud");
     expect(replies[0]?.text).toContain("• alpha — running");
     expect(replies[0]?.text).toContain("• beta — stopped");
+    // The delivered agent list IS the answer: turnComplete opts into the gated
+    // evaluator skip so the model cannot re-render it as a second message.
+    expect(result.verifiedUserFacing).toBe(true);
+    expect(result.turnComplete).toBe(true);
   });
 
   it("renders the designed empty state when there are no agents", async () => {
@@ -144,6 +152,8 @@ describe("CLOUD_LIST_AGENTS", () => {
     expect(result.success).toBe(true);
     expect(result.data).toMatchObject({ count: 0 });
     expect(replies[0]?.text).toContain("don't have any agents hosted");
+    // Empty states stay un-gated so the evaluator may still add guidance.
+    expect(result.turnComplete).toBeUndefined();
   });
 
   it("fails honestly on a cloud API error", async () => {

--- a/plugins/plugin-elizacloud/src/actions/cloud-account-status.ts
+++ b/plugins/plugin-elizacloud/src/actions/cloud-account-status.ts
@@ -84,6 +84,11 @@ export const cloudAccountStatusAction: Action = {
         text: `Eliza Cloud balance: $${balance.toFixed(2)}.`,
         userFacingText: reply,
         verifiedUserFacing: true,
+        // A single-operation read whose delivered reply IS the complete
+        // answer: the gated-evaluator skip stops the model from paraphrasing
+        // the already-delivered balance as a second message (same opt-in as
+        // LIST_CLOUD_APPS). Error exits stay un-gated.
+        turnComplete: true,
         data: { balance, low, critical, topUpUrl: TOP_UP_URL },
       };
     } catch (err) {

--- a/plugins/plugin-elizacloud/src/actions/list-cloud-agents.ts
+++ b/plugins/plugin-elizacloud/src/actions/list-cloud-agents.ts
@@ -83,6 +83,11 @@ export const listCloudAgentsAction: Action = {
         text: `Listed ${agents.length} hosted Eliza Cloud agent(s).`,
         userFacingText: reply,
         verifiedUserFacing: true,
+        // A single-operation read whose delivered reply IS the complete
+        // answer: the gated-evaluator skip stops the model from re-rendering
+        // the already-delivered list as a second message (same opt-in as
+        // LIST_CLOUD_APPS). Empty/error exits stay un-gated.
+        turnComplete: true,
         data: {
           count: agents.length,
           agents: agents.map((agent) => ({

--- a/plugins/plugin-personal-assistant/src/lifeops/action-effect-result.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/action-effect-result.test.ts
@@ -13,6 +13,10 @@ import {
 } from "@elizaos/core";
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { describe, expect, it, vi } from "vitest";
+import {
+  completeLifeOpsEffect,
+  lifeOpsNoopEffect,
+} from "./action-effect-result.js";
 import { createFamilyCommunicationsAction } from "./family-communications/action.js";
 import type { FamilyCommunicationsService } from "./family-communications/service.js";
 import { createHouseholdOperationsAction } from "./household-operations/action.js";
@@ -672,5 +676,64 @@ describe("LifeOps action effect settlement", () => {
     expect(result.success).toBe(false);
     expect(String(result.error)).toMatch(/invalid result|commit proof/iu);
     expect(malformedCallback).not.toHaveBeenCalled();
+  });
+});
+
+// The settlement helper's callback is the turn's single visible delivery of
+// the canonical text, so a successful settlement must also declare the turn
+// complete — that opts every LifeOps read/answer action (calendar feed,
+// contact search, owner records, …) into the planner's gated-evaluator skip in
+// one place, closing the double-speak where the model paraphrased an
+// already-delivered answer ("clear tomorrow." then "you're clear tomorrow.").
+describe("completeLifeOpsEffect turn completion", () => {
+  const receipt = () =>
+    lifeOpsNoopEffect({
+      receiptId: "CALENDAR:calendar.feed:message-effect-contract:snapshot-1",
+      operation: "calendar.feed",
+      resource: { kind: "runtime.message", id: "message-effect-contract" },
+      artifacts: [],
+      idempotency: { key: null, replayed: false },
+      observedAt: COMMITTED_AT,
+      reason: "Read-only evaluation left calendar state unchanged.",
+    });
+
+  it("declares a successful settlement turn-complete and delivers the text once", async () => {
+    const callback = vi.fn(async () => []);
+    const result = await completeLifeOpsEffect(
+      callback,
+      { success: true, text: "clear tomorrow." },
+      receipt(),
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      text: "clear tomorrow.",
+      userFacingText: "clear tomorrow.",
+      verifiedUserFacing: true,
+      turnComplete: true,
+    });
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith({ text: "clear tomorrow." });
+  });
+
+  it("preserves an action's explicit turnComplete: false disclaimer", async () => {
+    const result = await completeLifeOpsEffect(
+      undefined,
+      { success: true, text: "clear tomorrow.", turnComplete: false },
+      receipt(),
+    );
+
+    expect(result.turnComplete).toBe(false);
+  });
+
+  it("leaves failed settlements un-gated for evaluator recovery guidance", async () => {
+    const result = await completeLifeOpsEffect(
+      undefined,
+      { success: false, text: "The calendar provider is unavailable." },
+      receipt(),
+    );
+
+    expect(result.verifiedUserFacing).toBe(true);
+    expect(result.turnComplete).toBeUndefined();
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/action-effect-result.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/action-effect-result.ts
@@ -100,6 +100,15 @@ export async function completeLifeOpsEffect(
     text,
     userFacingText: text,
     verifiedUserFacing: true,
+    // The callback below is this turn's single visible delivery of the exact
+    // canonical text, so a successful settlement also declares the turn
+    // complete (unless the action explicitly disclaimed it). That opts into
+    // the planner's gated-evaluator skip, which keeps the model from shipping
+    // a second paraphrase of an answer the user already has. Failures stay
+    // un-gated: the evaluator may still add recovery guidance there.
+    ...(result.success === true
+      ? { turnComplete: result.turnComplete ?? true }
+      : {}),
     effectReceipts: [receipt],
     userFacingEffectReceiptIds: [receipt.receiptId],
   };


### PR DESCRIPTION
# read actions that already answered stop the model's second reply

## The bug (live trajectory)

User: *"whats on my calendar tomorrow"* → **two** Discord messages for one turn:

1. `clear tomorrow.` — the CALENDAR action's own settlement callback (`userFacingText`, `verifiedUserFacing: true`)
2. `you're clear tomorrow.` — the evaluator's separate `messageToUser`

The trajectory shows the CALENDAR tool returning `ok=true` with `userFacingText="clear tomorrow."`, then the in-loop evaluator — unaware the callback already delivered — authoring a semantic paraphrase. The existing redundancy suppression is deliberately byte-level (verbatim or strict-superset coverage of the delivered text), so a paraphrase like `you're clear tomorrow.` correctly survives it — and both bubbles ship.

**Root cause:** the LifeOps settlement boundary (`completeLifeOpsEffect`, `plugins/plugin-personal-assistant/src/lifeops/action-effect-result.ts`) delivers the canonical text through the callback and stamps `verifiedUserFacing: true`, but never declares `turnComplete` — so the evaluator LLM still runs and may re-word the answer.

## The fix — same contract as #17975 / #18094 / LIST_CLOUD_APPS (65b351608bc)

Core already ships the structural answer: `turnComplete: true` + `verifiedUserFacing: true` on a sole-tool success makes `tryGateEvaluator` skip the in-loop evaluator entirely and select the action's exact text as `finalMessage`, which the provenance gate then suppresses as already-callback-delivered. No dedupe heuristics were added — an action that already spoke simply declares its turn complete, exactly like the triage actions (`SEND_DRAFT`, `MANAGE_MESSAGE`, `RESPOND_TO_MESSAGE`) and `LIST_CLOUD_APPS` already do.

Opted-in surfaces (verified callback-delivering answers only; branch on the verified signal, never on action name):

| Surface | Coverage |
| --- | --- |
| `completeLifeOpsEffect` (plugin-personal-assistant) | one stamp at the shared settlement boundary covers every call site: `CALENDAR` umbrella (the live bug), `ENTITY` contact search, `LIFE` owner records, `SCHEDULED_TASKS`, household/food/school/family-communications |
| `respond()` in plugin-calendar `calendar-handler.ts` | standalone-host `CALENDAR` registration |
| `resultWithCallback()` in plugin-calendar `calendar-sources.ts` | `CALENDAR_SOURCES` list/select/connection reads (verified successes only) |
| plugin-elizacloud `CLOUD_LIST_AGENTS`, `CLOUD_ACCOUNT_STATUS` | the reads that mirror the already-fixed `LIST_CLOUD_APPS` sibling |

Guardrails preserved in every case:

- **success only** — failures stay un-gated so the evaluator may add recovery guidance;
- an explicit `turnComplete: false` disclaimer from an inner action is preserved;
- **no-callback contexts self-balance** — a verified result that never invoked the callback is absent from the delivered set, so its finalMessage ships as the sole delivery;
- multi-tool turns and planner `completed:false` disclaimers still fall through to the full evaluator (the gate requires a sole executed tool + drained queue), so legitimately-additive model replies are untouched.

## Test matrix

| Case | Test | Result |
| --- | --- | --- |
| (a) verified read + `turnComplete` → exactly ONE user-facing message, no paraphrase-capable model call | `message-runtime-stage1.test.ts` — "delivers a turnComplete verified read answer exactly once…" | pass |
| (b) side-effect action without a verified answer → model reply still ships | `message-runtime-stage1.test.ts` — "keeps the model reply for a side-effect action…" | pass |
| (c) byte-identical echo still deduped without `turnComplete` (regression) | `message-runtime-stage1.test.ts` — "still dedupes a byte-identical model echo…" | pass |
| settlement helper stamps/preserves/omits `turnComplete` | `action-effect-result.test.ts` — 3 new tests | pass |
| calendar feed read carries `turnComplete`; provider failure does not | `calendar-action-effect-receipts.test.ts` | pass |
| calendar source snapshot read carries `turnComplete` | `calendar-sources.test.ts` | pass |
| cloud agent list / balance carry `turnComplete`; empty state does not | `cloud-account-actions.test.ts` | pass |

## Verification

- `packages/core` — `message-runtime-stage1` **117 passed** (3 new); `message-action-dedupe` + `planner-happy-path` + `planner-loop` + `shortcut-gate` + `turn-delivery-floor` **175 passed**; `message.side-effect-claim` **43 passed**
- `plugins/plugin-calendar` — **515 passed | 4 skipped**
- `plugins/plugin-elizacloud` — **444 passed | 5 skipped**
- `plugins/plugin-personal-assistant` — targeted settlement + scheduler suites **22 passed** locally; the only completed local full run scored 1670 passed / 3 failed, and the failing file (`scheduler.no-reply-policy`, timing-sensitive) passes in isolation — the box's disk janitor kept deleting node_modules mid-run, so the CI plugin-tests lane is the authoritative full-suite result
- typecheck — turbo `typecheck` green for core, plugin-calendar, plugin-elizacloud, plugin-personal-assistant (69 tasks)
- lint — biome clean on all four packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:7743ec8c4fdef039cbe88c4fdc8d51db636b34be -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only message-turn behavior (action results + planner gate); no UI surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only; single-message behavior proven by deterministic runtime tests

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only; no walkable UI flow

<!-- evidence-row:backend-logs -->
- [x] [18119-doublespeak-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18119-doublespeak-backend-logs.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - repro + fix are deterministic (queued-model stage1 harness runs the real planner loop); originating live Discord trajectory showed CALENDAR ok=true userFacingText delivered, then a separate model paraphrase — quoted in the PR description; live bot not restarted per ops constraint

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain records changed; the ActionResult turnComplete contract is asserted across the suites in the backend-logs row
