### PR TITLE
fix(cloud): auth-cache warming gets a deadline and an authoritative escape

### DIFF
--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -9,6 +9,7 @@
 process.env.MOCK_REDIS = "1";
 process.env.CACHE_ENABLED = "true";
 process.env.INFERENCE_AUTH_CACHE_ENABLED = "true";
+process.env.INFERENCE_AUTH_HYDRATION_DEADLINE_MS = "60";
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { redactLogArgs } from "@elizaos/core";
@@ -596,4 +597,118 @@ describe("isInferenceAuthContext shape guard", () => {
       }),
     ).toBe(true);
   });
+});
+
+const { __clearInferenceApiKeyHydrationFailures } = await import(
+	"./inference-auth-context"
+);
+
+describe("hydration escape (#18246 — warming must not loop forever)", () => {
+
+	function workerCtx(captured: Promise<unknown>[]) {
+		return {
+			waitUntil: (p: Promise<unknown>) => {
+				captured.push(p);
+			},
+		} as never;
+	}
+
+	beforeEach(() => {
+		__clearInferenceApiKeyHydrationFailures();
+	});
+
+	test("three failed hydrations flip the next cacheOnly request to inline authoritative", async () => {
+		authImpl = async () => {
+			throw new Error("postgres unreachable");
+		};
+		const hydrations: Promise<unknown>[] = [];
+		for (let i = 0; i < 3; i++) {
+			const res = await resolveInferenceAuthContext(reqWithApiKey(), {
+				cacheOnly: true,
+				executionCtx: workerCtx(hydrations),
+			});
+			expect(res.kind).toBe("warming");
+			// Settle this round's hydration so the failure registers and the
+			// single-flight slot frees before the next request.
+			await Promise.all(hydrations.splice(0));
+		}
+		// Dependency recovered; a still-warming shortcut would 503 forever.
+		authImpl = async () => ({
+			user: { id: "user-1", organization_id: "org-1" },
+			apiKey: { id: "key-1" },
+		});
+		const escaped = await resolveInferenceAuthContext(reqWithApiKey(), {
+			cacheOnly: true,
+			executionCtx: workerCtx(hydrations),
+		});
+		expect(escaped.kind).toBe("authorized");
+		// The inline resolve wrote the cache — the loop self-healed.
+		const cached = await readInferenceAuthContext(hashApiKey(KEY));
+		expect(cached && isInferenceAuthContext(cached)).toBe(true);
+	});
+
+	test("a successful hydration resets the failure count", async () => {
+		authImpl = async () => {
+			throw new Error("blip");
+		};
+		const hydrations: Promise<unknown>[] = [];
+		for (let i = 0; i < 2; i++) {
+			await resolveInferenceAuthContext(reqWithApiKey(), {
+				cacheOnly: true,
+				executionCtx: workerCtx(hydrations),
+			});
+			await Promise.all(hydrations.splice(0));
+		}
+		authImpl = async () => ({
+			user: { id: "user-1", organization_id: "org-1" },
+			apiKey: { id: "key-1" },
+		});
+		// Successful hydration on round 3 clears the counter and the cache
+		// now answers directly.
+		await resolveInferenceAuthContext(reqWithApiKey(), {
+			cacheOnly: true,
+			executionCtx: workerCtx(hydrations),
+		});
+		await Promise.all(hydrations.splice(0));
+		const res = await resolveInferenceAuthContext(reqWithApiKey(), {
+			cacheOnly: true,
+			executionCtx: workerCtx(hydrations),
+		});
+		expect(res.kind).toBe("authorized");
+	});
+
+	test("a hung hydration hits the deadline, frees the slot, and counts toward escape", async () => {
+		let release: (() => void) | undefined;
+		authImpl = () =>
+			new Promise((resolve) => {
+				release = () =>
+					resolve({
+						user: { id: "user-1", organization_id: "org-1" },
+						apiKey: { id: "key-1" },
+					});
+			});
+		const hydrations: Promise<unknown>[] = [];
+		for (let i = 0; i < 3; i++) {
+			const res = await resolveInferenceAuthContext(reqWithApiKey(), {
+				cacheOnly: true,
+				executionCtx: workerCtx(hydrations),
+			});
+			expect(res.kind).toBe("warming");
+			// The deadline (env-shortened for tests) settles the raced
+			// hydration even though the underlying resolve never returns.
+			await Promise.all(hydrations.splice(0));
+		}
+		// After three deadline strikes the escape opens; a now-healthy
+		// dependency resolves inline instead of warming.
+		authImpl = async () => ({
+			user: { id: "user-1", organization_id: "org-1" },
+			apiKey: { id: "key-1" },
+		});
+		const escaped = await resolveInferenceAuthContext(reqWithApiKey(), {
+			cacheOnly: true,
+			executionCtx: workerCtx(hydrations),
+		});
+		expect(escaped.kind).toBe("authorized");
+		release?.();
+	});
 });

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -277,6 +277,44 @@ export function extractApiKeyCredential(req: Request): string | null {
   return extractApiKeyCredentialWithSource(req)?.rawKey ?? null;
 }
 
+/**
+ * Wall-clock bound on one background hydration attempt. A hung authoritative
+ * resolve (stalled Postgres, dead moderation dependency) must not pin the
+ * single-flight slot for the Worker isolate's lifetime — that turned a cold
+ * cache into a permanent 503 loop (live incident 2026-08-10: "warming"
+ * returned unchanged for minutes because the coalesced hydration never
+ * settled). On deadline the slot clears so the next request starts a fresh
+ * attempt, and the miss counts toward the authoritative-escape threshold.
+ */
+const HYDRATION_DEADLINE_MS = Number(
+  process.env.INFERENCE_AUTH_HYDRATION_DEADLINE_MS ?? "10000",
+);
+
+/**
+ * After this many consecutive failed or timed-out hydrations for one key,
+ * the cacheOnly warming shortcut is bypassed and the request resolves
+ * authoritatively inline: slower, but definitive — and the successful inline
+ * resolve writes the cache, self-healing the loop. "Retry shortly" must never
+ * be a lie the caller can't escape.
+ */
+const HYDRATION_FAILURE_ESCAPE_THRESHOLD = 3;
+
+const apiKeyHydrationFailures = new Map<string, number>();
+
+function noteHydrationFailure(keyHash: string): void {
+  apiKeyHydrationFailures.set(
+    keyHash,
+    (apiKeyHydrationFailures.get(keyHash) ?? 0) + 1,
+  );
+}
+
+function hydrationEscapeActive(keyHash: string): boolean {
+  return (
+    (apiKeyHydrationFailures.get(keyHash) ?? 0) >=
+    HYDRATION_FAILURE_ESCAPE_THRESHOLD
+  );
+}
+
 function getOrCreateApiKeyHydration(
   req: Request,
   keyHash: string,
@@ -288,7 +326,7 @@ function getOrCreateApiKeyHydration(
   // The outer Worker waitUntil retains this whole operation, so the
   // authoritative resolver intentionally runs without an execution context:
   // it must finish the cache write before releasing the single-flight slot.
-  const hydration = resolveInferenceAuthContext(req, {
+  const attempt = resolveInferenceAuthContext(req, {
     traceId,
     cacheOnly: false,
     forceAuthoritative: true,
@@ -300,6 +338,7 @@ function getOrCreateApiKeyHydration(
           throw new Error(`Suspended inference-auth decision cache write failed: ${write.kind}`);
         }
       }
+      apiKeyHydrationFailures.delete(keyHash);
     })
     .catch(async (error) => {
       const status = getErrorStatusCode(error);
@@ -312,22 +351,53 @@ function getOrCreateApiKeyHydration(
             cacheWrite: write.kind,
           });
         }
+        // A definitive rejection is a successful decision, not a failed
+        // hydration — the cache now answers; no escape pressure needed.
+        apiKeyHydrationFailures.delete(keyHash);
+      } else {
+        noteHydrationFailure(keyHash);
       }
       // error-policy:J7 the current request already returned an explicit
       // warming state; preserve the failure in logs and allow a later retry.
       logger.warn("[InferenceAuth] background hydration failed", {
         traceId: boundedTraceId(traceId),
+        failureCount: apiKeyHydrationFailures.get(keyHash) ?? 0,
         error: error instanceof Error ? error.message : String(error),
       });
     });
+  // Deadline: a never-settling attempt must not hold the single-flight slot.
+  // The timed-out promise resolves (never rejects), counts as a failure, and
+  // frees the slot for a fresh attempt on the next request.
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  const hydration = Promise.race([
+    attempt,
+    new Promise<void>((resolve) => {
+      deadline = setTimeout(() => {
+        noteHydrationFailure(keyHash);
+        logger.warn("[InferenceAuth] background hydration exceeded deadline", {
+          traceId: boundedTraceId(traceId),
+          deadlineMs: HYDRATION_DEADLINE_MS,
+          failureCount: apiKeyHydrationFailures.get(keyHash) ?? 0,
+        });
+        resolve();
+      }, HYDRATION_DEADLINE_MS);
+      if (typeof deadline.unref === "function") deadline.unref();
+    }),
+  ]);
   apiKeyHydrations.set(keyHash, hydration);
   const clear = () => {
+    if (deadline !== undefined) clearTimeout(deadline);
     if (apiKeyHydrations.get(keyHash) === hydration) {
       apiKeyHydrations.delete(keyHash);
     }
   };
   hydration.then(clear, clear);
   return hydration;
+}
+
+/** Test hook: reset the hydration-failure escape counters. */
+export function __clearInferenceApiKeyHydrationFailures(): void {
+  apiKeyHydrationFailures.clear();
 }
 
 /** Test hook for isolating coalesced API-key hydration state. */
@@ -453,7 +523,7 @@ export async function resolveInferenceAuthContext(
       trace.cacheRead = "unavailable";
     }
 
-    if (authCacheEnabled && options.cacheOnly) {
+    if (authCacheEnabled && options.cacheOnly && !hydrationEscapeActive(keyHash)) {
       trace.authoritative = "not_run";
       trace.result = "warming";
       if (cacheAvailable && options.executionCtx) {
@@ -461,6 +531,16 @@ export async function resolveInferenceAuthContext(
         options.executionCtx.waitUntil(hydration);
       }
       return { kind: "warming" };
+    }
+    if (authCacheEnabled && options.cacheOnly) {
+      // Escape hatch: repeated hydration failures/timeouts mean "retry
+      // shortly" has become a lie — resolve authoritatively inline instead.
+      // The successful resolve below writes the cache, healing the loop.
+      logger.warn("[InferenceAuth] hydration escape — resolving inline", {
+        traceId: boundedTraceId(options.traceId),
+        failureCount: apiKeyHydrationFailures.get(keyHash) ?? 0,
+      });
+      apiKeyHydrationFailures.delete(keyHash);
     }
 
     trace.authoritative = "error";


### PR DESCRIPTION
Fixes #18246.

Live incident: a valid agent key received `auth_cache_warming` 503s from /api/v1/chat/completions for 2.5+ minutes across 13 retries — "retry shortly" never became true, and the agent's image-description path surfaced it to users as a plain 503.

## Root causes (inference-auth-context.ts)
1. **No deadline on background hydration.** The single-flight slot (`apiKeyHydrations`) held the coalesced promise until it settled — a hung authoritative resolve pinned the slot for the Worker isolate's lifetime, so every subsequent request joined the dead promise and returned warming forever.
2. **No escalation on persistent failure.** A hydration that failed every time only logged (J7) and kept the caller in the warming loop indefinitely.

## Fix
- Hydration attempts race a deadline (default 10s, `INFERENCE_AUTH_HYDRATION_DEADLINE_MS`); timeout frees the slot for a fresh attempt and counts as a failure.
- Consecutive failures/timeouts per key are counted; at 3, the cacheOnly warming shortcut is bypassed and the request resolves **authoritatively inline** — slower but definitive, and the successful resolve writes the cache, self-healing the loop. Success resets the counter; 401/403 rejections don't count (they cache as definitive decisions).
- No behavior change for the healthy path: first misses still return warming + background hydration exactly as before.

## Tests
inference-auth-context.test.ts (real cache client, mocked auth seams): **27/27** including 3 new — three failed hydrations flip the next request to inline-authoritative (and the cache is written), a successful hydration resets the counter, and a hung hydration hits the (env-shortened) deadline, frees the slot, and counts toward escape. cloud/shared typecheck clean.

# Evidence

<!-- evidence-head:bb59ef1c4f2e3b35466d79be5543d6da6d743182 -->
- Before screenshots: N/A - backend-only change, no UI surface
- After screenshots: N/A - backend-only change, no UI surface
- Walkthrough video: N/A - backend-only change, no UI surface
- OCR review: N/A - backend-only change, no UI surface
- Frontend console/network logs: live 13-retry warming transcript in #18246
- Backend logs: bun test 27/27 transcript
- Real-LLM trajectory: N/A - auth path, no model call
- Domain artifacts: post-deploy live probe of /api/v1/chat/completions with the same key (acceptance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
