### PR TITLE
fix(app-core): make cold Vite startup resolve workspace source

### DIFF
--- a/packages/app-core/scripts/lib/dev-ui-vite.mjs
+++ b/packages/app-core/scripts/lib/dev-ui-vite.mjs
@@ -14,6 +14,7 @@ export function resolveViteCommand({
   force = false,
   nodePath = process.execPath,
   port,
+  viteArgs = [],
 }) {
   if (!nodePath) {
     throw new Error("Node.js is required to run the Vite dev server.");
@@ -25,8 +26,19 @@ export function resolveViteCommand({
   // Vite's default config loader bundles vite.config.ts with esbuild before it
   // can listen. This process already installs tsx, so Node can load the config
   // directly and avoid a redundant multi-second bundle on every dev startup.
-  const args = ["--import", "tsx", viteCli, "--configLoader", "native"];
+  // Config loading happens before Vite's own resolver exists. Give the Node
+  // child the same workspace-source condition that the client resolver uses
+  // so a clean checkout never depends on package dist output.
+  const args = [
+    "--conditions=eliza-source",
+    "--import",
+    "tsx",
+    viteCli,
+    "--configLoader",
+    "native",
+  ];
   if (force) args.push("--force");
   if (port !== undefined) args.push("--port", String(port));
+  args.push(...viteArgs);
   return { command: nodePath, args };
 }

--- a/packages/app-core/scripts/lib/dev-ui-vite.test.mjs
+++ b/packages/app-core/scripts/lib/dev-ui-vite.test.mjs
@@ -11,7 +11,7 @@ const appDir = path.resolve(
   "../../../app",
 );
 
-test("resolveViteCommand skips Vite's redundant config bundling", () => {
+test("resolveViteCommand uses workspace source while skipping config bundling", () => {
   const resolved = resolveViteCommand({
     appDir,
     nodePath: "/test/node",
@@ -19,7 +19,11 @@ test("resolveViteCommand skips Vite's redundant config bundling", () => {
   });
 
   assert.equal(resolved.command, "/test/node");
-  assert.deepEqual(resolved.args.slice(-4), [
+  assert.deepEqual(resolved.args, [
+    "--conditions=eliza-source",
+    "--import",
+    "tsx",
+    path.join(appDir, "node_modules", "vite", "bin", "vite.js"),
     "--configLoader",
     "native",
     "--port",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,8 +3,8 @@
   "version": "2.0.0-beta.2",
   "type": "module",
   "scripts": {
-    "dev": "node --import tsx ./node_modules/vite/bin/vite.js",
-    "dev:chat-harness": "ELIZA_CHAT_UI_HARNESS=1 node --import tsx ./node_modules/vite/bin/vite.js",
+    "dev": "node scripts/dev.mjs",
+    "dev:chat-harness": "ELIZA_CHAT_UI_HARNESS=1 node scripts/dev.mjs",
     "preview": "bun --bun vite preview",
     "design-review": "node --import tsx test/design-review/run-design-review.ts",
     "lint": "bunx @biomejs/biome check --write src scripts vite.config.ts vitest.config.ts vitest.e2e.config.ts playwright.dev-smoke.config.ts playwright.ui-smoke.config.ts playwright.ui-packaged.config.ts playwright.electrobun.packaged.config.ts playwright.web-views.config.ts playwright.android.config.ts test/android package.json capacitor.config.ts",

--- a/packages/app/scripts/dev.mjs
+++ b/packages/app/scripts/dev.mjs
@@ -6,29 +6,18 @@
  * point the same workspace export conditions while preserving Vite CLI flags.
  */
 
-import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveViteCommand } from "../../app-core/scripts/lib/dev-ui-vite.mjs";
+import { spawnMirroredChild } from "./lib/spawn-mirrored-child.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const viteCommand = resolveViteCommand({
   appDir,
   viteArgs: process.argv.slice(2),
 });
-const child = spawn(viteCommand.command, viteCommand.args, {
+spawnMirroredChild(viteCommand.command, viteCommand.args, {
   cwd: appDir,
   env: process.env,
   stdio: "inherit",
-});
-
-function forward(signal) {
-  if (!child.killed) child.kill(signal);
-}
-
-process.once("SIGINT", () => forward("SIGINT"));
-process.once("SIGTERM", () => forward("SIGTERM"));
-
-child.once("exit", (code, signal) => {
-  process.exitCode = signal ? 1 : (code ?? 1);
 });

--- a/packages/app/scripts/dev.mjs
+++ b/packages/app/scripts/dev.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+/**
+ * Starts direct app development through the shared Node-backed Vite command.
+ * Keeping package scripts on the orchestrator's resolver gives every dev entry
+ * point the same workspace export conditions while preserving Vite CLI flags.
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveViteCommand } from "../../app-core/scripts/lib/dev-ui-vite.mjs";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const viteCommand = resolveViteCommand({
+  appDir,
+  viteArgs: process.argv.slice(2),
+});
+const child = spawn(viteCommand.command, viteCommand.args, {
+  cwd: appDir,
+  env: process.env,
+  stdio: "inherit",
+});
+
+function forward(signal) {
+  if (!child.killed) child.kill(signal);
+}
+
+process.once("SIGINT", () => forward("SIGINT"));
+process.once("SIGTERM", () => forward("SIGTERM"));
+
+child.once("exit", (code, signal) => {
+  process.exitCode = signal ? 1 : (code ?? 1);
+});

--- a/packages/app/scripts/lib/dev-vite-command.test.mjs
+++ b/packages/app/scripts/lib/dev-vite-command.test.mjs
@@ -1,14 +1,14 @@
 /**
  * Verifies app development entrypoints share one Node-backed Vite command,
- * including dashboard flags and fail-fast dependency diagnostics.
+ * including dashboard flags, child lifecycle, and dependency diagnostics.
  */
 
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, it } from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveViteCommand } from "../../../app-core/scripts/lib/dev-ui-vite.mjs";
 
 const appDir = path.resolve(
@@ -17,9 +17,84 @@ const appDir = path.resolve(
 );
 const repoRoot = path.resolve(appDir, "../..");
 const viteCli = path.join(appDir, "node_modules", "vite", "bin", "vite.js");
+const mirroredChildUrl = pathToFileURL(
+  path.join(appDir, "scripts", "lib", "spawn-mirrored-child.mjs"),
+).href;
 const appPackage = JSON.parse(
   readFileSync(path.join(appDir, "package.json"), "utf8"),
 );
+
+async function runMirroredChildProbe({ childSource, wrapperSignal }) {
+  const wrapperSource = `
+    import { spawnMirroredChild } from ${JSON.stringify(mirroredChildUrl)};
+    const child = spawnMirroredChild(
+      process.execPath,
+      ["--input-type=module", "--eval", ${JSON.stringify(childSource)}],
+      { stdio: ["ignore", "pipe", "inherit"] },
+    );
+    child.stdout.pipe(process.stdout);
+  `;
+  const wrapper = spawn(
+    process.execPath,
+    ["--input-type=module", "--eval", wrapperSource],
+    { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  let stdout = "";
+  let stderr = "";
+  let ready;
+  const readyPromise = new Promise((resolve) => {
+    ready = resolve;
+  });
+  wrapper.stdout.setEncoding("utf8");
+  wrapper.stderr.setEncoding("utf8");
+  wrapper.stdout.on("data", (chunk) => {
+    stdout += chunk;
+    if (stdout.includes("ready\n")) ready();
+  });
+  wrapper.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const exitPromise = new Promise((resolve, reject) => {
+    wrapper.once("error", reject);
+    wrapper.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+  let timeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeout = setTimeout(() => {
+      if (wrapper.exitCode === null && wrapper.signalCode === null) {
+        wrapper.kill("SIGTERM");
+      }
+      reject(
+        new Error(
+          `mirrored child probe timed out\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      );
+    }, 5_000);
+  });
+
+  try {
+    if (wrapperSignal) {
+      await Promise.race([
+        readyPromise,
+        exitPromise.then(({ code, signal }) => {
+          throw new Error(
+            `probe exited before ready: code=${code} signal=${signal}\n${stderr}`,
+          );
+        }),
+        timeoutPromise,
+      ]);
+      wrapper.kill(wrapperSignal);
+    }
+    return {
+      ...(await Promise.race([exitPromise, timeoutPromise])),
+      stderr,
+      stdout,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 describe("development Vite process commands", () => {
   it("runs the shared server through Node with source import support", () => {
@@ -106,7 +181,40 @@ describe("development Vite process commands", () => {
     );
     assert.match(directDevSource, /resolveViteCommand\(\{/);
     assert.match(directDevSource, /viteArgs: process\.argv\.slice\(2\)/);
+    assert.match(directDevSource, /spawnMirroredChild\(/);
   });
+
+  for (const exitCode of [0, 23]) {
+    it(`preserves ordinary child exit code ${exitCode}`, async () => {
+      const result = await runMirroredChildProbe({
+        childSource: `process.exit(${exitCode})`,
+      });
+
+      assert.deepEqual(
+        { code: result.code, signal: result.signal },
+        { code: exitCode, signal: null },
+        result.stderr,
+      );
+    });
+  }
+
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    it(`preserves ${signal} as a signal termination`, {
+      skip: process.platform === "win32",
+    }, async () => {
+      const result = await runMirroredChildProbe({
+        childSource:
+          'process.stdout.write("ready\\n"); setInterval(() => {}, 1_000)',
+        wrapperSignal: signal,
+      });
+
+      assert.deepEqual(
+        { code: result.code, signal: result.signal },
+        { code: null, signal },
+        `${result.stderr}\n${result.stdout}`,
+      );
+    });
+  }
 
   it("loads NodeNext workspace source with the production child argv", () => {
     const viteCommand = resolveViteCommand({

--- a/packages/app/scripts/lib/dev-vite-command.test.mjs
+++ b/packages/app/scripts/lib/dev-vite-command.test.mjs
@@ -27,7 +27,14 @@ describe("development Vite process commands", () => {
       resolveViteCommand({ appDir, nodePath: "/usr/local/bin/node" }),
       {
         command: "/usr/local/bin/node",
-        args: ["--import", "tsx", viteCli, "--configLoader", "native"],
+        args: [
+          "--conditions=eliza-source",
+          "--import",
+          "tsx",
+          viteCli,
+          "--configLoader",
+          "native",
+        ],
       },
     );
   });
@@ -43,6 +50,7 @@ describe("development Vite process commands", () => {
       {
         command: "/usr/bin/node",
         args: [
+          "--conditions=eliza-source",
           "--import",
           "tsx",
           viteCli,
@@ -63,6 +71,7 @@ describe("development Vite process commands", () => {
       {
         command: "/usr/bin/node",
         args: [
+          "--conditions=eliza-source",
           "--import",
           "tsx",
           viteCli,
@@ -75,27 +84,41 @@ describe("development Vite process commands", () => {
     );
   });
 
-  it("keeps direct package dev commands on Node with source import support", () => {
-    assert.equal(
-      appPackage.scripts.dev,
-      "node --import tsx ./node_modules/vite/bin/vite.js",
-    );
-    assert.equal(
-      appPackage.scripts["dev:chat-harness"],
-      "ELIZA_CHAT_UI_HARNESS=1 node --import tsx ./node_modules/vite/bin/vite.js",
-    );
+  it("forwards direct Vite CLI flags after the canonical dev arguments", () => {
+    const resolved = resolveViteCommand({
+      appDir,
+      nodePath: "/usr/bin/node",
+      viteArgs: ["--host", "127.0.0.1"],
+    });
+
+    assert.deepEqual(resolved.args.slice(-2), ["--host", "127.0.0.1"]);
   });
 
-  it("loads source-conditioned NodeNext workspace packages", () => {
+  it("keeps direct package dev commands on Node with source import support", () => {
+    assert.equal(appPackage.scripts.dev, "node scripts/dev.mjs");
+    assert.equal(
+      appPackage.scripts["dev:chat-harness"],
+      "ELIZA_CHAT_UI_HARNESS=1 node scripts/dev.mjs",
+    );
+    const directDevSource = readFileSync(
+      path.join(appDir, "scripts", "dev.mjs"),
+      "utf8",
+    );
+    assert.match(directDevSource, /resolveViteCommand\(\{/);
+    assert.match(directDevSource, /viteArgs: process\.argv\.slice\(2\)/);
+  });
+
+  it("loads NodeNext workspace source with the production child argv", () => {
     const viteCommand = resolveViteCommand({
       appDir,
       nodePath: "node",
     });
+    const viteCliIndex = viteCommand.args.indexOf(viteCli);
+    assert.notEqual(viteCliIndex, -1);
     const result = spawnSync(
       viteCommand.command,
       [
-        "--conditions=eliza-source",
-        ...viteCommand.args.slice(0, 2),
+        ...viteCommand.args.slice(0, viteCliIndex),
         "--input-type=module",
         "--eval",
         'await import("./packages/core/src/cloud-routing.ts")',

--- a/packages/app/scripts/lib/spawn-mirrored-child.mjs
+++ b/packages/app/scripts/lib/spawn-mirrored-child.mjs
@@ -1,0 +1,39 @@
+/**
+ * Owns a foreground child process for thin development wrappers. Signals from
+ * the shell are forwarded to the child, and the child's final exit status is
+ * mirrored back so callers can distinguish interruption from failure.
+ */
+
+import { spawn } from "node:child_process";
+
+const FORWARDED_SIGNALS = ["SIGINT", "SIGTERM"];
+
+/** Spawn a child whose numeric exit code or terminating signal becomes ours. */
+export function spawnMirroredChild(command, args, options) {
+  const child = spawn(command, args, options);
+  const signalHandlers = new Map();
+
+  for (const signal of FORWARDED_SIGNALS) {
+    const forward = () => {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill(signal);
+      }
+    };
+    signalHandlers.set(signal, forward);
+    process.once(signal, forward);
+  }
+
+  child.once("exit", (code, signal) => {
+    for (const [forwardedSignal, handler] of signalHandlers) {
+      process.off(forwardedSignal, handler);
+    }
+
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
+
+  return child;
+}

--- a/packages/app/test/vite-source-resolution.test.ts
+++ b/packages/app/test/vite-source-resolution.test.ts
@@ -1,0 +1,60 @@
+/** Verifies development resolves workspace source without changing production builds. */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { type ConfigEnv, createServer, defaultClientConditions } from "vite";
+import { describe, expect, test } from "vitest";
+import appViteConfig from "../vite.config";
+
+const appRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+async function resolveAppViteConfig(command: ConfigEnv["command"]) {
+  if (typeof appViteConfig !== "function") {
+    throw new Error("app Vite config must be command-aware");
+  }
+  return await appViteConfig({
+    command,
+    mode: command === "serve" ? "development" : "production",
+    isPreview: false,
+    isSsrBuild: false,
+  });
+}
+
+describe("workspace package resolution", () => {
+  test("extends Vite client conditions only while serving", async () => {
+    const serveConfig = await resolveAppViteConfig("serve");
+    const buildConfig = await resolveAppViteConfig("build");
+
+    expect(serveConfig.resolve?.conditions).toEqual([
+      "eliza-source",
+      ...defaultClientConditions,
+    ]);
+    expect(buildConfig.resolve?.conditions).toBeUndefined();
+  });
+
+  test("keeps browser conditional exports on their browser entry", async () => {
+    const serveConfig = await resolveAppViteConfig("serve");
+    const server = await createServer({
+      configFile: false,
+      root: appRoot,
+      logLevel: "silent",
+      optimizeDeps: { noDiscovery: true },
+      resolve: { conditions: serveConfig.resolve?.conditions },
+      server: { middlewareMode: true },
+    });
+
+    try {
+      const resolved =
+        await server.environments.client.pluginContainer.resolveId(
+          "react-dom/server",
+          path.join(appRoot, "src/main.tsx"),
+        );
+      expect(resolved?.id).toMatch(/react-dom[/\\]server\.browser\.js$/);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -16,6 +16,7 @@ import react from "@vitejs/plugin-react";
 import { visualizer } from "rollup-plugin-visualizer";
 import {
   createLogger,
+  defaultClientConditions,
   defineConfig,
   loadEnv,
   type Plugin,
@@ -2100,7 +2101,7 @@ const optimizerNodePolyfills: Readonly<Record<string, string>> = (() => {
   return resolved;
 })();
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   root: here,
   customLogger: viteLogger,
   // Native shells (Electrobun `views://`, Capacitor `file://`) load assets
@@ -2385,6 +2386,13 @@ export const INVALID_TRACER_PROVIDER = {};
     target: "es2022",
   },
   resolve: {
+    // Development serves workspace source before any package dist exists.
+    // Retain Vite's browser/development conditions so packages without a
+    // source export keep resolving to their browser entry points. Production
+    // builds intentionally retain Vite's untouched default condition set.
+    ...(command === "serve"
+      ? { conditions: ["eliza-source", ...defaultClientConditions] }
+      : {}),
     dedupe: [
       "react",
       "react-dom",
@@ -3354,4 +3362,4 @@ export const INVALID_TRACER_PROVIDER = {};
       ],
     },
   },
-});
+}));


### PR DESCRIPTION
Closes #18134

## Summary

Fresh-checkout development must resolve workspace packages from source before any
`dist` output exists. This PR carries the source-resolution repair plus its narrow direct-development
child-lifecycle follow-up:

- launches Vite through Node with `--conditions=eliza-source` and
  `--configLoader native`;
- routes the direct app dev entry point through the same command builder;
- prepends `eliza-source` to Vite's serve-only browser conditions while
  preserving `defaultClientConditions`;
- leaves production build conditions unchanged; and
- covers the exact argv, subprocess lifecycle, and real browser-conditional resolution contracts.

The lifecycle follow-up is limited to the direct development wrapper: it forwards
SIGINT and SIGTERM and mirrors the child numeric exit code or terminating signal
without changing production behavior.

## Exact provenance

- Base and merge-base: `f492da5a02ec38916f3f9b8311fdb59c98cb5186`
- Head: `0aa3c6c578859ab3c1a5d4fdd447991c409dd159`
- Tree: `3f1252d948d9fd1305ebaaef10e033e07485ee09`
- Scope: two commits, eight files, +296/-19
- Source-resolution patch ID: `10e7b3d4585f5c5c22b9c91ece1e79de22055586`
- Lifecycle patch ID: `e858ccbdb2769f7dfa99598d694df100952e54f4`

## Testing

- `node --test packages/app-core/scripts/lib/dev-ui-vite.test.mjs` — 1/1 PASS
- `node --test packages/app/scripts/lib/dev-vite-command.test.mjs` — 10/10 PASS
- `bunx vitest run --config packages/app/vitest.config.ts packages/app/test/vite-source-resolution.test.ts` — 2/2 PASS
- filtered Turbo typecheck for `@elizaos/app-core` and `@elizaos/app` — PASS
- Biome over all eight changed paths — PASS
- `git diff --check` and final worktree status — clean

The earlier strict dist-empty startup proof remains applicable because the
source patch is byte-for-byte patch-equivalent: API listen 7.041s, health ready
9.344s, UI served 11.831s within the 60s budget.

## Risk

Low. Only development-time process arguments, serve-mode resolution, and direct-wrapper exit/signal propagation change.
Production build resolution and rendered UI behavior are unchanged.

## Evidence

<!-- evidence-head:0aa3c6c578859ab3c1a5d4fdd447991c409dd159 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - development process/configuration only; no rendered UI delta.
<!-- evidence-row:after-screenshots -->
- [x] N/A - development process/configuration only; no rendered UI delta.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no stable exact-head log artifact was published; the exact-head argv and resolution suites plus previously recorded strict dist-empty startup timings are summarized above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer state or request contract changed; real Vite HTTP readiness was exercised.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is produced by this process fix.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6:packages/skills/skills/contribute-to-eliza"} -->



