### PR TITLE
fix(core): shared-link read ships one prose summary, never the record dump

### DIFF
--- a/packages/core/src/features/working-memory/readAttachmentAction.delivery.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.delivery.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Delivery-selection coverage for ATTACHMENT action=read: which text ships to
+ * the user versus what stays planner-facing in `data`. Deterministic harness —
+ * a hand-rolled runtime stub captures the TEXT_SMALL call and returns a scripted
+ * summary; no module mocks and no live model.
+ *
+ * Regression under test (observed live, trajectory tj-d29ff62e98fbb2): a bare
+ * Discord link share routed to ATTACHMENT with addToClipboard=true, and the
+ * clipboard-requested branch switched user-visible delivery to the planner
+ * record dump — metadata envelope plus the full stored page — which shipped
+ * verbatim as a ~13-message Discord wall. The user-visible text must always be
+ * the prose answer unless the user explicitly asked for the attachment record.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { v4 as uuidv4 } from "uuid";
+import { describe, expect, it } from "vitest";
+import type {
+	HandlerCallback,
+	IAgentRuntime,
+	Media,
+	Memory,
+	UUID,
+} from "../../types/index.ts";
+import { ContentType } from "../../types/index.ts";
+import { readAttachmentAction } from "./readAttachmentAction.ts";
+
+const PAGE_MARKER = "Store encrypted hourly backups of your entire Umbrel";
+const STORED_PAGE = [
+	"umbrelOS - An elegant OS for your home server",
+	"",
+	PAGE_MARKER,
+	"",
+	"Bitcoin Node Install Lightning Node mempool - LibreOffice - Sphinx Relay - Tailscale - Nextcloud - Firefox",
+	"lorem ipsum ".repeat(400),
+].join("\n");
+
+const SUMMARY =
+	"umbrelOS is a free self-hosted home-server OS with one-click apps like a Bitcoin node, Nextcloud, and Jellyfin.";
+
+type ModelCall = { prompt: string; maxTokens: number };
+
+function makeAttachment(): Media {
+	return {
+		id: "webpage-85b0602a68906762298056cf",
+		url: "https://umbrel.com/umbrelos",
+		title: "umbrelos",
+		source: "Web",
+		contentType: ContentType.LINK,
+		text: STORED_PAGE,
+	};
+}
+
+function makeRuntime(params: {
+	modelResponse: string;
+	calls: ModelCall[];
+	agentId: UUID;
+}): IAgentRuntime {
+	const clipboardDir = mkdtempSync(path.join(tmpdir(), "attachment-clip-"));
+	const runtime = {
+		agentId: params.agentId,
+		getConversationLength: () => 8,
+		getMemories: async () => [],
+		getRoom: async () => null,
+		getWorld: async () => null,
+		getService: () => null,
+		getSetting: (key: string) =>
+			key === "CLIPBOARD_BASE_PATH" ? clipboardDir : undefined,
+		reportError: () => {},
+		useModel: async (_type: unknown, options: unknown) => {
+			const { prompt, maxTokens } = options as {
+				prompt: string;
+				maxTokens: number;
+			};
+			params.calls.push({ prompt, maxTokens });
+			return params.modelResponse;
+		},
+	};
+	return runtime as unknown as IAgentRuntime;
+}
+
+function makeMessage(params: { agentId: UUID; text: string }): Memory {
+	return {
+		id: uuidv4() as UUID,
+		agentId: params.agentId,
+		entityId: uuidv4() as UUID,
+		roomId: uuidv4() as UUID,
+		createdAt: Date.now(),
+		content: {
+			text: params.text,
+			source: "discord",
+			attachments: [makeAttachment()],
+		},
+	};
+}
+
+async function runRead(params: {
+	modelResponse: string;
+	text: string;
+	handlerParams?: Record<string, unknown>;
+}) {
+	const agentId = uuidv4() as UUID;
+	const calls: ModelCall[] = [];
+	const runtime = makeRuntime({
+		modelResponse: params.modelResponse,
+		calls,
+		agentId,
+	});
+	const message = makeMessage({ agentId, text: params.text });
+	const callbackTexts: string[] = [];
+	const callback: HandlerCallback = async (content) => {
+		if (typeof content?.text === "string") callbackTexts.push(content.text);
+		return [];
+	};
+	const result = await readAttachmentAction.handler?.(
+		runtime,
+		message,
+		undefined,
+		{ parameters: { action: "read", ...params.handlerParams } },
+		callback,
+	);
+	return { result, callbackTexts, calls };
+}
+
+describe("ATTACHMENT read delivery selection", () => {
+	it("bare link share with addToClipboard ships ONE prose summary, never the record dump", async () => {
+		const { result, callbackTexts } = await runRead({
+			modelResponse: SUMMARY,
+			text: "remilio nubilio (@1490833425802854491) https://umbrel.com/umbrelos",
+			handlerParams: {
+				addToClipboard: true,
+				attachmentId: "webpage-85b0602a68906762298056cf",
+			},
+		});
+
+		expect(result?.success).toBe(true);
+		// Exactly one message ships, and it is the authored summary.
+		expect(callbackTexts).toEqual([SUMMARY]);
+		expect(result?.userFacingText).toBe(SUMMARY);
+		expect(result?.verifiedUserFacing).toBe(true);
+		expect(result?.turnComplete).toBe(true);
+		// No planner envelope and no raw page content in the user-visible text.
+		for (const banned of ["Stored content", "ID: webpage-", PAGE_MARKER]) {
+			expect(callbackTexts[0]).not.toContain(banned);
+		}
+		// Clipboard persistence still happened; the state is planner-facing.
+		const clipboard = (result?.data as { clipboard?: { stored?: boolean } })
+			?.clipboard;
+		expect(clipboard?.stored).toBe(true);
+	});
+
+	it("keeps the fetched page as model context: prompt and data carry the stored content", async () => {
+		const { result, calls } = await runRead({
+			modelResponse: SUMMARY,
+			text: "https://umbrel.com/umbrelos",
+		});
+
+		expect(calls).toHaveLength(1);
+		// The model reads the page to author the summary...
+		expect(calls[0]?.prompt).toContain(PAGE_MARKER);
+		// ...under the bare-link one-take contract with a small budget.
+		expect(calls[0]?.prompt).toContain(
+			"Reply with ONE short take of at most two sentences",
+		);
+		expect(calls[0]?.maxTokens).toBe(256);
+		// The planner keeps the full content in data.
+		expect((result?.data as { content?: string })?.content).toContain(
+			PAGE_MARKER,
+		);
+	});
+
+	it("a real question next to the link answers the question, not a page take", async () => {
+		const { calls } = await runRead({
+			modelResponse: "It supports encrypted hourly backups.",
+			text: "does umbrelOS support backups? see https://umbrel.com/umbrelos",
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.prompt).not.toContain(
+			"Reply with ONE short take of at most two sentences",
+		);
+		expect(calls[0]?.maxTokens).toBeGreaterThan(256);
+	});
+
+	it("a short non-ask remark next to the link still gets the one-take treatment", async () => {
+		const { calls } = await runRead({
+			modelResponse: SUMMARY,
+			text: "check this out https://umbrel.com/umbrelos",
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.prompt).toContain(
+			"Reply with ONE short take of at most two sentences",
+		);
+		expect(calls[0]?.maxTokens).toBe(256);
+	});
+
+	it("an empty model response degrades to a short acknowledgement, never the raw page", async () => {
+		const { callbackTexts } = await runRead({
+			modelResponse: "",
+			text: "https://umbrel.com/umbrelos",
+		});
+
+		expect(callbackTexts).toHaveLength(1);
+		expect(callbackTexts[0]).toContain('Read "umbrelos"');
+		expect(callbackTexts[0]).not.toContain(PAGE_MARKER);
+		expect(callbackTexts[0]).not.toContain("Stored content");
+	});
+
+	it("an explicit ask for the attachment record still gets the record", async () => {
+		const { callbackTexts, calls } = await runRead({
+			modelResponse: SUMMARY,
+			text: "show me the attachment metadata for that link",
+		});
+
+		expect(calls).toHaveLength(0);
+		expect(callbackTexts).toHaveLength(1);
+		expect(callbackTexts[0]).toContain("ID: webpage-85b0602a68906762298056cf");
+		expect(callbackTexts[0]).toContain("Stored content: yes");
+	});
+});

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -13,6 +13,11 @@
  * the planner-emitted enum, deliberately doing no natural-language keyword
  * inference so routing stays language-agnostic (#10471).
  */
+
+import {
+	linkShareOwnText,
+	looksLikeBareLinkShare,
+} from "../../services/message/direct-action-heuristics.ts";
 import {
 	type Action,
 	type ActionResult,
@@ -42,6 +47,8 @@ const ATTACHMENT_ACTIONS = ["read", "save_as_document"] as const;
 const MAX_ATTACHMENT_ANSWER_CHARS = 32_000;
 const MIN_ATTACHMENT_ANSWER_TOKENS = 1024;
 const MAX_ATTACHMENT_ANSWER_TOKENS = 4096;
+/** A bare link share wants a one-to-two sentence reaction, not a page digest. */
+const BARE_LINK_ANSWER_TOKENS = 256;
 type AttachmentAction = (typeof ATTACHMENT_ACTIONS)[number];
 type AttachmentRecord = Awaited<
 	ReturnType<typeof readAttachmentRecords>
@@ -50,6 +57,25 @@ type AttachmentRecord = Awaited<
 function shouldShowAttachmentRecord(messageText: string): boolean {
 	return /\b(?:attachment|file)\s+(?:id|ids|metadata|details|info|record)\b/i.test(
 		messageText,
+	);
+}
+
+/** Question or explicit-ask phrasing in the user's own words (URLs and
+ * connector embed previews excluded, so a page title like "What is X?" never
+ * counts as the user asking). */
+const LINK_SHARE_ASK_PATTERN =
+	/(?:\?|\b(?:what|who|when|where|why|how|which|explain|summarize|summarise|summary|tldr|tl;dr|thoughts|opinion|review|eli5|tell\s+me|can\s+you|could\s+you|would\s+you)\b)/iu;
+
+/**
+ * True for "here's a link" with no actual ask. looksLikeBareLinkShare alone is
+ * a ROUTING predicate — it also accepts a short question next to the link
+ * (both fetch the page) — but a question wants the question answered, not a
+ * one-take page summary.
+ */
+function isLinkShareWithoutAsk(text: string): boolean {
+	return (
+		looksLikeBareLinkShare(text) &&
+		!LINK_SHARE_ASK_PATTERN.test(linkShareOwnText(text))
 	);
 }
 
@@ -164,17 +190,27 @@ async function answerAttachmentRequest(params: {
 	runtime: IAgentRuntime;
 	message: Memory;
 	content: string;
+	fallbackText: string;
 }): Promise<string> {
 	const userRequest =
 		typeof params.message.content.text === "string"
 			? params.message.content.text.trim()
 			: "";
+	// A message that is essentially just a URL asks for a short reaction to the
+	// page, not a rendition of it (observed live: a shared link answered with
+	// the whole stored page arrived as a ~13-message wall on Discord).
+	const bareLinkShare = isLinkShareWithoutAsk(userRequest);
 	const prompt = [
 		"You are answering a user request about an attachment.",
 		"Use only the attachment content, extracted text, transcript, or media description below.",
 		'Follow explicit formatting instructions from the user, including requests such as "only" or "keep it short".',
 		"If the requested answer is not in the attachment content, say that briefly.",
 		"Do not include attachment metadata, IDs, source labels, or implementation details.",
+		...(bareLinkShare
+			? [
+					"The user shared a link without asking a question. Reply with ONE short take of at most two sentences on what the page is. Never reproduce the page content.",
+				]
+			: []),
 		"",
 		`User request:\n${userRequest || "Read the attachment."}`,
 		"",
@@ -183,10 +219,14 @@ async function answerAttachmentRequest(params: {
 	const response = await params.runtime.useModel(ModelType.TEXT_SMALL, {
 		prompt,
 		temperature: 0,
-		maxTokens: attachmentAnswerTokenBudget(params.content),
+		maxTokens: bareLinkShare
+			? BARE_LINK_ANSWER_TOKENS
+			: attachmentAnswerTokenBudget(params.content),
 	});
 	const text = String(response).trim();
-	return text || params.content;
+	// Never fall back to the raw stored content: an empty model response must
+	// degrade to a short acknowledgement, not a verbatim page dump.
+	return text || params.fallbackText;
 }
 
 function getActionParams(
@@ -486,20 +526,26 @@ export const readAttachmentAction: Action = {
 				typeof messageWithParams.content.text === "string"
 					? messageWithParams.content.text.trim()
 					: "";
-			const visibleText =
-				hasContent &&
-				!clipboardResult.requested &&
-				!shouldShowAttachmentRecord(messageText)
+			// The record dump (metadata envelope + full stored content) is
+			// planner-facing and reaches chat only when the user explicitly asked
+			// for the attachment record. Every other read answers in prose —
+			// observed live: a clipboard-requested read of a shared link switched
+			// delivery to the record dump and shipped the whole scraped page
+			// verbatim to Discord. The planner still gets the full content and
+			// clipboard state through `data`.
+			const visibleText = shouldShowAttachmentRecord(messageText)
+				? responseText
+				: hasContent
 					? await answerAttachmentRequest({
 							runtime,
 							message: messageWithParams,
 							content: storedContent,
+							fallbackText:
+								records.length === 1
+									? `Read "${titleForRecord(records[0])}" but couldn't put an answer together — ask me something specific about it.`
+									: "Read the attachments but couldn't put an answer together — ask me something specific about them.",
 						})
-					: !hasContent &&
-							!clipboardResult.requested &&
-							!shouldShowAttachmentRecord(messageText)
-						? missingReadableContentMessage(records)
-						: responseText;
+					: missingReadableContentMessage(records);
 
 			if (callback) {
 				await callback({

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -17,6 +17,7 @@ import {
 	inferDirectCurrentRequestCandidateActions,
 	inferDirectCurrentRequestCandidateInference,
 	isShellDirectActionName,
+	linkShareOwnText,
 	looksLikeBareLinkShare,
 	looksLikeLocalShellRequest,
 	looksLikeWebSearchRequest,
@@ -40,6 +41,16 @@ describe("looksLikeBareLinkShare", () => {
 		// The embed title contains workflow-ish words ("decides to message
 		// people"); they must not read as user intent.
 		expect(looksLikeBareLinkShare(DISCORD_LINK_WITH_EMBED)).toBe(true);
+	});
+
+	it("fires even when the embed TITLE carries a work imperative — derived text never defeats the guard", () => {
+		const imperativeTitle = [
+			"https://example.com/build-guide",
+			"Embed #1:",
+			"  Title:Build and deploy your first app",
+			"  Description:A tutorial for creating projects",
+		].join("\n");
+		expect(looksLikeBareLinkShare(imperativeTitle)).toBe(true);
 	});
 
 	it("fires on a URL with short non-imperative commentary", () => {
@@ -72,6 +83,27 @@ describe("looksLikeBareLinkShare", () => {
 		expect(looksLikeBareLinkShare("")).toBe(false);
 		const longCommentary = `${"here is a very long analysis of the situation with many words that go on ".repeat(3)}https://example.com`;
 		expect(looksLikeBareLinkShare(longCommentary)).toBe(false);
+	});
+});
+
+describe("linkShareOwnText", () => {
+	it("keeps only the user's own words, punctuation intact", () => {
+		expect(
+			linkShareOwnText("does it support backups? https://example.com"),
+		).toBe("does it support backups?");
+		expect(linkShareOwnText("https://example.com/some/page")).toBe("");
+	});
+
+	it("drops connector embed preview text — a page title is not the user asking", () => {
+		// The embed title carries a question mark that must not surface as the
+		// user's own phrasing.
+		const shared = [
+			"https://example.com/what-is-it",
+			"Embed #1:",
+			"  Title:What is umbrelOS?",
+			"  Description:(none)",
+		].join("\n");
+		expect(linkShareOwnText(shared)).toBe("");
 	});
 });
 

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -128,9 +128,12 @@ const URL_TOKEN_PATTERN = /\bhttps?:\/\/[^\s<>()]+/giu;
 /** Connector-appended link-preview blocks (Discord renders shared-link embeds
  * into the processed text as "Embed #N:\n  Title:…\n  Description:…"). Preview
  * text is DERIVED from the linked page — it is never a user instruction, so
- * intent detection must not read it as one. */
+ * intent detection must not read it as one. The header tail must stay on
+ * `[ \t]*`: a `\s*` there greedily eats the newline plus the next line's
+ * indent, so the indented Title/Description lines never match and page-derived
+ * text leaks into the residue. */
 const LINK_EMBED_BLOCK_PATTERN =
-	/(?:^|\n)\s*Embed #\d+:\s*(?:\n[ \t]+[^\n]*)*/giu;
+	/(?:^|\n)[ \t]*Embed #\d+:[ \t]*(?:\n[ \t]+[^\n]*)*/giu;
 
 /** Explicit work imperatives in the user's OWN words (outside URLs and embed
  * previews) that turn a link share into a genuine request. */
@@ -167,6 +170,23 @@ export function looksLikeBareLinkShare(text: string): boolean {
 	if (residue.length > 120) return false;
 	if (residue.length === 0) return true;
 	return !LINK_SHARE_WORK_IMPERATIVE_PATTERN.test(residue);
+}
+
+/**
+ * The user's OWN words in a link-share message: connector-derived embed
+ * preview blocks and the URLs themselves removed, original punctuation kept.
+ * Lets delivery seams distinguish "here's a link" from "here's a link — does
+ * it do X?" without re-deriving the connector text shape (a bare share and a
+ * short question both route to the web-read light path, but they want
+ * different answer styles).
+ */
+export function linkShareOwnText(text: string): string {
+	return text
+		.trim()
+		.replace(LINK_EMBED_BLOCK_PATTERN, " ")
+		.replace(URL_TOKEN_PATTERN, " ")
+		.replace(/\s+/gu, " ")
+		.trim();
 }
 
 export function looksLikeWebSearchRequest(text: string): boolean {


### PR DESCRIPTION
## What

A bare shared URL on Discord answered with the RAW SCRAPED PAGE as a ~13-message wall instead of a short summary. Sharing `https://umbrel.com/umbrelos` produced "ID: webpage-85b0602a… / Name: umbrelos / Type: link / Source: Web / Stored content:" followed by the entire stored page ("Store encrypted hourly backups…", "Bitcoin Node Install…", app lists, …).

## Root cause (live trajectory evidence)

Trajectory `tj-d29ff62e98fbb2` (agent 6f110aa9, 2026-08-05): root message is the bare link; the planner called `ATTACHMENT` with `{"action":"read","addToClipboard":true,"attachmentId":"webpage-85b0602a68906762298056cf"}`. In `readAttachmentAction.ts`, `clipboardResult.requested` switched the user-visible text from the prose-answer path to `responseRecordText(...)` — the planner-facing record dump (metadata envelope + FULL stored content) — and that text shipped as the sole delivery (`verifiedUserFacing` + `turnComplete`), verbatim, chunked by Discord into ~13 bubbles. The tool result in the trajectory is byte-for-byte the observed Discord wall.

Two adjacent latent seams found while fixing:

- `answerAttachmentRequest` fell back to the RAW stored content whenever the model returned an empty string — a second path to a verbatim page dump.
- `LINK_EMBED_BLOCK_PATTERN` (the #18106 link-share guard) never actually stripped Discord embed `Title:`/`Description:` lines: the greedy `\s*` after `Embed #N:` consumes the newline + indent, so the indented-lines group can never match and page-derived text leaks into the intent residue. An embed title carrying a work imperative ("Build and deploy…") could defeat the no-spawn guard.

## Fix

- `packages/core/src/features/working-memory/readAttachmentAction.ts` — the record dump reaches chat only when the user explicitly asks for the attachment record ("show the attachment metadata"); every other read answers in prose. The planner keeps the full stored content, ids, and clipboard state in `data`. A link share with no actual ask gets a ONE-take answer (max two sentences, 256-token budget); a question next to the link still gets the question answered. Empty model output degrades to a short acknowledgement, never the raw page.
- `packages/core/src/services/message/direct-action-heuristics.ts` — new `linkShareOwnText()` (user's own words: embeds + URLs removed, punctuation kept) so the answer-style seam can tell "here's a link" from "here's a link — does it do X?"; fixed `LINK_EMBED_BLOCK_PATTERN` to really strip embed blocks.

Preserved: bare-link → WEB_FETCH-first light-path routing, the no-spawn guard (embed-derived text now defeats it even less), the unfetchable-link embed-metadata degrade, and explicit "build from this link" still routes to real work (`looksLikeBareLinkShare` still rejects work imperatives — covered by existing tests).

## Evidence

Live repro trajectory (before): `tj-d29ff62e98fbb2` — `ATTACHMENT` result text begins:

```
ID: webpage-85b0602a68906762298056cf
Name: umbrelos
Type: link
Source: Web
Stored content: yes
Added clipboard item cb-7e0146a2: umbrelos
Clipboard usage: 1/5.
Clear unused clipboard state when it is no longer needed.
umbrelOS - An elegant OS for your home server
…full scraped page…
```

Deterministic regression suite (after) — `readAttachmentAction.delivery.test.ts` replays the exact live shape (bare mention + link, `addToClipboard:true`, `webpage-…` attachment id) through the real handler with a scripted TEXT_SMALL:

| case | assertion | result |
| --- | --- | --- |
| bare link + addToClipboard (live repro) | exactly ONE callback; text = authored summary; no `Stored content` / `ID: webpage-` envelope; no raw page text; `verifiedUserFacing` + `turnComplete`; clipboard still stored | pass |
| model context preserved | TEXT_SMALL prompt contains the page text + one-take instruction @ 256 tokens; `data.content` carries full page | pass |
| question next to link | no one-take instruction; full answer budget | pass |
| short non-ask remark ("check this out") | one-take treatment | pass |
| empty model response | short acknowledgement, never the raw page | pass |
| explicit "attachment metadata" ask | record envelope still delivered | pass |
| embed title with work imperative | still a bare link share (guard not defeated) | pass |

Suites: `packages/core` features/working-memory + services/message + context-catalog (32 files, 349 tests) pass; `plugin-agent-orchestrator` `spawn-link-guard.test.ts` (no-spawn guard) passes; `packages/core` typecheck + biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Evidence Gate

<!-- evidence-head:34d88b60112ba5c31d78d0ffbf273e9d28f4ee66 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend-only core action delivery change with no rendered UI surface in the diff.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend-only core action delivery change with no rendered UI surface in the diff.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no frontend-testable flow; the change is delivery selection inside a core action, proven by the attached test-run log.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: scoped owning suites (packages/core working-memory + services/message + context-catalog: 32 files / 349 tests), plugin-agent-orchestrator spawn-link-guard (4/4), core typecheck exit 0, biome lint clean — https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18126-pr18126-test-run.log
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or network path is involved in this change.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: sanitized excerpt of the live BEFORE-fix repro trajectory tj-d29ff62e98fbb2 (bare umbrel.com link share; ATTACHMENT action=read with addToClipboard=true; the tool result text is byte-for-byte the raw-page wall that shipped to Discord) — https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18126-tj-d29ff62e98fbb2-before-repro-excerpt-v2.json — the full trajectory is withheld because it embeds an entity roster with third-party handles; the deterministic delivery suite in this PR replays the exact live message/params shape through the real handler.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - the delivered chat message text is the only domain artifact for this change; it is captured before-fix in the trajectory excerpt row and after-fix in the backend test log row.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface; every changed file is TypeScript under packages/core.
