### PR TITLE
fix(core): salvage malformed evaluator envelopes and degrade issue labels instead of failing the turn

### DIFF
--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -969,3 +969,87 @@ describe("native tool dialects never recover as the user-facing answer", () => {
 		expect(result.messageToUser).toContain("165G free");
 	});
 });
+
+describe("malformed envelope recovery (#18240 class — the 2026-08-10 leak)", () => {
+	const harness = (raw: string) => ({
+		runtime: { useModel: vi.fn(async () => raw) },
+		context: {
+			id: "ctx",
+			staticPrefix: {
+				characterPrompt: { content: "agent_name: Eliza", stable: true },
+			},
+			events: [],
+		},
+		trajectory: {
+			context: { id: "ctx" },
+			steps: [
+				{
+					kind: "tool",
+					tool: { name: "WEB_SEARCH" },
+					result: { success: true, text: "search results" },
+				},
+			],
+			archivedSteps: [],
+			plannedQueue: [],
+			evaluatorOutputs: [],
+		},
+	});
+
+	// The live incident shape: gemma double-escaped the quotes inside
+	// messageToUser (\\" instead of \"), so the literal backslash terminates
+	// the JSON string early and strict parsing rejects the whole envelope.
+	const overEscaped = [
+		"```json",
+		"{",
+		' "success": true,',
+		' "decision": "FINISH",',
+		' "thought": "Verified the protocol claims against the search results.",',
+		' "messageToUser": "here is the reality check:\\\\n\\\\nit isn\'t a legal firm—it doesn\'t \\\\"support\\\\" a filing because that is a structure you establish independently."',
+		"}",
+		"```",
+	].join("\n");
+
+	it("salvages an over-escaped envelope and delivers the trapped answer", async () => {
+		const result = await runEvaluator(harness(overEscaped));
+		expect(result.decision).toBe("FINISH");
+		expect(result.messageToUser).toContain("reality check");
+		expect(result.messageToUser).toContain('"support"');
+		// No machinery may ship.
+		expect(result.messageToUser).not.toContain("```");
+		expect(result.messageToUser).not.toContain('"decision"');
+		expect(result.messageToUser).not.toContain("\\n");
+	});
+
+	it("replans instead of shipping an envelope that stays unparseable after salvage", async () => {
+		// Truncated mid-string: no escape repair can make this parse.
+		const mangled = [
+			"```json",
+			'{ "success": true, "decision": "FINISH", "thought": "done", "messageToUser": "the answer is',
+		].join("\n");
+		const result = await runEvaluator(harness(mangled));
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser).toBeUndefined();
+	});
+
+	it("still recovers plain prose after a successful tool (existing path untouched)", async () => {
+		const result = await runEvaluator(
+			harness("the repo has 42 open issues, mostly about connectors."),
+		);
+		expect(result.decision).toBe("FINISH");
+		expect(result.messageToUser).toContain("42 open issues");
+	});
+
+	it("does not classify a user-asked-for JSON payload as a malformed envelope", async () => {
+		// A JSON payload without the envelope discriminator keys must not be
+		// captured by the malformed-envelope branch; it keeps the pre-existing
+		// parse-failure replan behavior (and still never ships as machinery).
+		const result = await runEvaluator(
+			harness('```json\n{ "name": "color-pop", "hue": 210 }\n```'),
+		);
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser).toBeUndefined();
+		expect(
+			(result.raw as { recoverySource?: string } | undefined)?.recoverySource,
+		).not.toBe("malformed_envelope_text");
+	});
+});

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -711,6 +711,37 @@ function recoverEvaluatorTextOutput(
 		};
 	}
 
+	// A response that IS an envelope — fenced or bare — but failed strict
+	// parsing is machinery, never prose. Salvage the known over-escaping
+	// quirk first (small models emit \\" and \\n inside string values, which
+	// terminates the JSON string early); if the repaired envelope parses, the
+	// user gets the answer trapped in `messageToUser`. If it still cannot be
+	// parsed, replan — the raw envelope must never ship as a reply (live
+	// leak 2026-08-10: a whole fenced FINISH envelope posted to the channel
+	// because only the trailing-envelope strip below guarded this path).
+	const envelopeShaped = looksLikeEvaluatorEnvelopeText(text);
+	if (envelopeShaped) {
+		const salvaged = salvageOverEscapedEnvelope(text);
+		if (salvaged) {
+			return {
+				success: salvaged.success,
+				decision: salvaged.decision,
+				thought: salvaged.thought,
+				messageToUser: salvaged.messageToUser,
+				raw: { recoverySource: "salvaged_over_escaped_envelope" },
+			};
+		}
+		return {
+			...output,
+			success: false,
+			decision: "CONTINUE",
+			thought:
+				"Evaluator emitted a malformed envelope instead of evaluator JSON; replanning from recorded tool results.",
+			parseError: undefined,
+			raw: { recoverySource: "malformed_envelope_text" },
+		};
+	}
+
 	if (!hasSuccessfulToolResult(trajectory)) return output;
 	if (!looksLikeUserFacingAnswer(text)) return output;
 
@@ -785,6 +816,78 @@ function stripTrailingEvaluatorEnvelope(text: string): string {
 	}
 	if (!isEvaluatorEnvelopeObject(parsed)) return text;
 	return trimmed.slice(0, trimmed.length - candidate.length).trimEnd();
+}
+
+/**
+ * True when the (fence-stripped) text is a single evaluator envelope by shape:
+ * one leading JSON object carrying the envelope's discriminator keys. Shape
+ * detection is deliberately parse-free so it still classifies envelopes whose
+ * JSON is broken — that is exactly the case it exists for.
+ */
+function looksLikeEvaluatorEnvelopeText(text: string): boolean {
+	const body = stripJsonFence(text);
+	if (!body.startsWith("{")) return false;
+	return (
+		/"success"\s*:/.test(body) &&
+		(/"decision"\s*:/.test(body) || /"route"\s*:/.test(body))
+	);
+}
+
+function stripJsonFence(text: string): string {
+	return text
+		.trim()
+		.replace(/^```(?:json)?\s*/i, "")
+		.replace(/\s*```$/, "")
+		.trim();
+}
+
+/**
+ * Deterministic repair for the known small-model envelope quirk: string
+ * values emitted with doubled escapes (`\\"`, `\\n`), where the literal
+ * backslash terminates the JSON string early and the whole envelope fails to
+ * parse. Collapses double-backslash-before-escape-char into a single escape
+ * and re-parses. Returns the normalized envelope only when the repaired body
+ * parses AND looks like a real envelope with a usable string
+ * `messageToUser`; anything else returns undefined so the caller replans.
+ */
+function salvageOverEscapedEnvelope(text: string):
+	| {
+			success: boolean;
+			decision: "FINISH" | "CONTINUE";
+			thought: string;
+			messageToUser: string;
+	  }
+	| undefined {
+	const body = stripJsonFence(text);
+	const repaired = body.replace(/\\\\(["nrt])/g, "\\$1");
+	if (repaired === body) return undefined;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(repaired);
+	} catch {
+		// error-policy:J3 untrusted model output; unrepairable stays unparsed
+		// and the caller replans instead of shipping it.
+		return undefined;
+	}
+	if (!isEvaluatorEnvelopeObject(parsed)) return undefined;
+	const record = parsed as Record<string, unknown>;
+	const messageToUser =
+		typeof record.messageToUser === "string" ? record.messageToUser.trim() : "";
+	if (!messageToUser) return undefined;
+	const rawDecision = (
+		(typeof record.decision === "string" && record.decision) ||
+		(typeof record.route === "string" && record.route) ||
+		"FINISH"
+	).toUpperCase();
+	return {
+		success: record.success === true,
+		decision: rawDecision === "CONTINUE" ? "CONTINUE" : "FINISH",
+		thought:
+			typeof record.thought === "string"
+				? record.thought
+				: "Recovered from an over-escaped evaluator envelope.",
+		messageToUser,
+	};
 }
 
 function isEvaluatorEnvelopeObject(value: unknown): boolean {

--- a/plugins/plugin-agent-orchestrator/src/actions/issue-create-degrade.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/issue-create-degrade.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Deterministic unit coverage for the issue-creation degrade seams added after
+ * the 2026-08-10 live incident: labels apply as a best-effort second step so a
+ * label-permission failure cannot kill the creation, and issue-op failures
+ * speak an in-voice line instead of raw provider JSON. Stubbed service, no
+ * network.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  createIssueWithBestEffortLabels,
+  issueFailureReply,
+} from "./tasks";
+
+const ISSUE = {
+  number: 7,
+  title: "planner leaked internal json",
+  url: "https://github.com/o/r/issues/7",
+  state: "open" as const,
+  labels: [],
+  body: "",
+};
+
+function stubService(overrides?: { addLabels?: () => Promise<void> }) {
+  return {
+    createIssue: vi.fn(async () => ISSUE),
+    addLabels: vi.fn(overrides?.addLabels ?? (async () => undefined)),
+  } as never;
+}
+
+describe("createIssueWithBestEffortLabels", () => {
+  it("creates without labels in the create call and applies them separately", async () => {
+    const service = stubService();
+    const { issue, labelNote } = await createIssueWithBestEffortLabels(
+      service,
+      "o/r",
+      { title: ISSUE.title, body: "b", labels: ["bug"] },
+    );
+    expect(issue.number).toBe(7);
+    expect(labelNote).toBe("");
+    const createArgs = (service as { createIssue: ReturnType<typeof vi.fn> })
+      .createIssue.mock.calls[0];
+    // The create call itself must never carry labels — that is what a
+    // read-tier token 403s on, killing the whole creation.
+    expect(JSON.stringify(createArgs)).not.toContain("labels");
+    expect(
+      (service as { addLabels: ReturnType<typeof vi.fn> }).addLabels,
+    ).toHaveBeenCalledWith("o/r", 7, ["bug"]);
+  });
+
+  it("a label-permission failure degrades to a note; the issue still exists", async () => {
+    const service = stubService({
+      addLabels: async () => {
+        throw new Error(
+          'You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"}',
+        );
+      },
+    });
+    const { issue, labelNote } = await createIssueWithBestEffortLabels(
+      service,
+      "o/r",
+      { title: ISSUE.title, body: "b", labels: ["bug"] },
+    );
+    expect(issue.number).toBe(7);
+    expect(labelNote).toContain("labels skipped");
+  });
+
+  it("skips the label step entirely when no labels were requested", async () => {
+    const service = stubService();
+    await createIssueWithBestEffortLabels(service, "o/r", {
+      title: ISSUE.title,
+      body: "b",
+      labels: [],
+    });
+    expect(
+      (service as { addLabels: ReturnType<typeof vi.fn> }).addLabels,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe("issueFailureReply", () => {
+  it("permission failures get a human line with no API payload", () => {
+    const reply = issueFailureReply(
+      "elizaOS/eliza",
+      'You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"} - https://docs.github.com/v3/issues/labels/',
+    );
+    expect(reply).toContain("doesn't have permission");
+    expect(reply).not.toContain("{");
+    expect(reply).not.toContain("docs.github.com");
+  });
+
+  it("not-found and generic failures stay in voice too", () => {
+    expect(issueFailureReply("o/r", "Not Found - 404")).toContain(
+      "doesn't exist",
+    );
+    expect(issueFailureReply("o/r", "socket hang up")).toContain(
+      "couldn't finish",
+    );
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -3618,6 +3618,48 @@ function parseLabels(input: unknown): string[] {
   return [];
 }
 
+/**
+ * Create an issue with labels applied as a SEPARATE best-effort step. Labels
+ * on GitHub's create call require push/triage access, so a read-tier token
+ * fails the ENTIRE creation over a decoration (live incident 2026-08-10: a
+ * good issue died on "You do not have permission to create labels"). Title
+ * and body always land; a label failure degrades to a short note.
+ */
+export async function createIssueWithBestEffortLabels(
+  service: CodingWorkspaceService,
+  repo: string,
+  options: { title: string; body: string; labels: string[] },
+): Promise<{ issue: IssueInfo; labelNote: string }> {
+  const issue = await service.createIssue(repo, {
+    title: options.title,
+    body: options.body,
+  });
+  if (options.labels.length === 0) return { issue, labelNote: "" };
+  try {
+    await service.addLabels(repo, issue.number, options.labels);
+    return { issue, labelNote: "" };
+  } catch {
+    // error-policy:J4 labels are decoration; the created issue is the
+    // deliverable and a label-permission failure must not fail the turn.
+    return { issue, labelNote: " (labels skipped — no permission)" };
+  }
+}
+
+/**
+ * One in-voice line for a failed issue operation. The raw provider error
+ * stays in the returned `error` field for the planner and in logs — chat
+ * gets a human sentence, never API JSON and docs links.
+ */
+export function issueFailureReply(repo: string, errorMessage: string): string {
+  if (/permission|unauthorized|forbidden|403/i.test(errorMessage)) {
+    return `couldn't do that on ${repo} — the connected github account doesn't have permission for it.`;
+  }
+  if (/not found|404/i.test(errorMessage)) {
+    return `couldn't find that on ${repo} — the repo or issue doesn't exist (or isn't visible to the connected account).`;
+  }
+  return `couldn't finish that github operation on ${repo}. logged the details.`;
+}
+
 async function handleIssueAction(
   service: CodingWorkspaceService,
   repo: string,
@@ -3639,12 +3681,15 @@ async function handleIssueAction(
           if (items.length > 0) {
             const labels = parseLabels(params.labels);
             const created: IssueInfo[] = [];
+            let bulkLabelNote = "";
             for (const item of items.slice(0, ISSUE_RESULT_LIMIT)) {
-              const issue = await service.createIssue(repo, {
-                title: item.title,
-                body: item.body ?? "",
-                labels: labels.length > 0 ? labels : undefined,
-              });
+              const { issue, labelNote } =
+                await createIssueWithBestEffortLabels(service, repo, {
+                  title: item.title,
+                  body: item.body ?? "",
+                  labels,
+                });
+              if (labelNote) bulkLabelNote = labelNote;
               created.push(issue);
             }
             // Create/list/get answers are the complete answer to the turn:
@@ -3654,7 +3699,7 @@ async function handleIssueAction(
             const summary = created
               .map((i) => `#${i.number}: ${i.title}\n  ${i.url}`)
               .join("\n");
-            const bulkText = `Created ${created.length} issues:\n${summary}`;
+            const bulkText = `Created ${created.length} issues${bulkLabelNote}:\n${summary}`;
             if (callback) await callback({ text: bulkText });
             return {
               success: true,
@@ -3674,12 +3719,12 @@ async function handleIssueAction(
         }
 
         const labels = parseLabels(params.labels);
-        const issue = await service.createIssue(repo, {
-          title,
-          body: body ?? "",
-          labels: labels.length > 0 ? labels : undefined,
-        });
-        const createdText = `Created issue #${issue.number}: ${issue.title}\n${issue.url}`;
+        const { issue, labelNote } = await createIssueWithBestEffortLabels(
+          service,
+          repo,
+          { title, body: body ?? "", labels },
+        );
+        const createdText = `Created issue #${issue.number}${labelNote}: ${issue.title}\n${issue.url}`;
         if (callback) await callback({ text: createdText });
         return {
           success: true,
@@ -3842,10 +3887,13 @@ async function handleIssueAction(
         return { success: false, error: "UNKNOWN_OPERATION" };
     }
   } catch (error) {
-    // error-policy:J1 issue-operation boundary → user-facing error + structured failure.
+    // error-policy:J1 issue-operation boundary → in-voice user line +
+    // structured failure. The raw provider message stays planner/log-facing
+    // only: shipping API JSON and docs links to chat was the 2026-08-10
+    // incident's second half.
     const errorMessage = error instanceof Error ? error.message : String(error);
     if (callback)
-      await callback({ text: `Issue operation failed: ${errorMessage}` });
+      await callback({ text: issueFailureReply(repo, errorMessage) });
     return { success: false, error: errorMessage };
   }
 }


### PR DESCRIPTION
Two live incidents from one turn (2026-08-10 03:26Z, busy group channel), both fixed:

## 1. Malformed evaluator envelope shipped raw to chat
The evaluator model emitted its FINISH envelope with double-escaped string values (\\" and \\n inside `messageToUser`) — the literal backslash terminates the JSON string, strict parsing rejects the envelope, and the text recovery path shipped the ENTIRE fenced JSON to the channel. The existing `stripTrailingEvaluatorEnvelope` guard only handles a *trailing, parseable* envelope, so a wholly-malformed one walked past it.

**Fix (evaluator.ts):**
- `salvageOverEscapedEnvelope()` — deterministic repair of the double-escape quirk; when the repaired envelope parses, the user gets the answer that was trapped in `messageToUser` (in the incident it was a good, complete answer).
- `looksLikeEvaluatorEnvelopeText()` — parse-free shape detection; an envelope-shaped response that stays unparseable after salvage REPLANS (mirroring the existing tool-syntax branch) and can never ship as a reply, however mangled.

## 2. Issue creation died on label permissions, then leaked the raw API error
`manage_issues create` passed labels inside GitHub's create call; labels-on-create needs push/triage, so a read-tier token 403'd and the ENTIRE creation failed — discarding a good title+body — and the raw API JSON + docs URL shipped to chat.

**Fix (tasks.ts):**
- `createIssueWithBestEffortLabels()` — create with title+body only, apply labels as a separate best-effort step; label failure degrades to "(labels skipped — no permission)" while the issue and URL still land.
- `issueFailureReply()` — issue-op failures speak one in-voice line; the raw provider message stays in the returned `error` field and logs only.

## Tests
- evaluator.test.ts +4: salvage of the incident's exact malformation shape delivers the trapped answer with zero machinery; unparseable-after-salvage replans; plain prose recovery untouched; non-envelope JSON payloads not misclassified. Suite 40/40.
- issue-create-degrade.test.ts (new) 5/5: create call carries no labels; label-permission failure yields issue + note; no-labels skips the step; permission/not-found/generic failures all stay in voice with no API payload.
- core typecheck clean. (The pre-existing `packages/auth` error on develop is untouched.)

# Evidence

<!-- evidence-head:2abf3201eb2ca436e1011627cfd848f97819642b -->
- Before screenshots: N/A - backend-only change, no UI surface
- After screenshots: N/A - backend-only change, no UI surface
- Walkthrough video: N/A - backend-only change, no UI surface
- OCR review: N/A - backend-only change, no UI surface
- Frontend console/network logs: N/A - backend-only change, no UI surface
- Backend logs: vitest transcript below
- Real-LLM trajectory: live incident trajectories (agent-local store) hold the exact malformed envelope bytes and the failed labels-on-create tool call; malformation shape replicated byte-pattern-exact in the new tests
- Domain artifacts:

```
bunx vitest run evaluator.test.ts issue-create-degrade.test.ts
 Test Files  2 passed (2)
      Tests  45 passed (45)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
