### PR TITLE
fix(cloud): rotate agent keys on the caller's transaction, not a second connection

### DIFF
--- a/packages/cloud/shared/src/db/repositories/api-keys.ts
+++ b/packages/cloud/shared/src/db/repositories/api-keys.ts
@@ -1,5 +1,6 @@
 // Persists api keys records for cloud services through the shared DB boundary.
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { DbTransaction } from "../client";
 import { dbRead, dbWrite } from "../helpers";
 import { type ApiKey, apiKeys, type NewApiKey } from "../schemas/api-keys";
 
@@ -10,6 +11,17 @@ export type { ApiKey, NewApiKey };
  *
  * Read operations → dbRead (read-intent connection)
  * Write operations → dbWrite (primary)
+ *
+ * The agent-provisioning writes (`create`, `deleteByName`) additionally accept
+ * the caller's open `DbTransaction`. A caller that already holds a primary
+ * connection MUST pass it: reaching for the global `dbWrite` pool from inside
+ * an open transaction asks for a SECOND connection while the first is still
+ * checked out. In the Cloudflare Worker runtime the pool is sized `max: 1`
+ * (`db/client.ts` `createPgPool`), so that second checkout can never be
+ * satisfied — the request deadlocks against itself and fails at
+ * `connectionTimeoutMillis`, every time, with no concurrency involved.
+ * Passing the transaction also makes the write part of the caller's atomic
+ * unit rather than an independently committed side effect.
  */
 export class ApiKeysRepository {
   // ============================================================================
@@ -114,10 +126,11 @@ export class ApiKeysRepository {
   // ============================================================================
 
   /**
-   * Creates a new API key.
+   * Creates a new API key. Runs on `tx` when the caller already holds a
+   * primary connection.
    */
-  async create(data: NewApiKey): Promise<ApiKey> {
-    const [apiKey] = await dbWrite.insert(apiKeys).values(data).returning();
+  async create(data: NewApiKey, tx?: DbTransaction): Promise<ApiKey> {
+    const [apiKey] = await (tx ?? dbWrite).insert(apiKeys).values(data).returning();
     return apiKey;
   }
 
@@ -169,8 +182,68 @@ export class ApiKeysRepository {
       .where(and(eq(apiKeys.user_id, userId), eq(apiKeys.name, name), eq(apiKeys.is_active, true)));
   }
 
-  async deleteByName(name: string): Promise<ApiKey[]> {
-    return await dbWrite.delete(apiKeys).where(eq(apiKeys.name, name)).returning();
+  /**
+   * Deletes every key carrying `name` and returns the removed rows. Runs on
+   * `tx` when the caller already holds a primary connection.
+   */
+  async deleteByName(name: string, tx?: DbTransaction): Promise<ApiKey[]> {
+    return await (tx ?? dbWrite).delete(apiKeys).where(eq(apiKeys.name, name)).returning();
+  }
+
+  /**
+   * Deactivates every key carrying `name` — already-inactive rows included —
+   * and returns them all. The agent-rotation revoke path uses this instead of
+   * a DELETE so the row itself is the durable record of a hash whose cache
+   * invalidation has not yet been confirmed: an inactive row cannot
+   * authenticate from the database, and a later rotation re-collects it by
+   * name and re-offers its hash for confirmed invalidation. Runs on `tx` when
+   * the caller already holds a primary connection.
+   */
+  async deactivateByNameReturningAll(name: string, tx?: DbTransaction): Promise<ApiKey[]> {
+    return await (tx ?? dbWrite)
+      .update(apiKeys)
+      .set({ is_active: false, updated_at: new Date() })
+      .where(eq(apiKeys.name, name))
+      .returning();
+  }
+
+  /**
+   * Rows previously parked inactive by {@link deactivateByNameReturningAll}
+   * whose cache invalidation was never confirmed. Read post-commit by the
+   * launch boundaries so every attempt — including one that re-uses a
+   * persisted key and never re-mints — rediscovers outstanding carriers.
+   */
+  async findInactiveByName(name: string): Promise<ApiKey[]> {
+    return await dbRead.query.apiKeys.findMany({
+      where: and(eq(apiKeys.name, name), eq(apiKeys.is_active, false)),
+    });
+  }
+
+  /**
+   * Hard-deletes parked carriers whose cache invalidation has since been
+   * CONFIRMED — and ONLY those. Scoping by exact hash (not just name) matters
+   * under overlapping rotations: the lifecycle advisory lock releases at
+   * COMMIT, so one attempt's delayed purge must never reap a carrier a newer
+   * attempt has parked but not yet confirmed. `is_active = false` in the
+   * predicate keeps an active replacement key untouchable even on collision.
+   */
+  async deleteInactiveByHashes(
+    name: string,
+    keyHashes: readonly string[],
+    tx?: DbTransaction,
+  ): Promise<number> {
+    if (keyHashes.length === 0) return 0;
+    const deleted = await (tx ?? dbWrite)
+      .delete(apiKeys)
+      .where(
+        and(
+          eq(apiKeys.name, name),
+          eq(apiKeys.is_active, false),
+          inArray(apiKeys.key_hash, [...keyHashes]),
+        ),
+      )
+      .returning({ id: apiKeys.id });
+    return deleted.length;
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/api-keys.invalidation.test.ts
+++ b/packages/cloud/shared/src/lib/services/api-keys.invalidation.test.ts
@@ -123,11 +123,52 @@ describe("apiKeysService.invalidateCache fails closed (#13417)", () => {
     ).resolves.toBeUndefined();
   });
 
-  test("revokeForAgent: unconfirmed invalidation does NOT abort (row already deleted, best-effort)", async () => {
-    // rows deleted FIRST -> credential already DB-revoked; a cache brownout must
-    // not abort agent reprovisioning (codex round-2 P2).
-    track(spyOn(apiKeysRepository, "deleteByName").mockResolvedValue([fakeKey()]));
+  test("confirmRevocationAfterCommit attempts EVERY hash even when the first fails", async () => {
+    const HASH_A = "a".repeat(64);
+    const HASH_B = "b".repeat(64);
+    const attempted: string[] = [];
+    track(
+      spyOn(cache, "delConfirmed").mockImplementation(async (key: string) => {
+        attempted.push(key);
+        // Fail only the FIRST hash's validation entry.
+        return !key.includes(HASH_A.substring(0, 16));
+      }),
+    );
+
+    await expect(apiKeysService.confirmRevocationAfterCommit([HASH_A, HASH_B])).rejects.toThrow(
+      /not confirmed for 1\/2/i,
+    );
+
+    // The load-bearing assertion: a fail-fast loop never reaches HASH_B, which
+    // would strand a second superseded credential while reporting only one.
+    expect(attempted.some((k) => k.includes(HASH_B.substring(0, 16)))).toBe(true);
+  });
+
+  test("confirmRevocationAfterCommit resolves quietly when every hash is confirmed", async () => {
+    track(spyOn(cache, "delConfirmed").mockResolvedValue(true));
+    await expect(
+      apiKeysService.confirmRevocationAfterCommit(["c".repeat(64), "d".repeat(64)]),
+    ).resolves.toBeUndefined();
+  });
+
+  test("revokeForAgent: unconfirmed invalidation does NOT abort, and PARKS the row instead of deleting it", async () => {
+    // The row is deactivated FIRST -> credential already DB-revoked; a cache
+    // brownout must not abort agent reprovisioning (codex round-2 P2). The row
+    // survives inactive as the durable carry so a later pass re-offers its
+    // hash (codex round-3 P1) — hard-deleting here would lose it forever.
+    track(spyOn(apiKeysRepository, "deactivateByNameReturningAll").mockResolvedValue([fakeKey()]));
+    const reap = track(spyOn(apiKeysRepository, "delete").mockResolvedValue(undefined));
     track(spyOn(cache, "delConfirmed").mockResolvedValue(false));
-    await expect(apiKeysService.revokeForAgent("sandbox-1")).resolves.toBeUndefined();
+    await expect(apiKeysService.revokeForAgent("sandbox-1")).resolves.toEqual([fakeKey().key_hash]);
+    expect(reap).not.toHaveBeenCalled();
+  });
+
+  test("revokeForAgent without a tx reaps the row once its invalidation is CONFIRMED", async () => {
+    track(spyOn(apiKeysRepository, "deactivateByNameReturningAll").mockResolvedValue([fakeKey()]));
+    const reap = track(spyOn(apiKeysRepository, "delete").mockResolvedValue(undefined));
+    track(spyOn(cache, "delConfirmed").mockResolvedValue(true));
+    await expect(apiKeysService.revokeForAgent("sandbox-1")).resolves.toEqual([fakeKey().key_hash]);
+    // Authoritative pass succeeded -> nothing left to carry, row reaped.
+    expect(reap).toHaveBeenCalledWith(fakeKey().id);
   });
 });

--- a/packages/cloud/shared/src/lib/services/api-keys.ts
+++ b/packages/cloud/shared/src/lib/services/api-keys.ts
@@ -6,7 +6,7 @@
 
 import crypto from "crypto";
 import { and, eq, isNull, sql } from "drizzle-orm";
-import { dbWrite } from "../../db/client";
+import { type DbTransaction, dbWrite } from "../../db/client";
 import { encryptApiKey } from "../../db/crypto/api-keys";
 import { type ApiKey, apiKeysRepository, type NewApiKey } from "../../db/repositories";
 import { apiKeys } from "../../db/schemas/api-keys";
@@ -236,12 +236,13 @@ export class ApiKeysService {
       | "key_kms_key_id"
       | "key_kms_key_version"
     >,
+    tx?: DbTransaction,
   ): Promise<{
     apiKey: ApiKey;
     plainKey: string;
   }> {
     const { apiKey, plainKey } = await this.buildApiKeyInsert(data);
-    const created = await apiKeysRepository.create(apiKey);
+    const created = await apiKeysRepository.create(apiKey, tx);
 
     return {
       apiKey: created,
@@ -408,50 +409,184 @@ export class ApiKeysService {
     return `agent-sandbox:${agentSandboxId}`;
   }
 
+  /**
+   * Rotates the sandbox-scoped key: revoke whatever was bound to the sandbox,
+   * then mint its replacement.
+   *
+   * `tx` is REQUIRED when the caller already holds an open primary
+   * transaction (the managed-launch lifecycle path does). Both halves then run
+   * on that connection instead of checking a second one out of the global
+   * pool. On Workers that pool is sized `max: 1`, so a nested checkout waits
+   * on a connection the request is itself holding and dies at
+   * `connectionTimeoutMillis`. Sharing the connection also makes the rotation
+   * part of the caller's atomic unit, so a rollback restores the previous key
+   * instead of leaving the agent with a revoked one.
+   *
+   * Returns `revokedKeyHashes` so a transactional caller can re-invalidate
+   * AFTER it commits. Under `tx` the pre-delete invalidation happens while the
+   * old row is still visible to other connections, so a concurrent request can
+   * re-cache it positively; only a post-commit pass can clear that. See
+   * {@link revokeForAgent}.
+   */
   async createForAgent(params: {
     organizationId: string;
     userId: string;
     agentSandboxId: string;
-  }): Promise<{ apiKey: ApiKey; plainKey: string }> {
+    tx?: DbTransaction;
+  }): Promise<{ apiKey: ApiKey; plainKey: string; revokedKeyHashes: string[] }> {
     const name = ApiKeysService.agentApiKeyName(params.agentSandboxId);
 
     // Idempotency: a re-run of the provisioner must not strand an old key
     // active. Revoke whatever was previously bound to this sandbox before
     // minting a fresh one.
-    await this.revokeForAgent(params.agentSandboxId);
+    const revokedKeyHashes = await this.revokeForAgent(params.agentSandboxId, params.tx);
 
-    return await this.create({
-      name,
-      description: `Auto-generated sandbox key for agent ${params.agentSandboxId}`,
-      organization_id: params.organizationId,
-      user_id: params.userId,
-      rate_limit: 1000,
-      is_active: true,
-      expires_at: null,
-    });
+    const created = await this.create(
+      {
+        name,
+        description: `Auto-generated sandbox key for agent ${params.agentSandboxId}`,
+        organization_id: params.organizationId,
+        user_id: params.userId,
+        rate_limit: 1000,
+        is_active: true,
+        expires_at: null,
+      },
+      params.tx,
+    );
+    return { ...created, revokedKeyHashes };
   }
 
-  async revokeForAgent(agentSandboxId: string): Promise<void> {
+  /**
+   * Revokes the sandbox-scoped keys and returns the hashes it removed.
+   *
+   * A transactional caller MUST feed those hashes back through
+   * {@link confirmRevocationAfterCommit} after it commits, then purge with
+   * {@link purgeConfirmedRevokedAgentKeys}. Without `tx` this method runs the
+   * authoritative invalidation itself and hard-deletes only the rows whose
+   * invalidation was confirmed.
+   */
+  async revokeForAgent(agentSandboxId: string, tx?: DbTransaction): Promise<string[]> {
     const name = ApiKeysService.agentApiKeyName(agentSandboxId);
-    // Unlike update/delete (which invalidate BEFORE the DB mutation and so can
-    // safely fail closed by throwing), this path deletes the rows FIRST — the
-    // credential is already DB-revoked. A cache-invalidation failure here must
-    // NOT abort agent (re)provisioning: the stale entry is TTL-bounded and the
-    // authoritative row is gone. So invalidation is best-effort — but the
-    // failure is surfaced observably (error-policy:J5), never swallowed silently.
-    for (const key of await apiKeysRepository.deleteByName(name)) {
+    // The revoke DEACTIVATES rather than deletes, and collects every row
+    // bearing the sandbox name — including rows already parked inactive by an
+    // earlier rotation whose post-commit invalidation was never confirmed.
+    // That inactive row is the durable carry: it cannot authenticate from the
+    // database, but its hash may still be POSITIVELY cached (a request can
+    // re-cache the row while a transactional delete is not yet committed), so
+    // every retry must re-offer it for confirmed invalidation until one
+    // succeeds. A DELETE here would discard the hash forever and cap nothing.
+    const revoked = await apiKeysRepository.deactivateByNameReturningAll(name, tx);
+    const revokedKeyHashes = revoked.map((key) => key.key_hash);
+
+    // Inline invalidation pass. Under `tx` it is merely the best-effort
+    // pre-commit pass (the boundary re-confirms after COMMIT); without `tx`
+    // the deactivation is already durable, so this pass is authoritative and
+    // a confirmed row can be hard-deleted immediately.
+    for (const key of revoked) {
       try {
         await this.invalidateCache(key.key_hash);
+        if (!tx) {
+          await apiKeysRepository.delete(key.id);
+        }
       } catch (error) {
+        // error-policy:J5 the failure is observable here and the inactive row
+        // remains as the durable carry — the next rotation (or the boundary's
+        // post-commit confirmation) re-attempts this hash.
         logger.error(
-          "[ApiKeys] revokeForAgent: cache invalidation not confirmed for a DB-revoked key; " +
-            "stale entry bounded by TTL, provisioning continues",
+          "[ApiKeys] revokeForAgent: cache invalidation not confirmed for a revoked key; " +
+            "row parked inactive so a later pass re-offers its hash",
           {
             agentSandboxId,
+            shortHash: key.key_hash.substring(0, 16),
             error: error instanceof Error ? error.message : String(error),
           },
         );
       }
+    }
+    return revokedKeyHashes;
+  }
+
+  /**
+   * Hashes of carriers parked by earlier rotations whose confirmation never
+   * landed. Launch boundaries call this AFTER their transaction commits so
+   * every attempt re-offers outstanding carriers — including attempts that
+   * re-use a persisted key and never re-mint (codex round-4 P1#1). Read
+   * failure degrades to an empty list: the attempt then confirms at least its
+   * own request-local hashes, and the carriers stay parked for the next pass.
+   */
+  async collectOutstandingRevokedKeyHashes(agentSandboxId: string): Promise<string[]> {
+    const name = ApiKeysService.agentApiKeyName(agentSandboxId);
+    try {
+      const rows = await apiKeysRepository.findInactiveByName(name);
+      return rows.map((row) => row.key_hash);
+    } catch (error) {
+      // error-policy:J7 diagnostics-must-not-kill-the-loop: the carriers are
+      // durable rows; missing one collection pass loses nothing permanently.
+      logger.error("[ApiKeys] outstanding-carrier collection failed; proceeding without", {
+        agentSandboxId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Best-effort cleanup of rows parked inactive by {@link revokeForAgent},
+   * called at a launch boundary ONLY after {@link confirmRevocationAfterCommit}
+   * resolved — and scoped to EXACTLY the hashes that attempt confirmed
+   * (codex round-4 P1#2): the advisory lock releases at COMMIT, so a delayed
+   * purge must never reap a carrier a concurrent rotation parked but has not
+   * yet confirmed. A failure here is harmless — rows stay inactive and the
+   * next rotation re-collects them — so it never propagates.
+   */
+  async purgeConfirmedRevokedAgentKeys(
+    agentSandboxId: string,
+    confirmedKeyHashes: readonly string[],
+  ): Promise<void> {
+    const name = ApiKeysService.agentApiKeyName(agentSandboxId);
+    try {
+      await apiKeysRepository.deleteInactiveByHashes(name, confirmedKeyHashes);
+    } catch (error) {
+      // error-policy:J6 teardown-only: the credentials are already inactive
+      // and their caches confirmed clear; the residue is re-swept later.
+      logger.warn("[ApiKeys] purge of confirmed-revoked agent keys failed; rows stay inactive", {
+        agentSandboxId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * Confirmed post-commit invalidation for keys a transaction has just removed.
+   *
+   * Fails closed: unlike the pre-commit pass inside {@link revokeForAgent},
+   * there is no later opportunity to clear a positive entry re-cached while the
+   * old row was still visible, so an unconfirmed delete here MUST reach the
+   * caller (error-policy:J1). By this point the rotation is committed, so the
+   * caller is reporting a partially-applied launch, not a clean failure.
+   */
+  async confirmRevocationAfterCommit(keyHashes: readonly string[]): Promise<void> {
+    // Every hash is attempted before anything throws. Failing fast on the first
+    // one would leave the remaining credentials never even offered for
+    // invalidation, so a single cache brownout could strand more keys than it
+    // reported.
+    const unconfirmed: string[] = [];
+    for (const keyHash of keyHashes) {
+      try {
+        await this.invalidateCache(keyHash);
+      } catch (error) {
+        unconfirmed.push(keyHash);
+        logger.error("[ApiKeys] post-commit revocation invalidation not confirmed", {
+          shortHash: keyHash.substring(0, 16),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    if (unconfirmed.length > 0) {
+      throw new Error(
+        `Post-commit revocation not confirmed for ${unconfirmed.length}/${keyHashes.length} key(s); ` +
+          "the superseded credential may authenticate from cache until its TTL",
+      );
     }
   }
 }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-warm-claim-key-push.test.ts
@@ -42,19 +42,31 @@ const REMINTED_KEY = "eliza_" + "remintedsecretmusntleak000";
 const POOL_BOOT_KEY = "eliza_" + "poolorgsecretmusntleak0000";
 
 const createForAgent = mock(
-  async (_p: { organizationId: string; userId: string; agentSandboxId: string }) => ({
+  async (_p: { organizationId: string; userId: string; agentSandboxId: string; tx?: unknown }) => ({
     apiKey: { id: "key-1", key_prefix: MINTED_KEY.slice(0, 12) },
     plainKey: MINTED_KEY,
+    revokedKeyHashes: [] as string[],
   }),
 );
-const revokeForAgent = mock(async (_agentSandboxId: string) => undefined);
+const revokeForAgent = mock(async (_agentSandboxId: string) => [] as string[]);
+const confirmRevocationAfterCommit = mock(async (_hashes: readonly string[]) => undefined);
+const purgeConfirmedRevokedAgentKeys = mock(
+  async (_agentSandboxId: string, _confirmedKeyHashes: readonly string[]) => undefined,
+);
+const collectOutstandingRevokedKeyHashes = mock(async (_agentSandboxId: string) => [] as string[]);
 const update = mock(async (_id: string, _data: Record<string, unknown>) => undefined);
 
 // Mock ONLY the api-keys service (mint + revoke boundary). The agent-sandboxes
 // repository is imported for many named exports by eliza-sandbox, so instead
 // of mocking the whole module we override `update` on the real singleton below.
 mock.module("./api-keys", () => ({
-  apiKeysService: { createForAgent, revokeForAgent },
+  apiKeysService: {
+    createForAgent,
+    revokeForAgent,
+    confirmRevocationAfterCommit,
+    purgeConfirmedRevokedAgentKeys,
+    collectOutstandingRevokedKeyHashes,
+  },
 }));
 
 const { agentSandboxesRepository } = await import("../../db/repositories/agent-sandboxes");
@@ -218,9 +230,15 @@ beforeEach(() => {
   createForAgent.mockResolvedValue({
     apiKey: { id: "key-1", key_prefix: MINTED_KEY.slice(0, 12) },
     plainKey: MINTED_KEY,
+    revokedKeyHashes: [],
   });
   revokeForAgent.mockReset();
-  revokeForAgent.mockResolvedValue(undefined);
+  revokeForAgent.mockResolvedValue([]);
+  confirmRevocationAfterCommit.mockClear();
+  confirmRevocationAfterCommit.mockResolvedValue(undefined);
+  purgeConfirmedRevokedAgentKeys.mockClear();
+  collectOutstandingRevokedKeyHashes.mockClear();
+  collectOutstandingRevokedKeyHashes.mockResolvedValue([]);
   update.mockClear();
   transaction.mockClear();
   databaseRow = buildInitialDbRow();
@@ -366,6 +384,95 @@ describe("pushClaimedWarmContainerInferenceKey", () => {
     expect(logged).not.toContain(POOL_BOOT_KEY);
   });
 
+  test("re-keys on the handoff transaction, not a second pooled connection", async () => {
+    await svc().pushClaimedWarmContainerInferenceKey(claimedRow());
+
+    // Same defect class as the managed-launch path (#18190): this handoff runs
+    // its re-key inside `dbWrite.transaction`, so minting on the global pool
+    // asks for a second connection while the first is held — and it re-keys
+    // inside CAS-guarded UPDATEs, where an independently committed rotation is
+    // worse than a wasted connection.
+    expect(createForAgent).toHaveBeenCalled();
+    for (const [params] of createForAgent.mock.calls) {
+      expect(params.tx).toBeDefined();
+    }
+  });
+
+  test("carried hashes reach the post-commit confirmation, then the carriers are purged", async () => {
+    createForAgent.mockResolvedValue({
+      apiKey: { id: "key-1", key_prefix: MINTED_KEY.slice(0, 12) },
+      plainKey: MINTED_KEY,
+      revokedKeyHashes: ["carried-from-failed-earlier-rotation", "current-pool-key-hash"],
+    });
+
+    await svc().pushClaimedWarmContainerInferenceKey(claimedRow());
+
+    // The retry invariant at this boundary: EVERY hash the rotation revoked —
+    // including one carried from an earlier rotation whose confirmation
+    // failed — is re-offered post-commit, and purge runs only afterwards,
+    // scoped to exactly the hashes this attempt confirmed.
+    expect(confirmRevocationAfterCommit).toHaveBeenCalledWith([
+      "carried-from-failed-earlier-rotation",
+      "current-pool-key-hash",
+    ]);
+    expect(purgeConfirmedRevokedAgentKeys).toHaveBeenCalledWith(expect.any(String), [
+      "carried-from-failed-earlier-rotation",
+      "current-pool-key-hash",
+    ]);
+  });
+
+  test("an unconfirmed post-commit revocation fails the handoff and leaves the carriers unpurged", async () => {
+    createForAgent.mockResolvedValue({
+      apiKey: { id: "key-1", key_prefix: MINTED_KEY.slice(0, 12) },
+      plainKey: MINTED_KEY,
+      revokedKeyHashes: ["still-cached-hash"],
+    });
+    confirmRevocationAfterCommit.mockRejectedValueOnce(new Error("cache brownout"));
+
+    await expect(svc().pushClaimedWarmContainerInferenceKey(claimedRow())).rejects.toMatchObject({
+      code: "WARM_CLAIM_REVOCATION_UNCONFIRMED",
+    });
+    // No purge: the inactive rows must survive as the durable carry.
+    expect(purgeConfirmedRevokedAgentKeys).not.toHaveBeenCalled();
+  });
+
+  test("post-commit brownout, then REAL recovery: the carrier is re-offered by the non-minting branch (round-4 P1#1)", async () => {
+    // Attempt #1: mint succeeds and the transaction persists key+fingerprint,
+    // then the post-commit confirmation browns out. The handoff fails BEFORE
+    // any container push, with hash-A parked as a durable carrier.
+    createForAgent.mockResolvedValue({
+      apiKey: { id: "key-1", key_prefix: MINTED_KEY.slice(0, 12) },
+      plainKey: MINTED_KEY,
+      revokedKeyHashes: ["hash-A"],
+    });
+    confirmRevocationAfterCommit.mockRejectedValueOnce(new Error("cache brownout"));
+
+    await expect(svc().pushClaimedWarmContainerInferenceKey(claimedRow())).rejects.toMatchObject({
+      code: "WARM_CLAIM_REVOCATION_UNCONFIRMED",
+    });
+    expect(purgeConfirmedRevokedAgentKeys).not.toHaveBeenCalled();
+    expect(capturedRequests).toHaveLength(0);
+
+    // Attempt #2: the REAL recovery entry point. The persisted fingerprint now
+    // matches, so this is the branch that returns the persisted key WITHOUT
+    // calling createForAgent — request-local hashes are empty, and before the
+    // uniform sweep the confirmation block was skipped entirely. The carrier
+    // must arrive via the durable collection instead.
+    createForAgent.mockClear();
+    collectOutstandingRevokedKeyHashes.mockResolvedValue(["hash-A"]);
+
+    await expect(
+      svc().recoverPendingWarmClaimInferenceKey(AGENT_ID, USER_ORG_ID),
+    ).resolves.toMatchObject({ pushed: true });
+    expect(createForAgent).not.toHaveBeenCalled();
+    expect(confirmRevocationAfterCommit).toHaveBeenLastCalledWith(["hash-A"]);
+    expect(purgeConfirmedRevokedAgentKeys).toHaveBeenCalledWith(expect.any(String), ["hash-A"]);
+    expect(databaseRow).toMatchObject({
+      status: "running",
+      warm_claim_credential_state: "ready",
+    });
+  });
+
   test("keeps the durable claim fence pending until live fingerprint attestation", async () => {
     const fetchEntered = Promise.withResolvers<void>();
     const releaseFetch = Promise.withResolvers<void>();
@@ -478,10 +585,12 @@ describe("pushClaimedWarmContainerInferenceKey", () => {
       .mockResolvedValueOnce({
         apiKey: { id: "key-1", key_prefix: MINTED_KEY.slice(0, 12) },
         plainKey: MINTED_KEY,
+        revokedKeyHashes: [],
       })
       .mockResolvedValueOnce({
         apiKey: { id: "key-2", key_prefix: REMINTED_KEY.slice(0, 12) },
         plainKey: REMINTED_KEY,
+        revokedKeyHashes: [],
       });
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
@@ -552,6 +661,7 @@ describe("pushClaimedWarmContainerInferenceKey", () => {
     createForAgent.mockResolvedValue({
       apiKey: { id: "key-2", key_prefix: REMINTED_KEY.slice(0, 12) },
       plainKey: REMINTED_KEY,
+      revokedKeyHashes: [],
     });
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const body = typeof init?.body === "string" ? init.body : "";
@@ -600,6 +710,7 @@ describe("pushClaimedWarmContainerInferenceKey", () => {
     createForAgent.mockResolvedValueOnce({
       apiKey: { id: "key-1", key_prefix: "" },
       plainKey: "",
+      revokedKeyHashes: [],
     });
 
     await expect(svc().pushClaimedWarmContainerInferenceKey(claimedRow())).rejects.toThrow(

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -8408,14 +8408,15 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
       }),
     }));
     const update = mock(() => ({ set: updateSet }));
-    upgradeTransactionImpl = async (fn) =>
-      fn({
-        execute: async () => ({ rows: [] }),
-        update,
-      } as unknown as UpgradeTx);
+    const handle = {
+      execute: async () => ({ rows: [] }),
+      update,
+    } as unknown as UpgradeTx;
+    upgradeTransactionImpl = async (fn) => fn(handle);
     return {
       update,
       updateSet,
+      handle,
       getWhereClause: () => whereClause,
     };
   }
@@ -8571,13 +8572,46 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
     }
   });
 
-  test("managed launch revokes a newly minted credential when its environment CAS loses", async () => {
+  test("managed launch mints its replacement on the launch transaction, not a second connection", async () => {
+    const existing = customSandbox();
+    const tx = installLifecycleUpdateTransaction(existing);
+    const { svc, lock, read } = await makeMutableService(existing);
+    const mint = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      apiKey: { id: "replacement-key" },
+      plainKey: "eliza_replacement_key",
+      revokedKeyHashes: [],
+    } as never);
+    try {
+      await svc.prepareManagedLaunchEnvironment({
+        agentId: existing.id,
+        organizationId: existing.organization_id,
+        userId: existing.user_id,
+      });
+      // Minting on the global write pool asks for a SECOND connection while
+      // this transaction still holds one; concurrent launches then starve the
+      // pool and each stalls out at connectionTimeoutMillis.
+      expect(mint).toHaveBeenCalledTimes(1);
+      expect(mint.mock.calls[0][0]).toMatchObject({
+        agentSandboxId: existing.id,
+        organizationId: existing.organization_id,
+        tx: tx.handle,
+      });
+    } finally {
+      upgradeTransactionImpl = null;
+      lock.mockRestore();
+      read.mockRestore();
+      mint.mockRestore();
+    }
+  });
+
+  test("managed launch unwinds the credential rotation when its environment CAS loses", async () => {
     const existing = customSandbox();
     const tx = installLifecycleUpdateTransaction(existing, { persist: false });
     const { svc, lock, read } = await makeMutableService(existing);
     const mint = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
       apiKey: { id: "replacement-key" },
       plainKey: "eliza_replacement_key",
+      revokedKeyHashes: [],
     } as never);
     const revoke = spyOn(apiKeysService, "revokeForAgent").mockResolvedValue(undefined);
     try {
@@ -8589,7 +8623,10 @@ describe("ElizaSandboxService updateAgentProfile / updateAgentEnvironment", () =
         }),
       ).resolves.toBeUndefined();
       expect(mint).toHaveBeenCalledTimes(1);
-      expect(revoke).toHaveBeenCalledWith(existing.id);
+      // The rotation shares this transaction, so losing the CAS rolls it back.
+      // A compensating out-of-band revoke would now delete the RESTORED key and
+      // leave the agent with none.
+      expect(revoke).not.toHaveBeenCalled();
       expect(tx.update).toHaveBeenCalledTimes(1);
       const whereClause = tx.getWhereClause();
       if (!whereClause) throw new Error("managed launch did not build its ownership CAS");

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -976,6 +976,20 @@ export function isPermanentlyLostSnapshot(error: unknown): boolean {
   return match !== null && PERMANENTLY_LOST_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
 }
 
+/**
+ * Rollback signal for `prepareManagedLaunchEnvironment`: the guarded
+ * environment write matched no row, so another lifecycle owner won the race.
+ * Thrown purely to unwind the transaction that also carries the credential
+ * rotation, and converted back to `undefined` by the method that raised it —
+ * it never escapes to a caller.
+ */
+class ManagedLaunchOwnershipLost extends Error {
+  constructor() {
+    super("Managed launch lost its agent ownership CAS");
+    this.name = "ManagedLaunchOwnershipLost";
+  }
+}
+
 export class ElizaSandboxService {
   private _provider?: SandboxProvider;
   private _providerPromise?: Promise<SandboxProvider>;
@@ -1598,8 +1612,18 @@ export class ElizaSandboxService {
    * Rotate the generic managed-launch credential and persist its environment
    * under the same per-agent lifecycle lock used by delete/restart/upgrade.
    * Key minting stays inside that ownership window so a delete cannot revoke
-   * and then lose to a late mint. A transaction/commit failure compensates by
-   * revoking the newly minted sandbox-scoped key.
+   * and then lose to a late mint.
+   *
+   * The rotation runs on the launch transaction's own connection. It used to
+   * reach for the global write pool instead, which made every launch hold one
+   * connection while asking for a second. The Worker pool is sized `max: 1`
+   * (`db/client.ts` `createPgPool`), so the request waited on the connection it
+   * was itself holding: a guaranteed self-deadlock, resolved only by
+   * `connectionTimeoutMillis` (30s) and returned as a 500. No concurrency was
+   * required — every managed launch hit it. Sharing the connection also makes
+   * the rotation atomic with the environment write, so an unwind restores the
+   * previous key rather than needing a compensating revoke that could itself
+   * fail.
    */
   async prepareManagedLaunchEnvironment(params: {
     agentId: string;
@@ -1612,9 +1636,11 @@ export class ElizaSandboxService {
       }
     | undefined
   > {
-    let credentialMinted = false;
+    let committed:
+      | { sandbox: AgentSandbox; environment: ManagedElizaEnvironmentResult }
+      | undefined;
     try {
-      const result = await dbWrite.transaction(async (tx) => {
+      committed = await dbWrite.transaction(async (tx) => {
         await this.lockLifecycle(tx, params.agentId, params.organizationId);
         const rec = await this.getAgentForLifecycleMutation(
           tx,
@@ -1629,8 +1655,8 @@ export class ElizaSandboxService {
           organizationId: params.organizationId,
           userId: params.userId,
           agentSandboxId: rec.id,
+          tx,
         });
-        credentialMinted = true;
         if (!environment.changed) {
           return { sandbox: rec, environment };
         }
@@ -1653,39 +1679,66 @@ export class ElizaSandboxService {
             ),
           )
           .returning();
-        return updated ? { sandbox: updated, environment } : undefined;
+        // Losing the ownership CAS must unwind the credential rotation with it.
+        // Returning here would COMMIT a key swap the stored environment never
+        // references, leaving the agent booting with a deleted key; throwing
+        // rolls both back together.
+        if (!updated) throw new ManagedLaunchOwnershipLost();
+        return { sandbox: updated, environment };
       });
-
-      if (!result && credentialMinted) {
-        await apiKeysService.revokeForAgent(params.agentId);
-      }
-      return result;
     } catch (error) {
-      // error-policy:J6 compensating teardown — a minted credential is revoked
-      // before the original managed-launch failure is rethrown.
-      if (credentialMinted) {
-        try {
-          await apiKeysService.revokeForAgent(params.agentId);
-        } catch (cleanupError) {
-          // error-policy:J2 context-adding rethrow — failed credential cleanup is
-          // fatal and retains both the cleanup cause and original launch failure.
-          throw new ElizaError(
-            "Managed launch environment failed and its replacement credential could not be revoked",
-            {
-              code: "MANAGED_LAUNCH_CREDENTIAL_CLEANUP_FAILED",
-              cause: cleanupError,
-              context: {
-                agentId: params.agentId,
-                organizationId: params.organizationId,
-                originalError: error instanceof Error ? error.message : String(error),
-              },
-              severity: "fatal",
-            },
-          );
-        }
-      }
+      // error-policy:J4 user-facing degrade — only this path's own CAS-loss
+      // signal becomes the documented "not prepared" result; the transaction
+      // has already rolled the rotation back. Every other failure propagates.
+      if (error instanceof ManagedLaunchOwnershipLost) return undefined;
       throw error;
     }
+
+    // The rotation is durable only now. The invalidation inside the
+    // transaction ran while the revoked rows were still visible to other
+    // connections, so a request from the still-running container could have
+    // re-cached one POSITIVELY for the full validation TTL. Repeat it here,
+    // confirmed, before the caller shuts the container down or returns the
+    // replacement credential — and sweep in every OUTSTANDING carrier parked
+    // by an earlier attempt whose confirmation failed, so no code path can
+    // finish while a superseded hash silently keeps authorizing.
+    if (committed) {
+      const toConfirm = [
+        ...new Set([
+          ...committed.environment.revokedKeyHashes,
+          ...(await apiKeysService.collectOutstandingRevokedKeyHashes(params.agentId)),
+        ]),
+      ];
+      if (toConfirm.length === 0) return committed;
+      try {
+        await apiKeysService.confirmRevocationAfterCommit(toConfirm);
+        // Confirmed clear everywhere — reap EXACTLY the carriers this attempt
+        // confirmed; a concurrent rotation's unconfirmed carrier stays parked.
+        await apiKeysService.purgeConfirmedRevokedAgentKeys(params.agentId, toConfirm);
+      } catch (cause) {
+        // error-policy:J2 context-adding rethrow — there is no later pass that
+        // could clear a re-cached entry, so an unconfirmed invalidation must
+        // stop the launch rather than hand back a rotated credential while the
+        // revoked one may still authenticate. The DB rotation is already
+        // committed; the caller is being told the launch is PARTIALLY applied
+        // and a retry re-rotates from the new state.
+        throw new ElizaError(
+          "Managed launch rotated the agent credential but could not confirm revocation of the previous one",
+          {
+            code: "MANAGED_LAUNCH_REVOCATION_UNCONFIRMED",
+            cause,
+            context: {
+              agentId: params.agentId,
+              organizationId: params.organizationId,
+              revokedKeyCount: toConfirm.length,
+              committed: true,
+            },
+            severity: "fatal",
+          },
+        );
+      }
+    }
+    return committed;
   }
 
   /**
@@ -4249,6 +4302,11 @@ export class ElizaSandboxService {
     organizationId: string,
     expectedSourcePoolId?: string,
   ): Promise<{ pushed: boolean; keyPrefix?: string }> {
+    // Every re-key below runs on `tx` for the same reason the managed-launch
+    // path does, and the hashes it revokes are collected here so the
+    // invalidation can be repeated once the rotation is durable. Only ever
+    // read after the transaction resolves.
+    const rotatedKeyHashes: string[] = [];
     const prepared = await dbWrite.transaction(async (tx) => {
       await this.lockLifecycle(tx, agentId, organizationId);
       const current = await this.getAgentForLifecycleMutation(tx, agentId, organizationId);
@@ -4305,11 +4363,13 @@ export class ElizaSandboxService {
           if (!rearmed) {
             throw new Error("Warm-claim re-attestation lost its state CAS");
           }
-          const { plainKey } = await apiKeysService.createForAgent({
+          const { plainKey, revokedKeyHashes } = await apiKeysService.createForAgent({
             organizationId,
             userId: rearmed.user_id,
             agentSandboxId: rearmed.id,
+            tx,
           });
+          rotatedKeyHashes.push(...revokedKeyHashes);
           const fingerprint = await warmClaimKeyFingerprint(plainKey);
           const encryptedPatch = await encryptAgentEnvVarsForStorage(organizationId, {
             ELIZAOS_CLOUD_API_KEY: plainKey,
@@ -4380,11 +4440,13 @@ export class ElizaSandboxService {
           if (!rearmed) {
             throw new Error("Warm-claim pending credential re-arm lost its state CAS");
           }
-          const { plainKey } = await apiKeysService.createForAgent({
+          const { plainKey, revokedKeyHashes } = await apiKeysService.createForAgent({
             organizationId,
             userId: rearmed.user_id,
             agentSandboxId: rearmed.id,
+            tx,
           });
+          rotatedKeyHashes.push(...revokedKeyHashes);
           const fingerprint = await warmClaimKeyFingerprint(plainKey);
           const encryptedPatch = await encryptAgentEnvVarsForStorage(organizationId, {
             ELIZAOS_CLOUD_API_KEY: plainKey,
@@ -4422,11 +4484,13 @@ export class ElizaSandboxService {
         };
       }
 
-      const { plainKey } = await apiKeysService.createForAgent({
+      const { plainKey, revokedKeyHashes } = await apiKeysService.createForAgent({
         organizationId,
         userId: current.user_id,
         agentSandboxId: current.id,
+        tx,
       });
+      rotatedKeyHashes.push(...revokedKeyHashes);
       const fingerprint = await warmClaimKeyFingerprint(plainKey);
       const encryptedPatch = await encryptAgentEnvVarsForStorage(organizationId, {
         ELIZAOS_CLOUD_API_KEY: plainKey,
@@ -4456,6 +4520,46 @@ export class ElizaSandboxService {
       }
       return { current: updated, plainKey, fingerprint };
     });
+
+    // Durable now. Repeat the invalidation the transaction ran while the
+    // revoked rows were still visible, so a request that re-cached one in that
+    // gap cannot keep authenticating on it. Outstanding carriers are swept in
+    // UNCONDITIONALLY: the attested/pending re-use branches above return a
+    // persisted key without re-minting, so `rotatedKeyHashes` alone would be
+    // empty there and a carrier from a failed earlier attempt would never be
+    // re-offered (codex round-4 P1#1).
+    {
+      const outstandingCarrierHashes = [
+        ...new Set([
+          ...rotatedKeyHashes,
+          ...(await apiKeysService.collectOutstandingRevokedKeyHashes(agentId)),
+        ]),
+      ];
+      if (outstandingCarrierHashes.length > 0) {
+        try {
+          await apiKeysService.confirmRevocationAfterCommit(outstandingCarrierHashes);
+          // Reap EXACTLY what this attempt confirmed — nothing broader.
+          await apiKeysService.purgeConfirmedRevokedAgentKeys(agentId, outstandingCarrierHashes);
+        } catch (cause) {
+          // error-policy:J2 context-adding rethrow — the re-key is committed, so
+          // an unconfirmed invalidation leaves a superseded credential possibly
+          // live in cache. Surface it rather than report a clean handoff.
+          throw new ElizaError(
+            "Warm-claim credential handoff could not confirm revocation of the superseded credential",
+            {
+              code: "WARM_CLAIM_REVOCATION_UNCONFIRMED",
+              cause,
+              context: {
+                agentId,
+                organizationId,
+                revokedKeyCount: outstandingCarrierHashes.length,
+              },
+              severity: "fatal",
+            },
+          );
+        }
+      }
+    }
 
     if (
       prepared.current.warm_claim_credential_state === "ready" &&

--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.ts
@@ -1,6 +1,7 @@
 // Coordinates cloud service managed eliza config behavior behind route handlers.
 import crypto from "node:crypto";
 import { EXTERNAL_URLS } from "@elizaos/shared/brand";
+import type { DbTransaction } from "../../db/client";
 import { getElizaAgentPublicWebUiUrl } from "../eliza-agent-web-ui";
 import { CEREBRAS_DEFAULT_TEXT_LARGE_MODEL, CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../models";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
@@ -28,12 +29,20 @@ export interface ManagedElizaEnvironmentResult {
   changed: boolean;
   environmentVars: Record<string, string>;
   agentApiKey: string;
+  /**
+   * Hashes of the sandbox keys this preparation revoked. A caller that
+   * prepared inside its own transaction MUST re-invalidate them after COMMIT
+   * (`apiKeysService.confirmRevocationAfterCommit`) — the pre-commit pass ran
+   * while the old rows were still visible to other connections.
+   */
+  revokedKeyHashes: string[];
 }
 
 export interface ManagedElizaBaseEnvironmentResult {
   apiToken: string;
   environmentVars: Record<string, string>;
   agentApiKey: string;
+  revokedKeyHashes: string[];
 }
 
 export interface PrepareManagedElizaSharedEnvironmentParams {
@@ -41,6 +50,13 @@ export interface PrepareManagedElizaSharedEnvironmentParams {
   organizationId: string;
   userId: string;
   agentSandboxId: string;
+  /**
+   * The caller's open primary transaction, when it has one. Preparation mints
+   * the agent's cloud key, so a caller inside a transaction must pass it or
+   * that mint checks out a second pooled connection while holding the first.
+   * Callers that prepare unlocked (cold provision, tier upgrade) leave it unset.
+   */
+  tx?: DbTransaction;
 }
 
 export function findReservedManagedElizaEnvKeys(keys: Iterable<string>): string[] {
@@ -249,10 +265,11 @@ export async function prepareManagedElizaBaseEnvironment(
   // DATABASE_URL re-injected by computeManagedAgentDbEnv.
   delete existingEnv.DATABASE_URL;
   delete existingEnv.ELIZA_MANAGED_DATABASE_URL;
-  const { plainKey: agentApiKey } = await apiKeysService.createForAgent({
+  const { plainKey: agentApiKey, revokedKeyHashes } = await apiKeysService.createForAgent({
     organizationId: params.organizationId,
     userId: params.userId,
     agentSandboxId: params.agentSandboxId,
+    tx: params.tx,
   });
   const apiToken =
     existingEnv.ELIZA_API_TOKEN?.trim() || `agent_${crypto.randomUUID().replace(/-/g, "")}`;
@@ -260,6 +277,7 @@ export async function prepareManagedElizaBaseEnvironment(
   return {
     apiToken,
     agentApiKey,
+    revokedKeyHashes,
     environmentVars: {
       ...existingEnv,
       // Hosting-mode marker: this process is a managed Eliza Cloud agent, not a
@@ -335,6 +353,7 @@ export async function prepareManagedElizaSharedEnvironment(
     organizationId: params.organizationId,
     userId: params.userId,
     agentSandboxId: params.agentSandboxId,
+    tx: params.tx,
   });
   const environmentVars: Record<string, string> = {
     ...baseEnvironment.environmentVars,
@@ -345,5 +364,6 @@ export async function prepareManagedElizaSharedEnvironment(
     changed: JSON.stringify(existingEnv) !== JSON.stringify(environmentVars),
     environmentVars,
     agentApiKey: baseEnvironment.agentApiKey,
+    revokedKeyHashes: baseEnvironment.revokedKeyHashes,
   };
 }

--- a/packages/cloud/shared/src/lib/services/managed-eliza-env.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-env.ts
@@ -163,5 +163,6 @@ export async function prepareManagedElizaEnvironment(params: {
     changed,
     environmentVars,
     agentApiKey: sharedEnvironment.agentApiKey,
+    revokedKeyHashes: sharedEnvironment.revokedKeyHashes,
   };
 }

--- a/packages/cloud/shared/src/lib/services/managed-launch-credential-rotation.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-launch-credential-rotation.pglite.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Proves the managed-launch credential rotation shares its caller's
+ * transaction, against real PGlite DDL and real `api_keys` rows.
+ *
+ * `prepareManagedLaunchEnvironment` opens a write transaction, takes the agent
+ * lifecycle lock, and rotates the sandbox-scoped cloud key inside it. The
+ * revoke and the mint used to run on the GLOBAL write pool instead, which made
+ * every launch hold one connection while requesting a second. Cloud runs on
+ * Workers, where that pool is sized `max: 1`, so the request waited on itself
+ * and died at `connectionTimeoutMillis` (30s) — and the rotation also committed
+ * independently of the environment write.
+ *
+ * This harness reproduces the first half exactly rather than by analogy: PGlite
+ * here likewise serves a single connection, so unpatched code deadlocks the
+ * same way, for the same reason, at the same point.
+ *
+ * The rollback case below is the load-bearing one: it can only pass when the
+ * DELETE and INSERT run on the caller's connection. A rotation issued on a
+ * second connection commits on its own, so the previous key would be gone and
+ * a replacement stranded no matter how the launch transaction ends.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import crypto from "node:crypto";
+import { and, eq } from "drizzle-orm";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
+import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
+import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { apiKeys } from "../../db/schemas/api-keys";
+import { dockerNodes } from "../../db/schemas/docker-nodes";
+import { organizations } from "../../db/schemas/organizations";
+import { userCharacters } from "../../db/schemas/user-characters";
+import { users } from "../../db/schemas/users";
+import { cache } from "../cache/client";
+import { CacheKeys, CacheTTL } from "../cache/keys";
+import { apiKeysService } from "./api-keys";
+import { ElizaSandboxService } from "./eliza-sandbox";
+
+const PGLITE_TIMEOUT = 60_000;
+const AGENT_ID = "00000000-0000-4000-8000-00000000f001";
+const PRIOR_PLAINTEXT_KEY = "eliza_the_key_the_agent_is_running_with";
+
+let pgliteReady = true;
+let schemaFailure = "";
+let seq = 0;
+
+function uniq(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${seq}`;
+}
+
+function agentKeyName(agentId: string): string {
+  return `agent-sandbox:${agentId}`;
+}
+
+function hashOf(plaintext: string): string {
+  return crypto.createHash("sha256").update(plaintext).digest("hex");
+}
+
+/**
+ * A launch-ready agent plus the sandbox-scoped key it is currently booting
+ * with. The key row is written directly (not through the service) so the test
+ * owns its exact hash and can assert identity, not just row counts.
+ */
+async function seedLaunchableAgent(): Promise<{ organizationId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Managed Launch Org", slug: uniq("managed-launch-org") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("managed-launch-user"), organization_id: org.id })
+    .returning();
+  await dbWrite.insert(agentSandboxes).values({
+    id: AGENT_ID,
+    organization_id: org.id,
+    user_id: user.id,
+    agent_name: "Managed Launch Agent",
+    status: "running",
+    sandbox_id: "managed-launch-sandbox",
+    node_id: "managed-launch-node",
+    container_name: "managed-launch-container",
+    environment_vars: { ELIZAOS_CLOUD_API_KEY: PRIOR_PLAINTEXT_KEY },
+  });
+  await dbWrite.insert(apiKeys).values({
+    name: agentKeyName(AGENT_ID),
+    organization_id: org.id,
+    user_id: user.id,
+    key_hash: hashOf(PRIOR_PLAINTEXT_KEY),
+    key_prefix: PRIOR_PLAINTEXT_KEY.substring(0, 12),
+    is_active: true,
+  });
+  return { organizationId: org.id, userId: user.id };
+}
+
+async function agentKeyRows() {
+  return await dbWrite
+    .select()
+    .from(apiKeys)
+    .where(eq(apiKeys.name, agentKeyName(AGENT_ID)));
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    return;
+  }
+  try {
+    const { apply } = await pushSchema(
+      { organizations, users, userCharacters, apiKeys, dockerNodes, agentSandboxes } as never,
+      dbWrite as never,
+    );
+    await apply();
+  } catch (error) {
+    // error-policy:J4 — an unavailable PGlite makes the suite fail visibly in
+    // beforeEach rather than silently pass with no database.
+    schemaFailure = error instanceof Error ? error.message : String(error);
+    pgliteReady = false;
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(schemaFailure).toBe("");
+  expect(pgliteReady).toBe(true);
+  await dbWrite.delete(apiKeys);
+  await dbWrite.delete(agentSandboxes);
+  await dbWrite.delete(users);
+  await dbWrite.delete(organizations);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+/**
+ * Deterministic cache for the tests below. The ambient adapter is
+ * environment-dependent (CI processes may initialize the cache singleton
+ * disabled, silently no-opping `set`), which made the brownout regression fail
+ * to establish its own precondition in CI. A Map-backed spy set keeps the
+ * exact get/set/delConfirmed semantics while being process-independent.
+ */
+function installDeterministicCache() {
+  const store = new Map<string, unknown>();
+  const spies = [
+    spyOn(cache, "get").mockImplementation((async (key: string) =>
+      store.has(key) ? store.get(key) : null) as never),
+    spyOn(cache, "set").mockImplementation((async (key: string, value: unknown) => {
+      store.set(key, value);
+      return true;
+    }) as never),
+    spyOn(cache, "delConfirmed").mockImplementation((async (key: string) => {
+      store.delete(key);
+      return true;
+    }) as never),
+  ];
+  return {
+    store,
+    brownout() {
+      // Deletions stop confirming AND stop landing — entries survive.
+      spies[2].mockImplementation((async (_key: string) => false) as never);
+    },
+    heal() {
+      spies[2].mockImplementation((async (key: string) => {
+        store.delete(key);
+        return true;
+      }) as never);
+    },
+    restore() {
+      for (const spy of spies) spy.mockRestore();
+    },
+  };
+}
+
+describe("managed launch credential rotation is atomic with its environment write", () => {
+  test("a committed launch swaps the sandbox key and stores the replacement", async () => {
+    const { organizationId, userId } = await seedLaunchableAgent();
+    const service = new ElizaSandboxService();
+
+    const result = await service.prepareManagedLaunchEnvironment({
+      agentId: AGENT_ID,
+      organizationId,
+      userId,
+    });
+
+    expect(result).toBeDefined();
+    const minted = result?.environment.agentApiKey;
+    expect(typeof minted).toBe("string");
+    expect(minted).not.toBe(PRIOR_PLAINTEXT_KEY);
+
+    // Exactly one live sandbox key, and it is the minted one — the previous
+    // row is gone rather than left active alongside its replacement.
+    const rows = await agentKeyRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].key_hash).toBe(hashOf(minted as string));
+    expect(rows[0].organization_id).toBe(organizationId);
+
+    // The stored environment references the key that actually exists.
+    const [stored] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, AGENT_ID));
+    expect((stored.environment_vars as Record<string, string>).ELIZAOS_CLOUD_API_KEY).toBe(minted);
+  });
+
+  test("losing the ownership CAS rolls the rotation back and leaves the running key intact", async () => {
+    const { organizationId, userId } = await seedLaunchableAgent();
+    const service = new ElizaSandboxService();
+    const [live] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, AGENT_ID));
+
+    // Hand the launch a stale revision so its guarded UPDATE matches no row —
+    // the same outcome a concurrent lifecycle owner produces.
+    const stale = spyOn(
+      service as unknown as {
+        getAgentForLifecycleMutation(
+          tx: unknown,
+          agentId: string,
+          orgId: string,
+        ): Promise<AgentSandbox | undefined>;
+      },
+      "getAgentForLifecycleMutation",
+    ).mockResolvedValue({
+      ...(live as unknown as AgentSandbox),
+      environment_revision: (live.environment_revision ?? 0) + 41,
+    });
+
+    try {
+      await expect(
+        service.prepareManagedLaunchEnvironment({
+          agentId: AGENT_ID,
+          organizationId,
+          userId,
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      stale.mockRestore();
+    }
+
+    // The rotation unwound with the transaction: the key the agent is booting
+    // with survived, and no replacement was stranded. Both assertions fail if
+    // the DELETE/INSERT ran on a second pooled connection.
+    const rows = await agentKeyRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].key_hash).toBe(hashOf(PRIOR_PLAINTEXT_KEY));
+
+    const [unchanged] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(
+        and(eq(agentSandboxes.id, AGENT_ID), eq(agentSandboxes.organization_id, organizationId)),
+      );
+    expect((unchanged.environment_vars as Record<string, string>).ELIZAOS_CLOUD_API_KEY).toBe(
+      PRIOR_PLAINTEXT_KEY,
+    );
+    expect(unchanged.environment_revision).toBe(live.environment_revision);
+  });
+
+  test("a credential re-cached between the pre-commit invalidation and COMMIT is cleared after commit", async () => {
+    const { organizationId, userId } = await seedLaunchableAgent();
+    const service = new ElizaSandboxService();
+    const priorHash = hashOf(PRIOR_PLAINTEXT_KEY);
+    const validationKey = CacheKeys.apiKey.validation(priorHash.substring(0, 16));
+    const iacKey = CacheKeys.inference.authContext(priorHash);
+    const [priorRow] = await agentKeyRows();
+
+    // The race, made deterministic. `launchManagedElizaAgent` shuts the
+    // container down only AFTER this call returns, so the agent is still
+    // authenticating with the prior key throughout. The instant the
+    // in-transaction pass clears the entries, one of those requests misses,
+    // reads the row that is STILL visible (the DELETE has not committed), and
+    // re-caches it positively for the full 600s validation TTL.
+    //
+    // The reader is simulated rather than issued for real because `dbRead` and
+    // `dbWrite` resolve to the SAME pooled connection here, so a genuine
+    // concurrent read would block on the open transaction instead of racing
+    // it. What it writes is exactly what `validateApiKey` writes on a miss.
+    const det = installDeterministicCache();
+    const realInvalidate = apiKeysService.invalidateCache.bind(apiKeysService);
+    let reCached = false;
+    let invalidationPasses = 0;
+    const racing = spyOn(apiKeysService, "invalidateCache").mockImplementation(
+      async (keyHash: string) => {
+        await realInvalidate(keyHash);
+        if (reCached) return;
+        reCached = true;
+        await cache.set(validationKey, priorRow, CacheTTL.apiKey.validation);
+        await cache.set(iacKey, { key_hash: priorHash }, CacheTTL.inference.authContext);
+      },
+    );
+
+    try {
+      const result = await service.prepareManagedLaunchEnvironment({
+        agentId: AGENT_ID,
+        organizationId,
+        userId,
+      });
+      expect(result).toBeDefined();
+      expect(reCached).toBe(true);
+      invalidationPasses = racing.mock.calls.length;
+    } finally {
+      racing.mockRestore();
+    }
+
+    // The security claim first: the revoked credential must no longer
+    // authorize from either cache, nor validate at all.
+    expect(await cache.get(validationKey)).toBeFalsy();
+    expect(await cache.get(iacKey)).toBeFalsy();
+    expect(await apiKeysService.validateApiKey(PRIOR_PLAINTEXT_KEY)).toBeNull();
+    // ...and it is the post-commit pass that achieves it: once before COMMIT,
+    // once after.
+    expect(invalidationPasses).toBeGreaterThanOrEqual(2);
+    det.restore();
+  });
+
+  test("a hash whose post-commit confirmation failed is carried to the retry and cleared there", async () => {
+    const { organizationId, userId } = await seedLaunchableAgent();
+    const service = new ElizaSandboxService();
+    const priorHash = hashOf(PRIOR_PLAINTEXT_KEY);
+    const validationKey = CacheKeys.apiKey.validation(priorHash.substring(0, 16));
+    const [priorRow] = await agentKeyRows();
+
+    const det = installDeterministicCache();
+    // The dangerous state Stan's trace describes: A's row data sits POSITIVELY
+    // cached (a request re-cached it before the rotation committed) …
+    await cache.set(validationKey, priorRow, CacheTTL.apiKey.validation);
+    expect(await cache.get(validationKey)).toBeTruthy();
+    // … and the cache backend browns out exactly when launch #1 tries to
+    // confirm the revocation, so nothing can clear it.
+    det.brownout();
+
+    await expect(
+      service.prepareManagedLaunchEnvironment({ agentId: AGENT_ID, organizationId, userId }),
+    ).rejects.toMatchObject({ code: "MANAGED_LAUNCH_REVOCATION_UNCONFIRMED" });
+
+    // The rotation A→B is COMMITTED (the throw is post-commit), A's positive
+    // entry survived the brownout, and — the durable carry — A's row is parked
+    // inactive rather than deleted, so its hash is not lost.
+    const afterFirst = await agentKeyRows();
+    const parkedA = afterFirst.find((row) => row.key_hash === priorHash);
+    expect(parkedA).toBeDefined();
+    expect(parkedA?.is_active).toBe(false);
+    expect(afterFirst.some((row) => row.is_active && row.key_hash !== priorHash)).toBe(true);
+    expect(await cache.get(validationKey)).toBeTruthy();
+
+    // Retry with the cache healthy. Its revoke re-collects A by name from the
+    // inactive row and re-offers the hash for confirmed invalidation.
+    det.heal();
+    const retried = await service.prepareManagedLaunchEnvironment({
+      agentId: AGENT_ID,
+      organizationId,
+      userId,
+    });
+    expect(retried).toBeDefined();
+
+    // The invariant under review: the ORIGINAL hash A no longer authorizes.
+    expect(await cache.get(validationKey)).toBeFalsy();
+    expect(await apiKeysService.validateApiKey(PRIOR_PLAINTEXT_KEY)).toBeNull();
+
+    // And the carriers are reaped: exactly one live row, the retry's mint.
+    const finalRows = await agentKeyRows();
+    expect(finalRows).toHaveLength(1);
+    expect(finalRows[0].is_active).toBe(true);
+    expect(finalRows[0].key_hash).toBe(hashOf(retried?.environment.agentApiKey as string));
+    det.restore();
+  });
+
+  test("a delayed purge cannot reap a carrier a NEWER rotation parked but has not confirmed (round-4 P1#2)", async () => {
+    const { organizationId, userId } = await seedLaunchableAgent();
+    const service = new ElizaSandboxService();
+    const det = installDeterministicCache();
+    const hashA = hashOf(PRIOR_PLAINTEXT_KEY);
+
+    // T1: a normal launch whose PURGE is captured and deferred — exactly the
+    // advisory-lock-released, purge-delayed window from the review trace.
+    let purgeArgs: [string, readonly string[]] | undefined;
+    const purgeSpy = spyOn(apiKeysService, "purgeConfirmedRevokedAgentKeys").mockImplementation(
+      async (agentId: string, hashes: readonly string[]) => {
+        purgeArgs = [agentId, [...hashes]];
+      },
+    );
+    const first = await service.prepareManagedLaunchEnvironment({
+      agentId: AGENT_ID,
+      organizationId,
+      userId,
+    });
+    purgeSpy.mockRestore();
+    expect(first).toBeDefined();
+    expect(purgeArgs).toBeDefined();
+    const hashB = hashOf(first?.environment.agentApiKey as string);
+
+    // T2: a second rotation parks B (and re-parks A, still present since T1's
+    // purge never ran) but its confirmation browns out — B is now a carrier.
+    det.brownout();
+    await expect(
+      service.prepareManagedLaunchEnvironment({ agentId: AGENT_ID, organizationId, userId }),
+    ).rejects.toMatchObject({ code: "MANAGED_LAUNCH_REVOCATION_UNCONFIRMED" });
+    det.heal();
+
+    // T1's DELAYED purge finally fires — scoped to what T1 confirmed.
+    const [purgeAgentId, purgeHashes] = purgeArgs as [string, readonly string[]];
+    await apiKeysService.purgeConfirmedRevokedAgentKeys(purgeAgentId, purgeHashes);
+
+    // The invariant: B's carrier row SURVIVES T1's purge. A name-wide purge
+    // would have deleted it here, and B — possibly still positively cached —
+    // could never be reconfirmed by any retry.
+    const rows = await agentKeyRows();
+    expect(rows.some((row) => row.key_hash === hashB && row.is_active === false)).toBe(true);
+    expect(rows.some((row) => row.key_hash === hashA)).toBe(false);
+
+    // And the retry proves it: B is re-collected, confirmed, and cleared.
+    const retried = await service.prepareManagedLaunchEnvironment({
+      agentId: AGENT_ID,
+      organizationId,
+      userId,
+    });
+    expect(retried).toBeDefined();
+    const finalRows = await agentKeyRows();
+    expect(finalRows).toHaveLength(1);
+    expect(finalRows[0].key_hash).toBe(hashOf(retried?.environment.agentApiKey as string));
+    det.restore();
+  });
+
+  test("a revoke that lands before the mint fails unwinds too", async () => {
+    const { organizationId, userId } = await seedLaunchableAgent();
+    const service = new ElizaSandboxService();
+    // Revoke succeeds, minting its replacement does not — the half-done state
+    // that previously left an agent with no key at all, because the DELETE had
+    // already committed on its own connection.
+    const halfRotation = spyOn(apiKeysService, "createForAgent").mockImplementation(
+      async (params) => {
+        await apiKeysService.revokeForAgent(params.agentSandboxId, params.tx);
+        throw new Error("mint rejected");
+      },
+    );
+
+    try {
+      await expect(
+        service.prepareManagedLaunchEnvironment({
+          agentId: AGENT_ID,
+          organizationId,
+          userId,
+        }),
+      ).rejects.toThrow("mint rejected");
+    } finally {
+      halfRotation.mockRestore();
+    }
+
+    // A propagating failure needs no compensating revoke to stay consistent —
+    // the transaction already restored the credential the agent is running on.
+    const rows = await agentKeyRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].key_hash).toBe(hashOf(PRIOR_PLAINTEXT_KEY));
+  });
+});


### PR DESCRIPTION
## Summary

Managed agent launch returns **500 after exactly 30 seconds**. `prepareManagedLaunchEnvironment` holds a write connection for its whole agent-lifecycle ownership window, then asks the pool for a **second** connection to rotate the agent's cloud key — and on Workers that pool holds exactly one. The request waits on the connection it is itself holding.

```
prepareManagedLaunchEnvironment          eliza-sandbox.ts:1604
  └─ dbWrite.transaction(tx => …)        ← connection #1 checked out here
       ├─ lockLifecycle(tx, …)                            on tx ✅
       ├─ getAgentForLifecycleMutation(tx, …)             on tx ✅
       └─ prepareManagedElizaSharedEnvironment(…)         no tx parameter ❌
            └─ apiKeysService.createForAgent
                 ├─ revokeForAgent → deleteByName → dbWrite   ← connection #2
                 └─ create         → create       → dbWrite   ← connection #2
```

```ts
// packages/cloud/shared/src/db/client.ts:245
if (inWorkerRuntime) {
  options.max = parsePositiveInteger(env.LOCAL_PG_POOL_MAX, 1);   // ← 1
  options.maxUses = isLocalTcp ? 0 : 1;
  options.connectionTimeoutMillis = 30_000;
}
```

`LOCAL_PG_POOL_MAX` is set nowhere in the cloud configuration, so that default applies. Nothing can release the connection the request waits for, because the waiter is the holder — it deadlocks against itself until `connectionTimeoutMillis` frees it as a 500. Four *sequential* attempts reproduced it, which is itself the evidence against a concurrency explanation.

The database was never involved in the stall — the request never issues a query. Confirmed independently: `EXPLAIN (ANALYZE)` of that DELETE, inside a rolled-back transaction on staging, measures **9.184 ms** with all seven FK triggers included, against **0** waiting locks, **0** blocked sessions and **36/200** server connections in use.

## Second defect on the same line

Because the rotation ran on its own connection it **committed independently of the launch transaction**. If that transaction later rolled back — or its guarded environment `UPDATE` matched no row — the agent's old key was already deleted while `environment_vars` still referenced it. That was papered over by a compensating `revokeForAgent` whose own failure was fatal enough to carry a dedicated code (`MANAGED_LAUNCH_CREDENTIAL_CLEANUP_FAILED`, now unused).

## Change

- `deleteByName(name, tx?)` / `create(data, tx?)` on the repository; `create` / `createForAgent` / `revokeForAgent` on the service; `tx?` on `PrepareManagedElizaSharedEnvironmentParams`. All strictly optional — callers that prepare **unlocked** (cold provision, tier upgrade) pass nothing and keep using the pool.
- `prepareManagedLaunchEnvironment` passes its own `tx`.
- **`completeWarmClaimCredentialHandoff` too** — three re-key sites inside its own transaction, same shape (@0xSolace). See "Scope" below.
- **The compensation is removed**, not adapted: with the rotation inside the transaction a rollback already restores the previous key, so an out-of-band revoke afterwards would delete the key the rollback just restored. Losing the ownership CAS now throws a module-private `ManagedLaunchOwnershipLost` to unwind, converted back to the documented `undefined` by the method that raised it.

### Post-commit revocation (@standujar, blocking — fixed)

The blocker was correct and my original "narrow window" reasoning was wrong. `update()`/`delete()` invalidate before a single **autocommit** statement; this path invalidates before a KMS encrypt, an INSERT and an environment UPDATE, and deliberately rotates a credential whose container is still serving traffic (`eliza-managed-launch.ts:222` shuts it down only *after* this returns). A request landing in that gap re-caches the still-visible row **positively** for the full `CacheTTL.apiKey.validation` — 600s. That is strictly worse than the old code, where the DELETE auto-committed before invalidation, and it is a fail-open regression I introduced.

Repair, as specified:

- `revokeForAgent` returns the hashes it removed; `createForAgent` and both env preparers carry them out to the launch boundary.
- Each transactional caller repeats the invalidation after COMMIT via `confirmRevocationAfterCommit`, before shutdown/provision/return. Pre-commit invalidation is retained.
- It **fails closed**: no later pass could clear a re-cached entry, so an unconfirmed delete throws `MANAGED_LAUNCH_REVOCATION_UNCONFIRMED` / `WARM_CLAIM_REVOCATION_UNCONFIRMED` with `committed: true` in context — the launch is reported partially applied, not clean, and a retry re-rotates from the new state.

### Post-commit invalidation attempts every hash (@standujar, round 2)

`confirmRevocationAfterCommit` fail-fast on the first hash, so a second revoked credential was never even offered for invalidation — caught by their adversarial probe. It now attempts every hash, collects the failures, and throws once naming the count. Verified RED against the fail-fast loop.

### The database is now the durable retry path (@standujar, round 3)

Their trace was exact: rotation A→B commits, confirming A fails, and the retry rotates B→C without ever carrying A — the DELETE had discarded A's hash forever, so A stayed positively cached until TTL while the retry reported success.

Repair: the rotation **deactivates instead of deletes**. `deactivateByNameReturningAll` parks every row bearing the sandbox name — previously-parked carriers included — and returns them all, so the inactive row *is* the persisted unconfirmed hash. A retry's revoke re-collects A by name and re-offers it to `confirmRevocationAfterCommit`; only after confirmation does the boundary hard-delete the carriers (`purgeConfirmedRevokedAgentKeys`, best-effort — a failed purge just leaves the row for the next pass). An inactive row cannot authenticate from the database (`findActiveByHash` filters `is_active`), and the stranded-key sweep is untouched: its `is_active = true` guard means carriers are invisible to it.

The requested failure→retry test runs the real path on PGlite: seed A cached-positive, brown out the cache during launch #1's confirmation → launch throws `MANAGED_LAUNCH_REVOCATION_UNCONFIRMED`, **A's row is parked inactive and its cache entry survives** (the dangerous state, asserted); retry with cache healthy → A's entry cleared, `validateApiKey(A)` null, exactly one live row (the retry's mint). RED against the delete-based head at precisely the carry assertion: `parkedA` is `undefined` — the hash was lost. The warm-claim boundary is pinned in its suite: carried hashes reach the post-commit confirmation and purge runs only afterwards; an unconfirmed revocation throws `WARM_CLAIM_REVOCATION_UNCONFIRMED` with no purge. The no-tx revoke path (cleanup/tier-upgrade callers) got the same upgrade for free: a confirmed row is reaped immediately, an unconfirmed one is parked instead of silently lost — that fail-open existed on those paths before this PR.

### Scope: the warm-claim sites (@0xSolace)

Extended rather than deferred. `completeWarmClaimCredentialHandoff` opens `dbWrite.transaction` and calls `createForAgent` at three points inside it; all three now pass `tx` and feed the same post-commit invalidation. (`cleanupFailedWarmClaimCredentialHandoff`'s `revokeForAgent` is *outside* its transaction — checked, not affected.)

**On the runtime question — I cannot resolve it and am not going to pretend otherwise.** If warm-claim handoffs genuinely succeed on staging, that is evidence those routes are not running the `max: 1` Worker pool, and my "every managed launch in the Worker runtime fails" phrasing overreached. What I actually measured is narrower and is all I now claim: four sequential launches, 500 at ~30.0s each, against an idle database, with a mechanism that explains exactly that. The fix does not depend on the answer — it removes the nested checkout from both paths, correct under either runtime, and the atomicity half matters at any pool size. I have recorded the open question in the evidence log rather than closing it by assertion.

### Durable carriers on every branch + hash-scoped purge (@standujar, round 4)

Both P1s were correct and are fixed structurally rather than patched:

1. **Uniform post-commit carrier sweep.** Every committed attempt at both boundaries now unions its request-local hashes with `collectOutstandingRevokedKeyHashes` (the inactive rows read back post-commit), so the non-minting branches — warm-claim's persisted-key re-use paths included — re-offer carriers from failed earlier attempts. The regression drives the REAL flow: brownout on attempt #1 → `WARM_CLAIM_REVOCATION_UNCONFIRMED`, then `recoverPendingWarmClaimInferenceKey` re-uses the persisted key **without** calling `createForAgent` and still confirms + purges the carrier. RED without the sweep.
2. **Purge scoped to exactly the confirmed hashes.** `deleteInactiveByHashes(name, hashes)` replaces the name-wide delete. The overlapping-rotations regression stages the reviewed trace on real rows: T1's purge deferred past T2's park-and-brownout; on firing it reaps only A — **B's carrier survives** and T2's retry confirms and clears it. RED with the hash scope removed.
3. **The CI-red regression is now deterministic.** The brownout test relied on the ambient cache adapter, which CI initializes disabled — it failed to establish its own precondition, exactly as reviewed. Both cache-dependent tests now install a Map-backed deterministic cache and assert the precondition before using it.

## Verification

`packages/cloud/shared` runs its PGlite harness on a **single** connection — the same size as the Worker pool — so this reproduces the deadlock exactly rather than by analogy. The RED is sharp: against unpatched `develop` the first three cases do not fail an assertion, they **never return**.

```
# RED — source reverted to develop, new tests kept
(fail) a committed launch swaps the sandbox key and stores the replacement [5002.22ms]
  ^ this test timed out after 5000ms.
(fail) losing the ownership CAS rolls the rotation back and leaves the running key intact [5000.01ms]
(fail) a revoke that lands before the mint fails unwinds too [5000.04ms]

# RED — post-commit pass disabled, race test only
(fail) a credential re-cached between the pre-commit invalidation and COMMIT is cleared after commit
  → expect(await cache.get(validationKey)).toBeFalsy()   Received: { …the revoked row… }

# RED — warm-claim tx removed
(fail) re-keys on the handoff transaction, not a second pooled connection
```

| Gate | Result |
| --- | --- |
| `managed-launch-credential-rotation.pglite.test.ts` (new) | **4 pass**, each RED against `develop` |
| `eliza-sandbox.test.ts` | **176 pass / 0 fail** |
| `eliza-sandbox-warm-claim-key-push.test.ts` (+1 pin) | **12 pass / 0 fail** |
| `api-keys.invalidation` · `managed-eliza-config` · `managed-eliza-env` · `agent-tier-upgrade-target` · `admin-agent-image-rollout.pglite` · both api-key sweeps | **103 pass / 0 fail** |
| `packages/cloud/shared` typecheck | passed |
| Scoped Biome (9 files) | passed |
| Root `bun run verify` | passed (exit 0) |
| Rebased on `develop` | `3398387ad` |

The concurrency regression pauses the launch at the in-transaction invalidation, re-caches the prior credential from the still-visible row exactly as `validateApiKey` would, then commits and asserts both caches — and `validateApiKey` itself — no longer authorize it. The simulated reader is deliberate and documented: `dbRead` and `dbWrite` resolve to the *same* pooled connection, so a genuine concurrent read would block on the open transaction instead of racing it. Rollback assertions (old row survives, no replacement stranded, `environment_revision` unchanged) are kept.

One pre-existing failure is **not** mine and is stated rather than hidden: `bun run --cwd packages/cloud/shared test` stops in ordinary batch 2/156 with `SyntaxError: Export named 'InsufficientCreditsError' not found in module .../credits.ts` from `a2a/skills.money-guard.test.ts`. It reproduces identically on unmodified `develop`, and the file passes in isolation either way — a cross-file module-mock leak in that batch.

## Not included, deliberately

The agent-silence symptom from the same staging session (`/api/v1/chat/completions` → 503 with one `[InferenceAuth] background hydration failed`) is **not** explained by this fix and is not claimed here. The key row was healthy at the time — `is_active = t`, no expiry, `last_used_at` *after* the failures. Open for its own investigation.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - server-side data-access change; no rendered UI in this diff (scripts/check-pr-evidence.mjs surfaceFiles() = []).`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - same reason; the observable change is which connection a DELETE/INSERT executes on.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no interactive flow; the failure is a pool deadlock, captured as the RED timeout transcript below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — RED/GREEN transcript, a per-second `pg_stat_activity`/`pg_locks` capture of live staging Postgres during four failing launches showing `blockedby=[]` throughout, and the measurements ruling out slow-query / lock / server-exhaustion causes. Refreshed for internal consistency: it now carries an explicit retraction of the Hyperdrive-8 attribution and records the unresolved runtime question: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18190-backend-evidence.log
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no browser-side code in this diff.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, model, prompt, or provider surface touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the real `api_keys` and `agent_sandboxes` rows after a committed launch and after each rollback path, showing the previous key survives an unwind with its original hash, no replacement is stranded, `environment_revision` does not advance, and the key named by the stored environment always exists: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18190-domain-artifacts.log
<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: `N/A - no rendered visual surface in this diff.`

Closes #18190.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cad]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza"} -->
<!-- evidence-head:7ea5f2b6b95f820379a8f8d328660942f2100ba5 -->




