### PR TITLE
fix(voice): route realtime consent/mint to the control-plane Worker on managed-cloud pairings

### DIFF
--- a/packages/ui/src/hooks/useRealtimeVoiceMint.dedicated-base.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceMint.dedicated-base.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Regression lock for LOGIN-FLOW-AUDIT 2026-08-09 cliff #3: on a DEDICATED
+ * cloud pairing (active server = `https://<agentId>.staging.elizacloud.ai`)
+ * the DEFAULT consent fetch must target the control-plane Worker — the
+ * consent route does not exist in the agent container, so a relative
+ * same-origin path 404s and the first voice tap dies with "Cartesia voice
+ * could not confirm microphone consent".
+ *
+ * These tests drive the hook's REAL default fetch path (no injected `fetch`)
+ * with the real persisted-server resolution mocked to the dedicated pairing
+ * state, and assert on the URL that reaches the shared CSRF fetch boundary.
+ * On a build without control-plane routing the consent POST arrives as the
+ * relative path (which `fetchWithCsrf` then resolves against the AGENT base)
+ * — exactly the live 404 — so this fails before the fix and passes after.
+ */
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const DEDICATED_AGENT_ID = "ef2fa8ee-1111-4222-8333-444455556666";
+const DEDICATED_BASE = `https://${DEDICATED_AGENT_ID}.staging.elizacloud.ai`;
+
+// The real csrf-client pulls the native (Capacitor) transport chain that is
+// not resolvable in this worktree; the assertion boundary here is the URL the
+// production code hands it, so a spy module is the honest seam.
+const fetchWithCsrf = vi.fn(
+  async (_url: string, _init?: RequestInit) =>
+    new Response(JSON.stringify({ consentNonce: "nonce-live" }), {
+      status: 200,
+    }),
+);
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: (url: string, init?: RequestInit) => fetchWithCsrf(url, init),
+}));
+
+// Real persisted-pairing state for the dedicated path: the active server is
+// the per-agent staging subdomain and the dedicated agent id resolves.
+vi.mock("../state/persistence", () => ({
+  loadPersistedActiveServer: () => ({
+    id: `cloud:${DEDICATED_AGENT_ID}`,
+    kind: "cloud",
+    label: "Eliza",
+    apiBase: DEDICATED_BASE,
+  }),
+}));
+vi.mock("../state/agent-session-recovery", () => ({
+  resolveDedicatedAgentId: () => DEDICATED_AGENT_ID,
+}));
+
+// The URL resolver reads the ACTIVE api base global; pin it to the dedicated
+// agent base exactly as the paired app does.
+vi.mock("../utils/eliza-globals", () => ({
+  getElizaApiBase: () => DEDICATED_BASE,
+}));
+
+import { useRealtimeVoiceMint } from "./useRealtimeVoiceMint";
+
+afterEach(() => {
+  fetchWithCsrf.mockClear();
+  window.localStorage.clear();
+});
+
+describe("useRealtimeVoiceMint on a dedicated cloud pairing (default fetch)", () => {
+  it("POSTs consent to the control-plane Worker, never the agent subdomain", async () => {
+    const { result } = renderHook(() => useRealtimeVoiceMint());
+    expect(result.current.agentId).toBe(DEDICATED_AGENT_ID);
+
+    const nonce = await result.current.getConsentNonce();
+    expect(nonce).toBe("nonce-live");
+
+    expect(fetchWithCsrf).toHaveBeenCalledTimes(1);
+    const [url] = fetchWithCsrf.mock.calls[0];
+    // The staging dedicated base must map to the staging control-plane API
+    // host. A relative path here is the 404 bug: fetchWithCsrf resolves it
+    // against the agent base, where the route does not exist.
+    expect(url).toBe(
+      "https://api-staging.elizacloud.ai/api/v1/voice/session/consent",
+    );
+  });
+
+  it("carries the Steward session bearer on the cross-origin consent call", async () => {
+    window.localStorage.setItem("steward_session_token", "steward-jwt");
+    const { result } = renderHook(() => useRealtimeVoiceMint());
+    await result.current.getConsentNonce();
+
+    const [, init] = fetchWithCsrf.mock.calls[0];
+    expect(new Headers(init?.headers).get("Authorization")).toBe(
+      "Bearer steward-jwt",
+    );
+  });
+});

--- a/packages/ui/src/hooks/useRealtimeVoiceMint.ts
+++ b/packages/ui/src/hooks/useRealtimeVoiceMint.ts
@@ -49,14 +49,20 @@ export function isRealtimeVoiceForceEnabled(): boolean {
 
 /**
  * The default consent fetch = the same CSRF/bearer helper every other dashboard
- * /api/v1 call uses.
+ * /api/v1 call uses, PLUS control-plane routing: the consent/probe routes only
+ * exist on the Eliza Cloud Worker, so on a managed-cloud agent base (dedicated
+ * subdomain or shared REST adapter) the relative path must resolve to the
+ * control-plane origin — resolving it against the AGENT base 404s inside the
+ * container (LOGIN-FLOW-AUDIT 2026-08-09 cliff #3). Self-hosted/standalone
+ * bases keep the unchanged relative same-origin path.
  */
 async function defaultConsentFetch(
   url: string,
   init?: RequestInit,
 ): Promise<Response> {
-  const { fetchWithCsrf } = await import("../api/csrf-client");
-  return fetchWithCsrf(url, init);
+  const { realtimeVoiceSessionFetch, resolveRealtimeVoiceSessionUrl } =
+    await import("../voice/realtime-voice-control-plane");
+  return realtimeVoiceSessionFetch(resolveRealtimeVoiceSessionUrl(url), init);
 }
 
 /** UUID v-any shape guard so we never mint with a non-UUID id (the route 400s). */

--- a/packages/ui/src/voice/realtime-voice-control-plane.test.ts
+++ b/packages/ui/src/voice/realtime-voice-control-plane.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Verifies control-plane routing for the realtime voice-session routes
+ * (consent/mint/probe): managed Eliza Cloud agent bases resolve to the
+ * environment's control-plane Worker origin; every other base keeps the
+ * unchanged relative same-origin path. This is the regression lock for
+ * LOGIN-FLOW-AUDIT 2026-08-09 cliff #3 (fresh dedicated pairing POSTed consent
+ * to the agent subdomain → 404 ×3 → "could not confirm microphone consent").
+ */
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The real csrf-client pulls the native (Capacitor) transport chain, which is
+// not resolvable in this worktree's symlinked node_modules. The fetch tests
+// only assert WHAT realtimeVoiceSessionFetch passes down to it, so a spy
+// module is the honest boundary (URL derivation — the code under test — stays
+// real).
+const fetchWithCsrf = vi.fn(
+  async (_url: string, _init?: RequestInit) => new Response("{}"),
+);
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: (url: string, init?: RequestInit) => fetchWithCsrf(url, init),
+}));
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+
+import {
+  realtimeVoiceControlPlaneOrigin,
+  realtimeVoiceSessionFetch,
+  resolveRealtimeVoiceSessionUrl,
+} from "./realtime-voice-control-plane";
+
+const CONSENT_PATH = "/api/v1/voice/session/consent";
+
+afterEach(() => {
+  fetchWithCsrf.mockClear();
+  window.localStorage.clear();
+});
+
+describe("realtimeVoiceControlPlaneOrigin", () => {
+  it("maps a dedicated staging agent base to the staging API host", () => {
+    expect(
+      realtimeVoiceControlPlaneOrigin(
+        "https://ef2fa8ee-1111-4222-8333-444455556666.staging.elizacloud.ai",
+      ),
+    ).toBe("https://api-staging.elizacloud.ai");
+  });
+
+  it("maps a dedicated production agent base to the production API host", () => {
+    expect(
+      realtimeVoiceControlPlaneOrigin(
+        "https://ef2fa8ee-1111-4222-8333-444455556666.elizacloud.ai",
+      ),
+    ).toBe("https://api.elizacloud.ai");
+  });
+
+  it("maps a shared-tier REST adapter base to its worker origin", () => {
+    expect(
+      realtimeVoiceControlPlaneOrigin(
+        "https://api-staging.elizacloud.ai/api/v1/eliza/agents/abc-123",
+      ),
+    ).toBe("https://api-staging.elizacloud.ai");
+  });
+
+  it("returns null for control-plane apex bases (same-origin already correct)", () => {
+    expect(
+      realtimeVoiceControlPlaneOrigin("https://api.elizacloud.ai"),
+    ).toBeNull();
+    expect(
+      realtimeVoiceControlPlaneOrigin("https://staging.elizacloud.ai"),
+    ).toBeNull();
+  });
+
+  it("returns null for self-hosted / standalone bases", () => {
+    expect(
+      realtimeVoiceControlPlaneOrigin("https://sol-dev.shad0w.xyz"),
+    ).toBeNull();
+    expect(realtimeVoiceControlPlaneOrigin("http://localhost:3000")).toBeNull();
+  });
+
+  it("returns null for blank and malformed bases", () => {
+    expect(realtimeVoiceControlPlaneOrigin("")).toBeNull();
+    expect(realtimeVoiceControlPlaneOrigin(null)).toBeNull();
+    expect(realtimeVoiceControlPlaneOrigin(undefined)).toBeNull();
+    expect(realtimeVoiceControlPlaneOrigin("not a url")).toBeNull();
+  });
+});
+
+describe("resolveRealtimeVoiceSessionUrl", () => {
+  it("absolutizes the consent path onto the control plane for a dedicated staging base", () => {
+    expect(
+      resolveRealtimeVoiceSessionUrl(
+        CONSENT_PATH,
+        "https://ef2fa8ee-1111-4222-8333-444455556666.staging.elizacloud.ai",
+      ),
+    ).toBe(`https://api-staging.elizacloud.ai${CONSENT_PATH}`);
+  });
+
+  it("absolutizes the mint path onto the control plane for a shared base", () => {
+    expect(
+      resolveRealtimeVoiceSessionUrl(
+        "/api/v1/voice/session",
+        "https://api.elizacloud.ai/api/v1/eliza/agents/abc",
+      ),
+    ).toBe("https://api.elizacloud.ai/api/v1/voice/session");
+  });
+
+  it("leaves the relative path unchanged for non-managed bases", () => {
+    expect(
+      resolveRealtimeVoiceSessionUrl(
+        CONSENT_PATH,
+        "https://sol-dev.shad0w.xyz",
+      ),
+    ).toBe(CONSENT_PATH);
+    expect(resolveRealtimeVoiceSessionUrl(CONSENT_PATH, null)).toBe(
+      CONSENT_PATH,
+    );
+  });
+});
+
+describe("realtimeVoiceSessionFetch", () => {
+  it("attaches the Steward session bearer on cross-origin control-plane calls", async () => {
+    window.localStorage.setItem(STEWARD_TOKEN_KEY, "steward-jwt-token");
+    await realtimeVoiceSessionFetch(
+      `https://api-staging.elizacloud.ai${CONSENT_PATH}`,
+      { method: "POST" },
+    );
+    expect(fetchWithCsrf).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchWithCsrf.mock.calls[0];
+    expect(url).toBe(`https://api-staging.elizacloud.ai${CONSENT_PATH}`);
+    expect(new Headers(init?.headers).get("Authorization")).toBe(
+      "Bearer steward-jwt-token",
+    );
+  });
+
+  it("never overwrites an explicit Authorization header", async () => {
+    window.localStorage.setItem(STEWARD_TOKEN_KEY, "steward-jwt-token");
+    await realtimeVoiceSessionFetch(
+      `https://api.elizacloud.ai${CONSENT_PATH}`,
+      { method: "POST", headers: { Authorization: "Bearer explicit" } },
+    );
+    const [, init] = fetchWithCsrf.mock.calls[0];
+    expect(new Headers(init?.headers).get("Authorization")).toBe(
+      "Bearer explicit",
+    );
+  });
+
+  it("passes relative same-origin paths through untouched (no forced bearer)", async () => {
+    window.localStorage.setItem(STEWARD_TOKEN_KEY, "steward-jwt-token");
+    const init: RequestInit = { method: "POST" };
+    await realtimeVoiceSessionFetch(CONSENT_PATH, init);
+    const [url, passedInit] = fetchWithCsrf.mock.calls[0];
+    expect(url).toBe(CONSENT_PATH);
+    expect(passedInit).toBe(init);
+  });
+
+  it("falls back to the plain CSRF fetch when no Steward session exists", async () => {
+    await realtimeVoiceSessionFetch(
+      `https://api.elizacloud.ai${CONSENT_PATH}`,
+      { method: "POST" },
+    );
+    const [, init] = fetchWithCsrf.mock.calls[0];
+    expect(new Headers(init?.headers).get("Authorization")).toBeNull();
+  });
+});

--- a/packages/ui/src/voice/realtime-voice-control-plane.ts
+++ b/packages/ui/src/voice/realtime-voice-control-plane.ts
@@ -1,0 +1,124 @@
+/**
+ * Control-plane routing for the realtime voice session routes (#18xxx,
+ * LOGIN-FLOW-AUDIT 2026-08-09 cliff #3).
+ *
+ * The consent (`POST /api/v1/voice/session/consent`), mint
+ * (`POST /api/v1/voice/session`) and force-arm health probe routes exist ONLY
+ * on the Eliza Cloud control-plane Worker (`api.elizacloud.ai` /
+ * `api-staging.elizacloud.ai`) — they need the Worker's DB repositories,
+ * consent-nonce store, and JWT signer. They are NOT mounted in agent
+ * containers, and the dedicated-agent proxy forwards unknown `/api/*` paths
+ * into the container, which 404s them.
+ *
+ * The voice client, however, issues those calls as RELATIVE paths through
+ * `fetchWithCsrf`, which resolves them against the ACTIVE AGENT base
+ * (`resolveApiUrl`). On the dedicated pairing path the active base is the
+ * per-agent subdomain (`https://<agentId>.staging.elizacloud.ai`), so a fresh
+ * user's first voice tap POSTed consent to the agent container and got 404 ×3
+ * ("Cartesia voice could not confirm microphone consent").
+ *
+ * This module derives the correct control-plane origin for the managed-cloud
+ * agent bases, mirroring the batch-voice precedent in
+ * `shared-runtime-voice.ts` (#15395/#16116):
+ *   - dedicated base  `https://<id>.elizacloud.ai`          → `https://api.elizacloud.ai`
+ *   - dedicated base  `https://<id>.staging.elizacloud.ai`  → `https://api-staging.elizacloud.ai`
+ *   - shared base     `<worker>/api/v1/eliza/agents/<id>`   → `<worker>` (path stripped)
+ *   - anything else (self-hosted, standalone dev adapter, control-plane
+ *     same-origin, blank) → null, and callers keep the EXISTING relative
+ *     same-origin paths unchanged.
+ *
+ * Auth for the cross-origin control-plane call is the canonical Steward
+ * session JWT (`readStoredStewardToken`), attached as `Authorization: Bearer`
+ * — the same pattern `local-asr-transcribe.ts` uses for its direct Worker
+ * route. Relying on `fetchWithCsrf`'s boot-config `apiToken` would send the
+ * AGENT pair token to the Worker, which cannot authenticate it.
+ */
+
+import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
+
+import {
+  DEFAULT_DIRECT_CLOUD_API_BASE_URL,
+  STAGING_DIRECT_CLOUD_API_BASE_URL,
+} from "../api/direct-cloud-endpoints";
+import { isDedicatedCloudAgentBase } from "../utils/cloud-agent-base";
+import { getElizaApiBase } from "../utils/eliza-globals";
+import { sharedRuntimeVoiceOrigin } from "./shared-runtime-voice";
+
+const STAGING_DEDICATED_SUFFIX = ".staging.elizacloud.ai";
+
+/**
+ * The control-plane Worker origin that serves the realtime voice-session
+ * routes for a given ACTIVE agent api base, or `null` when the base is not a
+ * managed Eliza Cloud agent base (self-hosted / standalone / same-origin
+ * control-plane — the relative path is already correct there).
+ */
+export function realtimeVoiceControlPlaneOrigin(
+  apiBase: string | null | undefined,
+): string | null {
+  const raw = apiBase?.trim();
+  if (!raw) return null;
+
+  // Shared-tier managed base: the worker origin is the base with the
+  // `/api/v1/eliza/agents/<id>` tail stripped (exact #15395 derivation).
+  const sharedOrigin = sharedRuntimeVoiceOrigin(raw);
+  if (sharedOrigin) return sharedOrigin;
+
+  // Dedicated managed base: map the per-agent subdomain to its environment's
+  // API host. The environment is encoded in the host itself
+  // (`.staging.elizacloud.ai` vs `.elizacloud.ai`), so this needs no config.
+  if (isDedicatedCloudAgentBase(raw)) {
+    try {
+      const host = new URL(raw).hostname.toLowerCase();
+      return host.endsWith(STAGING_DEDICATED_SUFFIX)
+        ? STAGING_DIRECT_CLOUD_API_BASE_URL
+        : DEFAULT_DIRECT_CLOUD_API_BASE_URL;
+    } catch {
+      // error-policy:J3 an unparseable base cannot be proven managed-cloud;
+      // fall through to the unchanged same-origin path (fail-closed to the
+      // pre-existing behavior).
+      return null;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a realtime voice-session route path (`/api/v1/voice/session[...]`)
+ * for the CURRENT active agent base: an absolute control-plane URL on managed
+ * cloud bases, the unchanged relative path everywhere else.
+ */
+export function resolveRealtimeVoiceSessionUrl(
+  path: string,
+  apiBase: string | null | undefined = getElizaApiBase(),
+): string {
+  const origin = realtimeVoiceControlPlaneOrigin(apiBase);
+  if (!origin) return path;
+  const suffix = path.startsWith("/") ? path : `/${path}`;
+  return `${origin.replace(/\/+$/, "")}${suffix}`;
+}
+
+/**
+ * The consent/mint/probe fetch. Same CSRF/bearer dashboard helper as before
+ * (lazily imported to keep the native transport chain off this module graph),
+ * plus the Steward session bearer when the request targets a cross-origin
+ * control-plane URL — `fetchWithCsrf` only knows the boot-config apiToken,
+ * which on a dedicated pairing is the AGENT token the Worker rejects.
+ */
+export async function realtimeVoiceSessionFetch(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const { fetchWithCsrf } = await import("../api/csrf-client");
+  if (/^https?:\/\//i.test(url)) {
+    const stewardToken = readStoredStewardToken()?.trim();
+    if (stewardToken) {
+      const headers = new Headers(init?.headers);
+      if (!headers.has("Authorization")) {
+        headers.set("Authorization", `Bearer ${stewardToken}`);
+      }
+      return fetchWithCsrf(url, { ...init, headers });
+    }
+  }
+  return fetchWithCsrf(url, init);
+}

--- a/packages/ui/src/voice/voice-session-client.ts
+++ b/packages/ui/src/voice/voice-session-client.ts
@@ -292,8 +292,16 @@ export function createVoiceSessionClient(
   const doFetch =
     options.fetch ??
     (async (url: string, init?: RequestInit) => {
-      const { fetchWithCsrf } = await import("../api/csrf-client");
-      return fetchWithCsrf(url, init);
+      // Mint targets the control-plane Worker on managed-cloud agent bases
+      // (the route does not exist in agent containers); everywhere else the
+      // relative same-origin path is unchanged. Mirrors the consent fetch in
+      // useRealtimeVoiceMint (LOGIN-FLOW-AUDIT 2026-08-09 cliff #3).
+      const { realtimeVoiceSessionFetch, resolveRealtimeVoiceSessionUrl } =
+        await import("./realtime-voice-control-plane");
+      return realtimeVoiceSessionFetch(
+        resolveRealtimeVoiceSessionUrl(url),
+        init,
+      );
     });
   const wsFactory =
     options.webSocketFactory ??


### PR DESCRIPTION
## The bug (LOGIN-FLOW-AUDIT-2026-08-09 cliff #3)

A fresh user's first voice tap on a **dedicated cloud pairing** dies with the red banner **"Cartesia voice could not confirm microphone consent. Tap Talk to retry."**

Live repro (staging, fresh mail.tm account, dedicated agent `ef2fa8ee…`): the client POSTs `/api/v1/voice/session/consent` and it lands on the **agent subdomain** (`ef2fa8ee….staging.elizacloud.ai`) → **404 ×3**.

## Root cause

The voice client issues consent/mint/probe as **relative paths** through `fetchWithCsrf`, whose `resolveApiUrl` resolves them against the **active agent base**. On a dedicated pairing that base is the per-agent subdomain; on shared-tier it's the `/api/v1/eliza/agents/<id>` REST adapter. But the realtime voice-session routes (`consent`, mint, `health` probe) exist **only on the control-plane Worker** (`packages/cloud/api/v1/voice/session/*`) — they need the Worker's DB repositories, consent-nonce store, and JWT signer, and are not mounted in agent containers. The dedicated-agent proxy forwards the unknown path into the container, which 404s.

This is distinct from the earlier consent-arming work (#16192 force-arm / standalone adapter, where **same-origin relative is correct** and stays byte-identical here). History check: the intended architecture is unambiguous — consent/mint are control-plane routes (SEC-21 server-enforced consent precedes mint, contract §7.1); the batch voice path already solved the identical wrong-base class client-side in `shared-runtime-voice.ts` (#15395, #16116). This PR applies the same pattern to the realtime routes.

## The fix

New `packages/ui/src/voice/realtime-voice-control-plane.ts`:

- `realtimeVoiceControlPlaneOrigin(apiBase)` — derives the Worker origin from the active base:
  - dedicated `<id>.elizacloud.ai` → `https://api.elizacloud.ai`
  - dedicated `<id>.staging.elizacloud.ai` → `https://api-staging.elizacloud.ai`
  - shared `<worker>/api/v1/eliza/agents/<id>` → `<worker>` (reuses the #15395 derivation)
  - everything else (self-hosted, standalone dev adapter, control-plane same-origin, blank) → `null` = **unchanged relative path**
- `realtimeVoiceSessionFetch` — same lazy `fetchWithCsrf` as before; on a cross-origin control-plane URL it attaches the canonical **Steward session JWT** as bearer (the boot-config `apiToken` on a dedicated pairing is the AGENT token, which the Worker cannot authenticate; same pattern as `local-asr-transcribe.ts`'s direct Worker route). Never overwrites an explicit Authorization header.

Wired into both default fetches: consent/probe (`useRealtimeVoiceMint`) and mint (`voice-session-client`). Injected test fetches untouched. The Worker's CORS already covers this: `/api/v1/voice/` is a public-token path prefix and the app hosts are first-party origins. Provider-agnostic — no Cartesia/Fish references.

## Proof (bidirectional)

`useRealtimeVoiceMint.dedicated-base.test.tsx` drives the hook's **real default fetch path** with the persisted dedicated-pairing state (`cloud:<id>` active server on `<id>.staging.elizacloud.ai`) and asserts the consent POST reaches `https://api-staging.elizacloud.ai/api/v1/voice/session/consent`:

- **on develop (fix reverted): FAILS** — the URL arrives as the relative `/api/v1/voice/session/consent`, which `resolveApiUrl` sends to the agent base = the live 404
- **with this PR: PASSES**

`realtime-voice-control-plane.test.ts` (13 tests) locks the origin table, URL resolution, bearer attachment, and the null/self-hosted passthrough.

Full local runs: mint hook (12) + dedicated-base (2) + resolver (13) + voice-session-client (39) + realtime session hook (22) + shared-runtime voice (27) = **115 passed**. `packages/ui` typecheck clean. Biome clean.

## CI note

develop is currently red repo-wide from the workflow-consolidation wip (`02d89802f`) — deleted `develop-pr-gate.yml` still actionlinted, Smoke missing playwright browsers, Quality `audit:scripts` residue. Fix PRs #18136/#18142/#18140 are owned by their authors. Failures matching that signature on this PR are the known outage, not this change; the touched-path suites above are proven locally.

## QA (staging, once deployed)

1. Fresh account → dedicated pairing (`/join` on app-staging) → open chat.
2. Tap Talk. DevTools: `POST https://api-staging.elizacloud.ai/api/v1/voice/session/consent` → 200 (was: agent subdomain → 404 ×3), then mint 200 → one WSS.
3. Self-hosted / sol-dev standalone: consent still same-origin relative (unchanged).