### PR TITLE
fix(core): failed sub-agent relay turns deliver the completed result instead of the canned fallback

### DIFF
--- a/packages/core/src/services/message.preserved-tool-result.test.ts
+++ b/packages/core/src/services/message.preserved-tool-result.test.ts
@@ -18,7 +18,11 @@ import type { PlannerToolResult } from "../runtime/planner-loop";
 import type { Action, Content, HandlerCallback, Memory, UUID } from "../types";
 import { ModelType } from "../types";
 import { ChannelType } from "../types/primitives";
-import { DefaultMessageService, preservedSettledToolResult } from "./message";
+import {
+	DefaultMessageService,
+	preservedSettledToolResult,
+	subAgentCompletionRelayBody,
+} from "./message";
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000081" as UUID;
 const USER_ID = "00000000-0000-0000-0000-000000000082" as UUID;
@@ -270,6 +274,65 @@ describe("planner-loop death after a completed tool", () => {
 		expect(delivered.join("\n").toLowerCase()).toContain("rate-limit");
 		expect(delivered.join("\n")).not.toContain(DIAGNOSTIC);
 		expect(result.responseContent?.text ?? "").not.toContain(DIAGNOSTIC);
+	});
+});
+
+describe("subAgentCompletionRelayBody parsing (#18208)", () => {
+	const RELAY_HEADER =
+		"[sub-agent: review pr 18175 (elizaos) — task_complete — this delegated task is DONE; the result is below, relay it to the user as the answer and do NOT start another sub-agent for it.]";
+	const RESULT_BODY =
+		"The PR fixes the pairing dead-end: hosts now redeem the in-progress pairing instead of dropping it. Two files changed, tests included.";
+
+	it("extracts the result body from a task_complete relay", () => {
+		expect(subAgentCompletionRelayBody(`${RELAY_HEADER}\n${RESULT_BODY}`)).toBe(
+			RESULT_BODY,
+		);
+	});
+
+	it("returns undefined for non-relay text, non-complete events, and empty bodies", () => {
+		expect(subAgentCompletionRelayBody("what's the weather")).toBeUndefined();
+		expect(
+			subAgentCompletionRelayBody(
+				"[sub-agent: devops (elizaos) — error]\nsub-agent reported an error",
+			),
+		).toBeUndefined();
+		expect(subAgentCompletionRelayBody(`${RELAY_HEADER}\n   `)).toBeUndefined();
+		expect(subAgentCompletionRelayBody(undefined)).toBeUndefined();
+	});
+
+	it("caps a runaway body", () => {
+		const huge = "x".repeat(5000);
+		const capped = subAgentCompletionRelayBody(`${RELAY_HEADER}\n${huge}`);
+		expect(capped).toBeDefined();
+		expect((capped as string).length).toBeLessThanOrEqual(1501);
+		expect(capped).toMatch(/…$/);
+	});
+
+	it("a failed relay turn delivers the completed result instead of the canned line", async () => {
+		// Same failing-turn harness as above (tool result carries nothing
+		// user-facing, every later model call dies) — but the TRIGGERING message
+		// is a task_complete relay, so the finished result it carries must win
+		// over any canned failure text.
+		const harness = await createHarness({
+			actionResult: { success: false, text: DIAGNOSTIC },
+		});
+
+		const result = await new DefaultMessageService().handleMessage(
+			harness.runtime,
+			makeMessage(harness.runtime, `${RELAY_HEADER}\n${RESULT_BODY}`),
+			harness.callback,
+		);
+
+		const delivered = visibleTexts(harness.callbacks);
+		const everything = [
+			...delivered,
+			String(result.responseContent?.text ?? ""),
+		].join("\n");
+		// The completed result reaches the user…
+		expect(everything).toContain("pairing dead-end");
+		// …and no canned failure/apology text replaces it.
+		expect(everything.toLowerCase()).not.toContain("runtime step failed");
+		expect(everything).not.toContain(DIAGNOSTIC);
 	});
 });
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1804,6 +1804,36 @@ function trackSettledPlannerToolResult(
 }
 
 /**
+ * The completed-result body of a sub-agent `task_complete` relay message, or
+ * undefined when the text is not such a relay or carries no body. The relay
+ * format is `[sub-agent: … — task_complete — …]\n<result body>` (see
+ * plugin-agent-orchestrator's sub-agent-router): the bracketed first segment
+ * is a planner-only directive and never user-facing; the body below it is the
+ * sub-agent's finished result, already composed for user delivery. Lets a
+ * failed relay turn deliver the completed result instead of discarding it for
+ * the generic failed-tool fallback (#18208). Capped so a runaway transcript
+ * cannot flood the channel.
+ */
+export function subAgentCompletionRelayBody(
+	text: string | undefined,
+): string | undefined {
+	if (!text) return undefined;
+	const trimmed = text.trimStart();
+	if (!trimmed.startsWith("[sub-agent:")) return undefined;
+	const headerEnd = trimmed.indexOf("]");
+	if (headerEnd < 0) return undefined;
+	if (!trimmed.slice(0, headerEnd + 1).includes("task_complete")) {
+		return undefined;
+	}
+	const body = trimmed.slice(headerEnd + 1).trim();
+	if (!body) return undefined;
+	const maxLength = 1500;
+	return body.length > maxLength
+		? `${body.slice(0, maxLength).trimEnd()}…`
+		: body;
+}
+
+/**
  * The most recent completed tool result whose `userFacingText` can still
  * rescue a turn after the planner loop dies: successful, non-terminal, and not
  * already delivered to the user through an action callback. Diagnostic
@@ -8447,7 +8477,32 @@ export async function runV5MessageRuntimeStage1(args: {
 					deliveredVisibleTexts,
 				);
 				if (!preservedToolResult) {
-					throw error;
+					// #18208: a task_complete relay turn carries the sub-agent's
+					// finished result in its own body — the last preserved source
+					// before conceding to the canned failure reply.
+					const relayBody = subAgentCompletionRelayBody(
+						args.message?.content?.text,
+					);
+					if (!relayBody) {
+						throw error;
+					}
+					// error-policy:J4 a completed sub-agent result is a designed
+					// degrade when the relay turn's planning fails; report the loop
+					// failure and deliver the result the sub-agent already produced.
+					endStatus = "errored";
+					args.runtime.reportError("MessageService.plannerLoop", error, {
+						roomId: args.message.roomId,
+					});
+					return {
+						kind: "direct_reply",
+						messageHandler,
+						result: createV5ReplyStrategyResult({
+							...args,
+							state: plannerState,
+							text: relayBody,
+							thought: messageHandler.thought,
+						}),
+					};
 				}
 				// error-policy:J4 a completed tool's user-facing result is a designed
 				// degrade when later planning/evaluation fails; report the loop
@@ -8655,6 +8710,24 @@ export async function runV5MessageRuntimeStage1(args: {
 						: "")
 				: preservedAnswerFallback;
 		let effectiveReplyText = plannedText || ackFallback;
+		// #18208: a failed sub-agent completion relay must not discard the
+		// finished result it carries. When the turn ended on the generic
+		// failed-tool fallback and the triggering message IS a task_complete
+		// relay — whose body is the sub-agent's completed result, composed for
+		// user delivery — deliver that body instead of the canned line. Every
+		// other failed turn keeps the canned fallback, and the replacement
+		// still flows through the egress/dedupe checks below.
+		if (effectiveReplyText === FAILED_TOOL_FALLBACK_MESSAGE) {
+			const relayBody = subAgentCompletionRelayBody(
+				args.message?.content?.text,
+			);
+			if (relayBody) {
+				logger.debug(
+					"[MessageService] failed relay turn degraded to preserved sub-agent result",
+				);
+				effectiveReplyText = relayBody;
+			}
+		}
 		const finalReplyEgressDecision = evaluatePlannedReplyEgress({
 			reply: effectiveReplyText,
 			actionResults,


### PR DESCRIPTION
Fixes #18208.

Three live incidents in one day: a sub-agent COMPLETED its task (a staging investigation, two PR reviews), its `task_complete` relay turn arrived carrying the finished result — and the user got "I tried to complete that, but the available runtime step failed before it produced a usable result." while the answer was discarded.

## Fix

The relay message's own body IS the completed result, already composed for user delivery (the bracketed `[sub-agent: … — task_complete — …]` first segment is planner-only). New `subAgentCompletionRelayBody()` extracts it (header-stripped, 1500-char capped), and it becomes the last preserved source on BOTH failure routes:
- planner returns `FAILED_TOOL_FALLBACK_MESSAGE` → replaced at the delivery choke point (flows through existing egress/dedupe checks)
- planner throws → the #18180 rescue seam tries it after preserved tool results, before conceding to the canned reply (J4, loop failure still reported)

Every non-relay failed turn keeps the existing behavior.

## Tests
`message.preserved-tool-result.test.ts`: 3 helper units (parse, non-relay/non-complete/empty rejects, runaway cap) + 1 real-pipeline integration (failing relay turn delivers the result, no canned text). Suites: preserved-tool-result + planner-rescue-lane **206/206**, answer-clobber-rescue green, core typecheck clean.

# Evidence

<!-- evidence-head:11ec56091a6755490d9c73f7dd7e4ea79b6c11dd -->
- Before screenshots: N/A - backend-only change, no UI surface
- After screenshots: N/A - backend-only change, no UI surface
- Walkthrough video: N/A - backend-only change, no UI surface
- OCR review: N/A - backend-only change, no UI surface
- Frontend console/network logs: N/A - backend-only change, no UI surface
- Backend logs: vitest transcript below
- Real-LLM trajectory: three sanitized live incidents documented in #18208 (spawn → task_complete relay → canned line shipped, result lost)
- Domain artifacts:

```
bunx vitest run message.preserved-tool-result.test.ts message-planner-rescue-lane.test.ts
 Tests  206 passed (206)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
