### PR TITLE
fix(eliza-code): cli marks the session user as owner so coding tools reach the planner

### DIFF
--- a/packages/examples/code/src/cli.ts
+++ b/packages/examples/code/src/cli.ts
@@ -335,13 +335,25 @@ async function runCLI(options: CLIOptions): Promise<CLIResult> {
     const agentModule = await import("./lib/agent.js");
     shutdownAgent = agentModule.shutdownAgent;
     const { initializeAgent } = agentModule;
-    runtime = await initializeAgent();
-
-    const agentClient = getAgentClient();
-    agentClient.setRuntime(runtime);
 
     const session = (await loadSession()) ?? createDefaultSessionState();
     const room = getCurrentRoomFromSession(session);
+
+    // Same owner/tooling bootstrap the ACP server does (see acp.ts): without
+    // it the CLI user resolves to GUEST and every OWNER/ADMIN-gated coding
+    // tool (FILE, SHELL, …) is withheld from the planner — the agent chats
+    // fine but can never act (live 2026-08-10: "I handled the available
+    // step." loops). The env seeds boot-time reads; the runtime setting is
+    // what getConfiguredOwnerEntityIds actually resolves per turn.
+    process.env.ELIZA_ADMIN_ENTITY_ID ??= session.identity.userId;
+    process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE ??= "1";
+    runtime = await initializeAgent();
+    (
+      runtime as unknown as { setSetting?: (k: string, v: unknown) => void }
+    ).setSetting?.("ELIZA_ADMIN_ENTITY_ID", session.identity.userId);
+
+    const agentClient = getAgentClient();
+    agentClient.setRuntime(runtime);
 
     appendSessionMessage(session, room, "user", message);
 


### PR DESCRIPTION
The eliza-code CLI chatted fine but could never act: "ship something" → "I handled the available step." loops (live 2026-08-10, TUI session). Instrumentation showed the ACTION_PLANNER call carrying **zero tools** while Stage-1 got its own.

## Root cause
FILE is ADMIN-gated and SHELL is OWNER-gated; the CLI never told the runtime its session user is the owner, so the sender resolved GUEST and every coding tool was withheld from the planner — the model then improvised `call:FILE{...}` DSL text that core deliberately does not execute. **acp.ts already contains the exact bootstrap** (owner marking via the runtime setting `getConfiguredOwnerEntityIds` reads + `ELIZA_PLANNER_FULL_ACTION_SURFACE`), with comments describing this gotcha — the CLI path simply never got it.

## Fix
Port the ACP server's owner/tooling bootstrap into the CLI: seed `ELIZA_ADMIN_ENTITY_ID` (+ full action surface) from the session identity before `initializeAgent()`, then set the runtime setting post-init, exactly as acp.ts does. Session load reordered ahead of runtime init so the identity exists at boot.

## Verification
Instrumented probe on the real pipeline: pre-fix `ACTION_PLANNER tools=undefined` → filler; with owner set `ACTION_PLANNER tools=5` → **FILE executed, hello.py written to disk** ("Wrote 25 bytes to …/hello.py"). Live acceptance on the deployed tree post-merge (one-shot + TUI).

# Evidence

<!-- evidence-head:69119fb6173de2b500e478eda893ee36992b67d0 -->
- Before screenshots: live TUI transcript in the incident (chat works, actions loop on filler)
- After screenshots: N/A - terminal CLI; acceptance transcript below
- Walkthrough video: N/A - terminal CLI
- OCR review: N/A - terminal CLI
- Frontend console/network logs: N/A - terminal CLI
- Backend logs: instrumented model-call transcript (tools=undefined → tools=5)
- Real-LLM trajectory: playground trajectories show Stage-1 nominating FILE+SHELL while the planner ran tool-less
- Domain artifacts: hello.py on disk from the verification run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
