### PR TITLE
fix(ci): finish workflow-consolidation residue cleanup

### DIFF
--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -67,8 +67,8 @@ jobs:
           "$RUNNER_TEMP/workflow-linters/actionlint"
           -config-file .github/actionlint.yaml
           .github/workflows/ci.yml
-          .github/workflows/develop-pr.yml
           .github/workflows/cloud-tests.yml
+          .github/workflows/develop-pr.yml
           .github/workflows/gitleaks.yml
           .github/workflows/test.yml
 

--- a/packages/cloud/scripts/bluebubbles-local-bridge.registered-e2e.test.ts
+++ b/packages/cloud/scripts/bluebubbles-local-bridge.registered-e2e.test.ts
@@ -183,7 +183,15 @@ describe("registered BlueBubbles local bridge E2E", () => {
           BLUEBUBBLES_MESSAGES_DB_PATH: messagesDbPath,
           BLUEBUBBLES_OUTBOUND_VALIDATION_PATH: join(
             temporaryDirectory,
-            "outbound-validation.json",
+            "bluebubbles-outbound-validation.json",
+          ),
+          BLUEBUBBLES_SHORTCUT_INPUT_DIR: join(
+            temporaryDirectory,
+            "bluebubbles-shortcut-inputs",
+          ),
+          BLUEBUBBLES_PENDING_REPLIES_PATH: join(
+            temporaryDirectory,
+            "bluebubbles-pending-replies.json",
           ),
           BLUEBUBBLES_LOOPBACK_NORMALIZATION_ENABLED: "true",
           ELIZA_CLOUD_BLUEBUBBLES_URL: `http://127.0.0.1:${cloud.port}/api/webhooks/bluebubbles/${bridgeId}`,

--- a/scripts/check-pr-agent-attribution.test.mjs
+++ b/scripts/check-pr-agent-attribution.test.mjs
@@ -674,6 +674,11 @@ Attribution status: self-reported
 
   it("discovers and validates every workflow-generated PR body", async () => {
     const workflowPaths = generatedPrWorkflowPaths();
+    // When the repository has no workflow-generated PRs (the docs-ci.yml
+    // lane was consolidated away), there is nothing to validate. The loop
+    // below still covers every discovered workflow, so this guard stays
+    // meaningful once a new PR-creating workflow is added.
+    if (workflowPaths.length === 0) return;
     for (const workflowPath of workflowPaths) {
       const source = workflowSource(workflowPath);
       assert.match(


### PR DESCRIPTION
Fixes #18132

## Summary

Seven-path residual after the half-landed workflow consolidation that blocked clean feature branches from completing required gates.

## Changes

### 1. Plugin coupling allowlist entries (audit-scripts)

`ci-path-gate.mjs` and `check-scenario-workflow-coverage.mjs` hardcode structural plugin sets that cannot be derived from per-package metadata:
- **ci-path-gate.mjs**: the `android_aab` lane enumerates the exact 10 plugins bundled into the release AAB
- **check-scenario-workflow-coverage.mjs**: the 4 scenario-bearing plugins counted and validated by the scenario checker

Added systemic-coupling allowlist entries to `script-plugin-coupling.allowlist.json` with durable reasons.

### 2. Deleted dead develop-pr-aggregate files

`develop-pr-aggregate.mjs` and its `develop-pr-aggregate.self-test.mjs` were dead code — the Develop PR Gate workflow they served was consolidated away. The self-test also imported `develop-pr-aggregate-workflow-contract.mjs` which was already deleted, making it a broken module. Both deleted.

### 3. Deleted orphaned Windows command contract pair

`.github/ci-windows-command-inventory.json` and `packages/scripts/ci-windows-command-coverage-contract.mjs` were resurrected even though the Windows contract lane was consolidated away. Only referenced each other. Both deleted.

### 4. BlueBubbles relay E2E artifact hermeticity

The registered relay E2E (`bluebubbles-local-bridge.registered-e2e.test.ts`) set `BLUEBUBBLES_MESSAGES_DB_PATH` to a temp directory but did NOT set `BLUEBUBBLES_OUTBOUND_VALIDATION_PATH`, `BLUEBUBBLES_SHORTCUT_INPUT_DIR`, or `BLUEBUBBLES_PENDING_REPLIES_PATH`. The bridge defaults those to `process.cwd()/.eliza-local/`, writing residue into the repository tree. Fixed by redirecting all three to the test-owned temporary directory.

### 5. Removed docs-ci.yml test assertions

`check-pr-agent-attribution.test.mjs` had two failing assertions:
- Test 19 ("carries both docs AI patch lanes"): opened deleted `.github/workflows/docs-ci.yml` — removed entirely
- Test 21 ("discovers and validates every workflow-generated PR body"): required >= 1 workflow-generated PR but the current topology has zero — updated to early-return when zero discovered while still validating every found workflow

### 6. develop-pr.yml actionlint/zizmor cleanup

The actionlint step named three deleted workflows (`develop-pr-gate.yml`, `local-inference-matrix.yml`, `stale-base-guard.yml`); the zizmor step named two deleted workflows. Fixed actionlint to target only surviving merge-critical workflows (`ci.yml`, `cloud-tests.yml`, `develop-pr.yml`, `gitleaks.yml`, `test.yml`); removed the vacuous zizmor step entirely.

## Verification

| Check | Result |
|-------|--------|
| `node packages/scripts/audit-scripts.mjs --json` | `{"ok": true}` — zero findings |
| `node --test scripts/check-pr-agent-attribution.test.mjs` | 20/20 pass |
| `node packages/scripts/ci-workflow-invariants.mjs` | contract passed |
| `node packages/scripts/audit-scripts.self-test.mjs` | self-test passed |
| `bun run test:scripts` | all pass except pre-existing flaky `atomic release refs` timeout (same on clean develop) |
| BlueBubbles relay E2E | pre-existing failure (missing `BLUEBUBBLES_GATEWAY_SECRET` env — unrelated to this PR; artifact paths now hermetic) |

<details>
<summary>audit-scripts output (clean)</summary>

```
$ node packages/scripts/audit-scripts.mjs --json
{
  "ok": true,
  "failures": []
}
```
</details>

<details>
<summary>PR attribution test output (20/20)</summary>

```
$ node --test scripts/check-pr-agent-attribution.test.mjs
# tests 20
# pass 20
# fail 0
```
</details>

<details>
<summary>ci-workflow-invariants output</summary>

```
$ node packages/scripts/ci-workflow-invariants.mjs
ci-workflow-invariants: merge-critical workflow contract passed
```
</details>

<!-- contribution-attribution:v1 -->
<!-- attribution-row:provider --> Provider: zai
<!-- attribution-row:models --> Model(s) used: `glm-5.2`
<!-- attribution-row:client --> Agent tooling: Hermes Agent
<!-- attribution-row:skill-revision --> Skill path: elizaOS/eliza@59ffb5ef600e7e86f7c6bb3a0c76e87c8d6e3cb2:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status --> Provenance status: self-reported
<!-- evidence-head:3dbaf640e929c0d21b4fa5cf12eac2798da90fd3 -->

<!-- evidence-row:backend-logs -->
- [ ] N/A - CI script-only change; verification logs are inline in the PR body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - CI script-only change; no frontend code modified

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI script-only change; no UI surface modified

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI script-only change; no UI surface modified

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CI script-only change; no user-facing behavior changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - CI script-only change; no model or inference path touched

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - CI script-only change; no runtime domain artifacts produced

<!-- evidence-row:ocr-review -->
- [ ] N/A - CI script-only change; no rendered text to OCR

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@59ffb5ef600e7e86f7c6bb3a0c76e87c8d6e3cb2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@59ffb5ef600e7e86f7c6bb3a0c76e87c8d6e3cb2:packages/skills/skills/contribute-to-eliza"} -->


