### PR TITLE
fix(plugin-elizacloud): retry cold-gateway warming 503 on the embeddings path

### DIFF
--- a/packages/agent/src/runtime/__tests__/default-documents.cloud-warming.test.ts
+++ b/packages/agent/src/runtime/__tests__/default-documents.cloud-warming.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Proves bundled-document seeding survives a cold Eliza Cloud embedding
+ * gateway through the real AgentRuntime model registry, HTTP client, and
+ * in-memory persistence adapter. The local server is deterministic but no
+ * runtime, model, transport, or database boundary is mocked.
+ */
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import {
+  AgentRuntime,
+  EventType,
+  InMemoryDatabaseAdapter,
+  MemoryType,
+  type UUID,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { registerCloudEmbeddingModels } from "../../../../../plugins/plugin-elizacloud/src/index.ts";
+
+import {
+  type DefaultDocumentDefinition,
+  seedBundledDocuments,
+} from "../default-documents.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-00000000c01d" as UUID;
+const EMBEDDING = Array.from({ length: 384 }, (_, index) => index / 384);
+const DOCUMENT: DefaultDocumentDefinition = {
+  key: "cold-cloud-seed",
+  version: 1,
+  filename: "cold-cloud-seed.txt",
+  contentType: "text/plain",
+  text: "A bundled document must survive a warming embedding gateway.",
+  fragments: [
+    { text: "A bundled document must survive a warming embedding gateway." },
+  ],
+};
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe("bundled documents with a warming cloud embedding gateway", () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (server) {
+      await closeServer(server);
+      server = undefined;
+    }
+  });
+
+  it("retries the one-shot seed, persists its real vector, and stays idempotent", async () => {
+    const requests: Array<{
+      authorization: string | undefined;
+      body: Record<string, unknown>;
+      path: string | undefined;
+    }> = [];
+    server = createServer(async (request, response) => {
+      const body = JSON.parse(await readBody(request)) as Record<
+        string,
+        unknown
+      >;
+      requests.push({
+        authorization: request.headers.authorization,
+        body,
+        path: request.url,
+      });
+
+      response.setHeader("content-type", "application/json");
+      if (requests.length <= 3) {
+        response.statusCode = 503;
+        response.end(
+          JSON.stringify({ error: { code: "embedding_cache_warming" } }),
+        );
+        return;
+      }
+
+      response.statusCode = 200;
+      response.end(
+        JSON.stringify({
+          data: [{ embedding: EMBEDDING, index: 0 }],
+          usage: { prompt_tokens: 11, total_tokens: 11 },
+        }),
+      );
+    });
+    await new Promise<void>((resolve) =>
+      server?.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the embedding test server to bind a TCP port");
+    }
+
+    const adapter = new InMemoryDatabaseAdapter();
+    await adapter.initialize();
+    const runtime = new AgentRuntime({
+      agentId: AGENT_ID,
+      adapter,
+      logLevel: "fatal",
+      settings: {
+        ELIZAOS_CLOUD_EMBEDDING_API_KEY: "test-embedding-key",
+        ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS: "384",
+        ELIZAOS_CLOUD_EMBEDDING_URL: `http://127.0.0.1:${address.port}`,
+      },
+    });
+    registerCloudEmbeddingModels(runtime);
+    const emitEvent = vi.spyOn(runtime, "emitEvent");
+
+    await seedBundledDocuments(runtime, [DOCUMENT]);
+
+    expect(requests).toHaveLength(4);
+    for (const request of requests) {
+      expect(request).toMatchObject({
+        authorization: "Bearer test-embedding-key",
+        path: "/api/v1/embeddings",
+        body: {
+          dimensions: 384,
+          input: [DOCUMENT.fragments[0].text],
+          model: "text-embedding-3-small",
+        },
+      });
+    }
+    expect(emitEvent).toHaveBeenCalledTimes(1);
+    expect(emitEvent).toHaveBeenCalledWith(
+      EventType.MODEL_USED,
+      expect.objectContaining({
+        source: "elizacloud",
+        type: "TEXT_EMBEDDING",
+        tokens: { completion: 0, prompt: 11, total: 11 },
+      }),
+    );
+
+    const fragments = await runtime.getMemories({
+      agentId: AGENT_ID,
+      roomId: AGENT_ID,
+      tableName: "document_fragments",
+      count: 10,
+    });
+    expect(fragments).toHaveLength(1);
+    expect(fragments[0]).toMatchObject({
+      content: { text: DOCUMENT.fragments[0].text },
+      embedding: EMBEDDING,
+      metadata: {
+        bundledDocumentKey: DOCUMENT.key,
+        type: MemoryType.FRAGMENT,
+      },
+    });
+
+    await seedBundledDocuments(runtime, [DOCUMENT]);
+    expect(requests).toHaveLength(4);
+    expect(emitEvent).toHaveBeenCalledTimes(1);
+    await expect(
+      runtime.getMemories({
+        agentId: AGENT_ID,
+        roomId: AGENT_ID,
+        tableName: "document_fragments",
+        count: 10,
+      }),
+    ).resolves.toHaveLength(1);
+  }, 10_000);
+});

--- a/plugins/plugin-elizacloud/__tests__/unit/embeddings.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/embeddings.test.ts
@@ -185,6 +185,82 @@ describe("handleBatchTextEmbedding no-marker-on-failure", () => {
   });
 });
 
+describe("handleBatchTextEmbedding cold-gateway warming retry (#18103)", () => {
+  // The structural warming 503 body the gateway emits while auth/billing
+  // caches hydrate (#17875's shape) — the class that dropped one-shot seeds.
+  function warmingResponse(): Response {
+    return new Response(
+      JSON.stringify({
+        error: {
+          message: "Authorization cache is warming. Retry shortly.",
+          type: "service_unavailable",
+          code: "auth_cache_warming",
+        },
+      }),
+      { status: 503, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  it("retries through the warming window and returns real vectors (seed survives a cold cache)", async () => {
+    vi.useFakeTimers();
+    try {
+      // Three warming 503s exceed the ordinary 2-attempt transient budget —
+      // proving the warming schedule is its own budget — then success.
+      requestRaw
+        .mockResolvedValueOnce(warmingResponse())
+        .mockResolvedValueOnce(warmingResponse())
+        .mockResolvedValueOnce(warmingResponse())
+        .mockResolvedValueOnce(embeddingResponse([vec(0.7)]));
+      const promise = handleBatchTextEmbedding(makeRuntime(), ["a"]);
+      await vi.runAllTimersAsync();
+      expect(await promise).toEqual([vec(0.7)]);
+      expect(requestRaw).toHaveBeenCalledTimes(4);
+      expect(emitModelUsageEvent).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still fails closed when the gateway keeps warming past the bounded budget", async () => {
+    vi.useFakeTimers();
+    try {
+      // Warming budget (4 retries) + transient budget (1 retry) all warming →
+      // terminal 503 throw, never a marker vector.
+      requestRaw.mockImplementation(async () => warmingResponse());
+      const promise = handleBatchTextEmbedding(makeRuntime(), ["a"]);
+      const assertion = expect(promise).rejects.toThrow(/API error: 503/);
+      await vi.runAllTimersAsync();
+      await assertion;
+      // 1 initial + 4 warming retries + 1 transient retry = 6 total attempts.
+      expect(requestRaw).toHaveBeenCalledTimes(6);
+      expect(emitModelUsageEvent).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a NON-warming 503 on the small transient budget (dead gateway fails promptly)", async () => {
+    vi.useFakeTimers();
+    try {
+      const dead = () =>
+        new Response(JSON.stringify({ error: { code: "upstream_error" } }), {
+          status: 503,
+          statusText: "Unavailable",
+          headers: { "Content-Type": "application/json" },
+        });
+      requestRaw.mockImplementation(async () => dead());
+      const promise = handleBatchTextEmbedding(makeRuntime(), ["a"]);
+      const assertion = expect(promise).rejects.toThrow(/API error: 503/);
+      await vi.runAllTimersAsync();
+      await assertion;
+      // No warming budget consumed: 1 initial + 1 transient retry only.
+      expect(requestRaw).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("embeddingBackoffMs cap + escalation", () => {
   afterEach(() => vi.restoreAllMocks());
 

--- a/plugins/plugin-elizacloud/src/models/embeddings.ts
+++ b/plugins/plugin-elizacloud/src/models/embeddings.ts
@@ -8,6 +8,7 @@ import {
 import { getSetting } from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
 import { createCloudApiClient } from "../utils/sdk-client";
+import { nextWarmingRetryDelayMs } from "./text";
 
 const MAX_BATCH_SIZE = 100;
 
@@ -206,7 +207,19 @@ export async function handleBatchTextEmbedding(
       // bounded exponential backoff (see EMBED_* constants) instead of a single
       // 30s blind sleep.
       let response: Response | null = null;
-      for (let attempt = 0; attempt < EMBED_MAX_ATTEMPTS; attempt++) {
+      // The cold-gateway warming 503 (`*_cache_warming` body, #17875) gets its
+      // OWN bounded budget, separate from the small transient budget below: a
+      // fresh container / node move / cache-TTL expiry answers the first
+      // /embeddings calls with a structural retry-shortly signal for ~3s while
+      // the Worker hydrates auth/billing caches. Spending the 2-attempt
+      // transient budget on that window dropped one-shot seed embeddings
+      // (bundled-document seeds are attempted exactly once) — #18103. The
+      // warming schedule sums past the measured recovery; anything still
+      // failing after it falls through to the existing transient policy so a
+      // genuinely dead gateway still fails promptly.
+      const warmingState = { attempt: 0 };
+      let attempt = 0;
+      for (;;) {
         const resp = await timeInferenceSpan(
           "cloud.embedding",
           () =>
@@ -238,11 +251,35 @@ export async function handleBatchTextEmbedding(
           );
         }
 
+        if (resp.status === 503) {
+          // Reading the body is safe here: a 503 never reaches the JSON
+          // success path, and the error path below uses only status/statusText.
+          const bodyText = await resp.text().catch(() => "");
+          const warmingDelayMs = nextWarmingRetryDelayMs(warmingState, resp, bodyText);
+          if (warmingDelayMs !== undefined) {
+            logger.warn(
+              `[BatchEmbeddings] cloud gateway is warming (503) — retrying in ${warmingDelayMs}ms (warming attempt ${warmingState.attempt})`
+            );
+            await sleep(warmingDelayMs, signal);
+            continue;
+          }
+          // Not a warming 503 (or the warming budget is spent): the ordinary
+          // transient policy applies. Body already drained above.
+          if (attempt < EMBED_MAX_ATTEMPTS - 1) {
+            const delay = embeddingBackoffMs(attempt, rateLimitInfo.retryAfter);
+            logger.warn(
+              `[BatchEmbeddings] ${resp.status} (attempt ${attempt + 1}/${EMBED_MAX_ATTEMPTS}) — backing off ${delay}ms`
+            );
+            attempt += 1;
+            await sleep(delay, signal);
+            continue;
+          }
+          response = resp;
+          break;
+        }
+
         const transient =
-          resp.status === 429 ||
-          resp.status === 502 ||
-          resp.status === 503 ||
-          resp.status === 504;
+          resp.status === 429 || resp.status === 502 || resp.status === 504;
         if (transient && attempt < EMBED_MAX_ATTEMPTS - 1) {
           const delay = embeddingBackoffMs(attempt, rateLimitInfo.retryAfter);
           logger.warn(
@@ -250,6 +287,7 @@ export async function handleBatchTextEmbedding(
           );
           // Drain the body so the underlying connection can be reused.
           await resp.text().catch(() => undefined);
+          attempt += 1;
           await sleep(delay, signal);
           continue;
         }


### PR DESCRIPTION
## Summary
#17875 gave the chat/completions and responses paths a bounded in-place retry for the cold-gateway warming 503 (`*_cache_warming` body while the Worker hydrates auth/billing caches). The **/embeddings batch path never got it**: it only had a small 2-attempt transient budget, which the ~3s warming window exceeds. One-shot seed embeddings (boot-time bundled-document seed is attempted exactly once) were silently dropped, leaving that content unsearchable.

Closes #18103.

## Live repro (staging, 2026-08-09)
Fresh dedicated agent provisioned on `ghcr.io/elizaos/eliza:develop` (digest a9965b7b):
```
[BatchEmbeddings] 503 (attempt 1/2) — backing off 1203ms
[BatchEmbeddings] Batch failed: [BatchEmbeddings] API error: 503 Service Unavailable
[eliza] Failed to seed bundled documents: [BatchEmbeddings] API error: 503 Service Unavailable
```
Same window, the chat turns retried per #17875 and succeeded. Embeddings did not.

## Fix
Reuse the exact structural gate + bounded schedule from `models/text.ts` (`nextWarmingRetryDelayMs`, exported by #17875) in `handleBatchTextEmbedding`:
- Only a 503 whose body carries a `*_cache_warming` code (or the retryable `service_unavailable` envelope) consumes the warming budget; the schedule sums past the measured recovery and honors `Retry-After` clamped to the cap.
- A **non-warming** 503 (dead gateway, provider-mapped 5xx) still rides the ordinary small transient budget and fails promptly.
- Terminal failures still throw — never marker vectors (Commandment 8 preserved).
- The warming budget is separate from the transient budget, mirroring the text path, so the two backoffs don't compound and a genuinely dead gateway isn't retried 6+ times on the *transient* classification.

## Tests (bidirectional)
- `retries through the warming window and returns real vectors` — 3 warming 503s (exceeds the old 2-attempt budget) then success ⇒ vectors returned, usage emitted. **Fails on the old code** (old code threw after attempt 2).
- `still fails closed when the gateway keeps warming past the bounded budget` — warming forever ⇒ terminal 503 throw after exactly 1 + 4 warming + 1 transient attempts, no usage event.
- `keeps a NON-warming 503 on the small transient budget` — dead-gateway 503 body ⇒ exactly 2 attempts, prompt failure (guards against over-retrying real outages).
- `retries the one-shot seed, persists its real vector, and stays idempotent` — a real local HTTP gateway returns 3 warming 503s, then a 384d vector; the real AgentRuntime model registry and InMemoryDatabaseAdapter persist exactly one fragment, emit one usage event, and make no second request or row on reseed.

`bun run vitest run __tests__/unit/embeddings.test.ts __tests__/unit/text-warming-retry.test.ts` → 33/33 pass. `tsc --noEmit` clean.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: sol (original implementation); openai/gpt-5 (review remediation, system-reported model family; deployment variant unavailable)
<!-- attribution-row:client -->
- Agent tooling: Sol and Codex
<!-- attribution-row:skill-revision -->
- Skill path: N/A - installed Codex plugin packages do not expose a repository commit SHA
<!-- attribution-row:status -->
- Provenance status: self-reported

# Evidence Gate

<!-- evidence-head:3c7a43faeb16c22f7a49bdee819f88f16299ce42 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend embedding retry and persistence behavior only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend embedding retry and persistence behavior only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the deterministic HTTP/runtime/persistence transcript exercises the complete affected path more precisely than a UI recording.
<!-- evidence-row:backend-logs -->
- [x] [18158-cold-seed-proof-3c7a43fa.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18158-cold-seed-proof-3c7a43fa.txt) — exact head: composed seeder 11/11, embedding/warming handlers 33/33, both package lints clean, plugin typecheck clean.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt or generative-model behavior; the changed model handler is a deterministic embedding HTTP transport, captured in the backend proof.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - persisted embedding row, vector, and idempotency assertions are recorded in the backend proof; no separate user-facing domain artifact is produced.
