### PR TITLE
fix(ci): restore changed-plugin test gate

### DIFF
--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -240,12 +240,10 @@ jobs:
 
           if [ "${#selected[@]}" -eq 0 ]; then
             echo "filter=" >> "$GITHUB_OUTPUT"
-            echo "count=0" >> "$GITHUB_OUTPUT"
             echo "No changed plugin package has a test script; nothing to gate."
           else
             joined=$(IFS='|'; echo "${selected[*]}")
             echo "filter=\\(plugins/($joined)\\)" >> "$GITHUB_OUTPUT"
-            echo "count=${#selected[@]}" >> "$GITHUB_OUTPUT"
             echo "Gating ${#selected[@]} plugin package(s): $joined"
           fi
 
@@ -275,4 +273,4 @@ jobs:
         run: |
           bun run build:core
           bun run build:views
-          node packages/scripts/run-all-tests.mjs --only=test --no-cloud --concurrency=3 --min-tasks=${{ steps.changed.outputs.count }}
+          node packages/scripts/run-all-tests.mjs --only=test --no-cloud --concurrency=3 --require-work

--- a/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
+++ b/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
@@ -128,6 +128,22 @@ describe("root test lane require-work wiring (#13620)", () => {
     expect(install).toBeGreaterThan(-1);
     expect(contract).toBeGreaterThan(install);
   });
+
+  test("the develop PR plugin lane uses the supported semantic guard", () => {
+    const workflow = readFileSync(
+      join(repoRoot, ".github", "workflows", "develop-pr.yml"),
+      "utf8",
+    );
+    const jobStart = workflow.indexOf("  plugin-tests:");
+    expect(jobStart).toBeGreaterThan(-1);
+    const job = workflow.slice(jobStart);
+    expect(job).toContain("TEST_PACKAGE_FILTER:");
+    expect(job).toContain(
+      "node packages/scripts/run-all-tests.mjs --only=test --no-cloud --concurrency=3 --require-work",
+    );
+    expect(job).not.toContain("--min-tasks");
+    expect(job).not.toContain("steps.changed.outputs.count");
+  });
 });
 
 describe("run-all-tests --require-work vacuous-green guard", () => {


### PR DESCRIPTION
# Relates to

Advances #17145 with a narrow hotfix for the already-landed changed-plugin gate. It does not close the broader migration tracked by #17542.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`bf030f0b66ea06ab8f553fef4331b64af1870145`).
- [x] Focused verification was run after sync; the unrelated full script-lane
      dependency failure is recorded below.
- [x] A reviewer can confirm the change from the executable contract and runner
      plan evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6659f25cd20eea80e4ad4a8a61a1e541b21551df:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@bf030f0b66ea06ab8f553fef4331b64af1870145`; zero conflicts.
- [x] The exact unrelated full-lane dependency blocker is documented in
      **Known gaps / failures** below.

# Risks

Low and limited to the merge-critical `develop` PR plugin test job. A changed
plugin package with a test script must now resolve at least one runnable test
task. That is the intended fail-closed behavior; PRs that do not select a
test-bearing plugin still skip the job exactly as before.

# Background

## What does this PR do?

The current workflow still passes `--min-tasks=<changed-plugin-count>` to
`run-all-tests.mjs`, but the current runner removed that option in favor of
`--require-work`. Every plugin-changing PR therefore exits with
`unknown argument(s): --min-tasks=1` before running a plugin test, as seen in
#18137's job: https://github.com/elizaOS/eliza/actions/runs/31316265949/job/93251911767.

This patch:

- switches only that job to the supported semantic `--require-work` guard;
- removes the now-unused numeric `count` output; and
- adds a focused workflow contract preventing `--min-tasks` or the stale count
  output from returning to the plugin job.

## What kind of change is this?

Bug fix for CI/test orchestration. No production runtime, UI, API, database, or
deployment behavior changes.

# Documentation changes needed?

No user-facing documentation change is needed. The executable workflow contract
is covered by the focused regression test.

# Testing

## Where should a reviewer start?

Review `.github/workflows/develop-pr.yml` and the new contract in
`packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts`.

## Detailed testing steps

Pinned Node `24.15.0` and Bun `1.3.14` on exact head
`d08f7092b9030704095db87e029383ccc0dee8d5`:

- `bun test packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts`
  — **17 pass / 0 fail / 38 assertions**.
- `actionlint .github/workflows/develop-pr.yml` — pass.
- `biome check packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts`
  — pass.
- Real runner plan with `TEST_PACKAGE_FILTER='\(plugins/(plugin-elizacloud)\)'`,
  `TEST_SCRIPT_FILTER='^test$'`, and `--require-work` — exit 0,
  `requireWork: true`, **1 package / 1 runnable task**.
- `git diff --check` — pass.

# Evidence Gate

<!-- evidence-head:d08f7092b9030704095db87e029383ccc0dee8d5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow and script-test contract only; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow and script-test contract only; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service path changed; the exact CI failure and runner-plan output are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, or state transition changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data is produced; the workflow contract and runner-plan summary are the relevant artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - this change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior changed.

## Backend + frontend logs

N/A - no backend or frontend runtime path changed. The failing GitHub Actions
job and the exact local runner-plan result are linked and summarized above.

## Screenshots (before / after) + video walkthrough

N/A - no UI files or rendered surfaces changed.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no interactive flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- `bun run test:scripts` was attempted from the clean worktree using the
  repository's shared dependency link. It reached the script inventory but
  failed in the unrelated provisioning-worker image-rollout test because that
  shared link does not contain `drizzle-orm`; its JUnit evidence file was then
  absent. This is an invalid local dependency setup, not a failure in either
  changed file. The complete focused guard suite, actionlint, Biome, and the
  real non-vacuous runner plan all pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@6659f25cd20eea80e4ad4a8a61a1e541b21551df:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@6659f25cd20eea80e4ad4a8a61a1e541b21551df:packages/skills/skills/contribute-to-eliza"} -->
