### PR TITLE
fix(app-core): stop the account keep-alive sweep from hammering dead refresh grants

### DIFF
--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -154,6 +154,16 @@ const OPENAI_COMPAT_BASE_BY_DIRECT_PROVIDER: Readonly<
 };
 
 const KEEP_ALIVE_INTERVAL_MS = 5 * 60_000;
+/**
+ * How long the keep-alive sweep waits before re-probing a parked
+ * (needs-reauth / invalid) SUBSCRIPTION account. A parked OAuth account's
+ * refresh grant is dead until a human re-auths, so each probe burns a doomed
+ * refresh attempt against the provider's token endpoint and emits an error
+ * log line — at the 5-minute sweep cadence that is ~288 spam lines per
+ * account per day. A credential update (re-auth) bypasses the cooldown, so
+ * recovered accounts still re-admit within one sweep.
+ */
+const PARKED_SUBSCRIPTION_PROBE_COOLDOWN_MS = 6 * 60 * 60_000;
 
 function accountSessionPct(account: LinkedAccountConfig): number {
   return typeof account.usage?.sessionPct === "number"
@@ -1583,7 +1593,30 @@ export async function sweepAccountPoolKeepAlive(
     await pool.sweepExpired(providerId);
     for (const record of listProviderAccounts(providerId)) {
       result.checked += 1;
-      if (pool.get(record.id, providerId)?.health === "expired") continue;
+      const pooled = pool.get(record.id, providerId);
+      if (pooled?.health === "expired") continue;
+
+      // A parked subscription account's refresh grant is dead until a human
+      // re-auths, so resolving it burns a doomed refresh against the
+      // provider's token endpoint (plus an error log line) every sweep,
+      // forever. Probe parked accounts only when the stored credential has
+      // changed since the last probe (a re-auth just landed — re-admit
+      // within one sweep) or the cooldown elapsed. Direct-API probes stay
+      // unthrottled: they read a static key with no network cost, and they
+      // are the heal path for accounts flagged by earlier failures.
+      if (
+        (pooled?.health === "needs-reauth" || pooled?.health === "invalid") &&
+        isSubscriptionProvider(providerId)
+      ) {
+        const lastProbeMs = pooled.healthDetail?.lastChecked ?? 0;
+        const credentialChanged = record.updatedAt > lastProbeMs;
+        if (
+          !credentialChanged &&
+          Date.now() - lastProbeMs < PARKED_SUBSCRIPTION_PROBE_COOLDOWN_MS
+        ) {
+          continue;
+        }
+      }
 
       // A Codex CLI may have rotated the one-time refresh token inside its
       // per-account CODEX_HOME mid-session; adopt it BEFORE resolving, or the
@@ -1592,16 +1625,24 @@ export async function sweepAccountPoolKeepAlive(
       if (providerId === "openai-codex") {
         await adoptRotatedCodexTokens(record.id);
       }
-      const token = await getAccountAccessToken(providerId, record.id, {
+      const outcome = await getAccountAccessToken(providerId, record.id, {
         storagePolicy: defaultRuntimeStoragePolicy(),
+        outcome: true,
       });
-      if (!token) {
+      if (!outcome.ok) {
         result.failed += 1;
-        await pool.markNeedsReauth(record.id, "No valid credential available", {
-          providerId,
-        });
+        // Only a proven credential failure parks the account. Transport and
+        // provider outages keep the current health — one network blip must
+        // not mass-flag a healthy fleet as needs-reauth — and the next sweep
+        // simply retries.
+        if (outcome.kind === "auth") {
+          await pool.markNeedsReauth(record.id, outcome.message, {
+            providerId,
+          });
+        }
         continue;
       }
+      const token = outcome.accessToken;
 
       if (!isSubscriptionProvider(providerId)) {
         // Direct-API providers have no usage probe, but a successful token

--- a/packages/app-core/src/services/multi-account-refresh-failover.test.ts
+++ b/packages/app-core/src/services/multi-account-refresh-failover.test.ts
@@ -1101,3 +1101,134 @@ describe("bridge.markNeedsReauth verifies before evicting", () => {
     );
   });
 });
+
+describe("keep-alive parked-account throttling", () => {
+  function deadGrantFetchStub(calls: string[]): typeof fetch {
+    return vi.fn(async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      return new Response(
+        JSON.stringify({
+          error: "invalid_grant",
+          error_description: "Refresh token expired",
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+  }
+
+  function usageOkResponse(): Response {
+    return new Response(
+      JSON.stringify({
+        five_hour_utilization: 0.1,
+        seven_day_utilization: 0.2,
+        seven_day_resets_at: Date.now() + HOUR_MS,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  it("parks a dead-grant subscription account once and stops burning refreshes on it", async () => {
+    // A revoked/expired Max login: access token stale, refresh grant dead.
+    writeAccount("anthropic-subscription", "claude-work", {
+      access: "expired-access",
+      refresh: "rt-dead",
+      expires: Date.now() - HOUR_MS,
+    });
+    const tokenCalls: string[] = [];
+    vi.stubGlobal("fetch", deadGrantFetchStub(tokenCalls));
+
+    const pool = getDefaultAccountPool();
+    await expect(sweepAccountPoolKeepAlive()).resolves.toEqual({
+      checked: 1,
+      refreshed: 0,
+      failed: 1,
+    });
+    expect(pool.get("claude-work", "anthropic-subscription")?.health).toBe(
+      "needs-reauth",
+    );
+    const attemptsAfterFirstSweep = tokenCalls.length;
+    expect(attemptsAfterFirstSweep).toBeGreaterThan(0);
+
+    // The next sweeps must not re-burn the dead grant — pre-fix this
+    // re-attempted (and error-logged) every 5-minute sweep forever.
+    await expect(sweepAccountPoolKeepAlive()).resolves.toEqual({
+      checked: 1,
+      refreshed: 0,
+      failed: 0,
+    });
+    await expect(sweepAccountPoolKeepAlive()).resolves.toEqual({
+      checked: 1,
+      refreshed: 0,
+      failed: 0,
+    });
+    expect(tokenCalls.length).toBe(attemptsAfterFirstSweep);
+    expect(pool.get("claude-work", "anthropic-subscription")?.health).toBe(
+      "needs-reauth",
+    );
+  });
+
+  it("re-probes and re-admits a parked subscription account after a re-auth lands", async () => {
+    process.env.ELIZA_ACCOUNT_POOL_USAGE_PRIMING = "false";
+    writeAccount("anthropic-subscription", "claude-work", {
+      access: "expired-access",
+      refresh: "rt-dead",
+      expires: Date.now() - HOUR_MS,
+    });
+    vi.stubGlobal("fetch", deadGrantFetchStub([]));
+    const pool = getDefaultAccountPool();
+    await sweepAccountPoolKeepAlive();
+    expect(pool.get("claude-work", "anthropic-subscription")?.health).toBe(
+      "needs-reauth",
+    );
+
+    // Re-auth: a fresh credential lands under the same account id, stamping a
+    // newer updatedAt than the park's lastChecked. That must bypass the
+    // probe cooldown so the account returns within one sweep.
+    await new Promise((r) => setTimeout(r, 10));
+    writeAccount("anthropic-subscription", "claude-work", {
+      access: "fresh-access",
+      refresh: "rt-fresh",
+      expires: Date.now() + HOUR_MS,
+    });
+    const usageSpy = vi.fn(async () => usageOkResponse());
+    await expect(
+      sweepAccountPoolKeepAlive({
+        fetch: usageSpy as unknown as typeof fetch,
+        sleep: async () => {},
+      }),
+    ).resolves.toEqual({ checked: 1, refreshed: 1, failed: 0 });
+    expect(usageSpy).toHaveBeenCalled();
+    expect(pool.get("claude-work", "anthropic-subscription")?.health).toBe(
+      "ok",
+    );
+  });
+
+  it("keeps account health when the token refresh fails transiently", async () => {
+    writeAccount("anthropic-subscription", "claude-work", {
+      access: "expired-access",
+      refresh: "rt-live",
+      expires: Date.now() - HOUR_MS,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("fetch failed: ETIMEDOUT");
+      }),
+    );
+    const pool = getDefaultAccountPool();
+    expect(pool.get("claude-work", "anthropic-subscription")?.health).toBe(
+      "ok",
+    );
+
+    await expect(sweepAccountPoolKeepAlive()).resolves.toEqual({
+      checked: 1,
+      refreshed: 0,
+      failed: 1,
+    });
+    // Pre-fix a network blip parked the account as needs-reauth, evicting a
+    // perfectly healthy credential from rotation.
+    expect(pool.get("claude-work", "anthropic-subscription")?.health).toBe(
+      "ok",
+    );
+  });
+});


### PR DESCRIPTION
## The incident

Live box, 2026-08-10: two anthropic-subscription accounts with expired refresh grants produced `[auth] Failed to refresh anthropic-subscription token ... invalid_grant: Refresh token expired` **176+ times** — the account-pool keep-alive sweep re-attempts the dead grant every 5 minutes, forever, hammering Anthropic's token endpoint and spamming the log.

## Root causes (two, same sweep)

1. `sweepAccountPoolKeepAlive` only skips `expired` health. An account it just parked as `needs-reauth` gets a full token resolution — i.e. a doomed refresh-grant burn — again on every subsequent sweep. `invalid_grant` is terminal until a human re-auths; retrying it on a timer can never succeed.
2. The sweep used the legacy nullable `getAccessToken` return, so **any** resolution failure — including a transient network blip — was treated as proof of credential death and parked the account as `needs-reauth`, evicting healthy credentials from rotation fleet-wide.

## Fix

- **Parked-probe cooldown (subscription providers only):** `needs-reauth`/`invalid` subscription accounts are re-probed at most every 6h (`PARKED_SUBSCRIPTION_PROBE_COOLDOWN_MS`), clocked off the pool's existing `healthDetail.lastChecked`. A **credential update bypasses the cooldown** (`record.updatedAt > lastChecked`), so a re-auth still re-admits the account within one sweep — the sweep remains the re-admit path. Direct-API probes stay unthrottled: they read a static key with no network cost and are the heal path the existing tests pin.
- **Typed outcomes:** the sweep now resolves with `outcome: true` and only parks on `kind === "auth"`. Transient transport failures keep current health and simply retry next sweep.

## Verification

- 3 new tests on the real-path harness (real credential store, real pool): dead grant parks once and later sweeps burn zero further token-endpoint calls; a re-auth bypasses the cooldown and returns the account to `ok` in one sweep; a transient ETIMEDOUT no longer parks a healthy account.
- Full account-pool surface green: 127 tests across 8 suites (refresh-failover 33, rotation/broker/pool 50, availability/status/affinity/bridge 44). app-core typecheck + biome clean.

# Evidence

<!-- evidence-head:dc179fc312c170452e8ed6294177de4957732750 -->
- Before screenshots: N/A - background service
- After screenshots: N/A - background service
- Walkthrough video: N/A - background service
- OCR review: N/A - background service
- Frontend console/network logs: N/A - background service
- Backend logs: live incident (176 invalid_grant retry lines at 5-min cadence) in PR thread
- Real-LLM trajectory: N/A - no model path
- Domain artifacts: pool health records (needs-reauth with lastChecked cooldown clock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
