### PR TITLE
fix(cloud): make fleet upgrade concurrency configurable

### DIFF
--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
@@ -19,6 +19,7 @@ const targetDigest = `sha256:${"a".repeat(64)}`;
 function installDeps(
   inFlight: number,
   candidates: Array<Record<string, string>> = [],
+  maxInflightUpgrades = 3,
 ) {
   const countInFlightByTypes = mock(async () => inFlight);
   const listRunningWithDigestOtherThan = mock(async () => candidates);
@@ -27,7 +28,10 @@ function installDeps(
     job: { id: "upgrade-job" },
   }));
   __setDepsForTests({
-    containersEnv: { defaultAgentImage: () => configuredImage },
+    containersEnv: {
+      defaultAgentImage: () => configuredImage,
+      maxInflightUpgrades: () => maxInflightUpgrades,
+    },
     resolveImageDigest: async () => targetDigest,
     jobsRepository: { countInFlightByTypes },
     agentSandboxesRepository: { listRunningWithDigestOtherThan },
@@ -56,6 +60,16 @@ describe("processFleetUpgradeCycle shared image-change capacity", () => {
       "agent_upgrade",
       "agent_admin_canary_image",
     ]);
+    expect(deps.listRunningWithDigestOtherThan).not.toHaveBeenCalled();
+    expect(deps.enqueueAgentUpgradeOnce).not.toHaveBeenCalled();
+  });
+
+  test("an env-configured zero limit pauses rollouts without a source hot patch", async () => {
+    const deps = installDeps(0, [], 0);
+
+    const result = await processFleetUpgradeCycle();
+
+    expect(result).toMatchObject({ action: "skip_capacity", inFlight: 0 });
     expect(deps.listRunningWithDigestOtherThan).not.toHaveBeenCalled();
     expect(deps.enqueueAgentUpgradeOnce).not.toHaveBeenCalled();
   });
@@ -293,6 +307,7 @@ describe("real one-shot daemon entrypoint", () => {
       "@elizaos/cloud-shared/lib/config/containers-env": {
         containersEnv: {
           defaultAgentImage: () => configuredImage,
+          maxInflightUpgrades: () => 3,
         },
         assertSSHKeyAvailable: () => {},
       },

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -953,15 +953,14 @@ export interface FleetUpgradeSummary {
   detail?: string;
 }
 
-const MAX_INFLIGHT_UPGRADES = 3;
-
 /**
  * Detect when the registry-side digest of the configured agent tag has moved
  * (e.g. a new `:develop` image was pushed) and enqueue blue/green
  * `agent_upgrade` jobs for every running agent still on the old digest.
  *
- * Rate-limited to at most `MAX_INFLIGHT_UPGRADES` upgrade jobs in flight at
- * any time so the fleet is never fully disrupted at once. The actual swap is
+ * Rate-limited to at most `MAX_INFLIGHT_UPGRADES` (default 3) upgrade jobs in
+ * flight at any time so the fleet is never fully disrupted at once. Set the
+ * env var to 0 to pause rollouts during an operational canary. The actual swap is
  * zero-downtime (a new container is provisioned on a different node, traffic
  * is atomically swapped, then the old container gets a 30s SIGTERM drain
  * before removal), so the rate limit is about resource pressure on
@@ -996,7 +995,7 @@ export async function processFleetUpgradeCycle(): Promise<FleetUpgradeSummary> {
     "agent_upgrade",
     "agent_admin_canary_image",
   ]);
-  const slack = MAX_INFLIGHT_UPGRADES - inFlight;
+  const slack = containersEnv.maxInflightUpgrades() - inFlight;
   if (slack <= 0) {
     return {
       action: "skip_capacity",

--- a/packages/cloud/shared/src/lib/config/containers-env-upgrades.test.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env-upgrades.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { containersEnv } from "./containers-env";
+
+const KEYS = ["MAX_INFLIGHT_UPGRADES", "CONTAINERS_MAX_INFLIGHT_UPGRADES"] as const;
+const saved = new Map<string, string | undefined>();
+
+function setEnv(values: Partial<Record<(typeof KEYS)[number], string>>): void {
+  for (const key of KEYS) {
+    if (!saved.has(key)) saved.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(values)) {
+    process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  for (const [key, value] of saved) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  saved.clear();
+});
+
+describe("maxInflightUpgrades", () => {
+  test("defaults to three and accepts zero as an operational pause", () => {
+    setEnv({});
+    expect(containersEnv.maxInflightUpgrades()).toBe(3);
+
+    setEnv({ MAX_INFLIGHT_UPGRADES: "0" });
+    expect(containersEnv.maxInflightUpgrades()).toBe(0);
+  });
+
+  test("prefers the established name and supports the CONTAINERS alias", () => {
+    setEnv({ CONTAINERS_MAX_INFLIGHT_UPGRADES: "7" });
+    expect(containersEnv.maxInflightUpgrades()).toBe(7);
+
+    setEnv({
+      MAX_INFLIGHT_UPGRADES: "2",
+      CONTAINERS_MAX_INFLIGHT_UPGRADES: "7",
+    });
+    expect(containersEnv.maxInflightUpgrades()).toBe(2);
+  });
+
+  test("clamps finite integers to the safe range and rejects invalid values", () => {
+    setEnv({ MAX_INFLIGHT_UPGRADES: "-4" });
+    expect(containersEnv.maxInflightUpgrades()).toBe(0);
+
+    setEnv({ MAX_INFLIGHT_UPGRADES: "99" });
+    expect(containersEnv.maxInflightUpgrades()).toBe(64);
+
+    setEnv({ MAX_INFLIGHT_UPGRADES: "2.9" });
+    expect(containersEnv.maxInflightUpgrades()).toBe(2);
+
+    setEnv({ MAX_INFLIGHT_UPGRADES: "not-a-number" });
+    expect(containersEnv.maxInflightUpgrades()).toBe(3);
+  });
+});

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -773,9 +773,7 @@ export const containersEnv = {
     const env = getCloudAwareEnv();
     const raw = pick(env.MAX_INFLIGHT_UPGRADES, env.CONTAINERS_MAX_INFLIGHT_UPGRADES);
     const parsed = raw !== undefined ? Number(raw) : Number.NaN;
-    return Number.isFinite(parsed)
-      ? Math.min(64, Math.max(0, Math.floor(parsed)))
-      : 3;
+    return Number.isFinite(parsed) ? Math.min(64, Math.max(0, Math.floor(parsed))) : 3;
   },
 
   /**

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -764,6 +764,21 @@ export const containersEnv = {
   // ── Warm pool ───────────────────────────────────────────────────────────
 
   /**
+   * Maximum ordinary/canary agent image upgrades allowed in flight together.
+   * Set to 0 to pause image churn during an operational canary such as a warm-
+   * pool refill without carrying a source hot patch that the next deploy wipes.
+   * Default: 3. Clamped to [0, 64].
+   */
+  maxInflightUpgrades(): number {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.MAX_INFLIGHT_UPGRADES, env.CONTAINERS_MAX_INFLIGHT_UPGRADES);
+    const parsed = raw !== undefined ? Number(raw) : Number.NaN;
+    return Number.isFinite(parsed)
+      ? Math.min(64, Math.max(0, Math.floor(parsed)))
+      : 3;
+  },
+
+  /**
    * Whether the agent warm pool is enabled. When false, claim flow always
    * falls through to the cold-start async path; replenish/drain crons stay inactive.
    * Default: false (opt-in).


### PR DESCRIPTION
## Summary

The staging warm-pool canary has repeatedly needed fleet image rollouts paused while a known-good pool image refills. `MAX_INFLIGHT_UPGRADES` was a source constant, so operators had to patch `provisioning-worker.ts` in place. Every automatic deploy reset that hot patch and immediately resumed image churn.

This makes the existing concurrency limit operational configuration:

- `MAX_INFLIGHT_UPGRADES` is the canonical env name, with `CONTAINERS_MAX_INFLIGHT_UPGRADES` as an alias.
- Default remains 3, preserving current behavior.
- `0` deliberately pauses ordinary and admin-canary image upgrades without modifying source.
- Values are integer-clamped to `[0, 64]`.
- `processFleetUpgradeCycle` resolves the limit each cycle, so a worker restart after an env-only change is sufficient.

This is scoped to image-rollout concurrency. It does not enable the warm pool, change tier preference, or touch production configuration.

## Verification

- `bun test packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts --test-name-pattern 'shared image-change capacity'` -> 3 pass
- `bun test packages/cloud/shared/src/lib/config/containers-env-upgrades.test.ts` -> 3 pass
- Scoped Biome -> clean
- `git diff --check` -> clean
- The full one-shot test could not load in this isolated worktree because the available shared `node_modules` cache lacks `drizzle-orm`; all selected changed-path tests pass.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - provisioning-daemon configuration only; no rendered UI.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - provisioning-daemon configuration only; no rendered UI.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no interactive surface.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
<details><summary>Targeted rollout-cycle test transcript</summary>

```text
(pass) pending or running admin canaries consume ordinary fleet rollout capacity
(pass) an env-configured zero limit pauses rollouts without a source hot patch
(pass) ordinary reconcile enqueues only the one slot left by shared canary load
3 pass, 0 fail, 11 expect() calls
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend files touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model, prompt, provider, or agent behavior touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts:
<details><summary>Environment contract test transcript</summary>

```text
(pass) defaults to three and accepts zero as an operational pause
(pass) prefers the established name and supports the CONTAINERS alias
(pass) clamps finite integers to the safe range and rejects invalid values
3 pass, 0 fail, 8 expect() calls
```
</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: `N/A - no rendered visual surface.`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai-codex/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: OpenClaw
<!-- attribution-row:skill-revision -->
- N/A - no repository contribution skill was used; task executed through OpenClaw tools.
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a665f92cf62ae918b32f70b9ecd08a7292a043a0 -->