### PR TITLE
fix(core): persist trajectory steps envelope-first so budget truncation never poisons the row

### DIFF
--- a/packages/core/src/features/trajectories/TrajectoriesService.test.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.test.ts
@@ -405,4 +405,146 @@ describe("TrajectoriesService", () => {
 			context: { field: "llm_call_count" },
 		});
 	});
+
+	it("keeps the step envelope readable when payload exhausts the sanitization budget", async () => {
+		const trajectoryId = "00000000-0000-4000-8000-000000000040";
+		const stepId = "00000000-0000-4000-8000-000000000041";
+		const row = makeTrajectoryRow(trajectoryId, stepId);
+		const service = new TrajectoriesService(createRuntimeWithoutSql());
+		const serviceInternals = service as unknown as {
+			stepToTrajectory: Map<string, string>;
+			executeRawSql: (
+				sqlText: string,
+			) => Promise<{ rows: Array<Record<string, unknown>>; columns: string[] }>;
+		};
+		serviceInternals.stepToTrajectory.set(stepId, trajectoryId);
+		serviceInternals.executeRawSql = async (sqlText: string) => {
+			if (sqlText.includes("SELECT * FROM trajectories")) {
+				return { rows: [row], columns: Object.keys(row) };
+			}
+			if (sqlText.includes("UPDATE trajectories SET")) {
+				const stepsJson = extractSqlStringAssignment(sqlText, "steps_json");
+				if (stepsJson) {
+					row.steps_json = stepsJson;
+				}
+			}
+			return { rows: [], columns: [] };
+		};
+
+		// Two planner-style calls whose tool schemas together cross the shared
+		// node budget at write time — the live incident shape (2026-08-10: the
+		// second call's tools broke out of the step object mid-walk and the
+		// dropped trailing keys made every subsequent read of the row throw).
+		const bigTools = Array.from({ length: 200 }, (_, i) => ({
+			name: `tool${i}`,
+			description: "d",
+			parameters: { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10 },
+		}));
+		const baseCall = {
+			stepId,
+			model: "zai-glm-4.7",
+			modelType: "ACTION_PLANNER",
+			provider: "cerebras",
+			systemPrompt: "system",
+			userPrompt: "user",
+			response: "ok",
+			temperature: 0,
+			maxTokens: 1024,
+			purpose: "action",
+			actionType: "runtime.useModel",
+			latencyMs: 1,
+		};
+		service.logLlmCall({ ...baseCall, tools: bigTools });
+		await service.flushWriteQueue(trajectoryId);
+		service.logLlmCall({ ...baseCall, tools: bigTools });
+		await service.flushWriteQueue(trajectoryId);
+
+		const afterOverflow = JSON.parse(row.steps_json);
+		expect(afterOverflow[0].reward).toBe(0);
+		expect(afterOverflow[0].done).toBe(false);
+		expect(Array.isArray(afterOverflow[0].providerAccesses)).toBe(true);
+		expect(afterOverflow[0].metadata.truncatedLlmCalls).toBe(1);
+
+		// The row must still accept captures — pre-fix this write was lost to
+		// TRAJECTORY_ROW_INVALID and the trajectory could never terminalize.
+		service.logLlmCall(baseCall);
+		await service.flushWriteQueue(trajectoryId);
+
+		const persisted = JSON.parse(row.steps_json);
+		expect(persisted[0].llmCalls).toHaveLength(2);
+		expect(persisted[0].reward).toBe(0);
+		expect(persisted[0].done).toBe(false);
+		expect(persisted[0].metadata.truncatedLlmCalls).toBe(1);
+	});
+
+	it("reads legacy rows whose steps lost trailing keys to budget truncation", async () => {
+		const trajectoryId = "00000000-0000-4000-8000-000000000050";
+		const stepId = "00000000-0000-4000-8000-000000000051";
+		const row = makeTrajectoryRow(trajectoryId, stepId);
+		// The exact persisted shape recovered from the incident database: the
+		// envelope stops after environmentState — no providerAccesses, reward,
+		// or done — with one otherwise-valid llmCall.
+		row.steps_json = JSON.stringify([
+			{
+				stepId,
+				stepNumber: 0,
+				timestamp: 1,
+				environmentState: { timestamp: 1 },
+				observation: {},
+				llmCalls: [
+					{
+						callId: "00000000-0000-4000-8000-000000000052",
+						timestamp: 1,
+						model: "gemma-4-31b",
+						systemPrompt: "s",
+						userPrompt: "u",
+						response: "r",
+						purpose: "action",
+					},
+				],
+			},
+		]);
+		const service = new TrajectoriesService(createRuntimeWithoutSql());
+		const serviceInternals = service as unknown as {
+			stepToTrajectory: Map<string, string>;
+			executeRawSql: (
+				sqlText: string,
+			) => Promise<{ rows: Array<Record<string, unknown>>; columns: string[] }>;
+		};
+		serviceInternals.stepToTrajectory.set(stepId, trajectoryId);
+		serviceInternals.executeRawSql = async (sqlText: string) => {
+			if (sqlText.includes("SELECT * FROM trajectories")) {
+				return { rows: [row], columns: Object.keys(row) };
+			}
+			if (sqlText.includes("UPDATE trajectories SET")) {
+				const stepsJson = extractSqlStringAssignment(sqlText, "steps_json");
+				if (stepsJson) {
+					row.steps_json = stepsJson;
+				}
+			}
+			return { rows: [], columns: [] };
+		};
+
+		service.logLlmCall({
+			stepId,
+			model: "gemma-4-31b",
+			modelType: "RESPONSE_HANDLER",
+			provider: "cerebras",
+			systemPrompt: "system",
+			userPrompt: "user",
+			response: "ok",
+			temperature: 0,
+			maxTokens: 64,
+			purpose: "action",
+			actionType: "runtime.useModel",
+			latencyMs: 1,
+		});
+		await service.flushWriteQueue(trajectoryId);
+
+		const persisted = JSON.parse(row.steps_json);
+		expect(persisted[0].llmCalls).toHaveLength(2);
+		expect(persisted[0].reward).toBe(0);
+		expect(persisted[0].done).toBe(false);
+		expect(persisted[0].providerAccesses).toEqual([]);
+	});
 });

--- a/packages/core/src/features/trajectories/TrajectoriesService.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.ts
@@ -8,7 +8,11 @@ import { v4 as uuidv4 } from "uuid";
 import { ElizaError } from "../../errors";
 import { logger } from "../../logger";
 import { serializeTrajectoryExport } from "../../services/trajectory-export";
-import { sanitizeTrajectoryJsonValue } from "../../services/trajectory-json";
+import {
+	createTrajectoryJsonBudget,
+	sanitizeTrajectoryJsonValue,
+	sanitizeTrajectoryJsonValueInBudget,
+} from "../../services/trajectory-json";
 import type {
 	TrajectoryExportOptions as CanonicalTrajectoryExportOptions,
 	TrajectoryDetailRecord,
@@ -519,22 +523,39 @@ function normalizeTrajectoryStep(value: unknown): TrajectoryStep | null {
 	const stepId = stringValue(value.stepId);
 	const stepNumber = numberValue(value.stepNumber);
 	const timestamp = numberValue(value.timestamp);
-	const environmentState = normalizeEnvironmentState(value.environmentState);
-	const observation = isJsonObject(value.observation)
-		? value.observation
-		: null;
+	// Rows written before envelope-first persistence could lose trailing step
+	// keys to sanitizer budget exhaustion (an oversized llmCall broke out of
+	// the object walk mid-step). ABSENT fields therefore decode to their
+	// startStep defaults so those rows stay readable and terminalizable;
+	// fields that are present but mistyped still reject the step.
+	const environmentState = Object.hasOwn(value, "environmentState")
+		? normalizeEnvironmentState(value.environmentState)
+		: timestamp !== null
+			? { timestamp }
+			: null;
+	const observation = Object.hasOwn(value, "observation")
+		? isJsonObject(value.observation)
+			? value.observation
+			: null
+		: {};
+	const llmCallsRaw = Object.hasOwn(value, "llmCalls") ? value.llmCalls : [];
+	const providerAccessesRaw = Object.hasOwn(value, "providerAccesses")
+		? value.providerAccesses
+		: [];
 	const hasAction = Object.hasOwn(value, "action");
 	const action = hasAction ? normalizeActionAttempt(value.action) : null;
-	const reward = numberValue(value.reward);
-	const done = booleanValue(value.done);
+	const reward = Object.hasOwn(value, "reward") ? numberValue(value.reward) : 0;
+	const done = Object.hasOwn(value, "done")
+		? booleanValue(value.done)
+		: false;
 	if (
 		!stepId ||
 		stepNumber === null ||
 		timestamp === null ||
 		!environmentState ||
 		!observation ||
-		!Array.isArray(value.llmCalls) ||
-		!Array.isArray(value.providerAccesses) ||
+		!Array.isArray(llmCallsRaw) ||
+		!Array.isArray(providerAccessesRaw) ||
 		(hasAction && !action) ||
 		reward === null ||
 		done === null
@@ -542,13 +563,13 @@ function normalizeTrajectoryStep(value: unknown): TrajectoryStep | null {
 		return null;
 	}
 	const llmCalls: LLMCall[] = [];
-	for (const callValue of value.llmCalls) {
+	for (const callValue of llmCallsRaw) {
 		const call = normalizeLlmCall(callValue);
 		if (!call) return null;
 		llmCalls.push(call);
 	}
 	const providerAccesses: ProviderAccess[] = [];
-	for (const accessValue of value.providerAccesses) {
+	for (const accessValue of providerAccessesRaw) {
 		const access = normalizeProviderAccess(accessValue);
 		if (!access) return null;
 		providerAccesses.push(access);
@@ -679,6 +700,113 @@ function sqlLiteral(v: unknown): string {
 	if (typeof v === "object")
 		return `'${stringifyTrajectoryJsonForSql(v).replace(/'/g, "''")}'`;
 	return `'${String(v).replace(/'/g, "''")}'`;
+}
+
+/**
+ * Persist steps envelope-first so a persisted row can ALWAYS be re-read by
+ * `parseTrajectorySteps`. The fields the strict reader requires (stepId,
+ * stepNumber, timestamp, environmentState, observation, reward, done) are
+ * written from their typed in-memory values; only the bulky payload —
+ * llmCalls, providerAccesses, action, reasoning, metadata — competes for the
+ * shared sanitization budget. Whole-graph sanitization used to let budget
+ * exhaustion inside one oversized llmCall (a planner call carrying large tool
+ * schemas crosses the node cap by itself) break out of the step object and
+ * drop its trailing required keys, poisoning the row for every subsequent
+ * read: later captures were lost and terminalization failed permanently.
+ *
+ * A payload entry that no longer satisfies its read contract after bounding
+ * is dropped and counted on `step.metadata.truncatedLlmCalls` /
+ * `.truncatedProviderAccesses` instead of being persisted as garbage.
+ */
+function boundStepsForPersistence(steps: TrajectoryStep[]): JsonValue[] {
+	const budget = createTrajectoryJsonBudget();
+	return steps.map((step) => {
+		const envCandidate = sanitizeTrajectoryJsonValueInBudget(
+			step.environmentState,
+			budget,
+		);
+		const environmentState: JsonValue = normalizeEnvironmentState(envCandidate)
+			? (envCandidate as JsonValue)
+			: { timestamp: step.timestamp };
+		const observationCandidate = sanitizeTrajectoryJsonValueInBudget(
+			step.observation,
+			budget,
+		);
+		const observation: JsonValue = isJsonObject(observationCandidate)
+			? observationCandidate
+			: {};
+
+		let truncatedLlmCalls = 0;
+		const llmCalls: JsonValue[] = [];
+		for (const call of step.llmCalls) {
+			const bounded = sanitizeTrajectoryJsonValueInBudget(call, budget);
+			if (bounded !== undefined && normalizeLlmCall(bounded)) {
+				llmCalls.push(bounded);
+			} else {
+				truncatedLlmCalls += 1;
+			}
+		}
+		let truncatedProviderAccesses = 0;
+		const providerAccesses: JsonValue[] = [];
+		for (const access of step.providerAccesses) {
+			const bounded = sanitizeTrajectoryJsonValueInBudget(access, budget);
+			if (bounded !== undefined && normalizeProviderAccess(bounded)) {
+				providerAccesses.push(bounded);
+			} else {
+				truncatedProviderAccesses += 1;
+			}
+		}
+
+		const actionCandidate =
+			step.action === undefined
+				? undefined
+				: sanitizeTrajectoryJsonValueInBudget(step.action, budget);
+		const action = normalizeActionAttempt(actionCandidate)
+			? actionCandidate
+			: undefined;
+		const reasoningCandidate =
+			typeof step.reasoning === "string"
+				? sanitizeTrajectoryJsonValueInBudget(step.reasoning, budget)
+				: undefined;
+		const metadataCandidate =
+			step.metadata === undefined
+				? undefined
+				: sanitizeTrajectoryJsonValueInBudget(step.metadata, budget);
+		const metadataBase = isJsonObject(metadataCandidate)
+			? metadataCandidate
+			: undefined;
+		const metadata =
+			truncatedLlmCalls > 0 || truncatedProviderAccesses > 0
+				? {
+						...(metadataBase ?? {}),
+						...(truncatedLlmCalls > 0 ? { truncatedLlmCalls } : {}),
+						...(truncatedProviderAccesses > 0
+							? { truncatedProviderAccesses }
+							: {}),
+					}
+				: metadataBase;
+
+		return {
+			stepId: step.stepId,
+			stepNumber: step.stepNumber,
+			timestamp: step.timestamp,
+			environmentState,
+			observation,
+			llmCalls,
+			providerAccesses,
+			...(action !== undefined ? { action } : {}),
+			reward: step.reward,
+			done: step.done,
+			...(typeof reasoningCandidate === "string"
+				? { reasoning: reasoningCandidate }
+				: {}),
+			...(metadata !== undefined ? { metadata } : {}),
+		};
+	});
+}
+
+function stepsSqlLiteral(steps: TrajectoryStep[]): string {
+	return `'${JSON.stringify(boundStepsForPersistence(steps)).replace(/'/g, "''")}'`;
 }
 
 function trajectoryRunIdWhereClause(runId: string): string {
@@ -1694,7 +1822,7 @@ export class TrajectoriesService extends Service {
           total_cache_read_input_tokens = ${totals.totalCacheReadInputTokens},
           total_cache_creation_input_tokens = ${totals.totalCacheCreationInputTokens},
           total_reward = ${trajectory.totalReward},
-          steps_json = ${sqlLiteral(trajectory.steps)},
+          steps_json = ${stepsSqlLiteral(trajectory.steps)},
           reward_components_json = ${sqlLiteral(trajectory.rewardComponents)},
           metrics_json = ${sqlLiteral(trajectory.metrics)},
           metadata_json = ${sqlLiteral(trajectory.metadata)},
@@ -1720,7 +1848,7 @@ export class TrajectoriesService extends Service {
           total_cache_read_input_tokens = ${totals.totalCacheReadInputTokens},
           total_cache_creation_input_tokens = ${totals.totalCacheCreationInputTokens},
           total_reward = ${trajectory.totalReward},
-          steps_json = ${sqlLiteral(trajectory.steps)},
+          steps_json = ${stepsSqlLiteral(trajectory.steps)},
           metadata = ${sqlLiteral(trajectory.metadata)},
           updated_at = ${sqlLiteral(updatedAtIso)}
         WHERE id = ${sqlLiteral(trajectoryId)}
@@ -1897,7 +2025,7 @@ export class TrajectoriesService extends Service {
 			const updatedAtIso = new Date().toISOString();
 			await this.executeRawSql(`
 				UPDATE trajectories SET
-					steps_json = ${sqlLiteral(trajectory.steps)},
+					steps_json = ${stepsSqlLiteral(trajectory.steps)},
 					step_count = ${totals.stepCount},
 					llm_call_count = ${totals.llmCallCount},
 					provider_access_count = ${totals.providerAccessCount},
@@ -2164,7 +2292,7 @@ export class TrajectoriesService extends Service {
 			const updatedAtIso = new Date().toISOString();
 			await this.executeRawSql(`
 				UPDATE trajectories SET
-					steps_json = ${sqlLiteral(trajectory.steps)},
+					steps_json = ${stepsSqlLiteral(trajectory.steps)},
 					step_count = ${totals.stepCount},
 					llm_call_count = ${totals.llmCallCount},
 					provider_access_count = ${totals.providerAccessCount},
@@ -2494,7 +2622,7 @@ export class TrajectoriesService extends Service {
 				const updatedAtIso = new Date().toISOString();
 				await execute(`
 				UPDATE trajectories SET
-					steps_json = ${sqlLiteral(trajectory.steps)},
+					steps_json = ${stepsSqlLiteral(trajectory.steps)},
 					step_count = ${totals.stepCount},
 					llm_call_count = ${totals.llmCallCount},
 					provider_access_count = ${totals.providerAccessCount},

--- a/packages/core/src/services/trajectory-json.ts
+++ b/packages/core/src/services/trajectory-json.ts
@@ -16,7 +16,8 @@ const TRAJECTORY_JSON_BUDGET_SLACK_BYTES = 1024;
 const TRAJECTORY_JSON_TRUNCATION_SUFFIX = "...[truncated]";
 const utf8Encoder = new TextEncoder();
 
-type SanitizationState = {
+/** @internal Exposed only through the opaque {@link TrajectoryJsonBudget}. */
+export type SanitizationState = {
 	seen: WeakSet<object>;
 	visitedNodes: number;
 	remainingBytes: number;
@@ -308,6 +309,36 @@ export function sanitizeTrajectoryJsonValue(
 		},
 		0,
 	);
+}
+
+/**
+ * Opaque handle for callers that must bound SEVERAL values under one shared
+ * node/byte budget (e.g. every payload field of a persisted trajectory step
+ * competes for the same row-size allowance). The internal state is not part
+ * of the public contract.
+ */
+export interface TrajectoryJsonBudget {
+	/** @internal */
+	state: SanitizationState;
+}
+
+export function createTrajectoryJsonBudget(): TrajectoryJsonBudget {
+	return {
+		state: {
+			seen: new WeakSet<object>(),
+			visitedNodes: 0,
+			remainingBytes:
+				TRAJECTORY_JSON_MAX_OUTPUT_BYTES - TRAJECTORY_JSON_BUDGET_SLACK_BYTES,
+			exhausted: false,
+		},
+	};
+}
+
+export function sanitizeTrajectoryJsonValueInBudget(
+	value: unknown,
+	budget: TrajectoryJsonBudget,
+): JsonValue | undefined {
+	return sanitizeTrajectoryJsonValueInternal(value, budget.state, 0);
 }
 
 export function sanitizeTrajectoryJsonObject(


### PR DESCRIPTION
## The incident

Live eliza-code TUI session (2026-08-10): every turn logged `TrajectoriesPlugin.endRetry — Trajectory row contains an invalid step (field: steps_json, stepIndex 0)` and `TRAJECTORY_TERMINALIZATION_FAILED`; the trajectory row wedged `active` forever and file exports wrote 0-step tj-*.json files.

## Root cause

`sanitizeTrajectoryJsonValue` bounds the WHOLE steps array under one shared budget (5000 nodes / 1MB). A planner llmCall carrying large native tool schemas crossed the node cap mid-walk; the sanitizer's object loop then `break`s — silently dropping the step's **trailing required keys** (`providerAccesses`, `reward`, `done`). The strict reader (`normalizeTrajectoryStep`) rejects the row on every subsequent read, so later captures are lost and terminalization fails permanently. Recovered from the incident database: step 5,004 nodes, one `__trajectoryTruncated` marker sitting inside a tool schema enum, exactly those three keys missing. The writer could emit JSON its own reader rejects.

## Fix — both sides of one contract

**Writer (envelope-first persistence):** new `boundStepsForPersistence` serializes the reader-required envelope (stepId/stepNumber/timestamp/environmentState/observation/reward/done) from typed values; only payload (llmCalls/providerAccesses/action/reasoning/metadata) competes for the shared budget. A payload entry that no longer satisfies its read contract after bounding is dropped and counted on `step.metadata.truncatedLlmCalls` / `.truncatedProviderAccesses` instead of persisting as garbage. All five `steps_json` write sites now go through it.

**Reader (legacy-row salvage):** absent envelope fields decode to their `startStep` defaults (`reward` 0, `done` false, arrays empty, `observation` {}) so rows poisoned before this fix stay readable and terminalizable. Present-but-mistyped fields still reject the step.

`trajectory-json.ts` gains `createTrajectoryJsonBudget` / `sanitizeTrajectoryJsonValueInBudget` so multiple values can share one bounded budget.

## Verification

- 2 new tests replay the incident: overflow write keeps the envelope + the row keeps accepting captures; the exact recovered on-disk legacy shape reads with defaults and round-trips.
- packages/core trajectory suites: 9/9 + 17/17. Core typecheck + biome clean.
- Live acceptance on the incident box after merge: TUI coding turn → trajectory completes with steps, no endRetry/terminalization errors.

# Evidence

<!-- evidence-head:d657aac949372a5a517102d6c1088284758a21d4 -->
- Before screenshots: N/A - runtime persistence
- After screenshots: N/A - runtime persistence
- Walkthrough video: N/A - runtime persistence
- OCR review: N/A - runtime persistence
- Frontend console/network logs: N/A - runtime persistence
- Backend logs: incident error lines + post-fix clean turn (PR thread)
- Real-LLM trajectory: the recovered poisoned row (5004 nodes, truncation marker in tool schema) + post-fix completed trajectory
- Domain artifacts: trajectories DB rows before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)
