### PR TITLE
fix(app): restore connector deep-link formatting

### DIFF
--- a/packages/app/src/deep-link-routing.ts
+++ b/packages/app/src/deep-link-routing.ts
@@ -64,9 +64,7 @@ export function resolveDeepLinkNavigationIntent(
   if (path === "connectors" || path === "settings/connectors") {
     return { viewId: "settings", viewPath: "/settings", subview: "connectors" };
   }
-  const connectorDetail = path.match(
-    /^settings\/connectors\/([a-z0-9-]+)$/i,
-  );
+  const connectorDetail = path.match(/^settings\/connectors\/([a-z0-9-]+)$/i);
   if (connectorDetail?.[1]) {
     const connectorId = connectorDetail[1].toLowerCase();
     return {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #18209.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on exact latest `origin/develop@a217b98f2dd87009ef9c5dd388eb4767a72348cb` with zero conflicts.
- [ ] `bun install` and the full root `bun run verify` were not repeated locally for this one-line formatter-only repair; the exact focused package checks are green below and exact-head CI remains required before merge.
- [x] A reviewer can confirm the change from the before/after Biome result and unchanged routing suite below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a217b98f2dd87009ef9c5dd388eb4767a72348cb:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Created directly from exact latest `origin/develop@a217b98f2dd87009ef9c5dd388eb4767a72348cb`; zero conflicts.
- [ ] Full root verify not repeated locally; focused exact-head proof is green and GitHub CI must be terminal green before merge.

# Risks

Low. This is Biome's canonical whitespace-only rewrite of one existing `path.match(...)` expression. Runtime values, regex, routing branches, tests, manifests, dependencies, and generated output are unchanged.

# Background

## What does this PR do?

Restores the `develop` formatting baseline left red by the final #18175 merge. It collapses one multiline connector-detail regex call to the single line emitted by both available repository Biome binaries.

## What kind of change is this?

Bug fix, non-breaking, source-format only.

# Documentation changes needed?

N/A - no behavior, public API, workflow, or operator contract changes.

# Testing

## Where should a reviewer start?

`packages/app/src/deep-link-routing.ts:67` and issue #18209's exact reproduction.

## Detailed testing steps

On exact head `44bb959802c84f31324f4e1242871c3aef002ef1`:

- `node_modules/.bin/biome check packages/app/src/deep-link-routing.ts` — PASS. Before the change, Biome 2.5.5 and 2.5.6 both exited 1 with the same proposed one-line format.
- pinned Bun 1.3.14 `bun test packages/app/src/deep-link-routing.test.ts` — 23 pass, 0 fail, 3066 assertions.
- pinned Bun 1.3.14 `bun run --cwd packages/app lint` — 272 files checked, no fixes or errors.
- `git diff --check` — PASS; one path, 1 insertion / 3 deletions.

# Evidence Gate

<!-- evidence-head:44bb959802c84f31324f4e1242871c3aef002ef1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - formatting-only `.ts` change has no rendered before surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - formatting-only `.ts` change has no rendered after surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or visual behavior changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend path changes; the deterministic Biome CLI output is recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime state or network behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, task, file-generation, wallet, or other domain state changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/runtime behavior.

## Backend + frontend logs

N/A - the affected boundary is the repository formatter. The exact pre-fix formatter error and post-fix PASS are summarized in **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - whitespace-only TypeScript formatting; no rendered output changes.

### Before

N/A - no visual surface.

### After

N/A - no visual surface.

### Walkthrough video

N/A - no interaction changes.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT surface.

## Known gaps / failures

- Full root `bun run verify` was not repeated locally; the focused formatter, complete deep-link routing unit file, package lint, and diff-check are green. Do not merge until exact-head GitHub gates are terminal green.
- The unrelated `plugin-tests` failure observed on #18175 is tracked separately by #18185 / #18193 and is intentionally outside this PR.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@a217b98f2dd87009ef9c5dd388eb4767a72348cb:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@a217b98f2dd87009ef9c5dd388eb4767a72348cb:packages/skills/skills/contribute-to-eliza"} -->
