### PR TITLE
fix(cloud): always mark managed agents as ELIZA_CLOUD_PROVISIONED

### DIFF
--- a/packages/agent/src/api/health-routes.cloud-provisioned.test.ts
+++ b/packages/agent/src/api/health-routes.cloud-provisioned.test.ts
@@ -1,12 +1,19 @@
 /**
- * Runtime-boundary coverage for GET /api/status `cloud.cloudProvisioned`.
- * Proves the managed hosting marker + credential contract reaches the status
- * payload the UI reads, and that a user-owned/self-hosted process without the
- * marker reports false. Uses the real isCloudProvisionedContainer detector via
- * plugin-elizacloud (no mock of the system under test).
+ * Hermetic integration for managed hosting detection through the real
+ * runtime boundary the UI reads:
+ *
+ *   prepareManagedElizaBaseEnvironment()
+ *     → container process env (producer map applied)
+ *     → isCloudProvisionedContainer() (shared detector used by elizacloud)
+ *     → handleHealthRoutes GET /api/status → cloud.cloudProvisioned
+ *
+ * Also covers self-hosted (no managed env) and bare-marker-without-credential
+ * controls. Snapshots and restores every process.env key this suite mutates.
  */
 
+import { mock } from "bun:test";
 import type { AgentRuntime } from "@elizaos/core";
+import { isCloudProvisionedContainer } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ElizaConfig } from "../config/config.ts";
 import {
@@ -14,15 +21,63 @@ import {
   handleHealthRoutes,
 } from "./health-routes.ts";
 
-const CLOUD_ENV_KEYS = [
-  "ELIZA_CLOUD_PROVISIONED",
-  "ELIZA_API_TOKEN",
-  "ELIZAOS_CLOUD_API_KEY",
-  "ELIZAOS_CLOUD_ENABLED",
-  "STEWARD_AGENT_TOKEN",
-] as const;
+// Mock the Cloud control-plane API-key mint used by the managed env producer so
+// the agent package can call prepareManagedElizaBaseEnvironment without a DB.
+mock.module(
+  new URL("../../../cloud/shared/src/lib/services/api-keys.ts", import.meta.url)
+    .href,
+  () => ({
+    apiKeysService: {
+      createForAgent: async () => ({ plainKey: "agent-api-key" }),
+    },
+  }),
+);
 
-function makeStatusContext(): {
+const { prepareManagedElizaBaseEnvironment } = await import(
+  new URL(
+    "../../../cloud/shared/src/lib/services/managed-eliza-config.ts",
+    import.meta.url,
+  ).href
+);
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return { ...process.env };
+}
+
+function restoreEnv(snapshot: Record<string, string | undefined>): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key];
+    }
+  }
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function applyProducerEnv(environmentVars: Record<string, string>): void {
+  for (const [key, value] of Object.entries(environmentVars)) {
+    process.env[key] = value;
+  }
+}
+
+function clearManagedDetectionKeys(): void {
+  for (const key of [
+    "ELIZA_CLOUD_PROVISIONED",
+    "ELIZA_API_TOKEN",
+    "ELIZAOS_CLOUD_API_KEY",
+    "ELIZAOS_CLOUD_ENABLED",
+    "STEWARD_AGENT_TOKEN",
+  ]) {
+    delete process.env[key];
+  }
+}
+
+function makeStatusContext(agentName: string): {
   ctx: HealthRouteContext;
   responses: Array<{ data: unknown; status: number }>;
 } {
@@ -35,7 +90,7 @@ function makeStatusContext(): {
     runtime,
     config: { connectors: {} } as ElizaConfig,
     agentState: "running",
-    agentName: "managed-test-agent",
+    agentName,
     model: undefined,
     startedAt: Date.now(),
     startup: { phase: "ready", attempt: 1 },
@@ -62,54 +117,60 @@ function makeStatusContext(): {
   };
 }
 
-describe("GET /api/status cloud.cloudProvisioned (managed vs user-owned)", () => {
-  const savedEnv = Object.fromEntries(
-    CLOUD_ENV_KEYS.map((key) => [key, process.env[key]]),
-  );
+describe("producer → detector → GET /api/status cloudProvisioned", () => {
+  let envSnapshot: Record<string, string | undefined>;
 
   beforeEach(() => {
-    for (const key of CLOUD_ENV_KEYS) {
-      delete process.env[key];
-    }
+    envSnapshot = snapshotEnv();
+    clearManagedDetectionKeys();
   });
 
   afterEach(() => {
-    for (const [key, value] of Object.entries(savedEnv)) {
-      if (value === undefined) delete process.env[key];
-      else process.env[key] = value;
-    }
+    restoreEnv(envSnapshot);
   });
 
-  it("reports cloudProvisioned true when the managed marker and a credential are present", async () => {
-    // Mirrors prepareManagedElizaBaseEnvironment + control-plane injection:
-    // flag is forced on, and a platform token is always present.
-    process.env.ELIZA_CLOUD_PROVISIONED = "1";
-    process.env.ELIZA_API_TOKEN = "agent_test_token_not_a_secret";
+  it("managed producer map yields cloud.cloudProvisioned true on /api/status", async () => {
+    const produced = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-boundary-1",
+      userId: "user-boundary-1",
+      agentSandboxId: "managed-boundary-agent",
+      existingEnv: {
+        // Caller tries to clear the marker; producer must still force it on.
+        ELIZA_CLOUD_PROVISIONED: "0",
+      },
+    });
 
-    const { ctx, responses } = makeStatusContext();
+    expect(produced.environmentVars.ELIZA_CLOUD_PROVISIONED).toBe("1");
+    expect(produced.environmentVars.ELIZA_API_TOKEN?.length).toBeGreaterThan(0);
+
+    // Control-plane container create injects the producer map as process env.
+    applyProducerEnv(produced.environmentVars);
+
+    // Real shared detector (same contract plugin-elizacloud / status use).
+    expect(isCloudProvisionedContainer()).toBe(true);
+
+    const { ctx, responses } = makeStatusContext("managed-boundary-agent");
     await expect(handleHealthRoutes(ctx)).resolves.toBe(true);
 
     expect(responses).toHaveLength(1);
     expect(responses[0].status).toBe(200);
     expect(responses[0].data).toMatchObject({
       state: "running",
-      agentName: "managed-test-agent",
+      agentName: "managed-boundary-agent",
       cloud: {
         cloudProvisioned: true,
         connectionStatus: "connected",
-        activeAgentId: "managed-test-agent",
+        activeAgentId: "managed-boundary-agent",
       },
     });
   });
 
-  it("reports cloudProvisioned false for a user-owned/self-hosted process", async () => {
-    // No ELIZA_CLOUD_PROVISIONED and no cloud credentials — the default local
-    // install shape. Flag alone without a credential must also stay false, but
-    // the self-hosted path is the complete absence of managed env.
-    const { ctx, responses } = makeStatusContext();
+  it("user-owned/self-hosted process without producer env reports false", async () => {
+    expect(isCloudProvisionedContainer()).toBe(false);
+
+    const { ctx, responses } = makeStatusContext("local-agent");
     await expect(handleHealthRoutes(ctx)).resolves.toBe(true);
 
-    expect(responses).toHaveLength(1);
     expect(responses[0].status).toBe(200);
     expect(responses[0].data).toMatchObject({
       cloud: {
@@ -121,11 +182,13 @@ describe("GET /api/status cloud.cloudProvisioned (managed vs user-owned)", () =>
     });
   });
 
-  it("does not treat a bare managed marker without credentials as provisioned", async () => {
+  it("bare managed marker without credentials stays unprovisioned", async () => {
     process.env.ELIZA_CLOUD_PROVISIONED = "1";
     // No ELIZA_API_TOKEN / STEWARD_AGENT_TOKEN / cloud API key.
 
-    const { ctx, responses } = makeStatusContext();
+    expect(isCloudProvisionedContainer()).toBe(false);
+
+    const { ctx, responses } = makeStatusContext("bare-marker-agent");
     await expect(handleHealthRoutes(ctx)).resolves.toBe(true);
 
     expect(responses[0].data).toMatchObject({

--- a/packages/agent/src/api/health-routes.cloud-provisioned.test.ts
+++ b/packages/agent/src/api/health-routes.cloud-provisioned.test.ts
@@ -3,66 +3,49 @@
  * runtime boundary the UI reads:
  *
  *   prepareManagedElizaBaseEnvironment()
- *     → container process env (producer map applied)
- *     → isCloudProvisionedContainer() (shared detector used by elizacloud)
+ *     → container process env (full producer map applied)
+ *     → isCloudProvisionedContainer() (@elizaos/shared)
  *     → handleHealthRoutes GET /api/status → cloud.cloudProvisioned
  *
  * Also covers self-hosted (no managed env) and bare-marker-without-credential
  * controls. Snapshots and restores every process.env key this suite mutates.
  */
 
-import { mock } from "bun:test";
 import type { AgentRuntime } from "@elizaos/core";
 import { isCloudProvisionedContainer } from "@elizaos/shared";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ElizaConfig } from "../config/config.ts";
 import {
   type HealthRouteContext,
   handleHealthRoutes,
 } from "./health-routes.ts";
 
-// Mock the Cloud control-plane API-key mint used by the managed env producer so
-// the agent package can call prepareManagedElizaBaseEnvironment without a DB.
-mock.module(
-  new URL("../../../cloud/shared/src/lib/services/api-keys.ts", import.meta.url)
-    .href,
-  () => ({
-    apiKeysService: {
-      createForAgent: async () => ({ plainKey: "agent-api-key" }),
-    },
-  }),
-);
+// Mock the control-plane API-key mint so the agent package can call the real
+// managed env producer without a Cloud DB. Path is static for vitest hoisting.
+vi.mock("../../../cloud/shared/src/lib/services/api-keys.ts", () => ({
+  apiKeysService: {
+    createForAgent: async () => ({
+      plainKey: "agent-api-key",
+      apiKey: {},
+    }),
+  },
+}));
 
 const { prepareManagedElizaBaseEnvironment } = await import(
-  new URL(
-    "../../../cloud/shared/src/lib/services/managed-eliza-config.ts",
-    import.meta.url,
-  ).href
+  "../../../cloud/shared/src/lib/services/managed-eliza-config.ts"
 );
 
-function snapshotEnv(): Record<string, string | undefined> {
+function snapshotEnv(): NodeJS.ProcessEnv {
   return { ...process.env };
 }
 
-function restoreEnv(snapshot: Record<string, string | undefined>): void {
+function restoreEnv(snapshot: NodeJS.ProcessEnv): void {
   for (const key of Object.keys(process.env)) {
     if (!(key in snapshot)) {
       delete process.env[key];
     }
   }
-  for (const [key, value] of Object.entries(snapshot)) {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-}
-
-function applyProducerEnv(environmentVars: Record<string, string>): void {
-  for (const [key, value] of Object.entries(environmentVars)) {
-    process.env[key] = value;
-  }
+  Object.assign(process.env, snapshot);
 }
 
 function clearManagedDetectionKeys(): void {
@@ -118,7 +101,7 @@ function makeStatusContext(agentName: string): {
 }
 
 describe("producer → detector → GET /api/status cloudProvisioned", () => {
-  let envSnapshot: Record<string, string | undefined>;
+  let envSnapshot: NodeJS.ProcessEnv;
 
   beforeEach(() => {
     envSnapshot = snapshotEnv();
@@ -143,10 +126,9 @@ describe("producer → detector → GET /api/status cloudProvisioned", () => {
     expect(produced.environmentVars.ELIZA_CLOUD_PROVISIONED).toBe("1");
     expect(produced.environmentVars.ELIZA_API_TOKEN?.length).toBeGreaterThan(0);
 
-    // Control-plane container create injects the producer map as process env.
-    applyProducerEnv(produced.environmentVars);
+    // Control-plane container create injects the full producer map.
+    Object.assign(process.env, produced.environmentVars);
 
-    // Real shared detector (same contract plugin-elizacloud / status use).
     expect(isCloudProvisionedContainer()).toBe(true);
 
     const { ctx, responses } = makeStatusContext("managed-boundary-agent");

--- a/packages/agent/src/api/health-routes.cloud-provisioned.test.ts
+++ b/packages/agent/src/api/health-routes.cloud-provisioned.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Runtime-boundary coverage for GET /api/status `cloud.cloudProvisioned`.
+ * Proves the managed hosting marker + credential contract reaches the status
+ * payload the UI reads, and that a user-owned/self-hosted process without the
+ * marker reports false. Uses the real isCloudProvisionedContainer detector via
+ * plugin-elizacloud (no mock of the system under test).
+ */
+
+import type { AgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ElizaConfig } from "../config/config.ts";
+import {
+  type HealthRouteContext,
+  handleHealthRoutes,
+} from "./health-routes.ts";
+
+const CLOUD_ENV_KEYS = [
+  "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_API_TOKEN",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_ENABLED",
+  "STEWARD_AGENT_TOKEN",
+] as const;
+
+function makeStatusContext(): {
+  ctx: HealthRouteContext;
+  responses: Array<{ data: unknown; status: number }>;
+} {
+  const responses: Array<{ data: unknown; status: number }> = [];
+  const runtime = {
+    plugins: [],
+    getModel: () => undefined,
+  } as unknown as AgentRuntime;
+  const state = {
+    runtime,
+    config: { connectors: {} } as ElizaConfig,
+    agentState: "running",
+    agentName: "managed-test-agent",
+    model: undefined,
+    startedAt: Date.now(),
+    startup: { phase: "ready", attempt: 1 },
+    plugins: [],
+    pendingRestartReasons: [],
+    connectorHealthMonitor: null,
+  };
+  return {
+    responses,
+    ctx: {
+      req: {} as HealthRouteContext["req"],
+      res: {} as HealthRouteContext["res"],
+      method: "GET",
+      pathname: "/api/status",
+      url: new URL("http://127.0.0.1/api/status"),
+      state,
+      json: (_res, data, status = 200) => {
+        responses.push({ data, status });
+      },
+      error: (_res, message, status = 500) => {
+        responses.push({ data: { error: message }, status });
+      },
+    },
+  };
+}
+
+describe("GET /api/status cloud.cloudProvisioned (managed vs user-owned)", () => {
+  const savedEnv = Object.fromEntries(
+    CLOUD_ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
+
+  beforeEach(() => {
+    for (const key of CLOUD_ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("reports cloudProvisioned true when the managed marker and a credential are present", async () => {
+    // Mirrors prepareManagedElizaBaseEnvironment + control-plane injection:
+    // flag is forced on, and a platform token is always present.
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZA_API_TOKEN = "agent_test_token_not_a_secret";
+
+    const { ctx, responses } = makeStatusContext();
+    await expect(handleHealthRoutes(ctx)).resolves.toBe(true);
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0].status).toBe(200);
+    expect(responses[0].data).toMatchObject({
+      state: "running",
+      agentName: "managed-test-agent",
+      cloud: {
+        cloudProvisioned: true,
+        connectionStatus: "connected",
+        activeAgentId: "managed-test-agent",
+      },
+    });
+  });
+
+  it("reports cloudProvisioned false for a user-owned/self-hosted process", async () => {
+    // No ELIZA_CLOUD_PROVISIONED and no cloud credentials — the default local
+    // install shape. Flag alone without a credential must also stay false, but
+    // the self-hosted path is the complete absence of managed env.
+    const { ctx, responses } = makeStatusContext();
+    await expect(handleHealthRoutes(ctx)).resolves.toBe(true);
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0].status).toBe(200);
+    expect(responses[0].data).toMatchObject({
+      cloud: {
+        cloudProvisioned: false,
+        connectionStatus: "disconnected",
+        activeAgentId: null,
+        hasApiKey: false,
+      },
+    });
+  });
+
+  it("does not treat a bare managed marker without credentials as provisioned", async () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    // No ELIZA_API_TOKEN / STEWARD_AGENT_TOKEN / cloud API key.
+
+    const { ctx, responses } = makeStatusContext();
+    await expect(handleHealthRoutes(ctx)).resolves.toBe(true);
+
+    expect(responses[0].data).toMatchObject({
+      cloud: {
+        cloudProvisioned: false,
+      },
+    });
+  });
+});

--- a/packages/agent/src/api/health-routes.ts
+++ b/packages/agent/src/api/health-routes.ts
@@ -18,6 +18,10 @@ import {
   getSwarmCoordinatorService,
   hasTextGenerationHandler,
 } from "@elizaos/core";
+// Pure env detector lives in shared so status can report managed hosting mode
+// without loading the full cloud plugin graph (which may fail in lean test
+// harnesses or partial installs).
+import { isCloudProvisionedContainer } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
 import { getDeferredBootStatus } from "../runtime/deferred-boot-status.ts";
 import { detectRuntimeModel } from "./agent-model.ts";
@@ -25,21 +29,20 @@ import type { ConnectorHealthMonitor } from "./connector-health.ts";
 import { probeRuntimeDatabaseLiveness } from "./database-liveness.ts";
 import { loadLocalInferenceRouteApi } from "./local-inference-server-api.ts";
 
-type CloudHealthApi = {
-  isCloudProvisionedContainer: () => boolean;
+type CloudApiKeyResolver = {
   resolveCloudApiKey: (
     config: ElizaConfig,
     runtime: AgentRuntime | null,
   ) => string | undefined;
 };
 
-let cloudHealthApiPromise: Promise<CloudHealthApi> | null = null;
+let cloudApiKeyResolverPromise: Promise<CloudApiKeyResolver> | null = null;
 
-function getCloudHealthApi(): Promise<CloudHealthApi> {
-  cloudHealthApiPromise ??= import(
+function getCloudApiKeyResolver(): Promise<CloudApiKeyResolver> {
+  cloudApiKeyResolverPromise ??= import(
     "@elizaos/plugin-elizacloud"
-  ) as Promise<CloudHealthApi>;
-  return cloudHealthApiPromise;
+  ) as Promise<CloudApiKeyResolver>;
+  return cloudApiKeyResolverPromise;
 }
 
 // ---------------------------------------------------------------------------
@@ -508,32 +511,25 @@ export async function handleHealthRoutes(
       state.model ??
       activeLocalModel ??
       detectRuntimeModel(state.runtime ?? null, state.config);
-    // Cloud health is optional status info under the same resilience contract:
-    // a missing/unloadable @elizaos/plugin-elizacloud must degrade to
-    // "disconnected", not 500 the status endpoint.
-    let cloudStatus = {
-      connectionStatus: "disconnected",
-      activeAgentId: null as string | null,
-      cloudProvisioned: false,
-      hasApiKey: false,
-    };
+    // Managed hosting detection is a pure env check from @elizaos/shared and
+    // must not depend on loading plugin-elizacloud. Optional hasApiKey still
+    // comes from the plugin and degrades to false if the plugin is unloadable
+    // — never 500 the status endpoint for optional cloud status fields.
+    const cloudProvisioned = isCloudProvisionedContainer();
+    let hasCloudApiKey = false;
     try {
-      const { isCloudProvisionedContainer, resolveCloudApiKey } =
-        await getCloudHealthApi();
-      const cloudProvisioned = isCloudProvisionedContainer();
-      const hasCloudApiKey = Boolean(
-        resolveCloudApiKey(state.config, state.runtime),
-      );
-      cloudStatus = {
-        connectionStatus:
-          cloudProvisioned || hasCloudApiKey ? "connected" : "disconnected",
-        activeAgentId: cloudProvisioned ? state.agentName : null,
-        cloudProvisioned,
-        hasApiKey: hasCloudApiKey,
-      };
+      const { resolveCloudApiKey } = await getCloudApiKeyResolver();
+      hasCloudApiKey = Boolean(resolveCloudApiKey(state.config, state.runtime));
     } catch {
-      // keep the disconnected default — cloud health is optional status info
+      // error-policy:J4 optional cloud API-key probe must not fail /api/status
     }
+    const cloudStatus = {
+      connectionStatus:
+        cloudProvisioned || hasCloudApiKey ? "connected" : "disconnected",
+      activeAgentId: cloudProvisioned ? state.agentName : null,
+      cloudProvisioned,
+      hasApiKey: hasCloudApiKey,
+    };
 
     json(res, {
       state: state.agentState,

--- a/packages/app-core/deploy/Dockerfile.cloud-agent
+++ b/packages/app-core/deploy/Dockerfile.cloud-agent
@@ -82,6 +82,11 @@ ENV NODE_PATH=/app/node_modules
 ENV NODE_ENV=production
 ENV PORT=${APP_PORT}
 ENV BRIDGE_PORT=${APP_BRIDGE_PORT}
+# Hosting-mode marker: this image is the managed Eliza Cloud agent container.
+# The agent server exposes it as cloudProvisioned so the UI can distinguish
+# managed Cloud from user-owned/self-hosted installs. Provisioning still also
+# injects this via prepareManagedElizaBaseEnvironment for non-image paths.
+ENV ELIZA_CLOUD_PROVISIONED=1
 
 # Health check endpoint
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \

--- a/packages/app-core/deploy/Dockerfile.cloud-agent
+++ b/packages/app-core/deploy/Dockerfile.cloud-agent
@@ -82,11 +82,6 @@ ENV NODE_PATH=/app/node_modules
 ENV NODE_ENV=production
 ENV PORT=${APP_PORT}
 ENV BRIDGE_PORT=${APP_BRIDGE_PORT}
-# Hosting-mode marker: this image is the managed Eliza Cloud agent container.
-# The agent server exposes it as cloudProvisioned so the UI can distinguish
-# managed Cloud from user-owned/self-hosted installs. Provisioning still also
-# injects this via prepareManagedElizaBaseEnvironment for non-image paths.
-ENV ELIZA_CLOUD_PROVISIONED=1
 
 # Health check endpoint
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \

--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
@@ -1,5 +1,5 @@
 // Exercises managed eliza config behavior with deterministic cloud-shared lib fixtures.
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("./api-keys", () => ({
   apiKeysService: {
@@ -395,5 +395,100 @@ describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
     expect(healed.ELIZA_AGENT_LOCAL_STATE).toBe("1");
     expect(healed.PGLITE_DATA_DIR).toBe("/root/.eliza/.pgdata");
     expect(healed.ELIZA_PLUGIN_SET).toBe("lean-chat");
+  });
+});
+
+/**
+ * Composed boundary: producer map → container env apply → detector contract that
+ * GET /api/status uses for `cloud.cloudProvisioned`. Mirrors
+ * packages/shared isCloudProvisionedContainer for the non-aliased keys the
+ * producer emits (flag + token / cloud API key).
+ */
+function isCloudProvisionedFromProcessEnv(): boolean {
+  const hasFlag = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  const hasSteward = Boolean(process.env.STEWARD_AGENT_TOKEN?.trim());
+  const hasApiToken = Boolean(process.env.ELIZA_API_TOKEN?.trim());
+  const hasCloudKey =
+    process.env.ELIZAOS_CLOUD_ENABLED === "true" &&
+    Boolean(process.env.ELIZAOS_CLOUD_API_KEY?.trim());
+  return hasFlag && (hasSteward || hasApiToken || hasCloudKey);
+}
+
+function statusCloudShape(agentName: string) {
+  const cloudProvisioned = isCloudProvisionedFromProcessEnv();
+  return {
+    connectionStatus: cloudProvisioned ? "connected" : "disconnected",
+    activeAgentId: cloudProvisioned ? agentName : null,
+    cloudProvisioned,
+  };
+}
+
+function applyContainerEnv(environmentVars: Record<string, string>) {
+  for (const [key, value] of Object.entries(environmentVars)) {
+    process.env[key] = value;
+  }
+}
+
+describe("managed producer → container env → status detector boundary", () => {
+  const boundaryKeys = [
+    "ELIZA_CLOUD_PROVISIONED",
+    "ELIZA_API_TOKEN",
+    "ELIZAOS_CLOUD_API_KEY",
+    "ELIZAOS_CLOUD_ENABLED",
+    "STEWARD_AGENT_TOKEN",
+  ] as const;
+  const savedBoundary = Object.fromEntries(
+    boundaryKeys.map((key) => [key, process.env[key]]),
+  );
+
+  beforeEach(() => {
+    for (const key of boundaryKeys) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedBoundary)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  test("producer force-set transports through container env into provisioned status shape", async () => {
+    const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
+
+    const produced = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-boundary-1",
+      userId: "user-boundary-1",
+      agentSandboxId: "managed-boundary-agent",
+      existingEnv: {
+        // Caller tries to clear the marker; producer must still force it on.
+        ELIZA_CLOUD_PROVISIONED: "0",
+      },
+    });
+
+    expect(produced.environmentVars.ELIZA_CLOUD_PROVISIONED).toBe("1");
+    expect(produced.environmentVars.ELIZA_API_TOKEN?.length).toBeGreaterThan(0);
+    expect(produced.environmentVars.ELIZAOS_CLOUD_ENABLED).toBe("true");
+    expect(produced.environmentVars.ELIZAOS_CLOUD_API_KEY).toBe("agent-api-key");
+
+    // Control-plane container create injects the producer map as process env.
+    applyContainerEnv(produced.environmentVars);
+
+    expect(isCloudProvisionedFromProcessEnv()).toBe(true);
+    expect(statusCloudShape("managed-boundary-agent")).toEqual({
+      connectionStatus: "connected",
+      activeAgentId: "managed-boundary-agent",
+      cloudProvisioned: true,
+    });
+  });
+
+  test("self-hosted process without producer env reports unprovisioned status shape", () => {
+    expect(isCloudProvisionedFromProcessEnv()).toBe(false);
+    expect(statusCloudShape("local-agent")).toEqual({
+      connectionStatus: "disconnected",
+      activeAgentId: null,
+      cloudProvisioned: false,
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
@@ -437,9 +437,7 @@ describe("managed producer → container env → status detector boundary", () =
     "ELIZAOS_CLOUD_ENABLED",
     "STEWARD_AGENT_TOKEN",
   ] as const;
-  const savedBoundary = Object.fromEntries(
-    boundaryKeys.map((key) => [key, process.env[key]]),
-  );
+  const savedBoundary = Object.fromEntries(boundaryKeys.map((key) => [key, process.env[key]]));
 
   beforeEach(() => {
     for (const key of boundaryKeys) {

--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
@@ -1,5 +1,5 @@
 // Exercises managed eliza config behavior with deterministic cloud-shared lib fixtures.
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("./api-keys", () => ({
   apiKeysService: {
@@ -395,98 +395,5 @@ describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
     expect(healed.ELIZA_AGENT_LOCAL_STATE).toBe("1");
     expect(healed.PGLITE_DATA_DIR).toBe("/root/.eliza/.pgdata");
     expect(healed.ELIZA_PLUGIN_SET).toBe("lean-chat");
-  });
-});
-
-/**
- * Composed boundary: producer map → container env apply → detector contract that
- * GET /api/status uses for `cloud.cloudProvisioned`. Mirrors
- * packages/shared isCloudProvisionedContainer for the non-aliased keys the
- * producer emits (flag + token / cloud API key).
- */
-function isCloudProvisionedFromProcessEnv(): boolean {
-  const hasFlag = process.env.ELIZA_CLOUD_PROVISIONED === "1";
-  const hasSteward = Boolean(process.env.STEWARD_AGENT_TOKEN?.trim());
-  const hasApiToken = Boolean(process.env.ELIZA_API_TOKEN?.trim());
-  const hasCloudKey =
-    process.env.ELIZAOS_CLOUD_ENABLED === "true" &&
-    Boolean(process.env.ELIZAOS_CLOUD_API_KEY?.trim());
-  return hasFlag && (hasSteward || hasApiToken || hasCloudKey);
-}
-
-function statusCloudShape(agentName: string) {
-  const cloudProvisioned = isCloudProvisionedFromProcessEnv();
-  return {
-    connectionStatus: cloudProvisioned ? "connected" : "disconnected",
-    activeAgentId: cloudProvisioned ? agentName : null,
-    cloudProvisioned,
-  };
-}
-
-function applyContainerEnv(environmentVars: Record<string, string>) {
-  for (const [key, value] of Object.entries(environmentVars)) {
-    process.env[key] = value;
-  }
-}
-
-describe("managed producer → container env → status detector boundary", () => {
-  const boundaryKeys = [
-    "ELIZA_CLOUD_PROVISIONED",
-    "ELIZA_API_TOKEN",
-    "ELIZAOS_CLOUD_API_KEY",
-    "ELIZAOS_CLOUD_ENABLED",
-    "STEWARD_AGENT_TOKEN",
-  ] as const;
-  const savedBoundary = Object.fromEntries(boundaryKeys.map((key) => [key, process.env[key]]));
-
-  beforeEach(() => {
-    for (const key of boundaryKeys) {
-      delete process.env[key];
-    }
-  });
-
-  afterEach(() => {
-    for (const [key, value] of Object.entries(savedBoundary)) {
-      if (value === undefined) delete process.env[key];
-      else process.env[key] = value;
-    }
-  });
-
-  test("producer force-set transports through container env into provisioned status shape", async () => {
-    const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
-
-    const produced = await prepareManagedElizaBaseEnvironment({
-      organizationId: "org-boundary-1",
-      userId: "user-boundary-1",
-      agentSandboxId: "managed-boundary-agent",
-      existingEnv: {
-        // Caller tries to clear the marker; producer must still force it on.
-        ELIZA_CLOUD_PROVISIONED: "0",
-      },
-    });
-
-    expect(produced.environmentVars.ELIZA_CLOUD_PROVISIONED).toBe("1");
-    expect(produced.environmentVars.ELIZA_API_TOKEN?.length).toBeGreaterThan(0);
-    expect(produced.environmentVars.ELIZAOS_CLOUD_ENABLED).toBe("true");
-    expect(produced.environmentVars.ELIZAOS_CLOUD_API_KEY).toBe("agent-api-key");
-
-    // Control-plane container create injects the producer map as process env.
-    applyContainerEnv(produced.environmentVars);
-
-    expect(isCloudProvisionedFromProcessEnv()).toBe(true);
-    expect(statusCloudShape("managed-boundary-agent")).toEqual({
-      connectionStatus: "connected",
-      activeAgentId: "managed-boundary-agent",
-      cloudProvisioned: true,
-    });
-  });
-
-  test("self-hosted process without producer env reports unprovisioned status shape", () => {
-    expect(isCloudProvisionedFromProcessEnv()).toBe(false);
-    expect(statusCloudShape("local-agent")).toEqual({
-      connectionStatus: "disconnected",
-      activeAgentId: null,
-      cloudProvisioned: false,
-    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
@@ -102,6 +102,22 @@ describe("managed Eliza environment", () => {
     expect(result.environmentVars.WAIFU_ELIZA_CLOUD_AGENT_ID).toBe("cloud-agent-1");
   });
 
+  test("marks managed containers as cloud-provisioned for UI env detection", async () => {
+    const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
+
+    const result = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentSandboxId: "cloud-agent-1",
+      existingEnv: {
+        // Callers must not be able to clear the managed hosting marker.
+        ELIZA_CLOUD_PROVISIONED: "0",
+      },
+    });
+
+    expect(result.environmentVars.ELIZA_CLOUD_PROVISIONED).toBe("1");
+  });
+
   test("preserves waifu-provided hosted UI enablement", async () => {
     const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
 

--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.ts
@@ -262,6 +262,12 @@ export async function prepareManagedElizaBaseEnvironment(
     agentApiKey,
     environmentVars: {
       ...existingEnv,
+      // Hosting-mode marker: this process is a managed Eliza Cloud agent, not a
+      // user-owned/self-hosted install. Always forced on for the managed path —
+      // callers cannot clear or override it (also in RESERVED_PLATFORM_ENV_KEYS).
+      // The agent server exposes it as `cloudProvisioned` on /api/status and
+      // /api/first-run/status so the UI can render managed vs user-owned UX.
+      ELIZA_CLOUD_PROVISIONED: "1",
       ELIZA_API_TOKEN: apiToken,
       ELIZA_ALLOW_WS_QUERY_TOKEN: "1",
       ELIZA_ALLOWED_ORIGINS: mergeManagedAllowedOrigins(existingEnv.ELIZA_ALLOWED_ORIGINS),

--- a/packages/cloud/shared/src/lib/services/managed-eliza-lean-chat-boot.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-lean-chat-boot.integration.test.ts
@@ -103,10 +103,10 @@ describe("D10 lean-chat local-state cloud agent boot — end-to-end", () => {
   test("(2) resolved lean-chat plugin set excludes local-inference/wallet/workflow, includes elizacloud", async () => {
     const env = await buildManagedEnv();
     // The plugin resolver reads these signals from process.env directly.
+    // Managed env producer always injects ELIZA_CLOUD_PROVISIONED=1 so the
+    // agent/UI can detect managed Cloud vs user-owned installs.
     Object.assign(process.env, env);
-    // ELIZA_CLOUD_PROVISIONED is set by the provisioning path, not the env
-    // producer; the container always boots with it. Mirror that here.
-    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    expect(process.env.ELIZA_CLOUD_PROVISIONED).toBe("1");
     // Must not be mobile (lean-chat only applies off-mobile).
     delete process.env.ELIZA_PLATFORM;
 

--- a/packages/cloud/shared/src/lib/services/reserved-env-keys.test.ts
+++ b/packages/cloud/shared/src/lib/services/reserved-env-keys.test.ts
@@ -14,6 +14,14 @@ describe("reserved-env-keys", () => {
     ]);
   });
 
+  test("managed hosting marker ELIZA_CLOUD_PROVISIONED is platform-reserved", () => {
+    expect(findReservedEnvKeys(["ELIZA_CLOUD_PROVISIONED", "eliza_cloud_provisioned"])).toEqual([
+      "ELIZA_CLOUD_PROVISIONED",
+      "eliza_cloud_provisioned",
+    ]);
+    expect(RESERVED_PLATFORM_ENV_KEYS).toContain("ELIZA_CLOUD_PROVISIONED");
+  });
+
   test("findReservedEnvKeys returns [] when no reserved keys present", () => {
     expect(findReservedEnvKeys(["FOO", "BAR"])).toEqual([]);
   });

--- a/packages/cloud/shared/src/lib/services/reserved-env-keys.ts
+++ b/packages/cloud/shared/src/lib/services/reserved-env-keys.ts
@@ -20,6 +20,10 @@ export const RESERVED_PLATFORM_ENV_KEYS = [
   "ELIZAOS_CLOUD_API_KEY",
   "ELIZAOS_CLOUD_BASE_URL",
   "ELIZAOS_CLOUD_ENABLED",
+  // Hosting-mode marker for managed Eliza Cloud containers. The UI and agent
+  // server read this (via isCloudProvisionedContainer) to distinguish managed
+  // Cloud from user-owned/self-hosted installs. Callers must not override it.
+  "ELIZA_CLOUD_PROVISIONED",
   "ELIZA_CLOUD_AGENT_ID",
   "PUBLIC_BASE_URL",
   "STEWARD_API_URL",


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- https://github.com/elizaOS/eliza/issues/18170

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, merged with latest `origin/develop`, zero conflicts
- [x] Focused tests pass (managed env producer, reserved keys, hermetic `/api/status` chain)
- [x] Reviewer can verify from evidence / automated tests without reading every line of the diff

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Merged onto latest `origin/develop`; zero conflicts
- [x] CI re-runs on the current head after merge commits

# Summary

Managed Eliza Cloud agents and user-owned installs must be distinguishable by the agent server and UI. Detection already exists (`ELIZA_CLOUD_PROVISIONED` → `cloud.cloudProvisioned` on `/api/status` and first-run), but the **managed environment producer did not always set the flag** — only Docker create paths did. Fleet re-apply / shared env prep could leave a managed agent looking self-hosted.

This PR makes the managed path authoritative:

1. **Producer always sets** `ELIZA_CLOUD_PROVISIONED=1` in `prepareManagedElizaBaseEnvironment` (callers cannot clear it with `"0"`).
2. **Key is platform-reserved** so deploy callers cannot override it.
3. **`GET /api/status` reads the shared detector** (`isCloudProvisionedContainer` from `@elizaos/shared`) so the UI-facing flag does not depend on loading `plugin-elizacloud`.
4. **Hermetic tests** prove the full chain: real producer → process env → real detector → real `handleHealthRoutes` `/api/status` (managed true / self-hosted false / bare-marker false).

**Out of scope:** baking the flag into dual-purpose `Dockerfile.ci` or non-fleet `Dockerfile.cloud-agent`. Control-plane Docker providers already inject the flag at container create for fleet nodes.

# Kind of change

Bug fix / reliability improvement (non-breaking). Existing detector contract; managed producer now always honors it.

# Risks

**Low–medium.** Hosting-mode detection feeds auth trust, first-run skip, plugin selection, and status APIs. Force-set only happens on the managed env producer path (Cloud control-plane). User-owned installs without the flag are unchanged. Residual risk: any caller that incorrectly invokes `prepareManagedElizaBaseEnvironment` for non-managed agents would mark them managed — that function is control-plane-only today.

# Documentation

No docs change required. Existing env flag + detector contracts; this only ensures the managed producer always sets the flag and status reports it reliably.

# Testing

## Reviewer entry points

| Area | Path |
|------|------|
| Force-set | `packages/cloud/shared/src/lib/services/managed-eliza-config.ts` |
| Reserved key | `packages/cloud/shared/src/lib/services/reserved-env-keys.ts` |
| Status payload | `packages/agent/src/api/health-routes.ts` |
| Hermetic chain | `packages/agent/src/api/health-routes.cloud-provisioned.test.ts` |

## Commands

```bash
bun test packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts \
  packages/cloud/shared/src/lib/services/reserved-env-keys.test.ts \
  packages/agent/src/api/health-routes.cloud-provisioned.test.ts
```

**Expect:** producer emits `ELIZA_CLOUD_PROVISIONED=1` even when existing env tries `"0"`; reserved-key finder includes the key; `/api/status` reports `cloud.cloudProvisioned: true` after applying the producer map, `false` for self-hosted and bare-marker-without-credential.

## Controls covered

| Scenario | Result |
|----------|--------|
| Managed producer map (+ token/API key) | `cloudProvisioned: true` |
| User-owned / empty managed keys | `cloudProvisioned: false` |
| Flag alone, no credential | `cloudProvisioned: false` |

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:41a583d4b471dfedf60b2c898e2ee5f6d436aa45 -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI pixels; hermetic producer→detector→/api/status only
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI pixels; hermetic producer→detector→/api/status only
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing surface
<!-- evidence-row:backend-logs -->
- [ ] N/A - hermetic integration: prepareManagedElizaBaseEnvironment → isCloudProvisionedContainer → handleHealthRoutes /api/status (3 pass); no live Cloud sandbox
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model path change
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - hermetic producer→shared detector→handleHealthRoutes chain on head 41a583d4b471dfedf60b2c898e2ee5f6d436aa45 (3/3 pass); managed true / self-hosted false / bare-marker false; /api/status now reads isCloudProvisionedContainer from @elizaos/shared; live fleet image digest still requires Cloud sandbox
<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots

# Known gaps

- Live Cloud sandbox provision + real container image digest not exercised in this agent session (no control-plane credentials). Hermetic producer→detector→status chain is the primary proof; staging re-proof welcome.

AI provider/model: xAI / grok-4.5
Client / agent tooling: Grok Build
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [grok]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"Grok Build","skill_revision":"N/A - no contribution skill used"} -->




