### PR TITLE
fix(core): embedding queue skips whitespace-only text the backends terminally reject

### DIFF
--- a/packages/core/src/services/embedding.test.ts
+++ b/packages/core/src/services/embedding.test.ts
@@ -165,6 +165,41 @@ describe("EmbeddingGenerationService processBatch", () => {
 		await service.stop();
 	});
 
+	test("whitespace-only text is skipped, never sent to the backend", async () => {
+		// Backends reject whitespace-only text as terminally invalid
+		// (plugin-elizacloud throws "Cannot generate embedding for empty
+		// text"), so retrying it can never succeed — the partition must
+		// trim-check, not just falsy-check (live 2026-08-10: image-only
+		// messages error-logged on every retry).
+		let lastTexts: string[] = [];
+		const runtime = makeRuntime({
+			batch: true,
+			batchHandler: async ({ texts }) => {
+				lastTexts = texts;
+				return texts.map((_, i) => [i, i + 1]);
+			},
+			updateMemory: async () => {},
+		});
+		const service = (await EmbeddingGenerationService.start(
+			runtime,
+		)) as EmbeddingGenerationService;
+		// biome-ignore lint/suspicious/noExplicitAny: drive the private batch processor directly
+		const processBatch = (service as any).batchQueue.options.processBatch as (
+			items: unknown[],
+		) => Promise<{ item: { memory: { id: string } }; success: boolean }[]>;
+
+		const items = [makeItem("id-ws", "  \n "), makeItem("id-ok", "real text")];
+		const outcomes = await processBatch(items);
+
+		expect(lastTexts).toEqual(["real text"]);
+		const byId = new Map(outcomes.map((o) => [o.item.memory.id, o.success]));
+		// The whitespace item resolves as handled — not an error, not a retry.
+		expect(byId.get("id-ws")).toBe(true);
+		expect(byId.get("id-ok")).toBe(true);
+
+		await service.stop();
+	});
+
 	test("an empty vector in the batch is failed, not falsely succeeded or persisted", async () => {
 		const written: { id: string; embedding: number[] }[] = [];
 		const runtime = makeRuntime({

--- a/packages/core/src/services/embedding.ts
+++ b/packages/core/src/services/embedding.ts
@@ -201,7 +201,11 @@ export class EmbeddingGenerationService extends Service {
 		const { memory } = item;
 
 		const memoryContent = memory.content;
-		if (!memoryContent.text) {
+		// Trim-check to match the embedding model contract: backends reject
+		// whitespace-only text, and no queue retry can ever change that
+		// (live 2026-08-10: image-only messages with whitespace text error-
+		// logged on every retry).
+		if (!memoryContent.text?.trim()) {
 			this.runtime.logger.warn(
 				{
 					src: "plugin:basic-capabilities:service:embedding",
@@ -328,7 +332,9 @@ export class EmbeddingGenerationService extends Service {
 		const skipped: EmbeddingQueueItem[] = [];
 		for (const item of items) {
 			const text = item.memory.content.text;
-			if (!text || item.memory.embedding) {
+			// Same trim rule as the per-item path — backends reject
+			// whitespace-only text as terminally invalid.
+			if (!text?.trim() || item.memory.embedding) {
 				skipped.push(item);
 			} else {
 				toEmbed.push({ item, text });


### PR DESCRIPTION
## The incident

Live box, 2026-08-10: image-only Discord messages (whitespace-only `content.text`) produced `EmbeddingService.generate — Cannot generate embedding for empty text` error + reportError on every queue retry (24 log entries and counting). The failure is terminal by contract — no retry can make whitespace embeddable — same class as the dead-grant refresh retries fixed in #18271.

## Root cause

The embedding service guards with a falsy check (`!text`) in both the per-item and batched paths, but the model backends reject on `!text.trim()` (plugin-elizacloud `embeddings.ts`, plugin-google-genai `embedding.ts`). Whitespace-only text passes the service guard and hands the backend a guaranteed failure to retry.

## Fix

Both partition sites now trim-check, matching the backend contract: whitespace-only memories are skipped (logged at warn, resolved as handled) instead of queued for doomed generation.

## Verification

- New test: whitespace-only item is never sent to the backend, resolves as handled (not error/retry); real text in the same batch still embeds.
- embedding suite 13/13. Biome clean.

# Evidence

<!-- evidence-head:b2a916b07d280cc50dcdeb4684c733b2ee187e7c -->
- Before screenshots: N/A - background service
- After screenshots: N/A - background service
- Walkthrough video: N/A - background service
- OCR review: N/A - background service
- Frontend console/network logs: N/A - background service
- Backend logs: live retry-error lines in PR thread
- Real-LLM trajectory: N/A - no model behavior change (empty text never reaches a model)
- Domain artifacts: N/A - covered by deterministic suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
