### PR TITLE
fix(core): deliver the failure reply once stage-1 committed to respond

### DIFF
--- a/packages/core/src/services/message.runtime-failure-suppression.test.ts
+++ b/packages/core/src/services/message.runtime-failure-suppression.test.ts
@@ -358,4 +358,108 @@ describe("planner failure after a promoted stage-1 answer", () => {
 		);
 		expect(visibleTexts.join("\n").toLowerCase()).not.toContain("rate-limit");
 	});
+
+	it("delivers the failure reply on an unaddressed group turn once stage-1 committed to respond", async () => {
+		// Stage 1 commits to RESPOND on a bare group message but produces no
+		// preservable answer (empty replyText, promoted to planning), and the
+		// planner then dies. The deterministic addressing gate alone would
+		// suppress the failure reply — the model's own RESPOND decision must
+		// qualify the turn for a visible failure instead of dead silence.
+		const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
+		for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
+			responseHandlerFieldRegistry.register(evaluator);
+		}
+		let stage1Served = false;
+		const runtime = createMockRuntime({
+			agentId: AGENT,
+			character: { name: "Remilio", bio: "test agent" },
+			logger: {
+				debug: vi.fn(),
+				info: vi.fn(),
+				warn: vi.fn(),
+				error: vi.fn(),
+				trace: vi.fn(),
+			} as unknown as IAgentRuntime["logger"],
+			getSetting: vi.fn(() => undefined),
+			getService: vi.fn(() => null),
+			getModel: vi.fn(() => async () => {
+				throw RATE_LIMIT_ERROR;
+			}),
+			useModel: vi.fn(async (modelType: unknown) => {
+				if (String(modelType) === "RESPONSE_HANDLER" && !stage1Served) {
+					stage1Served = true;
+					return {
+						text: "",
+						toolCalls: [
+							{
+								id: "handle-response-1",
+								name: "HANDLE_RESPONSE",
+								arguments: {
+									shouldRespond: "RESPOND",
+									thought: "",
+									contexts: ["general"],
+									intents: [],
+									candidateActionNames: [],
+									replyText: "",
+									facts: [],
+									relationships: [],
+									addressedTo: [],
+								},
+							},
+						],
+					};
+				}
+				throw RATE_LIMIT_ERROR;
+			}),
+			composeState: vi.fn(async () => makeState()),
+			runActionsByMode: vi.fn(async () => undefined),
+			applyPipelineHooks: vi.fn(async () => undefined),
+			emitEvent: vi.fn(async () => undefined),
+			reportError: vi.fn(),
+			startRun: vi.fn(() => RUN_ID),
+			getCurrentRunId: vi.fn(() => RUN_ID),
+			endRun: vi.fn(),
+			getMemoryById: vi.fn(async () => null),
+			createMemory: vi.fn(async () => asUUID(v4())),
+			updateMemory: vi.fn(async () => true),
+			queueEmbeddingGeneration: vi.fn(async () => undefined),
+			getParticipantUserState: vi.fn(async () => null),
+			getRoom: vi.fn(async () => makeRoom(ChannelType.GROUP)),
+			getRoomsByIds: vi.fn(async () => [makeRoom(ChannelType.GROUP)]),
+			getMemories: vi.fn(async () => []),
+			isCheckShouldRespondEnabled: vi.fn(() => true),
+			turnControllers: new TurnControllerRegistry(),
+			responseHandlerFieldRegistry,
+			responseHandlerFieldEvaluators: [
+				...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+			],
+			responseHandlerEvaluators: [
+				{
+					name: "test-clobber-to-ack",
+					priority: 100,
+					shouldRun: () => true,
+					evaluate: () => ({ reply: "On it.", requiresTool: true }),
+				},
+			],
+		} as never);
+
+		const service = new DefaultMessageService();
+		const deliveries: Content[] = [];
+		const result = await service.handleMessage(
+			runtime,
+			makeMessage({}),
+			async (content) => {
+				deliveries.push(content);
+				return [];
+			},
+		);
+
+		const visibleTexts = deliveries
+			.map((content) => (typeof content.text === "string" ? content.text : ""))
+			.filter((text) => text.trim().length > 0);
+
+		expect(result.didRespond).toBe(true);
+		expect(visibleTexts).toHaveLength(1);
+		expect(visibleTexts[0].toLowerCase()).toContain("rate-limit");
+	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -7069,6 +7069,13 @@ export async function runV5MessageRuntimeStage1(args: {
 	onResponseHandlerEarlyReply?: (
 		event: ResponseHandlerEarlyReplyEvent,
 	) => Promise<boolean> | Promise<void> | boolean | undefined;
+	/**
+	 * Fires once Stage 1 routing commits this turn to a response (final reply
+	 * or planning). Lets the caller distinguish "runtime died after the model
+	 * chose to answer" from "died before any respond decision existed" in its
+	 * failure-reply gate.
+	 */
+	onStage1RespondDecision?: () => void;
 }): Promise<V5MessageRuntimeStage1Result> {
 	const senderRole =
 		getTrajectoryContext()?.userRole ??
@@ -7839,6 +7846,13 @@ export async function runV5MessageRuntimeStage1(args: {
 				state: args.state,
 			};
 		}
+
+		// Past this point the Stage-1 model has committed this turn to a
+		// response (final reply or planning). Surface the per-message decision
+		// so a later runtime failure can qualify for a visible failure reply
+		// instead of the unaddressed-turn suppression — evaluator-demoted
+		// IGNOREs and the injection-gate return above never reach this.
+		args.onStage1RespondDecision?.();
 
 		if (route.type === "final_reply") {
 			// The simple-context reply IS the answer: Stage 1 emits `replyText` (→
@@ -11995,6 +12009,7 @@ export class DefaultMessageService implements IMessageService {
 		let routedDecision: ContextRoutingDecision | null = null;
 		let strategyResult: StrategyResult | null = null;
 		let _usedV5Runtime = false;
+		let stage1DecidedRespond = false;
 		let stage1RiskGateApplied = false;
 		const earlyReplyMessages: Memory[] = [];
 		const persistedEarlyReplyIds = new Set<string>();
@@ -12195,6 +12210,9 @@ export class DefaultMessageService implements IMessageService {
 									}
 								: {}),
 							onResponseHandlerEarlyReply: deliverResponseHandlerEarlyReply,
+							onStage1RespondDecision: () => {
+								stage1DecidedRespond = true;
+							},
 						}),
 					),
 					timeInferenceSpan("message:ingress:parallel-respond-hooks", () =>
@@ -12302,7 +12320,11 @@ export class DefaultMessageService implements IMessageService {
 					isAutonomous,
 					hasDeliveredEarlyReply: earlyReplyMessages.length > 0,
 				});
-				if (failureGate.addressed) {
+				// Stage 1 already made the per-message RESPOND decision for this
+				// turn before the runtime died — that is the model evaluation the
+				// deterministic gate defers to, so the anti-spam suppression
+				// (which exists for pre-decision throws) does not apply.
+				if (failureGate.addressed || stage1DecidedRespond) {
 					shouldRespondToMessage = true;
 					terminalDecision = null;
 					strategyResult = await this.buildStructuredFailureReply(


### PR DESCRIPTION
## What

`handleMessage`'s stage-1 failure catch decides whether to send the structured failure reply using only deterministic addressing signals (`isDeterministicallyAddressedTurn`: mention, reply, DM, autonomous, delivered early ack). The per-message decision the stage-1 model itself made — `shouldRespond: RESPOND` — is a local inside `runV5MessageRuntimeStage1`, lost the moment a later stage throws. So on an unaddressed group turn where the model committed to answering and the planner then died with nothing preservable, the owner saw **dead silence**: no answer, no failure notice, only a `suppressing failure reply` log line.

This threads that decision to the gate through a new optional `onStage1RespondDecision` callback on `runV5MessageRuntimeStage1` — the same seam pattern as the existing `onResponseHandlerEarlyReply` — emitted exactly once, after routing commits the turn to a response (final reply or planning). The catch gate becomes `failureGate.addressed || stage1DecidedRespond`.

**The anti-spam suppression is preserved by construction.** The emit sits after the ignored/stopped terminal return, so every pre-decision path keeps today's silence: stage-1 model-call throws (the historical 91-sends-in-2-days relay-room storm class), bot-noise triage, injection-gate blocks, evaluator-demoted IGNOREs, and addressed-to-other-participant routing. Under a planner-only outage the worst case is one failure reply per turn the model itself elected to answer — bounded 1:1 by healthy reply volume, and failure replies are synthetic-marked and filtered from recent-messages context, so there is no self-trigger loop.

Recent work (#18180, #18222) already rescues planner deaths that hold a preserved tool result or a sub-agent relay body; this closes the remaining structural hole for committed-respond turns with nothing to rescue.

## Evidence

- New test: committed-RESPOND planner death in an unaddressed group room delivers exactly one structured failure reply — **fails on unpatched code** (verified: 1/6 red before the fix, 6/6 green with it).
- Existing invariants re-pinned: pre-decision group silence, mention/DM delivery, abort propagation, preserved-answer rescue.
- Full message-service sweep: 30 files, 539/539 green. `tsc --noEmit` clean, biome clean.
- Independently reviewed by a three-lens adversarial pass (regression / state-concurrency / storm-shape); no refutation survived.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:0a60b1ac7faccf81d1d16f3651a87a82e9730874 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core runtime change; no rendered UI file in the diff

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core runtime change; no rendered UI file in the diff

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI surface; behavior proven by the deterministic suite with a counterfactual run (backend-logs row)

<!-- evidence-row:backend-logs -->
- [x] [18266-fix4-test-run.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18266-fix4-test-run.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic-harness change to the failure path; stage-1 decisions are stubbed HANDLE_RESPONSE tool calls, no live-model prompt change

<!-- evidence-row:domain-artifacts -->
- [x] [18266-fix4-gates.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18266-fix4-gates.log)
