### PR TITLE
feat(homepage): open Discord DM from Try Now

### DIFF
--- a/packages/homepage/package.json
+++ b/packages/homepage/package.json
@@ -13,7 +13,7 @@
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "check:release-data": "node ../app-core/scripts/check-homepage-release-data.mjs",
     "check:snapshot-inventory": "bun scripts/check-snapshot-inventory.ts",
-    "test": "bun test tests/smoke.node.test.mjs tests/screenshot-stability.node.test.mjs tests/e2e-port.node.test.mjs tests/channel-build-config.node.test.mjs tests/contact.test.ts tests/snapshot-inventory.test.ts tests/auth-return.test.ts tests/wallet-linking.test.ts tests/release-availability.test.ts edge/apple-app-site-association.test.ts tests/landing-a11y-helpers.test.ts",
+    "test": "bun test tests/smoke.node.test.mjs tests/screenshot-stability.node.test.mjs tests/e2e-port.node.test.mjs tests/channel-build-config.node.test.mjs tests/contact.test.ts tests/snapshot-inventory.test.ts tests/auth-return.test.ts tests/wallet-linking.test.ts tests/release-availability.test.ts edge/apple-app-site-association.test.ts tests/landing-a11y-helpers.test.ts src/lib/discord-dm-url.test.ts",
     "test:aasa-edge": "bun run typecheck:aasa-edge && bun test edge/apple-app-site-association.test.ts",
     "typecheck:aasa-edge": "bunx --package typescript@6.0.3 tsc --noEmit -p edge/tsconfig.json",
     "deploy:aasa-edge": "bunx wrangler@4.100.0 deploy --config wrangler-aasa.toml --strict",

--- a/packages/homepage/src/lib/discord-dm-url.test.ts
+++ b/packages/homepage/src/lib/discord-dm-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { buildDiscordDmUrl } from "./discord-dm-url";
+
+describe("buildDiscordDmUrl", () => {
+  it("builds the bot profile URL used to open a Discord DM", () => {
+    expect(buildDiscordDmUrl("1474591626759376967")).toBe(
+      "https://discord.com/users/1474591626759376967",
+    );
+  });
+
+  it("rejects missing or malformed application ids", () => {
+    expect(buildDiscordDmUrl()).toBeNull();
+    expect(buildDiscordDmUrl("not-an-id")).toBeNull();
+    expect(buildDiscordDmUrl("1474591626759376967/path")).toBeNull();
+  });
+});

--- a/packages/homepage/src/lib/discord-dm-url.ts
+++ b/packages/homepage/src/lib/discord-dm-url.ts
@@ -1,0 +1,8 @@
+/** Builds the public Discord profile/DM URL for the configured Eliza bot. */
+export function buildDiscordDmUrl(
+  applicationId = import.meta.env.VITE_DISCORD_CLIENT_ID,
+): string | null {
+  const normalized = applicationId?.trim();
+  if (!normalized || !/^\d{17,20}$/.test(normalized)) return null;
+  return `https://discord.com/users/${normalized}`;
+}

--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -41,6 +41,7 @@ import type {
   ChatRenderState,
   ModelBHandle,
 } from "@/components/ModelViewers/ModelB";
+import { buildDiscordDmUrl } from "@/lib/discord-dm-url";
 import { useT } from "@/providers/I18nProvider";
 
 // Heavy WebGL bundles stay behind Suspense so the interactive route chrome can
@@ -973,7 +974,14 @@ export default function Leaderboard() {
                   />
                   <AnimatedButton
                     type="button"
-                    onClick={() => navigate("/get-started")}
+                    onClick={() => {
+                      const discordDmUrl = buildDiscordDmUrl();
+                      if (discordDmUrl) {
+                        window.location.assign(discordDmUrl);
+                        return;
+                      }
+                      navigate("/get-started?guide=discord");
+                    }}
                     className="relative z-2 flex h-full w-full cursor-pointer items-center justify-center whitespace-nowrap rounded-full text-base font-semibold text-neutral-900"
                     style={{ opacity: tryAppearSpring.tryOpacity }}
                   >


### PR DESCRIPTION
## Summary

The canonical homepage `Try Now` button currently routes to `/get-started`, which starts web signup before the user reaches the shared messaging agent. This change makes it open the configured Eliza Discord bot profile/DM surface directly. If the Discord application ID is absent or malformed, it fails safely to the existing Discord setup guide.

The application ID remains environment-owned through `VITE_DISCORD_CLIENT_ID`; no staging or production bot ID is hard-coded in shipped code. The staging build was verified with application `1474591626759376967`.

## Validation

- `bun test packages/homepage/src/lib/discord-dm-url.test.ts` (2 pass)
- Biome clean on all touched files
- `packages/homepage` typecheck pass
- `packages/homepage` production build pass with the staging Discord application ID

## Deployment boundary

Draft only. Do not merge or deploy the homepage to production without Shadow's explicit approval. A Cloudflare Pages preview is pending because this host has no Cloudflare token/login and the canonical workflow does not accept feature refs for shared staging. No production deploy occurred.

<!-- evidence-head:b3c14d16481bcdedaabdb1e073e2db98b2f069c5 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - behavior-only navigation change; preview access pending

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Cloudflare preview access pending

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Cloudflare preview access pending

<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend-only change

<!-- evidence-row:frontend-logs -->
- [x] Local typecheck, unit-test, and production-build results documented above

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/runtime behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no schema or domain artifact change

<!-- evidence-row:ocr-review -->
- [ ] N/A - no copy or layout change

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai-codex/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: OpenClaw (Sol)
<!-- attribution-row:skill-revision -->
- Skill path: n/a
<!-- attribution-row:status -->
- Provenance status: self-reported
