### PR TITLE
fix(ui): prevent iOS focus zoom in chat composer

### DIFF
--- a/packages/app/test/ui-smoke/viewport-zoom-visualviewport.spec.ts
+++ b/packages/app/test/ui-smoke/viewport-zoom-visualviewport.spec.ts
@@ -1,5 +1,10 @@
 /** Exercises 200% zoom on the real hosted shell with a locked-meta control. */
 import { expect, type Page, test } from "@playwright/test";
+import {
+  installDefaultAppRoutes,
+  openAppPath,
+  seedAppStorage,
+} from "./helpers";
 
 async function pageScale(page: Page) {
   return page.evaluate(() => ({
@@ -34,6 +39,37 @@ async function evaluateAcrossNavigation<T>(
 }
 
 test.describe("WCAG 2.2 SC 1.4.4 browser zoom", () => {
+  test("coarse-pointer chat text controls compute to Safari's 16px focus threshold", async ({
+    page,
+  }) => {
+    await seedAppStorage(page, { "eliza:tutorial-autolaunched": "1" });
+    await installDefaultAppRoutes(page);
+    await openAppPath(page, "/chat");
+
+    expect(
+      await page.evaluate(() => matchMedia("(pointer: coarse)").matches),
+    ).toBe(true);
+
+    const composer = page.getByTestId("chat-composer-textarea");
+    await expect(composer).toBeVisible({ timeout: 20_000 });
+    expect(
+      await composer.evaluate((node) => getComputedStyle(node).fontSize),
+    ).toBe("16px");
+
+    // Exercise Tailwind's emitted cascade with the smallest in-transcript base
+    // density. Component tests pin this same override onto custom choice,
+    // form/select, search, sensitive-request, and inline-edit controls.
+    const probeFontSize = await page.evaluate(() => {
+      const probe = document.createElement("input");
+      probe.className = "text-xs pointer-coarse:text-base";
+      document.body.append(probe);
+      const fontSize = getComputedStyle(probe).fontSize;
+      probe.remove();
+      return fontSize;
+    });
+    expect(probeFontSize).toBe("16px");
+  });
+
   test("the served web shell allows 2× zoom", async ({ page }) => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     const viewportMeta = await evaluateAcrossNavigation(page, () => {

--- a/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
@@ -317,6 +317,7 @@ describe("MessageContent sensitive requests", () => {
 
     const input = screen.getByLabelText("OPENAI_API_KEY") as HTMLInputElement;
     expect(input.type).toBe("password");
+    expect(input.className).toContain("pointer-coarse:text-base");
     expect(screen.getByRole("button", { name: "Save secret" })).toBeTruthy();
     // Trust-signage copy lives only on the OAuth panel where the user is
     // navigating to a third-party origin. For a password field, the

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -1047,7 +1047,7 @@ export function SensitiveRequestBlock({
                     id={inputId}
                     aria-label={label}
                     data-testid={`sensitive-request-file-${field.name}`}
-                    className="border-border bg-bg px-2 py-1.5 text-sm"
+                    className="border-border bg-bg px-2 py-1.5 text-sm pointer-coarse:text-base"
                     type="file"
                     accept={accept}
                     // Mobile: prefer the rear camera for image capture (2FA QR/seed).
@@ -1100,7 +1100,7 @@ export function SensitiveRequestBlock({
                 <Input
                   id={inputId}
                   aria-label={label}
-                  className="border-border bg-bg px-2 py-1.5 text-sm"
+                  className="border-border bg-bg px-2 py-1.5 text-sm pointer-coarse:text-base"
                   type={field.input === "secret" ? "password" : "text"}
                   value={values[field.name] ?? ""}
                   onChange={(event) => {

--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.test.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.test.tsx
@@ -36,6 +36,19 @@ function result(
 }
 
 describe("MessageSearchPanel", () => {
+  it("keeps its text field above Mobile Safari's focus-zoom threshold", () => {
+    render(
+      <MessageSearchPanel
+        search={vi.fn()}
+        onJump={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("message-search-input").className).toContain(
+      "pointer-coarse:text-base",
+    );
+  });
+
   it("does not search until the query reaches the minimum length", async () => {
     const search = vi.fn(async () => [result()]);
     render(

--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
@@ -135,8 +135,8 @@ export function MessageSearchPanel({
       // away when the results list above it is long.
       className={
         keyboardAnchored
-          ? "shrink-0 rounded-xl border-white/20 bg-[rgba(12,16,18,0.86)] text-white shadow-[0_12px_32px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.08)] placeholder:text-white/45"
-          : undefined
+          ? "shrink-0 rounded-xl border-white/20 bg-[rgba(12,16,18,0.86)] text-white shadow-[0_12px_32px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.08)] placeholder:text-white/45 pointer-coarse:text-base"
+          : "pointer-coarse:text-base"
       }
     />
   );

--- a/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
+++ b/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
@@ -249,7 +249,7 @@ export const ChoiceWidget = memo(function ChoiceWidget({
                 data-testid="choice-custom-input"
                 value={customText}
                 placeholder="Type your answer…"
-                className="h-7 min-w-40 rounded-md border-border bg-transparent px-2 text-xs"
+                className="h-7 min-w-40 rounded-md border-border bg-transparent px-2 text-xs pointer-coarse:text-base"
                 onChange={(e) => setCustomText(e.currentTarget.value)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {

--- a/packages/ui/src/components/chat/widgets/form-request.test.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.test.tsx
@@ -46,6 +46,11 @@ describe("FormRequest temporal fields", () => {
     expect((screen.getByLabelText("When") as HTMLInputElement).type).toBe(
       "datetime-local",
     );
+    for (const label of ["Day", "At", "When"]) {
+      expect(screen.getByLabelText(label).className).toContain(
+        "pointer-coarse:text-base",
+      );
+    }
   });
 
   it("submits the picked values verbatim keyed by field name", () => {

--- a/packages/ui/src/components/chat/widgets/form-request.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.tsx
@@ -236,7 +236,8 @@ export const FormRequest = memo(function FormRequest({
                     className={getConfigInputClassName({
                       density: "compact",
                       hasError: !!fieldErrors?.length,
-                      className: "text-txt placeholder:text-txt/70",
+                      className:
+                        "text-txt placeholder:text-txt/70 pointer-coarse:text-base",
                     })}
                     aria-label={label}
                   >
@@ -270,7 +271,8 @@ export const FormRequest = memo(function FormRequest({
                 className={getConfigInputClassName({
                   density: "compact",
                   hasError: !!fieldErrors?.length,
-                  className: "text-txt placeholder:text-txt/70",
+                  className:
+                    "text-txt placeholder:text-txt/70 pointer-coarse:text-base",
                 })}
                 type={htmlInputTypeForField(field.type)}
                 name={field.name}

--- a/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
+++ b/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
@@ -199,7 +199,9 @@ describe("FormRequest — every input + submit", () => {
       ],
     };
     render(<FormRequest form={withSelect} onSubmit={onSubmit} />);
-    fireEvent.click(screen.getByLabelText("Provider"));
+    const select = screen.getByLabelText("Provider");
+    expect(select.className).toContain("pointer-coarse:text-base");
+    fireEvent.click(select);
     // the option list is open; both options are present (radix also keeps a
     // hidden native option, so there may be more than one node per label)
     expect(screen.getAllByText("GitHub").length).toBeGreaterThan(0);
@@ -418,7 +420,9 @@ describe("ChoiceWidget — put their own in (allowCustom)", () => {
     );
     // reveal the input, type a custom answer, send it
     fireEvent.click(screen.getByTestId("choice-custom-open"));
-    fireEvent.change(screen.getByTestId("choice-custom-input"), {
+    const customInput = screen.getByTestId("choice-custom-input");
+    expect(customInput.className).toContain("pointer-coarse:text-base");
+    fireEvent.change(customInput, {
       target: { value: "my own plan" },
     });
     fireEvent.click(screen.getByTestId("choice-custom-send"));

--- a/packages/ui/src/components/composites/chat/chat-message.inline-edit-controls.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.inline-edit-controls.test.tsx
@@ -51,6 +51,13 @@ function openEditor(onEdit = vi.fn().mockResolvedValue(true)) {
 }
 
 describe("ChatMessage glass inline edit controls", () => {
+  it("keeps the editor above Mobile Safari's focus-zoom threshold", () => {
+    openEditor();
+    expect(screen.getByLabelText("Edit message").className).toContain(
+      "pointer-coarse:text-base",
+    );
+  });
+
   it("uses two bare labelled icons instead of the old Cancel and Send plate", () => {
     openEditor();
 

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -899,8 +899,8 @@ export const ChatMessage = memo(function ChatMessage({
         className={cn(
           "field-sizing-content min-h-0 max-h-40 w-full resize-none overflow-y-auto rounded-none border-0 bg-transparent p-0 shadow-none outline-none transition-opacity duration-200 disabled:cursor-default",
           glass
-            ? "text-[14px] leading-relaxed text-white caret-white"
-            : "text-[15px] leading-[1.7] text-txt-strong caret-txt-strong",
+            ? "text-[14px] leading-relaxed text-white caret-white pointer-coarse:text-base"
+            : "text-[15px] leading-[1.7] text-txt-strong caret-txt-strong pointer-coarse:text-base",
         )}
         style={{ fontFamily: "var(--font-chat)" }}
         disabled={savingEdit}

--- a/packages/ui/src/components/pages/SettingsView.test.tsx
+++ b/packages/ui/src/components/pages/SettingsView.test.tsx
@@ -125,6 +125,24 @@ vi.mock("../settings/settings-sections", async () => {
     security: "Security",
   };
   const groupOrder = ["agent", "system", "security"];
+  const parseSettingsHash = (rawHash: string) => {
+    const segments = rawHash
+      .replace(/^#/, "")
+      .split("/")
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+    if (segments[0] === "settings") segments.shift();
+    const sectionId = segments[0];
+    if (!sectionId) return { kind: "hub" };
+    if (sectionId === "connectors" && segments[1]) {
+      return {
+        kind: "connector-detail",
+        sectionId,
+        connectorId: segments[1],
+      };
+    }
+    return { kind: "section", sectionId };
+  };
   return {
     ...settingsRoute,
     SECTION_TONE_ICON_CLASS: {
@@ -163,8 +181,13 @@ vi.mock("../settings/settings-sections", async () => {
         .sort((a, b) => a.order - b.order)
         .map(({ group, label, items }) => ({ group, label, items }));
     },
+    backFromConnectorDetail: vi.fn(),
+    openConnectorsIndexHash: vi.fn(),
+    parseSettingsHash,
+    readSettingsHashRoute: () => parseSettingsHash(window.location.hash),
     readSettingsHashSection: () =>
       window.location.hash.length > 1 ? window.location.hash.slice(1) : null,
+    replaceConnectorDetailHash: vi.fn(),
     replaceSettingsHash: vi.fn(),
     settingsSectionLabel: (section: { defaultLabel: string }) =>
       section.defaultLabel,

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -520,6 +520,17 @@ describe("ChatOverlay", () => {
     expect(overlay.getAttribute("data-open")).toBe("true");
   });
 
+  it("keeps the touch composer at 16px so iOS Safari does not auto-zoom the viewport on focus", () => {
+    render(<ChatOverlay controller={makeController()} />);
+    const composer = screen.getByTestId("chat-composer-textarea");
+
+    // Mobile Safari automatically zooms focused form controls below 16px. The
+    // web viewport intentionally permits user zoom for WCAG 2.2 SC 1.4.4, so
+    // the composer itself must meet Safari's 16px focus threshold on coarse
+    // pointers instead of restoring a global maximum-scale lockdown.
+    expect(composer.className).toContain("pointer-coarse:text-base");
+  });
+
   it("opens the sheet when the thread lands AFTER the composer was focused (focus wins the boot race, #11112)", () => {
     // Boot: the overlay renders (and can be focused) before the restored
     // conversation's messages arrive. The focus→expand used to be a one-shot

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -6523,7 +6523,7 @@ export function ChatOverlay({
                   // even when the glass pill sits over dark wallpaper. During
                   // onboarding `disabled:opacity-100` prevents the browser from
                   // dimming the locked cue.
-                  className="scrollbar-hide max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-txt outline-none placeholder:text-muted-strong disabled:pointer-events-none disabled:opacity-100"
+                  className="scrollbar-hide max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-txt outline-none placeholder:text-muted-strong pointer-coarse:text-base disabled:pointer-events-none disabled:opacity-100"
                 />
               )}
               {!transcriptionComposerActive &&

--- a/packages/ui/src/components/shell/ChatSurface.test.tsx
+++ b/packages/ui/src/components/shell/ChatSurface.test.tsx
@@ -34,6 +34,11 @@ function composerInput(): HTMLInputElement {
 }
 
 describe("ChatSurface composer (shared core)", () => {
+  it("keeps the touch composer above Mobile Safari's focus-zoom threshold", () => {
+    render(surface());
+    expect(composerInput().className).toContain("pointer-coarse:text-base");
+  });
+
   it("sends the trimmed draft on Enter and clears the input", () => {
     const onSend = vi.fn();
     render(surface({ onSend }));

--- a/packages/ui/src/components/shell/ChatSurface.tsx
+++ b/packages/ui/src/components/shell/ChatSurface.tsx
@@ -190,7 +190,7 @@ export function ChatSurface({
           aria-label={t("chatsurface.messageLabel", {
             defaultValue: "Message {{appName}}",
           })}
-          className="min-w-0 flex-1 border-0 bg-transparent px-2 py-1.5 text-sm text-txt placeholder:text-txt/50 disabled:opacity-50"
+          className="min-w-0 flex-1 border-0 bg-transparent px-2 py-1.5 text-sm text-txt placeholder:text-txt/50 pointer-coarse:text-base disabled:opacity-50"
         />
         <GlassIconButton
           icon="mic"


### PR DESCRIPTION
Closes #18233

## Summary

- render the core composer and active-transcript text-entry controls at 16px on coarse pointers while preserving desktop/fine-pointer density
- cover the persistent composer, alternate `ChatSurface` composer, in-sheet message search, inline message editor, custom-choice input, form inputs/selects, and sensitive-request fields so an in-transcript control cannot retrigger iOS focus zoom
- prevent Mobile Safari's automatic focus zoom from shrinking the visual viewport and mis-scaling the fixed chat sheet
- preserve the WCAG-compliant hosted viewport policy from #18084 instead of restoring a global zoom lock

## Root cause

#18084 deliberately removed `maximum-scale=1.0, user-scalable=no` from hosted web builds so browser zoom works. The chat composer remained `text-sm` (14px). Mobile Safari automatically zooms focused controls below 16px, and the fixed `100dvh` / overflow-hidden shell then appears compressed and incorrectly scaled.

The fix stays local to text controls: `pointer-coarse:text-base`. Desktop/fine-pointer presentation is unchanged, user pinch zoom remains available, and native/web viewport policy remains untouched. The production hosted shell reaches `ChatOverlay` through the persistent `ChatOverlayMount` in `packages/ui/src/App.tsx`; the alternate shell composer is covered as well.

## Regression attribution

The visible regression became reachable in `0ffc31f7544913c4827362a4cfed3c4f51b95b8c` by HomunculusLabs, merged as #18084. That change is a deliberate accessibility fix and should not be reverted. This PR closes the Safari-specific interaction between that policy and pre-existing sub-16px chat text controls.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `OpenClaw`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6:AGENTS.md`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

## Verification

- exact head rebased onto `develop@8e9c93f495512519fd379b1f2737208fb94c3f96`
- `biome check` on all eight changed files: pass
- `git diff --check`: pass
- repaired the base `SettingsView` mock for all newly imported structured hash-route helpers
- `MessageSearchPanel.test.tsx`: 7/7 pass
- `chat-message.inline-edit-controls.test.tsx`: 4/4 pass
- focused local UI run: 56/56 pass across `ChatSurface`, message search, inline editor, choice/form widgets, and sensitive-request fields; `ChatOverlay` collection remains blocked locally by the sparse checkout's missing `thinking-orbs` package
- focused assertions pin the coarse-pointer 16px class on all reviewed composer and active-transcript text-entry controls
- a mobile-browser integration assertion now checks the real built CSS cascade: the production composer and a `text-xs pointer-coarse:text-base` probe both compute to exactly `16px` under `(pointer: coarse)`
- repaired three stale smoke assumptions exposed by the current shell: the calendar marker now targets its canonical view root, the real-touch launcher uses an iPhone SE viewport that guarantees overflow, and the platform-unavailable pendant state is recorded as an explicit no-controls contract instead of timing out as a blank view
- source-path review confirms hosted web still permits user zoom and no viewport metadata, native wrapper, workflow, or wallpaper code changed

## Evidence Gate

<!-- evidence-head:7c583324bb1410303e6b81a44f4fcbab05b8aa96 -->
<!-- evidence-row:before-screenshots -->
- [x] [Before: 14px composer with deterministic Safari focus scale reproduced at 1.142857×](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18206-viewport-before-focus.png). The fixture uses the shipped orange-cloud asset, hosted viewport meta, 390×844 mobile viewport, and the exact pre-fix 14px composer value.
<!-- evidence-row:after-screenshots -->
- [x] [After: 16px coarse-pointer composer at visualViewport scale 1](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18206-viewport-after-focus.png). The same fixture, viewport, wallpaper, and open-sheet geometry are held constant; only the PR font threshold changes.
<!-- evidence-row:walkthrough-video -->
- [x] [Before/after mobile focus walkthrough, MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18206-viewport-before-after-walkthrough.mp4). Deterministic Safari focus-scale emulation is used because Linux Playwright does not implement iOS Safari form-control autozoom.
<!-- evidence-row:backend-logs -->
- [ ] N/A: renderer-only CSS utility and tests.
<!-- evidence-row:frontend-logs -->
- [x] [Frontend focus/viewport telemetry log (structured JSONL)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18206-viewport-frontend-console.jsonl).
<!-- evidence-row:llm-trajectory -->
- [ ] N/A: no model, prompt, action, or runtime behavior.
<!-- evidence-row:domain-artifacts -->
- [x] [Bidirectional visualViewport/composer/geometry telemetry](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18206-viewport-bidirectional-telemetry.json).
<!-- evidence-row:ocr-review -->
- [x] [Human/OCR review of both 390×844 evidence captures](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18206-viewport-ocr-review.txt).

## App audit receipt

- `bun run --cwd packages/app audit:app` was invoked twice locally. The full capture could not start in this checkout: first the sparse workspace omitted view packages, then the reused dependency tree failed the authoritative view-bundle build (`@xterm/xterm` resolution / old Rollup code-splitting behavior). No audit pass is claimed. Exact-head CI runs with a clean install, and real iOS device proof remains an explicit reviewer/QA gate.

## Device-proof boundary

The evidence above is deterministic WebKit/Safari-threshold evidence, not a claim that Linux Playwright is an iPhone. The walkthrough is also supplied in the repository-required MP4 format. No iOS simulator, macOS host, BrowserStack, or attached iPhone is available in this lane. The real-device acceptance check therefore remains explicit rather than being fabricated. The implementation uses Safari's documented behavior boundary, changes the production control's computed utility from 14px to 16px on coarse pointers, and leaves user zoom enabled.

## QA

1. After the next staging deploy, open staging on iPhone Safari or an installed iOS PWA at 100% page scale.
2. Tap `Ask Eliza` and confirm the sheet does not zoom, crop, or squish.
3. If remote inspection is available, confirm `window.visualViewport.scale === 1` after focus.
4. Open chat search and inline-edit a message; confirm those fields also do not trigger focus zoom.
5. Pinch zoom to 200% and confirm user zoom still works, proving #18084 was preserved.
6. Exercise custom choice, form/select, and sensitive-request fields in the transcript and confirm none trigger focus zoom.
7. On desktop, confirm compact typography remains unchanged.














