### PR TITLE
fix(ci): fail closed on non-public GHCR images (#18219)

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -493,50 +493,30 @@ jobs:
           subject-digest: ${{ steps.promote-demo.outputs.digest }}
           push-to-registry: true
 
-      - name: Make Docker image public
+      - name: Verify canonical image is anonymously pullable
         if: ${{ steps.image.outputs.publication_target == 'canonical' }}
-        # Idempotent — patching to public when already public is a no-op.
-        # Previously lived in image.yaml; folded in here on consolidation.
+        env:
+          EXPECTED_DIGEST: ${{ steps.push.outputs.digest }}
+          EXPECTED_IMAGE_ID: ${{ steps.push.outputs.image_id }}
+          GHCR_REPOSITORY: elizaos/eliza
+        # Package visibility is an organization setting; GitHub's Packages
+        # REST API exposes no visibility mutation. Prove the actual contract
+        # after bounded propagation retries instead of trusting the historical
+        # unsupported package-visibility request.
         run: |
-          curl \
-            -X PATCH \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/user/packages/container/${{ env.IMAGE_NAME }}/visibility \
-            -d '{"visibility":"public"}'
+          node packages/scripts/verify-ghcr-anonymous-manifest.mjs \
+            --repository "$GHCR_REPOSITORY" \
+            --digest "$EXPECTED_DIGEST" \
+            --image-id "$EXPECTED_IMAGE_ID"
 
       - name: Verify demo image is anonymously pullable
         if: ${{ steps.image.outputs.publication_target == 'demo' }}
         env:
           EXPECTED_DIGEST: ${{ steps.promote-demo.outputs.digest }}
           EXPECTED_IMAGE_ID: ${{ steps.push.outputs.image_id }}
+          GHCR_REPOSITORY: elizaos/eliza-demo
         run: |
-          set -euo pipefail
-          manifest_file="$(mktemp)"
-          headers_file="$(mktemp)"
-          trap 'rm -f "$manifest_file" "$headers_file"' EXIT
-          token="$(
-            curl --fail-with-body --silent --show-error \
-              'https://ghcr.io/token?scope=repository%3Aelizaos%2Feliza-demo%3Apull' |
-              jq -er '.token'
-          )"
-          curl --fail-with-body --silent --show-error \
-            --dump-header "$headers_file" \
-            --output "$manifest_file" \
-            -H 'Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json' \
-            -H "Authorization: Bearer $token" \
-            "https://ghcr.io/v2/elizaos/eliza-demo/manifests/$EXPECTED_DIGEST"
-          remote_digest="$(
-            tr -d '\r' < "$headers_file" |
-              awk 'tolower($1) == "docker-content-digest:" { print $2 }' |
-              tail -n 1
-          )"
-          remote_image_id="$(jq -er '.config.digest' "$manifest_file")"
-          if [ "$remote_digest" != "$EXPECTED_DIGEST" ]; then
-            echo "::error::Anonymous GHCR read returned a different manifest digest." >&2
-            exit 1
-          fi
-          if [ "$remote_image_id" != "$EXPECTED_IMAGE_ID" ]; then
-            echo "::error::Published demo manifest does not reference the boot-verified image config." >&2
-            exit 1
-          fi
+          node packages/scripts/verify-ghcr-anonymous-manifest.mjs \
+            --repository "$GHCR_REPOSITORY" \
+            --digest "$EXPECTED_DIGEST" \
+            --image-id "$EXPECTED_IMAGE_ID"

--- a/packages/scripts/__tests__/build-agent-image-workflow.test.ts
+++ b/packages/scripts/__tests__/build-agent-image-workflow.test.ts
@@ -304,23 +304,17 @@ describe("build-agent-image workflow", () => {
       "Verify demo image is anonymously pullable",
     );
     expect(publicProbe).toContain(
-      "https://ghcr.io/token?scope=repository%3Aelizaos%2Feliza-demo%3Apull",
+      "node packages/scripts/verify-ghcr-anonymous-manifest.mjs",
     );
-    expect(publicProbe).toContain(
-      "https://ghcr.io/v2/elizaos/eliza-demo/manifests/$EXPECTED_DIGEST",
-    );
-    expect(publicProbe).toContain(
-      'if [ "$remote_digest" != "$EXPECTED_DIGEST" ]',
-    );
-    expect(publicProbe).toContain(
-      'if [ "$remote_image_id" != "$EXPECTED_IMAGE_ID" ]',
-    );
+    expect(publicProbe).toContain('--repository "$GHCR_REPOSITORY"');
+    expect(publicProbe).toContain('--digest "$EXPECTED_DIGEST"');
+    expect(publicProbe).toContain('--image-id "$EXPECTED_IMAGE_ID"');
 
     expect(workflowText).toContain(
       `if: ${githubExpression("steps.image.outputs.publication_target == 'canonical'")}`,
     );
-    expect(workflowText).toContain(
-      `https://api.github.com/user/packages/container/${githubExpression("env.IMAGE_NAME")}/visibility`,
+    expect(workflowText).not.toContain(
+      "api.github.com/user/packages/container",
     );
     expect(workflowText).not.toContain(
       "api.github.com/orgs/elizaOS/packages/container/eliza-demo/visibility",
@@ -423,6 +417,43 @@ describe("build-agent-image workflow", () => {
     expect(runBlock).not.toContain("docker info || true");
     expect(runBlock).not.toContain("chmod 666");
     expect(runBlock).not.toContain("chmod 777");
+  });
+
+  test("proves canonical and demo publication through one anonymous verifier", () => {
+    const canonicalBlock = extractStepRunBlock(
+      "Verify canonical image is anonymously pullable",
+    );
+    const demoBlock = extractStepRunBlock(
+      "Verify demo image is anonymously pullable",
+    );
+
+    expect(canonicalBlock).toContain(
+      "node packages/scripts/verify-ghcr-anonymous-manifest.mjs",
+    );
+    expect(demoBlock).toBe(canonicalBlock);
+    expect(workflowText).toContain("GHCR_REPOSITORY: elizaos/eliza\n");
+    expect(workflowText).toContain("GHCR_REPOSITORY: elizaos/eliza-demo\n");
+    expect(workflowText).toContain(
+      `EXPECTED_DIGEST: ${githubExpression("steps.push.outputs.digest")}`,
+    );
+    expect(workflowText).toContain(
+      `EXPECTED_DIGEST: ${githubExpression("steps.promote-demo.outputs.digest")}`,
+    );
+    expect(workflowText).toContain(
+      `EXPECTED_IMAGE_ID: ${githubExpression("steps.push.outputs.image_id")}`,
+    );
+  });
+
+  test("does not retain the unsupported package-visibility mutation", () => {
+    const verificationBlocks = [
+      extractStepRunBlock("Verify canonical image is anonymously pullable"),
+      extractStepRunBlock("Verify demo image is anonymously pullable"),
+    ].join("\n");
+    expect(workflowText).not.toContain("/user/packages/");
+    expect(workflowText).not.toContain("/visibility");
+    expect(verificationBlocks).not.toContain("secrets.GITHUB_TOKEN");
+    expect(verificationBlocks).not.toContain("Authorization:");
+    expect(workflowStepNames()).not.toContain("Make Docker image public");
   });
 
   test("keeps Node ESM dist rewrite after the Turbo build", () => {

--- a/packages/scripts/__tests__/verify-ghcr-anonymous-manifest.test.ts
+++ b/packages/scripts/__tests__/verify-ghcr-anonymous-manifest.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Deterministic transport and integrity coverage for anonymous GHCR publication proof.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  GhcrVerificationError,
+  parseCliArguments,
+  verifyAnonymousGhcrManifest,
+} from "../verify-ghcr-anonymous-manifest.mjs";
+
+const DIGEST = `sha256:${"a".repeat(64)}`;
+const IMAGE_ID = `sha256:${"b".repeat(64)}`;
+
+function tokenResponse(token = "anonymous-token"): Response {
+  return Response.json({ token });
+}
+
+function manifestResponse({
+  digest = DIGEST,
+  imageId = IMAGE_ID,
+  status = 200,
+  body,
+}: {
+  digest?: string;
+  imageId?: string;
+  status?: number;
+  body?: string;
+} = {}): Response {
+  return new Response(body ?? JSON.stringify({ config: { digest: imageId } }), {
+    status,
+    headers: { "docker-content-digest": digest },
+  });
+}
+
+describe("anonymous GHCR manifest verification", () => {
+  test("accepts each CLI input exactly once and rejects ambiguous arguments", () => {
+    expect(
+      parseCliArguments([
+        "--digest",
+        DIGEST,
+        "--repository",
+        "elizaos/eliza",
+        "--image-id",
+        IMAGE_ID,
+      ]),
+    ).toEqual({
+      repository: "elizaos/eliza",
+      digest: DIGEST,
+      imageId: IMAGE_ID,
+    });
+    expect(() =>
+      parseCliArguments([
+        "--repository",
+        "elizaos/eliza",
+        "--repository",
+        "elizaos/eliza-demo",
+        "--digest",
+        DIGEST,
+        "--image-id",
+        IMAGE_ID,
+      ]),
+    ).toThrow("Expected one value each");
+    expect(() =>
+      parseCliArguments([
+        "--repository",
+        "elizaos/eliza",
+        "--digest",
+        DIGEST,
+        "--image-id",
+      ]),
+    ).toThrow("Expected one value each");
+  });
+
+  test("accepts only an anonymously readable exact manifest and image config", async () => {
+    const urls: string[] = [];
+    const result = await verifyAnonymousGhcrManifest({
+      repository: "ElizaOS/Eliza",
+      digest: DIGEST,
+      imageId: IMAGE_ID,
+      fetchImpl: async (input) => {
+        const url = String(input);
+        urls.push(url);
+        return url.includes("/token?") ? tokenResponse() : manifestResponse();
+      },
+      sleep: async () => {},
+    });
+
+    expect(result).toEqual({
+      repository: "elizaos/eliza",
+      digest: DIGEST,
+      imageId: IMAGE_ID,
+      attempts: 1,
+    });
+    expect(urls).toEqual([
+      "https://ghcr.io/token?scope=repository%3Aelizaos%2Feliza%3Apull",
+      `https://ghcr.io/v2/elizaos/eliza/manifests/${DIGEST}`,
+    ]);
+  });
+
+  test("retries propagation and then fails closed on persistent anonymous 404", async () => {
+    const retryMessages: string[] = [];
+    let fetchCount = 0;
+    const verification = verifyAnonymousGhcrManifest({
+      repository: "elizaos/eliza",
+      digest: DIGEST,
+      imageId: IMAGE_ID,
+      attempts: 3,
+      fetchImpl: async (input) => {
+        fetchCount += 1;
+        return String(input).includes("/token?")
+          ? tokenResponse()
+          : new Response("private-response-secret", { status: 404 });
+      },
+      sleep: async () => {},
+      onRetry: (message) => retryMessages.push(message),
+    });
+
+    await expect(verification).rejects.toEqual(
+      new GhcrVerificationError(
+        "Anonymous GHCR manifest request returned HTTP 404.",
+        { retryable: true },
+      ),
+    );
+    expect(fetchCount).toBe(6);
+    expect(retryMessages).toHaveLength(2);
+    expect(retryMessages.join("\n")).not.toContain("private-response-secret");
+  });
+
+  test("never retries an integrity mismatch", async () => {
+    let fetchCount = 0;
+    const verification = verifyAnonymousGhcrManifest({
+      repository: "elizaos/eliza",
+      digest: DIGEST,
+      imageId: IMAGE_ID,
+      fetchImpl: async (input) => {
+        fetchCount += 1;
+        return String(input).includes("/token?")
+          ? tokenResponse()
+          : manifestResponse({ digest: `sha256:${"c".repeat(64)}` });
+      },
+      sleep: async () => {},
+    });
+
+    await expect(verification).rejects.toThrow(
+      "Anonymous GHCR response returned a different manifest digest.",
+    );
+    expect(fetchCount).toBe(2);
+  });
+
+  test("fails closed without leaking malformed token or manifest bodies", async () => {
+    const tokenSecret = "token-response-secret-that-must-not-escape";
+    const malformedToken = verifyAnonymousGhcrManifest({
+      repository: "elizaos/eliza",
+      digest: DIGEST,
+      imageId: IMAGE_ID,
+      attempts: 1,
+      fetchImpl: async () => new Response(tokenSecret),
+      sleep: async () => {},
+    });
+    await expect(malformedToken).rejects.toThrow(
+      "Anonymous GHCR token request returned invalid JSON.",
+    );
+    await expect(malformedToken).rejects.not.toThrow(tokenSecret);
+
+    const manifestSecret = "manifest-response-secret-that-must-not-escape";
+    const malformedManifest = verifyAnonymousGhcrManifest({
+      repository: "elizaos/eliza",
+      digest: DIGEST,
+      imageId: IMAGE_ID,
+      attempts: 1,
+      fetchImpl: async (input) =>
+        String(input).includes("/token?")
+          ? tokenResponse()
+          : new Response(manifestSecret, {
+              headers: { "docker-content-digest": DIGEST },
+            }),
+      sleep: async () => {},
+    });
+    await expect(malformedManifest).rejects.toThrow(
+      "Anonymous GHCR manifest request returned invalid JSON.",
+    );
+    await expect(malformedManifest).rejects.not.toThrow(manifestSecret);
+  });
+
+  test("retries transport failures but preserves a sanitized typed cause chain", async () => {
+    const transportFailure = new Error(
+      "socket included a credential-shaped secret",
+    );
+    let fetchCount = 0;
+    const verification = verifyAnonymousGhcrManifest({
+      repository: "elizaos/eliza",
+      digest: DIGEST,
+      imageId: IMAGE_ID,
+      attempts: 2,
+      fetchImpl: async () => {
+        fetchCount += 1;
+        throw transportFailure;
+      },
+      sleep: async () => {},
+      onRetry: () => {},
+    });
+
+    try {
+      await verification;
+      throw new Error("verification unexpectedly succeeded");
+    } catch (error) {
+      expect(error).toBeInstanceOf(GhcrVerificationError);
+      expect((error as Error).message).toBe(
+        "Anonymous GHCR token request failed before receiving an HTTP response.",
+      );
+      expect((error as Error).message).not.toContain("credential-shaped");
+      expect((error as Error).cause).toBe(transportFailure);
+    }
+    expect(fetchCount).toBe(2);
+  });
+
+  test("rejects image-config drift and invalid retry configuration", async () => {
+    const verification = verifyAnonymousGhcrManifest({
+      repository: "elizaos/eliza",
+      digest: DIGEST,
+      imageId: IMAGE_ID,
+      fetchImpl: async (input) =>
+        String(input).includes("/token?")
+          ? tokenResponse()
+          : manifestResponse({ imageId: `sha256:${"c".repeat(64)}` }),
+      sleep: async () => {},
+    });
+    await expect(verification).rejects.toThrow(
+      "Published manifest does not reference the boot-verified image config.",
+    );
+    await expect(
+      verifyAnonymousGhcrManifest({
+        repository: "elizaos/eliza",
+        digest: DIGEST,
+        imageId: IMAGE_ID,
+        attempts: 0,
+      }),
+    ).rejects.toThrow("attempts must be an integer from 1 to 10");
+  });
+
+  test("rejects malformed repository and digest inputs before networking", async () => {
+    let fetchCount = 0;
+    const fetchImpl = async () => {
+      fetchCount += 1;
+      return tokenResponse();
+    };
+
+    await expect(
+      verifyAnonymousGhcrManifest({
+        repository: "elizaos/eliza/extra",
+        digest: DIGEST,
+        imageId: IMAGE_ID,
+        fetchImpl,
+      }),
+    ).rejects.toThrow("exactly one owner/name pair");
+    await expect(
+      verifyAnonymousGhcrManifest({
+        repository: "elizaos/eliza",
+        digest: "develop",
+        imageId: IMAGE_ID,
+        fetchImpl,
+      }),
+    ).rejects.toThrow("EXPECTED_DIGEST must be a sha256 digest");
+    expect(fetchCount).toBe(0);
+  });
+});

--- a/packages/scripts/verify-ghcr-anonymous-manifest.mjs
+++ b/packages/scripts/verify-ghcr-anonymous-manifest.mjs
@@ -1,0 +1,242 @@
+/**
+ * Proves that a published GHCR digest is anonymously readable and still
+ * references the locally boot-verified image configuration.
+ */
+
+import { pathToFileURL } from "node:url";
+
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const REPOSITORY_PATTERN = /^[a-z0-9._-]+\/[a-z0-9._-]+$/;
+const MANIFEST_ACCEPT = [
+  "application/vnd.docker.distribution.manifest.v2+json",
+  "application/vnd.oci.image.manifest.v1+json",
+].join(", ");
+
+export class GhcrVerificationError extends Error {
+  constructor(message, { retryable = false, cause } = {}) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = "GhcrVerificationError";
+    this.retryable = retryable;
+  }
+}
+
+export function parseCliArguments(argumentsList) {
+  const allowedNames = new Set(["--repository", "--digest", "--image-id"]);
+  const values = new Map();
+  for (let index = 0; index < argumentsList.length; index += 2) {
+    const name = argumentsList[index];
+    const value = argumentsList[index + 1];
+    if (!allowedNames.has(name) || !value || values.has(name)) {
+      throw new GhcrVerificationError(
+        "Expected one value each for --repository, --digest, and --image-id.",
+      );
+    }
+    values.set(name, value);
+  }
+  if (values.size !== allowedNames.size) {
+    throw new GhcrVerificationError(
+      "Expected one value each for --repository, --digest, and --image-id.",
+    );
+  }
+  return {
+    repository: values.get("--repository"),
+    digest: values.get("--digest"),
+    imageId: values.get("--image-id"),
+  };
+}
+
+function requireDigest(name, value) {
+  if (!DIGEST_PATTERN.test(value ?? "")) {
+    throw new GhcrVerificationError(`${name} must be a sha256 digest.`);
+  }
+  return value;
+}
+
+function requireRepository(value) {
+  const normalized = value?.toLowerCase();
+  if (!REPOSITORY_PATTERN.test(normalized ?? "")) {
+    throw new GhcrVerificationError(
+      "GHCR_REPOSITORY must contain exactly one owner/name pair.",
+    );
+  }
+  return normalized;
+}
+
+async function fetchWithoutLeakingResponse(fetchImpl, url, init, label) {
+  let response;
+  try {
+    response = await fetchImpl(url, init);
+  } catch (error) {
+    // error-policy:J2 preserve the transport failure as the cause while
+    // replacing its potentially sensitive message with verifier-owned context.
+    throw new GhcrVerificationError(
+      `${label} failed before receiving an HTTP response.`,
+      { retryable: true, cause: error },
+    );
+  }
+  if (!response.ok) {
+    throw new GhcrVerificationError(
+      `${label} returned HTTP ${response.status}.`,
+      { retryable: true },
+    );
+  }
+  return response;
+}
+
+async function parseJsonWithoutLeakingResponse(response, label) {
+  try {
+    return await response.json();
+  } catch (error) {
+    // error-policy:J2 preserve the parser failure as the cause without
+    // including registry-controlled response bytes in workflow output.
+    throw new GhcrVerificationError(`${label} returned invalid JSON.`, {
+      retryable: true,
+      cause: error,
+    });
+  }
+}
+
+async function verifyOnce({ repository, digest, imageId, fetchImpl }) {
+  const scope = encodeURIComponent(`repository:${repository}:pull`);
+  const tokenResponse = await fetchWithoutLeakingResponse(
+    fetchImpl,
+    `https://ghcr.io/token?scope=${scope}`,
+    {
+      headers: { Accept: "application/json" },
+      redirect: "error",
+      signal: AbortSignal.timeout(15_000),
+    },
+    "Anonymous GHCR token request",
+  );
+  const tokenPayload = await parseJsonWithoutLeakingResponse(
+    tokenResponse,
+    "Anonymous GHCR token request",
+  );
+  const token = tokenPayload?.token;
+  if (typeof token !== "string" || token.length === 0) {
+    throw new GhcrVerificationError(
+      "Anonymous GHCR token response did not contain a token.",
+      { retryable: true },
+    );
+  }
+
+  const manifestResponse = await fetchWithoutLeakingResponse(
+    fetchImpl,
+    `https://ghcr.io/v2/${repository}/manifests/${digest}`,
+    {
+      headers: {
+        Accept: MANIFEST_ACCEPT,
+        Authorization: `Bearer ${token}`,
+      },
+      redirect: "error",
+      signal: AbortSignal.timeout(15_000),
+    },
+    "Anonymous GHCR manifest request",
+  );
+  const remoteDigest = manifestResponse.headers.get("docker-content-digest");
+  if (remoteDigest !== digest) {
+    throw new GhcrVerificationError(
+      "Anonymous GHCR response returned a different manifest digest.",
+    );
+  }
+  const manifest = await parseJsonWithoutLeakingResponse(
+    manifestResponse,
+    "Anonymous GHCR manifest request",
+  );
+  if (manifest?.config?.digest !== imageId) {
+    throw new GhcrVerificationError(
+      "Published manifest does not reference the boot-verified image config.",
+    );
+  }
+}
+
+export async function verifyAnonymousGhcrManifest({
+  repository,
+  digest,
+  imageId,
+  fetchImpl = globalThis.fetch,
+  attempts = 6,
+  sleep = (milliseconds) =>
+    new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  onRetry = (message) => console.warn(message),
+}) {
+  const validatedRepository = requireRepository(repository);
+  const validatedDigest = requireDigest("EXPECTED_DIGEST", digest);
+  const validatedImageId = requireDigest("EXPECTED_IMAGE_ID", imageId);
+  if (!Number.isInteger(attempts) || attempts < 1 || attempts > 10) {
+    throw new GhcrVerificationError(
+      "attempts must be an integer from 1 to 10.",
+    );
+  }
+  if (typeof fetchImpl !== "function") {
+    throw new GhcrVerificationError("A fetch implementation is required.");
+  }
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      await verifyOnce({
+        repository: validatedRepository,
+        digest: validatedDigest,
+        imageId: validatedImageId,
+        fetchImpl,
+      });
+      return {
+        repository: validatedRepository,
+        digest: validatedDigest,
+        imageId: validatedImageId,
+        attempts: attempt,
+      };
+    } catch (error) {
+      // error-policy:J1 this CI verification boundary retries only typed,
+      // explicitly transient registry failures and otherwise fails closed.
+      const verificationError =
+        error instanceof GhcrVerificationError
+          ? error
+          : new GhcrVerificationError("Anonymous GHCR verification failed.", {
+              cause: error,
+            });
+      if (!verificationError.retryable || attempt === attempts) {
+        throw verificationError;
+      }
+      const delayMilliseconds = Math.min(2 ** (attempt - 1) * 2_000, 10_000);
+      onRetry(
+        `${verificationError.message} Retrying anonymous verification (${attempt + 1}/${attempts}) after ${delayMilliseconds}ms.`,
+      );
+      await sleep(delayMilliseconds);
+    }
+  }
+
+  throw new GhcrVerificationError(
+    "Anonymous GHCR verification exhausted retries.",
+  );
+}
+
+async function main() {
+  try {
+    const inputs = parseCliArguments(process.argv.slice(2));
+    const result = await verifyAnonymousGhcrManifest({
+      repository: inputs.repository,
+      digest: inputs.digest,
+      imageId: inputs.imageId,
+    });
+    console.log(
+      `Anonymous GHCR verification passed for ${result.repository}@${result.digest} after ${result.attempts} attempt(s).`,
+    );
+  } catch (error) {
+    // error-policy:J1 the executable boundary emits one sanitized annotation
+    // and preserves failure through the process exit code.
+    const message =
+      error instanceof GhcrVerificationError
+        ? error.message
+        : "Anonymous GHCR verification failed.";
+    console.error(`::error::${message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}


### PR DESCRIPTION
Closes #18219

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - contribute-to-eliza skill was not available`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Summary

The canonical agent-image workflow could report success even though its `Make Docker image public` request returned `404`. The deeper defect was not just missing `curl --fail`: the request targeted a package-visibility mutation that GitHub's documented Packages REST API does not expose. Treating any status as success would be wrong, but accepting a `200` from an unsupported endpoint would still be a brittle non-contract.

This repair removes that request and makes the actual publication contract fail closed:

- canonical and demo publications use one checked-in anonymous GHCR verifier;
- the verifier obtains an anonymous pull token, reads the exact digest, and requires both the `Docker-Content-Digest` and manifest config digest to match the image that booted locally;
- expected propagation failures receive bounded exponential retries, while integrity mismatches fail immediately;
- repository/digest/CLI inputs are validated before networking;
- transport and JSON failures preserve their causes internally while workflow output remains sanitized;
- no registry token or response body is emitted.

If the package is private, unavailable, points at different bytes, or cannot be proven public within the retry window, the workflow fails. Visibility remains an organization/package setting managed through GitHub's supported control surface.

## Behavioral proof

The verifier was exercised read-only against the exact canonical digest recorded in #18219. Anonymous GHCR returned the expected manifest and the verifier matched its config digest in one attempt:

```json
{"repository":"elizaos/eliza","digest":"sha256:cd5052ff0d4a953a5d4f2075989229ec652908bbc2c749788679738888b0151c","imageId":"sha256:1a70beac997667396d7ae638df6c9049cbda408fc17d9b268c2f13ef1bb66a65","attempts":1}
```

Deterministic transport coverage proves anonymous success, persistent `404`, transient transport failure, malformed token and manifest JSON, digest drift, image-config drift, invalid arguments, retry bounds, cause preservation, and response-secret non-disclosure.

## Pre-rebase full-path verification (source-equivalent implementation)

- `bun install` with Bun 1.3.14: passed; dependency graph unchanged
- workflow plus verifier suites: **19 passed, 0 failed, 126 assertions**
- `actionlint .github/workflows/build-agent-image.yml`: passed
- live anonymous canonical manifest/config verification: passed in one attempt
- `bun run verify`: passed across the full 140-package typecheck/lint/audit graph
- `git diff --check`: passed
- based on `origin/develop@e662c1e7c8f8ac0cacdaf2b51297c25cc434524b`

The noncanonical direct command `bun test packages/scripts/__tests__` is not used as proof: before the supported verification graph built workspace exports it hit an existing `@elizaos/core` resolution-order error; after the build it completed the assertions but Bun terminated with an internal `WriteFailed` while printing the enormous coverage table. The focused owning suites and the repository's supported `bun run verify` gate both pass.

## Exact rebase verification

On `cbc0330caac28c51c8d3e08925d7f3f5be82a92a`, rebased onto `origin/develop@48ba913c07e7d1ef76618a406bee7c36cbdc6348`:

- workflow and verifier suites: **19 passed, 0 failed, 126 assertions**
- `actionlint .github/workflows/build-agent-image.yml`: passed
- `bun run verify`: **348/348 tasks passed**
- `git diff --check`: passed

## Evidence matrix

<!-- evidence-head:cbc0330caac28c51c8d3e08925d7f3f5be82a92a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI publication workflow with no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI publication workflow with no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CI publication workflow with no rendered UI surface.

<!-- evidence-row:backend-logs -->
- [x] Exact-tree verification transcript:

<details><summary>workflow and repository verification output</summary>

```text
bun test build-agent-image-workflow + verify-ghcr-anonymous-manifest — 19 passed, 0 failed, 126 assertions
actionlint .github/workflows/build-agent-image.yml — exit 0, no diagnostics
bun run verify — 348/348 Turbo tasks successful; all repository audits passed
live anonymous GHCR verification — canonical digest/config matched in 1 attempt
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic CI publication logic with no model or agent path.

<!-- evidence-row:domain-artifacts -->
- [x] Live anonymous registry result:

<details><summary>canonical GHCR publication receipt</summary>

```json
{
  "repository": "elizaos/eliza",
  "digest": "sha256:cd5052ff0d4a953a5d4f2075989229ec652908bbc2c749788679738888b0151c",
  "imageId": "sha256:1a70beac997667396d7ae638df6c9049cbda408fc17d9b268c2f13ef1bb66a65",
  "attempts": 1
}
```

</details>

<!-- evidence-row:ocr-review -->
- [ ] N/A - CI publication workflow with no visual surface.

---

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: N/A - contribute-to-eliza skill was not available
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex","skill_revision":"N/A - contribute-to-eliza skill was not available"} -->


<!-- evidence-refresh:2026-08-10T18:55Z -->