### PR TITLE
fix(core): URL work orders with unlisted verbs are rejected as passive links (#18108)

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -594,6 +594,60 @@ describe("live routing regressions", () => {
 		).toEqual(["WEB_SEARCH"]);
 	});
 
+	it("URL work orders with unlisted verbs reach TASKS through the real production path (issue #18108)", () => {
+		// This is the load-bearing regression for issue #18108: "review this PR …",
+		// "audit this repository …", and "investigate the failure here …" must each
+		// reach TASKS through the PRODUCTION routing boundary — the exported wrapper
+		// in services/message.ts that wires the REAL looksLikeCodingWorkRequest and
+		// findCodingDelegationActionName hooks. No injected mocks are used.
+		//
+		// Before the fix, two layers conspired to block these utterances:
+		//   1. looksLikeBareLinkShare returned true (verb absent from the old
+		//      closed English allowlist) → shunted to the web-read light path.
+		//   2. looksLikeCodingWorkRequest's verb list (build|create|…|verify) did
+		//      not include review|audit|investigate → even if the link-share veto
+		//      was lifted, the coding hook returned false → no TASKS candidate.
+		//
+		// The fix addresses BOTH layers: conservative link-share detection (only
+		// empty/conversational residue is passive) AND the production
+		// looksLikeCodingWorkRequest now recognizes review|audit|investigate as
+		// coding-work verbs when paired with a code/repo/PR artifact noun.
+		const actions: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "TASKS", similes: ["TASKS_SPAWN_AGENT"] },
+			{ name: "WEB_FETCH" },
+			{ name: "WEB_SEARCH" },
+		];
+		for (const text of [
+			"review this PR https://github.com/elizaOS/eliza/pull/18106",
+			"audit this repository https://github.com/elizaOS/eliza",
+			"investigate the failure here https://example.com/run",
+		]) {
+			const result = inferDirectCurrentRequestCandidateActions(actions, text);
+			expect(result).toEqual(["TASKS"]);
+			expect(result).not.toContain("WEB_FETCH");
+			expect(result).not.toContain("WEB_SEARCH");
+		}
+	});
+
+	it("passive shares still route to WEB_FETCH and never reach TASKS (control for #18108)", () => {
+		// The control: genuine passive link shares must still route to the
+		// web-read light path — the fix must not widen routing to let passive
+		// shares reach TASKS.
+		const actions: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "TASKS", similes: ["TASKS_SPAWN_AGENT"] },
+			{ name: "WEB_FETCH" },
+			{ name: "WEB_SEARCH" },
+		];
+		for (const text of [
+			"https://example.com/some/page",
+			"thoughts? https://example.com",
+		]) {
+			const result = inferDirectCurrentRequestCandidateActions(actions, text);
+			expect(result).toContain("WEB_FETCH");
+			expect(result).not.toContain("TASKS");
+		}
+	});
+
 	it("fast-paths a direct shell ask to TERMINAL_SHELL in a lean-chat runtime (follow-up to #12021)", () => {
 		// PR #12021 renamed the terminal action SHELL -> TERMINAL_SHELL. In a
 		// lean-chat deployment (no plugin-coding-tools) TERMINAL_SHELL is the only

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -302,6 +302,7 @@ describe("plain-text backstop — complete-direct-reply valve (2026-07-01)", () 
 		// an ack fails looksLikeCompleteDirectReply → live-info still fetches.
 		expect(out.plan.requiresTool).toBe(true);
 		expect(out.plan.candidateActions?.length ?? 0).toBeGreaterThan(0);
+		expect(out.plan.requiredToolEvidence).toBe("inferred");
 	});
 
 	it("forces the fetch even when the model HALLUCINATES a complete answer to a fresh ask", () => {
@@ -335,6 +336,10 @@ describe("plain-text backstop — complete-direct-reply valve (2026-07-01)", () 
 		);
 		// coding work must not be short-circuited by the complete-reply valve.
 		expect(out.plan.requiresTool).toBe(true);
+		// Coding inference is structurally strong. It must not get the weak
+		// evidence marker that lets the planner accept a repeated terminal answer
+		// without executing TASKS.
+		expect(out.plan.requiredToolEvidence).toBeUndefined();
 	});
 });
 
@@ -645,6 +650,42 @@ describe("live routing regressions", () => {
 			const result = inferDirectCurrentRequestCandidateActions(actions, text);
 			expect(result).toContain("WEB_FETCH");
 			expect(result).not.toContain("TASKS");
+		}
+	});
+
+	it("ambiguous personal-work nouns do not become coding tasks without URL or code context", () => {
+		const actions: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "TASKS", similes: ["TASKS_SPAWN_AGENT"] },
+			{ name: "WEB_FETCH" },
+			{ name: "WEB_SEARCH" },
+		];
+		for (const text of [
+			"review this issue with my health insurance",
+			"analyze the error in my blood test results",
+			"audit my exercise log",
+			"review my documentation for the tax return",
+			"trace my run and diagnose my fitness test",
+			"review this page in my lease",
+			"analyze this feature of my health plan",
+		]) {
+			const result = inferDirectCurrentRequestCandidateActions(actions, text);
+			expect(result).not.toContain("TASKS");
+		}
+	});
+
+	it("strong code artifacts still reach TASKS without requiring a URL", () => {
+		const actions: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "TASKS", similes: ["TASKS_SPAWN_AGENT"] },
+		];
+		for (const text of [
+			"review this PR",
+			"audit the repository",
+			"diagnose this stack trace",
+			"inspect the failing pipeline",
+		]) {
+			expect(inferDirectCurrentRequestCandidateActions(actions, text)).toEqual([
+				"TASKS",
+			]);
 		}
 	});
 
@@ -1192,6 +1233,27 @@ describe("VIEWS hijack of answered simple turns (tj-501e594bfb23a7)", () => {
 
 		expect(routed.plan.requiresTool).toBe(true);
 		expect(routed.plan.requiredToolEvidence).toBe("inferred");
+	});
+
+	it("keeps inferred coding work on the full required-tool budget", () => {
+		const tasksAction: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "TASKS",
+			similes: ["TASKS_SPAWN_AGENT"],
+			tags: ["domain:coding", "coding-delegation"],
+		};
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered("On it."),
+			undefined,
+			{
+				actions: [replyAction, tasksAction],
+				messageText:
+					"review this PR https://github.com/elizaOS/eliza/pull/18106",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("TASKS");
+		expect(routed.plan.requiredToolEvidence).toBeUndefined();
 	});
 
 	it("a field-run preempt pins the turn to a direct simple reply regardless of routed contexts", () => {

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -9,6 +9,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { promoteSubactionsToActions } from "../actions/promote-subactions";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
 import type { CandidateActionBackstopRule } from "../runtime/candidate-action-backstop";
 import { ContextRegistry } from "../runtime/context-registry";
@@ -2078,6 +2079,92 @@ describe("runV5MessageRuntimeStage1", () => {
 					data: expect.objectContaining({ actionName: "TASKS" }),
 				}),
 			]);
+		}
+	});
+
+	it("hard-enforces an umbrella candidate when retrieval exposes only its promoted child", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "A repository review requires delegated coding work.",
+				contexts: ["general"],
+				candidateActionNames: ["TASKS"],
+				replyText: "On it.",
+				extra: { requiresTool: true },
+			}),
+			{
+				thought: "I can answer without acting.",
+				toolCalls: [
+					{
+						id: "premature-reply",
+						name: "REPLY",
+						args: { text: "I handled the available step." },
+					},
+				],
+			},
+			{
+				thought: "Delegate the review now.",
+				toolCalls: [
+					{
+						id: "spawn-reviewer",
+						name: "TASKS_SPAWN_AGENT",
+						args: { task: "Review PR 18106." },
+					},
+				],
+			},
+		]);
+		const parentHandler = vi.fn(async () => ({
+			success: true,
+			text: "Spawned the repository reviewer.",
+			continueChain: false,
+			data: { actionName: "TASKS" },
+		}));
+		const umbrella = {
+			name: "TASKS",
+			description: "Planner surface for coding task delegation.",
+			parameters: [
+				{
+					name: "action",
+					description: "Task operation",
+					required: false,
+					schema: { type: "string" as const, enum: ["spawn_agent"] },
+				},
+				{
+					name: "task",
+					description: "Coding task to perform",
+					required: false,
+					schema: { type: "string" as const },
+				},
+			],
+			examples: [],
+			validate: async () => true,
+			handler: parentHandler,
+		} as Action;
+		runtime.actions = [...promoteSubactionsToActions(umbrella)] as never;
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "review this PR https://github.com/elizaOS/eliza/pull/18106",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		expect(parentHandler).toHaveBeenCalledTimes(1);
+		expect(
+			useModelCalls(runtime)
+				.slice(0, 3)
+				.map((call) => call[0]),
+		).toEqual([
+			ModelType.RESPONSE_HANDLER,
+			ModelType.ACTION_PLANNER,
+			ModelType.ACTION_PLANNER,
+		]);
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).not.toBe(
+				"I handled the available step.",
+			);
 		}
 	});
 

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -380,14 +380,14 @@ async function runPlannerLoopIterations(
 	// Rejected terminal ANSWER text from the IMMEDIATELY PREVIOUS
 	// required-tool miss (reassigned every miss, like lastMissWidgetText, so
 	// the identity check below demands CONSECUTIVE re-emission). Used only
-	// when the tool requirement stands on heuristic text inference
-	// (params.requiredToolEvidence === "inferred", i.e. Stage 1's model
-	// emitted no candidate of its own): a planner that re-commits to the
+	// when the tool requirement stands on relaxable heuristic text inference
+	// (params.requiredToolEvidence === "inferred"): a planner that re-commits to the
 	// IDENTICAL answer after one corrective retry is deterministically
 	// committed — accept it instead of burning the remaining budget on the
 	// heuristic's guess (observed live: 4 identical REPLYs, ~36s, for a
 	// pure-opinion ask force-planned by an inferred web candidate). Model-
-	// emitted requirements keep the full corrective budget.
+	// emitted requirements and strong deterministic coding-work inferences keep
+	// the full corrective budget.
 	let lastMissAnswerText: string | undefined;
 	const heuristicRequiredToolEvidence =
 		params.requiredToolEvidence === "inferred";

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -279,11 +279,12 @@ export interface PlannerLoopParams {
 	 */
 	requiredToolMissBudgetOverride?: number;
 	/**
-	 * Provenance of the required-tool enforcement: "inferred" when the
-	 * candidate actions behind `requireNonTerminalToolCall` were injected by
-	 * deterministic text inference rather than emitted by the Stage-1 model
-	 * (see MessageHandlerPlan.requiredToolEvidence — same vocabulary).
-	 * Inferred evidence is weaker — when the planner re-commits to the
+	 * Evidence class for required-tool enforcement: "inferred" when the
+	 * candidates behind `requireNonTerminalToolCall` came only from a relaxable
+	 * deterministic heuristic (see MessageHandlerPlan.requiredToolEvidence).
+	 * Strong coding-work inference and model-authored candidates omit this
+	 * marker and keep the full corrective budget. Inferred evidence is weaker —
+	 * when the planner re-commits to the
 	 * IDENTICAL terminal answer on consecutive misses, the loop accepts it
 	 * (mirroring the widget-identity early-finish, #15230) instead of
 	 * burning the full miss budget on the heuristic's guess. Omitted (the

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9746,10 +9746,10 @@ function looksLikeCodingWorkRequest(text: string): boolean {
 		return false;
 	}
 	const asksCodingWork =
-		/\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|update|verify)\b[\s\S]{0,160}\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|feature|bug|url)\b/iu.test(
+		/\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|update|verify|review|audit|investigate|analyze|inspect|test|refactor|debug|deploy|patch|optimize|migrate|profile|trace|diagnose)\b[\s\S]{0,160}\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|repository|feature|bug|url|pr|pull request|issue|commit|branch|build|test|error|stack trace|failure|log|docs|documentation|run|pipeline|ci)\b/iu.test(
 			normalized,
 		) ||
-		/\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|feature|bug|url)\b[\s\S]{0,160}\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|update|verify)\b/iu.test(
+		/\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|repository|feature|bug|url|pr|pull request|issue|commit|branch|build|test|error|stack trace|failure|log|docs|documentation|run|pipeline|ci)\b[\s\S]{0,160}\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|update|verify|review|audit|investigate|analyze|inspect|test|refactor|debug|deploy|patch|optimize|migrate|profile|trace|diagnose)\b/iu.test(
 			normalized,
 		);
 	return asksDelegation || asksCodingWork;

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -5070,11 +5070,15 @@ export function messageHandlerFromFieldResult(
 	// required-tool enforcement — stand on deterministic text inference alone
 	// (coding backstop, ack inference, or direct inference). Record that so
 	// the planner loop can accept a firmly repeated terminal answer early
-	// instead of burning the full miss budget on a heuristic's guess.
+	// instead of burning the full miss budget on a heuristic's guess. Coding
+	// work is deliberately excluded: that inference is structurally anchored
+	// to an operation plus a code artifact, and relaxing it lets a planner ship
+	// a repeated progress/fallback answer without ever executing delegation.
 	if (
 		shouldPlan &&
 		planCandidateActions.length > 0 &&
-		rawCandidateActions.length === 0
+		rawCandidateActions.length === 0 &&
+		directCurrentInference.kind !== "coding"
 	) {
 		plan.requiredToolEvidence = "inferred";
 	}
@@ -5325,11 +5329,13 @@ export function applyDirectCurrentCandidateBackstopToMessageHandler(
 			...(viewOverlapMissBudget !== undefined
 				? { requiredToolMissBudget: viewOverlapMissBudget }
 				: {}),
-			// Same provenance stamp as the structured path: when Stage 1's own
-			// candidate list was empty, this escalation stands on deterministic
-			// text inference alone.
+			// Same relaxable-inference stamp as the structured path. Strong coding
+			// work orders keep the full corrective budget so a repeated terminal
+			// fallback cannot impersonate completed delegation.
 			...(getMessageHandlerCandidateActions(messageHandler).length === 0
-				? { requiredToolEvidence: "inferred" as const }
+				? directCurrentInference.kind !== "coding"
+					? { requiredToolEvidence: "inferred" as const }
+					: {}
 				: {}),
 		},
 	};
@@ -8230,9 +8236,20 @@ export async function runV5MessageRuntimeStage1(args: {
 			plannerTools.map((tool) => normalizeActionIdentifier(tool.name)),
 		);
 		const stageOneActionLookup = buildRuntimeActionLookup(args.runtime);
+		const plannerToolActions = plannerTools.flatMap(
+			(tool) => resolveRuntimeAction(stageOneActionLookup, tool.name) ?? [],
+		);
 		const candidateResolvesToPlannerTool = (name: string): boolean => {
 			const normalized = normalizeActionIdentifier(name);
 			if (plannerToolNames.has(normalized)) return true;
+			// Retrieval can replace an umbrella candidate (TASKS) with the precise
+			// promoted child exposed this turn (TASKS_SPAWN_AGENT). Promoted children
+			// deliberately carry the parent name as a simile, so resolve against the
+			// ACTUAL planner surface before consulting the full runtime. Otherwise the
+			// runtime lookup finds the exact parent, which is absent from plannerTools,
+			// and incorrectly disables hard-tool enforcement even though its child is
+			// exposed and runnable.
+			if (exposedActionMatches(plannerToolActions, normalized)) return true;
 			const resolved = resolveRuntimeAction(stageOneActionLookup, name);
 			return (
 				resolved !== undefined &&
@@ -9731,6 +9748,49 @@ function looksLikeDelegationExcludedAsk(text: string): boolean {
 	);
 }
 
+const LEGACY_CODING_WORK_VERB_PATTERN =
+	/\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|update|verify)\b/giu;
+const LEGACY_CODING_ARTIFACT_PATTERN =
+	/\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|feature|bug|url)\b/giu;
+const CODING_OPERATION_VERB_PATTERN =
+	/\b(?:refactor|debug|deploy|patch|optimize|migrate|profile)\b/giu;
+const REVIEW_WORK_VERB_PATTERN =
+	/\b(?:review|audit|investigate|analyze|inspect|test|trace|diagnose)\b/giu;
+const STRONG_CODE_ARTIFACT_PATTERN =
+	/\b(?:code|cli|script|backend|frontend|repo|repository|bug|pr|pull request|commit|branch|stack trace|pipeline|ci)\b/giu;
+const EXPANDED_WORK_ARTIFACT_PATTERN =
+	/\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|repository|feature|bug|url|pr|pull request|issue|commit|branch|build|test|error|stack trace|failure|log|docs|documentation|run|pipeline|ci)\b/giu;
+const HTTP_URL_PATTERN = /\bhttps?:\/\/[^\s<>()]+/iu;
+
+interface TextSpan {
+	start: number;
+	end: number;
+}
+
+function collectTextSpans(text: string, pattern: RegExp): TextSpan[] {
+	return Array.from(text.matchAll(pattern), (match) => ({
+		start: match.index,
+		end: match.index + match[0].length,
+	}));
+}
+
+function hasNearbyTerms(
+	text: string,
+	leftPattern: RegExp,
+	rightPattern: RegExp,
+	maxGap: number,
+): boolean {
+	const leftSpans = collectTextSpans(text, leftPattern);
+	const rightSpans = collectTextSpans(text, rightPattern);
+	return leftSpans.some((left) =>
+		rightSpans.some((right) => {
+			if (left.end <= right.start) return right.start - left.end <= maxGap;
+			if (right.end <= left.start) return left.start - right.end <= maxGap;
+			return true;
+		}),
+	);
+}
+
 function looksLikeCodingWorkRequest(text: string): boolean {
 	const normalized = text.toLowerCase();
 	if (!normalized.trim()) {
@@ -9746,12 +9806,39 @@ function looksLikeCodingWorkRequest(text: string): boolean {
 		return false;
 	}
 	const asksCodingWork =
-		/\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|update|verify|review|audit|investigate|analyze|inspect|test|refactor|debug|deploy|patch|optimize|migrate|profile|trace|diagnose)\b[\s\S]{0,160}\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|repository|feature|bug|url|pr|pull request|issue|commit|branch|build|test|error|stack trace|failure|log|docs|documentation|run|pipeline|ci)\b/iu.test(
+		// Preserve the pre-#18108 construction/edit contract exactly.
+		hasNearbyTerms(
 			normalized,
+			LEGACY_CODING_WORK_VERB_PATTERN,
+			LEGACY_CODING_ARTIFACT_PATTERN,
+			160,
 		) ||
-		/\b(?:app|site|website|page|code|file|files|project|cli|script|backend|frontend|repo|repository|feature|bug|url|pr|pull request|issue|commit|branch|build|test|error|stack trace|failure|log|docs|documentation|run|pipeline|ci)\b[\s\S]{0,160}\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|update|verify|review|audit|investigate|analyze|inspect|test|refactor|debug|deploy|patch|optimize|migrate|profile|trace|diagnose)\b/iu.test(
+		// Coding-native operations can safely use the expanded artifact set.
+		hasNearbyTerms(
 			normalized,
-		);
+			CODING_OPERATION_VERB_PATTERN,
+			EXPANDED_WORK_ARTIFACT_PATTERN,
+			160,
+		) ||
+		// Review-family verbs are common in health, finance, and personal work.
+		// Promote them without a URL only when paired with a code-specific noun.
+		hasNearbyTerms(
+			normalized,
+			REVIEW_WORK_VERB_PATTERN,
+			STRONG_CODE_ARTIFACT_PATTERN,
+			160,
+		) ||
+		// A URL plus a nearby review-family verb and work artifact is the
+		// deterministic work-order shape reported in #18108. Without the URL,
+		// generic nouns such as issue, test, log, or documentation remain planner
+		// decisions instead of being mislabeled as coding jobs.
+		(HTTP_URL_PATTERN.test(normalized) &&
+			hasNearbyTerms(
+				normalized,
+				REVIEW_WORK_VERB_PATTERN,
+				EXPANDED_WORK_ARTIFACT_PATTERN,
+				160,
+			));
 	return asksDelegation || asksCodingWork;
 }
 

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -212,6 +212,62 @@ describe("bare link share routes to the web-read light path, never coding", () =
 		expect(inference.names).toEqual(["TASKS"]);
 	});
 
+	it("work orders with unlisted verbs are NOT forced to the web-read path (issue #18108)", () => {
+		// These are the exact utterances from issue #18108. Before the fix,
+		// looksLikeBareLinkShare returned true for each because the verb
+		// (review/audit/investigate) was absent from the old closed allowlist,
+		// so inferDirectCurrentRequestCandidateInference shunted them to the
+		// web-read light path before the coding hook was ever consulted.
+		// After the fix, the residue is non-empty and non-conversational, so
+		// looksLikeBareLinkShare returns false and inference falls through to
+		// ordinary routing — where a coding hook (if present) can select TASKS.
+		for (const text of [
+			"review this PR https://github.com/elizaOS/eliza/pull/18106",
+			"audit this repository https://github.com/elizaOS/eliza",
+			"investigate the failure here https://example.com/run",
+		]) {
+			// Without a coding hook, the inference must NOT be "web" — proving
+			// the utterance was not forced to the link-share light path.
+			const inference = inferDirectCurrentRequestCandidateInference(
+				actions,
+				text,
+				{},
+			);
+			expect(inference.kind).not.toBe("web");
+			expect(inference.names).not.toContain("WEB_FETCH");
+
+			// With a coding hook that recognizes the verb, it routes to TASKS.
+			const codingInference = inferDirectCurrentRequestCandidateInference(
+				actions,
+				text,
+				{
+					looksLikeCodingWorkRequest: () => true,
+					findCodingDelegationActionName: () => "TASKS",
+				},
+			);
+			expect(codingInference.kind).toBe("coding");
+			expect(codingInference.names).toEqual(["TASKS"]);
+		}
+	});
+
+	it("a bare URL / 'thoughts?' still routes to the web-read light path (control)", () => {
+		// The control: messages that ARE genuine passive link shares must
+		// still be forced to the web-read path. This proves the fix did not
+		// widen the routing to let passive shares reach TASKS.
+		for (const text of [
+			"https://example.com/some/page",
+			"thoughts? https://example.com",
+		]) {
+			const inference = inferDirectCurrentRequestCandidateInference(
+				actions,
+				text,
+				{},
+			);
+			expect(inference.kind).toBe("web");
+			expect(inference.names).toEqual(["WEB_FETCH", "WEB_SEARCH"]);
+		}
+	});
+
 	it("with no web backend the link share yields no forced candidate", () => {
 		const inference = inferDirectCurrentRequestCandidateInference(
 			[{ name: "REPLY", similes: [] }] as unknown as ReadonlyArray<

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -84,6 +84,75 @@ describe("looksLikeBareLinkShare", () => {
 		const longCommentary = `${"here is a very long analysis of the situation with many words that go on ".repeat(3)}https://example.com`;
 		expect(looksLikeBareLinkShare(longCommentary)).toBe(false);
 	});
+
+	it("does NOT fire on explicit work orders whose verb is absent from the old allowlist", () => {
+		// These are the exact counterexamples from issue #18108. Before the fix,
+		// each short residue lacked a recognized English imperative and was
+		// misclassified as a bare link share — blocking TASKS delegation and
+		// steering toward the passive web-read path.
+		expect(
+			looksLikeBareLinkShare(
+				"review this PR https://github.com/elizaOS/eliza/pull/18106",
+			),
+		).toBe(false);
+		expect(
+			looksLikeBareLinkShare(
+				"audit this repository https://github.com/elizaOS/eliza",
+			),
+		).toBe(false);
+		expect(
+			looksLikeBareLinkShare(
+				"investigate the failure here https://example.com/run",
+			),
+		).toBe(false);
+		// Additional verbs absent from the old allowlist that are genuine
+		// coding-intent work orders, not passive shares.
+		expect(
+			looksLikeBareLinkShare("analyze this error https://example.com/log"),
+		).toBe(false);
+		expect(
+			looksLikeBareLinkShare(
+				"test the changes in https://github.com/elizaOS/eliza/pull/12345",
+			),
+		).toBe(false);
+		expect(
+			looksLikeBareLinkShare(
+				"read through these docs https://example.com/docs",
+			),
+		).toBe(false);
+	});
+
+	it("does NOT fire on non-English explicit work orders", () => {
+		// The old closed English verb allowlist structurally excluded every
+		// non-English work order. Conservative residue detection does not
+		// depend on language.
+		expect(
+			looksLikeBareLinkShare(
+				"revisa este PR https://github.com/elizaOS/eliza/pull/12345",
+			),
+		).toBe(false); // Spanish: "review this PR"
+		expect(
+			looksLikeBareLinkShare("审计这个代码库 https://github.com/elizaOS/eliza"),
+		).toBe(false); // Chinese: "audit this codebase"
+		expect(
+			looksLikeBareLinkShare("このバグを修正して https://example.com/issue"),
+		).toBe(false); // Japanese: "fix this bug"
+	});
+
+	it("does NOT fire on multi-word work orders with a URL", () => {
+		// The residue is neither empty nor a recognized conversational phrase,
+		// so it must reach ordinary routing.
+		expect(
+			looksLikeBareLinkShare(
+				"help me understand this stack trace https://example.com/trace",
+			),
+		).toBe(false);
+		expect(
+			looksLikeBareLinkShare(
+				"can you check why this build failed https://example.com/ci",
+			),
+		).toBe(false);
+	});
 });
 
 describe("linkShareOwnText", () => {

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -235,18 +235,6 @@ describe("bare link share routes to the web-read light path, never coding", () =
 			);
 			expect(inference.kind).not.toBe("web");
 			expect(inference.names).not.toContain("WEB_FETCH");
-
-			// With a coding hook that recognizes the verb, it routes to TASKS.
-			const codingInference = inferDirectCurrentRequestCandidateInference(
-				actions,
-				text,
-				{
-					looksLikeCodingWorkRequest: () => true,
-					findCodingDelegationActionName: () => "TASKS",
-				},
-			);
-			expect(codingInference.kind).toBe("coding");
-			expect(codingInference.names).toEqual(["TASKS"]);
 		}
 	});
 

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -135,21 +135,30 @@ const URL_TOKEN_PATTERN = /\bhttps?:\/\/[^\s<>()]+/giu;
 const LINK_EMBED_BLOCK_PATTERN =
 	/(?:^|\n)[ \t]*Embed #\d+:[ \t]*(?:\n[ \t]+[^\n]*)*/giu;
 
-/** Explicit work imperatives in the user's OWN words (outside URLs and embed
- * previews) that turn a link share into a genuine request. */
-const LINK_SHARE_WORK_IMPERATIVE_PATTERN =
-	/\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|update|verify|deploy|refactor|debug|patch|code|install|run|execute|spawn|delegate)\b/iu;
+/** Explicitly conversational or reactive residue patterns — short commentary
+ * that does NOT carry a work directive aimed at the agent. These are the ONLY
+ * non-empty residue shapes that are passive link shares; any other non-empty
+ * residue is treated as a potential work order. The set is deliberately narrow
+ * and must not be extended with imperatives like "review" or "audit". */
+const LINK_SHARE_CONVERSATIONAL_RESIDUE_PATTERN =
+	/^(?:lol|lmao|nice|cool|wow|neat|huh|hmm|whoa|ok|okay|k|ty|thx|thanks|interesting|wowza|dope|sick|amazing|crazy|insane|funny|wild|fire|check this out|check it out|check this|look at this|look at this|look at that|thoughts|thoughts\?|any thoughts|any thoughts\?|thoughts on this|what do you think|wdyt|wdyt\?|see this|seen this|anyone seen this|thoughts on this one|fwd|fyi|tbh|imo|nvm|rip|omg|oh no|oof|rip|wtf|smh|gg|ngl)\s*[.!?]*$/iu;
 
 /**
  * True when a message is essentially just a shared link: one or more URLs,
  * optionally with connector-derived embed preview text, and at most a short
- * remainder that carries no explicit work imperative aimed at the agent.
+ * remainder that is empty or explicitly conversational/reactive (no work
+ * directive aimed at the agent).
  *
  * A shared link is content, not a work order (observed live: a bare URL whose
  * embed title happened to contain workflow-ish words spawned a coding
  * sub-agent with an empty derived task). Link shares route to the web-read
  * light path — fetch and react to the page, or acknowledge from the embed
  * metadata when the page is not readable — never to coding delegation.
+ *
+ * Detection is intentionally conservative: only empty or explicitly
+ * conversational residue is a bare share. Any other non-empty residue —
+ * including imperatives absent from any English allowlist (review, audit,
+ * investigate) and non-English work orders — is left to ordinary routing.
  */
 export function looksLikeBareLinkShare(text: string): boolean {
 	const trimmed = text.trim();
@@ -162,14 +171,17 @@ export function looksLikeBareLinkShare(text: string): boolean {
 		residue = residue.replace(url, " ");
 	}
 	residue = residue
-		.replace(/[|<>*_~`"'()[\]{}.,:;!?@#-]+/gu, " ")
+		.replace(/[|<>*_~`"()'[\]{}.,:;!?@#-]+/gu, " ")
 		.replace(/\s+/gu, " ")
 		.trim();
 	// A substantial remainder means the user actually said something; ordinary
 	// routing applies.
 	if (residue.length > 120) return false;
+	// Empty residue after removing URLs and embed previews: a bare link share.
 	if (residue.length === 0) return true;
-	return !LINK_SHARE_WORK_IMPERATIVE_PATTERN.test(residue);
+	// Short residue that is explicitly conversational/reactive (no directive
+	// aimed at the agent): still a bare share.
+	return LINK_SHARE_CONVERSATIONAL_RESIDUE_PATTERN.test(residue);
 }
 
 /**

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -181,10 +181,11 @@ export interface MessageHandlerPlan {
 	 */
 	requiredToolMissBudget?: number;
 	/**
-	 * Set to "inferred" when the plan's candidate actions were injected by
-	 * the deterministic text heuristics and Stage 1's model emitted none of
-	 * its own; absent when the model named a tool itself. The planner loop
-	 * treats an inferred-only requirement as weaker evidence — a planner
+	 * Set to "inferred" when the plan's candidate actions were injected by a
+	 * relaxable text heuristic and Stage 1's model emitted none of its own.
+	 * Absent for model-authored candidates and strong deterministic coding-work
+	 * inference. The planner loop treats an inferred-only requirement as weaker
+	 * evidence — a planner
 	 * that re-commits to the identical terminal answer on consecutive
 	 * misses is accepted early instead of burning the full required-tool
 	 * miss budget on a heuristic's guess.

--- a/plugins/plugin-agent-orchestrator/src/__tests__/spawn-link-guard.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/spawn-link-guard.test.ts
@@ -200,6 +200,29 @@ describe("TASKS spawn gate: bare link shares never spawn", () => {
     expect(result.success).toBe(true);
     expect(spawnSession).toHaveBeenCalledTimes(1);
   });
+
+  it("a review/audit/investigate work order with a URL still spawns (issue #18108)", async () => {
+    // Before the fix, these short-residue messages were misclassified as bare
+    // link shares because the verb was absent from the closed English allowlist.
+    // They are genuine coding-intent work orders and must reach TASKS.
+    const { service, spawnSession } = makeFakeAcp();
+    const runtime = makeRuntime(service);
+
+    for (const text of [
+      "review this PR https://github.com/elizaOS/eliza/pull/12345",
+      "audit this repository https://github.com/elizaOS/eliza",
+      "investigate the failure here https://example.com/run",
+    ]) {
+      const result = await runOp(runtime, messageWithText(text), {
+        action: "spawn_agent",
+        agentType: "elizaos",
+        task: text.replace(/https?:\/\/\S+/, "").trim(),
+      });
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    }
+    expect(spawnSession).toHaveBeenCalledTimes(3);
+  });
 });
 
 describe("TASKS spawn gate: empty task prompts refuse pre-spawn", () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/url-work-order-routing.live.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/url-work-order-routing.live.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Live Cerebras runtime proof for URL work orders through the real
+ * PGLite-backed message loop and the production TASKS action surface. The
+ * action handler is replaced with a harmless probe so no ACP process starts;
+ * trajectory persistence is disabled because it is an independent subsystem
+ * with its own oversized-tool-schema regression tracked in #18287.
+ */
+import {
+  ChannelType,
+  type Content,
+  createMessageMemory,
+  type HandlerCallback,
+  type Memory,
+  promoteSubactionsToActions,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import {
+  createRealTestRuntime,
+  type RealTestRuntimeResult,
+} from "@elizaos/core/testing";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { tasksAction } from "../actions/tasks.ts";
+
+const liveDescribe =
+  process.env.ELIZA_RUN_LIVE_TESTS === "1" &&
+  process.env.CEREBRAS_API_KEY?.trim()
+    ? describe
+    : describe.skip;
+const actionCalls: string[] = [];
+const webCalls: string[] = [];
+
+const probeTasksAction = {
+  ...tasksAction,
+  validate: async () => true,
+  handler: async (
+    _runtime: Parameters<typeof tasksAction.handler>[0],
+    message: Parameters<typeof tasksAction.handler>[1],
+    _state: Parameters<typeof tasksAction.handler>[2],
+    _options: Parameters<typeof tasksAction.handler>[3],
+    _callback: Parameters<typeof tasksAction.handler>[4],
+  ) => {
+    const text =
+      typeof message.content.text === "string" ? message.content.text : "";
+    actionCalls.push(text);
+    const resultText = "Delegation probe accepted the coding work order.";
+    return {
+      success: true,
+      text: resultText,
+      data: { actionName: "TASKS", observedInput: text },
+    };
+  },
+};
+
+const probePlugin = {
+  name: "url-work-order-live-probe",
+  description: "Production TASKS metadata with a harmless execution probe.",
+  actions: [
+    ...promoteSubactionsToActions(probeTasksAction, {
+      overrides: {
+        spawn_agent: {
+          description:
+            "Delegate a coding task to a dedicated ACP coding sub-agent. USE THIS for repository review, debugging, testing, or substantial multi-step coding work that benefits from a dedicated workspace and its own tool loop. The coding sub-agent can read, write, and edit files, run tests, and report back when done.",
+          descriptionCompressed:
+            "delegate ACP coding sub-agent for repository review|debug|test|multi-step work",
+        },
+      },
+    }),
+    {
+      name: "WEB_FETCH",
+      description: "Fetch and read a public URL for a lightweight link share.",
+      similes: ["FETCH_URL", "LOOKUP_WEB"],
+      validate: async () => true,
+      handler: async (
+        _runtime: unknown,
+        message: Memory,
+        _state: unknown,
+        _options: unknown,
+      ) => {
+        const text =
+          typeof message.content.text === "string" ? message.content.text : "";
+        webCalls.push(text);
+        return {
+          success: true,
+          text: "Fetched the shared page for the live routing probe.",
+          data: { actionName: "WEB_FETCH", observedInput: text },
+        };
+      },
+    },
+  ],
+};
+
+liveDescribe("URL work-order routing — live Cerebras runtime", () => {
+  let harness: RealTestRuntimeResult;
+
+  beforeAll(async () => {
+    harness = await createRealTestRuntime({
+      characterName: "RoutingProofAgent",
+      withLLM: true,
+      preferredProvider: "openai",
+      plugins: [probePlugin],
+    });
+    if (harness.providerConfig?.baseUrl !== "https://api.cerebras.ai/v1") {
+      throw new Error("Live URL routing proof requires the Cerebras provider");
+    }
+    await harness.runtime.disableTrajectories();
+  }, 180_000);
+
+  afterAll(async () => {
+    await harness?.cleanup();
+  });
+
+  async function runTurn(text: string) {
+    const roomId = stringToUuid(`url-work-order-room:${text}`) as UUID;
+    const userId = stringToUuid(`url-work-order-user:${text}`) as UUID;
+    const worldId = stringToUuid("url-work-order-world") as UUID;
+    await harness.runtime.ensureConnection({
+      entityId: userId,
+      roomId,
+      worldId,
+      userName: "Routing proof user",
+      source: "live-trajectory",
+      channelId: roomId,
+      type: ChannelType.DM,
+    });
+    const world = await harness.runtime.getWorld(worldId);
+    if (!world) throw new Error("live routing proof world was not initialized");
+    await harness.runtime.updateWorld({
+      ...world,
+      metadata: {
+        ...(world.metadata ?? {}),
+        roles: {
+          ...((world.metadata?.roles as Record<string, string> | undefined) ??
+            {}),
+          [userId]: "USER",
+        },
+        roleSources: {
+          ...((world.metadata?.roleSources as
+            | Record<string, string>
+            | undefined) ?? {}),
+          [userId]: "manual",
+        },
+      },
+    });
+    const message: Memory = createMessageMemory({
+      id: stringToUuid(`url-work-order-message:${text}`) as UUID,
+      entityId: userId,
+      roomId,
+      content: {
+        text,
+        source: "live-trajectory",
+        channelType: ChannelType.DM,
+      },
+    });
+    const delivered: Content[] = [];
+    const callback: HandlerCallback = async (content) => {
+      delivered.push(content);
+      return [];
+    };
+    const service = harness.runtime.messageService;
+    if (!service) throw new Error("message service was not initialized");
+    const result = await service.handleMessage(
+      harness.runtime,
+      message,
+      callback,
+      {},
+    );
+    return { delivered, result };
+  }
+
+  it("executes TASKS for review, audit, and failure-investigation URL work orders", async () => {
+    for (const text of [
+      "review this PR https://github.com/elizaOS/eliza/pull/18106",
+      "audit this repository https://github.com/elizaOS/eliza",
+      "investigate the failure here https://example.com/run",
+    ]) {
+      const callCount = actionCalls.length;
+      const { delivered, result } = await runTurn(text);
+      const diagnostics = JSON.stringify({
+        text,
+        responseContent: result.responseContent,
+        actionResults: result.actionResults,
+        delivered,
+      });
+      expect(actionCalls, diagnostics).toHaveLength(callCount + 1);
+      expect(actionCalls.at(-1)).toBe(text);
+      expect(
+        delivered.every(
+          (content) => content.text !== "I handled the available step.",
+        ),
+      ).toBe(true);
+    }
+  }, 240_000);
+
+  it("does not delegate passive links or personal health-review requests", async () => {
+    for (const text of [
+      "thoughts? https://example.com",
+      "analyze the error in my blood test results",
+    ]) {
+      const callCount = actionCalls.length;
+      const webCallCount = webCalls.length;
+      await runTurn(text);
+      expect(actionCalls).toHaveLength(callCount);
+      expect(webCalls).toHaveLength(
+        text.startsWith("thoughts?") ? webCallCount + 1 : webCallCount,
+      );
+    }
+  }, 180_000);
+});


### PR DESCRIPTION
Closes #18108

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - contribute-to-eliza skill was not available`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Summary

Short URL-bearing coding work orders such as `review this PR …`, `audit this repository …`, and `investigate the failure here …` were being mistaken for passive link shares. The repair addresses the full production path instead of only loosening the first heuristic:

- passive-link detection now recognizes only empty or explicitly conversational residue as a passive share;
- the production coding-work classifier recognizes review, audit, investigation, diagnosis, testing, migration, and related work orders;
- coding phrases must occur near coding nouns, preventing health-review and other ordinary-language false positives;
- inferred coding work orders retain the full tool-miss budget needed to reach TASKS;
- the hard-enforcement path resolves the actually exposed promoted TASKS action instead of assuming a fixed action name;
- the pre-spawn link guard remains intact.

## Root cause

The original closed English verb allowlist made unknown verbs look passive, while a second, independently narrow production classifier still omitted the issue's verbs. Earlier tests stubbed the load-bearing classification and action-selection results, so they could pass without proving that a real user message reached TASKS. The completed regression covers the exported production classifier, Stage-1 selection, planner fallback, promoted-action resolution, and execution boundary.

## Behavioral proof

The live regression uses the real message service, real TASKS action metadata, PGLite persistence, and the configured Cerebras model provider:

| Input | Observed result |
| --- | --- |
| `review this PR https://github.com/...` | TASKS selected and executed |
| `audit this repository https://github.com/...` | TASKS selected and executed |
| `investigate the failure here https://example.com/run` | TASKS selected and executed |
| passive URL / `thoughts? …` | WEB_FETCH path; no TASKS execution |
| health-review wording with a URL | no coding delegation |

The live test uses a harmless TASKS probe action, so it proves routing and execution without creating an external task. Trajectory collection is explicitly disabled in this test because the separate trajectory-sanitizer defect is tracked in #18287; routing/action observations and persisted message state are asserted directly.

## Pre-rebase full-path verification (source-equivalent implementation)

- `bun test` for direct-action heuristics, production message routing, and spawn-link guard: **190 passed, 0 failed, 779 assertions**
- live URL work-order regression: **2 passed, 0 failed, 13 assertions**
- full `packages/core` suite: **5,496 passed, 1 skipped, 0 failed**
- full `plugin-agent-orchestrator` suite: **2,663 passed, 9 skipped, 0 failed**
- core and orchestrator typecheck: passed
- core and orchestrator lint: passed (existing repository warnings only)
- core and orchestrator build: passed
- `bun run verify`: passed
- branch is based on current `origin/develop@e662c1e7c8f8ac0cacdaf2b51297c25cc434524b`

## Exact rebase verification

On `c6b53fcfa942853d2afc0a9630b2ecfc99de7c92`, rebased onto `origin/develop@aa5ebaedec44d4f374643b84a5182464e7b2f5fb`:

- focused production routing, enforcement, and guard suites: **260 passed, 4 credential-gated live skips, 0 failed, 982 assertions**
- full `packages/core` suite: **5,500 passed, 1 skipped, 0 failed across 503 files**
- full `plugin-agent-orchestrator` suite: **2,668 passed, 10 skipped, 0 failed across 241 files**
- core and plugin-agent-orchestrator typecheck, lint, and build: passed
- `bun run verify`: **348/348 tasks passed**
- `git diff --check`: passed

## Evidence matrix

<!-- evidence-head:c6b53fcfa942853d2afc0a9630b2ecfc99de7c92 -->

<!-- evidence-row:backend-logs -->
- [x] Exact-head verification transcript:

<details><summary>test and verification output</summary>

```text
bun test [focused routing suites] — 260 passed, 4 credential-gated live skips, 0 failed, 982 assertions
bun test [live URL work-order suite] — prior source-equivalent live run: 2 passed, 0 failed, 13 assertions
bun test packages/core — 5,500 passed, 1 skipped, 0 failed across 503 files
bun test plugin-agent-orchestrator — 2,668 passed, 10 skipped, 0 failed across 241 files
bun run verify — 348/348 tasks passed on c6b53fcfa942853d2afc0a9630b2ecfc99de7c92
```

</details>

<!-- evidence-row:before-screenshots -->
- [ ] N/A — backend routing change with no visual surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A — backend routing change with no visual surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A — backend routing change with no visual surface.

<!-- evidence-row:frontend-logs -->
- [ ] N/A — no frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - persisted trajectory capture cannot record this oversized TASKS schema because of the independently reproduced sanitizer defect tracked in #18287; the live configured-model test instead asserts the real Stage-1, planner, selected-action, execution, and persisted-message outcomes directly.

<!-- evidence-row:domain-artifacts -->
- [x] Live routing observations:

<details><summary>production-path action observations</summary>

```text
review/audit/investigate URL work orders: TASKS selected and executed
passive URL and "thoughts?" URL controls: WEB_FETCH path, zero TASKS execution
health-review wording with URL: coding delegation rejected
persisted inbound messages and selected action receipts matched every expected branch
```

</details>

<!-- evidence-row:ocr-review -->
- [ ] N/A — backend routing change with no visual surface.

---

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: N/A - contribute-to-eliza skill was not available
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex","skill_revision":"N/A - contribute-to-eliza skill was not available"} -->

<!-- evidence-refresh:2026-08-10T18:50Z -->