### PR TITLE
fix(browser): gate wallet readiness by proven frame origin

### DIFF
--- a/packages/app/test/ui-smoke/browser-workspace.spec.ts
+++ b/packages/app/test/ui-smoke/browser-workspace.spec.ts
@@ -57,6 +57,17 @@ test("browser workspace can create, navigate, switch, and close tabs", async ({
   page,
   request,
 }) => {
+  const walletOriginMismatchWarnings: string[] = [];
+  page.on("console", (message) => {
+    const text = message.text();
+    if (
+      text.includes("Failed to execute 'postMessage'") &&
+      text.includes("target origin") &&
+      text.includes("does not match")
+    ) {
+      walletOriginMismatchWarnings.push(text);
+    }
+  });
   await resetBrowserWorkspaceTabs(request);
   await openAppPath(page, "/browser");
   await expect(page).toHaveURL(/\/browser$/, { timeout: 20_000 });
@@ -198,6 +209,7 @@ test("browser workspace can create, navigate, switch, and close tabs", async ({
   // server-owned.
   await closeAllButton.click();
   await expect(closeAllButton).toBeDisabled({ timeout: 60_000 });
+  expect(walletOriginMismatchWarnings).toEqual([]);
 });
 
 test("browser page clears the resting chat and keeps compact mobile chrome touch-safe", async ({

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
@@ -15,11 +15,25 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const walletStateHarness = vi.hoisted(() => ({
+  connected: false,
+  pendingApprovals: 0,
+}));
+
 vi.mock("../../state", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../state")>();
   const state = {
-    getStewardPending: () => null,
-    getStewardStatus: () => null,
+    getStewardPending: async () =>
+      Array.from(
+        { length: walletStateHarness.pendingApprovals },
+        (_, index) => ({
+          queueId: `pending-${index}`,
+        }),
+      ),
+    getStewardStatus: async () =>
+      walletStateHarness.connected
+        ? { available: true, configured: true, connected: true }
+        : null,
     setActionNotice: vi.fn(),
     t: (
       _key: string,
@@ -130,6 +144,8 @@ function deferred<T>(): {
 }
 
 beforeEach(() => {
+  walletStateHarness.connected = false;
+  walletStateHarness.pendingApprovals = 0;
   vi.mocked(client.getBrowserWorkspace).mockResolvedValue({
     mode: "web",
     tabs: [],
@@ -590,5 +606,83 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
 
     closedSnapshot.resolve({ mode: "web", tabs: [] });
     expect(await screen.findByText("No page open")).not.toBeNull();
+  });
+
+  it("preserves wallet readiness when Go resolves to the already-loaded URL", async () => {
+    vi.useFakeTimers();
+    walletStateHarness.connected = true;
+    walletStateHarness.pendingApprovals = 1;
+    vi.mocked(client.getBrowserWorkspace).mockResolvedValue(APPLE_WORKSPACE);
+    vi.mocked(client.navigateBrowserWorkspaceTab).mockResolvedValue({
+      tab: APPLE_WORKSPACE.tabs[0],
+    });
+
+    try {
+      render(<BrowserWorkspaceView />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const iframe = screen.getByTitle("Apple") as HTMLIFrameElement;
+      const postMessage = vi
+        .spyOn(iframe.contentWindow as Window, "postMessage")
+        .mockImplementation(() => undefined);
+      const readyCalls = () =>
+        postMessage.mock.calls.filter(
+          ([message]) =>
+            (message as { type?: unknown }).type === BROWSER_WALLET_READY_TYPE,
+        );
+
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            data: {
+              type: BROWSER_WALLET_REQUEST_TYPE,
+              requestId: "prove-loaded-origin",
+              method: "getState",
+            },
+            origin: "https://www.apple.com",
+            source: iframe.contentWindow,
+          }),
+        );
+        await Promise.resolve();
+      });
+      expect(readyCalls()).toHaveLength(1);
+      expect(readyCalls().at(-1)).toEqual([
+        {
+          type: BROWSER_WALLET_READY_TYPE,
+          state: expect.objectContaining({ pendingApprovals: 1 }),
+        },
+        "https://www.apple.com",
+      ]);
+
+      const address = screen.getByTestId("browser-workspace-address-input");
+      await act(async () => {
+        fireEvent.keyDown(address, { key: "Enter" });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(client.navigateBrowserWorkspaceTab).toHaveBeenCalledWith(
+        "tab-apple",
+        APPLE_WORKSPACE.tabs[0].url,
+      );
+      expect(iframe.src).toBe(APPLE_WORKSPACE.tabs[0].url);
+
+      walletStateHarness.pendingApprovals = 2;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+        await Promise.resolve();
+      });
+      expect(readyCalls()).toHaveLength(2);
+      expect(readyCalls().at(-1)).toEqual([
+        {
+          type: BROWSER_WALLET_READY_TYPE,
+          state: expect.objectContaining({ pendingApprovals: 2 }),
+        },
+        "https://www.apple.com",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
@@ -1,7 +1,7 @@
 /**
- * Verifies the Browser view's fullscreen chrome, focus handoff, and workspace
- * refresh precedence. The real component renders in jsdom with deterministic
- * API responses so background polls cannot impersonate foreground failures.
+ * Verifies Browser fullscreen chrome, focus handoff, refresh precedence, and
+ * wallet-origin authority. The real component renders in jsdom with
+ * deterministic workspace API responses.
  */
 // @vitest-environment jsdom
 
@@ -59,6 +59,9 @@ vi.mock("../../api", async (importOriginal) => {
       navigateBrowserWorkspaceTab: vi
         .fn()
         .mockRejectedValue(new Error("no api in test")),
+      closeBrowserWorkspaceTab: vi
+        .fn()
+        .mockRejectedValue(new Error("no api in test")),
       snapshotBrowserWorkspaceTab: vi
         .fn()
         .mockRejectedValue(new Error("no api in test")),
@@ -68,6 +71,10 @@ vi.mock("../../api", async (importOriginal) => {
 
 import { client } from "../../api";
 import { BrowserWorkspaceView } from "./BrowserWorkspaceView";
+import {
+  BROWSER_WALLET_READY_TYPE,
+  BROWSER_WALLET_REQUEST_TYPE,
+} from "./browser-workspace-wallet";
 
 const GOOGLE_WORKSPACE = {
   mode: "web" as const,
@@ -131,6 +138,9 @@ beforeEach(() => {
     new Error("no api in test"),
   );
   vi.mocked(client.navigateBrowserWorkspaceTab).mockRejectedValue(
+    new Error("no api in test"),
+  );
+  vi.mocked(client.closeBrowserWorkspaceTab).mockRejectedValue(
     new Error("no api in test"),
   );
 });
@@ -480,5 +490,105 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("updates wallet authority before iframe navigation and revokes it before closed-frame removal", async () => {
+    const navigationSnapshot = deferred<typeof EXAMPLE_WORKSPACE>();
+    const closedSnapshot = deferred<{ mode: "web"; tabs: [] }>();
+    let workspaceRead = 0;
+    vi.mocked(client.getBrowserWorkspace).mockImplementation(() => {
+      workspaceRead += 1;
+      if (workspaceRead === 1) return Promise.resolve(APPLE_WORKSPACE);
+      if (workspaceRead === 2) return navigationSnapshot.promise;
+      return closedSnapshot.promise;
+    });
+    vi.mocked(client.navigateBrowserWorkspaceTab).mockResolvedValue({
+      tab: EXAMPLE_WORKSPACE.tabs[0],
+    });
+    vi.mocked(client.closeBrowserWorkspaceTab).mockResolvedValue({
+      closed: true,
+    });
+
+    render(<BrowserWorkspaceView />);
+    const iframe = (await screen.findByTitle("Apple")) as HTMLIFrameElement;
+    const postMessageCalls: Array<[unknown, string]> = [];
+    const spiedWindows = new Set<Window>();
+    const spyFrameWindow = () => {
+      const frameWindow = iframe.contentWindow as Window;
+      if (!spiedWindows.has(frameWindow)) {
+        spiedWindows.add(frameWindow);
+        vi.spyOn(frameWindow, "postMessage").mockImplementation(
+          (message, targetOrigin) => {
+            postMessageCalls.push([message, String(targetOrigin)]);
+          },
+        );
+      }
+    };
+    spyFrameWindow();
+    const readyCalls = () =>
+      postMessageCalls.filter(
+        ([message]) =>
+          (message as { type?: unknown }).type === BROWSER_WALLET_READY_TYPE,
+      );
+    const requestState = async (origin: string, requestId: string) => {
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            data: {
+              type: BROWSER_WALLET_REQUEST_TYPE,
+              requestId,
+              method: "getState",
+            },
+            origin,
+            source: iframe.contentWindow,
+          }),
+        );
+        await Promise.resolve();
+      });
+    };
+
+    await requestState("https://www.apple.com", "ready-a");
+    expect(readyCalls()).toHaveLength(1);
+
+    const address = screen.getByTestId("browser-workspace-address-input");
+    fireEvent.change(address, {
+      target: { value: EXAMPLE_WORKSPACE.tabs[0].url },
+    });
+    fireEvent.keyDown(address, { key: "Enter" });
+    await waitFor(() =>
+      expect(client.navigateBrowserWorkspaceTab).toHaveBeenCalledWith(
+        "tab-apple",
+        EXAMPLE_WORKSPACE.tabs[0].url,
+      ),
+    );
+    await waitFor(() => expect(iframe.src).toBe(EXAMPLE_WORKSPACE.tabs[0].url));
+    expect(screen.getByTitle("Apple")).toBe(iframe);
+    spyFrameWindow();
+
+    await requestState("https://example.com", "ready-b");
+    expect(readyCalls()).toHaveLength(2);
+    expect(readyCalls().at(-1)?.[1]).toBe("https://example.com");
+    await requestState("https://www.apple.com", "stale-a");
+    expect(readyCalls()).toHaveLength(2);
+    await requestState("https://example.com", "duplicate-b");
+    expect(readyCalls()).toHaveLength(2);
+
+    navigationSnapshot.resolve(EXAMPLE_WORKSPACE);
+    expect(await screen.findByTitle("Example")).toBe(iframe);
+    expect(readyCalls()).toHaveLength(2);
+
+    fireEvent.click(screen.getByTestId("browser-workspace-close-all-tabs"));
+    await waitFor(() =>
+      expect(client.closeBrowserWorkspaceTab).toHaveBeenCalledWith("tab-apple"),
+    );
+    await waitFor(() =>
+      expect(client.getBrowserWorkspace).toHaveBeenCalledTimes(3),
+    );
+    const callsBeforeClosedRequest = postMessageCalls.length;
+    await requestState("https://example.com", "closed-b");
+    expect(postMessageCalls).toHaveLength(callsBeforeClosedRequest);
+
+    closedSnapshot.resolve({ mode: "web", tabs: [] });
+    expect(await screen.findByText("No page open")).not.toBeNull();
   });
 });

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -1335,12 +1335,12 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         url,
       );
       if (workspace.mode === "web") {
-        beginBrowserWalletFrameNavigation(selectedTabId, tab.url);
         // React won't re-navigate an existing iframe when only the src
         // attribute changes (same key = same DOM element). Set the src
         // directly via the ref in embedded web mode only.
         const iframe = iframeRefs.current.get(selectedTabId);
         if (iframe && iframe.src !== tab.url) {
+          beginBrowserWalletFrameNavigation(selectedTabId, tab.url);
           armBrowserWorkspaceIframeFocusReturn(iframe, {
             navigationUrl: tab.url,
           });

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -794,6 +794,17 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     }
   }, []);
 
+  const {
+    beginBrowserWalletFrameNavigation,
+    revokeBrowserWalletFrame,
+    syncBrowserWalletFrameTarget,
+  } = useBrowserWorkspaceWalletBridge({
+    iframeRefs,
+    workspaceTabs: workspace.mode === "web" ? workspace.tabs : [],
+    walletState: browserWalletState,
+    loadWalletState: loadBrowserWalletState,
+  });
+
   const loadBrowserBridgeState = useCallback(
     async (options?: { silent?: boolean }) => {
       if (browserBridgeUnsupportedInNativeLocalMode) {
@@ -1072,6 +1083,9 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         if (loadVersion !== workspaceLoadVersionRef.current) return;
         const previousSnapshot = workspaceSnapshotRef.current;
         for (const nextTab of snapshot.tabs) {
+          if (snapshot.mode === "web") {
+            syncBrowserWalletFrameTarget(nextTab.id, nextTab.url);
+          }
           const previousTab = previousSnapshot.tabs.find(
             (tab) => tab.id === nextTab.id,
           );
@@ -1090,6 +1104,14 @@ export function BrowserWorkspaceView(): React.JSX.Element {
               preserveExistingForUrl: true,
               navigationUrl: nextTab.url,
             });
+          }
+        }
+        if (previousSnapshot.mode === "web") {
+          const nextTabIds = new Set(snapshot.tabs.map((tab) => tab.id));
+          for (const previousTab of previousSnapshot.tabs) {
+            if (snapshot.mode !== "web" || !nextTabIds.has(previousTab.id)) {
+              revokeBrowserWalletFrame(previousTab.id);
+            }
           }
         }
         workspaceSnapshotRef.current = snapshot;
@@ -1129,6 +1151,8 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     [
       armBrowserWorkspaceIframeFocusReturn,
       readBrowserWorkspaceFocusReturnTarget,
+      revokeBrowserWalletFrame,
+      syncBrowserWalletFrameTarget,
     ],
   );
 
@@ -1311,6 +1335,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         url,
       );
       if (workspace.mode === "web") {
+        beginBrowserWalletFrameNavigation(selectedTabId, tab.url);
         // React won't re-navigate an existing iframe when only the src
         // attribute changes (same key = same DOM element). Set the src
         // directly via the ref in embedded web mode only.
@@ -1331,6 +1356,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     },
     [
       armBrowserWorkspaceIframeFocusReturn,
+      beginBrowserWalletFrameNavigation,
       browserTabRenderPath,
       loadWorkspace,
       openNewBrowserWorkspaceTab,
@@ -2156,13 +2182,6 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     };
   }, []);
 
-  const { postBrowserWalletReady } = useBrowserWorkspaceWalletBridge({
-    iframeRefs,
-    workspaceTabs: workspace.mode === "web" ? workspace.tabs : [],
-    walletState: browserWalletState,
-    loadWalletState: loadBrowserWalletState,
-  });
-
   const closeBrowserWorkspaceTabById = useCallback(
     async (tabId: string) => {
       // Native mobile shell: tabs are client-side. Drop the tab from state (the
@@ -2178,6 +2197,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         return;
       }
       await client.closeBrowserWorkspaceTab(tabId);
+      revokeBrowserWalletFrame(tabId);
       const snapshot = await client.getBrowserWorkspace();
       const nextId =
         snapshot.tabs.find((tab) => tab.id === selectedTabId)?.id ??
@@ -2191,7 +2211,12 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         silent: true,
       });
     },
-    [browserTabRenderPath, loadWorkspace, selectedTabId],
+    [
+      browserTabRenderPath,
+      loadWorkspace,
+      revokeBrowserWalletFrame,
+      selectedTabId,
+    ],
   );
 
   const closeAllBrowserWorkspaceTabs = useCallback(async () => {
@@ -2200,6 +2225,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     );
     for (const tab of closableTabs) {
       await client.closeBrowserWorkspaceTab(tab.id);
+      revokeBrowserWalletFrame(tab.id);
     }
     const snapshot = await client.getBrowserWorkspace();
     const nextId = snapshot.tabs[0]?.id ?? null;
@@ -2210,7 +2236,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     setLocationInput(snapshot.tabs.find((tab) => tab.id === nextId)?.url ?? "");
     setLocationDirty(false);
     await loadWorkspace({ preferTabId: nextId, silent: true });
-  }, [loadWorkspace, workspace.tabs]);
+  }, [loadWorkspace, revokeBrowserWalletFrame, workspace.tabs]);
 
   useEffect(() => {
     if (initialWorkspaceLoadStartedRef.current) return;
@@ -2334,6 +2360,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     if (workspace.mode === "web") {
       const iframe = iframeRefs.current.get(selectedTab.id);
       if (iframe) {
+        beginBrowserWalletFrameNavigation(selectedTab.id, selectedTab.url);
         armBrowserWorkspaceIframeFocusReturn(iframe, {
           navigationUrl: selectedTab.url,
         });
@@ -2349,6 +2376,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     await client.navigateBrowserWorkspaceTab(selectedTab.id, selectedTab.url);
   }, [
     armBrowserWorkspaceIframeFocusReturn,
+    beginBrowserWalletFrameNavigation,
     browserTabRenderPath,
     nativeTabSurfaces,
     selectedTab,
@@ -2991,7 +3019,6 @@ export function BrowserWorkspaceView(): React.JSX.Element {
       ) : browserTabRenderPath === "sandboxed-iframe" ? (
         workspace.tabs.map((tab) => {
           const active = tab.id === selectedTabId;
-          const highlighted = tab.visible;
           const frameBlocked = isBrowserWorkspaceFrameBlockedUrl(tab.url);
           const visibilityClass = active
             ? "pointer-events-auto opacity-100"
@@ -3063,9 +3090,6 @@ export function BrowserWorkspaceView(): React.JSX.Element {
               }}
               onLoad={(event) => {
                 beginBrowserWorkspaceIframeFocusSettle(event.currentTarget);
-                if (highlighted) {
-                  postBrowserWalletReady(tab, browserWalletState);
-                }
               }}
             />
           );

--- a/packages/ui/src/components/pages/useBrowserWorkspaceWalletBridge.test.tsx
+++ b/packages/ui/src/components/pages/useBrowserWorkspaceWalletBridge.test.tsx
@@ -42,6 +42,71 @@ afterEach(() => {
 });
 
 describe("useBrowserWorkspaceWalletBridge committed-origin ordering", () => {
+  it("deduplicates ready broadcasts by redacted payload value across fresh poll objects", async () => {
+    const iframe = document.createElement("iframe");
+    document.body.append(iframe);
+    const postMessage = vi
+      .spyOn(iframe.contentWindow as Window, "postMessage")
+      .mockImplementation(() => undefined);
+    const readyCalls = () =>
+      postMessage.mock.calls.filter(
+        ([message]) =>
+          (message as { type?: unknown }).type === BROWSER_WALLET_READY_TYPE,
+      );
+    const iframeRefs: RefObject<Map<string, HTMLIFrameElement | null>> = {
+      current: new Map([[TAB_ID, iframe]]),
+    };
+    const activeTab = tab("https://wallet.example/app");
+    let activeWalletState = walletState(4);
+    const { rerender } = renderHook(() =>
+      useBrowserWorkspaceWalletBridge({
+        iframeRefs,
+        workspaceTabs: [activeTab],
+        walletState: activeWalletState,
+        loadWalletState: async () => activeWalletState,
+      }),
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: BROWSER_WALLET_REQUEST_TYPE,
+            requestId: "prove-origin",
+            method: "getState",
+          },
+          origin: "https://wallet.example",
+          source: iframe.contentWindow,
+        }),
+      );
+      await Promise.resolve();
+    });
+    expect(readyCalls()).toHaveLength(1);
+
+    const previousState = activeWalletState;
+    activeWalletState = walletState(4);
+    expect(activeWalletState).not.toBe(previousState);
+    rerender();
+    expect(readyCalls()).toHaveLength(1);
+
+    activeWalletState = walletState(5);
+    rerender();
+    expect(readyCalls()).toHaveLength(2);
+    expect(readyCalls().at(-1)).toEqual([
+      {
+        type: BROWSER_WALLET_READY_TYPE,
+        state: expect.objectContaining({ pendingApprovals: 5 }),
+      },
+      "https://wallet.example",
+    ]);
+
+    const changedState = activeWalletState;
+    activeWalletState = walletState(5);
+    expect(activeWalletState).not.toBe(changedState);
+    rerender();
+    expect(readyCalls()).toHaveLength(2);
+  });
+
   it("suppresses unproven and cross-origin transition broadcasts, then sends the latest state to the exact proven origin", async () => {
     const iframe = document.createElement("iframe");
     document.body.append(iframe);

--- a/packages/ui/src/components/pages/useBrowserWorkspaceWalletBridge.test.tsx
+++ b/packages/ui/src/components/pages/useBrowserWorkspaceWalletBridge.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Verifies wallet-ready delivery ordering against a real iframe WindowProxy:
+ * broadcasts wait for a matching committed origin across initial load and navigation.
+ */
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BrowserWorkspaceTab } from "../../api";
+import {
+  BROWSER_WALLET_READY_TYPE,
+  BROWSER_WALLET_REQUEST_TYPE,
+  BROWSER_WALLET_RESPONSE_TYPE,
+  type BrowserWorkspaceWalletState,
+  EMPTY_BROWSER_WORKSPACE_WALLET_STATE,
+} from "./browser-workspace-wallet";
+import { useBrowserWorkspaceWalletBridge } from "./useBrowserWorkspaceWalletBridge";
+
+const TAB_ID = "tab-wallet";
+
+function tab(url: string): BrowserWorkspaceTab {
+  return {
+    id: TAB_ID,
+    title: new URL(url).hostname,
+    url,
+    visible: true,
+  } as BrowserWorkspaceTab;
+}
+
+function walletState(pendingApprovals: number): BrowserWorkspaceWalletState {
+  return {
+    ...EMPTY_BROWSER_WORKSPACE_WALLET_STATE,
+    pendingApprovals,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("useBrowserWorkspaceWalletBridge committed-origin ordering", () => {
+  it("suppresses unproven and cross-origin transition broadcasts, then sends the latest state to the exact proven origin", async () => {
+    const iframe = document.createElement("iframe");
+    document.body.append(iframe);
+    const postMessage = vi
+      .spyOn(iframe.contentWindow as Window, "postMessage")
+      .mockImplementation(() => undefined);
+    const readyCalls = () =>
+      postMessage.mock.calls.filter(
+        ([message]) =>
+          (message as { type?: unknown }).type === BROWSER_WALLET_READY_TYPE,
+      );
+    const iframeRefs: RefObject<Map<string, HTMLIFrameElement | null>> = {
+      current: new Map([[TAB_ID, iframe]]),
+    };
+    const request = async (
+      origin: string,
+      requestId: string,
+      method = "getState",
+    ) => {
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            data: {
+              type: BROWSER_WALLET_REQUEST_TYPE,
+              requestId,
+              method,
+            },
+            origin,
+            source: iframe.contentWindow,
+          }),
+        );
+        await Promise.resolve();
+      });
+    };
+    let activeTab = tab("https://a.example/page");
+    let activeWalletState = walletState(1);
+
+    const { result, rerender } = renderHook(() =>
+      useBrowserWorkspaceWalletBridge({
+        iframeRefs,
+        workspaceTabs: [activeTab],
+        walletState: activeWalletState,
+        loadWalletState: async () => activeWalletState,
+      }),
+    );
+
+    // The iframe still contains its inherited about:blank document here.
+    // Posting to the requested HTTPS origin would be dropped and would emit a
+    // browser warning, so readiness waits for a matching protocol message.
+    expect(postMessage).not.toHaveBeenCalled();
+
+    await request("null", "about-blank");
+    expect(postMessage).not.toHaveBeenCalled();
+
+    await request("https://a.example", "unknown-a", "future_method");
+    expect(readyCalls()).toHaveLength(0);
+    await vi.waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: BROWSER_WALLET_RESPONSE_TYPE,
+          requestId: "unknown-a",
+          ok: false,
+        }),
+        "https://a.example",
+      );
+    });
+
+    await request("https://a.example", "ready-a");
+    expect(readyCalls()).toHaveLength(1);
+    expect(readyCalls().at(-1)).toEqual([
+      {
+        type: BROWSER_WALLET_READY_TYPE,
+        state: expect.objectContaining({ pendingApprovals: 1 }),
+      },
+      "https://a.example",
+    ]);
+    await vi.waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: BROWSER_WALLET_RESPONSE_TYPE,
+          requestId: "ready-a",
+          ok: true,
+        }),
+        "https://a.example",
+      );
+    });
+    await request("https://a.example", "duplicate-a");
+    expect(readyCalls()).toHaveLength(1);
+
+    activeWalletState = walletState(2);
+    rerender();
+    expect(readyCalls()).toHaveLength(2);
+    expect(readyCalls().at(-1)).toEqual([
+      {
+        type: BROWSER_WALLET_READY_TYPE,
+        state: expect.objectContaining({ pendingApprovals: 2 }),
+      },
+      "https://a.example",
+    ]);
+
+    act(() =>
+      result.current.beginBrowserWalletFrameNavigation(
+        TAB_ID,
+        "https://b.example/next",
+      ),
+    );
+    await request("https://a.example", "stale-a");
+    expect(readyCalls()).toHaveLength(2);
+
+    await request("https://b.example", "ready-b");
+    expect(readyCalls()).toHaveLength(3);
+    expect(readyCalls().at(-1)).toEqual([
+      {
+        type: BROWSER_WALLET_READY_TYPE,
+        state: expect.objectContaining({ pendingApprovals: 2 }),
+      },
+      "https://b.example",
+    ]);
+
+    activeWalletState = walletState(3);
+    rerender();
+    expect(readyCalls()).toHaveLength(4);
+    expect(readyCalls().at(-1)).toEqual([
+      {
+        type: BROWSER_WALLET_READY_TYPE,
+        state: expect.objectContaining({ pendingApprovals: 3 }),
+      },
+      "https://b.example",
+    ]);
+
+    activeTab = tab("https://b.example/next");
+    rerender();
+    expect(readyCalls()).toHaveLength(4);
+
+    await request("https://b.example", "duplicate-b");
+    expect(readyCalls()).toHaveLength(4);
+
+    act(() => result.current.revokeBrowserWalletFrame(TAB_ID));
+    const callCountBeforeClosedRequest = postMessage.mock.calls.length;
+    await request("https://b.example", "closed-b");
+    expect(postMessage).toHaveBeenCalledTimes(callCountBeforeClosedRequest);
+    expect(postMessage.mock.calls.map(([, origin]) => origin)).not.toContain(
+      "*",
+    );
+  });
+});

--- a/packages/ui/src/components/pages/useBrowserWorkspaceWalletBridge.ts
+++ b/packages/ui/src/components/pages/useBrowserWorkspaceWalletBridge.ts
@@ -4,14 +4,21 @@
  * Iframes embedded by the browser workspace use window.postMessage to ask the
  * host for wallet state and to request signing / transactions. This hook owns
  * the origin verification, per-tab chain state, request dispatch, and the
- * "ready" broadcast when state changes or an iframe loads.
+ * "ready" broadcast after a frame proves its origin and when state changes.
  *
  * The caller passes in iframe refs, current tabs, and the wallet state it
- * maintains; the hook returns a single `postBrowserWalletReady` function used
- * for per-iframe onLoad and any other point-in-time broadcasts.
+ * maintains and records intended navigation/retirement before the DOM changes.
+ * A frame origin becomes eligible for broadcasts only after a wallet-protocol
+ * message proves that the loaded document matches that authoritative URL.
  */
 
-import { type RefObject, useCallback, useEffect, useRef } from "react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
 import type { BrowserWorkspaceTab } from "../../api";
 import {
   BROWSER_WALLET_READY_TYPE,
@@ -255,28 +262,44 @@ interface UseBrowserWorkspaceWalletBridgeOptions {
   loadWalletState: () => Promise<BrowserWorkspaceWalletState>;
 }
 
+interface BrowserWorkspaceWalletBridgeController {
+  beginBrowserWalletFrameNavigation: (tabId: string, url: string) => void;
+  revokeBrowserWalletFrame: (tabId: string) => void;
+  syncBrowserWalletFrameTarget: (tabId: string, url: string) => void;
+}
+
 export function useBrowserWorkspaceWalletBridge({
   iframeRefs,
   workspaceTabs,
   walletState,
   loadWalletState,
-}: UseBrowserWorkspaceWalletBridgeOptions): {
-  postBrowserWalletReady: (
-    tab: BrowserWorkspaceTab,
-    state: BrowserWorkspaceWalletState,
-  ) => void;
-} {
+}: UseBrowserWorkspaceWalletBridgeOptions): BrowserWorkspaceWalletBridgeController {
   const walletStateRef = useRef(walletState);
   const workspaceTabsRef = useRef(workspaceTabs);
   const chainIdByTabRef = useRef(new Map<string, number>());
+  const targetUrlByTabRef = useRef(new Map<string, string>());
+  const pendingTargetUrlByTabRef = useRef(new Map<string, string>());
+  const revokedTabIdsRef = useRef(new Set<string>());
+  const committedOriginByTabRef = useRef(new Map<string, string>());
+  const lastReadyStateByTabRef = useRef(
+    new Map<string, BrowserWorkspaceWalletState>(),
+  );
   walletStateRef.current = walletState;
   workspaceTabsRef.current = workspaceTabs;
 
   const postBrowserWalletReady = useCallback(
     (tab: BrowserWorkspaceTab, state: BrowserWorkspaceWalletState) => {
       const iframeWindow = iframeRefs.current?.get(tab.id)?.contentWindow;
-      const targetOrigin = resolveTargetOrigin(tab.url);
-      if (!iframeWindow || !targetOrigin) return;
+      const targetUrl = targetUrlByTabRef.current.get(tab.id);
+      const targetOrigin = targetUrl ? resolveTargetOrigin(targetUrl) : null;
+      if (
+        !iframeWindow ||
+        !targetOrigin ||
+        committedOriginByTabRef.current.get(tab.id) !== targetOrigin ||
+        lastReadyStateByTabRef.current.get(tab.id) === state
+      ) {
+        return;
+      }
       iframeWindow.postMessage(
         {
           type: BROWSER_WALLET_READY_TYPE,
@@ -284,12 +307,75 @@ export function useBrowserWorkspaceWalletBridge({
         },
         targetOrigin,
       );
+      lastReadyStateByTabRef.current.set(tab.id, state);
     },
     [iframeRefs],
   );
 
-  // Broadcast fresh state to every loaded iframe whenever the wallet state
-  // changes — so dApps see connection and chain updates without polling.
+  const beginBrowserWalletFrameNavigation = useCallback(
+    (tabId: string, url: string) => {
+      revokedTabIdsRef.current.delete(tabId);
+      pendingTargetUrlByTabRef.current.set(tabId, url);
+      targetUrlByTabRef.current.set(tabId, url);
+      committedOriginByTabRef.current.delete(tabId);
+      lastReadyStateByTabRef.current.delete(tabId);
+    },
+    [],
+  );
+
+  const revokeBrowserWalletFrame = useCallback((tabId: string) => {
+    revokedTabIdsRef.current.add(tabId);
+    pendingTargetUrlByTabRef.current.delete(tabId);
+    targetUrlByTabRef.current.delete(tabId);
+    committedOriginByTabRef.current.delete(tabId);
+    lastReadyStateByTabRef.current.delete(tabId);
+    chainIdByTabRef.current.delete(tabId);
+  }, []);
+
+  const syncBrowserWalletFrameTarget = useCallback(
+    (tabId: string, url: string) => {
+      if (revokedTabIdsRef.current.has(tabId)) return;
+      if (pendingTargetUrlByTabRef.current.has(tabId)) {
+        if (pendingTargetUrlByTabRef.current.get(tabId) !== url) return;
+        pendingTargetUrlByTabRef.current.delete(tabId);
+      }
+      if (targetUrlByTabRef.current.get(tabId) === url) return;
+      targetUrlByTabRef.current.set(tabId, url);
+      committedOriginByTabRef.current.delete(tabId);
+      lastReadyStateByTabRef.current.delete(tabId);
+    },
+    [],
+  );
+
+  // A WindowProxy exists while its initial about:blank document still has the
+  // parent's origin, and onLoad can also represent an opaque browser error
+  // document. URL changes therefore revoke the previous proof; a matching
+  // wallet-protocol message below commits the loaded origin again. An
+  // imperative navigation remains authoritative until the server snapshot
+  // catches up, so a stale render cannot reopen the previous origin.
+  useLayoutEffect(() => {
+    const knownTabIds = new Set<string>();
+    for (const tab of workspaceTabs) {
+      knownTabIds.add(tab.id);
+      syncBrowserWalletFrameTarget(tab.id, tab.url);
+    }
+    for (const tabId of targetUrlByTabRef.current.keys()) {
+      if (
+        !knownTabIds.has(tabId) &&
+        !pendingTargetUrlByTabRef.current.has(tabId)
+      ) {
+        targetUrlByTabRef.current.delete(tabId);
+        committedOriginByTabRef.current.delete(tabId);
+        lastReadyStateByTabRef.current.delete(tabId);
+      }
+    }
+    for (const tabId of revokedTabIdsRef.current) {
+      if (!knownTabIds.has(tabId)) {
+        revokedTabIdsRef.current.delete(tabId);
+      }
+    }
+  }, [syncBrowserWalletFrameTarget, workspaceTabs]);
+
   useEffect(() => {
     for (const tab of workspaceTabs) {
       postBrowserWalletReady(tab, walletState);
@@ -320,11 +406,22 @@ export function useBrowserWorkspaceWalletBridge({
         : null;
       if (!sourceTab || !sourceWindow) return;
 
+      const targetUrl = targetUrlByTabRef.current.get(sourceTab.id);
+      if (!targetUrl) return;
       const targetOrigin = resolveBrowserWorkspaceMessageOrigin(
         event.origin,
-        sourceTab.url,
+        targetUrl,
       );
       if (targetOrigin === null) return;
+
+      if (
+        request.method === "getState" &&
+        committedOriginByTabRef.current.get(sourceTab.id) !== targetOrigin
+      ) {
+        committedOriginByTabRef.current.set(sourceTab.id, targetOrigin);
+        lastReadyStateByTabRef.current.delete(sourceTab.id);
+        postBrowserWalletReady(sourceTab, walletStateRef.current);
+      }
 
       const respond = (response: BrowserWorkspaceWalletResponse) => {
         sourceWindow.postMessage(response, targetOrigin);
@@ -359,5 +456,9 @@ export function useBrowserWorkspaceWalletBridge({
     return () => window.removeEventListener("message", onMessage);
   }, [iframeRefs, loadWalletState, postBrowserWalletReady]);
 
-  return { postBrowserWalletReady };
+  return {
+    beginBrowserWalletFrameNavigation,
+    revokeBrowserWalletFrame,
+    syncBrowserWalletFrameTarget,
+  };
 }

--- a/packages/ui/src/components/pages/useBrowserWorkspaceWalletBridge.ts
+++ b/packages/ui/src/components/pages/useBrowserWorkspaceWalletBridge.ts
@@ -83,11 +83,13 @@ export function redactBrowserWorkspaceIframeWalletState(
   state: BrowserWorkspaceWalletState,
 ): BrowserWorkspaceWalletState {
   return {
-    ...state,
     address: null,
     connected: false,
     evmAddress: null,
     evmConnected: false,
+    mode: state.mode,
+    pendingApprovals: state.pendingApprovals,
+    reason: IFRAME_WALLET_CONNECTION_DISABLED_ERROR,
     messageSigningAvailable: false,
     transactionSigningAvailable: false,
     chainSwitchingAvailable: false,
@@ -96,7 +98,6 @@ export function redactBrowserWorkspaceIframeWalletState(
     solanaConnected: false,
     solanaMessageSigningAvailable: false,
     solanaTransactionSigningAvailable: false,
-    reason: IFRAME_WALLET_CONNECTION_DISABLED_ERROR,
   };
 }
 
@@ -281,9 +282,7 @@ export function useBrowserWorkspaceWalletBridge({
   const pendingTargetUrlByTabRef = useRef(new Map<string, string>());
   const revokedTabIdsRef = useRef(new Set<string>());
   const committedOriginByTabRef = useRef(new Map<string, string>());
-  const lastReadyStateByTabRef = useRef(
-    new Map<string, BrowserWorkspaceWalletState>(),
-  );
+  const lastReadyStateFingerprintByTabRef = useRef(new Map<string, string>());
   walletStateRef.current = walletState;
   workspaceTabsRef.current = workspaceTabs;
 
@@ -295,19 +294,28 @@ export function useBrowserWorkspaceWalletBridge({
       if (
         !iframeWindow ||
         !targetOrigin ||
-        committedOriginByTabRef.current.get(tab.id) !== targetOrigin ||
-        lastReadyStateByTabRef.current.get(tab.id) === state
+        committedOriginByTabRef.current.get(tab.id) !== targetOrigin
+      ) {
+        return;
+      }
+      const redactedState = redactBrowserWorkspaceIframeWalletState(state);
+      // The redactor emits a fixed-key primitive payload, so its serialized
+      // form is stable across the fresh object references produced by polling.
+      const stateFingerprint = JSON.stringify(redactedState);
+      if (
+        lastReadyStateFingerprintByTabRef.current.get(tab.id) ===
+        stateFingerprint
       ) {
         return;
       }
       iframeWindow.postMessage(
         {
           type: BROWSER_WALLET_READY_TYPE,
-          state: redactBrowserWorkspaceIframeWalletState(state),
+          state: redactedState,
         },
         targetOrigin,
       );
-      lastReadyStateByTabRef.current.set(tab.id, state);
+      lastReadyStateFingerprintByTabRef.current.set(tab.id, stateFingerprint);
     },
     [iframeRefs],
   );
@@ -318,7 +326,7 @@ export function useBrowserWorkspaceWalletBridge({
       pendingTargetUrlByTabRef.current.set(tabId, url);
       targetUrlByTabRef.current.set(tabId, url);
       committedOriginByTabRef.current.delete(tabId);
-      lastReadyStateByTabRef.current.delete(tabId);
+      lastReadyStateFingerprintByTabRef.current.delete(tabId);
     },
     [],
   );
@@ -328,7 +336,7 @@ export function useBrowserWorkspaceWalletBridge({
     pendingTargetUrlByTabRef.current.delete(tabId);
     targetUrlByTabRef.current.delete(tabId);
     committedOriginByTabRef.current.delete(tabId);
-    lastReadyStateByTabRef.current.delete(tabId);
+    lastReadyStateFingerprintByTabRef.current.delete(tabId);
     chainIdByTabRef.current.delete(tabId);
   }, []);
 
@@ -342,7 +350,7 @@ export function useBrowserWorkspaceWalletBridge({
       if (targetUrlByTabRef.current.get(tabId) === url) return;
       targetUrlByTabRef.current.set(tabId, url);
       committedOriginByTabRef.current.delete(tabId);
-      lastReadyStateByTabRef.current.delete(tabId);
+      lastReadyStateFingerprintByTabRef.current.delete(tabId);
     },
     [],
   );
@@ -366,7 +374,7 @@ export function useBrowserWorkspaceWalletBridge({
       ) {
         targetUrlByTabRef.current.delete(tabId);
         committedOriginByTabRef.current.delete(tabId);
-        lastReadyStateByTabRef.current.delete(tabId);
+        lastReadyStateFingerprintByTabRef.current.delete(tabId);
       }
     }
     for (const tabId of revokedTabIdsRef.current) {
@@ -419,7 +427,7 @@ export function useBrowserWorkspaceWalletBridge({
         committedOriginByTabRef.current.get(sourceTab.id) !== targetOrigin
       ) {
         committedOriginByTabRef.current.set(sourceTab.id, targetOrigin);
-        lastReadyStateByTabRef.current.delete(sourceTab.id);
+        lastReadyStateFingerprintByTabRef.current.delete(sourceTab.id);
         postBrowserWalletReady(sourceTab, walletStateRef.current);
       }
 


### PR DESCRIPTION
Closes #18125

## Summary

The Browser workspace previously treated iframe load as wallet readiness and could target `about:blank`, a stale tab origin, or an origin that had not proved it hosted the wallet protocol. This repair:

- commits readiness only after an exact-source, exact-origin, runtime-validated wallet `getState` request from the current tab URL;
- revokes the committed origin before navigation, reload, close, and tab replacement, while rejecting stale/null/unknown messages;
- deduplicates the fixed-key redacted wallet payload by semantic value, so polling cannot resend an unchanged state merely because it produced a fresh object;
- preserves a proven frame when same-URL navigation does not create a new document, while explicit reload still starts a new readiness episode;
- preserves the latest-load/background-refresh ordering from #18156 so stale workspace snapshots cannot restore a retired frame target;
- keeps every wallet protocol send on an exact validated origin; no wildcard target is used.

## Stack dependency

#18156 and #18167 are merged. This branch is rebuilt directly on current `develop`; it is no longer stacked, and its final diff contains only the amended wallet-origin packet.

## Exact provenance

- Head: `49c83ec8433cdb47e4a09501bf0689d1978255d3`
- Tree: `41f6702890147b0f48420c39a582ed87624b5e42`
- Parent/base: `2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6`
- Scope: two commits touching exactly five UI/App test paths
- Stable combined patch-id: `df877b2e62d660f55d5ea41d33fce5f5b1eb8805`, exactly matching reviewed amendments `33a2456a90a` + `3d4ceb5dc857`
- Independent corrected-amendment protocol/security review: PASS, no P0/P1/P2

## Protocol invariants proved

- no `about:blank`, iframe `onLoad`, opaque-origin, null-source, stale-source, unknown-method, or malformed event can commit readiness;
- only a valid inbound `getState` event whose `event.source` is the current frame and whose `event.origin` exactly matches the current tab URL commits the origin;
- A→B navigation revokes A before `src` changes, fences early B until the current frame proves it, and rejects late A;
- reload starts a new readiness episode even when the URL is unchanged;
- close revokes the selected frame before its snapshot/DOM ownership is retired, while a failed close preserves the still-live tab;
- state changes resend only to the currently proven exact origin; there is no `"*"` target.

## Testing

Final-head checks on current `develop`:

- focused UI wallet/Browser suites — 17/17 PASS
- `bun run --cwd packages/ui typecheck` — PASS
- exact five-path Biome + `git diff --check` — PASS
- stable patch-id equality with the reviewed amended packet — PASS

Previously captured behavior evidence for the byte-equivalent packet remains:

- real Browser Playwright — 3/3 PASS (create/navigate/switch/close, compact mobile geometry, delayed autofocus)
- exact recorded create/navigate/switch/history/close journey — 1/1 PASS
- recorded trace assertions — 0 wallet origin-mismatch warnings, 0 wallet protocol errors
- combined integration verification — 348/348 tasks plus every audit PASS

## Risks

The security boundary is deliberately fail-closed. A page that does not send the validated wallet `getState` protocol message receives no wallet snapshot. The main regression risks are prematurely trusting a replacement document or failing to deliver a later state update; the symmetric A→B, close, reload, duplicate/unknown, early/stale message, and state-change cases cover both sides.

## Documentation

N/A - no public API, configuration, or operator workflow changed.

## Evidence

The wrong behavior was a console-only browser security warning, not a visible product alert. The historical #18124 exact session is therefore retained as the before context: its UI screenshot anchors the run and its frontend log contains the pre-existing target-origin warning that opened #18125. The recorded `9bddaab` run drives the real Browser create, navigate, switch, back/forward, and close flow with recording and trace enabled. The final branch is a direct-on-`develop` rebuild with the identical stable wallet patch-id; its former stack parents are now merged and the only later base change is disjoint CI ordering. Final-head focused tests, typecheck, Biome, and diff checks were rerun above.

- **Before context:** [session screenshot](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18124-before-composite.jpg) · [frontend console/network log containing the origin mismatch](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18124-frontend-console-network.jsonl)
- **After exact head:** [screenshot](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18168-wallet-origin-after.jpg) · [11.08s H.264 walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18168-wallet-origin-after.mp4) · [Playwright trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18168-wallet-origin-trace.zip)
- **Manual frontend review:** [structured review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18168-frontend-console-review.json) records 0 target-origin mismatches and 0 wallet protocol errors. The remaining external-frame messages are Google autofocus policy and docs.elizaos.ai frame-ancestor CSP notices, unrelated to the wallet bridge.

The exact screenshot, full recording, four-frame contact sheet, and trace console were opened and reviewed by hand. The final Browser view is readable and unclipped, and no wallet warning, timeout alert, broken module, duplicate tab, or chat overlap appears.

<!-- evidence-head:496178433322aca0fa1066957924d996cd6554c4 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18124-before-composite.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18168-wallet-origin-after.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] [Exact-head Browser wallet-origin walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18168-wallet-origin-after.mp4)
<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only iframe protocol ordering change; no backend code or request handling changed.
<!-- evidence-row:frontend-logs -->
- [x] [Before warning log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18124-frontend-console-network.jsonl) · [exact-head frontend review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18168-frontend-console-review.json) · [exact-head trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18168-wallet-origin-trace.zip)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no wallet signing, transaction, balance, chain, database, memory, scheduling, generated-file, or audio artifact changed; only redacted client state delivery ordering changed.
<!-- evidence-row:ocr-review -->
- [x] [Exact-head visual/OCR review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18168-ocr-review.json)

## Known gaps / failures

None for source correctness. #18156 and #18167 are merged, so this PR is now unstacked directly on current `develop`. The recorded visual artifacts come from the byte-equivalent wallet packet before the mechanical base rebuild, as disclosed above.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6659f25cd20eea80e4ad4a8a61a1e541b21551df:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@6659f25cd20eea80e4ad4a8a61a1e541b21551df:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@6659f25cd20eea80e4ad4a8a61a1e541b21551df:packages/skills/skills/contribute-to-eliza"} -->

