### PR TITLE
test(eliza-code): pin TUI owner session bootstrap

### DIFF
--- a/packages/examples/code/src/app-session-bootstrap.test.ts
+++ b/packages/examples/code/src/app-session-bootstrap.test.ts
@@ -1,0 +1,39 @@
+/** Verifies that App reuses the session loaded before runtime initialization. */
+import { describe, expect, it } from "bun:test";
+import type { AgentRuntime } from "@elizaos/core";
+import { App } from "./App.js";
+import { useStore } from "./lib/store.js";
+
+describe("App session bootstrap", () => {
+  it("does not reload a session that the runtime owner bootstrap already loaded", async () => {
+    const previousState = useStore.getState();
+    let reloads = 0;
+    const runtime = {
+      agentId: "30000000-0000-4000-8000-000000000001",
+      character: {},
+      getService: () => null,
+      registerEvent: () => undefined,
+    } as unknown as AgentRuntime;
+    const app = new App(runtime);
+
+    try {
+      useStore.setState({
+        sessionLoaded: true,
+        loadSessionState: async () => {
+          reloads += 1;
+          throw new Error("loaded session was read twice");
+        },
+      });
+
+      const stopTimer = setTimeout(() => app.stop(), 10);
+      const result = await app.run().catch((error: unknown) => error);
+      clearTimeout(stopTimer);
+
+      expect(result).toBeUndefined();
+      expect(reloads).toBe(0);
+    } finally {
+      app.stop();
+      useStore.setState(previousState, true);
+    }
+  });
+});

--- a/packages/examples/code/src/lib/tui-owner.test.ts
+++ b/packages/examples/code/src/lib/tui-owner.test.ts
@@ -3,6 +3,9 @@
  * deterministic in-memory session persistence.
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { UUID } from "@elizaos/core";
 import { useStore } from "./store.js";
 import { resolveTuiOwnerUserId } from "./tui-owner.js";
@@ -36,5 +39,51 @@ describe("resolveTuiOwnerUserId", () => {
 
     await expect(resolveTuiOwnerUserId()).resolves.toBe(userId);
     expect(useStore.getState().identity).toBe(identity);
+  });
+
+  it("returns the persisted identity from a real session file", async () => {
+    const previousCwd = process.cwd();
+    const fixtureRoot = await mkdtemp(join(tmpdir(), "eliza-code-owner-"));
+    const sessionDir = join(fixtureRoot, ".eliza-code");
+    const identity = {
+      projectId: "10000000-0000-4000-8000-000000000001" as UUID,
+      userId: "10000000-0000-4000-8000-000000000002" as UUID,
+      worldId: "10000000-0000-4000-8000-000000000003" as UUID,
+      messageServerId: "10000000-0000-4000-8000-000000000004" as UUID,
+    };
+
+    try {
+      await mkdir(sessionDir);
+      await writeFile(
+        join(sessionDir, "session.json"),
+        JSON.stringify({
+          version: 1,
+          savedAt: Date.now(),
+          currentRoomId: "default-main-room",
+          currentTaskId: null,
+          rooms: [
+            {
+              id: "default-main-room",
+              name: "Main",
+              messages: [],
+              createdAt: Date.now(),
+              taskIds: [],
+              elizaRoomId: "20000000-0000-4000-8000-000000000001",
+            },
+          ],
+          cwd: fixtureRoot,
+          ...identity,
+        }),
+      );
+      process.chdir(fixtureRoot);
+      useStore.setState({ sessionLoaded: false });
+
+      await expect(resolveTuiOwnerUserId()).resolves.toBe(identity.userId);
+      expect(useStore.getState().identity).toEqual(identity);
+      expect(useStore.getState().sessionLoaded).toBe(true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
# Relates to

Relates to #18264.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto current `origin/develop`.
- [x] The branch contains only regression coverage that is still missing on current `develop`.
- [x] Focused tests, package lint, and package build pass on the exact head below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`, `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `codex`, `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@1a8db2e762e394b85ff48d4007fbf052e4356db4:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `e227f657d47a5601038ad15c182ccd1702d641fa`; zero conflicts (the touched package has no develop-side drift since the previous base).
- [x] Removed the superseded runtime implementation and kept only the test delta beyond `tui-owner`.

# Risks

Low. This PR changes tests only. It does not alter runtime behavior, persistence, or the TUI.

# Background

## What does this PR do?

Current `develop` now contains `resolveTuiOwnerUserId()` and the guarded `App.run()` session load. Its existing unit tests cover fresh and already-loaded in-memory state.

This PR adds the two remaining regression boundaries requested in review:

1. An actual `.eliza-code/session.json` fixture must hydrate the shared Zustand identity and return that persisted user ID to the runtime owner bootstrap.
2. `App.run()` must not read the session a second time after the owner bootstrap has already loaded it.

There is no parallel helper or production-code change left in this branch.

On the reviewer question about the 10 ms stop timer in `app-session-bootstrap.test.ts`: with the stubbed runtime (`getService` returns null), the path from `App.run()` entry to the `exitResolver` assignment contains no macrotask boundary — `initializeManagers()` is synchronous, `checkInterruptedTasks()` early-returns without ever suspending (one microtask hop), and `tui.start()` plus the promise executor run synchronously. A timer callback cannot run until the microtask queue drains, so the `stop()` timer can never observe an unassigned resolver regardless of machine load; the 10 ms value is not a correctness threshold. Verified empirically with 15 consecutive isolated runs of the file, zero failures.

## What kind of change is this?

Test-only regression coverage.

# Documentation changes needed?

No. Public behavior and commands are unchanged.

# Testing

## Where should a reviewer start?

- `packages/examples/code/src/lib/tui-owner.test.ts`
- `packages/examples/code/src/app-session-bootstrap.test.ts`

## Detailed testing steps

From `packages/examples/code`:

```bash
bun test --conditions=eliza-source src/lib/tui-owner.test.ts src/app-session-bootstrap.test.ts
bun run lint:check
bun run build
```

Observed on commit `0ca326e5cfe348bde20f4ad6d6ba83d850f93e48` with Bun 1.3.14: 4 tests passed with 10 assertions, package lint passed across 64 files with no fixes needed, and both bundles completed.

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:0ca326e5cfe348bde20f4ad6d6ba83d850f93e48 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is test-only coverage with no rendered change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this is test-only coverage with no rendered change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interaction or layout changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head verification:

```text
(pass) App session bootstrap > does not reload a session that the runtime owner bootstrap already loaded
(pass) resolveTuiOwnerUserId > returns the identity from the same store after loading it
(pass) resolveTuiOwnerUserId > does not reload and replace an already resolved store identity
(pass) resolveTuiOwnerUserId > returns the persisted identity from a real session file

4 pass
0 fail
10 expect() calls

Checked 64 files in 690ms. No fixes applied.

Bundled 89 modules
  index.js  0.47 MB
Bundled 103 modules
  acp.js  0.68 MB
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser or frontend transport changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifacts are the two committed regression tests at the exact head, [`tui-owner.test.ts`](https://github.com/krutftw/eliza/blob/0ca326e5cfe348bde20f4ad6d6ba83d850f93e48/packages/examples/code/src/lib/tui-owner.test.ts) and [`app-session-bootstrap.test.ts`](https://github.com/krutftw/eliza/blob/0ca326e5cfe348bde20f4ad6d6ba83d850f93e48/packages/examples/code/src/app-session-bootstrap.test.ts):

```text
$ git show --stat --oneline 0ca326e5cfe348bde20f4ad6d6ba83d850f93e48
0ca326e5c test(eliza-code): pin TUI owner session bootstrap
 packages/examples/code/src/app-session-bootstrap.test.ts | 39 +++++++++++++++++
 packages/examples/code/src/lib/tui-owner.test.ts         | 49 ++++++++++++++++++++++
 2 files changed, 88 insertions(+)
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Known gaps / failures

- The complete package suite reports 80 passed, 436 assertions, and one existing Windows-only failure: `tool-transcript.test.ts` expects `src/foo.ts` but receives `src\\foo.ts`. That test and implementation are untouched.
- The package `typecheck` script fails locally on Windows with pre-existing TS5097 errors from `plugins/plugin-scheduling/src/index.ts` (`.ts`-suffixed imports resolved through the `eliza-source` condition without `allowImportingTsExtensions` in this package's tsconfig). Reproduced identically with this PR's test files removed, and the scheduling/goals sources involved are byte-identical to the previous base where the CI typecheck lane passed.
- Root `bun run verify` passes the repository contract gates, then stops in the Turbo lane on `@elizaos/electrobun#lint:check` formatting diagnostics against generated Electrobun config output on Windows. The changed package's lint passes independently with no fixes needed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@1a8db2e762e394b85ff48d4007fbf052e4356db4:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [krutftw-eliza-pr-18270-current-develop]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@1a8db2e762e394b85ff48d4007fbf052e4356db4:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZP83XRQMX66ZEY4A385QB90","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-10T16:29:28.216Z","completed_at":"2026-08-10T16:32:15.184Z","skill_sha256":"f31090d0aae6a6f47cac70e1c1f915c64b43d025d5cc2d1b603656276fff94a0","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAEV18ACfdrEj5lGjsQuiKmXRk1ITXHPt9yVtkHA9RChs","device_key_id":"15b8ad91c037f0fdeaf4c179865d1f813bf46bdcf8cdf1600e00a86d25eb4414","device_signature":"lor3lGDTPtMV8Kd5p_F1dZbBItrSLCny-JefK6oI46nKcgk0L0t0h50y27i1YY5DRjxj1rE6npkIXisL47cbCw"}} -->

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [pr-18270-rebase-stabilize]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZT2EN365CRMMRHPBY8RJQVF","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-12T04:07:26.055Z","completed_at":"2026-08-12T04:48:49.844Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAEV18ACfdrEj5lGjsQuiKmXRk1ITXHPt9yVtkHA9RChs","device_key_id":"15b8ad91c037f0fdeaf4c179865d1f813bf46bdcf8cdf1600e00a86d25eb4414","device_signature":"wy7WMsl7MUQ-QjXNx2CQIdmgBgNVN0EA3b20oP__kFtd4k37xzjIZxrpXmqefJOmkKzkGKor-0c1DOtFp7B_Dw"}} -->
