### PR TITLE
fix(plugin-google-workspace): fail closed on header injection and recipient ambiguity

### DIFF
--- a/plugins/plugin-google-workspace/src/gmail-header-injection.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-header-injection.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression tests proving CR/LF sequences in caller-supplied header values
+ * (subject, recipients, threading ids) cannot inject extra MIME headers into
+ * the raw Gmail payload. Uses the real `GoogleGmailClient` with a stubbed
+ * client factory that captures the base64url `raw` message; deterministic.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { GoogleApiClientFactory } from "./client-factory.js";
+import { GoogleGmailClient } from "./gmail.js";
+
+const account = { accountId: "acct-1" };
+
+function createCapturingClient(): {
+  client: GoogleGmailClient;
+  sentRaw: () => string;
+} {
+  const send = vi.fn().mockResolvedValue({ data: { id: "m1", threadId: "t1", labelIds: [] } });
+  const factory = {
+    gmail: vi.fn().mockResolvedValue({ users: { messages: { send } } }),
+  } as unknown as GoogleApiClientFactory;
+  return {
+    client: new GoogleGmailClient(factory),
+    sentRaw: () => {
+      const raw = send.mock.calls[0]?.[0]?.requestBody?.raw as string;
+      return Buffer.from(raw, "base64url").toString("utf-8");
+    },
+  };
+}
+
+function headerBlock(mime: string): string {
+  return mime.split("\r\n\r\n")[0] ?? "";
+}
+
+describe("gmail raw message header injection", () => {
+  it("collapses CRLF in new-message subjects so no Bcc can be smuggled", async () => {
+    const { client, sentRaw } = createCapturingClient();
+    await client.sendGmailMessage({
+      ...account,
+      to: ["friend@example.com"],
+      subject: "hi\r\nBcc: attacker@evil.com",
+      bodyText: "hello",
+    });
+    const headers = headerBlock(sentRaw());
+    expect(headers).toContain("Subject: hi Bcc: attacker@evil.com");
+    expect(headers.split("\r\n")).not.toContain("Bcc: attacker@evil.com");
+  });
+
+  it("collapses CRLF in recipients and reply threading headers", async () => {
+    const { client, sentRaw } = createCapturingClient();
+    await client.sendGmailReply({
+      ...account,
+      to: ["friend@example.com\r\nBcc: attacker@evil.com"],
+      subject: "Re: hello\r\nX-Injected: 1",
+      bodyText: "reply",
+      inReplyTo: "<id@x>\r\nX-Also-Injected: 1",
+      references: "<id@x>",
+    });
+    const headerLines = headerBlock(sentRaw()).split("\r\n");
+    expect(headerLines).not.toContain("Bcc: attacker@evil.com");
+    expect(headerLines.some((line) => line.startsWith("X-Injected"))).toBe(false);
+    expect(headerLines.some((line) => line.startsWith("X-Also-Injected"))).toBe(false);
+  });
+});

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -273,6 +273,61 @@ describe("gmail send handler", () => {
     expect(sendGmailMessage).not.toHaveBeenCalled();
   });
 
+  it("refuses structurally when the contact has multiple distinct stored emails", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      entity: {
+        id: SHADOW_ID,
+        names: ["Shadow"],
+        components: [
+          { type: "contact_info", data: { email: "shadow.work@example.com" } },
+          { type: "rolodex", data: { email: "shadow.personal@example.com" } },
+        ],
+      },
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { entityId: SHADOW_ID as TargetInfo["entityId"] },
+      { text: "hello" }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "not_delivered",
+      code: "GMAIL_RECIPIENT_AMBIGUOUS",
+    });
+    expect(sendGmailMessage).not.toHaveBeenCalled();
+  });
+
+  it("ignores email-shaped values in unrelated fields when a named email field exists", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      entity: {
+        id: SHADOW_ID,
+        names: ["Shadow"],
+        components: [
+          { type: "notes", data: { assistant: "third.party@example.com" } },
+          { type: "contact_info", data: { email: "shadow@example.com" } },
+        ],
+      },
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { entityId: SHADOW_ID as TargetInfo["entityId"] },
+      { text: "hello" }
+    );
+
+    expect(outcome.kind).toBe("delivered");
+    expect(sendGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ to: ["shadow@example.com"] })
+    );
+  });
+
   it("refuses structurally when no recipient email can be resolved", async () => {
     const { runtime, sendGmailMessage } = runtimeStub({
       accounts: [CONNECTED_ACCOUNT],

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -109,44 +109,51 @@ async function resolveGmailAccountId(
   };
 }
 
+type RecipientResolution =
+  | { kind: "resolved"; email: string }
+  | { kind: "unresolved" }
+  | { kind: "ambiguous"; candidates: string[] };
+
 /**
- * Resolve the recipient address: literal target address first, then the
- * entity graph's stored email handles for an entity-store UUID.
+ * Resolve the recipient address fail-closed: a literal target address wins;
+ * otherwise the entity graph must yield exactly one distinct stored email
+ * (across explicitly email-named component fields, or — only when no named
+ * field exists — email-shaped component values). Multiple distinct candidates
+ * refuse rather than guess, so a contact with work + personal addresses never
+ * gets mail routed by component iteration order.
  */
 async function resolveRecipientEmail(
   runtime: IAgentRuntime,
   target: TargetInfo
-): Promise<string | null> {
+): Promise<RecipientResolution> {
   const literal = emailLiteral(target.channelId) ?? emailLiteral(target.entityId);
-  if (literal) return literal;
+  if (literal) return { kind: "resolved", email: literal };
 
   const entityId = String(target.entityId ?? "").trim();
   if (!UUID_PATTERN.test(entityId) || typeof runtime.getEntityById !== "function") {
-    return null;
+    return { kind: "unresolved" };
   }
   const entity = await runtime.getEntityById(entityId as UUID);
-  if (!entity) return null;
+  if (!entity) return { kind: "unresolved" };
 
-  // Prefer explicitly email-named component fields; fall back to any
-  // email-shaped component value (covers rolodex custom fields and handles).
-  let fallback: string | null = null;
+  const named = new Set<string>();
+  const emailShaped = new Set<string>();
   for (const component of entity.components ?? []) {
     const data = component.data ?? {};
     for (const key of EMAIL_COMPONENT_KEYS) {
       const value = emailLiteral(data[key]);
-      if (value) return value;
+      if (value) named.add(value.toLowerCase());
     }
-    if (!fallback) {
-      for (const value of Object.values(data)) {
-        const email = emailLiteral(value);
-        if (email) {
-          fallback = email;
-          break;
-        }
-      }
+    for (const value of Object.values(data)) {
+      const email = emailLiteral(value);
+      if (email) emailShaped.add(email.toLowerCase());
     }
   }
-  return fallback;
+
+  const candidates = named.size > 0 ? named : emailShaped;
+  if (candidates.size === 0) return { kind: "unresolved" };
+  if (candidates.size > 1) return { kind: "ambiguous", candidates: [...candidates].sort() };
+  return { kind: "resolved", email: [...candidates][0] };
 }
 
 function subjectFromContent(content: Content): string {
@@ -180,8 +187,8 @@ async function sendGmailFromTarget(
     };
   }
 
-  const recipient = await resolveRecipientEmail(runtime, target);
-  if (!recipient) {
+  const resolution = await resolveRecipientEmail(runtime, target);
+  if (resolution.kind === "unresolved") {
     return {
       kind: "not_delivered",
       code: "GMAIL_RECIPIENT_UNRESOLVED",
@@ -189,6 +196,16 @@ async function sendGmailFromTarget(
         "Could not resolve an email address for the recipient. Provide a literal address (name@example.com) or a contact with a stored email.",
     };
   }
+  if (resolution.kind === "ambiguous") {
+    return {
+      kind: "not_delivered",
+      code: "GMAIL_RECIPIENT_AMBIGUOUS",
+      message: `The contact has multiple stored email addresses (${resolution.candidates.join(
+        ", "
+      )}). Provide the literal address to use.`,
+    };
+  }
+  const recipient = resolution.email;
 
   const account = await resolveGmailAccountId(runtime, target.accountId);
   if ("error" in account) {

--- a/plugins/plugin-google-workspace/src/gmail.ts
+++ b/plugins/plugin-google-workspace/src/gmail.ts
@@ -333,13 +333,15 @@ export class GoogleGmailClient {
     }
   ): Promise<GoogleGmailSendResult> {
     const raw = encodeRawGmailMessage([
-      `To: ${params.to.join(", ")}`,
-      ...(params.cc && params.cc.length > 0 ? [`Cc: ${params.cc.join(", ")}`] : []),
-      `Subject: ${normalizeReplySubject(params.subject)}`,
+      `To: ${sanitizeMailHeaderValue(params.to.join(", "))}`,
+      ...(params.cc && params.cc.length > 0
+        ? [`Cc: ${sanitizeMailHeaderValue(params.cc.join(", "))}`]
+        : []),
+      `Subject: ${sanitizeMailHeaderValue(normalizeReplySubject(params.subject))}`,
       "MIME-Version: 1.0",
       "Content-Type: text/plain; charset=UTF-8",
-      ...(params.inReplyTo ? [`In-Reply-To: ${params.inReplyTo}`] : []),
-      ...(params.references ? [`References: ${params.references}`] : []),
+      ...(params.inReplyTo ? [`In-Reply-To: ${sanitizeMailHeaderValue(params.inReplyTo)}`] : []),
+      ...(params.references ? [`References: ${sanitizeMailHeaderValue(params.references)}`] : []),
       "",
       params.bodyText.replace(/\r?\n/g, "\r\n"),
     ]);
@@ -356,10 +358,14 @@ export class GoogleGmailClient {
     }
   ): Promise<GoogleGmailSendResult> {
     const raw = encodeRawGmailMessage([
-      `To: ${params.to.join(", ")}`,
-      ...(params.cc && params.cc.length > 0 ? [`Cc: ${params.cc.join(", ")}`] : []),
-      ...(params.bcc && params.bcc.length > 0 ? [`Bcc: ${params.bcc.join(", ")}`] : []),
-      `Subject: ${params.subject.trim() || "(no subject)"}`,
+      `To: ${sanitizeMailHeaderValue(params.to.join(", "))}`,
+      ...(params.cc && params.cc.length > 0
+        ? [`Cc: ${sanitizeMailHeaderValue(params.cc.join(", "))}`]
+        : []),
+      ...(params.bcc && params.bcc.length > 0
+        ? [`Bcc: ${sanitizeMailHeaderValue(params.bcc.join(", "))}`]
+        : []),
+      `Subject: ${sanitizeMailHeaderValue(params.subject.trim()) || "(no subject)"}`,
       "MIME-Version: 1.0",
       "Content-Type: text/plain; charset=UTF-8",
       "",
@@ -688,10 +694,12 @@ function collectMessagePart(
 
 function encodeMessage(input: GoogleSendEmailInput): string {
   const headers = [
-    `To: ${formatEmailAddresses(input.to)}`,
-    input.cc?.length ? `Cc: ${formatEmailAddresses(input.cc)}` : undefined,
-    input.bcc?.length ? `Bcc: ${formatEmailAddresses(input.bcc)}` : undefined,
-    `Subject: ${input.subject}`,
+    `To: ${sanitizeMailHeaderValue(formatEmailAddresses(input.to))}`,
+    input.cc?.length ? `Cc: ${sanitizeMailHeaderValue(formatEmailAddresses(input.cc))}` : undefined,
+    input.bcc?.length
+      ? `Bcc: ${sanitizeMailHeaderValue(formatEmailAddresses(input.bcc))}`
+      : undefined,
+    `Subject: ${sanitizeMailHeaderValue(input.subject)}`,
     "MIME-Version: 1.0",
   ].filter(Boolean);
 
@@ -909,6 +917,15 @@ function labelsForOperation(
     remove_label: { removeLabelIds: labelIds },
   };
   return labels[operation];
+}
+
+/**
+ * Collapses CR/LF sequences in caller-supplied header values so LLM-composed
+ * subjects or recipient strings cannot inject additional MIME headers (for
+ * example a smuggled `Bcc:`) into the raw message.
+ */
+function sanitizeMailHeaderValue(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
 }
 
 function normalizeReplySubject(subject: string): string {

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.test.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.test.ts
@@ -199,6 +199,19 @@ describe("GoogleGmailAdapter", () => {
     ).rejects.toThrow(/email-address recipient/);
   });
 
+  it("rejects a new draft when any requested recipient is invalid (no silent drop)", async () => {
+    const sendGmailMessage = vi.fn();
+    const runtime = runtimeWithGoogleService({ sendGmailMessage });
+    await expect(
+      new GoogleGmailAdapter().createDraft(runtime, {
+        source: "gmail",
+        to: [{ identifier: "valid@example.com" }, { identifier: "typo" }],
+        body: "hello",
+      })
+    ).rejects.toThrow(/invalid: typo/);
+    expect(sendGmailMessage).not.toHaveBeenCalled();
+  });
+
   it("manages Gmail messages and unsubscribe requests with plugin-google-workspace operations", async () => {
     const listGmailTriageMessages = vi.fn(async () => [gmailMessage()]);
     const modifyGmailMessages = vi.fn(async () => undefined);

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
@@ -163,10 +163,22 @@ function messageAccountId(message: MessageRef | null | undefined): string {
   return message?.worldId ?? DEFAULT_GOOGLE_ACCOUNT_ID;
 }
 
+/**
+ * Fail-closed recipient extraction for new outbound drafts: every requested
+ * recipient must be a literal email address. Throwing on any invalid entry
+ * (rather than filtering) prevents a mixed list like `[valid@x.com, typo]`
+ * from being accepted, cached, and later sent to only part of its audience
+ * while reporting success.
+ */
 function newDraftRecipients(draft: DraftRequest): string[] {
-  return draft.to
-    .map((recipient) => recipient.identifier.trim())
-    .filter((identifier) => isEmailAddress(identifier));
+  const identifiers = draft.to.map((recipient) => recipient.identifier.trim());
+  const invalid = identifiers.filter((identifier) => !isEmailAddress(identifier));
+  if (invalid.length > 0) {
+    throw new Error(
+      `[GoogleGmailAdapter] every new Gmail draft entry must be a literal email-address recipient; invalid: ${invalid.join(", ")}`
+    );
+  }
+  return identifiers;
 }
 
 export class GoogleGmailAdapter extends BaseMessageAdapter {


### PR DESCRIPTION
## Summary
Follow-up to #18112, which merged with an outstanding CHANGES_REQUESTED review. This closes the three fail-open holes in the new Gmail send surface:

1. **Email header injection (security).** `sendGmailMessage`/`sendGmailReply`/`encodeMessage` interpolated caller-supplied values straight into raw MIME header lines joined with `\r\n`. An LLM-composed subject like `hi\r\nBcc: attacker@evil.com` injected a hidden recipient — reachable via prompt injection since `DraftRequest.subject` and the connector subject derive from message content. Every caller-supplied header value (subject, recipients, threading ids) is now collapsed through `sanitizeMailHeaderValue`; regression tests decode the raw payload and assert no injected header lines.
2. **Recipient resolution not fail-closed** (flagged in @standujar's review). `resolveRecipientEmail` picked the first email-shaped component value by iteration order. It now requires exactly one distinct stored email: multiple candidates return a structural `GMAIL_RECIPIENT_AMBIGUOUS` refusal, and email-shaped values in unrelated fields are ignored when a named email field exists.
3. **Drafts silently dropped invalid recipients** (flagged in @standujar's review). `newDraftRecipients` filtered instead of failing, so `[valid@example.com, typo]` sent to one address and reported success. Any invalid entry now rejects the whole draft.

## Evidence
`bun run --cwd plugins/plugin-google-workspace test`: 13 files, 109 tests passed (5 new: 2 header-injection, 2 recipient ambiguity, 1 mixed-validity draft). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

<!-- evidence-head:193959fbc7c3bd49d925ce53d30d62717bec104c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend plugin fix (Gmail MIME construction and recipient resolution); no UI surface touched
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend plugin fix; no UI surface touched
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend plugin fix; no UI surface touched
<!-- evidence-row:backend-logs -->
- [x] Test transcript:

```
bun run --cwd plugins/plugin-google-workspace test
 RUN  v4.1.5 plugins/plugin-google-workspace
 Test Files  13 passed (13)
      Tests  109 passed (109)
   Duration  37.24s
including new: gmail-header-injection.test.ts (2 tests: CRLF subject cannot smuggle Bcc; CRLF in recipients/threading headers collapsed),
gmail-message-connector.test.ts (GMAIL_RECIPIENT_AMBIGUOUS refusal on multi-address contact; named email field wins over unrelated email-shaped values),
lifeops-message-adapter.test.ts (mixed-validity draft [valid@example.com, typo] rejected, no partial send)
tsc --noEmit: clean
```
<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend plugin fix; no frontend involved
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic sanitization/validation change; no LLM behavior change to capture
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - artifacts are the vitest transcript above; no other domain output

---
AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [claude]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A - no contribution skill used"} -->
