### PR TITLE
feat(ui): per-connector Settings detail pages with Delegate/Bot lens

### DIFF
--- a/packages/agent/src/config/schema.ts
+++ b/packages/agent/src/config/schema.ts
@@ -47,6 +47,15 @@ export type ConfigUiHint = {
   patternError?: string;
   /** Legacy conditional visibility. */
   showIf?: ShowIfCondition;
+  /**
+   * Show only after every listed key is present (draft non-empty or
+   * persisted/`isSet`, including masked secrets).
+   */
+  requires?: string | string[];
+  /** Show when any one of the listed keys is present. */
+  requiresAny?: string | string[];
+  /** Rich visibility condition (shared ConfigUiHint shape). */
+  visible?: unknown;
   /** Enhanced options for select/radio/multiselect fields. */
   options?: Array<{
     value: string;
@@ -117,6 +126,9 @@ export type PluginUiMetadata = {
       | "pattern"
       | "patternError"
       | "showIf"
+      | "requires"
+      | "requiresAny"
+      | "visible"
       | "options"
       | "min"
       | "max"

--- a/packages/app/src/deep-link-routing.test.ts
+++ b/packages/app/src/deep-link-routing.test.ts
@@ -346,13 +346,20 @@ describe("top-level-surface deep-link navigation intents", () => {
     });
   });
 
-  it("routes a per-provider connectors deep link to Settings → Connectors", () => {
+  it("routes a per-provider connectors deep link to Settings → connector detail", () => {
     expect(
       resolveDeepLinkNavigationIntent("settings/connectors/discord"),
     ).toEqual({
       viewId: "settings",
       viewPath: "/settings",
-      subview: "connectors",
+      subview: "connectors/discord",
+    });
+    expect(
+      resolveDeepLinkNavigationIntent("settings/connectors/twitter"),
+    ).toEqual({
+      viewId: "settings",
+      viewPath: "/settings",
+      subview: "connectors/x",
     });
   });
 

--- a/packages/app/src/deep-link-routing.ts
+++ b/packages/app/src/deep-link-routing.ts
@@ -34,6 +34,11 @@ export interface AssistantLaunchHashRouteOptions {
 export interface DeepLinkNavigationIntent {
   viewId: string;
   viewPath: string;
+  /**
+   * Settings section id, optionally with a nested connectors detail segment
+   * (`connectors` or `connectors/discord`). SettingsView / ConnectorsSection
+   * parse nested forms via the structured settings hash route helpers.
+   */
   subview?: string;
 }
 
@@ -54,14 +59,21 @@ export interface DeepLinkNavigationIntent {
 export function resolveDeepLinkNavigationIntent(
   path: string,
 ): DeepLinkNavigationIntent | null {
-  // eliza://connectors and eliza://settings/connectors/<provider> → open
-  // Settings focused on the Connectors section (a Settings section, not a
-  // top-level tab).
-  if (
-    path === "connectors" ||
-    /^settings\/connectors\/[a-z0-9-]+$/i.test(path)
-  ) {
+  // eliza://connectors → Settings → Connectors index.
+  // eliza://settings/connectors/<provider> → Settings → connector detail.
+  if (path === "connectors" || path === "settings/connectors") {
     return { viewId: "settings", viewPath: "/settings", subview: "connectors" };
+  }
+  const connectorDetail = path.match(
+    /^settings\/connectors\/([a-z0-9-]+)$/i,
+  );
+  if (connectorDetail?.[1]) {
+    const connectorId = connectorDetail[1].toLowerCase();
+    return {
+      viewId: "settings",
+      viewPath: "/settings",
+      subview: `connectors/${connectorId === "twitter" ? "x" : connectorId}`,
+    };
   }
 
   switch (path) {

--- a/packages/shared/src/config/config-catalog.test.ts
+++ b/packages/shared/src/config/config-catalog.test.ts
@@ -44,13 +44,21 @@ describe("config-catalog path helpers", () => {
 describe("config-catalog field visibility gates", () => {
   it("treats persisted setKeys as satisfied even without a draft value", () => {
     expect(
-      isConfigKeySatisfied("DISCORD_API_TOKEN", {}, new Set(["DISCORD_API_TOKEN"])),
+      isConfigKeySatisfied(
+        "DISCORD_API_TOKEN",
+        {},
+        new Set(["DISCORD_API_TOKEN"]),
+      ),
     ).toBe(true);
     expect(isConfigKeySatisfied("DISCORD_API_TOKEN", {}, new Set())).toBe(
       false,
     );
     expect(
-      isConfigKeySatisfied("DISCORD_API_TOKEN", { DISCORD_API_TOKEN: " abc " }, new Set()),
+      isConfigKeySatisfied(
+        "DISCORD_API_TOKEN",
+        { DISCORD_API_TOKEN: " abc " },
+        new Set(),
+      ),
     ).toBe(true);
   });
 

--- a/packages/shared/src/config/config-catalog.test.ts
+++ b/packages/shared/src/config/config-catalog.test.ts
@@ -4,7 +4,12 @@
  * and prototype-pollution guarding on write.
  */
 import { describe, expect, it } from "vitest";
-import { getByPath, setByPath } from "./config-catalog.js";
+import {
+  evaluateFieldVisibility,
+  getByPath,
+  isConfigKeySatisfied,
+  setByPath,
+} from "./config-catalog.js";
 
 describe("config-catalog path helpers", () => {
   it("resolves JSON Pointer escaped object keys", () => {
@@ -33,5 +38,69 @@ describe("config-catalog path helpers", () => {
 
     expect(data).toEqual({ "a/b": { "tilde~key": "value" } });
     expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+});
+
+describe("config-catalog field visibility gates", () => {
+  it("treats persisted setKeys as satisfied even without a draft value", () => {
+    expect(
+      isConfigKeySatisfied("DISCORD_API_TOKEN", {}, new Set(["DISCORD_API_TOKEN"])),
+    ).toBe(true);
+    expect(isConfigKeySatisfied("DISCORD_API_TOKEN", {}, new Set())).toBe(
+      false,
+    );
+    expect(
+      isConfigKeySatisfied("DISCORD_API_TOKEN", { DISCORD_API_TOKEN: " abc " }, new Set()),
+    ).toBe(true);
+  });
+
+  it("hides requires-gated fields until the credential is present", () => {
+    expect(
+      evaluateFieldVisibility({
+        requires: "DISCORD_API_TOKEN",
+        values: {},
+      }),
+    ).toBe(false);
+
+    expect(
+      evaluateFieldVisibility({
+        requires: "DISCORD_API_TOKEN",
+        values: {},
+        setKeys: new Set(["DISCORD_API_TOKEN"]),
+      }),
+    ).toBe(true);
+
+    expect(
+      evaluateFieldVisibility({
+        requires: "DISCORD_API_TOKEN",
+        values: { DISCORD_API_TOKEN: "draft-token" },
+      }),
+    ).toBe(true);
+  });
+
+  it("unlocks requiresAny when any alternate credential is present", () => {
+    expect(
+      evaluateFieldVisibility({
+        requiresAny: ["TWITTER_ACCESS_TOKEN", "TWITTER_CLIENT_ID"],
+        values: { TWITTER_CLIENT_ID: "client" },
+      }),
+    ).toBe(true);
+
+    expect(
+      evaluateFieldVisibility({
+        requiresAny: ["TWITTER_ACCESS_TOKEN", "TWITTER_CLIENT_ID"],
+        values: {},
+      }),
+    ).toBe(false);
+  });
+
+  it("evaluates visible path checks against masked setKeys", () => {
+    expect(
+      evaluateFieldVisibility({
+        visible: { path: "DISCORD_API_TOKEN" },
+        values: {},
+        setKeys: new Set(["DISCORD_API_TOKEN"]),
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/shared/src/config/config-catalog.ts
+++ b/packages/shared/src/config/config-catalog.ts
@@ -276,6 +276,99 @@ export function evaluateVisibility(
   return evaluateLogicExpression(condition as LogicExpression, state);
 }
 
+/** True when a draft/persisted config value counts as "filled in". */
+export function isConfigValuePresent(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value === "boolean") return true;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return Boolean(value);
+}
+
+function normalizeRequirementList(
+  keys: string | string[] | undefined,
+): string[] {
+  if (keys == null) return [];
+  const list = Array.isArray(keys) ? keys : [keys];
+  return list.map((key) => key.trim()).filter((key) => key.length > 0);
+}
+
+/**
+ * Whether `key` is present in live form values or already persisted (`setKeys`).
+ * Sensitive secrets are often `isSet` without a echoed `currentValue`, so
+ * `setKeys` is the only signal that unlocks dependent fields.
+ */
+export function isConfigKeySatisfied(
+  key: string,
+  values: Record<string, unknown>,
+  setKeys?: ReadonlySet<string>,
+): boolean {
+  if (setKeys?.has(key)) return true;
+  return isConfigValuePresent(values[key]);
+}
+
+/**
+ * Build the state object used for `visible` path checks. Persisted-but-masked
+ * secrets (in `setKeys`) are injected as `true` so `{ path: "TOKEN" }` works
+ * even when the form value is empty for security.
+ */
+export function buildConfigVisibilityState(
+  values: Record<string, unknown>,
+  setKeys?: ReadonlySet<string>,
+): Record<string, unknown> {
+  if (!setKeys || setKeys.size === 0) return values;
+  const state: Record<string, unknown> = { ...values };
+  for (const key of setKeys) {
+    if (!isConfigValuePresent(state[key])) {
+      state[key] = true;
+    }
+  }
+  return state;
+}
+
+/**
+ * Evaluate `requires` / `requiresAny` / `visible` for a config field.
+ * All declared gates must pass; missing gates are treated as open.
+ */
+export function evaluateFieldVisibility(options: {
+  hidden?: boolean;
+  requires?: string | string[];
+  requiresAny?: string | string[];
+  visible?: VisibilityCondition;
+  values: Record<string, unknown>;
+  setKeys?: ReadonlySet<string>;
+}): boolean {
+  if (options.hidden) return false;
+
+  const requires = normalizeRequirementList(options.requires);
+  if (
+    requires.length > 0 &&
+    !requires.every((key) =>
+      isConfigKeySatisfied(key, options.values, options.setKeys),
+    )
+  ) {
+    return false;
+  }
+
+  const requiresAny = normalizeRequirementList(options.requiresAny);
+  if (
+    requiresAny.length > 0 &&
+    !requiresAny.some((key) =>
+      isConfigKeySatisfied(key, options.values, options.setKeys),
+    )
+  ) {
+    return false;
+  }
+
+  if (options.visible === undefined) return true;
+  return evaluateVisibility(
+    options.visible,
+    buildConfigVisibilityState(options.values, options.setKeys),
+  );
+}
+
 // ── Visibility helpers (≈ json-render visibility.*) ─────────────────────
 
 export const visibility = {
@@ -1016,6 +1109,10 @@ export interface ResolvedField {
   advanced: boolean;
   hidden: boolean;
   width: "full" | "half" | "third";
+  /** All of these keys must be present (see {@link evaluateFieldVisibility}). */
+  requires?: string | string[];
+  /** Any one of these keys is enough. */
+  requiresAny?: string | string[];
   visible?: VisibilityCondition;
   validation?: ValidationConfig;
   readonly: boolean;
@@ -1065,6 +1162,8 @@ export function resolveFields(
       advanced: hint.advanced ?? false,
       hidden: hint.hidden ?? false,
       width: hint.width ?? (HALF_WIDTH_TYPES.has(fieldType) ? "half" : "full"),
+      requires: hint.requires,
+      requiresAny: hint.requiresAny,
       visible: hint.visible,
       validation: hint.validation,
       readonly: hint.readonly ?? false,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -408,6 +408,18 @@ export type ConfigUiHint = {
   pattern?: string;
   /** Error message when pattern doesn't match. */
   patternError?: string;
+  /**
+   * Show this field only after every listed credential/key is present
+   * (draft value non-empty, or already persisted/`isSet` — including
+   * sensitive secrets that never echo their value). Prefer this over a
+   * raw `visible` path check for "token first, then tuning" forms.
+   */
+  requires?: string | string[];
+  /**
+   * Like {@link requires}, but any one of the listed keys is enough
+   * (e.g. API-token mode OR OAuth client id).
+   */
+  requiresAny?: string | string[];
   /** Rich visibility condition. */
   visible?: VisibilityCondition;
   /** Declarative validation checks. */

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2326,7 +2326,10 @@ function AppContent() {
     const handleFocusConnector = (event: Event) => {
       const detail = (event as CustomEvent<FocusConnectorEventDetail>).detail;
       if (!detail?.connectorId) return;
-      setSettingsInitialSection("connectors");
+      const id = detail.connectorId.trim().toLowerCase();
+      setSettingsInitialSection(
+        id ? `connectors/${id === "twitter" ? "x" : id}` : "connectors",
+      );
       setTab("settings");
     };
     document.addEventListener(FOCUS_CONNECTOR_EVENT, handleFocusConnector);

--- a/packages/ui/src/components/composites/page-panel/page-panel-header.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-header.tsx
@@ -128,19 +128,23 @@ export function PanelNotice({
   tone = "default",
   ...props
 }: PanelNoticeProps) {
+  // Tone colors the copy only — never the action rail. Cascading `text-muted`
+  // onto buttons made primary CTAs (accent fill) render with unreadable labels.
+  const toneClass =
+    tone === "accent"
+      ? "text-txt"
+      : tone === "warning"
+        ? "text-txt"
+        : tone === "danger"
+          ? "text-danger"
+          : "text-muted";
+
   return (
     <div
       className={cn(
         // Dense by default — callers that need air add it explicitly. The old
         // px-1 py-2 read as empty padding inside accordion/setup rows.
         "px-0 py-0 text-sm",
-        tone === "accent"
-          ? "text-txt"
-          : tone === "warning"
-            ? "text-txt"
-            : tone === "danger"
-              ? "text-danger"
-              : "text-muted",
         className,
       )}
       {...props}
@@ -150,13 +154,20 @@ export function PanelNotice({
         // narrow). Avoid sm:-only row which stacked buttons under the copy on
         // mid-width settings panes.
         <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
-          <div className="min-w-0 flex-1 basis-[min(100%,16rem)]">{children}</div>
-          <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2">
+          <div
+            className={cn(
+              "min-w-0 flex-1 basis-[min(100%,16rem)]",
+              toneClass,
+            )}
+          >
+            {children}
+          </div>
+          <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2 text-txt">
             {actions}
           </div>
         </div>
       ) : (
-        children
+        <div className={toneClass}>{children}</div>
       )}
     </div>
   );

--- a/packages/ui/src/components/composites/page-panel/page-panel-header.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-header.tsx
@@ -131,7 +131,9 @@ export function PanelNotice({
   return (
     <div
       className={cn(
-        "px-1 py-2 text-sm",
+        // Dense by default — callers that need air add it explicitly. The old
+        // px-1 py-2 read as empty padding inside accordion/setup rows.
+        "px-0 py-0 text-sm",
         tone === "accent"
           ? "text-txt"
           : tone === "warning"
@@ -144,9 +146,14 @@ export function PanelNotice({
       {...props}
     >
       {actions ? (
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>{children}</div>
-          <div className="shrink-0">{actions}</div>
+        // Always left copy / right actions (wrap only when the row is too
+        // narrow). Avoid sm:-only row which stacked buttons under the copy on
+        // mid-width settings panes.
+        <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+          <div className="min-w-0 flex-1 basis-[min(100%,16rem)]">{children}</div>
+          <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2">
+            {actions}
+          </div>
         </div>
       ) : (
         children

--- a/packages/ui/src/components/composites/page-panel/page-panel-header.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-header.tsx
@@ -155,14 +155,11 @@ export function PanelNotice({
         // mid-width settings panes.
         <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
           <div
-            className={cn(
-              "min-w-0 flex-1 basis-[min(100%,16rem)]",
-              toneClass,
-            )}
+            className={cn("min-w-0 flex-1 basis-[min(100%,16rem)]", toneClass)}
           >
             {children}
           </div>
-          <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2 text-txt">
+          <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2 text-txt-strong">
             {actions}
           </div>
         </div>

--- a/packages/ui/src/components/config-ui/config-field.tsx
+++ b/packages/ui/src/components/config-ui/config-field.tsx
@@ -25,6 +25,7 @@ import {
 } from "../ui/dialog";
 import { Input } from "../ui/input";
 import { Switch } from "../ui/switch";
+import { Textarea } from "../ui/textarea";
 import { defaultRenderers } from "./config-field.helpers";
 
 /** Field chrome layout. `row` = one setting per line (label left, control right). */
@@ -38,6 +39,18 @@ const DIALOG_EDIT_TYPES = new Set([
   "email",
   "textarea",
   "string",
+  "json",
+  "code",
+  "array",
+  "keyvalue",
+]);
+
+const MULTILINE_DIALOG_TYPES = new Set([
+  "textarea",
+  "json",
+  "code",
+  "array",
+  "keyvalue",
 ]);
 
 function displayValue(
@@ -99,7 +112,6 @@ export function ConfigField({
   const label = renderProps.hint.label ?? renderProps.key;
   const errors = renderProps.errors ?? [];
   const hasError = errors.length > 0;
-  const isRequiredEmpty = renderProps.required && !renderProps.isSet;
   const helpText = renderProps.hint.help ?? renderProps.schema.description;
   const isBoolean =
     renderProps.fieldType === "boolean" ||
@@ -111,6 +123,7 @@ export function ConfigField({
     (DIALOG_EDIT_TYPES.has(renderProps.fieldType) ||
       renderProps.fieldType === "text" ||
       !renderProps.fieldType);
+  const usesMultilineDialog = MULTILINE_DIALOG_TYPES.has(renderProps.fieldType);
 
   const renderFn =
     renderer ??
@@ -189,13 +202,8 @@ export function ConfigField({
         className={cn(
           "group/field border-b border-border/40 px-4 py-3.5 last:border-b-0",
           renderProps.readonly && "pointer-events-none",
-          isRequiredEmpty && "relative",
         )}
       >
-        {isRequiredEmpty ? (
-          <div className="absolute bottom-2 left-0 top-2 w-[2px] rounded-full bg-destructive opacity-40" />
-        ) : null}
-
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0 flex-1 space-y-0.5">
             <div className="flex flex-wrap items-center gap-2">
@@ -269,41 +277,58 @@ export function ConfigField({
                       >
                         {label}
                       </label>
-                      <Input
-                        id={`${fieldId}-edit`}
-                        type={
-                          renderProps.fieldType === "password" ||
-                          renderProps.hint.sensitive
-                            ? "password"
-                            : renderProps.fieldType === "number"
-                              ? "number"
-                              : renderProps.fieldType === "email"
-                                ? "email"
-                                : renderProps.fieldType === "url"
-                                  ? "url"
-                                  : "text"
-                        }
-                        value={draft}
-                        autoFocus
-                        placeholder={
-                          renderProps.hint.placeholder ||
-                          (renderProps.hint.sensitive ||
-                          renderProps.fieldType === "password"
-                            ? t("config-field.secretPlaceholder", {
-                                defaultValue: "Enter new value",
-                              })
-                            : undefined)
-                        }
-                        onChange={(event) => setDraft(event.target.value)}
-                        onKeyDown={(event) => {
-                          if (event.key === "Enter") {
-                            event.preventDefault();
-                            renderProps.onChange(draft);
-                            setEditOpen(false);
+                      {usesMultilineDialog ? (
+                        <Textarea
+                          id={`${fieldId}-edit`}
+                          value={draft}
+                          autoFocus
+                          rows={8}
+                          placeholder={
+                            renderProps.hint.placeholder ||
+                            t("config-field.enterValue", {
+                              defaultValue: "Enter a value",
+                            })
                           }
-                        }}
-                        className="h-10 border-border/60 bg-bg-muted"
-                      />
+                          onChange={(event) => setDraft(event.target.value)}
+                          className="min-h-40 resize-y border-border/60 bg-bg-muted font-mono text-sm"
+                        />
+                      ) : (
+                        <Input
+                          id={`${fieldId}-edit`}
+                          type={
+                            renderProps.fieldType === "password" ||
+                            renderProps.hint.sensitive
+                              ? "password"
+                              : renderProps.fieldType === "number"
+                                ? "number"
+                                : renderProps.fieldType === "email"
+                                  ? "email"
+                                  : renderProps.fieldType === "url"
+                                    ? "url"
+                                    : "text"
+                          }
+                          value={draft}
+                          autoFocus
+                          placeholder={
+                            renderProps.hint.placeholder ||
+                            (renderProps.hint.sensitive ||
+                            renderProps.fieldType === "password"
+                              ? t("config-field.secretPlaceholder", {
+                                  defaultValue: "Enter new value",
+                                })
+                              : undefined)
+                          }
+                          onChange={(event) => setDraft(event.target.value)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                              event.preventDefault();
+                              renderProps.onChange(draft);
+                              setEditOpen(false);
+                            }
+                          }}
+                          className="h-10 border-border/60 bg-bg-muted"
+                        />
+                      )}
                     </div>
 
                     <DialogFooter className="gap-2 sm:gap-2">
@@ -349,13 +374,9 @@ export function ConfigField({
       }
       className={`group/field py-2.5 ${
         renderProps.readonly ? "pointer-events-none" : ""
-      } ${isRequiredEmpty ? "relative" : ""}`}
+      }`}
     >
-      {isRequiredEmpty && (
-        <div className="absolute bottom-2.5 left-0 top-2.5 w-[2px] rounded-full bg-destructive opacity-40" />
-      )}
-
-      <div className={isRequiredEmpty ? "pl-2.5" : ""}>
+      <div>
         <div className="mb-1.5 flex items-center gap-2">
           <span
             className="font-semibold leading-tight"

--- a/packages/ui/src/components/config-ui/config-field.tsx
+++ b/packages/ui/src/components/config-ui/config-field.tsx
@@ -232,11 +232,11 @@ export function ConfigField({
                   disabled={renderProps.readonly}
                   onClick={() => setEditOpen(true)}
                   className={cn(
-                    "inline-flex max-w-[14rem] items-center gap-1.5 rounded-md border border-border/70 bg-bg-muted/80 px-2.5 py-1.5 text-left text-xs font-medium text-txt-strong transition-colors",
-                    "hover:border-border hover:bg-bg-hover",
+                    "inline-flex max-w-[14rem] items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1.5 text-left text-xs font-semibold text-txt-strong transition-colors",
+                    "hover:border-border-strong hover:bg-bg-hover",
                     !isConfigValueFilled(renderProps.value) &&
                       !renderProps.isSet &&
-                      "text-muted",
+                      "font-medium text-muted-strong",
                   )}
                   data-testid={`config-field-edit-${renderProps.key}`}
                 >

--- a/packages/ui/src/components/config-ui/config-field.tsx
+++ b/packages/ui/src/components/config-ui/config-field.tsx
@@ -141,6 +141,9 @@ export function ConfigField({
     () => displayValue(renderProps, t),
     [renderProps, t],
   );
+  const isSensitiveEdit =
+    renderProps.hint.sensitive || renderProps.fieldType === "password";
+  const canSaveDraft = !isSensitiveEdit || draft.trim().length > 0;
 
   const statusBadges = (
     <>
@@ -246,6 +249,10 @@ export function ConfigField({
                       !renderProps.isSet &&
                       "font-medium text-muted-strong",
                   )}
+                  aria-label={t("config-field.editLabel", {
+                    defaultValue: "Edit {{label}}",
+                    label,
+                  })}
                   data-testid={`config-field-edit-${renderProps.key}`}
                 >
                   <span className="min-w-0 truncate">{chipLabel}</span>
@@ -320,11 +327,11 @@ export function ConfigField({
                           }
                           onChange={(event) => setDraft(event.target.value)}
                           onKeyDown={(event) => {
-                            if (event.key === "Enter") {
-                              event.preventDefault();
-                              renderProps.onChange(draft);
-                              setEditOpen(false);
-                            }
+                            if (event.key !== "Enter") return;
+                            event.preventDefault();
+                            if (!canSaveDraft) return;
+                            renderProps.onChange(draft);
+                            setEditOpen(false);
                           }}
                           className="h-10 border-border/60 bg-bg-muted"
                         />
@@ -345,7 +352,9 @@ export function ConfigField({
                         type="button"
                         variant="default"
                         size="sm"
+                        disabled={!canSaveDraft}
                         onClick={() => {
+                          if (!canSaveDraft) return;
                           renderProps.onChange(draft);
                           setEditOpen(false);
                         }}

--- a/packages/ui/src/components/config-ui/config-field.tsx
+++ b/packages/ui/src/components/config-ui/config-field.tsx
@@ -1,13 +1,84 @@
 /**
  * Renders one plugin configuration field with the standard label, status,
  * renderer, validation, and help-text structure used by config panels.
+ *
+ * In `row` layout (connector detail), text/number values rest as a trailing
+ * chip that opens an edit dialog — matching the Devin settings pattern —
+ * while booleans stay an inline switch.
  */
+import { Pencil } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import type {
   FieldRenderer,
   FieldRenderProps,
 } from "../../config/config-catalog";
+import { cn } from "../../lib/utils";
 import { useAppSelector } from "../../state";
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Input } from "../ui/input";
+import { Switch } from "../ui/switch";
 import { defaultRenderers } from "./config-field.helpers";
+
+/** Field chrome layout. `row` = one setting per line (label left, control right). */
+export type ConfigFieldLayout = "stacked" | "row";
+
+const DIALOG_EDIT_TYPES = new Set([
+  "text",
+  "password",
+  "number",
+  "url",
+  "email",
+  "textarea",
+  "string",
+]);
+
+function displayValue(
+  renderProps: FieldRenderProps,
+  t: (key: string, opts?: { defaultValue?: string }) => string,
+): string {
+  if (renderProps.hint.sensitive || renderProps.fieldType === "password") {
+    if (renderProps.isSet || isConfigValueFilled(renderProps.value)) {
+      return "••••••••";
+    }
+    return t("config-field.setValue", { defaultValue: "Set value" });
+  }
+  if (isConfigValueFilled(renderProps.value)) {
+    const raw = Array.isArray(renderProps.value)
+      ? renderProps.value.join(", ")
+      : String(renderProps.value);
+    return raw.length > 28 ? `${raw.slice(0, 26)}…` : raw;
+  }
+  if (renderProps.isSet) {
+    return t("config-field.configured", { defaultValue: "Configured" });
+  }
+  return t("config-field.setValue", { defaultValue: "Set value" });
+}
+
+function isConfigValueFilled(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (Array.isArray(value)) return value.length > 0;
+  return Boolean(value);
+}
+
+function draftFromProps(renderProps: FieldRenderProps): string {
+  if (renderProps.hint.sensitive || renderProps.fieldType === "password") {
+    // Never echo secrets into the dialog — start empty for replace-on-save.
+    return "";
+  }
+  if (renderProps.value == null) return "";
+  if (Array.isArray(renderProps.value)) return renderProps.value.join(", ");
+  return String(renderProps.value);
+}
 
 /**
  * Wraps a field renderer with the standard label row, env key display,
@@ -17,21 +88,257 @@ export function ConfigField({
   renderProps,
   renderer,
   pluginId,
+  layout = "stacked",
 }: {
   renderProps: FieldRenderProps;
   renderer: FieldRenderer;
   pluginId?: string;
+  layout?: ConfigFieldLayout;
 }) {
   const t = useAppSelector((s) => s.t);
   const label = renderProps.hint.label ?? renderProps.key;
   const errors = renderProps.errors ?? [];
   const hasError = errors.length > 0;
   const isRequiredEmpty = renderProps.required && !renderProps.isSet;
+  const helpText = renderProps.hint.help ?? renderProps.schema.description;
+  const isBoolean =
+    renderProps.fieldType === "boolean" ||
+    renderProps.fieldType === "switch" ||
+    renderProps.fieldType === "checkbox";
+  const usesEditDialog =
+    layout === "row" &&
+    !isBoolean &&
+    (DIALOG_EDIT_TYPES.has(renderProps.fieldType) ||
+      renderProps.fieldType === "text" ||
+      !renderProps.fieldType);
 
   const renderFn =
     renderer ??
     defaultRenderers[renderProps.fieldType] ??
     defaultRenderers.text;
+
+  const [editOpen, setEditOpen] = useState(false);
+  const [draft, setDraft] = useState(() => draftFromProps(renderProps));
+
+  useEffect(() => {
+    if (editOpen) setDraft(draftFromProps(renderProps));
+  }, [editOpen, renderProps]);
+
+  const chipLabel = useMemo(
+    () => displayValue(renderProps, t),
+    [renderProps, t],
+  );
+
+  const statusBadges = (
+    <>
+      {renderProps.required && !renderProps.isSet ? (
+        <span className="shrink-0 rounded-sm bg-[color-mix(in_srgb,var(--destructive)_10%,transparent)] px-1.5 py-px text-2xs font-semibold text-destructive">
+          {t("secretsview.Required")}
+        </span>
+      ) : null}
+      {renderProps.isSet && layout === "stacked" ? (
+        <span className="inline-flex shrink-0 items-center gap-1 text-2xs font-medium text-ok">
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-ok" />
+          {t("config-field.Configured")}
+        </span>
+      ) : null}
+    </>
+  );
+
+  const errorBlock = hasError ? (
+    <div className="mt-1.5 flex flex-col gap-0.5">
+      {errors.map((err) => (
+        <div
+          key={err}
+          className="flex items-start gap-1 leading-snug"
+          style={{
+            fontSize: "var(--plugin-error-size)",
+            color: "var(--plugin-error)",
+          }}
+        >
+          <span className="mt-px shrink-0">{t("config-field.Times")}</span>
+          <span>{err}</span>
+        </div>
+      ))}
+    </div>
+  ) : null;
+
+  const helpBlock = helpText ? (
+    <div
+      className={cn(
+        "leading-relaxed text-muted",
+        layout === "row" ? "line-clamp-2 text-xs" : "mt-1 line-clamp-2",
+      )}
+      style={{
+        fontSize: layout === "row" ? undefined : "var(--plugin-help-size)",
+        color: "var(--plugin-help)",
+      }}
+    >
+      {helpText}
+    </div>
+  ) : null;
+
+  if (layout === "row") {
+    const fieldId = pluginId
+      ? `field-${pluginId}-${renderProps.key}`
+      : `field-${renderProps.key}`;
+
+    return (
+      <div
+        id={fieldId}
+        className={cn(
+          "group/field border-b border-border/40 px-4 py-3.5 last:border-b-0",
+          renderProps.readonly && "pointer-events-none",
+          isRequiredEmpty && "relative",
+        )}
+      >
+        {isRequiredEmpty ? (
+          <div className="absolute bottom-2 left-0 top-2 w-[2px] rounded-full bg-destructive opacity-40" />
+        ) : null}
+
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium leading-snug text-txt-strong">
+                {label}
+              </span>
+              {statusBadges}
+            </div>
+            {helpBlock}
+            {errorBlock}
+          </div>
+
+          <div className="shrink-0 pt-0.5">
+            {isBoolean ? (
+              <Switch
+                aria-label={label}
+                checked={
+                  renderProps.value === true ||
+                  renderProps.value === "true" ||
+                  renderProps.value === "1" ||
+                  (!renderProps.isSet &&
+                    (renderProps.schema.default === true ||
+                      renderProps.schema.default === "true"))
+                }
+                disabled={renderProps.readonly}
+                onCheckedChange={(next) => {
+                  renderProps.onChange(String(next));
+                }}
+              />
+            ) : usesEditDialog ? (
+              <>
+                <button
+                  type="button"
+                  disabled={renderProps.readonly}
+                  onClick={() => setEditOpen(true)}
+                  className={cn(
+                    "inline-flex max-w-[14rem] items-center gap-1.5 rounded-md border border-border/70 bg-bg-muted/80 px-2.5 py-1.5 text-left text-xs font-medium text-txt-strong transition-colors",
+                    "hover:border-border hover:bg-bg-hover",
+                    !isConfigValueFilled(renderProps.value) &&
+                      !renderProps.isSet &&
+                      "text-muted",
+                  )}
+                  data-testid={`config-field-edit-${renderProps.key}`}
+                >
+                  <span className="min-w-0 truncate">{chipLabel}</span>
+                  <Pencil className="h-3 w-3 shrink-0 text-muted" aria-hidden />
+                </button>
+
+                <Dialog open={editOpen} onOpenChange={setEditOpen}>
+                  <DialogContent className="max-w-md gap-4 bg-card sm:max-w-md">
+                    <DialogHeader>
+                      <DialogTitle>
+                        {t("config-field.changeTitle", {
+                          defaultValue: "Change {{label}}",
+                          label,
+                        })}
+                      </DialogTitle>
+                      <DialogDescription>
+                        {helpText ||
+                          t("config-field.changeDescription", {
+                            defaultValue: "Enter a new value for {{label}}.",
+                            label,
+                          })}
+                      </DialogDescription>
+                    </DialogHeader>
+
+                    <div className="space-y-2">
+                      <label
+                        htmlFor={`${fieldId}-edit`}
+                        className="text-sm font-medium text-txt-strong"
+                      >
+                        {label}
+                      </label>
+                      <Input
+                        id={`${fieldId}-edit`}
+                        type={
+                          renderProps.fieldType === "password" ||
+                          renderProps.hint.sensitive
+                            ? "password"
+                            : renderProps.fieldType === "number"
+                              ? "number"
+                              : renderProps.fieldType === "email"
+                                ? "email"
+                                : renderProps.fieldType === "url"
+                                  ? "url"
+                                  : "text"
+                        }
+                        value={draft}
+                        autoFocus
+                        placeholder={
+                          renderProps.hint.placeholder ||
+                          (renderProps.hint.sensitive ||
+                          renderProps.fieldType === "password"
+                            ? t("config-field.secretPlaceholder", {
+                                defaultValue: "Enter new value",
+                              })
+                            : undefined)
+                        }
+                        onChange={(event) => setDraft(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.preventDefault();
+                            renderProps.onChange(draft);
+                            setEditOpen(false);
+                          }
+                        }}
+                        className="h-10 border-border/60 bg-bg-muted"
+                      />
+                    </div>
+
+                    <DialogFooter className="gap-2 sm:gap-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="text-txt"
+                        onClick={() => setEditOpen(false)}
+                      >
+                        {t("common.cancel", { defaultValue: "Cancel" })}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="default"
+                        size="sm"
+                        onClick={() => {
+                          renderProps.onChange(draft);
+                          setEditOpen(false);
+                        }}
+                      >
+                        {t("common.save", { defaultValue: "Save" })}
+                      </Button>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+              </>
+            ) : (
+              <div className="w-[min(100%,16rem)]">{renderFn(renderProps)}</div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -40,18 +347,16 @@ export function ConfigField({
           ? `field-${pluginId}-${renderProps.key}`
           : `field-${renderProps.key}`
       }
-      className={`py-2.5 group/field ${
+      className={`group/field py-2.5 ${
         renderProps.readonly ? "pointer-events-none" : ""
       } ${isRequiredEmpty ? "relative" : ""}`}
     >
-      {/* Required-but-empty accent bar */}
       {isRequiredEmpty && (
-        <div className="absolute left-0 top-2.5 bottom-2.5 w-[2px] bg-destructive opacity-40 rounded-full" />
+        <div className="absolute bottom-2.5 left-0 top-2.5 w-[2px] rounded-full bg-destructive opacity-40" />
       )}
 
       <div className={isRequiredEmpty ? "pl-2.5" : ""}>
-        {/* Label row */}
-        <div className="flex items-center gap-2 mb-1.5">
+        <div className="mb-1.5 flex items-center gap-2">
           <span
             className="font-semibold leading-tight"
             style={{
@@ -61,63 +366,12 @@ export function ConfigField({
           >
             {label}
           </span>
-          {renderProps.required && !renderProps.isSet && (
-            <span className="text-2xs text-destructive font-semibold px-1.5 py-px bg-[color-mix(in_srgb,var(--destructive)_10%,transparent)] rounded-sm shrink-0">
-              {t("secretsview.Required")}
-            </span>
-          )}
-          {renderProps.isSet && (
-            <span className="inline-flex items-center gap-1 text-2xs text-ok font-medium shrink-0">
-              <span className="inline-block w-1.5 h-1.5 rounded-full bg-ok" />
-
-              {t("config-field.Configured")}
-            </span>
-          )}
+          {statusBadges}
         </div>
 
-        {/* Field renderer */}
         {renderFn(renderProps)}
-
-        {/* Errors */}
-        {hasError && (
-          <div className="mt-1.5 flex flex-col gap-0.5">
-            {errors.map((err) => (
-              <div
-                key={err}
-                className="leading-snug flex items-start gap-1"
-                style={{
-                  fontSize: "var(--plugin-error-size)",
-                  color: "var(--plugin-error)",
-                }}
-              >
-                <span className="shrink-0 mt-px">
-                  {t("config-field.Times")}
-                </span>
-                <span>{err}</span>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Help text */}
-        {(renderProps.hint.help || renderProps.schema.description) && (
-          <div
-            className="mt-1 leading-relaxed line-clamp-2"
-            style={{
-              fontSize: "var(--plugin-help-size)",
-              color: "var(--plugin-help)",
-            }}
-          >
-            {renderProps.hint.help ?? renderProps.schema.description}
-            {renderProps.schema.default != null && (
-              <span className="opacity-90">
-                {" "}
-                {t("common.default", { defaultValue: "Default" })}{" "}
-                {String(renderProps.schema.default)})
-              </span>
-            )}
-          </div>
-        )}
+        {errorBlock}
+        {helpBlock ? <div className="mt-1">{helpBlock}</div> : null}
       </div>
     </div>
   );

--- a/packages/ui/src/components/config-ui/config-field.tsx
+++ b/packages/ui/src/components/config-ui/config-field.tsx
@@ -131,6 +131,7 @@ export function ConfigField({
     defaultRenderers.text;
 
   const [editOpen, setEditOpen] = useState(false);
+  const [clearConfirming, setClearConfirming] = useState(false);
   const [draft, setDraft] = useState(() => draftFromProps(renderProps));
 
   useEffect(() => {
@@ -144,6 +145,8 @@ export function ConfigField({
   const isSensitiveEdit =
     renderProps.hint.sensitive || renderProps.fieldType === "password";
   const canSaveDraft = !isSensitiveEdit || draft.trim().length > 0;
+  const canClearSecret =
+    isSensitiveEdit && renderProps.isSet && !renderProps.required;
 
   const statusBadges = (
     <>
@@ -241,7 +244,10 @@ export function ConfigField({
                 <button
                   type="button"
                   disabled={renderProps.readonly}
-                  onClick={() => setEditOpen(true)}
+                  onClick={() => {
+                    setClearConfirming(false);
+                    setEditOpen(true);
+                  }}
                   className={cn(
                     "inline-flex max-w-[14rem] items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1.5 text-left text-xs font-semibold text-txt-strong transition-colors",
                     "hover:border-border-strong hover:bg-bg-hover",
@@ -259,7 +265,13 @@ export function ConfigField({
                   <Pencil className="h-3 w-3 shrink-0 text-muted" aria-hidden />
                 </button>
 
-                <Dialog open={editOpen} onOpenChange={setEditOpen}>
+                <Dialog
+                  open={editOpen}
+                  onOpenChange={(open) => {
+                    setEditOpen(open);
+                    if (!open) setClearConfirming(false);
+                  }}
+                >
                   <DialogContent className="max-w-md gap-4 bg-card sm:max-w-md">
                     <DialogHeader>
                       <DialogTitle>
@@ -338,29 +350,84 @@ export function ConfigField({
                       )}
                     </div>
 
+                    {clearConfirming ? (
+                      <div
+                        role="alert"
+                        className="rounded-sm border border-danger/50 bg-destructive-subtle px-3 py-2 text-xs text-danger"
+                      >
+                        {t("config-field.clearConfirmation", {
+                          defaultValue:
+                            "Remove {{label}}? The removal is applied when you save changes.",
+                          label,
+                        })}
+                      </div>
+                    ) : null}
+
                     <DialogFooter className="gap-2 sm:gap-2">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="text-txt"
-                        onClick={() => setEditOpen(false)}
-                      >
-                        {t("common.cancel", { defaultValue: "Cancel" })}
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="default"
-                        size="sm"
-                        disabled={!canSaveDraft}
-                        onClick={() => {
-                          if (!canSaveDraft) return;
-                          renderProps.onChange(draft);
-                          setEditOpen(false);
-                        }}
-                      >
-                        {t("common.save", { defaultValue: "Save" })}
-                      </Button>
+                      {clearConfirming ? (
+                        <>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setClearConfirming(false)}
+                          >
+                            {t("config-field.keepValue", {
+                              defaultValue: "Keep value",
+                            })}
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => {
+                              renderProps.onChange("");
+                              setClearConfirming(false);
+                              setEditOpen(false);
+                            }}
+                          >
+                            {t("config-field.clearValue", {
+                              defaultValue: "Clear value",
+                            })}
+                          </Button>
+                        </>
+                      ) : (
+                        <>
+                          {canClearSecret ? (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="mr-auto text-danger hover:text-danger"
+                              onClick={() => setClearConfirming(true)}
+                            >
+                              {t("common.clear", { defaultValue: "Clear" })}
+                            </Button>
+                          ) : null}
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="text-txt"
+                            onClick={() => setEditOpen(false)}
+                          >
+                            {t("common.cancel", { defaultValue: "Cancel" })}
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="default"
+                            size="sm"
+                            disabled={!canSaveDraft}
+                            onClick={() => {
+                              if (!canSaveDraft) return;
+                              renderProps.onChange(draft);
+                              setEditOpen(false);
+                            }}
+                          >
+                            {t("common.save", { defaultValue: "Save" })}
+                          </Button>
+                        </>
+                      )}
                     </DialogFooter>
                   </DialogContent>
                 </Dialog>

--- a/packages/ui/src/components/config-ui/config-renderer.tsx
+++ b/packages/ui/src/components/config-ui/config-renderer.tsx
@@ -26,10 +26,11 @@ import {
   resolveFields,
   runValidation,
 } from "../../config/config-catalog";
+import { cn } from "../../lib/utils";
 import { useAppSelector } from "../../state";
 import type { ConfigUiHint, PluginUiTheme } from "../../types";
 import { Button } from "../ui/button";
-import { ConfigField } from "./config-field";
+import { ConfigField, type ConfigFieldLayout } from "./config-field";
 
 // ── Props ──────────────────────────────────────────────────────────────
 
@@ -59,6 +60,12 @@ export interface ConfigRendererProps {
   showValidationSummary?: boolean;
   /** Partial theme overrides for plugin UI tokens. */
   theme?: Partial<PluginUiTheme>;
+  /**
+   * `grid` (default) — multi-column field grid.
+   * `rows` — one full-width settings row per field (label/help left, control
+   * right), matching the Devin-style connector detail surface.
+   */
+  layout?: "grid" | "rows";
 }
 
 /** Handle exposed by ConfigRenderer via ref for parent-driven validation. */
@@ -268,9 +275,12 @@ export const ConfigRenderer = forwardRef<
     renderField: renderFieldOverride,
     showValidationSummary = true,
     theme,
+    layout = "grid",
   }: ConfigRendererProps,
   ref,
 ) {
+  const fieldLayout: ConfigFieldLayout =
+    layout === "rows" ? "row" : "stacked";
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<Map<string, string[]>>(
     new Map(),
@@ -424,26 +434,38 @@ export const ConfigRenderer = forwardRef<
     (field: ResolvedField) => {
       const rp = buildRenderProps(field);
       const renderer = registry.resolveOrFallback(field.fieldType);
+      // Rows layout always spans the full track — never pair two settings on
+      // one horizontal line.
+      const spanClass =
+        layout === "rows" ? "col-span-6" : widthClass(field.width);
 
       if (renderFieldOverride) {
         return (
-          <div key={field.key} className={widthClass(field.width)}>
+          <div key={field.key} className={spanClass}>
             {renderFieldOverride(rp, renderer)}
           </div>
         );
       }
 
       return (
-        <div key={field.key} className={widthClass(field.width)}>
+        <div key={field.key} className={spanClass}>
           <ConfigField
             renderProps={rp}
             renderer={renderer}
             pluginId={pluginId}
+            layout={fieldLayout}
           />
         </div>
       );
     },
-    [buildRenderProps, registry, renderFieldOverride, pluginId],
+    [
+      buildRenderProps,
+      registry,
+      renderFieldOverride,
+      pluginId,
+      layout,
+      fieldLayout,
+    ],
   );
 
   // ── Resolve and partition fields ─────────────────────────────────────
@@ -599,15 +621,26 @@ export const ConfigRenderer = forwardRef<
       {[...groups.entries()].map(([group, fields], groupIndex) => (
         <div key={group} className={groupIndex > 0 ? "mt-5" : ""}>
           {showHeaders && (
-            <div className="flex items-center gap-2 mb-3">
+            <div
+              className={cn(
+                "mb-3 flex items-center gap-2",
+                layout === "rows" && "px-1",
+              )}
+            >
               <span className="text-base leading-none">{groupIcon(group)}</span>
               <span className="text-xs font-bold uppercase tracking-wider text-txt opacity-70">
                 {group}
               </span>
-              <span className="flex-1 h-px bg-border ml-1" />
+              <span className="ml-1 h-px flex-1 bg-border" />
             </div>
           )}
-          <div className="grid grid-cols-6 gap-x-5 gap-y-0">
+          <div
+            className={
+              layout === "rows"
+                ? "overflow-hidden rounded-lg border border-border/60 bg-card/30"
+                : "grid grid-cols-6 gap-x-5 gap-y-0"
+            }
+          >
             {fields.map((f) => renderField(f))}
           </div>
         </div>
@@ -621,7 +654,13 @@ export const ConfigRenderer = forwardRef<
             setAdvancedOpen={setAdvancedOpen}
           />
           {advancedOpen && (
-            <div className="grid grid-cols-6 gap-x-5 gap-y-0 pt-1 animate-[cr-slide_var(--duration-normal,200ms)_ease]">
+            <div
+              className={
+                layout === "rows"
+                  ? "mt-1 overflow-hidden rounded-lg border border-border/60 bg-card/30 animate-[cr-slide_var(--duration-normal,200ms)_ease]"
+                  : "grid grid-cols-6 gap-x-5 gap-y-0 pt-1 animate-[cr-slide_var(--duration-normal,200ms)_ease]"
+              }
+            >
               {advanced.map((f) => renderField(f))}
             </div>
           )}

--- a/packages/ui/src/components/config-ui/config-renderer.tsx
+++ b/packages/ui/src/components/config-ui/config-renderer.tsx
@@ -22,7 +22,7 @@ import type {
   ResolvedField,
 } from "../../config/config-catalog";
 import {
-  evaluateVisibility,
+  evaluateFieldVisibility,
   resolveFields,
   runValidation,
 } from "../../config/config-catalog";
@@ -332,17 +332,18 @@ export const ConfigRenderer = forwardRef<
 
   const isFieldVisible = useCallback(
     (field: ResolvedField): boolean => {
-      // Hidden fields are never visible
-      if (field.hidden) return false;
-
-      // Rich visibility condition (json-render style) takes priority
-      if (field.visible !== undefined) {
-        return evaluateVisibility(field.visible, values);
-      }
-
-      return true;
+      // requires / requiresAny honor setKeys so masked secrets unlock
+      // dependent fields (poll interval, channel lists, …) without echoing.
+      return evaluateFieldVisibility({
+        hidden: field.hidden,
+        requires: field.requires,
+        requiresAny: field.requiresAny,
+        visible: field.visible,
+        values,
+        setKeys,
+      });
     },
-    [values],
+    [values, setKeys],
   );
 
   // ── Field change handler ─────────────────────────────────────────────

--- a/packages/ui/src/components/connectors/ConnectorChannelModeSwitch.stories.tsx
+++ b/packages/ui/src/components/connectors/ConnectorChannelModeSwitch.stories.tsx
@@ -1,0 +1,39 @@
+/**
+ * Storybook stories for `ConnectorChannelModeSwitch` — the global Delegate/Bot
+ * lens toggle at the top of Settings → Connectors — under a mock app context.
+ * The switch writes the shared channel-mode store, so toggling in the story is
+ * live.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import type { AppContextValue } from "../../state/types";
+import { AppContext } from "../../state/useApp";
+import { ConnectorChannelModeSwitch } from "./ConnectorChannelModeSwitch";
+
+const mockAppContext = new Proxy({} as AppContextValue, {
+  get(_, prop) {
+    if (prop === "t") {
+      return (_key: string, opts?: { defaultValue?: string }) =>
+        opts?.defaultValue ?? "";
+    }
+    if (prop === "uiLanguage") return "en";
+    return () => {};
+  },
+});
+
+const meta = {
+  title: "Connectors/ConnectorChannelModeSwitch",
+  component: ConnectorChannelModeSwitch,
+  decorators: [
+    (Story) => (
+      <AppContext.Provider value={mockAppContext}>
+        <Story />
+      </AppContext.Provider>
+    ),
+  ],
+} satisfies Meta<typeof ConnectorChannelModeSwitch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/ui/src/components/connectors/ConnectorChannelModeSwitch.tsx
+++ b/packages/ui/src/components/connectors/ConnectorChannelModeSwitch.tsx
@@ -1,0 +1,66 @@
+/**
+ * Global Delegate / Bot segmented switch for the Connectors surface. Rendered
+ * left-aligned at the top of Settings → Connectors (below the page header
+ * divider); writes the shared channel-mode store (`connector-channel-mode.ts`)
+ * that the section body reads to filter connectors and their setup modes.
+ */
+
+import { useAppSelector } from "../../state";
+import { SegmentedControl } from "../ui/segmented-control";
+import {
+  type ConnectorChannelMode,
+  setConnectorChannelMode,
+  useConnectorChannelMode,
+} from "./connector-channel-mode";
+
+/** Short human labels + tooltips for the two lenses, i18n-keyed. */
+export function connectorChannelModeCopy(
+  t: (key: string, options?: Record<string, unknown>) => string,
+): Record<ConnectorChannelMode, { label: string; description: string }> {
+  return {
+    delegate: {
+      label: t("connectors.channelMode.delegate.label", {
+        defaultValue: "Delegate",
+      }),
+      description: t("connectors.channelMode.delegate.description", {
+        defaultValue:
+          "Your accounts — the agent reads incoming messages and replies as you.",
+      }),
+    },
+    bot: {
+      label: t("connectors.channelMode.bot.label", { defaultValue: "Bot" }),
+      description: t("connectors.channelMode.bot.description", {
+        defaultValue:
+          "The agent's own bot — connect it to a platform and chat with it from there.",
+      }),
+    },
+  };
+}
+
+export function ConnectorChannelModeSwitch() {
+  const t = useAppSelector((s) => s.t);
+  const channelMode = useConnectorChannelMode();
+  const copy = connectorChannelModeCopy(t);
+
+  return (
+    <SegmentedControl<ConnectorChannelMode>
+      aria-label={t("connectors.channelMode.switchLabel", {
+        defaultValue: "Connector mode",
+      })}
+      value={channelMode}
+      onValueChange={setConnectorChannelMode}
+      // Contained chip: outer border + wash so the lens reads as a control
+      // (not bare text tabs). Active segment uses the app's orange
+      // selected-chip idiom — never blue; hover darkens the orange wash.
+      className="max-w-full shrink-0 self-start rounded-md border border-border/60 bg-card/50 p-0.5"
+      buttonClassName="px-3 py-1.5"
+      activeButtonClassName="border border-accent bg-accent/10 text-accent hover:bg-accent/15 hover:text-accent"
+      inactiveButtonClassName="border border-transparent text-muted hover:bg-bg-hover hover:text-txt"
+      items={(["delegate", "bot"] as const).map((mode) => ({
+        value: mode,
+        label: <span title={copy[mode].description}>{copy[mode].label}</span>,
+        testId: `connector-channel-mode-${mode}`,
+      }))}
+    />
+  );
+}

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
@@ -12,7 +12,10 @@ import {
   getConnectorPluginManagedAccountOption,
 } from "./connector-account-options";
 import type { ConnectorChannelMode } from "./connector-channel-mode";
-import { getDeclaredConnectorModes } from "./connector-mode-registry";
+import {
+  connectorSupportsChannelMode,
+  getDeclaredConnectorModes,
+} from "./connector-mode-registry";
 
 export type ConnectorMode = {
   id: string;
@@ -26,9 +29,20 @@ export type ConnectorMode = {
 function withPluginManagedMode(
   connectorId: string,
   modes: ConnectorMode[],
+  channelMode?: ConnectorChannelMode,
 ): ConnectorMode[] {
   const option = getConnectorPluginManagedAccountOption(connectorId);
   if (!option) return modes;
+  // Same policy as the Connectors index: a catalog connector classified out of
+  // the active lens (e.g. Google under Bot via its fallback) must not expose
+  // plugin-managed inventory there. Mixed-role connectors stay available in
+  // both lenses; their panel filters records by stored account role.
+  if (
+    channelMode !== undefined &&
+    !connectorSupportsChannelMode(connectorId, channelMode)
+  ) {
+    return modes;
+  }
   return [
     {
       id: CONNECTOR_PLUGIN_MANAGED_MODE_ID,
@@ -45,8 +59,8 @@ function withPluginManagedMode(
  * the connector plugin declared in the connector-mode registry. Cloud-only
  * modes are filtered out when Eliza Cloud is not connected. When a global
  * `channelMode` lens is given, declared modes classified into the *other* lens
- * are filtered out too. Plugin-managed inventory remains available in either
- * lens because its panel filters stored records by their actual account role.
+ * are filtered out too, and plugin-managed injection follows the same
+ * `connectorSupportsChannelMode` policy used by the index/detail surfaces.
  */
 export function getConnectorModes(
   connectorId: string,
@@ -73,7 +87,7 @@ export function getConnectorModes(
       descriptionKey: mode.descriptionKey,
       managementMode: mode.managementMode,
     }));
-  return withPluginManagedMode(connectorId, modes);
+  return withPluginManagedMode(connectorId, modes, lens);
 }
 
 /**

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
@@ -11,6 +11,7 @@ import {
   connectorAccountManagementPanelPluginId,
   getConnectorPluginManagedAccountOption,
 } from "./connector-account-options";
+import type { ConnectorChannelMode } from "./connector-channel-mode";
 import { getDeclaredConnectorModes } from "./connector-mode-registry";
 
 export type ConnectorMode = {
@@ -42,15 +43,28 @@ function withPluginManagedMode(
 /**
  * Returns available modes for a connector, rendered generically from the modes
  * the connector plugin declared in the connector-mode registry. Cloud-only
- * modes are filtered out when Eliza Cloud is not connected.
+ * modes are filtered out when Eliza Cloud is not connected. When a global
+ * `channelMode` lens is given, declared modes classified into the *other* lens
+ * are filtered out too (unclassified modes are lens-neutral and always kept, as
+ * is the injected plugin-managed account-inventory mode).
  */
 export function getConnectorModes(
   connectorId: string,
-  options?: { elizaCloudConnected?: boolean },
+  options?: {
+    elizaCloudConnected?: boolean;
+    channelMode?: ConnectorChannelMode;
+  },
 ): ConnectorMode[] {
   const cloud = options?.elizaCloudConnected ?? false;
+  const lens = options?.channelMode;
   const modes: ConnectorMode[] = getDeclaredConnectorModes(connectorId)
     .filter((mode) => cloud || !mode.cloudOnly)
+    .filter(
+      (mode) =>
+        lens === undefined ||
+        mode.channelMode === undefined ||
+        mode.channelMode === lens,
+    )
     .map((mode) => ({
       id: mode.id,
       label: mode.label,

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
@@ -10,6 +10,7 @@ import {
   type ConnectorManagementMode,
   connectorAccountManagementPanelPluginId,
   getConnectorPluginManagedAccountOption,
+  getConnectorPluginManagedChannelMode,
 } from "./connector-account-options";
 import type { ConnectorChannelMode } from "./connector-channel-mode";
 import { getDeclaredConnectorModes } from "./connector-mode-registry";
@@ -26,9 +27,18 @@ export type ConnectorMode = {
 function withPluginManagedMode(
   connectorId: string,
   modes: ConnectorMode[],
+  channelMode?: ConnectorChannelMode,
 ): ConnectorMode[] {
   const option = getConnectorPluginManagedAccountOption(connectorId);
-  if (!option) return modes;
+  const managedChannelMode = getConnectorPluginManagedChannelMode(connectorId);
+  if (
+    !option ||
+    (channelMode !== undefined &&
+      managedChannelMode !== undefined &&
+      managedChannelMode !== channelMode)
+  ) {
+    return modes;
+  }
   return [
     {
       id: CONNECTOR_PLUGIN_MANAGED_MODE_ID,
@@ -45,8 +55,8 @@ function withPluginManagedMode(
  * the connector plugin declared in the connector-mode registry. Cloud-only
  * modes are filtered out when Eliza Cloud is not connected. When a global
  * `channelMode` lens is given, declared modes classified into the *other* lens
- * are filtered out too (unclassified modes are lens-neutral and always kept, as
- * is the injected plugin-managed account-inventory mode).
+ * are filtered out too. The plugin-managed inventory follows its catalog role:
+ * OWNER → Delegate, AGENT → Bot, and TEAM/unclassified remains lens-neutral.
  */
 export function getConnectorModes(
   connectorId: string,
@@ -73,7 +83,7 @@ export function getConnectorModes(
       descriptionKey: mode.descriptionKey,
       managementMode: mode.managementMode,
     }));
-  return withPluginManagedMode(connectorId, modes);
+  return withPluginManagedMode(connectorId, modes, lens);
 }
 
 /**

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
@@ -10,7 +10,6 @@ import {
   type ConnectorManagementMode,
   connectorAccountManagementPanelPluginId,
   getConnectorPluginManagedAccountOption,
-  getConnectorPluginManagedChannelMode,
 } from "./connector-account-options";
 import type { ConnectorChannelMode } from "./connector-channel-mode";
 import { getDeclaredConnectorModes } from "./connector-mode-registry";
@@ -27,18 +26,9 @@ export type ConnectorMode = {
 function withPluginManagedMode(
   connectorId: string,
   modes: ConnectorMode[],
-  channelMode?: ConnectorChannelMode,
 ): ConnectorMode[] {
   const option = getConnectorPluginManagedAccountOption(connectorId);
-  const managedChannelMode = getConnectorPluginManagedChannelMode(connectorId);
-  if (
-    !option ||
-    (channelMode !== undefined &&
-      managedChannelMode !== undefined &&
-      managedChannelMode !== channelMode)
-  ) {
-    return modes;
-  }
+  if (!option) return modes;
   return [
     {
       id: CONNECTOR_PLUGIN_MANAGED_MODE_ID,
@@ -55,8 +45,8 @@ function withPluginManagedMode(
  * the connector plugin declared in the connector-mode registry. Cloud-only
  * modes are filtered out when Eliza Cloud is not connected. When a global
  * `channelMode` lens is given, declared modes classified into the *other* lens
- * are filtered out too. The plugin-managed inventory follows its catalog role:
- * OWNER → Delegate, AGENT → Bot, and TEAM/unclassified remains lens-neutral.
+ * are filtered out too. Plugin-managed inventory remains available in either
+ * lens because its panel filters stored records by their actual account role.
  */
 export function getConnectorModes(
   connectorId: string,
@@ -83,7 +73,7 @@ export function getConnectorModes(
       descriptionKey: mode.descriptionKey,
       managementMode: mode.managementMode,
     }));
-  return withPluginManagedMode(connectorId, modes, lens);
+  return withPluginManagedMode(connectorId, modes);
 }
 
 /**

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.hooks.ts
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.hooks.ts
@@ -10,14 +10,20 @@ import {
   getDefaultConnectorModeId,
   modeToSetupPluginId,
 } from "./ConnectorModeSelector.helpers";
+import type { ConnectorChannelMode } from "./connector-channel-mode";
 
 /**
  * Hook to manage connector mode state. Reads initial mode from config
- * or defaults to the first available mode.
+ * or defaults to the first available mode. When the available mode list
+ * changes (Eliza Cloud connects, the global channel-mode lens flips) a
+ * selection that is no longer offered re-defaults automatically.
  */
 export function useConnectorMode(
   connectorId: string,
-  options?: { elizaCloudConnected?: boolean },
+  options?: {
+    elizaCloudConnected?: boolean;
+    channelMode?: ConnectorChannelMode;
+  },
 ) {
   const modes = getConnectorModes(connectorId, options);
   const defaultMode = getDefaultConnectorModeId(connectorId, modes);

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.tsx
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.tsx
@@ -8,6 +8,7 @@
 import { useAppSelector } from "../../state";
 import { Button } from "../ui/button";
 import { getConnectorModes } from "./ConnectorModeSelector.helpers";
+import type { ConnectorChannelMode } from "./connector-channel-mode";
 
 export type { ConnectorMode } from "./ConnectorModeSelector.helpers";
 
@@ -16,14 +17,20 @@ export function ConnectorModeSelector({
   selectedMode,
   onModeChange,
   elizaCloudConnected,
+  channelMode,
 }: {
   connectorId: string;
   selectedMode: string;
   onModeChange: (modeId: string) => void;
   elizaCloudConnected?: boolean;
+  /** Global channel-mode lens; filters out modes classified into the other lens. */
+  channelMode?: ConnectorChannelMode;
 }) {
   const t = useAppSelector((s) => s.t);
-  const modes = getConnectorModes(connectorId, { elizaCloudConnected });
+  const modes = getConnectorModes(connectorId, {
+    elizaCloudConnected,
+    channelMode,
+  });
 
   if (modes.length <= 1) return null;
 

--- a/packages/ui/src/components/connectors/ConnectorQrPairingOverlay.test.tsx
+++ b/packages/ui/src/components/connectors/ConnectorQrPairingOverlay.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Verifies the shared Signal/WhatsApp QR pairing surface uses the connector
+ * detail action-row contract in deterministic idle and connected states.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../state", () => ({
+  useAppSelector: (
+    selector: (state: { t: (key: string) => string }) => unknown,
+  ) => selector({ t: (key) => key }),
+}));
+
+import { ConnectorQrPairingOverlay } from "./ConnectorQrPairingOverlay";
+
+const baseProps = {
+  connectorName: "Signal",
+  qrDataUrl: null,
+  phoneNumber: null,
+  error: null,
+  onStartPairing: vi.fn(),
+  onStopPairing: vi.fn(),
+  onDisconnect: vi.fn(),
+  idleDescription: "Pair Signal from Signal Desktop.",
+  connectLabel: "Connect Signal",
+  tryAgainLabel: "Try again",
+  timeoutMessage: "Pairing timed out.",
+  defaultErrorMessage: "Pairing failed.",
+  qrAlt: "Signal QR code",
+  generatingLabel: "Generating QR…",
+  scanTitle: "Scan with Signal Desktop",
+  steps: [],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ConnectorQrPairingOverlay", () => {
+  it("renders idle copy on the left and the primary connect action on the right", () => {
+    render(<ConnectorQrPairingOverlay {...baseProps} status="idle" />);
+
+    const button = screen.getByRole("button", { name: "Connect Signal" });
+    const actionRail = button.parentElement;
+
+    expect(button.className).toContain("bg-accent");
+    expect(actionRail?.previousElementSibling?.textContent).toContain(
+      "Pair Signal from Signal Desktop.",
+    );
+
+    fireEvent.click(button);
+    expect(baseProps.onStartPairing).toHaveBeenCalledOnce();
+  });
+
+  it("keeps disconnect as the trailing action after pairing", () => {
+    render(
+      <ConnectorQrPairingOverlay
+        {...baseProps}
+        status="connected"
+        phoneNumber="5550100"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "common.disconnect" });
+    expect(button.parentElement?.previousElementSibling?.textContent).toContain(
+      "common.connected (5550100)",
+    );
+
+    fireEvent.click(button);
+    expect(baseProps.onDisconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/components/connectors/ConnectorQrPairingOverlay.tsx
+++ b/packages/ui/src/components/connectors/ConnectorQrPairingOverlay.tsx
@@ -9,6 +9,7 @@
 import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import { useAppSelector } from "../../state";
+import { PagePanel } from "../composites/page-panel";
 import { Button } from "../ui/button";
 
 type ConnectorPairingStatus =
@@ -97,86 +98,81 @@ export function ConnectorQrPairingOverlay({
 
   if (status === "connected") {
     return (
-      <div className="mt-3 border border-ok bg-[var(--ok-subtle)] p-4">
-        <div className="flex items-center gap-2">
-          <span className="inline-block h-2 w-2 rounded-full bg-ok" />
-          <span className="text-xs font-medium text-ok">
-            {t("common.connected")}
-            {phoneNumber ? ` (${connectedPhonePrefix}${phoneNumber})` : ""}
-          </span>
+      <PagePanel.Notice
+        tone="accent"
+        actions={
+          !onConnected ? (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => void onDisconnect()}
+            >
+              {t("common.disconnect")}
+            </Button>
+          ) : undefined
+        }
+      >
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 text-xs font-semibold text-ok">
+            <span className="inline-block h-2 w-2 rounded-full bg-ok" />
+            <span>
+              {t("common.connected")}
+              {phoneNumber ? ` (${connectedPhonePrefix}${phoneNumber})` : ""}
+            </span>
+          </div>
+          <p className="text-xs-tight text-muted">
+            {connectedMessage ??
+              (onConnected
+                ? `Finishing ${connectorName} setup...`
+                : `${connectorName} is paired. Auth state is saved for automatic reconnection.`)}
+          </p>
         </div>
-        <div className="mt-1 text-2xs text-muted">
-          {connectedMessage ??
-            (onConnected
-              ? `Finishing ${connectorName} setup...`
-              : `${connectorName} is paired. Auth state is saved for automatic reconnection.`)}
-        </div>
-        {!onConnected ? (
-          <Button
-            variant="destructive"
-            size="sm"
-            className="mt-2 text-2xs"
-            onClick={() => void onDisconnect()}
-          >
-            {t("common.disconnect")}
-          </Button>
-        ) : null}
-      </div>
+      </PagePanel.Notice>
     );
   }
 
   if (status === "error" || status === "timeout") {
     return (
-      <div className="mt-3 border border-danger bg-[var(--destructive-subtle)] p-4">
-        <div className="mb-2 text-xs text-danger">
+      <PagePanel.Notice
+        tone="danger"
+        actions={
+          <Button variant="default" size="sm" onClick={start}>
+            {tryAgainLabel}
+          </Button>
+        }
+      >
+        <p className="text-xs-tight">
           {status === "timeout"
             ? timeoutMessage
             : (error ?? defaultErrorMessage)}
-        </div>
-        <Button
-          variant="outline"
-          size="sm"
-          className="text-xs-tight"
-          style={{ borderColor: "var(--accent)", color: "var(--accent)" }}
-          onClick={start}
-        >
-          {tryAgainLabel}
-        </Button>
-      </div>
+        </p>
+      </PagePanel.Notice>
     );
   }
 
   if (status === "idle" || status === "disconnected") {
     return (
-      <div className="mt-3 border border-border bg-bg-hover p-4">
-        <div className="mb-2 text-xs text-muted">{idleDescription}</div>
-        {idleDetail ? (
-          <div className="mb-2 text-2xs text-muted opacity-70">
-            {idleDetail}
-          </div>
-        ) : null}
-        {error ? <div className="mb-2 text-xs text-danger">{error}</div> : null}
-        <Button
-          variant="outline"
-          size="sm"
-          className="text-xs-tight"
-          style={{ borderColor: "var(--accent)", color: "var(--accent)" }}
-          onClick={start}
-        >
-          {connectLabel}
-        </Button>
-      </div>
+      <PagePanel.Notice
+        tone={error ? "danger" : "default"}
+        actions={
+          <Button variant="default" size="sm" onClick={start}>
+            {connectLabel}
+          </Button>
+        }
+      >
+        <div className="space-y-1">
+          <p className="text-xs-tight text-muted">{idleDescription}</p>
+          {idleDetail ? (
+            <p className="text-2xs text-muted">{idleDetail}</p>
+          ) : null}
+          {error ? <p className="text-xs text-danger">{error}</p> : null}
+        </div>
+      </PagePanel.Notice>
     );
   }
 
   return (
-    <div
-      className="mt-3 p-4"
-      style={{
-        border: "1px solid rgba(255,255,255,0.08)",
-        background: "rgba(255,255,255,0.04)",
-      }}
-    >
+    <div className="rounded-sm border border-border/60 bg-card/60 p-4">
       <div className="flex flex-col items-start gap-4 sm:flex-row">
         <div className="shrink-0">
           {qrDataUrl ? (

--- a/packages/ui/src/components/connectors/ConnectorSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/ConnectorSetupPanel.tsx
@@ -7,7 +7,6 @@
 
 import { getBootConfig } from "../../config/boot-config";
 import { BlueBubblesStatusPanel } from "./BlueBubblesStatusPanel";
-import { ConnectorAccountList } from "./ConnectorAccountList";
 import { ConnectorAccountSetupScope } from "./ConnectorAccountSetupScope";
 import {
   connectorSetupRegistry,
@@ -18,9 +17,11 @@ import {
   getConnectorPluginManagedAccountOption,
   parseConnectorAccountManagementPanelPluginId,
 } from "./connector-account-options";
+import { useConnectorChannelMode } from "./connector-channel-mode";
 import { resolveConnectorSetupPanelToken } from "./connector-setup-panel-registry";
 import { DiscordLocalConnectorPanel } from "./DiscordLocalConnectorPanel";
 import { IMessageStatusPanel } from "./IMessageStatusPanel";
+import { OwnerAgentConnectorSetupPanel } from "./OwnerAgentConnectorSetupPanel";
 import { SignalQrOverlay } from "./SignalQrOverlay";
 import { TelegramAccountConnectorPanel } from "./TelegramAccountConnectorPanel";
 import { TelegramBotSetupPanel } from "./TelegramBotSetupPanel";
@@ -33,19 +34,25 @@ function ConnectorAccountManagementPanel({
   provider: string;
   connectorId: string;
 }) {
+  const channelMode = useConnectorChannelMode();
   const option =
     getConnectorPluginManagedAccountOption(connectorId) ??
     getConnectorPluginManagedAccountOption(provider);
   const createInput = option?.supportsOAuth
     ? undefined
-    : () => getConnectorPluginManagedAccountCreateInput(connectorId);
+    : getConnectorPluginManagedAccountCreateInput(connectorId);
 
   return (
-    <ConnectorAccountList
+    <OwnerAgentConnectorSetupPanel
       provider={provider}
       connectorId={connectorId}
-      title={option?.title ?? "Plugin-managed accounts"}
-      onAddAccount={createInput}
+      enableOwner={channelMode === "delegate"}
+      enableAgent={channelMode === "bot"}
+      enableTeam
+      description={option?.description}
+      onAddAccount={
+        createInput ? (role) => ({ ...createInput, role }) : undefined
+      }
     />
   );
 }

--- a/packages/ui/src/components/connectors/DiscordLocalConnectorPanel.tsx
+++ b/packages/ui/src/components/connectors/DiscordLocalConnectorPanel.tsx
@@ -248,50 +248,12 @@ export function DiscordLocalConnectorPanel() {
   return (
     <PagePanel.Notice
       tone={error ? "danger" : status?.authenticated ? "accent" : "default"}
-      className="mt-4"
-    >
-      <div className="space-y-3 text-xs">
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="font-semibold text-txt">
-            {status?.authenticated
-              ? t("pluginsview.DiscordLocalAuthorized", {
-                  defaultValue: "Discord desktop is authorized.",
-                })
-              : t("pluginsview.DiscordLocalAuthorizePrompt", {
-                  defaultValue:
-                    "Authorize the app against the local Discord desktop app to read notifications, subscribe to channels, and send replies through macOS UI automation.",
-                })}
-          </div>
-          {connectedUser ? (
-            <code className="rounded-sm border border-border/40 bg-bg/60 px-2 py-1 text-xs-tight text-muted-strong">
-              {connectedUser}
-            </code>
-          ) : null}
-        </div>
-
-        {status?.ipcPath ? (
-          <div className="text-muted">
-            {t("pluginsview.DiscordLocalIpcPath", {
-              defaultValue: "Discord IPC socket",
-            })}
-            :{" "}
-            <code className="text-xs-tight text-muted-strong">
-              {status.ipcPath}
-            </code>
-          </div>
-        ) : null}
-
-        {status?.lastError ? (
-          <div className="text-danger">{status.lastError}</div>
-        ) : null}
-        {error ? <div className="text-danger">{error}</div> : null}
-        {saveMessage ? <div className="text-ok">{saveMessage}</div> : null}
-
-        <div className="flex flex-wrap items-center gap-2">
+      actions={
+        <>
           <Button
             variant="outline"
             size="sm"
-            className="h-8 rounded-sm px-4 text-xs-tight font-semibold"
+            className="h-8 rounded-sm px-3 text-xs-tight font-semibold"
             onClick={() => {
               void refreshStatus();
             }}
@@ -301,28 +263,11 @@ export function DiscordLocalConnectorPanel() {
               ? t("common.loading", { defaultValue: "Loading…" })
               : t("common.refresh", { defaultValue: "Refresh" })}
           </Button>
-          <Button
-            variant="default"
-            size="sm"
-            className="h-8 rounded-sm px-4 text-xs-tight font-semibold"
-            onClick={() => {
-              void handleAuthorize();
-            }}
-            disabled={authorizing || !status?.available}
-          >
-            {authorizing
-              ? t("pluginsview.DiscordLocalAuthorizing", {
-                  defaultValue: "Authorizing…",
-                })
-              : t("pluginsview.DiscordLocalAuthorize", {
-                  defaultValue: "Authorize Discord desktop",
-                })}
-          </Button>
           {status?.authenticated ? (
             <Button
               variant="outline"
               size="sm"
-              className="h-8 rounded-sm px-4 text-xs-tight font-semibold"
+              className="h-8 rounded-sm px-3 text-xs-tight font-semibold"
               onClick={() => {
                 void handleDisconnect();
               }}
@@ -334,14 +279,67 @@ export function DiscordLocalConnectorPanel() {
                   })
                 : t("common.disconnect")}
             </Button>
-          ) : null}
+          ) : (
+            <Button
+              variant="default"
+              size="sm"
+              className="h-8 rounded-sm px-3 text-xs-tight font-semibold"
+              onClick={() => {
+                void handleAuthorize();
+              }}
+              disabled={authorizing || !status?.available}
+            >
+              {authorizing
+                ? t("pluginsview.DiscordLocalAuthorizing", {
+                    defaultValue: "Authorizing…",
+                  })
+                : t("pluginsview.DiscordLocalAuthorize", {
+                    defaultValue: "Authorize Discord desktop",
+                  })}
+            </Button>
+          )}
+        </>
+      }
+    >
+      {/* Single dense copy block on the left; actions sit on the right via
+          PagePanel.Notice. No extra title that duplicates the primary button. */}
+      <div className="space-y-1 text-xs">
+        <div className="font-medium leading-snug text-txt">
+          {status?.authenticated
+            ? t("pluginsview.DiscordLocalAuthorized", {
+                defaultValue: "Discord desktop is authorized.",
+              })
+            : t("pluginsview.DiscordLocalAuthorizePrompt", {
+                defaultValue:
+                  "Authorize Eliza against the local Discord desktop app to read notifications, subscribe to channels, and send replies through macOS UI automation.",
+              })}
         </div>
-
+        {connectedUser ? (
+          <code className="inline-flex rounded-sm border border-border/40 bg-bg/60 px-2 py-0.5 text-xs-tight text-muted-strong">
+            {connectedUser}
+          </code>
+        ) : null}
+        {status?.ipcPath ? (
+          <div className="text-muted">
+            {t("pluginsview.DiscordLocalIpcPath", {
+              defaultValue: "Discord IPC socket",
+            })}
+            :{" "}
+            <code className="text-xs-tight text-muted-strong">
+              {status.ipcPath}
+            </code>
+          </div>
+        ) : null}
+        {status?.lastError ? (
+          <div className="text-danger">{status.lastError}</div>
+        ) : null}
+        {error ? <div className="text-danger">{error}</div> : null}
+        {saveMessage ? <div className="text-ok">{saveMessage}</div> : null}
         {!status?.available ? (
           <div className="text-muted">
             {t("pluginsview.DiscordLocalUnavailable", {
               defaultValue:
-                "Save the local Discord client ID and client secret above, enable the connector, and keep the Discord desktop app running on this Mac.",
+                "Save the local Discord client ID and client secret, enable the connector, and keep the Discord desktop app running on this device.",
             })}
           </div>
         ) : null}
@@ -439,11 +437,17 @@ export function DiscordLocalConnectorPanel() {
                     })}
                   </div>
                 )}
-                <div className="flex flex-wrap items-center gap-2">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <span className="text-muted">
+                    {t("pluginsview.DiscordLocalSelectedCount", {
+                      count: selectedChannelIds.length,
+                      defaultValue: "{{count}} selected",
+                    })}
+                  </span>
                   <Button
                     variant="default"
                     size="sm"
-                    className="h-8 rounded-sm px-4 text-xs-tight font-semibold"
+                    className="h-8 shrink-0 rounded-sm px-4 text-xs-tight font-semibold sm:self-end"
                     onClick={() => {
                       void handleSaveSubscriptions();
                     }}
@@ -455,12 +459,6 @@ export function DiscordLocalConnectorPanel() {
                           defaultValue: "Save channel subscriptions",
                         })}
                   </Button>
-                  <span className="text-muted">
-                    {t("pluginsview.DiscordLocalSelectedCount", {
-                      count: selectedChannelIds.length,
-                      defaultValue: "{{count}} selected",
-                    })}
-                  </span>
                 </div>
               </div>
             ) : null}

--- a/packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.test.tsx
+++ b/packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Verifies mixed plugin-managed account records are filtered by their actual
+ * stored role for the active identity lens; deterministic hooks, no backend.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ConnectorAccountRecord } from "../../api/client-agent";
+
+const records: ConnectorAccountRecord[] = [
+  {
+    id: "owner-1",
+    provider: "slack",
+    connectorId: "slack",
+    label: "Owner record",
+    role: "OWNER",
+    status: "connected",
+  },
+  {
+    id: "agent-1",
+    provider: "slack",
+    connectorId: "slack",
+    label: "Agent record",
+    role: "AGENT",
+    status: "connected",
+  },
+  {
+    id: "team-1",
+    provider: "slack",
+    connectorId: "slack",
+    label: "Team record",
+    role: "TEAM",
+    status: "connected",
+  },
+  {
+    id: "unknown-1",
+    provider: "slack",
+    connectorId: "slack",
+    label: "Unknown record",
+    status: "connected",
+  },
+];
+
+vi.mock("../../hooks/useConnectorAccounts", () => ({
+  useConnectorAccounts: () => ({
+    data: { provider: "slack", connectorId: "slack", accounts: records },
+    accounts: records,
+    loading: false,
+    error: null,
+    saving: new Set<string>(),
+    defaultAccountId: null,
+    selectedAccountId: null,
+    selectedAccount: null,
+    effectiveAccountId: null,
+    setSelectedAccountId: vi.fn(),
+    refresh: vi.fn(async () => {}),
+    add: vi.fn(async () => ({ success: true })),
+    startOAuth: vi.fn(async () => ({ success: true })),
+    update: vi.fn(async (_id, body) => ({ ...records[0], ...body })),
+    test: vi.fn(async () => ({ success: true })),
+    refreshAccount: vi.fn(async () => ({ success: true })),
+    remove: vi.fn(async () => ({ success: true })),
+    makeDefault: vi.fn(async () => ({ success: true })),
+  }),
+}));
+
+vi.mock("./ConnectorAccountCard", () => ({
+  ConnectorAccountCard: ({ account }: { account: ConnectorAccountRecord }) => (
+    <div>{account.label}</div>
+  ),
+}));
+
+import { OwnerAgentConnectorSetupPanel } from "./OwnerAgentConnectorSetupPanel";
+
+afterEach(cleanup);
+
+describe("OwnerAgentConnectorSetupPanel", () => {
+  it("shows OWNER plus neutral TEAM/unknown records in Delegate", () => {
+    render(
+      <OwnerAgentConnectorSetupPanel
+        provider="slack"
+        enableOwner
+        enableAgent={false}
+        enableTeam
+      />,
+    );
+
+    expect(screen.getByText("Owner record")).toBeTruthy();
+    expect(screen.queryByText("Agent record")).toBeNull();
+    expect(screen.getByText("Team record")).toBeTruthy();
+    expect(screen.getByText("Unknown record")).toBeTruthy();
+  });
+
+  it("shows AGENT plus neutral TEAM/unknown records in Bot", () => {
+    render(
+      <OwnerAgentConnectorSetupPanel
+        provider="slack"
+        enableOwner={false}
+        enableAgent
+        enableTeam
+      />,
+    );
+
+    expect(screen.queryByText("Owner record")).toBeNull();
+    expect(screen.getByText("Agent record")).toBeTruthy();
+    expect(screen.getByText("Team record")).toBeTruthy();
+    expect(screen.getByText("Unknown record")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx
@@ -17,6 +17,10 @@
  * this component for an AGENT-only flow while keeping the dual-role shape.
  */
 
+import type {
+  ConnectorAccountCreateInput,
+  ConnectorAccountRole,
+} from "../../api/client-agent";
 import { useConnectorAccounts } from "../../hooks/useConnectorAccounts";
 import { cn } from "../../lib/utils";
 import {
@@ -33,6 +37,15 @@ export interface OwnerAgentConnectorSetupPanelProps {
   enableOwner?: boolean;
   /** When false, the AGENT section is hidden (e.g. owner-only connector). */
   enableAgent?: boolean;
+  /** TEAM accounts are identity-neutral and may appear in either lens. */
+  enableTeam?: boolean;
+  /** Optional non-OAuth account factory; OAuth lists use their normal flow. */
+  onAddAccount?: (
+    role: ConnectorAccountRole,
+  ) =>
+    | Promise<ConnectorAccountCreateInput | undefined>
+    | ConnectorAccountCreateInput
+    | undefined;
   ownerTitle?: string;
   agentTitle?: string;
   /** Optional help text rendered above the two sections. */
@@ -46,6 +59,8 @@ export function OwnerAgentConnectorSetupPanel({
   pollMs,
   enableOwner = true,
   enableAgent = true,
+  enableTeam = false,
+  onAddAccount,
   ownerTitle,
   agentTitle,
   description,
@@ -76,6 +91,7 @@ export function OwnerAgentConnectorSetupPanel({
           accountRole="OWNER"
           title={ownerTitle}
           externalAccounts={accountsHook}
+          onAddAccount={onAddAccount ? () => onAddAccount("OWNER") : undefined}
         />
       ) : null}
       {enableAgent ? (
@@ -85,6 +101,16 @@ export function OwnerAgentConnectorSetupPanel({
           accountRole="AGENT"
           title={agentTitle}
           externalAccounts={accountsHook}
+          onAddAccount={onAddAccount ? () => onAddAccount("AGENT") : undefined}
+        />
+      ) : null}
+      {enableTeam ? (
+        <ConnectorAccountList
+          provider={provider}
+          connectorId={connectorId}
+          accountRole="TEAM"
+          externalAccounts={accountsHook}
+          onAddAccount={onAddAccount ? () => onAddAccount("TEAM") : undefined}
         />
       ) : null}
       {hasUnknownRoleAccounts ? (

--- a/packages/ui/src/components/connectors/TelegramBotSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/TelegramBotSetupPanel.tsx
@@ -84,8 +84,23 @@ export function TelegramBotSetupPanel() {
 
   if (status === "connected" && botInfo) {
     return (
-      <PagePanel.Notice tone="accent" className="mt-4">
-        <div className="space-y-2 text-xs">
+      <PagePanel.Notice
+        tone="accent"
+        className="mt-4"
+        actions={
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 rounded-sm px-4 text-xs-tight font-semibold"
+            onClick={() => {
+              void disconnect();
+            }}
+          >
+            {t("common.disconnect", { defaultValue: "Disconnect" })}
+          </Button>
+        }
+      >
+        <div className="space-y-1 text-xs">
           <div className="font-semibold text-txt">
             {t("pluginsview.TelegramConnected", {
               defaultValue: "Telegram bot connected",
@@ -99,16 +114,6 @@ export function TelegramBotSetupPanel() {
                 "Your bot is saved and will auto-connect on next start. Enable the Telegram plugin above if it isn't already active.",
             })}
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8 rounded-sm px-4 text-xs-tight font-semibold"
-            onClick={() => {
-              void disconnect();
-            }}
-          >
-            {t("common.disconnect", { defaultValue: "Disconnect" })}
-          </Button>
         </div>
       </PagePanel.Notice>
     );
@@ -118,72 +123,73 @@ export function TelegramBotSetupPanel() {
     <PagePanel.Notice
       tone={status === "error" ? "danger" : "default"}
       className="mt-4"
+      actions={
+        <Button
+          variant="default"
+          size="sm"
+          className="h-8 rounded-sm px-4 text-xs-tight font-semibold"
+          onClick={() => {
+            void validateAndSave();
+          }}
+          disabled={status === "validating" || !token.trim()}
+        >
+          {status === "validating"
+            ? t("common.validating", { defaultValue: "Validating\u2026" })
+            : t("common.connect", { defaultValue: "Connect" })}
+        </Button>
+      }
     >
       <div className="space-y-3 text-xs">
-        <div className="font-semibold text-txt">
-          {t("pluginsview.TelegramSetupTitle", {
-            defaultValue: "Connect a Telegram Bot",
-          })}
+        <div className="space-y-1">
+          <div className="font-semibold text-txt">
+            {t("pluginsview.TelegramSetupTitle", {
+              defaultValue: "Connect a Telegram Bot",
+            })}
+          </div>
+          <ol className="list-inside list-decimal space-y-1 text-muted">
+            <li>
+              {t("common.open", {
+                defaultValue: "Open ",
+              })}
+              <a
+                href="https://t.me/BotFather"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-accent underline"
+              >
+                @BotFather
+              </a>
+              {t("pluginsview.TelegramStep1b", {
+                defaultValue: " on Telegram",
+              })}
+            </li>
+            <li>
+              {t("pluginsview.TelegramStep2", {
+                defaultValue:
+                  "Send /newbot and follow the prompts to create your bot",
+              })}
+            </li>
+            <li>
+              {t("pluginsview.TelegramStep3", {
+                defaultValue: "Copy the bot token and paste it below",
+              })}
+            </li>
+          </ol>
         </div>
 
-        <ol className="list-inside list-decimal space-y-1 text-muted">
-          <li>
-            {t("common.open", {
-              defaultValue: "Open ",
-            })}
-            <a
-              href="https://t.me/BotFather"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-accent underline"
-            >
-              @BotFather
-            </a>
-            {t("pluginsview.TelegramStep1b", {
-              defaultValue: " on Telegram",
-            })}
-          </li>
-          <li>
-            {t("pluginsview.TelegramStep2", {
-              defaultValue:
-                "Send /newbot and follow the prompts to create your bot",
-            })}
-          </li>
-          <li>
-            {t("pluginsview.TelegramStep3", {
-              defaultValue: "Copy the bot token and paste it below",
-            })}
-          </li>
-        </ol>
-
-        <div className="flex items-center gap-2">
-          <Input
-            type="password"
-            value={token}
-            onChange={(e) => {
-              setToken(e.target.value);
-              if (status === "error") setStatus("idle");
-            }}
-            placeholder="123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
-            className="h-8 flex-1 rounded-sm border border-border/50 bg-bg/70 px-3 text-xs-tight text-txt placeholder:text-muted/50  "
-            onKeyDown={(e) => {
-              if (e.key === "Enter") void validateAndSave();
-            }}
-          />
-          <Button
-            variant="default"
-            size="sm"
-            className="h-8 rounded-sm px-4 text-xs-tight font-semibold"
-            onClick={() => {
-              void validateAndSave();
-            }}
-            disabled={status === "validating" || !token.trim()}
-          >
-            {status === "validating"
-              ? t("common.validating", { defaultValue: "Validating\u2026" })
-              : t("common.connect", { defaultValue: "Connect" })}
-          </Button>
-        </div>
+        <Input
+          type="password"
+          value={token}
+          onChange={(e) => {
+            setToken(e.target.value);
+            if (status === "error") setStatus("idle");
+          }}
+          placeholder="123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+          className="h-8 w-full rounded-sm border border-border/50 bg-bg/70 px-3 text-xs-tight text-txt placeholder:text-muted/50"
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void validateAndSave();
+          }}
+        />
 
         {error ? <div className="text-danger">{error}</div> : null}
       </div>

--- a/packages/ui/src/components/connectors/connector-account-options.ts
+++ b/packages/ui/src/components/connectors/connector-account-options.ts
@@ -24,7 +24,6 @@ import type {
   ConnectorAccountPurpose,
   ConnectorAccountRole,
 } from "../../api/client-agent";
-import type { ConnectorChannelMode } from "./connector-channel-mode";
 
 export interface ConnectorAccountOption<T extends string> {
   value: T;
@@ -229,17 +228,6 @@ export function hasConnectorPluginManagedAccounts(
   connectorId: string | undefined,
 ): boolean {
   return getConnectorPluginManagedAccountOption(connectorId) !== null;
-}
-
-/** Maps account ownership to the connector lens that may manage that account. */
-export function getConnectorPluginManagedChannelMode(
-  connectorId: string | undefined,
-): ConnectorChannelMode | undefined {
-  const role = getConnectorPluginManagedAccountOption(connectorId)?.defaultRole;
-  if (role === "OWNER") return "delegate";
-  if (role === "AGENT") return "bot";
-  // TEAM has no single owner/bot identity, so it remains lens-neutral.
-  return undefined;
 }
 
 export function connectorAccountManagementPanelPluginId(

--- a/packages/ui/src/components/connectors/connector-account-options.ts
+++ b/packages/ui/src/components/connectors/connector-account-options.ts
@@ -24,6 +24,7 @@ import type {
   ConnectorAccountPurpose,
   ConnectorAccountRole,
 } from "../../api/client-agent";
+import type { ConnectorChannelMode } from "./connector-channel-mode";
 
 export interface ConnectorAccountOption<T extends string> {
   value: T;
@@ -228,6 +229,17 @@ export function hasConnectorPluginManagedAccounts(
   connectorId: string | undefined,
 ): boolean {
   return getConnectorPluginManagedAccountOption(connectorId) !== null;
+}
+
+/** Maps account ownership to the connector lens that may manage that account. */
+export function getConnectorPluginManagedChannelMode(
+  connectorId: string | undefined,
+): ConnectorChannelMode | undefined {
+  const role = getConnectorPluginManagedAccountOption(connectorId)?.defaultRole;
+  if (role === "OWNER") return "delegate";
+  if (role === "AGENT") return "bot";
+  // TEAM has no single owner/bot identity, so it remains lens-neutral.
+  return undefined;
 }
 
 export function connectorAccountManagementPanelPluginId(

--- a/packages/ui/src/components/connectors/connector-channel-mode.test.ts
+++ b/packages/ui/src/components/connectors/connector-channel-mode.test.ts
@@ -101,6 +101,25 @@ describe("getConnectorModes channel-mode filtering", () => {
     }
   });
 
+  it("applies the same fallback lens policy to catalog-backed detail modes", () => {
+    // Google is Delegate-only via fallback + catalog plugin-managed inventory.
+    // Index classification and getConnectorModes must agree so a Bot deep link
+    // cannot expose plugin-managed / AGENT inventory under the wrong lens.
+    expect(connectorSupportsChannelMode("google", "delegate")).toBe(true);
+    expect(connectorSupportsChannelMode("google", "bot")).toBe(false);
+
+    const delegateIds = getConnectorModes("google", {
+      channelMode: "delegate",
+    }).map((mode) => mode.id);
+    const botIds = getConnectorModes("google", { channelMode: "bot" }).map(
+      (mode) => mode.id,
+    );
+
+    expect(delegateIds).toContain("plugin-managed");
+    expect(botIds).not.toContain("plugin-managed");
+    expect(botIds).toEqual([]);
+  });
+
   it("hides delegate-only QR settings from WhatsApp Business mode", () => {
     expect(getConnectorModeHiddenConfigKeys("whatsapp", "business")).toEqual([
       "WHATSAPP_AUTH_METHOD",

--- a/packages/ui/src/components/connectors/connector-channel-mode.test.ts
+++ b/packages/ui/src/components/connectors/connector-channel-mode.test.ts
@@ -13,7 +13,10 @@ import {
   getConnectorChannelMode,
   setConnectorChannelMode,
 } from "./connector-channel-mode";
-import { connectorSupportsChannelMode } from "./connector-mode-registry";
+import {
+  connectorSupportsChannelMode,
+  getConnectorModeHiddenConfigKeys,
+} from "./connector-mode-registry";
 
 afterEach(() => {
   setConnectorChannelMode("delegate");
@@ -32,11 +35,11 @@ describe("connector channel-mode store", () => {
 });
 
 describe("connectorSupportsChannelMode", () => {
-  it("classifies bot-only connectors out of the delegate lens", () => {
-    // Slack declares only bot-identity modes (OAuth workspace bot, socket
-    // tokens) — no way for the agent to act as the owner.
+  it("includes role-classified plugin-managed identities", () => {
+    // Slack's declared app-token modes are bots, while its account catalog also
+    // exposes an OWNER OAuth inventory under Delegate.
     expect(connectorSupportsChannelMode("slack", "bot")).toBe(true);
-    expect(connectorSupportsChannelMode("slack", "delegate")).toBe(false);
+    expect(connectorSupportsChannelMode("slack", "delegate")).toBe(true);
   });
 
   it("classifies delegate-only connectors out of the bot lens", () => {
@@ -88,13 +91,33 @@ describe("getConnectorModes channel-mode filtering", () => {
     expect(bot).not.toContain("account");
   });
 
-  it("keeps the injected plugin-managed account mode under both lenses", () => {
-    for (const channelMode of ["delegate", "bot"] as const) {
-      const ids = getConnectorModes("telegram", { channelMode }).map(
-        (mode) => mode.id,
-      );
-      expect(ids).toContain("plugin-managed");
-    }
+  it("filters plugin-managed modes by their catalog account role", () => {
+    const telegramDelegate = getConnectorModes("telegram", {
+      channelMode: "delegate",
+    }).map((mode) => mode.id);
+    const telegramBot = getConnectorModes("telegram", {
+      channelMode: "bot",
+    }).map((mode) => mode.id);
+    const slackDelegate = getConnectorModes("slack", {
+      channelMode: "delegate",
+    }).map((mode) => mode.id);
+    const slackBot = getConnectorModes("slack", {
+      channelMode: "bot",
+    }).map((mode) => mode.id);
+
+    expect(telegramDelegate).not.toContain("plugin-managed");
+    expect(telegramBot).toContain("plugin-managed");
+    expect(slackDelegate).toContain("plugin-managed");
+    expect(slackBot).not.toContain("plugin-managed");
+  });
+
+  it("hides delegate-only QR settings from WhatsApp Business mode", () => {
+    expect(getConnectorModeHiddenConfigKeys("whatsapp", "business")).toEqual([
+      "WHATSAPP_AUTH_METHOD",
+      "WHATSAPP_AUTH_DIR",
+      "WHATSAPP_PRINT_QR",
+    ]);
+    expect(getConnectorModeHiddenConfigKeys("whatsapp", "qr")).toEqual([]);
   });
 
   it("leaves the mode list unfiltered when no lens is given", () => {

--- a/packages/ui/src/components/connectors/connector-channel-mode.test.ts
+++ b/packages/ui/src/components/connectors/connector-channel-mode.test.ts
@@ -1,0 +1,108 @@
+/** Verifies the connector channel-mode lens through the package's configured test harness. */
+// @vitest-environment jsdom
+/**
+ * Covers the localStorage-backed Delegate/Bot lens store and how the lens
+ * filters the connector-mode registry: per-connector support, per-mode
+ * filtering in `getConnectorModes`, and lens-neutrality of unclassified
+ * connectors. In-memory registry + jsdom localStorage, no runtime.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { getConnectorModes } from "./ConnectorModeSelector.helpers";
+import {
+  getConnectorChannelMode,
+  setConnectorChannelMode,
+} from "./connector-channel-mode";
+import { connectorSupportsChannelMode } from "./connector-mode-registry";
+
+afterEach(() => {
+  setConnectorChannelMode("delegate");
+  window.localStorage.clear();
+});
+
+describe("connector channel-mode store", () => {
+  it("defaults to delegate and persists an explicit choice", () => {
+    expect(getConnectorChannelMode()).toBe("delegate");
+    setConnectorChannelMode("bot");
+    expect(getConnectorChannelMode()).toBe("bot");
+    expect(window.localStorage.getItem("eliza:connectors:channelMode")).toBe(
+      "bot",
+    );
+  });
+});
+
+describe("connectorSupportsChannelMode", () => {
+  it("classifies bot-only connectors out of the delegate lens", () => {
+    // Slack declares only bot-identity modes (OAuth workspace bot, socket
+    // tokens) — no way for the agent to act as the owner.
+    expect(connectorSupportsChannelMode("slack", "bot")).toBe(true);
+    expect(connectorSupportsChannelMode("slack", "delegate")).toBe(false);
+  });
+
+  it("classifies delegate-only connectors out of the bot lens", () => {
+    // Signal's single mode links a device to the owner's own account.
+    expect(connectorSupportsChannelMode("signal", "delegate")).toBe(true);
+    expect(connectorSupportsChannelMode("signal", "bot")).toBe(false);
+  });
+
+  it("keeps dual-identity connectors in both lenses", () => {
+    for (const connector of ["discord", "telegram", "whatsapp", "imessage"]) {
+      expect(connectorSupportsChannelMode(connector, "delegate")).toBe(true);
+      expect(connectorSupportsChannelMode(connector, "bot")).toBe(true);
+    }
+  });
+
+  it("classifies single-form connectors through the registered fallback", () => {
+    // Bluesky's credential form configures the agent's own account → bot only.
+    expect(connectorSupportsChannelMode("bluesky", "bot")).toBe(true);
+    expect(connectorSupportsChannelMode("bluesky", "delegate")).toBe(false);
+    // Instagram credentials are the owner's own account → delegate only.
+    expect(connectorSupportsChannelMode("instagram", "delegate")).toBe(true);
+    expect(connectorSupportsChannelMode("instagram", "bot")).toBe(false);
+  });
+
+  it("treats unknown connectors with no declared modes as lens-neutral", () => {
+    expect(connectorSupportsChannelMode("acmechat-unknown", "delegate")).toBe(
+      true,
+    );
+    expect(connectorSupportsChannelMode("acmechat-unknown", "bot")).toBe(true);
+  });
+});
+
+describe("getConnectorModes channel-mode filtering", () => {
+  it("keeps only the lens's modes for a dual-identity connector", () => {
+    const delegate = getConnectorModes("telegram", {
+      elizaCloudConnected: true,
+      channelMode: "delegate",
+    }).map((mode) => mode.id);
+    const bot = getConnectorModes("telegram", {
+      elizaCloudConnected: true,
+      channelMode: "bot",
+    }).map((mode) => mode.id);
+
+    expect(delegate).toContain("account");
+    expect(delegate).not.toContain("bot");
+    expect(delegate).not.toContain("cloud-bot");
+    expect(bot).toContain("bot");
+    expect(bot).toContain("cloud-bot");
+    expect(bot).not.toContain("account");
+  });
+
+  it("keeps the injected plugin-managed account mode under both lenses", () => {
+    for (const channelMode of ["delegate", "bot"] as const) {
+      const ids = getConnectorModes("telegram", { channelMode }).map(
+        (mode) => mode.id,
+      );
+      expect(ids).toContain("plugin-managed");
+    }
+  });
+
+  it("leaves the mode list unfiltered when no lens is given", () => {
+    const ids = getConnectorModes("telegram", {
+      elizaCloudConnected: true,
+    }).map((mode) => mode.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(["account", "bot", "cloud-bot"]),
+    );
+  });
+});

--- a/packages/ui/src/components/connectors/connector-channel-mode.test.ts
+++ b/packages/ui/src/components/connectors/connector-channel-mode.test.ts
@@ -35,17 +35,16 @@ describe("connector channel-mode store", () => {
 });
 
 describe("connectorSupportsChannelMode", () => {
-  it("includes role-classified plugin-managed identities", () => {
-    // Slack's declared app-token modes are bots, while its account catalog also
-    // exposes an OWNER OAuth inventory under Delegate.
+  it("keeps mixed-role plugin-managed inventories in both lenses", () => {
+    // Slack's declared app-token modes are bots, but stored plugin-managed
+    // records can independently be OWNER, AGENT, or TEAM.
     expect(connectorSupportsChannelMode("slack", "bot")).toBe(true);
     expect(connectorSupportsChannelMode("slack", "delegate")).toBe(true);
   });
 
-  it("classifies delegate-only connectors out of the bot lens", () => {
-    // Signal's single mode links a device to the owner's own account.
-    expect(connectorSupportsChannelMode("signal", "delegate")).toBe(true);
-    expect(connectorSupportsChannelMode("signal", "bot")).toBe(false);
+  it("classifies delegate-only connectors without mixed inventory out of Bot", () => {
+    expect(connectorSupportsChannelMode("bluebubbles", "delegate")).toBe(true);
+    expect(connectorSupportsChannelMode("bluebubbles", "bot")).toBe(false);
   });
 
   it("keeps dual-identity connectors in both lenses", () => {
@@ -91,24 +90,15 @@ describe("getConnectorModes channel-mode filtering", () => {
     expect(bot).not.toContain("account");
   });
 
-  it("filters plugin-managed modes by their catalog account role", () => {
-    const telegramDelegate = getConnectorModes("telegram", {
-      channelMode: "delegate",
-    }).map((mode) => mode.id);
-    const telegramBot = getConnectorModes("telegram", {
-      channelMode: "bot",
-    }).map((mode) => mode.id);
-    const slackDelegate = getConnectorModes("slack", {
-      channelMode: "delegate",
-    }).map((mode) => mode.id);
-    const slackBot = getConnectorModes("slack", {
-      channelMode: "bot",
-    }).map((mode) => mode.id);
-
-    expect(telegramDelegate).not.toContain("plugin-managed");
-    expect(telegramBot).toContain("plugin-managed");
-    expect(slackDelegate).toContain("plugin-managed");
-    expect(slackBot).not.toContain("plugin-managed");
+  it("keeps plugin-managed mode available for actual-role filtering", () => {
+    for (const connector of ["telegram", "slack"]) {
+      for (const channelMode of ["delegate", "bot"] as const) {
+        const ids = getConnectorModes(connector, { channelMode }).map(
+          (mode) => mode.id,
+        );
+        expect(ids).toContain("plugin-managed");
+      }
+    }
   });
 
   it("hides delegate-only QR settings from WhatsApp Business mode", () => {

--- a/packages/ui/src/components/connectors/connector-channel-mode.ts
+++ b/packages/ui/src/components/connectors/connector-channel-mode.ts
@@ -1,0 +1,98 @@
+/**
+ * Global connector channel-mode lens (localStorage-backed): whether the
+ * Connectors surface presents connectors as delegate channels (the agent works
+ * inside the owner's own accounts, reading and replying as them) or as bot
+ * channels (the agent has its own bot presence the owner messages from those
+ * platforms). One shared store so the Settings header switch and the section
+ * body stay in sync without context plumbing; persists across reloads.
+ */
+import { useSyncExternalStore } from "react";
+import { shellLocalStorage } from "../../surface-realm-channel";
+
+/**
+ * The two ways a connector channel can relate to the agent:
+ * - `"delegate"` — the agent acts through the owner's own account on the
+ *   platform (personal Telegram, WhatsApp QR pairing, Signal device link,
+ *   iMessage on the owner's number, …).
+ * - `"bot"` — the agent is its own bot identity on the platform (bot tokens,
+ *   OAuth workspace bots, hosted cloud gateways) that the owner chats with.
+ */
+export type ConnectorChannelMode = "delegate" | "bot";
+
+export const CONNECTOR_CHANNEL_MODES: readonly ConnectorChannelMode[] = [
+  "delegate",
+  "bot",
+];
+
+const STORAGE_KEY = "eliza:connectors:channelMode";
+const DEFAULT_MODE: ConnectorChannelMode = "delegate";
+
+const listeners = new Set<() => void>();
+
+function coerce(raw: string | null): ConnectorChannelMode {
+  return raw === "bot" || raw === "delegate" ? raw : DEFAULT_MODE;
+}
+
+function readStorage(): ConnectorChannelMode {
+  if (typeof window === "undefined") return DEFAULT_MODE;
+  try {
+    return coerce(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return DEFAULT_MODE;
+  }
+}
+
+// Cached snapshot: `getSnapshot` runs on every render of every subscriber, so
+// it must return a stable primitive without per-render localStorage I/O.
+let cachedMode = readStorage();
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key !== null && event.key !== STORAGE_KEY) return;
+    const next = readStorage();
+    if (next === cachedMode) return;
+    cachedMode = next;
+    for (const listener of listeners) {
+      listener();
+    }
+  });
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): ConnectorChannelMode {
+  return cachedMode;
+}
+
+function getServerSnapshot(): ConnectorChannelMode {
+  return DEFAULT_MODE;
+}
+
+export function getConnectorChannelMode(): ConnectorChannelMode {
+  return cachedMode;
+}
+
+export function setConnectorChannelMode(mode: ConnectorChannelMode): void {
+  if (typeof window !== "undefined") {
+    try {
+      shellLocalStorage.setItem(STORAGE_KEY, mode);
+    } catch {
+      // localStorage unavailable (private mode, quota, …) — in-memory only.
+    }
+  }
+  if (mode === cachedMode) return;
+  cachedMode = mode;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** The current lens, subscribed — re-renders when any surface switches it. */
+export function useConnectorChannelMode(): ConnectorChannelMode {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/packages/ui/src/components/connectors/connector-mode-registry.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.ts
@@ -14,6 +14,7 @@ import {
   type ConnectorManagementMode,
   normalizeConnectorCatalogId,
 } from "./connector-account-options";
+import type { ConnectorChannelMode } from "./connector-channel-mode";
 
 /**
  * Declarative description of a single connector setup mode: the metadata a
@@ -52,6 +53,14 @@ export interface ConnectorModeDeclaration {
   setupPluginId: string;
   /** Mode is only offered when Eliza Cloud is connected. */
   cloudOnly?: boolean;
+  /**
+   * Which global channel-mode lens this setup mode belongs to: `"delegate"`
+   * when the agent acts through the owner's own account on the platform, or
+   * `"bot"` when the agent runs as its own bot identity the owner messages.
+   * The Connectors surface filters modes (and connectors) by the active lens.
+   * Omitted = the mode is identity-neutral and shown under both lenses.
+   */
+  channelMode?: ConnectorChannelMode;
   /**
    * UI affordance a cloud-managed gateway mode declares so the connector page
    * renders the right gateway setup surface generically, instead of matching
@@ -214,6 +223,54 @@ export function getConnectorModeConfigFormHint(
     : { fallback: declaration.configFormHint };
 }
 
+/**
+ * Channel-mode classification for connectors with NO declared mode list —
+ * the single-credential-form connectors (bluesky, matrix, msteams, …) whose
+ * whole setup surface belongs to one lens. Keyed by normalized connector id;
+ * a connector plugin can register its own via
+ * {@link registerConnectorChannelModeFallback}. Connectors absent from both
+ * this map and the mode registry stay lens-neutral (shown under both lenses),
+ * the safe default for unknown third-party connectors.
+ */
+const fallbackChannelModes = new Map<string, ConnectorChannelMode>();
+
+export function registerConnectorChannelModeFallback(
+  connectorId: string,
+  channelMode: ConnectorChannelMode,
+): void {
+  fallbackChannelModes.set(
+    normalizeConnectorCatalogId(connectorId),
+    channelMode,
+  );
+}
+
+/**
+ * Whether a connector belongs under the given global channel-mode lens.
+ *
+ * A connector with declared modes matches when any mode is classified into the
+ * lens (a mode omitting `channelMode` is lens-neutral and always matches). A
+ * connector with no declared modes uses its registered fallback classification;
+ * with neither, it shows under both lenses. A connector whose every declared
+ * mode is classified into the *other* lens (e.g. Slack under `"delegate"`,
+ * Signal under `"bot"`) is filtered out of that lens by the Connectors surface.
+ */
+export function connectorSupportsChannelMode(
+  connectorId: string,
+  channelMode: ConnectorChannelMode,
+): boolean {
+  const modes = getDeclaredConnectorModes(connectorId);
+  if (modes.length === 0) {
+    const fallback = fallbackChannelModes.get(
+      normalizeConnectorCatalogId(connectorId),
+    );
+    return fallback === undefined || fallback === channelMode;
+  }
+  return modes.some(
+    (mode) =>
+      mode.channelMode === undefined || mode.channelMode === channelMode,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Built-in connector mode declarations.
 //
@@ -234,6 +291,7 @@ registerConnectorModes("discord", [
     descriptionKey: "connectormode.discord.managed.description",
     managementMode: "cloud-managed",
     setupPluginId: "discord",
+    channelMode: "bot",
     cloudOnly: true,
     cloudGatewaySetup: "managed-agent-picker",
     cloudGatewayProvider: "eliza-cloud-discord",
@@ -246,6 +304,7 @@ registerConnectorModes("discord", [
     descriptionKey: "connectormode.discord.local.description",
     managementMode: "local-setup",
     setupPluginId: "discordlocal",
+    channelMode: "delegate",
   },
   {
     id: "bot",
@@ -256,6 +315,7 @@ registerConnectorModes("discord", [
     descriptionKey: "connectormode.discord.bot.description",
     managementMode: "local-config",
     setupPluginId: "discord",
+    channelMode: "bot",
     defaultPriority: 1,
     configFormHintKey: "settings.sections.connectors.discordAppIdHint",
     configFormHint:
@@ -273,6 +333,7 @@ registerConnectorModes("telegram", [
     descriptionKey: "connectormode.telegram.cloudBot.description",
     managementMode: "cloud-managed",
     setupPluginId: "telegram",
+    channelMode: "bot",
     cloudOnly: true,
     cloudGatewaySetup: "webhook-notice",
   },
@@ -284,6 +345,7 @@ registerConnectorModes("telegram", [
     descriptionKey: "connectormode.telegram.bot.description",
     managementMode: "local-config",
     setupPluginId: "telegram",
+    channelMode: "bot",
     defaultPriority: 1,
   },
   {
@@ -295,6 +357,7 @@ registerConnectorModes("telegram", [
     descriptionKey: "connectormode.telegram.account.description",
     managementMode: "local-setup",
     setupPluginId: "telegramaccount",
+    channelMode: "delegate",
   },
 ]);
 
@@ -308,6 +371,7 @@ registerConnectorModes("slack", [
     descriptionKey: "connectormode.slack.oauth.description",
     managementMode: "cloud-managed",
     setupPluginId: "slack",
+    channelMode: "bot",
     cloudOnly: true,
     defaultPriority: 1,
   },
@@ -320,6 +384,7 @@ registerConnectorModes("slack", [
     descriptionKey: "connectormode.slack.socket.description",
     managementMode: "local-config",
     setupPluginId: "slack",
+    channelMode: "bot",
     defaultPriority: 2,
   },
 ]);
@@ -334,6 +399,7 @@ registerConnectorModes("x", [
     descriptionKey: "connectormode.x.oauth.description",
     managementMode: "cloud-managed",
     setupPluginId: "x",
+    channelMode: "delegate",
     cloudOnly: true,
     defaultPriority: 1,
   },
@@ -346,6 +412,7 @@ registerConnectorModes("x", [
     descriptionKey: "connectormode.x.localOauth.description",
     managementMode: "local-config",
     setupPluginId: "x",
+    channelMode: "delegate",
     defaultPriority: 2,
   },
   {
@@ -357,6 +424,7 @@ registerConnectorModes("x", [
     descriptionKey: "connectormode.x.developer.description",
     managementMode: "local-config",
     setupPluginId: "x",
+    channelMode: "delegate",
   },
 ]);
 
@@ -369,6 +437,7 @@ registerConnectorModes("signal", [
     descriptionKey: "connectormode.signal.qr.description",
     managementMode: "local-setup",
     setupPluginId: "signal",
+    channelMode: "delegate",
   },
 ]);
 
@@ -381,6 +450,7 @@ registerConnectorModes("whatsapp", [
     descriptionKey: "connectormode.whatsapp.qr.description",
     managementMode: "local-setup",
     setupPluginId: "whatsapp",
+    channelMode: "delegate",
   },
   {
     id: "business",
@@ -391,6 +461,7 @@ registerConnectorModes("whatsapp", [
     descriptionKey: "connectormode.whatsapp.business.description",
     managementMode: "local-config",
     setupPluginId: "whatsapp",
+    channelMode: "bot",
   },
 ]);
 
@@ -402,6 +473,7 @@ registerConnectorModes("imessage", [
       "Register a Mac-hosted BlueBubbles relay for your real iPhone number; each sender reaches their own Eliza Cloud agent.",
     managementMode: "cloud-managed",
     setupPluginId: "bluebubbles",
+    channelMode: "delegate",
     cloudOnly: true,
     cloudGatewaySetup: "phone-registration",
     defaultPriority: 0,
@@ -415,6 +487,7 @@ registerConnectorModes("imessage", [
     descriptionKey: "connectormode.imessage.direct.description",
     managementMode: "local-setup",
     setupPluginId: "imessage",
+    channelMode: "delegate",
     defaultPriority: 1,
   },
   {
@@ -426,6 +499,7 @@ registerConnectorModes("imessage", [
     descriptionKey: "connectormode.imessage.bluebubbles.description",
     managementMode: "local-config",
     setupPluginId: "bluebubbles",
+    channelMode: "delegate",
   },
   {
     id: "blooio",
@@ -436,6 +510,7 @@ registerConnectorModes("imessage", [
     descriptionKey: "connectormode.imessage.blooio.description",
     managementMode: "cloud-managed",
     setupPluginId: "blooio",
+    channelMode: "bot",
     cloudOnly: true,
   },
 ]);
@@ -448,6 +523,7 @@ registerConnectorModes("bluebubbles", [
       "Register this Mac/iPhone bridge with Eliza Cloud so each sender reaches their own agent.",
     managementMode: "cloud-managed",
     setupPluginId: "bluebubbles",
+    channelMode: "delegate",
     cloudOnly: true,
     cloudGatewaySetup: "phone-registration",
     defaultPriority: 0,
@@ -459,6 +535,38 @@ registerConnectorModes("bluebubbles", [
       "Connect this app directly to a BlueBubbles server on your local network.",
     managementMode: "local-config",
     setupPluginId: "bluebubbles",
+    channelMode: "delegate",
     defaultPriority: 1,
   },
 ]);
+
+// ---------------------------------------------------------------------------
+// Channel-mode fallbacks for the single-form connectors (no declared mode
+// list). "bot" = the connector configures the agent's own standalone account /
+// bot app that the owner chats with; "delegate" = the credentials are the
+// owner's own account, which the agent works inside. Connectors not listed
+// here (and not in the mode registry) stay visible under both lenses.
+// ---------------------------------------------------------------------------
+
+for (const connectorId of [
+  "bluesky",
+  "farcaster",
+  "nostr",
+  "matrix",
+  "msteams",
+  "mattermost",
+  "google-chat",
+  "feishu",
+  "line",
+  "zalo",
+  "tlon",
+  "nextcloud-talk",
+  "twitch",
+  "blooio",
+]) {
+  registerConnectorChannelModeFallback(connectorId, "bot");
+}
+
+for (const connectorId of ["instagram", "zalouser", "google"]) {
+  registerConnectorChannelModeFallback(connectorId, "delegate");
+}

--- a/packages/ui/src/components/connectors/connector-mode-registry.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.ts
@@ -12,6 +12,8 @@
 
 import {
   type ConnectorManagementMode,
+  getConnectorPluginManagedAccountOption,
+  getConnectorPluginManagedChannelMode,
   normalizeConnectorCatalogId,
 } from "./connector-account-options";
 import type { ConnectorChannelMode } from "./connector-channel-mode";
@@ -99,6 +101,8 @@ export interface ConnectorModeDeclaration {
    */
   configFormHintKey?: string;
   configFormHint?: string;
+  /** Config keys belonging to another setup mode and hidden for this mode. */
+  hiddenConfigKeys?: readonly string[];
   /**
    * Preference rank when picking the default selected mode (lower wins). Ties
    * are broken by declaration order. Modes without a rank are never chosen as
@@ -206,6 +210,17 @@ export interface ConnectorConfigFormHint {
  * is scoped to the modes that declare it, so it does not leak onto an unrelated
  * selected mode.
  */
+export function getConnectorModeHiddenConfigKeys(
+  connectorId: string,
+  modeId: string | null | undefined,
+): readonly string[] {
+  if (!modeId) return [];
+  return (
+    getDeclaredConnectorModes(connectorId).find((mode) => mode.id === modeId)
+      ?.hiddenConfigKeys ?? []
+  );
+}
+
 export function getConnectorModeConfigFormHint(
   connectorId: string,
   modeId: string | null | undefined,
@@ -265,9 +280,17 @@ export function connectorSupportsChannelMode(
     );
     return fallback === undefined || fallback === channelMode;
   }
-  return modes.some(
+  const declaredModeMatches = modes.some(
     (mode) =>
       mode.channelMode === undefined || mode.channelMode === channelMode,
+  );
+  const hasManagedMode =
+    getConnectorPluginManagedAccountOption(connectorId) !== null;
+  const managedMode = getConnectorPluginManagedChannelMode(connectorId);
+  return (
+    declaredModeMatches ||
+    (hasManagedMode &&
+      (managedMode === undefined || managedMode === channelMode))
   );
 }
 
@@ -462,6 +485,11 @@ registerConnectorModes("whatsapp", [
     managementMode: "local-config",
     setupPluginId: "whatsapp",
     channelMode: "bot",
+    hiddenConfigKeys: [
+      "WHATSAPP_AUTH_METHOD",
+      "WHATSAPP_AUTH_DIR",
+      "WHATSAPP_PRINT_QR",
+    ],
   },
 ]);
 

--- a/packages/ui/src/components/connectors/connector-mode-registry.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.ts
@@ -13,7 +13,6 @@
 import {
   type ConnectorManagementMode,
   getConnectorPluginManagedAccountOption,
-  getConnectorPluginManagedChannelMode,
   normalizeConnectorCatalogId,
 } from "./connector-account-options";
 import type { ConnectorChannelMode } from "./connector-channel-mode";
@@ -286,12 +285,7 @@ export function connectorSupportsChannelMode(
   );
   const hasManagedMode =
     getConnectorPluginManagedAccountOption(connectorId) !== null;
-  const managedMode = getConnectorPluginManagedChannelMode(connectorId);
-  return (
-    declaredModeMatches ||
-    (hasManagedMode &&
-      (managedMode === undefined || managedMode === channelMode))
-  );
+  return declaredModeMatches || hasManagedMode;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/components/connectors/connector-ui-groups.ts
+++ b/packages/ui/src/components/connectors/connector-ui-groups.ts
@@ -1,0 +1,117 @@
+/**
+ * Client-side Connectors index grouping. Explicit catalog (not id heuristics):
+ * every first-party connector is assigned a group; unknowns fall through to
+ * Other. When the plugins API gains `connectorSubtype`, replace this map with
+ * the wire field — until then the index still matches the Devin-style grouped
+ * list without inventing groups from name substrings.
+ */
+
+export type ConnectorUiGroupId = "messaging" | "social" | "other";
+
+export interface ConnectorUiGroupMeta {
+  id: ConnectorUiGroupId;
+  label: string;
+  description: string;
+  order: number;
+}
+
+export const CONNECTOR_UI_GROUPS: readonly ConnectorUiGroupMeta[] = [
+  {
+    id: "messaging",
+    label: "Messaging",
+    description: "Chat apps the agent can use in this mode",
+    order: 0,
+  },
+  {
+    id: "social",
+    label: "Social",
+    description: "Public networks and feeds",
+    order: 1,
+  },
+  {
+    id: "other",
+    label: "Other",
+    description: "Additional connectors",
+    order: 2,
+  },
+] as const;
+
+const GROUP_BY_ID: Readonly<Record<string, ConnectorUiGroupId>> = {
+  discord: "messaging",
+  telegram: "messaging",
+  signal: "messaging",
+  whatsapp: "messaging",
+  imessage: "messaging",
+  bluebubbles: "messaging",
+  blooio: "messaging",
+  slack: "messaging",
+  msteams: "messaging",
+  mattermost: "messaging",
+  "google-chat": "messaging",
+  matrix: "messaging",
+  feishu: "messaging",
+  line: "messaging",
+  zalo: "messaging",
+  zalouser: "messaging",
+  tlon: "messaging",
+  "nextcloud-talk": "messaging",
+  x: "social",
+  twitter: "social",
+  instagram: "social",
+  farcaster: "social",
+  bluesky: "social",
+  nostr: "social",
+  twitch: "social",
+  google: "other",
+};
+
+export function getConnectorUiGroupId(connectorId: string): ConnectorUiGroupId {
+  const key = connectorId.trim().toLowerCase();
+  return GROUP_BY_ID[key] ?? "other";
+}
+
+export function connectorStatusLabel(
+  plugin: {
+    enabled: boolean;
+    configured: boolean;
+    validationErrors: readonly unknown[];
+    loadError?: string | null;
+    isActive?: boolean;
+  },
+  t: (key: string, opts?: { defaultValue?: string }) => string,
+): { label: string; tone: "ok" | "warn" | "muted" | "danger" } {
+  if (plugin.loadError) {
+    return {
+      label: t("connectors.status.loadFailed", {
+        defaultValue: "Load failed",
+      }),
+      tone: "danger",
+    };
+  }
+  if (!plugin.enabled) {
+    return {
+      label: t("connectors.status.disabled", { defaultValue: "Disabled" }),
+      tone: "muted",
+    };
+  }
+  if (plugin.validationErrors.length > 0 || !plugin.configured) {
+    return {
+      label: t("connectors.status.needsSetup", {
+        defaultValue: "Needs setup",
+      }),
+      tone: "warn",
+    };
+  }
+  if (plugin.enabled && plugin.isActive === false) {
+    return {
+      label: t("connectors.status.enabledInactive", {
+        defaultValue: "Enabled",
+      }),
+      tone: "warn",
+    };
+  }
+  return {
+    label: t("connectors.status.enabled", { defaultValue: "Enabled" }),
+    tone: "ok",
+  };
+}

--- a/packages/ui/src/components/pages/PluginConfigForm.test.tsx
+++ b/packages/ui/src/components/pages/PluginConfigForm.test.tsx
@@ -168,6 +168,18 @@ describe("PluginConfigForm connector row layout", () => {
     expect(save.hasAttribute("disabled")).toBe(true);
     fireEvent.click(save);
     expect(onParamChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Remove API token?",
+    );
+    expect(onParamChange).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Clear value" }));
+    expect(onParamChange).toHaveBeenCalledWith(
+      "discord",
+      "DISCORD_API_TOKEN",
+      "",
+    );
   });
 
   it("edits structured text through the same Save/Cancel dialog pattern", () => {

--- a/packages/ui/src/components/pages/PluginConfigForm.test.tsx
+++ b/packages/ui/src/components/pages/PluginConfigForm.test.tsx
@@ -18,8 +18,15 @@ vi.mock("../../state", () => ({
     sel(stateMock.value),
 }));
 
-function t(key: string, options?: { defaultValue?: string }) {
-  return options?.defaultValue ?? key;
+function t(
+  key: string,
+  options?: { defaultValue?: string; [key: string]: unknown },
+) {
+  let result = options?.defaultValue ?? key;
+  for (const [name, value] of Object.entries(options ?? {})) {
+    result = result.replace(`{{${name}}}`, String(value));
+  }
+  return result;
 }
 
 function makeParam(
@@ -112,6 +119,57 @@ describe("PluginConfigForm connector row layout", () => {
     expect(configField("imessage", "IMESSAGE_ENABLED")).toBeNull();
   });
 
+  it("does not clear a configured secret when its empty edit dialog is saved", () => {
+    const onParamChange = vi.fn();
+    const plugin = makePlugin({
+      id: "discord",
+      key: "DISCORD_API_TOKEN",
+      parameters: [
+        makeParam("DISCORD_API_TOKEN", {
+          sensitive: true,
+          isSet: true,
+          currentValue: null,
+        }),
+        makeParam("DISCORD_SIGNING_SECRET", {
+          sensitive: true,
+          isSet: true,
+          currentValue: null,
+        }),
+      ],
+      configUiHints: {
+        DISCORD_API_TOKEN: {
+          label: "API token",
+          type: "password",
+          sensitive: true,
+        },
+        DISCORD_SIGNING_SECRET: {
+          label: "Signing secret",
+          type: "password",
+          sensitive: true,
+        },
+      },
+    });
+
+    render(
+      <PluginConfigForm
+        plugin={plugin}
+        pluginConfigs={{}}
+        onParamChange={onParamChange}
+        layout="rows"
+      />,
+    );
+
+    const edit = screen.getByRole("button", { name: "Edit API token" });
+    expect(
+      screen.getByRole("button", { name: "Edit Signing secret" }),
+    ).toBeTruthy();
+    fireEvent.click(edit);
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(save);
+    expect(onParamChange).not.toHaveBeenCalled();
+  });
+
   it("edits structured text through the same Save/Cancel dialog pattern", () => {
     const onParamChange = vi.fn();
     const plugin = makePlugin({
@@ -137,7 +195,7 @@ describe("PluginConfigForm connector row layout", () => {
     expect(
       document.querySelector('textarea[data-field-type="json"]'),
     ).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: /Set value/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit Allowed chats" }));
     const editor = screen.getByRole("textbox", { name: "Allowed chats" });
     fireEvent.change(editor, { target: { value: '["chat-1"]' } });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));

--- a/packages/ui/src/components/pages/PluginConfigForm.test.tsx
+++ b/packages/ui/src/components/pages/PluginConfigForm.test.tsx
@@ -89,6 +89,67 @@ afterEach(() => {
   cleanup();
 });
 
+describe("PluginConfigForm connector row layout", () => {
+  it("omits keys owned by the surrounding connector surface", () => {
+    const plugin = makePlugin({
+      id: "imessage",
+      key: "IMESSAGE_ENABLED",
+      configUiHints: {
+        IMESSAGE_ENABLED: { label: "Enabled", group: "advanced" },
+      },
+    });
+
+    render(
+      <PluginConfigForm
+        plugin={plugin}
+        pluginConfigs={{}}
+        onParamChange={vi.fn()}
+        layout="rows"
+        hiddenKeys={["IMESSAGE_ENABLED"]}
+      />,
+    );
+
+    expect(configField("imessage", "IMESSAGE_ENABLED")).toBeNull();
+  });
+
+  it("edits structured text through the same Save/Cancel dialog pattern", () => {
+    const onParamChange = vi.fn();
+    const plugin = makePlugin({
+      id: "feishu",
+      key: "FEISHU_ALLOWED_CHATS",
+      configUiHints: {
+        FEISHU_ALLOWED_CHATS: {
+          label: "Allowed chats",
+          type: "json",
+        },
+      },
+    });
+
+    render(
+      <PluginConfigForm
+        plugin={plugin}
+        pluginConfigs={{}}
+        onParamChange={onParamChange}
+        layout="rows"
+      />,
+    );
+
+    expect(
+      document.querySelector('textarea[data-field-type="json"]'),
+    ).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Set value/ }));
+    const editor = screen.getByRole("textbox", { name: "Allowed chats" });
+    fireEvent.change(editor, { target: { value: '["chat-1"]' } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onParamChange).toHaveBeenCalledWith(
+      "feishu",
+      "FEISHU_ALLOWED_CHATS",
+      '["chat-1"]',
+    );
+  });
+});
+
 describe("PluginConfigForm modeToggle configUiHint", () => {
   it("hides the backing field when the hidden-mode value is active", () => {
     const onParamChange = vi.fn();

--- a/packages/ui/src/components/pages/PluginConfigForm.tsx
+++ b/packages/ui/src/components/pages/PluginConfigForm.tsx
@@ -63,12 +63,15 @@ export function PluginConfigForm({
   pluginConfigs,
   onParamChange,
   layout = "grid",
+  hiddenKeys = [],
 }: {
   plugin: PluginInfo;
   pluginConfigs: Record<string, Record<string, string>>;
   onParamChange: (pluginId: string, paramKey: string, value: string) => void;
   /** Forwarded to ConfigRenderer — use `rows` for one setting per line. */
   layout?: "grid" | "rows";
+  /** Keys owned by a surrounding settings surface and omitted from this form. */
+  hiddenKeys?: readonly string[];
 }) {
   const params = plugin.parameters ?? [];
   const { schema, hints: autoHints } = useMemo(
@@ -86,8 +89,11 @@ export function PluginConfigForm({
         merged[key] = { ...merged[key], ...serverHint };
       }
     }
+    for (const key of hiddenKeys) {
+      merged[key] = { ...merged[key], hidden: true };
+    }
     return merged;
-  }, [autoHints, plugin.configUiHints]);
+  }, [autoHints, hiddenKeys, plugin.configUiHints]);
 
   const getCurrentValue = useCallback(
     (param: PluginParamDef): string => {

--- a/packages/ui/src/components/pages/PluginConfigForm.tsx
+++ b/packages/ui/src/components/pages/PluginConfigForm.tsx
@@ -62,10 +62,13 @@ export function PluginConfigForm({
   plugin,
   pluginConfigs,
   onParamChange,
+  layout = "grid",
 }: {
   plugin: PluginInfo;
   pluginConfigs: Record<string, Record<string, string>>;
   onParamChange: (pluginId: string, paramKey: string, value: string) => void;
+  /** Forwarded to ConfigRenderer — use `rows` for one setting per line. */
+  layout?: "grid" | "rows";
 }) {
   const params = plugin.parameters ?? [];
   const { schema, hints: autoHints } = useMemo(
@@ -241,6 +244,7 @@ export function PluginConfigForm({
         registry={defaultRegistry}
         pluginId={plugin.id}
         onChange={handleChange}
+        layout={layout}
       />
     </>
   );

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -14,23 +14,23 @@ import { useAgentElement } from "../../agent-surface";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { ContentLayout } from "../../layouts/content-layout";
 import { cn } from "../../lib/utils";
+import { getWindowNavigationPath } from "../../navigation";
 import { isAndroidCloudBuild } from "../../platform/android-runtime";
-import { useAppSelectorShallow } from "../../state";
+import { useAppSelector, useAppSelectorShallow } from "../../state";
 import { useEnabledViewKinds } from "../../state/useViewKinds";
 import { PermissionPrimingModal } from "../permissions/PermissionPrimingModal";
 import { DesktopSettingsNavigation } from "../settings/DesktopSettingsNavigation";
 import { SettingsHubList } from "../settings/SettingsHubList";
-import { getWindowNavigationPath } from "../../navigation";
-import { useAppSelector } from "../../state";
 import {
+  backFromConnectorDetail,
   type GroupedSettingsSections,
   getAllSettingsSections,
   groupSettingsSections,
-  openConnectorDetailHash,
   openConnectorsIndexHash,
   parseSettingsHash,
   readSettingsHashRoute,
   readSettingsHashSection,
+  replaceConnectorDetailHash,
   replaceSettingsHash,
   type SettingsRoute,
   type SettingsSectionDef,
@@ -277,7 +277,7 @@ export function SettingsView({
     const connectorId = connectorsPath[1]?.toLowerCase();
     if (connectorId) {
       setActiveSection("connectors");
-      openConnectorDetailHash(connectorId === "twitter" ? "x" : connectorId);
+      replaceConnectorDetailHash(connectorId === "twitter" ? "x" : connectorId);
       setSettingsRoute({
         kind: "connector-detail",
         sectionId: "connectors",
@@ -310,12 +310,7 @@ export function SettingsView({
   }, []);
 
   const backToConnectorsIndex = useCallback(() => {
-    setActiveSection("connectors");
-    openConnectorsIndexHash();
-    setSettingsRoute({ kind: "section", sectionId: "connectors" });
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(new Event("popstate"));
-    }
+    backFromConnectorDetail();
   }, []);
 
   useEffect(() => {
@@ -326,7 +321,7 @@ export function SettingsView({
     if (route.kind === "connector-detail") {
       setActiveSection("connectors");
       setSettingsRoute(route);
-      openConnectorDetailHash(route.connectorId);
+      replaceConnectorDetailHash(route.connectorId);
       if (typeof window !== "undefined") {
         window.dispatchEvent(new Event("popstate"));
       }

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -20,12 +20,19 @@ import { useEnabledViewKinds } from "../../state/useViewKinds";
 import { PermissionPrimingModal } from "../permissions/PermissionPrimingModal";
 import { DesktopSettingsNavigation } from "../settings/DesktopSettingsNavigation";
 import { SettingsHubList } from "../settings/SettingsHubList";
+import { getWindowNavigationPath } from "../../navigation";
+import { useAppSelector } from "../../state";
 import {
   type GroupedSettingsSections,
   getAllSettingsSections,
   groupSettingsSections,
+  openConnectorDetailHash,
+  openConnectorsIndexHash,
+  parseSettingsHash,
+  readSettingsHashRoute,
   readSettingsHashSection,
   replaceSettingsHash,
+  type SettingsRoute,
   type SettingsSectionDef,
   settingsSectionLabel,
   settingsSectionTitle,
@@ -224,10 +231,14 @@ export function SettingsView({
     loadPlugins: s.loadPlugins,
     walletEnabled: s.walletEnabled,
   }));
+  const plugins = useAppSelector((s) => s.plugins);
   const enabledKinds = useEnabledViewKinds();
   const isDesktop = useMediaQuery("(min-width: 1024px)");
   const [activeSection, setActiveSection] = useState<string | null>(
     () => initialSection ?? readSettingsHashSection(),
+  );
+  const [settingsRoute, setSettingsRoute] = useState<SettingsRoute>(() =>
+    readSettingsHashRoute(),
   );
   const [primePermission, setPrimePermission] = useState<PermissionId | null>(
     null,
@@ -254,21 +265,76 @@ export function SettingsView({
     void loadPlugins();
   }, [loadPlugins]);
 
+  // Legacy path deep links: /connectors, /connectors/<id>, /settings/connectors/<id>
+  // → structured hash the connectors body already understands.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const path = getWindowNavigationPath();
+    const connectorsPath = path.match(
+      /^\/(?:settings\/)?connectors(?:\/([a-z0-9-]+))?\/?$/i,
+    );
+    if (!connectorsPath) return;
+    const connectorId = connectorsPath[1]?.toLowerCase();
+    if (connectorId) {
+      setActiveSection("connectors");
+      openConnectorDetailHash(connectorId === "twitter" ? "x" : connectorId);
+      setSettingsRoute({
+        kind: "connector-detail",
+        sectionId: "connectors",
+        connectorId: connectorId === "twitter" ? "x" : connectorId,
+      });
+    } else {
+      setActiveSection("connectors");
+      openConnectorsIndexHash();
+      setSettingsRoute({ kind: "section", sectionId: "connectors" });
+    }
+    window.dispatchEvent(new Event("popstate"));
+  }, []);
+
   const openSection = useCallback((sectionId: string) => {
     setActiveSection(sectionId);
     replaceSettingsHash(sectionId);
+    setSettingsRoute({ kind: "section", sectionId });
   }, []);
 
   const backToHub = useCallback(() => {
     setActiveSection(null);
+    setSettingsRoute({ kind: "hub" });
     if (typeof window !== "undefined") {
-      window.history.replaceState(null, "", "#");
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${window.location.search}`,
+      );
+    }
+  }, []);
+
+  const backToConnectorsIndex = useCallback(() => {
+    setActiveSection("connectors");
+    openConnectorsIndexHash();
+    setSettingsRoute({ kind: "section", sectionId: "connectors" });
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event("popstate"));
     }
   }, []);
 
   useEffect(() => {
     if (!initialSection) return;
-    openSection(initialSection);
+    // initialSection may be a nested connectors route (`connectors/discord`)
+    // from deep links / focus events — parse before treating it as a flat id.
+    const route = parseSettingsHash(initialSection);
+    if (route.kind === "connector-detail") {
+      setActiveSection("connectors");
+      setSettingsRoute(route);
+      openConnectorDetailHash(route.connectorId);
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new Event("popstate"));
+      }
+      return;
+    }
+    if (route.kind === "section") {
+      openSection(route.sectionId);
+    }
   }, [initialSection, openSection]);
 
   useEffect(() => {
@@ -283,6 +349,8 @@ export function SettingsView({
   useEffect(() => {
     if (typeof window === "undefined") return;
     const handleLocationChange = () => {
+      const route = readSettingsHashRoute();
+      setSettingsRoute(route);
       const nextSection = readSettingsHashSection();
       if (
         nextSection &&
@@ -320,13 +388,32 @@ export function SettingsView({
   const displayedSectionDef = isDesktop ? desktopSectionDef : activeSectionDef;
 
   // Mobile keeps the uniform top bar: the hub shows "Settings" and a section
-  // shows its title with a back action. Desktop uses an in-pane title instead.
+  // shows its title with a back action. Connector detail is one level deeper
+  // (detail → connectors index → settings hub → launcher).
   const settingsTitle = t("nav.settings", { defaultValue: "Settings" });
-  const headerTitle = activeSectionDef
-    ? settingsSectionTitle(activeSectionDef, t)
-    : settingsTitle;
-  const onBack = activeSectionDef ? backToHub : navigateBackToLauncher;
-  const backLabel = activeSectionDef ? "Back to Settings" : "Back to launcher";
+  const connectorDetailId =
+    settingsRoute.kind === "connector-detail"
+      ? settingsRoute.connectorId
+      : null;
+  const connectorDetailName = connectorDetailId
+    ? (plugins.find((p) => p.id === connectorDetailId)?.name ??
+      connectorDetailId)
+    : null;
+  const headerTitle = connectorDetailName
+    ? connectorDetailName
+    : activeSectionDef
+      ? settingsSectionTitle(activeSectionDef, t)
+      : settingsTitle;
+  const onBack = connectorDetailId
+    ? backToConnectorsIndex
+    : activeSectionDef
+      ? backToHub
+      : navigateBackToLauncher;
+  const backLabel = connectorDetailId
+    ? "Back to Connectors"
+    : activeSectionDef
+      ? "Back to Settings"
+      : "Back to launcher";
   const desktopSidebar = isDesktop ? (
     <DesktopSettingsNavigation
       grouped={grouped}

--- a/packages/ui/src/components/pages/__e2e__/run-connectors-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-connectors-e2e.mjs
@@ -7,7 +7,8 @@
  * loads it in headless chromium via Playwright, and:
  *
  *   - asserts the Signal config form AND the delegated account-management
- *     setup panel co-render (the #10705 fix),
+ *     setup panel co-render (the #10705 fix): lens-scoped OWNER section,
+ *     presentation description, and a canned OWNER account,
  *   - captures screenshots at desktop (1280×900) and mobile (390×844).
  *
  * With --with-baseline it ALSO builds the fixture against the pre-fix
@@ -174,8 +175,12 @@ async function snap(page, name) {
 }
 
 const CONFIG_FIELD = "#field-signal-SIGNAL_PHONE_NUMBER";
-const PANEL_TITLE = "Signal accounts";
+// Lens-scoped account management no longer renders the cosmetic catalog title
+// ("Signal accounts"). Under the default Delegate lens the OWNER section uses
+// the role default title and the canned OWNER account from the api stub.
+const PANEL_SECTION_TITLE = "Owner accounts";
 const ACCOUNT_LABEL = "Owner device";
+const PANEL_DESCRIPTION = "Manage Signal account records";
 
 async function capture(browser, { label, js, css, expectConfigForm }) {
   const html = `<!doctype html><html><head><meta charset="utf-8"><title>connectors e2e — ${label}</title>
@@ -204,14 +209,16 @@ async function capture(browser, { label, js, css, expectConfigForm }) {
     await page.waitForTimeout(400);
 
     const hasConfigField = (await page.locator(CONFIG_FIELD).count()) > 0;
-    const hasPanelTitle =
-      (await page.locator(`text=${PANEL_TITLE}`).count()) > 0;
+    const hasPanelSection =
+      (await page.locator(`text=${PANEL_SECTION_TITLE}`).count()) > 0;
+    const hasPanelDescription =
+      (await page.locator(`text=${PANEL_DESCRIPTION}`).count()) > 0;
     const hasAccount =
       (await page.locator(`text=${ACCOUNT_LABEL}`).count()) > 0;
 
     assert(
-      hasPanelTitle && hasAccount,
-      `${label}/${vpName}: delegated setup panel renders ("${PANEL_TITLE}" + "${ACCOUNT_LABEL}")`,
+      hasPanelSection && hasPanelDescription && hasAccount,
+      `${label}/${vpName}: delegated setup panel renders ("${PANEL_SECTION_TITLE}" + description + "${ACCOUNT_LABEL}")`,
     );
     assert(
       hasConfigField === expectConfigForm,

--- a/packages/ui/src/components/settings/ConnectorsSection.test.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.test.tsx
@@ -2,11 +2,17 @@
 // @vitest-environment jsdom
 /**
  * Renders ConnectorsSection with a mocked App context and connector-mode
- * registry to assert icon fallbacks (no raw emoji glyphs) and the setup-panel
- * routing. jsdom, no backend.
+ * registry to assert index/detail routing, icon fallbacks, and setup-panel
+ * co-render on the detail page. jsdom, no backend.
  */
 
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginInfo } from "../../api";
 
@@ -49,8 +55,6 @@ vi.mock("../connectors/WhatsAppQrOverlay", () => ({
   WhatsAppQrOverlay: () => <div />,
 }));
 
-// Controllable connector-mode per plugin id. Defaults to a benign mode so the
-// pre-existing icon test is unaffected; tests opt into telegram/discord modes.
 const connectorModeMock = vi.hoisted(() => ({
   byId: {} as Record<
     string,
@@ -58,6 +62,7 @@ const connectorModeMock = vi.hoisted(() => ({
       setupPluginId: string | null;
       selectedMode: string;
       modes: Array<{ id: string; managementMode: string | undefined }>;
+      setSelectedMode?: (id: string) => void;
     }
   >,
 }));
@@ -67,6 +72,7 @@ vi.mock("../connectors/ConnectorModeSelector.hooks", () => ({
       setupPluginId: pluginId,
       selectedMode: "default",
       modes: [{ id: "default", managementMode: undefined }],
+      setSelectedMode: () => {},
     },
 }));
 vi.mock("../connectors/ConnectorModeSelector", () => ({
@@ -77,10 +83,15 @@ vi.mock("../connectors/ConnectorSetupPanel", () => ({
     <div data-testid="connector-setup-panel">setup:{pluginId}</div>
   ),
 }));
+vi.mock("../connectors/ConnectorSetupPanel.helpers", () => ({
+  hasConnectorSetupPanel: (id: string) =>
+    id === "telegram" || id === "whatsapp",
+}));
 vi.mock("../pages/PluginConfigForm", () => ({
   PluginConfigForm: () => <div data-testid="plugin-config-form" />,
 }));
 
+import { setConnectorChannelMode } from "../connectors/connector-channel-mode";
 import { ConnectorsSection } from "./ConnectorsSection";
 
 function plugin(overrides: Partial<PluginInfo> = {}): PluginInfo {
@@ -101,6 +112,10 @@ function plugin(overrides: Partial<PluginInfo> = {}): PluginInfo {
   } as PluginInfo;
 }
 
+function openDetail(name: string) {
+  fireEvent.click(screen.getByRole("button", { name: new RegExp(name, "i") }));
+}
+
 describe("ConnectorsSection", () => {
   beforeEach(() => {
     appMock.value = {
@@ -113,6 +128,8 @@ describe("ConnectorsSection", () => {
       t: (_key, options) => options?.defaultValue ?? _key,
     };
     connectorModeMock.byId = {};
+    setConnectorChannelMode("delegate");
+    window.history.replaceState(null, "", "/");
   });
 
   afterEach(() => {
@@ -146,14 +163,12 @@ describe("ConnectorsSection", () => {
     };
   }
 
-  // Regression #10281: Settings → Connectors must co-render the live setup
-  // panel alongside the env-config form (the canonical /connectors page does).
-  // Before the fix, the showPluginConfig branch dropped the panel.
-  it("co-renders the live setup panel alongside the config form for telegram bot mode", () => {
+  it("opens a detail page from the index and co-renders setup + config for telegram bot mode", () => {
     connectorModeMock.byId.telegram = {
       setupPluginId: "telegram",
       selectedMode: "bot",
       modes: [{ id: "bot", managementMode: "local-config" }],
+      setSelectedMode: () => {},
     };
     appMock.value.plugins = [
       plugin({
@@ -164,20 +179,21 @@ describe("ConnectorsSection", () => {
     ];
 
     render(<ConnectorsSection />);
+    expect(screen.getByTestId("connectors-index")).toBeTruthy();
+    openDetail("Telegram");
 
+    expect(screen.getByTestId("connector-detail")).toBeTruthy();
     expect(screen.getByTestId("plugin-config-form")).toBeTruthy();
     const panel = screen.getByTestId("connector-setup-panel");
-    expect(panel).toBeTruthy();
     expect(panel.textContent ?? "").toContain("telegram");
   });
 
-  // whatsapp business mode is the third local-config + has-panel case; it must
-  // co-render like /connectors does (the panel is the whatsapp pairing surface).
-  it("co-renders the setup panel for whatsapp business mode", () => {
+  it("co-renders the setup panel for whatsapp business mode on detail", () => {
     connectorModeMock.byId.whatsapp = {
       setupPluginId: "whatsapp",
       selectedMode: "business",
       modes: [{ id: "business", managementMode: "local-config" }],
+      setSelectedMode: () => {},
     };
     appMock.value.plugins = [
       plugin({
@@ -188,6 +204,7 @@ describe("ConnectorsSection", () => {
     ];
 
     render(<ConnectorsSection />);
+    openDetail("WhatsApp");
 
     expect(screen.getByTestId("plugin-config-form")).toBeTruthy();
     expect(
@@ -197,11 +214,12 @@ describe("ConnectorsSection", () => {
     ).toBe(true);
   });
 
-  it("renders no setup panel for a local-config connector that has none (discord)", () => {
+  it("renders config form without setup panel for discord bot local-config", () => {
     connectorModeMock.byId.discord = {
       setupPluginId: "discord",
       selectedMode: "bot",
       modes: [{ id: "bot", managementMode: "local-config" }],
+      setSelectedMode: () => {},
     };
     appMock.value.plugins = [
       plugin({
@@ -212,8 +230,51 @@ describe("ConnectorsSection", () => {
     ];
 
     render(<ConnectorsSection />);
+    openDetail("Discord");
 
     expect(screen.getByTestId("plugin-config-form")).toBeTruthy();
     expect(screen.queryByTestId("connector-setup-panel")).toBeNull();
+  });
+
+  it("hides bot-only connectors under the delegate lens and restores them via the footnote switch", () => {
+    appMock.value.plugins = [
+      plugin({ id: "slack", name: "Slack" }),
+      plugin({ id: "signal", name: "Signal" }),
+    ];
+
+    render(<ConnectorsSection />);
+
+    expect(screen.getByText("Signal")).toBeTruthy();
+    expect(screen.queryByText("Slack")).toBeNull();
+    const footnoteSwitch = screen.getByRole("button", {
+      name: /Switch to/,
+    });
+
+    fireEvent.click(footnoteSwitch);
+
+    expect(screen.getByText("Slack")).toBeTruthy();
+    expect(screen.queryByText("Signal")).toBeNull();
+    expect(screen.getByRole("button", { name: /Switch to/ })).toBeTruthy();
+  });
+
+  it("keeps unclassified connectors visible under both lenses", () => {
+    appMock.value.plugins = [
+      plugin({ id: "acmechat-unknown", name: "Acme Chat" }),
+    ];
+
+    render(<ConnectorsSection />);
+    expect(screen.getByText("Acme Chat")).toBeTruthy();
+
+    act(() => setConnectorChannelMode("bot"));
+    expect(screen.getByText("Acme Chat")).toBeTruthy();
+  });
+
+  it("returns to the index from detail back control", () => {
+    appMock.value.plugins = [plugin({ id: "signal", name: "Signal" })];
+    render(<ConnectorsSection />);
+    openDetail("Signal");
+    expect(screen.getByTestId("connector-detail")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("connector-detail-back"));
+    expect(screen.getByTestId("connectors-index")).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/settings/ConnectorsSection.test.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.test.tsx
@@ -404,12 +404,14 @@ describe("ConnectorsSection", () => {
     expect(screen.getByText("Acme Chat")).toBeTruthy();
   });
 
-  it("returns to the index from detail back control", () => {
+  it("returns to the index from detail back control", async () => {
     appMock.value.plugins = [plugin({ id: "signal", name: "Signal" })];
     render(<ConnectorsSection />);
     openDetail("Signal");
     expect(screen.getByTestId("connector-detail")).toBeTruthy();
     fireEvent.click(screen.getByTestId("connector-detail-back"));
-    expect(screen.getByTestId("connectors-index")).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.getByTestId("connectors-index")).toBeTruthy(),
+    );
   });
 });

--- a/packages/ui/src/components/settings/ConnectorsSection.test.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.test.tsx
@@ -409,9 +409,33 @@ describe("ConnectorsSection", () => {
     render(<ConnectorsSection />);
     openDetail("Signal");
     expect(screen.getByTestId("connector-detail")).toBeTruthy();
-    fireEvent.click(screen.getByTestId("connector-detail-back"));
+    const back = screen.getByTestId("connector-detail-back");
+    // Mobile uses ViewHeader; this control is desktop-only with a 44px target.
+    expect(back.className).toMatch(/\bhidden\b/);
+    expect(back.className).toMatch(/\bmd:inline-flex\b/);
+    expect(back.className).toMatch(/\bmin-h-11\b/);
+    fireEvent.click(back);
     await waitFor(() =>
       expect(screen.getByTestId("connectors-index")).toBeTruthy(),
+    );
+  });
+
+  it("rejects a fallback-classified connector deep link under the wrong lens", async () => {
+    // Google is Delegate-only; a Bot-lens deep link must not open its detail.
+    appMock.value.plugins = [plugin({ id: "google", name: "Google" })];
+    act(() => setConnectorChannelMode("bot"));
+    window.history.replaceState(null, "", "/#connectors/google");
+    window.dispatchEvent(new Event("popstate"));
+
+    render(<ConnectorsSection />);
+    await waitFor(() =>
+      expect(screen.getByTestId("connector-not-found")).toBeTruthy(),
+    );
+    expect(screen.queryByTestId("connector-detail")).toBeNull();
+
+    act(() => setConnectorChannelMode("delegate"));
+    await waitFor(() =>
+      expect(screen.getByTestId("connector-detail")).toBeTruthy(),
     );
   });
 });

--- a/packages/ui/src/components/settings/ConnectorsSection.test.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.test.tsx
@@ -369,13 +369,13 @@ describe("ConnectorsSection", () => {
   it("hides bot-only connectors under the delegate lens and restores them via the footnote switch", () => {
     appMock.value.plugins = [
       plugin({ id: "slack", name: "Slack" }),
-      plugin({ id: "signal", name: "Signal" }),
+      plugin({ id: "bluebubbles", name: "BlueBubbles" }),
       plugin({ id: "matrix", name: "Matrix" }),
     ];
 
     render(<ConnectorsSection />);
 
-    expect(screen.getByText("Signal")).toBeTruthy();
+    expect(screen.getByText("BlueBubbles")).toBeTruthy();
     // Slack remains available through its OWNER-role plugin-managed inventory;
     // its app-token modes themselves are still Bot-only.
     expect(screen.getByText("Slack")).toBeTruthy();
@@ -388,7 +388,7 @@ describe("ConnectorsSection", () => {
 
     expect(screen.getByText("Slack")).toBeTruthy();
     expect(screen.getByText("Matrix")).toBeTruthy();
-    expect(screen.queryByText("Signal")).toBeNull();
+    expect(screen.queryByText("BlueBubbles")).toBeNull();
     expect(screen.getByRole("button", { name: /Switch to/ })).toBeTruthy();
   });
 

--- a/packages/ui/src/components/settings/ConnectorsSection.test.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.test.tsx
@@ -12,6 +12,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginInfo } from "../../api";
@@ -88,7 +89,34 @@ vi.mock("../connectors/ConnectorSetupPanel.helpers", () => ({
     id === "telegram" || id === "whatsapp",
 }));
 vi.mock("../pages/PluginConfigForm", () => ({
-  PluginConfigForm: () => <div data-testid="plugin-config-form" />,
+  PluginConfigForm: ({
+    plugin,
+    onParamChange,
+  }: {
+    plugin: PluginInfo;
+    onParamChange: (pluginId: string, key: string, value: string) => void;
+  }) => (
+    <div data-testid="plugin-config-form">
+      <button
+        type="button"
+        onClick={() => onParamChange(plugin.id, "TOKEN", "token-value")}
+      >
+        Stage token
+      </button>
+      <button
+        type="button"
+        onClick={() => onParamChange(plugin.id, "TOKEN", "newer-token")}
+      >
+        Stage newer token
+      </button>
+      <button
+        type="button"
+        onClick={() => onParamChange(plugin.id, "APP_ID", "app-value")}
+      >
+        Stage app ID
+      </button>
+    </div>
+  ),
 }));
 
 import { setConnectorChannelMode } from "../connectors/connector-channel-mode";
@@ -234,6 +262,108 @@ describe("ConnectorsSection", () => {
 
     expect(screen.getByTestId("plugin-config-form")).toBeTruthy();
     expect(screen.queryByTestId("connector-setup-panel")).toBeNull();
+  });
+
+  it("commits multi-field drafts once and blocks duplicate saves", async () => {
+    let resolveSave: ((saved: boolean) => void) | undefined;
+    appMock.value.handlePluginConfigSave = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    appMock.value.plugins = [
+      plugin({
+        id: "discord",
+        name: "Discord",
+        parameters: [tokenParam("DISCORD_API_TOKEN")],
+      }),
+    ];
+
+    render(<ConnectorsSection />);
+    openDetail("Discord");
+    fireEvent.click(screen.getByRole("button", { name: "Stage token" }));
+    fireEvent.click(screen.getByRole("button", { name: "Stage app ID" }));
+
+    const save = screen.getByRole("button", { name: "Save changes" });
+    fireEvent.click(save);
+    fireEvent.click(save);
+
+    expect(appMock.value.handlePluginConfigSave).toHaveBeenCalledOnce();
+    expect(appMock.value.handlePluginConfigSave).toHaveBeenCalledWith(
+      "discord",
+      { TOKEN: "token-value", APP_ID: "app-value" },
+    );
+    resolveSave?.(true);
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull(),
+    );
+  });
+
+  it("preserves a newer same-field edit when an older save completes", async () => {
+    let resolveFirst: ((saved: boolean) => void) | undefined;
+    appMock.value.handlePluginConfigSave = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(true);
+    appMock.value.plugins = [
+      plugin({
+        id: "discord",
+        name: "Discord",
+        parameters: [tokenParam("DISCORD_API_TOKEN")],
+      }),
+    ];
+
+    render(<ConnectorsSection />);
+    openDetail("Discord");
+    fireEvent.click(screen.getByRole("button", { name: "Stage token" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    fireEvent.click(screen.getByRole("button", { name: "Stage newer token" }));
+    resolveFirst?.(true);
+
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("button", { name: "Save changes" })
+          .hasAttribute("disabled"),
+      ).toBe(false),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() =>
+      expect(appMock.value.handlePluginConfigSave).toHaveBeenCalledTimes(2),
+    );
+    expect(appMock.value.handlePluginConfigSave).toHaveBeenLastCalledWith(
+      "discord",
+      { TOKEN: "newer-token" },
+    );
+  });
+
+  it("retains staged drafts after a failed save and lets Cancel discard them", async () => {
+    appMock.value.handlePluginConfigSave = vi.fn(async () => false);
+    appMock.value.plugins = [
+      plugin({
+        id: "discord",
+        name: "Discord",
+        parameters: [tokenParam("DISCORD_API_TOKEN")],
+      }),
+    ];
+
+    render(<ConnectorsSection />);
+    openDetail("Discord");
+    fireEvent.click(screen.getByRole("button", { name: "Stage token" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Save changes" })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
   });
 
   it("hides bot-only connectors under the delegate lens and restores them via the footnote switch", () => {

--- a/packages/ui/src/components/settings/ConnectorsSection.test.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.test.tsx
@@ -240,12 +240,16 @@ describe("ConnectorsSection", () => {
     appMock.value.plugins = [
       plugin({ id: "slack", name: "Slack" }),
       plugin({ id: "signal", name: "Signal" }),
+      plugin({ id: "matrix", name: "Matrix" }),
     ];
 
     render(<ConnectorsSection />);
 
     expect(screen.getByText("Signal")).toBeTruthy();
-    expect(screen.queryByText("Slack")).toBeNull();
+    // Slack remains available through its OWNER-role plugin-managed inventory;
+    // its app-token modes themselves are still Bot-only.
+    expect(screen.getByText("Slack")).toBeTruthy();
+    expect(screen.queryByText("Matrix")).toBeNull();
     const footnoteSwitch = screen.getByRole("button", {
       name: /Switch to/,
     });
@@ -253,6 +257,7 @@ describe("ConnectorsSection", () => {
     fireEvent.click(footnoteSwitch);
 
     expect(screen.getByText("Slack")).toBeTruthy();
+    expect(screen.getByText("Matrix")).toBeTruthy();
     expect(screen.queryByText("Signal")).toBeNull();
     expect(screen.getByRole("button", { name: /Switch to/ })).toBeTruthy();
   });

--- a/packages/ui/src/components/settings/ConnectorsSection.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.tsx
@@ -515,10 +515,12 @@ function ConnectorDetailPage({
   return (
     <div className="flex flex-col gap-6" data-testid="connector-detail">
       <div className="flex flex-col gap-3">
+        {/* Mobile already has ViewHeader "Back to Connectors"; keep this control
+            desktop-only so we do not double-render an undersized touch target. */}
         <button
           type="button"
           onClick={onBack}
-          className="self-start text-xs font-medium text-muted hover:text-txt"
+          className="hidden self-start text-xs font-medium text-muted hover:text-txt md:inline-flex min-h-11 items-center"
           data-testid="connector-detail-back"
         >
           {t("connectors.detail.back", { defaultValue: "← Connectors" })}
@@ -754,14 +756,20 @@ export function ConnectorsSection() {
     [allConnectorPlugins, channelMode],
   );
 
+  // Detail uses the same lens policy as the index: a connector classified out
+  // of the active Delegate/Bot lens is not a valid detail target there (deep
+  // links under the wrong lens surface the not-found path until the lens
+  // matches).
   const detailPlugin = useMemo(() => {
     if (!detailId) return null;
-    return (
+    const plugin =
       allConnectorPlugins.find(
         (p) => normalizeConnectorRouteId(p.id) === detailId,
-      ) ?? null
-    );
-  }, [allConnectorPlugins, detailId]);
+      ) ?? null;
+    if (!plugin) return null;
+    if (!connectorSupportsChannelMode(plugin.id, channelMode)) return null;
+    return plugin;
+  }, [allConnectorPlugins, channelMode, detailId]);
 
   const openDetail = useCallback((connectorId: string) => {
     openConnectorDetailHash(connectorId);

--- a/packages/ui/src/components/settings/ConnectorsSection.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.tsx
@@ -15,6 +15,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useSyncExternalStore,
 } from "react";
@@ -68,6 +69,7 @@ import {
   openConnectorDetailHash,
   openConnectorsIndexHash,
   readSettingsHashRoute,
+  replaceConnectorDetailHash,
   type SettingsRoute,
 } from "./settings-route";
 
@@ -269,9 +271,12 @@ function ConnectorConfigurationSurface({ plugin }: { plugin: PluginInfo }) {
   const handlePluginConfigSave = useAppSelector(
     (s) => s.handlePluginConfigSave,
   );
+  const pluginSaving = useAppSelector((s) => s.pluginSaving);
   const [pluginConfigs, setPluginConfigs] = useState<
     Record<string, Record<string, string>>
   >({});
+  const [localSaving, setLocalSaving] = useState(false);
+  const saveInFlightRef = useRef(false);
   // Only offer setup modes that belong to the active Delegate/Bot lens.
   const channelMode = useConnectorChannelMode();
   const connectorMode = useConnectorMode(plugin.id, {
@@ -308,37 +313,60 @@ function ConnectorConfigurationSurface({ plugin }: { plugin: PluginInfo }) {
     ],
     [connectorMode.selectedMode, plugin],
   );
-  // Row/dialog UX persists per field on dialog Save (or toggle) — no bulk
-  // "Save settings" footer. Keep a local draft map only so chips reflect the
-  // value immediately while the server write is in flight.
+  const pendingConfig = pluginConfigs[plugin.id] ?? {};
+  const hasPendingConfig = Object.keys(pendingConfig).length > 0;
+  const isSaving = localSaving || pluginSaving.has(plugin.id);
+
+  // Dialog Save stages a field. The trailing action row commits the complete
+  // credential bundle once so the runtime applies/restarts at most once.
   const handleParamChange = useCallback(
     (pluginId: string, paramKey: string, value: string) => {
       setPluginConfigs((prev) => ({
         ...prev,
         [pluginId]: { ...prev[pluginId], [paramKey]: value },
       }));
-      void (async () => {
-        const saved = await handlePluginConfigSave(pluginId, {
-          [paramKey]: value,
-        });
-        if (!saved) return;
-        setPluginConfigs((prev) => {
-          const current = prev[pluginId];
-          if (!current || !(paramKey in current)) return prev;
-          const nextForPlugin = { ...current };
-          delete nextForPlugin[paramKey];
-          const next = { ...prev };
-          if (Object.keys(nextForPlugin).length === 0) {
-            delete next[pluginId];
-          } else {
-            next[pluginId] = nextForPlugin;
-          }
-          return next;
-        });
-      })();
     },
-    [handlePluginConfigSave],
+    [],
   );
+
+  const handleSave = useCallback(async () => {
+    if (saveInFlightRef.current || Object.keys(pendingConfig).length === 0) {
+      return;
+    }
+    saveInFlightRef.current = true;
+    const submitted = { ...pendingConfig };
+    setLocalSaving(true);
+    try {
+      const saved = await handlePluginConfigSave(plugin.id, submitted);
+      if (!saved) return;
+      // Do not clear a value edited again while this request was in flight.
+      setPluginConfigs((prev) => {
+        const current = prev[plugin.id];
+        if (!current) return prev;
+        const remaining = Object.fromEntries(
+          Object.entries(current).filter(
+            ([key, value]) => submitted[key] !== value,
+          ),
+        );
+        const next = { ...prev };
+        if (Object.keys(remaining).length === 0) delete next[plugin.id];
+        else next[plugin.id] = remaining;
+        return next;
+      });
+    } finally {
+      saveInFlightRef.current = false;
+      setLocalSaving(false);
+    }
+  }, [handlePluginConfigSave, pendingConfig, plugin.id]);
+
+  const handleCancel = useCallback(() => {
+    setPluginConfigs((prev) => {
+      if (!prev[plugin.id]) return prev;
+      const next = { ...prev };
+      delete next[plugin.id];
+      return next;
+    });
+  }, [plugin.id]);
 
   return (
     <div className="flex flex-col gap-3 [&>*]:mt-0">
@@ -372,6 +400,30 @@ function ConnectorConfigurationSurface({ plugin }: { plugin: PluginInfo }) {
                   })
                 : configFormHint.fallback}
             </p>
+          ) : null}
+          {hasPendingConfig || isSaving ? (
+            <div className="flex items-center justify-end gap-2 border-t border-border/50 pt-3">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleCancel}
+                disabled={isSaving}
+              >
+                {t("common.cancel", { defaultValue: "Cancel" })}
+              </Button>
+              <Button
+                variant="default"
+                size="sm"
+                onClick={() => void handleSave()}
+                disabled={!hasPendingConfig || isSaving}
+              >
+                {isSaving
+                  ? t("common.saving", { defaultValue: "Saving…" })
+                  : t("pluginsview.SaveSettings", {
+                      defaultValue: "Save changes",
+                    })}
+              </Button>
+            </div>
           ) : null}
         </>
       ) : setupPanel ? (
@@ -466,7 +518,7 @@ function ConnectorDetailPage({
         <button
           type="button"
           onClick={onBack}
-          className="self-start text-xs font-medium text-muted hover:text-txt"
+          className="hidden self-start text-xs font-medium text-muted hover:text-txt md:inline-flex"
           data-testid="connector-detail-back"
         >
           {t("connectors.detail.back", { defaultValue: "← Connectors" })}
@@ -713,7 +765,12 @@ export function ConnectorsSection() {
 
   const openDetail = useCallback((connectorId: string) => {
     openConnectorDetailHash(connectorId);
-    // replaceState does not emit hashchange — nudge subscribers.
+    // pushState does not emit popstate/hashchange — nudge subscribers.
+    window.dispatchEvent(new Event("popstate"));
+  }, []);
+
+  const focusDetail = useCallback((connectorId: string) => {
+    replaceConnectorDetailHash(connectorId);
     window.dispatchEvent(new Event("popstate"));
   }, []);
 
@@ -728,18 +785,18 @@ export function ConnectorsSection() {
     const handleFocusConnector = (event: Event) => {
       const detail = (event as CustomEvent<FocusConnectorEventDetail>).detail;
       if (!detail?.connectorId) return;
-      openDetail(detail.connectorId);
+      focusDetail(detail.connectorId);
       clearPendingFocusConnector(detail.connectorId);
     };
     document.addEventListener(FOCUS_CONNECTOR_EVENT, handleFocusConnector);
     const pending = readPendingFocusConnector();
     if (pending) {
-      openDetail(pending);
+      focusDetail(pending);
       clearPendingFocusConnector(pending);
     }
     return () =>
       document.removeEventListener(FOCUS_CONNECTOR_EVENT, handleFocusConnector);
-  }, [openDetail]);
+  }, [focusDetail]);
 
   if (allConnectorPlugins.length === 0) {
     return (

--- a/packages/ui/src/components/settings/ConnectorsSection.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.tsx
@@ -4,7 +4,7 @@
  * surface — Connection / Support / General cards — not inline accordions.
  */
 
-import { ChevronRight, type LucideIcon, type LucideProps, Puzzle, Save } from "lucide-react";
+import { ChevronRight, type LucideIcon, type LucideProps, Puzzle } from "lucide-react";
 import {
   forwardRef,
   useCallback,
@@ -253,14 +253,14 @@ function ConnectorConfigurationSurface({
   const handlePluginConfigSave = useAppSelector(
     (s) => s.handlePluginConfigSave,
   );
-  const pluginSaving = useAppSelector((s) => s.pluginSaving);
-  const pluginSaveSuccess = useAppSelector((s) => s.pluginSaveSuccess);
   const [pluginConfigs, setPluginConfigs] = useState<
     Record<string, Record<string, string>>
   >({});
-  // Detail is lens-independent: show every setup mode the connector declares.
+  // Only offer setup modes that belong to the active Delegate/Bot lens.
+  const channelMode = useConnectorChannelMode();
   const connectorMode = useConnectorMode(plugin.id, {
     elizaCloudConnected,
+    channelMode,
   });
   const setupPluginId = connectorMode.setupPluginId;
   const setupPanel =
@@ -282,91 +282,80 @@ function ConnectorConfigurationSurface({
     hasParameters: plugin.parameters.length > 0,
     setupTargetsPlugin: (setupPluginId ?? plugin.id) === plugin.id,
   });
-  const pendingConfig = pluginConfigs[plugin.id] ?? {};
-  const hasPendingConfig = Object.keys(pendingConfig).length > 0;
-  const isSaving = pluginSaving.has(plugin.id);
-  const didSave = pluginSaveSuccess.has(plugin.id);
-
+  // Row/dialog UX persists per field on dialog Save (or toggle) — no bulk
+  // "Save settings" footer. Keep a local draft map only so chips reflect the
+  // value immediately while the server write is in flight.
   const handleParamChange = useCallback(
     (pluginId: string, paramKey: string, value: string) => {
       setPluginConfigs((prev) => ({
         ...prev,
         [pluginId]: { ...prev[pluginId], [paramKey]: value },
       }));
+      void (async () => {
+        const saved = await handlePluginConfigSave(pluginId, {
+          [paramKey]: value,
+        });
+        if (!saved) return;
+        setPluginConfigs((prev) => {
+          const current = prev[pluginId];
+          if (!current || !(paramKey in current)) return prev;
+          const nextForPlugin = { ...current };
+          delete nextForPlugin[paramKey];
+          const next = { ...prev };
+          if (Object.keys(nextForPlugin).length === 0) {
+            delete next[pluginId];
+          } else {
+            next[pluginId] = nextForPlugin;
+          }
+          return next;
+        });
+      })();
     },
-    [],
+    [handlePluginConfigSave],
   );
-
-  const handleSave = useCallback(async () => {
-    const saved = await handlePluginConfigSave(plugin.id, pendingConfig);
-    if (!saved) return;
-    setPluginConfigs((prev) => {
-      const next = { ...prev };
-      delete next[plugin.id];
-      return next;
-    });
-  }, [handlePluginConfigSave, pendingConfig, plugin.id]);
 
   return (
     <div className="flex flex-col gap-3 [&>*]:mt-0">
       {connectorMode.modes.length > 1 ? (
-        <ConnectorModeSelector
-          connectorId={plugin.id}
-          selectedMode={connectorMode.selectedMode}
-          onModeChange={connectorMode.setSelectedMode}
-          elizaCloudConnected={elizaCloudConnected}
-        />
+        <div className="px-1">
+          <ConnectorModeSelector
+            connectorId={plugin.id}
+            selectedMode={connectorMode.selectedMode}
+            onModeChange={connectorMode.setSelectedMode}
+            elizaCloudConnected={elizaCloudConnected}
+            channelMode={channelMode}
+          />
+        </div>
       ) : null}
 
       {showPluginConfig ? (
-        <div className="space-y-3">
+        <>
           <PluginConfigForm
             plugin={plugin}
             pluginConfigs={pluginConfigs}
             onParamChange={handleParamChange}
+            layout="rows"
           />
           {setupPanel}
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-            <div className="min-w-0 flex-1">
-              {configFormHint ? (
-                <span className="text-xs-tight text-muted">
-                  {configFormHint.key
-                    ? t(configFormHint.key, {
-                        defaultValue: configFormHint.fallback,
-                      })
-                    : configFormHint.fallback}
-                </span>
-              ) : null}
-            </div>
-            <Button
-              variant="default"
-              size="sm"
-              className="h-8 shrink-0 gap-1.5 self-end rounded-sm px-3 text-xs-tight font-semibold sm:self-start"
-              onClick={() => {
-                void handleSave();
-              }}
-              disabled={!hasPendingConfig || isSaving}
-            >
-              <Save className="h-3.5 w-3.5" aria-hidden="true" />
-              {isSaving
-                ? t("common.saving", { defaultValue: "Saving..." })
-                : didSave
-                  ? t("pluginsview.Saved", { defaultValue: "Saved" })
-                  : t("pluginsview.SaveSettings", {
-                      defaultValue: "Save settings",
-                    })}
-            </Button>
-          </div>
-        </div>
+          {configFormHint ? (
+            <p className="px-1 text-xs-tight text-muted">
+              {configFormHint.key
+                ? t(configFormHint.key, {
+                    defaultValue: configFormHint.fallback,
+                  })
+                : configFormHint.fallback}
+            </p>
+          ) : null}
+        </>
       ) : setupPanel ? (
         setupPanel
       ) : (
-        <div className="text-xs-tight text-muted">
+        <p className="px-1 text-xs-tight text-muted">
           {t("settings.sections.connectors.ownSetupSurface", {
             defaultValue: "{{name}} uses its own setup surface.",
             name: plugin.name,
           })}
-        </div>
+        </p>
       )}
     </div>
   );
@@ -471,24 +460,36 @@ function ConnectorDetailPage({
         </div>
       </div>
 
+      {/* Load/enable is the global gate — always first when present. */}
+      <SettingsCard>
+        <SettingsCardRow
+          title={t("settings.sections.connectors.enablePlugin", {
+            defaultValue: "Enable {{name}} connector",
+            name: plugin.name,
+          })}
+          description={t("settings.sections.connectors.enableHelp", {
+            defaultValue:
+              "Load the plugin so the agent can use this channel when configured.",
+          })}
+          action={
+            <ConnectorEnableSwitch
+              plugin={plugin}
+              busy={busy}
+              onToggle={(checked) => {
+                void onToggle(checked);
+              }}
+            />
+          }
+        />
+      </SettingsCard>
+
       <section className="space-y-2">
         <h3 className="text-xs font-medium text-muted">
           {t("connectors.detail.connection", { defaultValue: "Connection" })}
         </h3>
-        <SettingsCard>
-          <SettingsCardRow
-            title={t("connectors.detail.connectionTitle", {
-              defaultValue: "Connection",
-            })}
-            description={t("connectors.detail.connectionHelp", {
-              defaultValue: "Set up how Eliza talks to {{name}}.",
-              name: plugin.name,
-            })}
-          />
-          <div className="border-t border-border/50 px-4 py-3">
-            <ConnectorConfigurationSurface plugin={plugin} />
-          </div>
-        </SettingsCard>
+        {/* No outer SettingsCard here — row layout / setup panels bring their
+            own chrome. Nesting cards left a hollow gap above the old save bar. */}
+        <ConnectorConfigurationSurface plugin={plugin} />
       </section>
 
       {links.length > 0 ? (
@@ -530,36 +531,10 @@ function ConnectorDetailPage({
           </SettingsCard>
         </section>
       ) : null}
-
-      <section className="space-y-2">
-        <h3 className="text-xs font-medium text-muted">
-          {t("connectors.detail.general", { defaultValue: "General" })}
-        </h3>
-        <SettingsCard>
-          <SettingsCardRow
-            title={t("settings.sections.connectors.enablePlugin", {
-              defaultValue: "Enable {{name}} connector",
-              name: plugin.name,
-            })}
-            description={t("settings.sections.connectors.enableHelp", {
-              defaultValue:
-                "Load the plugin so the agent can use this channel when configured.",
-            })}
-            action={
-              <ConnectorEnableSwitch
-                plugin={plugin}
-                busy={busy}
-                onToggle={(checked) => {
-                  void onToggle(checked);
-                }}
-              />
-            }
-          />
-        </SettingsCard>
-      </section>
     </div>
   );
 }
+
 
 function ConnectorsIndex({
   connectors,

--- a/packages/ui/src/components/settings/ConnectorsSection.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.tsx
@@ -4,7 +4,12 @@
  * surface — Connection / Support / General cards — not inline accordions.
  */
 
-import { ChevronRight, type LucideIcon, type LucideProps, Puzzle } from "lucide-react";
+import {
+  ChevronRight,
+  type LucideIcon,
+  type LucideProps,
+  Puzzle,
+} from "lucide-react";
 import {
   forwardRef,
   useCallback,
@@ -40,6 +45,7 @@ import {
 import {
   connectorSupportsChannelMode,
   getConnectorModeConfigFormHint,
+  getConnectorModeHiddenConfigKeys,
 } from "../connectors/connector-mode-registry";
 import {
   CONNECTOR_UI_GROUPS,
@@ -69,6 +75,18 @@ import {
  * Whether Settings → Connectors should render the generic plugin-config (env
  * credential) form for the selected connector mode.
  */
+export function getConnectorSurfaceOwnedConfigKeys(
+  plugin: Pick<PluginInfo, "parameters">,
+): string[] {
+  return plugin.parameters
+    .filter(
+      (parameter) =>
+        parameter.description.trim().toLowerCase() ===
+        "enable or disable this feature",
+    )
+    .map((parameter) => parameter.key);
+}
+
 export function shouldRenderConnectorConfigForm(args: {
   managementMode: ConnectorMode["managementMode"] | undefined;
   hasParameters: boolean;
@@ -192,7 +210,9 @@ function SettingsCardRow({
       <div className="min-w-0 flex-1 space-y-0.5">
         <div className="text-sm font-medium text-txt-strong">{title}</div>
         {description ? (
-          <div className="text-xs leading-relaxed text-muted">{description}</div>
+          <div className="text-xs leading-relaxed text-muted">
+            {description}
+          </div>
         ) : null}
       </div>
       {action ? (
@@ -243,11 +263,7 @@ function ConnectorListRow({
   );
 }
 
-function ConnectorConfigurationSurface({
-  plugin,
-}: {
-  plugin: PluginInfo;
-}) {
+function ConnectorConfigurationSurface({ plugin }: { plugin: PluginInfo }) {
   const t = useAppSelector((s) => s.t);
   const elizaCloudConnected = useAppSelector((s) => s.elizaCloudConnected);
   const handlePluginConfigSave = useAppSelector(
@@ -282,6 +298,16 @@ function ConnectorConfigurationSurface({
     hasParameters: plugin.parameters.length > 0,
     setupTargetsPlugin: (setupPluginId ?? plugin.id) === plugin.id,
   });
+  const hiddenConfigKeys = useMemo(
+    () => [
+      ...getConnectorSurfaceOwnedConfigKeys(plugin),
+      ...getConnectorModeHiddenConfigKeys(
+        plugin.id,
+        connectorMode.selectedMode,
+      ),
+    ],
+    [connectorMode.selectedMode, plugin],
+  );
   // Row/dialog UX persists per field on dialog Save (or toggle) — no bulk
   // "Save settings" footer. Keep a local draft map only so chips reflect the
   // value immediately while the server write is in flight.
@@ -335,6 +361,7 @@ function ConnectorConfigurationSurface({
             pluginConfigs={pluginConfigs}
             onParamChange={handleParamChange}
             layout="rows"
+            hiddenKeys={hiddenConfigKeys}
           />
           {setupPanel}
           {configFormHint ? (
@@ -453,7 +480,12 @@ function ConnectorDetailPage({
               {plugin.name}
             </h2>
             <p className="mt-0.5 text-sm text-muted">{tagline}</p>
-            <p className={cn("mt-1 text-xs font-medium", statusToneClass(status.tone))}>
+            <p
+              className={cn(
+                "mt-1 text-xs font-medium",
+                statusToneClass(status.tone),
+              )}
+            >
               {status.label}
             </p>
           </div>
@@ -518,7 +550,11 @@ function ConnectorDetailPage({
                     className="h-8 rounded-sm px-3 text-xs-tight font-semibold"
                     asChild
                   >
-                    <a href={link.url} target="_blank" rel="noopener noreferrer">
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       {t("connectors.detail.openLink", {
                         defaultValue: "Open",
                       })}{" "}
@@ -534,7 +570,6 @@ function ConnectorDetailPage({
     </div>
   );
 }
-
 
 function ConnectorsIndex({
   connectors,
@@ -562,9 +597,9 @@ function ConnectorsIndex({
     }
     return CONNECTOR_UI_GROUPS.map((meta) => ({
       meta,
-      items: (buckets.get(meta.id) ?? []).slice().sort((a, b) =>
-        a.name.localeCompare(b.name),
-      ),
+      items: (buckets.get(meta.id) ?? [])
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name)),
     })).filter((entry) => entry.items.length > 0);
   }, [connectors]);
 
@@ -722,7 +757,7 @@ export function ConnectorsSection() {
         <div className="space-y-3" data-testid="connector-not-found">
           <p className="text-sm text-muted">
             {t("connectors.detail.notFound", {
-              defaultValue: "Connector \"{{id}}\" was not found.",
+              defaultValue: 'Connector "{{id}}" was not found.',
               id: detailId,
             })}
           </p>

--- a/packages/ui/src/components/settings/ConnectorsSection.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.tsx
@@ -65,9 +65,9 @@ import {
 import { Button } from "../ui/button";
 import { Switch } from "../ui/switch";
 import {
+  backFromConnectorDetail,
   normalizeConnectorRouteId,
   openConnectorDetailHash,
-  openConnectorsIndexHash,
   readSettingsHashRoute,
   replaceConnectorDetailHash,
   type SettingsRoute,
@@ -518,7 +518,7 @@ function ConnectorDetailPage({
         <button
           type="button"
           onClick={onBack}
-          className="hidden self-start text-xs font-medium text-muted hover:text-txt md:inline-flex"
+          className="self-start text-xs font-medium text-muted hover:text-txt"
           data-testid="connector-detail-back"
         >
           {t("connectors.detail.back", { defaultValue: "← Connectors" })}
@@ -775,8 +775,7 @@ export function ConnectorsSection() {
   }, []);
 
   const backToIndex = useCallback(() => {
-    openConnectorsIndexHash();
-    window.dispatchEvent(new Event("popstate"));
+    backFromConnectorDetail();
   }, []);
 
   // Focus / deep-link events navigate to detail (no accordion open).

--- a/packages/ui/src/components/settings/ConnectorsSection.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.tsx
@@ -1,25 +1,17 @@
 /**
- * Settings → Connectors section.
- *
- * The connector id→panel dispatch is hardcoded — AGENTS.md commandment 5 (zero
- * polymorphism for runtime type branching) explicitly allows this for
- * adapter/target registries.
+ * Settings → Connectors: index list (Delegate/Bot lens + grouped rows) and
+ * per-connector detail pages (`#connectors/<id>`). Setup lives on the detail
+ * surface — Connection / Support / General cards — not inline accordions.
  */
 
-import {
-  ChevronDown,
-  type LucideIcon,
-  type LucideProps,
-  Puzzle,
-  Save,
-} from "lucide-react";
+import { ChevronRight, type LucideIcon, type LucideProps, Puzzle, Save } from "lucide-react";
 import {
   forwardRef,
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import { useAgentElement } from "../../agent-surface";
 import type { PluginInfo } from "../../api";
@@ -29,41 +21,53 @@ import {
   type FocusConnectorEventDetail,
   readPendingFocusConnector,
 } from "../../events";
+import { cn } from "../../lib/utils";
 import { useAppSelector } from "../../state";
+import {
+  ConnectorChannelModeSwitch,
+  connectorChannelModeCopy,
+} from "../connectors/ConnectorChannelModeSwitch";
 import { ConnectorModeSelector } from "../connectors/ConnectorModeSelector";
 import type { ConnectorMode } from "../connectors/ConnectorModeSelector.helpers";
 import { useConnectorMode } from "../connectors/ConnectorModeSelector.hooks";
 import { ConnectorSetupPanel } from "../connectors/ConnectorSetupPanel";
 import { hasConnectorSetupPanel } from "../connectors/ConnectorSetupPanel.helpers";
-import { getConnectorModeConfigFormHint } from "../connectors/connector-mode-registry";
+import {
+  type ConnectorChannelMode,
+  setConnectorChannelMode,
+  useConnectorChannelMode,
+} from "../connectors/connector-channel-mode";
+import {
+  connectorSupportsChannelMode,
+  getConnectorModeConfigFormHint,
+} from "../connectors/connector-mode-registry";
+import {
+  CONNECTOR_UI_GROUPS,
+  connectorStatusLabel,
+  getConnectorUiGroupId,
+} from "../connectors/connector-ui-groups";
 import { getBrandIcon } from "../conversations/brand-icons";
 import { PluginConfigForm } from "../pages/PluginConfigForm";
 import {
   ALWAYS_ON_PLUGIN_IDS,
+  getPluginResourceLinks,
   iconImageSource,
+  pluginResourceLinkLabel,
   resolveIcon,
 } from "../pages/plugin-list-utils";
 import { Button } from "../ui/button";
 import { Switch } from "../ui/switch";
-import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
-
-type ConnectorStatusTone = "ok" | "warn" | "off";
+import {
+  normalizeConnectorRouteId,
+  openConnectorDetailHash,
+  openConnectorsIndexHash,
+  readSettingsHashRoute,
+  type SettingsRoute,
+} from "./settings-route";
 
 /**
  * Whether Settings → Connectors should render the generic plugin-config (env
  * credential) form for the selected connector mode.
- *
- * The form is shown for a `local-config` mode whose setup target is the
- * plugin itself and that actually declares parameters — and for connectors
- * with NO declared mode list at all (farcaster, bluesky, matrix, nostr, …):
- * those have no dedicated panel to protect, so a declared-parameters plugin
- * gets the credential form instead of a dead-end. Every other mode kind —
- * `local-setup` (iMessage Full-Disk-Access status, Signal/WhatsApp QR pairing,
- * Discord/Telegram desktop panels), `plugin-managed` account lists, and
- * `cloud-managed` gateways — keeps its dedicated {@link ConnectorSetupPanel}
- * surface. Gating on the mode KIND rather than the incidental
- * "this plugin declares parameters" is what keeps those dedicated panels
- * reachable instead of being overwritten by a raw env form.
  */
 export function shouldRenderConnectorConfigForm(args: {
   managementMode: ConnectorMode["managementMode"] | undefined;
@@ -78,29 +82,39 @@ export function shouldRenderConnectorConfigForm(args: {
   );
 }
 
-function statusTone(plugin: PluginInfo): ConnectorStatusTone {
-  if (!plugin.enabled) return "off";
-  if (plugin.validationErrors.length > 0) return "warn";
-  if (!plugin.configured) return "warn";
-  return "ok";
+function subscribeHash(onStoreChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener("hashchange", onStoreChange);
+  window.addEventListener("popstate", onStoreChange);
+  return () => {
+    window.removeEventListener("hashchange", onStoreChange);
+    window.removeEventListener("popstate", onStoreChange);
+  };
 }
 
-function statusDotClass(tone: ConnectorStatusTone): string {
-  switch (tone) {
-    case "ok":
-      return "bg-ok";
-    case "warn":
-      return "bg-warn";
-    case "off":
-      return "bg-muted/60";
-  }
+// useSyncExternalStore requires a stable getSnapshot reference equality when
+// the underlying store has not changed — parse once per hash string.
+let cachedRouteHash = "\0";
+let cachedRoute: SettingsRoute = { kind: "hub" };
+const SERVER_ROUTE: SettingsRoute = { kind: "hub" };
+
+function getSettingsRouteSnapshot(): SettingsRoute {
+  if (typeof window === "undefined") return SERVER_ROUTE;
+  const hash = window.location.hash;
+  if (hash === cachedRouteHash) return cachedRoute;
+  cachedRouteHash = hash;
+  cachedRoute = readSettingsHashRoute();
+  return cachedRoute;
 }
 
-/**
- * A {@link LucideIcon}-compatible medallion icon for a connector so it can be
- * passed to {@link SettingsRow}'s `icon` slot — brand SVG, plugin image, or a
- * Puzzle fallback.
- */
+function useSettingsRoute(): SettingsRoute {
+  return useSyncExternalStore(
+    subscribeHash,
+    getSettingsRouteSnapshot,
+    () => SERVER_ROUTE,
+  );
+}
+
 function connectorIcon(plugin: PluginInfo): LucideIcon {
   const Brand = getBrandIcon(plugin.id);
   const icon = resolveIcon(plugin);
@@ -125,7 +139,115 @@ function connectorIcon(plugin: PluginInfo): LucideIcon {
   });
 }
 
-function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
+function statusToneClass(tone: "ok" | "warn" | "muted" | "danger"): string {
+  switch (tone) {
+    case "ok":
+      return "text-ok";
+    case "warn":
+      return "text-warn";
+    case "danger":
+      return "text-danger";
+    default:
+      return "text-muted";
+  }
+}
+
+function SettingsCard({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-lg border border-border/60 bg-card/40",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SettingsCardRow({
+  title,
+  description,
+  action,
+  className,
+}: {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-start justify-between gap-x-4 gap-y-2 px-4 py-3",
+        className,
+      )}
+    >
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <div className="text-sm font-medium text-txt-strong">{title}</div>
+        {description ? (
+          <div className="text-xs leading-relaxed text-muted">{description}</div>
+        ) : null}
+      </div>
+      {action ? (
+        <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2">
+          {action}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ConnectorListRow({
+  plugin,
+  onOpen,
+}: {
+  plugin: PluginInfo;
+  onOpen: () => void;
+}) {
+  const t = useAppSelector((s) => s.t);
+  const Icon = useMemo(() => connectorIcon(plugin), [plugin]);
+  const status = connectorStatusLabel(plugin, t);
+  const label = t("connectors.configure", {
+    defaultValue: "Configure",
+  });
+
+  return (
+    <button
+      type="button"
+      data-connector={plugin.id}
+      data-testid={`connector-row-${plugin.id}`}
+      onClick={onOpen}
+      className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-bg-hover/60"
+    >
+      <Icon className="h-[18px] w-[18px] shrink-0 text-muted" />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-txt-strong">
+          {plugin.name}
+        </span>
+        <span className={cn("block text-xs", statusToneClass(status.tone))}>
+          {status.label}
+        </span>
+      </span>
+      <span className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-muted">
+        {label}
+        <ChevronRight className="h-4 w-4" aria-hidden />
+      </span>
+    </button>
+  );
+}
+
+function ConnectorConfigurationSurface({
+  plugin,
+}: {
+  plugin: PluginInfo;
+}) {
   const t = useAppSelector((s) => s.t);
   const elizaCloudConnected = useAppSelector((s) => s.elizaCloudConnected);
   const handlePluginConfigSave = useAppSelector(
@@ -136,7 +258,10 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
   const [pluginConfigs, setPluginConfigs] = useState<
     Record<string, Record<string, string>>
   >({});
-  const connectorMode = useConnectorMode(plugin.id, { elizaCloudConnected });
+  // Detail is lens-independent: show every setup mode the connector declares.
+  const connectorMode = useConnectorMode(plugin.id, {
+    elizaCloudConnected,
+  });
   const setupPluginId = connectorMode.setupPluginId;
   const setupPanel =
     setupPluginId && hasConnectorSetupPanel(setupPluginId) ? (
@@ -148,9 +273,6 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
   const selectedMode = connectorMode.modes.find(
     (mode) => mode.id === connectorMode.selectedMode,
   );
-  // Owner-declared config-form footnote for the selected mode (e.g. Discord's
-  // "Application ID is optional" hint), resolved from connector-mode metadata
-  // instead of matching plugin.id (#12090 item 28).
   const configFormHint = getConnectorModeConfigFormHint(
     plugin.id,
     connectorMode.selectedMode,
@@ -158,9 +280,6 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
   const showPluginConfig = shouldRenderConnectorConfigForm({
     managementMode: selectedMode?.managementMode,
     hasParameters: plugin.parameters.length > 0,
-    // Mirror the canonical /connectors fallback: a connector with no declared
-    // mode list has no companion setup plugin, so its own credential form is
-    // the setup surface (previously a dead-end "uses its own setup surface").
     setupTargetsPlugin: (setupPluginId ?? plugin.id) === plugin.id,
   });
   const pendingConfig = pluginConfigs[plugin.id] ?? {};
@@ -179,8 +298,6 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
   );
 
   const handleSave = useCallback(async () => {
-    // Only clear the draft when the save persisted — sensitive params never
-    // echo back from the server, so wiping on failure loses the pasted token.
     const saved = await handlePluginConfigSave(plugin.id, pendingConfig);
     if (!saved) return;
     setPluginConfigs((prev) => {
@@ -191,7 +308,7 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
   }, [handlePluginConfigSave, pendingConfig, plugin.id]);
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-3 [&>*]:mt-0">
       {connectorMode.modes.length > 1 ? (
         <ConnectorModeSelector
           connectorId={plugin.id}
@@ -208,19 +325,23 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
             pluginConfigs={pluginConfigs}
             onParamChange={handleParamChange}
           />
-          {/* Co-render the live setup/status panel (e.g. Telegram bot-token
-              validation + identity) directly under the env-config form, matching
-              the canonical /connectors surface (plugin-view-connectors.tsx) where
-              the panel sits between the form and the save action. Without this, a
-              `local-config` connector that also has a setup panel (telegram bot
-              mode) showed the raw-token form only. `setupPanel` is already
-              null-gated to `setupPluginId`, so it is a no-op otherwise. */}
           {setupPanel}
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+            <div className="min-w-0 flex-1">
+              {configFormHint ? (
+                <span className="text-xs-tight text-muted">
+                  {configFormHint.key
+                    ? t(configFormHint.key, {
+                        defaultValue: configFormHint.fallback,
+                      })
+                    : configFormHint.fallback}
+                </span>
+              ) : null}
+            </div>
             <Button
               variant="default"
               size="sm"
-              className="h-8 gap-1.5 rounded-sm px-4 text-xs-tight font-semibold"
+              className="h-8 shrink-0 gap-1.5 self-end rounded-sm px-3 text-xs-tight font-semibold sm:self-start"
               onClick={() => {
                 void handleSave();
               }}
@@ -235,15 +356,6 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
                       defaultValue: "Save settings",
                     })}
             </Button>
-            {configFormHint ? (
-              <span className="text-xs-tight text-muted">
-                {configFormHint.key
-                  ? t(configFormHint.key, {
-                      defaultValue: configFormHint.fallback,
-                    })
-                  : configFormHint.fallback}
-              </span>
-            ) : null}
           </div>
         </div>
       ) : setupPanel ? (
@@ -293,8 +405,6 @@ function ConnectorEnableSwitch({
       ref={ref}
       checked={plugin.enabled}
       disabled={busy}
-      onClick={(event) => event.stopPropagation()}
-      onKeyDown={(event) => event.stopPropagation()}
       onCheckedChange={(checked) => onToggle(checked)}
       aria-label={label}
       {...agentProps}
@@ -302,122 +412,326 @@ function ConnectorEnableSwitch({
   );
 }
 
-function ConnectorRow({
+function ConnectorDetailPage({
   plugin,
-  busy,
-  onToggle,
+  onBack,
 }: {
   plugin: PluginInfo;
-  busy: boolean;
-  onToggle: (enabled: boolean) => void;
+  onBack: () => void;
 }) {
-  const tone = statusTone(plugin);
-  const icon = useMemo(() => connectorIcon(plugin), [plugin]);
+  const t = useAppSelector((s) => s.t);
+  const handlePluginToggle = useAppSelector((s) => s.handlePluginToggle);
+  const [busy, setBusy] = useState(false);
+  const Icon = useMemo(() => connectorIcon(plugin), [plugin]);
+  const status = connectorStatusLabel(plugin, t);
+  const links = useMemo(() => getPluginResourceLinks(plugin), [plugin]);
+  const tagline =
+    plugin.description?.trim() ||
+    t("connectors.detail.taglineFallback", {
+      defaultValue: "Connect {{name}} so the agent can use this channel.",
+      name: plugin.name,
+    });
+
+  const onToggle = useCallback(
+    async (enabled: boolean) => {
+      setBusy(true);
+      try {
+        await handlePluginToggle(plugin.id, enabled);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [handlePluginToggle, plugin.id],
+  );
 
   return (
-    <details className="group relative" data-connector={plugin.id}>
-      <summary className="cursor-pointer select-none list-none pr-14">
-        <SettingsRow
-          icon={icon}
-          label={
-            <span className="flex min-w-0 items-center gap-2">
-              <span className="truncate">{plugin.name}</span>
-              <span
-                className={`h-1.5 w-1.5 shrink-0 rounded-full ${statusDotClass(tone)}`}
-                aria-hidden="true"
+    <div className="flex flex-col gap-6" data-testid="connector-detail">
+      <div className="flex flex-col gap-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="self-start text-xs font-medium text-muted hover:text-txt"
+          data-testid="connector-detail-back"
+        >
+          {t("connectors.detail.back", { defaultValue: "← Connectors" })}
+        </button>
+        <div className="flex items-start gap-3">
+          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-border/50 bg-bg-accent/70">
+            <Icon className="h-5 w-5 text-txt" />
+          </span>
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold tracking-tight text-txt-strong">
+              {plugin.name}
+            </h2>
+            <p className="mt-0.5 text-sm text-muted">{tagline}</p>
+            <p className={cn("mt-1 text-xs font-medium", statusToneClass(status.tone))}>
+              {status.label}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <section className="space-y-2">
+        <h3 className="text-xs font-medium text-muted">
+          {t("connectors.detail.connection", { defaultValue: "Connection" })}
+        </h3>
+        <SettingsCard>
+          <SettingsCardRow
+            title={t("connectors.detail.connectionTitle", {
+              defaultValue: "Connection",
+            })}
+            description={t("connectors.detail.connectionHelp", {
+              defaultValue: "Set up how Eliza talks to {{name}}.",
+              name: plugin.name,
+            })}
+          />
+          <div className="border-t border-border/50 px-4 py-3">
+            <ConnectorConfigurationSurface plugin={plugin} />
+          </div>
+        </SettingsCard>
+      </section>
+
+      {links.length > 0 ? (
+        <section className="space-y-2">
+          <h3 className="text-xs font-medium text-muted">
+            {t("connectors.detail.support", { defaultValue: "Support" })}
+          </h3>
+          <SettingsCard>
+            {links.map((link, index) => (
+              <SettingsCardRow
+                key={link.key}
+                className={index > 0 ? "border-t border-border/50" : undefined}
+                title={pluginResourceLinkLabel(t, link.key)}
+                description={
+                  link.key === "guide"
+                    ? t("connectors.detail.docsHelp", {
+                        defaultValue: "Learn how {{name}} works with Eliza.",
+                        name: plugin.name,
+                      })
+                    : undefined
+                }
+                action={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-8 rounded-sm px-3 text-xs-tight font-semibold"
+                    asChild
+                  >
+                    <a href={link.url} target="_blank" rel="noopener noreferrer">
+                      {t("connectors.detail.openLink", {
+                        defaultValue: "Open",
+                      })}{" "}
+                      ↗
+                    </a>
+                  </Button>
+                }
               />
-            </span>
-          }
-          trailing={
-            <ChevronDown
-              aria-hidden
-              className="h-4 w-4 shrink-0 text-muted transition-transform group-open:rotate-180"
-            />
-          }
-        />
-      </summary>
-      <div className="absolute right-0 top-3 z-10">
-        <ConnectorEnableSwitch
-          plugin={plugin}
-          busy={busy}
-          onToggle={onToggle}
-        />
+            ))}
+          </SettingsCard>
+        </section>
+      ) : null}
+
+      <section className="space-y-2">
+        <h3 className="text-xs font-medium text-muted">
+          {t("connectors.detail.general", { defaultValue: "General" })}
+        </h3>
+        <SettingsCard>
+          <SettingsCardRow
+            title={t("settings.sections.connectors.enablePlugin", {
+              defaultValue: "Enable {{name}} connector",
+              name: plugin.name,
+            })}
+            description={t("settings.sections.connectors.enableHelp", {
+              defaultValue:
+                "Load the plugin so the agent can use this channel when configured.",
+            })}
+            action={
+              <ConnectorEnableSwitch
+                plugin={plugin}
+                busy={busy}
+                onToggle={(checked) => {
+                  void onToggle(checked);
+                }}
+              />
+            }
+          />
+        </SettingsCard>
+      </section>
+    </div>
+  );
+}
+
+function ConnectorsIndex({
+  connectors,
+  hiddenConnectors,
+  channelMode,
+  onOpen,
+}: {
+  connectors: PluginInfo[];
+  hiddenConnectors: PluginInfo[];
+  channelMode: ConnectorChannelMode;
+  onOpen: (id: string) => void;
+}) {
+  const t = useAppSelector((s) => s.t);
+  const channelModeCopy = connectorChannelModeCopy(t);
+  const otherChannelMode: ConnectorChannelMode =
+    channelMode === "delegate" ? "bot" : "delegate";
+
+  const grouped = useMemo(() => {
+    const buckets = new Map<string, PluginInfo[]>();
+    for (const plugin of connectors) {
+      const groupId = getConnectorUiGroupId(plugin.id);
+      const list = buckets.get(groupId) ?? [];
+      list.push(plugin);
+      buckets.set(groupId, list);
+    }
+    return CONNECTOR_UI_GROUPS.map((meta) => ({
+      meta,
+      items: (buckets.get(meta.id) ?? []).slice().sort((a, b) =>
+        a.name.localeCompare(b.name),
+      ),
+    })).filter((entry) => entry.items.length > 0);
+  }, [connectors]);
+
+  return (
+    <div className="flex flex-col gap-5" data-testid="connectors-index">
+      <div className="flex flex-col items-start gap-1">
+        <ConnectorChannelModeSwitch />
+        <p className="text-xs-tight text-muted">
+          {channelModeCopy[channelMode].description}
+        </p>
       </div>
-      <div className="pb-3 pl-[30px]">
-        <ConnectorBody plugin={plugin} />
-      </div>
-    </details>
+
+      {grouped.map(({ meta, items }) => (
+        <section key={meta.id} className="space-y-2">
+          <div>
+            <h3 className="text-sm font-medium text-txt-strong">
+              {t(`connectors.groups.${meta.id}.label`, {
+                defaultValue: meta.label,
+              })}
+            </h3>
+            <p className="text-xs text-muted">
+              {t(`connectors.groups.${meta.id}.description`, {
+                defaultValue: meta.description,
+              })}
+            </p>
+          </div>
+          <SettingsCard>
+            {items.map((plugin, index) => (
+              <div
+                key={plugin.id}
+                className={index > 0 ? "border-t border-border/50" : undefined}
+              >
+                <ConnectorListRow
+                  plugin={plugin}
+                  onOpen={() => onOpen(plugin.id)}
+                />
+              </div>
+            ))}
+          </SettingsCard>
+        </section>
+      ))}
+
+      {hiddenConnectors.length > 0 ? (
+        <p className="text-xs-tight text-muted">
+          {t("settings.sections.connectors.channelModeHidden", {
+            defaultValue: "Available in {{mode}} mode: {{names}}.",
+            mode: channelModeCopy[otherChannelMode].label,
+            names: hiddenConnectors.map((p) => p.name).join(", "),
+          })}{" "}
+          <button
+            type="button"
+            className="font-medium text-accent underline-offset-2 hover:underline"
+            onClick={() => setConnectorChannelMode(otherChannelMode)}
+          >
+            {t("settings.sections.connectors.channelModeSwitch", {
+              defaultValue: "Switch to {{mode}}",
+              mode: channelModeCopy[otherChannelMode].label,
+            })}
+          </button>
+        </p>
+      ) : null}
+    </div>
   );
 }
 
 export function ConnectorsSection() {
   const plugins = useAppSelector((s) => s.plugins);
-  const handlePluginToggle = useAppSelector((s) => s.handlePluginToggle);
   const t = useAppSelector((s) => s.t);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const [togglingPlugins, setTogglingPlugins] = useState<Set<string>>(
-    new Set(),
+  const channelMode = useConnectorChannelMode();
+  const route = useSettingsRoute();
+  const detailId =
+    route.kind === "connector-detail"
+      ? normalizeConnectorRouteId(route.connectorId)
+      : null;
+
+  const allConnectorPlugins = useMemo(
+    () =>
+      plugins.filter(
+        (p) =>
+          p.category === "connector" &&
+          !ALWAYS_ON_PLUGIN_IDS.has(p.id) &&
+          p.visible !== false,
+      ),
+    [plugins],
   );
 
-  const connectorPlugins = plugins.filter(
-    (p) =>
-      p.category === "connector" &&
-      !ALWAYS_ON_PLUGIN_IDS.has(p.id) &&
-      p.visible !== false,
+  const connectorPlugins = useMemo(
+    () =>
+      allConnectorPlugins.filter((p) =>
+        connectorSupportsChannelMode(p.id, channelMode),
+      ),
+    [allConnectorPlugins, channelMode],
   );
 
-  const focusConnector = useCallback((connectorId: string) => {
-    const escapedId = connectorId.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-    const focus = () => {
-      const row = containerRef.current?.querySelector(
-        `[data-connector="${escapedId}"]`,
-      );
-      if (!(row instanceof HTMLDetailsElement)) return false;
-      row.open = true;
-      row.scrollIntoView({ block: "center", behavior: "smooth" });
-      const summary = row.querySelector("summary");
-      if (summary instanceof HTMLElement)
-        summary.focus({ preventScroll: true });
-      clearPendingFocusConnector(connectorId);
-      return true;
-    };
-    if (focus()) return;
-    window.setTimeout(() => {
-      focus();
-    }, 80);
+  const hiddenConnectors = useMemo(
+    () =>
+      allConnectorPlugins.filter(
+        (p) => !connectorSupportsChannelMode(p.id, channelMode),
+      ),
+    [allConnectorPlugins, channelMode],
+  );
+
+  const detailPlugin = useMemo(() => {
+    if (!detailId) return null;
+    return (
+      allConnectorPlugins.find(
+        (p) => normalizeConnectorRouteId(p.id) === detailId,
+      ) ?? null
+    );
+  }, [allConnectorPlugins, detailId]);
+
+  const openDetail = useCallback((connectorId: string) => {
+    openConnectorDetailHash(connectorId);
+    // replaceState does not emit hashchange — nudge subscribers.
+    window.dispatchEvent(new Event("popstate"));
   }, []);
 
+  const backToIndex = useCallback(() => {
+    openConnectorsIndexHash();
+    window.dispatchEvent(new Event("popstate"));
+  }, []);
+
+  // Focus / deep-link events navigate to detail (no accordion open).
   useEffect(() => {
     if (typeof document === "undefined") return;
     const handleFocusConnector = (event: Event) => {
       const detail = (event as CustomEvent<FocusConnectorEventDetail>).detail;
       if (!detail?.connectorId) return;
-      focusConnector(detail.connectorId);
+      openDetail(detail.connectorId);
+      clearPendingFocusConnector(detail.connectorId);
     };
     document.addEventListener(FOCUS_CONNECTOR_EVENT, handleFocusConnector);
     const pending = readPendingFocusConnector();
-    if (pending) focusConnector(pending);
+    if (pending) {
+      openDetail(pending);
+      clearPendingFocusConnector(pending);
+    }
     return () =>
       document.removeEventListener(FOCUS_CONNECTOR_EVENT, handleFocusConnector);
-  }, [focusConnector]);
+  }, [openDetail]);
 
-  const handleToggle = useCallback(
-    async (pluginId: string, enabled: boolean) => {
-      setTogglingPlugins((prev) => new Set(prev).add(pluginId));
-      try {
-        await handlePluginToggle(pluginId, enabled);
-      } finally {
-        setTogglingPlugins((prev) => {
-          const next = new Set(prev);
-          next.delete(pluginId);
-          return next;
-        });
-      }
-    },
-    [handlePluginToggle],
-  );
-
-  if (connectorPlugins.length === 0) {
+  if (allConnectorPlugins.length === 0) {
     return (
       <p className="text-sm text-muted">
         {t("pluginsview.NoConnectorsAvailable", {
@@ -427,30 +741,38 @@ export function ConnectorsSection() {
     );
   }
 
-  return (
-    <SettingsStack>
-      <SettingsGroup
-        bare
-        title={t("settings.sections.connectors.groupTitle", {
-          defaultValue: "Connectors",
-        })}
-      >
-        <div ref={containerRef} className="flex flex-col">
-          {connectorPlugins.map((plugin) => {
-            const isBusy = togglingPlugins.has(plugin.id);
-            return (
-              <ConnectorRow
-                key={plugin.id}
-                plugin={plugin}
-                busy={isBusy}
-                onToggle={(checked) => {
-                  void handleToggle(plugin.id, checked);
-                }}
-              />
-            );
-          })}
+  if (detailId) {
+    if (!detailPlugin) {
+      return (
+        <div className="space-y-3" data-testid="connector-not-found">
+          <p className="text-sm text-muted">
+            {t("connectors.detail.notFound", {
+              defaultValue: "Connector \"{{id}}\" was not found.",
+              id: detailId,
+            })}
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={backToIndex}
+            className="h-8 rounded-sm px-3 text-xs-tight font-semibold"
+          >
+            {t("connectors.detail.backToList", {
+              defaultValue: "Back to Connectors",
+            })}
+          </Button>
         </div>
-      </SettingsGroup>
-    </SettingsStack>
+      );
+    }
+    return <ConnectorDetailPage plugin={detailPlugin} onBack={backToIndex} />;
+  }
+
+  return (
+    <ConnectorsIndex
+      connectors={connectorPlugins}
+      hiddenConnectors={hiddenConnectors}
+      channelMode={channelMode}
+      onOpen={openDetail}
+    />
   );
 }

--- a/packages/ui/src/components/settings/settings-route.test.ts
+++ b/packages/ui/src/components/settings/settings-route.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for structured Settings hash routes (flat sections + nested
+ * connectors detail). Deterministic pure parsing — no registry dependency.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  normalizeConnectorRouteId,
+  parseSettingsHash,
+  settingsRouteToHash,
+} from "./settings-route";
+
+describe("parseSettingsHash", () => {
+  it("parses hub, flat section, and connectors detail", () => {
+    expect(parseSettingsHash("")).toEqual({ kind: "hub" });
+    expect(parseSettingsHash("#")).toEqual({ kind: "hub" });
+    expect(parseSettingsHash("#appearance")).toEqual({
+      kind: "section",
+      sectionId: "appearance",
+    });
+    expect(parseSettingsHash("#connectors")).toEqual({
+      kind: "section",
+      sectionId: "connectors",
+    });
+    expect(parseSettingsHash("#connectors/discord")).toEqual({
+      kind: "connector-detail",
+      sectionId: "connectors",
+      connectorId: "discord",
+    });
+  });
+
+  it("applies billing/api-keys aliases and twitter→x on connector ids", () => {
+    expect(parseSettingsHash("#billing")).toEqual({
+      kind: "section",
+      sectionId: "cloud-billing",
+    });
+    expect(parseSettingsHash("#connectors/Twitter")).toEqual({
+      kind: "connector-detail",
+      sectionId: "connectors",
+      connectorId: "x",
+    });
+  });
+
+  it("collapses illegal nesting under non-connectors sections to the section", () => {
+    expect(parseSettingsHash("#appearance/theme")).toEqual({
+      kind: "section",
+      sectionId: "appearance",
+    });
+  });
+});
+
+describe("settingsRouteToHash", () => {
+  it("round-trips connector detail", () => {
+    expect(
+      settingsRouteToHash({
+        kind: "connector-detail",
+        sectionId: "connectors",
+        connectorId: "telegram",
+      }),
+    ).toBe("#connectors/telegram");
+  });
+});
+
+describe("normalizeConnectorRouteId", () => {
+  it("lower-cases and aliases twitter", () => {
+    expect(normalizeConnectorRouteId(" Discord ")).toBe("discord");
+    expect(normalizeConnectorRouteId("twitter")).toBe("x");
+  });
+});

--- a/packages/ui/src/components/settings/settings-route.test.ts
+++ b/packages/ui/src/components/settings/settings-route.test.ts
@@ -6,6 +6,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  backFromConnectorDetail,
   normalizeConnectorRouteId,
   openConnectorDetailHash,
   parseSettingsHash,
@@ -15,6 +16,12 @@ import {
 beforeEach(() => {
   window.history.replaceState(null, "", "/#connectors");
 });
+
+function nextPopState(): Promise<void> {
+  return new Promise((resolve) => {
+    window.addEventListener("popstate", () => resolve(), { once: true });
+  });
+}
 
 describe("parseSettingsHash", () => {
   it("parses hub, flat section, and connectors detail", () => {
@@ -72,12 +79,27 @@ describe("connector detail history", () => {
     openConnectorDetailHash("signal");
     expect(window.location.hash).toBe("#connectors/signal");
 
-    await new Promise<void>((resolve) => {
-      window.addEventListener("popstate", () => resolve(), { once: true });
-      window.history.back();
-    });
+    const popped = nextPopState();
+    window.history.back();
+    await popped;
 
     expect(window.location.hash).toBe("#connectors");
+  });
+
+  it("consumes detail on visible Back so the next hardware Back leaves index", async () => {
+    window.history.replaceState(null, "", "/#appearance");
+    window.history.pushState(null, "", "#connectors");
+    openConnectorDetailHash("signal");
+
+    let popped = nextPopState();
+    backFromConnectorDetail();
+    await popped;
+    expect(window.location.hash).toBe("#connectors");
+
+    popped = nextPopState();
+    window.history.back();
+    await popped;
+    expect(window.location.hash).toBe("#appearance");
   });
 });
 

--- a/packages/ui/src/components/settings/settings-route.test.ts
+++ b/packages/ui/src/components/settings/settings-route.test.ts
@@ -7,9 +7,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   backFromConnectorDetail,
+  isPushedConnectorDetailRoute,
   normalizeConnectorRouteId,
   openConnectorDetailHash,
   parseSettingsHash,
+  replaceConnectorDetailHash,
   settingsRouteToHash,
 } from "./settings-route";
 
@@ -100,6 +102,40 @@ describe("connector detail history", () => {
     window.history.back();
     await popped;
     expect(window.location.hash).toBe("#appearance");
+  });
+
+  it("preserves the pushed marker when programmatic focus replaces detail A with detail B", async () => {
+    // [appearance, connectors, detail A] → focus detail B → visible Back →
+    // hardware Back must leave connectors (not stall on a replaced index).
+    window.history.replaceState(null, "", "/#appearance");
+    window.history.pushState(null, "", "#connectors");
+    openConnectorDetailHash("signal");
+    expect(window.location.hash).toBe("#connectors/signal");
+    expect(isPushedConnectorDetailRoute()).toBe(true);
+
+    replaceConnectorDetailHash("discord");
+    expect(window.location.hash).toBe("#connectors/discord");
+    expect(isPushedConnectorDetailRoute()).toBe(true);
+
+    let popped = nextPopState();
+    backFromConnectorDetail();
+    await popped;
+    expect(window.location.hash).toBe("#connectors");
+
+    popped = nextPopState();
+    window.history.back();
+    await popped;
+    expect(window.location.hash).toBe("#appearance");
+  });
+
+  it("keeps direct/programmatic detail entry marker-free", () => {
+    window.history.replaceState(null, "", "/#connectors");
+    replaceConnectorDetailHash("signal");
+    expect(window.location.hash).toBe("#connectors/signal");
+    expect(isPushedConnectorDetailRoute()).toBe(false);
+
+    backFromConnectorDetail();
+    expect(window.location.hash).toBe("#connectors");
   });
 });
 

--- a/packages/ui/src/components/settings/settings-route.test.ts
+++ b/packages/ui/src/components/settings/settings-route.test.ts
@@ -1,14 +1,20 @@
 /**
  * Unit tests for structured Settings hash routes (flat sections + nested
- * connectors detail). Deterministic pure parsing — no registry dependency.
+ * connectors detail), including real browser-history traversal in jsdom.
  */
+// @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   normalizeConnectorRouteId,
+  openConnectorDetailHash,
   parseSettingsHash,
   settingsRouteToHash,
 } from "./settings-route";
+
+beforeEach(() => {
+  window.history.replaceState(null, "", "/#connectors");
+});
 
 describe("parseSettingsHash", () => {
   it("parses hub, flat section, and connectors detail", () => {
@@ -58,6 +64,20 @@ describe("settingsRouteToHash", () => {
         connectorId: "telegram",
       }),
     ).toBe("#connectors/telegram");
+  });
+});
+
+describe("connector detail history", () => {
+  it("returns index → detail navigation to the index on browser Back", async () => {
+    openConnectorDetailHash("signal");
+    expect(window.location.hash).toBe("#connectors/signal");
+
+    await new Promise<void>((resolve) => {
+      window.addEventListener("popstate", () => resolve(), { once: true });
+      window.history.back();
+    });
+
+    expect(window.location.hash).toBe("#connectors");
   });
 });
 

--- a/packages/ui/src/components/settings/settings-route.ts
+++ b/packages/ui/src/components/settings/settings-route.ts
@@ -161,3 +161,17 @@ export function replaceConnectorDetailHash(connectorId: string): void {
 export function isPushedConnectorDetailRoute(): boolean {
   return Boolean(window.history.state?.[CONNECTOR_DETAIL_HISTORY_KEY]);
 }
+
+/**
+ * Visible Back consumes a user-pushed detail entry. Direct/programmatic detail
+ * routes have no marker, so they safely canonicalize to the connectors index.
+ */
+export function backFromConnectorDetail(): void {
+  if (typeof window === "undefined") return;
+  if (isPushedConnectorDetailRoute()) {
+    window.history.back();
+    return;
+  }
+  openConnectorsIndexHash();
+  window.dispatchEvent(new Event("popstate"));
+}

--- a/packages/ui/src/components/settings/settings-route.ts
+++ b/packages/ui/src/components/settings/settings-route.ts
@@ -148,13 +148,41 @@ export function openConnectorDetailHash(connectorId: string): void {
   );
 }
 
-/** Programmatic focus/deep links canonicalize without polluting history. */
+/**
+ * Programmatic focus/deep links canonicalize without polluting history.
+ * When the current entry is already a user-pushed connector detail, preserve
+ * the detail marker so detail→detail focus swaps keep a single consumable
+ * history entry (visible Back still returns to the index; the next hardware
+ * Back leaves connectors entirely).
+ */
 export function replaceConnectorDetailHash(connectorId: string): void {
+  if (typeof window === "undefined") return;
   const route = connectorDetailRoute(connectorId);
   if (!route) {
     openConnectorsIndexHash();
     return;
   }
+  const nextHash = settingsRouteToHash(route);
+  const currentHash = window.location.hash || "#";
+  if (currentHash === nextHash) return;
+
+  const currentRoute = parseSettingsHash(currentHash);
+  if (
+    currentRoute.kind === "connector-detail" &&
+    isPushedConnectorDetailRoute()
+  ) {
+    const currentState =
+      window.history.state && typeof window.history.state === "object"
+        ? window.history.state
+        : {};
+    window.history.replaceState(
+      { ...currentState, [CONNECTOR_DETAIL_HISTORY_KEY]: true },
+      "",
+      nextHash,
+    );
+    return;
+  }
+
   replaceSettingsHashRoute(route);
 }
 

--- a/packages/ui/src/components/settings/settings-route.ts
+++ b/packages/ui/src/components/settings/settings-route.ts
@@ -1,0 +1,125 @@
+/**
+ * Structured Settings hash routes. Most sections are flat (`#appearance`);
+ * Connectors alone nests a detail segment (`#connectors/discord`) so index and
+ * per-connector config pages share one section registration without inventing
+ * a second settings section per connector.
+ *
+ * Section-id validity against the live registry is applied by callers (see
+ * `readSettingsHashSection` in settings-sections.ts) so this module stays free
+ * of a circular import with the section registry.
+ */
+
+/** Flat section, or Connectors index / connector detail. */
+export type SettingsRoute =
+  | { kind: "hub" }
+  | { kind: "section"; sectionId: string }
+  | { kind: "connector-detail"; sectionId: "connectors"; connectorId: string };
+
+const SETTINGS_HASH_ALIASES: Readonly<Record<string, string>> = {
+  cloud: "ai-model",
+  providers: "ai-model",
+  billing: "cloud-billing",
+  "api-keys": "cloud-api-keys",
+  // Legacy aliases that still appear in bookmarks / deep links.
+  twitter: "x",
+};
+
+/** Canonicalize a connector id segment (trim, lower-case, alias map). */
+export function normalizeConnectorRouteId(raw: string): string {
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) return trimmed;
+  return SETTINGS_HASH_ALIASES[trimmed] ?? trimmed;
+}
+
+/**
+ * Parse a raw location hash (with or without leading `#`) into a settings
+ * route. Does not consult the section registry — callers drop unknown section
+ * ids. Nested paths under non-connectors sections collapse to that section.
+ */
+export function parseSettingsHash(rawHash: string): SettingsRoute {
+  const withoutHash = rawHash.replace(/^#/, "").trim();
+  if (!withoutHash) return { kind: "hub" };
+
+  const segments = withoutHash.split("/").filter(Boolean);
+  if (segments.length === 0) return { kind: "hub" };
+
+  const head = SETTINGS_HASH_ALIASES[segments[0]!] ?? segments[0]!;
+
+  if (segments.length === 1) {
+    return { kind: "section", sectionId: head };
+  }
+
+  // Only connectors may nest: #connectors/<connectorId>
+  if (head === "connectors" && segments.length >= 2) {
+    const connectorId = normalizeConnectorRouteId(segments[1]!);
+    if (!connectorId) {
+      return { kind: "section", sectionId: "connectors" };
+    }
+    return {
+      kind: "connector-detail",
+      sectionId: "connectors",
+      connectorId,
+    };
+  }
+
+  // Nested path under a non-connectors section — keep the section, drop the rest.
+  return { kind: "section", sectionId: head };
+}
+
+export function readSettingsHashRoute(): SettingsRoute {
+  if (typeof window === "undefined") return { kind: "hub" };
+  return parseSettingsHash(window.location.hash);
+}
+
+/** Section id only — back-compat for callers that ignore connector detail. */
+export function readSettingsHashSectionId(): string | null {
+  const route = readSettingsHashRoute();
+  if (route.kind === "hub") return null;
+  return route.sectionId;
+}
+
+export function settingsRouteToHash(route: SettingsRoute): string {
+  if (route.kind === "hub") return "#";
+  if (route.kind === "section") return `#${route.sectionId}`;
+  return `#connectors/${normalizeConnectorRouteId(route.connectorId)}`;
+}
+
+/**
+ * Write the settings hash without pushing history. `replaceState` does not
+ * fire `hashchange`, so callers must update their own React state in the same
+ * turn (or listen to `popstate` only for true history walks).
+ */
+export function replaceSettingsHashRoute(route: SettingsRoute): void {
+  if (typeof window === "undefined") return;
+  const nextHash = settingsRouteToHash(route);
+  const current = window.location.hash || "#";
+  if (current === nextHash || (nextHash === "#" && (current === "" || current === "#"))) {
+    return;
+  }
+  if (nextHash === "#") {
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${window.location.search}`,
+    );
+    return;
+  }
+  window.history.replaceState(null, "", nextHash);
+}
+
+export function openConnectorsIndexHash(): void {
+  replaceSettingsHashRoute({ kind: "section", sectionId: "connectors" });
+}
+
+export function openConnectorDetailHash(connectorId: string): void {
+  const id = normalizeConnectorRouteId(connectorId);
+  if (!id) {
+    openConnectorsIndexHash();
+    return;
+  }
+  replaceSettingsHashRoute({
+    kind: "connector-detail",
+    sectionId: "connectors",
+    connectorId: id,
+  });
+}

--- a/packages/ui/src/components/settings/settings-route.ts
+++ b/packages/ui/src/components/settings/settings-route.ts
@@ -15,6 +15,8 @@ export type SettingsRoute =
   | { kind: "section"; sectionId: string }
   | { kind: "connector-detail"; sectionId: "connectors"; connectorId: string };
 
+const CONNECTOR_DETAIL_HISTORY_KEY = "elizaSettingsConnectorDetail";
+
 const SETTINGS_HASH_ALIASES: Readonly<Record<string, string>> = {
   cloud: "ai-model",
   providers: "ai-model",
@@ -41,17 +43,18 @@ export function parseSettingsHash(rawHash: string): SettingsRoute {
   if (!withoutHash) return { kind: "hub" };
 
   const segments = withoutHash.split("/").filter(Boolean);
-  if (segments.length === 0) return { kind: "hub" };
+  const [rawHead, rawConnectorId] = segments;
+  if (!rawHead) return { kind: "hub" };
 
-  const head = SETTINGS_HASH_ALIASES[segments[0]!] ?? segments[0]!;
+  const head = SETTINGS_HASH_ALIASES[rawHead] ?? rawHead;
 
   if (segments.length === 1) {
     return { kind: "section", sectionId: head };
   }
 
   // Only connectors may nest: #connectors/<connectorId>
-  if (head === "connectors" && segments.length >= 2) {
-    const connectorId = normalizeConnectorRouteId(segments[1]!);
+  if (head === "connectors" && rawConnectorId) {
+    const connectorId = normalizeConnectorRouteId(rawConnectorId);
     if (!connectorId) {
       return { kind: "section", sectionId: "connectors" };
     }
@@ -93,7 +96,10 @@ export function replaceSettingsHashRoute(route: SettingsRoute): void {
   if (typeof window === "undefined") return;
   const nextHash = settingsRouteToHash(route);
   const current = window.location.hash || "#";
-  if (current === nextHash || (nextHash === "#" && (current === "" || current === "#"))) {
+  if (
+    current === nextHash ||
+    (nextHash === "#" && (current === "" || current === "#"))
+  ) {
     return;
   }
   if (nextHash === "#") {
@@ -111,15 +117,47 @@ export function openConnectorsIndexHash(): void {
   replaceSettingsHashRoute({ kind: "section", sectionId: "connectors" });
 }
 
-export function openConnectorDetailHash(connectorId: string): void {
+function connectorDetailRoute(connectorId: string): SettingsRoute | null {
   const id = normalizeConnectorRouteId(connectorId);
-  if (!id) {
-    openConnectorsIndexHash();
-    return;
-  }
-  replaceSettingsHashRoute({
+  if (!id) return null;
+  return {
     kind: "connector-detail",
     sectionId: "connectors",
     connectorId: id,
-  });
+  };
+}
+
+/** User navigation creates a real history entry so browser/hardware Back works. */
+export function openConnectorDetailHash(connectorId: string): void {
+  if (typeof window === "undefined") return;
+  const route = connectorDetailRoute(connectorId);
+  if (!route) {
+    openConnectorsIndexHash();
+    return;
+  }
+  const nextHash = settingsRouteToHash(route);
+  if (window.location.hash === nextHash) return;
+  const currentState =
+    window.history.state && typeof window.history.state === "object"
+      ? window.history.state
+      : {};
+  window.history.pushState(
+    { ...currentState, [CONNECTOR_DETAIL_HISTORY_KEY]: true },
+    "",
+    nextHash,
+  );
+}
+
+/** Programmatic focus/deep links canonicalize without polluting history. */
+export function replaceConnectorDetailHash(connectorId: string): void {
+  const route = connectorDetailRoute(connectorId);
+  if (!route) {
+    openConnectorsIndexHash();
+    return;
+  }
+  replaceSettingsHashRoute(route);
+}
+
+export function isPushedConnectorDetailRoute(): boolean {
+  return Boolean(window.history.state?.[CONNECTOR_DETAIL_HISTORY_KEY]);
 }

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -33,6 +33,10 @@ import {
 import { type ComponentType, type LazyExoticComponent, lazy } from "react";
 import { registerCloudConnectorsSettingsSection } from "../../cloud/connectors";
 import {
+  readSettingsHashSectionId,
+  replaceSettingsHashRoute,
+} from "./settings-route";
+import {
   CLOUD_SETTINGS_GROUP_ID,
   listExtraSettingsGroups,
   registerSettingsGroup,
@@ -748,31 +752,33 @@ export function settingsSectionTitle(
   return t(section.titleKey, { defaultValue: section.defaultTitle });
 }
 
-/**
- * Legacy hash aliases → section ids. `#billing` / `#api-keys` are the hashes
- * older in-app links and bookmarks carry; the registered cloud sections use
- * `cloud-*` ids so they never collide with the built-in local sections.
- */
-const SETTINGS_HASH_ALIASES: Readonly<Record<string, string>> = {
-  cloud: "ai-model",
-  providers: "ai-model",
-  billing: "cloud-billing",
-  "api-keys": "cloud-api-keys",
-};
+export {
+  normalizeConnectorRouteId,
+  openConnectorDetailHash,
+  openConnectorsIndexHash,
+  parseSettingsHash,
+  readSettingsHashRoute,
+  readSettingsHashSectionId,
+  replaceSettingsHashRoute,
+  settingsRouteToHash,
+  type SettingsRoute,
+} from "./settings-route";
 
+/**
+ * Back-compat: section id only. Nested connector detail (`#connectors/discord`)
+ * still resolves to `"connectors"` so existing SettingsView callers keep the
+ * section selected while the connectors body reads the detail segment. Unknown
+ * section ids return null (registry gate).
+ */
 export function readSettingsHashSection(): string | null {
-  if (typeof window === "undefined") return null;
-  const rawHash = window.location.hash.replace(/^#/, "");
-  if (!rawHash) return null;
-  const hash = SETTINGS_HASH_ALIASES[rawHash] ?? rawHash;
-  return getAllSettingsSections().some((section) => section.id === hash)
-    ? hash
+  const sectionId = readSettingsHashSectionId();
+  if (!sectionId) return null;
+  return getAllSettingsSections().some((section) => section.id === sectionId)
+    ? sectionId
     : null;
 }
 
+/** Write a flat section hash (clears any connector detail segment). */
 export function replaceSettingsHash(sectionId: string): void {
-  if (typeof window === "undefined") return;
-  const nextHash = `#${sectionId}`;
-  if (window.location.hash === nextHash) return;
-  window.history.replaceState(null, "", nextHash);
+  replaceSettingsHashRoute({ kind: "section", sectionId });
 }

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -33,14 +33,14 @@ import {
 import { type ComponentType, type LazyExoticComponent, lazy } from "react";
 import { registerCloudConnectorsSettingsSection } from "../../cloud/connectors";
 import {
-  readSettingsHashSectionId,
-  replaceSettingsHashRoute,
-} from "./settings-route";
-import {
   CLOUD_SETTINGS_GROUP_ID,
   listExtraSettingsGroups,
   registerSettingsGroup,
 } from "../../cloud/settings/cloud-settings-group";
+import {
+  readSettingsHashSectionId,
+  replaceSettingsHashRoute,
+} from "./settings-route";
 import {
   SETTINGS_GROUP_LABEL,
   SETTINGS_GROUP_ORDER,
@@ -753,15 +753,17 @@ export function settingsSectionTitle(
 }
 
 export {
+  backFromConnectorDetail,
   normalizeConnectorRouteId,
   openConnectorDetailHash,
   openConnectorsIndexHash,
   parseSettingsHash,
   readSettingsHashRoute,
   readSettingsHashSectionId,
+  replaceConnectorDetailHash,
   replaceSettingsHashRoute,
-  settingsRouteToHash,
   type SettingsRoute,
+  settingsRouteToHash,
 } from "./settings-route";
 
 /**

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -21,22 +21,29 @@ import * as React from "react";
 import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm text-sm font-medium  transition-colors     disabled:pointer-events-none disabled:opacity-50 cursor-pointer [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  // Disabled states keep solid type color (no blanket opacity) so labels stay
+  // readable on accent fills — opacity-50 made orange CTAs look muddy/gray.
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm text-sm font-medium transition-colors disabled:pointer-events-none disabled:cursor-not-allowed cursor-pointer [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-accent text-accent-fg hover:bg-accent-hover",
-        surface: "bg-card text-muted-strong hover:bg-surface",
+        default:
+          "bg-accent text-accent-fg hover:bg-accent-hover disabled:bg-accent/45 disabled:text-accent-fg",
+        surface:
+          "bg-card text-muted-strong hover:bg-surface disabled:text-muted",
         surfaceAccent:
-          "bg-accent-subtle text-txt-strong hover:bg-accent-subtle/70",
+          "bg-accent-subtle text-txt-strong hover:bg-accent-subtle/70 disabled:text-muted",
         surfaceDestructive:
-          "bg-destructive-subtle text-danger hover:bg-destructive-subtle/70",
+          "bg-destructive-subtle text-danger hover:bg-destructive-subtle/70 disabled:text-muted",
         destructive:
-          "bg-destructive text-destructive-fg hover:bg-destructive/85",
-        outline: "bg-card text-txt hover:bg-surface",
-        secondary: "bg-bg-accent text-txt hover:bg-surface",
-        ghost: "text-muted-strong hover:bg-surface hover:text-txt",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-destructive text-destructive-fg hover:bg-destructive/85 disabled:bg-destructive/45 disabled:text-destructive-fg",
+        outline:
+          "border border-border/70 bg-card text-txt-strong hover:bg-surface hover:text-txt-strong disabled:border-border/50 disabled:bg-card disabled:text-muted-strong",
+        secondary:
+          "bg-bg-accent text-txt hover:bg-surface disabled:text-muted",
+        ghost:
+          "text-muted-strong hover:bg-surface hover:text-txt disabled:text-muted",
+        link: "text-primary underline-offset-4 hover:underline disabled:text-muted",
       },
       size: {
         default:

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -27,23 +27,25 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
+        // Keep disabled primary actions visibly subdued without lowering the
+        // orange fill so far that its dark label loses contrast (45% failed).
         default:
-          "bg-accent text-accent-fg hover:bg-accent-hover disabled:bg-accent/45 disabled:text-accent-fg",
+          "bg-accent text-accent-fg hover:bg-accent-hover disabled:bg-accent/80 disabled:text-accent-fg",
         surface:
-          "bg-card text-muted-strong hover:bg-surface disabled:text-muted",
+          "bg-card text-txt-strong hover:bg-surface disabled:text-muted-strong",
         surfaceAccent:
-          "bg-accent-subtle text-txt-strong hover:bg-accent-subtle/70 disabled:text-muted",
+          "bg-accent-subtle text-txt-strong hover:bg-accent-subtle/70 disabled:text-muted-strong",
         surfaceDestructive:
-          "bg-destructive-subtle text-danger hover:bg-destructive-subtle/70 disabled:text-muted",
+          "bg-destructive-subtle text-danger hover:bg-destructive-subtle/70 disabled:text-muted-strong",
         destructive:
-          "bg-destructive text-destructive-fg hover:bg-destructive/85 disabled:bg-destructive/45 disabled:text-destructive-fg",
+          "bg-destructive text-destructive-fg hover:bg-destructive/85 disabled:bg-destructive/65 disabled:text-destructive-fg",
         outline:
-          "border border-border/70 bg-card text-txt-strong hover:bg-surface hover:text-txt-strong disabled:border-border/50 disabled:bg-card disabled:text-muted-strong",
+          "border border-border bg-card text-txt-strong hover:border-border-strong hover:bg-surface hover:text-txt-strong disabled:border-border/60 disabled:bg-card disabled:text-muted-strong",
         secondary:
-          "bg-bg-accent text-txt hover:bg-surface disabled:text-muted",
+          "bg-bg-accent text-txt-strong hover:bg-surface disabled:text-muted-strong",
         ghost:
-          "text-muted-strong hover:bg-surface hover:text-txt disabled:text-muted",
-        link: "text-primary underline-offset-4 hover:underline disabled:text-muted",
+          "text-txt-strong hover:bg-surface hover:text-txt-strong disabled:text-muted-strong",
+        link: "text-accent underline-offset-4 hover:underline disabled:text-muted-strong",
       },
       size: {
         default:

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -547,8 +547,12 @@ export function tabFromPath(pathname: string, basePath = ""): Tab | null {
     return "settings";
   }
 
-  // Legacy /connectors — redirect into Settings → Connectors.
-  if (normalized === "/connectors") return "settings";
+  // Legacy /connectors and /connectors/<id> — Settings → Connectors (index or
+  // detail). The hash `#connectors` / `#connectors/<id>` is written by the
+  // shell when these paths are opened so ConnectorsSection can deep-link.
+  if (normalized === "/connectors" || normalized.startsWith("/connectors/")) {
+    return "settings";
+  }
 
   // Check current paths first, then route unknown top-level paths through the
   // view registry. Plugin views can declare routes that are not built-in tabs;

--- a/plugins/plugin-discord/package.json
+++ b/plugins/plugin-discord/package.json
@@ -169,6 +169,67 @@
 				"required": false,
 				"sensitive": false
 			}
+		},
+		"configUiHints": {
+			"DISCORD_API_TOKEN": {
+				"label": "Bot token",
+				"order": 1,
+				"group": "connection"
+			},
+			"DISCORD_APPLICATION_ID": {
+				"label": "Application ID",
+				"order": 2,
+				"group": "connection"
+			},
+			"CHANNEL_IDS": {
+				"label": "Respond in channels",
+				"order": 10,
+				"group": "behavior",
+				"requires": "DISCORD_API_TOKEN"
+			},
+			"DISCORD_LISTEN_CHANNEL_IDS": {
+				"label": "Listen-only channels",
+				"order": 11,
+				"group": "behavior",
+				"requires": "DISCORD_API_TOKEN"
+			},
+			"DISCORD_VOICE_CHANNEL_ID": {
+				"label": "Voice channel",
+				"order": 12,
+				"group": "behavior",
+				"requires": "DISCORD_API_TOKEN"
+			},
+			"DISCORD_VOICE_TRANSCRIPTS": {
+				"label": "Voice transcripts",
+				"order": 13,
+				"group": "behavior",
+				"requires": "DISCORD_API_TOKEN"
+			},
+			"DISCORD_SHOULD_IGNORE_BOT_MESSAGES": {
+				"label": "Ignore other bots",
+				"order": 14,
+				"group": "behavior",
+				"requires": "DISCORD_API_TOKEN"
+			},
+			"DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES": {
+				"label": "Ignore DMs",
+				"order": 15,
+				"group": "behavior",
+				"requires": "DISCORD_API_TOKEN"
+			},
+			"DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS": {
+				"label": "Only respond to mentions",
+				"order": 16,
+				"group": "behavior",
+				"requires": "DISCORD_API_TOKEN"
+			},
+			"DISCORD_TEST_CHANNEL_ID": {
+				"label": "Test channel",
+				"order": 20,
+				"group": "advanced",
+				"advanced": true,
+				"requires": "DISCORD_API_TOKEN"
+			}
 		}
 	},
 	"eliza": {

--- a/plugins/plugin-imessage/__tests__/package-config.test.ts
+++ b/plugins/plugin-imessage/__tests__/package-config.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Verifies the published iMessage configuration hints keep runtime-defaulted
+ * policy controls visible without requiring optional path overrides.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+interface PackageManifest {
+  agentConfig?: {
+    configUiHints?: Record<string, { requiresAny?: string[] }>;
+  };
+}
+
+const manifest = JSON.parse(
+  readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), "utf8")
+) as PackageManifest;
+
+describe("iMessage package config hints", () => {
+  it("does not gate default-backed behavior fields on optional paths", () => {
+    const hints = manifest.agentConfig?.configUiHints ?? {};
+    for (const key of [
+      "IMESSAGE_POLL_INTERVAL_MS",
+      "IMESSAGE_DM_POLICY",
+      "IMESSAGE_GROUP_POLICY",
+      "IMESSAGE_ALLOW_FROM",
+    ]) {
+      expect(hints[key]?.requiresAny).toBeUndefined();
+    }
+  });
+});

--- a/plugins/plugin-imessage/package.json
+++ b/plugins/plugin-imessage/package.json
@@ -117,6 +117,48 @@
         "required": false,
         "sensitive": false
       }
+    },
+    "configUiHints": {
+      "IMESSAGE_CLI_PATH": {
+        "label": "CLI path",
+        "order": 1,
+        "group": "connection"
+      },
+      "IMESSAGE_DB_PATH": {
+        "label": "Database path",
+        "order": 2,
+        "group": "connection"
+      },
+      "IMESSAGE_ENABLED": {
+        "label": "Enabled",
+        "order": 3,
+        "group": "connection"
+      },
+      "IMESSAGE_POLL_INTERVAL_MS": {
+        "label": "Polling interval",
+        "unit": "ms",
+        "order": 10,
+        "group": "behavior",
+        "requiresAny": ["IMESSAGE_CLI_PATH", "IMESSAGE_DB_PATH"]
+      },
+      "IMESSAGE_DM_POLICY": {
+        "label": "DM policy",
+        "order": 11,
+        "group": "behavior",
+        "requiresAny": ["IMESSAGE_CLI_PATH", "IMESSAGE_DB_PATH"]
+      },
+      "IMESSAGE_GROUP_POLICY": {
+        "label": "Group policy",
+        "order": 12,
+        "group": "behavior",
+        "requiresAny": ["IMESSAGE_CLI_PATH", "IMESSAGE_DB_PATH"]
+      },
+      "IMESSAGE_ALLOW_FROM": {
+        "label": "Allow from",
+        "order": 13,
+        "group": "behavior",
+        "requiresAny": ["IMESSAGE_CLI_PATH", "IMESSAGE_DB_PATH"]
+      }
     }
   }
 }

--- a/plugins/plugin-imessage/package.json
+++ b/plugins/plugin-imessage/package.json
@@ -138,26 +138,22 @@
         "label": "Polling interval",
         "unit": "ms",
         "order": 10,
-        "group": "behavior",
-        "requiresAny": ["IMESSAGE_CLI_PATH", "IMESSAGE_DB_PATH"]
+        "group": "behavior"
       },
       "IMESSAGE_DM_POLICY": {
         "label": "DM policy",
         "order": 11,
-        "group": "behavior",
-        "requiresAny": ["IMESSAGE_CLI_PATH", "IMESSAGE_DB_PATH"]
+        "group": "behavior"
       },
       "IMESSAGE_GROUP_POLICY": {
         "label": "Group policy",
         "order": 12,
-        "group": "behavior",
-        "requiresAny": ["IMESSAGE_CLI_PATH", "IMESSAGE_DB_PATH"]
+        "group": "behavior"
       },
       "IMESSAGE_ALLOW_FROM": {
         "label": "Allow from",
         "order": 13,
-        "group": "behavior",
-        "requiresAny": ["IMESSAGE_CLI_PATH", "IMESSAGE_DB_PATH"]
+        "group": "behavior"
       }
     }
   }

--- a/plugins/plugin-x/package.json
+++ b/plugins/plugin-x/package.json
@@ -405,6 +405,227 @@
         "default": "home",
         "sensitive": false
       }
+    },
+    "configUiHints": {
+      "TWITTER_API_KEY": { "order": 1, "group": "connection" },
+      "TWITTER_API_SECRET_KEY": { "order": 2, "group": "connection" },
+      "TWITTER_ACCESS_TOKEN": { "order": 3, "group": "connection" },
+      "TWITTER_ACCESS_TOKEN_SECRET": { "order": 4, "group": "connection" },
+      "TWITTER_CLIENT_ID": { "order": 5, "group": "connection" },
+      "TWITTER_REDIRECT_URI": { "order": 6, "group": "connection" },
+      "TWITTER_ACCOUNTS": { "order": 7, "group": "connection" },
+      "TWITTER_POLL_INTERVAL": {
+        "label": "Timeline poll interval",
+        "unit": "s",
+        "order": 20,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_RETRY_LIMIT": {
+        "order": 21,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_DRY_RUN": {
+        "order": 22,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_ENABLE_POST": {
+        "order": 23,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_POST_INTERVAL_MIN": {
+        "order": 24,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_POST_INTERVAL_MAX": {
+        "order": 25,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_POST_INTERVAL": {
+        "order": 26,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_POST_IMMEDIATELY": {
+        "order": 27,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_POST_INTERVAL_VARIANCE": {
+        "order": 28,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_INTERACTION_INTERVAL_MIN": {
+        "order": 29,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_INTERACTION_INTERVAL_MAX": {
+        "order": 30,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_INTERACTION_INTERVAL_VARIANCE": {
+        "order": 31,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_ACTION_INTERVAL": {
+        "order": 32,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_ENGAGEMENT_INTERVAL": {
+        "order": 33,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_ENGAGEMENT_INTERVAL_MIN": {
+        "order": 34,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_ENGAGEMENT_INTERVAL_MAX": {
+        "order": 35,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_DISCOVERY_INTERVAL_MIN": {
+        "order": 36,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_DISCOVERY_INTERVAL_MAX": {
+        "order": 37,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_TARGET_USERS": {
+        "order": 38,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_TIMELINE_ALGORITHM": {
+        "order": 39,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      },
+      "TWITTER_TIMELINE_MODE": {
+        "order": 40,
+        "group": "behavior",
+        "requiresAny": [
+          "TWITTER_ACCESS_TOKEN",
+          "TWITTER_API_KEY",
+          "TWITTER_CLIENT_ID",
+          "TWITTER_ACCOUNTS"
+        ]
+      }
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
# Relates to

No linked issue was created before this work began. This PR is the acceptance record for the Settings → Connectors migration.

Definition of Done: [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] Targets `develop`; branch rebases/merges from `develop` have remained conflict-free.
- [ ] Full `bun run verify` and required visual evidence are still pending.
- [x] Focused behavior is covered by deterministic tests listed below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `pi`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Summary

Migrates **Settings → Connectors** from inline accordions to a dense index/detail workflow:

- Grouped connector index with a persisted **Delegate / Bot** identity lens.
- Per-connector routes at `#connectors/<id>` with browser/hardware Back support.
- Connector enable/load switch first; duplicate schema-level `Enabled` fields are hidden.
- One config item per row.
- Text, number, secret, JSON, array, code, and multiline values rest as value chips and open a **Save / Cancel** dialog.
- Dialog Save stages edits locally; **Save changes / Cancel** commits or discards the complete bundle atomically.
- Signal and WhatsApp QR states use the same description-left/action-right pattern as other connectors.
- Required fields use badges without decorative left bars.
- Stronger contrast for primary/disabled CTAs, neutral actions, and value chips.
- Deep links and programmatic connector focus remain supported.

# Identity classification

Declared setup modes are filtered by identity. Plugin-managed inventories are filtered from each stored account record—not the catalog creation default:

- `OWNER` → Delegate
- `AGENT` → Bot
- `TEAM` or unknown role → visible in both lenses

| Connector | Delegate | Bot |
| --- | --- | --- |
| Discord | Desktop App | OAuth Gateway, Bot Token |
| Telegram | Personal Account; stored OWNER/TEAM accounts | Cloud Gateway, Bot Token; stored AGENT/TEAM accounts |
| Slack | Stored OWNER/TEAM accounts | OAuth App, Socket Mode; stored AGENT/TEAM accounts |
| X | OAuth, local OAuth2, developer tokens; stored OWNER/TEAM accounts | Stored AGENT/TEAM accounts |
| Signal | QR-linked account; stored OWNER/TEAM accounts | Stored AGENT/TEAM accounts |
| WhatsApp | QR-linked personal account; stored OWNER/TEAM accounts | Business Cloud API; stored AGENT/TEAM accounts |
| iMessage | iPhone gateway, direct chat.db, BlueBubbles | Blooio cloud number |
| BlueBubbles | Cloud and local owner bridge | — |

Single-form fallback classifications:

- **Bot:** Bluesky, Farcaster, Nostr, Matrix, MS Teams, Mattermost, Google Chat, Feishu, LINE, Zalo Official, Tlon, Nextcloud Talk, Twitch, Blooio.
- **Delegate:** Instagram, Zalo User, Google Workspace.
- Unknown third-party connectors intentionally remain visible in both lenses.

## Known identity ambiguities

The following plugins do not declare account ownership strongly enough to classify every credential with certainty:

- Slack Socket Mode still includes optional `SLACK_USER_TOKEN` in an otherwise bot-oriented schema.
- Tlon credentials can represent an agent ship or the owner’s ship.
- Matrix credentials can represent a dedicated bot user or an owner account.
- Instagram supports personal, brand, and bot-like profiles.
- Bluesky app passwords can technically belong to either identity.
- X OAuth2 and OAuth1 modes remain one same-lens schema; this is setup-mode leakage, not a Delegate/Bot error.

# Review fixes included

- Atomic bundle save prevents overlapping plugin restarts and stale-completion draft loss.
- Failed saves retain drafts; duplicate Save clicks are ignored.
- Configured secrets cannot be deleted by empty Save/Enter.
- Optional secrets retain an explicit confirmed **Clear → Clear value** path.
- Masked secret chips have distinct accessible names (`Edit <field>`).
- User-opened detail routes use `pushState`; visible Back consumes that entry. Programmatic/deep-linked details retain replace semantics.
- Default-backed iMessage policy controls no longer require optional CLI/database path overrides.
- Mixed plugin-managed OWNER/AGENT records are separated by actual stored role; TEAM/unknown remain neutral.
- Programmatic detail→detail focus preserves the user-pushed history marker so visible Back then hardware Back leave the connectors stack cleanly.
- Catalog-backed detail modes follow the same `connectorSupportsChannelMode` lens policy as the index (e.g. Google under Bot does not expose plugin-managed inventory).
- Mobile detail hides the in-content Back control; ViewHeader remains the sole mobile Back target (`hidden` / `md:inline-flex`, `min-h-11`).

# Risks

**Medium.** This changes shared config-field and button primitives plus connector routing/history. Primary risks are incorrect identity filtering, lost config drafts, accidental secret deletion, and duplicate history entries. Focused tests cover each path; visual evidence and full repository verification remain outstanding.

# Testing

## Automated

- [x] UI focused suite: **6 files / focused connector routing/history/config tests passed** (re-run after re-review)
  - lens and mode filtering
  - mixed OWNER/AGENT/TEAM/unknown account records
  - atomic multi-field saves, duplicate saves, stale completions, failures, and Cancel
  - secret accessible names, empty-save safety, and confirmed deletion
  - QR action-row states
  - browser and visible-Back history behavior
  - duplicate field hiding and structured-value dialogs
- [x] iMessage manifest regression: **1 test passed**
- [x] `bun run --cwd packages/ui typecheck`
- [x] `bun run --cwd plugins/plugin-imessage typecheck`
- [x] Biome checks for touched files
- [x] `git diff --check`

## Reviewer walkthrough

1. Open Settings → Connectors and switch Delegate/Bot.
2. Open Discord, Telegram, Slack, Signal, WhatsApp, iMessage, and BlueBubbles details.
3. Confirm only identity-appropriate modes/accounts appear.
4. Edit two config values; verify they stage before one atomic Save changes action.
5. Open a configured optional secret; verify empty Save is disabled and Clear requires confirmation.
6. Navigate index → detail → visible Back → browser/hardware Back; verify each history level is consumed once.

# Evidence Gate

<!-- evidence-head:b8b37b722145822644b6322e4077739368e01106 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before desktop/mobile screenshots: pending; not claimed.
<!-- evidence-row:after-screenshots -->
- [ ] After desktop/mobile screenshots: pending; not claimed.
<!-- evidence-row:walkthrough-video -->
- [ ] MP4 walkthrough: pending; not claimed.
<!-- evidence-row:backend-logs -->
- [ ] Backend config-save/restart logs: pending; not claimed.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: pending; not claimed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A — no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A — this UI migration produces no domain artifact.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual review: pending; not claimed.

## Known gaps / failures

- `audit:app` was retried with the pinned Node 24 runtime, but the Playwright worker aborted with `Project "audit-app" not found`; no screenshots from that run are claimed.
- Required fork workflows still require maintainer approval before trusted checks can run.
- Formal reviewer assignment is blocked by fork permissions; exact-head re-review requests are posted as PR comments.

AI provider/model: openai-codex / gpt-5.6-sol
Client / agent tooling: pi
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [pi]
<!-- eliza-computer-attribution:v1 {"provider":"openai-codex","model":"gpt-5.6-sol","client":"pi","skill_revision":"N/A - no contribution skill used"} -->


