### PR TITLE
fix(orchestrator): settle issue-comment confirmations so the planner does not double-message

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -3829,11 +3829,19 @@ async function handleIssueAction(
           };
         }
         const comment = await service.addComment(repo, issueNumber, body);
-        if (callback)
-          await callback({
-            text: `Added comment to issue #${issueNumber}: ${comment.url}`,
-          });
-        return { success: true, data: { comment } };
+        const commentedText = `Added comment to issue #${issueNumber}: ${comment.url}`;
+        if (callback) await callback({ text: commentedText });
+        // Settled like create/list/get: the callback is the sole delivery, so
+        // the planner does not append a second "done, commented" bubble
+        // (live double-message 2026-08-10, same class as the create paths).
+        return {
+          success: true,
+          text: commentedText,
+          userFacingText: commentedText,
+          verifiedUserFacing: true,
+          turnComplete: true,
+          data: { comment },
+        };
       }
 
       case "close": {


### PR DESCRIPTION
Live find minutes after #18242: "comment on elizaOS/eliza issue 18240: …" produced TWO messages — the action callback ("Added comment to issue #18240: <url>") and the planner's paraphrase ("done. commented on issue 18240.") one second later. The comment subaction returned a bare `{success, data}` with no settlement, unlike create/list/get.

Fix: settle the comment confirmation (`userFacingText` + `verifiedUserFacing` + `turnComplete`) exactly like the sibling subactions — callback becomes the sole delivery, one message ships.

Also filed alongside: the multi-step composition gap where a terminal `list` preempts a follow-up `comment` (see issue). Tests: degrade suite 5/5; live re-probe post-deploy is the acceptance.

# Evidence

<!-- evidence-head:127ccaa409b4ddb734c708e9942b7cf9159310a3 -->
- Before screenshots: N/A - backend-only change, no UI surface
- After screenshots: N/A - backend-only change, no UI surface
- Walkthrough video: N/A - backend-only change, no UI surface
- OCR review: N/A - backend-only change, no UI surface
- Frontend console/network logs: N/A - backend-only change, no UI surface
- Backend logs: vitest 5/5
- Real-LLM trajectory: live double-message pair (04:28:31 + 04:28:32Z) in the agent store; post-deploy re-probe = single message
- Domain artifacts: issue comment thread on the probe issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
