### PR TITLE
fix(build): remove react paths mappings that bun executes as runtime code

### DIFF
--- a/packages/app-core/tsconfig.build.json
+++ b/packages/app-core/tsconfig.build.json
@@ -30,12 +30,6 @@
       "@elizaos/plugin-wechat": ["../../plugins/plugin-wechat/dist/index.d.ts"],
       "drizzle-orm": ["../../plugins/plugin-sql/node_modules/drizzle-orm"],
       "drizzle-orm/*": ["../../plugins/plugin-sql/node_modules/drizzle-orm/*"],
-      "react": ["./node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime.d.ts"],
-      "react/jsx-dev-runtime": [
-        "./node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": ["./node_modules/@types/react-dom/index.d.ts"],
       "@elizaos/capacitor-canvas": [
         "../../plugins/plugin-native-canvas/dist/esm/index.d.ts"
       ],

--- a/packages/app-core/tsconfig.json
+++ b/packages/app-core/tsconfig.json
@@ -97,12 +97,6 @@
       "@elizaos/core/*": ["../core/src/*"],
       "drizzle-orm": ["../../plugins/plugin-sql/node_modules/drizzle-orm"],
       "drizzle-orm/*": ["../../plugins/plugin-sql/node_modules/drizzle-orm/*"],
-      "react": ["./node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime.d.ts"],
-      "react/jsx-dev-runtime": [
-        "./node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": ["./node_modules/@types/react-dom/index.d.ts"],
       "@elizaos/plugin-local-inference": [
         "../../plugins/plugin-local-inference/src/index.ts"
       ],

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -58,13 +58,6 @@
       "@elizaos/shared": ["../shared/src/index.ts"],
       "@elizaos/ui": ["../ui/src/index.ts"],
       "@elizaos/ui/*": ["../ui/src/*"],
-      "react": ["../../node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": ["../../node_modules/@types/react/jsx-runtime.d.ts"],
-      "react/jsx-dev-runtime": [
-        "../../node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": ["../../node_modules/@types/react-dom/index.d.ts"],
-      "react-dom/client": ["../../node_modules/@types/react-dom/client.d.ts"],
       "@elizaos/plugin-capacitor-bridge": [
         "../../plugins/plugin-capacitor-bridge/src/index.ts"
       ],

--- a/packages/app/tsconfig.typecheck.json
+++ b/packages/app/tsconfig.typecheck.json
@@ -79,13 +79,6 @@
       "csstype": [
         "../../node_modules/.bun/csstype@3.2.3/node_modules/csstype/index.d.ts"
       ],
-      "react": ["../../node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": ["../../node_modules/@types/react/jsx-runtime.d.ts"],
-      "react/jsx-dev-runtime": [
-        "../../node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": ["../../node_modules/@types/react-dom/index.d.ts"],
-      "react-dom/client": ["../../node_modules/@types/react-dom/client.d.ts"],
       "@elizaos/plugin-workflow": [
         "../../plugins/plugin-workflow/dist/index.d.ts"
       ],

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -34,15 +34,7 @@
       "@elizaos/core": ["../core/src/index.node.ts"],
       "@elizaos/core/*": ["../core/src/*"],
       "@elizaos/logger": ["../logger/src/index.ts"],
-      "@elizaos/logger/*": ["../logger/src/*"],
-      "react": ["../app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": ["../app-core/node_modules/@types/react-dom/index.d.ts"]
+      "@elizaos/logger/*": ["../logger/src/*"]
     }
   },
   "exclude": [

--- a/plugins/plugin-blocker/tsconfig.json
+++ b/plugins/plugin-blocker/tsconfig.json
@@ -39,16 +39,6 @@
       "@elizaos/shared/*": ["../../packages/shared/src/*"],
       "@elizaos/agent": ["../../packages/agent/src/index.ts"],
       "@elizaos/agent/*": ["../../packages/agent/src/*"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/plugins/plugin-contacts/tsconfig.json
+++ b/plugins/plugin-contacts/tsconfig.json
@@ -78,16 +78,6 @@
       "@elizaos/plugin-whatsapp": [
         "../../plugins/plugin-whatsapp/src/index.ts"
       ],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-contacts": ["../plugin-native-contacts/src/index.ts"],
       "@elizaos/capacitor-contacts/*": ["../plugin-native-contacts/src/*"],
       "@elizaos/capacitor-contacts/web": [

--- a/plugins/plugin-documents/tsconfig.json
+++ b/plugins/plugin-documents/tsconfig.json
@@ -36,16 +36,6 @@
       "@elizaos/app-core/*": ["../../packages/app-core/src/*"],
       "@elizaos/ui": ["../../packages/ui/src/index.ts"],
       "@elizaos/ui/*": ["../../packages/ui/src/*"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/plugins/plugin-finances/tsconfig.json
+++ b/plugins/plugin-finances/tsconfig.json
@@ -43,16 +43,6 @@
       "@elizaos/agent/*": ["../../packages/agent/src/*"],
       "@elizaos/plugin-browser": ["../plugin-browser/src/index.ts"],
       "@elizaos/plugin-browser/*": ["../plugin-browser/src/*"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/plugins/plugin-goals/tsconfig.json
+++ b/plugins/plugin-goals/tsconfig.json
@@ -41,16 +41,6 @@
       "@elizaos/shared/*": ["../../packages/shared/src/*"],
       "@elizaos/agent": ["../../packages/agent/src/index.ts"],
       "@elizaos/agent/*": ["../../packages/agent/src/*"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/plugins/plugin-health/tsconfig.json
+++ b/plugins/plugin-health/tsconfig.json
@@ -33,16 +33,6 @@
       "@elizaos/shared/*": ["../../packages/shared/src/*"],
       "@elizaos/plugin-health": ["./src/index.ts"],
       "@elizaos/plugin-health/*": ["./src/*"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/plugins/plugin-inbox/tsconfig.json
+++ b/plugins/plugin-inbox/tsconfig.json
@@ -42,16 +42,6 @@
       "@elizaos/plugin-google-workspace/*": [
         "../plugin-google-workspace/src/*"
       ],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/plugins/plugin-local-inference/tsconfig.json
+++ b/plugins/plugin-local-inference/tsconfig.json
@@ -77,14 +77,7 @@
 			"@elizaos/plugin-wallet/*": ["../plugin-wallet/src/*"],
 			"csstype": [
 				"../../node_modules/.bun/csstype@3.2.3/node_modules/csstype/index.d.ts"
-			],
-			"react": ["../../node_modules/@types/react/index.d.ts"],
-			"react/jsx-runtime": ["../../node_modules/@types/react/jsx-runtime.d.ts"],
-			"react/jsx-dev-runtime": [
-				"../../node_modules/@types/react/jsx-dev-runtime.d.ts"
-			],
-			"react-dom": ["../../node_modules/@types/react-dom/index.d.ts"],
-			"react-dom/client": ["../../node_modules/@types/react-dom/client.d.ts"]
+			]
 		}
 	},
 	"include": ["src/**/*"],

--- a/plugins/plugin-messages/tsconfig.json
+++ b/plugins/plugin-messages/tsconfig.json
@@ -31,13 +31,6 @@
         "../../plugins/plugin-workflow/src/index.ts"
       ],
       "@elizaos/plugin-workflow/*": ["../../plugins/plugin-workflow/src/*"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/plugins/plugin-native-settings/tsconfig.json
+++ b/plugins/plugin-native-settings/tsconfig.json
@@ -19,14 +19,7 @@
     "paths": {
       "@elizaos/core": ["../../packages/core/dist/index.d.ts"],
       "@elizaos/ui": ["../../packages/ui/dist/index.d.ts"],
-      "@elizaos/capacitor-system": ["../plugin-native-system/src/index.ts"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ]
+      "@elizaos/capacitor-system": ["../plugin-native-system/src/index.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/plugins/plugin-notes/tsconfig.json
+++ b/plugins/plugin-notes/tsconfig.json
@@ -17,14 +17,7 @@
       "@elizaos/core": ["../../packages/core/src/index.node.ts"],
       "@elizaos/core/*": ["../../packages/core/src/*"],
       "@elizaos/ui": ["../../packages/ui/src/index.ts"],
-      "@elizaos/ui/*": ["../../packages/ui/src/*"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ]
+      "@elizaos/ui/*": ["../../packages/ui/src/*"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"],

--- a/plugins/plugin-phone/tsconfig.json
+++ b/plugins/plugin-phone/tsconfig.json
@@ -65,16 +65,6 @@
       "@elizaos/shared/*": ["../../packages/shared/src/*"],
       "@elizaos/plugin-signal": ["../plugin-signal/src/index.ts"],
       "@elizaos/plugin-signal/*": ["../plugin-signal/src/*"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-phone": [
         "../../plugins/plugin-native-phone/src/index.ts"
       ],

--- a/plugins/plugin-registry/tsconfig.json
+++ b/plugins/plugin-registry/tsconfig.json
@@ -16,10 +16,6 @@
     "outDir": "./dist",
     "rootDir": "../..",
     "paths": {
-      "react": ["../../node_modules/@types/react"],
-      "react/*": ["../../node_modules/@types/react/*"],
-      "react-dom": ["../../node_modules/@types/react-dom"],
-      "react-dom/*": ["../../node_modules/@types/react-dom/*"],
       "csstype": [
         "../../node_modules/.bun/csstype@3.2.3/node_modules/csstype/index.d.ts"
       ],

--- a/plugins/plugin-relationships/tsconfig.json
+++ b/plugins/plugin-relationships/tsconfig.json
@@ -44,16 +44,6 @@
       "@elizaos/plugin-task-coordinator": [
         "../plugin-task-coordinator/dist/index.d.ts"
       ],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/plugins/plugin-scheduling/tsconfig.json
+++ b/plugins/plugin-scheduling/tsconfig.json
@@ -38,16 +38,6 @@
       "@elizaos/shared/*": ["../../packages/shared/src/*"],
       "@elizaos/agent": ["../../packages/agent/src/index.ts"],
       "@elizaos/agent/*": ["../../packages/agent/src/*"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/plugins/plugin-todos/tsconfig.json
+++ b/plugins/plugin-todos/tsconfig.json
@@ -36,16 +36,6 @@
       "@elizaos/shared/*": ["../../packages/shared/src/*"],
       "@elizaos/agent": ["../../packages/agent/src/index.ts"],
       "@elizaos/agent/*": ["../../packages/agent/src/*"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/plugins/plugin-trajectory-logger/tsconfig.json
+++ b/plugins/plugin-trajectory-logger/tsconfig.json
@@ -47,16 +47,6 @@
       "@elizaos/shared/*": ["../../packages/shared/src/*"],
       "@elizaos/vault": ["../../packages/vault/src/index.ts"],
       "@elizaos/vault/*": ["../../packages/vault/src/*"],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/plugin-local-inference": [
         "../../plugins/plugin-local-inference/src/index.ts"
       ],

--- a/plugins/plugin-wifi/tsconfig.json
+++ b/plugins/plugin-wifi/tsconfig.json
@@ -61,16 +61,6 @@
       "@elizaos/plugin-whatsapp": [
         "../../plugins/plugin-whatsapp/src/index.ts"
       ],
-      "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
-      "react/jsx-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
-      ],
-      "react/jsx-dev-runtime": [
-        "../../packages/app-core/node_modules/@types/react/jsx-dev-runtime.d.ts"
-      ],
-      "react-dom": [
-        "../../packages/app-core/node_modules/@types/react-dom/index.d.ts"
-      ],
       "@elizaos/plugin-mcp": ["../../plugins/plugin-mcp/src/index.ts"],
       "@elizaos/plugin-mcp/*": ["../../plugins/plugin-mcp/src/*"],
       "@elizaos/plugin-workflow": [


### PR DESCRIPTION
Found while bringing the restored eliza-code (#18250) up in source mode: any `--conditions eliza-source` execution whose graph crosses one of 23 packages died with

> Fatal error: export as namespace React; — Unexpected as — at @types/react/index.d.ts:68

## Root cause
23 tsconfigs carry paths entries mapping `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, and `react-dom` to **@types/react `.d.ts` files**. That's type-resolution plumbing from an era before per-package `@types/react` devDeps — but **bun honors tsconfig paths at runtime/bundling**, so any source-mode execution resolves `react` to a type-declaration file and executes it as code. (The mapped app-core path is also dead, so resolution fell back to the root store's @types/react.)

## Fix
Remove the react/react-dom paths entries from all 23 tsconfigs. Type resolution is unaffected: every one of these packages already has `@types/react` in devDependencies and standard `@types` lookup (plus their explicit typeRoots) resolves it — verified by baseline parity (plugin-goals: 0 tsc errors before, 0 after). Runtime resolution heals: `react/jsx-dev-runtime` resolves to the real `react@19.2.5` from every affected package, and `bun build --conditions eliza-source` of plugin-goals, plugin-agent-orchestrator, and eliza-code's entry now succeeds where all three previously died on the d.ts parse.

## Evidence

<!-- evidence-head:b0dfe696cdd1530143587665c06f4e207244e44d -->
- Before screenshots: N/A - build-config-only change
- After screenshots: N/A - build-config-only change
- Walkthrough video: N/A - build-config-only change
- OCR review: N/A - build-config-only change
- Frontend console/network logs: N/A - build-config-only change
- Backend logs: before/after `bun build --conditions eliza-source` transcripts (d.ts fatal → clean build); `import.meta.resolve("react/jsx-dev-runtime")` from plugin-goals: @types/react.d.ts → react@19.2.5/jsx-dev-runtime.js
- Real-LLM trajectory: N/A - no model path
- Domain artifacts: live eliza-code one-shot run on the deployed tree post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
