### PR TITLE
fix(ui): app hosts redeem pairing in-process instead of dead-ending on /pair

### DIFF
--- a/packages/ui/src/hooks/useAgentSessionRecovery.test.tsx
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.test.tsx
@@ -89,6 +89,18 @@ function Probe(props: {
   return null;
 }
 
+// App-mode host detection reads window.location.hostname; jsdom's default
+// (localhost) is neither an app host nor a per-agent host, so the pairing
+// hand-off cases below pin it explicitly.
+const realLocation = window.location;
+
+function setHostname(hostname: string): void {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...realLocation, hostname },
+  });
+}
+
 function cloudServer(agentId: string) {
   return {
     kind: "cloud" as const,
@@ -101,6 +113,10 @@ function cloudServer(agentId: string) {
 afterEach(() => {
   cleanup();
   delete (globalThis as { Capacitor?: unknown }).Capacitor;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: realLocation,
+  });
   vi.clearAllMocks();
   // Restore the default "no cookie" behavior after clearAllMocks wipes it.
   mockEnsureCloudSession.mockImplementation(async () => Promise.resolve(null));
@@ -180,6 +196,60 @@ describe("useAgentSessionRecovery", () => {
         isRecoveryTargetCurrent: expect.any(Function),
         commitPairedInProcess: expect.any(Function),
       }),
+    );
+  });
+
+  it("uses in-process pairing on the Eliza app hosts so entry never leaves the origin", async () => {
+    // Regression pin for the app-staging pairing dead-end. The chat floor
+    // (app-mode.ts) stopped ENTRY from redirecting into the per-agent /pair,
+    // but recovery still did: a cold-starting agent cannot redeem the 60s
+    // one-time token, the relay answered 403, and the browser rendered
+    // "Sign-in link expired" — bouncing the user back through a second full
+    // sign-in. On an app host recovery must redeem in-process instead.
+    setHostname("app-staging.elizacloud.ai");
+    mockCloudToken.mockReturnValue("steward.jwt.token");
+    mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+    mockRunRecovery.mockReturnValue(new Promise(() => {}));
+
+    const statuses: string[] = [];
+    render(
+      <Probe
+        active
+        reason="remote_auth_required"
+        onStatus={(s) => statuses.push(s)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(statuses).toContain("recovering");
+    });
+    expect(mockRunRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({ consumeRedirectInProcess: true }),
+    );
+  });
+
+  it("keeps the browser navigation hand-off on non-app hosts", async () => {
+    // The dedicated per-agent host still has no same-origin chat app to fall
+    // back to, so its /pair relay hand-off must stay untouched.
+    setHostname("agent-1.elizacloud.ai");
+    mockCloudToken.mockReturnValue("steward.jwt.token");
+    mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+    mockRunRecovery.mockReturnValue(new Promise(() => {}));
+
+    const statuses: string[] = [];
+    render(
+      <Probe
+        active
+        reason="remote_auth_required"
+        onStatus={(s) => statuses.push(s)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(statuses).toContain("recovering");
+    });
+    expect(mockRunRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({ consumeRedirectInProcess: false }),
     );
   });
 

--- a/packages/ui/src/hooks/useAgentSessionRecovery.ts
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.ts
@@ -21,6 +21,7 @@
 import { logger } from "@elizaos/logger";
 import { useEffect, useRef, useState } from "react";
 import { getCloudAuthToken } from "../api/client-cloud";
+import { isAppModeHost } from "../cloud/app-mode/app-mode";
 import { persistCloudPairApiToken } from "../components/auth/CloudPairRelay";
 import { getBootConfig } from "../config/boot-config";
 import { persistActiveServerCredential } from "../state/active-server-credential";
@@ -72,7 +73,21 @@ function defaultNavigate(url: string): void {
   }
 }
 
-function shouldConsumePairRedirectInProcess(): boolean {
+/**
+ * Whether recovery redeems the one-time pairing token in-process instead of
+ * full-page navigating into the per-agent `/pair` relay.
+ *
+ * Native has always consumed in-process (it has no browser navigation). The
+ * Eliza app hosts must too: `../cloud/app-mode/app-mode.ts` established the
+ * chat floor because a cold-starting agent cannot consume a 60s one-time token
+ * inside its TTL, so the redirect dead-ends on "Sign-in link expired" and the
+ * user is bounced back through a second full sign-in. Entry stopped
+ * pairing-redirecting there (#18016); recovery is the remaining caller that
+ * did, which reopened the same dead-end on app-staging. The exchange endpoint
+ * (`/api/auth/pair/native`) authenticates with the Cloud session the browser
+ * already holds, so the app hosts can redeem it directly and stay same-origin.
+ */
+function isNativeRuntime(): boolean {
   try {
     const cap = (globalThis as Record<string, unknown>).Capacitor as
       | { isNativePlatform?: () => boolean }
@@ -83,6 +98,10 @@ function shouldConsumePairRedirectInProcess(): boolean {
     // navigation remains the compatible fallback.
     return false;
   }
+}
+
+function shouldConsumePairRedirectInProcess(): boolean {
+  return isNativeRuntime() || isAppModeHost();
 }
 
 function normalizedOptionalValue(value: string | undefined): string {
@@ -148,8 +167,11 @@ export function useAgentSessionRecovery(
   useEffect(() => {
     const consumeRedirectInProcess = shouldConsumePairRedirectInProcess();
     const activeServer = active ? loadPersistedActiveServer() : null;
+    // Deliberately keyed to the native runtime, not to in-process redemption:
+    // the app hosts now redeem in-process too, and this flag drives the
+    // native-only managed-recovery status UI.
     const isManagedNative =
-      consumeRedirectInProcess && isManagedCloudAgentServer(activeServer);
+      isNativeRuntime() && isManagedCloudAgentServer(activeServer);
     const fallbackStatus = (
       managedStatus: ManagedCloudAgentRecoveryStatus = "cloud-retry-required",
     ): AgentSessionRecoveryStatus => (isManagedNative ? managedStatus : "idle");


### PR DESCRIPTION
## Summary

Session recovery on the Eliza app hosts (`app.elizacloud.ai`, `app-staging.elizacloud.ai`) full-page-redirected the browser into the per-agent `/pair?token=…` relay. A cold-starting agent cannot redeem the 60s one-time pairing token, the relay answered `403`, and the browser dead-ended on **"Sign-in link expired"** — bouncing the user back through a second complete Google sign-in.

`packages/ui/src/cloud/app-mode/app-mode.ts` already established the **chat floor** for exactly this failure — entry "never pairing-redirects into a per-agent web UI, because a cold-starting agent cannot consume a 60s one-time pairing token and the redirect dead-ends on 'Sign-in link expired' (**the app-staging cold-start regression this floor exists for**)" (#18016). That closed the front door for *entry*; `useAgentSessionRecovery` was the remaining caller that still did it.

This makes the app hosts redeem the token **in-process** — the same path native has always used — so recovery never leaves the origin. `/api/auth/pair/native` authenticates with the Cloud session the browser already holds, so no new capability is required.

## Reproduced live on staging before fixing

Full DevTools transcript in the frontend-logs row. The artifacts rule out every theory except this one:

| Observation | Value |
| --- | --- |
| Sign-in leg 1 | `authorize?redirect_uri=https%3A%2F%2F**app-staging**.e…` → **healthy**, same-origin |
| Failure | `…staging.elizacloud.ai/pair?token=UR0FBmsx…` → **403**, 11.01 s (cold-start signature) |
| Pairing-token mints | **exactly one** (`200`), `"expiresIn": 60` |
| Token in the 403 URL | **byte-identical** to the minted one |
| Mint timing | `Queued at 3 min / Started at 3 min` — minted *after* Google, not before |

So the token was **fresh and single-use-clean when it was rejected**: this is not expiry, not a stale link, not double-minting. "Sign-in link expired" is a mislabel — [`cloud-pair-route.ts`](https://github.com/elizaOS/eliza/blob/develop/packages/agent/src/api/cloud-pair-route.ts) collapses every `401/403/410` into that one string, and the Cloud side answers `{"error":"Invalid or expired pairing code"}` for every cause (verified with a credential-free probe against `api-staging`). The dead-end only exists because an app host redirected into `/pair` at all.

## Change

- `shouldConsumePairRedirectInProcess()` now returns true on the app hosts as well as native, via the existing `isAppModeHost()` predicate — no new host list.
- `isManagedNative` is re-keyed to the native runtime explicitly, so narrowing the redirect behavior does **not** change the native-only managed-recovery status UI.
- Per-agent hosts and every other origin keep the `/pair` navigation hand-off unchanged (they have no same-origin chat app to fall back to).

## Verification

| Gate | Result |
| --- | --- |
| New regression pin, RED without the fix | `× uses in-process pairing on the Eliza app hosts…` — 1 failed / 20 passed |
| Same pin, GREEN with the fix | 21 passed |
| `packages/ui` hooks + app-mode + CloudRouterShell chat-floor pins | **53 files / 454 tests passed** |
| `packages/ui` typecheck | no errors in changed files |
| Scoped Biome | passed |
| `git diff --check` | passed |
| Root `bun run verify` | **passed (exit 0)** at `393926a23` |

Run on macOS arm64 with the repo-pinned toolchain (Bun 1.3.14, Node 24.15.0).

## Follow-ups deliberately not in this PR

Both are real and were found during the same investigation; each deserves its own change:

1. **The failure is undiagnosable.** `401/403/410` all render as "Sign-in link expired" even when the token is provably fresh. The upstream status/code should survive into the logged line and the user-facing copy.
2. **A staging agent's error page hardcodes `https://www.elizacloud.ai/dashboard/agents`** — the *production* console — in `renderErrorHtml`. Separately, `cloud-pair-route.ts:50` defaults to production Cloud when `ELIZAOS_CLOUD_BASE_URL` is unset; staging's Worker config sets it correctly today, so this is a latent cross-environment hazard rather than the cause here.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered-UI surface changed. scripts/check-pr-evidence.mjs surfaceFiles() returns [] for this diff (the .ts is not a visual extension; the .test.tsx is excluded as a test file). The user-visible failure is a redirect/network behavior, captured in the frontend-logs row instead.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - same reason: zero visual surface files in this diff, verified mechanically with the gate's own surfaceFiles() helper.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - the change removes a cross-origin redirect; there is no new or altered rendered surface to walk through. The full live click-through that produced the 403 is transcribed request-by-request in the frontend-logs row.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — RED/GREEN regression transcript plus the related suite runs: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18178-pairing-fix-tests.log
<!-- evidence-row:frontend-logs -->
- [x] Frontend network logs — full DevTools navigation chain from the live staging reproduction (both sign-in legs, the 403, the pairing-token response body and Timing tab), plus a credential-free probe of the Cloud endpoint's error taxonomy: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18178-staging-repro-network-redacted.log
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, model, prompt, or provider surface is touched; this is browser redirect routing in a React hook.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the minted pairing-token record (`token`, `redirectUrl`, `expiresIn: 60`), its Timing-tab measurements, and the verbatim 403 relay page it produced: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18178-pairing-domain-records-redacted.log
<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: `N/A - no rendered visual surface changed in this diff (gate surfaceFiles() = []).`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

— [cad]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A - no contribution skill used"} -->
<!-- evidence-head:393926a230b3d9ed7f7e5e4d4ef3dc6f24bc1eca -->
