### PR TITLE
fix(ci): finish workflow-consolidation residue cleanup

### DIFF
--- a/.github/scripts/install-workflow-linters.sh
+++ b/.github/scripts/install-workflow-linters.sh
@@ -4,33 +4,24 @@
 set -euo pipefail
 
 ACTIONLINT_VERSION="1.7.12"
-ZIZMOR_VERSION="1.28.0"
 destination="${1:-${RUNNER_TEMP:-/tmp}/workflow-linters}"
 
 case "$(uname -s)-$(uname -m)" in
   Linux-x86_64)
     actionlint_asset="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
     actionlint_sha="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
-    zizmor_asset="zizmor-x86_64-unknown-linux-gnu.tar.gz"
-    zizmor_sha="e87b67160194884e375a46a12c57ccc904f762b53845f254fab7f17d98809c09"
     ;;
   Linux-aarch64|Linux-arm64)
     actionlint_asset="actionlint_${ACTIONLINT_VERSION}_linux_arm64.tar.gz"
     actionlint_sha="325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6"
-    zizmor_asset="zizmor-aarch64-unknown-linux-gnu.tar.gz"
-    zizmor_sha="324e43770cfacf4216f8aefb287263b5b5c733c85b03bf7583b5cc4a0460239e"
     ;;
   Darwin-x86_64)
     actionlint_asset="actionlint_${ACTIONLINT_VERSION}_darwin_amd64.tar.gz"
     actionlint_sha="5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644"
-    zizmor_asset="zizmor-x86_64-apple-darwin.tar.gz"
-    zizmor_sha="40a58d8560d65c71357b3977d0da425773bf8f10bf1ffd38099d963d3afdf3aa"
     ;;
   Darwin-arm64)
     actionlint_asset="actionlint_${ACTIONLINT_VERSION}_darwin_arm64.tar.gz"
     actionlint_sha="aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f"
-    zizmor_asset="zizmor-aarch64-apple-darwin.tar.gz"
-    zizmor_sha="54949bbd6b4c8527046bb8990bac9e0dab3eec787640f4e6199ae121dd1040be"
     ;;
   *)
     printf 'unsupported workflow-linter host: %s-%s\n' "$(uname -s)" "$(uname -m)" >&2
@@ -60,18 +51,11 @@ download_and_verify() {
 }
 
 actionlint_archive="$scratch/$actionlint_asset"
-zizmor_archive="$scratch/$zizmor_asset"
 download_and_verify \
   "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${actionlint_asset}" \
   "$actionlint_sha" \
   "$actionlint_archive"
-download_and_verify \
-  "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/${zizmor_asset}" \
-  "$zizmor_sha" \
-  "$zizmor_archive"
 
 tar -xzf "$actionlint_archive" -C "$scratch" actionlint
-tar -xzf "$zizmor_archive" -C "$scratch" zizmor
 install -m 0755 "$scratch/actionlint" "$destination/actionlint"
-install -m 0755 "$scratch/zizmor" "$destination/zizmor"
 printf '%s\n' "$destination"

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -66,22 +66,11 @@ jobs:
         run: >-
           "$RUNNER_TEMP/workflow-linters/actionlint"
           -config-file .github/actionlint.yaml
+          .github/workflows/ci.yml
           .github/workflows/develop-pr.yml
-          .github/workflows/develop-pr-gate.yml
           .github/workflows/cloud-tests.yml
           .github/workflows/gitleaks.yml
-          .github/workflows/local-inference-matrix.yml
-          .github/workflows/stale-base-guard.yml
           .github/workflows/test.yml
-
-      - name: Run zizmor on base-trusted workflows
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          "$RUNNER_TEMP/workflow-linters/zizmor"
-          --offline
-          .github/workflows/develop-pr-gate.yml
-          .github/workflows/stale-base-guard.yml
 
   typecheck:
     runs-on: ubuntu-latest

--- a/packages/cloud/scripts/bluebubbles-local-bridge.registered-e2e.test.ts
+++ b/packages/cloud/scripts/bluebubbles-local-bridge.registered-e2e.test.ts
@@ -181,6 +181,10 @@ describe("registered BlueBubbles local bridge E2E", () => {
           BLUEBUBBLES_BRIDGE_ID: bridgeId,
           BLUEBUBBLES_GATEWAY_PHONE_NUMBER: "+14155550123",
           BLUEBUBBLES_MESSAGES_DB_PATH: messagesDbPath,
+          BLUEBUBBLES_OUTBOUND_VALIDATION_PATH: join(
+            temporaryDirectory,
+            "outbound-validation.json",
+          ),
           BLUEBUBBLES_LOOPBACK_NORMALIZATION_ENABLED: "true",
           ELIZA_CLOUD_BLUEBUBBLES_URL: `http://127.0.0.1:${cloud.port}/api/webhooks/bluebubbles/${bridgeId}`,
           BLUEBUBBLES_AUTO_START: "false",

--- a/scripts/check-pr-agent-attribution.test.mjs
+++ b/scripts/check-pr-agent-attribution.test.mjs
@@ -433,18 +433,12 @@ describe("PR agent attribution", () => {
 
     // Filled template rows + full terminal footer must still pass the CI gate.
     const filled = template
-      .replace(
-        /`yes` \/ `no - human-only contribution`/,
-        "yes",
-      )
+      .replace(/`yes` \/ `no - human-only contribution`/, "yes")
       .replace(
         /`provider\/model-id` \/ `None - human-only contribution`/,
         "`xai/grok-4.5`",
       )
-      .replace(
-        /`client-name` \/ `None - human-only contribution`/,
-        "grok",
-      )
+      .replace(/`client-name` \/ `None - human-only contribution`/, "grok")
       .replace(
         /`owner\/repo@full-commit-sha:path` \/ `N\/A - no contribution skill used`/,
         "`elizaOS/eliza@0123456789abcdef0123456789abcdef01234567:packages/skills/skills/contribute-to-eliza`",
@@ -574,34 +568,6 @@ Attribution status: self-reported
     assert.match(workflow, /"\$BASE_SHA\.\.\.\$HEAD_SHA"/);
   });
 
-  it("carries both docs AI patch lanes into a develop-based policy-complete PR", () => {
-    const workflow = workflowSource(".github/workflows/docs-ci.yml");
-    assert.match(
-      workflow,
-      /git diff --no-ext-diff --no-textconv --binary\s*\\\s*"\$\{\{ steps\.link-base\.outputs\.sha \}\}" HEAD/,
-    );
-    assert.match(
-      workflow,
-      /git diff --no-ext-diff --no-textconv --binary\s*\\\s*"\$\{\{ steps\.quality-base\.outputs\.sha \}\}" HEAD/,
-    );
-    assert.match(workflow, /name: docs-link-fixes-\$\{\{ github\.run_id \}\}/);
-    assert.match(
-      workflow,
-      /name: docs-quality-fixes-\$\{\{ github\.run_id \}\}/,
-    );
-    assert.equal(
-      [...workflow.matchAll(/git apply --3way "\$patch"/g)].length,
-      1,
-      "the combined PR job must apply every downloaded patch through one fail-fast loop",
-    );
-    assert.match(workflow, /ref: develop/);
-    assert.match(workflow, /git config user\.name "github-actions\[bot\]"/);
-    assert.doesNotMatch(
-      workflow,
-      /git commit[\s\S]{0,180}\|\| (?:true|exit 0)/,
-    );
-  });
-
   it("normalizes only exact first-party Dependabot PRs with a valid visible policy", () => {
     const workflow = workflowSource(".github/workflows/pr.yaml");
     const jobStart = workflow.indexOf("  normalize-dependabot-body:");
@@ -708,10 +674,6 @@ Attribution status: self-reported
 
   it("discovers and validates every workflow-generated PR body", async () => {
     const workflowPaths = generatedPrWorkflowPaths();
-    assert.ok(
-      workflowPaths.length >= 1,
-      "expected all repository PR-creation workflows to be discovered",
-    );
     for (const workflowPath of workflowPaths) {
       const source = workflowSource(workflowPath);
       assert.match(


### PR DESCRIPTION
Closes #18132

## Summary

Later `develop` commits legitimately superseded four items from the original seven-path packet: the script-coupling allowlist landed, and the self-test aliases plus Windows command contract became live workflow dependencies. This exact patch carries only the remaining workflow-consolidation repairs:

- retargets `develop-pr.yml` actionlint to the five existing merge-critical workflows and removes the vacuous `zizmor` invocation whose only targets were deleted;
- removes the now-unused `zizmor` download, checksum, extraction, and installation path while preserving the pinned `actionlint` installer;
- keeps BlueBubbles outbound-validation state inside the relay test's owned temporary directory;
- removes the retired `docs-ci.yml` attribution assertion and the invalid “at least one generated PR workflow” requirement while continuing to validate every future workflow PR creator that discovery finds.

No product runtime, rendered UI, Windows lane, release authority, or unrelated test behavior changes are included.

## Exact proof

- Head: `310f5d6b213b4faf2cc070040ff10641ddcb6e0f`
- Tree: `b04dfeae176f75284f1aef9bdc4dc120975e5e1c`
- Parent/base: `7ba2f23a45ccd1974d2a5f8a9fdf7eb1c29fad55`
- Scope: one commit, exactly four intended paths, clean worktree, `git diff --check` PASS
- Rebase from reviewed `a74c583`: conflict-free; the original three-path repair remains patch-identical and the only source addition is the reviewer-requested removal of the unused `zizmor` installer path
- Node 24.15.0 attribution self-test: 20/20 PASS
- Isolated workflow-linter install: only pinned `actionlint` is installed; no unused `zizmor` binary or network dependency remains
- Pinned `actionlint` across `ci.yml`, `develop-pr.yml`, `cloud-tests.yml`, `gitleaks.yml`, and `test.yml`: PASS
- Real BlueBubbles relay subprocess E2E: 1/1, 40 assertions; no repository residue
- `bun run test:scripts`: PASS
- `RUN_TURBO_CONCURRENCY=4 bun run verify`: 346/346 plus every audit PASS

## Trusted-base bootstrap

`check-pr-evidence` deliberately loads and executes validator tests from the PR base SHA. Base `7ba2f23a` still contains the stale test that opens deleted `.github/workflows/docs-ci.yml` and requires at least one workflow PR creator, so this PR's own evidence check cannot observe the validator repair it carries.

Landing therefore requires fresh exact-head human approval, every other attributable exact-head check green, and an explicit maintainer bootstrap merge. Immediately after merge, the validator must pass from the new base and a fresh evidence run must recover.

## Evidence

<!-- evidence-head:310f5d6b213b4faf2cc070040ff10641ddcb6e0f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - repository and CI hygiene only; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - repository and CI hygiene only; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production backend behavior changed; the targeted relay subprocess proof is recorded in Exact proof above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, action, provider, prompt, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - repository-policy cleanup produces no user-domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7ba2f23a45ccd1974d2a5f8a9fdf7eb1c29fad55:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@7ba2f23a45ccd1974d2a5f8a9fdf7eb1c29fad55:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@7ba2f23a45ccd1974d2a5f8a9fdf7eb1c29fad55:packages/skills/skills/contribute-to-eliza"} -->
