### PR TITLE
fix(cloud): pin the staging onboarding app origin to app-staging.elizacloud.ai

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -426,6 +426,23 @@ AGENT_ROUTER_ORIGIN_HOST = "eliza-staging-1.elizacloud.ai"
 WAIFU_SERVICE_ORG_ID = "d96d3fc8-cc07-40be-b81c-ba7a7b4e8028"
 WAIFU_SERVICE_USER_ID = "90101225-836f-4fa7-a69c-f70691dcf256"
 ELIZA_APP_URL = "https://eliza.app"
+# Onboarding dashboard/billing links. Production pins the Eliza *app* host
+# (app.elizacloud.ai), deliberately not the console apex, so this must pin the
+# app host's staging peer — app-staging.elizacloud.ai, the `eliza-app` Pages
+# domain owned by terraform/cloudflare/pages-domains and reclaimed from the prod
+# wildcard by the staging Worker route above. Unpinned, `getOnboardingAppUrl`
+# fell through to NEXT_PUBLIC_APP_URL and emitted the staging *console* apex:
+# right environment, wrong surface, and silently divergent from production.
+# Same environment-peer rule as STAGING_ELIZA_APP_ORIGIN in
+# packages/ui/src/utils/cloud-agent-base.ts (#15161).
+ELIZA_ONBOARDING_APP_URL = "https://app-staging.elizacloud.ai"
+# ELIZA_ONBOARDING_LOGIN_APP_URL is deliberately NOT pinned here. `/get-started`
+# is served by the homepage, and the homepage has exactly one deployment
+# (`eliza-app-home` -> eliza.app) whose bundle is compiled against the
+# production API. Pinning it would freeze a staging continuation token into a
+# production redemption endpoint that cannot resolve it. Staging keeps falling
+# through to the code default until a staging homepage exists; tracked as a
+# release blocker in #18197.
 NEXT_PUBLIC_NETWORK = "base"
 NEXT_PUBLIC_SOLANA_RPC_URL = "https://api.mainnet-beta.solana.com"
 GITHUB_ORG_NAME = "eliza-cloud-apps"

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-host-contract.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-host-contract.test.ts
@@ -1,10 +1,26 @@
 /**
- * Pins the two onboarding frontend ownership contracts. `/get-started` belongs
- * to the homepage; dashboard and billing routes belong to the Cloud app.
+ * Deployment contract for the two onboarding frontend origins: `/get-started`
+ * belongs to the homepage, dashboard and billing links belong to the Cloud app.
+ *
+ * The contract is checked through effective resolution, not string presence.
+ * Each case parses one deployed environment's complete `[vars]` block out of the
+ * Worker config, installs it as the cloud bindings context exactly as the
+ * request pipeline does, and asserts the URLs the onboarding state machine
+ * actually emits. A wrong host therefore fails here even when the key is
+ * present, and an origin that resolves correctly through a fallback is not
+ * reported as a gap. Real resolver, real config, in-memory session store.
  */
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { runWithCloudBindingsAsync } from "../../runtime/cloud-bindings";
+import {
+  type OnboardingSession,
+  type OnboardingSessionStore,
+  runOnboardingChatWithStore,
+} from "./onboarding-chat";
+
+const WRANGLER_PATH = join(import.meta.dir, "../../../../../api/wrangler.toml");
 
 function tomlSection(source: string, name: string): string {
   const header = `[${name}]`;
@@ -16,17 +32,130 @@ function tomlSection(source: string, name: string): string {
   return nextSectionIndex < 0 ? body : body.slice(0, nextSectionIndex);
 }
 
-describe("Telegram onboarding host deployment contract", () => {
-  test("default and production keep login and dashboard origins separate", () => {
-    const wrangler = readFileSync(
-      join(import.meta.dir, "../../../../../api/wrangler.toml"),
-      "utf8",
-    );
+/**
+ * The string vars of one section, shaped like the `c.env` bindings a deployed
+ * Worker receives. Cloudflare does not inherit top-level `[vars]` into a named
+ * environment, so a section is read alone — never merged with `[vars]`.
+ */
+function environmentBindings(section: string): Record<string, string> {
+  const bindings: Record<string, string> = {};
+  for (const line of tomlSection(readFileSync(WRANGLER_PATH, "utf8"), section).split("\n")) {
+    const match = /^\s*([A-Za-z0-9_]+)\s*=\s*"([^"]*)"\s*$/.exec(line);
+    if (match) bindings[match[1]] = match[2];
+  }
+  if (Object.keys(bindings).length === 0) {
+    throw new Error(`TOML section [${section}] parsed to zero string vars`);
+  }
+  return bindings;
+}
 
-    for (const section of ["vars", "env.production.vars"]) {
-      const vars = tomlSection(wrangler, section);
-      expect(vars).toContain('ELIZA_ONBOARDING_LOGIN_APP_URL = "https://eliza.app"');
-      expect(vars).toContain('ELIZA_ONBOARDING_APP_URL = "https://app.elizacloud.ai"');
-    }
+function memoryStore(): OnboardingSessionStore {
+  const sessions = new Map<string, OnboardingSession>();
+  return {
+    async load(sessionId) {
+      return sessions.get(sessionId) ?? null;
+    },
+    async save(session) {
+      sessions.set(session.id, session);
+    },
+  };
+}
+
+/**
+ * One onboarding turn under a deployed environment's bindings. A trusted phone
+ * identity that supplies a name reaches the login handoff without an
+ * authenticated user, so the turn resolves both origins and never touches
+ * provisioning, the database, or the account store.
+ */
+async function resolveOnboardingOrigins(
+  section: string,
+): Promise<{ loginOrigin: string; appOrigin: string }> {
+  const sessionId = "platform:blooio:+14155550123";
+  const result = await runWithCloudBindingsAsync(environmentBindings(section), () =>
+    runOnboardingChatWithStore(
+      {
+        message: "call me Sam",
+        platform: "blooio",
+        platformUserId: "+14155550123",
+        trustedPlatformIdentity: true,
+      },
+      sessionId,
+      memoryStore(),
+    ),
+  );
+
+  expect(result.requiresLogin).toBe(true);
+  return {
+    loginOrigin: new URL(result.loginUrl).origin,
+    appOrigin: new URL(result.controlPanelUrl).origin,
+  };
+}
+
+/**
+ * `appOrigin` is the Eliza *app* host, never the console apex: production pins
+ * app.elizacloud.ai while its NEXT_PUBLIC_APP_URL is the apex elizacloud.ai, and
+ * staging's peer of that app host is app-staging.elizacloud.ai (the `eliza-app`
+ * Pages domain, same environment-peer rule as STAGING_ELIZA_APP_ORIGIN in
+ * packages/ui/src/utils/cloud-agent-base.ts).
+ *
+ * `loginOrigin` is the homepage. Staging has no homepage deployment of its own,
+ * so it still resolves the production one — a live release blocker recorded in
+ * #18197, not an approved mapping. The expectation below documents the defect so
+ * it cannot drift silently; closing #18197 must change it.
+ */
+const ONBOARDING_HOST_CONTRACT: ReadonlyArray<{
+  section: string;
+  loginOrigin: string;
+  appOrigin: string;
+}> = [
+  {
+    section: "vars",
+    loginOrigin: "https://eliza.app",
+    appOrigin: "https://app.elizacloud.ai",
+  },
+  {
+    section: "env.production.vars",
+    loginOrigin: "https://eliza.app",
+    appOrigin: "https://app.elizacloud.ai",
+  },
+  {
+    section: "env.staging.vars",
+    loginOrigin: "https://eliza.app",
+    appOrigin: "https://app-staging.elizacloud.ai",
+  },
+];
+
+const PRODUCTION_APP_ORIGINS = ["https://app.elizacloud.ai", "https://elizacloud.ai"];
+
+describe("onboarding host deployment contract", () => {
+  test.each(ONBOARDING_HOST_CONTRACT)(
+    "$section resolves the onboarding origins its bindings deploy",
+    async ({ section, loginOrigin, appOrigin }) => {
+      const resolved = await resolveOnboardingOrigins(section);
+      expect(resolved.appOrigin).toBe(appOrigin);
+      expect(resolved.loginOrigin).toBe(loginOrigin);
+    },
+  );
+
+  test.each(ONBOARDING_HOST_CONTRACT)(
+    "$section keeps the login origin off the dashboard origin",
+    async ({ section }) => {
+      const resolved = await resolveOnboardingOrigins(section);
+      expect(resolved.loginOrigin).not.toBe(resolved.appOrigin);
+    },
+  );
+
+  test("staging never resolves a production dashboard origin", async () => {
+    const resolved = await resolveOnboardingOrigins("env.staging.vars");
+    expect(PRODUCTION_APP_ORIGINS).not.toContain(resolved.appOrigin);
+  });
+
+  test("the staging section pins the app origin instead of inheriting one", () => {
+    const staging = environmentBindings("env.staging.vars");
+    // Resolution alone cannot tell a pin from a fallback: NEXT_PUBLIC_APP_URL
+    // would answer for ELIZA_ONBOARDING_APP_URL and quietly hand back the
+    // console apex the moment the explicit key is dropped.
+    expect(staging.ELIZA_ONBOARDING_APP_URL).toBe("https://app-staging.elizacloud.ai");
+    expect(staging.NEXT_PUBLIC_APP_URL).toBe("https://staging.elizacloud.ai");
   });
 });


### PR DESCRIPTION
Closes #18230.

# Relates to

Follow-up blocker filed from this review: #18197 (staging has no homepage bundle
wired to `api-staging.elizacloud.ai`).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun run verify` was run after sync; result recorded under **Known gaps /
      failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` @ `3398387adfdd9f91f95d5c966fe1464433477dc7`; zero conflicts.
- [x] Post-sync gate results are in **Known gaps / failures** and in the
      RED/GREEN evidence log.

# Risks

**Low.** One Worker variable in `[env.staging.vars]` and one test file. No
production or default `[vars]` change (byte-identical before and after), no code
change, no route/DNS/Terraform change. The pinned host is already a
Terraform-owned Pages domain, already routed to the staging Worker, and already
in the CORS and OAuth-redirect allowlists, so nothing new has to be provisioned.
Worst case if the pin were wrong: staging onboarding dashboard links land on a
staging host that renders the same SPA bundle — the failure mode is cosmetic and
staging-only, and revert is a one-line change.

# Background

## What does this PR do?

**Retraction first.** The first revision of this PR claimed staging fell through
to the production default and was serving `app.elizacloud.ai` links. That was
wrong, and I have withdrawn it. `getOnboardingAppUrl` resolves
`ELIZA_ONBOARDING_APP_URL` → `NEXT_PUBLIC_ELIZA_APP_URL` → `NEXT_PUBLIC_APP_URL`
→ the code default, and `[env.staging.vars]` already pins `NEXT_PUBLIC_APP_URL`
to `https://staging.elizacloud.ai`. Running the real resolver against develop's
own bindings proves it (attached evidence, section 1):

```
[env.staging.vars]  (origin/develop 3398387a)
  ELIZA_ONBOARDING_APP_URL = (absent)
  NEXT_PUBLIC_APP_URL = "https://staging.elizacloud.ai"
  -> dashboard/agents URL : https://staging.elizacloud.ai/dashboard/agents
```

The wrangler warning that started this was real — those two keys genuinely exist
only at the top level — but the conclusion drawn from it was not. `@standujar`
was right on both counts.

**What is actually wrong.** Production deliberately separates the onboarding app
origin from the console apex: `ELIZA_ONBOARDING_APP_URL = https://app.elizacloud.ai`
while `NEXT_PUBLIC_APP_URL = https://elizacloud.ai`. Staging, having never pinned
the key, inherited the *console* apex through the fallback. Right environment,
wrong surface, and nobody chose it — it is whatever `NEXT_PUBLIC_APP_URL`
happened to be.

The app host's staging peer is `app-staging.elizacloud.ai`, and the repository
already says so in six places:

| Source | Evidence |
| --- | --- |
| `packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/main.tf:21` | staging custom domain of the `eliza-app` Pages project (prod sibling in the same map is `app.elizacloud.ai`) |
| `packages/cloud/api/wrangler.toml:369` | `app-staging.elizacloud.ai/*` reclaimed from the prod `*.elizacloud.ai` wildcard by the staging Worker |
| `packages/cloud/scripts/verify-environment-routing.mjs:56` | `{ domain: "app-staging.elizacloud.ai", environment: "staging" }` in the authoritative environment map |
| `packages/ui/src/utils/cloud-agent-base.ts:225` | `STAGING_ELIZA_APP_ORIGIN = "https://app-staging.elizacloud.ai"` — the same environment-peer rule shipped for #15161 |
| `packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts:48` | already a first-party CORS origin |
| `packages/cloud/shared/src/lib/security/redirect-validation.ts:20` | already an allowlisted OAuth-callback redirect target |

So `[env.staging.vars]` now pins `ELIZA_ONBOARDING_APP_URL = "https://app-staging.elizacloud.ai"`.

**`ELIZA_ONBOARDING_LOGIN_APP_URL` is dropped, not pinned.** `/get-started` is
served by the homepage; the homepage has exactly one deployment
(`eliza-app-home` → `eliza.app`, `--branch main`) and its bundle is compiled
against the production API because `deploy-homepage.yml` never sets
`VITE_ELIZACLOUD_API_URL` and `packages/homepage/src/lib/api/client.ts:5`
defaults to `https://www.elizacloud.ai`. Staging binds its own `CACHE_KV`
namespace and its own `ONBOARDING_SESSIONS` Durable Object namespace, so a
staging continuation token is unresolvable by the production Worker. Writing
that dead end into the deploy config would have blessed it. Filed as a release
blocker instead: **#18197**.

**The contract test no longer greps TOML.** The old assertion
(`expect(vars).toContain('ELIZA_ONBOARDING_APP_URL = "<host>"')`) passes for any
host spelled the same way in the config and the test, which is exactly how the
wrong mapping got a green run. Each case now loads one environment's complete
`[vars]` block, installs it through `runWithCloudBindingsAsync()` the way the
Worker request pipeline does, and asserts the URLs
`runOnboardingChatWithStore()` actually emits.

One string assertion is kept and deliberately scoped: resolution alone cannot
distinguish a pin from a fallback, because `NEXT_PUBLIC_APP_URL` would silently
answer the moment the explicit key is deleted. That test asserts the key is
present; the behavioral tests assert what it produces.

## What kind of change is this?

Bug fix (configuration correctness) plus a test that can actually detect the
class of bug it claims to cover.

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning
lives in `[env.staging.vars]` comments next to the value, and the open gap lives
in #18197.

# Testing

## Where should a reviewer start?

The attached resolution log. It shows, for `[vars]`, `[env.staging.vars]` and
`[env.production.vars]`, both before (`origin/develop`) and after (this head),
which keys are present and which URLs the real onboarding state machine emits.
Only `[env.staging.vars]` changes.

## Detailed testing steps

```bash
git fetch origin && git checkout 2d190944d5f93603097e4c4289e28838d7e71dc9

# behavioral: exercises the resolver against the committed staging bindings
bun test --isolate packages/cloud/shared/src/lib/services/eliza-app/onboarding-host-contract.test.ts

# prove the test is not vacuous: set [env.staging.vars] back to
# ELIZA_ONBOARDING_APP_URL = "https://staging.elizacloud.ai" and rerun.
# It fails on the emitted origin, not on a string match:
#   Expected: "https://app-staging.elizacloud.ai"
#   Received: "https://staging.elizacloud.ai"

bun test --isolate packages/cloud/shared/src/lib/services/eliza-app/
bun test --isolate packages/cloud/scripts/__tests__/verify-environment-routing.test.ts \
                   packages/cloud/shared/src/lib/oidc/config.test.ts
bun run --cwd packages/cloud/shared typecheck
```

# Evidence Gate

<!-- evidence-head:2d190944d5f93603097e4c4289e28838d7e71dc9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - configuration and test-only diff; no rendered UI file is touched (two files: packages/cloud/api/wrangler.toml, one .test.ts).`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - same reason. The observable change is which origin a deploy-time Worker binding resolves, captured as text in the resolution log below.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no interactive flow in this diff. The user-visible artifact is a URL string, shown before and after in the resolution log.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — effective resolution through the real onboarding state machine, before (`origin/develop`) and after (this head), for all three deployed environments, plus the topology citations that make `app-staging.elizacloud.ai` the correct peer: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18186-onboarding-origin-resolution.log
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no browser-side code in this diff.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, model, prompt, or provider surface touched. The onboarding reply path exercised by the test is deterministic and model-free (asserted by onboarding-chat.test.ts, "stays deterministic and model-free even when a Cerebras key is configured").`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — RED/GREEN transcript proving the rewritten test fails on the emitted origin rather than on a TOML string, every gate run at this head with exact counts, and the pre-existing single-process mock leak shown to be independent of this PR: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18186-contract-test-redgreen.log
<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: `N/A - no rendered visual surface in this diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, model, prompt, provider, or action surface is touched.`

## Backend + frontend logs

Backend: the two logs linked above. Frontend: `N/A - no browser-side code in
this diff.`

<details>
<summary>Effective resolution, before and after (excerpt)</summary>

```
BEFORE — origin/develop @ 3398387a
[env.staging.vars]
  ELIZA_ONBOARDING_APP_URL       = (absent)
  ELIZA_ONBOARDING_LOGIN_APP_URL = (absent)
  NEXT_PUBLIC_ELIZA_APP_URL      = (absent)
  NEXT_PUBLIC_APP_URL            = "https://staging.elizacloud.ai"
  -> dashboard/agents URL : https://staging.elizacloud.ai/dashboard/agents
  -> resolved app origin  : https://staging.elizacloud.ai
  -> resolved login origin: https://eliza.app

AFTER — this head @ 2d190944d
[env.staging.vars]
  ELIZA_ONBOARDING_APP_URL       = "https://app-staging.elizacloud.ai"
  ELIZA_ONBOARDING_LOGIN_APP_URL = (absent)
  NEXT_PUBLIC_ELIZA_APP_URL      = (absent)
  NEXT_PUBLIC_APP_URL            = "https://staging.elizacloud.ai"
  -> dashboard/agents URL : https://app-staging.elizacloud.ai/dashboard/agents
  -> resolved app origin  : https://app-staging.elizacloud.ai
  -> resolved login origin: https://eliza.app   <-- still production; #18197
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - the diff touches no rendered surface. scripts/check-pr-evidence.mjs
surfaceFiles() is empty for these two paths.`

### Before

`N/A`

### After

`N/A`

### Walkthrough video

`N/A`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT surface is touched.`

## Known gaps / failures

1. **Staging login handoff still resolves the production homepage.** Not fixed
   here and deliberately not papered over — see #18197. The contract test
   records `https://eliza.app` as staging's login origin with a comment naming
   the issue, so closing #18197 must flip that expectation rather than silently
   drift.

2. **No live probe.** No deploy, `wrangler deploy`, workflow dispatch,
   environment approval, DNS/Pages/Terraform mutation, or secret access was
   performed. `app-staging.elizacloud.ai` was not fetched, and the
   staging-token-against-production-auth failure in #18197 was not reproduced
   live — doing so means replaying a staging session token against a production
   auth route. Every claim here is instead grounded in committed files, each
   cited by path and line.

3. **Pre-existing single-process test-mock leak in this directory.** Running
   `packages/cloud/shared/src/lib/services/eliza-app/` in one bun process (no
   `--isolate`) fails `provisioning.test.ts` and
   `provisioning.error-policy.test.ts` with `SyntaxError: Export named
   'getInteractiveCerebrasLanguageModel' not found`. Shown to be independent of
   this PR in the RED/GREEN log: it reproduces at the previous head with this
   PR's files stashed (90 pass / 2 fail), and with three develop-owned files and
   nothing of mine present (58 pass / 10 fail). The package's own entry point
   runs `bun test --isolate`, which is green: **113 pass / 0 fail**.

4. **`bun run verify`: passed, exit 0** at this head, after the rebase — the
   full chain including `turbo run typecheck lint:check` over 261 cache-miss
   package tasks and every repository audit through `audit:focused-tests`
   (`[anti-larp] scanned 7723 test files — 0 focused, 0 orphaned skip(s)`).
   The transcript tail is in the RED/GREEN log, section 4. No `bun run test`
   full-repository lane was run; the owning directory and the two
   wrangler-coupled suites were run instead, with counts above.

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cad]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza"} -->

