### PR TITLE
fix(ci): hold an indirected Bun base image to the canonical pin

### DIFF
--- a/packages/cloud/services/agent-server/Dockerfile
+++ b/packages/cloud/services/agent-server/Dockerfile
@@ -1,8 +1,10 @@
 # BUN_BASE selects the Bun base image. Default targets linux/amd64 + linux/arm64
-# via upstream oven/bun. For linux/riscv64 (no upstream image — oven-sh/bun#6266,
-# #21923), build a local Bun image via elizaOS/os packages/os/toolchains/bun-riscv64/build.sh
-# and pass --build-arg BUN_BASE=<local-tag>.
-ARG BUN_BASE=oven/bun:canary-alpine
+# via upstream oven/bun, pinned to the canonical version in
+# .github/ci-bun-version.json so the deployed runtime is the one CI validates.
+# For linux/riscv64 (no upstream image — oven-sh/bun#6266, #21923), build a local
+# Bun image via elizaOS/os packages/os/toolchains/bun-riscv64/build.sh and pass
+# --build-arg BUN_BASE=<local-tag>.
+ARG BUN_BASE=oven/bun:1.3.14-alpine
 
 FROM ${BUN_BASE} AS deps
 WORKDIR /app

--- a/packages/cloud/services/gateway-discord/Dockerfile
+++ b/packages/cloud/services/gateway-discord/Dockerfile
@@ -13,10 +13,12 @@
 #   docker build -f packages/cloud/services/gateway-discord/Dockerfile .
 
 # BUN_BASE selects the Bun base image. Default targets linux/amd64 + linux/arm64
-# via upstream oven/bun. For linux/riscv64 (no upstream image — oven-sh/bun#6266,
-# #21923), build a local Bun image via elizaOS/os packages/os/toolchains/bun-riscv64/build.sh
-# and pass --build-arg BUN_BASE=<local-tag>.
-ARG BUN_BASE=oven/bun:canary-alpine
+# via upstream oven/bun, pinned to the canonical version in
+# .github/ci-bun-version.json so the deployed runtime is the one CI validates.
+# For linux/riscv64 (no upstream image — oven-sh/bun#6266, #21923), build a local
+# Bun image via elizaOS/os packages/os/toolchains/bun-riscv64/build.sh and pass
+# --build-arg BUN_BASE=<local-tag>.
+ARG BUN_BASE=oven/bun:1.3.14-alpine
 
 FROM ${BUN_BASE} AS base
 

--- a/packages/cloud/services/gateway-webhook/Dockerfile
+++ b/packages/cloud/services/gateway-webhook/Dockerfile
@@ -14,10 +14,12 @@
 # installing the whole monorepo (32 packages rather than several thousand).
 
 # BUN_BASE selects the Bun base image. Default targets linux/amd64 + linux/arm64
-# via upstream oven/bun. For linux/riscv64 (no upstream image — oven-sh/bun#6266,
-# #21923), build a local Bun image via elizaOS/os packages/os/toolchains/bun-riscv64/build.sh
-# and pass --build-arg BUN_BASE=<local-tag>.
-ARG BUN_BASE=oven/bun:canary-alpine
+# via upstream oven/bun, pinned to the canonical version in
+# .github/ci-bun-version.json so the deployed runtime is the one CI validates.
+# For linux/riscv64 (no upstream image — oven-sh/bun#6266, #21923), build a local
+# Bun image via elizaOS/os packages/os/toolchains/bun-riscv64/build.sh and pass
+# --build-arg BUN_BASE=<local-tag>.
+ARG BUN_BASE=oven/bun:1.3.14-alpine
 
 FROM ${BUN_BASE} AS base
 

--- a/packages/scripts/__tests__/ci-bun-version-contract.test.ts
+++ b/packages/scripts/__tests__/ci-bun-version-contract.test.ts
@@ -465,6 +465,81 @@ jobs:
     expect(install?.classification).toBe("canonical");
   });
 
+  test("fails a base image reached through a non-BUN_VERSION ARG", () => {
+    // The shape the deployed cloud services use. The image reference never
+    // touches a FROM line, so the `FROM oven/bun:` matcher never sees it, and
+    // the ARG is not named BUN_VERSION, so the ARG scan skips it too — a
+    // floating canary rode into three production images past a contract whose
+    // headline promise is that no floating tag survives (#17044).
+    expectViolation(
+      buildRepo({
+        files: {
+          "services/gw/Dockerfile": [
+            "ARG BUN_BASE=oven/bun:canary-alpine",
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: Dockerfile ARG interpolation, not a JS template
+            "FROM ${BUN_BASE} AS base",
+            "",
+          ].join("\n"),
+        },
+      }),
+      /ARG BUN_BASE=oven\/bun:canary-alpine/,
+    );
+    expectViolation(
+      buildRepo({
+        files: {
+          "services/gw/Dockerfile": [
+            "ENV BUN_IMAGE=oven/bun:latest",
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: Dockerfile ARG interpolation, not a JS template
+            "FROM ${BUN_IMAGE}",
+            "",
+          ].join("\n"),
+        },
+      }),
+      /oven\/bun:latest/,
+    );
+  });
+
+  test("accepts a canonical base image reached through an ARG, variant included", () => {
+    const inventory = inventoryOf(
+      buildRepo({
+        files: {
+          "services/gw/Dockerfile": [
+            `ARG BUN_BASE=oven/bun:${CANONICAL}-alpine`,
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: Dockerfile ARG interpolation, not a JS template
+            "FROM ${BUN_BASE} AS base",
+            "",
+          ].join("\n"),
+        },
+      }),
+    );
+    const arg = inventory.find(
+      (s) => s.surface === "dockerfile-base-image-arg",
+    );
+    expect(arg?.classification).toBe("canonical");
+    expect(arg?.value).toBe(`${CANONICAL}-alpine`);
+  });
+
+  test("leaves a non-oven ARG default alone (local RISC-V build override)", () => {
+    // riscv64 has no upstream oven/bun image, so these Dockerfiles document a
+    // locally built tag passed via --build-arg. It declares no oven/bun
+    // runtime and must not be forced onto the canonical pin.
+    const inventory = inventoryOf(
+      buildRepo({
+        files: {
+          "services/gw/Dockerfile": [
+            "ARG BUN_BASE=local/bun-riscv64:dev",
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: Dockerfile ARG interpolation, not a JS template
+            "FROM ${BUN_BASE} AS base",
+            "",
+          ].join("\n"),
+        },
+      }),
+    );
+    expect(
+      inventory.filter((s) => s.surface === "dockerfile-base-image-arg"),
+    ).toEqual([]);
+  });
+
   test("fails a divergent oven-sh release download URL", () => {
     expectViolation(
       buildRepo({

--- a/packages/scripts/ci-bun-version-contract.mjs
+++ b/packages/scripts/ci-bun-version-contract.mjs
@@ -1138,6 +1138,42 @@ function scanDockerfile({ rel, text, canonical, record, violate }) {
     }
   }
 
+  // A base image also reaches FROM through an ARG/ENV of any name:
+  //   ARG BUN_BASE=oven/bun:canary-alpine
+  //   FROM ${BUN_BASE}
+  // The FROM matcher below requires a literal `oven/bun:` on the FROM line, and
+  // the declaration scan above reads only BUN_VERSION, so this shape cleared
+  // both while pinning nothing. That is how a floating canary became the
+  // runtime of three deployed cloud service images without a single violation
+  // (#17044). The reference is a runtime declaration wherever it is written.
+  for (let i = 0; i < lines.length; i++) {
+    const decl = lines[i].match(
+      /^\s*(ARG|ENV)\s+([A-Za-z_][A-Za-z0-9_]*)[= ]["']?oven\/bun:([A-Za-z0-9._-]+)["']?/,
+    );
+    if (!decl) continue;
+    const [, kind, name, tag] = decl;
+    // Variant suffixes (-alpine, -slim, -distroless) are a base-image choice;
+    // only the version prefix must match the canonical pin.
+    const tagVersion = tag.match(/^(\d+\.\d+\.\d+)(?:-[A-Za-z0-9.-]+)?$/)?.[1];
+    const pinned = tagVersion === canonical;
+    record({
+      surface: "dockerfile-base-image-arg",
+      file: rel,
+      line: i + 1,
+      value: tag,
+      classification: pinned
+        ? "canonical"
+        : /^(canary|latest)(?:-|$)/.test(tag)
+          ? "floating"
+          : "divergent",
+    });
+    if (!pinned) {
+      violate(
+        `${rel}:${i + 1}: ${kind} ${name}=oven/bun:${tag} — a base image reached through ${kind} ${name} must be the canonical ${canonical} (${VERSION_FILE}) (variant suffixes allowed). Pass an out-of-tree image with --build-arg rather than defaulting to a floating tag.`,
+      );
+    }
+  }
+
   for (let i = 0; i < lines.length; i++) {
     const from = lines[i].match(
       /^\s*FROM\s+(?:--platform=\S+\s+)?oven\/bun:([^\s]+)/i,


### PR DESCRIPTION
# Relates to

Relates to #17044. It does not close that issue — the remaining acceptance criteria there cover manifests, templates, workflows, and the type-package inventory. This closes one surface that survived #17599's sweep.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` at `9fd7b5fa8f`; zero conflicts.
- [x] `bun run verify` passes post-sync (`VERIFY_EXIT=0`).

# Risks

Low. One added scan in a repository contract script plus a version tag in three Dockerfiles. The contract change can only add violations, never suppress one — it introduces a new surface and never relaxes an existing classification. The Dockerfile change moves the three services from an unpinned, mutable tag to the version the rest of the repository already declares, and the documented `--build-arg BUN_BASE=<local-tag>` override for RISC-V is preserved and covered by a test.

# Background

## What does this PR do?

A Bun base image can reach `FROM` through an `ARG` of any name:

```dockerfile
ARG BUN_BASE=oven/bun:canary-alpine
FROM ${BUN_BASE} AS base
```

Two scans in `ci-bun-version-contract.mjs` should have caught that, and the reference falls between them:

- the base-image scan requires a literal `oven/bun:` **on the FROM line**, and this FROM line reads `FROM ${BUN_BASE} AS base`;
- the declaration scan reads only `ARG`/`ENV BUN_VERSION`, and this ARG is `BUN_BASE`.

So the shape cleared the contract while pinning nothing. All three deployed cloud service images use exactly it, which is how a floating `canary` became their production runtime — today an unreleased Bun `1.4.0` that can change on any pull — while CI validated `1.3.14`.

This adds a scan for `ARG`/`ENV` defaults holding an `oven/bun:` reference regardless of variable name, and pins `agent-server`, `gateway-discord`, and `gateway-webhook` to the canonical version. A non-`oven/bun` default is deliberately left alone so the documented local RISC-V build override keeps working.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The three Dockerfile comments that describe `BUN_BASE` are updated in place to name `.github/ci-bun-version.json` as the version source.

# Testing

## Where should a reviewer start?

`packages/scripts/ci-bun-version-contract.mjs` — the new `dockerfile-base-image-arg` scan, immediately above the existing `FROM oven/bun:` matcher it complements.

## Detailed testing steps

Reverting only the three Dockerfiles and rerunning the contract reproduces the escape (the contract passes with three floating images in tree). Reverting only the script turns the three new tests red.

```bash
node packages/scripts/ci-bun-version-contract.mjs
bun test packages/scripts/__tests__/ci-bun-version-contract.test.ts
docker build -f packages/cloud/services/gateway-webhook/Dockerfile -t bunpin-proof .
docker run --rm --entrypoint bun bunpin-proof --version
```

# Evidence Gate

<!-- evidence-head:98a1fc2008ac19ca758127855472cf84978ccec0 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - build-toolchain and repository-contract change; no rendered UI surface in this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - same reason; the observable change is which Bun binary the deployed containers run.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no interactive user flow; the failure mode is a build-time version selection, captured as the before/after contract transcript below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — the real contract executing against the real tree, before and after, plus RED/GREEN on the new tests:

  <details><summary>contract against the tree, before the script change (the escape)</summary>

  ```text
  $ node packages/scripts/ci-bun-version-contract.mjs
  ci bun version contract passed (canonical 1.3.14; 238 sites scanned; 49 workflow pin(s)
  in lockstep; 3 gate lane(s) pinned; ...)
  exit=0

  ...with all three service images floating on oven/bun:canary-alpine in that same tree.
  ```
  </details>

  <details><summary>RED — new tests against the unmodified script</summary>

  ```text
  $ bun test packages/scripts/__tests__/ci-bun-version-contract.test.ts -t "ARG"
  (fail) accepts a canonical base image reached through an ARG, variant included
    expect(received).toBe(expected)
    Expected: "canonical"
    Received: undefined
   5 pass, 2 fail
  ```
  </details>

  <details><summary>GREEN — script fixed, contract now sees the three real violations</summary>

  ```text
  $ node packages/scripts/ci-bun-version-contract.mjs
  [ci-bun-version-contract] FAIL 3 Bun runtime contract violation(s):
  - packages/cloud/services/agent-server/Dockerfile:5: ARG BUN_BASE=oven/bun:canary-alpine
    — a base image reached through ARG BUN_BASE must be the canonical 1.3.14 ...
  - packages/cloud/services/gateway-discord/Dockerfile:19: ARG BUN_BASE=oven/bun:canary-alpine ...
  - packages/cloud/services/gateway-webhook/Dockerfile:20: ARG BUN_BASE=oven/bun:canary-alpine ...
  ```
  </details>

  <details><summary>GREEN — images pinned; contract, suite, and root verify all pass</summary>

  ```text
  $ node packages/scripts/ci-bun-version-contract.mjs
  ci bun version contract passed (canonical 1.3.14; 241 sites scanned; ...
  classifications: ... canonical=76 ...)

  $ bun test packages/scripts/__tests__/ci-bun-version-contract.test.ts
  63 pass, 0 fail

  $ bun run verify
  [anti-larp] scanned 7773 test files — 0 focused, 0 orphaned skip(s)
  VERIFY_EXIT=0
  ```
  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no browser-side code in this diff.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, model, prompt, or provider surface touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the built container, which is the artifact this change governs. `gateway-webhook` built from the repository root on the pinned base, and the runtime inside it verified:

  ```text
  $ docker build -f packages/cloud/services/gateway-webhook/Dockerfile -t bunpin-proof .
  #22 naming to docker.io/library/bunpin-proof:latest done
  BUILD_EXIT=0

  $ docker run --rm --entrypoint bun bunpin-proof --version
  1.3.14
  ```

  What the two tags actually resolve to, which is the defect:

  ```text
  oven/bun:canary-alpine   sha256:ba693c8109807e2cdbd6f6c79895681226f9c9122f647b6a5ff4e248dd64518f
                           Bun.version = 1.4.0   Bun.revision = 52bf09cb1
  oven/bun:1.3.14-alpine   sha256:5acc90a93e91ff07bf72aa90a7c9f0fa189765aec90b47bdbf2152d2196383c0
                           Bun.version = 1.3.14  Bun.revision = 0d9b296af

  $ npm view bun version
  1.3.14        # no 1.4.0 is published
  ```

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: `N/A - no rendered visual surface in this diff.`

# Known gaps / failures

None blocking. One thing deliberately **not** claimed: I originally suspected the canary base of breaking outbound service auth on staging, and I could not reproduce it. Both images preserve an `Authorization` header on `fetch` including across a 307, and both emit 64-byte raw P1363 ES256 WebCrypto signatures. The defect this PR fixes is runtime divergence and non-reproducible builds — not a known auth regression. Recorded on #17044 as well, so nobody escalates it on a premise it cannot carry.

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [cad]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"N/A"} -->
