### PR TITLE
fix(ui): default runtime chooser ON in Vite dev mode

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -574,9 +574,9 @@ installPackagedShellStorageTestBridge();
 // Branded AOSP/ElizaOS device images ARE the agent: pre-seed the on-device
 // agent as the startup target on first frame. Stock-phone sideload builds
 // self-exclude inside preSeedAndroidLocalRuntimeIfFresh (#14390): a fresh
-// install lands in onboarding, whose runtime chooser (enabled by default on
-// those builds) starts the local agent on demand only after the user picks
-// it. No-op on iOS/desktop/web and cloud builds.
+// install lands in onboarding; when that build explicitly enables the runtime
+// chooser, the local agent starts on demand only after the user picks it.
+// No-op on iOS/desktop/web and cloud builds.
 if (!hasFirstRunRuntimeOverride()) {
   preSeedAndroidLocalRuntimeIfFresh();
 }

--- a/packages/app/test/dev-smoke/runtime-chooser-default.spec.ts
+++ b/packages/app/test/dev-smoke/runtime-chooser-default.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Proves the runtime chooser's default through the real `bun run dev` Vite
+ * transform and renderer, with deterministic first-run HTTP boundaries.
+ */
+
+import { mkdir } from "node:fs/promises";
+import { expect, type Page, type Route, test } from "@playwright/test";
+import {
+  expectNoRenderTelemetryErrors,
+  installDefaultAppRoutes,
+  installRenderTelemetryGuard,
+  seedAppStorage,
+} from "../ui-smoke/helpers";
+
+async function fulfillJson(
+  route: Route,
+  status: number,
+  body: Record<string, unknown>,
+): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function routeFreshFirstRun(page: Page): Promise<void> {
+  await page.route("**/api/auth/status", async (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await fulfillJson(route, 200, {
+      required: false,
+      authenticated: true,
+      loginRequired: false,
+      localAccess: true,
+      passwordConfigured: false,
+      pairingEnabled: false,
+      expiresAt: null,
+    });
+  });
+  await page.route("**/api/first-run/status", async (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await fulfillJson(route, 200, { complete: false, cloudProvisioned: false });
+  });
+}
+
+test("Vite development offers cloud, local, and remote without an override", async ({
+  page,
+}, testInfo) => {
+  await installRenderTelemetryGuard(page);
+  await installDefaultAppRoutes(page);
+  await routeFreshFirstRun(page);
+  await page.addInitScript(() => {
+    const win = window as unknown as Record<string, unknown>;
+    win.__ELIZA_APP_API_BASE__ = window.location.origin;
+    win.__ELIZAOS_APP_BOOT_CONFIG__ = { apiBase: window.location.origin };
+    win.__electrobunWindowId = 1;
+  });
+  await seedAppStorage(page, {
+    "eliza:first-run-complete": "",
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  await expect(
+    page.getByText("First, where should your agent run?", { exact: false }),
+  ).toBeVisible({ timeout: 20_000 });
+  for (const runtime of ["cloud", "local", "remote"]) {
+    await expect(
+      page.getByTestId(`choice-__first_run__:runtime:${runtime}`),
+    ).toBeVisible();
+  }
+  expect(
+    await page.evaluate(() =>
+      localStorage.getItem("eliza:enable-runtime-chooser"),
+    ),
+  ).toBeNull();
+  await expectNoRenderTelemetryErrors(page, "Vite development runtime chooser");
+
+  await mkdir(testInfo.outputDir, { recursive: true });
+  async function capture(name: string): Promise<void> {
+    const screenshotPath = testInfo.outputPath(`${name}.png`);
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    await testInfo.attach(name, {
+      path: screenshotPath,
+      contentType: "image/png",
+    });
+  }
+
+  await capture("runtime-chooser-vite-development-desktop-rest");
+  await page.getByTestId("choice-__first_run__:runtime:local").hover();
+  await capture("runtime-chooser-vite-development-desktop-hover");
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.reload({ waitUntil: "domcontentloaded" });
+  for (const runtime of ["cloud", "local", "remote"]) {
+    await expect(
+      page.getByTestId(`choice-__first_run__:runtime:${runtime}`),
+    ).toBeVisible();
+  }
+  await capture("runtime-chooser-vite-development-mobile-rest");
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.addInitScript(() =>
+    localStorage.setItem("eliza:enable-runtime-chooser", "0"),
+  );
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(
+    page.getByText("Sign in to Eliza Cloud", { exact: true }),
+  ).toBeVisible();
+  for (const runtime of ["local", "remote"]) {
+    await expect(
+      page.getByTestId(`choice-__first_run__:runtime:${runtime}`),
+    ).toHaveCount(0);
+  }
+  await capture("runtime-chooser-before-cloud-only-desktop");
+});

--- a/packages/app/test/ui-smoke/onboarding-cloud-only.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-cloud-only.spec.ts
@@ -3,8 +3,9 @@
  *
  * Unlike the onboarding-to-home lanes (which opt in to the dev-only runtime
  * chooser via injectFullCapabilityHost), these specs boot the app exactly as a
- * shipped build does: no chooser override, so onboarding is the single
- * "Sign in to Eliza Cloud" step. Covered: the sign-in-only greeting (no
+ * shipped build does: an explicit `"0"` override reproduces the production
+ * default while the Playwright Vite server intentionally defaults development
+ * to the chooser. Covered: the sign-in-only greeting (no
  * local/remote options), the tap-driven flow to a real completion at
  * provisioning success (no tutorial gate), session injection (a stored steward
  * session skips the sign-in ask — zero interactions to the onboarded home),
@@ -67,7 +68,10 @@ test.describe("cloud-only onboarding (production default)", () => {
     // Zero existing cloud agents: the bind is a silent auto-provision, so the
     // whole flow is greeting → one tap → onboarded home.
     await installCloudRoutes(page, { agentCount: 0 });
-    await seedAppStorage(page, { "eliza:first-run-complete": "" });
+    await seedAppStorage(page, {
+      "eliza:first-run-complete": "",
+      "eliza:enable-runtime-chooser": "0",
+    });
 
     await page.goto("/", { waitUntil: "domcontentloaded" });
 
@@ -89,7 +93,10 @@ test.describe("cloud-only onboarding (production default)", () => {
     await injectCloudAuthToken(page);
     const state = await installHomeRoutes(page);
     await installCloudRoutes(page, { agentCount: 0 });
-    await seedAppStorage(page, { "eliza:first-run-complete": "" });
+    await seedAppStorage(page, {
+      "eliza:first-run-complete": "",
+      "eliza:enable-runtime-chooser": "0",
+    });
 
     await page.goto("/", { waitUntil: "domcontentloaded" });
 
@@ -108,7 +115,10 @@ test.describe("cloud-only onboarding (production default)", () => {
     await injectCloudAuthToken(page);
     const state = await installHomeRoutes(page);
     await installCloudRoutes(page);
-    await seedAppStorage(page, { "eliza:first-run-complete": "" });
+    await seedAppStorage(page, {
+      "eliza:first-run-complete": "",
+      "eliza:enable-runtime-chooser": "0",
+    });
 
     await page.goto("/", { waitUntil: "domcontentloaded" });
 

--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -255,10 +255,10 @@ export async function injectFullCapabilityHost(page: Page): Promise<void> {
     win.__ELIZAOS_APP_BOOT_CONFIG__ = { apiBase: origin };
     win.__ELIZAOS_API_BASE__ = origin;
     win.__electrobunWindowId = 1;
-    // The runtime chooser (local/remote onboarding paths) is OFF by default
-    // (#13377, cloud-only onboarding). A full-capability host is exactly the
-    // environment where the Local runtime is testable, so these lanes opt in;
-    // the cloud-only default is covered by onboarding-cloud-only.spec.ts.
+    // Production remains cloud-only by default (#13377). These helpers also run
+    // against packaged builds where Vite's development default is absent, so
+    // opt in explicitly; the production default is covered by
+    // onboarding-cloud-only.spec.ts with the inverse override.
     window.localStorage.setItem("eliza:enable-runtime-chooser", "1");
   });
 }
@@ -1006,8 +1006,8 @@ export async function completeCloudOnboardingToHome(
 
 // ── Cloud-only onboarding (#13377) — the production default ─────────────────
 //
-// With the runtime chooser OFF (no eliza:enable-runtime-chooser override, no
-// VITE_ELIZA_ENABLE_RUNTIME_CHOOSER build flag) onboarding is a single
+// With the runtime chooser OFF (explicit override, or a production build with
+// no VITE_ELIZA_ENABLE_RUNTIME_CHOOSER build flag) onboarding is a single
 // "Sign in to Eliza Cloud" step: the greeting seeds ONE choice button, a
 // usable stored session skips the ask entirely, and provisioning success
 // completes first-run for real — no tutorial/accent completion gate.

--- a/packages/app/test/ui-smoke/runtime-configurability.spec.ts
+++ b/packages/app/test/ui-smoke/runtime-configurability.spec.ts
@@ -85,8 +85,9 @@ test("in-chat first-run exposes cloud and local runtimes and Local is configurab
   await injectFullCapabilityHost(page);
   await seedAppStorage(page, {
     "eliza:first-run-complete": "",
-    // These specs drive the Local/on-device runtime cards; the chooser is off
-    // by default since cloud-only onboarding (#13377/#15532) - opt back in.
+    // This suite serves the production renderer bundle, so opt into the
+    // retained local/remote paths explicitly. The Vite-development default is
+    // exercised against `bun run dev` in the dev-smoke lane.
     "eliza:enable-runtime-chooser": "1",
   });
 
@@ -137,8 +138,6 @@ test("in-chat first-run survives browser back and forward while it churns", asyn
   await injectFullCapabilityHost(page);
   await seedAppStorage(page, {
     "eliza:first-run-complete": "",
-    // These specs drive the Local/on-device runtime cards; the chooser is off
-    // by default since cloud-only onboarding (#13377/#15532) - opt back in.
     "eliza:enable-runtime-chooser": "1",
   });
 

--- a/packages/ui/src/first-run/first-run-runtime-flag.test.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.test.ts
@@ -1,14 +1,10 @@
-/** Verifies isRuntimeChooserEnabled through the package's configured test harness. */
-// @vitest-environment jsdom
-
 /**
- * The runtime-chooser gate (#13377/#15527): cloud-only onboarding is the
- * default on production builds; the localStorage override flips it without a
- * rebuild; Vite dev mode (`bun run dev`) defaults it to ON so developers can
- * pick local without manual configuration; the Play-Store cloud-locked Android
- * build can never re-enable it; and Android local sideload/system builds follow
- * the same cloud-only default unless a developer/test lane opts into the chooser.
+ * Verifies the runtime-chooser gate through the package's jsdom harness.
+ * Cloud-only onboarding is the production default; Vite development and
+ * explicit overrides expose local and remote choices, while the Play-Store
+ * cloud-locked Android invariant remains absolute.
  */
+// @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/first-run/first-run-runtime-flag.test.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.test.ts
@@ -3,10 +3,11 @@
 
 /**
  * The runtime-chooser gate (#13377/#15527): cloud-only onboarding is the
- * default on web/desktop builds; the localStorage override flips it without a
- * rebuild; the Play-Store cloud-locked Android build can never re-enable it;
- * and Android local sideload/system builds follow the same cloud-only default
- * unless a developer/test lane opts into the chooser.
+ * default on production builds; the localStorage override flips it without a
+ * rebuild; Vite dev mode (`bun run dev`) defaults it to ON so developers can
+ * pick local without manual configuration; the Play-Store cloud-locked Android
+ * build can never re-enable it; and Android local sideload/system builds follow
+ * the same cloud-only default unless a developer/test lane opts into the chooser.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -37,23 +38,23 @@ afterEach(() => {
 });
 
 describe("isRuntimeChooserEnabled", () => {
-  it("defaults to OFF — cloud-only onboarding is the production default", () => {
-    expect(isRuntimeChooserEnabled()).toBe(false);
-  });
-
-  it("the localStorage override enables the chooser without a rebuild", () => {
-    localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "1");
+  it("defaults to ON in Vite dev mode so developers can choose local", () => {
     expect(isRuntimeChooserEnabled()).toBe(true);
   });
 
-  it("an explicit '0' override keeps the chooser off", () => {
+  it("the localStorage '0' override disables the chooser even in dev mode", () => {
     localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "0");
     expect(isRuntimeChooserEnabled()).toBe(false);
   });
 
-  it("garbage override values fall back to the build default (off)", () => {
+  it("the localStorage '1' override enables the chooser without a rebuild", () => {
+    localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "1");
+    expect(isRuntimeChooserEnabled()).toBe(true);
+  });
+
+  it("garbage override values fall back to the build default (dev=on)", () => {
     localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "yes please");
-    expect(isRuntimeChooserEnabled()).toBe(false);
+    expect(isRuntimeChooserEnabled()).toBe(true);
   });
 
   it("the cloud-locked Android build can never re-enable the chooser", () => {
@@ -62,8 +63,12 @@ describe("isRuntimeChooserEnabled", () => {
     expect(isRuntimeChooserEnabled()).toBe(false);
   });
 
-  it("the Android local sideload build still defaults the chooser OFF", () => {
+  it("the Android local sideload build still respects an explicit '0' override", () => {
+    // In vitest import.meta.env.DEV is statically replaced with true, so we
+    // can't simulate a production Android build here. Instead verify the
+    // explicit '0' override keeps the chooser off on the sideload build.
     mocks.isAndroidLocalSideloadBuild.mockReturnValue(true);
+    localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "0");
     expect(isRuntimeChooserEnabled()).toBe(false);
   });
 

--- a/packages/ui/src/first-run/first-run-runtime-flag.test.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.test.ts
@@ -14,23 +14,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   isAndroidCloudBuild: vi.fn(() => false),
-  isAndroidLocalSideloadBuild: vi.fn(() => false),
 }));
 
 vi.mock("../platform/android-runtime", () => ({
   isAndroidCloudBuild: mocks.isAndroidCloudBuild,
-  isAndroidLocalSideloadBuild: mocks.isAndroidLocalSideloadBuild,
 }));
 
 import {
   isRuntimeChooserEnabled,
   RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY,
+  resolveRuntimeChooserEnabled,
 } from "./first-run-runtime-flag";
 
 beforeEach(() => {
   localStorage.clear();
   mocks.isAndroidCloudBuild.mockReturnValue(false);
-  mocks.isAndroidLocalSideloadBuild.mockReturnValue(false);
 });
 
 afterEach(() => {
@@ -38,11 +36,13 @@ afterEach(() => {
 });
 
 describe("isRuntimeChooserEnabled", () => {
-  it("defaults to ON in Vite dev mode so developers can choose local", () => {
-    expect(isRuntimeChooserEnabled()).toBe(true);
+  it("keeps test mode cloud-only instead of mistaking DEV=true for the dev server", () => {
+    expect(import.meta.env.DEV).toBe(true);
+    expect(import.meta.env.MODE).toBe("test");
+    expect(isRuntimeChooserEnabled()).toBe(false);
   });
 
-  it("the localStorage '0' override disables the chooser even in dev mode", () => {
+  it("the localStorage '0' override disables the chooser", () => {
     localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "0");
     expect(isRuntimeChooserEnabled()).toBe(false);
   });
@@ -52,9 +52,9 @@ describe("isRuntimeChooserEnabled", () => {
     expect(isRuntimeChooserEnabled()).toBe(true);
   });
 
-  it("garbage override values fall back to the build default (dev=on)", () => {
+  it("garbage override values fall back to the build default", () => {
     localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "yes please");
-    expect(isRuntimeChooserEnabled()).toBe(true);
+    expect(isRuntimeChooserEnabled()).toBe(false);
   });
 
   it("the cloud-locked Android build can never re-enable the chooser", () => {
@@ -62,19 +62,63 @@ describe("isRuntimeChooserEnabled", () => {
     localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "1");
     expect(isRuntimeChooserEnabled()).toBe(false);
   });
+});
 
-  it("the Android local sideload build still respects an explicit '0' override", () => {
-    // In vitest import.meta.env.DEV is statically replaced with true, so we
-    // can't simulate a production Android build here. Instead verify the
-    // explicit '0' override keeps the chooser off on the sideload build.
-    mocks.isAndroidLocalSideloadBuild.mockReturnValue(true);
-    localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "0");
-    expect(isRuntimeChooserEnabled()).toBe(false);
+describe("resolveRuntimeChooserEnabled", () => {
+  const productionDefaults = {
+    isCloudLockedAndroid: false,
+    override: null,
+    isViteDev: false,
+    isBuildEnabled: false,
+  } as const;
+
+  it("keeps an unflagged production build cloud-only", () => {
+    expect(resolveRuntimeChooserEnabled(productionDefaults)).toBe(false);
   });
 
-  it("an explicit '1' override enables the chooser on the sideload build", () => {
-    mocks.isAndroidLocalSideloadBuild.mockReturnValue(true);
-    localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "1");
-    expect(isRuntimeChooserEnabled()).toBe(true);
+  it("enables an unflagged Vite development build", () => {
+    expect(
+      resolveRuntimeChooserEnabled({
+        ...productionDefaults,
+        isViteDev: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows an explicit build flag in production", () => {
+    expect(
+      resolveRuntimeChooserEnabled({
+        ...productionDefaults,
+        isBuildEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("gives either explicit runtime override precedence over both defaults", () => {
+    expect(
+      resolveRuntimeChooserEnabled({
+        ...productionDefaults,
+        override: true,
+      }),
+    ).toBe(true);
+    expect(
+      resolveRuntimeChooserEnabled({
+        ...productionDefaults,
+        override: false,
+        isViteDev: true,
+        isBuildEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps a cloud-locked Android build disabled under every opt-in", () => {
+    expect(
+      resolveRuntimeChooserEnabled({
+        isCloudLockedAndroid: true,
+        override: true,
+        isViteDev: true,
+        isBuildEnabled: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/ui/src/first-run/first-run-runtime-flag.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.ts
@@ -1,14 +1,17 @@
 /**
  * Gate for the first-run runtime chooser (the local / remote onboarding paths).
  *
- * The product onboards through Eliza Cloud only by default (#13377/#15527): the
- * chooser is OFF unless a developer/test build explicitly enables it. The
- * Play-Store cloud-locked Android variant can never enable the chooser because
- * that build must not expose a local backend regardless of developer overrides.
- * The local and remote paths stay in-tree for development: a build can enable
- * the chooser with `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=1`, and tests or a
- * running shell can flip the localStorage override without a rebuild (explicit
- * "1"/"0" beats the build default).
+ * The product onboards through Eliza Cloud only by default in production
+ * (#13377/#15527): the chooser is OFF unless a developer/test build explicitly
+ * enables it. In Vite dev mode (`bun run dev`), the chooser defaults to ON so
+ * developers see the full local/cloud/remote options without manual flag-wiring.
+ * The Play-Store cloud-locked Android variant can never enable the chooser
+ * because that build must not expose a local backend regardless of developer
+ * overrides. The local and remote paths stay in-tree for development: a
+ * production build can enable the chooser with
+ * `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=1`, and tests or a running shell can flip
+ * the localStorage override without a rebuild (explicit "1"/"0" beats the
+ * build default).
  */
 
 import { isAndroidCloudBuild } from "../platform/android-runtime";
@@ -32,28 +35,49 @@ function readOverride(): boolean | null {
   }
 }
 
-function readBuildDefault(): boolean {
-  // import.meta.env is statically replaced by Vite at compile time, so this
-  // read collapses to a constant in the shipped bundle.
-  const env =
+function readEnv(): Record<string, unknown> {
+  if (
     typeof import.meta !== "undefined" &&
     (import.meta as { env?: Record<string, unknown> }).env
-      ? (import.meta as { env: Record<string, unknown> }).env
-      : {};
-  return env.VITE_ELIZA_ENABLE_RUNTIME_CHOOSER === "1";
+  ) {
+    return (import.meta as { env: Record<string, unknown> }).env;
+  }
+  return {};
+}
+
+/**
+ * True only when running under the Vite dev server (`bun run dev`). The
+ * runtime chooser defaults to ON in this mode so developers can pick
+ * local/cloud/remote without setting the localStorage override or the
+ * VITE_ELIZA_ENABLE_RUNTIME_CHOOSER flag. Production builds compile
+ * `import.meta.env.DEV` to `false`, so this is a no-op in shipped bundles.
+ */
+function readDevMode(): boolean {
+  return readEnv().DEV === true;
+}
+
+function readBuildDefault(): boolean {
+  return readEnv().VITE_ELIZA_ENABLE_RUNTIME_CHOOSER === "1";
 }
 
 /**
  * Whether onboarding offers the full runtime chooser (cloud / local / remote).
  * False (the default on production builds) means cloud-only onboarding:
  * sign in to Eliza Cloud is the one and only path, and completing it completes
- * first-run. Development and test builds opt into the local/remote chooser via
- * the Vite flag or the localStorage override; Android local sideloads no longer
- * special-case the production default.
+ * first-run. In Vite dev mode (`bun run dev`) the chooser defaults to ON so
+ * developers can choose local without manual configuration. Production and
+ * test builds opt into the local/remote chooser via the Vite flag or the
+ * localStorage override; Android local sideloads no longer special-case the
+ * production default.
  */
 export function isRuntimeChooserEnabled(): boolean {
   if (isAndroidCloudBuild()) return false;
   const override = readOverride();
   if (override !== null) return override;
+  // In Vite dev mode (`bun run dev`), default the chooser to ON so developers
+  // can pick local without manual configuration. This applies to web/desktop
+  // dev builds only — Android and other non-Vite platforms fall through to the
+  // build-flag default.
+  if (readDevMode()) return true;
   return readBuildDefault();
 }

--- a/packages/ui/src/first-run/first-run-runtime-flag.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.ts
@@ -53,11 +53,38 @@ function readEnv(): Record<string, unknown> {
  * `import.meta.env.DEV` to `false`, so this is a no-op in shipped bundles.
  */
 function readDevMode(): boolean {
-  return readEnv().DEV === true;
+  const env = readEnv();
+  // Vitest also sets DEV=true, but MODE="test". Requiring both values keeps
+  // the developer convenience scoped to the actual default Vite dev server.
+  return env.DEV === true && env.MODE === "development";
 }
 
 function readBuildDefault(): boolean {
   return readEnv().VITE_ELIZA_ENABLE_RUNTIME_CHOOSER === "1";
+}
+
+/** Inputs to the environment-independent runtime-chooser policy. */
+export interface RuntimeChooserGateInputs {
+  isCloudLockedAndroid: boolean;
+  override: boolean | null;
+  isViteDev: boolean;
+  isBuildEnabled: boolean;
+}
+
+/**
+ * Resolve chooser availability without depending on Vite's compile-time env.
+ * The cloud-locked Android invariant is absolute, then an explicit runtime
+ * override wins over the development and build defaults.
+ */
+export function resolveRuntimeChooserEnabled({
+  isCloudLockedAndroid,
+  override,
+  isViteDev,
+  isBuildEnabled,
+}: RuntimeChooserGateInputs): boolean {
+  if (isCloudLockedAndroid) return false;
+  if (override !== null) return override;
+  return isViteDev || isBuildEnabled;
 }
 
 /**
@@ -71,13 +98,10 @@ function readBuildDefault(): boolean {
  * production default.
  */
 export function isRuntimeChooserEnabled(): boolean {
-  if (isAndroidCloudBuild()) return false;
-  const override = readOverride();
-  if (override !== null) return override;
-  // In Vite dev mode (`bun run dev`), default the chooser to ON so developers
-  // can pick local without manual configuration. This applies to web/desktop
-  // dev builds only — Android and other non-Vite platforms fall through to the
-  // build-flag default.
-  if (readDevMode()) return true;
-  return readBuildDefault();
+  return resolveRuntimeChooserEnabled({
+    isCloudLockedAndroid: isAndroidCloudBuild(),
+    override: readOverride(),
+    isViteDev: readDevMode(),
+    isBuildEnabled: readBuildDefault(),
+  });
 }


### PR DESCRIPTION
## Summary

Makes the local/cloud/remote runtime chooser the default only under the real Vite development server. Production and test bundles remain cloud-only unless explicitly enabled, the runtime `"0"`/`"1"` override remains authoritative, and a Play-Store cloud-locked Android build remains unable to expose local execution.

## Review repairs

- Extracted an environment-independent policy so production, Vite development, build-flag, runtime-override, and cloud-locked Android precedence are tested directly.
- Requires both `DEV === true` and `MODE === "development"`; Vitest also reports `DEV=true`, so checking `DEV` alone silently changed the test environment's product default.
- Added a real `bun run dev` Playwright lane with no chooser override. It exercises the actual Vite transform and renderer, asserts all three choices, checks renderer telemetry, and captures desktop rest/hover plus mobile rest.
- Added the inverse real-renderer proof: an explicit `"0"` override restores the cloud-only baseline without writing through the app's reserved-storage broker.
- Corrected stale app-test and Android comments so production-dist test fixtures are not presented as development defaults.

## Exact rebase verification

On `9d47fa04aa313c72c352139274d3813b9c037044`, rebased onto `origin/develop@41fe41186396842c0bc124c647409b8db125f02a`:

- environment-independent UI policy: **10 passed**
- real `bun run dev` Vite renderer: **1 passed**
- production-dist onboarding/runtime smoke: **5 passed**
- `@elizaos/ui` and `@elizaos/app` typecheck, lint, and build: passed
- `bun run verify`: **348/348 tasks passed**
- `git diff --check`: passed

`bun run --cwd packages/app audit:app` completed **214/215 captures with 0 broken**. Its only failure is the existing unrelated minimalism ratchet: builtin-browser mobile portrait/landscape, builtin-plugins mobile portrait, and builtin-trajectories mobile landscape. None of those views are touched by this PR. The exact changed first-run surface passed dedicated real-Vite desktop rest/hover, mobile, explicit-`0` cloud-only, telemetry, and manual pixel review. Packaged OCR triage covered **212 views: 192 verified, 0 broken, 20 needs-eyeball**.

<!-- evidence-head:9d47fa04aa313c72c352139274d3813b9c037044 -->

<!-- evidence-row:before-screenshots -->
- [x] [Before — cloud-only desktop baseline](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18226-runtime-chooser-before-cloud-only-desktop.png)

<!-- evidence-row:after-screenshots -->
- [x] [After — Vite development desktop rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18226-runtime-chooser-vite-development-desktop-rest.png)
- [x] [After — Vite development desktop hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18226-runtime-chooser-vite-development-desktop-hover.png)
- [x] [After — Vite development mobile rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18226-runtime-chooser-vite-development-mobile-rest.png)

<!-- evidence-row:walkthrough-video -->
- [x] [Real Vite development walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18226-video.webm)

<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend build-policy change; deterministic HTTP boundaries are exercised by Playwright and no backend behavior changes.

<!-- evidence-row:frontend-logs -->
<details><summary>Playwright and renderer telemetry</summary>

```text
Vite development offers cloud, local, and remote without an override: passed
expectNoRenderTelemetryErrors(...): passed
Production-dist onboarding/runtime smoke: 5 passed
```
</details>

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, planner, or trajectory behavior changes.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the reviewed screenshots and walkthrough are the behavior artifacts for this UI policy change.

<!-- evidence-row:ocr-review -->
- [x] OCR text readout: https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18226-pr18226-ocr.txt

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`, `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3d899bbaf4d61f742f19151601847e581ab5670c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [hermes/t3rpz] [codex/openai-gpt-5.6-sol]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@3d899bbaf4d61f742f19151601847e581ab5670c:packages/skills/skills/contribute-to-eliza"} -->
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"N/A"} -->


<!-- evidence-refresh:2026-08-10T19:12Z -->