### PR TITLE
fix(homepage): provisioning polling no longer appends duplicate onboarding replies

### DIFF
--- a/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
@@ -386,7 +386,8 @@ describe("onboarding chat — trusted platform gateway caller", () => {
       );
       expect(first.status).toBe(200);
       const firstData = await dataOf(first.clone());
-      const firstMessages = (firstData.messages as Array<{ role: string; content: string }>) ?? [];
+      const firstMessages =
+        (firstData.messages as Array<{ role: string; content: string }>) ?? [];
 
       // Repeated status-only polls through the Hono route.
       for (let i = 0; i < 5; i++) {

--- a/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-onboarding-chat-platform-caller.test.ts
@@ -364,4 +364,112 @@ describe("onboarding chat — trusted platform gateway caller", () => {
     expect(response.status).toBe(400);
     expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();
   });
+
+  describe("statusOnly poll — #18078 route-level contract", () => {
+    /**
+     * Exercises the Hono chatSchema parse + route forwarding of the statusOnly
+     * flag. The route parses the request body, extracts statusOnly from the
+     * schema, and forwards it to runOnboardingChat. Repeated status-only
+     * requests for one session must leave the transcript unchanged — no
+     * poll-generated duplicate assistant entries.
+     */
+    test("repeated status-only polls leave the returned transcript unchanged", async () => {
+      spyOn(elizaAppSessionService, "validateAuthHeader").mockResolvedValue({
+        userId: "user-9",
+        organizationId: "org-9",
+      });
+
+      // First turn: a real user message so the session has content.
+      const first = await post(
+        { message: "My name is Alice", platform: "web" },
+        "Bearer browser-session",
+      );
+      expect(first.status).toBe(200);
+      const firstData = await dataOf(first.clone());
+      const firstMessages = (firstData.messages as Array<{ role: string; content: string }>) ?? [];
+
+      // Repeated status-only polls through the Hono route.
+      for (let i = 0; i < 5; i++) {
+        const poll = await post(
+          {
+            sessionId: firstData.sessionId as string,
+            statusOnly: true,
+            platform: "web",
+          },
+          "Bearer browser-session",
+        );
+        expect(poll.status).toBe(200);
+        const pollData = await dataOf(poll.clone());
+        const pollMessages =
+          (pollData.messages as Array<{ role: string; content: string }>) ?? [];
+
+        // Each poll must return the same number of messages — no growth.
+        expect(pollMessages.length).toBe(firstMessages.length);
+      }
+
+      // After 5 status-only polls, the final transcript must still match the
+      // initial state exactly.
+      const final = await post(
+        {
+          sessionId: firstData.sessionId as string,
+          statusOnly: true,
+          platform: "web",
+        },
+        "Bearer browser-session",
+      );
+      const finalData = await dataOf(final.clone());
+      const finalMessages =
+        (finalData.messages as Array<{ role: string; content: string }>) ?? [];
+
+      expect(finalMessages.length).toBe(firstMessages.length);
+
+      // The transcript must contain exactly the expected content, proving no
+      // duplicate "Eliza onboarding:" assistant entries were appended.
+      const assistantContents = finalMessages
+        .filter((m) => m.role === "assistant")
+        .map((m) => m.content);
+      const firstAssistantContents = firstMessages
+        .filter((m) => m.role === "assistant")
+        .map((m) => m.content);
+      expect(assistantContents).toEqual(firstAssistantContents);
+    });
+
+    test("statusOnly flag is parsed by chatSchema and forwarded to runOnboardingChat", async () => {
+      spyOn(elizaAppSessionService, "validateAuthHeader").mockResolvedValue({
+        userId: "user-9",
+        organizationId: "org-9",
+      });
+
+      // Start a real session first.
+      const first = await post(
+        { message: "My name is Bob", platform: "web" },
+        "Bearer browser-session",
+      );
+      expect(first.status).toBe(200);
+      const firstData = await dataOf(first.clone());
+
+      // Send a status-only poll with a message attached — the route must
+      // parse statusOnly from the body and forward it so the service skips
+      // message processing entirely.
+      const poll = await post(
+        {
+          sessionId: firstData.sessionId as string,
+          statusOnly: true,
+          message: "This should be ignored",
+          platform: "web",
+        },
+        "Bearer browser-session",
+      );
+      expect(poll.status).toBe(200);
+      const pollData = await dataOf(poll.clone());
+      const pollMessages =
+        (pollData.messages as Array<{ role: string; content: string }>) ?? [];
+
+      // The message "This should be ignored" must NOT appear as a user turn.
+      const userContents = pollMessages
+        .filter((m) => m.role === "user")
+        .map((m) => m.content);
+      expect(userContents).not.toContain("This should be ignored");
+    });
+  });
 });

--- a/packages/cloud/api/eliza-app/onboarding/chat/route.ts
+++ b/packages/cloud/api/eliza-app/onboarding/chat/route.ts
@@ -42,6 +42,7 @@ const chatSchema = z.object({
   platform: platformSchema.optional(),
   platformUserId: z.string().trim().max(256).optional(),
   platformDisplayName: z.string().trim().max(120).optional(),
+  statusOnly: z.boolean().optional(),
 });
 
 /**
@@ -145,6 +146,7 @@ app.post("/", async (c) => {
       authenticatedUser: caller.authenticatedUser,
       trustedPlatformIdentity: caller.trustedPlatformIdentity,
       idempotencyKey: idempotencyKey || undefined,
+      statusOnly: parsed.data.statusOnly ?? false,
     });
 
     // A platform gateway relays a reply back over the connector; it reads

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -1556,9 +1556,18 @@ describe("runOnboardingChat", () => {
         const transcript = String(
           (rememberRequests[0]?.body as { text: string }).text,
         );
+
+        // Count both user lines AND assistant lines to catch any
+        // poll-generated duplicate "Eliza onboarding:" entries that a
+        // user-only assertion would miss.
         const userLines = transcript.match(/^User: /gm) ?? [];
         expect(userLines).toHaveLength(1);
         expect(transcript).toContain("User: My name is Sam");
+
+        // The assistant reply fires exactly once. Poll-generated duplicates
+        // serialize as "Eliza onboarding: ..." — assert there is at most one.
+        const onboardingLines = transcript.match(/^Eliza onboarding:/gm) ?? [];
+        expect(onboardingLines.length).toBeLessThanOrEqual(1);
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -1553,9 +1553,9 @@ describe("runOnboardingChat", () => {
 
         // Exactly one remember call with a transcript containing no duplicates.
         expect(rememberRequests).toHaveLength(1);
-        const transcript = String(
-          (rememberRequests[0]?.body as { text: string }).text,
-        );
+        const firstRequest = rememberRequests[0];
+        if (!firstRequest) throw new Error("Expected at least one remember request");
+        const transcript = String((firstRequest.body as { text: string }).text);
 
         // Count both user lines AND assistant lines to catch any
         // poll-generated duplicate "Eliza onboarding:" entries that a

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -1024,11 +1024,14 @@ describe("runOnboardingChat", () => {
       expect(first.session.history).toHaveLength(1);
       expect(first.session.history[0]?.role).toBe("assistant");
 
+      // A second message-less turn (status poll, continuation poll) must NOT
+      // grow history — the proactive welcome fires only once per session.
+      // Regression for #18078: repeated polls were appending duplicate
+      // assistant-only entries.
       const second = await runTrustedPhoneTurn("   \n\t  ");
-      expect(second.session.history).toHaveLength(2);
-      expect(
-        second.session.history.every((m: OnboardingChatMessage) => m.role === "assistant"),
-      ).toBe(true);
+      expect(second.session.history).toHaveLength(1);
+      expect(typeof second.reply).toBe("string");
+      expect(second.reply.length).toBeGreaterThan(0);
     });
 
     test("emoji-only messages never capture a name and the reply stays ASCII", async () => {
@@ -1396,6 +1399,166 @@ describe("runOnboardingChat", () => {
             error: "body stream broke",
           }),
         );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+
+  describe("provisioning poll duplicates (#18078)", () => {
+    test("repeated message-less status polls do not grow session history", async () => {
+      const first = await runTrustedPhoneTurn("");
+      expect(first.session.history).toHaveLength(1);
+      expect(first.session.history[0]?.role).toBe("assistant");
+
+      // Simulate 5s-interval browser polling: no message, no statusOnly flag
+      // (the backend guard handles this independently of the frontend flag).
+      for (let i = 0; i < 5; i++) {
+        const poll = await runTrustedPhoneTurn("");
+        expect(poll.session.history).toHaveLength(1);
+        expect(typeof poll.reply).toBe("string");
+        expect(poll.reply.length).toBeGreaterThan(0);
+      }
+
+      // After all polls, history still has exactly one entry.
+      const final = getCachedSession(PLATFORM_SESSION);
+      expect(final.history).toHaveLength(1);
+    });
+
+    test("statusOnly flag suppresses the proactive welcome even on a fresh session", async () => {
+      const result = await runOnboardingChat({
+        platform: "blooio",
+        platformUserId: PHONE,
+        sessionId: PLATFORM_SESSION,
+        trustedPlatformIdentity: true,
+        statusOnly: true,
+      });
+
+      expect(result.session.history).toHaveLength(0);
+      expect(typeof result.reply).toBe("string");
+      expect(result.reply.length).toBeGreaterThan(0);
+    });
+
+    test("statusOnly with a message still does not mutate history or capture a name", async () => {
+      const result = await runOnboardingChat({
+        message: "My name is Eve",
+        platform: "blooio",
+        platformUserId: PHONE,
+        sessionId: PLATFORM_SESSION,
+        trustedPlatformIdentity: true,
+        statusOnly: true,
+      });
+
+      // statusOnly must override message processing entirely.
+      expect(result.session.history).toHaveLength(0);
+      expect(result.session.name).toBeUndefined();
+      expect(typeof result.reply).toBe("string");
+      expect(result.reply.length).toBeGreaterThan(0);
+    });
+
+    test("real user messages continue to create user/assistant turns", async () => {
+      const first = await runTrustedPhoneTurn("My name is Alice");
+      expect(first.session.history).toHaveLength(2); // user + assistant
+      expect(first.session.history[0]?.role).toBe("user");
+      expect(first.session.history[0]?.content).toBe("My name is Alice");
+      expect(first.session.history[1]?.role).toBe("assistant");
+
+      // A status poll between real messages does not grow history.
+      const poll = await runTrustedPhoneTurn("");
+      expect(poll.session.history).toHaveLength(2);
+
+      // Another real message adds a new turn.
+      const second = await runTrustedPhoneTurn("hello again");
+      expect(second.session.history).toHaveLength(4); // 2 prior + user + assistant
+      expect(second.session.history[2]?.role).toBe("user");
+      expect(second.session.history[2]?.content).toBe("hello again");
+      expect(second.session.history[3]?.role).toBe("assistant");
+    });
+
+    test("handoff transcript contains no poll-generated duplicates", async () => {
+      const originalFetch = globalThis.fetch;
+      const rememberRequests: Array<{ body: unknown }> = [];
+      globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        rememberRequests.push({
+          body: init?.body ? JSON.parse(String(init.body)) : null,
+        });
+        return new Response("{}", { status: 200 });
+      }) as typeof fetch;
+
+      try {
+        findOrCreateByPhone.mockResolvedValue({
+          user: { id: "user-1", name: null },
+          organization: { id: "org-1" },
+          isNew: true,
+        });
+        // Start with provisioning pending — no handoff yet.
+        ensureElizaAppProvisioning.mockResolvedValue({
+          status: "provisioning",
+          agentId: "agent-1",
+          bridgeUrl: null,
+          sandbox: null,
+        });
+        launchManagedElizaAgent.mockResolvedValue({
+          appUrl: "https://app.elizacloud.ai/dashboard/agents/agent-1",
+          connection: {
+            apiBase: "https://agent-1.example/",
+            token: "agent-token",
+          },
+        });
+
+        // Start with a real user message so the transcript has real content.
+        const named = await runOnboardingChat({
+          message: "My name is Sam",
+          platform: "blooio",
+          platformUserId: PHONE,
+          sessionId: PLATFORM_SESSION,
+          trustedPlatformIdentity: true,
+          authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        });
+
+        // No handoff while provisioning is pending.
+        expect(rememberRequests).toHaveLength(0);
+
+        // Simulate several status polls while provisioning is still pending.
+        for (let i = 0; i < 3; i++) {
+          await runOnboardingChat({
+            platform: "blooio",
+            sessionId: continuationToken(named),
+            authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+            statusOnly: true,
+          });
+        }
+
+        // Still no handoff — polls never triggered one.
+        expect(rememberRequests).toHaveLength(0);
+
+        // Provisioning reaches running — the next turn fires the handoff.
+        ensureElizaAppProvisioning.mockResolvedValue({
+          status: "running",
+          agentId: "agent-1",
+          bridgeUrl: "https://agent-1.example",
+          sandbox: {
+            id: "agent-1",
+            status: "running",
+            bridge_url: "https://agent-1.example",
+          },
+        });
+
+        await runOnboardingChat({
+          platform: "blooio",
+          sessionId: continuationToken(named),
+          authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+          statusOnly: true,
+        });
+
+        // Exactly one remember call with a transcript containing no duplicates.
+        expect(rememberRequests).toHaveLength(1);
+        const transcript = String(
+          (rememberRequests[0]?.body as { text: string }).text,
+        );
+        const userLines = transcript.match(/^User: /gm) ?? [];
+        expect(userLines).toHaveLength(1);
+        expect(transcript).toContain("User: My name is Sam");
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -79,6 +79,13 @@ export interface OnboardingChatInput {
   continuationMode?: "trusted-telegram";
   /** Stable transport delivery id. Replays return the original result. */
   idempotencyKey?: string;
+  /**
+   * Read-only status poll. When true the call returns the current provisioning
+   * state and a deterministic reply but never appends to session history, even
+   * on a brand-new session. Browser polling uses this so repeated 5 s polls
+   * cannot grow the durable transcript with duplicate status copy.
+   */
+  statusOnly?: boolean;
 }
 
 export interface OnboardingChatCta {
@@ -1006,7 +1013,12 @@ export async function runOnboardingChatWithStore(
 
   session = await maybeLinkAuthenticatedPlatformIdentity(session, input);
 
-  const userMessage = input.message?.trim().slice(0, MAX_MESSAGE_LENGTH);
+  // statusOnly is a read-only poll: skip all user-message processing so it
+  // can never mutate session history, name, or preferred-name state, even if
+  // a caller accidentally includes a message field.
+  const userMessage = input.statusOnly
+    ? undefined
+    : input.message?.trim().slice(0, MAX_MESSAGE_LENGTH);
   let preferredNameProvidedThisTurn = false;
   if (userMessage) {
     session = appendMessage(session, "user", userMessage);
@@ -1073,6 +1085,19 @@ export async function runOnboardingChatWithStore(
     requiresLogin && hasPreferredName(session) && rendersLoginAsButton(session.platform)
       ? buildLoginCta(loginUrl)
       : null;
+  // A turn with no user message produces a proactive welcome only the FIRST
+  // time — the initial mount/poll that has no user content yet. Every
+  // subsequent message-less turn (status-only polls every 5 s, continuation
+  // polls) returns the current provisioning state and a deterministic reply
+  // but leaves session.history untouched. Without this guard the durable
+  // transcript grows one assistant-only entry per poll; those duplicates are
+  // then returned to the UI and copied into managed-agent memory.
+  //
+  // The explicit statusOnly flag (sent by browser polling) is belt-and-
+  // suspenders: even if a poll arrives against a fresh session, statusOnly
+  // suppresses the welcome append — the initial mount POST already produced it.
+  const isFirstWelcome = !userMessage && session.history.length === 0 && !input.statusOnly;
+  const shouldAppendReply = userMessage || isFirstWelcome;
   const reply = generateOnboardingReply({
     session,
     provisioning,
@@ -1082,7 +1107,9 @@ export async function runOnboardingChatWithStore(
     cta,
   });
 
-  session = appendMessage(session, "assistant", reply);
+  if (shouldAppendReply) {
+    session = appendMessage(session, "assistant", reply);
+  }
   await store.save(session);
 
   return {

--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -13,7 +13,7 @@
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "check:release-data": "node ../app-core/scripts/check-homepage-release-data.mjs",
     "check:snapshot-inventory": "bun scripts/check-snapshot-inventory.ts",
-    "test": "bun test tests/smoke.node.test.mjs tests/screenshot-stability.node.test.mjs tests/e2e-port.node.test.mjs tests/channel-build-config.node.test.mjs tests/contact.test.ts tests/snapshot-inventory.test.ts tests/auth-return.test.ts tests/wallet-linking.test.ts tests/release-availability.test.ts edge/apple-app-site-association.test.ts tests/landing-a11y-helpers.test.ts",
+    "test": "bun test tests/smoke.node.test.mjs tests/screenshot-stability.node.test.mjs tests/e2e-port.node.test.mjs tests/channel-build-config.node.test.mjs tests/contact.test.ts tests/snapshot-inventory.test.ts tests/auth-return.test.ts tests/wallet-linking.test.ts tests/release-availability.test.ts edge/apple-app-site-association.test.ts tests/landing-a11y-helpers.test.ts tests/provisioning-poll-body.test.ts tests/provisioning-poll-hook.test.ts",
     "test:aasa-edge": "bun run typecheck:aasa-edge && bun test edge/apple-app-site-association.test.ts",
     "typecheck:aasa-edge": "bunx --package typescript@6.0.3 tsc --noEmit -p edge/tsconfig.json",
     "deploy:aasa-edge": "bunx wrangler@4.100.0 deploy --config wrangler-aasa.toml --strict",

--- a/packages/homepage/src/lib/hooks/use-eliza-app-provisioning-chat.ts
+++ b/packages/homepage/src/lib/hooks/use-eliza-app-provisioning-chat.ts
@@ -6,6 +6,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { elizacloudAuthFetch } from "@/lib/api/client";
+import { buildProvisioningPollBody } from "@/lib/provisioning-poll-body";
 
 export interface ProvisioningChatMessage {
   id: string;
@@ -201,10 +202,7 @@ export function useElizaAppProvisioningChat(
           "/api/eliza-app/onboarding/chat",
           {
             method: "POST",
-            body: JSON.stringify({
-              sessionId: onboardingSessionId ?? undefined,
-              platform: onboardingSessionId ? "blooio" : "web",
-            }),
+            body: JSON.stringify(buildProvisioningPollBody(onboardingSessionId)),
           },
         );
         if (stoppedRef.current) return;

--- a/packages/homepage/src/lib/hooks/use-eliza-app-provisioning-chat.ts
+++ b/packages/homepage/src/lib/hooks/use-eliza-app-provisioning-chat.ts
@@ -202,7 +202,9 @@ export function useElizaAppProvisioningChat(
           "/api/eliza-app/onboarding/chat",
           {
             method: "POST",
-            body: JSON.stringify(buildProvisioningPollBody(onboardingSessionId)),
+            body: JSON.stringify(
+              buildProvisioningPollBody(onboardingSessionId),
+            ),
           },
         );
         if (stoppedRef.current) return;

--- a/packages/homepage/src/lib/provisioning-poll-body.ts
+++ b/packages/homepage/src/lib/provisioning-poll-body.ts
@@ -1,0 +1,21 @@
+/**
+ * Request body construction for the shared-onboarding provisioning poll.
+ * Extracted from the React hook so the polling request contract (statusOnly,
+ * platform derivation, no user message) is covered by unit tests without a
+ * full React hook test harness.
+ */
+
+/**
+ * Builds the request body for a shared-onboarding status poll. The polling
+ * effect calls this immediately and every 5 s so repeated polls cannot grow
+ * the durable transcript with duplicate status copy.
+ */
+export function buildProvisioningPollBody(
+  onboardingSessionId?: string | null,
+): { sessionId?: string; platform: string; statusOnly: true } {
+  return {
+    sessionId: onboardingSessionId ?? undefined,
+    platform: onboardingSessionId ? "blooio" : "web",
+    statusOnly: true,
+  };
+}

--- a/packages/homepage/tests/provisioning-poll-body.test.ts
+++ b/packages/homepage/tests/provisioning-poll-body.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Contract tests for the shared-onboarding provisioning poll body. The polling
+ * effect fires immediately and every 5 s; these tests pin the request contract
+ * (statusOnly flag, platform derivation, no user message) without requiring a
+ * full React hook test harness.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildProvisioningPollBody } from "../src/lib/provisioning-poll-body";
+
+describe("buildProvisioningPollBody", () => {
+  test("always sends statusOnly: true", () => {
+    const body = buildProvisioningPollBody("session-abc");
+    expect(body.statusOnly).toBe(true);
+  });
+
+  test("never includes a message field", () => {
+    const body = buildProvisioningPollBody("session-abc");
+    expect(body).not.toHaveProperty("message");
+  });
+
+  test("uses blooio platform when a session id is present", () => {
+    const body = buildProvisioningPollBody("platform:blooio:+1234567890");
+    expect(body.platform).toBe("blooio");
+    expect(body.sessionId).toBe("platform:blooio:+1234567890");
+  });
+
+  test("uses web platform and undefined session when no session id", () => {
+    const body = buildProvisioningPollBody(null);
+    expect(body.platform).toBe("web");
+    expect(body.sessionId).toBeUndefined();
+  });
+
+  test("handles undefined session id", () => {
+    const body = buildProvisioningPollBody(undefined);
+    expect(body.platform).toBe("web");
+    expect(body.sessionId).toBeUndefined();
+    expect(body.statusOnly).toBe(true);
+  });
+});

--- a/packages/homepage/tests/provisioning-poll-hook.test.ts
+++ b/packages/homepage/tests/provisioning-poll-hook.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Hook-level test for the shared-onboarding provisioning poll.
+ *
+ * Mounts useElizaAppProvisioningChat with a shared onboarding session id,
+ * controls elizacloudAuthFetch via mock.module, and proves:
+ * - the immediate (mount) request carries statusOnly via buildProvisioningPollBody
+ * - the 5-second interval request carries statusOnly with no message
+ * - the returned transcript has no poll-generated duplicate assistant replies
+ * - cleanup (isReady / unmount) stops further polling
+ *
+ * Uses jsdom (already a root devDependency) to provide the DOM React needs,
+ * and bun:test's mock.module to intercept the auth-fetch seam.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Capture every fetch invocation so tests can assert on the request body.
+const fetchCalls: Array<{ url: string; body: unknown }> = [];
+
+// The mock returns a provisioning-pending response so the poll loop keeps
+// running until the test deliberately flips the status to "running".
+let nextStatus = "pending";
+let nextBridgeUrl: string | null = null;
+
+// mock.module intercepts the import inside use-eliza-app-provisioning-chat.ts.
+// The source file uses the @/ alias (resolved by Vite/tsconfig to src/), so we
+// register the mock under both the alias path and the relative path.
+const clientMock = {
+  elizacloudAuthFetch: mock(async (url: string, init?: RequestInit) => {
+    const bodyStr = init?.body as string | undefined;
+    let parsedBody: unknown = undefined;
+    if (bodyStr) {
+      try {
+        parsedBody = JSON.parse(bodyStr);
+      } catch {
+        parsedBody = bodyStr;
+      }
+    }
+    fetchCalls.push({ url, body: parsedBody });
+
+    if (url === "/api/eliza-app/onboarding/chat") {
+      const isStatusOnly =
+        typeof parsedBody === "object" &&
+        parsedBody !== null &&
+        (parsedBody as Record<string, unknown>).statusOnly === true;
+
+      return {
+        success: true,
+        data: {
+          reply: isStatusOnly
+            ? "on it, your agent is spinning up now."
+            : "Hi! I'm Eliza.",
+          provisioning: {
+            status: nextStatus,
+            agentId: nextStatus === "running" ? "agent-123" : null,
+            bridgeUrl: nextBridgeUrl,
+          },
+          messages: [
+            { role: "assistant" as const, content: "Hi! I'm Eliza.", createdAt: "2026-01-01T00:00:00Z" },
+          ],
+          handoffComplete: false,
+        },
+      };
+    }
+
+    return { success: true, data: {} };
+  }),
+};
+// Register mocks for the @/-prefixed modules the hook imports.
+// bun:test does not read tsconfig.app.json (where the Vite "@" alias lives),
+// so we use mock.module to intercept both the alias form and the real path.
+mock.module("@/lib/api/client", () => clientMock);
+// provisioning-poll-body is a pure function — let the real module load but
+// intercept the alias so it resolves.
+mock.module("@/lib/provisioning-poll-body", () =>
+  import("../src/lib/provisioning-poll-body").then((m) => m),
+);
+
+// Import after mocks are registered.
+const { useElizaAppProvisioningChat } = await import(
+  "../src/lib/hooks/use-eliza-app-provisioning-chat"
+);
+const React = await import("react");
+const { createRoot } = await import("react-dom/client");
+const { JSDOM } = await import("jsdom");
+
+function setupDom() {
+  const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+    url: "http://localhost",
+    pretendToBeVisual: true,
+  });
+  const { window } = dom;
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.window = window;
+  g.document = window.document;
+  g.navigator = window.navigator;
+  g.HTMLElement = window.HTMLElement;
+  g.localStorage = window.localStorage;
+  g.clearInterval = window.clearInterval.bind(window);
+  g.setInterval = window.setInterval.bind(window);
+  return window as unknown as Window & typeof globalThis;
+}
+
+interface ObservedState {
+  messages: Array<{ role: string; content: string }>;
+  containerStatus: string;
+  isReady: boolean;
+}
+
+function mountHook(
+  active: boolean,
+  sessionId: string | null,
+): { getState: () => ObservedState; unmount: () => void } {
+  const window = (globalThis as unknown as { window: Window }).window;
+  let state: ObservedState = {
+    messages: [],
+    containerStatus: "pending",
+    isReady: false,
+  };
+
+  function TestHarness() {
+    const result = useElizaAppProvisioningChat(active, sessionId);
+    React.useEffect(() => {
+      state = {
+        messages: result.messages.map((m) => ({ role: m.role, content: m.content })),
+        containerStatus: result.containerStatus,
+        isReady: result.isReady,
+      };
+    });
+    return React.createElement("div");
+  }
+
+  const container = window.document.getElementById("root")!;
+  // Clear any previous render (container is a known empty div from setupDom)
+  container.textContent = "";
+  const root = createRoot(container);
+  root.render(React.createElement(TestHarness));
+
+  return {
+    getState: () => state,
+    unmount: () => root.unmount(),
+  };
+}
+
+describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
+  beforeEach(() => {
+    setupDom();
+    fetchCalls.length = 0;
+    nextStatus = "pending";
+    nextBridgeUrl = null;
+  });
+
+  test("immediate poll sends statusOnly:true with no message field", async () => {
+    const { unmount } = mountHook(true, "platform:blooio:+123****7890");
+
+    // Wait for the mount effect + immediate poll to fire
+    await new Promise((r) => setTimeout(r, 150));
+
+    const chatCalls = fetchCalls.filter((c) => c.url === "/api/eliza-app/onboarding/chat");
+
+    // The polling effect fires immediately on mount. That call uses
+    // buildProvisioningPollBody which must carry statusOnly:true.
+    const pollCalls = chatCalls.filter((c) => {
+      const body = c.body as Record<string, unknown> | undefined;
+      return body?.statusOnly === true;
+    });
+
+    expect(pollCalls.length).toBeGreaterThanOrEqual(1);
+
+    // Every poll call must have statusOnly:true and must NOT have a message field
+    for (const call of pollCalls) {
+      const body = call.body as Record<string, unknown>;
+      expect(body.statusOnly).toBe(true);
+      expect(body).not.toHaveProperty("message");
+    }
+
+    // The poll body must include the sessionId and correct platform
+    const firstPoll = pollCalls[0].body as Record<string, unknown>;
+    expect(firstPoll.sessionId).toBe("platform:blooio:+123****7890");
+    expect(firstPoll.platform).toBe("blooio");
+
+    unmount();
+  });
+
+  test("repeated polls do not append duplicate assistant replies to the transcript", async () => {
+    const { getState, unmount } = mountHook(true, "platform:blooio:+123****7890");
+
+    // Let the mount effect + immediate poll fire
+    await new Promise((r) => setTimeout(r, 200));
+
+    const pollCalls = fetchCalls.filter((c) => {
+      if (c.url !== "/api/eliza-app/onboarding/chat") return false;
+      const body = c.body as Record<string, unknown> | undefined;
+      return body?.statusOnly === true;
+    });
+
+    // At least 1 status-only poll should have fired
+    expect(pollCalls.length).toBeGreaterThanOrEqual(1);
+
+    // The transcript visible to the UI must not contain duplicate assistant
+    // replies from poll turns. The backend's statusOnly guard means poll
+    // responses carry one welcome message array; the hook's applyOnboardingResponse
+    // replaces (not appends) the messages. So no matter how many polls fire,
+    // the assistant message count stays bounded.
+    const state = getState();
+    const assistantMessages = state.messages.filter((m) => m.role === "assistant");
+    expect(assistantMessages.length).toBeLessThanOrEqual(2);
+
+    unmount();
+  });
+
+  test("cleanup on unmount stops the polling interval", async () => {
+    const { unmount } = mountHook(true, "platform:blooio:+123****7890");
+
+    await new Promise((r) => setTimeout(r, 150));
+    const callsBefore = fetchCalls.filter(
+      (c) => c.url === "/api/eliza-app/onboarding/chat",
+    ).length;
+
+    unmount();
+
+    // Wait long enough for at least one more poll cycle (5 s interval)
+    // to have fired if the interval were NOT cleared.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const callsAfter = fetchCalls.filter(
+      (c) => c.url === "/api/eliza-app/onboarding/chat",
+    ).length;
+
+    // No new calls should have arrived after unmount
+    expect(callsAfter).toBe(callsBefore);
+  });
+});

--- a/packages/homepage/tests/provisioning-poll-hook.test.ts
+++ b/packages/homepage/tests/provisioning-poll-hook.test.ts
@@ -3,13 +3,14 @@
  *
  * Mounts useElizaAppProvisioningChat with a shared onboarding session id,
  * controls elizacloudAuthFetch via mock.module, and proves:
- * - the immediate (mount) request carries statusOnly via buildProvisioningPollBody
- * - the 5-second interval request carries statusOnly with no message
+ * - the immediate (mount) request carries statusOnly:true with no message
+ * - the 5-second interval request carries statusOnly:true with no message
  * - the returned transcript has no poll-generated duplicate assistant replies
- * - cleanup (isReady / unmount) stops further polling
+ * - cleanup (ready-state transition and unmount) stops further polling
  *
  * Uses jsdom (already a root devDependency) to provide the DOM React needs,
- * and bun:test's mock.module to intercept the auth-fetch seam.
+ * and a controllable setInterval shim so tests advance the 5 s interval
+ * deterministically without real-time waits.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -20,6 +21,18 @@ const fetchCalls: Array<{ url: string; body: unknown }> = [];
 // running until the test deliberately flips the status to "running".
 let nextStatus = "pending";
 let nextBridgeUrl: string | null = null;
+
+// --- Controllable interval scheduler ---
+// Production calls setInterval(cb, 5000). We capture the callback so tests
+// can fire it on demand, proving the interval retry (not just the immediate
+// call) carries the correct body. We also track which timers were cleared.
+interface CapturedTimer {
+  callback: () => void;
+  cleared: boolean;
+  delay: number;
+}
+let capturedTimers: CapturedTimer[] = [];
+let activeTimers: Set<CapturedTimer> = new Set();
 
 // mock.module intercepts the import inside use-eliza-app-provisioning-chat.ts.
 // The source file uses the @/ alias (resolved by Vite/tsconfig to src/), so we
@@ -43,6 +56,9 @@ const clientMock = {
         parsedBody !== null &&
         (parsedBody as Record<string, unknown>).statusOnly === true;
 
+      // When the test sets nextStatus to "running", include a bridgeUrl so
+      // the hook transitions to isReady and stops the interval.
+      const isRunning = nextStatus === "running";
       return {
         success: true,
         data: {
@@ -51,8 +67,8 @@ const clientMock = {
             : "Hi! I'm Eliza.",
           provisioning: {
             status: nextStatus,
-            agentId: nextStatus === "running" ? "agent-123" : null,
-            bridgeUrl: nextBridgeUrl,
+            agentId: isRunning ? "agent-123" : null,
+            bridgeUrl: isRunning ? "https://agent-123.example" : null,
           },
           messages: [
             { role: "assistant" as const, content: "Hi! I'm Eliza.", createdAt: "2026-01-01T00:00:00Z" },
@@ -95,9 +111,33 @@ function setupDom() {
   g.navigator = window.navigator;
   g.HTMLElement = window.HTMLElement;
   g.localStorage = window.localStorage;
-  g.clearInterval = window.clearInterval.bind(window);
-  g.setInterval = window.setInterval.bind(window);
+
+  // Override setInterval with a controllable shim. Production schedules the
+  // 5-second poll via setInterval; we capture the callback so tests can fire
+  // it manually and assert the interval retry body.
+  g.setInterval = ((callback: () => void, delay: number) => {
+    const timer: CapturedTimer = { callback, cleared: false, delay };
+    capturedTimers.push(timer);
+    activeTimers.add(timer);
+    return timer as unknown as number;
+  }) as typeof setInterval;
+  g.clearInterval = ((id: number) => {
+    const timer = id as unknown as CapturedTimer;
+    timer.cleared = true;
+    activeTimers.delete(timer);
+  }) as typeof clearInterval;
+
   return window as unknown as Window & typeof globalThis;
+}
+
+/** Fire all active (non-cleared) interval callbacks once. */
+async function tickIntervals() {
+  const timers = [...activeTimers];
+  for (const timer of timers) {
+    if (!timer.cleared) {
+      await timer.callback();
+    }
+  }
 }
 
 interface ObservedState {
@@ -147,12 +187,14 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
     fetchCalls.length = 0;
     nextStatus = "pending";
     nextBridgeUrl = null;
+    capturedTimers = [];
+    activeTimers = new Set();
   });
 
   test("immediate poll sends statusOnly:true with no message field", async () => {
     const { unmount } = mountHook(true, "platform:blooio:+123****7890");
 
-    // Wait for the mount effect + immediate poll to fire
+    // Wait for the mount effect + immediate poll to fire.
     await new Promise((r) => setTimeout(r, 150));
 
     const chatCalls = fetchCalls.filter((c) => c.url === "/api/eliza-app/onboarding/chat");
@@ -181,26 +223,64 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
     unmount();
   });
 
+  test("5-second interval retry also sends statusOnly:true with no message", async () => {
+    const { unmount } = mountHook(true, "platform:blooio:+123****7890");
+
+    // Wait for mount + immediate poll.
+    await new Promise((r) => setTimeout(r, 150));
+
+    const callsAfterImmediate = fetchCalls.filter(
+      (c) => c.url === "/api/eliza-app/onboarding/chat",
+    ).length;
+
+    // The hook must have registered an interval timer with 5000ms delay.
+    expect(capturedTimers.length).toBeGreaterThanOrEqual(1);
+    const pollTimer = capturedTimers[capturedTimers.length - 1];
+    expect(pollTimer.delay).toBe(5000);
+
+    // Fire the interval callback to simulate the 5-second tick.
+    await tickIntervals();
+
+    // Allow the async fetch to resolve.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const callsAfterInterval = fetchCalls.filter(
+      (c) => c.url === "/api/eliza-app/onboarding/chat",
+    ).length;
+
+    // At least one more call arrived after the interval tick.
+    expect(callsAfterInterval).toBeGreaterThan(callsAfterImmediate);
+
+    // The interval-triggered call(s) must carry statusOnly:true with no message.
+    const intervalCalls = fetchCalls
+      .filter((c) => c.url === "/api/eliza-app/onboarding/chat")
+      .slice(callsAfterImmediate);
+
+    for (const call of intervalCalls) {
+      const body = call.body as Record<string, unknown>;
+      expect(body.statusOnly).toBe(true);
+      expect(body).not.toHaveProperty("message");
+    }
+
+    unmount();
+  });
+
   test("repeated polls do not append duplicate assistant replies to the transcript", async () => {
     const { getState, unmount } = mountHook(true, "platform:blooio:+123****7890");
 
-    // Let the mount effect + immediate poll fire
-    await new Promise((r) => setTimeout(r, 200));
+    // Wait for mount + immediate poll.
+    await new Promise((r) => setTimeout(r, 150));
 
-    const pollCalls = fetchCalls.filter((c) => {
-      if (c.url !== "/api/eliza-app/onboarding/chat") return false;
-      const body = c.body as Record<string, unknown> | undefined;
-      return body?.statusOnly === true;
-    });
-
-    // At least 1 status-only poll should have fired
-    expect(pollCalls.length).toBeGreaterThanOrEqual(1);
+    // Fire multiple interval ticks to simulate several 5-second polls.
+    for (let i = 0; i < 3; i++) {
+      await tickIntervals();
+      await new Promise((r) => setTimeout(r, 50));
+    }
 
     // The transcript visible to the UI must not contain duplicate assistant
     // replies from poll turns. The backend's statusOnly guard means poll
     // responses carry one welcome message array; the hook's applyOnboardingResponse
-    // replaces (not appends) the messages. So no matter how many polls fire,
-    // the assistant message count stays bounded.
+    // replaces (not appends) the messages.
     const state = getState();
     const assistantMessages = state.messages.filter((m) => m.role === "assistant");
     expect(assistantMessages.length).toBeLessThanOrEqual(2);
@@ -208,25 +288,70 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
     unmount();
   });
 
+  test("ready-state transition stops further polling", async () => {
+    const { getState, unmount } = mountHook(true, "platform:blooio:+123****7890");
+
+    // Wait for mount + immediate poll (status pending).
+    await new Promise((r) => setTimeout(r, 150));
+
+    // Flip the mock so the next response is provisioning=running with a bridgeUrl.
+    nextStatus = "running";
+
+    // Fire the interval tick — the hook should see isReady and stop polling.
+    await tickIntervals();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The hook must have transitioned to ready.
+    expect(getState().isReady).toBe(true);
+
+    // After the ready transition, the cleanup function should have cleared
+    // the interval. Verify no new calls arrive from further ticks.
+    const callsAfterReady = fetchCalls.filter(
+      (c) => c.url === "/api/eliza-app/onboarding/chat",
+    ).length;
+
+    // Even if we fire timers manually, cleared timers are skipped.
+    await tickIntervals();
+    await new Promise((r) => setTimeout(r, 50));
+
+    const callsAfterExtraTick = fetchCalls.filter(
+      (c) => c.url === "/api/eliza-app/onboarding/chat",
+    ).length;
+
+    // No new calls should have arrived.
+    expect(callsAfterExtraTick).toBe(callsAfterReady);
+
+    unmount();
+  });
+
   test("cleanup on unmount stops the polling interval", async () => {
     const { unmount } = mountHook(true, "platform:blooio:+123****7890");
 
+    // Wait for mount + immediate poll.
     await new Promise((r) => setTimeout(r, 150));
+
     const callsBefore = fetchCalls.filter(
       (c) => c.url === "/api/eliza-app/onboarding/chat",
     ).length;
 
+    // Verify an interval was active.
+    expect(activeTimers.size).toBeGreaterThanOrEqual(1);
+
     unmount();
 
-    // Wait long enough for at least one more poll cycle (5 s interval)
-    // to have fired if the interval were NOT cleared.
-    await new Promise((r) => setTimeout(r, 200));
+    // After unmount, all timers should be cleared.
+    const activeAfterUnmount = [...activeTimers].filter((t) => !t.cleared);
+    expect(activeAfterUnmount.length).toBe(0);
+
+    // Fire interval ticks — since they are cleared, no calls should arrive.
+    await tickIntervals();
+    await new Promise((r) => setTimeout(r, 50));
 
     const callsAfter = fetchCalls.filter(
       (c) => c.url === "/api/eliza-app/onboarding/chat",
     ).length;
 
-    // No new calls should have arrived after unmount
+    // No new calls should have arrived after unmount.
     expect(callsAfter).toBe(callsBefore);
   });
 });

--- a/packages/homepage/tests/provisioning-poll-hook.test.ts
+++ b/packages/homepage/tests/provisioning-poll-hook.test.ts
@@ -20,7 +20,6 @@ const fetchCalls: Array<{ url: string; body: unknown }> = [];
 // The mock returns a provisioning-pending response so the poll loop keeps
 // running until the test deliberately flips the status to "running".
 let nextStatus = "pending";
-let nextBridgeUrl: string | null = null;
 
 // --- Controllable interval scheduler ---
 // Production calls setInterval(cb, 5000). We capture the callback so tests
@@ -40,7 +39,7 @@ let activeTimers: Set<CapturedTimer> = new Set();
 const clientMock = {
   elizacloudAuthFetch: mock(async (url: string, init?: RequestInit) => {
     const bodyStr = init?.body as string | undefined;
-    let parsedBody: unknown = undefined;
+    let parsedBody: unknown;
     if (bodyStr) {
       try {
         parsedBody = JSON.parse(bodyStr);
@@ -71,7 +70,11 @@ const clientMock = {
             bridgeUrl: isRunning ? "https://agent-123.example" : null,
           },
           messages: [
-            { role: "assistant" as const, content: "Hi! I'm Eliza.", createdAt: "2026-01-01T00:00:00Z" },
+            {
+              role: "assistant" as const,
+              content: "Hi! I'm Eliza.",
+              createdAt: "2026-01-01T00:00:00Z",
+            },
           ],
           handoffComplete: false,
         },
@@ -161,7 +164,10 @@ function mountHook(
     const result = useElizaAppProvisioningChat(active, sessionId);
     React.useEffect(() => {
       state = {
-        messages: result.messages.map((m) => ({ role: m.role, content: m.content })),
+        messages: result.messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+        })),
         containerStatus: result.containerStatus,
         isReady: result.isReady,
       };
@@ -169,7 +175,8 @@ function mountHook(
     return React.createElement("div");
   }
 
-  const container = window.document.getElementById("root")!;
+  const container = window.document.getElementById("root");
+  if (!container) throw new Error("root element not found");
   // Clear any previous render (container is a known empty div from setupDom)
   container.textContent = "";
   const root = createRoot(container);
@@ -186,7 +193,6 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
     setupDom();
     fetchCalls.length = 0;
     nextStatus = "pending";
-    nextBridgeUrl = null;
     capturedTimers = [];
     activeTimers = new Set();
   });
@@ -197,7 +203,9 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
     // Wait for the mount effect + immediate poll to fire.
     await new Promise((r) => setTimeout(r, 150));
 
-    const chatCalls = fetchCalls.filter((c) => c.url === "/api/eliza-app/onboarding/chat");
+    const chatCalls = fetchCalls.filter(
+      (c) => c.url === "/api/eliza-app/onboarding/chat",
+    );
 
     // The polling effect fires immediately on mount. That call uses
     // buildProvisioningPollBody which must carry statusOnly:true.
@@ -266,7 +274,10 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
   });
 
   test("repeated polls do not append duplicate assistant replies to the transcript", async () => {
-    const { getState, unmount } = mountHook(true, "platform:blooio:+123****7890");
+    const { getState, unmount } = mountHook(
+      true,
+      "platform:blooio:+123****7890",
+    );
 
     // Wait for mount + immediate poll.
     await new Promise((r) => setTimeout(r, 150));
@@ -282,14 +293,19 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
     // responses carry one welcome message array; the hook's applyOnboardingResponse
     // replaces (not appends) the messages.
     const state = getState();
-    const assistantMessages = state.messages.filter((m) => m.role === "assistant");
+    const assistantMessages = state.messages.filter(
+      (m) => m.role === "assistant",
+    );
     expect(assistantMessages.length).toBeLessThanOrEqual(2);
 
     unmount();
   });
 
   test("ready-state transition stops further polling", async () => {
-    const { getState, unmount } = mountHook(true, "platform:blooio:+123****7890");
+    const { getState, unmount } = mountHook(
+      true,
+      "platform:blooio:+123****7890",
+    );
 
     // Wait for mount + immediate poll (status pending).
     await new Promise((r) => setTimeout(r, 150));


### PR DESCRIPTION
Fixes #18078.

## Summary

Provisioning polls now have an explicit `statusOnly` contract and cannot create chat turns. The initial proactive welcome is recorded once, subsequent message-less polls leave `session.history` unchanged, and real user messages still produce user/assistant pairs. This prevents polling copy from reaching either the browser transcript or the managed-agent handoff memory.

The homepage sends the status-only request on the immediate poll and every five-second retry. The Cloud API validates and forwards the flag; the shared onboarding service enforces history immutability even if a caller omits the flag and sends an empty existing-session turn.

## Review repairs

- Added a controllable interval harness that exercises the actual five-second callback and proves ready-state and unmount cleanup.
- Added Hono route tests so schema parsing and forwarding are covered, not merely the service implementation.
- Strengthened handoff coverage to inspect both user and `Eliza onboarding:` transcript lines.
- Fixed the changed tests' Biome and unsafe-optional-chaining failures.
- Rebased the unchanged five-commit patch onto current `develop`.

## Verification on exact head

- shared onboarding service: 54 passed, 0 failed, 289 assertions
- Cloud API Hono route: 12 passed, 0 failed, 49 assertions
- homepage suite: 85 passed, 0 failed, 199 assertions
- homepage typecheck, lint, and production build: passed
- cloud/shared typecheck and lint: passed
- cloud/api typecheck, Worker dry-run build, and lint: passed
- `bun run verify`: 348/348 tasks; all repository audits passed
- `git diff --check`: passed
- base: `origin/develop@6426594d7c0b343ad8d881d704e2c1e59856526f`

<!-- evidence-head:6efa1b8aca829f176d288d7d856dcb0fc143d31d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - request and backend transcript semantics changed; no rendered layout or styling changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - request and backend transcript semantics changed; no rendered layout or styling changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic polling and transcript contracts are exercised below the visual layer.

<!-- evidence-row:backend-logs -->
- [x] Exact-head backend verification:

```text
shared onboarding service: 54 passed, 0 failed, 289 assertions
Cloud API Hono route: 12 passed, 0 failed, 49 assertions
cloud/shared + cloud/api typecheck and lint passed; Worker production dry-run built successfully
```

<!-- evidence-row:frontend-logs -->
- [x] Exact-head frontend verification:

```text
homepage suite: 85 passed, 0 failed, 199 assertions
immediate poll and controlled 5000 ms retry both sent statusOnly:true without message
ready-state and unmount cleanup prevented subsequent scheduled requests; typecheck/lint/build passed
```

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - polling, reply selection, and transcript persistence are deterministic and model-free.

<!-- evidence-row:domain-artifacts -->
- [x] Handoff/transcript contract:

```text
Five repeated status-only Hono requests returned the exact initial message count and assistant content.
The persisted session history did not grow, a status-only payload carrying a message did not create a user turn,
and the managed-agent remember transcript contained one real user line with no poll-generated assistant duplicates.
```

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text or visual artifact changed.

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`, `RepoPrompt CE`, `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7ba2f23a45ccd1974d2a5f8a9fdf7eb1c29fad55:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-refresh:6efa1b8a -->

— [hermes/t3rpz] [codex/openai-gpt-5.6-sol]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@7ba2f23a45ccd1974d2a5f8a9fdf7eb1c29fad55:packages/skills/skills/contribute-to-eliza"} -->
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"N/A"} -->
