### PR TITLE
fix(cloud): give cloud-files-route tests the package's slow-host timeout budget

### DIFF
--- a/packages/cloud/api/__tests__/cloud-files-route.test.ts
+++ b/packages/cloud/api/__tests__/cloud-files-route.test.ts
@@ -1,9 +1,22 @@
 // Exercises cloud API tests cloud files route.test behavior with deterministic Worker route fixtures.
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	afterAll,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	setDefaultTimeout,
+	test,
+} from "bun:test";
 import { Hono } from "hono";
 import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
 import * as rateLimitActual from "@/lib/middleware/rate-limit-hono-cloudflare";
 import * as cloudFilesActual from "@/lib/services/cloud-files";
+
+// Pure-mock suite that runs in ~1.5s idle, but on a CPU-starved host the
+// first test has been observed at 6.4s — past bun's 5s default. Match the
+// package's slow-host budget (see sso-bridge.test.ts).
+setDefaultTimeout(90_000);
 
 const ORG = "00000000-0000-4000-8000-0000000000aa";
 const OTHER_ORG = "00000000-0000-4000-8000-0000000000cc";


### PR DESCRIPTION
## What

`packages/cloud/api/__tests__/cloud-files-route.test.ts` was the only heavy api suite still riding bun's **5000ms default** per-test timeout. Adopt the package's established slow-host budget — `setDefaultTimeout(90_000)` at module top, exactly as `sso-bridge.test.ts` and `steward-session-logout-marker-gate.test.ts` do (`oidc-provider.test.ts` uses 120s). **No assertion, fixture, or ordering changes** — all 34 `expect()` calls untouched. One file, +14/−1.

## Why

The suite is pure-mock and runs in ~1.5s idle, but it flakes deterministically under host CPU starvation: reproduced with 64 burner processes + `taskpolicy -c background` (mimicking a saturated shared CI runner) —

```
(fail) /api/v1/files > lists active files scoped to the authenticated organization
with filters and pagination [6415.42ms]  ^ this test timed out after 5000ms.
10 pass 1 fail
```

It also surfaced organically during a package health audit when three suites ran in parallel on one machine: the file failed under load, then passed standalone twice.

---

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8` (fix + verification), `anthropic/claude-fable-5` (audit + flake reproduction)
<!-- attribution-row:client -->
- Client / agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

---

# Evidence

<!-- evidence-head:5b17aa73c977effd177ed27bb5fa63538465ec1f -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only change; no UI surface is added or altered.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only change; no UI surface is added or altered.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the change is a per-test timeout budget in one api test file.`
<!-- evidence-row:backend-logs -->
- [x] Reproduction and verification runs:

```
BEFORE (develop, starved host: 64 CPU burners + taskpolicy -c background):
  (fail) /api/v1/files > lists active files scoped to the authenticated
  organization with filters and pagination [6415.42ms]
  ^ this test timed out after 5000ms.  10 pass 1 fail  [276.64s]
BEFORE (develop, idle host): 11 pass 0 fail [1.51s]  — classic starvation flake

AFTER (this PR, idle host, x3):
  run 1: 11 pass 0 fail  Ran 11 tests across 1 file. [965.00ms]
  run 2: 11 pass 0 fail  Ran 11 tests across 1 file. [661.00ms]
  run 3: 11 pass 0 fail  Ran 11 tests across 1 file. [636.00ms]
AFTER (this PR, same starvation recipe, x3):
  RESULT run 1: PASS  11 pass 0 fail
  RESULT run 2: PASS  11 pass 0 fail
  RESULT run 3: PASS  11 pass 0 fail
  DONE: 0 failures of 3 starved runs
```

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no browser-observable change; api test file only.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model path is touched.`

---

Note on unrelated red checks at open time: `unit-tests`/`lint-and-types`/`integration-tests` failed with a runner-infra error ("Can't find action.yml under /opt/actions-runner/..."), and `lint` fails on `packages/scripts/*.mjs` files this PR does not touch (develop-wide, with fix branches already in flight). This diff is one test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
