### PR TITLE
fix(agent,workflow): auto-disable triggers whose workflow no longer exists

### DIFF
--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -52,7 +52,9 @@ interface MockRuntimeHandle {
     context?: Record<string, unknown>;
   }>;
   setDispatchResult: (
-    result: { ok: true; executionId?: string } | { ok: false; error: string },
+    result:
+      | { ok: true; executionId?: string }
+      | { ok: false; error: string; code?: string },
   ) => void;
   setWorkflowServicePresent: (present: boolean) => void;
   setNotifyError: (error: Error | null) => void;
@@ -96,6 +98,7 @@ function makeRuntime(): MockRuntimeHandle {
     ok: boolean;
     executionId?: string;
     error?: string;
+    code?: string;
   } = { ok: true, executionId: "exec-1" };
   let workflowServicePresent = true;
 
@@ -550,6 +553,43 @@ describe("executeTriggerTask", () => {
     expect(result.error).toBe("boom");
     // The run still records and persists (error is observable, not swallowed).
     expect(handle.updatedTasks).toHaveLength(1);
+  });
+
+  it("disables the trigger with one final notification when the workflow no longer exists", async () => {
+    handle.setDispatchResult({
+      ok: false,
+      error: "Workflow not found: wf-gone",
+      code: "workflow_not_found",
+    });
+    const task = makeTriggerTask({
+      triggerType: "interval",
+      displayName: "Device health check",
+    });
+
+    const result = await executeTriggerTask(handle.runtime, task, {
+      source: "scheduler",
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.taskDeleted).toBe(true);
+    expect(handle.runtime.deleteTask).toHaveBeenCalledWith(task.id);
+    expect(handle.notifyCalls).toHaveLength(1);
+    const notif = handle.notifyCalls[0];
+    expect(notif.title).toBe('Automation "Device health check" disabled');
+    expect(notif.body).toContain("no longer exists");
+  });
+
+  it("keeps retrying an uncoded transient dispatch failure (task stays)", async () => {
+    handle.setDispatchResult({ ok: false, error: "engine busy" });
+    const task = makeTriggerTask({ triggerType: "interval" });
+
+    const result = await executeTriggerTask(handle.runtime, task, {
+      source: "scheduler",
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.taskDeleted).toBe(false);
+    expect(handle.runtime.deleteTask).not.toHaveBeenCalled();
   });
 
   it("reports an error when the WORKFLOW_DISPATCH service never registers (bounded wait)", async () => {

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -206,6 +206,7 @@ interface WorkflowDispatchServiceLike {
     error?: string;
     executionId?: string;
     dedup?: boolean;
+    code?: string;
   }>;
 }
 
@@ -260,7 +261,10 @@ async function dispatchWorkflow(
   task: Task,
   trigger: WorkflowTriggerConfig,
   event?: TriggerExecutionOptions["event"],
-): Promise<{ ok: true; executionId?: string } | { ok: false; error: string }> {
+): Promise<
+  | { ok: true; executionId?: string }
+  | { ok: false; error: string; code?: string }
+> {
   if (!trigger.workflowId) {
     return { ok: false, error: "workflow trigger missing workflowId" };
   }
@@ -292,7 +296,11 @@ async function dispatchWorkflow(
   });
   return result.ok
     ? { ok: true, executionId: result.executionId }
-    : { ok: false, error: result.error ?? "workflow execution failed" };
+    : {
+        ok: false,
+        error: result.error ?? "workflow execution failed",
+        ...(result.code ? { code: result.code } : {}),
+      };
 }
 
 interface AutonomyRoomService {
@@ -511,6 +519,7 @@ export async function executeTriggerTask(
   let status: TriggerExecutionResult["status"] = "success";
   let errorMessage = "";
   let workflowExecutionId: string | undefined;
+  let workflowGone = false;
 
   const result =
     trigger.kind === "workflow"
@@ -523,6 +532,11 @@ export async function executeTriggerTask(
   } else {
     status = "error";
     errorMessage = result.error;
+    // A workflow_not_found dispatch is permanent: the workflow row was
+    // deleted, so every future fire of this schedule fails identically. One
+    // final "disabled" notification and task deletion below replace the
+    // hourly failed-automation storm.
+    workflowGone = "code" in result && result.code === "workflow_not_found";
     runtime.logger.error(
       {
         src: "trigger-runtime",
@@ -533,16 +547,23 @@ export async function executeTriggerTask(
         workflowId:
           trigger.kind === "workflow" ? trigger.workflowId : undefined,
         error: errorMessage,
+        ...(workflowGone ? { permanentFailure: "workflow_not_found" } : {}),
       },
-      "Trigger dispatch failed",
+      workflowGone
+        ? "Trigger workflow no longer exists; disabling the schedule"
+        : "Trigger dispatch failed",
     );
     // Scheduled automations run without the user in the chat loop, so a
     // dispatch failure is otherwise invisible. Surface it on the notification
     // rail (fire-and-forget; never let a notify failure mask the trigger error).
     void getNotifier(runtime)
       ?.notify({
-        title: `Automation "${trigger.displayName}" failed`,
-        body: errorMessage.slice(0, 200),
+        title: workflowGone
+          ? `Automation "${trigger.displayName}" disabled`
+          : `Automation "${trigger.displayName}" failed`,
+        body: workflowGone
+          ? "Its workflow no longer exists, so the schedule was removed. Recreate the automation if you still need it."
+          : errorMessage.slice(0, 200),
         category: "workflow",
         priority: "high",
         source: "trigger",
@@ -625,6 +646,7 @@ export async function executeTriggerTask(
   };
 
   const shouldDeleteTask =
+    workflowGone ||
     updatedTrigger.triggerType === "once" ||
     (typeof updatedTrigger.maxRuns === "number" &&
       updatedTrigger.maxRuns > 0 &&

--- a/plugins/plugin-workflow/__tests__/unit/workflow-dispatch.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-dispatch.test.ts
@@ -8,6 +8,7 @@ import {
   registerWorkflowDispatchService,
   WORKFLOW_DISPATCH_SERVICE_TYPE,
 } from '../../src/services/workflow-dispatch';
+import { WorkflowApiError } from '../../src/types/index';
 
 // `mock.module` replaces the module globally for the rest of the bun-test run,
 // so preserve every real `@elizaos/core` export and swap in a complete spy
@@ -155,6 +156,32 @@ describe('workflow dispatch service', () => {
       { src: 'plugin:workflow:dispatch' },
       'Workflow execution failed for wf-1: engine offline'
     );
+  });
+
+  it('classes a 404 as workflow_not_found so schedulers can disable the trigger', async () => {
+    const embedded = makeEmbeddedService();
+    embedded.executeWorkflow.mockImplementation(async () => {
+      throw new WorkflowApiError('Workflow not found: wf-gone', 404);
+    });
+    const dispatch = createWorkflowDispatchService(makeRuntime(embedded) as never);
+
+    await expect(dispatch.execute('wf-gone')).resolves.toEqual({
+      ok: false,
+      error: 'Workflow not found: wf-gone',
+      code: 'workflow_not_found',
+    });
+  });
+
+  it('leaves non-404 WorkflowApiErrors uncoded (transient failures keep retrying)', async () => {
+    const embedded = makeEmbeddedService();
+    embedded.executeWorkflow.mockImplementation(async () => {
+      throw new WorkflowApiError('engine busy', 503);
+    });
+    const dispatch = createWorkflowDispatchService(makeRuntime(embedded) as never);
+
+    const result = await dispatch.execute('wf-1');
+    expect(result.ok).toBe(false);
+    expect(result.code).toBeUndefined();
   });
 
   it('registers a stoppable service entry in the runtime services map', async () => {

--- a/plugins/plugin-workflow/src/services/workflow-dispatch.ts
+++ b/plugins/plugin-workflow/src/services/workflow-dispatch.ts
@@ -16,6 +16,7 @@
 
 import type { IAgentRuntime } from '@elizaos/core';
 import { logger } from '@elizaos/core';
+import { WorkflowApiError } from '../types/index';
 import {
   EMBEDDED_WORKFLOW_SERVICE_TYPE,
   type EmbeddedWorkflowService,
@@ -33,6 +34,13 @@ export interface WorkflowDispatchResult {
    * instead of treating the call as a fresh execution.
    */
   dedup?: boolean;
+  /**
+   * Machine-readable permanent-failure class. `workflow_not_found` means the
+   * target workflow row no longer exists, so retrying the same dispatch can
+   * never succeed — callers owning a schedule (the trigger dispatcher) should
+   * disable it instead of re-firing forever. Absent for transient failures.
+   */
+  code?: 'workflow_not_found';
 }
 
 /**
@@ -195,11 +203,17 @@ async function runDispatch(
     });
     return execution.id ? { ok: true, executionId: execution.id } : { ok: true };
   } catch (err) {
+    // error-policy:J1 dispatch boundary — the trigger scheduler consumes a
+    // structured result; a permanent not-found is classed so it can disable
+    // the schedule instead of re-firing forever.
     const message = err instanceof Error ? err.message : String(err);
     logger.warn(
       { src: 'plugin:workflow:dispatch' },
       `Workflow execution failed for ${workflowId}: ${message}`
     );
+    if (err instanceof WorkflowApiError && err.statusCode === 404) {
+      return { ok: false, error: message, code: 'workflow_not_found' };
+    }
     return { ok: false, error: message };
   }
 }


### PR DESCRIPTION
## What

A workflow-kind trigger whose workflow was deleted re-fired forever: every dispatch failed with the same not-found error, each fire logging an error and pushing a high-priority "Automation failed" notification. Observed live: one orphaned trigger re-firing hourly, ~96 failure notifications/day, no way out short of manually hunting the task row.

The fix threads the failure *class* through the boundary instead of matching free text:

- **`WORKFLOW_DISPATCH` service** (`plugin-workflow`): the dispatch catch now recognizes the typed `WorkflowApiError` 404 from the embedded workflow lookup and stamps `code: "workflow_not_found"` on its structured result. The 404 is only reachable from the workflow-row lookup on this path, and non-404 `WorkflowApiError`s stay uncoded.
- **Trigger dispatcher** (`packages/agent`): a coded `workflow_not_found` folds into the *existing* delete machinery — the run record persists (runCount, lastStatus, lastError), the task is deleted through the same path once/maxRuns exhaustion already uses, and the user gets ONE final notification: `Automation "<name>" disabled` with a recreate hint, instead of the hourly failure storm.
- **Fail-open on doubt:** any uncoded failure (engine busy, boot race, subsystem unavailable) keeps today's retry behavior untouched.

## Evidence

- `plugin-workflow` dispatch suite: 9/9 (2 new: 404 → coded result; 503 → uncoded).
- `packages/agent` triggers suite: 23/23 (2 new: coded failure → task deleted + "disabled" notification; uncoded failure → task stays, keeps retrying). Existing failure-notification and maxRuns cases unchanged.
- `tsc --noEmit` and biome clean on both packages.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:d6bc330d92f18271b83bafe69c111171afb04a88 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend scheduler/service change, no rendered UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend scheduler/service change, no rendered UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI surface; deterministic suites prove the disable path (backend-logs row)

<!-- evidence-row:backend-logs -->
- [x] [18274-pr18274-ev.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18274-pr18274-ev.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-facing change; typed error-code threading through the dispatch boundary

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the reviewable artifacts are the 109-line diff and the two suite logs in backend-logs
