### PR TITLE
fix(local-inference): unify runtime and transport ownership

### DIFF
--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -1100,10 +1100,6 @@ export async function startApiServer(
     },
     configureServer: async (httpServer) => {
       await callerOptions?.configureServer?.(httpServer);
-      const { deviceBridge } = await import(
-        "@elizaos/plugin-local-inference/services"
-      );
-      deviceBridge.attachToHttpServer(httpServer);
     },
   });
   logger.info(

--- a/plugins/plugin-capacitor-bridge/AGENTS.md
+++ b/plugins/plugin-capacitor-bridge/AGENTS.md
@@ -4,7 +4,7 @@ Capacitor WebSocket bridge enabling stock iOS and Android Eliza builds to run lo
 
 ## Purpose / role
 
-This package is the agent-side half of the native Capacitor inference path. Its `mobileDeviceBridgePlugin` owns the canonical runtime service, while lower-level bootstrap utilities consumed by the agent bundle attach the transport and defer model-handler registration until a serving device exists. On stock (non-AOSP) mobile builds, llama.cpp is exposed to the WebView through a Capacitor native plugin; this package bridges that native layer back to the elizaOS runtime's model-handler system.
+This package is the agent-side half of the native Capacitor inference path. Its `mobileDeviceBridgePlugin` owns per-runtime registration and subscriptions, while the Node HTTP server owns the process-global WebSocket transport so an outgoing runtime cannot disconnect its replacement. Lower-level bootstrap utilities consumed by the agent bundle attach that transport and defer model-handler registration until a serving device exists. On stock (non-AOSP) mobile builds, llama.cpp is exposed to the WebView through a Capacitor native plugin; this package bridges that native layer back to the elizaOS runtime's model-handler system.
 
 It is loaded explicitly by the agent bundle CLI — not auto-enabled. Android and iOS entry points differ (see Layout below).
 
@@ -16,7 +16,7 @@ The plugin owns service lifecycle; its bootstrap registers model handlers direct
 |---|---|
 | `mobileDeviceBridgePlugin` | Registers the canonical `MobileDeviceBridgeService`; the pre-initialize bootstrap installs this same plugin so later plugin registration remains idempotent. |
 | `ensureMobileDeviceBridgeInferenceHandlers(runtime)` | Registers the canonical `MobileDeviceBridgeService` before initialization, then registers `TEXT_SMALL`, `TEXT_LARGE`, and `TEXT_EMBEDDING` handlers only after a bionic host or real device can serve them. Android path only (iOS uses native IPC). Gated by `ELIZA_DEVICE_BRIDGE_ENABLED=1`. |
-| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the canonical singleton's WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server`. Runtime service stop removes the hook, closes clients, cancels pending calls, and clears heartbeat timers. |
+| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the canonical singleton's WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server`. The server close boundary removes the hook, closes clients, cancels pending calls, and clears heartbeat timers; runtime stop releases only that runtime's subscription. |
 | `getMobileDeviceBridgeStatus()` | Returns `MobileDeviceBridgeStatus`: enabled, connected devices, loaded model path, pending request counts. |
 | `loadMobileDeviceBridgeModel(modelPath, modelId?)` | Imperatively load a GGUF into the connected Android device. |
 | `unloadMobileDeviceBridgeModel()` | Unload the current model from the connected Android device. |

--- a/plugins/plugin-capacitor-bridge/AGENTS.md
+++ b/plugins/plugin-capacitor-bridge/AGENTS.md
@@ -4,18 +4,19 @@ Capacitor WebSocket bridge enabling stock iOS and Android Eliza builds to run lo
 
 ## Purpose / role
 
-This package is the agent-side half of the native Capacitor inference path. It is NOT a standard elizaOS plugin that exports a `Plugin` object; instead it exports lower-level bootstrap utilities consumed by the agent bundle at startup. On stock (non-AOSP) mobile builds, llama.cpp is exposed to the WebView through a Capacitor native plugin; this package bridges that native layer back to the elizaOS runtime's model-handler system.
+This package is the agent-side half of the native Capacitor inference path. Its `mobileDeviceBridgePlugin` owns the canonical runtime service, while lower-level bootstrap utilities consumed by the agent bundle attach the transport and defer model-handler registration until a serving device exists. On stock (non-AOSP) mobile builds, llama.cpp is exposed to the WebView through a Capacitor native plugin; this package bridges that native layer back to the elizaOS runtime's model-handler system.
 
 It is loaded explicitly by the agent bundle CLI — not auto-enabled. Android and iOS entry points differ (see Layout below).
 
 ## Plugin surface
 
-This package has no `Plugin` object. It registers model handlers directly on `AgentRuntime`:
+The plugin owns service lifecycle; its bootstrap registers model handlers directly on `AgentRuntime`:
 
 | Export | Description |
 |---|---|
-| `ensureMobileDeviceBridgeInferenceHandlers(runtime)` | Registers `TEXT_SMALL`, `TEXT_LARGE`, and `TEXT_EMBEDDING` model handlers on the runtime. Android path only (iOS uses native IPC). Gated by `ELIZA_DEVICE_BRIDGE_ENABLED=1`. |
-| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server`. |
+| `mobileDeviceBridgePlugin` | Registers the canonical `MobileDeviceBridgeService`; the pre-initialize bootstrap installs this same plugin so later plugin registration remains idempotent. |
+| `ensureMobileDeviceBridgeInferenceHandlers(runtime)` | Registers the canonical `MobileDeviceBridgeService` before initialization, then registers `TEXT_SMALL`, `TEXT_LARGE`, and `TEXT_EMBEDDING` handlers only after a bionic host or real device can serve them. Android path only (iOS uses native IPC). Gated by `ELIZA_DEVICE_BRIDGE_ENABLED=1`. |
+| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the canonical singleton's WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server`. Runtime service stop removes the hook, closes clients, cancels pending calls, and clears heartbeat timers. |
 | `getMobileDeviceBridgeStatus()` | Returns `MobileDeviceBridgeStatus`: enabled, connected devices, loaded model path, pending request counts. |
 | `loadMobileDeviceBridgeModel(modelPath, modelId?)` | Imperatively load a GGUF into the connected Android device. |
 | `unloadMobileDeviceBridgeModel()` | Unload the current model from the connected Android device. |

--- a/plugins/plugin-capacitor-bridge/CLAUDE.md
+++ b/plugins/plugin-capacitor-bridge/CLAUDE.md
@@ -4,7 +4,7 @@ Capacitor WebSocket bridge enabling stock iOS and Android Eliza builds to run lo
 
 ## Purpose / role
 
-This package is the agent-side half of the native Capacitor inference path. Its `mobileDeviceBridgePlugin` owns the canonical runtime service, while lower-level bootstrap utilities consumed by the agent bundle attach the transport and defer model-handler registration until a serving device exists. On stock (non-AOSP) mobile builds, llama.cpp is exposed to the WebView through a Capacitor native plugin; this package bridges that native layer back to the elizaOS runtime's model-handler system.
+This package is the agent-side half of the native Capacitor inference path. Its `mobileDeviceBridgePlugin` owns per-runtime registration and subscriptions, while the Node HTTP server owns the process-global WebSocket transport so an outgoing runtime cannot disconnect its replacement. Lower-level bootstrap utilities consumed by the agent bundle attach that transport and defer model-handler registration until a serving device exists. On stock (non-AOSP) mobile builds, llama.cpp is exposed to the WebView through a Capacitor native plugin; this package bridges that native layer back to the elizaOS runtime's model-handler system.
 
 It is loaded explicitly by the agent bundle CLI — not auto-enabled. Android and iOS entry points differ (see Layout below).
 
@@ -16,7 +16,7 @@ The plugin owns service lifecycle; its bootstrap registers model handlers direct
 |---|---|
 | `mobileDeviceBridgePlugin` | Registers the canonical `MobileDeviceBridgeService`; the pre-initialize bootstrap installs this same plugin so later plugin registration remains idempotent. |
 | `ensureMobileDeviceBridgeInferenceHandlers(runtime)` | Registers the canonical `MobileDeviceBridgeService` before initialization, then registers `TEXT_SMALL`, `TEXT_LARGE`, and `TEXT_EMBEDDING` handlers only after a bionic host or real device can serve them. Android path only (iOS uses native IPC). Gated by `ELIZA_DEVICE_BRIDGE_ENABLED=1`. |
-| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the canonical singleton's WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server`. Runtime service stop removes the hook, closes clients, cancels pending calls, and clears heartbeat timers. |
+| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the canonical singleton's WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server`. The server close boundary removes the hook, closes clients, cancels pending calls, and clears heartbeat timers; runtime stop releases only that runtime's subscription. |
 | `getMobileDeviceBridgeStatus()` | Returns `MobileDeviceBridgeStatus`: enabled, connected devices, loaded model path, pending request counts. |
 | `loadMobileDeviceBridgeModel(modelPath, modelId?)` | Imperatively load a GGUF into the connected Android device. |
 | `unloadMobileDeviceBridgeModel()` | Unload the current model from the connected Android device. |

--- a/plugins/plugin-capacitor-bridge/CLAUDE.md
+++ b/plugins/plugin-capacitor-bridge/CLAUDE.md
@@ -4,18 +4,19 @@ Capacitor WebSocket bridge enabling stock iOS and Android Eliza builds to run lo
 
 ## Purpose / role
 
-This package is the agent-side half of the native Capacitor inference path. It is NOT a standard elizaOS plugin that exports a `Plugin` object; instead it exports lower-level bootstrap utilities consumed by the agent bundle at startup. On stock (non-AOSP) mobile builds, llama.cpp is exposed to the WebView through a Capacitor native plugin; this package bridges that native layer back to the elizaOS runtime's model-handler system.
+This package is the agent-side half of the native Capacitor inference path. Its `mobileDeviceBridgePlugin` owns the canonical runtime service, while lower-level bootstrap utilities consumed by the agent bundle attach the transport and defer model-handler registration until a serving device exists. On stock (non-AOSP) mobile builds, llama.cpp is exposed to the WebView through a Capacitor native plugin; this package bridges that native layer back to the elizaOS runtime's model-handler system.
 
 It is loaded explicitly by the agent bundle CLI — not auto-enabled. Android and iOS entry points differ (see Layout below).
 
 ## Plugin surface
 
-This package has no `Plugin` object. It registers model handlers directly on `AgentRuntime`:
+The plugin owns service lifecycle; its bootstrap registers model handlers directly on `AgentRuntime`:
 
 | Export | Description |
 |---|---|
-| `ensureMobileDeviceBridgeInferenceHandlers(runtime)` | Registers `TEXT_SMALL`, `TEXT_LARGE`, and `TEXT_EMBEDDING` model handlers on the runtime. Android path only (iOS uses native IPC). Gated by `ELIZA_DEVICE_BRIDGE_ENABLED=1`. |
-| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server`. |
+| `mobileDeviceBridgePlugin` | Registers the canonical `MobileDeviceBridgeService`; the pre-initialize bootstrap installs this same plugin so later plugin registration remains idempotent. |
+| `ensureMobileDeviceBridgeInferenceHandlers(runtime)` | Registers the canonical `MobileDeviceBridgeService` before initialization, then registers `TEXT_SMALL`, `TEXT_LARGE`, and `TEXT_EMBEDDING` handlers only after a bionic host or real device can serve them. Android path only (iOS uses native IPC). Gated by `ELIZA_DEVICE_BRIDGE_ENABLED=1`. |
+| `attachMobileDeviceBridgeToServer(httpServer)` | Attaches the canonical singleton's WebSocket upgrade handler at `/api/local-inference/device-bridge` to an existing Node `http.Server`. Runtime service stop removes the hook, closes clients, cancels pending calls, and clears heartbeat timers. |
 | `getMobileDeviceBridgeStatus()` | Returns `MobileDeviceBridgeStatus`: enabled, connected devices, loaded model path, pending request counts. |
 | `loadMobileDeviceBridgeModel(modelPath, modelId?)` | Imperatively load a GGUF into the connected Android device. |
 | `unloadMobileDeviceBridgeModel()` | Unload the current model from the connected Android device. |

--- a/plugins/plugin-capacitor-bridge/src/index.ts
+++ b/plugins/plugin-capacitor-bridge/src/index.ts
@@ -16,8 +16,7 @@ export async function runIosBridgeCli(argv?: string[]): Promise<void> {
 	await runIosBridgeCli(argv);
 }
 
-import type { Plugin } from "@elizaos/core";
-import { CapacitorMobileDeviceBridgeService } from "./mobile-device-bridge-bootstrap.js";
+import { mobileDeviceBridgePlugin } from "./mobile-device-bridge-bootstrap.js";
 
 export {
 	attachMobileDeviceBridgeToServer,
@@ -27,19 +26,9 @@ export {
 	loadMobileDeviceBridgeModel,
 	type MobileDeviceBridgeStatus,
 	mobileDeviceBridge,
+	mobileDeviceBridgePlugin,
 	unloadMobileDeviceBridgeModel,
 } from "./mobile-device-bridge-bootstrap.js";
-
-/**
- * Mobile-host plugin: registers the device bridge as a runtime service so
- * consumers resolve it via `runtime.getService(ServiceType.MOBILE_DEVICE_BRIDGE)`.
- */
-export const mobileDeviceBridgePlugin: Plugin = {
-	name: "capacitor-bridge",
-	description:
-		"Registers the mobile device inference bridge as a runtime service.",
-	services: [CapacitorMobileDeviceBridgeService],
-};
 
 export default mobileDeviceBridgePlugin;
 export {

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.gating.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.gating.test.ts
@@ -19,10 +19,18 @@ const ENV_KEYS = [
 const saved: Record<string, string | undefined> = {};
 
 function fakeRuntime() {
-	return {
+	const runtime = {
+		hasService: vi.fn(() => false),
 		registerModel: vi.fn(),
+		registerService: vi.fn(async () => undefined),
+		registerPlugin: vi.fn(async (plugin: { services?: unknown[] }) => {
+			for (const service of plugin.services ?? []) {
+				await runtime.registerService(service);
+			}
+		}),
 		getModel: vi.fn(() => undefined),
 	};
+	return runtime;
 }
 
 describe("ensureMobileDeviceBridgeInferenceHandlers — dead-bridge gating (#11277)", () => {

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.serving-status.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.serving-status.test.ts
@@ -24,10 +24,18 @@ const saved: Record<string, string | undefined> = {};
 const linuxAbstractSocketIt = process.platform === "linux" ? it : it.skip;
 
 function fakeRuntime() {
-	return {
+	const runtime = {
+		hasService: vi.fn(() => false),
 		registerModel: vi.fn(),
+		registerService: vi.fn(async () => undefined),
+		registerPlugin: vi.fn(async (plugin: { services?: unknown[] }) => {
+			for (const service of plugin.services ?? []) {
+				await runtime.registerService(service);
+			}
+		}),
 		getModel: vi.fn(() => undefined),
 	};
+	return runtime;
 }
 
 /** Fresh module instance so registeredModelTrigger starts null per test. */

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -56,6 +56,7 @@ const DEFAULT_CALL_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const DEFAULT_LOAD_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const SERVICE_ENABLED = process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1";
 const registeredRuntimes = new WeakSet<AgentRuntime>();
+let registeredRuntimeCount = 0;
 const deviceAttachUnsubscribers = new WeakMap<AgentRuntime, () => void>();
 /**
  * The trigger that actually bound the capacitor-llama handlers, or null while
@@ -354,6 +355,7 @@ class MobileDeviceBridge {
 	private lifecycleGeneration = 0;
 	private attachedServer: HttpServer | null = null;
 	private upgradeHandler: UpgradeHandler | null = null;
+	private serverCloseHandler: (() => void) | null = null;
 	private readonly sockets = new Set<MinimalWebSocket>();
 	private readonly heartbeatTimers = new Map<
 		MinimalWebSocket,
@@ -404,10 +406,33 @@ class MobileDeviceBridge {
 			);
 			return;
 		}
+		const serverCloseHandler = () => {
+			// error-policy:J6 the server close is already committed; transport
+			// teardown failures are logged after every release path has been attempted.
+			void this.close().catch((error) => {
+				logger.warn(
+					"[mobile-device-bridge] Server-owned transport teardown failed:",
+					error instanceof Error ? error.message : String(error),
+				);
+			});
+		};
+		server.once("close", serverCloseHandler);
 		const generation = this.lifecycleGeneration;
-		const wsModule = await import("ws");
-		if (generation !== this.lifecycleGeneration || this.wss) return;
+		let wsModule: unknown;
+		try {
+			wsModule = await import("ws");
+		} catch (error) {
+			// error-policy:J6 the provisional close listener is attach-attempt
+			// teardown; release it before preserving the import failure for the caller.
+			server.off("close", serverCloseHandler);
+			throw error;
+		}
+		if (generation !== this.lifecycleGeneration || this.wss) {
+			server.off("close", serverCloseHandler);
+			return;
+		}
 		if (!isWsModule(wsModule)) {
+			server.off("close", serverCloseHandler);
 			throw new Error("ws module did not expose WebSocketServer/WebSocket");
 		}
 		const ws = wsModule;
@@ -430,6 +455,7 @@ class MobileDeviceBridge {
 		};
 		this.attachedServer = server;
 		this.upgradeHandler = upgradeHandler;
+		this.serverCloseHandler = serverCloseHandler;
 		server.on("upgrade", upgradeHandler);
 
 		logger.info(
@@ -646,15 +672,18 @@ class MobileDeviceBridge {
 		pending.clear();
 	}
 
-	/** Release the HTTP upgrade hook, clients, timers, and outstanding RPCs. */
+	/** Release the server-owned upgrade hook, clients, timers, and outstanding RPCs. */
 	async close(): Promise<void> {
 		const closeErrors: Error[] = [];
 		this.lifecycleGeneration += 1;
 		const server = this.attachedServer;
 		const upgradeHandler = this.upgradeHandler;
+		const serverCloseHandler = this.serverCloseHandler;
 		this.attachedServer = null;
 		this.upgradeHandler = null;
+		this.serverCloseHandler = null;
 		if (server && upgradeHandler) server.off("upgrade", upgradeHandler);
+		if (server && serverCloseHandler) server.off("close", serverCloseHandler);
 
 		this.attachListeners.clear();
 		const stopped = new Error(
@@ -684,6 +713,7 @@ class MobileDeviceBridge {
 		}
 		this.sockets.clear();
 		this.devices.clear();
+		registeredModelTrigger = null;
 
 		const wss = this.wss;
 		this.wss = null;
@@ -2033,9 +2063,10 @@ export class CapacitorMobileDeviceBridgeService extends MobileDeviceBridgeServic
 		const runtime = this.runtime as AgentRuntime;
 		deviceAttachUnsubscribers.get(runtime)?.();
 		deviceAttachUnsubscribers.delete(runtime);
-		registeredRuntimes.delete(runtime);
-		registeredModelTrigger = null;
-		await mobileDeviceBridge.close();
+		if (registeredRuntimes.delete(runtime)) {
+			registeredRuntimeCount = Math.max(0, registeredRuntimeCount - 1);
+		}
+		if (registeredRuntimeCount === 0) registeredModelTrigger = null;
 	}
 }
 
@@ -2269,6 +2300,7 @@ function registerMobileDeviceBridgeModels(
 		`[mobile-device-bridge] Registered ${PROVIDER} handlers for TEXT_SMALL / TEXT_LARGE${embeddingModelPath ? " / TEXT_EMBEDDING" : ""} at priority ${LOCAL_INFERENCE_PRIORITY} (via ${trigger})`,
 	);
 	registeredRuntimes.add(runtime);
+	registeredRuntimeCount += 1;
 	registeredModelTrigger = trigger;
 	return true;
 }

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -40,8 +40,10 @@ import {
 	MobileDeviceBridgeService,
 	type MobileDeviceBridgeStatus,
 	ModelType,
+	type Plugin,
 	resolveBackgroundInferenceBudget,
 	resolveStateDir,
+	ServiceType,
 	type TextEmbeddingParams,
 } from "@elizaos/core";
 import { resolveStoredModelPath } from "./shared/local-inference-stored-path.ts";
@@ -54,6 +56,7 @@ const DEFAULT_CALL_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const DEFAULT_LOAD_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const SERVICE_ENABLED = process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1";
 const registeredRuntimes = new WeakSet<AgentRuntime>();
+const deviceAttachUnsubscribers = new WeakMap<AgentRuntime, () => void>();
 /**
  * The trigger that actually bound the capacitor-llama handlers, or null while
  * nothing registered them. "bionic-host" is the true in-process serving signal
@@ -167,6 +170,7 @@ interface MinimalWebSocket {
 	readyState: number;
 	send(data: string): void;
 	close(code?: number, reason?: string): void;
+	terminate?(): void;
 	on(event: "message", listener: (data: Buffer | string) => void): unknown;
 	on(event: "close", listener: () => void): unknown;
 	on(event: "error", listener: (err: Error) => void): unknown;
@@ -184,7 +188,14 @@ interface WssInstance {
 		cb: (ws: MinimalWebSocket) => void,
 	): void;
 	on(event: "error", listener: (err: Error) => void): unknown;
+	close(callback?: (error?: Error) => void): void;
 }
+
+type UpgradeHandler = (
+	request: IncomingMessage,
+	socket: Duplex,
+	head: Buffer,
+) => void;
 
 interface WsModule {
 	WebSocketServer: new (options: {
@@ -340,6 +351,14 @@ export type { MobileDeviceBridgeStatus };
 
 class MobileDeviceBridge {
 	private wss: WssInstance | null = null;
+	private lifecycleGeneration = 0;
+	private attachedServer: HttpServer | null = null;
+	private upgradeHandler: UpgradeHandler | null = null;
+	private readonly sockets = new Set<MinimalWebSocket>();
+	private readonly heartbeatTimers = new Map<
+		MinimalWebSocket,
+		ReturnType<typeof setInterval>
+	>();
 	private readonly devices = new Map<string, ConnectedDevice>();
 	private readonly attachListeners = new Set<() => void>();
 	private readonly pendingLoads = new Map<string, Pending<void>>();
@@ -371,7 +390,8 @@ class MobileDeviceBridge {
 				this.pendingLoads.size +
 				this.pendingUnloads.size +
 				this.pendingGenerates.size +
-				this.pendingEmbeds.size,
+				this.pendingEmbeds.size +
+				this.pendingFormatChats.size,
 			modelPath: resolveLocalModelPath("TEXT_LARGE"),
 		};
 	}
@@ -384,7 +404,9 @@ class MobileDeviceBridge {
 			);
 			return;
 		}
+		const generation = this.lifecycleGeneration;
 		const wsModule = await import("ws");
+		if (generation !== this.lifecycleGeneration || this.wss) return;
 		if (!isWsModule(wsModule)) {
 			throw new Error("ws module did not expose WebSocketServer/WebSocket");
 		}
@@ -399,13 +421,16 @@ class MobileDeviceBridge {
 			logger.warn("[mobile-device-bridge] WSS error:", err.message);
 		});
 
-		server.on("upgrade", (request, socket, head) => {
+		const upgradeHandler: UpgradeHandler = (request, socket, head) => {
 			const url = new URL(request.url ?? "/", "http://localhost");
 			if (url.pathname !== DEVICE_BRIDGE_PATH) return;
 			wss.handleUpgrade(request, socket, head, (client: MinimalWebSocket) => {
 				this.handleConnection(client, ws.WebSocket, url);
 			});
-		});
+		};
+		this.attachedServer = server;
+		this.upgradeHandler = upgradeHandler;
+		server.on("upgrade", upgradeHandler);
 
 		logger.info(
 			`[mobile-device-bridge] Listening for Capacitor device bridge at ${DEVICE_BRIDGE_PATH}`,
@@ -417,6 +442,13 @@ class MobileDeviceBridge {
 		WsCtor: WsConstructor,
 		url: URL,
 	) {
+		this.sockets.add(socket);
+		socket.on("close", () => {
+			this.sockets.delete(socket);
+			const heartbeat = this.heartbeatTimers.get(socket);
+			if (heartbeat) clearInterval(heartbeat);
+			this.heartbeatTimers.delete(socket);
+		});
 		const queryToken = url.searchParams.get("token")?.trim();
 		if (
 			!this.expectedPairingToken ||
@@ -507,6 +539,7 @@ class MobileDeviceBridge {
 		if (typeof heartbeat === "object" && "unref" in heartbeat) {
 			(heartbeat as { unref(): void }).unref();
 		}
+		this.heartbeatTimers.set(socket, heartbeat);
 	}
 
 	private handleDeviceMessage(msg: DeviceOutbound): void {
@@ -587,8 +620,9 @@ class MobileDeviceBridge {
 	 * bootstrap defers registration through this hook when neither the bionic
 	 * host nor a connected device is available at boot.
 	 */
-	onDeviceAttached(listener: () => void): void {
+	onDeviceAttached(listener: () => void): () => void {
 		this.attachListeners.add(listener);
+		return () => this.attachListeners.delete(listener);
 	}
 
 	private notifyDeviceAttached(): void {
@@ -599,6 +633,79 @@ class MobileDeviceBridge {
 
 	private primaryDevice(): ConnectedDevice | null {
 		return this.devices.values().next().value ?? null;
+	}
+
+	private rejectPending<T>(
+		pending: Map<string, Pending<T>>,
+		error: Error,
+	): void {
+		for (const item of pending.values()) {
+			clearTimeout(item.timeout);
+			item.reject(error);
+		}
+		pending.clear();
+	}
+
+	/** Release the HTTP upgrade hook, clients, timers, and outstanding RPCs. */
+	async close(): Promise<void> {
+		const closeErrors: Error[] = [];
+		this.lifecycleGeneration += 1;
+		const server = this.attachedServer;
+		const upgradeHandler = this.upgradeHandler;
+		this.attachedServer = null;
+		this.upgradeHandler = null;
+		if (server && upgradeHandler) server.off("upgrade", upgradeHandler);
+
+		this.attachListeners.clear();
+		const stopped = new Error(
+			"DEVICE_BRIDGE_STOPPED: mobile device bridge runtime stopped",
+		);
+		this.rejectPending(this.pendingLoads, stopped);
+		this.rejectPending(this.pendingUnloads, stopped);
+		this.rejectPending(this.pendingGenerates, stopped);
+		this.rejectPending(this.pendingEmbeds, stopped);
+		this.rejectPending(this.pendingFormatChats, stopped);
+
+		for (const heartbeat of this.heartbeatTimers.values()) {
+			clearInterval(heartbeat);
+		}
+		this.heartbeatTimers.clear();
+		for (const socket of this.sockets) {
+			try {
+				if (socket.terminate) socket.terminate();
+				else socket.close(1001, "runtime-stopped");
+			} catch (error) {
+				// error-policy:J6 every remaining transport resource still receives
+				// its teardown opportunity before the aggregate reaches runtime stop.
+				closeErrors.push(
+					error instanceof Error ? error : new Error(String(error)),
+				);
+			}
+		}
+		this.sockets.clear();
+		this.devices.clear();
+
+		const wss = this.wss;
+		this.wss = null;
+		if (wss) {
+			try {
+				await new Promise<void>((resolve, reject) => {
+					wss.close((error) => (error ? reject(error) : resolve()));
+				});
+			} catch (error) {
+				// error-policy:J6 socket cleanup above is complete; preserve the WSS
+				// close failure for the runtime's teardown diagnostics.
+				closeErrors.push(
+					error instanceof Error ? error : new Error(String(error)),
+				);
+			}
+		}
+		if (closeErrors.length > 0) {
+			throw new AggregateError(
+				closeErrors,
+				"Mobile device bridge transport teardown failed",
+			);
+		}
 	}
 
 	private sendToPrimary<T>(
@@ -1922,8 +2029,28 @@ export class CapacitorMobileDeviceBridgeService extends MobileDeviceBridgeServic
 		await unloadMobileDeviceBridgeModel();
 	}
 
-	async stop(): Promise<void> {}
+	async stop(): Promise<void> {
+		const runtime = this.runtime as AgentRuntime;
+		deviceAttachUnsubscribers.get(runtime)?.();
+		deviceAttachUnsubscribers.delete(runtime);
+		registeredRuntimes.delete(runtime);
+		registeredModelTrigger = null;
+		await mobileDeviceBridge.close();
+	}
 }
+
+/**
+ * Mobile-host plugin owning the canonical bridge service. The pre-initialize
+ * bootstrap registers this plugin, rather than its service class directly, so
+ * a later character-plugin pass sees the same plugin name and cannot duplicate
+ * the singleton service instance or its teardown call.
+ */
+export const mobileDeviceBridgePlugin: Plugin = {
+	name: "capacitor-bridge",
+	description:
+		"Registers the mobile device inference bridge as a runtime service.",
+	services: [CapacitorMobileDeviceBridgeService],
+};
 
 export async function attachMobileDeviceBridgeToServer(
 	server: HttpServer,
@@ -2154,6 +2281,9 @@ export async function ensureMobileDeviceBridgeInferenceHandlers(
 		logger.debug("[mobile-device-bridge] Disabled or AOSP local llama active");
 		return false;
 	}
+	if (!runtime.hasService(ServiceType.MOBILE_DEVICE_BRIDGE)) {
+		await runtime.registerPlugin(mobileDeviceBridgePlugin);
+	}
 	if (registeredRuntimes.has(runtime)) {
 		logger.debug("[mobile-device-bridge] Handlers already registered");
 		return true;
@@ -2184,8 +2314,17 @@ export async function ensureMobileDeviceBridgeInferenceHandlers(
 		"[mobile-device-bridge] No bionic host delegation and no device bridge attached — " +
 			`${PROVIDER} TEXT handlers stay unregistered until a device bridge connects`,
 	);
-	mobileDeviceBridge.onDeviceAttached(() => {
-		registerMobileDeviceBridgeModels(runtime, "device-bridge");
-	});
-	return false;
+	if (!deviceAttachUnsubscribers.has(runtime)) {
+		const registerOnAttach = () => {
+			registerMobileDeviceBridgeModels(runtime, "device-bridge");
+		};
+		deviceAttachUnsubscribers.set(
+			runtime,
+			mobileDeviceBridge.onDeviceAttached(registerOnAttach),
+		);
+		// Close the status-check/subscription race: if registration landed after
+		// the earlier check, bind the handlers now through the same callback.
+		if (mobileDeviceBridge.status().connected) registerOnAttach();
+	}
+	return registeredRuntimes.has(runtime);
 }

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-headless-boot.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-headless-boot.test.ts
@@ -1,6 +1,6 @@
 /**
  * Boots the canonical device bridge through a real AgentRuntime and HTTP/WebSocket
- * transport, proving attach-gated handlers and runtime-owned teardown.
+ * transport, proving attach-gated handlers and server-owned teardown.
  */
 
 import { mkdtempSync, writeFileSync } from "node:fs";
@@ -71,7 +71,7 @@ function closeServer(server: http.Server): Promise<void> {
 }
 
 describe("canonical mobile device bridge headless boot", () => {
-	it("waits for attach, serves through one handler, and tears transport down", async () => {
+	it("waits for attach, serves through one handler, and lets the server tear transport down", async () => {
 		const bridge = await import("./mobile-device-bridge-bootstrap");
 		const runtime = new AgentRuntime({
 			logLevel: "fatal",
@@ -205,6 +205,13 @@ describe("canonical mobile device bridge headless boot", () => {
 				socket?.once("close", () => resolve()),
 			);
 			await runtime.stop();
+			expect(server.listenerCount("upgrade")).toBe(1);
+			expect(bridge.mobileDeviceBridge.status().pendingRequests).toBe(1);
+
+			// The HTTP server owns the process-global transport. Runtime replacement
+			// must not tear it away from the incoming runtime, while the server close
+			// boundary still releases every transport resource.
+			server.emit("close");
 			await pendingStopped;
 			await clientClosed;
 			expect(bridge.mobileDeviceBridge.status().connected).toBe(false);

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-headless-boot.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-headless-boot.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Boots the canonical device bridge through a real AgentRuntime and HTTP/WebSocket
+ * transport, proving attach-gated handlers and runtime-owned teardown.
+ */
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { AgentRuntime, ModelType, ServiceType } from "@elizaos/core";
+import { afterAll, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+
+const savedEnv = {
+	ELIZA_DEVICE_BRIDGE_ENABLED: process.env.ELIZA_DEVICE_BRIDGE_ENABLED,
+	ELIZA_DEVICE_PAIRING_TOKEN: process.env.ELIZA_DEVICE_PAIRING_TOKEN,
+	ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD:
+		process.env.ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD,
+	ELIZA_LOCAL_CHAT_MODEL_PATH: process.env.ELIZA_LOCAL_CHAT_MODEL_PATH,
+	ELIZA_LOCAL_LLAMA: process.env.ELIZA_LOCAL_LLAMA,
+};
+
+const pairingToken = "headless-bridge-pairing-token";
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "device-bridge-boot-"));
+const modelPath = path.join(stateDir, "headless-chat.gguf");
+writeFileSync(modelPath, "deterministic headless bridge fixture");
+process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+process.env.ELIZA_DEVICE_PAIRING_TOKEN = pairingToken;
+process.env.ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD = "1";
+process.env.ELIZA_LOCAL_CHAT_MODEL_PATH = modelPath;
+delete process.env.ELIZA_LOCAL_LLAMA;
+
+afterAll(() => {
+	for (const [key, value] of Object.entries(savedEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+});
+
+async function waitFor(
+	predicate: () => boolean,
+	label: string,
+	timeoutMs = 3_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline)
+			throw new Error(`Timed out waiting for ${label}`);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+function listen(server: http.Server): Promise<number> {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				reject(new Error("Headless bridge server did not expose a TCP port"));
+				return;
+			}
+			resolve(address.port);
+		});
+	});
+}
+
+function closeServer(server: http.Server): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.close((error) => (error ? reject(error) : resolve()));
+	});
+}
+
+describe("canonical mobile device bridge headless boot", () => {
+	it("waits for attach, serves through one handler, and tears transport down", async () => {
+		const bridge = await import("./mobile-device-bridge-bootstrap");
+		const runtime = new AgentRuntime({
+			logLevel: "fatal",
+			plugins: [bridge.mobileDeviceBridgePlugin],
+		});
+		const server = http.createServer((_req, res) => res.end("ok"));
+		let socket: WebSocket | null = null;
+
+		try {
+			await expect(
+				bridge.ensureMobileDeviceBridgeInferenceHandlers(runtime),
+			).resolves.toBe(false);
+			await expect(
+				bridge.ensureMobileDeviceBridgeInferenceHandlers(runtime),
+			).resolves.toBe(false);
+			expect(runtime.hasService(ServiceType.MOBILE_DEVICE_BRIDGE)).toBe(true);
+			expect(
+				runtime
+					.getModelRegistrations()
+					.filter((entry) => entry.provider === "capacitor-llama"),
+			).toHaveLength(0);
+
+			await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+			const service = await runtime.getServiceLoadPromise(
+				ServiceType.MOBILE_DEVICE_BRIDGE,
+			);
+			expect(service).toBeInstanceOf(bridge.CapacitorMobileDeviceBridgeService);
+			expect(
+				runtime.getServicesByType(ServiceType.MOBILE_DEVICE_BRIDGE),
+			).toHaveLength(1);
+			expect(
+				runtime.plugins.filter(
+					(plugin) => plugin.name === bridge.mobileDeviceBridgePlugin.name,
+				),
+			).toHaveLength(1);
+
+			await Promise.all([
+				bridge.attachMobileDeviceBridgeToServer(server),
+				bridge.attachMobileDeviceBridgeToServer(server),
+			]);
+			expect(server.listenerCount("upgrade")).toBe(1);
+			const port = await listen(server);
+			socket = new WebSocket(
+				`ws://127.0.0.1:${port}/api/local-inference/device-bridge?token=${pairingToken}`,
+			);
+			await new Promise<void>((resolve, reject) => {
+				socket?.once("open", resolve);
+				socket?.once("error", reject);
+			});
+
+			socket.on("message", (raw) => {
+				const message = JSON.parse(raw.toString()) as {
+					type: string;
+					correlationId?: string;
+					prompt?: string;
+				};
+				if (message.type === "generate" && message.prompt !== "pending") {
+					socket?.send(
+						JSON.stringify({
+							type: "generateResult",
+							correlationId: message.correlationId,
+							ok: true,
+							text: "headless-device-reply",
+							promptTokens: 2,
+							outputTokens: 3,
+							durationMs: 5,
+						}),
+					);
+				}
+			});
+			socket.send(
+				JSON.stringify({
+					type: "register",
+					payload: {
+						deviceId: "headless-device",
+						pairingToken,
+						capabilities: {
+							platform: "android",
+							deviceModel: "headless-test",
+							totalRamGb: 8,
+							cpuCores: 8,
+							gpu: { backend: "vulkan", available: true },
+						},
+						loadedPath: modelPath,
+					},
+				}),
+			);
+
+			await waitFor(
+				() => bridge.mobileDeviceBridge.status().connected,
+				"device registration",
+			);
+			await waitFor(
+				() =>
+					runtime
+						.getModelRegistrations()
+						.some(
+							(entry) =>
+								entry.modelType === ModelType.TEXT_SMALL &&
+								entry.provider === "capacitor-llama",
+						),
+				"attach-gated model registration",
+			);
+			const textRegistrations = runtime
+				.getModelRegistrations()
+				.filter(
+					(entry) =>
+						entry.modelType === ModelType.TEXT_SMALL &&
+						entry.provider === "capacitor-llama",
+				);
+			expect(textRegistrations).toHaveLength(1);
+
+			const registeredHandler = runtime.models
+				.get(ModelType.TEXT_SMALL)
+				?.find((entry) => entry.provider === "capacitor-llama")?.handler;
+			if (!registeredHandler)
+				throw new Error("Bridge TEXT_SMALL handler missing");
+			await expect(
+				registeredHandler(runtime, { prompt: "headless request" }),
+			).resolves.toBe("headless-device-reply");
+
+			const pending = bridge.mobileDeviceBridge.generate({ prompt: "pending" });
+			await waitFor(
+				() => bridge.mobileDeviceBridge.status().pendingRequests === 1,
+				"pending device RPC",
+			);
+			const pendingStopped = expect(pending).rejects.toThrow(
+				"DEVICE_BRIDGE_STOPPED",
+			);
+			const clientClosed = new Promise<void>((resolve) =>
+				socket?.once("close", () => resolve()),
+			);
+			await runtime.stop();
+			await pendingStopped;
+			await clientClosed;
+			expect(bridge.mobileDeviceBridge.status().connected).toBe(false);
+			expect(bridge.mobileDeviceBridge.status().pendingRequests).toBe(0);
+			expect(server.listenerCount("upgrade")).toBe(0);
+		} finally {
+			if (socket?.readyState === WebSocket.OPEN) socket.close();
+			await runtime.stop({ fast: true });
+			if (server.listening) await closeServer(server);
+		}
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-runtime-replacement.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-runtime-replacement.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Exercises Capacitor bridge ownership across two real AgentRuntime instances.
+ * The HTTP server is intentionally unbound: only listener and service lifecycle
+ * are under test, so no TCP port is opened.
+ */
+
+import http from "node:http";
+import { AgentRuntime, ServiceType } from "@elizaos/core";
+import { afterAll, describe, expect, it } from "vitest";
+
+const savedEnv = {
+	ELIZA_DEVICE_BRIDGE_ENABLED: process.env.ELIZA_DEVICE_BRIDGE_ENABLED,
+	ELIZA_DEVICE_PAIRING_TOKEN: process.env.ELIZA_DEVICE_PAIRING_TOKEN,
+	ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD:
+		process.env.ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD,
+	ELIZA_LOCAL_LLAMA: process.env.ELIZA_LOCAL_LLAMA,
+};
+
+process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+process.env.ELIZA_DEVICE_PAIRING_TOKEN = "runtime-replacement-ownership";
+process.env.ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD = "1";
+delete process.env.ELIZA_LOCAL_LLAMA;
+
+afterAll(() => {
+	for (const [key, value] of Object.entries(savedEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+});
+
+describe("mobile device bridge runtime replacement ownership", () => {
+	it("keeps the shared server transport alive when the old runtime stops", async () => {
+		const bridge = await import("./mobile-device-bridge-bootstrap");
+		const server = http.createServer();
+		const previousRuntime = new AgentRuntime({ logLevel: "fatal" });
+		const replacementRuntime = new AgentRuntime({ logLevel: "fatal" });
+
+		try {
+			await bridge.ensureMobileDeviceBridgeInferenceHandlers(previousRuntime);
+			await previousRuntime.initialize({
+				allowNoDatabase: true,
+				skipMigrations: true,
+			});
+			await previousRuntime.getServiceLoadPromise(
+				ServiceType.MOBILE_DEVICE_BRIDGE,
+			);
+			await bridge.attachMobileDeviceBridgeToServer(server);
+
+			await bridge.ensureMobileDeviceBridgeInferenceHandlers(
+				replacementRuntime,
+			);
+			await replacementRuntime.initialize({
+				allowNoDatabase: true,
+				skipMigrations: true,
+			});
+			await replacementRuntime.getServiceLoadPromise(
+				ServiceType.MOBILE_DEVICE_BRIDGE,
+			);
+
+			expect(server.listenerCount("upgrade")).toBe(1);
+			await previousRuntime.stop({ fast: true });
+
+			expect(server.listenerCount("upgrade")).toBe(1);
+			expect(
+				replacementRuntime.getService(ServiceType.MOBILE_DEVICE_BRIDGE),
+			).toBeInstanceOf(bridge.CapacitorMobileDeviceBridgeService);
+
+			// A real server close event owns final transport teardown. Emitting it on
+			// this deliberately unbound server proves the ownership boundary without
+			// opening a TCP listener.
+			server.emit("close");
+			expect(server.listenerCount("upgrade")).toBe(0);
+		} finally {
+			await previousRuntime.stop({ fast: true });
+			await replacementRuntime.stop({ fast: true });
+			await bridge.mobileDeviceBridge.close();
+		}
+	});
+});

--- a/plugins/plugin-local-inference/AGENTS.md
+++ b/plugins/plugin-local-inference/AGENTS.md
@@ -4,7 +4,7 @@ Eliza-1 local inference provider: text generation, embeddings, TTS, ASR, image g
 
 ## Purpose / role
 
-This plugin registers model handlers for `TEXT_SMALL`, `TEXT_LARGE`, `TEXT_EMBEDDING`, `IMAGE`, `IMAGE_DESCRIPTION`, `TEXT_TO_SPEECH`, and `TRANSCRIPTION`. It also exposes the `GENERATE_MEDIA` agent action and HTTP routes for the model catalog, download orchestration, hardware detection, and voice tooling. The plugin is opt-in: it must be added to the elizaOS agent's plugin list. It requires at minimum one active local backend (an Eliza-1 GGUF bundle loaded via `LocalInferenceService` or an AOSP/device-bridge loader); without one, every model call throws `LocalInferenceUnavailableError` with code `LOCAL_INFERENCE_UNAVAILABLE`.
+This plugin registers model handlers for `TEXT_SMALL`, `TEXT_LARGE`, `TEXT_EMBEDDING`, `IMAGE`, `IMAGE_DESCRIPTION`, `TEXT_TO_SPEECH`, and `TRANSCRIPTION`. It also exposes the `GENERATE_MEDIA` agent action and HTTP routes for the model catalog, download orchestration, hardware detection, and voice tooling. The plugin is opt-in: it must be added to the elizaOS agent's plugin list. It requires at minimum one active local backend (an Eliza-1 GGUF bundle loaded via `LocalInferenceService`, an AOSP/Capacitor/bionic loader, or the canonical mobile bridge service); without one, every model call throws `LocalInferenceUnavailableError` with code `LOCAL_INFERENCE_UNAVAILABLE`.
 
 ## Plugin surface
 
@@ -25,6 +25,8 @@ The plugin owns the `VoiceProfileStore` (speaker centroids); a merge-engine plug
 `TEXT_EMBEDDING` is **not** registered on the static plugin object — it is wired at boot by `ensureLocalInferenceHandler()` in the runtime subpath to avoid claiming the embedding slot before a backend is active.
 
 ### Registered elizaOS services
+- `LocalInferenceLoaderRuntimeService` (`src/services/runtime-services.ts`) — runtime-owned adapter for the selected AOSP, Capacitor, or bionic-host loader. Registration is safe before `AgentRuntime.initialize()`; the boot hook waits for startup only after initialization, and runtime stop releases the selected backend. Stock device-bridge inference remains owned by `@elizaos/plugin-capacitor-bridge` through core's `MobileDeviceBridgeService` seam and registers handlers only after a device attaches.
+- `TimedAsrService` (`src/services/runtime-services.ts`) — additive `timedAsr` seam for fused per-word timings. Meeting transcription discovers it without importing this plugin or widening the string-only `TRANSCRIPTION` model contract.
 - `LocalPiiRecognizerService` (`src/pii/service.ts`) — registers under core's `PII_ENTITY_RECOGNIZER_SERVICE`; supplies the `LlmEntityRecognizer` (`src/pii/llm-recognizer.ts`) that the runtime's PII pseudonymization layer composes with its regex recognizer when `ELIZA_PII_SWAP_ENABLED` is on. Detection runs as a JSON-extraction prompt on the resident local backend through the inference priority gate; only values found verbatim in the source text are emitted, and `getRecognizer()` returns `null` (regex-only degrade) while no generation-capable local backend is active.
 
 ### Services (consumed, not registered as elizaOS services)
@@ -101,6 +103,7 @@ src/
   services/
     index.ts                      Re-exports all service surfaces
     service.ts                    LocalInferenceService singleton (download, active-model, catalog, routing)
+    runtime-services.ts           AgentRuntime service classes for the selected loader and timed ASR
     engine.ts                     LocalInferenceEngine — llama.cpp FFI, one model at a time
     memory-arbiter.ts             MemoryArbiter — cross-plugin model handle arbiter (WS1)
     active-model.ts               ActiveModelCoordinator, load-args resolution, manifest validation

--- a/plugins/plugin-local-inference/CLAUDE.md
+++ b/plugins/plugin-local-inference/CLAUDE.md
@@ -4,7 +4,7 @@ Eliza-1 local inference provider: text generation, embeddings, TTS, ASR, image g
 
 ## Purpose / role
 
-This plugin registers model handlers for `TEXT_SMALL`, `TEXT_LARGE`, `TEXT_EMBEDDING`, `IMAGE`, `IMAGE_DESCRIPTION`, `TEXT_TO_SPEECH`, and `TRANSCRIPTION`. It also exposes the `GENERATE_MEDIA` agent action and HTTP routes for the model catalog, download orchestration, hardware detection, and voice tooling. The plugin is opt-in: it must be added to the elizaOS agent's plugin list. It requires at minimum one active local backend (an Eliza-1 GGUF bundle loaded via `LocalInferenceService` or an AOSP/device-bridge loader); without one, every model call throws `LocalInferenceUnavailableError` with code `LOCAL_INFERENCE_UNAVAILABLE`.
+This plugin registers model handlers for `TEXT_SMALL`, `TEXT_LARGE`, `TEXT_EMBEDDING`, `IMAGE`, `IMAGE_DESCRIPTION`, `TEXT_TO_SPEECH`, and `TRANSCRIPTION`. It also exposes the `GENERATE_MEDIA` agent action and HTTP routes for the model catalog, download orchestration, hardware detection, and voice tooling. The plugin is opt-in: it must be added to the elizaOS agent's plugin list. It requires at minimum one active local backend (an Eliza-1 GGUF bundle loaded via `LocalInferenceService`, an AOSP/Capacitor/bionic loader, or the canonical mobile bridge service); without one, every model call throws `LocalInferenceUnavailableError` with code `LOCAL_INFERENCE_UNAVAILABLE`.
 
 ## Plugin surface
 
@@ -25,6 +25,8 @@ The plugin owns the `VoiceProfileStore` (speaker centroids); a merge-engine plug
 `TEXT_EMBEDDING` is **not** registered on the static plugin object — it is wired at boot by `ensureLocalInferenceHandler()` in the runtime subpath to avoid claiming the embedding slot before a backend is active.
 
 ### Registered elizaOS services
+- `LocalInferenceLoaderRuntimeService` (`src/services/runtime-services.ts`) — runtime-owned adapter for the selected AOSP, Capacitor, or bionic-host loader. Registration is safe before `AgentRuntime.initialize()`; the boot hook waits for startup only after initialization, and runtime stop releases the selected backend. Stock device-bridge inference remains owned by `@elizaos/plugin-capacitor-bridge` through core's `MobileDeviceBridgeService` seam and registers handlers only after a device attaches.
+- `TimedAsrService` (`src/services/runtime-services.ts`) — additive `timedAsr` seam for fused per-word timings. Meeting transcription discovers it without importing this plugin or widening the string-only `TRANSCRIPTION` model contract.
 - `LocalPiiRecognizerService` (`src/pii/service.ts`) — registers under core's `PII_ENTITY_RECOGNIZER_SERVICE`; supplies the `LlmEntityRecognizer` (`src/pii/llm-recognizer.ts`) that the runtime's PII pseudonymization layer composes with its regex recognizer when `ELIZA_PII_SWAP_ENABLED` is on. Detection runs as a JSON-extraction prompt on the resident local backend through the inference priority gate; only values found verbatim in the source text are emitted, and `getRecognizer()` returns `null` (regex-only degrade) while no generation-capable local backend is active.
 
 ### Services (consumed, not registered as elizaOS services)
@@ -101,6 +103,7 @@ src/
   services/
     index.ts                      Re-exports all service surfaces
     service.ts                    LocalInferenceService singleton (download, active-model, catalog, routing)
+    runtime-services.ts           AgentRuntime service classes for the selected loader and timed ASR
     engine.ts                     LocalInferenceEngine — llama.cpp FFI, one model at a time
     memory-arbiter.ts             MemoryArbiter — cross-plugin model handle arbiter (WS1)
     active-model.ts               ActiveModelCoordinator, load-args resolution, manifest validation

--- a/plugins/plugin-local-inference/__tests__/ensure-assigned-model-loaded.test.ts
+++ b/plugins/plugin-local-inference/__tests__/ensure-assigned-model-loaded.test.ts
@@ -3,7 +3,12 @@
  * exercising the assignments/installed-model/loader state via hoisted mocks
  * rather than a real backend load.
  */
-import { type AgentRuntime, ModelType } from "@elizaos/core";
+import {
+	type AgentRuntime,
+	ModelType,
+	type Service,
+	type ServiceClass,
+} from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const modeState = vi.hoisted(() => ({ mode: "local" }));
@@ -129,6 +134,8 @@ function makeRuntime(): {
 	};
 } {
 	const registrations: Registration[] = [];
+	const serviceClasses = new Map<string, ServiceClass>();
+	const services = new Map<string, Service>();
 	const loader = {
 		currentModelPath: vi.fn(() => loaderState.currentPath),
 		loadModel: vi.fn(async (args: unknown) => {
@@ -146,15 +153,26 @@ function makeRuntime(): {
 		}),
 		embed: vi.fn(async () => ({ embedding: [0.1, 0.2], tokens: 2 })),
 	};
-	const runtime = {
+	let runtime!: AgentRuntime;
+	runtime = {
 		agentId: "agent-test",
 		getModel: vi.fn(() => undefined),
 		getSetting: vi.fn((key: string) =>
 			key === "ELIZA_RUNTIME_MODE" ? modeState.mode : undefined,
 		),
 		getService: vi.fn((name: string) =>
-			name === "localInferenceLoader" ? loader : null,
+			name === "localInferenceLoader" ? loader : (services.get(name) ?? null),
 		),
+		getServiceLoadPromise: vi.fn(async (serviceType: string) => {
+			const running = services.get(serviceType);
+			if (running) return running;
+			const serviceClass = serviceClasses.get(serviceType);
+			if (!serviceClass)
+				throw new Error(`Service ${serviceType} not registered`);
+			const service = await serviceClass.start(runtime);
+			services.set(serviceType, service);
+			return service;
+		}),
 		registerModel: vi.fn(
 			(
 				modelType: string | number,
@@ -165,7 +183,9 @@ function makeRuntime(): {
 				registrations.push({ modelType, provider, priority, handler });
 			},
 		),
-		registerService: vi.fn(),
+		registerService: vi.fn(async (serviceClass: ServiceClass) => {
+			serviceClasses.set(serviceClass.serviceType, serviceClass);
+		}),
 	} as unknown as AgentRuntime;
 	return { registrations, runtime, loader };
 }

--- a/plugins/plugin-local-inference/src/runtime/capacitor-llama.d.ts
+++ b/plugins/plugin-local-inference/src/runtime/capacitor-llama.d.ts
@@ -20,6 +20,6 @@ declare module "@elizaos/capacitor-llama" {
 	): DeviceBridgeClient;
 
 	export function registerCapacitorLlamaLoader(runtime: {
-		registerService?: (name: string, impl: unknown) => unknown;
-	}): void;
+		registerService?: unknown;
+	}): Promise<boolean>;
 }

--- a/plugins/plugin-local-inference/src/runtime/device-bridge-service-ownership.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/device-bridge-service-ownership.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Replays the headless pre-init/post-init bridge order against a real runtime,
+ * proving the local boot hook reuses the canonical service without a dead loader.
+ */
+
+import { AgentRuntime, ServiceType } from "@elizaos/core";
+import { afterAll, describe, expect, it } from "vitest";
+import { ensureLocalInferenceHandler } from "./ensure-local-inference-handler";
+
+const savedEnv = {
+	ELIZA_DEVICE_BRIDGE_ENABLED: process.env.ELIZA_DEVICE_BRIDGE_ENABLED,
+	ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD:
+		process.env.ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD,
+	ELIZA_LOCAL_LLAMA: process.env.ELIZA_LOCAL_LLAMA,
+};
+
+process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+process.env.ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD = "1";
+delete process.env.ELIZA_LOCAL_LLAMA;
+
+afterAll(() => {
+	for (const [key, value] of Object.entries(savedEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+});
+
+describe("device bridge service ownership", () => {
+	it("keeps the env-only provider unregistered through the post-init hook", async () => {
+		const bridge = await import(
+			"@elizaos/plugin-capacitor-bridge/mobile-device-bridge-bootstrap"
+		);
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+
+		try {
+			await expect(
+				bridge.ensureMobileDeviceBridgeInferenceHandlers(runtime),
+			).resolves.toBe(false);
+			expect(runtime.hasService(ServiceType.MOBILE_DEVICE_BRIDGE)).toBe(true);
+
+			await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+			await ensureLocalInferenceHandler(runtime);
+
+			expect(
+				runtime
+					.getModelRegistrations()
+					.filter((entry) => entry.provider === "eliza-device-bridge"),
+			).toHaveLength(0);
+			expect(runtime.hasService("localInferenceLoader")).toBe(false);
+			expect(
+				runtime.getService(ServiceType.MOBILE_DEVICE_BRIDGE),
+			).toBeInstanceOf(bridge.CapacitorMobileDeviceBridgeService);
+		} finally {
+			await runtime.stop({ fast: true });
+		}
+	});
+});

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
@@ -4,7 +4,12 @@
  * assignments, and the registry are mocked; no model loads.
  */
 
-import { type AgentRuntime, ModelType } from "@elizaos/core";
+import {
+	AgentRuntime,
+	ModelType,
+	type Service,
+	type ServiceClass,
+} from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const modeState = vi.hoisted(() => ({ mode: "local" }));
@@ -41,6 +46,11 @@ const engineState = vi.hoisted(() => ({
 	prewarmConversation: vi.fn(async () => true),
 	synthesizeSpeech: vi.fn(async () => new Uint8Array([1, 2, 3])),
 	transcribePcm: vi.fn(async () => "transcribed"),
+	transcribePcmTimed: vi.fn(async () => ({
+		text: "timed transcription",
+		words: [{ word: "timed", start: 0, end: 0.25 }],
+	})),
+	voice: vi.fn(() => ({})),
 	warnIfParallelTooLow: vi.fn(),
 }));
 const arbiterState = vi.hoisted(() => ({
@@ -113,7 +123,9 @@ vi.mock("../services/voice", () => ({
 import { resolveLocalInferenceLoadArgs } from "../services/active-model";
 import { probeHardware } from "../services/hardware";
 import { installRouterHandler } from "../services/router-handler";
+import { TimedAsrService } from "../services/runtime-services";
 import { VoiceStartupError } from "../services/voice/errors";
+import { registerLocalInferenceBoot } from "./boot";
 import { ensureLocalInferenceHandler } from "./ensure-local-inference-handler";
 
 interface Registration {
@@ -128,13 +140,28 @@ function makeRuntime(): {
 	runtime: AgentRuntime;
 } {
 	const registrations: Registration[] = [];
-	const runtime = {
+	const serviceClasses = new Map<string, ServiceClass>();
+	const services = new Map<string, Service>();
+	let runtime!: AgentRuntime;
+	runtime = {
 		agentId: "agent-test",
 		getModel: vi.fn(() => undefined),
 		getSetting: vi.fn((key: string) =>
 			key === "ELIZA_RUNTIME_MODE" ? modeState.mode : undefined,
 		),
-		getService: vi.fn(() => null),
+		getService: vi.fn(
+			(serviceType: string) => services.get(serviceType) ?? null,
+		),
+		getServiceLoadPromise: vi.fn(async (serviceType: string) => {
+			const running = services.get(serviceType);
+			if (running) return running;
+			const serviceClass = serviceClasses.get(serviceType);
+			if (!serviceClass)
+				throw new Error(`Service ${serviceType} not registered`);
+			const service = await serviceClass.start(runtime);
+			services.set(serviceType, service);
+			return service;
+		}),
 		setSetting: vi.fn(),
 		registerModel: vi.fn(
 			(
@@ -151,7 +178,9 @@ function makeRuntime(): {
 				});
 			},
 		),
-		registerService: vi.fn(),
+		registerService: vi.fn(async (serviceClass: ServiceClass) => {
+			serviceClasses.set(serviceClass.serviceType, serviceClass);
+		}),
 	} as unknown as AgentRuntime;
 	return { registrations, runtime };
 }
@@ -178,10 +207,13 @@ beforeEach(() => {
 	hardwareState.probe = { memory: { totalGb: 8 } };
 	delete process.env.ELIZA_LOCAL_LLAMA;
 	delete process.env.ELIZA_DEVICE_BRIDGE_ENABLED;
+	delete process.env.ELIZA_BIONIC_HOST_DELEGATED;
+	delete process.env.ELIZA_BIONIC_INFERENCE_SOCK;
 	delete process.env.ELIZA_DISABLE_LOCAL_EMBEDDINGS;
 	engineState.available.mockResolvedValue(true);
 	engineState.currentModelPath.mockReturnValue(null);
 	engineState.hasLoadedModel.mockReturnValue(false);
+	engineState.voice.mockReturnValue({});
 	arbiterState.hasCapability.mockImplementation(
 		(capability: string) => capability === "vision-describe",
 	);
@@ -195,6 +227,33 @@ beforeEach(() => {
 });
 
 describe("ensureLocalInferenceHandler", () => {
+	it("boots timed ASR through a real AgentRuntime and stops it cleanly", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		const stop = vi.spyOn(TimedAsrService.prototype, "stop");
+
+		try {
+			await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+			await registerLocalInferenceBoot(runtime);
+
+			const timedAsr = runtime.getService<TimedAsrService>("timedAsr");
+			expect(timedAsr).toBeInstanceOf(TimedAsrService);
+			if (!timedAsr) throw new Error("timed ASR service did not start");
+			expect(timedAsr.isAvailable()).toBe(true);
+			await expect(
+				timedAsr.transcribeWav(new Uint8Array([1, 2, 3])),
+			).resolves.toEqual({
+				text: "timed transcription",
+				words: [{ word: "timed", start: 0, end: 0.25 }],
+			});
+
+			await runtime.stop();
+			expect(stop).toHaveBeenCalledTimes(1);
+		} finally {
+			await runtime.stop({ fast: true });
+			stop.mockRestore();
+		}
+	});
+
 	it("registers Eliza-1 text, embedding, voice, and transcription handlers in local mode", async () => {
 		const { registrations, runtime } = makeRuntime();
 

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -31,10 +31,11 @@ import {
 	type ImageDescriptionResult,
 	inferenceRamClassFromEnv,
 	logger,
+	type MobileDeviceBridgeService,
 	ModelType,
 	renderMessageHandlerStablePrefix,
 	resolveBackgroundInferenceBudget,
-	Service,
+	ServiceType,
 	type TextEmbeddingParams,
 	type TextToSpeechParams,
 	type TranscriptionParams,
@@ -57,13 +58,18 @@ import {
 	extractPromptCacheKey,
 	resolveLocalCacheKey,
 } from "../services/cache-bridge";
-import { deviceBridge } from "../services/device-bridge";
 import { localInferenceEngine } from "../services/engine";
 import { handlerRegistry } from "../services/handler-registry";
 import { probeHardware } from "../services/hardware";
 import { tryGetMemoryArbiter } from "../services/memory-arbiter";
 import { listInstalledModels } from "../services/registry";
 import { installRouterHandler } from "../services/router-handler";
+import {
+	LOCAL_INFERENCE_LOADER_SERVICE_TYPE,
+	registerLocalInferenceLoaderService,
+	registerTimedAsrService,
+	TIMED_ASR_SERVICE_TYPE,
+} from "../services/runtime-services";
 import {
 	type ElizaHarnessSchema,
 	elizaHarnessSchemaFromSkeleton,
@@ -1233,69 +1239,6 @@ function makeBionicImageDescriptionHandler(): ImageDescriptionHandler {
 }
 
 /**
- * Register the device-bridge loader on the runtime. Accepts load/generate
- * calls whether or not a mobile device is currently connected — parked
- * calls resolve on reconnect (up to a timeout). Cheaper than waiting for
- * the first device register to register the service: ordering is already
- * handled inside `DeviceBridge.generate`.
- */
-function registerDeviceBridgeLoader(runtime: AgentRuntime): void {
-	const withRegistration = runtime as AgentRuntime & {
-		registerService?: (name: string, impl: unknown) => unknown;
-	};
-	if (typeof withRegistration.registerService !== "function") return;
-	const loader: LocalInferenceLoader = {
-		loadModel: (args) => deviceBridge.loadModel(args),
-		unloadModel: () => deviceBridge.unloadModel(),
-		currentModelPath: () => deviceBridge.currentModelPath(),
-		generate: (args) => deviceBridge.generate(args),
-		embed: (args) => deviceBridge.embed(args),
-	};
-	// Expose the process-wide MemoryArbiter through the registered
-	// `localInferenceLoader` service so provider.ts can route
-	// IMAGE_DESCRIPTION (WS2) and IMAGE (WS3) requests to the arbiter.
-	// Without this accessor the IMAGE handler unconditionally surfaces
-	// `capability_unavailable` because the registered service has no
-	// arbiter accessor — the singleton `localInferenceService` is not
-	// the same object that gets registered with the runtime.
-	const loaderWithArbiter = Object.assign(loader, {
-		getMemoryArbiter: () => tryGetMemoryArbiter(),
-	});
-	withRegistration.registerService("localInferenceLoader", loaderWithArbiter);
-}
-
-/**
- * Expose fused v12 word timings as an additive runtime service. Consumers such
- * as plugin-meetings can discover this structural seam without importing this
- * plugin or widening the string-only TRANSCRIPTION model contract.
- */
-class TimedAsrService extends Service {
-	static serviceType = "timedAsr";
-	capabilityDescription =
-		"Word-timed local ASR over the fused voice engine (transcribeWav returns per-word timings).";
-
-	static async start(runtime: IAgentRuntime): Promise<TimedAsrService> {
-		return new TimedAsrService(runtime);
-	}
-
-	async stop(): Promise<void> {}
-
-	isAvailable(): boolean {
-		return localInferenceEngine.voice() !== null;
-	}
-
-	async transcribeWav(wav: Uint8Array, signal?: AbortSignal) {
-		const audio = decodeMonoPcm16Wav(wav);
-		return localInferenceEngine.transcribePcmTimed(audio, signal);
-	}
-}
-
-async function registerTimedAsrService(runtime: AgentRuntime): Promise<void> {
-	if (typeof runtime.registerService !== "function") return;
-	await runtime.registerService(TimedAsrService);
-}
-
-/**
  * AOSP / generic-FFI path: load the fused `libelizainference.so` into the bun
  * process via `bun:ffi` (the AOSP plugin's loader; libllama is retired). The
  * loader stays inactive at runtime when neither `ELIZA_LOCAL_LLAMA === "1"`
@@ -1353,18 +1296,17 @@ export function bionicInferenceSocketName(
  * AOSP / Capacitor / device-bridge loaders: the whole point is that the GPU is
  * out of reach for the in-process FFI path on this (musl) process.
  */
-function tryRegisterBionicHostLoader(runtime: AgentRuntime): boolean {
+async function tryRegisterBionicHostLoader(
+	runtime: AgentRuntime,
+): Promise<boolean> {
 	const socketName = bionicInferenceSocketName();
 	if (!socketName) return false;
-	const withRegistration = runtime as AgentRuntime & {
-		registerService?: (name: string, impl: unknown) => unknown;
-	};
-	if (typeof withRegistration.registerService !== "function") return false;
 	const loader: LocalInferenceLoader = new BionicHostLoader(socketName);
 	const loaderWithArbiter = Object.assign(loader, {
 		getMemoryArbiter: () => tryGetMemoryArbiter(),
 	});
-	withRegistration.registerService("localInferenceLoader", loaderWithArbiter);
+	await registerLocalInferenceLoaderService(runtime, loaderWithArbiter);
+	await runtime.getServiceLoadPromise(LOCAL_INFERENCE_LOADER_SERVICE_TYPE);
 	logger.info(
 		`[local-inference] Registered bionic-host loader; text generation delegates to the in-process GPU host over UDS "${socketName}"`,
 	);
@@ -1388,8 +1330,11 @@ async function tryRegisterAospLlamaLoader(
 			);
 			return false;
 		}
-		const result = await mod.registerAospLlamaLoader(runtime);
-		return Boolean(result);
+		const registered = Boolean(await mod.registerAospLlamaLoader(runtime));
+		if (registered) {
+			await runtime.getServiceLoadPromise(LOCAL_INFERENCE_LOADER_SERVICE_TYPE);
+		}
+		return registered;
 	} catch (err) {
 		logger.error(
 			"[local-inference] AOSP llama adapter unavailable while ELIZA_LOCAL_LLAMA=1:",
@@ -1412,9 +1357,9 @@ async function tryRegisterCapacitorLoader(
 		const { registerCapacitorLlamaLoader } = await import(
 			"@elizaos/capacitor-llama"
 		);
-		const capacitorRuntime: Parameters<typeof registerCapacitorLlamaLoader>[0] =
-			Object.create(runtime);
-		registerCapacitorLlamaLoader(capacitorRuntime);
+		const registered = await registerCapacitorLlamaLoader(runtime);
+		if (!registered) return false;
+		await runtime.getServiceLoadPromise(LOCAL_INFERENCE_LOADER_SERVICE_TYPE);
 		logger.info(
 			"[local-inference] Registered capacitor-llama loader for mobile on-device inference",
 		);
@@ -1426,6 +1371,26 @@ async function tryRegisterCapacitorLoader(
 		);
 	}
 	return false;
+}
+
+async function resolveMobileDeviceBridgeService(
+	runtime: AgentRuntime,
+): Promise<MobileDeviceBridgeService | null> {
+	if (!runtime.hasService(ServiceType.MOBILE_DEVICE_BRIDGE)) return null;
+	await runtime.getServiceLoadPromise(ServiceType.MOBILE_DEVICE_BRIDGE);
+	return runtime.getService<MobileDeviceBridgeService>(
+		ServiceType.MOBILE_DEVICE_BRIDGE,
+	);
+}
+
+function installLocalRouterAndMark(
+	runtime: AgentRuntime,
+	runtimeWithRegistration: RuntimeWithLocalInferenceFlag,
+): void {
+	installRouterHandler(runtime, {
+		skipSlots: isLocalEmbeddingDisabledByEnv() ? ["TEXT_EMBEDDING"] : [],
+	});
+	runtimeWithRegistration[LOCAL_INFERENCE_HANDLER_INSTALLED] = true;
 }
 
 /**
@@ -1532,6 +1497,7 @@ export async function ensureLocalInferenceHandler(
 	// registers during the rest of boot. Idempotent per-runtime.
 	handlerRegistry.installOn(runtime);
 	await registerTimedAsrService(runtime);
+	await runtime.getServiceLoadPromise(TIMED_ASR_SERVICE_TYPE);
 
 	// Loader precedence:
 	//   1. AOSP native FFI loader when running inside the AOSP agent process
@@ -1539,20 +1505,19 @@ export async function ensureLocalInferenceHandler(
 	//      libllama.so is dlopen'd directly, no IPC.
 	//   2. Capacitor native adapter when running on a mobile device with the
 	//      Capacitor APK shell.
-	//   3. Device-bridge (WebSocket to a paired phone) when explicitly
-	//      opted in via ELIZA_DEVICE_BRIDGE_ENABLED=1.
-	//   4. Standalone node-llama-cpp engine for desktop / server.
+	//   3. Standalone node-llama-cpp engine for desktop / server.
 	//
-	// All four satisfy the same `localInferenceLoader` service contract.
-	// A later registration overrides an earlier one, so we register in
-	// LOWEST-priority order first; the AOSP loader runs last so it wins on
-	// AOSP builds. Each `try*Loader` is idempotent and gated on its own env
-	// signal, so they're safe to chain.
+	// These backends satisfy the `localInferenceLoader` service contract. Select
+	// exactly one: duplicate service classes make `getService()` ambiguous and
+	// transfer teardown ownership away from the backend that actually won. The
+	// stock WebSocket device bridge is deliberately separate: capacitor-bridge
+	// owns it through `MobileDeviceBridgeService` and registers model handlers
+	// only after a paired device can serve them.
 	// Bionic-host delegation wins over every other loader: when set, the GPU is
 	// only reachable from the in-process app host, so the musl agent must NOT try
 	// the in-process FFI / device-bridge paths (the app shell already suppressed
 	// ELIZA_LOCAL_LLAMA in this case).
-	const bionicHostRegistered = tryRegisterBionicHostLoader(runtime);
+	const bionicHostRegistered = await tryRegisterBionicHostLoader(runtime);
 	const aospRegistered =
 		!bionicHostRegistered && (await tryRegisterAospLlamaLoader(runtime));
 	const capacitorRegistered =
@@ -1562,11 +1527,38 @@ export async function ensureLocalInferenceHandler(
 	const deviceBridgeEnabled =
 		!bionicHostRegistered &&
 		process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1";
-	if (!aospRegistered && !capacitorRegistered && deviceBridgeEnabled) {
-		registerDeviceBridgeLoader(runtime);
+
+	// The AOSP bootstrap already registered its complete handler set before
+	// runtime.initialize() so embedding probes can use it. The post-init hook
+	// only starts/reuses that same service owner and installs routing metadata;
+	// adding generic handlers here would duplicate the same provider and revive
+	// the earlier-loader tie that leaked native ownership.
+	if (aospRegistered) {
+		installLocalRouterAndMark(runtime, runtimeWithRegistration);
 		logger.info(
-			"[local-inference] Registered device-bridge loader; inference routes to paired mobile device when connected",
+			"[local-inference] Reused the pre-initialize AOSP loader and handler set",
 		);
+		return;
+	}
+
+	// Stock device-bridge handlers belong to plugin-capacitor-bridge and are
+	// registered only after its canonical singleton has a real attached device.
+	// Resolve that singleton through the core service seam for lifecycle
+	// ownership, but never manufacture a second loader/provider from the env flag.
+	if (!capacitorRegistered && deviceBridgeEnabled) {
+		const bridgeService = await resolveMobileDeviceBridgeService(runtime);
+		if (bridgeService) {
+			const status = bridgeService.getMobileDeviceBridgeStatus();
+			logger.info(
+				`[local-inference] Canonical mobile device bridge service ready (${status.connected ? "device attached" : "waiting for attach"}); handler registration stays with the bridge owner`,
+			);
+		} else {
+			logger.warn(
+				"[local-inference] ELIZA_DEVICE_BRIDGE_ENABLED=1 but the canonical mobile device bridge service is not registered; leaving device handlers unregistered",
+			);
+		}
+		installLocalRouterAndMark(runtime, runtimeWithRegistration);
+		return;
 	}
 
 	// Text/voice availability and embedding availability are independent on
@@ -1580,9 +1572,7 @@ export async function ensureLocalInferenceHandler(
 	// is actually available.
 	const generalBackendAvailable =
 		bionicHostRegistered ||
-		aospRegistered ||
 		capacitorRegistered ||
-		deviceBridgeEnabled ||
 		(await localInferenceEngine.available());
 	if (!generalBackendAvailable) {
 		logger.debug(
@@ -1751,13 +1741,10 @@ export async function ensureLocalInferenceHandler(
 	// The router sits at Number.MAX_SAFE_INTEGER so the runtime dispatches
 	// to it first; at dispatch time it picks a real provider via
 	// `routing-policy` and calls that handler directly.
-	installRouterHandler(runtime, {
-		skipSlots: isLocalEmbeddingDisabledByEnv() ? ["TEXT_EMBEDDING"] : [],
-	});
+	installLocalRouterAndMark(runtime, runtimeWithRegistration);
 	logger.info(
 		"[local-inference] Installed top-priority router for cross-provider routing",
 	);
-	runtimeWithRegistration[LOCAL_INFERENCE_HANDLER_INSTALLED] = true;
 
 	// Warm-on-load (item I3): if a local model is already resident, KV-prefill
 	// the Stage-1 stable prefix onto the deterministic system-prefix slot so

--- a/plugins/plugin-local-inference/src/services/device-bridge.ts
+++ b/plugins/plugin-local-inference/src/services/device-bridge.ts
@@ -34,16 +34,12 @@ import fs from "node:fs/promises";
 import type { Server as HttpServer, IncomingMessage } from "node:http";
 import path from "node:path";
 import type { Duplex } from "node:stream";
-import type { AgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import {
 	computeGenerationThroughput,
 	type GenerationThroughput,
 } from "@elizaos/shared/local-inference";
-import type {
-	LocalInferenceLoadArgs,
-	LocalInferenceLoader,
-} from "./active-model";
+import type { LocalInferenceLoadArgs } from "./active-model";
 import { localInferenceRoot } from "./paths";
 
 const DEFAULT_CALL_TIMEOUT_MS = 60_000;
@@ -1205,33 +1201,4 @@ export function buildDeviceResourceMetricsDevPayload(
 		latest: bridge.latestGenerationMetrics(),
 		recentGenerations: bridge.recentGenerationMetrics(limit),
 	};
-}
-
-export function registerDeviceBridgeLoader(
-	runtime: AgentRuntime & {
-		registerService?: (name: string, impl: unknown) => unknown;
-	},
-): void {
-	if (typeof runtime.registerService !== "function") return;
-	const loader: LocalInferenceLoader = {
-		async loadModel(args: LocalInferenceLoadArgs) {
-			await deviceBridge.loadModel(args);
-		},
-		async unloadModel() {
-			await deviceBridge.unloadModel();
-		},
-		currentModelPath() {
-			return deviceBridge.currentModelPath();
-		},
-		async generate(args) {
-			return deviceBridge.generate(args);
-		},
-		async embed(args) {
-			return deviceBridge.embed(args);
-		},
-	};
-	runtime.registerService("localInferenceLoader", loader);
-	logger.info(
-		"[device-bridge] Registered device-bridge loader for remote on-device inference",
-	);
 }

--- a/plugins/plugin-local-inference/src/services/runtime-services.test.ts
+++ b/plugins/plugin-local-inference/src/services/runtime-services.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Exercises local-inference service registration against a real AgentRuntime:
+ * initialize, lazy start, synchronous discovery, and runtime-owned teardown.
+ */
+
+import { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+	LOCAL_INFERENCE_LOADER_SERVICE_TYPE,
+	LocalInferenceLoaderRuntimeService,
+	registerLocalInferenceLoaderService,
+	registerTimedAsrService,
+	TIMED_ASR_SERVICE_TYPE,
+	TimedAsrService,
+} from "./runtime-services";
+
+describe("local-inference runtime services", () => {
+	it("boots, resolves, and stops loader and timed-ASR services through AgentRuntime", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		const loadModel = vi.fn(async () => undefined);
+		const unloadModel = vi.fn(async () => undefined);
+		const generate = vi.fn(async () => "local reply");
+		const stopLoader = vi.fn(async () => undefined);
+
+		try {
+			// Registration is intentionally safe before initialize; waiting for
+			// service startup here would deadlock on the runtime init barrier.
+			await registerTimedAsrService(runtime);
+			await registerLocalInferenceLoaderService(
+				runtime,
+				{
+					loadModel,
+					unloadModel,
+					currentModelPath: () => "/models/eliza.gguf",
+					generate,
+				},
+				{ stop: stopLoader },
+			);
+			await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+
+			expect(runtime.getService(TIMED_ASR_SERVICE_TYPE)).toBeNull();
+			expect(
+				runtime.getService(LOCAL_INFERENCE_LOADER_SERVICE_TYPE),
+			).toBeNull();
+
+			await runtime.getServiceLoadPromise(TIMED_ASR_SERVICE_TYPE);
+			await runtime.getServiceLoadPromise(LOCAL_INFERENCE_LOADER_SERVICE_TYPE);
+
+			const timedAsr = runtime.getService<TimedAsrService>(
+				TIMED_ASR_SERVICE_TYPE,
+			);
+			const loader = runtime.getService<LocalInferenceLoaderRuntimeService>(
+				LOCAL_INFERENCE_LOADER_SERVICE_TYPE,
+			);
+			expect(timedAsr).toBeInstanceOf(TimedAsrService);
+			expect(loader).toBeInstanceOf(LocalInferenceLoaderRuntimeService);
+			if (!loader?.generate) {
+				throw new Error("local inference loader did not expose generation");
+			}
+			expect(loader?.embed).toBeUndefined();
+
+			await loader.loadModel({ modelPath: "/models/eliza.gguf" });
+			await expect(loader.generate({ prompt: "hello" })).resolves.toBe(
+				"local reply",
+			);
+			expect(loadModel).toHaveBeenCalledWith({
+				modelPath: "/models/eliza.gguf",
+			});
+
+			await runtime.stop();
+			expect(stopLoader).toHaveBeenCalledTimes(1);
+			expect(unloadModel).not.toHaveBeenCalled();
+		} finally {
+			await runtime.stop({ fast: true });
+		}
+	});
+});

--- a/plugins/plugin-local-inference/src/services/runtime-services.ts
+++ b/plugins/plugin-local-inference/src/services/runtime-services.ts
@@ -1,0 +1,148 @@
+/**
+ * Runtime-owned service adapters for local inference loaders and timed ASR.
+ * Registration remains separate from startup so callers may register during
+ * initialization without waiting on the runtime's initialization barrier.
+ */
+
+import { createService, type IAgentRuntime, Service } from "@elizaos/core";
+import type {
+	LocalInferenceLoadArgs,
+	LocalInferenceLoader,
+} from "./active-model";
+import { localInferenceEngine } from "./engine";
+import { decodeMonoPcm16Wav } from "./voice";
+
+export const LOCAL_INFERENCE_LOADER_SERVICE_TYPE = "localInferenceLoader";
+export const TIMED_ASR_SERVICE_TYPE = "timedAsr";
+
+export type RuntimeServiceRegistrar = Pick<IAgentRuntime, "registerService">;
+
+type Generate = NonNullable<LocalInferenceLoader["generate"]>;
+type Embed = NonNullable<LocalInferenceLoader["embed"]>;
+
+export interface RuntimeLocalInferenceLoader extends LocalInferenceLoader {
+	getMemoryArbiter?: () => unknown;
+	transcribe?: (args: {
+		pcmBase64: string;
+		sampleRate: number;
+	}) => Promise<string>;
+	describeImage?: (args: {
+		imageBase64: string;
+		mmprojPath?: string;
+		prompt?: string;
+	}) => Promise<string>;
+}
+
+/** Service instance that delegates the runtime lifecycle to one selected backend. */
+export class LocalInferenceLoaderRuntimeService
+	extends Service
+	implements LocalInferenceLoader
+{
+	override capabilityDescription =
+		"Owns the selected local-inference loader for this agent runtime.";
+
+	readonly generate?: Generate;
+	readonly embed?: Embed;
+	readonly getMemoryArbiter?: () => unknown;
+	readonly transcribe?: RuntimeLocalInferenceLoader["transcribe"];
+	readonly describeImage?: RuntimeLocalInferenceLoader["describeImage"];
+
+	constructor(
+		runtime: IAgentRuntime,
+		private readonly loader: RuntimeLocalInferenceLoader,
+		private readonly stopLoader: () => Promise<void>,
+	) {
+		super(runtime);
+		if (loader.generate) this.generate = loader.generate.bind(loader);
+		if (loader.embed) this.embed = loader.embed.bind(loader);
+		if (loader.getMemoryArbiter) {
+			this.getMemoryArbiter = loader.getMemoryArbiter.bind(loader);
+		}
+		if (loader.transcribe) this.transcribe = loader.transcribe.bind(loader);
+		if (loader.describeImage) {
+			this.describeImage = loader.describeImage.bind(loader);
+		}
+	}
+
+	async loadModel(args: LocalInferenceLoadArgs): Promise<void> {
+		await this.loader.loadModel(args);
+	}
+
+	async unloadModel(): Promise<void> {
+		await this.loader.unloadModel();
+	}
+
+	currentModelPath(): string | null {
+		return this.loader.currentModelPath();
+	}
+
+	override async stop(): Promise<void> {
+		await this.stopLoader();
+	}
+}
+
+/**
+ * Register a loader class without starting it. A post-initialize caller that
+ * needs the instance immediately must await `getServiceLoadPromise()`.
+ */
+export async function registerLocalInferenceLoaderService(
+	runtime: RuntimeServiceRegistrar,
+	loader: RuntimeLocalInferenceLoader,
+	options: { stop?: () => Promise<void> } = {},
+): Promise<void> {
+	const stopLoader = options.stop ?? (() => loader.unloadModel());
+	const serviceClass = createService<LocalInferenceLoaderRuntimeService>(
+		LOCAL_INFERENCE_LOADER_SERVICE_TYPE,
+	)
+		.withDescription(
+			"Owns the selected local-inference loader for this agent runtime.",
+		)
+		.withStart(
+			async (serviceRuntime) =>
+				new LocalInferenceLoaderRuntimeService(
+					serviceRuntime,
+					loader,
+					stopLoader,
+				),
+		)
+		.build();
+	await runtime.registerService(serviceClass);
+}
+
+/** Additive word-timed ASR surface consumed by meeting transcription. */
+export class TimedAsrService extends Service {
+	static override serviceType = TIMED_ASR_SERVICE_TYPE;
+	override capabilityDescription =
+		"Exposes fused word-timed ASR without widening the transcription model contract.";
+
+	static override async start(
+		runtime: IAgentRuntime,
+	): Promise<TimedAsrService> {
+		return new TimedAsrService(runtime);
+	}
+
+	isAvailable(): boolean {
+		return localInferenceEngine.voice() !== null;
+	}
+
+	async transcribeWav(
+		wav: Uint8Array,
+		signal?: AbortSignal,
+	): Promise<
+		Awaited<ReturnType<typeof localInferenceEngine.transcribePcmTimed>>
+	> {
+		const audio = decodeMonoPcm16Wav(wav);
+		return localInferenceEngine.transcribePcmTimed(audio, signal);
+	}
+
+	override stop(): Promise<void> {
+		return Promise.resolve();
+	}
+}
+
+/** Register timed ASR without crossing the runtime initialization barrier. */
+export async function registerTimedAsrService(
+	runtime: RuntimeServiceRegistrar,
+): Promise<void> {
+	await runtime.registerService(TimedAsrService);
+}

--- a/plugins/plugin-native-inference/AGENTS.md
+++ b/plugins/plugin-native-inference/AGENTS.md
@@ -20,9 +20,12 @@ changing its ABI, model selection, or memory policy.
   always disables the path.
 - The library is expected at `<agent-root>/<abi>/libelizainference.so`, where
   `<abi>` is `arm64-v8a`, `x86_64`, or `riscv64`.
-- `registerAospLlamaLoader()` exposes the fused loader as
-  `localInferenceLoader`; `ensureAospLocalInferenceHandlers()` registers model
-  handlers only after the capability probes succeed.
+- `ensureAospLocalInferenceHandlers()` builds one fused loader before runtime
+  initialization, wraps that serving instance in the `localInferenceLoader`
+  service, and registers handlers over the same instrumented loader.
+  `registerAospLlamaLoader()` reuses that owner after initialization instead of
+  rebuilding it. Runtime stop cancels/joins prewarm work, stops the idle
+  unloader, unloads the context, and closes the native library exactly once.
 - Text, MTP, KV-cache quantization, TTS, and ASR share one fused inference
   context. Do not add a parallel local model process or direct `libllama` FFI
   adapter.

--- a/plugins/plugin-native-inference/CLAUDE.md
+++ b/plugins/plugin-native-inference/CLAUDE.md
@@ -20,9 +20,12 @@ changing its ABI, model selection, or memory policy.
   always disables the path.
 - The library is expected at `<agent-root>/<abi>/libelizainference.so`, where
   `<abi>` is `arm64-v8a`, `x86_64`, or `riscv64`.
-- `registerAospLlamaLoader()` exposes the fused loader as
-  `localInferenceLoader`; `ensureAospLocalInferenceHandlers()` registers model
-  handlers only after the capability probes succeed.
+- `ensureAospLocalInferenceHandlers()` builds one fused loader before runtime
+  initialization, wraps that serving instance in the `localInferenceLoader`
+  service, and registers handlers over the same instrumented loader.
+  `registerAospLlamaLoader()` reuses that owner after initialization instead of
+  rebuilding it. Runtime stop cancels/joins prewarm work, stops the idle
+  unloader, unloads the context, and closes the native library exactly once.
 - Text, MTP, KV-cache quantization, TTS, and ASR share one fused inference
   context. Do not add a parallel local model process or direct `libllama` FFI
   adapter.

--- a/plugins/plugin-native-inference/__tests__/aosp-local-inference-bootstrap.test.ts
+++ b/plugins/plugin-native-inference/__tests__/aosp-local-inference-bootstrap.test.ts
@@ -1,33 +1,83 @@
 /**
- * Unit tests for the pure bootstrap helpers — load-arg building, generate
- * token-budget resolution, embedding gating, bundled-model resolution, and
- * memory-eviction thresholds. No native library or model is loaded; the
- * helpers run against real filesystem tempdirs and env overrides, so the
- * assertions cover the deterministic JS logic rather than the FFI boundary.
+ * Covers AOSP bootstrap helpers and loader ownership. Pure helpers use real
+ * filesystem tempdirs and env overrides; service lifecycle uses a real
+ * AgentRuntime with a deterministic loader, never the native FFI boundary.
  */
 
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { AgentRuntime, ModelType } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   firstSentenceEndIndex,
   resolveAospGenerateTokenBudget,
 } from "../src/aosp-llama-paths";
 import {
+  type AospLoader,
+  AospLoaderRuntimeService,
   aospAsrAssetsPresent,
   buildAospLoadModelArgs,
   buildGenerateArgsFromParams,
   disabledAospEmbeddingVector,
+  ensureAospLocalInferenceHandlers,
   flattenGenerateTextParamsForAospPrompt,
   isAospLocalEmbeddingEnabled,
   makeAospTextToSpeechHandler,
   parseMemAvailableMb,
   readAssignedBundledModels,
+  registerAospLlamaLoader,
+  registerAospLoaderService,
   removeAospGeneratedStagingDir,
   shouldEvictChatForAvailMb,
   VOICE_COLOAD_KEEP_AVAIL_MB,
 } from "../src/aosp-local-inference-bootstrap";
+
+describe("AOSP loader runtime service", () => {
+  it("registers, starts, discovers, and stops through a real AgentRuntime", async () => {
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+    let currentPath: string | null = null;
+    let unloads = 0;
+    const loader: AospLoader = {
+      async loadModel(args) {
+        currentPath = args.modelPath;
+      },
+      async unloadModel() {
+        unloads += 1;
+        currentPath = null;
+      },
+      currentModelPath: () => currentPath,
+      generate: async ({ prompt }) => `aosp:${prompt}`,
+      embed: async () => ({ embedding: [0.25, 0.5], tokens: 1 }),
+    };
+
+    try {
+      // Public mobile bootstrap can register before initialize. Startup stays
+      // lazy so registration never waits on the runtime initialization barrier.
+      await registerAospLoaderService(runtime, loader);
+      await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+      expect(runtime.getService("localInferenceLoader")).toBeNull();
+
+      await runtime.getServiceLoadPromise("localInferenceLoader");
+      const service = runtime.getService<AospLoaderRuntimeService>(
+        "localInferenceLoader",
+      );
+      expect(service).toBeInstanceOf(AospLoaderRuntimeService);
+      if (!service) throw new Error("AOSP loader service did not start");
+
+      await service.loadModel({ modelPath: "/models/aosp.gguf" });
+      await expect(service.generate({ prompt: "hello" })).resolves.toBe(
+        "aosp:hello",
+      );
+      expect(service.currentModelPath()).toBe("/models/aosp.gguf");
+
+      await runtime.stop();
+      expect(unloads).toBe(1);
+    } finally {
+      await runtime.stop({ fast: true });
+    }
+  });
+});
 
 function withEnv<T>(
   overrides: Record<string, string | undefined>,
@@ -55,6 +105,138 @@ function withEnv<T>(
     }
   }
 }
+
+async function withEnvAsync<T>(
+  overrides: Record<string, string | undefined>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(overrides)) {
+    previous.set(key, process.env[key]);
+    const value = overrides[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+describe("AOSP headless boot ownership", () => {
+  it("builds one serving loader before initialize and tears that owner down once", async () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "aosp-owner-boot-"));
+    const modelsDir = path.join(stateDir, "local-inference", "models");
+    const chatPath = path.join(modelsDir, "chat.gguf");
+    mkdirSync(modelsDir, { recursive: true });
+    writeFileSync(chatPath, "deterministic test model");
+    writeFileSync(
+      path.join(modelsDir, "manifest.json"),
+      JSON.stringify({
+        models: [{ role: "chat", ggufFile: path.basename(chatPath) }],
+      }),
+    );
+
+    await withEnvAsync(
+      {
+        ELIZA_LOCAL_LLAMA: "1",
+        ELIZA_DISABLE_FFI_LLAMA: undefined,
+        ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD: "1",
+        ELIZA_DISABLE_VOICE_AUTO_DOWNLOAD: "1",
+        ELIZA_AOSP_TTS_PREWARM: "0",
+        ELIZA_STATE_DIR: stateDir,
+      },
+      async () => {
+        const runtime = new AgentRuntime({ logLevel: "fatal" });
+        let builderCalls = 0;
+        let currentPath: string | null = null;
+        let unloads = 0;
+        let closes = 0;
+        const rawLoader: AospLoader = {
+          async loadModel(args) {
+            currentPath = args.modelPath;
+          },
+          async unloadModel() {
+            unloads += 1;
+            currentPath = null;
+          },
+          currentModelPath: () => currentPath,
+          generate: async ({ prompt }) => `owned:${prompt}`,
+          embed: async () => ({ embedding: [0.5], tokens: 1 }),
+          async close() {
+            closes += 1;
+          },
+        };
+        const options = {
+          buildLoader: async () => {
+            builderCalls += 1;
+            return rawLoader;
+          },
+          prewarm: false,
+        };
+
+        try {
+          await expect(
+            ensureAospLocalInferenceHandlers(runtime, options),
+          ).resolves.toBe(true);
+          expect(builderCalls).toBe(1);
+          expect(
+            runtime
+              .getRegisteredServiceTypes()
+              .filter((type) => type === "localInferenceLoader"),
+          ).toHaveLength(1);
+
+          await runtime.initialize({
+            allowNoDatabase: true,
+            skipMigrations: true,
+          });
+          await expect(registerAospLlamaLoader(runtime, options)).resolves.toBe(
+            true,
+          );
+          await runtime.getServiceLoadPromise("localInferenceLoader");
+          await expect(
+            ensureAospLocalInferenceHandlers(runtime, options),
+          ).resolves.toBe(true);
+          expect(builderCalls).toBe(1);
+
+          for (const modelType of [
+            ModelType.TEXT_SMALL,
+            ModelType.TEXT_LARGE,
+            ModelType.TEXT_EMBEDDING,
+            ModelType.TEXT_TO_SPEECH,
+          ]) {
+            expect(
+              runtime
+                .getModelRegistrations()
+                .filter(
+                  (entry) =>
+                    entry.modelType === modelType &&
+                    entry.provider === "eliza-aosp-llama",
+                ),
+            ).toHaveLength(1);
+          }
+
+          const handler = runtime.getModel(ModelType.TEXT_SMALL);
+          if (!handler) throw new Error("AOSP TEXT_SMALL handler missing");
+          await expect(
+            handler(runtime, { prompt: "boot-order" }),
+          ).resolves.toBe("owned:boot-order");
+          expect(currentPath).toBe(chatPath);
+
+          await runtime.stop();
+          expect(unloads).toBe(1);
+          expect(closes).toBe(1);
+        } finally {
+          await runtime.stop({ fast: true });
+        }
+      },
+    );
+  });
+});
 
 describe("flattenGenerateTextParamsForAospPrompt", () => {
   it("passes through a legacy prompt unchanged", () => {

--- a/plugins/plugin-native-inference/__tests__/inference-memory-policy.test.ts
+++ b/plugins/plugin-native-inference/__tests__/inference-memory-policy.test.ts
@@ -219,6 +219,38 @@ describe("InferenceIdleUnloader", () => {
     expect(harness.state.loaded).toBe(true);
   });
 
+  it("stops the timer and joins an active unload before teardown continues", async () => {
+    const clock = { t: 0 };
+    let releaseUnload: (() => void) | null = null;
+    let unloaded = false;
+    const unloader = new InferenceIdleUnloader({
+      idleUnloadMs: IDLE_MS,
+      isLoaded: () => !unloaded,
+      unload: () =>
+        new Promise<void>((resolve) => {
+          releaseUnload = () => {
+            unloaded = true;
+            resolve();
+          };
+        }),
+      now: () => clock.t,
+    });
+
+    clock.t = IDLE_MS;
+    const tick = unloader.tick();
+    let stopped = false;
+    const stop = unloader.stop().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+    if (!releaseUnload) throw new Error("idle unload never started");
+    releaseUnload();
+    await expect(tick).resolves.toBe("unloaded");
+    await stop;
+    expect(stopped).toBe(true);
+  });
+
   it("tolerates a double-ended use handle", async () => {
     const harness = makeModelHarness();
     const clock = { t: 0 };

--- a/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
@@ -49,6 +49,7 @@ import { pipeline } from "node:stream/promises";
 import {
   type AgentRuntime,
   applyBackgroundInferenceBudget,
+  createService,
   type GenerateTextParams,
   getInferencePriorityGate,
   type IAgentRuntime,
@@ -57,6 +58,7 @@ import {
   ModelType,
   resolveBackgroundInferenceBudget,
   resolveStateDir,
+  Service,
   type TextEmbeddingParams,
   type TextToSpeechParams,
   type TranscriptionParams,
@@ -88,6 +90,10 @@ import {
 const SERVICE_NAME = "localInferenceLoader";
 const PROVIDER = "eliza-aosp-llama";
 const registeredRuntimes = new WeakSet<AgentRuntime>();
+const aospOwnerPromises = new WeakMap<
+  IAgentRuntime,
+  Promise<AospLoaderOwner | null>
+>();
 const AOSP_ACTIVE_MODEL_STATE_FILE = "aosp-active.json";
 let routeActivationLoader: AospLoader | null = null;
 
@@ -125,6 +131,8 @@ export interface AospLoader {
     embedding: number[];
     tokens: number;
   }>;
+  /** Release the loader's native library handle after its model is unloaded. */
+  close?(): Promise<void>;
 }
 
 /**
@@ -154,6 +162,9 @@ export function instrumentLoaderForIdleTracking(
     unloadModel: () => loader.unloadModel(),
     generate: track(loader.generate.bind(loader)),
     embed: track(loader.embed.bind(loader)),
+    ...(loader.close
+      ? { close: () => loader.close?.() ?? Promise.resolve() }
+      : {}),
   };
 }
 
@@ -952,8 +963,66 @@ function findCloudCandidate(
   return null;
 }
 
-interface RuntimeWithRegisterService {
-  registerService?: (name: string, impl: unknown) => unknown;
+/** Runtime service that owns one fused AOSP loader and releases it on stop. */
+export class AospLoaderRuntimeService extends Service implements AospLoader {
+  override capabilityDescription =
+    "Owns the fused AOSP local-inference loader for this agent runtime.";
+
+  constructor(
+    runtime: IAgentRuntime,
+    private readonly loader: AospLoader,
+    private readonly stopLoader: () => Promise<void>,
+  ) {
+    super(runtime);
+  }
+
+  async loadModel(args: AospLoadModelArgs): Promise<void> {
+    await this.loader.loadModel(args);
+  }
+
+  async unloadModel(): Promise<void> {
+    await this.loader.unloadModel();
+  }
+
+  currentModelPath(): string | null {
+    return this.loader.currentModelPath();
+  }
+
+  async generate(args: Parameters<AospLoader["generate"]>[0]): Promise<string> {
+    return this.loader.generate(args);
+  }
+
+  async embed(
+    args: Parameters<AospLoader["embed"]>[0],
+  ): ReturnType<AospLoader["embed"]> {
+    return this.loader.embed(args);
+  }
+
+  override async stop(): Promise<void> {
+    await this.stopLoader();
+  }
+}
+
+/** Register the class without waiting on the runtime initialization barrier. */
+export async function registerAospLoaderService(
+  runtime: Pick<IAgentRuntime, "registerService">,
+  loader: AospLoader,
+  options: {
+    start?: () => void;
+    stop?: () => Promise<void>;
+  } = {},
+): Promise<void> {
+  const stopLoader = options.stop ?? (() => loader.unloadModel());
+  const serviceClass = createService<AospLoaderRuntimeService>(SERVICE_NAME)
+    .withDescription(
+      "Owns the fused AOSP local-inference loader for this agent runtime.",
+    )
+    .withStart(async (serviceRuntime) => {
+      options.start?.();
+      return new AospLoaderRuntimeService(serviceRuntime, loader, stopLoader);
+    })
+    .build();
+  await runtime.registerService(serviceClass);
 }
 
 /**
@@ -973,18 +1042,17 @@ interface RuntimeWithRegisterService {
  * dynamically import it to wire the `localInferenceLoader` service.
  */
 export async function registerAospLlamaLoader(
-  runtime: RuntimeWithRegisterService,
+  runtime: IAgentRuntime,
+  options: AospLocalInferenceBootstrapOptions = {},
 ): Promise<boolean> {
   if (!isAospEnabled()) return false;
-  if (typeof runtime.registerService !== "function") return false;
-  const loader = await tryBuildAospFusedTextLoader();
-  if (!loader) {
+  const owner = await ensureAospLoaderOwner(runtime, options);
+  if (!owner) {
     logger.error(
       "[aosp-local-inference] fused libelizainference text loader unavailable (lib absent or pre-ABI-v9); localInferenceLoader NOT registered.",
     );
     return false;
   }
-  runtime.registerService(SERVICE_NAME, loader);
   logger.info(
     "[aosp-local-inference] Registered fused libelizainference localInferenceLoader (ELIZA_LOCAL_LLAMA=1)",
   );
@@ -1656,6 +1724,176 @@ function makeLoaderLifecycle(loader: AospLoader): {
   };
 }
 
+export interface AospLocalInferenceBootstrapOptions {
+  /** Deterministic builder injection for boot-order ownership tests. */
+  buildLoader?: () => Promise<AospLoader | null>;
+  /** Disable latency-only prewarm tasks while retaining production lifecycle. */
+  prewarm?: boolean;
+}
+
+interface AospLoaderOwner {
+  readonly loader: AospLoader;
+  readonly lifecycle: ReturnType<typeof makeLoaderLifecycle>;
+  registerTtsPrewarm(start: () => () => Promise<void>): void;
+  start(): void;
+  stop(): Promise<void>;
+}
+
+async function buildAospLoaderOwner(
+  runtime: IAgentRuntime,
+  options: AospLocalInferenceBootstrapOptions,
+): Promise<AospLoaderOwner | null> {
+  const rawLoader = await (
+    options.buildLoader ?? tryBuildAospFusedTextLoader
+  )();
+  if (!rawLoader) return null;
+
+  const inferenceRamClass = classifyInferenceRamClass();
+  const idleUnloadMs = resolveInferenceIdleUnloadMs(inferenceRamClass);
+  let markLifecycleEvicted: () => void = () => {};
+  const idleUnloader = new InferenceIdleUnloader({
+    idleUnloadMs,
+    // The bun agent never receives onTrimMemory (it is not an Android
+    // component), so /proc/meminfo MemAvailable is its pressure signal.
+    pressureCheck: makeProcMeminfoPressureCheck(inferenceRamClass),
+    isLoaded: () => rawLoader.currentModelPath() !== null,
+    unload: async () => {
+      await rawLoader.unloadModel();
+      markLifecycleEvicted();
+      writeAospLlamaDebugLog("bootstrap:idleUnload:released", {
+        idleUnloadMs,
+        ramClass: inferenceRamClass,
+      });
+    },
+    logger: {
+      info: (msg) => logger.info(msg),
+      warn: (msg) => logger.warn(msg),
+    },
+  });
+  const loader = instrumentLoaderForIdleTracking(rawLoader, idleUnloader);
+  const lifecycle = makeLoaderLifecycle(loader);
+  markLifecycleEvicted = lifecycle.markEvicted;
+
+  let started = false;
+  let stopped = false;
+  let chatPrewarm: Promise<void> | null = null;
+  let startTtsPrewarm: (() => () => Promise<void>) | null = null;
+  let stopTtsPrewarm: (() => Promise<void>) | null = null;
+  let stopPromise: Promise<void> | null = null;
+  const shouldPrewarm = options.prewarm !== false;
+
+  const owner: AospLoaderOwner = {
+    loader,
+    lifecycle,
+    registerTtsPrewarm(start) {
+      startTtsPrewarm = start;
+      if (started && !stopped && shouldPrewarm && !stopTtsPrewarm) {
+        stopTtsPrewarm = start();
+      }
+    },
+    start() {
+      if (started || stopped) return;
+      started = true;
+      idleUnloader.start();
+      logger.info(
+        `[aosp-local-inference] inference memory policy: ramClass=${inferenceRamClass} idleUnloadMs=${idleUnloadMs} (#11760)`,
+      );
+      if (!shouldPrewarm) return;
+      chatPrewarm = lifecycle.ensureChatLoaded().catch((err) => {
+        // error-policy:J7 chat prewarm is a latency optimization; the first
+        // real TEXT request retries through the same lifecycle.
+        logger.warn(
+          "[aosp-local-inference] Chat model pre-warm failed (will retry on first request): " +
+            (err instanceof Error ? err.message : String(err)),
+        );
+      });
+      if (startTtsPrewarm) stopTtsPrewarm = startTtsPrewarm();
+    },
+    stop() {
+      if (stopPromise) return stopPromise;
+      stopped = true;
+      const idleStopped = idleUnloader.stop();
+      stopPromise = (async () => {
+        await idleStopped;
+        await stopTtsPrewarm?.();
+        await chatPrewarm;
+
+        let unloadError: unknown;
+        try {
+          if (loader.currentModelPath() !== null) {
+            await loader.unloadModel();
+          }
+        } catch (error) {
+          // error-policy:J6 teardown still closes the dlopen handle before the
+          // original unload failure is rethrown to the runtime boundary.
+          unloadError = error;
+        }
+        try {
+          await loader.close?.();
+        } catch (closeError) {
+          // error-policy:J6 report both native teardown failures without
+          // skipping either release operation.
+          if (unloadError) {
+            throw new AggregateError(
+              [unloadError, closeError],
+              "AOSP local-inference unload and library close both failed",
+            );
+          }
+          throw closeError;
+        } finally {
+          if (routeActivationLoader === loader) routeActivationLoader = null;
+          registeredRuntimes.delete(runtime as AgentRuntime);
+          aospOwnerPromises.delete(runtime);
+        }
+        if (unloadError) throw unloadError;
+      })();
+      return stopPromise;
+    },
+  };
+
+  try {
+    await registerAospLoaderService(runtime, loader, {
+      start: owner.start,
+      stop: owner.stop,
+    });
+  } catch (registrationError) {
+    // error-policy:J6 service registration owns the native handle transfer;
+    // construction rollback releases it before preserving the primary failure.
+    try {
+      await owner.stop();
+    } catch (cleanupError) {
+      // error-policy:J6 rollback attempted every owner release operation; keep
+      // both the primary registration and teardown failures observable.
+      throw new AggregateError(
+        [registrationError, cleanupError],
+        "AOSP local-inference service registration and rollback both failed",
+        { cause: registrationError },
+      );
+    }
+    throw registrationError;
+  }
+  routeActivationLoader = loader;
+  return owner;
+}
+
+async function ensureAospLoaderOwner(
+  runtime: IAgentRuntime,
+  options: AospLocalInferenceBootstrapOptions,
+): Promise<AospLoaderOwner | null> {
+  const existing = aospOwnerPromises.get(runtime);
+  if (existing) return existing;
+
+  const pending = buildAospLoaderOwner(runtime, options);
+  aospOwnerPromises.set(runtime, pending);
+  let owner: AospLoaderOwner | null = null;
+  try {
+    owner = await pending;
+    return owner;
+  } finally {
+    if (!owner) aospOwnerPromises.delete(runtime);
+  }
+}
+
 /**
  * Route one text generation through the process-wide interactive-over-
  * background lane (elizaOS/eliza#11914). The fused context runs one decode at
@@ -1913,8 +2151,10 @@ function encodeWavPcm16(pcm: Float32Array, sampleRate: number): Uint8Array {
 export function prewarmAospKokoroTextToSpeechHandler(
   handler: TextToSpeechHandler,
   opts: AospKokoroPrewarmOptions = {},
-): void {
-  if (readBooleanEnv("ELIZA_AOSP_TTS_PREWARM") !== true) return;
+): () => Promise<void> {
+  if (readBooleanEnv("ELIZA_AOSP_TTS_PREWARM") !== true) {
+    return () => Promise.resolve();
+  }
 
   const delayMs = readPositiveIntEnv("ELIZA_AOSP_TTS_PREWARM_DELAY_MS", 5_000);
   const timeoutMs = readPositiveIntEnv(
@@ -1924,7 +2164,9 @@ export function prewarmAospKokoroTextToSpeechHandler(
   const text =
     process.env.ELIZA_AOSP_TTS_PREWARM_TEXT?.trim() || "Hello from Eliza.";
 
-  setTimeout(() => {
+  let activeController: AbortController | null = null;
+  let activeTask: Promise<void> | null = null;
+  const delay = setTimeout(() => {
     if (opts.shouldSkip?.()) {
       logger.info(
         "[aosp-local-inference] Kokoro TEXT_TO_SPEECH pre-warm skipped; foreground TTS already warmed the backend",
@@ -1933,8 +2175,9 @@ export function prewarmAospKokoroTextToSpeechHandler(
     }
     const started = Date.now();
     const abortController = new AbortController();
+    activeController = abortController;
     const timeout = setTimeout(() => abortController.abort(), timeoutMs);
-    void handler({} as never, {
+    activeTask = handler({} as never, {
       text,
       signal: abortController.signal,
     })
@@ -1953,8 +2196,18 @@ export function prewarmAospKokoroTextToSpeechHandler(
       })
       .finally(() => {
         clearTimeout(timeout);
+        activeController = null;
       });
   }, delayMs);
+  if (typeof delay === "object" && "unref" in delay) delay.unref();
+
+  return async () => {
+    clearTimeout(delay);
+    activeController?.abort(
+      new Error("AOSP local-inference runtime stopped during TTS pre-warm"),
+    );
+    await activeTask;
+  };
 }
 
 function resolveAssignedChatBundleRoot(): string {
@@ -2770,7 +3023,6 @@ interface AospFusedTextLoaderState {
   ffi: BunFfiModule;
   symbols: Record<string, (...args: unknown[]) => unknown>;
   helpers: AospFfiPointerHelpers;
-  close: () => void;
   ctx: bigint;
   binding: AospFusedStreamingLlmBinding;
   bundleRoot: string;
@@ -2989,6 +3241,7 @@ export async function tryBuildAospFusedTextLoader(): Promise<AospLoader | null> 
   }
 
   let state: AospFusedTextLoaderState | null = null;
+  let libraryClosed = false;
 
   const destroyState = (): void => {
     if (!state) return;
@@ -3000,10 +3253,22 @@ export async function tryBuildAospFusedTextLoader(): Promise<AospLoader | null> 
     state = null;
   };
 
+  const closeLibrary = (): void => {
+    if (libraryClosed) return;
+    destroyState();
+    lib.close();
+    libraryClosed = true;
+  };
+
   const loader: AospLoader = {
     currentModelPath: () => state?.modelPath ?? null,
 
     async loadModel(args: AospLoadModelArgs): Promise<void> {
+      if (libraryClosed) {
+        throw new Error(
+          "[aosp-local-inference] fused text loader used after runtime teardown",
+        );
+      }
       // One EliInferenceContext per bundle: the C side resolves text vs
       // embedding regions per call (`llm_stream_*` vs `embed`), so chat and
       // embedding loads SHARE the context — we never destroy + recreate when
@@ -3031,7 +3296,6 @@ export async function tryBuildAospFusedTextLoader(): Promise<AospLoader | null> 
           ffi,
           symbols,
           helpers,
-          close: lib.close,
           ctx,
           binding: createAospStreamingLlmBinding({
             ctx,
@@ -3095,6 +3359,10 @@ export async function tryBuildAospFusedTextLoader(): Promise<AospLoader | null> 
 
     async unloadModel(): Promise<void> {
       destroyState();
+    },
+
+    async close(): Promise<void> {
+      closeLibrary();
     },
 
     async generate(args): Promise<string> {
@@ -3200,6 +3468,7 @@ export async function tryBuildAospFusedTextLoader(): Promise<AospLoader | null> 
  */
 export async function ensureAospLocalInferenceHandlers(
   runtime: AgentRuntime,
+  options: AospLocalInferenceBootstrapOptions = {},
 ): Promise<boolean> {
   // console.log because logger.info routing in the mobile agent process
   // sometimes hides early bootstrap output behind the pino transport,
@@ -3240,59 +3509,19 @@ export async function ensureAospLocalInferenceHandlers(
   // cloud-fallback handler at priority -1 then routes recoverable failures to
   // a cloud provider via the local-unavailable classifier).
   console.log("[aosp-local-inference] building fused text loader…");
-  const fusedTextLoader = await tryBuildAospFusedTextLoader();
+  const owner = await ensureAospLoaderOwner(runtime, options);
   console.log(
-    `[aosp-local-inference] fused text loader ${fusedTextLoader ? "ready" : "unavailable"}`,
+    `[aosp-local-inference] fused text loader ${owner ? "ready" : "unavailable"}`,
   );
-  if (!fusedTextLoader) {
+  if (!owner) {
     console.error("[aosp-local-inference] fused text loader unavailable");
     logger.error(
       "[aosp-local-inference] fused libelizainference text loader unavailable (lib absent or pre-ABI-v9); TEXT_* handlers NOT wired. Local text inference is unavailable.",
     );
     return false;
   }
-
-  // Inference memory policy (#11760): free the loaded model after a RAM-class
-  // idle window so the pinned weights don't keep this process at the top of
-  // lmkd's kill list between conversations. Every loader use routes through the
-  // instrumented wrapper so the idle clock is accurate; the unload flows
-  // through the same lifecycle plumbing the voice handlers' out-of-band
-  // eviction already uses (`unloadModel` + `markEvicted` → the next request
-  // reloads via `ensureChatLoaded`).
-  const inferenceRamClass = classifyInferenceRamClass();
-  const idleUnloadMs = resolveInferenceIdleUnloadMs(inferenceRamClass);
-  let markLifecycleEvicted: () => void = () => {};
-  const idleUnloader = new InferenceIdleUnloader({
-    idleUnloadMs,
-    // The bun agent never receives onTrimMemory (it is not an Android
-    // component), so /proc/meminfo MemAvailable is its pressure signal.
-    pressureCheck: makeProcMeminfoPressureCheck(inferenceRamClass),
-    isLoaded: () => fusedTextLoader.currentModelPath() !== null,
-    unload: async () => {
-      await fusedTextLoader.unloadModel();
-      markLifecycleEvicted();
-      writeAospLlamaDebugLog("bootstrap:idleUnload:released", {
-        idleUnloadMs,
-        ramClass: inferenceRamClass,
-      });
-    },
-    logger: {
-      info: (msg) => logger.info(msg),
-      warn: (msg) => logger.warn(msg),
-    },
-  });
-  const textLoader = instrumentLoaderForIdleTracking(
-    fusedTextLoader,
-    idleUnloader,
-  );
-  routeActivationLoader = textLoader;
-
-  const lifecycle = makeLoaderLifecycle(textLoader);
-  markLifecycleEvicted = lifecycle.markEvicted;
-  idleUnloader.start();
-  logger.info(
-    `[aosp-local-inference] inference memory policy: ramClass=${inferenceRamClass} idleUnloadMs=${idleUnloadMs} (#11760)`,
-  );
+  const textLoader = owner.loader;
+  const lifecycle = owner.lifecycle;
   // TEXT_EMBEDDING is wired unconditionally: chat + embedding loads share one
   // fused EliInferenceContext, and the C side resolves the text vs embedding
   // region per call (`llm_stream_*` vs `embed`), so there is no cross-mode
@@ -3362,25 +3591,13 @@ export async function ensureAospLocalInferenceHandlers(
     );
   }
 
-  // Pre-warm the chat model so the first incoming chat request doesn't
-  // pay the fused context-create + first-load cost inside the request
-  // handler. The load is best-effort: if the bundled chat file is missing
-  // we let the
-  // request handler bubble up a clear error instead of crashing the
-  // boot. ensureChatLoaded is also memoized at the lifecycle layer, so
-  // calling it here doesn't conflict with the first real request.
-  // error-policy:J7 chat pre-warm is a latency optimization; a failure is logged
-  // and the first real TEXT request re-attempts the load (makeGenerateHandler ->
-  // lifecycle.ensureChatLoaded). Not a request path.
-  void lifecycle.ensureChatLoaded().catch((err) => {
-    logger.warn(
-      "[aosp-local-inference] Chat model pre-warm failed (will retry on first request): " +
-        (err instanceof Error ? err.message : String(err)),
-    );
-  });
-  prewarmAospKokoroTextToSpeechHandler(baseKokoroTextToSpeechHandler, {
-    shouldSkip: () => foregroundKokoroTextToSpeechUsed,
-  });
+  // Runtime service start owns both prewarm tasks; service stop cancels/joins
+  // them before unloading and closing the exact loader used by these handlers.
+  owner.registerTtsPrewarm(() =>
+    prewarmAospKokoroTextToSpeechHandler(baseKokoroTextToSpeechHandler, {
+      shouldSkip: () => foregroundKokoroTextToSpeechUsed,
+    }),
+  );
 
   const registeredList = `TEXT_SMALL / TEXT_LARGE / TEXT_EMBEDDING / TEXT_TO_SPEECH${
     asrAssetsPresent ? " / TRANSCRIPTION" : ""

--- a/plugins/plugin-native-inference/src/inference-memory-policy.ts
+++ b/plugins/plugin-native-inference/src/inference-memory-policy.ts
@@ -221,6 +221,7 @@ export class InferenceIdleUnloader {
   private inFlight = 0;
   private timer: NodeJS.Timeout | null = null;
   private unloading = false;
+  private activeUnload: Promise<IdleUnloadTickResult> | null = null;
 
   constructor(opts: InferenceIdleUnloaderOptions) {
     this.idleUnloadMs = opts.idleUnloadMs;
@@ -250,10 +251,12 @@ export class InferenceIdleUnloader {
     this.timer = t;
   }
 
-  stop(): void {
-    if (!this.timer) return;
-    clearInterval(this.timer);
-    this.timer = null;
+  async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.activeUnload;
   }
 
   /**
@@ -298,7 +301,18 @@ export class InferenceIdleUnloader {
     return "warm";
   }
 
-  private async runUnload(
+  private runUnload(
+    reason: string,
+    result: "unloaded" | "pressure-unloaded",
+  ): Promise<IdleUnloadTickResult> {
+    const pending = this.performUnload(reason, result);
+    this.activeUnload = pending;
+    return pending.finally(() => {
+      if (this.activeUnload === pending) this.activeUnload = null;
+    });
+  }
+
+  private async performUnload(
     reason: string,
     result: "unloaded" | "pressure-unloaded",
   ): Promise<IdleUnloadTickResult> {

--- a/plugins/plugin-native-llama/AGENTS.md
+++ b/plugins/plugin-native-llama/AGENTS.md
@@ -12,7 +12,7 @@ This package does not register elizaOS actions, providers, evaluators, or routes
 
 - **`CapacitorLlamaAdapter`** — class implementing `LlamaAdapter`. One instance per native context (chat and embedding run as separate instances). Core methods: `load`, `unload`, `generate`, `generateStream`, `embed`, `formatChat`, `getHardwareInfo`, `cancelGenerate`, `setCacheType`, `setSpecType`, `setDrafter`, `trimMemory`, `onToken`, `dispose`.
 - **`capacitorLlama`** — default singleton `LlamaAdapter` (back-compat; new code should use `registerCapacitorLlamaLoader` which creates per-role instances).
-- **`registerCapacitorLlamaLoader(runtime)`** — registers the `localInferenceLoader` service on the elizaOS runtime; creates separate chat and embedding adapter instances to avoid native context ID collisions (fix for eliza#7681).
+- **`registerCapacitorLlamaLoader(runtime)`** — asynchronously registers the `localInferenceLoader` service class without waiting on runtime initialization. Startup creates separate chat and embedding adapter instances to avoid native context ID collisions (fix for eliza#7681); runtime stop disposes both contexts.
 - **`DeviceBridgeClient`** / **`startDeviceBridgeClient`** — WebSocket client that runs inside the mobile app; relays `load`/`generate`/`embed`/`formatChat` RPC from the agent container to the device over the `device-bridge` WebSocket protocol.
 - **`serializeTokenTree`** / **`deserializeTokenTree`** — binary codec for `TokenTreeDescriptor` payloads used by the native speculative-decode sampler hook (wire format: little-endian, magic `0x544B5452`, version 1).
 

--- a/plugins/plugin-native-llama/CLAUDE.md
+++ b/plugins/plugin-native-llama/CLAUDE.md
@@ -12,7 +12,7 @@ This package does not register elizaOS actions, providers, evaluators, or routes
 
 - **`CapacitorLlamaAdapter`** — class implementing `LlamaAdapter`. One instance per native context (chat and embedding run as separate instances). Core methods: `load`, `unload`, `generate`, `generateStream`, `embed`, `formatChat`, `getHardwareInfo`, `cancelGenerate`, `setCacheType`, `setSpecType`, `setDrafter`, `trimMemory`, `onToken`, `dispose`.
 - **`capacitorLlama`** — default singleton `LlamaAdapter` (back-compat; new code should use `registerCapacitorLlamaLoader` which creates per-role instances).
-- **`registerCapacitorLlamaLoader(runtime)`** — registers the `localInferenceLoader` service on the elizaOS runtime; creates separate chat and embedding adapter instances to avoid native context ID collisions (fix for eliza#7681).
+- **`registerCapacitorLlamaLoader(runtime)`** — asynchronously registers the `localInferenceLoader` service class without waiting on runtime initialization. Startup creates separate chat and embedding adapter instances to avoid native context ID collisions (fix for eliza#7681); runtime stop disposes both contexts.
 - **`DeviceBridgeClient`** / **`startDeviceBridgeClient`** — WebSocket client that runs inside the mobile app; relays `load`/`generate`/`embed`/`formatChat` RPC from the agent container to the device over the `device-bridge` WebSocket protocol.
 - **`serializeTokenTree`** / **`deserializeTokenTree`** — binary codec for `TokenTreeDescriptor` payloads used by the native speculative-decode sampler hook (wire format: little-endian, magic `0x544B5452`, version 1).
 

--- a/plugins/plugin-native-llama/README.md
+++ b/plugins/plugin-native-llama/README.md
@@ -9,7 +9,7 @@ so the `ActiveModelCoordinator` in `@elizaos/ui`
 
 ## What it does
 
-- Registers as the runtime's `localInferenceLoader` service during the
+- Registers a runtime-owned `localInferenceLoader` service class during the
   Capacitor bootstrap via `registerCapacitorLlamaLoader(runtime)`.
 - Maps `load({ modelPath })` → `initContext` (one native context per adapter
   instance; chat and embedding run on separate instances to avoid context
@@ -55,8 +55,13 @@ Two ways to wire the adapter into a runtime:
   ```ts
   import { registerCapacitorLlamaLoader } from "@elizaos/capacitor-llama";
 
-  registerCapacitorLlamaLoader(runtime);
+  await registerCapacitorLlamaLoader(runtime);
   ```
+
+  Registration is safe before `runtime.initialize()`. A caller registering
+  after initialization and synchronously probing the service should first
+  await `runtime.getServiceLoadPromise("localInferenceLoader")`. Runtime stop
+  disposes both native role contexts.
 
 - **`capacitorLlama`** — the default singleton `LlamaAdapter`, used directly by
   callers that don't need per-role context separation.

--- a/plugins/plugin-native-llama/src/capacitor-llama-adapter.test.ts
+++ b/plugins/plugin-native-llama/src/capacitor-llama-adapter.test.ts
@@ -150,6 +150,33 @@ function installMockPlugin(opts: MockOptions = {}): MockPluginState {
 }
 
 describe("CapacitorLlamaAdapter context-id allocation (issue #7681)", () => {
+  it("registers one service class and releases both role contexts on stop", async () => {
+    vi.resetModules();
+    const state = installMockPlugin();
+    const { CapacitorLlamaLoaderRuntimeService, registerCapacitorLlamaLoader } =
+      await import("./capacitor-llama-adapter");
+    const registerService = vi.fn(async () => undefined);
+
+    await expect(
+      registerCapacitorLlamaLoader({ registerService }),
+    ).resolves.toBe(true);
+    expect(registerService).toHaveBeenCalledWith(
+      CapacitorLlamaLoaderRuntimeService,
+    );
+    expect(registerService.mock.calls[0]).toHaveLength(1);
+
+    const service = await CapacitorLlamaLoaderRuntimeService.start({});
+    await service.loadModel({ modelPath: "/tmp/llama.gguf" });
+    await service.loadModel({ modelPath: "/tmp/bge-small.gguf" });
+    expect(state.initContextCalls).toHaveLength(2);
+
+    await service.stop();
+    expect(state.releaseCalls).toHaveLength(2);
+    expect(new Set(state.releaseCalls.map((call) => call.contextId)).size).toBe(
+      2,
+    );
+  });
+
   it("allocates distinct context ids for two separate adapter instances", async () => {
     vi.resetModules();
     const state = installMockPlugin();

--- a/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
+++ b/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
@@ -1243,65 +1243,89 @@ function looksLikeEmbeddingModelPath(modelPath: string): boolean {
   );
 }
 
-export function registerCapacitorLlamaLoader(runtime: {
-  registerService?: (name: string, impl: unknown) => unknown;
-}): void {
-  if (typeof runtime.registerService !== "function") return;
+/**
+ * Runtime service with separate chat and embedding contexts. It is structural
+ * by design so this low-level Capacitor package does not acquire a runtime
+ * dependency on the full framework package.
+ */
+export class CapacitorLlamaLoaderRuntimeService {
+  static readonly serviceType = "localInferenceLoader";
+  readonly capabilityDescription =
+    "Owns isolated Capacitor llama.cpp chat and embedding contexts.";
 
-  // Two distinct adapter instances so the chat LLM and embedding model
-  // each allocate their own native context id. This is the fix for
-  // elizaOS/eliza#7681 — the previous single-adapter design routed every
-  // operation through CONTEXT_ID=1, and a `completion(contextId=1)` call
-  // would resolve to whichever model registered against id 1 last
-  // (typically the bge-small embedding model on Android), emitting
-  // `[unused{N}]` / `[PAD]` reserved tokens.
-  const chatAdapter = new CapacitorLlamaAdapter();
-  const embeddingAdapter = new CapacitorLlamaAdapter();
+  private readonly chatAdapter = new CapacitorLlamaAdapter();
+  private readonly embeddingAdapter = new CapacitorLlamaAdapter();
 
-  function adapterFor(modelPath: string): CapacitorLlamaAdapter {
-    return looksLikeEmbeddingModelPath(modelPath)
-      ? embeddingAdapter
-      : chatAdapter;
+  static async start(
+    _runtime: unknown,
+  ): Promise<CapacitorLlamaLoaderRuntimeService> {
+    return new CapacitorLlamaLoaderRuntimeService();
   }
 
-  runtime.registerService("localInferenceLoader", {
-    async loadModel(args: LoadOptions): Promise<void> {
-      await adapterFor(args.modelPath).load(args);
-    },
-    async unloadModel(): Promise<void> {
-      // Each adapter manages its own context lifecycle inside
-      // `load()` (releasing the prior context before reinitializing on the
-      // same id). Tearing down both adapters here would defeat the
-      // per-instance routing — `ensureAssignedModelLoaded` calls
-      // `unloadModel()` before every `loadModel()` on the assumption of
-      // single-model behaviour, and we must not let that unconditionally
-      // kill the embedding adapter when only the chat model is swapping.
-    },
-    currentModelPath(): string | null {
-      // The chat path is the primary "active" model from the runtime's
-      // perspective; embedding is treated as a sidecar.
-      return (
-        chatAdapter.currentModelPath() ?? embeddingAdapter.currentModelPath()
-      );
-    },
-    async generate(args: {
-      prompt: string;
-      stopSequences?: string[];
-      maxTokens?: number;
-      temperature?: number;
-    }): Promise<string> {
-      const result = await chatAdapter.generate({
-        prompt: args.prompt,
-        stopSequences: args.stopSequences,
-        maxTokens: args.maxTokens,
-        temperature: args.temperature,
-      });
-      return result.text;
-    },
-    async embed(args: {
-      input: string;
-    }): Promise<{ embedding: number[]; tokens: number }> {
-      return embeddingAdapter.embed({ input: args.input });
-    },
-  });
+  private adapterFor(modelPath: string): CapacitorLlamaAdapter {
+    return looksLikeEmbeddingModelPath(modelPath)
+      ? this.embeddingAdapter
+      : this.chatAdapter;
+  }
+
+  async loadModel(args: LoadOptions): Promise<void> {
+    await this.adapterFor(args.modelPath).load(args);
+  }
+
+  unloadModel(): Promise<void> {
+    // Each adapter manages its own context lifecycle inside `load()`. The
+    // runtime calls this before a role swap, so unloading both here would kill
+    // the unaffected sibling context.
+    return Promise.resolve();
+  }
+
+  currentModelPath(): string | null {
+    return (
+      this.chatAdapter.currentModelPath() ??
+      this.embeddingAdapter.currentModelPath()
+    );
+  }
+
+  async generate(args: {
+    prompt: string;
+    stopSequences?: string[];
+    maxTokens?: number;
+    temperature?: number;
+  }): Promise<string> {
+    const result = await this.chatAdapter.generate({
+      prompt: args.prompt,
+      stopSequences: args.stopSequences,
+      maxTokens: args.maxTokens,
+      temperature: args.temperature,
+    });
+    return result.text;
+  }
+
+  async embed(args: {
+    input: string;
+  }): Promise<{ embedding: number[]; tokens: number }> {
+    return this.embeddingAdapter.embed({ input: args.input });
+  }
+
+  async stop(): Promise<void> {
+    await Promise.all([
+      this.chatAdapter.dispose(),
+      this.embeddingAdapter.dispose(),
+    ]);
+  }
+}
+
+/**
+ * Register the service class without starting it. The runtime may call this
+ * before initialization; post-initialize consumers that need it immediately
+ * await `getServiceLoadPromise("localInferenceLoader")` themselves.
+ */
+export async function registerCapacitorLlamaLoader(runtime: {
+  registerService?: unknown;
+}): Promise<boolean> {
+  if (typeof runtime.registerService !== "function") return false;
+  await Reflect.apply(runtime.registerService, runtime, [
+    CapacitorLlamaLoaderRuntimeService,
+  ]);
+  return true;
 }


### PR DESCRIPTION
Closes #18135

## Summary

Local inference now has one explicit runtime owner per selected backend, and the
Capacitor device transport has process/server ownership rather than accidental
runtime ownership.

- replaces removed two-argument service registration with runtime-owned service
  classes across desktop, device-bridge, AOSP, and Capacitor loaders;
- preserves backend-specific model unload and teardown behavior;
- registers before initialization without crossing the runtime start barrier;
- keeps the process-global device transport alive while a runtime is replaced;
- removes only the departing runtime's subscription during runtime stop; and
- performs final transport teardown at server/process close.

This fixes both the original `SERVICE_TYPE_MISSING` startup failure and the
hot-reload regression where stopping the old runtime closed the transport needed
by its replacement.

## Exact provenance

- Base: `2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6`
- Head: `5652a9389afd46b278b8a5f91a9058a85bf4b75a`
- Tree: `718c4f5c4f188e080c40622333ce5cbaea6b59d8`
- Commit 1: `ca4d2aa526cd0bfb30ab16a7931b16715eba94c1`
  (`fix(local-inference): unify runtime service ownership`)
- Commit 2: `5652a9389afd46b278b8a5f91a9058a85bf4b75a`
  (`fix(capacitor-bridge): preserve transport across runtime replacement`)
- Stable patch IDs: `e6d2075be71cf9bc4bb2843ddcec1e2f9b8314ec`
  and `de7813687dfade97b05be4a9cc6b771084b666e3`, identical to the independently
  reviewed prepared commits.
- Both commits applied directly to current `develop` with zero conflicts.

## Testing

- local-inference ownership/handler suite — 4 files, 31/31 PASS
- Capacitor bridge gating/headless/replacement suite — 4 files, 6 PASS, 2
  intentional platform skips
- native-inference bootstrap + memory-policy suite — 65/65 PASS
- native-llama adapter suite — 18/18 PASS
- Core Node/browser/edge/testing build and declarations — PASS
- targeted Turbo `@elizaos/app-core` typecheck — 69/69 scoped dependency tasks PASS
- local-inference, Capacitor bridge, native-inference, and native-llama
  typechecks — PASS
- Biome over every changed supported source file — 19 files PASS
- all four changed `CLAUDE.md` / `AGENTS.md` pairs remain byte-identical
- `git diff --check` and final worktree status — clean

The same two stable patches also passed the combined integration train's focused
native/service matrix and repository verify. Independent review found no
P0/P1/P2 issue after the transport-ownership amendment.

## Risk

Medium. Startup and teardown ownership changes across several local-inference
backends. The runtime-replacement test specifically locks the non-obvious
invariant: replacing one runtime must not close the process-global transport.
No native ABI or inference algorithm changes.

## Evidence

<!-- evidence-head:a83a2c682cd9568ec469700fb362da49a50cbde8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - service lifecycle change has no rendered UI delta.
<!-- evidence-row:after-screenshots -->
- [x] N/A - service lifecycle change has no rendered UI delta.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no stable real-platform log artifact was published; exact-head suites exercise the real AgentRuntime lifecycle and transport replacement boundary in process.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer state or request/response contract changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action, provider, prompt, or model-output behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - runtime service ownership and final teardown are asserted directly, but this lifecycle fix creates no persistent user artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

## Documentation

The affected package guides document the runtime/service owner and final
transport teardown boundaries.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - contribute-to-eliza skill was not available in this environment`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - contribute-to-eliza skill was not available in this environment"} -->

