### PR TITLE
fix(vision): make capability readiness honest and fail closed (#16341)

### DIFF
--- a/plugins/plugin-vision/src/action.capture-hardening.test.ts
+++ b/plugins/plugin-vision/src/action.capture-hardening.test.ts
@@ -11,6 +11,7 @@ import {
 import sharp from "sharp";
 import { describe, expect, it, vi } from "vitest";
 import { visionAction } from "./action";
+import { VisionMode } from "./types";
 
 async function makePng(): Promise<Buffer> {
   return sharp({
@@ -41,6 +42,7 @@ function makeRuntime(captureImage: () => Promise<Buffer | null>) {
     isActive: () => true,
     captureImage,
     getCameraInfo: () => ({ id: "cam-1", name: "Camera", connected: true }),
+    getVisionMode: () => VisionMode.CAMERA,
     getCapabilities: () => ({
       objectDetection: false,
       ocr: false,
@@ -118,5 +120,22 @@ describe("VISION capture hardening", () => {
         ],
       }),
     );
+  });
+
+  it("refuses capture in SCREEN mode even when a camera remains connected", async () => {
+    const captureImage = vi.fn(async () => makePng());
+    const { runtime, visionService } = makeRuntime(captureImage);
+    visionService.getVisionMode = () => VisionMode.SCREEN;
+
+    const result = await visionAction.handler(
+      runtime,
+      makeMessage(),
+      undefined,
+      { action: "capture" },
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.data?.error).toContain("disabled in SCREEN vision mode");
+    expect(captureImage).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-vision/src/action.capture-hardening.test.ts
+++ b/plugins/plugin-vision/src/action.capture-hardening.test.ts
@@ -41,6 +41,14 @@ function makeRuntime(captureImage: () => Promise<Buffer | null>) {
     isActive: () => true,
     captureImage,
     getCameraInfo: () => ({ id: "cam-1", name: "Camera", connected: true }),
+    getCapabilities: () => ({
+      objectDetection: false,
+      ocr: false,
+      faceRecognition: false,
+      screenCapture: false,
+      camera: true,
+      audio: false,
+    }),
   };
   const runtime = Object.assign(Object.create(null) as IAgentRuntime, {
     agentId: "agent",

--- a/plugins/plugin-vision/src/action.describe-readiness.test.ts
+++ b/plugins/plugin-vision/src/action.describe-readiness.test.ts
@@ -80,6 +80,7 @@ describe("VISION describe readiness", () => {
     const callback = vi.fn(async () => undefined);
     const visionService = {
       isActive: () => false,
+      getVisionMode: () => VisionMode.OFF,
       getCapabilities: () => ({
         objectDetection: false,
         ocr: false,
@@ -108,6 +109,46 @@ describe("VISION describe readiness", () => {
     expect(callback).toHaveBeenCalledWith(
       expect.objectContaining({
         text: expect.stringContaining("No vision input is available"),
+      }),
+    );
+  });
+
+  it("surfaces the concrete backend reason while an active screen loop has no frame", async () => {
+    const callback = vi.fn(async () => undefined);
+    const visionService = {
+      isActive: () => true,
+      getVisionMode: () => VisionMode.SCREEN,
+      getCapabilities: () => ({
+        objectDetection: false,
+        ocr: false,
+        faceRecognition: false,
+        screenCapture: false,
+        camera: false,
+        audio: false,
+        unavailableReasons: {
+          screenCapture: "Screen capture permission denied",
+        },
+      }),
+    };
+    const runtime = Object.assign(Object.create(null) as IAgentRuntime, {
+      agentId: UUID,
+      getService: vi.fn(() => visionService),
+      createMemory: vi.fn(async () => undefined),
+    });
+
+    const result = await visionAction.handler(
+      runtime,
+      makeMessage(),
+      undefined,
+      { action: "describe" },
+      callback,
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.data?.error).toBe("Screen capture permission denied");
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("Screen capture permission denied"),
       }),
     );
   });

--- a/plugins/plugin-vision/src/action.describe-readiness.test.ts
+++ b/plugins/plugin-vision/src/action.describe-readiness.test.ts
@@ -152,4 +152,40 @@ describe("VISION describe readiness", () => {
       }),
     );
   });
+
+  it("does not let a connected camera satisfy SCREEN-mode readiness", async () => {
+    const getEnhancedSceneDescription = vi.fn();
+    const visionService = {
+      isActive: () => true,
+      getVisionMode: () => VisionMode.SCREEN,
+      getEnhancedSceneDescription,
+      getCapabilities: () => ({
+        objectDetection: false,
+        ocr: false,
+        faceRecognition: false,
+        screenCapture: false,
+        camera: true,
+        audio: false,
+        unavailableReasons: {
+          screenCapture: "Screen capture permission denied",
+        },
+      }),
+    };
+    const runtime = Object.assign(Object.create(null) as IAgentRuntime, {
+      agentId: UUID,
+      getService: vi.fn(() => visionService),
+      createMemory: vi.fn(async () => undefined),
+    });
+
+    const result = await visionAction.handler(
+      runtime,
+      makeMessage(),
+      undefined,
+      { action: "describe" },
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.data?.error).toBe("Screen capture permission denied");
+    expect(getEnhancedSceneDescription).not.toHaveBeenCalled();
+  });
 });

--- a/plugins/plugin-vision/src/action.describe-readiness.test.ts
+++ b/plugins/plugin-vision/src/action.describe-readiness.test.ts
@@ -75,4 +75,40 @@ describe("VISION describe readiness", () => {
     expect(getEnhancedSceneDescription).toHaveBeenCalledOnce();
     expect(visionService.getSceneDescription).not.toHaveBeenCalled();
   });
+
+  it("reports an inactive service as unavailable instead of indefinitely initializing", async () => {
+    const callback = vi.fn(async () => undefined);
+    const visionService = {
+      isActive: () => false,
+      getCapabilities: () => ({
+        objectDetection: false,
+        ocr: false,
+        faceRecognition: false,
+        screenCapture: false,
+        camera: false,
+        audio: false,
+      }),
+    };
+    const runtime = Object.assign(Object.create(null) as IAgentRuntime, {
+      agentId: UUID,
+      getService: vi.fn(() => visionService),
+      createMemory: vi.fn(async () => undefined),
+    });
+
+    const result = await visionAction.handler(
+      runtime,
+      makeMessage(),
+      undefined,
+      { action: "describe" },
+      callback,
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.data?.error).toContain("inactive");
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("No vision input is available"),
+      }),
+    );
+  });
 });

--- a/plugins/plugin-vision/src/action.describe-readiness.test.ts
+++ b/plugins/plugin-vision/src/action.describe-readiness.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Describe-action tests for screen-only readiness and enhanced-scene routing.
+ */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { visionAction } from "./action";
+import { VisionMode } from "./types";
+
+const UUID = "00000000-0000-4000-8000-000000000001" as const;
+
+function makeMessage(): Memory {
+  return {
+    id: UUID,
+    entityId: UUID,
+    agentId: UUID,
+    roomId: UUID,
+    worldId: UUID,
+    content: { text: "describe my screen" },
+  };
+}
+
+describe("VISION describe readiness", () => {
+  it("uses the enhanced screen scene when screen capture is the only ready input", async () => {
+    const getEnhancedSceneDescription = vi.fn(async () => ({
+      timestamp: Date.now(),
+      description: "A terminal window is open.",
+      objects: [],
+      people: [],
+      sceneChanged: false,
+      changePercentage: 0,
+      screenCapture: {
+        timestamp: Date.now(),
+        width: 1280,
+        height: 720,
+        data: Buffer.from("screen"),
+        tiles: [],
+      },
+    }));
+    const visionService = {
+      isActive: () => true,
+      getCapabilities: () => ({
+        objectDetection: false,
+        ocr: false,
+        faceRecognition: false,
+        screenCapture: true,
+        camera: false,
+        audio: false,
+      }),
+      getEnhancedSceneDescription,
+      getSceneDescription: vi.fn(() => {
+        throw new Error("camera-only scene accessor must not be used");
+      }),
+      getCameraInfo: () => null,
+      getVisionMode: () => VisionMode.SCREEN,
+    };
+    const runtime = Object.assign(Object.create(null) as IAgentRuntime, {
+      agentId: UUID,
+      getService: vi.fn((name: string) =>
+        name === "VISION" ? visionService : null,
+      ),
+      createMemory: vi.fn(async () => undefined),
+    });
+
+    const result = await visionAction.handler(
+      runtime,
+      makeMessage(),
+      undefined,
+      { action: "describe" },
+    );
+
+    expect(result?.success).toBe(true);
+    expect(result?.text).toContain("Looking at the screen");
+    expect(result?.text).toContain("A terminal window is open");
+    expect(getEnhancedSceneDescription).toHaveBeenCalledOnce();
+    expect(visionService.getSceneDescription).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -252,13 +252,14 @@ async function runDescribe(
   const visionService = runtime.getService<VisionService>("VISION");
   const caps = visionService?.getCapabilities();
   const hasReadyInput = Boolean(caps?.camera || caps?.screenCapture);
+  const serviceActive = visionService?.isActive() === true;
 
-  if (!visionService?.isActive() || !hasReadyInput) {
-    const hasConfiguredInput = Boolean(visionService && caps);
-    const thought = hasConfiguredInput
+  if (!serviceActive || !hasReadyInput) {
+    const awaitingFirstInput = serviceActive && !hasReadyInput;
+    const thought = awaitingFirstInput
       ? "Vision service is not fully initialized yet."
       : "Vision service is not available — no camera or screen capture is connected.";
-    const text = hasConfiguredInput
+    const text = awaitingFirstInput
       ? "I'm still initializing my vision. Please try again in a moment."
       : "I cannot see anything right now. No vision input is available.";
     await saveExecutionRecord(runtime, message, thought, text, ["VISION"]);
@@ -276,7 +277,9 @@ async function runDescribe(
       data: {
         actionName: "VISION",
         op: "describe",
-        error: "Vision service not available or no camera connected",
+        error: awaitingFirstInput
+          ? "Vision input has not produced a frame yet"
+          : "Vision service is inactive or has no available input",
       },
     };
   }

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -256,11 +256,16 @@ async function runDescribe(
 
   if (!serviceActive || !hasReadyInput) {
     const awaitingFirstInput = serviceActive && !hasReadyInput;
+    const visionMode = visionService?.getVisionMode();
+    const unavailableReason =
+      visionMode === VisionMode.CAMERA
+        ? caps?.unavailableReasons?.camera
+        : caps?.unavailableReasons?.screenCapture;
     const thought = awaitingFirstInput
-      ? "Vision service is not fully initialized yet."
+      ? `Vision input is unavailable${unavailableReason ? `: ${unavailableReason}` : "."}`
       : "Vision service is not available — no camera or screen capture is connected.";
     const text = awaitingFirstInput
-      ? "I'm still initializing my vision. Please try again in a moment."
+      ? `I cannot see anything right now${unavailableReason ? `: ${unavailableReason}` : "."}`
       : "I cannot see anything right now. No vision input is available.";
     await saveExecutionRecord(runtime, message, thought, text, ["VISION"]);
     if (callback) {
@@ -278,7 +283,7 @@ async function runDescribe(
         actionName: "VISION",
         op: "describe",
         error: awaitingFirstInput
-          ? "Vision input has not produced a frame yet"
+          ? (unavailableReason ?? "Vision input has not produced a frame yet")
           : "Vision service is inactive or has no available input",
       },
     };

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -250,14 +250,15 @@ async function runDescribe(
   callback?: HandlerCallback,
 ): Promise<ActionResult> {
   const visionService = runtime.getService<VisionService>("VISION");
+  const caps = visionService?.getCapabilities();
+  const hasReadyInput = Boolean(caps?.camera || caps?.screenCapture);
 
-  if (!visionService?.isActive()) {
-    const caps = visionService?.getCapabilities();
-    const hasAnyVisionInput = caps?.camera || caps?.screenCapture;
-    const thought = hasAnyVisionInput
+  if (!visionService?.isActive() || !hasReadyInput) {
+    const hasConfiguredInput = Boolean(visionService && caps);
+    const thought = hasConfiguredInput
       ? "Vision service is not fully initialized yet."
       : "Vision service is not available — no camera or screen capture is connected.";
-    const text = hasAnyVisionInput
+    const text = hasConfiguredInput
       ? "I'm still initializing my vision. Please try again in a moment."
       : "I cannot see anything right now. No vision input is available.";
     await saveExecutionRecord(runtime, message, thought, text, ["VISION"]);
@@ -282,14 +283,19 @@ async function runDescribe(
 
   try {
     const scene = await withVisionTimeout(
-      visionService.getSceneDescription(),
+      visionService.getEnhancedSceneDescription(),
       "vision scene description",
     );
     const cameraInfo = visionService.getCameraInfo();
+    const visionMode = visionService.getVisionMode();
 
     if (!scene) {
-      const thought = "Camera is connected but no scene has been analyzed yet.";
-      const text = `Camera "${cameraInfo?.name}" is connected, but I haven't analyzed any scenes yet. Please wait a moment.`;
+      const thought =
+        "A vision input is ready but no scene has been analyzed yet.";
+      const source = caps?.camera
+        ? `Camera "${cameraInfo?.name ?? "unknown"}"`
+        : "Screen capture";
+      const text = `${source} is ready, but I haven't analyzed any scenes yet. Please wait a moment.`;
       await saveExecutionRecord(runtime, message, thought, text, ["VISION"]);
       if (callback) {
         await callback({ thought, text, actions: ["VISION"] });
@@ -326,7 +332,12 @@ async function runDescribe(
     const detailLevel =
       options.detailLevel === "summary" ? "summary" : "detailed";
 
-    let description = `Looking through ${cameraInfo?.name || "the camera"}, `;
+    let description =
+      visionMode === VisionMode.SCREEN
+        ? "Looking at the screen, "
+        : visionMode === VisionMode.BOTH
+          ? "Using the camera and screen, "
+          : `Looking through ${cameraInfo?.name || "the camera"}, `;
     description += scene.description;
 
     if (detailLevel === "detailed" && peopleCount > 0) {

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -252,9 +252,14 @@ async function runDescribe(
   const visionService = runtime.getService<VisionService>("VISION");
 
   if (!visionService?.isActive()) {
-    const thought =
-      "Vision service is not available or no camera is connected.";
-    const text = "I cannot see anything right now. No camera is available.";
+    const caps = visionService?.getCapabilities();
+    const hasAnyVisionInput = caps?.camera || caps?.screenCapture;
+    const thought = hasAnyVisionInput
+      ? "Vision service is not fully initialized yet."
+      : "Vision service is not available — no camera or screen capture is connected.";
+    const text = hasAnyVisionInput
+      ? "I'm still initializing my vision. Please try again in a moment."
+      : "I cannot see anything right now. No vision input is available.";
     await saveExecutionRecord(runtime, message, thought, text, ["VISION"]);
     if (callback) {
       await callback({ thought, text, actions: ["VISION"] });
@@ -451,10 +456,16 @@ async function runCapture(
 ): Promise<ActionResult> {
   const visionService = runtime.getService<VisionService>("VISION");
 
-  if (!visionService?.isActive()) {
-    const thought =
-      "Vision service is not available or no camera is connected.";
-    const text = "I cannot capture an image right now. No camera is available.";
+  // Capture requires a camera. Check capability honestly — SCREEN mode with
+  // no camera should fail closed here, not pass isActive() and fail later.
+  const caps = visionService?.getCapabilities();
+  if (!visionService?.isActive() || !caps?.camera) {
+    const thought = caps?.camera
+      ? "Vision service is not fully initialized yet."
+      : "No camera is connected.";
+    const text = caps?.camera
+      ? "I'm still initializing my vision. Please try again in a moment."
+      : "I cannot capture an image right now. No camera is available.";
     await saveExecutionRecord(runtime, message, thought, text, ["VISION"]);
     if (callback) {
       await callback({ thought, text, actions: ["VISION"] });

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -25,7 +25,7 @@ import {
   type ScreenCaptureBridgeService,
 } from "./screen-capture-bridge";
 import type { VisionService } from "./service";
-import { VisionMode } from "./types";
+import { hasReadyInputForMode, VisionMode } from "./types";
 
 const VISION_ACTION_TIMEOUT_MS = 10_000;
 const MAX_VISION_TEXT_LENGTH = 4000;
@@ -251,12 +251,12 @@ async function runDescribe(
 ): Promise<ActionResult> {
   const visionService = runtime.getService<VisionService>("VISION");
   const caps = visionService?.getCapabilities();
-  const hasReadyInput = Boolean(caps?.camera || caps?.screenCapture);
+  const visionMode = visionService?.getVisionMode();
+  const hasReadyInput = hasReadyInputForMode(caps, visionMode);
   const serviceActive = visionService?.isActive() === true;
 
   if (!serviceActive || !hasReadyInput) {
     const awaitingFirstInput = serviceActive && !hasReadyInput;
-    const visionMode = visionService?.getVisionMode();
     const unavailableReason =
       visionMode === VisionMode.CAMERA
         ? caps?.unavailableReasons?.camera
@@ -478,29 +478,35 @@ async function runCapture(
   // Capture requires a camera. Check capability honestly — SCREEN mode with
   // no camera should fail closed here, not pass isActive() and fail later.
   const caps = visionService?.getCapabilities();
-  if (!visionService?.isActive() || !caps?.camera) {
-    const thought = caps?.camera
-      ? "Vision service is not fully initialized yet."
-      : "No camera is connected.";
-    const text = caps?.camera
-      ? "I'm still initializing my vision. Please try again in a moment."
-      : "I cannot capture an image right now. No camera is available.";
+  const visionMode = visionService?.getVisionMode();
+  const cameraModeActive =
+    visionMode === VisionMode.CAMERA || visionMode === VisionMode.BOTH;
+  if (!visionService?.isActive() || !cameraModeActive || !caps?.camera) {
+    const unavailableReason = !visionService
+      ? "Vision service is not available"
+      : !cameraModeActive
+        ? `Camera capture is disabled in ${visionMode ?? "the current"} vision mode`
+        : !caps?.camera
+          ? (caps?.unavailableReasons?.camera ?? "No camera is connected")
+          : "Camera processing is not active";
+    const thought = unavailableReason;
+    const text = `I cannot capture an image right now: ${unavailableReason}.`;
     await saveExecutionRecord(runtime, message, thought, text, ["VISION"]);
     if (callback) {
       await callback({ thought, text, actions: ["VISION"] });
     }
     return {
       success: false,
-      text: "Vision service unavailable - cannot capture image",
+      text,
       values: {
         success: false,
         visionAvailable: false,
-        error: "Vision service not available",
+        error: unavailableReason,
       },
       data: {
         actionName: "VISION",
         op: "capture",
-        error: "Vision service not available or no camera connected",
+        error: unavailableReason,
       },
     };
   }

--- a/plugins/plugin-vision/src/face-recognition-ggml.ts
+++ b/plugins/plugin-vision/src/face-recognition-ggml.ts
@@ -390,6 +390,8 @@ export interface DetectedFace {
 export class FaceRecognition {
   private readonly detector = new BlazeFaceGgmlDetector();
   private readonly embedder = new FaceEmbedGgmlRecognizer();
+  private initialized = false;
+  private initPromise: Promise<void> | null = null;
   private detectorAvailable: boolean | null = null;
   private readonly faceLibrary: FaceLibrary = {
     faces: new Map(),
@@ -400,6 +402,40 @@ export class FaceRecognition {
   private readonly FACE_MATCH_THRESHOLD = 0.6;
   // Minimum face size in pixels.
   private readonly MIN_FACE_SIZE = 50;
+
+  /** Load both native models before this pipeline is reported as ready. */
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    if (this.initPromise) return this.initPromise;
+    this.initPromise = (async () => {
+      try {
+        await this.detector.initialize();
+        await this.embedder.initialize();
+        this.initialized = true;
+      } catch (error) {
+        // error-policy:J6 best-effort teardown must preserve the init failure.
+        const cleanup = await Promise.allSettled([
+          this.detector.dispose(),
+          this.embedder.dispose(),
+        ]);
+        for (const result of cleanup) {
+          if (result.status === "rejected") {
+            logger.warn(
+              `${FACE_REC_TAG} partial-init cleanup failed: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
+            );
+          }
+        }
+        throw error;
+      } finally {
+        this.initPromise = null;
+      }
+    })();
+    return this.initPromise;
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
 
   /**
    * Detect faces in a raw RGBA frame and compute an embedding for each.
@@ -424,6 +460,8 @@ export class FaceRecognition {
       );
       return [];
     }
+
+    if (!this.initialized) await this.initialize();
 
     if (this.detectorAvailable === null) {
       this.detectorAvailable = await BlazeFaceGgmlDetector.isAvailable();
@@ -557,8 +595,20 @@ export class FaceRecognition {
   }
 
   async dispose(): Promise<void> {
-    await this.detector.dispose();
-    await this.embedder.dispose();
+    const cleanup = await Promise.allSettled([
+      this.detector.dispose(),
+      this.embedder.dispose(),
+    ]);
+    // error-policy:J6 best-effort teardown releases both native models.
+    for (const result of cleanup) {
+      if (result.status === "rejected") {
+        logger.warn(
+          `${FACE_REC_TAG} dispose failed: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
+        );
+      }
+    }
+    this.initialized = false;
+    this.initPromise = null;
   }
 }
 

--- a/plugins/plugin-vision/src/face-recognition-readiness.test.ts
+++ b/plugins/plugin-vision/src/face-recognition-readiness.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Native face-pipeline lifecycle tests using deterministic backend doubles.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { FaceRecognition } from "./face-recognition-ggml";
+
+function installBackends(
+  pipeline: FaceRecognition,
+  options: { embedderFails?: boolean } = {},
+) {
+  const detector = {
+    initialize: vi.fn(async () => undefined),
+    dispose: vi.fn(async () => undefined),
+  };
+  const embedder = {
+    initialize: options.embedderFails
+      ? vi.fn(async () => {
+          throw new Error("embedder unavailable");
+        })
+      : vi.fn(async () => undefined),
+    dispose: vi.fn(async () => undefined),
+  };
+  Reflect.set(pipeline, "detector", detector);
+  Reflect.set(pipeline, "embedder", embedder);
+  return { detector, embedder };
+}
+
+describe("FaceRecognition readiness", () => {
+  it("becomes ready only after detector and embedder initialize", async () => {
+    const pipeline = new FaceRecognition();
+    const { detector, embedder } = installBackends(pipeline);
+
+    expect(pipeline.isInitialized()).toBe(false);
+    await pipeline.initialize();
+
+    expect(detector.initialize).toHaveBeenCalledOnce();
+    expect(embedder.initialize).toHaveBeenCalledOnce();
+    expect(pipeline.isInitialized()).toBe(true);
+  });
+
+  it("disposes partial native state and stays unavailable when initialization fails", async () => {
+    const pipeline = new FaceRecognition();
+    const { detector, embedder } = installBackends(pipeline, {
+      embedderFails: true,
+    });
+
+    await expect(pipeline.initialize()).rejects.toThrow("embedder unavailable");
+
+    expect(detector.dispose).toHaveBeenCalledOnce();
+    expect(embedder.dispose).toHaveBeenCalledOnce();
+    expect(pipeline.isInitialized()).toBe(false);
+  });
+});

--- a/plugins/plugin-vision/src/ocr-service.ts
+++ b/plugins/plugin-vision/src/ocr-service.ts
@@ -296,13 +296,6 @@ export class OCRService {
       const backend = await factory();
       if (!backend) continue;
       try {
-        if (backend.name === "doctr") {
-          // Defer GGUF load until first use so OCRService.initialize stays
-          // cheap. DoctrBackend.initialize() is what triggers the FFI load.
-          this.backends.push(backend);
-          if (!this.chosen) this.chosen = backend;
-          continue;
-        }
         await backend.initialize();
         this.backends.push(backend);
         if (!this.chosen) this.chosen = backend;
@@ -310,7 +303,12 @@ export class OCRService {
         logger.warn(
           `[OCR] backend ${backend.name} unavailable: ${error instanceof Error ? error.message : String(error)}`,
         );
-        await backend.dispose().catch(() => {});
+        await backend.dispose().catch((disposeError) => {
+          // error-policy:J6 best-effort teardown preserves the init failure.
+          logger.warn(
+            `[OCR] cleanup for unavailable ${backend.name} backend failed: ${disposeError instanceof Error ? disposeError.message : String(disposeError)}`,
+          );
+        });
       }
     }
 
@@ -335,9 +333,6 @@ export class OCRService {
     let lastError: unknown = null;
     for (const backend of ordered) {
       try {
-        if (backend.name === "doctr" && backend instanceof DoctrBackend) {
-          await backend.initialize();
-        }
         return await backend.extractText(imageBuffer);
       } catch (error) {
         lastError = error;

--- a/plugins/plugin-vision/src/provider.test.ts
+++ b/plugins/plugin-vision/src/provider.test.ts
@@ -13,7 +13,11 @@ import {
 
 function makeRuntime(
   sceneDescription: SceneDescription,
-  overrides?: { capabilities?: VisionCapabilities; isActive?: boolean },
+  overrides?: {
+    capabilities?: VisionCapabilities;
+    isActive?: boolean;
+    visionMode?: VisionMode;
+  },
 ): IAgentRuntime {
   const defaultCaps: VisionCapabilities = {
     objectDetection: false,
@@ -40,7 +44,7 @@ function makeRuntime(
       connected: true,
     })),
     isActive: vi.fn(() => overrides?.isActive ?? true),
-    getVisionMode: vi.fn(() => VisionMode.CAMERA),
+    getVisionMode: vi.fn(() => overrides?.visionMode ?? VisionMode.CAMERA),
     getScreenCapture: vi.fn(async () => null),
     getEntityTracker: vi.fn(() => null),
     getCapabilities: vi.fn(() => overrides?.capabilities ?? defaultCaps),
@@ -258,5 +262,42 @@ describe("visionProvider", () => {
     expect(caps).toBeDefined();
     expect(caps.camera).toBe(false);
     expect(caps.unavailableReasons?.camera).toBe("No camera connected");
+  });
+
+  it("does not report a scheduled screen loop as available before a frame succeeds", async () => {
+    const runtime = makeRuntime(
+      {
+        timestamp: 0,
+        description: "",
+        objects: [],
+        people: [],
+        sceneChanged: false,
+        changePercentage: 0,
+      },
+      {
+        isActive: true,
+        visionMode: VisionMode.SCREEN,
+        capabilities: {
+          objectDetection: false,
+          ocr: false,
+          faceRecognition: false,
+          screenCapture: false,
+          camera: false,
+          audio: false,
+          unavailableReasons: {
+            screenCapture: "Screen capture permission denied",
+          },
+        },
+      },
+    );
+
+    const result = await visionProvider.get(
+      runtime,
+      { worldId: "world-1" } as Memory,
+      {} as State,
+    );
+
+    expect(result.values?.visionAvailable).toBe(false);
+    expect(result.text).toContain("Screen capture permission denied");
   });
 });

--- a/plugins/plugin-vision/src/provider.test.ts
+++ b/plugins/plugin-vision/src/provider.test.ts
@@ -5,9 +5,31 @@
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { visionProvider } from "./provider";
-import { type SceneDescription, VisionMode } from "./types";
+import {
+  type SceneDescription,
+  type VisionCapabilities,
+  VisionMode,
+} from "./types";
 
-function makeRuntime(sceneDescription: SceneDescription): IAgentRuntime {
+function makeRuntime(
+  sceneDescription: SceneDescription,
+  overrides?: { capabilities?: VisionCapabilities; isActive?: boolean },
+): IAgentRuntime {
+  const defaultCaps: VisionCapabilities = {
+    objectDetection: false,
+    ocr: true,
+    faceRecognition: false,
+    screenCapture: false,
+    camera: true,
+    audio: false,
+    unavailableReasons: {
+      objectDetection: "Object detection not enabled",
+      faceRecognition: "Face recognition backend not initialized or not enabled",
+      screenCapture: "Screen mode not active",
+      audio: "Audio capture not configured",
+    },
+  };
+
   const visionService = {
     getEnhancedSceneDescription: vi.fn(async () => sceneDescription),
     getSceneDescription: vi.fn(async () => sceneDescription),
@@ -16,10 +38,11 @@ function makeRuntime(sceneDescription: SceneDescription): IAgentRuntime {
       name: "Test Camera",
       connected: true,
     })),
-    isActive: vi.fn(() => true),
+    isActive: vi.fn(() => overrides?.isActive ?? true),
     getVisionMode: vi.fn(() => VisionMode.CAMERA),
     getScreenCapture: vi.fn(async () => null),
     getEntityTracker: vi.fn(() => null),
+    getCapabilities: vi.fn(() => overrides?.capabilities ?? defaultCaps),
   };
 
   return Object.assign(Object.create(null) as IAgentRuntime, {
@@ -72,5 +95,165 @@ describe("visionProvider", () => {
     expect(result.text).toContain(
       "VLM description is stale because describe is paused (memory-cap)",
     );
+  });
+
+  it("surfaces capability readiness honestly when backends are unavailable", async () => {
+    const runtime = makeRuntime(
+      {
+        timestamp: Date.now(),
+        description: "Scene with no YOLO.",
+        objects: [
+          {
+            id: "obj-1",
+            type: "chair",
+            confidence: 0.6,
+            boundingBox: { x: 0, y: 0, width: 10, height: 10 },
+          },
+        ],
+        people: [],
+        sceneChanged: false,
+        changePercentage: 5,
+        objectDetectionSource: "motion",
+      },
+      {
+        capabilities: {
+          objectDetection: false,
+          ocr: false,
+          faceRecognition: false,
+          screenCapture: false,
+          camera: true,
+          audio: false,
+          unavailableReasons: {
+            objectDetection: "native library failed to load",
+            ocr: "OCR not enabled",
+            faceRecognition: "Face recognition backend not initialized or not enabled",
+            screenCapture: "Screen mode not active",
+            audio: "Audio capture not configured",
+          },
+        },
+      },
+    );
+
+    const result = await visionProvider.get(
+      runtime,
+      { worldId: "world-1" } as Memory,
+      {} as State,
+    );
+
+    const caps = result.values?.capabilities as VisionCapabilities;
+
+    // Capabilities are surfaced with honest false values.
+    expect(caps).toBeDefined();
+    expect(caps.objectDetection).toBe(false);
+    expect(caps.ocr).toBe(false);
+    expect(caps.faceRecognition).toBe(false);
+    // Camera IS available.
+    expect(caps.camera).toBe(true);
+    // Unavailable reasons are provided for each false capability.
+    expect(caps.unavailableReasons?.objectDetection).toBe(
+      "native library failed to load",
+    );
+    expect(caps.unavailableReasons?.ocr).toBe("OCR not enabled");
+
+    // Detection provenance is surfaced: objects came from motion heuristics.
+    expect(result.values?.objectDetectionSource).toBe("motion");
+    expect(result.text).toContain("via motion heuristics");
+  });
+
+  it("reports all-capabilities-available when backends are initialized", async () => {
+    const runtime = makeRuntime(
+      {
+        timestamp: Date.now(),
+        description: "Full vision scene.",
+        objects: [
+          {
+            id: "obj-1",
+            type: "person",
+            confidence: 0.95,
+            boundingBox: { x: 0, y: 0, width: 100, height: 200 },
+          },
+        ],
+        people: [],
+        sceneChanged: true,
+        changePercentage: 30,
+        objectDetectionSource: "yolo",
+      },
+      {
+        capabilities: {
+          objectDetection: true,
+          ocr: true,
+          faceRecognition: true,
+          screenCapture: true,
+          camera: true,
+          audio: true,
+        },
+      },
+    );
+
+    const result = await visionProvider.get(
+      runtime,
+      { worldId: "world-1" } as Memory,
+      {} as State,
+    );
+
+    const caps = result.values?.capabilities as VisionCapabilities;
+
+    expect(caps.objectDetection).toBe(true);
+    expect(caps.ocr).toBe(true);
+    expect(caps.faceRecognition).toBe(true);
+    expect(caps.screenCapture).toBe(true);
+    expect(caps.camera).toBe(true);
+    expect(caps.audio).toBe(true);
+    // No unavailable reasons when all are available.
+    expect(caps.unavailableReasons).toBeUndefined();
+
+    // Detection provenance shows YOLO.
+    expect(result.values?.objectDetectionSource).toBe("yolo");
+    expect(result.text).toContain("via YOLO");
+  });
+
+  it("includes capabilities in the inactive/service-not-started state", async () => {
+    const runtime = makeRuntime(
+      {
+        timestamp: 0,
+        description: "",
+        objects: [],
+        people: [],
+        sceneChanged: false,
+        changePercentage: 0,
+      },
+      {
+        isActive: false,
+        capabilities: {
+          objectDetection: false,
+          ocr: false,
+          faceRecognition: false,
+          screenCapture: false,
+          camera: false,
+          audio: false,
+          unavailableReasons: {
+            camera: "No camera connected",
+            objectDetection: "Object detection not enabled",
+            ocr: "OCR not enabled",
+            faceRecognition: "Face recognition backend not initialized or not enabled",
+            screenCapture: "Screen mode not active",
+            audio: "Audio capture not configured",
+          },
+        },
+      },
+    );
+
+    const result = await visionProvider.get(
+      runtime,
+      { worldId: "world-1" } as Memory,
+      {} as State,
+    );
+
+    const caps = result.values?.capabilities as VisionCapabilities;
+
+    expect(result.values?.visionAvailable).toBe(false);
+    expect(caps).toBeDefined();
+    expect(caps.camera).toBe(false);
+    expect(caps.unavailableReasons?.camera).toBe("No camera connected");
   });
 });

--- a/plugins/plugin-vision/src/provider.test.ts
+++ b/plugins/plugin-vision/src/provider.test.ts
@@ -300,4 +300,42 @@ describe("visionProvider", () => {
     expect(result.values?.visionAvailable).toBe(false);
     expect(result.text).toContain("Screen capture permission denied");
   });
+
+  it("does not let an idle connected camera satisfy SCREEN-mode readiness", async () => {
+    const runtime = makeRuntime(
+      {
+        timestamp: 0,
+        description: "stale camera scene",
+        objects: [],
+        people: [],
+        sceneChanged: false,
+        changePercentage: 0,
+      },
+      {
+        isActive: true,
+        visionMode: VisionMode.SCREEN,
+        capabilities: {
+          objectDetection: false,
+          ocr: false,
+          faceRecognition: false,
+          screenCapture: false,
+          camera: true,
+          audio: false,
+          unavailableReasons: {
+            screenCapture: "Screen capture permission denied",
+          },
+        },
+      },
+    );
+
+    const result = await visionProvider.get(
+      runtime,
+      { worldId: "world-1" } as Memory,
+      {} as State,
+    );
+
+    expect(result.values?.visionAvailable).toBe(false);
+    expect(result.text).toContain("Screen capture permission denied");
+    expect(result.text).not.toContain("stale camera scene");
+  });
 });

--- a/plugins/plugin-vision/src/provider.test.ts
+++ b/plugins/plugin-vision/src/provider.test.ts
@@ -24,7 +24,8 @@ function makeRuntime(
     audio: false,
     unavailableReasons: {
       objectDetection: "Object detection not enabled",
-      faceRecognition: "Face recognition backend not initialized or not enabled",
+      faceRecognition:
+        "Face recognition backend not initialized or not enabled",
       screenCapture: "Screen mode not active",
       audio: "Audio capture not configured",
     },
@@ -126,7 +127,8 @@ describe("visionProvider", () => {
           unavailableReasons: {
             objectDetection: "native library failed to load",
             ocr: "OCR not enabled",
-            faceRecognition: "Face recognition backend not initialized or not enabled",
+            faceRecognition:
+              "Face recognition backend not initialized or not enabled",
             screenCapture: "Screen mode not active",
             audio: "Audio capture not configured",
           },
@@ -235,7 +237,8 @@ describe("visionProvider", () => {
             camera: "No camera connected",
             objectDetection: "Object detection not enabled",
             ocr: "OCR not enabled",
-            faceRecognition: "Face recognition backend not initialized or not enabled",
+            faceRecognition:
+              "Face recognition backend not initialized or not enabled",
             screenCapture: "Screen mode not active",
             audio: "Audio capture not configured",
           },

--- a/plugins/plugin-vision/src/provider.ts
+++ b/plugins/plugin-vision/src/provider.ts
@@ -16,7 +16,6 @@ import type {
   DetectionSource,
   EnhancedSceneDescription,
   EntityAttributes,
-  VisionCapabilities,
 } from "./types";
 
 const MAX_VISION_OBJECTS_IN_STATE = 50;

--- a/plugins/plugin-vision/src/provider.ts
+++ b/plugins/plugin-vision/src/provider.ts
@@ -13,8 +13,10 @@ import {
 import type { VisionService } from "./service";
 import type {
   BoundingBox,
+  DetectionSource,
   EnhancedSceneDescription,
   EntityAttributes,
+  VisionCapabilities,
 } from "./types";
 
 const MAX_VISION_OBJECTS_IN_STATE = 50;
@@ -65,6 +67,7 @@ export const visionProvider: Provider = {
       const isActive = visionService.isActive();
       const visionMode = visionService.getVisionMode();
       const screenCapture = await visionService.getScreenCapture();
+      const capabilities = visionService.getCapabilities();
       const _worldId = message.worldId || "default-world";
       const entityTracker = visionService.getEntityTracker();
 
@@ -148,6 +151,7 @@ export const visionProvider: Provider = {
           cameraStatus: cameraInfo
             ? `Camera "${cameraInfo.name}" detected but not active`
             : "No camera",
+          capabilities,
         };
       } else {
         perceptionText = `Vision mode: ${visionMode}\n\n`;
@@ -214,7 +218,15 @@ export const visionProvider: Provider = {
               .slice(0, MAX_VISION_OBJECTS_IN_STATE)
               .map((o) => o.type);
             const uniqueObjects = [...new Set(objectTypes)];
-            perceptionText += `\n\nObjects detected: ${uniqueObjects.join(", ")}`;
+            const sourceLabel: Record<DetectionSource, string> = {
+              yolo: "YOLO",
+              motion: "motion heuristics",
+              vlm: "VLM",
+            };
+            const src = sceneDescription.objectDetectionSource
+              ? ` (via ${sourceLabel[sceneDescription.objectDetectionSource]})`
+              : "";
+            perceptionText += `\n\nObjects detected${src}: ${uniqueObjects.join(", ")}`;
           }
 
           if (sceneDescription.sceneChanged) {
@@ -299,6 +311,8 @@ export const visionProvider: Provider = {
           cameraId: cameraInfo?.id,
           peopleCount: sceneDescription?.people.length || 0,
           objectCount: sceneDescription?.objects.length || 0,
+          objectDetectionSource:
+            sceneDescription?.objectDetectionSource || null,
           sceneAge: sceneDescription
             ? Math.round(
                 (Date.now() -
@@ -320,6 +334,7 @@ export const visionProvider: Provider = {
           activeEntities: entityData?.activeEntities || [],
           recentlyLeft: entityData?.recentlyLeft || [],
           entityStatistics: entityData?.statistics || null,
+          capabilities,
         };
 
         data = {

--- a/plugins/plugin-vision/src/provider.ts
+++ b/plugins/plugin-vision/src/provider.ts
@@ -17,6 +17,7 @@ import type {
   EnhancedSceneDescription,
   EntityAttributes,
 } from "./types";
+import { VisionMode } from "./types";
 
 const MAX_VISION_OBJECTS_IN_STATE = 50;
 const MAX_VISION_PEOPLE_IN_STATE = 25;
@@ -67,6 +68,7 @@ export const visionProvider: Provider = {
       const visionMode = visionService.getVisionMode();
       const screenCapture = await visionService.getScreenCapture();
       const capabilities = visionService.getCapabilities();
+      const hasReadyInput = capabilities.camera || capabilities.screenCapture;
       const _worldId = message.worldId || "default-world";
       const entityTracker = visionService.getEntityTracker();
 
@@ -135,18 +137,24 @@ export const visionProvider: Provider = {
       let values = {};
       let data = {};
 
-      if (!isActive) {
+      if (!isActive || !hasReadyInput) {
         perceptionText = `Vision mode: ${visionMode}\n`;
         if (visionMode === "OFF") {
           perceptionText += "Vision is disabled.";
+        } else if (isActive) {
+          const unavailableReason =
+            visionMode === VisionMode.CAMERA
+              ? capabilities.unavailableReasons?.camera
+              : capabilities.unavailableReasons?.screenCapture;
+          perceptionText += `Vision input unavailable${unavailableReason ? `: ${unavailableReason}` : "."}`;
         } else {
-          perceptionText += "Vision service is initializing...";
+          perceptionText += "Vision service is not active.";
         }
 
         values = {
           visionAvailable: false,
           visionMode,
-          sceneDescription: "Vision not active",
+          sceneDescription: "Vision input unavailable",
           cameraStatus: cameraInfo
             ? `Camera "${cameraInfo.name}" detected but not active`
             : "No camera",

--- a/plugins/plugin-vision/src/provider.ts
+++ b/plugins/plugin-vision/src/provider.ts
@@ -220,7 +220,6 @@ export const visionProvider: Provider = {
             const sourceLabel: Record<DetectionSource, string> = {
               yolo: "YOLO",
               motion: "motion heuristics",
-              vlm: "VLM",
             };
             const src = sceneDescription.objectDetectionSource
               ? ` (via ${sourceLabel[sceneDescription.objectDetectionSource]})`

--- a/plugins/plugin-vision/src/provider.ts
+++ b/plugins/plugin-vision/src/provider.ts
@@ -17,7 +17,7 @@ import type {
   EnhancedSceneDescription,
   EntityAttributes,
 } from "./types";
-import { VisionMode } from "./types";
+import { hasReadyInputForMode, VisionMode } from "./types";
 
 const MAX_VISION_OBJECTS_IN_STATE = 50;
 const MAX_VISION_PEOPLE_IN_STATE = 25;
@@ -68,7 +68,7 @@ export const visionProvider: Provider = {
       const visionMode = visionService.getVisionMode();
       const screenCapture = await visionService.getScreenCapture();
       const capabilities = visionService.getCapabilities();
-      const hasReadyInput = capabilities.camera || capabilities.screenCapture;
+      const hasReadyInput = hasReadyInputForMode(capabilities, visionMode);
       const _worldId = message.worldId || "default-world";
       const entityTracker = visionService.getEntityTracker();
 

--- a/plugins/plugin-vision/src/service-capabilities.test.ts
+++ b/plugins/plugin-vision/src/service-capabilities.test.ts
@@ -76,6 +76,65 @@ describe("VisionService capability readiness", () => {
     });
   });
 
+  it("uses completed worker output as readiness instead of worker allocation", async () => {
+    const service = new VisionService(makeRuntime());
+    Reflect.set(service, "visionConfig", {
+      visionMode: VisionMode.SCREEN,
+      ocrEnabled: true,
+    });
+    Reflect.set(service, "workerManager", {
+      getReadiness: () => ({ screenCapture: true, ocr: true }),
+      getLatestScreenCapture: () => ({
+        timestamp: 42,
+        width: 1280,
+        height: 720,
+        data: Buffer.alloc(0),
+        tiles: [],
+      }),
+    });
+
+    expect(service.getCapabilities()).toMatchObject({
+      screenCapture: true,
+      ocr: true,
+    });
+    expect(await service.getScreenCapture()).toMatchObject({
+      timestamp: 42,
+      width: 1280,
+      height: 720,
+    });
+  });
+
+  it("runs the documented motion fallback when YOLO is unavailable", async () => {
+    const service = new VisionService(makeRuntime());
+    const motionObjects = [
+      {
+        id: "motion-1",
+        type: "motion-object",
+        confidence: 0.8,
+        boundingBox: { x: 0, y: 0, width: 64, height: 64 },
+      },
+    ];
+    const detectMotionObjects = vi.fn(async () => motionObjects);
+    Reflect.set(service, "objectDetector", null);
+    Reflect.set(service, "detectMotionObjects", detectMotionObjects);
+    const detectObjectsWithFallback = Reflect.get(
+      service,
+      "detectObjectsWithFallback",
+    ) as (
+      frame: { timestamp: number; width: number; height: number; data: Buffer },
+      jpegBuffer: Buffer,
+    ) => Promise<{ objects: typeof motionObjects; source: string }>;
+
+    const result = await detectObjectsWithFallback.call(
+      service,
+      { timestamp: 1, width: 1, height: 1, data: Buffer.alloc(4) },
+      Buffer.from("jpeg"),
+    );
+
+    expect(result).toEqual({ objects: motionObjects, source: "motion" });
+    expect(detectMotionObjects).toHaveBeenCalledOnce();
+  });
+
   it("changes screen readiness only after real capture outcomes and clears it on stop", async () => {
     const service = new VisionService(makeRuntime());
     Reflect.set(service, "visionConfig", {

--- a/plugins/plugin-vision/src/service-capabilities.test.ts
+++ b/plugins/plugin-vision/src/service-capabilities.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Capability-state regressions for the real VisionService lifecycle proxies.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { VisionService } from "./service";
+import { VisionMode } from "./types";
+
+function makeRuntime(): IAgentRuntime {
+  return Object.assign(Object.create(null) as IAgentRuntime, {
+    agentId: "agent",
+    character: {},
+    getSetting: vi.fn(() => undefined),
+    getService: vi.fn(() => null),
+    getServicesByType: vi.fn(() => []),
+  });
+}
+
+describe("VisionService capability readiness", () => {
+  it("does not confuse scheduled loops or allocated objects with ready backends", () => {
+    const service = new VisionService(makeRuntime());
+    Reflect.set(service, "visionConfig", {
+      visionMode: VisionMode.SCREEN,
+      enableObjectDetection: true,
+      enableFaceRecognition: true,
+      ocrEnabled: true,
+    });
+    Reflect.set(service, "screenProcessingInterval", { scheduled: true });
+    Reflect.set(service, "objectDetector", {});
+    Reflect.set(service, "hasObjectDetection", false);
+    Reflect.set(service, "faceRecognition", { isInitialized: () => false });
+    Reflect.set(service, "hasFaceRecognition", true);
+    Reflect.set(service, "audioCapture", { isActive: () => false });
+    Reflect.set(service, "ocrService", { isInitialized: () => false });
+
+    const capabilities = service.getCapabilities();
+
+    expect(capabilities).toMatchObject({
+      objectDetection: false,
+      ocr: false,
+      faceRecognition: false,
+      screenCapture: false,
+      camera: false,
+      audio: false,
+    });
+    expect(capabilities.unavailableReasons?.screenCapture).toContain(
+      "first successful frame",
+    );
+  });
+
+  it("reports ready only after every backend-specific readiness check passes", () => {
+    const service = new VisionService(makeRuntime());
+    Reflect.set(service, "visionConfig", {
+      visionMode: VisionMode.BOTH,
+      enableObjectDetection: true,
+      enableFaceRecognition: true,
+      ocrEnabled: true,
+    });
+    Reflect.set(service, "objectDetector", {});
+    Reflect.set(service, "hasObjectDetection", true);
+    Reflect.set(service, "faceRecognition", { isInitialized: () => true });
+    Reflect.set(service, "hasFaceRecognition", true);
+    Reflect.set(service, "screenCaptureReady", true);
+    Reflect.set(service, "camera", {});
+    Reflect.set(service, "audioCapture", { isActive: () => true });
+    Reflect.set(service, "ocrService", { isInitialized: () => true });
+
+    expect(service.getCapabilities()).toEqual({
+      objectDetection: true,
+      ocr: true,
+      faceRecognition: true,
+      screenCapture: true,
+      camera: true,
+      audio: true,
+    });
+  });
+
+  it("changes screen readiness only after real capture outcomes and clears it on stop", async () => {
+    const service = new VisionService(makeRuntime());
+    Reflect.set(service, "visionConfig", {
+      visionMode: VisionMode.SCREEN,
+      ocrEnabled: false,
+    });
+    const captureScreen = vi
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error("permission denied"))
+      .mockResolvedValueOnce({
+        timestamp: Date.now(),
+        width: 1,
+        height: 1,
+        data: Buffer.from("frame"),
+        tiles: [],
+      });
+    Reflect.set(service, "screenCapture", {
+      captureScreen,
+      getActiveTile: () => null,
+    });
+    Reflect.set(
+      service,
+      "updateEnhancedSceneDescription",
+      vi.fn(async () => undefined),
+    );
+    const captureAndProcessScreen = Reflect.get(
+      service,
+      "captureAndProcessScreen",
+    ) as () => Promise<void>;
+
+    await captureAndProcessScreen.call(service);
+    expect(service.getCapabilities().screenCapture).toBe(false);
+    expect(
+      service.getCapabilities().unavailableReasons?.screenCapture,
+    ).toContain("permission");
+
+    await captureAndProcessScreen.call(service);
+    expect(service.getCapabilities().screenCapture).toBe(true);
+
+    Reflect.set(service, "screenProcessingInterval", { scheduled: true });
+    const stopProcessing = Reflect.get(service, "stopProcessing") as () => void;
+    stopProcessing.call(service);
+    expect(service.getCapabilities().screenCapture).toBe(false);
+  });
+});

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -711,6 +711,10 @@ export class VisionService extends Service {
         logger.info("[VisionService] Batch audio capture initialized");
       }
     } catch (error) {
+      // error-policy:J4 user-facing degrade — audio is optional; reset the
+      // fields so capability checks honestly report audio as unavailable.
+      this.audioCapture = null;
+      this.streamingAudioCapture = null;
       logger.error(
         { error },
         "[VisionService] Failed to initialize audio capture:",
@@ -1040,10 +1044,12 @@ export class VisionService extends Service {
         // Reuse last detection results if not updating
         detectedObjects = this.lastSceneDescription.objects;
         people = this.lastSceneDescription.people;
+        objectDetectionSource = this.lastSceneDescription.objectDetectionSource;
       } else {
         // Fall back to motion-based detection
         detectedObjects = await this.detectMotionObjects(frame);
         people = await this.detectPeopleFromMotion(frame, detectedObjects);
+        objectDetectionSource = "motion";
       }
 
       // Face recognition and entity tracking
@@ -2049,7 +2055,7 @@ export class VisionService extends Service {
   public getCapabilities(): VisionCapabilities {
     const caps: VisionCapabilities = {
       objectDetection: this.hasObjectDetection,
-      ocr: this.visionConfig.ocrEnabled ?? false,
+      ocr: this.visionConfig.ocrEnabled ? this.ocrService.isInitialized() : false,
       faceRecognition: this.hasFaceRecognition,
       screenCapture: this.screenProcessingInterval !== null,
       camera: this.camera !== null,
@@ -2084,8 +2090,7 @@ export class VisionService extends Service {
     }
 
     if (!caps.camera) {
-      reasons.camera =
-        this.camera === null ? "No camera connected" : "Camera not active";
+      reasons.camera = "No camera connected";
     }
 
     if (!caps.audio) {
@@ -2131,6 +2136,7 @@ export class VisionService extends Service {
         this.hasFaceRecognition = true;
         this.faceRecognitionUnavailableReason = null;
       } catch (error) {
+        // error-policy:J2 wrap+rethrow with unavailable reason for capability surface
         this.faceRecognitionUnavailableReason =
           error instanceof Error ? error.message : String(error);
         throw error;

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -509,6 +509,7 @@ export class VisionService extends Service {
         try {
           await this.getFaceRecognition();
         } catch (faceError) {
+          // error-policy:J4 optional face inference remains explicitly unavailable.
           logger.warn(
             "[VisionService] Face recognition unavailable:",
             faceError instanceof Error ? faceError.message : String(faceError),
@@ -573,6 +574,7 @@ export class VisionService extends Service {
         }
       }
     } catch (error) {
+      // error-policy:J4 screen capture stays available while OCR is explicitly unavailable.
       this.ocrUnavailableReason =
         "OCR backend failed to initialize; verify the platform provider or native model files";
       logger.warn(
@@ -592,6 +594,7 @@ export class VisionService extends Service {
 
       logger.info("[VisionService] Screen vision initialized");
     } catch (error) {
+      // error-policy:J4 the provider failure remains visible until a real frame succeeds.
       this.screenCaptureUnavailableReason =
         "Screen capture backend failed to initialize for this platform";
       logger.warn(
@@ -1029,23 +1032,9 @@ export class VisionService extends Service {
         // Object detection via the ggml YOLOv8 detector. The detector
         // consumes an encoded image buffer (it reads metadata via sharp), so
         // we reuse the JPEG already produced above for the VLM path.
-        if (this.visionConfig.enableObjectDetection && this.objectDetector) {
-          try {
-            detectedObjects = await this.objectDetector.detect(jpegBuffer);
-            objectDetectionSource = "yolo";
-            logger.debug(
-              `[VisionService] YOLOv8 detected ${detectedObjects.length} objects`,
-            );
-          } catch (detectError) {
-            logger.warn(
-              "[VisionService] YOLOv8 object detection failed, falling back to motion-based:",
-              detectError instanceof Error
-                ? detectError.message
-                : String(detectError),
-            );
-            detectedObjects = await this.detectMotionObjects(frame);
-            objectDetectionSource = "motion";
-          }
+        if (this.visionConfig.enableObjectDetection) {
+          ({ objects: detectedObjects, source: objectDetectionSource } =
+            await this.detectObjectsWithFallback(frame, jpegBuffer));
         }
 
         // No ggml pose backend yet — when pose detection is requested, fall
@@ -1660,6 +1649,33 @@ export class VisionService extends Service {
     return filtered;
   }
 
+  /** Run the requested native detector, falling back honestly when unavailable. */
+  private async detectObjectsWithFallback(
+    frame: VisionFrame,
+    jpegBuffer: Buffer,
+  ): Promise<{ objects: DetectedObject[]; source: DetectionSource }> {
+    if (this.objectDetector) {
+      try {
+        const objects = await this.objectDetector.detect(jpegBuffer);
+        logger.debug(
+          `[VisionService] YOLOv8 detected ${objects.length} objects`,
+        );
+        return { objects, source: "yolo" };
+      } catch (error) {
+        // error-policy:J4 native failure degrades to distinctly labeled motion output.
+        logger.warn(
+          "[VisionService] YOLOv8 object detection failed, falling back to motion-based:",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+
+    return {
+      objects: await this.detectMotionObjects(frame),
+      source: "motion",
+    };
+  }
+
   private mergeAdjacentObjects(objects: DetectedObject[]): DetectedObject[] {
     if (objects.length === 0) {
       return [];
@@ -1823,6 +1839,7 @@ export class VisionService extends Service {
     try {
       capture = await this.screenCapture.captureScreen();
     } catch (error) {
+      // error-policy:J4 a failed capture clears the public readiness state.
       this.screenCaptureReady = false;
       this.screenCaptureUnavailableReason =
         "Screen capture failed; verify host support and screen-recording permission";
@@ -1845,6 +1862,8 @@ export class VisionService extends Service {
       // Update enhanced scene description
       await this.updateEnhancedSceneDescription();
     } catch (error) {
+      // error-policy:J7 frame diagnostics must not kill the capture loop.
+      this.runtime.reportError("VisionService.screenFrame", error);
       logger.error({ error }, "[VisionService] Error processing screen frame:");
     }
   }
@@ -1862,6 +1881,7 @@ export class VisionService extends Service {
         this.ocrUnavailableReason = null;
       }
     } catch (error) {
+      // error-policy:J4 the OCR failure remains explicit until extraction recovers.
       this.ocrUnavailableReason =
         "OCR backend failed while processing the latest screen frame";
       logger.error({ error }, "[VisionService] Error analyzing tile:");
@@ -1939,7 +1959,9 @@ export class VisionService extends Service {
   }
 
   public async getScreenCapture(): Promise<ScreenCapture | null> {
-    return this.lastScreenCapture;
+    return (
+      this.workerManager?.getLatestScreenCapture() ?? this.lastScreenCapture
+    );
   }
 
   public getVisionMode(): VisionMode {
@@ -2086,16 +2108,19 @@ export class VisionService extends Service {
    * collected for surfaced diagnostics.
    */
   public getCapabilities(): VisionCapabilities {
+    const workerReadiness = this.workerManager?.getReadiness();
     const caps: VisionCapabilities = {
       objectDetection: this.hasObjectDetection && this.objectDetector !== null,
       ocr:
         Boolean(this.visionConfig.ocrEnabled) &&
-        this.ocrService.isInitialized() &&
-        this.ocrUnavailableReason === null,
+        ((this.ocrService.isInitialized() &&
+          this.ocrUnavailableReason === null) ||
+          workerReadiness?.ocr === true),
       faceRecognition:
         this.hasFaceRecognition &&
         this.faceRecognition?.isInitialized() === true,
-      screenCapture: this.screenCaptureReady,
+      screenCapture:
+        this.screenCaptureReady || workerReadiness?.screenCapture === true,
       camera: this.camera !== null,
       audio:
         this.audioCapture?.isActive() === true ||

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -51,12 +51,14 @@ import {
   type BoundingBox,
   type CameraInfo,
   type DetectedObject,
+  type DetectionSource,
   type EnhancedSceneDescription,
   type PersonInfo,
   type SceneDescription,
   type ScreenCapture,
   type ScreenTile,
   type TileAnalysis,
+  type VisionCapabilities,
   type VisionConfig,
   type VisionFrame,
   VisionMode,
@@ -235,10 +237,14 @@ export class VisionService extends Service {
   private isProcessingScreen = false;
   private objectDetector: YOLODetector | null = null;
   private hasObjectDetection = false;
+  // Reason why object detection is unavailable (null when available or not requested).
+  private objectDetectionUnavailableReason: string | null = null;
   // Lazily constructed: the face backend is dynamically imported on first use
   // so plugin-vision's module graph never pulls native code at module-eval
   // (required for the Android bun-musl agent).
   private faceRecognition: FaceRecognition | null = null;
+  private hasFaceRecognition = false;
+  private faceRecognitionUnavailableReason: string | null = null;
   private entityTracker: EntityTracker;
   private audioCapture: AudioCaptureService | null = null;
   private streamingAudioCapture: StreamingAudioCaptureService | null = null;
@@ -472,17 +478,23 @@ export class VisionService extends Service {
           this.objectDetector = new YOLODetector();
           await this.objectDetector.initialize();
           this.hasObjectDetection = true;
+          this.objectDetectionUnavailableReason = null;
           logger.info(
             "[VisionService] ggml YOLOv8 object detector initialized",
           );
         } catch (yoloError) {
           // Native lib / GGUF not built yet — leave object detection off so
           // the motion/heuristic + VLM fallback still runs. Never fake it.
+          // Record the reason so capability checks can surface it.
           this.objectDetector = null;
           this.hasObjectDetection = false;
+          this.objectDetectionUnavailableReason =
+            yoloError instanceof Error
+              ? yoloError.message
+              : String(yoloError);
           logger.warn(
             "[VisionService] ggml YOLOv8 detector unavailable, object detection disabled (using motion/heuristic + VLM fallback):",
-            yoloError instanceof Error ? yoloError.message : String(yoloError),
+            this.objectDetectionUnavailableReason,
           );
         }
       }
@@ -969,6 +981,7 @@ export class VisionService extends Service {
 
       let detectedObjects: DetectedObject[] = [];
       let people: PersonInfo[] = [];
+      let objectDetectionSource: DetectionSource | undefined;
 
       if (
         shouldUpdateTf &&
@@ -986,6 +999,7 @@ export class VisionService extends Service {
         if (this.visionConfig.enableObjectDetection && this.objectDetector) {
           try {
             detectedObjects = await this.objectDetector.detect(jpegBuffer);
+            objectDetectionSource = "yolo";
             logger.debug(
               `[VisionService] YOLOv8 detected ${detectedObjects.length} objects`,
             );
@@ -997,6 +1011,7 @@ export class VisionService extends Service {
                 : String(detectError),
             );
             detectedObjects = await this.detectMotionObjects(frame);
+            objectDetectionSource = "motion";
           }
         }
 
@@ -1224,6 +1239,7 @@ export class VisionService extends Service {
         descriptionStale,
         describePaused,
         ...(describePauseReason ? { describePauseReason } : {}),
+        ...(objectDetectionSource ? { objectDetectionSource } : {}),
       };
 
       // Enhanced logging
@@ -2014,7 +2030,73 @@ export class VisionService extends Service {
   }
 
   public isActive(): boolean {
-    return this.camera !== null && this.frameProcessingInterval !== null;
+    // Camera-mode active: camera connected and processing frames.
+    if (this.camera !== null && this.frameProcessingInterval !== null) {
+      return true;
+    }
+    // Screen-mode active: screen processing loop running.
+    if (this.screenProcessingInterval !== null) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Honest capability readiness snapshot. Each field is true only when the
+   * corresponding backend initialized successfully. Unavailable reasons are
+   * collected for surfaced diagnostics.
+   */
+  public getCapabilities(): VisionCapabilities {
+    const caps: VisionCapabilities = {
+      objectDetection: this.hasObjectDetection,
+      ocr: this.visionConfig.ocrEnabled ?? false,
+      faceRecognition: this.hasFaceRecognition,
+      screenCapture: this.screenProcessingInterval !== null,
+      camera: this.camera !== null,
+      audio:
+        this.audioCapture !== null || this.streamingAudioCapture !== null,
+    };
+
+    const reasons: NonNullable<VisionCapabilities["unavailableReasons"]> = {};
+
+    if (!caps.objectDetection) {
+      reasons.objectDetection = this.objectDetectionUnavailableReason
+        ?? (this.visionConfig.enableObjectDetection
+          ? "YOLO backend not initialized"
+          : "Object detection not enabled");
+    }
+
+    if (!caps.ocr) {
+      reasons.ocr = "OCR not enabled";
+    }
+
+    if (!caps.faceRecognition) {
+      reasons.faceRecognition = this.faceRecognitionUnavailableReason
+        ?? "Face recognition backend not initialized or not enabled";
+    }
+
+    if (!caps.screenCapture) {
+      const mode = this.visionConfig.visionMode;
+      reasons.screenCapture =
+        mode === VisionMode.SCREEN || mode === VisionMode.BOTH
+          ? "Screen capture pipeline not started"
+          : "Screen mode not active";
+    }
+
+    if (!caps.camera) {
+      reasons.camera =
+        this.camera === null ? "No camera connected" : "Camera not active";
+    }
+
+    if (!caps.audio) {
+      reasons.audio = "Audio capture not configured";
+    }
+
+    if (Object.keys(reasons).length > 0) {
+      caps.unavailableReasons = reasons;
+    }
+
+    return caps;
   }
 
   // Helper methods for face recognition
@@ -2043,8 +2125,16 @@ export class VisionService extends Service {
 
   public async getFaceRecognition(): Promise<FaceRecognition> {
     if (!this.faceRecognition) {
-      const { FaceRecognition } = await import("./face-recognition-ggml");
-      this.faceRecognition = new FaceRecognition();
+      try {
+        const { FaceRecognition } = await import("./face-recognition-ggml");
+        this.faceRecognition = new FaceRecognition();
+        this.hasFaceRecognition = true;
+        this.faceRecognitionUnavailableReason = null;
+      } catch (error) {
+        this.faceRecognitionUnavailableReason =
+          error instanceof Error ? error.message : String(error);
+        throw error;
+      }
     }
     return this.faceRecognition;
   }
@@ -2068,6 +2158,13 @@ export class VisionService extends Service {
       await this.objectDetector.dispose();
       this.objectDetector = null;
       this.hasObjectDetection = false;
+      this.objectDetectionUnavailableReason = "Service stopped";
+    }
+
+    if (this.faceRecognition) {
+      this.faceRecognition = null;
+      this.hasFaceRecognition = false;
+      this.faceRecognitionUnavailableReason = "Service stopped";
     }
 
     if (this.workerManager) {

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -237,7 +237,6 @@ export class VisionService extends Service {
   private isProcessingScreen = false;
   private objectDetector: YOLODetector | null = null;
   private hasObjectDetection = false;
-  // Reason why object detection is unavailable (null when available or not requested).
   private objectDetectionUnavailableReason: string | null = null;
   // Lazily constructed: the face backend is dynamically imported on first use
   // so plugin-vision's module graph never pulls native code at module-eval
@@ -251,7 +250,10 @@ export class VisionService extends Service {
 
   // Screen vision components
   private screenCapture: ScreenCaptureService;
+  private screenCaptureReady = false;
+  private screenCaptureUnavailableReason: string | null = null;
   private ocrService: OCRService;
+  private ocrUnavailableReason: string | null = null;
   private lastScreenCapture: ScreenCapture | null = null;
   private lastEnhancedScene: EnhancedSceneDescription | null = null;
 
@@ -290,6 +292,7 @@ export class VisionService extends Service {
     updateInterval: 100, // Process frames every 100ms
     enablePoseDetection: false,
     enableObjectDetection: false,
+    enableFaceRecognition: false,
     tfUpdateInterval: 1000, // TensorFlow update every 1 second
     vlmUpdateInterval: 10000, // VLM update every 10 seconds
     tfChangeThreshold: 10, // 10% change triggers TF update
@@ -380,6 +383,11 @@ export class VisionService extends Service {
       enablePoseDetection:
         runtime.getSetting("ENABLE_POSE_DETECTION") === "true" ||
         runtime.getSetting("VISION_ENABLE_POSE_DETECTION") === "true",
+      enableFaceRecognition: getBooleanSetting(
+        "ENABLE_FACE_RECOGNITION",
+        "VISION_ENABLE_FACE_RECOGNITION",
+        false,
+      ),
       tfUpdateInterval:
         Number(
           runtime.getSetting("TF_UPDATE_INTERVAL") ||
@@ -489,12 +497,21 @@ export class VisionService extends Service {
           this.objectDetector = null;
           this.hasObjectDetection = false;
           this.objectDetectionUnavailableReason =
-            yoloError instanceof Error
-              ? yoloError.message
-              : String(yoloError);
+            "YOLO backend failed to initialize; verify the native library and model weights";
           logger.warn(
             "[VisionService] ggml YOLOv8 detector unavailable, object detection disabled (using motion/heuristic + VLM fallback):",
-            this.objectDetectionUnavailableReason,
+            yoloError instanceof Error ? yoloError.message : String(yoloError),
+          );
+        }
+      }
+
+      if (this.visionConfig.enableFaceRecognition) {
+        try {
+          await this.getFaceRecognition();
+        } catch (faceError) {
+          logger.warn(
+            "[VisionService] Face recognition unavailable:",
+            faceError instanceof Error ? faceError.message : String(faceError),
           );
         }
       }
@@ -532,9 +549,9 @@ export class VisionService extends Service {
   }
 
   private async initializeScreenVision(): Promise<void> {
-    try {
-      logger.info("[VisionService] Initializing screen vision...");
+    logger.info("[VisionService] Initializing screen vision...");
 
+    try {
       // Check if we should use worker threads for high-FPS processing
       const useWorkers =
         this.visionConfig.targetScreenFPS &&
@@ -552,9 +569,19 @@ export class VisionService extends Service {
         // Initialize OCR if enabled
         if (this.visionConfig.ocrEnabled) {
           await this.ocrService.initialize();
+          this.ocrUnavailableReason = null;
         }
       }
+    } catch (error) {
+      this.ocrUnavailableReason =
+        "OCR backend failed to initialize; verify the platform provider or native model files";
+      logger.warn(
+        "[VisionService] OCR unavailable; screen capture will continue without OCR:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
 
+    try {
       // Get screen info
       const screenInfo = await this.screenCapture.getScreenInfo();
       if (screenInfo) {
@@ -565,7 +592,9 @@ export class VisionService extends Service {
 
       logger.info("[VisionService] Screen vision initialized");
     } catch (error) {
-      logger.error(
+      this.screenCaptureUnavailableReason =
+        "Screen capture backend failed to initialize for this platform";
+      logger.warn(
         { error },
         "[VisionService] Failed to initialize screen vision:",
       );
@@ -1055,21 +1084,9 @@ export class VisionService extends Service {
       // Face recognition and entity tracking
       const faceProfiles = new Map<string, string>();
       const recognizedFaces: RecognizedFace[] = [];
-      const getSettingString = (key: string): string | undefined => {
-        const value = this.runtime.getSetting(key);
-        return value === true || value === false
-          ? String(value)
-          : typeof value === "string"
-            ? value
-            : typeof value === "number"
-              ? String(value)
-              : undefined;
-      };
-      const enableFaceRecognition =
-        getSettingString("ENABLE_FACE_RECOGNITION") === "true";
 
       if (
-        enableFaceRecognition &&
+        this.visionConfig.enableFaceRecognition &&
         people.length > 0 &&
         frame.width > 0 &&
         frame.height > 0 &&
@@ -1802,11 +1819,22 @@ export class VisionService extends Service {
   }
 
   private async captureAndProcessScreen(): Promise<void> {
+    let capture: ScreenCapture;
     try {
-      // Capture screen
-      const capture = await this.screenCapture.captureScreen();
-      this.lastScreenCapture = capture;
+      capture = await this.screenCapture.captureScreen();
+    } catch (error) {
+      this.screenCaptureReady = false;
+      this.screenCaptureUnavailableReason =
+        "Screen capture failed; verify host support and screen-recording permission";
+      logger.error({ error }, "[VisionService] Error capturing screen:");
+      return;
+    }
 
+    this.lastScreenCapture = capture;
+    this.screenCaptureReady = true;
+    this.screenCaptureUnavailableReason = null;
+
+    try {
       // Process active tile
       const activeTile = this.screenCapture.getActiveTile();
       if (activeTile?.data) {
@@ -1817,7 +1845,7 @@ export class VisionService extends Service {
       // Update enhanced scene description
       await this.updateEnhancedSceneDescription();
     } catch (error) {
-      logger.error({ error }, "[VisionService] Error capturing screen:");
+      logger.error({ error }, "[VisionService] Error processing screen frame:");
     }
   }
 
@@ -1831,8 +1859,11 @@ export class VisionService extends Service {
       if (this.visionConfig.ocrEnabled && tile.data) {
         analysis.ocr = await this.ocrService.extractFromTile(tile);
         analysis.text = analysis.ocr.fullText;
+        this.ocrUnavailableReason = null;
       }
     } catch (error) {
+      this.ocrUnavailableReason =
+        "OCR backend failed while processing the latest screen frame";
       logger.error({ error }, "[VisionService] Error analyzing tile:");
     }
 
@@ -2015,6 +2046,8 @@ export class VisionService extends Service {
     if (this.screenProcessingInterval) {
       clearInterval(this.screenProcessingInterval);
       this.screenProcessingInterval = null;
+      this.screenCaptureReady = false;
+      this.screenCaptureUnavailableReason = "Screen processing is stopped";
     }
 
     if (this.arbiterUnsubscribe) {
@@ -2054,39 +2087,52 @@ export class VisionService extends Service {
    */
   public getCapabilities(): VisionCapabilities {
     const caps: VisionCapabilities = {
-      objectDetection: this.hasObjectDetection,
-      ocr: this.visionConfig.ocrEnabled ? this.ocrService.isInitialized() : false,
-      faceRecognition: this.hasFaceRecognition,
-      screenCapture: this.screenProcessingInterval !== null,
+      objectDetection: this.hasObjectDetection && this.objectDetector !== null,
+      ocr:
+        Boolean(this.visionConfig.ocrEnabled) &&
+        this.ocrService.isInitialized() &&
+        this.ocrUnavailableReason === null,
+      faceRecognition:
+        this.hasFaceRecognition &&
+        this.faceRecognition?.isInitialized() === true,
+      screenCapture: this.screenCaptureReady,
       camera: this.camera !== null,
       audio:
-        this.audioCapture !== null || this.streamingAudioCapture !== null,
+        this.audioCapture?.isActive() === true ||
+        this.streamingAudioCapture?.isActive() === true,
     };
 
     const reasons: NonNullable<VisionCapabilities["unavailableReasons"]> = {};
 
     if (!caps.objectDetection) {
-      reasons.objectDetection = this.objectDetectionUnavailableReason
-        ?? (this.visionConfig.enableObjectDetection
+      reasons.objectDetection =
+        this.objectDetectionUnavailableReason ??
+        (this.visionConfig.enableObjectDetection
           ? "YOLO backend not initialized"
           : "Object detection not enabled");
     }
 
     if (!caps.ocr) {
-      reasons.ocr = "OCR not enabled";
+      reasons.ocr = this.visionConfig.ocrEnabled
+        ? (this.ocrUnavailableReason ?? "OCR backend is not initialized")
+        : "OCR not enabled";
     }
 
     if (!caps.faceRecognition) {
-      reasons.faceRecognition = this.faceRecognitionUnavailableReason
-        ?? "Face recognition backend not initialized or not enabled";
+      reasons.faceRecognition =
+        this.faceRecognitionUnavailableReason ??
+        (this.visionConfig.enableFaceRecognition
+          ? "Face recognition backend is not initialized"
+          : "Face recognition not enabled");
     }
 
     if (!caps.screenCapture) {
-      const mode = this.visionConfig.visionMode;
       reasons.screenCapture =
-        mode === VisionMode.SCREEN || mode === VisionMode.BOTH
-          ? "Screen capture pipeline not started"
-          : "Screen mode not active";
+        this.screenCaptureUnavailableReason ??
+        (this.visionConfig.visionMode === VisionMode.SCREEN ||
+        this.visionConfig.visionMode === VisionMode.BOTH
+          ? "Screen capture is awaiting its first successful frame"
+          : "Screen mode not active");
     }
 
     if (!caps.camera) {
@@ -2094,7 +2140,10 @@ export class VisionService extends Service {
     }
 
     if (!caps.audio) {
-      reasons.audio = "Audio capture not configured";
+      reasons.audio =
+        this.audioCapture || this.streamingAudioCapture
+          ? "Audio capture backend is not active"
+          : "Audio capture not configured";
     }
 
     if (Object.keys(reasons).length > 0) {
@@ -2132,13 +2181,15 @@ export class VisionService extends Service {
     if (!this.faceRecognition) {
       try {
         const { FaceRecognition } = await import("./face-recognition-ggml");
-        this.faceRecognition = new FaceRecognition();
+        const candidate = new FaceRecognition();
+        await candidate.initialize();
+        this.faceRecognition = candidate;
         this.hasFaceRecognition = true;
         this.faceRecognitionUnavailableReason = null;
       } catch (error) {
-        // error-policy:J2 wrap+rethrow with unavailable reason for capability surface
+        // error-policy:J2 record stable context and rethrow the backend failure.
         this.faceRecognitionUnavailableReason =
-          error instanceof Error ? error.message : String(error);
+          "Face recognition backend failed to initialize; verify the native library and both model files";
         throw error;
       }
     }
@@ -2168,6 +2219,7 @@ export class VisionService extends Service {
     }
 
     if (this.faceRecognition) {
+      await this.faceRecognition.dispose();
       this.faceRecognition = null;
       this.hasFaceRecognition = false;
       this.faceRecognitionUnavailableReason = "Service stopped";
@@ -2182,6 +2234,8 @@ export class VisionService extends Service {
     this.lastFrame = null;
     this.lastSceneDescription = null;
     this.lastScreenCapture = null;
+    this.screenCaptureReady = false;
+    this.screenCaptureUnavailableReason = "Service stopped";
     this.lastEnhancedScene = null;
     this.dirtyTileDescriber = null;
     this.dirtyTileDescriberInit = false;
@@ -2190,6 +2244,7 @@ export class VisionService extends Service {
 
     // Dispose of models
     await this.ocrService.dispose();
+    this.ocrUnavailableReason = "Service stopped";
 
     logger.info("[VisionService] Stopped.");
   }

--- a/plugins/plugin-vision/src/types.ts
+++ b/plugins/plugin-vision/src/types.ts
@@ -37,7 +37,7 @@ export interface SceneDescription {
   describePaused?: boolean;
   describePauseReason?: Exclude<DescribePauseReason, null>;
   audioTranscription?: string;
-  /** Backend that produced the objects array — "yolo", "motion", or "vlm". */
+  /** Backend that produced the objects array. */
   objectDetectionSource?: DetectionSource;
 }
 
@@ -297,4 +297,4 @@ export interface VisionCapabilities {
 }
 
 /** Provenance of a detection result, so callers can tell YOLO apart from heuristics. */
-export type DetectionSource = "yolo" | "motion" | "vlm";
+export type DetectionSource = "yolo" | "motion";

--- a/plugins/plugin-vision/src/types.ts
+++ b/plugins/plugin-vision/src/types.ts
@@ -273,7 +273,7 @@ export interface WorldState {
 /**
  * Honest capability readiness snapshot. Each field reports whether the real
  * backend is initialized — never true when the backend failed to load or is
- * absent. The provider and routes surface this so callers can distinguish
+ * absent. The provider surface this so callers can distinguish
  * "unavailable" from "ready but empty".
  */
 export interface VisionCapabilities {
@@ -295,8 +295,3 @@ export interface VisionCapabilities {
 
 /** Provenance of a detection result, so callers can tell YOLO apart from heuristics. */
 export type DetectionSource = "yolo" | "motion" | "vlm";
-
-export interface DetectedObjectWithSource extends DetectedObject {
-  /** Which backend produced this detection. */
-  source: DetectionSource;
-}

--- a/plugins/plugin-vision/src/types.ts
+++ b/plugins/plugin-vision/src/types.ts
@@ -165,6 +165,7 @@ export interface VisionConfig {
   updateInterval?: number;
   enablePoseDetection?: boolean;
   enableObjectDetection?: boolean;
+  enableFaceRecognition?: boolean;
   tfUpdateInterval?: number;
   vlmUpdateInterval?: number;
   tfChangeThreshold?: number;
@@ -273,7 +274,7 @@ export interface WorldState {
 /**
  * Honest capability readiness snapshot. Each field reports whether the real
  * backend is initialized — never true when the backend failed to load or is
- * absent. The provider surface this so callers can distinguish
+ * absent. The provider surfaces this so callers can distinguish
  * "unavailable" from "ready but empty".
  */
 export interface VisionCapabilities {
@@ -290,7 +291,9 @@ export interface VisionCapabilities {
   /** True when audio capture initialized. */
   audio: boolean;
   /** Human-readable reasons for unavailable capabilities, keyed by field. */
-  unavailableReasons?: Partial<Record<keyof Omit<VisionCapabilities, "unavailableReasons">, string>>;
+  unavailableReasons?: Partial<
+    Record<keyof Omit<VisionCapabilities, "unavailableReasons">, string>
+  >;
 }
 
 /** Provenance of a detection result, so callers can tell YOLO apart from heuristics. */

--- a/plugins/plugin-vision/src/types.ts
+++ b/plugins/plugin-vision/src/types.ts
@@ -37,6 +37,8 @@ export interface SceneDescription {
   describePaused?: boolean;
   describePauseReason?: Exclude<DescribePauseReason, null>;
   audioTranscription?: string;
+  /** Backend that produced the objects array — "yolo", "motion", or "vlm". */
+  objectDetectionSource?: DetectionSource;
 }
 
 export interface DetectedObject {
@@ -266,4 +268,35 @@ export interface WorldState {
     leftAt: number;
     lastPosition: BoundingBox;
   }>;
+}
+
+/**
+ * Honest capability readiness snapshot. Each field reports whether the real
+ * backend is initialized — never true when the backend failed to load or is
+ * absent. The provider and routes surface this so callers can distinguish
+ * "unavailable" from "ready but empty".
+ */
+export interface VisionCapabilities {
+  /** True when a ggml YOLOv8 detector loaded and has valid weights. */
+  objectDetection: boolean;
+  /** True when a native OCR backend initialized. */
+  ocr: boolean;
+  /** True when face recognition backend loaded. */
+  faceRecognition: boolean;
+  /** True when screen capture pipeline initialized. */
+  screenCapture: boolean;
+  /** True when camera capture initialized. */
+  camera: boolean;
+  /** True when audio capture initialized. */
+  audio: boolean;
+  /** Human-readable reasons for unavailable capabilities, keyed by field. */
+  unavailableReasons?: Partial<Record<keyof Omit<VisionCapabilities, "unavailableReasons">, string>>;
+}
+
+/** Provenance of a detection result, so callers can tell YOLO apart from heuristics. */
+export type DetectionSource = "yolo" | "motion" | "vlm";
+
+export interface DetectedObjectWithSource extends DetectedObject {
+  /** Which backend produced this detection. */
+  source: DetectionSource;
 }

--- a/plugins/plugin-vision/src/types.ts
+++ b/plugins/plugin-vision/src/types.ts
@@ -296,5 +296,24 @@ export interface VisionCapabilities {
   >;
 }
 
+/** Whether the currently selected mode has at least one completed input. */
+export function hasReadyInputForMode(
+  capabilities: VisionCapabilities | undefined,
+  mode: VisionMode | undefined,
+): boolean {
+  if (!capabilities || !mode) return false;
+  switch (mode) {
+    case VisionMode.CAMERA:
+      return capabilities.camera;
+    case VisionMode.SCREEN:
+      return capabilities.screenCapture;
+    case VisionMode.BOTH:
+      return capabilities.camera || capabilities.screenCapture;
+    case VisionMode.OFF:
+      return false;
+  }
+  return false;
+}
+
 /** Provenance of a detection result, so callers can tell YOLO apart from heuristics. */
 export type DetectionSource = "yolo" | "motion";

--- a/plugins/plugin-vision/src/vision-worker-manager-readiness.test.ts
+++ b/plugins/plugin-vision/src/vision-worker-manager-readiness.test.ts
@@ -39,4 +39,37 @@ describe("VisionWorkerManager readiness", () => {
       ocr: true,
     });
   });
+
+  it("clears cached readiness after worker failure and recovers on newer output", () => {
+    const manager = new VisionWorkerManager({ ocrEnabled: true });
+    const state = Reflect.get(manager, "screenAtomicState") as Int32Array;
+    Atomics.store(state, 2, 1280);
+    Atomics.store(state, 3, 720);
+    Atomics.store(state, 5, 42);
+    Atomics.store(state, 0, 1);
+    Reflect.set(manager, "latestOCRResult", {
+      text: "ready",
+      fullText: "ready",
+      blocks: [],
+    });
+    expect(manager.getReadiness()).toEqual({
+      screenCapture: true,
+      ocr: true,
+    });
+
+    const clearScreen = Reflect.get(
+      manager,
+      "clearScreenCaptureReadiness",
+    ) as () => void;
+    const clearOCR = Reflect.get(manager, "clearOCRReadiness") as () => void;
+    clearScreen.call(manager);
+    clearOCR.call(manager);
+    expect(manager.getReadiness()).toEqual({
+      screenCapture: false,
+      ocr: false,
+    });
+
+    Atomics.store(state, 0, 2);
+    expect(manager.getReadiness().screenCapture).toBe(true);
+  });
 });

--- a/plugins/plugin-vision/src/vision-worker-manager-readiness.test.ts
+++ b/plugins/plugin-vision/src/vision-worker-manager-readiness.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Worker-manager readiness tests use shared-buffer metadata without spawning workers.
+ */
+
+import { describe, expect, it } from "vitest";
+import { VisionWorkerManager } from "./vision-worker-manager";
+
+describe("VisionWorkerManager readiness", () => {
+  it("does not treat zero-filled shared memory as a completed frame", () => {
+    const manager = new VisionWorkerManager({ ocrEnabled: true });
+
+    expect(manager.getLatestScreenCapture()).toBeNull();
+    expect(manager.getReadiness()).toEqual({
+      screenCapture: false,
+      ocr: false,
+    });
+  });
+
+  it("becomes ready only after committed screen and OCR results exist", () => {
+    const manager = new VisionWorkerManager({ ocrEnabled: true });
+    const state = Reflect.get(manager, "screenAtomicState") as Int32Array;
+    Atomics.store(state, 2, 1280);
+    Atomics.store(state, 3, 720);
+    Atomics.store(state, 5, 42);
+    Atomics.store(state, 0, 1);
+
+    expect(manager.getReadiness()).toEqual({
+      screenCapture: true,
+      ocr: false,
+    });
+
+    Reflect.set(manager, "latestOCRResult", {
+      text: "",
+      fullText: "",
+      blocks: [],
+    });
+    expect(manager.getReadiness()).toEqual({
+      screenCapture: true,
+      ocr: true,
+    });
+  });
+});

--- a/plugins/plugin-vision/src/vision-worker-manager.ts
+++ b/plugins/plugin-vision/src/vision-worker-manager.ts
@@ -107,6 +107,7 @@ export class VisionWorkerManager {
           lastUpdate: Date.now(),
         });
       } else if (msg.type === "error") {
+        this.clearScreenCaptureReadiness();
         logger.error("[ScreenCaptureWorker] Error:", msg.error);
       } else if (msg.type === "log") {
         this.handleWorkerLog("ScreenCaptureWorker", msg);
@@ -114,6 +115,7 @@ export class VisionWorkerManager {
     });
 
     this.screenCaptureWorker.on("error", (error) => {
+      this.clearScreenCaptureReadiness();
       logger.error(
         "[ScreenCaptureWorker] Worker error:",
         error instanceof Error ? error.message : String(error),
@@ -122,6 +124,7 @@ export class VisionWorkerManager {
     });
 
     this.screenCaptureWorker.on("exit", (code) => {
+      this.clearScreenCaptureReadiness();
       if (code !== 0) {
         logger.error(
           `[ScreenCaptureWorker] Worker stopped with exit code ${code}`,
@@ -156,6 +159,7 @@ export class VisionWorkerManager {
       } else if (msg.type === "ocr_complete") {
         this.updateOCRCache(msg);
       } else if (msg.type === "error") {
+        this.clearOCRReadiness();
         logger.error("[OCRWorker] Error:", msg.error);
       } else if (msg.type === "log") {
         this.handleWorkerLog("OCRWorker", msg);
@@ -163,6 +167,7 @@ export class VisionWorkerManager {
     });
 
     this.ocrWorker.on("error", (error) => {
+      this.clearOCRReadiness();
       logger.error(
         "[OCRWorker] Worker error:",
         error instanceof Error ? error.message : String(error),
@@ -171,6 +176,7 @@ export class VisionWorkerManager {
     });
 
     this.ocrWorker.on("exit", (code) => {
+      this.clearOCRReadiness();
       if (code !== 0) {
         logger.error(`[OCRWorker] Worker stopped with exit code ${code}`);
         setTimeout(() => this.restartOCRWorker(), 1000);
@@ -181,9 +187,7 @@ export class VisionWorkerManager {
   private updateOCRCache(_msg: unknown): void {
     try {
       const result = this.readOCRResult();
-      if (result) {
-        this.latestOCRResult = result;
-      }
+      this.latestOCRResult = result;
     } catch (error) {
       logger.error(
         { error },
@@ -272,6 +276,18 @@ export class VisionWorkerManager {
       screenCapture: this.getLatestScreenCapture() !== null,
       ocr: this.latestOCRResult !== null,
     };
+  }
+
+  private clearScreenCaptureReadiness(): void {
+    this.latestScreenCapture = null;
+    this.lastProcessedFrameId = Atomics.load(
+      this.screenAtomicState,
+      this.FRAME_ID_INDEX,
+    );
+  }
+
+  private clearOCRReadiness(): void {
+    this.latestOCRResult = null;
   }
 
   getLatestEnhancedScene(): EnhancedSceneDescription {
@@ -387,6 +403,10 @@ export class VisionWorkerManager {
     }
 
     await Promise.all(stopPromises);
+    this.screenCaptureWorker = null;
+    this.ocrWorker = null;
+    this.clearScreenCaptureReadiness();
+    this.clearOCRReadiness();
     logger.info("[VisionWorkerManager] All workers stopped");
   }
 
@@ -431,6 +451,7 @@ export class VisionWorkerManager {
 
     try {
       if (this.screenCaptureWorker) {
+        this.clearScreenCaptureReadiness();
         this.screenCaptureWorker.removeAllListeners();
         this.screenCaptureWorker = null;
       }
@@ -463,6 +484,7 @@ export class VisionWorkerManager {
 
     try {
       if (this.ocrWorker) {
+        this.clearOCRReadiness();
         this.ocrWorker.removeAllListeners();
         this.ocrWorker = null;
       }

--- a/plugins/plugin-vision/src/vision-worker-manager.ts
+++ b/plugins/plugin-vision/src/vision-worker-manager.ts
@@ -225,6 +225,12 @@ export class VisionWorkerManager {
   getLatestScreenCapture(): ScreenCapture | null {
     const frameId = Atomics.load(this.screenAtomicState, this.FRAME_ID_INDEX);
 
+    // SharedArrayBuffer metadata starts zeroed; the worker increments the id
+    // only after committing its first complete frame.
+    if (frameId <= 0) {
+      return null;
+    }
+
     if (frameId <= this.lastProcessedFrameId) {
       return this.latestScreenCapture;
     }
@@ -258,6 +264,14 @@ export class VisionWorkerManager {
     }
 
     return this.latestScreenCapture;
+  }
+
+  /** Readiness is based on completed worker output, not allocated workers. */
+  getReadiness(): { screenCapture: boolean; ocr: boolean } {
+    return {
+      screenCapture: this.getLatestScreenCapture() !== null,
+      ocr: this.latestOCRResult !== null,
+    };
   }
 
   getLatestEnhancedScene(): EnhancedSceneDescription {


### PR DESCRIPTION
## Summary

Makes `plugin-vision` capability and top-level availability reporting depend on completed backend work instead of configuration flags, allocated objects, or scheduled timers. Camera/screen actions now fail closed with the concrete backend reason, while motion fallback output is explicitly distinguished from native YOLO output.

This is the capability-readiness slice of #16341. It deliberately **does not close the parent tracker**: cancellable capture/media identity and the larger frame-correlated worker protocol remain separate acceptance scopes.

Refs #16341.

## Review findings repaired

- `isActive()` was camera-only, so a working screen-only service appeared inactive.
- The original patch made a scheduled screen interval look ready before any frame succeeded. Worker shared memory also starts zero-filled, which was incorrectly interpreted as frame `0`.
- The provider could say `visionAvailable: true` while every real input capability was false.
- Readiness was not mode-sensitive: a connected camera could make `SCREEN` mode appear available and allow camera capture while the service was configured for screen input.
- Screen/OCR worker errors, exits, restarts, and stops retained cached readiness; a failed OCR read could also leave stale output looking current.
- The describe action could say “initializing” forever after a permission or backend failure and used the camera-only scene accessor in screen mode.
- `OCR_ENABLED`, allocated audio objects, and allocated face objects were treated as proof of initialized/active backends.
- The high-FPS worker path could perform real OCR while the new capability surface reported it permanently unavailable.
- Logs promised a motion fallback when YOLO initialization failed, but that path actually returned an empty object list.
- `DetectionSource` advertised a `vlm` source that never produces the structured objects array.
- Face readiness was marked true before both native models loaded, and partial initialization did not reliably clean up both models.

## Resulting contract

- `VisionCapabilities` reports object detection, OCR, face recognition, screen capture, camera, and audio separately, with an unavailable reason for every false capability.
- Screen and worker readiness begins only after the first committed frame/result and clears after failure, exit, restart, or stop.
- `visionAvailable` requires both an active processing loop and a ready input for the configured mode.
- Screen-only describe uses the enhanced scene; capture remains camera-only and fails closed in screen mode.
- YOLO failure runs the documented motion fallback and labels its provenance as `motion`; only actual YOLO output is labeled `yolo`.
- Face readiness requires both detector and embedder initialization, with partial-init cleanup and service-stop disposal.

## Verification

Exact head: `49c539f33b1d39fb925e0f08a56809c5fd8c8a20`
Base: `aff54b6d69d1ea758357853ee33f81bb6461e0e8`

- `bun run --cwd plugins/plugin-vision test`: 42 files passed; 255 tests passed, 1 tracked platform skip.
- `bun run --cwd plugins/plugin-vision typecheck`: passed.
- `bun run --cwd plugins/plugin-vision lint:check`: 117 files clean.
- `bun run --cwd plugins/plugin-vision build`: Node, Workers, and declaration builds passed.
- Real macOS `ScreenCaptureService` capture: 3456×2234, 960,639 bytes, 12 tiles, non-empty active tile; captured content was not uploaded.
- Real macOS Apple Vision `VNRecognizeText`: 8/8 tests passed over the rendered OCR screenshot, including positive-area boxes.
- `bun run verify`: 348/348 tasks and all repository audits passed on the exact head.
- All six commits retained their stable patch IDs across the final rebase onto `develop`.

<!-- evidence-head:49c539f33b1d39fb925e0f08a56809c5fd8c8a20 -->
<!-- evidence-refresh:49c539f33b1d39fb925e0f08a56809c5fd8c8a20 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend capability/runtime contract only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend capability/runtime contract only; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow changed in this scoped slice.

<!-- evidence-row:backend-logs -->
- [x] [Package, real screen-capture, and real OCR validation log from the patch-identical vision tree](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18245-pr18245-validation.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser/network behavior changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-selection, prompt, planner, or model-output contract changes; readiness and action branches are deterministic and tested below the model boundary.

<!-- evidence-row:domain-artifacts -->
- [x] [Real capture dimensions, SHA-256, tiling result, and native OCR result summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18245-pr18245-domain.log)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no app pixel/text rendering changed; the native OCR backend proof is linked as a domain artifact above.

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`, `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [hermes/t3rpz] [codex/openai-gpt-5.6-sol]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza"} -->
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"N/A"} -->
