### PR TITLE
fix(cloud): land login funnel in agent chat

### DIFF
--- a/packages/ui/src/cloud/app-mode/app-mode.ts
+++ b/packages/ui/src/cloud/app-mode/app-mode.ts
@@ -39,6 +39,19 @@ export const APP_MODE_HOSTNAMES: ReadonlySet<string> = new Set([
   "app-staging.elizacloud.ai",
 ]);
 
+/** Trusted apex-console → app-host pairing for cross-origin product entry. */
+export function appModeOriginForApexHostname(hostname: string): string | null {
+  switch (hostname.toLowerCase()) {
+    case "elizacloud.ai":
+    case "www.elizacloud.ai":
+      return "https://app.elizacloud.ai";
+    case "staging.elizacloud.ai":
+      return "https://app-staging.elizacloud.ai";
+    default:
+      return null;
+  }
+}
+
 /** Dev-only app-mode emulation: the app hosts are never `localhost`, so the
  * entry routing is otherwise untestable in `vite dev`. Vite inlines the env
  * read on literal access, and production-mode packages/app builds REFUSE to

--- a/packages/ui/src/cloud/join/JoinPage.apex-handoff.test.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.apex-handoff.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Mounts the authenticated join page at the real production apex origin and
+ * proves its app-host handoff wins before any agent selection or provisioning.
+ */
+// @vitest-environment jsdom
+// @vitest-environment-options {"url": "https://elizacloud.ai/join"}
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { appModeNavigation } from "../app-mode/app-mode";
+
+const { runJoinFlowMock } = vi.hoisted(() => ({
+  runJoinFlowMock: vi.fn(),
+}));
+
+vi.mock("./lib/use-join-session", () => ({
+  useJoinSessionAuth: () => ({ ready: true, authenticated: true }),
+}));
+
+vi.mock("./lib/run-join-flow", () => ({
+  runJoinFlow: runJoinFlowMock,
+}));
+
+vi.mock("../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? "",
+}));
+
+import JoinPage from "./JoinPage";
+
+const realReplace = appModeNavigation.replace;
+let replacedUrls: string[];
+
+beforeEach(() => {
+  runJoinFlowMock.mockReset();
+  replacedUrls = [];
+  appModeNavigation.replace = (url: string) => {
+    replacedUrls.push(url);
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  appModeNavigation.replace = realReplace;
+});
+
+describe("JoinPage apex app handoff", () => {
+  it("replaces to the paired app origin before provisioning", async () => {
+    render(<JoinPage />);
+
+    await waitFor(() => {
+      expect(replacedUrls).toEqual(["https://app.elizacloud.ai/"]);
+    });
+    expect(window.location.hostname).toBe("elizacloud.ai");
+    expect(runJoinFlowMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/cloud/join/JoinPage.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.tsx
@@ -28,8 +28,10 @@ import {
   savePersistedFirstRunComplete,
 } from "../../state/persistence";
 import { openCloudBillingConsole } from "../billing-console";
+import { appModeNavigation } from "../app-mode/app-mode";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { describeJoinCreditGateError } from "./lib/join-credit-gate-error";
+import { resolveApexJoinHandoff } from "./lib/apex-app-handoff";
 import {
   resolveJoinAuthToken,
   resolveJoinCloudApiBase,
@@ -76,6 +78,10 @@ export default function JoinPage(): React.JSX.Element {
   const [creditGateWithheldReason, setCreditGateWithheldReason] = useState<
     "ip_daily_cap" | "count_unavailable" | null
   >(null);
+  const appHandoff =
+    typeof window === "undefined"
+      ? null
+      : resolveApexJoinHandoff(window.location.hostname);
   // Guard so React StrictMode's double-mount (and re-renders) don't double-run
   // the provisioning network calls.
   const startedRef = useRef(false);
@@ -113,7 +119,7 @@ export default function JoinPage(): React.JSX.Element {
       // the resolved agent in scope for future telemetry without unused-var noise.
       void result;
       if (typeof window !== "undefined") {
-        window.location.assign("/");
+        appModeNavigation.assign("/");
       }
     } catch (err) {
       // The Cloud's credit gate (402) is a payment state, not a connection
@@ -138,12 +144,19 @@ export default function JoinPage(): React.JSX.Element {
   }, []);
 
   useEffect(() => {
-    if (!session.ready) return;
-    if (!session.authenticated) return;
+    if (!session.ready || !session.authenticated) return;
+    if (appHandoff) {
+      // The apex is the billing console and cannot boot chat. Hand off before
+      // any join/provisioning request. The app host restores the domain-wide
+      // session through the existing SSO bridge, then its entry gate selects
+      // or provisions the agent and opens chat.
+      appModeNavigation.replace(appHandoff);
+      return;
+    }
     if (startedRef.current) return;
     startedRef.current = true;
     void start();
-  }, [session.ready, session.authenticated, start]);
+  }, [session.ready, session.authenticated, appHandoff, start]);
 
   const handleRetry = useCallback(() => {
     startedRef.current = true;

--- a/packages/ui/src/cloud/join/JoinPage.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.tsx
@@ -27,11 +27,11 @@ import {
   savePersistedActiveServer,
   savePersistedFirstRunComplete,
 } from "../../state/persistence";
-import { openCloudBillingConsole } from "../billing-console";
 import { appModeNavigation } from "../app-mode/app-mode";
+import { openCloudBillingConsole } from "../billing-console";
 import { useCloudT } from "../shell/CloudI18nProvider";
-import { describeJoinCreditGateError } from "./lib/join-credit-gate-error";
 import { resolveApexJoinHandoff } from "./lib/apex-app-handoff";
+import { describeJoinCreditGateError } from "./lib/join-credit-gate-error";
 import {
   resolveJoinAuthToken,
   resolveJoinCloudApiBase,

--- a/packages/ui/src/cloud/join/lib/apex-app-handoff.test.ts
+++ b/packages/ui/src/cloud/join/lib/apex-app-handoff.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { resolveApexJoinHandoff } from "./apex-app-handoff";
+
+describe("apex /join app handoff", () => {
+  it("routes production and staging apex hosts to their paired app chat host", () => {
+    expect(resolveApexJoinHandoff("elizacloud.ai")).toBe(
+      "https://app.elizacloud.ai/",
+    );
+    expect(resolveApexJoinHandoff("www.elizacloud.ai")).toBe(
+      "https://app.elizacloud.ai/",
+    );
+    expect(resolveApexJoinHandoff("staging.elizacloud.ai")).toBe(
+      "https://app-staging.elizacloud.ai/",
+    );
+  });
+
+  it("never redirects app, preview, per-agent, or lookalike hosts", () => {
+    expect(resolveApexJoinHandoff("app.elizacloud.ai")).toBeNull();
+    expect(resolveApexJoinHandoff("preview.pages.dev")).toBeNull();
+    expect(resolveApexJoinHandoff("agent.elizacloud.ai")).toBeNull();
+    expect(resolveApexJoinHandoff("elizacloud.ai.evil.example")).toBeNull();
+  });
+});

--- a/packages/ui/src/cloud/join/lib/apex-app-handoff.ts
+++ b/packages/ui/src/cloud/join/lib/apex-app-handoff.ts
@@ -1,0 +1,12 @@
+import { appModeOriginForApexHostname } from "../../app-mode/app-mode";
+
+/**
+ * Resolve the trusted app-host destination for `/join` on an apex console.
+ * The app-mode pairing is an exact deployed-host allowlist, so previews,
+ * localhost, per-agent hosts, and attacker-controlled suffixes cannot become
+ * cross-origin navigation targets.
+ */
+export function resolveApexJoinHandoff(hostname: string): string | null {
+  const appOrigin = appModeOriginForApexHostname(hostname);
+  return appOrigin ? `${appOrigin}/` : null;
+}

--- a/packages/ui/src/cloud/public-pages/lib/login-return-to.test.ts
+++ b/packages/ui/src/cloud/public-pages/lib/login-return-to.test.ts
@@ -2,10 +2,9 @@
 // @vitest-environment jsdom
 
 /**
- * Post-login destination resolution: explicit returnTo always wins; the
- * default is host-dependent — the apex console (elizacloud.ai) lands on
- * /dashboard (the agent app never boots there), every other host keeps the
- * /join drop-into-chat flow. Protocol-relative values are rejected.
+ * Post-login destination resolution: explicit returnTo always wins; every
+ * host defaults to the /join drop-into-chat flow. Apex /join performs a
+ * trusted handoff to the paired app host. Protocol-relative values are rejected.
  */
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -31,13 +30,13 @@ describe("login return-to resolution", () => {
     });
   });
 
-  it("defaults to the /dashboard console on an apex control-plane host", () => {
+  it("defaults apex login to the /join drop-into-chat flow", () => {
     setHostname("elizacloud.ai");
-    expect(defaultLoginReturnTo()).toBe("/dashboard");
-    expect(resolveLoginReturnTo(params())).toBe("/dashboard");
+    expect(defaultLoginReturnTo()).toBe("/join");
+    expect(resolveLoginReturnTo(params())).toBe("/join");
   });
 
-  it("defaults to the /join drop-into-chat flow on app hosts", () => {
+  it("defaults app-host login to the /join drop-into-chat flow", () => {
     setHostname("app.elizacloud.ai");
     expect(defaultLoginReturnTo()).toBe("/join");
     setHostname("localhost");
@@ -55,9 +54,7 @@ describe("login return-to resolution", () => {
 
   it("rejects protocol-relative and external values", () => {
     setHostname("elizacloud.ai");
-    expect(resolveLoginReturnTo(params("//evil.example"))).toBe("/dashboard");
-    expect(resolveLoginReturnTo(params("https://evil.example"))).toBe(
-      "/dashboard",
-    );
+    expect(resolveLoginReturnTo(params("//evil.example"))).toBe("/join");
+    expect(resolveLoginReturnTo(params("https://evil.example"))).toBe("/join");
   });
 });

--- a/packages/ui/src/cloud/public-pages/lib/login-return-to.ts
+++ b/packages/ui/src/cloud/public-pages/lib/login-return-to.ts
@@ -5,18 +5,14 @@
  * round-trip (which can't carry it in the OAuth `redirect_uri`).
  */
 
-import { isApexControlPlaneHost } from "../../shell/apex-host";
-
-// The post-login landing is host-dependent. On the app domains the join flow
-// (`/join`) select-or-provisions a Cloud agent and drops the user straight
-// into chat (the headline migration outcome). On an apex control-plane host
-// (elizacloud.ai — the CONSOLE) chat doesn't exist and the agent app never
-// boots (see AppCatchAllRoute), so login lands on the `/dashboard` console
-// overview instead of running an agent-provisioning flow the console can't
-// use. Called by every post-auth surface (login, email magic-link callback,
-// invite accept) so they all agree.
+// Every successful login enters through `/join`. On an app host, that flow
+// selects or provisions the user's agent and opens chat. On an apex console
+// host, JoinPage immediately hands off to the paired app host before making
+// provisioning calls. Keeping the destination as a same-origin path preserves
+// OAuth returnTo safety while ensuring the billing console remains an explicit
+// destination, never the default login landing.
 export function defaultLoginReturnTo(): string {
-  return isApexControlPlaneHost() ? "/dashboard" : "/join";
+  return "/join";
 }
 const PENDING_OAUTH_RETURN_TO_KEY = "eliza.login.oauth.returnTo";
 const PENDING_OAUTH_RETURN_TO_TTL_MS = 10 * 60 * 1000;


### PR DESCRIPTION
## Problem
Fresh email/OAuth sign-ins on `elizacloud.ai` and `staging.elizacloud.ai` default to `/dashboard`, the billing console, even though the product/chat surface lives on the paired app host. Apex `/join` also provisions and then navigates to apex `/`, which sends the user back to the dashboard.

## Fix
- make `/join` the default post-login destination on every host
- on deployed apex `/join`, hand off immediately to the exact allowlisted paired app origin before any provisioning call
- let the existing cross-host SSO bridge restore the session on the app origin, where the app-mode entry gate selects/provisions the agent and opens chat
- preserve explicit `returnTo` destinations, so billing/dashboard remains directly reachable
- production and staging mappings are explicit; previews, localhost, per-agent hosts, and lookalikes do not cross-origin redirect

## Bidirectional proof
The updated regression test captures the behavior change directly:
- develop: apex `defaultLoginReturnTo()` expected `/dashboard`
- this PR: apex `defaultLoginReturnTo()` expects `/join`

The handoff matrix proves:
- `elizacloud.ai` / `www.elizacloud.ai` -> `https://app.elizacloud.ai/`
- `staging.elizacloud.ai` -> `https://app-staging.elizacloud.ai/`
- app/preview/per-agent/lookalike hosts -> no handoff

## Validation
- `bunx vitest run` across the mounted `JoinPage`, apex mapping, login return, app-entry (zero/existing agent), app-host SSO, and SSO bridge suites: **72/72 pass**
- Mounted `JoinPage` proof starts at exact `https://elizacloud.ai/join`, asserts `replace("https://app.elizacloud.ai/")`, and proves `runJoinFlow` is never called before the cross-origin handoff
- `bun run --cwd packages/app audit:app`: **214/215 pass**; all 212 views rendered with `broken=0`, and the only gate failure is four unrelated pre-existing minimalism-ratchet findings in builtin browser/plugins/trajectories views (full report attached; no baseline was refreshed)
- Biome on all touched files passes
- `git diff --check` passes

No production deploy. No check weakening or auto-merge.

## Evidence

<!-- evidence-head:c5c5794d1f18683c62abfd125c0024e1a6f288d4 -->

<!-- evidence-row:before-screenshots -->
- [x] ![base apex join failure](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18138-before-apex-join.png) — merge-base browser at the production apex hostname stays on `/join`, calls the unsupported apex agents endpoint, and renders the 502 dead end.

<!-- evidence-row:after-screenshots -->
- [x] ![repaired app-host arrival](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18138-after-app-handoff-f44d.png) — exact-head browser reaches the real `https://app.elizacloud.ai/` product shell and its sign-in onboarding state.

<!-- evidence-row:walkthrough-video -->
- [x] [exact-head apex-to-app browser recording](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18138-page@8ce85ffc13957cf9c4edf113733de8df.webm)

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend implementation changed.

<!-- evidence-row:frontend-logs -->
- [x] [72-test exact-head funnel contract](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18138-pr18138-funnel-contract-tests-c5c.txt); the attached walkthrough records the source-identical browser origin transition before the final develop rebase.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic navigation and auth-routing code does not invoke a model.

<!-- evidence-row:domain-artifacts -->
- [x] [18138-app-audit-report-v2.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18138-app-audit-report-v2.json)

<!-- evidence-row:ocr-review -->
- [x] [direct visual and text review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/18138-ocr-visual-review-f44d.txt)

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS repository review workflow
Attribution status: maintainer review and repair recorded
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/repository-review"} -->

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5 (maintainer remediation; system-reported model family, deployment variant unavailable)
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - installed Codex plugin packages do not expose a repository commit SHA
<!-- attribution-row:status -->
- Provenance status: self-reported
