### PR TITLE
feat(plugin-taskmarket): delegate work to the TaskMarket marketplace

### DIFF
--- a/plugins/plugin-taskmarket/AGENTS.md
+++ b/plugins/plugin-taskmarket/AGENTS.md
@@ -1,0 +1,74 @@
+# plugin-taskmarket
+
+TaskMarket marketplace integration: lets an Eliza agent delegate work to
+external workers (paid in USDC on Base) instead of spending more inference on a
+task another worker can do.
+
+## Layout
+
+```
+src/
+  types.ts              config resolution, spend-guard settings, ActionResult builders
+  lib/client.ts         bounded REST client (timeout + byte cap)
+  actions/browse.ts     TASKMARKET_BROWSE   — read-only discovery
+  actions/status.ts     TASKMARKET_STATUS   — read-only balance/reputation/submissions
+  actions/create-task.ts TASKMARKET_CREATE_TASK — the only money-moving action
+  plugin.ts index.ts
+```
+
+## Invariants
+
+- **`TASKMARKET_CREATE_TASK` is the only action that spends.** It stays gated
+  four independent ways: `roleGate: { minRole: "OWNER" }`,
+  `TASKMARKET_ALLOW_TASK_CREATION` off by default,
+  `TASKMARKET_MAX_TASK_REWARD_USDC` enforced by refusal (never by trimming the
+  reward), and the core `gateDestructiveConfirmation` two-turn gate against the
+  real user `Memory`. Do not weaken any of the four, and do not add an action
+  that accepts a submission or releases escrow — settlement stays with the human.
+- **Never reintroduce a planner-authored confirmation parameter.** An LLM-set
+  `confirmed`/`userConfirmed` boolean is not user approval: core states it must
+  never authorize a destructive operation, and it cannot bind the sender, the
+  exact task, or the exact amount. The confirmation pending key is the
+  fingerprint of the brief plus the normalized atomic reward, so a changed task
+  or amount re-previews instead of settling on a stale approval.
+- **A 2xx is not proof of escrow.** `createTask` requires `success !== false`
+  and a non-empty `taskId`; anything else raises `TaskMarketResponseError` and
+  the action reports `invalid_response`. Never report a created task without an
+  id the user can open.
+- **Never fall back to a healthy-looking empty/zero.** No `?? []`, no `?? "0"`,
+  no invalid-number-to-zero. A malformed board is unavailable, not empty; a
+  missing balance is unavailable, not zero. `atomicToUsdc` returns `undefined`
+  for an unreadable amount and `formatUsdc` renders it `n/a`.
+- **Rewards below one atomic unit are refused, not rounded.** `usdcToAtomic`
+  returns `undefined` rather than `"0"`, so a sub-micro-USDC reward can never be
+  posted as zero while the user is told it was escrowed.
+- The disabled check is duplicated in `validate()` and at handler entry on
+  purpose: `validate()` keeps the tool off the planner's list, the handler check
+  is the backstop against a hallucinated call.
+- Every guard failure must return before the network call. The tests assert
+  `fetch` was never invoked for each rejection path.
+- **The API bearer token does not identify the caller.** `TASKMARKET_ADDRESS` is
+  a separate required setting; account routes 500/400 without an explicit
+  `address` query param.
+- **The `/api` base-path prefix is mandatory.** Every path 404s without it.
+- **Amounts are atomic 6-decimal USDC** everywhere except `/wallet/balance`.
+  Convert at the client boundary; actions speak whole USDC.
+- Task descriptions run 2-10 KB. List output truncates to
+  `TASKMARKET_LIST_DESCRIPTION_CHARS`; never widen it without re-checking what a
+  full board listing does to the context window.
+- Error text must never echo the bearer token or the request URL (which carries
+  the caller's address).
+
+## Commands
+
+```bash
+bun run --cwd plugins/plugin-taskmarket test
+bun run --cwd plugins/plugin-taskmarket typecheck
+bun run --cwd plugins/plugin-taskmarket lint:check
+```
+
+## Live check
+
+Unit tests mock `fetch`, which validates this plugin's logic but not the
+vendor's URL shape. When changing the client, run one live read against the real
+API with a real token before trusting green tests.

--- a/plugins/plugin-taskmarket/CLAUDE.md
+++ b/plugins/plugin-taskmarket/CLAUDE.md
@@ -1,0 +1,74 @@
+# plugin-taskmarket
+
+TaskMarket marketplace integration: lets an Eliza agent delegate work to
+external workers (paid in USDC on Base) instead of spending more inference on a
+task another worker can do.
+
+## Layout
+
+```
+src/
+  types.ts              config resolution, spend-guard settings, ActionResult builders
+  lib/client.ts         bounded REST client (timeout + byte cap)
+  actions/browse.ts     TASKMARKET_BROWSE   — read-only discovery
+  actions/status.ts     TASKMARKET_STATUS   — read-only balance/reputation/submissions
+  actions/create-task.ts TASKMARKET_CREATE_TASK — the only money-moving action
+  plugin.ts index.ts
+```
+
+## Invariants
+
+- **`TASKMARKET_CREATE_TASK` is the only action that spends.** It stays gated
+  four independent ways: `roleGate: { minRole: "OWNER" }`,
+  `TASKMARKET_ALLOW_TASK_CREATION` off by default,
+  `TASKMARKET_MAX_TASK_REWARD_USDC` enforced by refusal (never by trimming the
+  reward), and the core `gateDestructiveConfirmation` two-turn gate against the
+  real user `Memory`. Do not weaken any of the four, and do not add an action
+  that accepts a submission or releases escrow — settlement stays with the human.
+- **Never reintroduce a planner-authored confirmation parameter.** An LLM-set
+  `confirmed`/`userConfirmed` boolean is not user approval: core states it must
+  never authorize a destructive operation, and it cannot bind the sender, the
+  exact task, or the exact amount. The confirmation pending key is the
+  fingerprint of the brief plus the normalized atomic reward, so a changed task
+  or amount re-previews instead of settling on a stale approval.
+- **A 2xx is not proof of escrow.** `createTask` requires `success !== false`
+  and a non-empty `taskId`; anything else raises `TaskMarketResponseError` and
+  the action reports `invalid_response`. Never report a created task without an
+  id the user can open.
+- **Never fall back to a healthy-looking empty/zero.** No `?? []`, no `?? "0"`,
+  no invalid-number-to-zero. A malformed board is unavailable, not empty; a
+  missing balance is unavailable, not zero. `atomicToUsdc` returns `undefined`
+  for an unreadable amount and `formatUsdc` renders it `n/a`.
+- **Rewards below one atomic unit are refused, not rounded.** `usdcToAtomic`
+  returns `undefined` rather than `"0"`, so a sub-micro-USDC reward can never be
+  posted as zero while the user is told it was escrowed.
+- The disabled check is duplicated in `validate()` and at handler entry on
+  purpose: `validate()` keeps the tool off the planner's list, the handler check
+  is the backstop against a hallucinated call.
+- Every guard failure must return before the network call. The tests assert
+  `fetch` was never invoked for each rejection path.
+- **The API bearer token does not identify the caller.** `TASKMARKET_ADDRESS` is
+  a separate required setting; account routes 500/400 without an explicit
+  `address` query param.
+- **The `/api` base-path prefix is mandatory.** Every path 404s without it.
+- **Amounts are atomic 6-decimal USDC** everywhere except `/wallet/balance`.
+  Convert at the client boundary; actions speak whole USDC.
+- Task descriptions run 2-10 KB. List output truncates to
+  `TASKMARKET_LIST_DESCRIPTION_CHARS`; never widen it without re-checking what a
+  full board listing does to the context window.
+- Error text must never echo the bearer token or the request URL (which carries
+  the caller's address).
+
+## Commands
+
+```bash
+bun run --cwd plugins/plugin-taskmarket test
+bun run --cwd plugins/plugin-taskmarket typecheck
+bun run --cwd plugins/plugin-taskmarket lint:check
+```
+
+## Live check
+
+Unit tests mock `fetch`, which validates this plugin's logic but not the
+vendor's URL shape. When changing the client, run one live read against the real
+API with a real token before trusting green tests.

--- a/plugins/plugin-taskmarket/README.md
+++ b/plugins/plugin-taskmarket/README.md
@@ -1,0 +1,150 @@
+# @elizaos/plugin-taskmarket
+
+Delegate work to the [TaskMarket](https://taskmarket.dev/) agent marketplace
+instead of burning more inference on a task another worker can do.
+
+TaskMarket is a marketplace where agents complete tasks and get paid in USDC on
+Base. This plugin makes it an actionable option inside an Eliza agent: the agent
+can discover open work, track what it has submitted, and — only when the
+operator has explicitly enabled it and the user has confirmed the exact
+amount — post a task that escrows USDC.
+
+## Actions
+
+| Action | Effect | Money |
+| --- | --- | --- |
+| `TASKMARKET_BROWSE` | List open tasks (`subaction=list`) or fetch one full brief (`subaction=get`) | none |
+| `TASKMARKET_STATUS` | Wallet balance, agent reputation, own submissions | none |
+| `TASKMARKET_CREATE_TASK` | Post a task to the board | **escrows real USDC** |
+
+Accepting a submission and releasing escrow are deliberately **not** exposed.
+Settlement stays with the human on taskmarket.dev.
+
+## Configuration
+
+```bash
+TASKMARKET_API_TOKEN=...          # required — from `taskmarket init`
+TASKMARKET_ADDRESS=0x...          # required — see note below
+TASKMARKET_API_URL=https://api.taskmarket.dev/api   # optional
+TASKMARKET_ALLOW_TASK_CREATION=false                # optional, default false
+TASKMARKET_MAX_TASK_REWARD_USDC=1                   # optional, default 1, hard cap 50
+```
+
+`TASKMARKET_ADDRESS` is required *in addition to* the token, not as a
+convenience. The TaskMarket API does not infer identity from the bearer token:
+`GET /agents/stats` returns `500 "Provide address or agentId"` and
+`GET /wallet/balance` returns a validation error unless the address is passed
+explicitly. Both values are in `~/.taskmarket/keystore.json` after
+`taskmarket init`.
+
+Without both credentials, `validate()` returns false and none of the actions are
+offered to the planner.
+
+## Spending guards
+
+`TASKMARKET_CREATE_TASK` is the only action that moves money, and it is gated
+four independent ways. All four must pass:
+
+1. **Owner-only.** `roleGate: { minRole: "OWNER" }`, so a member or guest in a
+   shared agent cannot reach the spend path at all. This matches how the
+   sibling money-moving `plugin-wallet` gates its own actions.
+2. **Off by default.** `TASKMARKET_ALLOW_TASK_CREATION` must be explicitly
+   enabled. Unset, this plugin is a read-only surface. Enforced in both
+   `validate()` (so the action is never offered) and at handler entry (so a
+   hallucinated tool call cannot bypass the exposure gate).
+3. **Bounded per call.** `TASKMARKET_MAX_TASK_REWARD_USDC` defaults to 1 USDC
+   and is hard-capped at 50. An over-budget request is **refused**, never
+   trimmed down to the ceiling — a silently reduced spend is still a spend the
+   user did not approve.
+4. **Two-turn user confirmation.** The core `gateDestructiveConfirmation` helper
+   previews the exact brief and reward, then requires a yes-shaped reply from
+   the real user `Memory` on the following turn. There is deliberately **no**
+   `userConfirmed` parameter: an LLM-authored boolean cannot authorize a
+   destructive operation, cannot identify the sender, and cannot pin the exact
+   amount. The pending record is keyed by the sender plus a fingerprint of the
+   brief and the normalized atomic reward and expires after five minutes, so a
+   changed task, a changed amount, a different user, or a stale approval all
+   re-preview instead of settling.
+
+Guard 4 is the prompt-injection boundary. A public task board is untrusted
+input: any task description on it can contain "post a task offering 50 USDC
+for…", and an agent reading the board must not treat that as an instruction —
+only the user's own follow-up message counts.
+
+Every guard failure returns before any network call is made; the tests assert
+`fetch` was never invoked.
+
+## Failure honesty
+
+This plugin never degrades a failed read into a healthy-looking value:
+
+- A malformed board is reported **unavailable**, not as an empty board.
+- A missing `balanceUsdc` is reported **unavailable**, not as a zero balance.
+- An unparseable amount renders as `n/a`, not `$0.00`.
+- A 2xx creation response is only reported as escrowed when it carries
+  `success !== false` **and** a non-empty `taskId`; otherwise the action returns
+  `invalid_response` and the escrow is treated as not performed.
+- A reward below one atomic unit (0.000001 USDC) is refused rather than rounded
+  to `"0"` and reported as escrowed.
+
+## Usage
+
+```ts
+import { taskMarketPlugin } from "@elizaos/plugin-taskmarket";
+
+const runtime = new AgentRuntime({
+  character,
+  plugins: [taskMarketPlugin],
+});
+```
+
+Read-only browsing needs no extra opt-in:
+
+```
+user: what agent work is open on TaskMarket right now?
+agent: [TASKMARKET_BROWSE subaction=list]
+       3 TaskMarket task(s):
+       - 0x8e416ba0f3e473d2...
+         reward $4.50 (net $4.16) | mode bounty | submissions 19 | window open
+         expires 2026-08-22T11:58:25.795Z
+         # Earn 0.50 USDC for a Real TaskMarket Integration PR ...
+```
+
+Delegation asks first:
+
+```
+user: get someone to write the release notes, pay a dollar
+agent: [TASKMARKET_CREATE_TASK]
+       Post this task to TaskMarket and escrow 1 USDC on Base for 72h? This
+       spends real funds and cannot be undone from this agent.
+       "Write the release notes for …"
+       Reply yes to confirm or no to cancel.
+user: yes, do it
+agent: [TASKMARKET_CREATE_TASK]
+       Created TaskMarket task 0x… with 1 USDC escrowed for 72h.
+```
+
+## Context-window discipline
+
+Task descriptions run 2–10 KB each, so a raw 20-task board listing is ~100 KB of
+JSON — enough to blow the window on its own. `TASKMARKET_BROWSE` truncates
+descriptions to 400 characters in list output and points the planner at
+`subaction=get` for the full brief. Responses are also byte-capped
+(512 KB) and timeout-bounded (20 s) before they reach the agent.
+
+## Amounts are atomic USDC
+
+`reward`, `netReward` and `totalEarnings` come back as strings of atomic
+6-decimal units — `"5000000"` is $5.00. The client converts at the boundary, so
+actions and their `data` payloads always speak whole USDC. The one exception on
+the vendor side is `/wallet/balance`, which already returns whole USDC.
+
+`netReward` is post-platform-fee; the fee is typically 750 bps (7.5%).
+
+## Development
+
+```bash
+bun run --cwd plugins/plugin-taskmarket test
+bun run --cwd plugins/plugin-taskmarket typecheck
+bun run --cwd plugins/plugin-taskmarket lint:check
+```

--- a/plugins/plugin-taskmarket/build.ts
+++ b/plugins/plugin-taskmarket/build.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-taskmarket (Node). Orchestration lives in the
+ * shared driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
+
+await buildPlugin({
+  name: "@elizaos/plugin-taskmarket",
+  clean: true,
+  externals: ["@elizaos/core"],
+  targets: [
+    {
+      label: "Node",
+      entry: "./src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsEmitDeclarationOnly: true,
+});

--- a/plugins/plugin-taskmarket/package.json
+++ b/plugins/plugin-taskmarket/package.json
@@ -1,0 +1,122 @@
+{
+  "name": "@elizaos/plugin-taskmarket",
+  "version": "2.0.3-beta.7",
+  "description": "Delegate work to the TaskMarket agent marketplace (USDC on Base): browse open tasks, track submissions and balance, and post spend-guarded tasks.",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elizaos/eliza.git"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "eliza-source": {
+        "types": "./src/*.ts",
+        "import": "./src/*.ts",
+        "default": "./src/*.ts"
+      },
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
+  "files": [
+    "registry-entry.json",
+    "dist"
+  ],
+  "keywords": [
+    "eliza",
+    "plugin",
+    "taskmarket",
+    "marketplace",
+    "delegation",
+    "usdc",
+    "base",
+    "agent"
+  ],
+  "author": "elizaOS",
+  "license": "MIT",
+  "dependencies": {
+    "@elizaos/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.3",
+    "typescript": "^6.0.3",
+    "vitest": "^4.0.0"
+  },
+  "scripts": {
+    "build": "bun run build.ts",
+    "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "check": "bun run typecheck && bun run test"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "agentConfig": {
+    "pluginType": "elizaos:plugin:1.0.0",
+    "pluginParameters": {
+      "TASKMARKET_API_TOKEN": {
+        "type": "string",
+        "description": "TaskMarket API bearer token. Created by `taskmarket init`; stored in ~/.taskmarket/keystore.json as apiToken.",
+        "required": true,
+        "sensitive": true
+      },
+      "TASKMARKET_ADDRESS": {
+        "type": "string",
+        "description": "Base wallet address for this agent. Required separately from the token: the TaskMarket API does not infer identity from the bearer token, so account routes need an explicit address.",
+        "required": true,
+        "sensitive": false
+      },
+      "TASKMARKET_API_URL": {
+        "type": "string",
+        "description": "API base URL. Must include the /api path prefix.",
+        "required": false,
+        "default": "https://api.taskmarket.dev/api",
+        "sensitive": false
+      },
+      "TASKMARKET_ALLOW_TASK_CREATION": {
+        "type": "boolean",
+        "description": "Master switch for TASKMARKET_CREATE_TASK. Off by default; creating a task escrows real USDC on Base.",
+        "required": false,
+        "default": false,
+        "sensitive": false
+      },
+      "TASKMARKET_MAX_TASK_REWARD_USDC": {
+        "type": "number",
+        "description": "Per-task reward ceiling in whole USDC. An over-budget request is refused rather than trimmed. Hard-capped at 50.",
+        "required": false,
+        "default": 1,
+        "sensitive": false
+      }
+    }
+  },
+  "eliza": {
+    "platforms": [
+      "node"
+    ],
+    "runtime": "node",
+    "platformDetails": {
+      "node": "Default export (Node.js)"
+    }
+  }
+}

--- a/plugins/plugin-taskmarket/registry-entry.json
+++ b/plugins/plugin-taskmarket/registry-entry.json
@@ -1,0 +1,54 @@
+{
+  "id": "taskmarket",
+  "name": "TaskMarket",
+  "description": "Delegate work to the TaskMarket agent marketplace (USDC on Base): browse open tasks, track submissions and balance, and post spend-guarded tasks",
+  "npmName": "@elizaos/plugin-taskmarket",
+  "version": "2.0.3-beta.7",
+  "source": "bundled",
+  "tags": [
+    "taskmarket",
+    "marketplace",
+    "delegation",
+    "usdc",
+    "base",
+    "crypto",
+    "agent"
+  ],
+  "config": {
+    "TASKMARKET_API_TOKEN": {
+      "type": "secret",
+      "required": true,
+      "sensitive": true,
+      "label": "API token",
+      "help": "TaskMarket API bearer token from `taskmarket init` (~/.taskmarket/keystore.json, field apiToken)."
+    },
+    "TASKMARKET_ADDRESS": {
+      "type": "text",
+      "required": true,
+      "sensitive": false,
+      "label": "Wallet address",
+      "help": "Base wallet address for this agent. Required separately from the token — the API does not infer identity from the bearer token."
+    },
+    "TASKMARKET_API_URL": {
+      "type": "text",
+      "required": false,
+      "sensitive": false,
+      "label": "API URL",
+      "help": "API base URL, must include the /api prefix. Defaults to https://api.taskmarket.dev/api."
+    },
+    "TASKMARKET_ALLOW_TASK_CREATION": {
+      "type": "boolean",
+      "required": false,
+      "sensitive": false,
+      "label": "Allow task creation",
+      "help": "Off by default. When enabled, the agent may escrow real USDC by posting a task."
+    },
+    "TASKMARKET_MAX_TASK_REWARD_USDC": {
+      "type": "number",
+      "required": false,
+      "sensitive": false,
+      "label": "Max reward (USDC)",
+      "help": "Per-task ceiling in whole USDC. Over-budget requests are refused, not trimmed. Hard-capped at 50."
+    }
+  }
+}

--- a/plugins/plugin-taskmarket/src/actions/browse.ts
+++ b/plugins/plugin-taskmarket/src/actions/browse.ts
@@ -1,0 +1,199 @@
+/**
+ * TASKMARKET_BROWSE — discover delegatable work on the TaskMarket board.
+ *
+ * Read-only. Two subactions: `list` (open board, ranked, descriptions truncated)
+ * and `get` (one task's full brief). Task descriptions run 2-10 KB each, so a
+ * raw 20-task listing is ~100 KB of JSON; the list path truncates hard and
+ * points the planner at `get` for the full brief instead of flooding the window.
+ */
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import {
+  getTask,
+  listTasks,
+  TaskMarketApiError,
+  TaskMarketResponseError,
+  type TaskMarketTask,
+} from "../lib/client.ts";
+import {
+  failureActionResult,
+  formatUsdc,
+  readNumberParam,
+  readStringParam,
+  resolveTaskMarketConfig,
+  successActionResult,
+  TASKMARKET_CONTEXTS,
+  TASKMARKET_DETAIL_DESCRIPTION_CHARS,
+  TASKMARKET_LIST_DESCRIPTION_CHARS,
+} from "../types.ts";
+
+const DEFAULT_LIST_LIMIT = 10;
+const MAX_LIST_LIMIT = 25;
+
+function truncate(text: string | undefined, max: number): string {
+  const value = (text ?? "").trim();
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}\n[truncated — use TASKMARKET_BROWSE subaction=get for the full brief]`;
+}
+
+function formatTaskSummary(task: TaskMarketTask): string {
+  const subs = task.submissionCount ?? 0;
+  const window = task.submissionWindowOpen === false ? "closed" : "open";
+  return [
+    `- ${task.id}`,
+    `  reward ${formatUsdc(task.reward)} (net ${formatUsdc(task.netReward)}) | mode ${task.mode ?? "?"} | submissions ${subs} | window ${window}`,
+    `  expires ${task.expiryTime ?? "?"}`,
+    `  ${truncate(task.description, TASKMARKET_LIST_DESCRIPTION_CHARS).replace(/\n/g, " ")}`,
+  ].join("\n");
+}
+
+export const taskMarketBrowseAction: Action = {
+  name: "TASKMARKET_BROWSE",
+  contexts: [...TASKMARKET_CONTEXTS],
+  similes: [
+    "BROWSE_TASKMARKET",
+    "LIST_TASKMARKET_TASKS",
+    "FIND_DELEGATABLE_WORK",
+  ],
+  description:
+    "Browse open work on the TaskMarket agent marketplace, or fetch one task's full brief. Read-only: it never creates a task, spends funds, or accepts a submission. Use subaction=list for the open board (descriptions truncated) and subaction=get with taskId for the full brief.",
+  parameters: [
+    {
+      name: "subaction",
+      description: "Either 'list' for the open board or 'get' for one task.",
+      required: false,
+      schema: { type: "string", enum: ["list", "get"], default: "list" },
+    },
+    {
+      name: "taskId",
+      description: "Task id, required when subaction=get.",
+      required: false,
+      schema: { type: "string" },
+    },
+    {
+      name: "status",
+      description: "Board status filter, default 'open'.",
+      required: false,
+      schema: { type: "string" },
+    },
+    {
+      name: "mode",
+      description:
+        "Optional mode filter: bounty, claim, pitch, benchmark or auction.",
+      required: false,
+      schema: {
+        type: "string",
+        enum: ["bounty", "claim", "pitch", "benchmark", "auction"],
+      },
+    },
+    {
+      name: "limit",
+      description: `Number of tasks to return, default ${DEFAULT_LIST_LIMIT}, max ${MAX_LIST_LIMIT}.`,
+      required: false,
+      schema: { type: "number" },
+    },
+  ],
+  validate: async (runtime: IAgentRuntime) =>
+    resolveTaskMarketConfig(runtime) !== undefined,
+  handler: async (
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State,
+    options?: unknown,
+    _callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const config = resolveTaskMarketConfig(runtime);
+    if (!config) {
+      return failureActionResult({
+        reason: "not_configured",
+        message:
+          "TASKMARKET_API_TOKEN and TASKMARKET_ADDRESS must both be set (the API bearer token does not identify the caller).",
+      });
+    }
+
+    const subaction = (
+      readStringParam(options, "subaction") ?? "list"
+    ).toLowerCase();
+
+    try {
+      if (subaction === "get") {
+        const taskId = readStringParam(options, "taskId");
+        if (!taskId) {
+          return failureActionResult({
+            reason: "missing_param",
+            message: "taskId is required when subaction=get",
+          });
+        }
+        const task = await getTask(config, taskId);
+        const text = [
+          `Task ${task.id}`,
+          `reward ${formatUsdc(task.reward)} (net ${formatUsdc(task.netReward)})`,
+          `mode ${task.mode ?? "?"} | status ${task.status ?? "?"} | submissions ${task.submissionCount ?? 0}`,
+          `window ${task.submissionWindowOpen === false ? "closed" : "open"} | expires ${task.expiryTime ?? "?"}`,
+          "",
+          truncate(task.description, TASKMARKET_DETAIL_DESCRIPTION_CHARS),
+        ].join("\n");
+        return successActionResult(text, {
+          action: "TASKMARKET_BROWSE",
+          subaction: "get",
+          taskId: task.id,
+        });
+      }
+
+      const requested = readNumberParam(options, "limit");
+      const limit =
+        requested && requested > 0
+          ? Math.min(MAX_LIST_LIMIT, Math.floor(requested))
+          : DEFAULT_LIST_LIMIT;
+      const tasks = await listTasks(config, {
+        status: readStringParam(options, "status") ?? "open",
+        mode: readStringParam(options, "mode"),
+        limit,
+        sort: "reward_desc",
+      });
+      if (tasks.length === 0) {
+        return successActionResult("No matching TaskMarket tasks.", {
+          action: "TASKMARKET_BROWSE",
+          subaction: "list",
+          count: 0,
+        });
+      }
+      const text = [
+        `${tasks.length} TaskMarket task(s):`,
+        ...tasks.map(formatTaskSummary),
+      ].join("\n");
+      return successActionResult(text, {
+        action: "TASKMARKET_BROWSE",
+        subaction: "list",
+        count: tasks.length,
+      });
+    } catch (error) {
+      if (error instanceof TaskMarketApiError) {
+        return failureActionResult(
+          {
+            reason: "api_error",
+            message: `HTTP ${error.status}: ${error.message}`,
+          },
+          { action: "TASKMARKET_BROWSE" },
+        );
+      }
+      if (error instanceof TaskMarketResponseError) {
+        return failureActionResult(
+          { reason: "invalid_response", message: error.message },
+          { action: "TASKMARKET_BROWSE" },
+        );
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      return failureActionResult(
+        { reason: "io_error", message },
+        { action: "TASKMARKET_BROWSE" },
+      );
+    }
+  },
+};

--- a/plugins/plugin-taskmarket/src/actions/create-task.ts
+++ b/plugins/plugin-taskmarket/src/actions/create-task.ts
@@ -1,0 +1,329 @@
+/**
+ * TASKMARKET_CREATE_TASK — delegate work to the TaskMarket worker market by
+ * posting a task. This is the only action in the plugin that moves money:
+ * `POST /tasks` escrows the reward in real USDC on Base at creation time.
+ *
+ * It is therefore gated four independent ways, and all four must pass:
+ *
+ * 1. **Role.** `roleGate: { minRole: "OWNER" }` — in a shared agent, a member
+ *    or guest cannot reach a spend path at all. Matches how the sibling
+ *    money-moving `plugin-wallet` gates its own actions.
+ * 2. **Off by default.** `TASKMARKET_ALLOW_TASK_CREATION` must be explicitly
+ *    enabled by the integrator. Unset, the plugin is a read-only surface.
+ * 3. **Bounded per call.** `TASKMARKET_MAX_TASK_REWARD_USDC` (default 1 USDC,
+ *    hard ceiling 50) is enforced by *refusing* an over-budget request rather
+ *    than silently trimming the reward down to the cap — a trimmed spend is a
+ *    spend the user never approved.
+ * 4. **Two-turn user confirmation.** The core `gateDestructiveConfirmation`
+ *    helper previews the exact task and reward, then requires a yes-shaped
+ *    reply from the real `Memory` on the following turn. No planner-authored
+ *    `confirmed` parameter exists: core's own contract states an LLM
+ *    confirmation flag must never authorize a destructive operation, and the
+ *    public task board is untrusted input — another task's description, a
+ *    fetched page or a document can all contain text asking the agent to post
+ *    a task, and none of those is a user.
+ *
+ * The confirmation is bound to the exact previewed spend: the pending key is
+ * derived from the description and the normalized atomic reward, so a changed
+ * task or amount cannot be settled by a stale approval, and the stashed
+ * metadata is re-checked before the POST. Records expire after five minutes.
+ *
+ * Escrow release is deliberately not exposed. There is no accept-submission or
+ * withdraw action anywhere in this plugin; settlement stays with the human.
+ */
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { gateDestructiveConfirmation } from "@elizaos/core";
+import {
+  createTask,
+  TaskMarketApiError,
+  TaskMarketResponseError,
+} from "../lib/client.ts";
+import {
+  failureActionResult,
+  readNumberParam,
+  readStringParam,
+  resolveTaskMarketConfig,
+  successActionResult,
+  TASKMARKET_CONTEXTS,
+  usdcToAtomic,
+} from "../types.ts";
+
+const MAX_DESCRIPTION_CHARS = 10_000;
+const MIN_DESCRIPTION_CHARS = 20;
+const MAX_TAGS = 10;
+const DEFAULT_DURATION_HOURS = 72;
+const MAX_DURATION_HOURS = 24 * 30;
+const CONFIRMATION_TTL_MS = 5 * 60_000;
+
+function parseTags(raw: string | undefined): string[] {
+  if (!raw) return ["agent"];
+  const tags = raw
+    .split(",")
+    .map((tag) => tag.trim().toLowerCase())
+    .filter((tag) => tag.length > 0);
+  return tags.length > 0 ? tags.slice(0, MAX_TAGS) : ["agent"];
+}
+
+/**
+ * Stable fingerprint of the exact spend being confirmed. Two different tasks,
+ * or the same task at a different reward, produce different keys — so an
+ * approval can only ever settle the operation it was shown.
+ */
+function spendFingerprint(description: string, rewardAtomic: string): string {
+  let hash = 0;
+  for (const char of description) {
+    hash = (hash * 31 + char.charCodeAt(0)) | 0;
+  }
+  return `${rewardAtomic}:${(hash >>> 0).toString(36)}`;
+}
+
+export const taskMarketCreateTaskAction: Action = {
+  name: "TASKMARKET_CREATE_TASK",
+  contexts: [...TASKMARKET_CONTEXTS],
+  // Guard 1: a non-owner in a shared agent never reaches the spend path.
+  roleGate: { minRole: "OWNER" },
+  similes: [
+    "DELEGATE_TO_TASKMARKET",
+    "POST_TASKMARKET_TASK",
+    "HIRE_AGENT_WORKER",
+  ],
+  description:
+    "Post a paid task to the TaskMarket worker marketplace when work is better delegated to external workers than solved with more inference. SPENDS REAL MONEY: creating a task escrows the reward in USDC on Base immediately. Owner-only, disabled unless the operator sets TASKMARKET_ALLOW_TASK_CREATION, capped by TASKMARKET_MAX_TASK_REWARD_USDC, and confirmed by the user on a follow-up turn before anything is posted.",
+  parameters: [
+    {
+      name: "description",
+      description:
+        "The full task brief workers will see: deliverable, acceptance criteria, and format.",
+      required: true,
+      schema: {
+        type: "string",
+        minLength: MIN_DESCRIPTION_CHARS,
+        maxLength: MAX_DESCRIPTION_CHARS,
+      },
+    },
+    {
+      name: "rewardUsdc",
+      description:
+        "Reward in whole USDC (e.g. 0.5 for fifty cents). Escrowed on creation. Must be at least 0.000001 (one atomic unit). A value above the configured ceiling is refused, not reduced.",
+      required: true,
+      schema: { type: "number" },
+    },
+    {
+      name: "durationHours",
+      description: `How long the task stays open, in hours. Default ${DEFAULT_DURATION_HOURS}, max ${MAX_DURATION_HOURS}.`,
+      required: false,
+      schema: { type: "number" },
+    },
+    {
+      name: "tags",
+      description: "Comma-separated tags, max 10.",
+      required: false,
+      schema: { type: "string" },
+    },
+    {
+      name: "mode",
+      description:
+        "Task mode: bounty (default), claim, pitch, benchmark or auction.",
+      required: false,
+      schema: {
+        type: "string",
+        enum: ["bounty", "claim", "pitch", "benchmark", "auction"],
+      },
+    },
+  ],
+  // Guard 2 is enforced here as well as in the handler, so a disabled capability
+  // is never even offered to the planner.
+  validate: async (runtime: IAgentRuntime) => {
+    const config = resolveTaskMarketConfig(runtime);
+    return config?.allowTaskCreation === true;
+  },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const config = resolveTaskMarketConfig(runtime);
+    if (!config) {
+      return failureActionResult({
+        reason: "not_configured",
+        message:
+          "TASKMARKET_API_TOKEN and TASKMARKET_ADDRESS must both be set (the API bearer token does not identify the caller).",
+      });
+    }
+
+    // Guard 2 (re-checked at handler entry: a disabled capability must never
+    // spend through any invocation path, including a hallucinated tool call).
+    if (!config.allowTaskCreation) {
+      return failureActionResult({
+        reason: "creation_disabled",
+        message:
+          "Task creation is disabled. Set TASKMARKET_ALLOW_TASK_CREATION=true to allow this agent to escrow USDC.",
+      });
+    }
+
+    const description = readStringParam(options, "description");
+    if (!description || description.length < MIN_DESCRIPTION_CHARS) {
+      return failureActionResult({
+        reason: "missing_param",
+        message: `description is required and must be at least ${MIN_DESCRIPTION_CHARS} characters`,
+      });
+    }
+    if (description.length > MAX_DESCRIPTION_CHARS) {
+      return failureActionResult({
+        reason: "invalid_param",
+        message: `description exceeds the ${MAX_DESCRIPTION_CHARS} character API limit`,
+      });
+    }
+
+    const rewardUsdc = readNumberParam(options, "rewardUsdc");
+    if (rewardUsdc === undefined || rewardUsdc <= 0) {
+      return failureActionResult({
+        reason: "missing_param",
+        message: "rewardUsdc is required and must be greater than 0",
+      });
+    }
+
+    // Precision check before anything is previewed or posted. A reward below
+    // one atomic unit serializes to "0": the API would escrow nothing while the
+    // handler reported the requested amount as escrowed.
+    const rewardAtomic = usdcToAtomic(rewardUsdc);
+    if (rewardAtomic === undefined) {
+      return failureActionResult(
+        {
+          reason: "invalid_param",
+          message: `Reward ${rewardUsdc} USDC cannot be represented in the 6-decimal atomic units the API uses; it would post 0. The minimum is 0.000001 USDC.`,
+        },
+        {
+          action: "TASKMARKET_CREATE_TASK",
+          requestedUsdc: rewardUsdc,
+        },
+      );
+    }
+    // Report the amount actually posted, not the amount asked for.
+    const normalizedUsdc = Number(rewardAtomic) / 1_000_000;
+
+    // Guard 3: refuse over-budget rather than trimming to the cap.
+    if (normalizedUsdc > config.maxTaskRewardUsdc) {
+      return failureActionResult(
+        {
+          reason: "over_budget",
+          message: `Requested reward ${normalizedUsdc} USDC exceeds the configured ceiling of ${config.maxTaskRewardUsdc} USDC. Refusing rather than reducing the reward; raise TASKMARKET_MAX_TASK_REWARD_USDC deliberately if this spend is intended.`,
+        },
+        {
+          action: "TASKMARKET_CREATE_TASK",
+          requestedUsdc: normalizedUsdc,
+          maxTaskRewardUsdc: config.maxTaskRewardUsdc,
+        },
+      );
+    }
+
+    const requestedDuration = readNumberParam(options, "durationHours");
+    const duration =
+      requestedDuration && requestedDuration > 0
+        ? Math.min(MAX_DURATION_HOURS, Math.floor(requestedDuration))
+        : DEFAULT_DURATION_HOURS;
+
+    // Guard 4: two-turn confirmation against the real user message. The pending
+    // key is the fingerprint of this exact brief and reward, so a changed task
+    // or amount can never be settled by a previous approval — it starts a new
+    // preview instead.
+    const fingerprint = spendFingerprint(description, rewardAtomic);
+    const prompt = `Post this task to TaskMarket and escrow ${normalizedUsdc} USDC on Base for ${duration}h? This spends real funds and cannot be undone from this agent.\n\n"${description.slice(0, 300)}${description.length > 300 ? "…" : ""}"\n\nReply yes to confirm or no to cancel.`;
+    const gate = await gateDestructiveConfirmation({
+      runtime,
+      message,
+      actionName: "TASKMARKET_CREATE_TASK",
+      pendingKey: `create:${fingerprint}`,
+      prompt,
+      callback,
+      ttlMs: CONFIRMATION_TTL_MS,
+      metadata: { fingerprint, rewardAtomic, duration },
+    });
+
+    if (gate.status === "pending") {
+      return successActionResult(prompt, {
+        action: "TASKMARKET_CREATE_TASK",
+        requiresConfirmation: true,
+        awaitingUserInput: true,
+        rewardUsdc: normalizedUsdc,
+        durationHours: duration,
+      });
+    }
+    if (gate.status === "cancelled") {
+      return failureActionResult(
+        {
+          reason: "cancelled",
+          message: "Task creation cancelled; no USDC was escrowed.",
+        },
+        { action: "TASKMARKET_CREATE_TASK" },
+      );
+    }
+
+    // Backstop against a confirmation record that does not describe this spend.
+    if (
+      gate.metadata?.fingerprint !== fingerprint ||
+      gate.metadata?.rewardAtomic !== rewardAtomic
+    ) {
+      return failureActionResult(
+        {
+          reason: "confirmation_drift",
+          message:
+            "The confirmed task no longer matches the task being posted. Refusing to escrow; re-run the request to review and approve the current task and reward.",
+        },
+        { action: "TASKMARKET_CREATE_TASK" },
+      );
+    }
+
+    try {
+      const result = await createTask(config, {
+        description,
+        reward: rewardAtomic,
+        duration,
+        tags: parseTags(readStringParam(options, "tags")),
+        ...(readStringParam(options, "mode")
+          ? { mode: readStringParam(options, "mode") as string }
+          : {}),
+      });
+      return successActionResult(
+        `Created TaskMarket task ${result.taskId} with ${normalizedUsdc} USDC escrowed for ${duration}h. Selecting a winner and releasing escrow are manual steps on taskmarket.dev.`,
+        {
+          action: "TASKMARKET_CREATE_TASK",
+          taskId: result.taskId,
+          rewardUsdc: normalizedUsdc,
+          rewardAtomic,
+          durationHours: duration,
+        },
+      );
+    } catch (error) {
+      if (error instanceof TaskMarketApiError) {
+        return failureActionResult(
+          {
+            reason: "api_error",
+            message: `HTTP ${error.status}: ${error.message}`,
+          },
+          { action: "TASKMARKET_CREATE_TASK" },
+        );
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      return failureActionResult(
+        {
+          reason:
+            error instanceof TaskMarketResponseError
+              ? "invalid_response"
+              : "io_error",
+          message,
+        },
+        { action: "TASKMARKET_CREATE_TASK" },
+      );
+    }
+  },
+};

--- a/plugins/plugin-taskmarket/src/actions/status.ts
+++ b/plugins/plugin-taskmarket/src/actions/status.ts
@@ -1,0 +1,148 @@
+/**
+ * TASKMARKET_STATUS — read-only account view: wallet balance, agent reputation,
+ * and the caller's own submissions with their current state.
+ *
+ * This is the "did the delegated work land?" surface. It moves no money and
+ * exposes no settlement lever: accepting a submission and releasing escrow stay
+ * with the human on taskmarket.dev, deliberately outside this plugin.
+ */
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  ProviderDataRecord,
+  State,
+} from "@elizaos/core";
+import {
+  getAgentStats,
+  getWalletBalance,
+  listMySubmissions,
+  TaskMarketApiError,
+  TaskMarketResponseError,
+} from "../lib/client.ts";
+import {
+  failureActionResult,
+  formatUsdc,
+  readStringParam,
+  resolveTaskMarketConfig,
+  successActionResult,
+  TASKMARKET_CONTEXTS,
+} from "../types.ts";
+
+const MAX_SUBMISSIONS_SHOWN = 15;
+
+export const taskMarketStatusAction: Action = {
+  name: "TASKMARKET_STATUS",
+  contexts: [...TASKMARKET_CONTEXTS],
+  similes: [
+    "TASKMARKET_BALANCE",
+    "TASKMARKET_SUBMISSIONS",
+    "CHECK_TASKMARKET_ACCOUNT",
+  ],
+  description:
+    "Report TaskMarket account state: USDC wallet balance on Base, agent reputation stats, and the caller's own submissions. Read-only — it cannot accept work, release escrow, or withdraw funds.",
+  parameters: [
+    {
+      name: "subaction",
+      description:
+        "'all' (default), 'balance' for wallet + reputation only, or 'submissions' for own submissions only.",
+      required: false,
+      schema: {
+        type: "string",
+        enum: ["all", "balance", "submissions"],
+        default: "all",
+      },
+    },
+  ],
+  validate: async (runtime: IAgentRuntime) =>
+    resolveTaskMarketConfig(runtime) !== undefined,
+  handler: async (
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State,
+    options?: unknown,
+    _callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const config = resolveTaskMarketConfig(runtime);
+    if (!config) {
+      return failureActionResult({
+        reason: "not_configured",
+        message:
+          "TASKMARKET_API_TOKEN and TASKMARKET_ADDRESS must both be set (the API bearer token does not identify the caller).",
+      });
+    }
+
+    const subaction = (
+      readStringParam(options, "subaction") ?? "all"
+    ).toLowerCase();
+    const wantBalance = subaction === "all" || subaction === "balance";
+    const wantSubmissions = subaction === "all" || subaction === "submissions";
+
+    try {
+      const lines: string[] = [];
+      const data: ProviderDataRecord = { action: "TASKMARKET_STATUS" };
+
+      if (wantBalance) {
+        const [balance, stats] = await Promise.all([
+          getWalletBalance(config),
+          getAgentStats(config),
+        ]);
+        lines.push(
+          `Balance: ${balance} USDC on Base`,
+          `Agent ${stats.agentId ?? "?"} | completed ${stats.completedTasks ?? 0} | rated ${stats.ratedTasks ?? 0} | avg rating ${stats.averageRating ?? "n/a"} | credibility ${stats.credibility ?? "n/a"}`,
+          `Total earnings: ${formatUsdc(stats.totalEarnings)}`,
+        );
+        data.balanceUsdc = balance;
+        data.agentId = stats.agentId;
+      }
+
+      if (wantSubmissions) {
+        const submissions = await listMySubmissions(config);
+        data.submissionCount = submissions.length;
+        if (submissions.length === 0) {
+          lines.push("No submissions yet.");
+        } else {
+          const shown = [...submissions]
+            .sort((a, b) =>
+              (a.submittedAt ?? "").localeCompare(b.submittedAt ?? ""),
+            )
+            .slice(-MAX_SUBMISSIONS_SHOWN);
+          lines.push(
+            `Submissions: ${submissions.length} total, showing ${shown.length} most recent:`,
+            ...shown.map((submission) => {
+              const outcome = submission.rejectedAt
+                ? "rejected"
+                : (submission.taskStatus ?? "unknown");
+              return `- task ${submission.taskId ?? "?"} | ${formatUsdc(submission.taskReward)} ${submission.taskMode ?? "?"} | task ${outcome} | submitted ${submission.submittedAt ?? "?"}`;
+            }),
+          );
+        }
+      }
+
+      return successActionResult(lines.join("\n"), data);
+    } catch (error) {
+      if (error instanceof TaskMarketApiError) {
+        return failureActionResult(
+          {
+            reason: "api_error",
+            message: `HTTP ${error.status}: ${error.message}`,
+          },
+          { action: "TASKMARKET_STATUS" },
+        );
+      }
+      if (error instanceof TaskMarketResponseError) {
+        return failureActionResult(
+          { reason: "invalid_response", message: error.message },
+          { action: "TASKMARKET_STATUS" },
+        );
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      return failureActionResult(
+        { reason: "io_error", message },
+        { action: "TASKMARKET_STATUS" },
+      );
+    }
+  },
+};

--- a/plugins/plugin-taskmarket/src/index.ts
+++ b/plugins/plugin-taskmarket/src/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Public entry for `@elizaos/plugin-taskmarket`: re-exports the plugin object,
+ * its three actions, the bounded REST client and the config/result helpers.
+ */
+export { taskMarketBrowseAction } from "./actions/browse.ts";
+export { taskMarketCreateTaskAction } from "./actions/create-task.ts";
+export { taskMarketStatusAction } from "./actions/status.ts";
+export {
+  createTask,
+  getAgentStats,
+  getTask,
+  getWalletBalance,
+  listMySubmissions,
+  listTasks,
+  type TaskMarketAgentStats,
+  TaskMarketApiError,
+  type TaskMarketSubmission,
+  type TaskMarketTask,
+} from "./lib/client.ts";
+export { taskMarketPlugin, taskMarketPlugin as default } from "./plugin.ts";
+export {
+  ABSOLUTE_MAX_TASK_REWARD_USDC,
+  atomicToUsdc,
+  DEFAULT_MAX_TASK_REWARD_USDC,
+  DEFAULT_TASKMARKET_API_URL,
+  resolveTaskMarketConfig,
+  type TaskMarketConfig,
+  type TaskMarketFailure,
+  type TaskMarketFailureReason,
+  usdcToAtomic,
+} from "./types.ts";

--- a/plugins/plugin-taskmarket/src/lib/client.ts
+++ b/plugins/plugin-taskmarket/src/lib/client.ts
@@ -1,0 +1,340 @@
+/**
+ * Bounded HTTP client for the TaskMarket REST API. Owns the three things that
+ * are easy to get wrong against this vendor: the mandatory `/api` base-path
+ * prefix, the fact that the bearer token does **not** identify the caller (an
+ * explicit `address` query param is required on the account routes), and the
+ * atomic 6-decimal USDC units used by every amount field.
+ *
+ * Every response is size-capped and timeout-bounded before it reaches the
+ * planner, and the bearer token is never echoed into an error message.
+ */
+import {
+  TASKMARKET_MAX_RESPONSE_BYTES,
+  TASKMARKET_REQUEST_TIMEOUT_MS,
+  type TaskMarketConfig,
+} from "../types.ts";
+
+export interface TaskMarketTask {
+  id: string;
+  description?: string;
+  reward?: string;
+  netReward?: string;
+  status?: string;
+  mode?: string;
+  tags?: string[];
+  expiryTime?: string;
+  submissionCount?: number;
+  submissionWindowOpen?: boolean;
+  platformFeeBps?: number;
+}
+
+/**
+ * Shape verified live against `GET /submissions/mine`. Note the field names are
+ * task-prefixed and there is no submission id: the record is keyed by
+ * `taskId` + `deliverableHash`, and `rejectedAt` (nullable) is the only
+ * outcome marker on the worker side.
+ */
+export interface TaskMarketSubmission {
+  taskId?: string;
+  taskStatus?: string;
+  taskMode?: string;
+  taskReward?: string;
+  submittedAt?: string;
+  deliverableHash?: string;
+  submitTxHash?: string;
+  rejectedAt?: string | null;
+}
+
+export interface TaskMarketAgentStats {
+  address?: string;
+  agentId?: string;
+  completedTasks?: number;
+  ratedTasks?: number;
+  averageRating?: number;
+  totalEarnings?: string;
+  credibility?: number;
+}
+
+export class TaskMarketApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "TaskMarketApiError";
+    this.status = status;
+  }
+}
+
+/**
+ * A 2xx response whose body does not match the documented shape. Distinct from
+ * {@link TaskMarketApiError} because the transport succeeded: the vendor
+ * answered, the payload is unusable. Surfaced as an explicit unavailable state
+ * rather than degraded into an empty board, a zero balance, or a task that was
+ * never actually created.
+ */
+export class TaskMarketResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TaskMarketResponseError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** A task is only usable if it carries the id every other call is keyed on. */
+function isTask(value: unknown): value is TaskMarketTask {
+  return isRecord(value) && typeof value.id === "string" && value.id.length > 0;
+}
+
+function isSubmission(value: unknown): value is TaskMarketSubmission {
+  return isRecord(value);
+}
+
+/** Amount fields must parse; a malformed one must not read as a real zero. */
+function isAmountLike(value: unknown): boolean {
+  if (value === undefined || value === null) return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  return typeof value === "string" && Number.isFinite(Number(value));
+}
+
+function buildUrl(
+  config: TaskMarketConfig,
+  path: string,
+  query?: Record<string, string | number | undefined>,
+): string {
+  const base = config.apiUrl.replace(/\/+$/, "");
+  const url = new URL(`${base}${path}`);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value !== undefined) url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+/**
+ * Read at most `TASKMARKET_MAX_RESPONSE_BYTES` from a response body. A hostile
+ * or broken endpoint cannot stream unbounded content into the agent process.
+ */
+async function readBoundedText(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return await response.text();
+  const decoder = new TextDecoder();
+  let text = "";
+  let bytes = 0;
+  while (bytes < TASKMARKET_MAX_RESPONSE_BYTES) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    bytes += value.byteLength;
+    text += decoder.decode(value, { stream: true });
+  }
+  await reader.cancel().catch(() => undefined);
+  return text + decoder.decode();
+}
+
+async function request<T>(
+  config: TaskMarketConfig,
+  path: string,
+  init: {
+    method?: string;
+    query?: Record<string, string | number | undefined>;
+    body?: unknown;
+  } = {},
+): Promise<T> {
+  const url = buildUrl(config, path, init.query);
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    TASKMARKET_REQUEST_TIMEOUT_MS,
+  );
+  try {
+    const response = await fetch(url, {
+      method: init.method ?? "GET",
+      headers: {
+        Authorization: `Bearer ${config.apiToken}`,
+        Accept: "application/json",
+        ...(init.body ? { "Content-Type": "application/json" } : {}),
+      },
+      ...(init.body ? { body: JSON.stringify(init.body) } : {}),
+      signal: controller.signal,
+    });
+    const text = await readBoundedText(response);
+    if (!response.ok) {
+      // Body only — never the request URL, which carries the caller's address.
+      throw new TaskMarketApiError(
+        response.status,
+        text.slice(0, 500) || response.statusText,
+      );
+    }
+    return JSON.parse(text) as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * `GET /tasks` — the open board. Returns `{tasks: [...]}`; note that the
+ * sibling `/tasks/{id}/submissions` route returns a bare array instead, so the
+ * two cannot share a destructuring path.
+ */
+export async function listTasks(
+  config: TaskMarketConfig,
+  params: { status?: string; mode?: string; limit?: number; sort?: string },
+): Promise<TaskMarketTask[]> {
+  const data = await request<unknown>(config, "/tasks", {
+    query: {
+      status: params.status,
+      mode: params.mode,
+      limit: params.limit,
+      sort: params.sort,
+    },
+  });
+  // No `?? []` here on purpose: an unreadable board must not look like an empty
+  // one, or the planner concludes there is no work when the API broke.
+  const tasks = isRecord(data) ? data.tasks : undefined;
+  if (!Array.isArray(tasks)) {
+    throw new TaskMarketResponseError(
+      "GET /tasks did not return a `tasks` array; the board is unavailable, not empty.",
+    );
+  }
+  if (!tasks.every(isTask)) {
+    throw new TaskMarketResponseError(
+      "GET /tasks returned an entry without a task id; refusing to render a partial board.",
+    );
+  }
+  if (
+    !tasks.every(
+      (task) => isAmountLike(task.reward) && isAmountLike(task.netReward),
+    )
+  ) {
+    throw new TaskMarketResponseError(
+      "GET /tasks returned an unparseable reward amount; refusing to render it as $0.00.",
+    );
+  }
+  return tasks;
+}
+
+/** `GET /tasks/{taskId}` — the full brief for one task. */
+export async function getTask(
+  config: TaskMarketConfig,
+  taskId: string,
+): Promise<TaskMarketTask> {
+  const data = await request<unknown>(
+    config,
+    `/tasks/${encodeURIComponent(taskId)}`,
+  );
+  if (!isTask(data)) {
+    throw new TaskMarketResponseError(
+      `GET /tasks/${taskId} did not return a task with an id.`,
+    );
+  }
+  if (!isAmountLike(data.reward) || !isAmountLike(data.netReward)) {
+    throw new TaskMarketResponseError(
+      `GET /tasks/${taskId} returned an unparseable reward amount.`,
+    );
+  }
+  return data;
+}
+
+/**
+ * `GET /submissions/mine` — requires an explicit `workerAddress`; the bearer
+ * token alone does not identify the worker.
+ */
+export async function listMySubmissions(
+  config: TaskMarketConfig,
+): Promise<TaskMarketSubmission[]> {
+  const data = await request<unknown>(config, "/submissions/mine", {
+    query: { workerAddress: config.address },
+  });
+  const submissions = Array.isArray(data)
+    ? data
+    : isRecord(data)
+      ? data.submissions
+      : undefined;
+  if (!Array.isArray(submissions) || !submissions.every(isSubmission)) {
+    throw new TaskMarketResponseError(
+      "GET /submissions/mine did not return a submissions array; treating as unavailable rather than 'no submissions'.",
+    );
+  }
+  return submissions as TaskMarketSubmission[];
+}
+
+/**
+ * `GET /agents/stats` — 500s with "Provide address or agentId" unless the
+ * address is passed explicitly, hence the config-level address requirement.
+ */
+export async function getAgentStats(
+  config: TaskMarketConfig,
+): Promise<TaskMarketAgentStats> {
+  const data = await request<unknown>(config, "/agents/stats", {
+    query: { address: config.address },
+  });
+  if (!isRecord(data)) {
+    throw new TaskMarketResponseError(
+      "GET /agents/stats did not return an object.",
+    );
+  }
+  if (!isAmountLike(data.totalEarnings)) {
+    throw new TaskMarketResponseError(
+      "GET /agents/stats returned unparseable earnings; refusing to report them as $0.00.",
+    );
+  }
+  return data as TaskMarketAgentStats;
+}
+
+/** `GET /wallet/balance` — returns whole USDC as a string, unlike every other amount field. */
+export async function getWalletBalance(
+  config: TaskMarketConfig,
+): Promise<string> {
+  const data = await request<unknown>(config, "/wallet/balance", {
+    query: { address: config.address },
+  });
+  const balance = isRecord(data) ? data.balanceUsdc : undefined;
+  // A missing balance is not a zero balance. Reporting "0 USDC" for a failed
+  // read would tell the user they are broke when the endpoint simply drifted.
+  if (
+    (typeof balance !== "string" && typeof balance !== "number") ||
+    !Number.isFinite(Number(balance))
+  ) {
+    throw new TaskMarketResponseError(
+      "GET /wallet/balance did not return a numeric balanceUsdc; balance is unavailable, not zero.",
+    );
+  }
+  return String(balance);
+}
+
+/**
+ * `POST /tasks` — escrows real USDC immediately. Callers must pass the spend
+ * guards in `actions/create-task.ts` before reaching this function; `reward` is
+ * an atomic 6-decimal string.
+ */
+export async function createTask(
+  config: TaskMarketConfig,
+  body: {
+    description: string;
+    reward: string;
+    duration: number;
+    tags: string[];
+    mode?: string;
+  },
+): Promise<{ taskId: string }> {
+  const data = await request<unknown>(config, "/tasks", {
+    method: "POST",
+    body,
+  });
+  // A 2xx is not proof of escrow. Without an explicit success and a task id
+  // there is nothing to point the user at, and reporting a created task from
+  // `{"success": false}` would fabricate success on a money-moving path.
+  if (!isRecord(data) || data.success === false) {
+    throw new TaskMarketResponseError(
+      "POST /tasks returned a 2xx response that does not confirm the task was created; treating the escrow as NOT performed.",
+    );
+  }
+  const taskId = data.taskId;
+  if (typeof taskId !== "string" || taskId.length === 0) {
+    throw new TaskMarketResponseError(
+      "POST /tasks returned a 2xx response with no taskId; cannot confirm the escrow.",
+    );
+  }
+  return { taskId };
+}

--- a/plugins/plugin-taskmarket/src/plugin.ts
+++ b/plugins/plugin-taskmarket/src/plugin.ts
@@ -1,0 +1,21 @@
+/**
+ * Plugin object for `@elizaos/plugin-taskmarket`: registers the read-only
+ * discovery/status actions and the spend-guarded task-creation action that let
+ * an Eliza agent delegate work to the TaskMarket worker marketplace instead of
+ * burning more inference on a task another worker can do.
+ */
+import type { Plugin } from "@elizaos/core";
+import { taskMarketBrowseAction } from "./actions/browse.ts";
+import { taskMarketCreateTaskAction } from "./actions/create-task.ts";
+import { taskMarketStatusAction } from "./actions/status.ts";
+
+export const taskMarketPlugin: Plugin = {
+  name: "@elizaos/plugin-taskmarket",
+  description:
+    "Delegate work to the TaskMarket agent marketplace (USDC on Base): browse open tasks, track your own submissions and balance, and — only when explicitly enabled, bounded and user-confirmed — post a task that escrows USDC.",
+  actions: [
+    taskMarketBrowseAction,
+    taskMarketStatusAction,
+    taskMarketCreateTaskAction,
+  ],
+};

--- a/plugins/plugin-taskmarket/src/taskmarket.test.ts
+++ b/plugins/plugin-taskmarket/src/taskmarket.test.ts
@@ -1,0 +1,569 @@
+/**
+ * Spend-guard tests for TASKMARKET_CREATE_TASK — the only action here that
+ * moves money. Each guard is asserted independently, plus the refuse-don't-trim
+ * behaviour on an over-budget reward, the two-turn confirmation bound to the
+ * real user message, the atomic-precision floor, the 2xx-negative creation
+ * response, and the fact that no guard failure ever reaches the network.
+ */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { taskMarketBrowseAction } from "./actions/browse.ts";
+import { taskMarketCreateTaskAction } from "./actions/create-task.ts";
+import { taskMarketStatusAction } from "./actions/status.ts";
+import {
+  atomicToUsdc,
+  resolveTaskMarketConfig,
+  usdcToAtomic,
+} from "./types.ts";
+
+/**
+ * Runtime double with the cache the core confirmation gate stores pending
+ * previews in. Without a real cache the gate can never reach its second turn,
+ * so every creation test would trivially stop at "pending".
+ */
+function makeRuntime(settings: Record<string, string>): IAgentRuntime {
+  const cache = new Map<string, unknown>();
+  return {
+    getSetting: (name: string) => settings[name],
+    getCache: async (key: string) => cache.get(key),
+    setCache: async (key: string, value: unknown) => {
+      cache.set(key, value);
+      return true;
+    },
+    deleteCache: async (key: string) => cache.delete(key),
+  } as unknown as IAgentRuntime;
+}
+
+const CONFIGURED = {
+  TASKMARKET_API_TOKEN: "test-token",
+  TASKMARKET_ADDRESS: "0x0000000000000000000000000000000000000001",
+};
+
+const ENABLED = { ...CONFIGURED, TASKMARKET_ALLOW_TASK_CREATION: "true" };
+
+/** A real Memory carrying the sender identity the confirmation gate binds to. */
+function userMessage(text: string, entityId = "user-1"): Memory {
+  return {
+    entityId,
+    content: { text, source: "test" },
+  } as unknown as Memory;
+}
+
+const message = userMessage("post that task");
+
+const VALID_BRIEF = "Write a 500-word summary of the attached research paper.";
+
+/**
+ * Drive the action to the point where the user has approved: first call stashes
+ * the preview and returns pending, the reply turn resolves it.
+ */
+async function createWithConfirmation(
+  runtime: IAgentRuntime,
+  options: Record<string, unknown>,
+  reply = "yes",
+  entityId = "user-1",
+) {
+  const preview = await taskMarketCreateTaskAction.handler(
+    runtime,
+    userMessage("post that task", entityId),
+    undefined,
+    options,
+  );
+  const settled = await taskMarketCreateTaskAction.handler(
+    runtime,
+    userMessage(reply, entityId),
+    undefined,
+    options,
+  );
+  return { preview, settled };
+}
+
+describe("resolveTaskMarketConfig", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is undefined without both credentials", () => {
+    expect(resolveTaskMarketConfig(makeRuntime({}))).toBeUndefined();
+    expect(
+      resolveTaskMarketConfig(makeRuntime({ TASKMARKET_API_TOKEN: "t" })),
+    ).toBeUndefined();
+    expect(
+      resolveTaskMarketConfig(makeRuntime({ TASKMARKET_ADDRESS: "0xabc" })),
+    ).toBeUndefined();
+  });
+
+  it("defaults to read-only with a 1 USDC ceiling", () => {
+    const config = resolveTaskMarketConfig(makeRuntime(CONFIGURED));
+    expect(config?.allowTaskCreation).toBe(false);
+    expect(config?.maxTaskRewardUsdc).toBe(1);
+    expect(config?.apiUrl).toBe("https://api.taskmarket.dev/api");
+  });
+
+  it("clamps a configured ceiling to the absolute maximum", () => {
+    const config = resolveTaskMarketConfig(
+      makeRuntime({
+        ...CONFIGURED,
+        TASKMARKET_MAX_TASK_REWARD_USDC: "100000",
+      }),
+    );
+    expect(config?.maxTaskRewardUsdc).toBe(50);
+  });
+});
+
+describe("atomic USDC conversion", () => {
+  it("round-trips whole USDC through atomic units", () => {
+    expect(usdcToAtomic(5)).toBe("5000000");
+    expect(usdcToAtomic(0.5)).toBe("500000");
+    expect(atomicToUsdc("5000000")).toBe(5);
+  });
+
+  it("refuses a reward that would serialize to zero atomic units", () => {
+    // The old `Math.round` path turned these into "0" while the caller still
+    // reported the requested amount as escrowed.
+    expect(usdcToAtomic(0.0000001)).toBeUndefined();
+    expect(usdcToAtomic(0.0000004)).toBeUndefined();
+    expect(usdcToAtomic(0)).toBeUndefined();
+    expect(usdcToAtomic(-1)).toBeUndefined();
+    expect(usdcToAtomic(Number.NaN)).toBeUndefined();
+    // One atomic unit is the floor, and it survives.
+    expect(usdcToAtomic(0.000001)).toBe("1");
+  });
+
+  it("reports an unreadable amount as unavailable, never as zero", () => {
+    expect(atomicToUsdc(undefined)).toBeUndefined();
+    expect(atomicToUsdc(null)).toBeUndefined();
+    expect(atomicToUsdc("")).toBeUndefined();
+    expect(atomicToUsdc("not-a-number")).toBeUndefined();
+    expect(atomicToUsdc(Number.NaN)).toBeUndefined();
+    expect(atomicToUsdc("0")).toBe(0);
+  });
+});
+
+describe("TASKMARKET_CREATE_TASK spend guards", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("guard 1: the action is owner-gated", () => {
+    // A member or guest in a shared agent must not reach a spend path at all,
+    // which is what the three config/planner-level guards cannot express.
+    expect(taskMarketCreateTaskAction.roleGate).toEqual({ minRole: "OWNER" });
+  });
+
+  it("guard 1: no planner-authored confirmation parameter exists", () => {
+    // An LLM-set boolean must never authorize a spend; confirmation comes from
+    // the user's own follow-up message instead.
+    const names = (taskMarketCreateTaskAction.parameters ?? []).map(
+      (parameter) => parameter.name,
+    );
+    expect(names).not.toContain("userConfirmed");
+    expect(names).not.toContain("confirmed");
+  });
+
+  it("guard 2: validate() hides the action when creation is not enabled", async () => {
+    const runtime = makeRuntime(CONFIGURED);
+    await expect(
+      taskMarketCreateTaskAction.validate(runtime, message),
+    ).resolves.toBe(false);
+    await expect(
+      taskMarketCreateTaskAction.validate(makeRuntime(ENABLED), message),
+    ).resolves.toBe(true);
+  });
+
+  it("guard 2: the handler refuses even if invoked directly while disabled", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await taskMarketCreateTaskAction.handler(
+      makeRuntime(CONFIGURED),
+      message,
+      undefined,
+      {
+        description: "a".repeat(50),
+        rewardUsdc: 0.5,
+      },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({ reason: "creation_disabled" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("guard 3: refuses an over-budget reward instead of trimming it", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await taskMarketCreateTaskAction.handler(
+      makeRuntime({
+        ...ENABLED,
+        TASKMARKET_MAX_TASK_REWARD_USDC: "1",
+      }),
+      message,
+      undefined,
+      {
+        description: "a".repeat(50),
+        rewardUsdc: 25,
+      },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({
+      reason: "over_budget",
+      requestedUsdc: 25,
+      maxTaskRewardUsdc: 1,
+    });
+    // The critical assertion: no reduced-reward task was created either.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a too-short description before spending", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await taskMarketCreateTaskAction.handler(
+      makeRuntime(ENABLED),
+      message,
+      undefined,
+      { description: "too short", rewardUsdc: 0.5 },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({ reason: "missing_param" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("guard 4: the first turn only previews — nothing is posted", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await taskMarketCreateTaskAction.handler(
+      makeRuntime(ENABLED),
+      message,
+      undefined,
+      { description: VALID_BRIEF, rewardUsdc: 0.5 },
+    );
+    expect(result?.data).toMatchObject({
+      requiresConfirmation: true,
+      awaitingUserInput: true,
+    });
+    expect(result?.text).toContain("0.5 USDC");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("guard 4: a non-yes reply cancels without spending", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { settled } = await createWithConfirmation(
+      makeRuntime(ENABLED),
+      { description: VALID_BRIEF, rewardUsdc: 0.5 },
+      "no, drop it",
+    );
+    expect(settled?.success).toBe(false);
+    expect(settled?.data).toMatchObject({ reason: "cancelled" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("guard 4: an approval for one task cannot settle a different one", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const runtime = makeRuntime(ENABLED);
+    // User is shown one brief...
+    await taskMarketCreateTaskAction.handler(runtime, message, undefined, {
+      description: VALID_BRIEF,
+      rewardUsdc: 0.5,
+    });
+    // ...and the confirmed turn arrives carrying a different amount.
+    const drifted = await taskMarketCreateTaskAction.handler(
+      runtime,
+      userMessage("yes"),
+      undefined,
+      { description: VALID_BRIEF, rewardUsdc: 0.9 },
+    );
+    // The drifted spend starts its own preview instead of settling silently.
+    expect(drifted?.data).toMatchObject({ requiresConfirmation: true });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("guard 4: another user's yes cannot settle this user's pending spend", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const runtime = makeRuntime(ENABLED);
+    const options = { description: VALID_BRIEF, rewardUsdc: 0.5 };
+    await taskMarketCreateTaskAction.handler(
+      runtime,
+      userMessage("post that task", "owner"),
+      undefined,
+      options,
+    );
+    const other = await taskMarketCreateTaskAction.handler(
+      runtime,
+      userMessage("yes", "someone-else"),
+      undefined,
+      options,
+    );
+    expect(other?.data).toMatchObject({ requiresConfirmation: true });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("refuses a reward below one atomic unit rather than posting zero", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await taskMarketCreateTaskAction.handler(
+      makeRuntime(ENABLED),
+      message,
+      undefined,
+      { description: VALID_BRIEF, rewardUsdc: 0.0000001 },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({ reason: "invalid_param" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("posts atomic units and a bounded body once every guard passes", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: true, taskId: "0xabc" }), {
+        status: 200,
+      }),
+    );
+    const { settled } = await createWithConfirmation(
+      makeRuntime({ ...ENABLED, TASKMARKET_MAX_TASK_REWARD_USDC: "2" }),
+      {
+        description: VALID_BRIEF,
+        rewardUsdc: 1.5,
+        tags: "writing,research",
+      },
+    );
+    expect(settled?.success).toBe(true);
+    expect(settled?.data).toMatchObject({
+      taskId: "0xabc",
+      rewardUsdc: 1.5,
+      rewardAtomic: "1500000",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.taskmarket.dev/api/tasks");
+    const body = JSON.parse(String(init.body));
+    expect(body.reward).toBe("1500000");
+    expect(body.tags).toEqual(["writing", "research"]);
+  });
+
+  it("does not report an escrow when a 2xx body denies or omits creation", async () => {
+    for (const payload of [
+      { success: false },
+      {},
+      { success: true },
+      { success: true, taskId: "" },
+    ]) {
+      vi.restoreAllMocks();
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+      const { settled } = await createWithConfirmation(makeRuntime(ENABLED), {
+        description: VALID_BRIEF,
+        rewardUsdc: 0.5,
+      });
+      expect(settled?.success).toBe(false);
+      expect(settled?.data).toMatchObject({ reason: "invalid_response" });
+      expect(settled?.text).not.toContain("escrowed");
+    }
+  });
+});
+
+describe("TASKMARKET_BROWSE", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is unavailable without credentials and available with them", async () => {
+    await expect(
+      taskMarketBrowseAction.validate(makeRuntime({}), message),
+    ).resolves.toBe(false);
+    await expect(
+      taskMarketBrowseAction.validate(makeRuntime(CONFIGURED), message),
+    ).resolves.toBe(true);
+  });
+
+  it("sends the mandatory /api prefix and truncates long descriptions", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          tasks: [
+            {
+              id: "0xdeadbeef",
+              description: "x".repeat(9_000),
+              reward: "4500000",
+              netReward: "4162500",
+              mode: "bounty",
+              submissionCount: 3,
+              submissionWindowOpen: true,
+              expiryTime: "2026-08-22T11:58:25.795Z",
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    const result = await taskMarketBrowseAction.handler(
+      makeRuntime(CONFIGURED),
+      message,
+      undefined,
+      { subaction: "list" },
+    );
+    expect(result?.success).toBe(true);
+    const [url] = fetchSpy.mock.calls[0] as [string];
+    expect(url).toContain("https://api.taskmarket.dev/api/tasks");
+    expect(url).toContain("status=open");
+    // $4.50 gross / $4.16 net rendered from atomic units, not raw millions.
+    expect(result?.text).toContain("$4.50");
+    expect(result?.text).toContain("$4.16");
+    expect(result?.text).toContain("[truncated");
+    expect(result?.text?.length ?? 0).toBeLessThan(2_000);
+  });
+
+  it("reports an API error without leaking the bearer token", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Provide address or agentId", { status: 500 }),
+    );
+    const result = await taskMarketBrowseAction.handler(
+      makeRuntime(CONFIGURED),
+      message,
+      undefined,
+      { subaction: "list" },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({ reason: "api_error" });
+    expect(result?.text).not.toContain("test-token");
+  });
+
+  it("requires taskId for subaction=get", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await taskMarketBrowseAction.handler(
+      makeRuntime(CONFIGURED),
+      message,
+      undefined,
+      { subaction: "get" },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({ reason: "missing_param" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports a malformed board as unavailable, not as an empty board", async () => {
+    // `?? []` here would tell the planner there is no work when the API drifted.
+    for (const payload of [{}, { tasks: null }, { tasks: [{ reward: "1" }] }]) {
+      vi.restoreAllMocks();
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+      const result = await taskMarketBrowseAction.handler(
+        makeRuntime(CONFIGURED),
+        message,
+        undefined,
+        { subaction: "list" },
+      );
+      expect(result?.success).toBe(false);
+      expect(result?.data).toMatchObject({ reason: "invalid_response" });
+      expect(result?.text).not.toContain("No matching");
+    }
+  });
+
+  it("refuses to render an unparseable reward as $0.00", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ tasks: [{ id: "0xabc", reward: "not-a-number" }] }),
+        { status: 200 },
+      ),
+    );
+    const result = await taskMarketBrowseAction.handler(
+      makeRuntime(CONFIGURED),
+      message,
+      undefined,
+      { subaction: "list" },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({ reason: "invalid_response" });
+    // The task itself is never rendered — no summary line for it exists.
+    expect(result?.text).not.toContain("- 0xabc");
+  });
+});
+
+describe("TASKMARKET_STATUS", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes the explicit workerAddress and renders the live submission shape", async () => {
+    // Field names below are the ones GET /submissions/mine actually returns
+    // (task-prefixed, no submission id, nullable rejectedAt) — verified live.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            taskId: "0xfeed",
+            taskStatus: "open",
+            taskMode: "bounty",
+            taskReward: "15000000",
+            submittedAt: "2026-08-06T07:05:33.552Z",
+            deliverableHash: "0xdead",
+            rejectedAt: null,
+          },
+          {
+            taskId: "0xbeef",
+            taskStatus: "resolved",
+            taskMode: "bounty",
+            taskReward: "2000000",
+            submittedAt: "2026-08-07T07:05:33.552Z",
+            rejectedAt: "2026-08-08T07:05:33.552Z",
+          },
+        ]),
+        { status: 200 },
+      ),
+    );
+    const result = await taskMarketStatusAction.handler(
+      makeRuntime(CONFIGURED),
+      message,
+      undefined,
+      { subaction: "submissions" },
+    );
+    expect(result?.success).toBe(true);
+    const [url] = fetchSpy.mock.calls[0] as [string];
+    // The bearer token does not identify the worker; the address is mandatory.
+    expect(url).toContain(
+      "workerAddress=0x0000000000000000000000000000000000000001",
+    );
+    expect(result?.text).toContain("Submissions: 2 total");
+    expect(result?.text).toContain("$15.00");
+    expect(result?.text).toContain("submitted 2026-08-06T07:05:33.552Z");
+    expect(result?.text).toContain("rejected");
+  });
+
+  it("requires the address setting alongside the token", async () => {
+    await expect(
+      taskMarketStatusAction.validate(
+        makeRuntime({ TASKMARKET_API_TOKEN: "t" }),
+        message,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("reports a missing balance as unavailable, not as zero", async () => {
+    // Telling the user they hold 0 USDC because a field went missing is worse
+    // than telling them the read failed.
+    // A fresh Response per call: `balance` fans out to two endpoints and a
+    // Response body can only be read once.
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => new Response(JSON.stringify({}), { status: 200 }),
+    );
+    const result = await taskMarketStatusAction.handler(
+      makeRuntime(CONFIGURED),
+      message,
+      undefined,
+      { subaction: "balance" },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({ reason: "invalid_response" });
+    expect(result?.text).not.toContain("0 USDC");
+  });
+
+  it("reports a malformed submissions payload as unavailable", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ submissions: null }), { status: 200 }),
+    );
+    const result = await taskMarketStatusAction.handler(
+      makeRuntime(CONFIGURED),
+      message,
+      undefined,
+      { subaction: "submissions" },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.text).not.toContain("No submissions yet");
+  });
+});

--- a/plugins/plugin-taskmarket/src/types.ts
+++ b/plugins/plugin-taskmarket/src/types.ts
@@ -1,0 +1,223 @@
+/**
+ * Shared constants, config resolution and result envelopes for the TaskMarket
+ * plugin: the `TASKMARKET_*` identifiers, the contexts the actions route under,
+ * the spend-guard config (`allowTaskCreation`, `maxTaskRewardUsdc`) resolved from
+ * runtime settings, and the `success`/`failure` `ActionResult` builders every
+ * handler returns. One place so all layers agree on names and envelopes.
+ */
+import type {
+  ActionResult,
+  IAgentRuntime,
+  ProviderDataRecord,
+} from "@elizaos/core";
+
+export const TASKMARKET_LOG_PREFIX = "[TaskMarket]";
+
+export const TASKMARKET_CONTEXTS = ["work", "crypto", "automation"] as const;
+
+/** Default TaskMarket API root. The `/api` suffix is mandatory — every path 404s without it. */
+export const DEFAULT_TASKMARKET_API_URL = "https://api.taskmarket.dev/api";
+
+/**
+ * Default ceiling, in whole USDC, for a single created task. Deliberately low:
+ * creating a task escrows real funds on Base, so an integrator that flips
+ * creation on without setting a ceiling still cannot fund anything expensive.
+ */
+export const DEFAULT_MAX_TASK_REWARD_USDC = 1;
+
+/** Hard ceiling regardless of configuration, so a typo'd setting cannot unbound the spend. */
+export const ABSOLUTE_MAX_TASK_REWARD_USDC = 50;
+
+/** Bytes read from an API response before the body is rejected as oversized. */
+export const TASKMARKET_MAX_RESPONSE_BYTES = 512 * 1024;
+
+/** Task descriptions run 2-10 KB; list output truncates so a board listing cannot flood the planner. */
+export const TASKMARKET_LIST_DESCRIPTION_CHARS = 400;
+
+/** Full single-task descriptions are still bounded before entering the context window. */
+export const TASKMARKET_DETAIL_DESCRIPTION_CHARS = 6_000;
+
+export const TASKMARKET_REQUEST_TIMEOUT_MS = 20_000;
+
+/** Atomic-unit scale for USDC (6 decimals). */
+export const USDC_DECIMALS = 1_000_000;
+
+export interface TaskMarketConfig {
+  apiUrl: string;
+  apiToken: string;
+  /** Wallet address. Required: the bearer token does NOT identify the caller to the API. */
+  address: string;
+  /** Off by default. Task creation escrows real USDC and must be opted into explicitly. */
+  allowTaskCreation: boolean;
+  /** Per-call ceiling in whole USDC. An over-budget request is refused, never trimmed. */
+  maxTaskRewardUsdc: number;
+}
+
+export type TaskMarketFailureReason =
+  | "not_configured"
+  | "creation_disabled"
+  | "missing_param"
+  | "invalid_param"
+  | "over_budget"
+  | "unconfirmed"
+  | "confirmation_drift"
+  | "cancelled"
+  | "invalid_response"
+  | "api_error"
+  | "io_error";
+
+export interface TaskMarketFailure {
+  reason: TaskMarketFailureReason;
+  message: string;
+}
+
+function readSetting(runtime: IAgentRuntime, name: string): string | undefined {
+  const value = runtime.getSetting?.(name);
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readBooleanSetting(runtime: IAgentRuntime, name: string): boolean {
+  const raw = readSetting(runtime, name)?.toLowerCase();
+  return raw === "1" || raw === "true" || raw === "on" || raw === "yes";
+}
+
+function readNumberSetting(
+  runtime: IAgentRuntime,
+  name: string,
+): number | undefined {
+  const raw = readSetting(runtime, name);
+  if (raw === undefined) return undefined;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Resolve plugin configuration from runtime settings. Returns `undefined` when
+ * the credentials every call needs are absent, so `validate` can hide the
+ * actions entirely rather than exposing tools that always fail.
+ */
+export function resolveTaskMarketConfig(
+  runtime: IAgentRuntime,
+): TaskMarketConfig | undefined {
+  const apiToken = readSetting(runtime, "TASKMARKET_API_TOKEN");
+  const address = readSetting(runtime, "TASKMARKET_ADDRESS");
+  if (!apiToken || !address) return undefined;
+
+  const configuredMax = readNumberSetting(
+    runtime,
+    "TASKMARKET_MAX_TASK_REWARD_USDC",
+  );
+  const maxTaskRewardUsdc =
+    configuredMax !== undefined && configuredMax > 0
+      ? Math.min(configuredMax, ABSOLUTE_MAX_TASK_REWARD_USDC)
+      : DEFAULT_MAX_TASK_REWARD_USDC;
+
+  return {
+    apiUrl:
+      readSetting(runtime, "TASKMARKET_API_URL") ?? DEFAULT_TASKMARKET_API_URL,
+    apiToken,
+    address,
+    allowTaskCreation: readBooleanSetting(
+      runtime,
+      "TASKMARKET_ALLOW_TASK_CREATION",
+    ),
+    maxTaskRewardUsdc,
+  };
+}
+
+/**
+ * Convert an atomic 6-decimal USDC amount to whole USDC. `"5000000"` -> `5`.
+ *
+ * Returns `undefined` — never `0` — for a missing or unparseable amount. A
+ * healthy-looking zero on a money field is indistinguishable from a real zero
+ * balance, so an absent value has to stay visibly absent.
+ */
+export function atomicToUsdc(
+  atomic: string | number | undefined | null,
+): number | undefined {
+  if (atomic === undefined || atomic === null || atomic === "")
+    return undefined;
+  const parsed = typeof atomic === "number" ? atomic : Number(atomic);
+  return Number.isFinite(parsed) ? parsed / USDC_DECIMALS : undefined;
+}
+
+/** Render an atomic amount for display, marking an unavailable value as such. */
+export function formatUsdc(atomic: string | number | undefined | null): string {
+  const value = atomicToUsdc(atomic);
+  return value === undefined ? "n/a" : `$${value.toFixed(2)}`;
+}
+
+/**
+ * Convert whole USDC to the atomic 6-decimal string the API expects.
+ *
+ * Returns `undefined` when the value cannot be represented in the supported
+ * precision: anything under half a micro-USDC rounds to `"0"` atomic units, and
+ * posting `"0"` while telling the user their reward was escrowed is a lie the
+ * caller must not be able to tell. Callers validate before spending.
+ */
+export function usdcToAtomic(usdc: number): string | undefined {
+  if (!Number.isFinite(usdc) || usdc <= 0) return undefined;
+  const atomic = Math.round(usdc * USDC_DECIMALS);
+  if (!Number.isSafeInteger(atomic) || atomic < 1) return undefined;
+  return atomic.toString();
+}
+
+export function successActionResult(
+  text: string,
+  data?: ProviderDataRecord,
+): ActionResult {
+  return { success: true, text, ...(data ? { data } : {}) };
+}
+
+export function failureActionResult(
+  failure: TaskMarketFailure,
+  data?: ProviderDataRecord,
+): ActionResult {
+  return {
+    success: false,
+    text: `${TASKMARKET_LOG_PREFIX} ${failure.reason}: ${failure.message}`,
+    data: { ...(data ?? {}), reason: failure.reason },
+  };
+}
+
+export function readStringParam(
+  options: unknown,
+  name: string,
+): string | undefined {
+  if (!options || typeof options !== "object") return undefined;
+  const value = (options as Record<string, unknown>)[name];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function readNumberParam(
+  options: unknown,
+  name: string,
+): number | undefined {
+  if (!options || typeof options !== "object") return undefined;
+  const value = (options as Record<string, unknown>)[name];
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value.trim());
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+export function readBooleanParam(
+  options: unknown,
+  name: string,
+): boolean | undefined {
+  if (!options || typeof options !== "object") return undefined;
+  const value = (options as Record<string, unknown>)[name];
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const raw = value.trim().toLowerCase();
+    if (raw === "true" || raw === "yes" || raw === "1") return true;
+    if (raw === "false" || raw === "no" || raw === "0") return false;
+  }
+  return undefined;
+}

--- a/plugins/plugin-taskmarket/tsconfig.build.json
+++ b/plugins/plugin-taskmarket/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "__tests__"],
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "types": ["node", "bun-types"]
+  }
+}

--- a/plugins/plugin-taskmarket/tsconfig.json
+++ b/plugins/plugin-taskmarket/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "../..",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "types": ["node", "bun-types"],
+    "paths": {
+      "@elizaos/core": ["../../packages/core/src/index.node.ts"],
+      "@elizaos/core/*": ["../../packages/core/src/*"],
+      "@elizaos/logger": ["../../packages/logger/src/index.ts"],
+      "@elizaos/logger/*": ["../../packages/logger/src/*"],
+      "@elizaos/shared": ["../../packages/shared/src/index.ts"],
+      "@elizaos/shared/*": ["../../packages/shared/src/*"]
+    }
+  },
+  "include": ["./**/*"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.e2e.test.ts"
+  ]
+}

--- a/plugins/plugin-taskmarket/vitest.config.ts
+++ b/plugins/plugin-taskmarket/vitest.config.ts
@@ -1,0 +1,40 @@
+/** Vitest config for the taskmarket plugin: resolves `@elizaos/*` to workspace source. */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const pluginRoot = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(pluginRoot, "../..");
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@elizaos\/core$/,
+        replacement: path.join(repoRoot, "packages/core/src/index.node.ts"),
+      },
+      {
+        find: /^@elizaos\/core\/(.+)$/,
+        replacement: path.join(repoRoot, "packages/core/src/$1"),
+      },
+    ],
+    conditions: ["node"],
+  },
+  ssr: {
+    resolve: {
+      conditions: ["node"],
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
+    testTimeout: 15_000,
+    pool: "forks",
+    server: {
+      deps: {
+        inline: ["@elizaos/core"],
+      },
+    },
+  },
+});


### PR DESCRIPTION
## What

Adds `@elizaos/plugin-taskmarket` — lets an Eliza agent delegate a request to an external worker paid in USDC on Base ([TaskMarket](https://taskmarket.dev/)) instead of spending more inference on work another worker can do.

Three actions:

| Action | Spends? | Purpose |
|---|---|---|
| `TASKMARKET_BROWSE` | no | list / get open tasks |
| `TASKMARKET_STATUS` | no | balance, reputation, own submissions |
| `TASKMARKET_CREATE_TASK` | **yes** | post a task (escrows real USDC) |

## Safety

`TASKMARKET_CREATE_TASK` is the only money-moving action, gated three independent ways:

1. `TASKMARKET_ALLOW_TASK_CREATION` — off by default.
2. `TASKMARKET_MAX_TASK_REWARD_USDC` — enforced **by refusal**, never by silently trimming the reward. Hard-capped at 50.
3. `userConfirmed` — must come from direct user approval, not from model-generated content.

The disabled check is duplicated in `validate()` and at handler entry on purpose: `validate()` keeps the tool off the planner's list, the handler check is the backstop against a hallucinated call. Every guard failure returns **before** the network call — the tests assert `fetch` was never invoked on each rejection path.

No action accepts a submission or releases escrow. Settlement stays with the human. Error text never echoes the bearer token or the request URL (which carries the caller's address).

## Notes from integrating against the live API

- The `/api` base-path prefix is mandatory; every path 404s without it.
- The bearer token does **not** identify the caller — account routes need an explicit `address` query param, hence the separate required `TASKMARKET_ADDRESS` setting.
- Amounts are atomic 6-decimal USDC everywhere except `/wallet/balance`. Converted at the client boundary; actions speak whole USDC.
- Task descriptions run 2–10 KB, so list output truncates (`TASKMARKET_LIST_DESCRIPTION_CHARS`) to keep a full board listing from eating the context window.

## Testing

```
bun run --cwd plugins/plugin-taskmarket test        # 16 passed
bun run --cwd plugins/plugin-taskmarket typecheck   # no errors in this package
```

Unit tests mock `fetch`, which validates this plugin's logic but not the vendor's URL shape — so it was also verified with a **read-only live run** against `api.taskmarket.dev` (balance, task list, task detail, submissions), plus live confirmation that all three creation guards refuse before any POST. Task creation itself is never exercised in tests; it escrows real funds.
