### PR TITLE
fix(agent): stop asserting expiry on unattributed pairing rejections; env-correct console link

### DIFF
--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -251,4 +251,129 @@ describe("handleStandaloneCloudPairRoute", () => {
       'href="https://www.elizacloud.ai/dashboard/agents"',
     );
   });
+
+  // The configured base URL is untrusted input rendered into an href, and
+  // parseability is not a safety property. A scriptable or non-web scheme must
+  // never become the link at all.
+  it.each([
+    ["a non-web scheme", "javascript:alert(1)//"],
+    ["a data URL", "data:text/html,<script>alert(1)</script>"],
+    ["a file URL", "file:///etc/passwd"],
+    ["quote-bearing input", 'https://evil.example"><script>alert(1)</script>'],
+    ["a non-loopback http origin", "http://evil.example"],
+  ])("refuses %s and falls back to a known-safe console", async (_n, raw) => {
+    process.env.ELIZAOS_CLOUD_BASE_URL = raw;
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 410 })),
+    );
+
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({ pathname: "/pair", search: "?token=expired" }),
+      harness.res,
+    );
+
+    const body = harness.body();
+    expect(/<a href="([^"]*)"/.exec(body)?.[1]).toBe(
+      "https://www.elizacloud.ai/dashboard/agents",
+    );
+    expect(body).not.toContain("javascript:");
+    expect(body).not.toContain("data:text/html");
+    expect(body).not.toContain("file://");
+    expect(body).not.toContain("evil.example");
+    expect(body).not.toContain("<script>");
+  });
+
+  // A self-hosted https console IS a legitimate target, so the guarantee there
+  // is canonicalization: credentials, path, query, and fragment never survive
+  // into the attribute.
+  it.each([
+    ["embedded credentials", "https://console.example.test"],
+    ["path, query and fragment", "https://console.example.test"],
+  ])("strips %s down to a canonical origin", async (label, expectedOrigin) => {
+    process.env.ELIZAOS_CLOUD_BASE_URL = label.startsWith("embedded")
+      ? "https://user:pass@console.example.test"
+      : "https://console.example.test/x?y=1#z";
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 410 })),
+    );
+
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({ pathname: "/pair", search: "?token=expired" }),
+      harness.res,
+    );
+
+    const body = harness.body();
+    expect(/<a href="([^"]*)"/.exec(body)?.[1]).toBe(
+      `${expectedOrigin}/dashboard/agents`,
+    );
+    expect(body).not.toContain("user:pass");
+    expect(body).not.toContain("y=1");
+  });
+
+  it("serves a loopback console link for a self-hosted http deployment", async () => {
+    process.env.ELIZAOS_CLOUD_BASE_URL = "http://localhost:3000/api/v1";
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 410 })),
+    );
+
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({ pathname: "/pair", search: "?token=expired" }),
+      harness.res,
+    );
+
+    expect(harness.body()).toContain(
+      'href="http://localhost:3000/dashboard/agents"',
+    );
+  });
+
+  it("emits exactly one structured rejection log, with no pairing token in it", async () => {
+    const { logger } = await import("@elizaos/core");
+    vi.mocked(logger.warn).mockClear();
+    process.env.ELIZAOS_CLOUD_BASE_URL =
+      "https://api-staging.elizacloud.ai/api/v1";
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 403 })),
+    );
+
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({
+        pathname: "/pair",
+        search: "?token=super-secret-pairing-token",
+        host: "agent-123.staging.elizacloud.ai",
+        proto: "https",
+      }),
+      harness.res,
+    );
+
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledTimes(1);
+    // Context-first, message-second: the @elizaos/core logger signature.
+    const [context, message] = vi.mocked(logger.warn).mock
+      .calls[0] as unknown as [Record<string, unknown>, string];
+    expect(message).toContain("[cloud-pair]");
+    expect(context).toMatchObject({
+      status: 403,
+      exchangeUrl: "https://api-staging.elizacloud.ai/api/auth/pair",
+      requestOrigin: "https://agent-123.staging.elizacloud.ai",
+    });
+    // The pairing token is a single-use credential; it must never be logged.
+    expect(JSON.stringify({ message, context })).not.toContain(
+      "super-secret-pairing-token",
+    );
+  });
 });

--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -75,6 +75,8 @@ function fakeReq(opts: {
 
 const originalFetch = globalThis.fetch;
 
+const originalCloudBaseUrl = process.env.ELIZAOS_CLOUD_BASE_URL;
+
 beforeEach(() => {
   __resetCloudPairRateLimitForTests();
 });
@@ -82,6 +84,13 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.fetch = originalFetch;
   vi.unstubAllGlobals();
+  // The console-link cases pin the agent's environment; leaking that would
+  // silently retarget every later case's recovery link.
+  if (originalCloudBaseUrl === undefined) {
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+  } else {
+    process.env.ELIZAOS_CLOUD_BASE_URL = originalCloudBaseUrl;
+  }
 });
 
 describe("handleStandaloneCloudPairRoute", () => {
@@ -169,7 +178,77 @@ describe("handleStandaloneCloudPairRoute", () => {
     );
 
     expect(harness.status()).toBe(403);
-    expect(harness.body()).toContain("Sign-in link expired");
+    expect(harness.body()).toContain("Sign-in link could not be verified");
     expect(harness.body()).not.toContain('window.location.replace("/")');
+  });
+
+  it("does not assert expiry for a rejection Cloud never attributed to expiry", async () => {
+    // Cloud returns the same opaque body for expired / unknown / origin-bound /
+    // cross-environment rejections. #18178 was a FRESH token rejected here, and
+    // the "expired" copy sent the reporter chasing the wrong cause.
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 403 })),
+    );
+
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({ pathname: "/pair", search: "?token=fresh-but-rejected" }),
+      harness.res,
+    );
+
+    expect(harness.status()).toBe(403);
+    expect(harness.body()).not.toContain("Sign-in link expired");
+    expect(harness.body()).toContain("did not accept this sign-in link");
+  });
+
+  it("points the recovery link at the console for the agent's OWN environment", async () => {
+    // A staging agent linking users at the production console is a dead end:
+    // the account, org, and agent all live in the staging deployment.
+    process.env.ELIZAOS_CLOUD_BASE_URL =
+      "https://api-staging.elizacloud.ai/api/v1";
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 410 })),
+    );
+
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({
+        pathname: "/pair",
+        search: "?token=expired",
+        host: "agent-123.staging.elizacloud.ai",
+      }),
+      harness.res,
+    );
+
+    expect(harness.body()).toContain(
+      'href="https://staging.elizacloud.ai/dashboard/agents"',
+    );
+    expect(harness.body()).not.toContain("www.elizacloud.ai");
+  });
+
+  it("keeps the production console link for a production agent", async () => {
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.elizacloud.ai/api/v1";
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 410 })),
+    );
+
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({ pathname: "/pair", search: "?token=expired" }),
+      harness.res,
+    );
+
+    expect(harness.body()).toContain(
+      'href="https://www.elizacloud.ai/dashboard/agents"',
+    );
   });
 });

--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -318,6 +318,31 @@ describe("handleStandaloneCloudPairRoute", () => {
     expect(body).not.toContain("y=1");
   });
 
+  // The allowlist is keyed by a parsed hostname, so an inherited member name
+  // must not be mistaken for a configured mapping and skip canonicalization.
+  it.each([["constructor"], ["__proto__"]])(
+    "does not treat the inherited key %s as an allowlisted console host",
+    async (hostname) => {
+      process.env.ELIZAOS_CLOUD_BASE_URL = `https://${hostname}/api/v1`;
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValue(new Response(JSON.stringify({}), { status: 410 })),
+      );
+
+      const harness = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({ pathname: "/pair", search: "?token=expired" }),
+        harness.res,
+      );
+
+      expect(/<a href="([^"]*)"/.exec(harness.body())?.[1]).toBe(
+        `https://${hostname}/dashboard/agents`,
+      );
+    },
+  );
+
   it("serves a loopback console link for a self-hosted http deployment", async () => {
     process.env.ELIZAOS_CLOUD_BASE_URL = "http://localhost:3000/api/v1";
     vi.stubGlobal(

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -59,6 +59,32 @@ function resolveCloudAuthRoot(): string {
   return resolveCloudApiBaseUrl().replace(/\/api\/v1\/?$/, "");
 }
 
+/** API host -> the console host that actually serves `/dashboard/*` for the
+ * SAME environment. A staging agent linking a user at the production console
+ * (or at its own API origin, which serves no UI) is a dead link, so the
+ * mapping is explicit rather than string-munged. */
+const CLOUD_CONSOLE_ORIGIN_BY_API_HOST: Record<string, string> = {
+  "api.elizacloud.ai": "https://www.elizacloud.ai",
+  "api-staging.elizacloud.ai": "https://staging.elizacloud.ai",
+};
+
+/**
+ * Console origin for the environment this agent is actually attached to.
+ * Falls back to the resolved cloud root for self-hosted deployments, whose
+ * console is served from that same origin.
+ */
+function resolveCloudConsoleOrigin(): string {
+  const root = resolveCloudAuthRoot();
+  try {
+    const host = new URL(root).hostname.toLowerCase();
+    return CLOUD_CONSOLE_ORIGIN_BY_API_HOST[host] ?? root;
+  } catch {
+    // error-policy:J3 a malformed configured base URL is untrusted input; the
+    // production console is the only safe default for a link we cannot derive.
+    return "https://www.elizacloud.ai";
+  }
+}
+
 function resolveRequestOrigin(req: http.IncomingMessage): string {
   const proto =
     (req.headers["x-forwarded-proto"] as string | undefined) ||
@@ -152,7 +178,7 @@ function renderErrorHtml(title: string, message: string): string {
   <div class="card">
     <h1>${safeTitle}</h1>
     <p>${safeMessage}</p>
-    <a href="https://www.elizacloud.ai/dashboard/agents" target="_top" rel="noopener">Back to Eliza Cloud</a>
+    <a href="${escapeHtml(resolveCloudConsoleOrigin())}/dashboard/agents" target="_top" rel="noopener">Back to Eliza Cloud</a>
   </div>
 </body>
 </html>`;
@@ -266,12 +292,22 @@ export async function handleStandaloneCloudPairRoute(
   }
 
   if (status === 401 || status === 403 || status === 410) {
+    // Cloud answers the same opaque "Invalid or expired pairing code" for an
+    // expired token, an unknown one, an origin the token is not bound to, and
+    // a cross-environment mint. Asserting expiry to the user sends them to
+    // retry a link that was never the problem — the app-host dead-end (#18178)
+    // was diagnosed only after proving the rejected token was seconds old.
+    // Keep the copy about what is actually known, and put the upstream status
+    // and the exchange origin in the log so the next report is actionable.
+    logger.warn(
+      `[cloud-pair] exchange rejected status=${status} exchangeUrl=${exchangeUrl} requestOrigin=${origin}`,
+    );
     sendHtml(
       res,
       403,
       renderErrorHtml(
-        "Sign-in link expired",
-        "Pairing links are single-use and only valid for a minute. Open your agent again from Eliza Cloud.",
+        "Sign-in link could not be verified",
+        "Eliza Cloud did not accept this sign-in link. It may have already been used, or it may have expired — pairing links are single-use and short-lived. Open your agent again from Eliza Cloud to get a fresh one.",
       ),
     );
     return true;

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -68,21 +68,64 @@ const CLOUD_CONSOLE_ORIGIN_BY_API_HOST: Record<string, string> = {
   "api-staging.elizacloud.ai": "https://staging.elizacloud.ai",
 };
 
+const PRODUCTION_CONSOLE_ORIGIN = "https://www.elizacloud.ai";
+
+function isLoopbackHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host === "localhost" || host === "127.0.0.1" || host === "[::1]";
+}
+
 /**
  * Console origin for the environment this agent is actually attached to.
- * Falls back to the resolved cloud root for self-hosted deployments, whose
- * console is served from that same origin.
+ *
+ * The configured base URL is untrusted input that ends up inside an `href`, so
+ * parseability alone is not a safety property: `javascript:` parses fine, and
+ * credentials/path/query in a configured URL must never reach the attribute.
+ * Only an https origin (or loopback http, for self-hosted development) becomes
+ * a clickable link, and always as the parser's canonical `origin` rather than
+ * the raw configured string. Anything else falls back to the production
+ * console, which is a dead-but-harmless link rather than a scriptable one.
  */
 function resolveCloudConsoleOrigin(): string {
-  const root = resolveCloudAuthRoot();
+  let url: URL;
   try {
-    const host = new URL(root).hostname.toLowerCase();
-    return CLOUD_CONSOLE_ORIGIN_BY_API_HOST[host] ?? root;
+    url = new URL(resolveCloudAuthRoot());
   } catch {
-    // error-policy:J3 a malformed configured base URL is untrusted input; the
-    // production console is the only safe default for a link we cannot derive.
-    return "https://www.elizacloud.ai";
+    // error-policy:J3 a malformed configured base URL is untrusted input; a
+    // known-safe origin is the only defensible default for a rendered link.
+    return PRODUCTION_CONSOLE_ORIGIN;
   }
+
+  const mapped = CLOUD_CONSOLE_ORIGIN_BY_API_HOST[url.hostname.toLowerCase()];
+  if (mapped) return mapped;
+
+  if (
+    url.protocol === "https:" ||
+    (url.protocol === "http:" && isLoopbackHostname(url.hostname))
+  ) {
+    return url.origin;
+  }
+
+  return PRODUCTION_CONSOLE_ORIGIN;
+}
+
+/**
+ * Attribute-context escaping. `escapeHtml` covers text nodes only and leaves
+ * quotes intact, which would let a quote-bearing value break out of an
+ * attribute even after the origin allowlist above.
+ */
+function escapeHtmlAttribute(value: string): string {
+  return value.replace(/[<>&"']/g, (c) =>
+    c === "<"
+      ? "&lt;"
+      : c === ">"
+        ? "&gt;"
+        : c === "&"
+          ? "&amp;"
+          : c === '"'
+            ? "&quot;"
+            : "&#39;",
+  );
 }
 
 function resolveRequestOrigin(req: http.IncomingMessage): string {
@@ -178,7 +221,7 @@ function renderErrorHtml(title: string, message: string): string {
   <div class="card">
     <h1>${safeTitle}</h1>
     <p>${safeMessage}</p>
-    <a href="${escapeHtml(resolveCloudConsoleOrigin())}/dashboard/agents" target="_top" rel="noopener">Back to Eliza Cloud</a>
+    <a href="${escapeHtmlAttribute(`${resolveCloudConsoleOrigin()}/dashboard/agents`)}" target="_top" rel="noopener">Back to Eliza Cloud</a>
   </div>
 </body>
 </html>`;
@@ -251,6 +294,7 @@ export async function handleStandaloneCloudPairRoute(
   const exchangeUrl = `${resolveCloudAuthRoot()}/api/auth/pair`;
   let exchanged: PairResponse | null = null;
   let status = 0;
+  let nonOkExchange = false;
   try {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), RELAY_TIMEOUT_MS);
@@ -270,9 +314,9 @@ export async function handleStandaloneCloudPairRoute(
         .json()
         .catch(() => null)) as PairResponse | null;
     } else {
-      logger.warn(
-        `[cloud-pair] exchange returned non-2xx status=${status} url=${exchangeUrl}`,
-      );
+      // The rejection branches below own the diagnostic for the statuses they
+      // handle; a second generic line here would double-report the same event.
+      nonOkExchange = true;
     }
   } catch (err) {
     logger.error(
@@ -299,8 +343,11 @@ export async function handleStandaloneCloudPairRoute(
     // was diagnosed only after proving the rejected token was seconds old.
     // Keep the copy about what is actually known, and put the upstream status
     // and the exchange origin in the log so the next report is actionable.
+    // Structured context, never the token itself: the pairing token is a
+    // single-use credential and must not reach logs.
     logger.warn(
-      `[cloud-pair] exchange rejected status=${status} exchangeUrl=${exchangeUrl} requestOrigin=${origin}`,
+      { status, exchangeUrl, requestOrigin: origin },
+      "[cloud-pair] exchange rejected the pairing token",
     );
     sendHtml(
       res,
@@ -326,6 +373,13 @@ export async function handleStandaloneCloudPairRoute(
   }
 
   if (!exchanged || typeof exchanged.apiKey !== "string" || !exchanged.apiKey) {
+    // Covers both an unhandled non-2xx (500s, gateway errors) and a 2xx whose
+    // body lacked the key. Same structured shape as the rejection branch so
+    // one query surfaces every failed exchange; never logs the token.
+    logger.warn(
+      { status, exchangeUrl, requestOrigin: origin, nonOkExchange },
+      "[cloud-pair] exchange did not yield an agent credential",
+    );
     sendHtml(
       res,
       502,

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -62,11 +62,14 @@ function resolveCloudAuthRoot(): string {
 /** API host -> the console host that actually serves `/dashboard/*` for the
  * SAME environment. A staging agent linking a user at the production console
  * (or at its own API origin, which serves no UI) is a dead link, so the
- * mapping is explicit rather than string-munged. */
-const CLOUD_CONSOLE_ORIGIN_BY_API_HOST: Record<string, string> = {
-  "api.elizacloud.ai": "https://www.elizacloud.ai",
-  "api-staging.elizacloud.ai": "https://staging.elizacloud.ai",
-};
+ * mapping is explicit rather than string-munged. A `Map` rather than an object
+ * literal because the lookup key is a parsed hostname: `constructor` and
+ * `__proto__` resolve to inherited members on an object literal and would
+ * return a non-origin value that bypasses the canonicalization below. */
+const CLOUD_CONSOLE_ORIGIN_BY_API_HOST = new Map<string, string>([
+  ["api.elizacloud.ai", "https://www.elizacloud.ai"],
+  ["api-staging.elizacloud.ai", "https://staging.elizacloud.ai"],
+]);
 
 const PRODUCTION_CONSOLE_ORIGIN = "https://www.elizacloud.ai";
 
@@ -96,7 +99,9 @@ function resolveCloudConsoleOrigin(): string {
     return PRODUCTION_CONSOLE_ORIGIN;
   }
 
-  const mapped = CLOUD_CONSOLE_ORIGIN_BY_API_HOST[url.hostname.toLowerCase()];
+  const mapped = CLOUD_CONSOLE_ORIGIN_BY_API_HOST.get(
+    url.hostname.toLowerCase(),
+  );
   if (mapped) return mapped;
 
   if (


### PR DESCRIPTION
Closes #18184

## Summary

Two defects found while diagnosing #18178, each fixed here with a RED/GREEN pin.

**1. The relay asserts expiry for rejections Cloud never attributed to expiry.**
`cloud-pair-route.ts` maps every `401/403/410` from `/api/auth/pair` to "Sign-in link expired / Pairing links are single-use and only valid for a minute." But Cloud answers the same opaque body for *all* of expired, unknown, origin-bound, already-redeemed, and cross-environment rejections — verified with a credential-free probe:

```
$ curl -X POST https://api-staging.elizacloud.ai/api/auth/pair \
    -H 'content-type: application/json' -d '{"token":"definitely-not-a-real-token"}'
{"error":"Invalid or expired pairing code"}   HTTP 401
```

In #18178 the rejected token was **provably fresh** — minted once, `expiresIn: 60`, byte-identical to the one redeemed, and minted *after* the sign-in leg per its Timing tab. The page told the user their link had expired and to fetch a new one, which was the one thing guaranteed not to help. That mislabel is most of why the bug survived to a live report.

Now: the copy states what is actually known ("Eliza Cloud did not accept this sign-in link… it may have already been used, or it may have expired"), and the upstream `status`, `exchangeUrl`, and `requestOrigin` go to the log so the next report is actionable instead of a guess.

**2. A staging agent sent users to the production console.**
`renderErrorHtml` hardcoded `https://www.elizacloud.ai/dashboard/agents`. On `<agent>.staging.elizacloud.ai` that is a dead recovery link — the account, org, and agent all live in the staging deployment. The link now resolves from the agent's own configured Cloud API host through an explicit map (`api.` → `www.`, `api-staging.` → `staging.`), falling back to the resolved cloud root for self-hosted deployments, whose console is served from that same origin.

Deliberately an explicit table rather than string-munging the hostname: the API origin serves no UI, so a wrong derivation is another dead link.

## Review response (reviewed `8ca053e55` → current head `2a727f721`)

Rebased on `origin/develop` after the review, so the commits were rewritten: `8ca053e55` → `dc240808d`, `ff12b6e95` → `c68e401ff`, plus the allowlist commit below. The review's original SHAs remain reachable on GitHub for diffing against exactly what was reviewed.

**P1 — the recovery `href` accepted any parseable URL.** Correct and reproducible: `javascript:alert(1)//` parsed fine, the unmapped-host branch returned the raw configured string rather than a canonical origin, and `escapeHtml` (a text-node escaper) left quotes intact. The previous hardcoded link had no such surface — I introduced it. Now: parse once, allowlist `https:` (plus loopback `http:` for self-hosted dev), emit the parser's canonical `origin` so credentials/path/query/fragment cannot survive, and escape in attribute context. Seven new link pins cover non-web schemes, quote-bearing input, credentials, path/query, and non-loopback http. Replaying this file's current tests against `8ca053e55`'s source gives **7 failed / 9 passed** — six of the seven link pins plus the diagnostics cardinality pin — with the `javascript:` case yielding the literal `href="javascript:alert(1)/dashboard/agents"`. The seventh link pin (quote-bearing input) passes at that head too, because such a value fails `new URL()` and hits the malformed-input fallback; the attribute escaper is defense in depth for it rather than the fix, and the pin is kept regardless.

Follow-up found while re-auditing that function for this response: the allowlist was an object literal keyed by a parsed hostname, so `https://constructor` and `https://__proto__` reached inherited `Object.prototype` members, returned a truthy non-string, and skipped the `url.origin` canonicalization entirely. Not exploitable — the value is operator-configured and the output is still attribute-escaped, so no scriptable scheme results — but it defeats the guarantee this function exists to make. Now a `Map`, with two pins that fail against the object-literal version.

**P1 — evidence.** Agreed that this is a rendered-UI change regardless of what `surfaceFiles()` classifies. Before/after full-page desktop **and** mobile captures, an MP4 of rejection → recovery navigation, and an OCR readout are attached below. They are rendered by driving the **real route handler** with a stubbed Cloud response, not hand-written markup: the "before" HTML comes from `origin/develop`'s copy of the handler and the "after" from this branch's, both under the same staging configuration, so the diff in the images is the diff in the code. Regenerated from scratch and re-reviewed at the current head: the re-render reproduces the published captures — same DOM readback, same OCR text — because the allowlist follow-up above does not change the rendered output for a mapped host. Each capture's `<a href>` and `<h1>` were read back out of the live DOM rather than the source string:

```
before/desktop: h1="Sign-in link expired"                href=https://www.elizacloud.ai/dashboard/agents
before/mobile:  h1="Sign-in link expired"                href=https://www.elizacloud.ai/dashboard/agents
after/desktop:  h1="Sign-in link could not be verified"  href=https://staging.elizacloud.ai/dashboard/agents
after/mobile:   h1="Sign-in link could not be verified"  href=https://staging.elizacloud.ai/dashboard/agents
```

The `surfaceFiles()` gap you identified (server-rendered HTML under `packages/agent/src/api` auto-classified non-visual) is real and worth its own fix; flagging rather than widening the gate inside this PR.

**P2 — diagnostics.** Consolidated: the generic non-2xx warn is gone, the rejection path emits exactly one structured `logger.warn` (context-first, per the `@elizaos/core` signature) carrying `status` / `exchangeUrl` / `requestOrigin`, and the previously silent non-2xx fall-through now reports too. Tests assert the field values, the call cardinality, and that the pairing token never appears in the log.

**Publication gates.** Owning issue #18184 filed; the visible provenance footer and a real skill revision are now present.

## Verification

| Gate | Result |
| --- | --- |
| Original pins, RED without the fix | `× does not redirect on expired or rejected pairing links`<br>`× does not assert expiry for a rejection Cloud never attributed to expiry`<br>`× points the recovery link at the console for the agent's OWN environment`<br>**3 failed / 4 passed** |
| Security + diagnostics pins, RED against reviewed `8ca053e55` | **7 failed / 9 passed** |
| Allowlist prototype-key pins, RED against the object-literal lookup | `× does not treat the inherited key constructor as an allowlisted console host`<br>`× does not treat the inherited key __proto__ as an allowlisted console host`<br>**2 failed / 16 passed** |
| All pins, GREEN at current head (`cloud-pair-route.test.ts`) | **18 passed / 18** |
| `bun run --cwd packages/agent test` (full lane) | **384 / 386 batches passed.** The 2 failures are unbuilt workspace plugin dists in a fresh worktree (`@elizaos/plugin-meetings` entry unresolvable; `@elizaos/plugin-wallet/diagnostic` missing) — neither touches this diff, and both files pass once those plugins are built: `Test Files 2 passed (2)` |
| `packages/agent` typecheck | 2 errors, both **pre-existing** in `plugins/plugin-agent-orchestrator/src/services/smithers-task-integration.ts` (`TS2550 findLast`, `TS7006`). That file is byte-identical to `origin/develop` and untouched here; reverting this PR's two files reproduces the same two errors exactly. No errors in the changed files. |
| Scoped Biome on both changed files | passed, no fixes applied |
| `git diff --check` | passed |

Run on macOS arm64 with the repo-pinned toolchain (Bun 1.3.14, Node 24.15.0).

## Scope

Copy + logging + link resolution only. No change to which statuses are treated as failures, to the exchange itself, or to the success path — #18178 already removed the app-host redirect that produced the dead-end; this makes the remaining surfaces honest for the per-agent hosts that still use the relay.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots (desktop + mobile), rendered from the real handler at `origin/develop`: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18181-pair-error-before-desktop.jpg https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18181-pair-error-before-mobile.jpg
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots (desktop + mobile), re-rendered and re-reviewed at the current head `2a727f721`: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18181-pair-error-after-desktop.jpg https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18181-pair-error-after-mobile.jpg
<!-- evidence-row:walkthrough-video -->
- [x] MP4 of rejection → recovery navigation, before then after: the recovery link is clicked and the Eliza Cloud sign-in page loads in both runs, so the link resolves to a live console rather than erroring. Which console it is comes from the DOM `href` readback above — `www.` before, `staging.` after — not from the video, which has no address bar: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18181-pair-error-recovery-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [x] Backend logs — RED/GREEN transcripts for both rounds, plus the pre/post-fix resolver behavior table: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18181-diagnosability-tests.log https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18181-hardening-tests.log
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no browser-side code in this diff; the page is server-rendered HTML. The live browser network capture that motivated it is attached to #18178.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, model, prompt, or provider surface touched; this is an HTTP relay's error rendering.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the Cloud endpoint's opaque error taxonomy (the reason the copy could not assert expiry), captured verbatim from a credential-free probe of `api-staging`: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18181-pair-endpoint-taxonomy.log
<!-- evidence-row:ocr-review -->
- [x] OCR text readout (tesseract.js) of all four before/after captures, desktop and mobile, reviewed against the rendered copy: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18181-pair-error-ocr.txt

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cad]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza"} -->
<!-- evidence-head:2a727f721694ba086e04f7fac42dbdd93aeeadcd -->

