### PR TITLE
fix(plugin-elizacloud): terminate empty agent inventory

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -5559,6 +5559,8 @@ describe("runV5MessageRuntimeStage1", () => {
 // reply, and byte-identical echoes stay deduped without `turnComplete`.
 describe("verified read actions own the turn's single user-facing message", () => {
 	const CALENDAR_ANSWER = "clear tomorrow.";
+	const CLOUD_EMPTY_ANSWER =
+		"You don't have any agents hosted on Eliza Cloud yet. You can provision one from the Cloud console, or ask me to create one.";
 
 	function makeCalendarReadAction(handler: Action["handler"]): Action {
 		return {
@@ -5643,6 +5645,85 @@ describe("verified read actions own the turn's single user-facing message", () =
 		expect(delivered).toEqual([CALENDAR_ANSWER]);
 		// The gated evaluator skips the paraphrase-capable model call outright:
 		// Stage 1 + planner only, no in-loop evaluator call remains queued.
+		expect(useModelCalls(runtime).map((call) => call[0])).toEqual([
+			ModelType.RESPONSE_HANDLER,
+			ModelType.ACTION_PLANNER,
+		]);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent).toBeNull();
+			expect(result.result.responseMessages).toEqual([]);
+		}
+	});
+
+	it("delivers the CLOUD_LIST_AGENTS zero-agent answer exactly once with no evaluator call", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["cloud", "settings"],
+				candidateActionNames: ["CLOUD_LIST_AGENTS"],
+				replyText: "",
+				extra: { requiresTool: true },
+			}),
+			{
+				thought: "Read the owner's hosted agent inventory.",
+				toolCalls: [
+					{
+						id: "cloud-list-agents-1",
+						name: "CLOUD_LIST_AGENTS",
+						args: {},
+					},
+				],
+			},
+		]);
+		const cloudListHandler = vi.fn(
+			async (_runtime, _message, _state, _options, callback) => {
+				await callback?.({
+					text: CLOUD_EMPTY_ANSWER,
+					source: "action",
+					action: "CLOUD_LIST_AGENTS",
+				});
+				return {
+					success: true,
+					text: "User has no hosted Eliza Cloud agents.",
+					userFacingText: CLOUD_EMPTY_ANSWER,
+					verifiedUserFacing: true,
+					turnComplete: true,
+					data: { count: 0, agents: [] },
+				};
+			},
+		);
+		runtime.actions = [
+			{
+				name: "CLOUD_LIST_AGENTS",
+				similes: ["MY_CLOUD_AGENTS"],
+				tags: ["domain:cloud", "capability:read"],
+				description: "List the owner's hosted Eliza Cloud agents.",
+				contexts: ["cloud", "settings"],
+				suppressPostActionContinuation: true,
+				validate: async () => true,
+				handler: cloudListHandler,
+			} as Action,
+		] as never;
+		const deliveredVisibleTexts = new Set<string>();
+		const delivered: string[] = [];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "what cloud agents do I have?" }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+			deliveredVisibleTexts,
+			callback: async (content) => {
+				if (content.text) {
+					delivered.push(content.text);
+					deliveredVisibleTexts.add(content.text.toLowerCase());
+				}
+				return [];
+			},
+		});
+
+		expect(cloudListHandler).toHaveBeenCalledTimes(1);
+		expect(delivered).toEqual([CLOUD_EMPTY_ANSWER]);
 		expect(useModelCalls(runtime).map((call) => call[0])).toEqual([
 			ModelType.RESPONSE_HANDLER,
 			ModelType.ACTION_PLANNER,

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-account-actions.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-account-actions.test.ts
@@ -152,7 +152,26 @@ describe("CLOUD_LIST_AGENTS", () => {
     expect(result.success).toBe(true);
     expect(result.data).toMatchObject({ count: 0 });
     expect(replies[0]?.text).toContain("don't have any agents hosted");
-    // Empty states stay un-gated so the evaluator may still add guidance.
+    // The callback already contains the complete empty-state answer and both
+    // supported next steps, so no evaluator may paraphrase it into bubble two.
+    expect(result.verifiedUserFacing).toBe(true);
+    expect(result.turnComplete).toBe(true);
+  });
+
+  it("keeps the signed-out recovery path non-terminal", async () => {
+    const runtime = makeRuntime({ baseUrl: server.url, authenticated: false });
+    const { replies, callback } = collectCallback();
+    const result = await listCloudAgentsAction.handler(
+      runtime,
+      message("my hosted agents"),
+      STATE,
+      undefined,
+      callback
+    );
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({ reason: "not_connected" });
+    expect(replies[0]?.text).toContain("not connected to Eliza Cloud");
+    expect(result.verifiedUserFacing).toBeUndefined();
     expect(result.turnComplete).toBeUndefined();
   });
 
@@ -169,6 +188,8 @@ describe("CLOUD_LIST_AGENTS", () => {
     );
     expect(result.success).toBe(false);
     expect(result.data).toMatchObject({ reason: "error" });
+    expect(result.verifiedUserFacing).toBeUndefined();
+    expect(result.turnComplete).toBeUndefined();
   });
 });
 

--- a/plugins/plugin-elizacloud/src/actions/list-cloud-agents.ts
+++ b/plugins/plugin-elizacloud/src/actions/list-cloud-agents.ts
@@ -67,6 +67,12 @@ export const listCloudAgentsAction: Action = {
           success: true,
           text: "User has no hosted Eliza Cloud agents.",
           userFacingText: EMPTY_MESSAGE,
+          verifiedUserFacing: true,
+          // The callback already delivered the complete empty-state answer and
+          // both supported next steps. Mark it terminal just like a non-empty
+          // inventory so the evaluator cannot paraphrase it into a second
+          // user-visible bubble.
+          turnComplete: true,
           data: { count: 0, agents: [] },
         };
       }
@@ -86,7 +92,7 @@ export const listCloudAgentsAction: Action = {
         // A single-operation read whose delivered reply IS the complete
         // answer: the gated-evaluator skip stops the model from re-rendering
         // the already-delivered list as a second message (same opt-in as
-        // LIST_CLOUD_APPS). Empty/error exits stay un-gated.
+        // LIST_CLOUD_APPS). Failure exits stay un-gated.
         turnComplete: true,
         data: {
           count: agents.length,


### PR DESCRIPTION
Closes #18120

# Relates to

- [x] This PR targets `develop` at `6659f25cd20eea80e4ad4a8a61a1e541b21551df`; `git merge-tree --write-tree origin/develop HEAD` is conflict-free.
- [ ] Full `bun run verify` is delegated to the freshly rebased exact-head CI. The affected packages, full action/evaluator test files, typechecks, build, formatting, and diff checks are green below.
- [x] The evidence below proves the callback is the sole user-visible delivery and that recovery failures remain non-terminal.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on the latest `origin/develop` at publication time; zero conflicts and `0 behind / 1 ahead`.
- [ ] Full repository verification is deferred to CI until the freshly rebased exact-head CI completes. Focused current-head proof is complete.

# Risks

Low. The runtime change adds the existing verified-terminal markers only to the successful zero-agent inventory. New negative assertions keep signed-out and Cloud API failures non-terminal so the evaluator may still provide recovery guidance.

# Background

## What does this PR do?

`CLOUD_LIST_AGENTS` already callback-delivers a complete empty-state answer with both supported next steps. It nevertheless omitted `verifiedUserFacing` and `turnComplete`, leaving the paraphrase-capable evaluator free to create a second semantic bubble.

This patch puts that designed empty state on the same terminal read contract as a non-empty inventory. It also adds a real Stage-1 action/evaluator regression proving one callback delivery and no evaluator model call.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No product documentation change is needed; the action result contract and tests document the behavior.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-elizacloud/src/actions/list-cloud-agents.ts`
2. `plugins/plugin-elizacloud/__tests__/unit/cloud-account-actions.test.ts`
3. `packages/core/src/__tests__/message-runtime-stage1.test.ts`

## Detailed testing steps

- `plugins/plugin-elizacloud` full unit suite: **27 files, 215 passed, 2 skipped**.
- Core Stage-1 message-runtime file: **120/120 passed**.
- Focused Cloud account action file: **17/17 passed**.
- Focused terminal-read group: **6 passed, 114 skipped**.
- Plugin typecheck: PASS.
- Core typecheck: PASS.
- Core Node/browser/edge/testing build: PASS.
- Plugin Node/browser/CJS/views build plus built-package import: PASS.
- Biome on changed product/test files: PASS.
- `git diff --check`: PASS.

# Evidence Gate

<!-- evidence-head:bae555cd162dd481e7d793f38d6ec76ecede98d4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes; this is an action-result delivery contract.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive frontend flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no external backend or provider call is required; loopback SDK tests exercise empty, signed-out, and API-error results deterministically.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the corrected contract intentionally prevents the evaluator/model call. The hermetic Stage-1 trajectory asserts exactly `RESPONSE_HANDLER` then `ACTION_PLANNER`, one callback delivery, and no third evaluator call.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head action/evaluator contract proof.

<details>
<summary>Domain artifact transcript</summary>

```text
plugins/plugin-elizacloud full unit suite: 27 files, 215 passed, 2 skipped.
Core Stage-1 message-runtime file: 120/120 passed; focused Cloud account action file: 17/17 passed.
Terminal-read regression: RESPONSE_HANDLER then ACTION_PLANNER, one callback delivery, and no evaluator/model follow-up call.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or text layout changes.

# Evidence Details

## Real LLM-call trajectory

N/A: this regression is specifically that a successful terminal read must not make the post-action model call. The deterministic runtime queue would throw on any unexpected third call, and the exact test additionally asserts the two permitted model slots.

## Backend + frontend logs

N/A: no live service, credential, login, provider, deployment, or paid resource is involved.

## Screenshots (before / after) + video walkthrough

N/A: no UI file or rendered surface changed.

## Audio / voice walkthrough

N/A: no voice path changed.

## Known gaps / failures

- Full root `bun run verify` is delegated to the freshly rebased exact-head CI; the focused current-develop proof below is green.
- An initial isolated package build reached source compilation but could not verify workspace imports until current core/shared/Cloud SDK artifacts were built in the worktree. After building those exact-current dependencies, the full plugin build and built-package import passed.
- No real provider trajectory was run: the acceptance invariant is the absence of that provider/evaluator call, proven at the real message-loop boundary without credentials or cost.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza"} -->



