### PR TITLE
fix(homepage): imperative swipe gesture on page ref

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -206,16 +206,6 @@
           }
         }
       }
-    },
-    {
-      "includes": ["packages/homepage/src/pages/landing.tsx"],
-      "linter": {
-        "rules": {
-          "a11y": {
-            "noStaticElementInteractions": "off"
-          }
-        }
-      }
     }
   ],
   "formatter": {

--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -205,21 +205,6 @@ export default function Leaderboard() {
     config: { mass: 1, tension: 120, friction: 8 },
   }));
 
-  // Capture-phase native guard: the platform switcher is a horizontal drag
-  // surface whose path crosses images and links, and a native HTML drag both
-  // breaks the gesture and wedges pointer input (Chromium never acks further
-  // mouse events mid-DnD). The React onDragStart on the root div misses drags
-  // originating in subtrees where synthetic delivery lapses, so cancel at the
-  // window in the capture phase for the landing page's lifetime.
-  useEffect(() => {
-    const cancelNativeDrag = (event: DragEvent) => event.preventDefault();
-    window.addEventListener("dragstart", cancelNativeDrag, { capture: true });
-    return () =>
-      window.removeEventListener("dragstart", cancelNativeDrag, {
-        capture: true,
-      });
-  }, []);
-
   useEffect(() => {
     if (!measured) return;
     lScaleApi.start({
@@ -743,6 +728,8 @@ export default function Leaderboard() {
     config: { mass: 1, tension: 340, friction: 20 },
   });
 
+  const pageRef = useRef<HTMLDivElement>(null);
+
   const switchPlatform = useCallback(
     (dir: -1 | 1) => {
       const idx = platforms.indexOf(platform);
@@ -753,10 +740,12 @@ export default function Leaderboard() {
     [platform, changePlatform],
   );
 
-  const bind = useDrag(
+  // Bind through use-gesture's imperative target API so the static page
+  // surface keeps its honest semantics while retaining the recognizer's
+  // pointer capture, touch cancellation, multi-input, and swipe behavior.
+  useDrag(
     ({ swipe: [sx], movement: [mx], last }) => {
-      if (switcherOpen) return;
-      if (!last) return;
+      if (switcherOpenRef.current || !last) return;
       if (sx !== 0) {
         switchPlatform(sx as -1 | 1);
       } else if (Math.abs(mx) > 50) {
@@ -764,19 +753,31 @@ export default function Leaderboard() {
       }
     },
     {
+      target: pageRef,
       axis: "x",
       swipe: { velocity: 0.3, distance: 30 },
       filterTaps: true,
     },
   );
 
+  // Native image/link dragging can take ownership before pointer-up and wedge
+  // Chromium's gesture stream. Capture it on this surface, not the window, so
+  // unrelated controls outside the landing interaction keep native behavior.
+  useEffect(() => {
+    const surface = pageRef.current;
+    if (!surface) return;
+    const cancelNativeDrag = (event: DragEvent) => event.preventDefault();
+    surface.addEventListener("dragstart", cancelNativeDrag, { capture: true });
+    return () => {
+      surface.removeEventListener("dragstart", cancelNativeDrag, {
+        capture: true,
+      });
+    };
+  }, []);
+
   return (
     <div
-      {...bind()}
-      // Horizontal swipes cross the QR image and Get Started link; without
-      // this, a mouse drag starts native HTML drag-and-drop instead of the
-      // platform-switch gesture (and wedges pointer input mid-drag).
-      onDragStart={(event) => event.preventDefault()}
+      ref={pageRef}
       className="theme-app min-h-screen"
       style={{
         touchAction: "pan-y",

--- a/packages/homepage/tests/e2e/app-routes-flow.spec.ts
+++ b/packages/homepage/tests/e2e/app-routes-flow.spec.ts
@@ -296,6 +296,48 @@ test("landing page renders its animated shell and primary entrypoint", async ({
   await waitForLandingIntro(page);
 });
 
+test("landing swipe keeps pointer direction and surface-scoped drag prevention", async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  const surface = page.locator("div.theme-app").first();
+  const imessage = page.getByRole("button", { name: "iMessage" });
+  const telegram = page.getByRole("button", { name: "Telegram" });
+  await expect(surface).toBeVisible();
+  await expect(imessage).toHaveAttribute("aria-pressed", "true");
+
+  const drag = async (fromRatio: number, toRatio: number) => {
+    const box = await surface.boundingBox();
+    if (!box) throw new Error("Landing swipe surface has no bounds");
+    const y = box.y + box.height / 2;
+    await page.mouse.move(box.x + box.width * fromRatio, y);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width * toRatio, y, { steps: 2 });
+    await page.mouse.up();
+  };
+
+  await drag(0.7, 0.3);
+  await expect(telegram).toHaveAttribute("aria-pressed", "true");
+  await drag(0.3, 0.7);
+  await expect(imessage).toHaveAttribute("aria-pressed", "true");
+
+  const dragGuard = await surface.evaluate((root) => {
+    const target = root.querySelector("img, a");
+    if (!(target instanceof HTMLElement)) {
+      return { foundTarget: false, defaultPrevented: false };
+    }
+    const event = new DragEvent("dragstart", {
+      bubbles: true,
+      cancelable: true,
+    });
+    target.dispatchEvent(event);
+    return { foundTarget: true, defaultPrevented: event.defaultPrevented };
+  });
+  expect(dragGuard).toEqual({ foundTarget: true, defaultPrevented: true });
+});
+
 test("landing composer is inert while hidden and stays in-viewport when active", async ({
   page,
 }) => {


### PR DESCRIPTION
Closes #18129.

## Summary

Moves the landing-page swipe recognizer from JSX props on a static root `<div>` to `@use-gesture/react`'s imperative `target` API. The page keeps honest document semantics while preserving the library's pointer capture, touch cancellation, multi-input handling, swipe thresholds, and direction behavior.

Native HTML drag prevention is also attached imperatively and capture-phase scoped to the landing surface. The repository-wide `noStaticElementInteractions` exception for this file is removed.

## Review repair

The originally published patch replaced `useDrag` with hand-rolled `touchstart`/`touchend` listeners. That made lint green by moving interaction out of JSX, but discarded pointer/mouse support, library cancellation behavior, and the exact production recognizer—the surface-level workaround this issue should avoid. This exact head retains `useDrag`, uses its supported ref target, and adds real Chromium coverage for both swipe directions and the scoped native-drag guard.

## Verification on exact head

- homepage tests: 75 passed, 0 failed, 174 assertions
- homepage typecheck: passed
- homepage lint: 94 files clean with the suppression removed
- homepage production build: passed
- real Chromium page-surface swipe and drag-prevention E2E: 1 passed
- `bun run verify`: 348/348 tasks; all repository audits passed
- `git diff --check`: passed
- base: `origin/develop@e662c1e7c8f8ac0cacdaf2b51297c25cc434524b`

<!-- evidence-head:25788a79ec23b9dd2bd2ab29d6476c8be678bde2 -->

<!-- evidence-row:before-screenshots -->
- [x] [Develop mobile capture, 390x844](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/pr18253-before.png)

<!-- evidence-row:after-screenshots -->
- [x] [Exact-head mobile capture, 390x844](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/pr18253-after-exact.png)

<!-- evidence-row:walkthrough-video -->
- [x] [Exact-head bidirectional page-surface swipe walkthrough, 390x844 H.264 MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/pr18253-walkthrough.mp4)

<!-- evidence-row:backend-logs -->
- [ ] N/A - homepage-only interaction binding; no server or backend path changed.

<!-- evidence-row:frontend-logs -->
- [x] Exact-head browser and package verification:

```text
Chromium E2E: landing swipe keeps pointer direction and surface-scoped drag prevention — passed
Homepage suite: 75 passed, 0 failed, 174 assertions
Homepage typecheck, Biome lint, and production Vite build — passed
```

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, planner, prompt, provider, or agent behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Gesture contract exercised in a real browser:

```text
The exact page surface began on iMessage, a left pointer drag selected Telegram,
a right pointer drag returned to iMessage, and a cancelable dragstart dispatched
from a nested image/link was default-prevented by the surface-scoped capture listener.
```

<!-- evidence-row:ocr-review -->
- [x] [Exact-head OCR and visual review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/pr18253-ocr-exact.txt)

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`, `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [hermes/t3rpz] [codex/openai-gpt-5.6-sol]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza"} -->
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"N/A"} -->