### PR TITLE
fix(orchestrator): keep issue confirmations clean — label degrade stays planner-side

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -3699,15 +3699,20 @@ async function handleIssueAction(
             const summary = created
               .map((i) => `#${i.number}: ${i.title}\n  ${i.url}`)
               .join("\n");
-            const bulkText = `Created ${created.length} issues${bulkLabelNote}:\n${summary}`;
+            // The chat confirmation stays clean; a label degrade is recorded
+            // planner-side (`text` + data) so the model can answer honestly
+            // if asked, without machinery notes in the user's message.
+            const bulkText = `Created ${created.length} issues:\n${summary}`;
             if (callback) await callback({ text: bulkText });
             return {
               success: true,
-              text: bulkText,
+              text: bulkLabelNote
+                ? `${bulkText}\n(requested labels not applied: no label permission on ${repo})`
+                : bulkText,
               userFacingText: bulkText,
               verifiedUserFacing: true,
               turnComplete: true,
-              data: { issues: created },
+              data: { issues: created, labelsApplied: !bulkLabelNote },
             };
           }
 
@@ -3724,15 +3729,19 @@ async function handleIssueAction(
           repo,
           { title, body: body ?? "", labels },
         );
-        const createdText = `Created issue #${issue.number}${labelNote}: ${issue.title}\n${issue.url}`;
+        // Clean human confirmation only; the label degrade stays
+        // planner-side (`text` + data) — no machinery notes in chat.
+        const createdText = `Created issue #${issue.number}: ${issue.title}\n${issue.url}`;
         if (callback) await callback({ text: createdText });
         return {
           success: true,
-          text: createdText,
+          text: labelNote
+            ? `${createdText}\n(requested labels not applied: no label permission on ${repo})`
+            : createdText,
           userFacingText: createdText,
           verifiedUserFacing: true,
           turnComplete: true,
-          data: { issue },
+          data: { issue, labelsApplied: !labelNote },
         };
       }
 


### PR DESCRIPTION
Follow-up to #18238. The "(labels skipped — no permission)" note shipped inside the user-facing confirmation — machinery in chat, exactly the class the parent PR was killing. Owner feedback: pointless noise for the reader.

Now: the chat confirmation is purely human ("Created issue #N: title + url"); the label degrade is recorded planner-side in the result `text` and `data.labelsApplied`, so the model can answer "did you label it?" honestly without the note ever appearing unprompted.

Tests: degrade suite 5/5 (helper contract unchanged); live-verified on the deployed agent (clean confirmation on a label-denied repo).

# Evidence

<!-- evidence-head:bc820f3bfdeadb5acc356796b1b34c0acb61932a -->
- Before screenshots: N/A - backend-only change, no UI surface
- After screenshots: N/A - backend-only change, no UI surface
- Walkthrough video: N/A - backend-only change, no UI surface
- OCR review: N/A - backend-only change, no UI surface
- Frontend console/network logs: N/A - backend-only change, no UI surface
- Backend logs: vitest 5/5 (issue-create-degrade.test.ts)
- Real-LLM trajectory: live probe on the deployed agent post-merge (label-denied repo → clean confirmation, degrade visible in the result text planner-side)
- Domain artifacts: live-created probe issue confirmations before/after (parenthetical present → absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
