### PR TITLE
fix(browser): keep background refresh timeouts out of the foreground

### DIFF
--- a/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
@@ -1,12 +1,12 @@
 /**
- * Verifies the Browser view's fullscreen chrome contract: with the builtin
- * registry declaring `header: "fullscreen"`, the view owns its whole surface
- * and embedded page loads cannot take focus from the control that opened it.
- * Renders the real component in jsdom with deterministic workspace API data.
+ * Verifies the Browser view's fullscreen chrome, focus handoff, and workspace
+ * refresh precedence. The real component renders in jsdom with deterministic
+ * API responses so background polls cannot impersonate foreground failures.
  */
 // @vitest-environment jsdom
 
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -96,6 +96,31 @@ const APPLE_WORKSPACE = {
     },
   ],
 };
+
+const EXAMPLE_WORKSPACE = {
+  mode: "web" as const,
+  tabs: [
+    {
+      ...APPLE_WORKSPACE.tabs[0],
+      title: "Example",
+      url: "https://example.com/",
+    },
+  ],
+};
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 beforeEach(() => {
   vi.mocked(client.getBrowserWorkspace).mockResolvedValue({
@@ -289,5 +314,164 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
         }),
       ),
     );
+  });
+
+  it("keeps transient background refresh timeouts off a healthy page and retries single-flight", async () => {
+    vi.useFakeTimers();
+    const pendingRefresh = deferred<typeof GOOGLE_WORKSPACE>();
+    vi.mocked(client.getBrowserWorkspace)
+      .mockReset()
+      .mockResolvedValueOnce(GOOGLE_WORKSPACE)
+      .mockImplementationOnce(() => pendingRefresh.promise)
+      .mockResolvedValueOnce(APPLE_WORKSPACE);
+
+    try {
+      render(<BrowserWorkspaceView />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(screen.getByTitle("Google")).not.toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_500);
+      });
+      expect(client.getBrowserWorkspace).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(7_500);
+      });
+      expect(client.getBrowserWorkspace).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        pendingRefresh.reject(new Error("Request timed out after 10000ms"));
+        await Promise.resolve();
+      });
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(screen.getByTitle("Google")).not.toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_500);
+      });
+      expect(client.getBrowserWorkspace).toHaveBeenCalledTimes(3);
+      expect(screen.getByTitle("Apple")).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps an explicit action refresh failure observable", async () => {
+    vi.mocked(client.getBrowserWorkspace)
+      .mockResolvedValueOnce(APPLE_WORKSPACE)
+      .mockRejectedValueOnce(new Error("Explicit refresh failed"));
+    vi.mocked(client.openBrowserWorkspaceTab).mockResolvedValue({
+      tab: GOOGLE_WORKSPACE.tabs[0],
+    });
+
+    render(<BrowserWorkspaceView />);
+    expect(await screen.findByTitle("Apple")).not.toBeNull();
+    fireEvent.click(screen.getByTestId("browser-workspace-nav-new-tab"));
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Explicit refresh failed",
+    );
+  });
+
+  it("shows an initial load failure until a later background retry succeeds", async () => {
+    vi.useFakeTimers();
+    vi.mocked(client.getBrowserWorkspace)
+      .mockReset()
+      .mockRejectedValueOnce(new Error("Initial workspace load failed"))
+      .mockResolvedValueOnce(APPLE_WORKSPACE);
+
+    try {
+      render(<BrowserWorkspaceView />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(screen.getByRole("alert").textContent).toContain(
+        "Initial workspace load failed",
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_500);
+      });
+      expect(screen.getByTitle("Apple")).not.toBeNull();
+      expect(screen.queryByRole("alert")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the StrictMode initial load single-flight and loading until it settles", async () => {
+    const pendingInitialLoad = deferred<typeof APPLE_WORKSPACE>();
+    vi.mocked(client.getBrowserWorkspace)
+      .mockReset()
+      .mockImplementation(() => pendingInitialLoad.promise);
+
+    render(<BrowserWorkspaceView />, { reactStrictMode: true });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(client.getBrowserWorkspace).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Loading browser workspace")).not.toBeNull();
+    expect(screen.queryByText("No page open")).toBeNull();
+
+    await act(async () => {
+      pendingInitialLoad.resolve(APPLE_WORKSPACE);
+      await Promise.resolve();
+    });
+    expect(screen.getByTitle("Apple")).not.toBeNull();
+    expect(screen.queryByText("Loading browser workspace")).toBeNull();
+  });
+
+  it("does not let a stale background response overwrite a newer navigation", async () => {
+    vi.useFakeTimers();
+    const pendingRefresh = deferred<typeof GOOGLE_WORKSPACE>();
+    vi.mocked(client.getBrowserWorkspace)
+      .mockReset()
+      .mockResolvedValueOnce(APPLE_WORKSPACE)
+      .mockImplementationOnce(() => pendingRefresh.promise)
+      .mockResolvedValueOnce(EXAMPLE_WORKSPACE);
+    vi.mocked(client.navigateBrowserWorkspaceTab).mockResolvedValue({
+      tab: EXAMPLE_WORKSPACE.tabs[0],
+    });
+
+    try {
+      render(<BrowserWorkspaceView />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(screen.getByTitle("Apple")).not.toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_500);
+      });
+      expect(client.getBrowserWorkspace).toHaveBeenCalledTimes(2);
+
+      const address = screen.getByTestId("browser-workspace-address-input");
+      await act(async () => {
+        fireEvent.change(address, {
+          target: { value: "https://example.com/" },
+        });
+        fireEvent.keyDown(address, { key: "Enter" });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(client.getBrowserWorkspace).toHaveBeenCalledTimes(3);
+      expect(screen.getByTitle("Example")).not.toBeNull();
+
+      await act(async () => {
+        pendingRefresh.resolve(GOOGLE_WORKSPACE);
+        await Promise.resolve();
+      });
+      expect(screen.getByTitle("Example")).not.toBeNull();
+      expect(screen.queryByTitle("Google")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -585,6 +585,15 @@ export function BrowserWorkspaceView(): React.JSX.Element {
   const initialBrowseHandledRef = useRef(false);
   const workspaceRootRef = useRef<HTMLElement | null>(null);
   const workspaceSnapshotRef = useRef<BrowserWorkspaceSnapshot>(workspace);
+  // Polls are slower than their cadence when the API is unhealthy. Keep them
+  // single-flight, and order every response so a late poll cannot roll back a
+  // newer user action or turn stale-state refresh noise into a page failure.
+  const workspaceLoadVersionRef = useRef(0);
+  const foregroundWorkspaceLoadsRef = useRef(0);
+  const visibleWorkspaceLoadsRef = useRef(0);
+  const workspaceActionsInFlightRef = useRef(0);
+  const backgroundWorkspaceRefreshInFlightRef = useRef(false);
+  const initialWorkspaceLoadStartedRef = useRef(false);
   const iframeRefs = useRef(new Map<string, HTMLIFrameElement | null>());
   const registeredIframeElementsRef = useRef(new WeakSet<HTMLIFrameElement>());
   const iframeFocusHandoffsRef = useRef(
@@ -1043,12 +1052,24 @@ export function BrowserWorkspaceView(): React.JSX.Element {
   }, [releaseBrowserWorkspaceIframeFocusReturn]);
 
   const loadWorkspace = useCallback(
-    async (options?: { preferTabId?: string | null; silent?: boolean }) => {
-      if (!options?.silent) {
+    async (options?: {
+      preferTabId?: string | null;
+      silent?: boolean;
+      background?: boolean;
+    }) => {
+      const background = options?.background === true;
+      const showLoading = options?.silent !== true;
+      if (!background) {
+        foregroundWorkspaceLoadsRef.current += 1;
+      }
+      const loadVersion = ++workspaceLoadVersionRef.current;
+      if (showLoading) {
+        visibleWorkspaceLoadsRef.current += 1;
         setLoading(true);
       }
       try {
         const snapshot = await client.getBrowserWorkspace();
+        if (loadVersion !== workspaceLoadVersionRef.current) return;
         const previousSnapshot = workspaceSnapshotRef.current;
         for (const nextTab of snapshot.tabs) {
           const previousTab = previousSnapshot.tabs.find(
@@ -1081,6 +1102,11 @@ export function BrowserWorkspaceView(): React.JSX.Element {
           ),
         );
       } catch (error) {
+        if (background || loadVersion !== workspaceLoadVersionRef.current) {
+          // error-policy:J4 poll — retain the last successful workspace on a
+          // transient background failure; the next visible tick retries.
+          return;
+        }
         const message =
           error instanceof Error
             ? error.message
@@ -1089,8 +1115,14 @@ export function BrowserWorkspaceView(): React.JSX.Element {
               });
         setLoadError(message);
       } finally {
-        if (!options?.silent) {
-          setLoading(false);
+        if (!background) {
+          foregroundWorkspaceLoadsRef.current -= 1;
+        }
+        if (showLoading) {
+          visibleWorkspaceLoadsRef.current -= 1;
+          if (visibleWorkspaceLoadsRef.current === 0) {
+            setLoading(false);
+          }
         }
       }
     },
@@ -1108,6 +1140,8 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     ) => {
       const actionFocusReturnTarget = readBrowserWorkspaceFocusReturnTarget();
       browserActionFocusReturnTargetRef.current = actionFocusReturnTarget;
+      workspaceActionsInFlightRef.current += 1;
+      workspaceLoadVersionRef.current += 1;
       setBusyAction(actionKey);
       try {
         await action();
@@ -1121,6 +1155,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
               }));
         setActionNoticeRef.current(message, "error", 4_000);
       } finally {
+        workspaceActionsInFlightRef.current -= 1;
         setBusyAction(null);
         if (
           browserActionFocusReturnTargetRef.current === actionFocusReturnTarget
@@ -1131,6 +1166,26 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     },
     [readBrowserWorkspaceFocusReturnTarget],
   );
+
+  const refreshWorkspaceInBackground = useCallback(async () => {
+    if (
+      backgroundWorkspaceRefreshInFlightRef.current ||
+      foregroundWorkspaceLoadsRef.current > 0 ||
+      workspaceActionsInFlightRef.current > 0
+    ) {
+      return;
+    }
+    backgroundWorkspaceRefreshInFlightRef.current = true;
+    try {
+      await loadWorkspace({
+        preferTabId: selectedTabId,
+        silent: true,
+        background: true,
+      });
+    } finally {
+      backgroundWorkspaceRefreshInFlightRef.current = false;
+    }
+  }, [loadWorkspace, selectedTabId]);
 
   const loadSelectedBrowserWorkspaceSnapshot = useCallback(
     async (tabId: string, mode: BrowserWorkspaceSnapshot["mode"]) => {
@@ -2158,6 +2213,8 @@ export function BrowserWorkspaceView(): React.JSX.Element {
   }, [loadWorkspace, workspace.tabs]);
 
   useEffect(() => {
+    if (initialWorkspaceLoadStartedRef.current) return;
+    initialWorkspaceLoadStartedRef.current = true;
     void loadWorkspace();
   }, [loadWorkspace]);
 
@@ -2177,7 +2234,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
   }, [browserBridgeSupported, loadBrowserBridgeState, workspace.mode]);
 
   useIntervalWhenDocumentVisible(() => {
-    void loadWorkspace({ preferTabId: selectedTabId, silent: true });
+    void refreshWorkspaceInBackground();
   }, POLL_INTERVAL_MS);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #18148

## Summary

A 2.5-second Browser workspace poll could overlap while the shared API client waited up to 10 seconds, and a rejected silent poll wrote into the foreground error alert even when a good embedded page remained available. This repair:

- makes background refresh single-flight and skips it while a visible load or Browser action owns the workspace;
- gives latest-started authoritative work precedence so stale completions cannot overwrite newer state;
- keeps transient background failures behind the last good snapshot while preserving explicit/initial errors;
- clears prior foreground errors after a successful authoritative refresh;
- makes the initial StrictMode load single-flight and keeps loading visible until every visible request settles;
- freezes the concurrency, timeout, retry, stale-result, action, and explicit-error boundaries in real component tests.

No iframe origin, wallet, navigation, server, database, or role-policy behavior changes.

## Exact provenance

- Head: `4ce93c29a360669f6af657651be1c8191f33313c`
- Tree: `c08e53b82382a9eedf5c6565e1d854de0b77b20c`
- Parent/base: `6659f25cd20eea80e4ad4a8a61a1e541b21551df`
- Scope: one clean commit touching exactly `BrowserWorkspaceView.tsx` and its chrome test
- Rebase from reviewed 067fe7b4561f1b2215c324742c99f1fb08ebae8b: conflict-free across every develop advance through 6659f25c; each git range-diff is exact = and the two product blobs remain byte-identical
- Independent source/adversarial review: PASS, no P0/P1/P2

## Testing

- Browser component suite — 13/13 PASS
- Independent forced-overlap visible-load matrix — 2/2 PASS
- Real Browser Playwright on the exact publication head with dynamic ports — 3/3 PASS (create/navigate/switch/close, mobile chrome/chat geometry, delayed iframe autofocus)
- Prior full Chromium/WebKit + mobile portrait/landscape + desktop + iPad matrix — 18/18 PASS; Browser product blobs are byte-identical and later develop drift is path-disjoint
- `bun run --cwd packages/ui typecheck` — PASS
- exact two-path Biome and `git diff --check` — PASS
- `bun run verify` — 346/346 tasks plus every audit PASS on exact head
- full app audit — 215/215 PASS; 0 needs-work, 0 broken, 0 OCR broken/regressions

## Risks

Low and bounded to Browser workspace refresh scheduling. The main risks are hiding a true foreground failure or allowing stale state to win. Initial and explicit rejection controls remain visible; version/action/background/foreground counters and the forced-overlap tests cover both completion orders.

## Documentation

N/A - no public API, configuration, or operator workflow changed.

## Evidence

The deterministic control and repaired flows use the same real Browser interaction and 10-second wait on current base `6659f25c`:

- **Before:** six overlapping workspace GETs; the healthy page stays visible, but a red `Request timed out after 10000ms` alert appears. [Screenshot](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-before.png) · [16.52s H.264 recording](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-before.mp4) · [diagnostics](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-before.json)
- **After:** two single-flight workspace GETs; the healthy page remains continuously visible and no alert appears. [Screenshot](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-after.png) · [16.48s H.264 recording](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-after.mp4) · [diagnostics](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-after.json)

Both recordings and four-frame contact sheets spanning their full duration were manually inspected. Each flow has zero console errors, page errors, HTTP errors, or unrelated request failures; the one scoped workspace abort is the deliberately delayed timeout.

The full app audit passed 215/215 with 200 good, 12 needs-eyeball, 0 needs-work, and 0 broken findings. OCR recorded 192 verified, 20 needs-eyeball, 0 broken, and 0 regressions. The full audit remains behavior-valid: all audited Browser and runner blobs are byte-identical through current base 6659f25c, while subsequent develop changes are confined to CI/workflow, BlueBubbles, attribution-test, and Homepage paths.

Rendered Browser matrix, all manually inspected:

- [Mobile portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-mobile-portrait.png)
- [Mobile landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-mobile-landscape.png)
- [Desktop landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-desktop-landscape.png)
- [iPad portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-ipad-portrait.png)

<!-- evidence-head:4ce93c29a360669f6af657651be1c8191f33313c -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-before.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-after.png)
<!-- evidence-row:walkthrough-video -->
- [x] [Before recording](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-before.mp4) · [After recording](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-after.mp4)
<!-- evidence-row:backend-logs -->
- [x] N/A - no production backend code changed; the real Browser client drives a controlled delayed API response.
<!-- evidence-row:frontend-logs -->
- [x] [Before diagnostics](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-before.json) · [After diagnostics](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-browser-background-timeout-after.json)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, scheduling, wallet, chain, generated-file, or audio artifact changed.
<!-- evidence-row:ocr-review -->
- [x] [OCR triage](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18156-ocr-triage.json)

## Known gaps / failures

None. No source, test, visual, console, network, or evidence failure is being waived.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6659f25cd20eea80e4ad4a8a61a1e541b21551df:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@6659f25cd20eea80e4ad4a8a61a1e541b21551df:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@6659f25cd20eea80e4ad4a8a61a1e541b21551df:packages/skills/skills/contribute-to-eliza"} -->
