### PR TITLE
fix(ci): preserve Pages artifacts across failed-only reruns

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -900,8 +900,28 @@ jobs:
     if: ${{ !cancelled() && (needs.migrate-db.result == 'success' || (github.event_name == 'pull_request' && needs.migrate-db.result == 'skipped')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # GitHub preserves outputs from successful jobs when only failed jobs are
+    # rerun. Consumers must therefore use the producer's attempt, not their own
+    # newer github.run_attempt. A full rerun executes this job again and emits
+    # the new attempt, so its deploy jobs consume the newly built artifacts.
+    outputs:
+      artifact_run_id: ${{ steps.pages-artifact.outputs.run_id }}
+      artifact_run_attempt: ${{ steps.pages-artifact.outputs.run_attempt }}
+      artifact_source_sha: ${{ steps.pages-artifact.outputs.source_sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Bind Pages artifacts to this producer attempt
+        id: pages-artifact
+        env:
+          PRODUCER_RUN_ID: ${{ github.run_id }}
+          PRODUCER_RUN_ATTEMPT: ${{ github.run_attempt }}
+          PRODUCER_SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          echo "run_id=$PRODUCER_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "run_attempt=$PRODUCER_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$PRODUCER_SOURCE_SHA" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -940,7 +960,7 @@ jobs:
       - name: Upload console artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: pages-console-${{ github.run_id }}-${{ github.run_attempt }}
+          name: pages-console-${{ steps.pages-artifact.outputs.run_id }}-${{ steps.pages-artifact.outputs.run_attempt }}
           path: |
             packages/app/dist
             packages/app/functions
@@ -969,7 +989,7 @@ jobs:
       - name: Upload app artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: pages-app-${{ github.run_id }}-${{ github.run_attempt }}
+          name: pages-app-${{ steps.pages-artifact.outputs.run_id }}-${{ steps.pages-artifact.outputs.run_attempt }}
           path: |
             packages/app/dist
             packages/app/functions
@@ -1118,10 +1138,36 @@ jobs:
           # lookup during setup. See elizaOS/eliza#10839.
           bun-version: "1.3.14"
 
+      - name: Resolve immutable console artifact
+        id: pages-artifact
+        env:
+          PRODUCER_RUN_ID: ${{ needs.build-pages.outputs.artifact_run_id }}
+          PRODUCER_RUN_ATTEMPT: ${{ needs.build-pages.outputs.artifact_run_attempt }}
+          PRODUCER_SOURCE_SHA: ${{ needs.build-pages.outputs.artifact_source_sha }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PRODUCER_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Pages producer run ID is missing or invalid"
+            exit 1
+          fi
+          if ! [[ "$PRODUCER_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Pages producer run attempt is missing or invalid"
+            exit 1
+          fi
+          if [ "$PRODUCER_RUN_ID" != "$GITHUB_RUN_ID" ]; then
+            echo "::error::Pages artifact run mismatch: producer=$PRODUCER_RUN_ID consumer=$GITHUB_RUN_ID"
+            exit 1
+          fi
+          if [ "$PRODUCER_SOURCE_SHA" != "$GITHUB_SHA" ]; then
+            echo "::error::Pages artifact SHA mismatch: producer=$PRODUCER_SOURCE_SHA consumer=$GITHUB_SHA"
+            exit 1
+          fi
+          echo "name=pages-console-${PRODUCER_RUN_ID}-${PRODUCER_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+
       - name: Download immutable console artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: pages-console-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ steps.pages-artifact.outputs.name }}
           path: ${{ env.CHECKOUT_DIR }}/packages/app
 
       - name: Legacy inline fallback - install dependencies
@@ -1526,10 +1572,36 @@ jobs:
           # lookup during setup. See elizaOS/eliza#10839.
           bun-version: "1.3.14"
 
+      - name: Resolve immutable app artifact
+        id: pages-artifact
+        env:
+          PRODUCER_RUN_ID: ${{ needs.build-pages.outputs.artifact_run_id }}
+          PRODUCER_RUN_ATTEMPT: ${{ needs.build-pages.outputs.artifact_run_attempt }}
+          PRODUCER_SOURCE_SHA: ${{ needs.build-pages.outputs.artifact_source_sha }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PRODUCER_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Pages producer run ID is missing or invalid"
+            exit 1
+          fi
+          if ! [[ "$PRODUCER_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Pages producer run attempt is missing or invalid"
+            exit 1
+          fi
+          if [ "$PRODUCER_RUN_ID" != "$GITHUB_RUN_ID" ]; then
+            echo "::error::Pages artifact run mismatch: producer=$PRODUCER_RUN_ID consumer=$GITHUB_RUN_ID"
+            exit 1
+          fi
+          if [ "$PRODUCER_SOURCE_SHA" != "$GITHUB_SHA" ]; then
+            echo "::error::Pages artifact SHA mismatch: producer=$PRODUCER_SOURCE_SHA consumer=$GITHUB_SHA"
+            exit 1
+          fi
+          echo "name=pages-app-${PRODUCER_RUN_ID}-${PRODUCER_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+
       - name: Download immutable app artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: pages-app-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ steps.pages-artifact.outputs.name }}
           path: ${{ env.CHECKOUT_DIR }}/packages/app
 
       - name: Legacy inline fallback - install dependencies

--- a/packages/scripts/__tests__/cloud-cf-pages-artifact-rerun-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-pages-artifact-rerun-workflow.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Contract for Pages artifacts across GitHub Actions rerun attempts.
+ *
+ * A failed-only rerun keeps outputs from the successful build-pages job. The
+ * deploy jobs must resolve that producer attempt instead of assuming their own
+ * newer github.run_attempt produced another artifact. A full rerun executes
+ * build-pages again, so the same output contract selects the new attempt.
+ */
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveGnuBash } from "../lib/gnu-shell.mjs";
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const workflowSource = readFileSync(
+  new URL(".github/workflows/cloud-cf-deploy.yml", repoRoot),
+  "utf8",
+);
+
+interface WorkflowStep {
+  env?: Record<string, string>;
+  id?: string;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+}
+
+interface WorkflowJob {
+  needs?: string[] | string;
+  outputs?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const buildJob = workflow.jobs?.["build-pages"];
+const deployJobs = [
+  {
+    artifactPrefix: "pages-console",
+    download: "Download immutable console artifact",
+    jobId: "deploy-console",
+    resolver: "Resolve immutable console artifact",
+  },
+  {
+    artifactPrefix: "pages-app",
+    download: "Download immutable app artifact",
+    jobId: "deploy-app",
+    resolver: "Resolve immutable app artifact",
+  },
+] as const;
+
+function namedStep(job: WorkflowJob | undefined, name: string): WorkflowStep {
+  const step = job?.steps?.find((candidate) => candidate.name === name);
+  if (!step) throw new Error(`Missing workflow step: ${name}`);
+  return step;
+}
+
+interface ResolverInput {
+  consumerAttempt: string;
+  consumerRunId?: string;
+  consumerSha?: string;
+  producerAttempt: string;
+  producerRunId?: string;
+  producerSha?: string;
+}
+
+function runResolver(step: WorkflowStep, input: ResolverInput) {
+  if (!GNU_BASH || !step.run) {
+    throw new Error("Resolver execution requires bash >= 4 and a run script");
+  }
+
+  const directory = mkdtempSync(join(tmpdir(), "cloud-cf-pages-artifact-"));
+  const outputPath = join(directory, "github-output");
+  const runId = "31336372345";
+  const sha = "4166a72707556591e58eb68114a137385ce2c3ff";
+
+  try {
+    const result = spawnSync(GNU_BASH, ["-c", step.run], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_RUN_ATTEMPT: input.consumerAttempt,
+        GITHUB_RUN_ID: input.consumerRunId ?? runId,
+        GITHUB_SHA: input.consumerSha ?? sha,
+        PRODUCER_RUN_ATTEMPT: input.producerAttempt,
+        PRODUCER_RUN_ID: input.producerRunId ?? runId,
+        PRODUCER_SOURCE_SHA: input.producerSha ?? sha,
+      },
+    });
+    return {
+      ...result,
+      output: existsSync(outputPath) ? readFileSync(outputPath, "utf8") : "",
+    };
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+const GNU_BASH = resolveGnuBash();
+const executedDescribe = GNU_BASH ? describe : describe.skip;
+
+describe("Cloud CF Pages artifact metadata", () => {
+  test("exports immutable producer identity and uses it for both uploads", () => {
+    expect(buildJob?.outputs).toEqual({
+      artifact_run_id: "$" + "{{ steps.pages-artifact.outputs.run_id }}",
+      artifact_run_attempt:
+        "$" + "{{ steps.pages-artifact.outputs.run_attempt }}",
+      artifact_source_sha:
+        "$" + "{{ steps.pages-artifact.outputs.source_sha }}",
+    });
+
+    const metadata = namedStep(
+      buildJob,
+      "Bind Pages artifacts to this producer attempt",
+    );
+    expect(metadata.id).toBe("pages-artifact");
+    expect(metadata.env).toEqual({
+      PRODUCER_RUN_ID: "$" + "{{ github.run_id }}",
+      PRODUCER_RUN_ATTEMPT: "$" + "{{ github.run_attempt }}",
+      PRODUCER_SOURCE_SHA: "$" + "{{ github.sha }}",
+    });
+
+    for (const { artifactPrefix } of deployJobs) {
+      const surface = artifactPrefix === "pages-console" ? "console" : "app";
+      const upload = namedStep(buildJob, `Upload ${surface} artifact`);
+      expect(upload.with?.name).toBe(
+        `${artifactPrefix}-` +
+          "$" +
+          "{{ steps.pages-artifact.outputs.run_id }}-" +
+          "$" +
+          "{{ steps.pages-artifact.outputs.run_attempt }}",
+      );
+    }
+  });
+
+  test("uses the same fail-closed resolver contract for App and Console", () => {
+    for (const { download, jobId, resolver } of deployJobs) {
+      const job = workflow.jobs?.[jobId];
+      const resolveStep = namedStep(job, resolver);
+      const downloadStep = namedStep(job, download);
+
+      expect(resolveStep.id).toBe("pages-artifact");
+      expect(resolveStep.env).toEqual({
+        PRODUCER_RUN_ID:
+          "$" + "{{ needs.build-pages.outputs.artifact_run_id }}",
+        PRODUCER_RUN_ATTEMPT:
+          "$" + "{{ needs.build-pages.outputs.artifact_run_attempt }}",
+        PRODUCER_SOURCE_SHA:
+          "$" + "{{ needs.build-pages.outputs.artifact_source_sha }}",
+      });
+      expect(resolveStep.run).toContain(
+        'if [ "$PRODUCER_RUN_ID" != "$GITHUB_RUN_ID" ]',
+      );
+      expect(resolveStep.run).toContain(
+        'if [ "$PRODUCER_SOURCE_SHA" != "$GITHUB_SHA" ]',
+      );
+      expect(resolveStep.run).not.toContain("GITHUB_RUN_ATTEMPT");
+      expect(downloadStep.with?.name).toBe(
+        "$" + "{{ steps.pages-artifact.outputs.name }}",
+      );
+    }
+  });
+
+  test("keeps the deploy and served-frontend freshness gates strict", () => {
+    for (const { jobId } of deployJobs) {
+      const job = workflow.jobs?.[jobId];
+      expect(job?.needs).toEqual(["migrate-db", "build-pages"]);
+
+      const guard = namedStep(job, "Deploy freshness guard");
+      const verification = namedStep(job, "Verify Pages frontend freshness");
+      expect(guard.run).toContain("deploy-freshness-guard-cli.mjs");
+      expect(verification.if).toContain(
+        "steps.freshness.outputs.should_deploy == 'true'",
+      );
+      expect(verification.run).toContain(
+        "packages/cloud/scripts/verify-pages-frontend-cli.mjs",
+      );
+    }
+  });
+});
+
+executedDescribe("Cloud CF Pages artifact resolver", () => {
+  test("failed-only attempt 2 consumes attempt 1 for App and Console", () => {
+    for (const { artifactPrefix, jobId, resolver } of deployJobs) {
+      const result = runResolver(namedStep(workflow.jobs?.[jobId], resolver), {
+        consumerAttempt: "2",
+        producerAttempt: "1",
+      });
+      expect(result.status).toBe(0);
+      expect(result.output).toBe(`name=${artifactPrefix}-31336372345-1\n`);
+    }
+  });
+
+  test("full rerun attempt 3 consumes attempt 3 for App and Console", () => {
+    for (const { artifactPrefix, jobId, resolver } of deployJobs) {
+      const result = runResolver(namedStep(workflow.jobs?.[jobId], resolver), {
+        consumerAttempt: "3",
+        producerAttempt: "3",
+      });
+      expect(result.status).toBe(0);
+      expect(result.output).toBe(`name=${artifactPrefix}-31336372345-3\n`);
+    }
+  });
+
+  test("rejects missing, cross-run, and cross-SHA producer metadata", () => {
+    for (const { jobId, resolver } of deployJobs) {
+      const step = namedStep(workflow.jobs?.[jobId], resolver);
+      const invalidAttempt = runResolver(step, {
+        consumerAttempt: "2",
+        producerAttempt: "",
+      });
+      expect(invalidAttempt.status).toBe(1);
+      expect(invalidAttempt.stdout).toContain(
+        "Pages producer run attempt is missing or invalid",
+      );
+
+      const crossRun = runResolver(step, {
+        consumerAttempt: "2",
+        producerAttempt: "1",
+        producerRunId: "31336372344",
+      });
+      expect(crossRun.status).toBe(1);
+      expect(crossRun.stdout).toContain("Pages artifact run mismatch");
+
+      const crossSha = runResolver(step, {
+        consumerAttempt: "2",
+        producerAttempt: "1",
+        producerSha: "0000000000000000000000000000000000000000",
+      });
+      expect(crossSha.status).toBe(1);
+      expect(crossSha.stdout).toContain("Pages artifact SHA mismatch");
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #18214.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and the full `bun run verify` were not repeated locally after
      this patch-equivalent rebase; the exact-head required CI must be green
      before merge. Focused acceptance gates are complete below.
- [x] A reviewer can confirm the change works without reading the code, from the
      deterministic resolver matrix and test results below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@fa8b9c3ca9d81ef265e2d6349c98eac1eaa4b119:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at
      `2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6`; zero conflicts.
- [ ] Full local `bun run verify` was not repeated post-sync; merge remains
      blocked on all required checks passing on exact head
      `fa8b9c3ca9d81ef265e2d6349c98eac1eaa4b119`.

# Risks

Low. The change is limited to the App and Console Pages artifact handoff in one
workflow. It fails closed on missing or invalid metadata, a different workflow
run, or a different source SHA. The existing frontend freshness verification
remains unchanged.

# Background

## What does this PR do?

Exports immutable Pages artifact provenance from `build-pages` and has both
deploy jobs resolve their exact artifact name from those producer outputs.
Consequently:

- a failed-only rerun can reuse the successful producer from attempt 1 while its
  consumer runs in attempt 2;
- a full rerun produces and consumes attempt 3 artifacts;
- App and Console remain bound to the current workflow run and exact source SHA;
- no broad or stale artifact fallback is introduced.

This matches GitHub's failed-job rerun behavior: successful job outputs and
artifacts from the previous attempt remain available to rerun jobs.

## What kind of change is this?

Bug fix (non-breaking CI workflow correction).

# Documentation changes needed?

No project documentation change is needed. The workflow contract is covered by
a focused executable regression test.

# Testing

## Where should a reviewer start?

Review the `build-pages` outputs and the two `Resolve immutable ... artifact`
steps in `.github/workflows/cloud-cf-deploy.yml`, then the focused contract test
in `packages/scripts/__tests__/cloud-cf-pages-artifact-rerun-workflow.test.ts`.

## Detailed testing steps

Post-sync head: `fa8b9c3ca9d81ef265e2d6349c98eac1eaa4b119`, based exactly on
`develop@2e60c9a2b6cfbb1b22910ba5dd797d97089ccdc6`.

Pinned toolchain: Bun `1.3.14`, Node `24.15.0`; execution used a disposable
macOS sandbox with network denied and a fresh temporary home.

- Patch equivalence: stable patch-id
  `3ec2d6814db46ba9cc3938db35821b3181338d1b` across every rebase;
  `git range-diff` reports `=`.
- Focused workflow suites: 79 pass, 0 fail, 19,017 assertions:
  `cloud-cf-pages-artifact-rerun-workflow.test.ts`,
  `cloud-cf-voice-deploy-workflow.test.ts`, and
  `ci-bun-version-contract.test.ts`.
- `actionlint .github/workflows/cloud-cf-deploy.yml` — pass with actionlint
  `1.7.12`.
- Biome check on the new test — pass; no fixes applied.
- `git diff --check origin/develop...HEAD` — pass.

The contract test executes the resolver shell verbatim for both App and Console:

| Scenario | Producer metadata | Consumer attempt | Exact result |
| --- | ---: | ---: | --- |
| Failed-only rerun | attempt 1 | attempt 2 | `pages-{app,console}-31336372345-1` |
| Full rerun | attempt 3 | attempt 3 | `pages-{app,console}-31336372345-3` |
| Missing attempt / cross-run / cross-SHA | invalid | any | exits non-zero |

No deployment or production mutation was performed.

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:39f1c3c2acdf5ceafcc04d1a27a721a24bc43dcd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - workflow-only CI change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - workflow-only CI change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or rendered user flow changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path changed; executable contract output is in the PR Testing section
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime code or request changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, task, wallet, generated file, or audio behavior changed
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - this is a workflow-only artifact-routing change. The deterministic shell
contract and validation results are reported under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface or user flow changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

The full repository `bun run verify` was not repeated locally after the
patch-equivalent rebase. This does not relax the gate: the PR must not merge
until all required GitHub checks pass on exact head
`fa8b9c3ca9d81ef265e2d6349c98eac1eaa4b119` and an independent reviewer approves
that same head. No live deployment was run because the issue scope is workflow
plumbing only and explicitly excludes production mutation.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@fa8b9c3ca9d81ef265e2d6349c98eac1eaa4b119:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@fa8b9c3ca9d81ef265e2d6349c98eac1eaa4b119:packages/skills/skills/contribute-to-eliza"} -->





