### PR TITLE
fix(homepage): unbreak workspace lint - suppress a11y rule on the swipe wrapper

### DIFF
--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -756,6 +756,7 @@ export default function Leaderboard() {
   );
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: pointer-gesture swipe/drag surface only; the switcher buttons remain the keyboard-accessible platform-switch path.
     <div
       {...bind()}
       // Horizontal swipes cross the QR image and Get Started link; without


### PR DESCRIPTION
## What

Workspace lint is red on develop: f4941fce4cc added an `onDragStart` handler to the landing page's `useDrag` swipe wrapper, tripping `lint/a11y/noStaticElementInteractions` in `packages/homepage/src/pages/landing.tsx`. The required `lint` check now fails for every develop PR (observed on #18126).

## Fix

Suppress the rule on the wrapper with a rationale comment, following the existing `packages/ui/src/components/pages/DocumentsView.tsx` precedent: the wrapper is a pointer-gesture (swipe/drag) surface only, and the platform switcher buttons remain the keyboard-accessible path.

Comment-only change — `bun run check:comment-only` verifies the code token stream is identical to origin/develop.

## Verification

- `bun run --cwd packages/homepage lint:check` — clean (was: 1 error).
- `bun run check:comment-only` — OK, comments only.
- homepage `landing-a11y-helpers` + smoke tests — 13/13 pass.
- Built and served the page; captured desktop + mobile screenshots before/after (identical rendering) and a swipe-gesture walkthrough video; OCR readout confirms rendered text intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Evidence Gate

<!-- evidence-head:de7dd60a71efa9624e3ba5c2411d88b266ba90af -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots (develop HEAD 31235fbbf, pre-fix build): desktop https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18128-before-desktop.jpg mobile https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18128-before-mobile.jpg
<!-- evidence-row:after-screenshots -->
- [x] After screenshots (this head, comment-only change, identical rendering): desktop https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18128-after-desktop.jpg mobile https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18128-after-mobile.jpg
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video (landing page load + the horizontal swipe gesture the changed wrapper owns, both directions): https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18128-after-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [x] Backend logs: lint clean + comment-only token check OK + homepage tests 13/13 — https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18128-heal-pr-checks.log
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs from the after-fix capture session (page load HTTP 200, console + failed-request stream): https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18128-frontend-console-v2.log
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - comment-only lint suppression touching no agent, action, provider, prompt, or model path.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no database, wallet, scheduled-task, or generated-file artifacts exist for a comment-only lint suppression.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: tesseract.js text readout over the before/after full-page screenshots, rendered text intact and identical — https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18128-ocr-review.md

Closes #18129
