### PR TITLE
fix(browser): contain tab switcher scrolling and dismissal

### DIFF
--- a/packages/app/test/ui-smoke/browser-workspace.spec.ts
+++ b/packages/app/test/ui-smoke/browser-workspace.spec.ts
@@ -312,6 +312,170 @@ test("browser page clears the resting chat and keeps compact mobile chrome touch
   await expect(chatOverlay).not.toHaveAttribute("data-open", "true");
 });
 
+test("browser tab switcher keeps fixed chrome reachable while the tab list scrolls in mobile landscape", async ({
+  page,
+  request,
+}) => {
+  await page.setViewportSize({ width: 844, height: 390 });
+  await resetBrowserWorkspaceTabs(request);
+  for (let index = 1; index <= 8; index += 1) {
+    const response = await request.post("/api/browser-workspace/tabs", {
+      data: {
+        url: "about:blank",
+        title: `Evidence tab ${index}`,
+        show: index === 1,
+        partition: "persist:eliza-browser",
+        kind: "standard",
+      },
+    });
+    expect(response.ok(), await response.text()).toBe(true);
+  }
+
+  await openAppPath(page, "/browser");
+  const browserWorkspaceView = page.getByTestId("browser-workspace-view");
+  await expect(browserWorkspaceView).toBeVisible({ timeout: 60_000 });
+  await expect(
+    browserWorkspaceView.getByTestId("browser-workspace-tab-count"),
+  ).toHaveText("8", { timeout: 120_000 });
+  await browserWorkspaceView
+    .getByTestId("browser-workspace-tab-fold-control")
+    .click();
+
+  const switcher = page.getByTestId("browser-workspace-tab-switcher");
+  const header = switcher.getByTestId("browser-workspace-tab-switcher-header");
+  const scroller = switcher.getByTestId(
+    "browser-workspace-tab-switcher-scroll",
+  );
+  const newTab = switcher.getByTestId("browser-workspace-tab-switcher-new-tab");
+  const dialogClose = switcher.getByRole("button", {
+    name: "Close",
+    exact: true,
+  });
+  await expect(switcher).toBeVisible();
+  await expect(header).toBeVisible();
+  await expect(scroller).toBeVisible();
+  await expect(newTab).toBeVisible();
+  await expect(dialogClose).toBeVisible();
+
+  const readGeometry = () =>
+    page.evaluate(() => {
+      const dialog = document.querySelector<HTMLElement>(
+        '[data-testid="browser-workspace-tab-switcher"]',
+      );
+      const fixedHeader = document.querySelector<HTMLElement>(
+        '[data-testid="browser-workspace-tab-switcher-header"]',
+      );
+      const tabScroller = document.querySelector<HTMLElement>(
+        '[data-testid="browser-workspace-tab-switcher-scroll"]',
+      );
+      const addTab = document.querySelector<HTMLElement>(
+        '[data-testid="browser-workspace-tab-switcher-new-tab"]',
+      );
+      const chat = document.querySelector<HTMLElement>(
+        '[data-testid="chat-sheet-surface"]',
+      );
+      const close = Array.from(
+        dialog?.querySelectorAll<HTMLElement>("button") ?? [],
+      ).find((element) => element.getAttribute("aria-label") === "Close");
+      if (!dialog || !fixedHeader || !tabScroller || !addTab || !chat || !close)
+        return null;
+
+      const rect = (element: HTMLElement) => {
+        const box = element.getBoundingClientRect();
+        return {
+          top: box.top,
+          right: box.right,
+          bottom: box.bottom,
+          left: box.left,
+          width: box.width,
+          height: box.height,
+        };
+      };
+      const dialogRect = rect(dialog);
+      const controls = Array.from(
+        new Set(
+          Array.from(
+            dialog.querySelectorAll<HTMLElement>("button, [role='tab']"),
+          ),
+        ),
+      ).map((control) => ({
+        label:
+          control.getAttribute("aria-label") ??
+          control.textContent?.replace(/\s+/g, " ").trim() ??
+          control.tagName,
+        ...rect(control),
+      }));
+      return {
+        dialog: dialogRect,
+        header: rect(fixedHeader),
+        scroller: {
+          ...rect(tabScroller),
+          clientHeight: tabScroller.clientHeight,
+          scrollHeight: tabScroller.scrollHeight,
+          scrollTop: tabScroller.scrollTop,
+          overflowY: getComputedStyle(tabScroller).overflowY,
+        },
+        newTab: rect(addTab),
+        close: rect(close),
+        chat: rect(chat),
+        undersizedControls: controls.filter(
+          (control) => control.width < 44 || control.height < 44,
+        ),
+        horizontalOverflow:
+          document.documentElement.scrollWidth - window.innerWidth,
+      };
+    });
+
+  const beforeScroll = await readGeometry();
+  expect(beforeScroll).not.toBeNull();
+  expect(beforeScroll?.scroller.overflowY).toBe("auto");
+  expect(beforeScroll?.scroller.scrollHeight).toBeGreaterThan(
+    beforeScroll?.scroller.clientHeight ?? Number.POSITIVE_INFINITY,
+  );
+  expect(beforeScroll?.scroller.top).toBeGreaterThanOrEqual(
+    beforeScroll?.header.bottom ?? Number.POSITIVE_INFINITY,
+  );
+  expect(beforeScroll?.scroller.bottom).toBeLessThanOrEqual(
+    beforeScroll?.dialog.bottom ?? 0,
+  );
+  expect(beforeScroll?.dialog.bottom).toBeLessThanOrEqual(
+    beforeScroll?.chat.top ?? 0,
+  );
+  expect(beforeScroll?.newTab.top).toBeGreaterThanOrEqual(
+    beforeScroll?.dialog.top ?? Number.POSITIVE_INFINITY,
+  );
+  expect(beforeScroll?.close.top).toBeGreaterThanOrEqual(
+    beforeScroll?.dialog.top ?? Number.POSITIVE_INFINITY,
+  );
+  expect(beforeScroll?.undersizedControls).toEqual([]);
+  expect(beforeScroll?.horizontalOverflow).toBe(0);
+
+  await scroller.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect
+    .poll(async () => scroller.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(0);
+  await expect(
+    switcher.getByRole("tab", { name: "Evidence tab 8" }),
+  ).toBeVisible();
+
+  const afterScroll = await readGeometry();
+  expect(afterScroll).not.toBeNull();
+  expect(Math.round(afterScroll?.header.top ?? -1)).toBe(
+    Math.round(beforeScroll?.header.top ?? -2),
+  );
+  expect(Math.round(afterScroll?.newTab.top ?? -1)).toBe(
+    Math.round(beforeScroll?.newTab.top ?? -2),
+  );
+  expect(Math.round(afterScroll?.close.top ?? -1)).toBe(
+    Math.round(beforeScroll?.close.top ?? -2),
+  );
+  await expect(header).toBeVisible();
+  await expect(newTab).toBeVisible();
+  await expect(dialogClose).toBeVisible();
+});
+
 test("browser iframe focus handoff survives delayed autofocus without stealing deliberate clicks", async ({
   page,
   request,

--- a/packages/ui/src/components/pages/BrowserTabSwitcher.tsx
+++ b/packages/ui/src/components/pages/BrowserTabSwitcher.tsx
@@ -19,7 +19,13 @@
 import { Globe, Plus, X } from "lucide-react";
 import { useAgentElement } from "../../agent-surface";
 import { Button } from "../ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
 
 /** A tab as the switcher needs to render it — the view maps its richer
  *  `BrowserWorkspaceTab` down to this display shape so the switcher stays free
@@ -297,12 +303,12 @@ export function BrowserTabSwitcher({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        showCloseButton
+        showCloseButton={false}
         data-testid="browser-workspace-tab-switcher"
         data-view-overlay="browser-tabs"
         data-chat-clearance-aware="true"
-        overlayClassName="z-[8800] bg-black/65"
-        className="z-[8810] gap-4 rounded-3xl border-border/60 bg-[color-mix(in_srgb,var(--bg)_88%,transparent)] shadow-[0_24px_80px_rgba(0,0,0,.48)] max-sm:-translate-y-1/2 max-sm:rounded-3xl"
+        overlayClassName="z-[8800] bg-black/70"
+        className="z-[8810] grid-rows-[auto_minmax(0,1fr)] gap-4 rounded-3xl border-border/60 bg-bg shadow-[0_24px_80px_rgba(0,0,0,.48)] max-sm:-translate-y-1/2 max-sm:rounded-3xl"
         style={{
           top: "calc((100dvh - var(--eliza-chat-clearance, 5.25rem)) / 2)",
           bottom: "auto",
@@ -310,7 +316,10 @@ export function BrowserTabSwitcher({
             "min(calc(100dvh - var(--eliza-chat-clearance, 5.25rem) - var(--safe-area-top, 0px) - 1.5rem), 42rem)",
         }}
       >
-        <DialogHeader className="flex-row items-center justify-between gap-2 pr-8 text-left">
+        <DialogHeader
+          data-testid="browser-workspace-tab-switcher-header"
+          className="flex-row items-center justify-between gap-2 pr-12 text-left"
+        >
           <DialogTitle>{title}</DialogTitle>
           <Button
             type="button"
@@ -329,7 +338,11 @@ export function BrowserTabSwitcher({
             <span className="truncate">{newTabLabel}</span>
           </Button>
         </DialogHeader>
-        <div className="min-h-0 flex-1 overflow-y-auto">
+        <div
+          data-testid="browser-workspace-tab-switcher-scroll"
+          data-scroll-cert-scroller
+          className="min-h-0 overflow-y-auto overscroll-contain"
+        >
           {folded.count === 0 ? (
             <p className="px-1 py-6 text-center text-sm text-muted">
               {emptyLabel}
@@ -367,6 +380,12 @@ export function BrowserTabSwitcher({
             </div>
           )}
         </div>
+        <DialogClose
+          aria-label="Close"
+          className="absolute right-1 top-1 inline-flex h-11 w-11 items-center justify-center rounded-sm text-muted opacity-70 transition-opacity hover:text-txt hover:opacity-100 disabled:pointer-events-none"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </DialogClose>
       </DialogContent>
     </Dialog>
   );

--- a/packages/ui/src/components/pages/browser-tab-switcher.test.tsx
+++ b/packages/ui/src/components/pages/browser-tab-switcher.test.tsx
@@ -159,6 +159,7 @@ describe("BrowserTabSwitcher", () => {
   it("renders a card per tab with its title, across all sections", () => {
     renderSwitcher();
     const dialog = screen.getByTestId("browser-workspace-tab-switcher");
+    expect(document.body.innerHTML).not.toContain("backdrop-blur");
     // 12 tab cards present (8 user + 3 agent + 1 app).
     for (const id of ["user-0", "user-7", "agent-0", "agent-2", "app-0"]) {
       expect(within(dialog).getByTestId(`browser-tab-card-${id}`)).toBeTruthy();
@@ -209,9 +210,13 @@ describe("BrowserTabSwitcher", () => {
     renderSwitcher();
     const agentCard = screen.getByTestId("browser-tab-card-agent-0");
     const userCard = screen.getByTestId("browser-tab-card-user-0");
-    expect(agentCard.innerHTML).toContain("border-border/70");
-    expect(agentCard.innerHTML).not.toContain("accent");
-    expect(userCard.innerHTML).not.toContain("bg-bg-muted text-txt");
+    const agentMonogram = within(agentCard).getByText("A");
+    const userMonogram = within(userCard).getByText("U");
+    expect(agentMonogram.className).toContain("border-border/70");
+    expect(agentMonogram.className).not.toContain("ring-");
+    expect(agentMonogram.className).not.toContain("accent");
+    expect(userMonogram.className).not.toContain("border-border/70");
+    expect(userMonogram.className).not.toContain("bg-bg-muted");
   });
 
   it("shows a neutral session dot (not the monogram) for the focused tab", () => {
@@ -245,6 +250,7 @@ describe("BrowserTabSwitcher", () => {
     renderSwitcher();
     const dialog = screen.getByTestId("browser-workspace-tab-switcher");
     expect(dialog.className).toContain("z-[8810]");
+    expect(dialog.className).toContain("grid-rows-[auto_minmax(0,1fr)]");
     expect(dialog.getAttribute("data-chat-clearance-aware")).toBe("true");
     expect(dialog.style.top).toContain("--eliza-chat-clearance");
     expect(dialog.style.maxHeight).toContain("--eliza-chat-clearance");
@@ -257,6 +263,29 @@ describe("BrowserTabSwitcher", () => {
       (element) => element.className.includes("z-[8800]"),
     );
     expect(overlay).toBeTruthy();
+  });
+
+  it("keeps fixed chrome outside the shrinkable tab scroller with touch-safe dismissal", () => {
+    const { onOpenChange } = renderSwitcher();
+    const dialog = screen.getByTestId("browser-workspace-tab-switcher");
+    const header = within(dialog).getByTestId(
+      "browser-workspace-tab-switcher-header",
+    );
+    const scroller = within(dialog).getByTestId(
+      "browser-workspace-tab-switcher-scroll",
+    );
+    const close = within(dialog).getByRole("button", { name: "Close" });
+
+    expect(header.className).toContain("pr-12");
+    expect(scroller.className).toContain("min-h-0");
+    expect(scroller.className).toContain("overflow-y-auto");
+    expect(scroller.className).toContain("overscroll-contain");
+    expect(scroller.hasAttribute("data-scroll-cert-scroller")).toBe(true);
+    expect(close.className).toContain("h-11");
+    expect(close.className).toContain("w-11");
+
+    fireEvent.click(close);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it('"new tab" opens a tab and closes the switcher', () => {


### PR DESCRIPTION
# Relates to

Closes #18153.

- [x] This PR targets `develop` and is rebased onto exact current `origin/develop` with zero conflicts.
- [x] A frozen offline `bun install` and `bun run verify` passed after sync.
- [x] A reviewer can confirm the rendered repair from retained before/after viewport matrices, an MP4 walkthrough, exact geometry, the full visual audit, and logs below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Immutable packet

- Base and sole parent: `6659f25cd20eea80e4ad4a8a61a1e541b21551df`
- HEAD: `750163ff8e52c1e714cd249ec00146ce30768910`
- Tree: `3a80bfdaaba86590dce5cd89adc1eae00ac282f7`
- Scope: one clean commit, exactly 3 changed paths
- Stable patch ID: `2c4f509bf469c017815fdba479aa2791429124ae`
- Range-diff: reviewed source `f6aa456a002 = 750163ff8e5` through exact rebases

# Sync with develop

- [x] Fetched, mechanically rebased onto exact `origin/develop` at `6659f25cd20eea80e4ad4a8a61a1e541b21551df`, and rechecked the remote immediately before publication.
- [x] The intervening develop commits had no semantic overlap; patch ID stayed stable and range-diff reports the reviewed patch as equal.
- [x] `RUN_TURBO_CONCURRENCY=4 bun run verify` passes post-sync: 346/346 Turbo tasks followed by every repository audit.

# Risks

Low. The production change is confined to the Browser tab-switcher dialog. It replaces only this consumer's shared default close with an equivalent Radix `DialogClose`, preserving dismissal semantics while enlarging the target; shared dialogs are untouched. The new grid-row containment affects only the switcher's long-list overflow.

# Background

## What does this PR do?

Current `develop` already contains the upstream removal of the switcher's ring utilities and both blur classes. This packet preserves that base styling and completes the remaining visual and accessibility contract:

- makes the dialog and backdrop genuinely opaque enough to isolate tab content;
- gives the dialog an explicit shrinkable content row so a long list scrolls inside the constrained landscape surface;
- keeps the title, New tab control, and global dismissal reachable while the list scrolls;
- replaces the Browser-scoped 16×16 default dismissal with a real 44×44 `DialogClose` without changing shared dialog behavior;
- freezes opacity, containment, dismissal semantics, and real 844×390 geometry in focused tests.

## What kind of change is this?

Bug fix (non-breaking Browser UI layout and accessibility repair).

# Documentation changes needed?

No. This repairs existing Browser switcher behavior and test contracts; no user or package API changes.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/components/pages/BrowserTabSwitcher.tsx`, then its component contract in `browser-tab-switcher.test.tsx`, and finally the real app geometry regression in `packages/app/test/ui-smoke/browser-workspace.spec.ts`.

## Detailed testing steps

All final commands passed on exact source HEAD `750163ff8e52c1e714cd249ec00146ce30768910`:

- configured UI Vitest: 3 files, 19/19 tests passed (component, no-blur gate, no-ring gate)
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/app typecheck`
- targeted Biome on all 3 changed files
- real live-renderer Browser geometry Playwright at 844×390: 1/1 passed
- `bun run verify`: 346/346 Turbo tasks plus all follow-on audits passed
- `git diff --check` and exact clean-scope checks

The retained exact-current-base evidence composition contains only reviewed audit-runner behavior plus this byte-identical source commit. Its full audit passed 215/215 tests and scored all 212 populated views with `broken=0`, `needs-work=0`, `good=200`; OCR reported 0 broken and 0 regressions. All four default Browser captures and every explicit open-switcher rest/scroll/hover-focus capture were opened and manually reviewed.

The explicit 844×390 before/after geometry records the production defect and repair:

- before: list scroller bottom `717px` escaped a dialog ending at `322px`; dismissal was `16×16px`;
- after: list scroller bottom `297px` stays inside the same `322px` dialog; dismissal is `44×44px`;
- after: every dialog control is at least 44×44, horizontal overflow is 0, the list scrolls to tab 8, fixed chrome remains stationary, the dialog remains above page content and below persistent chat, and the surface is fully opaque (`rgb(5, 5, 6)`) with no backdrop filter.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:750163ff8e52c1e714cd249ec00146ce30768910 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-before-matrix.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-after-matrix.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-walkthrough-after.mp4
<!-- evidence-row:backend-logs -->
- [x] [18167-audit-app.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-audit-app.log)
<!-- evidence-row:frontend-logs -->
- [x] [18167-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-report.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - a style/layout repair creates no application-domain records.
<!-- evidence-row:ocr-review -->
- [x] [18167-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-ocr-triage.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

The full audit log records the live app/API fixture startup and 215/215 test completion. The audit report records per-view console errors, render issues, overflow, hover, density, and computed verdicts; all four Browser views have zero console errors and a `good` verdict. The retained Playwright trace captures the explicit request/state/render path for the open switcher.

## Screenshots (before / after) + video walkthrough

The matrices are ordered desktop 1440×900, portrait 390×844, and landscape 844×390. The separate geometry and trace artifacts below make the constrained-landscape scroll and 44px target proof machine-inspectable as well as visible.

### Before

![Before switcher matrix — desktop, portrait, landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-before-matrix.jpg)

[Constrained-landscape list remains clipped after attempted scroll](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-before-landscape-scrolled.jpg) · [before geometry JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-geometry-before.json)

### After

![After switcher matrix — desktop, portrait, landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-after-matrix.jpg)

[Constrained-landscape tab 8 reached by contained scroll](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-after-landscape-scrolled.jpg) · [desktop hover/focus state](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-after-desktop-hover-focus.jpg) · [after geometry JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-geometry-after.json)

### Walkthrough video

https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-walkthrough-after.mp4

[Retained Playwright trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18167-browser-switcher-trace-after.zip)

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, omnivoice, or audio behavior changed.

## Known gaps / failures

None. Every final source gate, exact-current-base audit, explicit capture run, OCR check, and root verification is green. No protected/default development port was used; the real app harness allocated isolated ephemeral ports and stopped cleanly.

---

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [baseline-smoke]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no repository contribution skill used"} -->

