### PR TITLE
fix(orchestrator): verify-failed completions with no live URL get the honest failure reply

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
@@ -79,11 +79,51 @@ describe("subAgentFailureResponseEvaluator", () => {
     }
   });
 
-  it("does NOT fire for task_complete (that is the completion evaluator's job)", () => {
+  it("does NOT fire for a clean task_complete (that is the completion evaluator's job)", () => {
     const context = makeContext({
       metadata: { subAgentEvent: "task_complete" },
     });
     expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it("fires for a verify-failed task_complete with no URL that probed live", () => {
+    // The completion evaluator's gate steps aside for this shape (it requires
+    // at least one live URL to relay a caveated deliverable), so without the
+    // failure twin the outcome rides on the planner volunteering a reply.
+    const context = makeContext({
+      text: "[sub-agent: bean-bar (claude) — task_complete]\nBuild finished.\n[verification: the following URL(s) the sub-agent referenced are NOT reachable — do NOT tell the user the app is live]\n  - https://example.org/apps/bean-bar/ → HTTP 404",
+      metadata: { subAgentEvent: "task_complete", subAgentLabel: "bean-bar" },
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(true);
+    const result = subAgentFailureResponseEvaluator.evaluate(context);
+    expect(result.reply).toContain(`Couldn't finish the "bean-bar" task`);
+  });
+
+  it("does NOT fire for a verify-failed task_complete that still has a live URL", () => {
+    // A caveated deliverable exists — the completion evaluator owns that turn.
+    const context = makeContext({
+      text: "[sub-agent: bean-bar (claude) — task_complete]\nBuild finished.\n[verification: the following URL(s) the sub-agent referenced are NOT reachable — do NOT tell the user the app is live]\n  - https://example.org/apps/bean-bar/style.css → HTTP 404",
+      metadata: {
+        subAgentEvent: "task_complete",
+        subAgentLabel: "bean-bar",
+        subAgentVerifiedUrls: ["https://example.org/apps/bean-bar/"],
+      },
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it("fires when every metadata-verified URL is in the completion's dead list", () => {
+    // Route-alias expansion can stamp a public URL as "verified" even though
+    // its direct probe was dead; a dead-listed URL is not a deliverable.
+    const context = makeContext({
+      text: "[sub-agent: bean-bar (claude) — task_complete]\nBuild finished.\n[verification: the following URL(s) the sub-agent referenced are NOT reachable — do NOT tell the user the app is live]\n  - https://example.org/apps/bean-bar/ → HTTP 404",
+      metadata: {
+        subAgentEvent: "task_complete",
+        subAgentLabel: "bean-bar",
+        subAgentVerifiedUrls: ["https://example.org/apps/bean-bar/"],
+      },
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(true);
   });
 
   it("does NOT fire for non sub-agent messages", () => {

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -323,7 +323,7 @@ function stripRouterAnnotations(text: string): string {
     .trim();
 }
 
-function completionHasVerificationFailure(text: string): boolean {
+export function completionHasVerificationFailure(text: string): boolean {
   return (
     text.includes("[verification:") ||
     text.includes("NOT reachable") ||
@@ -386,7 +386,7 @@ function deadUrlKeysFromCompletionText(text: string): Set<string> {
 // into subAgentVerifiedUrls (the router verifies the loopback page live, then
 // expands it to all route aliases). The annotation's dead list is the ground
 // truth for what actually probed dead, so drop those before relaying.
-function verifiedUrlsExcludingDead(
+export function verifiedUrlsExcludingDead(
   message: Memory,
   completionText: string,
 ): string[] {

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
@@ -15,6 +15,10 @@ import {
   type ResponseHandlerEvaluator,
   SIMPLE_CONTEXT_ID,
 } from "@elizaos/core";
+import {
+  completionHasVerificationFailure,
+  verifiedUrlsExcludingDead,
+} from "./sub-agent-completion.js";
 
 const SUB_AGENT_SOURCE = MESSAGE_SOURCE_SUB_AGENT;
 
@@ -84,7 +88,19 @@ function isTerminalSubAgentFailure(message: Memory): boolean {
   if (!content || !metadata) return false;
   const source = textOf(content.source).toLowerCase();
   if (source !== SUB_AGENT_SOURCE && metadata.subAgent !== true) return false;
-  return TERMINAL_FAILURE_EVENTS.has(textOf(metadata.subAgentEvent));
+  const event = textOf(metadata.subAgentEvent);
+  if (TERMINAL_FAILURE_EVENTS.has(event)) return true;
+  // A task_complete stamped with the router's verification-failure annotation
+  // and no URL that actually probed live delivered nothing usable — in user
+  // terms a terminal failure. The completion evaluator steps aside for this
+  // shape (its gate requires a live URL to relay), so without this twin the
+  // outcome rides on the planner model volunteering a reply.
+  if (event !== "task_complete") return false;
+  const text = textOf(content.text);
+  return (
+    completionHasVerificationFailure(text) &&
+    verifiedUrlsExcludingDead(message, text).length === 0
+  );
 }
 
 // Trim the router's error narration to a single short, user-readable clause:


### PR DESCRIPTION
## What

A `task_complete` stamped with the router's verification-failure annotation and **no URL that actually probed live** delivered nothing usable — yet neither response-handler evaluator owned the turn. The completion evaluator's gate deliberately steps aside for that shape (it relays only when a live URL exists to caveat), and the failure twin covered only `error` / `state_lost_exhausted` / `round_trip_cap_exceeded`. The outcome rode on the planner model volunteering a reply: fine on strong models, dead silence on weak ones.

This closes the gap by treating that shape as what it is in user terms — a terminal failure. `sub-agent-failure` now also fires for `task_complete` when the completion text carries the verification-failure annotation and the dead-list-filtered verified-URL set is empty. The dead-list filter matters: route-alias expansion can stamp a public URL as "verified" even though its direct probe was in the dead set — a dead-listed URL is not a deliverable. The two evaluators stay mutually exclusive by construction: any URL that probed live keeps the turn with the completion evaluator's caveated relay (`isSuccessfulSubAgentCompletion` uses the same `verifiedUrlsExcludingDead` helper, now shared).

Completes the delivery-guarantee arc: #17916 landed the caveated-relay and origin-source-stamp halves; this is the remaining no-deliverable case.

## Evidence

- `sub-agent-failure-evaluator` suite: 13/13 (3 new: verify-failed + no live URL fires with the honest reply; verify-failed + live URL defers to the completion evaluator; all-verified-URLs-dead fires). Clean `task_complete` still never fires.
- `tsc --noEmit` and biome clean on the plugin.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:0fbfe8ae52e6375bae20582c1ee05a1bc84e39d5 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - runtime evaluator change, no rendered UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - runtime evaluator change, no rendered UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI surface; deterministic evaluator suite proves the gate (backend-logs row)

<!-- evidence-row:backend-logs -->
- [x] [18275-pr18275-ev.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18275-pr18275-ev.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic evaluator gate change; the harness drives the real evaluators with synthetic router memories, no live-model prompt change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the reviewable artifacts are the 60-line diff and the suite log in backend-logs
