### PR TITLE
fix(ui): control-plane hosts are connected-over-rest — never dial the unservable /ws

### DIFF
--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -291,6 +291,28 @@ describe("ElizaClient websocket connection policy", () => {
     expect(client.getConnectionState().state).toBe("connected");
   });
 
+  it("treats a control-plane host base as connected without opening a websocket (#18172)", () => {
+    const instances = stubWebSocketWithInstances();
+    // staging console — the alias Worker routes only /api*//steward* and
+    // strips Connection/Upgrade, so /ws can never upgrade; dialing it burned
+    // 15 reconnects and raised the fatal overlay over a working REST backend.
+    const client = new ElizaClient(
+      "https://staging.elizacloud.ai",
+      "cloud-token",
+    );
+    client.connectWs();
+    expect(instances).toHaveLength(0);
+    expect(client.getConnectionState().state).toBe("connected");
+  });
+
+  it("covers production control-plane hosts too, not just staging", () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://app.elizacloud.ai", "cloud-token");
+    client.connectWs();
+    expect(instances).toHaveLength(0);
+    expect(client.getConnectionState().state).toBe("connected");
+  });
+
   it("still goes failed for a non-cloud agent base after WS exhaustion (overlay preserved)", () => {
     vi.useFakeTimers();
     try {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -480,7 +480,15 @@ function shouldTreatAsConnectedWithoutWebSocket(
     isIosInProcessLocalAgentBase(value) ||
     isLocalAgentIpcBase(value) ||
     isSharedRuntimeRestAdapterBase(value) ||
-    isDedicatedCloudAgentBase(value)
+    isDedicatedCloudAgentBase(value) ||
+    // Control-plane hosts structurally cannot serve `/ws`: the alias Worker
+    // routes only `/api*`/`/steward*` to the API and strips
+    // `Connection`/`Upgrade` before proxying, so the SPA answers the upgrade
+    // with 200 + index.html. Since #17801 removed the synthetic-host WS skip,
+    // browsers on these hosts dialed it anyway, burned all reconnect attempts,
+    // and raised the fatal "Lost backend connection." overlay over a fully
+    // working REST/SSE backend (#18172). Connected-over-REST, no WS attempt.
+    isElizaCloudControlPlaneBase(value)
   );
 }
 
@@ -1710,7 +1718,12 @@ export class ElizaClient {
         // full-screen "Lost backend connection" overlay. Degrade to a non-fatal
         // connected-over-REST state and keep probing in the background (see
         // scheduleReconnect's 30s loop) so live updates resume on WS recovery.
-        if (isDedicatedCloudAgentBase(this.baseUrl)) {
+        if (
+          isDedicatedCloudAgentBase(this.baseUrl) ||
+          // Control-plane hosts serve chat over REST/SSE and can never
+          // complete a WS upgrade (#18172) — same non-fatal degrade.
+          isElizaCloudControlPlaneBase(this.baseUrl)
+        ) {
           this.connectionState = "connected";
           this.disconnectedAt = null;
         } else {


### PR DESCRIPTION
Fixes #18172.

Since #17801 removed the synthetic-host WS skip, browsers on cloud control-plane hosts dial `wss://<host>/ws` — an endpoint the edge structurally cannot serve (the alias Worker routes only `/api*`/`/steward*` and strips `Connection`/`Upgrade`; the SPA answers the upgrade with 200 + index.html). The client burns all 15 reconnect attempts and raises the fatal full-screen "Lost backend connection." overlay over a fully working REST/SSE backend. Hit staging on 2026-08-09 (multiple dev reports); production reproduces identically once #17801 promotes to main.

## Fix
The existing `isElizaCloudControlPlaneBase()` predicate joins the two seams that already handle dedicated agents:
- `shouldTreatAsConnectedWithoutWebSocket()` — no WS attempt at all, connected-over-REST (mirrors the dedicated-agent + shared-adapter carve-outs)
- the reconnect-exhaustion degrade in `connectWs().onclose` — safety-net: non-fatal connected state instead of the overlay

Evidence for the unservable upgrade (live probes, issue #18172): WS client → CLOSE 1002 "Expected 101" on all four hosts; curl upgrade → HTTP/2 200 text/html.

## Tests
`client-base-websocket.test.ts`: staging + production control-plane bases open zero sockets and report connected; non-cloud bases still fail to the overlay after exhaustion (preserved). 23/23; ui typecheck clean.

# Evidence

<!-- evidence-head:6b60bc67339bdf7b96c987d9d515a53a4b998667 -->
- Before screenshots: N/A - fix prevents a transient overlay; state transition covered by unit tests below
- After screenshots: N/A - see above
- Walkthrough video: N/A - see above
- OCR review: N/A - no rendered-pixel change
- Frontend console/network logs: live WS probes in #18172 (CLOSE 1002 / HTTP 200 on all four hosts)
- Backend logs: N/A - client-only change
- Real-LLM trajectory: N/A - no model path
- Domain artifacts:

```
bunx vitest run packages/ui/src/api/client-base-websocket.test.ts
 Tests  23 passed (23)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
