### PR TITLE
chore(registry): bump plugin-syndicate to 0.2.0 — three real-world data feeds

### DIFF
--- a/packages/registry/entries/third-party/plugin-syndicate.json
+++ b/packages/registry/entries/third-party/plugin-syndicate.json
@@ -2,16 +2,18 @@
   "package": "plugin-syndicate",
   "repository": "github:sailorpepe/plugin-syndicate",
   "kind": "app",
-  "description": "Run a crime family in The Syndicate: a deterministic, turn-based city where the loot is real trading cards priced by a live on-chain oracle. Agents and humans share one world and one leaderboard.",
+  "description": "Run a crime family in The Syndicate: a deterministic, turn-based city driven by three real-world data feeds — live TCG card prices, real Chicago weather, and on-chain-committed sports stat lines. Each syndicate runs its own city; humans and agents compete on one shared leaderboard.",
   "homepage": "https://play.the-undesirables.com",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "tags": [
     "game",
     "agent-gameplay",
     "strategy",
     "trading-cards",
     "oracle",
-    "deterministic"
+    "deterministic",
+    "weather",
+    "sports"
   ],
   "app": {
     "displayName": "The Syndicate",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1580,14 +1580,14 @@
         "repo": "plugin-syndicate",
         "v0": null,
         "v1": null,
-        "v2": "0.1.1"
+        "v2": "0.2.0"
       },
       "supports": {
         "v0": false,
         "v1": false,
         "v2": true
       },
-      "description": "Run a crime family in The Syndicate: a deterministic, turn-based city where the loot is real trading cards priced by a live on-chain oracle. Agents and humans share one world and one leaderboard.",
+      "description": "Run a crime family in The Syndicate: a deterministic, turn-based city driven by three real-world data feeds — live TCG card prices, real Chicago weather, and on-chain-committed sports stat lines. Each syndicate runs its own city; humans and agents compete on one shared leaderboard.",
       "homepage": "https://play.the-undesirables.com",
       "topics": [
         "game",
@@ -1595,7 +1595,9 @@
         "strategy",
         "trading-cards",
         "oracle",
-        "deterministic"
+        "deterministic",
+        "weather",
+        "sports"
       ],
       "stargazers_count": 0,
       "language": "TypeScript",


### PR DESCRIPTION
Updates The Syndicate's registry entry from 0.1.1 to [0.2.0](https://www.npmjs.com/package/plugin-syndicate/v/0.2.0), with a corrected description.

## What changed in the game

The Syndicate now runs on **three real-world data feeds**, all live in production:

- **Card prices** (existing) — loot carries live TCG oracle prices; a held stash re-prices daily against the market.
- **Chicago weather** (new) — the engine resolves each day under the latest real O'Hare observation (NWS/KORD): rain hampers drive-bys and favors laying low, heatwaves pay extortion premiums. A Weather Book takes tickets on tomorrow's sky, settled by the actual observation.
- **Sports stat lines** (new) — a Sports Book sets player props from a daily on-chain-committed panel covering four leagues (MLB, NFL, NHL, NBA; 5,000+ players). The book offers leagues currently **in season** — MLB today, others as their seasons return — because props settle on what a player actually does in his next real game, and an offseason book would only ever void. Every settled ticket cites a public Merkle-proof route.

All betting is **in-game capital only**, stated in SKILL.md and in the API's own responses — pretend money, real data. Also new: deterministic daily "Commission" contracts that give agents explicit short-term goals.

## What changed in the plugin (0.1.1 → 0.2.0)

- `SYNDICATE_MOVE` documents the two new bet verbs; state summaries now surface the weather, the active contract, and any open tickets. 13/13 tests pass on the published build.
- **Description correction:** the previous entry said agents and humans "share one world." Testing showed each session receives its own city instance — the *leaderboard* is what is shared. The entry now says so.

## Checklist

- [x] `version` 0.2.0 is live on npm; the published artifact was installed and verified (actions load, new verb documentation present)
- [x] All three feeds verified against production before this PR was written: the weather event opens each resolved day, a sports ticket places and correctly waits for the player's next real game, and invalid player ids are rejected
- [x] `bun run --cwd packages/registry validate` — 38 entries validated
- [x] `bun run --cwd packages/registry generate` — regenerated; deterministic (run twice, identical output)
- [x] Entry file ends with a trailing newline; the diff is exactly 2 files (no lockfiles this time)

## Verify without installing

The game is playable right now — no auth, no API key: **https://mcp.the-undesirables.com** (`syndicate_state` / `syndicate_move` / `syndicate_leaderboard`), or plain HTTP per [SKILL.md](https://play.the-undesirables.com/SKILL.md). The first response of a new session already carries `weather`, `sportsBook`, and both books' odds.
