### PR TITLE
fix(ci): restore managed dedicated canary in live smoke

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,9 +37,11 @@ the `pr.yaml` title check cover narrower contracts. None replaces the
 ## Manual operations
 
 - `live-smoke.yml` is the general credential-backed dispatcher. Its input
-  selects `app`, `scenarios`, `cloud`, `voice`, or `all`. Specialized app and
-  voice evidence also flows through `app-live-e2e.yml` and
-  `voice-live-e2e.yml`, which run on schedule or dispatch.
+  selects `app`, `scenarios`, `cloud`, `voice`, `dedicated`, or `all`. The
+  `dedicated` suite owns the managed dedicated staging canary and exact
+  stale-canary recovery. Specialized app and voice evidence also flows through
+  `app-live-e2e.yml` and `voice-live-e2e.yml`, which run on schedule or
+  dispatch.
 - `release.yaml` is the npm, canonical Git tag, and GitHub Release authority.
   It creates the release as the final step of its npm/version transaction.
   The stable tag then triggers `release-electrobun.yml`, which resolves and

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -13,7 +13,12 @@ on:
         required: true
         default: all
         type: choice
-        options: [all, app, scenarios, cloud, voice]
+        options: [all, app, scenarios, cloud, voice, dedicated]
+      stale_canary_suffix:
+        description: "Exact prior dedicated-canary suffix (r<run-id>a<attempt>) to verify and delete before the fresh canary"
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: live-smoke-${{ inputs.suite }}
@@ -25,6 +30,7 @@ permissions:
 jobs:
   smoke:
     name: ${{ inputs.suite }}
+    if: inputs.suite != 'dedicated'
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     env:
@@ -76,3 +82,233 @@ jobs:
           WHISPER_STT_URL: ${{ vars.ELIZA_VOICE_WHISPER_STT_URL }}
           WHISPER_STT_MODEL: ${{ vars.ELIZA_VOICE_WHISPER_STT_MODEL }}
         run: bun test packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts
+
+  dedicated:
+    name: Managed dedicated staging canary
+    if: inputs.suite == 'all' || inputs.suite == 'dedicated'
+    runs-on: ubuntu-24.04
+    environment: staging
+    # Serialize this live lifecycle even when an `all` run overlaps a
+    # `dedicated` run. Cleanup must finish before another canary starts.
+    concurrency:
+      group: managed-dedicated-staging-canary
+      cancel-in-progress: false
+    # Absolute script deadlines stay below this cap and reserve time for the
+    # finally cleanup before Actions can terminate the job.
+    timeout-minutes: 45
+    env:
+      CLOUD_DEDICATED_CANARY_BASE_URL: https://api-staging.elizacloud.ai
+      CLOUD_DEDICATED_CANARY_EVIDENCE_PATH: reports/managed-dedicated-canary.json
+      CLOUD_DEDICATED_CANARY_STALE_CANARY_SUFFIX: ${{ inputs.stale_canary_suffix || '' }}
+      # Keep this identical to App Live's accepted repository-secret contract.
+      ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY }}
+    steps:
+      - name: Require real Cloud credential
+        shell: bash
+        run: |
+          set -euo pipefail
+          cloud_key_without_whitespace="${ELIZAOS_CLOUD_API_KEY:-}"
+          cloud_key_without_whitespace="${cloud_key_without_whitespace//[[:space:]]/}"
+          if [[ -z "$cloud_key_without_whitespace" ]]; then
+            echo "::error::Managed dedicated canary requires ELIZAOS_CLOUD_API_KEY or ELIZACLOUD_API_KEY; refusing green-by-skip."
+            exit 1
+          fi
+          unset cloud_key_without_whitespace
+
+      - name: Require exact staging target
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          const expected = "https://api-staging.elizacloud.ai";
+          const raw = process.env.CLOUD_DEDICATED_CANARY_BASE_URL ?? "";
+          let url;
+          try {
+            url = new URL(raw);
+          } catch {
+            throw new Error("Managed dedicated canary target is not a valid URL");
+          }
+          if (
+            url.origin !== expected ||
+            url.username ||
+            url.password ||
+            (url.pathname !== "/" && url.pathname !== "") ||
+            url.search ||
+            url.hash
+          ) {
+            throw new Error(
+              "Managed dedicated canary is pinned to the exact staging origin without userinfo, path, query, or fragment",
+            );
+          }
+          NODE
+
+      - name: Bind stale-recovery intent
+        id: recovery_intent
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import { appendFileSync } from "node:fs";
+          const raw =
+            process.env.CLOUD_DEDICATED_CANARY_STALE_CANARY_SUFFIX ?? "";
+          const requested = raw !== "";
+          if (requested && !/^r[1-9]\d{7,19}a[1-9]\d{0,3}$/.test(raw)) {
+            throw new Error("Stale-canary recovery input is invalid");
+          }
+          appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `requested=${requested ? "true" : "false"}\n`,
+          );
+          NODE
+
+      - name: Checkout exact run commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - name: Validate canary and workflow contracts
+        run: |
+          bun test \
+            packages/cloud/scripts/admin/bridge-reply-verdict.test.ts \
+            packages/cloud/scripts/admin/managed-dedicated-canary.test.ts \
+            packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
+
+      - name: Run bounded managed dedicated canary
+        id: live
+        shell: bash
+        run: |
+          set +e
+          mkdir -p reports
+          bun run packages/cloud/scripts/admin/managed-dedicated-canary.ts
+          status=$?
+          set -e
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Validate privacy-safe evidence artifact
+        id: privacy
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_path="$CLOUD_DEDICATED_CANARY_EVIDENCE_PATH"
+          if [[ ! -s "$evidence_path" ]]; then
+            echo "::error::Canary produced no evidence artifact to privacy-check."
+            exit 1
+          fi
+          bun -e '
+            import { readFileSync, renameSync, writeFileSync } from "node:fs";
+            import { canonicalizeManagedDedicatedCanaryArtifact } from "./packages/cloud/scripts/admin/managed-dedicated-canary.ts";
+            const evidencePath = process.env.CLOUD_DEDICATED_CANARY_EVIDENCE_PATH;
+            if (!evidencePath) {
+              console.error("::error::Canary evidence path is not configured.");
+              process.exit(1);
+            }
+            const { canonical, errors } = canonicalizeManagedDedicatedCanaryArtifact(
+              readFileSync(evidencePath, "utf8"),
+            );
+            if (errors.length > 0) {
+              console.error("::error::Canary evidence failed strict privacy validation: " + errors.join(","));
+              process.exit(1);
+            }
+            if (canonical === null) process.exit(1);
+            const canonicalPath = evidencePath + ".validated-" + process.pid;
+            writeFileSync(canonicalPath, canonical, { mode: 0o600 });
+            renameSync(canonicalPath, evidencePath);
+          '
+          echo "validated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload privacy-safe timing and path evidence
+        if: ${{ always() && steps.privacy.outputs.validated == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: managed-dedicated-canary-${{ github.run_id }}-${{ github.run_attempt }}
+          path: reports/managed-dedicated-canary.json
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Enforce live proof, deployed SHA, and cleanup
+        if: ${{ always() }}
+        env:
+          LIVE_PROCESS_STATUS: ${{ steps.live.outputs.status }}
+          PRIVACY_VALIDATED: ${{ steps.privacy.outputs.validated }}
+          EXPECTED_RECOVERY_REQUESTED: ${{ steps.recovery_intent.outputs.requested }}
+          EXPECTED_SOURCE_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_path="$CLOUD_DEDICATED_CANARY_EVIDENCE_PATH"
+          if [[ ! -s "$evidence_path" ]]; then
+            echo "::error::Canary produced no evidence; zero-executed/skip outcomes are failures."
+            exit 1
+          fi
+          if [[ "${PRIVACY_VALIDATED:-missing}" != "true" ]]; then
+            echo "::error::Canary evidence did not pass the separate strict privacy validator."
+            exit 1
+          fi
+
+          deployed_commit="$(
+            bun -e '
+              import { readFileSync } from "node:fs";
+              import { validateManagedDedicatedCanaryEvidence } from "./packages/cloud/scripts/admin/managed-dedicated-canary.ts";
+              const evidence = JSON.parse(readFileSync(process.env.CLOUD_DEDICATED_CANARY_EVIDENCE_PATH, "utf8"));
+              const errors = validateManagedDedicatedCanaryEvidence(evidence);
+              const expectedRecoveryRequested =
+                process.env.EXPECTED_RECOVERY_REQUESTED === "true";
+              if (evidence.recovery?.requested !== expectedRecoveryRequested) {
+                errors.push("workflow_recovery_intent_mismatch");
+              }
+              if (errors.length > 0) {
+                console.error("::error::Canary evidence rejected: " + errors.join(","));
+                process.exit(1);
+              }
+              process.stdout.write(evidence.deployedCommit);
+            '
+          )"
+
+          if [[ "${LIVE_PROCESS_STATUS:-missing}" != "0" ]]; then
+            echo "::error::Live canary process exited ${LIVE_PROCESS_STATUS:-without status}."
+            exit 1
+          fi
+          if ! git cat-file -e "${deployed_commit}^{commit}" 2>/dev/null; then
+            echo "::error::Staging reported a deploy commit absent from this repository checkout."
+            exit 1
+          fi
+          expected_source_sha="${EXPECTED_SOURCE_SHA:-}"
+          if [[ -z "$expected_source_sha" ]] || ! git cat-file -e "${expected_source_sha}^{commit}" 2>/dev/null; then
+            echo "::error::Expected canary source commit is absent from this repository checkout."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$expected_source_sha" "$deployed_commit"; then
+            echo "::error::Staging deploy does not contain this canary's expected source commit."
+            exit 1
+          fi
+
+          bun -e '
+            import { readFileSync } from "node:fs";
+            const evidence = JSON.parse(readFileSync(process.env.CLOUD_DEDICATED_CANARY_EVIDENCE_PATH, "utf8"));
+            const t = evidence.timingsMs;
+            console.log("### Managed dedicated staging canary");
+            console.log("");
+            console.log("- deployed commit: `" + evidence.deployedCommit + "`");
+            console.log("- tier: `" + evidence.path.observedTier + "`");
+            console.log("- paths: `" + evidence.path.successfulPaths + "/2`");
+            console.log("- bridge transport: `" + evidence.path.bridgeTransport + "`");
+            console.log("- chat requests: `" + evidence.capacity.chatRequests + "/" + evidence.capacity.maxChatRequests + "`");
+            console.log("- recovery requested: `" + evidence.recovery.requested + "`");
+            console.log("- recovery match: `" + evidence.recovery.match + "`");
+            console.log("- recovery performed: `" + evidence.recovery.performed + "`");
+            console.log("- recovery confirmed: `" + evidence.recovery.confirmed + "`");
+            console.log("- cleanup: `" + evidence.cleanup.status + "`");
+            console.log("");
+            console.log("| phase | ms |");
+            console.log("| --- | ---: |");
+            for (const phase of ["health", "capacityGuard", "create", "ready", "bridge", "sse", "cleanup", "total"]) {
+              if (Number.isFinite(t[phase])) console.log("| " + phase + " | " + t[phase] + " |");
+            }
+          ' >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Managed dedicated canary passed with exact cleanup."

--- a/packages/cloud/scripts/admin/MANAGED_DEDICATED_CANARY.md
+++ b/packages/cloud/scripts/admin/MANAGED_DEDICATED_CANARY.md
@@ -2,7 +2,9 @@
 
 `managed-dedicated-canary.ts` is the canonical live proof for the managed
 Cloud dedicated-agent path. It is an explicit operator-run diagnostic and is
-not part of routine pull-request or scheduled CI.
+not part of routine pull-request or scheduled CI. Dispatch `Live Smoke` with
+the `dedicated` suite (`all` also includes it); the consolidated
+`.github/workflows/live-smoke.yml` is its only workflow owner.
 
 The lane deliberately does not call Hetzner. It presents the existing
 repository Cloud bearer to the staging Worker; the deployed managed
@@ -22,8 +24,9 @@ disposable identity row to leak or clean separately.
   caps control-plane calls at 30 seconds and has a 45-minute hard cap that
   leaves room for `finally` cleanup.
 - A maintainer may recover one investigated leftover by dispatching with its
-  exact deterministic suffix (`r<run-id>a<attempt>`). Recovery requires exactly
-  one prefix match, verifies ID, full name, creation timestamp, and
+  exact deterministic suffix (`r<run-id>a<attempt>`) in the
+  `stale_canary_suffix` input. Recovery requires exactly one prefix match,
+  verifies ID, full name, creation timestamp, and
   `dedicated-always` tier with a fresh GET, then sends those immutable identity
   fields through the normal authenticated DELETE/job path. The lifecycle
   transaction rechecks them under the per-agent lock and atomically refuses

--- a/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Locks the credential, target, evidence, and cleanup boundaries that make the
+ * managed dedicated canary safe to invoke from the consolidated live workflow.
+ */
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+
+interface WorkflowStep {
+  env?: Record<string, string>;
+  id?: string;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string | number | boolean>;
+}
+
+interface WorkflowJob {
+  concurrency?: {
+    "cancel-in-progress": boolean;
+    group: string;
+  };
+  env?: Record<string, string>;
+  environment?: string;
+  if?: string;
+  "runs-on"?: string;
+  steps: WorkflowStep[];
+  "timeout-minutes"?: number;
+}
+
+interface LiveSmokeWorkflow {
+  jobs: {
+    dedicated: WorkflowJob;
+    smoke: WorkflowJob;
+  };
+  on: {
+    workflow_dispatch: {
+      inputs: {
+        stale_canary_suffix: {
+          default: string;
+          required: boolean;
+          type: string;
+        };
+        suite: {
+          options: string[];
+        };
+      };
+    };
+  };
+}
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+const workflowPath = resolve(repoRoot, ".github/workflows/live-smoke.yml");
+const retiredWorkflowPath = resolve(
+  repoRoot,
+  ".github/workflows/managed-dedicated-canary.yml",
+);
+const workflowSource = readFileSync(workflowPath, "utf8");
+const workflow = parse(workflowSource) as LiveSmokeWorkflow;
+const dedicated = workflow.jobs.dedicated;
+
+function githubExpression(body: string): string {
+  return ["$", "{{ ", body, " }}"].join("");
+}
+
+function bracedExpansion(body: string): string {
+  return ["$", "{", body, "}"].join("");
+}
+
+function namedStep(name: string): WorkflowStep {
+  const step = dedicated.steps.find((candidate) => candidate.name === name);
+  if (!step)
+    throw new Error(`Missing managed dedicated workflow step: ${name}`);
+  return step;
+}
+
+describe("managed dedicated live-smoke workflow contract", () => {
+  test("has one manual owner and a dedicated dispatch route", () => {
+    expect(Object.keys(workflow.on)).toEqual(["workflow_dispatch"]);
+    expect(workflow.on.workflow_dispatch.inputs.suite.options).toEqual([
+      "all",
+      "app",
+      "scenarios",
+      "cloud",
+      "voice",
+      "dedicated",
+    ]);
+    expect(
+      workflow.on.workflow_dispatch.inputs.stale_canary_suffix,
+    ).toMatchObject({ default: "", required: false, type: "string" });
+    expect(workflow.jobs.smoke.if).toBe("inputs.suite != 'dedicated'");
+    expect(dedicated.if).toBe(
+      "inputs.suite == 'all' || inputs.suite == 'dedicated'",
+    );
+    expect(existsSync(retiredWorkflowPath)).toBe(false);
+  });
+
+  test("serializes the bounded staging lifecycle", () => {
+    expect(dedicated["runs-on"]).toBe("ubuntu-24.04");
+    expect(dedicated.environment).toBe("staging");
+    expect(dedicated["timeout-minutes"]).toBe(45);
+    expect(dedicated.concurrency).toEqual({
+      group: "managed-dedicated-staging-canary",
+      "cancel-in-progress": false,
+    });
+  });
+
+  test("fails closed on credentials, target drift, and invalid recovery intent", () => {
+    expect(dedicated.env?.CLOUD_DEDICATED_CANARY_BASE_URL).toBe(
+      "https://api-staging.elizacloud.ai",
+    );
+    expect(dedicated.env?.CLOUD_DEDICATED_CANARY_EVIDENCE_PATH).toBe(
+      "reports/managed-dedicated-canary.json",
+    );
+    expect(dedicated.env?.CLOUD_DEDICATED_CANARY_STALE_CANARY_SUFFIX).toBe(
+      githubExpression("inputs.stale_canary_suffix || ''"),
+    );
+    expect(dedicated.env?.ELIZAOS_CLOUD_API_KEY).toBe(
+      githubExpression(
+        "secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY",
+      ),
+    );
+
+    const credential = namedStep("Require real Cloud credential").run ?? "";
+    expect(credential).toContain("cloud_key_without_whitespace");
+    expect(credential).toContain("refusing green-by-skip");
+    expect(credential).toContain("exit 1");
+
+    const target = namedStep("Require exact staging target").run ?? "";
+    expect(target).toContain(
+      'const expected = "https://api-staging.elizacloud.ai"',
+    );
+    expect(target).toContain("url.username");
+    expect(target).toContain("url.password");
+    expect(target).toContain("url.pathname");
+    expect(target).toContain("url.search");
+    expect(target).toContain("url.hash");
+
+    const recovery = namedStep("Bind stale-recovery intent");
+    expect(recovery.id).toBe("recovery_intent");
+    expect(recovery.run).toContain("/^r[1-9]\\d{7,19}a[1-9]\\d{0,3}$/");
+    expect(recovery.run).toContain("requested=$" + "{requested");
+  });
+
+  test("checks out full history and validates deterministic contracts", () => {
+    const checkout = namedStep("Checkout exact run commit");
+    expect(checkout.uses).toBe(
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+    );
+    expect(checkout.with?.["fetch-depth"]).toBe(0);
+    expect(checkout.with?.submodules).toBe(false);
+
+    const setup = namedStep("Setup Bun");
+    expect(setup.uses).toBe(
+      "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
+    );
+    expect(setup.with?.["bun-version"]).toBe("1.3.14");
+
+    const validation = namedStep("Validate canary and workflow contracts").run;
+    expect(validation).toContain("bridge-reply-verdict.test.ts");
+    expect(validation).toContain("managed-dedicated-canary.test.ts");
+    expect(validation).toContain("managed-dedicated-canary-workflow.test.ts");
+  });
+
+  test("uploads only canonical privacy-validated evidence", () => {
+    const live = namedStep("Run bounded managed dedicated canary");
+    expect(live.id).toBe("live");
+    expect(live.run).toContain("managed-dedicated-canary.ts");
+    expect(live.run).toContain("status=$?");
+    expect(live.run).toContain('echo "status=$status" >> "$GITHUB_OUTPUT"');
+
+    const privacy = namedStep("Validate privacy-safe evidence artifact");
+    expect(privacy.id).toBe("privacy");
+    expect(privacy.if).toBe(githubExpression("always()"));
+    expect(privacy.run).toContain("canonicalizeManagedDedicatedCanaryArtifact");
+    expect(privacy.run).toContain("errors.length > 0");
+    expect(privacy.run).toContain("mode: 0o600");
+    expect(privacy.run).toContain('echo "validated=true"');
+
+    const upload = namedStep("Upload privacy-safe timing and path evidence");
+    expect(upload.if).toBe(
+      githubExpression("always() && steps.privacy.outputs.validated == 'true'"),
+    );
+    expect(upload.uses).toBe(
+      "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    );
+    expect(upload.with?.path).toBe("reports/managed-dedicated-canary.json");
+    expect(upload.with?.["retention-days"]).toBe(14);
+  });
+
+  test("requires live success, the deployed ancestry, and exact cleanup", () => {
+    const enforce = namedStep("Enforce live proof, deployed SHA, and cleanup");
+    expect(enforce.if).toBe(githubExpression("always()"));
+    expect(enforce.env).toMatchObject({
+      EXPECTED_RECOVERY_REQUESTED: githubExpression(
+        "steps.recovery_intent.outputs.requested",
+      ),
+      EXPECTED_SOURCE_SHA: githubExpression("github.sha"),
+      LIVE_PROCESS_STATUS: githubExpression("steps.live.outputs.status"),
+      PRIVACY_VALIDATED: githubExpression("steps.privacy.outputs.validated"),
+    });
+    expect(enforce.run).toContain("validateManagedDedicatedCanaryEvidence");
+    expect(enforce.run).toContain("workflow_recovery_intent_mismatch");
+    expect(enforce.run).toContain(
+      `"${bracedExpansion("LIVE_PROCESS_STATUS:-missing")}" != "0"`,
+    );
+    expect(enforce.run).toContain(
+      `git cat-file -e "${bracedExpansion("deployed_commit")}^{commit}"`,
+    );
+    expect(enforce.run).toContain(
+      'git merge-base --is-ancestor "$expected_source_sha" "$deployed_commit"',
+    );
+    expect(enforce.run).toContain("evidence.cleanup.status");
+    expect(enforce.run).toContain(
+      "Managed dedicated canary passed with exact cleanup.",
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

Relates to #16741. This restores the managed-dedicated half of that issue; it intentionally does not close the separate Headscale health-check half.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` (`15ece9a356874057ae0e9db281be628d4d61c660`) with zero conflicts.
- [ ] Full `bun install && bun run verify` was not counted: the shared dependency farm is incomplete for Cloud typechecking. Exact focused validation and the limitation are recorded below.
- [x] A reviewer can confirm the workflow contract from the focused tests and static workflow validation below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ba6602104e7066f21930a649cbf81896b4b727d0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop` `15ece9a356874057ae0e9db281be628d4d61c660`; zero conflicts.
- [ ] Full `bun run verify` is not claimed; see **Known gaps / failures**.

# Risks

Medium, operationally bounded. This adds a credential-backed staging lifecycle job, but it is manual-only, pinned to the exact staging origin, protected by the existing `staging` Environment, serialized to one canary, capped at 45 minutes, fail-closed on missing credentials/evidence, and always enforces exact cleanup. It contains no production target or production mutation path.

# Background

## What does this PR do?

- Adds `dedicated` to the consolidated `Live Smoke` workflow and makes `all` include the same managed-dedicated canary.
- Restores the repository's canonical `managed-dedicated-canary.ts` as an executable staging job after its former standalone workflow owner was retired.
- Preserves a fixed single-canary concurrency group, exact `https://api-staging.elizacloud.ai` target validation, credential fail-closed preflight, optional exact-identity stale-canary recovery, strict privacy canonicalization, bounded artifact retention, deployed-SHA ancestry enforcement, and final cleanup verification.
- Adds a focused YAML contract test and updates the workflow/canary ownership documentation.

## What kind of change is this?

Bug fix / CI and staging operations repair.

# Documentation changes needed?

Documentation is updated in `.github/workflows/README.md` and `packages/cloud/scripts/admin/MANAGED_DEDICATED_CANARY.md`.

# Testing

## Where should a reviewer start?

1. `.github/workflows/live-smoke.yml`
2. `packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts`
3. `packages/cloud/scripts/admin/MANAGED_DEDICATED_CANARY.md`

## Detailed testing steps

- Pre-rebase head `8a377d0047e44c0050bad9ed7adfc23e9bfe695b`: pinned Bun 1.3.14 focused contract/canary suite **57/57 passed**.
- Current rebased head `ba6602104e7066f21930a649cbf81896b4b727d0`: pinned Bun 1.3.14 focused contract/canary suite **57/57 passed**; range-diff is exact, stable patch-id is unchanged, and all four changed result blobs are identical.
- `actionlint .github/workflows/live-smoke.yml`: **passed**.
- Biome on the new workflow contract test: **passed**.
- `git diff --check origin/develop...HEAD`: **passed**.
- `git merge-base --is-ancestor origin/develop HEAD`: **passed**.

# Evidence Gate

<!-- evidence-head:dd275f2fdbccb366feb1c6d1d7a036ea3194003f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow-only change; the executable evidence is the exact-head workflow contract test.
<!-- evidence-row:backend-logs -->
- [x] N/A - pre-merge, GitHub cannot dispatch this new workflow definition from the default branch until it is merged. The first protected staging dispatch is an explicit post-merge gate.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, provider, action, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - pre-merge, the job itself requires, privacy-validates, uploads, and verifies the managed-dedicated canary artifact; a missing or invalid artifact fails the run.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior change.

## Backend + frontend logs

N/A pre-merge. After merge, dispatch `Live Smoke` with `suite=dedicated` under the protected `staging` Environment. The workflow must produce its validated JSON artifact and pass deployed-SHA ancestry plus cleanup enforcement before this canary is treated as release evidence.

## Screenshots (before / after) + video walkthrough

N/A - workflow-only change.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- Full `bun run verify:cloud` could not be interpreted in the shared checkout because its symlinked dependency farm lacks unrelated packages including `drizzle`/`ai`; focused lint/test validation above is green.
- No live staging lifecycle is claimed from the PR branch. The workflow must first exist on the default branch; a protected post-merge `dedicated` dispatch remains required before production promotion.
- The Headscale API-key health lane mentioned by #16741 is intentionally outside this PR.

# Deploy Notes

No production deployment or mutation. After merge, run the protected staging-only `Live Smoke` workflow with `suite=dedicated`; require a green canary, privacy-safe artifact, exact served ancestry, and cleanup before considering production promotion.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@ba6602104e7066f21930a649cbf81896b4b727d0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@ba6602104e7066f21930a649cbf81896b4b727d0:packages/skills/skills/contribute-to-eliza"} -->






