### PR TITLE
fix(app): preserve audit projects across Playwright workers

### DIFF
--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -11,6 +11,11 @@ import { defineConfig, devices } from "@playwright/test";
 // derive the on-disk WAV from it for Chromium's --use-file-for-fake-audio-capture.
 import { KNOWN_PHRASE_WAV_DATA_URL } from "../ui/src/voice/voice-selftest/fixtures/known-phrase";
 import {
+  resolveRequestedAuditProjects,
+  UI_SMOKE_AUDIT_PROJECTS_ENV,
+  writeAuditProjectPropagation,
+} from "./scripts/lib/playwright-audit-projects.mjs";
+import {
   ASSERTION_GRADE_DASHBOARD_SPECS,
   DASHBOARD_E2E_DEVICE_MATRIX,
 } from "./test/ui-smoke/device-matrix";
@@ -67,14 +72,20 @@ const VOICE_MIC_SPEC = /(voice-realaudio|transcript-realaudio)\.spec\.ts/;
 const WEBKIT_POINTER_FOCUS_SPEC =
   /(chat-overlay-controls-interactions|conversation-management|slash-commands|plugin-views-visual)\.spec\.ts/;
 const webkitLaneEnabled = process.env.PLAYWRIGHT_WEBKIT === "1";
+const requestedAuditProjects = resolveRequestedAuditProjects({
+  argv: process.argv,
+  serialized: process.env[UI_SMOKE_AUDIT_PROJECTS_ENV],
+});
+// Playwright reloads this module inside workers without the launcher's CLI
+// arguments, so publish the allowlisted selection before that process boundary.
+writeAuditProjectPropagation(process.env, requestedAuditProjects);
 const projectRequested = (projectName: string): boolean =>
-  process.argv.some((value, index) => {
-    if (value === `--project=${projectName}`) return true;
-    return value === "--project" && process.argv[index + 1] === projectName;
-  });
+  requestedAuditProjects.includes(projectName);
 // The all-views aesthetic audit (#8796) walks ~50 views × 2 viewports; it is a
 // dedicated tool run via `audit:app`, not part of the default e2e smoke.
 const AUDIT_APP_SPEC = /all-views-aesthetic-audit\.spec\.ts/;
+const AUDIT_PROJECT_WORKER_CONTRACT_SPEC =
+  /audit-project-worker-contract\.spec\.ts/;
 const auditAppEnabled = projectRequested("audit-app");
 // Screenshot inventory for the offline vision-review tool. It records readiness
 // failures in JSON instead of asserting them, so it is an audit artifact
@@ -174,6 +185,7 @@ export default defineConfig({
         VOICE_MIC_SPEC,
         AI_QA_CAPTURE_SPEC,
         AUDIT_APP_SPEC,
+        AUDIT_PROJECT_WORKER_CONTRACT_SPEC,
         AUDIT_CLOUD_SPEC,
         AUDIT_APP_DROPDOWN_SPEC,
         /viewport-zoom-visualviewport\.spec\.ts/,
@@ -288,7 +300,7 @@ export default defineConfig({
             // All-views aesthetic audit (#8796) — run with `audit:app`
             // (`--project=audit-app`). Walks every view at desktop + mobile internally.
             name: "audit-app",
-            testMatch: AUDIT_APP_SPEC,
+            testMatch: [AUDIT_APP_SPEC, AUDIT_PROJECT_WORKER_CONTRACT_SPEC],
             use: {
               ...devices["Desktop Chrome"],
               ...withChromiumLaunchOptions(),
@@ -305,7 +317,7 @@ export default defineConfig({
             // VITE_PLAYWRIGHT_TEST_AUTH=true; the runner invalidates dist for this
             // project so a cached non-auth build cannot skip the local auth shell.
             name: "audit-cloud",
-            testMatch: AUDIT_CLOUD_SPEC,
+            testMatch: [AUDIT_CLOUD_SPEC, AUDIT_PROJECT_WORKER_CONTRACT_SPEC],
             use: {
               ...devices["Desktop Chrome"],
               ...withChromiumLaunchOptions(),
@@ -321,7 +333,10 @@ export default defineConfig({
             // renderer built with VITE_PLAYWRIGHT_TEST_AUTH=true so the Steward auth
             // shell serves the app-detail route.
             name: "audit-app-dropdown",
-            testMatch: AUDIT_APP_DROPDOWN_SPEC,
+            testMatch: [
+              AUDIT_APP_DROPDOWN_SPEC,
+              AUDIT_PROJECT_WORKER_CONTRACT_SPEC,
+            ],
             use: {
               ...devices["Desktop Chrome"],
               ...withChromiumLaunchOptions(),

--- a/packages/app/scripts/lib/playwright-audit-projects.mjs
+++ b/packages/app/scripts/lib/playwright-audit-projects.mjs
@@ -1,0 +1,68 @@
+/**
+ * Carries explicitly requested aesthetic-audit projects from the Playwright
+ * launcher into configuration reloads while keeping default E2E audit-free.
+ */
+
+export const UI_SMOKE_AUDIT_PROJECTS = Object.freeze([
+  "audit-app",
+  "audit-cloud",
+  "audit-app-dropdown",
+]);
+
+export const UI_SMOKE_AUDIT_PROJECTS_ENV =
+  "ELIZA_UI_SMOKE_REQUESTED_AUDIT_PROJECTS";
+
+export function auditProjectsRequestedByArgs(argv) {
+  const requested = new Set();
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    const project = value.startsWith("--project=")
+      ? value.slice("--project=".length)
+      : value === "--project"
+        ? argv[index + 1]
+        : null;
+    if (project && UI_SMOKE_AUDIT_PROJECTS.includes(project)) {
+      requested.add(project);
+    }
+  }
+  return UI_SMOKE_AUDIT_PROJECTS.filter((project) => requested.has(project));
+}
+
+export function propagatedAuditProjects(serialized) {
+  if (!serialized?.trim()) return [];
+  const projects = serialized
+    .split(",")
+    .map((project) => project.trim())
+    .filter(Boolean);
+  const unsupported = projects.filter(
+    (project) => !UI_SMOKE_AUDIT_PROJECTS.includes(project),
+  );
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Unsupported propagated UI-smoke audit project(s): ${unsupported.join(", ")}`,
+    );
+  }
+  return UI_SMOKE_AUDIT_PROJECTS.filter((project) =>
+    projects.includes(project),
+  );
+}
+
+export function resolveRequestedAuditProjects({ argv, serialized }) {
+  const requested = new Set([
+    ...auditProjectsRequestedByArgs(argv),
+    ...propagatedAuditProjects(serialized),
+  ]);
+  return UI_SMOKE_AUDIT_PROJECTS.filter((project) => requested.has(project));
+}
+
+export function writeAuditProjectPropagation(targetEnv, projects) {
+  const requested = new Set(projects);
+  const serialized = UI_SMOKE_AUDIT_PROJECTS.filter((project) =>
+    requested.has(project),
+  ).join(",");
+  if (serialized) {
+    targetEnv[UI_SMOKE_AUDIT_PROJECTS_ENV] = serialized;
+  } else {
+    delete targetEnv[UI_SMOKE_AUDIT_PROJECTS_ENV];
+  }
+}

--- a/packages/app/scripts/playwright-audit-projects.test.mjs
+++ b/packages/app/scripts/playwright-audit-projects.test.mjs
@@ -1,0 +1,187 @@
+/**
+ * Exercises the app runner through real Playwright launcher and worker
+ * processes, including stale-environment isolation for default E2E.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  auditProjectsRequestedByArgs,
+  propagatedAuditProjects,
+  resolveRequestedAuditProjects,
+  UI_SMOKE_AUDIT_PROJECTS,
+  UI_SMOKE_AUDIT_PROJECTS_ENV,
+  writeAuditProjectPropagation,
+} from "./lib/playwright-audit-projects.mjs";
+
+const appDir = path.resolve(import.meta.dirname, "..");
+const runner = path.join(appDir, "scripts", "run-ui-playwright.mjs");
+const workerContract = "test/ui-smoke/audit-project-worker-contract.spec.ts";
+
+function runPlaywright(args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.platform === "win32" ? "node.exe" : "node",
+      [runner, ...args],
+      {
+        cwd: appDir,
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, 20_000);
+    child.once("close", (code, signal) => {
+      clearTimeout(timeout);
+      if (timedOut) {
+        reject(
+          new Error(
+            `Playwright audit-project regression timed out.\n${stdout}${stderr}`,
+          ),
+        );
+        return;
+      }
+      resolve({ code, signal, stdout, stderr });
+    });
+  });
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe("audit-project propagation contract", () => {
+  test("normalizes both Playwright project argument forms", () => {
+    expect(
+      auditProjectsRequestedByArgs([
+        "--project=chromium",
+        "--project=audit-cloud",
+        "--project",
+        "audit-app",
+        "--project=audit-cloud",
+      ]),
+    ).toEqual(["audit-app", "audit-cloud"]);
+    expect(
+      resolveRequestedAuditProjects({
+        argv: ["--project=audit-app-dropdown"],
+        serialized: "audit-cloud",
+      }),
+    ).toEqual(["audit-cloud", "audit-app-dropdown"]);
+  });
+
+  test("rejects unsupported propagated names", () => {
+    expect(() => propagatedAuditProjects("audit-app,chromium")).toThrow(
+      "Unsupported propagated UI-smoke audit project(s): chromium",
+    );
+  });
+
+  test("overwrites and clears propagation state", () => {
+    const env = { [UI_SMOKE_AUDIT_PROJECTS_ENV]: "audit-app" };
+    writeAuditProjectPropagation(env, ["audit-cloud"]);
+    expect(env[UI_SMOKE_AUDIT_PROJECTS_ENV]).toBe("audit-cloud");
+    writeAuditProjectPropagation(env, []);
+    expect(env).not.toHaveProperty(UI_SMOKE_AUDIT_PROJECTS_ENV);
+  });
+});
+
+test("propagates audit projects to workers without enabling them by default", async () => {
+  const tempRoot = mkdtempSync(
+    path.join(tmpdir(), "eliza-audit-project-propagation-"),
+  );
+  const server = http.createServer((_, response) => {
+    response.writeHead(200, { "content-type": "text/plain" });
+    response.end("audit project regression\n");
+  });
+
+  await listen(server);
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error(
+      "Audit-project regression server did not expose a TCP port.",
+    );
+  }
+
+  const baseEnv = {
+    ...process.env,
+    ELIZA_AUDIT_APP_DIR: path.join(tempRoot, "audit-output"),
+    ELIZA_UI_SMOKE_REUSE_SERVER: "1",
+    ELIZA_UI_SMOKE_PORT: String(address.port),
+    ELIZA_UI_SMOKE_SKIP_BUILD: "1",
+    ELIZA_UI_SMOKE_SKIP_CORE_BUILD: "1",
+    ELIZA_UI_SMOKE_SKIP_VIEW_BUILD: "1",
+    ELIZA_UI_SMOKE_VIEW_LOCK_NAMESPACE: `audit-project-regression-${process.pid}`,
+  };
+
+  try {
+    for (const project of UI_SMOKE_AUDIT_PROJECTS) {
+      const result = await runPlaywright(
+        [
+          "--config",
+          "playwright.ui-smoke.config.ts",
+          `--project=${project}`,
+          workerContract,
+        ],
+        baseEnv,
+      );
+      expect(
+        result.code,
+        `${project} failed across the Playwright worker boundary:\n${result.stdout}${result.stderr}`,
+      ).toBe(0);
+      expect(`${result.stdout}${result.stderr}`).not.toContain(
+        `Project "${project}" not found in the worker process`,
+      );
+    }
+
+    const defaultResult = await runPlaywright(
+      [
+        "--config",
+        "playwright.ui-smoke.config.ts",
+        "--list",
+        "--pass-with-no-tests",
+        workerContract,
+      ],
+      {
+        ...baseEnv,
+        [UI_SMOKE_AUDIT_PROJECTS_ENV]: "audit-app",
+      },
+    );
+    expect(
+      defaultResult.code,
+      `default E2E project selection failed:\n${defaultResult.stdout}${defaultResult.stderr}`,
+    ).toBe(0);
+    expect(defaultResult.stdout).toMatch(/Total:\s+0 tests/);
+    for (const project of UI_SMOKE_AUDIT_PROJECTS) {
+      expect(defaultResult.stdout).not.toContain(`[${project}]`);
+    }
+  } finally {
+    await close(server);
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}, 45_000);

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -9,6 +9,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { getFreePort } from "../test/utils/get-free-port.mjs";
 import { resolveAuditAppOutput } from "./lib/audit-output.mjs";
+import {
+  auditProjectsRequestedByArgs,
+  writeAuditProjectPropagation,
+} from "./lib/playwright-audit-projects.mjs";
 import { withElizaSourceNodeOptions } from "./lib/playwright-node-options.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -159,6 +163,9 @@ function resolveNodeCommand() {
 }
 
 const env = { ...process.env };
+// Derive the handoff from this invocation alone so a stale parent environment
+// can never opt the default E2E command into a dedicated audit project.
+writeAuditProjectPropagation(env, auditProjectsRequestedByArgs(playwrightArgs));
 delete env.NO_COLOR;
 delete env.FORCE_COLOR;
 delete env.CLICOLOR_FORCE;

--- a/packages/app/test/ui-smoke/audit-project-worker-contract.spec.ts
+++ b/packages/app/test/ui-smoke/audit-project-worker-contract.spec.ts
@@ -1,0 +1,14 @@
+/**
+ * Verifies that each opt-in aesthetic-audit project remains identifiable in a
+ * real Playwright worker after the launcher process has loaded configuration.
+ */
+
+import { expect, test } from "@playwright/test";
+import { UI_SMOKE_AUDIT_PROJECTS } from "../../scripts/lib/playwright-audit-projects.mjs";
+
+test("worker retains the explicitly requested audit project", ({
+  browserName,
+}, testInfo) => {
+  expect(browserName).toBe("chromium");
+  expect(UI_SMOKE_AUDIT_PROJECTS).toContain(testInfo.project.name);
+});


### PR DESCRIPTION
Closes #18151

## Summary

Dedicated aesthetic-audit projects were present while Playwright first loaded the config, but disappeared when the config was reloaded in worker processes because those workers no longer had the launcher's `--project` arguments. This repair:

- carries only the allowlisted `audit-app`, `audit-cloud`, and `audit-app-dropdown` selections across the launcher/worker boundary;
- clears inherited propagation state for ordinary E2E runs so audit projects remain opt-in;
- adds a real launcher-to-Chromium-worker contract for all three projects and the default no-audit path;
- restores a complete `audit:app` run with all computed and OCR verdicts green.

No product route, component, visual style, API, database, or runtime-agent behavior changes.

## Exact provenance

- Head: `e9b3e9dff436d52bd841748161e9ab13af1f93e7`
- Tree: `3121e30062adf1ecc4bf85aaf82adf53e933a29b`
- Parent/base: `456c20c4bb3d1e77b1f6424e8c5e559354e20c8f`
- Scope: one clean commit touching exactly five app test-runner/config files
- Rebase from reviewed `18c2f580fa5faca0a84edee4d63e81ad001f026b`: conflict-free; `git range-diff` is exact `=`
- Independent source/contract review: PASS, no P0/P1/P2

## Testing

- `bun test scripts/playwright-audit-projects.test.mjs` — 4/4 PASS, 16 assertions, including real launcher/Chromium-worker processes
- `bun run --cwd packages/app audit:app` — 215/215 PASS; 212 captures; computed broken=0 and needs-work=0; OCR broken=0
- manual inspection — 12 heuristic captures plus fallback classes, desktop, and tablet reviewed
- `bun run --cwd packages/app typecheck` — PASS
- `bun run --cwd packages/app build:web` — PASS
- exact five-path Biome and `git diff --check` — PASS
- `bun run verify` — 346/346 tasks plus all audits PASS on the exact rebased head

## Risks

Low and bounded to Playwright project selection. The main risk is accidentally enabling expensive audit projects in default E2E; the runner deliberately derives propagation from the current invocation only, and the real regression test starts with stale inherited state and proves zero default audit tests are selected.

## Documentation

N/A - no public product, API, configuration, or operator command changed. Existing audit commands now execute their documented projects correctly.

## Evidence

Full run evidence and manual review notes: https://github.com/elizaOS/eliza/issues/18151#issuecomment-5230993149

<!-- evidence-head:e9b3e9dff436d52bd841748161e9ab13af1f93e7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this fixes the audit runner boundary; it does not change rendered product pixels.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this fixes the audit runner boundary; it does not change rendered product pixels.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production backend path changed.
<!-- evidence-row:frontend-logs -->
- [x] Real launcher and Chromium-worker output is captured in the issue evidence and the 4/4 process-level regression.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The full audit produced 212 captures and its report; computed and OCR verdicts were reviewed and are green.
<!-- evidence-row:ocr-review -->
- [x] OCR reviewed all 212 captures with broken=0; representative heuristic/fallback/desktop/tablet captures were manually inspected.

## Known gaps / failures

- The full app package Vitest lane is 623/624 on this base because `ui-smoke-coverage.test.ts` still references the separately tracked, consolidation-deleted `all-views-interaction.spec.ts`. This packet does not touch that inventory or semantic harness; focused runner tests, the real full audit, app typecheck/build, and root verify all pass.
- The current trusted-base PR evidence self-test is independently broken by retired `docs-ci.yml` assumptions and is being repaired in #18136; this branch cannot self-heal a validator intentionally loaded from its base.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@456c20c4bb3d1e77b1f6424e8c5e559354e20c8f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
