### PR TITLE
chore(agent): restore Biome formatting broken by #18207

### DIFF
--- a/packages/agent/src/actions/knowledge.ts
+++ b/packages/agent/src/actions/knowledge.ts
@@ -457,7 +457,9 @@ export const searchKnowledgeAction: Action = {
     return {
       success: true,
       text,
-      ...(items.length ? { userFacingText: text, verifiedUserFacing: true } : {}),
+      ...(items.length
+        ? { userFacingText: text, verifiedUserFacing: true }
+        : {}),
       data: { query, count: items.length, items },
     };
   },


### PR DESCRIPTION
## Summary

[#18207](https://github.com/elizaOS/eliza/pull/18207) (`77e2330b5`) landed a spread expression in `packages/agent/src/actions/knowledge.ts` formatted differently than Biome's output. Since then `@elizaos/agent#lint:check` fails on **every** branch based on current `develop`, which fails the `Quality` CI job and root `bun run verify` repo-wide — every open PR eats a guaranteed red until this lands.

One file, 3 lines, formatter output only (`biome check --write ./src`, "Fixed 1 file"). Zero code-token changes.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - formatter-only change; no rendered UI.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - formatter-only whitespace change with no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no interactive flow; the observable change is a lint gate exit code.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — the gate transition, run locally on pinned Bun 1.3.14:

  ```
  # origin/develop (a217b98f2..HEAD includes 77e2330b5)
  $ bun run --cwd packages/agent lint:check
  × Formatter would have printed the following content:  (knowledge.ts)
  error: script "lint:check" exited with code 1
  # after this commit
  $ bun run --cwd packages/agent lint:check
  Checked 870 files. No fixes needed.  exit=0
  ```
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no browser-side code in this diff.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, model, prompt, or provider surface touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the artifact is the 3-line formatter diff itself, reviewable inline.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: `N/A - no rendered visual surface in this diff.`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cad]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:7a784cd668bfdfa2129ec92c5d8e48500294851a -->
