### PR TITLE
fix(browser): keep page controls clear of the resting chat composer

### DIFF
--- a/packages/app/test/audit/browser-overlay-clearance.test.ts
+++ b/packages/app/test/audit/browser-overlay-clearance.test.ts
@@ -28,4 +28,13 @@ describe("browser overlay clearance regression (#14320)", () => {
       "[@media(orientation:landscape)_and_(max-height:520px)]:pb-",
     );
   });
+
+  it("ends the live page and native-surface anchor above the resting chat footprint", () => {
+    expect(source).toContain('data-chat-clearance-aware="true"');
+    expect(source).toContain('data-testid="browser-workspace-surface-panel"');
+    expect(source).toContain("var(--eliza-chat-clearance,5.25rem)");
+    expect(source).toContain("var(--eliza-mobile-nav-offset,0px)");
+    expect(source).toContain("var(--safe-area-bottom,0px)");
+    expect(source).toContain("var(--android-gesture-inset-bottom,0px)");
+  });
 });

--- a/packages/app/test/ui-smoke/browser-workspace.spec.ts
+++ b/packages/app/test/ui-smoke/browser-workspace.spec.ts
@@ -200,6 +200,118 @@ test("browser workspace can create, navigate, switch, and close tabs", async ({
   await expect(closeAllButton).toBeDisabled({ timeout: 60_000 });
 });
 
+test("browser page clears the resting chat and keeps compact mobile chrome touch-safe", async ({
+  page,
+  request,
+}) => {
+  await resetBrowserWorkspaceTabs(request);
+  await openAppPath(page, "/browser");
+  const browserWorkspaceView = page.getByTestId("browser-workspace-view");
+  await expect(browserWorkspaceView).toBeVisible({ timeout: 60_000 });
+
+  const addressInput = browserWorkspaceView.getByTestId(
+    "browser-workspace-address-input",
+  );
+  await expect(addressInput).toBeVisible({ timeout: 120_000 });
+  await addressInput.fill("example.com");
+  await addressInput.press("Enter");
+
+  const pageSurface = browserWorkspaceView.getByTestId(
+    "browser-workspace-surface-panel",
+  );
+  const iframe = browserWorkspaceView.locator("iframe").first();
+  await expect(iframe).toBeVisible({ timeout: 20_000 });
+  const collapsedGeometry = await page.evaluate(() => {
+    const surface = document.querySelector<HTMLElement>(
+      '[data-testid="browser-workspace-surface-panel"]',
+    );
+    const frame = document.querySelector<HTMLIFrameElement>(
+      '[data-testid="browser-workspace-view"] iframe',
+    );
+    const chat = document.querySelector<HTMLElement>(
+      '[data-testid="chat-sheet-surface"]',
+    );
+    const toolbar = document.querySelector<HTMLElement>(
+      '[data-testid="browser-workspace-toolbar"]',
+    );
+    if (!surface || !frame || !chat || !toolbar) return null;
+    return {
+      surfaceBottom: surface.getBoundingClientRect().bottom,
+      frameBottom: frame.getBoundingClientRect().bottom,
+      chatTop: chat.getBoundingClientRect().top,
+      toolbarHeight: toolbar.getBoundingClientRect().height,
+      viewportWidth: window.innerWidth,
+      controls: Array.from(
+        toolbar.querySelectorAll<HTMLElement>("button, input"),
+      ).map((control) => ({
+        label:
+          control.getAttribute("aria-label") ??
+          control.getAttribute("data-testid") ??
+          control.tagName,
+        width: control.getBoundingClientRect().width,
+        height: control.getBoundingClientRect().height,
+      })),
+    };
+  });
+  expect(collapsedGeometry).not.toBeNull();
+  expect(collapsedGeometry?.surfaceBottom).toBeLessThanOrEqual(
+    (collapsedGeometry?.chatTop ?? 0) - 7,
+  );
+  expect(collapsedGeometry?.frameBottom).toBeLessThanOrEqual(
+    collapsedGeometry?.surfaceBottom ?? 0,
+  );
+  for (const control of collapsedGeometry?.controls ?? []) {
+    expect(control.height, control.label).toBeGreaterThanOrEqual(44);
+    expect(control.width, control.label).toBeGreaterThanOrEqual(44);
+  }
+  if ((collapsedGeometry?.viewportWidth ?? 0) < 640) {
+    expect(collapsedGeometry?.toolbarHeight).toBeLessThanOrEqual(100);
+  }
+
+  const surfaceBeforeSafeArea = await pageSurface.boundingBox();
+  const surfaceBeforeSafeAreaBottom =
+    (surfaceBeforeSafeArea?.y ?? 0) + (surfaceBeforeSafeArea?.height ?? 0);
+  await page.evaluate(() => {
+    document.documentElement.style.setProperty("--safe-area-bottom", "24px");
+  });
+  await expect
+    .poll(async () => {
+      const box = await pageSurface.boundingBox();
+      return box ? Math.round(box.y + box.height) : null;
+    })
+    .toBe(Math.round(surfaceBeforeSafeAreaBottom - 24));
+
+  const composer = page.getByRole("combobox", { name: "message" });
+  await composer.focus();
+  const chatOverlay = page.getByTestId("chat-overlay");
+  await expect(chatOverlay).toHaveAttribute("data-open", "true");
+  const expandedGeometry = await page.evaluate(() => {
+    const surface = document.querySelector<HTMLElement>(
+      '[data-testid="browser-workspace-surface-panel"]',
+    );
+    const chat = document.querySelector<HTMLElement>(
+      '[data-testid="chat-overlay"]',
+    );
+    if (!surface || !chat) return null;
+    const surfaceZ = Number.parseInt(getComputedStyle(surface).zIndex, 10);
+    return {
+      surfaceBottom: surface.getBoundingClientRect().bottom,
+      chatZ: Number(getComputedStyle(chat).zIndex),
+      surfaceZ: Number.isFinite(surfaceZ) ? surfaceZ : 0,
+    };
+  });
+  expect(expandedGeometry).not.toBeNull();
+  expect(Math.round(expandedGeometry?.surfaceBottom ?? 0)).toBe(
+    Math.round(surfaceBeforeSafeAreaBottom - 24),
+  );
+  expect(expandedGeometry?.chatZ).toBeGreaterThan(
+    expandedGeometry?.surfaceZ ?? 0,
+  );
+
+  await page.keyboard.press("Escape");
+  await expect(chatOverlay).not.toHaveAttribute("data-open", "true");
+});
+
 test("browser iframe focus handoff survives delayed autofocus without stealing deliberate clicks", async ({
   page,
   request,

--- a/packages/ui/src/components/pages/BrowserTabSwitcher.tsx
+++ b/packages/ui/src/components/pages/BrowserTabSwitcher.tsx
@@ -200,7 +200,7 @@ function BrowserTabCard({
         onClick={onActivate}
         variant="ghost"
         className={`flex h-auto min-h-11 w-full min-w-0 flex-col items-start justify-start gap-1 whitespace-normal rounded-xl border p-3 text-left font-normal transition-colors ${
-          tab.closable ? "pr-10" : "pr-3"
+          tab.closable ? "pr-14" : "pr-3"
         } ${
           active
             ? "border-txt/20 bg-bg-muted/80 text-txt shadow-[inset_0_1px_0_rgba(255,255,255,.06)]"
@@ -247,7 +247,7 @@ function BrowserTabCard({
             onClose();
           }}
           data-testid={`browser-tab-card-close-${tab.id}`}
-          className="absolute right-1 top-1 h-9 w-9 rounded-full text-muted transition-colors hover:bg-bg-muted/60 hover:text-danger"
+          className="absolute right-1 top-1 h-11 w-11 rounded-full text-muted transition-colors hover:bg-bg-muted/60 hover:text-danger"
         >
           <X className="h-4 w-4" />
         </Button>
@@ -316,7 +316,7 @@ export function BrowserTabSwitcher({
             type="button"
             variant="ghost"
             size="sm"
-            className="h-9 min-h-9 shrink-0 gap-1.5 rounded-full border border-border/50 bg-card/55 px-3 hover:bg-bg-muted/70"
+            className="h-11 min-h-11 shrink-0 gap-1.5 rounded-full border border-border/50 bg-card/55 px-3 hover:bg-bg-muted/70"
             disabled={actionsDisabled}
             onClick={() => {
               onNewTab();

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
@@ -144,6 +144,40 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
     ).toBe(true);
   });
 
+  it("reserves the measured resting chat footprint and safe-area stack from the page viewport", async () => {
+    render(<BrowserWorkspaceView />);
+    expect(await screen.findByText("No page open")).not.toBeNull();
+
+    const root = screen.getByTestId("browser-workspace-view");
+    const surface = screen.getByTestId("browser-workspace-surface-panel");
+    expect(root.getAttribute("data-chat-clearance-aware")).toBe("true");
+    expect(root.className).toContain("--eliza-chat-clearance");
+    expect(root.className).toContain("--eliza-mobile-nav-offset");
+    expect(root.className).toContain("--safe-area-bottom");
+    expect(root.className).toContain("--android-gesture-inset-bottom");
+    expect(root.contains(surface)).toBe(true);
+  });
+
+  it("uses a compact two-row mobile toolbar without shrinking any navigation target below 44px", async () => {
+    render(<BrowserWorkspaceView />);
+    expect(await screen.findByText("No page open")).not.toBeNull();
+
+    const toolbar = screen.getByTestId("browser-workspace-toolbar");
+    const nav = toolbar.firstElementChild as HTMLElement | null;
+    expect(nav).not.toBeNull();
+    expect(nav?.className).toContain("grid-cols-");
+    expect(nav?.className).toContain("sm:grid-cols-");
+    expect(nav?.className).toContain("gap-1");
+    expect(nav?.className).toContain("py-1");
+
+    expect(
+      screen.getByTestId("browser-workspace-address-input").className,
+    ).toContain("col-span-2");
+    for (const control of toolbar.querySelectorAll("button, input")) {
+      expect(control.className).toMatch(/(?:h-11|min-h-11)/);
+    }
+  });
+
   it("returns autofocus that arrives after iframe load to the control that opened Browser", async () => {
     vi.mocked(client.getBrowserWorkspace).mockResolvedValue(GOOGLE_WORKSPACE);
     const composer = document.createElement("textarea");

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -2502,7 +2502,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
   });
 
   const navNode = (
-    <div className="flex flex-wrap items-center gap-2 px-3 py-2">
+    <div className="grid grid-cols-[minmax(0,1fr)_repeat(3,2.75rem)] items-center gap-1 px-1.5 py-1 sm:grid-cols-[minmax(10rem,4fr)_repeat(3,2.75rem)_minmax(10rem,5fr)_repeat(2,2.75rem)] sm:gap-1.5 sm:px-2 sm:py-1.5 lg:gap-2 lg:px-3 lg:py-2">
       {/* Folded tabs (#13596): one compact count control opens the switcher —
           no permanent tab strip. It names the active tab so the user always
           knows which page is live even with the rest folded away. */}
@@ -2628,7 +2628,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         })}
         data-testid="browser-workspace-address-input"
         disabled={busyAction !== null || selectedTabIsInternal}
-        className="h-11 min-w-[10rem] flex-1 rounded-full border-border/40 bg-card/70 px-4 text-sm text-txt"
+        className="col-span-2 h-11 min-w-[10rem] flex-1 rounded-full border-border/40 bg-card/70 px-4 text-sm text-txt sm:col-span-1"
       />
       <BrowserNavButton
         agentId="go"
@@ -2672,7 +2672,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         }
         variant="ghost"
         size="icon"
-        className="h-8 w-8"
+        className="h-11 w-11"
         aria-label={t("browserworkspace.OpenExternal", {
           defaultValue: "Open external",
         })}
@@ -2915,9 +2915,10 @@ export function BrowserWorkspaceView(): React.JSX.Element {
               : "pointer-events-none opacity-0";
             return (
               // The native WKWebView / Android WebView is layered over this
-              // placeholder by `useMobileNativeTabSurfaces`; the div only reports
-              // the full content rect. React chrome is composed through native
-              // occlusion holes, so the page is never resized around the chat.
+              // placeholder by `useMobileNativeTabSurfaces`; the div reports
+              // the chat-safe content rect. Expanded overlays still use native
+              // occlusion holes, while the resting composer owns real layout
+              // space so page controls never sit underneath it.
               <div
                 key={tab.id}
                 ref={(el) =>
@@ -3124,17 +3125,19 @@ export function BrowserWorkspaceView(): React.JSX.Element {
   // this view edge-to-edge (`header: "fullscreen"` in the builtin registry), so
   // the view owns its whole chrome — no host ViewHeader row, no workspace
   // chrome. The toolbar (folded-tab control + URL bar) floats as a glass panel
-  // over the opaque app background using the same clamp gutter, safe-area
-  // padding, and glass material the Notes and Calendar views use, and the web
-  // surface fills the remaining height as a second rounded panel. Tabs stay
-  // folded into the switcher (no permanent tab strip), matching #13596.
+  // over the opaque app background. Compact mobile gutters leave more room for
+  // the page without shrinking touch targets; large screens retain the shared
+  // Notes/Calendar clamp rhythm. The web surface fills the remaining height as
+  // a second rounded panel. Tabs stay folded into the switcher (no permanent
+  // tab strip), matching #13596.
   const mainNode = (
     <main
       ref={workspaceRootRef}
       aria-label={t("browserworkspace.ViewTitle", { defaultValue: "Browser" })}
       data-testid="browser-workspace-view"
+      data-chat-clearance-aware="true"
       tabIndex={-1}
-      className="relative flex h-full min-h-0 w-full min-w-0 flex-col gap-[clamp(8px,1.6vw,14px)] overflow-hidden bg-bg px-[clamp(8px,2.4vw,24px)] pt-[calc(clamp(8px,2.4vw,24px)+var(--safe-area-top,0px))] pb-[clamp(8px,2.4vw,24px)]"
+      className="relative flex h-full min-h-0 w-full min-w-0 flex-col gap-1.5 overflow-hidden bg-bg px-1.5 pt-[calc(0.375rem+var(--safe-area-top,0px))] pb-[calc(0.5rem+var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-chat-clearance,5.25rem))] lg:gap-[clamp(8px,1.6vw,14px)] lg:px-[clamp(8px,2.4vw,24px)] lg:pt-[calc(clamp(8px,2.4vw,24px)+var(--safe-area-top,0px))] lg:pb-[calc(clamp(8px,2.4vw,24px)+var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-chat-clearance,5.25rem))]"
     >
       <div
         data-testid="browser-workspace-toolbar"
@@ -3146,7 +3149,10 @@ export function BrowserWorkspaceView(): React.JSX.Element {
           A shadow on this near-full-viewport panel reads as visual furniture
           (and the minimalism occupancy scan rightly counts it as such in
           short landscape); the toolbar above keeps the full glass treatment. */}
-      <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-3xl bg-[color-mix(in_srgb,var(--card)_76%,transparent)]">
+      <div
+        data-testid="browser-workspace-surface-panel"
+        className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-3xl bg-[color-mix(in_srgb,var(--card)_76%,transparent)]"
+      >
         {browserSurface}
       </div>
     </main>


### PR DESCRIPTION
# Relates to

Closes #18122

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` dependencies are present and `bun run verify` passed after sync.
- [x] A reviewer can confirm the change from the attached responsive screenshots, recordings, traces, audit output, and geometry tests.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@fc8a18dc0af7bf416a7028756f0a07b50a7133c5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. The change is limited to Browser workspace layout and its tests. The main risk is responsive geometry across viewport/safe-area combinations; four real Playwright viewport contracts, the full app audit, and manual rendered review cover that surface.

# Background

## What does this PR do?

- Reserves measured space above the globally topmost resting chat composer, mobile navigation, safe area, and gesture inset so the Browser page and native surface never hide controls behind chat.
- Keeps expanded chat above the page without resizing the already-reserved Browser surface.
- Compacts mobile Browser chrome into a deterministic two-row layout and desktop/tablet chrome into one row.
- Preserves 44px minimum targets for navigation, tabs, close, reload, external-open, and Go controls.
- Adds structural/component tests plus real geometry coverage at mobile portrait, mobile landscape, iPad, and desktop sizes.

## What kind of change is this?

Bug fix and responsive UI improvement.

# Documentation changes needed?

No documentation change is required; this repairs the existing Browser and global chat-overlay layout contract.

# Testing

## Where should a reviewer start?

Open `/browser` at 390x844 and 1440x900. Load a page, keep chat resting, then expand/collapse chat and open the tab switcher.

## Detailed testing steps

1. Open the Browser view and load `https://example.com`.
2. Verify the bottom of the live page ends at least 8px above the resting chat composer.
3. Expand/collapse chat; verify expanded chat remains topmost while Browser surface height stays stable.
4. Repeat at mobile landscape, iPad portrait, and desktop.
5. Open the tab switcher and verify it remains above chat with 44px close/new-tab targets.

Automated proof:

- Focused UI component contracts: 8/8.
- App structural clearance contracts: 2/2.
- Browser Playwright geometry: 4/4 at 390x844, 844x390, 820x1180, and 1440x900.
- Root `bun run verify`: 346/346 plus audits.
- Full app visual/OCR audit: results attached below.

# Evidence Gate

<!-- evidence-head:52d07e6e531b8b5ed62834e1d3659d1eee24ec0a -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18124-before-composite.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18124-after-composite.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18124-walkthrough-combined.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - Pure client layout change; backend code is unchanged, and isolated backend health/chat smoke was green.
<!-- evidence-row:frontend-logs -->
- [x] [18124-frontend-console-network.jsonl](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18124-frontend-console-network.jsonl)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No database, memory, task, wallet, or other domain state changed.
<!-- evidence-row:ocr-review -->
- [x] [18124-ocr-review.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18124-ocr-review.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

The isolated preview reported ready/runtime/database/coordinator healthy with 26 loaded and 0 failed plugins. A real temporary conversation returned and persisted `preview healthy`, then was deleted. The attached sanitized Playwright console/network records include the pre-existing wallet-ready origin-order warning classified below.

## Screenshots (before / after) + video walkthrough

Exact-head desktop/mobile before and after JPGs and desktop/mobile MP4 walkthroughs are attached through the evidence rows.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

The exact trace exposes one pre-existing Browser wallet-bridge ordering warning: an explicit-origin ready packet is attempted before the iframe leaves its parent-origin initial document, then the existing `onLoad` path resends successfully. The five-path layout commit does not touch that hook; #18125 tracks the separate fail-closed ordering repair. Desktop E2E uses the repository's native-surface placeholder, while the mobile recording exercises the loaded `example.com` page; both layouts share the same clearance contract under test.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@fc8a18dc0af7bf416a7028756f0a07b50a7133c5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [fix/browser-compact-chat-reserve]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@fc8a18dc0af7bf416a7028756f0a07b50a7133c5:packages/skills/skills/contribute-to-eliza"} -->


