### PR TITLE
fix(examples): re-green example-code — format, shared session factory, ghost tsconfig

### DIFF
--- a/packages/examples/code/src/cli.ts
+++ b/packages/examples/code/src/cli.ts
@@ -19,10 +19,14 @@ import type { AgentRuntime } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { getAgentClient } from "./lib/agent-client.js";
 import { getCwd, setCwd } from "./lib/cwd.js";
-import { ensureSessionIdentity, getMainRoomElizaId } from "./lib/identity.js";
 import { loadEnv } from "./lib/load-env.js";
 import { resolveModelProvider } from "./lib/model-provider.js";
-import { loadSession, type SessionState, saveSession } from "./lib/session.js";
+import {
+  createDefaultSessionState,
+  loadSession,
+  type SessionState,
+  saveSession,
+} from "./lib/session.js";
 import type { ChatRoom, Message, MessageRole } from "./types.js";
 
 // ============================================================================
@@ -243,26 +247,6 @@ async function getMessage(options: CLIOptions): Promise<string | null> {
   }
 
   return null;
-}
-
-function createDefaultSessionState(): SessionState {
-  const identity = ensureSessionIdentity();
-  const room: ChatRoom = {
-    id: "default-main-room",
-    name: "Main",
-    messages: [],
-    createdAt: new Date(),
-    taskIds: [],
-    elizaRoomId: getMainRoomElizaId(identity),
-  };
-
-  return {
-    rooms: [room],
-    currentRoomId: room.id,
-    currentTaskId: null,
-    cwd: getCwd(),
-    identity,
-  };
 }
 
 function getCurrentRoomFromSession(session: SessionState): ChatRoom {

--- a/packages/examples/code/src/index.ts
+++ b/packages/examples/code/src/index.ts
@@ -137,12 +137,15 @@ async function runInteractive(): Promise<void> {
     process.exit(1);
   }
 
-  const [{ App }, { initializeAgent }, { loadSession, createDefaultSessionState }] =
-    await Promise.all([
-      import("./App.js"),
-      import("./lib/agent.js"),
-      import("./lib/session.js"),
-    ]);
+  const [
+    { App },
+    { initializeAgent },
+    { loadSession, createDefaultSessionState },
+  ] = await Promise.all([
+    import("./App.js"),
+    import("./lib/agent.js"),
+    import("./lib/session.js"),
+  ]);
 
   let runtime: AgentRuntime | undefined;
   let app: InstanceType<typeof App> | undefined;

--- a/packages/examples/code/src/lib/session.ts
+++ b/packages/examples/code/src/lib/session.ts
@@ -13,8 +13,10 @@ import type {
   SubAgentType,
   TaskPaneVisibility,
 } from "../types.js";
+import { getCwd } from "./cwd.js";
 import {
   ensureSessionIdentity,
+  getMainRoomElizaId,
   isUuidString,
   type SessionIdentity,
 } from "./identity.js";
@@ -190,6 +192,30 @@ export interface SessionState {
   taskPaneVisibility?: TaskPaneVisibility;
   taskPaneWidthFraction?: number;
   showFinishedTasks?: boolean;
+}
+
+/**
+ * Fresh single-room session for a first run or an unreadable session file.
+ * Shared by the TUI and CLI entries so both bootstrap the same owner identity.
+ */
+export function createDefaultSessionState(): SessionState {
+  const identity = ensureSessionIdentity();
+  const room: ChatRoom = {
+    id: "default-main-room",
+    name: "Main",
+    messages: [],
+    createdAt: new Date(),
+    taskIds: [],
+    elizaRoomId: getMainRoomElizaId(identity),
+  };
+
+  return {
+    rooms: [room],
+    currentRoomId: room.id,
+    currentTaskId: null,
+    cwd: getCwd(),
+    identity,
+  };
 }
 
 /**

--- a/packages/examples/code/tsconfig.json
+++ b/packages/examples/code/tsconfig.json
@@ -21,6 +21,5 @@
     "types": ["node", "bun"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"],
-  "extends": "../../../tsconfig.dist-paths.json"
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## What

The eliza-code restore left `@elizaos/example-code` red three ways on develop, which turns the `lint`, `Quality`, and `typecheck` lanes red for **every open PR** (first seen on #18266's run; the package is untouched by that diff):

1. **Unformatted entry file** — `src/index.ts` fails `lint:check`. Fixed with the biome-emitted format (byte-identical to `biome check --write` output).
2. **Import of a function that never existed in the module** — `index.ts` imports `createDefaultSessionState` from `lib/session.js`, but it only existed as a private copy inside `cli.ts` (TS2339). Promoted the factory into `lib/session.ts` as the single shared export and pointed `cli.ts` at it — same promote-the-private-copy pattern as core's `unwrapUserMessageText`.
3. **Ghost tsconfig extends** — the package extends `tsconfig.dist-paths.json`, deleted from the repo root in the workspace consolidation (TS5083). Dropped; the package's own `compilerOptions` (bundler resolution + `eliza-source` condition) cover resolution.

## Evidence

- `bun run --cwd packages/examples/code typecheck` (`tsc --noEmit`) — red before (TS5083 + TS2339), silent-green after.
- `bun run --cwd packages/examples/code lint:check` — red before, green after (gates log attached).
- No behavior change: the promoted factory is the verbatim `cli.ts` implementation.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:1c7a14e5229b80d27d71740e38253284a5aece19 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - build-config and module-wiring fix, no rendered UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - build-config and module-wiring fix, no rendered UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no runtime behavior change to demonstrate; the factory is the verbatim cli.ts implementation relocated

<!-- evidence-row:backend-logs -->
- [x] [18268-lintfix-gates.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18268-lintfix-gates.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-facing change; type/format/wiring only

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the reviewable artifacts are the +33/-24 diff and the gates log in backend-logs
