### PR TITLE
test(ci): guard Smoke Playwright bootstrap

### DIFF
--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -11,6 +11,46 @@ import { fileURLToPath } from "node:url";
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 const githubRoot = join(repoRoot, ".github");
 
+type WorkflowStep = {
+  if?: string;
+  name?: string;
+  run?: string;
+};
+
+const smokeBrowserInstallCommand =
+  "PLAYWRIGHT_INSTALL_CWD=packages/app .github/scripts/install-playwright-browsers.sh chromium webkit";
+
+function assertSmokeE2eBrowserBootstrap(source: string): void {
+  const workflow = Bun.YAML.parse(source) as {
+    jobs?: { smoke?: { steps?: WorkflowStep[] } };
+  };
+  const steps = workflow.jobs?.smoke?.steps ?? [];
+  const installIndex = steps.findIndex(
+    (step) => step.run === smokeBrowserInstallCommand,
+  );
+  const e2eIndex = steps.findIndex((step) => step.run === "bun run test:e2e");
+
+  if (installIndex < 0) {
+    throw new Error("Smoke must install Chromium and WebKit before E2E");
+  }
+  if (e2eIndex < 0) {
+    throw new Error("Smoke must retain the deterministic E2E command");
+  }
+  if (installIndex >= e2eIndex) {
+    throw new Error("Smoke must install browsers before running E2E");
+  }
+
+  const zeroKeyCondition = "needs.changes.outputs.zero_key == 'true'";
+  if (
+    steps[installIndex]?.if !== zeroKeyCondition ||
+    steps[e2eIndex]?.if !== zeroKeyCondition
+  ) {
+    throw new Error(
+      "Smoke browser bootstrap and E2E must share the zero-key condition",
+    );
+  }
+}
+
 function collectYamlFiles(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const path = join(directory, entry.name);
@@ -127,16 +167,45 @@ describe("GitHub action supply-chain references", () => {
     );
   });
 
+  test("installs both app browser engines before deterministic smoke E2E", () => {
+    const source = readFileSync(
+      join(githubRoot, "workflows", "ci.yml"),
+      "utf8",
+    );
+
+    expect(() => assertSmokeE2eBrowserBootstrap(source)).not.toThrow();
+    expect(() =>
+      assertSmokeE2eBrowserBootstrap(
+        source.replace(
+          smokeBrowserInstallCommand,
+          "echo browser-install-removed",
+        ),
+      ),
+    ).toThrow("Smoke must install Chromium and WebKit before E2E");
+
+    const installStep = `      - name: Install Playwright browsers
+        if: needs.changes.outputs.zero_key == 'true'
+        run: ${smokeBrowserInstallCommand}
+
+`;
+    const afterE2e = source
+      .replace(installStep, "")
+      .replace(
+        "        run: bun run test:e2e\n",
+        (command) => `${command}\n${installStep}`,
+      );
+    expect(() => assertSmokeE2eBrowserBootstrap(afterE2e)).toThrow(
+      "Smoke must install browsers before running E2E",
+    );
+  });
+
   test("provisions homepage Chromium without requiring self-hosted sudo", () => {
     const source = readFileSync(
       join(githubRoot, "workflows", "quality.yml"),
       "utf8",
     );
     const workflow = Bun.YAML.parse(source) as {
-      jobs?: Record<
-        string,
-        { "runs-on"?: string; "timeout-minutes"?: number }
-      >;
+      jobs?: Record<string, { "runs-on"?: string; "timeout-minutes"?: number }>;
     };
     const job = workflow.jobs?.["homepage-build"];
     const formatGate = workflow.jobs?.["format-check"];


### PR DESCRIPTION
Follow-up to #18139

## Summary

Current develop now provisions Chromium and WebKit before the canonical CI Smoke E2E command through commit ae5260923ade914eddee795cf5d0b9d1fbcf9b9b. This rebased follow-up keeps only the missing regression contract.

The parsed YAML contract proves that the Smoke job:

- retains the repository-owned Chromium and WebKit installer with the app Playwright working directory;
- runs that installer before bun run test:e2e;
- uses the same zero-key condition for installation and E2E;
- fails closed when the install step is missing or moved after E2E.

No workflow command, product runtime, or deployment path changes in this PR.

## Exact-head validation

- Base: fc96a7499ec6e757a56812fdb8d252d5b4787f07
- Head: 540e3414d60cb314893228c80862f1b5c794d907
- Tree: ed7fcf7da35e4777ae4d43c0550c11a1d94d3aea
- Scope: one test file, one commit
- Node 24.15.0, Bun 1.3.14
- bun test packages/scripts/__tests__/github-action-pinning.test.ts --no-env-file: 11/11 PASS
- Missing-step negative fixture: expected failure, Smoke must install Chromium and WebKit before E2E
- Wrong-order negative fixture: expected failure, Smoke must install browsers before running E2E
- Biome 2.5.6: PASS
- git diff --check: PASS

The original hosted failure is run 31303575208, job 93220282749. No workflow was retried or dispatched while preparing this change.

## Evidence

<!-- evidence-head:e071a7dbfdf9313390812ad47c1be9f8731cc507 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI contract only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI contract only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - the diff changes only a workflow pinning contract test and a UI-smoke spec; no server process runs in this change.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Workflow pinning contract run on the current head:

<details><summary>bun test github-action-pinning — output</summary>

```
$ bun test packages/scripts/__tests__/github-action-pinning.test.ts
bun test v1.3.14 (0d9b296a)
 11 pass
 0 fail
 38 expect() calls
Ran 11 tests across 1 file. [516.00ms]
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@e37924817dd457f3c5cc1547531c7054336a3740:packages/skills/skills/contribute-to-eliza"} -->




