### PR TITLE
fix(eliza-code): tui gets the owner bootstrap and quit always returns the terminal

### DIFF
--- a/packages/examples/code/src/index.ts
+++ b/packages/examples/code/src/index.ts
@@ -137,16 +137,30 @@ async function runInteractive(): Promise<void> {
     process.exit(1);
   }
 
-  const [{ App }, { initializeAgent }] = await Promise.all([
-    import("./App.js"),
-    import("./lib/agent.js"),
-  ]);
+  const [{ App }, { initializeAgent }, { loadSession, createDefaultSessionState }] =
+    await Promise.all([
+      import("./App.js"),
+      import("./lib/agent.js"),
+      import("./lib/session.js"),
+    ]);
 
   let runtime: AgentRuntime | undefined;
   let app: InstanceType<typeof App> | undefined;
 
+  // Same owner/tooling bootstrap as the ACP server and the one-shot CLI
+  // (acp.ts / cli.ts): without it the TUI user resolves to GUEST and every
+  // OWNER/ADMIN-gated coding tool is withheld from the planner — the agent
+  // chats but can never act (live 2026-08-10 TUI session: "ship something"
+  // looped "I handled the available step.").
+  const session = (await loadSession()) ?? createDefaultSessionState();
+  process.env.ELIZA_ADMIN_ENTITY_ID ??= session.identity.userId;
+  process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE ??= "1";
+
   // Initialize the agent
   runtime = await initializeAgent({ codingOnly: shouldRunCodingOnly() });
+  (
+    runtime as unknown as { setSetting?: (k: string, v: unknown) => void }
+  ).setSetting?.("ELIZA_ADMIN_ENTITY_ID", session.identity.userId);
 
   // Handle SIGINT (Ctrl+C) and SIGTERM
   const handleSignal = () => {
@@ -170,8 +184,15 @@ async function runInteractive(): Promise<void> {
   await app.run();
   activeApp = undefined;
 
-  // App exited normally (e.g., Ctrl+Q)
-  await cleanup(runtime);
+  // App exited normally (e.g., Ctrl+Q / double Ctrl+C). Cleanup is bounded and
+  // the process exits explicitly: leaked runtime handles (DB, timers) must
+  // never hold the user's terminal hostage after a quit (live 2026-08-10:
+  // quit ran but the prompt never returned).
+  await Promise.race([
+    cleanup(runtime),
+    new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
+  ]);
+  process.exit(0);
 }
 
 // ============================================================================


### PR DESCRIPTION
Follow-up to #18254 — two more live TUI findings (owner's hands-on session, 2026-08-10):

1. **The TUI path never got the owner bootstrap.** `-i` runs `runInteractive()` in index.ts, which calls `initializeAgent()` directly — bypassing the cli.ts flow #18254 fixed. Interactive users still resolved GUEST: chat worked, no coding tool could ever fire. Fix: the same session-identity owner bootstrap (env seed + runtime setting), now in the interactive path too. All three entrypoints (acp, one-shot cli, TUI) are aligned.

2. **Quit never returned the terminal.** After `app.run()` resolves, `cleanup()` was awaited with no `process.exit()` — leaked runtime handles (DB, timers) kept bun alive, so Ctrl+C/Ctrl+Q visibly "did nothing" and the user's shell hung. Fix: cleanup bounded to 5s, then explicit `process.exit(0)`.

## Verification
Entry compiles in source mode; live acceptance on the deployed box: SIGINT/quit returns the shell promptly, and a TUI "ship something"-class ask executes real FILE/SHELL work (same bootstrap already proven on the one-shot path: hello.py written + run + "output is 55").

# Evidence

<!-- evidence-head:bb2cdd97f7508f24c3bb74f0ebec46cca1a37904 -->
- Before screenshots: owner's live TUI transcript (chat fine, actions loop, quit hangs)
- After screenshots: N/A - terminal CLI; acceptance transcript in PR thread
- Walkthrough video: N/A - terminal CLI
- OCR review: N/A - terminal CLI
- Frontend console/network logs: N/A - terminal CLI
- Backend logs: acceptance transcripts (exit timing + tool execution)
- Real-LLM trajectory: playground trajectory store (Stage-1 → planner with tools → FILE/SHELL execution)
- Domain artifacts: files written by the acceptance runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
