### PR TITLE
fix(homepage): recover eliza.app from cached MIME failures

### DIFF
--- a/packages/homepage/index.html
+++ b/packages/homepage/index.html
@@ -14,7 +14,7 @@
     <link
       rel="preload"
       as="image"
-      href="/brand/favicons/favicon.svg"
+      href="/eliza-logo.webp"
       type="image/webp"
       fetchpriority="high"
     />

--- a/packages/homepage/tests/smoke.node.test.mjs
+++ b/packages/homepage/tests/smoke.node.test.mjs
@@ -13,6 +13,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageJsonPath = resolve(__dirname, "../package.json");
+const indexHtmlPath = resolve(__dirname, "../index.html");
 const pruneAssetsPath = resolve(
   __dirname,
   "../scripts/prune-unused-static-assets.mjs",
@@ -108,6 +109,31 @@ test("large visual assets receive a durable browser cache policy", () => {
       ),
     );
   }
+});
+
+test("preloaded image declares the MIME type of the referenced asset", () => {
+  const indexHtml = readFileSync(indexHtmlPath, "utf8");
+  const preloadTag = indexHtml.match(/<link(?=[^>]*rel="preload")[^>]*>/)?.[0];
+
+  assert.ok(preloadTag, "expected an image preload tag");
+  assert.match(preloadTag, /href="\/eliza-logo\.webp"/);
+  assert.match(preloadTag, /type="image\/webp"/);
+  assert.doesNotMatch(preloadTag, /favicon\.svg/);
+});
+
+test("built asset URLs include a deployment-specific cache revision", () => {
+  const viteConfig = readFileSync(viteConfigPath, "utf8");
+
+  assert.match(viteConfig, /process\.env\.GITHUB_SHA/);
+  assert.match(viteConfig, /process\.env\.CF_PAGES_COMMIT_SHA/);
+  assert.match(
+    viteConfig,
+    /entryFileNames: `assets\/\[name\]-\[hash\]-\$\{homepageBuildRevision\}\.js`/,
+  );
+  assert.match(
+    viteConfig,
+    /chunkFileNames: `assets\/\[name\]-\[hash\]-\$\{homepageBuildRevision\}\.js`/,
+  );
 });
 
 test("reduced-motion keeps functional loading indicators animated", () => {

--- a/packages/homepage/vite.config.ts
+++ b/packages/homepage/vite.config.ts
@@ -10,6 +10,14 @@ import react from "@vitejs/plugin-react";
 import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 
+const homepageBuildRevision = (
+  process.env.GITHUB_SHA ??
+  process.env.CF_PAGES_COMMIT_SHA ??
+  "local"
+)
+  .slice(0, 12)
+  .replaceAll(/[^a-zA-Z0-9_-]/g, "-");
+
 export default defineConfig({
   plugins: [
     react(),
@@ -105,5 +113,14 @@ export default defineConfig({
   },
   build: {
     chunkSizeWarningLimit: 1200,
+    rollupOptions: {
+      output: {
+        // A deployment revision prevents a browser-cached failed module
+        // response from pinning a later production build to the same URL.
+        entryFileNames: `assets/[name]-[hash]-${homepageBuildRevision}.js`,
+        chunkFileNames: `assets/[name]-[hash]-${homepageBuildRevision}.js`,
+        assetFileNames: `assets/[name]-[hash]-${homepageBuildRevision}[extname]`,
+      },
+    },
   },
 });


### PR DESCRIPTION
# Relates to

Closes #18236.

- [x] Targets `develop` and was created from the latest `origin/develop`.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` pass.
- [x] The production artifact was exercised in a real browser and its entry assets were checked for status and MIME type.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@15662f050c0014857bd020174516aee1abe1301b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop` at `15662f050c0014857bd020174516aee1abe1301b`; zero conflicts.
- [x] `bun run verify` passes post-sync: 346/346 Turbo tasks plus every repository audit.

# Risks

Low. The change affects generated homepage asset names and one preload URL. Existing content hashes remain in every filename; the additional deployment revision only prevents two production revisions from reusing the same browser cache key.

# Background

## What does this PR do?

- restores the WebP logo preload instead of declaring an SVG favicon as `image/webp`
- adds the production commit revision to generated JS, CSS, and chunk filenames
- adds regression tests for the MIME contract and deployment-specific asset naming

## Root cause

`eliza.app` could retain a failed module response under a one-year immutable `/assets/*` cache key. Cloudflare served the current files correctly and the exact `pages.dev` deployment rendered, but an affected browser kept an empty React root and only showed the orange HTML body background. The HTML also had an independent invalid preload declaration: `/brand/favicons/favicon.svg` with `type="image/webp"`.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. The package documentation already describes the hashed Cloudflare Pages artifact and immutable cache policy.

# Testing

## Where should a reviewer start?

Review `packages/homepage/vite.config.ts`, then build with a known `GITHUB_SHA` and inspect `dist/index.html`.

## Detailed testing steps

1. `bun run --cwd packages/homepage test`
2. `bun run --cwd packages/homepage typecheck`
3. `bun run --cwd packages/homepage lint:check`
4. `GITHUB_SHA=0123456789abcdef0123456789abcdef01234567 bun run --cwd packages/homepage build`
5. `bun run --cwd packages/homepage test:e2e -- tests/e2e/live-routes.spec.ts`
6. `bun run verify`
7. Serve `dist/` and confirm React mounts, the preload is `/eliza-logo.webp` with `image/webp`, and every generated asset URL ends in `-0123456789ab.js` or `-0123456789ab.css`.

Observed results: 74 package tests passed; 8/8 live route browser tests passed; typecheck, lint, production build, artifact MIME checks, and the root verify gate passed.

# Evidence Gate

<!-- evidence-head:61ac402aebba841426c062a905d028351e06745e -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18237-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18237-after-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18237-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - static Cloudflare Pages application; no backend path executes
<!-- evidence-row:frontend-logs -->
- [x] [18237-frontend-log.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18237-frontend-log.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [18237-domain-artifact.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18237-domain-artifact.txt)
<!-- evidence-row:ocr-review -->
- [x] [18237-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18237-ocr-review.txt)

# Evidence Details

## Known gaps / failures

The first local unit-test iteration exposed an over-broad test regular expression; it was corrected before commit and all required checks were rerun successfully. No product-code check is failing.

## Deploy notes

Merging into `develop` triggers `.github/workflows/deploy-homepage.yml`, which builds, runs the full browser suite, and deploys `packages/homepage/dist` to the `eliza-app-home` production branch serving `eliza.app` and `www.eliza.app`.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@15662f050c0014857bd020174516aee1abe1301b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex-desktop","skill_revision":"elizaOS/eliza@15662f050c0014857bd020174516aee1abe1301b:packages/skills/skills/contribute-to-eliza"} -->


