### PR TITLE
feat(cloud): boot-time missing-envVars reporting for OAuth providers (#18205)

### DIFF
--- a/packages/cloud/api/health/operational/route.test.ts
+++ b/packages/cloud/api/health/operational/route.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Exercises /api/health/operational route behavior against mocked OAuth
+ * diagnostics. bun-test does not resolve `@/lib/*` path aliases, so all
+ * dependencies are mocked; the `getProviderEnvDiagnostics` return value
+ * is controlled to verify the route serializes it correctly.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const isStewardPlatformConfigured = mock(() => true);
+
+const defaultDiagnostics = [
+  {
+    id: "google",
+    name: "Google",
+    type: "oauth2",
+    configured: true,
+    missingEnvVars: [],
+    requiredForDeployment: true,
+  },
+  {
+    id: "microsoft",
+    name: "Microsoft",
+    type: "oauth2",
+    configured: false,
+    missingEnvVars: ["MICROSOFT_CLIENT_ID", "MICROSOFT_CLIENT_SECRET"],
+    requiredForDeployment: false,
+  },
+];
+
+let mockDiagnostics = defaultDiagnostics.map((entry) => ({ ...entry }));
+const getProviderEnvDiagnostics = mock(() => mockDiagnostics);
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: unknown, error: unknown) => {
+    const ctx = c as { json: (body: unknown, status?: number) => Response };
+    return ctx.json({ error: String(error) }, 500);
+  },
+}));
+
+mock.module("@/lib/runtime/cloud-bindings", () => ({
+  getCloudAwareEnv: () => ({
+    EVM_PAYOUT_PRIVATE_KEY: "configured",
+    CRON_SECRET: "configured",
+  }),
+}));
+
+mock.module("@/lib/services/steward-platform-users", () => ({
+  isStewardPlatformConfigured,
+}));
+
+mock.module("@/lib/services/oauth/provider-registry", () => ({
+  getProviderEnvDiagnostics,
+}));
+
+const { default: operationalHealth } = await import("./route");
+
+function buildApp() {
+  const app = new Hono();
+  app.route("/", operationalHealth);
+  return app;
+}
+
+describe("GET /api/health/operational — OAuth providers", () => {
+  beforeEach(() => {
+    mockDiagnostics = defaultDiagnostics.map((entry) => ({ ...entry }));
+  });
+
+  test("response includes oauth_providers array with per-provider status", async () => {
+    const res = await buildApp().request("/");
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("ok");
+
+    const providers = body.oauth_providers as Array<Record<string, unknown>>;
+    expect(Array.isArray(providers)).toBe(true);
+    expect(providers.length).toBe(2);
+
+    const google = providers[0] as Record<string, unknown>;
+    expect(google.id).toBe("google");
+    expect(google.configured).toBe(true);
+    expect(google.missingEnvVars).toEqual([]);
+
+    const ms = providers[1] as Record<string, unknown>;
+    expect(ms.id).toBe("microsoft");
+    expect(ms.configured).toBe(false);
+    expect(ms.missingEnvVars).toEqual([
+      "MICROSOFT_CLIENT_ID",
+      "MICROSOFT_CLIENT_SECRET",
+    ]);
+  });
+
+  test("checks.oauth_providers summary is present and matches the array", async () => {
+    const res = await buildApp().request("/");
+    const body = (await res.json()) as Record<string, unknown>;
+
+    const checks = body.checks as Record<string, unknown>;
+    expect(checks.oauth_providers).toBeDefined();
+    const summary = checks.oauth_providers as {
+      configured: boolean;
+      message: string;
+    };
+    expect(summary.configured).toBe(true);
+    expect(summary.message).toContain(
+      "All 1 deployment-required OAuth providers configured",
+    );
+  });
+
+  test("a missing deployment-required provider degrades health", async () => {
+    mockDiagnostics = defaultDiagnostics.map((entry) =>
+      entry.id === "google"
+        ? {
+            ...entry,
+            configured: false,
+            missingEnvVars: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+          }
+        : { ...entry },
+    );
+
+    const res = await buildApp().request("/");
+    const body = (await res.json()) as {
+      status: string;
+      checks: Record<string, { configured: boolean; message: string }>;
+    };
+
+    expect(body.status).toBe("degraded");
+    expect(body.checks.oauth_providers).toEqual({
+      configured: false,
+      message: "Missing deployment-required OAuth providers: google",
+    });
+  });
+
+  test("response is never cached", async () => {
+    const res = await buildApp().request("/");
+    expect(res.headers.get("cache-control")).toBe("no-store, max-age=0");
+  });
+});

--- a/packages/cloud/api/health/operational/route.ts
+++ b/packages/cloud/api/health/operational/route.ts
@@ -17,6 +17,7 @@
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { getCloudAwareEnv } from "@/lib/runtime/cloud-bindings";
+import { getProviderEnvDiagnostics } from "@/lib/services/oauth/provider-registry";
 import { isStewardPlatformConfigured } from "@/lib/services/steward-platform-users";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -66,10 +67,26 @@ app.get("/", (c) => {
         : "CRON_SECRET not set — scheduled jobs (container-billing, process-redemptions) cannot authenticate",
     };
 
+    const oauthProviders = getProviderEnvDiagnostics();
+    const requiredOAuthProviders = oauthProviders.filter(
+      (provider) => provider.requiredForDeployment,
+    );
+    const missingRequiredOAuthProviders = requiredOAuthProviders.filter(
+      (provider) => !provider.configured,
+    );
+    const oauthProvidersCheck: CheckResult = {
+      configured: missingRequiredOAuthProviders.length === 0,
+      message:
+        missingRequiredOAuthProviders.length === 0
+          ? `All ${requiredOAuthProviders.length} deployment-required OAuth providers configured`
+          : `Missing deployment-required OAuth providers: ${missingRequiredOAuthProviders.map((provider) => provider.id).join(", ")}`,
+    };
+
     const allOk =
       steward.configured &&
       (evmConfigured || solanaConfigured) &&
-      crons.configured;
+      crons.configured &&
+      oauthProvidersCheck.configured;
 
     return c.json(
       {
@@ -80,12 +97,15 @@ app.get("/", (c) => {
           steward_platform: steward,
           payouts,
           crons,
+          oauth_providers: oauthProvidersCheck,
         },
+        oauth_providers: oauthProviders,
       },
       200,
       { "Cache-Control": "no-store, max-age=0" },
     );
   } catch (error) {
+    // error-policy:J1 translate an operational-health boundary failure into the shared API error shape.
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/api/src/bootstrap-app.test.ts
+++ b/packages/cloud/api/src/bootstrap-app.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { expect, test } from "bun:test";
+import type { Bindings } from "@/types/cloud-worker-env";
 
 const { createApp, isRedisIndependentInferencePath } = await import(
   "./bootstrap-app"
@@ -12,14 +13,54 @@ const { createApp, isRedisIndependentInferencePath } = await import(
 
 function environment(limiter: {
   limit(options: { key: string }): Promise<{ success: boolean }>;
-}) {
+}): Bindings {
   return {
     ENVIRONMENT: "staging",
     NODE_ENV: "production",
     REDIS_RATE_LIMITING: "false",
+    GOOGLE_CLIENT_ID: "configured",
+    GOOGLE_CLIENT_SECRET: "configured",
     GLOBAL_RATE_LIMITER: limiter,
-  } as never;
+  } as unknown as Bindings;
 }
+
+test("missing required OAuth credentials are logged once per app isolate", async () => {
+  const app = createApp();
+  const calls: unknown[][] = [];
+  const originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => calls.push(args);
+
+  try {
+    const env = {
+      ...environment({
+        async limit() {
+          return { success: true };
+        },
+      }),
+      GOOGLE_CLIENT_ID: "",
+      GOOGLE_CLIENT_SECRET: "",
+    } as never;
+    for (let index = 0; index < 2; index += 1) {
+      const response = await app.fetch(
+        new Request("https://api.example.test/api/i18n/locale"),
+        env,
+      );
+      expect(response.status).toBe(200);
+    }
+  } finally {
+    console.error = originalConsoleError;
+  }
+
+  const diagnostics = calls.filter(
+    (args) =>
+      args[0] === "[bootstrap-app] Required OAuth provider is not configured",
+  );
+  expect(diagnostics).toHaveLength(1);
+  expect(diagnostics[0]?.[1]).toMatchObject({
+    providerId: "google",
+    missingEnvVars: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+  });
+});
 
 test("the global native limiter rejects before auth and generated routes", async () => {
   const keys: string[] = [];
@@ -109,6 +150,8 @@ test("production inference remains reachable when Railway Redis is unavailable",
       ENVIRONMENT: "production",
       NODE_ENV: "production",
       REDIS_RATE_LIMITING: "true",
+      GOOGLE_CLIENT_ID: "configured",
+      GOOGLE_CLIENT_SECRET: "configured",
       GLOBAL_RATE_LIMITER: {
         async limit() {
           return { success: true };

--- a/packages/cloud/api/src/bootstrap-app.ts
+++ b/packages/cloud/api/src/bootstrap-app.ts
@@ -26,6 +26,7 @@ import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
 import { runWithRequestContext } from "@/lib/runtime/request-context";
 import { configureAppsDeprovisionTrigger } from "@/lib/services/app-db-deprovision-job-service";
 import { configureAppsDeployTrigger } from "@/lib/services/app-deploy-job-service";
+import { getProviderEnvDiagnostics } from "@/lib/services/oauth/provider-registry";
 import { setRuntimeR2Bucket } from "@/lib/storage/r2-runtime-binding";
 import { logger } from "@/lib/utils/logger";
 import { describeUnhandledError } from "@/lib/utils/unhandled-error-detail";
@@ -179,6 +180,35 @@ function countryFromHeaders(headers: Headers): string | null {
   return null;
 }
 
+/**
+ * Log missing OAuth provider env vars on the first request in an isolate, the
+ * earliest point where Worker bindings exist. Required providers are errors;
+ * optional integrations are one verbose summary. No values are logged.
+ */
+function logProviderEnvDiagnostics(): void {
+  const unconfigured = getProviderEnvDiagnostics().filter(
+    (provider) => !provider.configured,
+  );
+  const required = unconfigured.filter(
+    (provider) => provider.requiredForDeployment,
+  );
+  const optional = unconfigured.filter(
+    (provider) => !provider.requiredForDeployment,
+  );
+  for (const provider of required) {
+    logger.error("[bootstrap-app] Required OAuth provider is not configured", {
+      providerId: provider.id,
+      missingEnvVars: provider.missingEnvVars,
+    });
+  }
+  if (optional.length > 0) {
+    logger.info("[bootstrap-app] Optional OAuth providers are not configured", {
+      count: optional.length,
+      providerIds: optional.map((provider) => provider.id),
+    });
+  }
+}
+
 export function createApp(): Hono<AppEnv> {
   // Initialise the global audit dispatcher (auth_events sink + optional
   // console sink) before any route handlers run. Idempotent — safe to
@@ -206,15 +236,25 @@ export function createApp(): Hono<AppEnv> {
 
   const app = new Hono<AppEnv>({ strict: false });
 
+  // Once-per-isolate guard for missing OAuth provider env vars. Must run
+  // inside the request middleware so `getCloudAwareEnv()` sees the Worker
+  // bindings — at `createApp()` time only `process.env` is available, which
+  // would produce false warnings on deployed Workers.
+  let providerEnvVarsLogged = false;
+
   app.use("*", async (c, next) => {
     setRuntimeR2Bucket(c.env.BLOB);
     await runWithCloudBindingsAsync(
       c.env as Record<string, unknown>,
-      async () =>
+      async () => {
+        if (!providerEnvVarsLogged) {
+          logProviderEnvDiagnostics();
+          providerEnvVarsLogged = true;
+        }
         // Expose the client IP + a stable per-request idempotency key to shared
         // library code (anti-sybil grant checks; idempotent money settlement,
         // #10423) without threading them through every call site.
-        runWithRequestContext(
+        return runWithRequestContext(
           {
             clientIp: getRequestIp(c),
             idempotencyKey:
@@ -223,7 +263,8 @@ export function createApp(): Hono<AppEnv> {
               crypto.randomUUID(),
           },
           async () => runWithDbCacheAsync(async () => next()),
-        ),
+        );
+      },
     );
   });
 

--- a/packages/cloud/shared/src/lib/services/oauth/index.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/index.ts
@@ -32,10 +32,12 @@ export {
   getAllProviderIds,
   getConfiguredProviders,
   getProvider,
+  getProviderEnvDiagnostics,
   isProviderConfigured,
   isValidProvider,
   OAUTH_PROVIDERS,
   type OAuthProviderConfig,
+  type ProviderEnvDiagnostic,
 } from "./provider-registry";
 
 // Advanced use cases

--- a/packages/cloud/shared/src/lib/services/oauth/provider-registry.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/provider-registry.test.ts
@@ -1,22 +1,21 @@
-// Exercises provider registry behavior with deterministic cloud-shared lib fixtures.
+/**
+ * Exercises provider-registry lookup, scope, and credential diagnostics with
+ * deterministic cloud-binding contexts and no external OAuth traffic.
+ */
 import { describe, expect, test } from "vitest";
+import { runWithCloudBindings } from "../../runtime/cloud-bindings";
 import {
   getAllowedScopes,
   getAllProviderIds,
   getCallbackUrl,
   getNestedValue,
   getProvider,
+  getProviderEnvDiagnostics,
+  isProviderConfigured,
   isValidProvider,
   type OAuthProviderConfig,
   resolveRequestedScopes,
 } from "./provider-registry";
-
-/**
- * OAuth provider registry. The security-critical piece is resolveRequestedScopes:
- * a requested scope not in the provider's allowlist must THROW (no scope
- * escalation); empty requests fall back to default scopes. Provider lookup is
- * case-insensitive and getNestedValue must never throw on missing paths.
- */
 
 const provider = (o: Partial<OAuthProviderConfig>): OAuthProviderConfig =>
   ({
@@ -69,5 +68,104 @@ describe("getCallbackUrl / getNestedValue", () => {
     expect(getNestedValue(obj, "data.viewer.id")).toBe("abc");
     expect(getNestedValue(obj, "data.missing.id")).toBeUndefined();
     expect(getNestedValue(null, "a.b")).toBeUndefined();
+  });
+});
+
+describe("getProviderEnvDiagnostics", () => {
+  test("returns one entry per provider with configured + missingEnvVars fields", () => {
+    const diagnostics = getProviderEnvDiagnostics();
+    const providerIds = getAllProviderIds();
+
+    expect(diagnostics).toHaveLength(providerIds.length);
+
+    for (const entry of diagnostics) {
+      expect(entry.id).toBeDefined();
+      expect(entry.name).toBeDefined();
+      expect(entry.type).toBeDefined();
+      expect(typeof entry.configured).toBe("boolean");
+      expect(Array.isArray(entry.missingEnvVars)).toBe(true);
+      expect(typeof entry.requiredForDeployment).toBe("boolean");
+
+      if (entry.configured) {
+        expect(entry.missingEnvVars).toEqual([]);
+      } else {
+        expect(entry.missingEnvVars.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("entries map 1:1 to the registry by id", () => {
+    const diagnostics = getProviderEnvDiagnostics();
+    const providerIds = new Set(getAllProviderIds());
+    const diagnosticIds = new Set(diagnostics.map((d) => d.id));
+    expect(diagnosticIds).toEqual(providerIds);
+  });
+
+  test("Twitter reports the satisfied alternative instead of contradictory missing vars", () => {
+    const twitter = getProvider("twitter") as OAuthProviderConfig;
+    const result = runWithCloudBindings(
+      {
+        TWITTER_API_KEY: "",
+        TWITTER_API_SECRET_KEY: "",
+        TWITTER_CLIENT_ID: "client-id",
+      },
+      () => ({
+        configured: isProviderConfigured(twitter),
+        diagnostic: getProviderEnvDiagnostics().find((d) => d.id === "twitter"),
+      }),
+    );
+
+    expect(result.configured).toBe(true);
+    expect(result.diagnostic).toMatchObject({
+      configured: true,
+      missingEnvVars: [],
+    });
+  });
+
+  test("reports the shortest actionable alternative when no Twitter path is complete", () => {
+    const diagnostic = runWithCloudBindings(
+      {
+        TWITTER_API_KEY: "",
+        TWITTER_API_SECRET_KEY: "",
+        TWITTER_CLIENT_ID: "",
+      },
+      () => getProviderEnvDiagnostics().find((d) => d.id === "twitter"),
+    );
+
+    expect(diagnostic).toMatchObject({
+      configured: false,
+      missingEnvVars: ["TWITTER_CLIENT_ID"],
+    });
+  });
+
+  test("respects runWithCloudBindings context for env-var detection", () => {
+    const inside = runWithCloudBindings(
+      { GOOGLE_CLIENT_ID: "id", GOOGLE_CLIENT_SECRET: "secret" },
+      () => getProviderEnvDiagnostics().find((d) => d.id === "google"),
+    );
+
+    expect(inside).toBeDefined();
+    expect(inside?.missingEnvVars).toEqual([]);
+    expect(inside?.configured).toBe(true);
+    expect(inside?.requiredForDeployment).toBe(true);
+  });
+
+  test("rejects whitespace-only required Google credentials", () => {
+    const google = getProvider("google") as OAuthProviderConfig;
+    const diagnostic = runWithCloudBindings(
+      { GOOGLE_CLIENT_ID: "  ", GOOGLE_CLIENT_SECRET: "\t" },
+      () => getProviderEnvDiagnostics().find((d) => d.id === "google"),
+    );
+    const configured = runWithCloudBindings(
+      { GOOGLE_CLIENT_ID: "  ", GOOGLE_CLIENT_SECRET: "\t" },
+      () => isProviderConfigured(google),
+    );
+
+    expect(configured).toBe(false);
+    expect(diagnostic).toMatchObject({
+      configured: false,
+      requiredForDeployment: true,
+      missingEnvVars: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/oauth/provider-registry.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/provider-registry.ts
@@ -110,6 +110,15 @@ export interface OAuthProviderConfig {
   envVars: string[];
 
   /**
+   * Alternative complete credential sets. A provider is configured when any
+   * one set is present; diagnostics report the smallest missing set.
+   */
+  envVarAlternatives?: string[][];
+
+  /** Missing credentials for this provider degrade deployment health. */
+  requiredForDeployment?: boolean;
+
+  /**
    * OAuth endpoints for authorization flow.
    * Required for oauth2 and oauth1a types.
    */
@@ -231,6 +240,7 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     description: "Gmail, Calendar, and Contacts",
     type: "oauth2",
     envVars: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+    requiredForDeployment: true,
     endpoints: {
       authorization: "https://accounts.google.com/o/oauth2/v2/auth",
       token: "https://oauth2.googleapis.com/token",
@@ -658,6 +668,7 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     description: "Post tweets, read timeline",
     type: "oauth1a",
     envVars: ["TWITTER_API_KEY", "TWITTER_API_SECRET_KEY"],
+    envVarAlternatives: [["TWITTER_API_KEY", "TWITTER_API_SECRET_KEY"], ["TWITTER_CLIENT_ID"]],
     endpoints: {
       authorization: "https://api.twitter.com/oauth/authorize",
       token: "https://api.twitter.com/oauth/access_token",
@@ -775,13 +786,31 @@ export function getProvider(platformId: string): OAuthProviderConfig | null {
   return OAUTH_PROVIDERS[platformId.toLowerCase()] || null;
 }
 
-/** Check if provider has required env vars (API key providers always return true). */
+function hasNonBlankEnvValue(env: NodeJS.ProcessEnv, variable: string): boolean {
+  const value = env[variable];
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function getCredentialAlternatives(provider: OAuthProviderConfig): string[][] {
+  return provider.envVarAlternatives ?? [provider.envVars];
+}
+
+function getMissingEnvVars(provider: OAuthProviderConfig, env: NodeJS.ProcessEnv): string[] {
+  const alternatives = getCredentialAlternatives(provider);
+  if (alternatives.some((set) => set.every((v) => hasNonBlankEnvValue(env, v)))) {
+    return [];
+  }
+  return (
+    alternatives
+      .map((set) => set.filter((v) => !hasNonBlankEnvValue(env, v)))
+      .sort((a, b) => a.length - b.length)[0] ?? []
+  );
+}
+
+/** Check if one complete provider credential set is present. */
 export function isProviderConfigured(provider: OAuthProviderConfig): boolean {
   const env = getCloudAwareEnv();
-  if (provider.id === "twitter") {
-    return Boolean((env.TWITTER_API_KEY && env.TWITTER_API_SECRET_KEY) || env.TWITTER_CLIENT_ID);
-  }
-  return provider.envVars.length === 0 || provider.envVars.every((v) => !!env[v]);
+  return getMissingEnvVars(provider, env).length === 0;
 }
 
 /** Get all providers with required env vars configured. */
@@ -792,6 +821,42 @@ export function getConfiguredProviders(): OAuthProviderConfig[] {
 /** Get configured OAuth providers (oauth2 or oauth1a, not api_key). */
 export function getConfiguredOAuthProviders(): OAuthProviderConfig[] {
   return getConfiguredProviders().filter((p) => p.type === "oauth2" || p.type === "oauth1a");
+}
+
+/**
+ * Per-provider env-var diagnostic for boot-time and health surfaces.
+ *
+ * The registry knows every provider's required `envVars`, so missing keys
+ * are cheap to detect without a live OAuth round-trip. Returns one entry
+ * per provider with the `configured` boolean and the list of missing env
+ * var names — never their values.
+ *
+ * `configured` mirrors the canonical `isProviderConfigured`. Providers with
+ * alternative credential paths report no missing variables when any complete
+ * path is present; otherwise `missingEnvVars` is the shortest actionable set.
+ */
+export interface ProviderEnvDiagnostic {
+  id: string;
+  name: string;
+  type: OAuthProviderType;
+  configured: boolean;
+  missingEnvVars: string[];
+  requiredForDeployment: boolean;
+}
+
+export function getProviderEnvDiagnostics(): ProviderEnvDiagnostic[] {
+  const env = getCloudAwareEnv();
+  return Object.values(OAUTH_PROVIDERS).map((provider) => {
+    const missingEnvVars = getMissingEnvVars(provider, env);
+    return {
+      id: provider.id,
+      name: provider.name,
+      type: provider.type,
+      configured: missingEnvVars.length === 0,
+      missingEnvVars,
+      requiredForDeployment: provider.requiredForDeployment === true,
+    };
+  });
 }
 
 function normalizeScopes(scopes: string[] | undefined): string[] {

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -245,6 +245,9 @@ export interface Bindings {
   STEWARD_SESSION_SECRET?: string;
   /** Optional dedicated secret for OAuth success-page HMAC proofs; falls back to STEWARD_SESSION_SECRET. */
   OAUTH_SUCCESS_PROOF_SECRET?: string;
+  /** Required managed Google OAuth application credentials. */
+  GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
   STEWARD_JWT_SECRET?: string;
   /** Steward vault encryption master password. Required for wallet/key operations. */
   STEWARD_MASTER_PASSWORD?: string;


### PR DESCRIPTION
## Summary

Closes #18205.

Makes OAuth credential drift observable at the earliest safe Worker boundary and in `/api/health/operational`, without logging or returning credential values. Managed Google is treated as operationally required; optional integrations remain diagnostic-only.

## Deep-review repairs

- Runs boot diagnostics inside `runWithCloudBindingsAsync`, where Cloudflare bindings actually exist, and emits them once per app isolate.
- Uses structured logging: one error per missing required provider and one compact info summary for optional providers. Only provider IDs and missing variable names are emitted.
- Generalizes alternative credential sets in the provider registry instead of preserving a Twitter-only special case. The canonical configured check and diagnostics now share one implementation.
- Treats blank/whitespace-only credentials as absent and reports the shortest actionable alternative set.
- Adds a typed `requiredForDeployment` policy and marks managed Google required. Missing Google credentials now make operational health visibly `degraded`; missing optional connectors do not.
- Adds Worker binding types for the managed Google credentials.
- Proves first-request logging is once-per-isolate and extends real route/provider tests across configured, missing, alternative, and whitespace-only cases.

## Deployment custody finding

Production and staging currently report Google configured. Their GitHub deployment-environment secret-name inventories do not contain `GOOGLE_CLIENT_ID` or `GOOGLE_CLIENT_SECRET`, so the earlier repair draft's workflow preflight/republish change would have failed the next deployment and potentially overwritten the actual out-of-band custody path. That unsafe workflow change was removed. This PR detects drift without pretending GitHub Actions owns secrets it does not own; documenting the authoritative custody remains an operations action from #18205.

## Verification

```text
provider-registry: 11 passed, 144 assertions
bootstrap + operational health: 9 passed, 43 assertions
@elizaos/cloud-shared typecheck: passed
@elizaos/cloud-api typecheck + production Worker bundle dry-run: passed
Biome (8 changed files): passed
@elizaos/cloud-shared complete suite: 666 files across 156 isolated batches passed
@elizaos/cloud-api complete suite: all 233 isolated files passed
bun run verify: 348/348 tasks; all repository audits passed
```

<!-- evidence-head:3126f988ca1448a59ba4701c9dc1fddbc98eb0af -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only Cloud Worker diagnostics and health JSON; no rendered surface changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only Cloud Worker diagnostics and health JSON; no rendered surface changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user interface or interaction flow changes.

<!-- evidence-row:backend-logs -->
<details><summary>Focused backend proof</summary>

```text
getProviderEnvDiagnostics: 11 passed, 0 failed, 144 assertions
bootstrap-app + /api/health/operational: 9 passed, 0 failed, 43 assertions
missing required OAuth credentials are logged once per app isolate: passed
a missing deployment-required provider degrades health: passed
wrangler deploy --env production --dry-run: passed
```
</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser behavior changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, planner, or trajectory behavior changes.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the API JSON and structured log contracts are covered by the backend transcript and tests above.

<!-- evidence-refresh:3126f988ca1448a59ba4701c9dc1fddbc98eb0af -->

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`, `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [hermes/t3rpz] [codex/openai-gpt-5.6-sol]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza"} -->
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"N/A"} -->
