### PR TITLE
fix(core): promoted virtuals stop inheriting the parent simile array that retrieval drops as ambiguous

### DIFF
--- a/packages/core/src/actions/__tests__/promote-subactions.test.ts
+++ b/packages/core/src/actions/__tests__/promote-subactions.test.ts
@@ -498,3 +498,46 @@ describe("MESSAGE umbrella planner tools footprint (real surface)", () => {
 		}
 	});
 });
+
+describe("promoted virtual similes", () => {
+	it("keeps the parent's simile array on the parent alone", () => {
+		// Retrieval drops any simile claimed by more than one catalog parent
+		// (#16567). If every promoted virtual inherited the parent array, a
+		// two-subaction umbrella would get its ENTIRE simile surface dropped
+		// as ambiguous — the live 2026-08-10 failure where all TASKS similes
+		// died and issue asks fell back to web search.
+		const parent = makeUmbrella({
+			similes: ["SHARED_ALIAS_ONE", "SHARED_ALIAS_TWO"],
+		});
+		const [umbrella, ...virtuals] = promoteSubactionsToActions(parent);
+
+		expect(umbrella.similes).toEqual(
+			expect.arrayContaining(["SHARED_ALIAS_ONE", "SHARED_ALIAS_TWO"]),
+		);
+		expect(virtuals.length).toBeGreaterThan(1);
+		for (const virtual of virtuals) {
+			expect(virtual.similes).not.toContain("SHARED_ALIAS_ONE");
+			expect(virtual.similes).not.toContain("SHARED_ALIAS_TWO");
+			// The virtual still routes through the family surface and its own
+			// subaction name.
+			expect(virtual.similes).toContain("WIDGET");
+		}
+		const names = new Set(virtuals.map((v) => v.name));
+		expect(names).toContain("WIDGET_CREATE");
+		const create = findVirtual(virtuals, "WIDGET_CREATE");
+		expect(create.similes).toContain("CREATE");
+	});
+
+	it("keeps per-subaction override similes on their own virtual only", () => {
+		const parent = makeUmbrella({ similes: ["FAMILY_ALIAS"] });
+		const [, ...virtuals] = promoteSubactionsToActions(parent, {
+			overrides: { read: { similes: ["PEEK_WIDGET"] } },
+		});
+		const read = findVirtual(virtuals, "WIDGET_READ");
+		expect(read.similes).toContain("PEEK_WIDGET");
+		for (const virtual of virtuals) {
+			if (virtual.name === "WIDGET_READ") continue;
+			expect(virtual.similes).not.toContain("PEEK_WIDGET");
+		}
+	});
+});

--- a/packages/core/src/actions/promote-subactions.ts
+++ b/packages/core/src/actions/promote-subactions.ts
@@ -369,8 +369,16 @@ export function promoteSubactionsToActions(
 			new Set([
 				// Parent's name is first so simile-based search/routing can still
 				// find promoted actions through the parent surface.
+				//
+				// The parent's own simile ARRAY is deliberately NOT inherited:
+				// retrieval drops any simile claimed by more than one catalog
+				// parent as ambiguous (#16567), so with two or more promoted
+				// virtuals, inheritance guarantees every family simile is claimed
+				// by every sibling and dropped — killing simile routing for the
+				// whole umbrella (live 2026-08-10: all TASKS similes dead and
+				// "any new issues?" fell back to web search). The umbrella stays
+				// registered and remains those similes' single owner.
 				toUpperSnake(parent.name),
-				...(parent.similes ?? []),
 				...(override.similes ?? []),
 				toUpperSnake(sub),
 			]),


### PR DESCRIPTION
## The incident

Live, 2026-08-10 (post-restart battery): "any new issues on the eliza repo?" — the bot could not route to `manage_issues` and fell back to web search ("search didn't return a clean list"). Boot logs showed the whole TASKS family's similes dropped: `simile claimed by multiple parents — dropped from routing as ambiguous (parents=["TASKS_CONTROL","TASKS_CREATE"])` for EVERY simile on the action — including the GITHUB_* names #18242 added specifically so stage-1 guesses would land.

## Root cause — two fixes fighting

`promoteSubactionsToActions` copies the umbrella's ENTIRE simile array into every promoted virtual (`TASKS_CREATE`, `TASKS_CONTROL`, …). That predates the retrieval ambiguity guard (#16567), which drops any simile claimed by more than one catalog parent. Combined: with two or more virtuals, every inherited simile is claimed by every sibling **by construction**, so the guard kills the family's entire simile surface. Simile routing for every multi-subaction umbrella has been silently dead since #16567 landed.

## Fix

Promoted virtuals no longer inherit the parent simile array. Each virtual keeps: the parent's NAME (family-surface routing; name-colliding similes are already filtered by the guard), its own subaction name, and any per-subaction override similes. The umbrella stays registered and remains the single owner of the shared similes — restoring the deterministic routing the guard was written to protect.

## Verification

- 2 new tests: parent array stays on the parent alone (two-virtual promotion keeps every virtual free of the shared aliases); override similes stay on their own virtual.
- promote-subactions + to-tool suites 41/41; action-retrieval suites 31/31.
- Live acceptance on the deployed box: post-restart boot has zero ambiguous-simile warnings for promoted families, and the exact failing ask routes to `manage_issues` and answers with real issue data.

# Evidence

<!-- evidence-head:563f579c52b64e9d1f6e88da136668a33a14b108 -->
- Before screenshots: N/A - routing internals
- After screenshots: N/A - routing internals
- Walkthrough video: N/A - routing internals
- OCR review: N/A - routing internals
- Frontend console/network logs: N/A - routing internals
- Backend logs: before/after boot logs (ambiguous-simile warns → zero) in PR thread
- Real-LLM trajectory: live failing turn (web-search fallback) + post-fix turn (manage_issues routes)
- Domain artifacts: N/A - covered by trajectory row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
