### PR TITLE
test(core): restore real document embedding regression contracts

### DIFF
--- a/packages/core/src/features/documents/service-batch-embed.test.ts
+++ b/packages/core/src/features/documents/service-batch-embed.test.ts
@@ -1,36 +1,26 @@
 /**
- * Unit tests for `DocumentService`'s batched fragment-embedding path
- * (`TEXT_EMBEDDING_BATCH`): one batch call embeds every fragment in order, and an
- * absent batch model or a wrong-shaped batch result falls back to the serial
- * per-fragment embed with no fragment left unembedded. Drives `createMockRuntime`
- * with a deterministic text-derived fake embedding (a vector traces back to the
- * exact fragment text) — no live model or DB.
+ * Exercises batched document embeddings through a real AgentRuntime model
+ * registry and in-memory persistence, including both serial fallback paths.
  */
 import { describe, expect, test } from "vitest";
-import { createMockRuntime } from "../../testing/mock-runtime";
-import type { Memory, UUID } from "../../types";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import type { Character, JsonValue, Memory, UUID } from "../../types";
 import { ModelType } from "../../types";
 import { DocumentService } from "./service.ts";
 
+const AGENT_ID = "00000000-0000-0000-0000-00000000b47c" as UUID;
+const ITEM_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID;
 const DOCUMENT_FRAGMENTS_TABLE = "document_fragments";
 
-/**
- * Deterministic, text-derived "embedding": distinct per distinct text so a
- * vector can be traced back to the exact text it was generated from. This lets
- * the tests prove (1) the right vector landed on the right fragment (ordering)
- * and (2) the batch path embeds the SAME text the serial path embeds.
- */
 function vecOf(text: string): number[] {
-	let h = 0;
-	for (let i = 0; i < text.length; i++) {
-		h = (h * 31 + text.charCodeAt(i)) >>> 0;
+	let hash = 0;
+	for (let index = 0; index < text.length; index++) {
+		hash = (hash * 31 + text.charCodeAt(index)) >>> 0;
 	}
-	return [h % 100000, text.length];
+	return [hash % 100_000, text.length];
 }
 
-// Six distinct ~70-char paragraphs. With the small split target below each
-// paragraph becomes its own fragment (two never fit in one chunk), so every
-// run produces several fragments with distinct text → distinct vectors.
 const DOC_TEXT = [
 	"Alpha paragraph: the quick brown fox reviews the refund policy details.",
 	"Bravo paragraph: service level agreements and uptime commitments listed.",
@@ -40,10 +30,11 @@ const DOC_TEXT = [
 	"Foxtrot paragraph: security posture, encryption at rest and in transit.",
 ].join("\n\n");
 
-// Force several small fragments regardless of the default 1500-token target.
-const SPLIT_OPTS = { targetTokens: 24, overlap: 2, modelContextSize: 4096 };
-
-const ITEM_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID;
+const SPLIT_OPTIONS = {
+	targetTokens: 24,
+	overlap: 2,
+	modelContextSize: 4096,
+};
 
 function makeItem() {
 	return {
@@ -53,167 +44,209 @@ function makeItem() {
 	};
 }
 
-interface Captured {
-	fragments: Memory[];
-	documents: Memory[];
+type ModelParams = Record<string, JsonValue | object>;
+
+function requireText(params: ModelParams): string {
+	const text = params.text;
+	if (typeof text !== "string") {
+		throw new Error("Single embedding request must contain text");
+	}
+	return text;
 }
 
-/** Snapshot persisted memories per table, copying the embedding at call time. */
-function captureCreateMemory(captured: Captured) {
-	return async (memory: Memory, table: string): Promise<UUID> => {
-		const snapshot: Memory = {
-			...memory,
-			embedding: memory.embedding ? [...memory.embedding] : undefined,
-		};
-		if (table === DOCUMENT_FRAGMENTS_TABLE) {
-			captured.fragments.push(snapshot);
-		} else {
-			captured.documents.push(snapshot);
+function requireTexts(params: ModelParams): string[] {
+	const texts = params.texts;
+	if (!Array.isArray(texts)) {
+		throw new Error("Batch embedding request must contain texts");
+	}
+	const validated: string[] = [];
+	for (const text of texts) {
+		if (typeof text !== "string") {
+			throw new Error("Batch embedding texts must all be strings");
 		}
-		return memory.id as UUID;
-	};
+		validated.push(text);
+	}
+	return validated;
 }
 
-describe("DocumentService — batched fragment embedding (TEXT_EMBEDDING_BATCH)", () => {
-	test("batch model registered → ONE batch call embeds all fragments in order and persists them", async () => {
-		let batchCalls = 0;
-		let singleEmbedCalls = 0;
-		let serialEmbedCalls = 0;
-		let batchTexts: string[] = [];
-		const captured: Captured = { fragments: [], documents: [] };
+interface HarnessOptions {
+	single: (text: string) => number[] | Promise<number[]>;
+	batch?: (texts: string[]) => number[][] | Promise<number[][]>;
+}
 
-		const runtime = createMockRuntime({
-			getMemoryById: async () => null,
-			updateMemory: async () => true,
-			createMemory: captureCreateMemory(captured),
-			// Presence (truthiness) of a batch handler is all the service checks.
-			getModel: (type: string) =>
-				type === ModelType.TEXT_EMBEDDING_BATCH
-					? async () => [] // never invoked; useModel is used instead
-					: undefined,
-			useModel: (type: string, params: { text?: string; texts?: string[] }) => {
-				if (type === ModelType.TEXT_EMBEDDING_BATCH) {
-					batchCalls++;
-					batchTexts = params.texts ?? [];
-					return Promise.resolve(batchTexts.map(vecOf));
-				}
-				if (type === ModelType.TEXT_EMBEDDING) {
-					singleEmbedCalls++;
-					return Promise.resolve(vecOf(params.text ?? ""));
-				}
-				throw new Error(`unexpected model ${type}`);
+async function makeHarness(options: HarnessOptions): Promise<{
+	runtime: AgentRuntime;
+	service: DocumentService;
+}> {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.initialize();
+	const runtime = new AgentRuntime({
+		agentId: AGENT_ID,
+		character: {
+			name: "DocumentBatchEmbeddingTestAgent",
+			bio: "Exercises document embedding storage semantics.",
+			settings: {},
+		} as Character,
+		adapter,
+		logLevel: "fatal",
+	});
+	runtime.registerModel(
+		ModelType.TEXT_EMBEDDING,
+		async (_runtime, params) => options.single(requireText(params)),
+		"document-batch-test-single",
+		100,
+	);
+	const batch = options.batch;
+	if (batch) {
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING_BATCH,
+			async (_runtime, params) => batch(requireTexts(params)),
+			"document-batch-test-batch",
+			100,
+		);
+	}
+	return { runtime, service: new DocumentService(runtime) };
+}
+
+function fragmentPosition(fragment: Memory): number {
+	const position = fragment.metadata?.position;
+	if (typeof position !== "number") {
+		throw new Error(`Fragment ${fragment.id} has no numeric position`);
+	}
+	return position;
+}
+
+async function getStoredFragments(runtime: AgentRuntime): Promise<Memory[]> {
+	const memories = await runtime.getMemories({
+		tableName: DOCUMENT_FRAGMENTS_TABLE,
+		agentId: AGENT_ID,
+		roomId: AGENT_ID,
+		count: 20,
+	});
+	return memories
+		.filter((memory) => memory.metadata?.documentId === ITEM_ID)
+		.sort((left, right) => fragmentPosition(left) - fragmentPosition(right));
+}
+
+function expectTextDerivedEmbeddings(fragments: Memory[]): void {
+	for (const fragment of fragments) {
+		const text = fragment.content.text;
+		if (typeof text !== "string") {
+			throw new Error(`Fragment ${fragment.id} has no text`);
+		}
+		expect(fragment.embedding).toEqual(vecOf(text));
+	}
+}
+
+describe("DocumentService batched fragment embedding", () => {
+	test("uses one batch call and persists every ordered vector", async () => {
+		const batches: string[][] = [];
+		let singleCalls = 0;
+		const { runtime, service } = await makeHarness({
+			single: (text) => {
+				singleCalls++;
+				return vecOf(text);
 			},
-			addEmbeddingToMemory: async (memory: Memory) => {
-				serialEmbedCalls++;
-				memory.embedding = vecOf(memory.content.text ?? "");
-				return memory;
+			batch: (texts) => {
+				batches.push([...texts]);
+				return texts.map(vecOf);
 			},
 		});
 
-		const service = new DocumentService(runtime);
-		await service._internalAddDocument(makeItem(), SPLIT_OPTS);
+		await service._internalAddDocument(makeItem(), SPLIT_OPTIONS);
 
-		// Multiple fragments → batching is meaningful.
-		expect(captured.fragments.length).toBeGreaterThanOrEqual(2);
-		// Exactly ONE batch round-trip (not N), and the serial path untouched.
+		const fragments = await getStoredFragments(runtime);
+		expect(fragments).toHaveLength(6);
+		expect(batches).toHaveLength(1);
+		expect(singleCalls).toBe(0);
+		expect(batches[0]).toEqual(
+			fragments.map((fragment) => fragment.content.text),
+		);
+		expectTextDerivedEmbeddings(fragments);
+		await expect(runtime.getMemoryById(ITEM_ID)).resolves.toMatchObject({
+			id: ITEM_ID,
+			metadata: { documentId: ITEM_ID },
+		});
+	});
+
+	test("uses the real single-model path when no batch model is registered", async () => {
+		const singleTexts: string[] = [];
+		const { runtime, service } = await makeHarness({
+			single: (text) => {
+				singleTexts.push(text);
+				return vecOf(text);
+			},
+		});
+
+		expect(runtime.getModel(ModelType.TEXT_EMBEDDING_BATCH)).toBeUndefined();
+		await service._internalAddDocument(makeItem(), SPLIT_OPTIONS);
+
+		const fragments = await getStoredFragments(runtime);
+		expect(fragments).toHaveLength(6);
+		expect(singleTexts).toEqual(
+			fragments.map((fragment) => fragment.content.text),
+		);
+		expectTextDerivedEmbeddings(fragments);
+	});
+
+	test("rejects a one-of-six batch result and serially embeds every fragment", async () => {
+		let batchCalls = 0;
+		const singleTexts: string[] = [];
+		const { runtime, service } = await makeHarness({
+			single: (text) => {
+				singleTexts.push(text);
+				return vecOf(text);
+			},
+			batch: () => {
+				batchCalls++;
+				return [[0, 0]];
+			},
+		});
+
+		await service._internalAddDocument(makeItem(), SPLIT_OPTIONS);
+
+		const fragments = await getStoredFragments(runtime);
+		expect(fragments).toHaveLength(6);
 		expect(batchCalls).toBe(1);
-		expect(singleEmbedCalls).toBe(0);
-		expect(serialEmbedCalls).toBe(0);
-		// The batch embedded exactly the fragment texts (count match).
-		expect(batchTexts.length).toBe(captured.fragments.length);
-		// Every fragment was persisted WITH its embedding, and that embedding is
-		// the vector for ITS OWN text — proving the right vector landed on the
-		// right fragment (ordering) and that the embedded text matches what the
-		// serial addEmbeddingToMemory path would have embedded (content.text).
-		for (const fragment of captured.fragments) {
-			expect(fragment.embedding).toEqual(vecOf(fragment.content.text ?? ""));
-		}
-		// Batch texts are exactly the fragment texts, in fragment order.
-		expect(batchTexts).toEqual(
-			captured.fragments.map((f) => f.content.text ?? ""),
+		expect(singleTexts).toEqual(
+			fragments.map((fragment) => fragment.content.text),
+		);
+		expectTextDerivedEmbeddings(fragments);
+		expect(runtime.getRecentReportedErrors()).toContainEqual(
+			expect.objectContaining({
+				scope: "DocumentService.batchFragmentEmbedding",
+				message: "TEXT_EMBEDDING_BATCH returned 1 vectors for 6 fragments",
+				context: expect.objectContaining({ fragmentCount: 6 }),
+			}),
 		);
 	});
 
-	test("no batch model → falls back to the serial per-fragment path and embeds + persists all N", async () => {
-		let batchCalls = 0;
-		let serialEmbedCalls = 0;
-		const captured: Captured = { fragments: [], documents: [] };
-
-		const runtime = createMockRuntime({
-			getMemoryById: async () => null,
-			updateMemory: async () => true,
-			createMemory: captureCreateMemory(captured),
-			// A single-text model is registered, but no batch model.
-			getModel: (type: string) =>
-				type === ModelType.TEXT_EMBEDDING ? async () => [] : undefined,
-			useModel: (type: string) => {
-				if (type === ModelType.TEXT_EMBEDDING_BATCH) {
-					batchCalls++;
-				}
-				return Promise.resolve([]);
+	test("reports a batch provider error and persists serially generated vectors", async () => {
+		const singleTexts: string[] = [];
+		const { runtime, service } = await makeHarness({
+			single: (text) => {
+				singleTexts.push(text);
+				return vecOf(text);
 			},
-			addEmbeddingToMemory: async (memory: Memory) => {
-				serialEmbedCalls++;
-				memory.embedding = vecOf(memory.content.text ?? "");
-				return memory;
+			batch: () => {
+				throw new Error("batch embedding endpoint unavailable");
 			},
 		});
 
-		const service = new DocumentService(runtime);
-		await service._internalAddDocument(makeItem(), SPLIT_OPTS);
+		await service._internalAddDocument(makeItem(), SPLIT_OPTIONS);
 
-		expect(captured.fragments.length).toBeGreaterThanOrEqual(2);
-		// Batch model absent → batch is never attempted.
-		expect(batchCalls).toBe(0);
-		// One embed per fragment via the serial path.
-		expect(serialEmbedCalls).toBe(captured.fragments.length);
-		for (const fragment of captured.fragments) {
-			expect(fragment.embedding).toEqual(vecOf(fragment.content.text ?? ""));
-		}
-	});
-
-	test("batch returns the wrong vector count → falls back to serial (no fragment left unembedded)", async () => {
-		let batchCalls = 0;
-		let serialEmbedCalls = 0;
-		const reportedErrors: unknown[] = [];
-		const captured: Captured = { fragments: [], documents: [] };
-
-		const runtime = createMockRuntime({
-			getMemoryById: async () => null,
-			updateMemory: async () => true,
-			createMemory: captureCreateMemory(captured),
-			getModel: (type: string) =>
-				type === ModelType.TEXT_EMBEDDING_BATCH ? async () => [] : undefined,
-			useModel: (type: string) => {
-				if (type === ModelType.TEXT_EMBEDDING_BATCH) {
-					batchCalls++;
-					// WRONG shape: one vector for N (>= 2) texts → must trigger fallback.
-					return Promise.resolve([[0, 0]]);
-				}
-				throw new Error(`unexpected model ${type}`);
-			},
-			addEmbeddingToMemory: async (memory: Memory) => {
-				serialEmbedCalls++;
-				memory.embedding = vecOf(memory.content.text ?? "");
-				return memory;
-			},
-			reportError: (_scope, error) => {
-				reportedErrors.push(error);
-			},
-		});
-
-		const service = new DocumentService(runtime);
-		await service._internalAddDocument(makeItem(), SPLIT_OPTS);
-
-		expect(captured.fragments.length).toBeGreaterThanOrEqual(2);
-		// Batch was attempted exactly once, then abandoned for the serial path.
-		expect(batchCalls).toBe(1);
-		expect(serialEmbedCalls).toBe(captured.fragments.length);
-		expect(reportedErrors).toHaveLength(1);
-		// No fragment left unembedded; each carries the vector for its own text.
-		for (const fragment of captured.fragments) {
-			expect(fragment.embedding).toBeDefined();
-			expect(fragment.embedding).toEqual(vecOf(fragment.content.text ?? ""));
-		}
+		const fragments = await getStoredFragments(runtime);
+		expect(fragments).toHaveLength(6);
+		expect(singleTexts).toEqual(
+			fragments.map((fragment) => fragment.content.text),
+		);
+		expectTextDerivedEmbeddings(fragments);
+		expect(runtime.getRecentReportedErrors()).toContainEqual(
+			expect.objectContaining({
+				scope: "DocumentService.batchFragmentEmbedding",
+				message: "batch embedding endpoint unavailable",
+				context: expect.objectContaining({ fragmentCount: 6 }),
+			}),
+		);
 	});
 });

--- a/packages/core/src/features/documents/service-character-ingest.test.ts
+++ b/packages/core/src/features/documents/service-character-ingest.test.ts
@@ -1,13 +1,14 @@
 /**
- * Unit tests for `DocumentService` character-document ingestion under boot races:
- * it waits for a late `TEXT_EMBEDDING` registration before ingesting (rather than
- * writing empty-fragment stubs), and reprocesses an existing zero-fragment
- * document stub. Drives `createMockRuntime` with Vitest fake timers —
- * deterministic, no live model or DB.
+ * Exercises character-document boot races and atomic pre-chunked ingestion.
+ * Timing seams use a mock runtime; persistence and embedding failures use a real
+ * AgentRuntime, model registry, and in-memory adapter.
  */
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { ElizaError } from "../../errors";
+import { AgentRuntime } from "../../runtime";
 import { createMockRuntime, MOCK_AGENT_ID } from "../../testing/mock-runtime";
-import type { Memory, UUID } from "../../types";
+import type { Character, Memory, UUID } from "../../types";
 import { MemoryType, ModelType } from "../../types";
 import { DocumentService } from "./service.ts";
 
@@ -16,6 +17,33 @@ const DOCUMENT_FRAGMENTS_TABLE = "document_fragments";
 
 function embeddingFor(text: string): number[] {
 	return [text.length, 1, 0.5];
+}
+
+async function createRealRuntime(): Promise<AgentRuntime> {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.initialize();
+	return new AgentRuntime({
+		agentId: MOCK_AGENT_ID,
+		character: {
+			name: "DocumentCharacterIngestTestAgent",
+			bio: "Exercises character document persistence through the real runtime.",
+			settings: {},
+		} as Character,
+		adapter,
+		logLevel: "fatal",
+	});
+}
+
+async function getStoredMemories(
+	runtime: AgentRuntime,
+	tableName: string,
+): Promise<Memory[]> {
+	return runtime.getMemories({
+		tableName,
+		agentId: MOCK_AGENT_ID,
+		roomId: MOCK_AGENT_ID,
+		count: 20,
+	});
 }
 
 describe("DocumentService character document ingestion boot races", () => {
@@ -143,29 +171,8 @@ describe("DocumentService character document ingestion boot races", () => {
 	});
 
 	test("persists a pre-chunked parent and all anchored fragments in one batch", async () => {
-		const batches: Array<
-			Array<{ memory: Memory; tableName: string; unique?: boolean }>
-		> = [];
-		const runtime = createMockRuntime({
-			getSetting: () => undefined,
-			redactSecrets: (text: string) => text,
-			getModel: (type: string) =>
-				type === ModelType.TEXT_EMBEDDING
-					? async () => embeddingFor("registered")
-					: undefined,
-			getMemoryById: async () => null,
-			addEmbeddingToMemory: async (memory: Memory) => {
-				memory.embedding = embeddingFor(memory.content.text ?? "");
-				return memory;
-			},
-			createMemory: vi.fn(async () => {
-				throw new Error("single-row persistence must not run");
-			}),
-			createMemories: async (entries) => {
-				batches.push(entries);
-				return entries.map((entry) => entry.memory.id as UUID);
-			},
-		});
+		const runtime = await createRealRuntime();
+		const createMemories = vi.spyOn(runtime, "createMemories");
 		const service = new DocumentService(runtime);
 
 		const result = await service.addDocument({
@@ -190,42 +197,61 @@ describe("DocumentService character document ingestion boot races", () => {
 		});
 
 		expect(result.fragmentCount).toBe(2);
-		expect(batches).toHaveLength(1);
-		expect(batches[0].map((entry) => entry.tableName)).toEqual([
-			DOCUMENTS_TABLE,
+		expect(createMemories).toHaveBeenCalledTimes(1);
+		expect(createMemories.mock.calls[0]?.[0]).toHaveLength(3);
+		const documents = await getStoredMemories(runtime, DOCUMENTS_TABLE);
+		const fragments = await getStoredMemories(
+			runtime,
 			DOCUMENT_FRAGMENTS_TABLE,
-			DOCUMENT_FRAGMENTS_TABLE,
-		]);
-		expect(batches[0][1].memory.metadata).toMatchObject({
-			segmentIds: ["s1"],
-			startMs: 0,
-			endMs: 900,
-			position: 0,
-		});
+		);
+		expect(documents).toHaveLength(1);
+		expect(fragments).toHaveLength(2);
+		expect(
+			fragments.every((fragment) => fragment.embedding === undefined),
+		).toBe(true);
+		expect(fragments).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					metadata: expect.objectContaining({
+						segmentIds: ["s1"],
+						startMs: 0,
+						endMs: 900,
+						position: 0,
+					}),
+				}),
+				expect.objectContaining({
+					metadata: expect.objectContaining({
+						segmentIds: ["s2"],
+						startMs: 1000,
+						endMs: 1800,
+						position: 1,
+					}),
+				}),
+			]),
+		);
 	});
 
 	test("does not write the parent when any pre-chunked embedding fails", async () => {
-		const createMemories = vi.fn();
 		let embeddings = 0;
-		const runtime = createMockRuntime({
-			getSetting: () => undefined,
-			redactSecrets: (text: string) => text,
-			getModel: (type: string) =>
-				type === ModelType.TEXT_EMBEDDING
-					? async () => embeddingFor("registered")
-					: undefined,
-			getMemoryById: async () => null,
-			addEmbeddingToMemory: async (memory: Memory) => {
+		const runtime = await createRealRuntime();
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			async (_runtime, params) => {
+				const text = params.text;
+				if (typeof text !== "string") {
+					throw new Error("embedding input must contain text");
+				}
 				embeddings++;
-				if (embeddings === 1) memory.embedding = embeddingFor("first");
-				return memory;
+				return embeddings === 1 ? embeddingFor(text) : [];
 			},
-			createMemories,
-		});
+			"document-character-ingest-test",
+			100,
+		);
 		const service = new DocumentService(runtime);
 
-		await expect(
-			service.addDocument({
+		let thrown: unknown;
+		try {
+			await service.addDocument({
 				agentId: MOCK_AGENT_ID,
 				worldId: MOCK_AGENT_ID,
 				roomId: MOCK_AGENT_ID,
@@ -244,8 +270,33 @@ describe("DocumentService character document ingestion boot races", () => {
 						metadata: { segmentIds: ["s2"], startMs: 600, endMs: 1000 },
 					},
 				],
-			}),
-		).rejects.toThrow(/Failed to process document/);
-		expect(createMemories).not.toHaveBeenCalled();
+			});
+		} catch (error) {
+			thrown = error;
+		}
+
+		if (!(thrown instanceof ElizaError)) {
+			throw new Error("Expected document ingestion to throw ElizaError", {
+				cause: thrown,
+			});
+		}
+		expect(thrown.code).toBe("DOCUMENT_PROCESSING_FAILED");
+		expect(thrown.cause).toBeInstanceOf(ElizaError);
+		if (!(thrown.cause instanceof ElizaError)) {
+			throw new Error(
+				"Expected document failure to preserve its fragment cause",
+			);
+		}
+		expect(thrown.cause).toMatchObject({
+			code: "DOCUMENT_FRAGMENT_EMBED_FAILED",
+			context: { documentId: expect.any(String), position: 1 },
+		});
+		expect(embeddings).toBe(2);
+		await expect(getStoredMemories(runtime, DOCUMENTS_TABLE)).resolves.toEqual(
+			[],
+		);
+		await expect(
+			getStoredMemories(runtime, DOCUMENT_FRAGMENTS_TABLE),
+		).resolves.toEqual([]);
 	});
 });


### PR DESCRIPTION
Closes #18141

## Summary

The document regression fixtures now exercise the real runtime contract instead
of partial mocks that bypass model registration and persistence.

- `service-batch-embed.test.ts` drives ordered batch embedding, serial fallback,
  malformed batch counts, and provider failures through a real `AgentRuntime`,
  registered model handlers, and initialized `InMemoryDatabaseAdapter`;
- `service-character-ingest.test.ts` proves parent/fragment persistence, anchor
  metadata, the nested empty-embedding failure, and failure atomicity; and
- no production source, schema, prompt, model policy, or UI changes.

## Exact provenance

- Base: `2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6`
- Head: `f5443c345a98b6c4975512ad967613e3ae5c4481`
- Tree: `d8f978076ae17c4be78044024d2ce9aae2d14ff6`
- Scope: one commit touching exactly two test files
- Stable patch ID: `59b4b5ff3031e39b53132604ca16f87838b97654`,
  identical to the independently reviewed prepared and integration-tested patch
- Applied directly to current `develop` with zero conflicts

## Testing

- document batch, character-ingest, and regression-lane suites — 3 files,
  71/71 PASS
- `bun run --cwd packages/core typecheck` — PASS
- Biome over both changed files — PASS
- `git diff --check` and final worktree status — clean

The same stable patch also passed the combined integration train's Core matrix
and repository verify. Independent review found no P0/P1/P2 issue.

## Risk

Low. This is test-only. The fixtures use the real runtime model registry and
in-memory persistence while keeping deterministic embedding handlers.

## Evidence

<!-- evidence-head:5c147f40aa9321ec5f72592a58d4fc4ba569fcee -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Core test-only change; no rendered UI delta.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Core test-only change; no rendered UI delta.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production backend path changed; exact-head tests exercise the real runtime/model/persistence boundary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend source or request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no production model behavior changed; deterministic handlers are registered only inside tests.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - test-only regression contract; exact-head tests inspect in-memory persisted document and fragment rows plus atomic failure state, but no durable production artifact is created.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

## Documentation

N/A - no public API, configuration, or operator workflow changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6:packages/skills/skills/contribute-to-eliza"} -->
