### PR TITLE
fix(plugins): keep launch registries aligned

### DIFF
--- a/packages/agent/src/api/views-registry.package-resolution.test.ts
+++ b/packages/agent/src/api/views-registry.package-resolution.test.ts
@@ -27,6 +27,13 @@ describe("pluginPackageNameCandidates", () => {
     ]);
   });
 
+  it("does not duplicate the plugin- prefix from runtime-facing names", () => {
+    expect(pluginPackageNameCandidates("plugin-health")).toEqual([
+      "@elizaos/plugin-health",
+      "plugin-health",
+    ]);
+  });
+
   it("uses a scoped plugin name as-is", () => {
     expect(pluginPackageNameCandidates("@elizaos/plugin-inbox")).toEqual([
       "@elizaos/plugin-inbox",
@@ -66,6 +73,37 @@ describe("registerPluginViews package-dir resolution", () => {
     // Normalized so the assertion holds on Windows path separators too.
     const pluginDir = (entry?.pluginDir ?? "").split("\\").join("/");
     expect(pluginDir).toContain("plugins/plugin-blocker");
+  });
+});
+
+describe("registerPluginViews prefixed runtime name resolution", () => {
+  const PLUGIN_NAME = "plugin-health";
+
+  afterEach(() => {
+    unregisterPluginViews(PLUGIN_NAME);
+  });
+
+  it("resolves a plugin-prefixed runtime name to the real workspace package", async () => {
+    const plugin: Plugin = {
+      name: PLUGIN_NAME,
+      description: "prefixed runtime-name resolution fixture",
+      views: [
+        {
+          id: "health-resolution-fixture",
+          label: "Health fixture",
+          bundlePath: "dist/views/bundle.js",
+        },
+      ],
+    } as Plugin;
+
+    await registerPluginViews(plugin);
+
+    const entry = listViews({ includeAllKinds: true }).find(
+      (view) => view.id === "health-resolution-fixture",
+    );
+    expect(entry).toBeDefined();
+    const pluginDir = (entry?.pluginDir ?? "").split("\\").join("/");
+    expect(pluginDir).toContain("plugins/plugin-health");
   });
 });
 

--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -104,6 +104,16 @@ async function resolvePluginPackageDir(
   const req = createRequire(import.meta.url);
   const packageNames = pluginPackageNameCandidates(pluginName);
 
+  // In a source checkout, the workspace is authoritative. Bun can otherwise
+  // resolve a scoped package from its global install cache even when that
+  // package is not a dependency of this workspace, serving a stale published
+  // view instead of the bundle under review. Packaged installs have no nearby
+  // workspace root and naturally fall through to normal package resolution.
+  for (const packageName of packageNames) {
+    const workspaceDir = await resolveWorkspacePluginPackageDir(packageName);
+    if (workspaceDir) return workspaceDir;
+  }
+
   for (const packageName of packageNames) {
     // Preferred: resolve the package's own package.json directly. Requires the
     // package to expose "./package.json" in its exports map.
@@ -130,11 +140,6 @@ async function resolvePluginPackageDir(
     } catch {
       // Package is not reachable from this module under this name.
     }
-  }
-
-  for (const packageName of packageNames) {
-    const workspaceDir = await resolveWorkspacePluginPackageDir(packageName);
-    if (workspaceDir) return workspaceDir;
   }
 
   logger.warn(

--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -84,9 +84,12 @@ const VIEW_BUNDLE_WARNING_BYTES = 1024 * 1024;
  * view against a directory that isn't this plugin at all.
  */
 export function pluginPackageNameCandidates(pluginName: string): string[] {
-  return pluginName.startsWith("@")
-    ? [pluginName]
-    : [`@elizaos/plugin-${pluginName}`, pluginName];
+  if (pluginName.startsWith("@")) return [pluginName];
+
+  const shortName = pluginName.startsWith("plugin-")
+    ? pluginName.slice("plugin-".length)
+    : pluginName;
+  return [`@elizaos/plugin-${shortName}`, pluginName];
 }
 
 /**

--- a/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
@@ -447,6 +447,21 @@ describe("collectPluginNames runtime mode provider policy", () => {
     expect(names.has("agent-orchestrator")).toBe(true);
   });
 
+  it("resolves the persisted Agent Orchestrator registry id to its plugin package", () => {
+    const names = collectPluginNames({
+      plugins: {
+        allow: ["agent-orchestrator"],
+        entries: {
+          "agent-orchestrator": { enabled: true },
+        },
+      },
+    } as ElizaConfig);
+
+    expect(names.has("@elizaos/plugin-agent-orchestrator")).toBe(true);
+    expect(names.has("@elizaos/core")).toBe(false);
+    expect(names.has("@elizaos/plugin-core")).toBe(false);
+  });
+
   it("lets ELIZA_AGENT_ORCHESTRATOR=false override coding-agent defaults", () => {
     process.env.ELIZA_AGENT_ORCHESTRATOR = "false";
     process.env.ELIZA_DEFAULT_AGENT_TYPE = "opencode";

--- a/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
@@ -355,6 +355,43 @@ describe("app plugin compatibility routes", () => {
     expect(drift.plugins[0]?.drift_flags).not.toContain("entries_vs_allowlist");
   });
 
+  it("keeps a canonical disabled entry disabled when the runtime plugin is loaded", () => {
+    currentConfig = {
+      env: {},
+      plugins: {
+        allow: [],
+        entries: {
+          "google-workspace": { enabled: false },
+        },
+      },
+    };
+    const googleEntry = {
+      id: "google",
+      name: "Google Workspace",
+      npmName: "@elizaos/plugin-google-workspace",
+      description: "",
+      tags: [],
+      kind: "connector",
+      subtype: "email",
+      config: {},
+      render: {},
+      resources: {},
+      version: "1.0.0",
+    };
+    mocks.loadRegistry.mockReturnValue({
+      all: [googleEntry],
+      byId: new Map([["google", googleEntry]]),
+    });
+
+    const response = buildPluginListResponse({
+      plugins: [{ name: "google" }],
+    } as never);
+
+    expect(response.plugins.find((plugin) => plugin.id === "google")).toEqual(
+      expect.objectContaining({ enabled: false, isActive: true }),
+    );
+  });
+
   it("replaces a stale compatibility alias with the canonical package on enable", () => {
     currentConfig = {
       env: {},

--- a/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises the app-core compatibility routes against persisted plugin state,
+ * including the invariants shared with the canonical core toggle surface.
+ */
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -77,6 +82,7 @@ vi.mock("@elizaos/vault", () => ({
 }));
 
 import {
+  analyzePluginStateDrift,
   buildPluginListResponse,
   handlePluginsCompatRoutes,
   persistCompatPluginMutation,
@@ -219,6 +225,7 @@ describe("app plugin compatibility routes", () => {
 
     expect(result.status).toBe(200);
     expect(savedConfig?.plugins).toEqual({
+      allow: ["@elizaos/plugin-discord"],
       entries: {
         discord: {
           enabled: true,
@@ -228,6 +235,155 @@ describe("app plugin compatibility routes", () => {
     expect(savedConfig?.connectors).toEqual({
       discord: {
         enabled: true,
+      },
+    });
+  });
+
+  it("removes every plugin alias from the allowlist when disabling", () => {
+    currentConfig = {
+      env: {},
+      plugins: {
+        allow: ["discord", "@elizaos/plugin-discord", "@elizaos/plugin-openai"],
+        entries: {
+          discord: { enabled: true },
+        },
+      },
+    };
+
+    const result = persistCompatPluginMutation(
+      "discord",
+      { enabled: false },
+      makePlugin(),
+    );
+
+    expect(result.status).toBe(200);
+    expect(savedConfig?.plugins).toEqual({
+      allow: ["@elizaos/plugin-openai"],
+      entries: {
+        discord: {
+          enabled: false,
+        },
+      },
+    });
+    expect(savedConfig?.connectors).toEqual({
+      discord: {
+        enabled: false,
+      },
+    });
+  });
+
+  it("keeps app plugin entries and the canonical allowlist aligned", () => {
+    const personalAssistant = makePlugin({
+      id: "personal-assistant",
+      name: "Personal Assistant",
+      category: "app",
+      npmName: "@elizaos/plugin-personal-assistant",
+    });
+    const result = persistCompatPluginMutation(
+      "personal-assistant",
+      { enabled: true },
+      personalAssistant,
+    );
+
+    expect(result.status).toBe(200);
+    expect(savedConfig?.plugins).toEqual({
+      allow: ["@elizaos/plugin-personal-assistant"],
+      entries: {
+        "personal-assistant": {
+          enabled: true,
+        },
+      },
+    });
+    expect(savedConfig?.connectors).toBeUndefined();
+
+    const drift = analyzePluginStateDrift(
+      [{ ...personalAssistant, enabled: true }],
+      savedConfig ?? {},
+      { "personal-assistant": { enabled: true } },
+      new Set(["@elizaos/plugin-personal-assistant"]),
+    );
+    expect(drift.plugins[0]?.drift_flags).not.toContain("entries_vs_allowlist");
+  });
+
+  it("canonicalizes mismatched runtime and package identities when disabling", () => {
+    currentConfig = {
+      env: {},
+      plugins: {
+        allow: [
+          "google",
+          "@elizaos/plugin-google-workspace",
+          "@elizaos/plugin-openai",
+        ],
+        entries: {
+          google: { enabled: true },
+          "google-workspace": { enabled: true },
+        },
+      },
+    };
+    const google = makePlugin({
+      id: "google",
+      name: "Google Workspace",
+      category: "feature",
+      npmName: "@elizaos/plugin-google-workspace",
+      enabled: false,
+    });
+
+    const result = persistCompatPluginMutation(
+      "google",
+      { enabled: false },
+      google,
+    );
+
+    expect(result.status).toBe(200);
+    expect(savedConfig?.plugins).toEqual({
+      allow: ["@elizaos/plugin-openai"],
+      entries: {
+        "google-workspace": { enabled: false },
+      },
+    });
+
+    const savedPlugins = savedConfig?.plugins as {
+      allow: string[];
+      entries: Record<string, { enabled?: unknown }>;
+    };
+    const drift = analyzePluginStateDrift(
+      [google],
+      {},
+      savedPlugins.entries,
+      new Set(savedPlugins.allow),
+    );
+    expect(drift.plugins[0]?.drift_flags).not.toContain("entries_vs_allowlist");
+  });
+
+  it("replaces a stale compatibility alias with the canonical package on enable", () => {
+    currentConfig = {
+      env: {},
+      plugins: {
+        allow: ["google", "@elizaos/plugin-openai"],
+        entries: {
+          google: { enabled: false },
+        },
+      },
+    };
+    const google = makePlugin({
+      id: "google",
+      name: "Google Workspace",
+      category: "feature",
+      npmName: "@elizaos/plugin-google-workspace",
+      enabled: true,
+    });
+
+    const result = persistCompatPluginMutation(
+      "google",
+      { enabled: true },
+      google,
+    );
+
+    expect(result.status).toBe(200);
+    expect(savedConfig?.plugins).toEqual({
+      allow: ["@elizaos/plugin-openai", "@elizaos/plugin-google-workspace"],
+      entries: {
+        "google-workspace": { enabled: true },
       },
     });
   });

--- a/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
@@ -388,6 +388,54 @@ describe("app plugin compatibility routes", () => {
     });
   });
 
+  it("canonicalizes legacy app-package identities in both directions", () => {
+    currentConfig = {
+      env: {},
+      plugins: {
+        allow: ["log-viewer", "@elizaos/plugin-openai"],
+        entries: {
+          "log-viewer": { enabled: false },
+        },
+      },
+    };
+    const logViewer = makePlugin({
+      id: "log-viewer",
+      name: "Log Viewer",
+      category: "app",
+      npmName: "@elizaos/app-log-viewer",
+      enabled: false,
+    });
+
+    const enabledResult = persistCompatPluginMutation(
+      "log-viewer",
+      { enabled: true },
+      logViewer,
+    );
+
+    expect(enabledResult.status).toBe(200);
+    expect(savedConfig?.plugins).toEqual({
+      allow: ["@elizaos/plugin-openai", "@elizaos/app-log-viewer"],
+      entries: {
+        "app-log-viewer": { enabled: true },
+      },
+    });
+
+    currentConfig = savedConfig ?? {};
+    const disabledResult = persistCompatPluginMutation(
+      "log-viewer",
+      { enabled: false },
+      logViewer,
+    );
+
+    expect(disabledResult.status).toBe(200);
+    expect(savedConfig?.plugins).toEqual({
+      allow: ["@elizaos/plugin-openai"],
+      entries: {
+        "app-log-viewer": { enabled: false },
+      },
+    });
+  });
+
   it("does not mark a plugin active from unrelated loaded-name substrings", () => {
     const discordEntry = {
       id: "discord",

--- a/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
@@ -425,6 +425,55 @@ describe("app plugin compatibility routes", () => {
     });
   });
 
+  it("falls back to the registry id for non-plugin package metadata", () => {
+    currentConfig = {
+      env: {},
+      plugins: {
+        allow: ["@elizaos/core"],
+        entries: {
+          core: { enabled: false },
+        },
+      },
+    };
+    const orchestrator = makePlugin({
+      id: "agent-orchestrator",
+      name: "Agent Orchestrator",
+      category: "feature",
+      npmName: "@elizaos/core",
+      enabled: true,
+    });
+
+    const result = persistCompatPluginMutation(
+      "agent-orchestrator",
+      { enabled: true },
+      orchestrator,
+    );
+
+    expect(result.status).toBe(200);
+    expect(savedConfig?.plugins).toEqual({
+      allow: ["agent-orchestrator"],
+      entries: {
+        "agent-orchestrator": { enabled: true },
+      },
+    });
+
+    currentConfig = clone(savedConfig ?? {});
+    savedConfig = undefined;
+    const disabled = persistCompatPluginMutation(
+      "agent-orchestrator",
+      { enabled: false },
+      orchestrator,
+    );
+
+    expect(disabled.status).toBe(200);
+    expect(savedConfig?.plugins).toEqual({
+      allow: [],
+      entries: {
+        "agent-orchestrator": { enabled: false },
+      },
+    });
+  });
+
   it("canonicalizes legacy app-package identities in both directions", () => {
     currentConfig = {
       env: {},

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -1266,10 +1266,12 @@ export function buildPluginListResponse(runtime: AgentRuntime | null): {
     const existing = plugins.get(pluginId);
     if (existing) {
       existing.isActive = true;
-      if (
-        existing.enabled !== true &&
-        configEntries[pluginId]?.enabled == null
-      ) {
+      const persistedEnabled = readPluginEntryEnabled(
+        pluginId,
+        existing.npmName ?? pluginName,
+        configEntries,
+      );
+      if (existing.enabled !== true && persistedEnabled === undefined) {
         existing.enabled = true;
       }
       if (!existing.version) {
@@ -1287,9 +1289,7 @@ export function buildPluginListResponse(runtime: AgentRuntime | null): {
         "Loaded runtime plugin discovered without manifest metadata.",
       tags: [],
       enabled:
-        typeof configEntries[pluginId]?.enabled === "boolean"
-          ? Boolean(configEntries[pluginId]?.enabled)
-          : true,
+        readPluginEntryEnabled(pluginId, pluginName, configEntries) ?? true,
       configured: true,
       envKey: null,
       category: "feature",

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -546,7 +546,21 @@ function shortPluginIdFromNpmName(npmName: string | null): string | null {
   if (npmName.startsWith("@elizaos/plugin-")) {
     return npmName.slice("@elizaos/plugin-".length);
   }
+  // First-party libraries can describe bundled features, but only plugin/app
+  // packages are runtime identities; the registry id owns every other case.
+  if (npmName.startsWith("@elizaos/")) {
+    return null;
+  }
   return normalizePluginId(npmName);
+}
+
+function canonicalPluginPackageName(
+  pluginId: string,
+  npmName: string | undefined,
+): string {
+  return shortPluginIdFromNpmName(npmName ?? null)
+    ? (npmName ?? pluginId)
+    : pluginId;
 }
 
 function canonicalPluginEntryId(
@@ -581,17 +595,22 @@ function writePluginAllowListEnabled(
   config.plugins.allow ??= [];
 
   const shortNpmId = shortPluginIdFromNpmName(npmName ?? null);
+  const canonicalPackageName = canonicalPluginPackageName(pluginId, npmName);
   const canonicalAliases = new Set(
-    [npmName, shortNpmId ?? (npmName ? undefined : pluginId)].filter(
+    [canonicalPackageName, shortNpmId].filter(
       (value): value is string => typeof value === "string" && value.length > 0,
     ),
   );
-  const staleCompatibilityAlias =
-    shortNpmId && pluginId !== shortNpmId ? pluginId : null;
+  const staleAliases = new Set(
+    [
+      shortNpmId && pluginId !== shortNpmId ? pluginId : null,
+      npmName && npmName !== canonicalPackageName ? npmName : null,
+    ].filter((value): value is string => value !== null),
+  );
 
-  if (staleCompatibilityAlias) {
+  if (staleAliases.size > 0) {
     config.plugins.allow = config.plugins.allow.filter(
-      (candidate) => candidate !== staleCompatibilityAlias,
+      (candidate) => !staleAliases.has(candidate),
     );
   }
 
@@ -599,7 +618,7 @@ function writePluginAllowListEnabled(
     if (
       !config.plugins.allow.some((candidate) => canonicalAliases.has(candidate))
     ) {
-      config.plugins.allow.push(npmName ?? pluginId);
+      config.plugins.allow.push(canonicalPackageName);
     }
     return;
   }
@@ -623,6 +642,10 @@ export function analyzePluginStateDrift(
         ? plugin.npmName
         : null;
     const shortId = shortPluginIdFromNpmName(npmName) ?? pluginId;
+    const canonicalPackageName = canonicalPluginPackageName(
+      pluginId,
+      npmName ?? undefined,
+    );
     const uiEnabled = Boolean(plugin.enabled);
     const compatEnabled =
       category === "connector"
@@ -643,7 +666,7 @@ export function analyzePluginStateDrift(
     const enabledAllowList =
       allowList === null || npmName == null
         ? null
-        : allowList.has(npmName) || allowList.has(shortId);
+        : allowList.has(canonicalPackageName) || allowList.has(shortId);
     const isActive = Boolean(plugin.isActive);
     const driftFlags: PluginDriftFlag[] = [];
 
@@ -878,7 +901,10 @@ async function applyCompatRuntimeMutation(options: {
       previousConfig,
       nextConfig,
       changedPluginId: pluginId,
-      changedPluginPackage: plugin.npmName,
+      changedPluginPackage: canonicalPluginPackageName(
+        pluginId,
+        plugin.npmName,
+      ),
       config:
         body.config &&
         typeof body.config === "object" &&
@@ -1401,19 +1427,30 @@ export function persistCompatPluginMutation(
   config.plugins ??= {};
   config.plugins.entries ??= {};
   const canonicalEntryId = canonicalPluginEntryId(pluginId, plugin.npmName);
+  const npmDerivedEntryId = plugin.npmName
+    ? normalizePluginId(plugin.npmName)
+    : null;
   const compatibilityEntry = config.plugins.entries[pluginId] as
     | Record<string, unknown>
     | undefined;
+  const npmDerivedEntry = npmDerivedEntryId
+    ? (config.plugins.entries[npmDerivedEntryId] as
+        | Record<string, unknown>
+        | undefined)
+    : undefined;
   const canonicalEntry = config.plugins.entries[canonicalEntryId] as
     | Record<string, unknown>
     | undefined;
   const pluginEntry = {
     ...(compatibilityEntry ?? {}),
+    ...(npmDerivedEntry ?? {}),
     ...(canonicalEntry ?? {}),
   };
   config.plugins.entries[canonicalEntryId] = pluginEntry;
-  if (canonicalEntryId !== pluginId) {
-    delete config.plugins.entries[pluginId];
+  for (const alias of new Set([pluginId, npmDerivedEntryId])) {
+    if (alias && alias !== canonicalEntryId) {
+      delete config.plugins.entries[alias];
+    }
   }
 
   if (typeof body.enabled === "boolean") {

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -1,15 +1,13 @@
+/**
+ * Compatibility routes that expose plugin configuration through the app-core
+ * HTTP surface while keeping every persisted enablement model synchronized.
+ */
+
 import fs from "node:fs";
 import type http from "node:http";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-// Consolidated from packages/app-core/src/api/plugins-routes.ts.
-// Moved from packages/app-core/src/api/plugins-routes.ts into the
-// @elizaos/plugin-registry plugin. Both agent-internal helpers
-// (@elizaos/agent) and app-core-internal helpers (@elizaos/app-core) are
-// imported through their respective public package surfaces; no more
-// `../registry`, `../services/*`, `./auth`, `./compat-route-shared`, or
-// `./response` cross-package deep imports.
 import {
   type AdvancedCapabilityPluginId,
   applyPluginRuntimeMutation,
@@ -513,10 +511,11 @@ function resolvePersistedPluginEnabled(
   configEntries: Record<string, { enabled?: unknown }>,
   config: Record<string, unknown>,
 ): boolean | undefined {
-  const pluginEnabled =
-    typeof configEntries[pluginId]?.enabled === "boolean"
-      ? Boolean(configEntries[pluginId]?.enabled)
-      : undefined;
+  const pluginEnabled = readPluginEntryEnabled(
+    pluginId,
+    npmName,
+    configEntries,
+  );
 
   if (category === "connector") {
     const connectorEnabled = readCompatSectionEnabled(
@@ -550,6 +549,66 @@ function shortPluginIdFromNpmName(npmName: string | null): string | null {
   return normalizePluginId(npmName);
 }
 
+function canonicalPluginEntryId(
+  pluginId: string,
+  npmName: string | undefined,
+): string {
+  return shortPluginIdFromNpmName(npmName ?? null) ?? pluginId;
+}
+
+function readPluginEntryEnabled(
+  pluginId: string,
+  npmName: string | undefined,
+  configEntries: Record<string, { enabled?: unknown }>,
+): boolean | undefined {
+  const canonicalId = canonicalPluginEntryId(pluginId, npmName);
+  const canonicalEnabled = configEntries[canonicalId]?.enabled;
+  if (typeof canonicalEnabled === "boolean") return canonicalEnabled;
+
+  const compatibilityEnabled = configEntries[pluginId]?.enabled;
+  return typeof compatibilityEnabled === "boolean"
+    ? compatibilityEnabled
+    : undefined;
+}
+
+function writePluginAllowListEnabled(
+  config: ReturnType<typeof loadElizaConfig>,
+  pluginId: string,
+  npmName: string | undefined,
+  enabled: boolean,
+): void {
+  config.plugins ??= {};
+  config.plugins.allow ??= [];
+
+  const shortNpmId = shortPluginIdFromNpmName(npmName ?? null);
+  const canonicalAliases = new Set(
+    [npmName, shortNpmId ?? (npmName ? undefined : pluginId)].filter(
+      (value): value is string => typeof value === "string" && value.length > 0,
+    ),
+  );
+  const staleCompatibilityAlias =
+    shortNpmId && pluginId !== shortNpmId ? pluginId : null;
+
+  if (staleCompatibilityAlias) {
+    config.plugins.allow = config.plugins.allow.filter(
+      (candidate) => candidate !== staleCompatibilityAlias,
+    );
+  }
+
+  if (enabled) {
+    if (
+      !config.plugins.allow.some((candidate) => canonicalAliases.has(candidate))
+    ) {
+      config.plugins.allow.push(npmName ?? pluginId);
+    }
+    return;
+  }
+
+  config.plugins.allow = config.plugins.allow.filter(
+    (candidate) => !canonicalAliases.has(candidate),
+  );
+}
+
 export function analyzePluginStateDrift(
   pluginList: CompatPluginRecord[],
   configRecord: Record<string, unknown>,
@@ -576,10 +635,11 @@ export function analyzePluginStateDrift(
             ),
           )
         : undefined;
-    const entryEnabled =
-      typeof configEntries[pluginId]?.enabled === "boolean"
-        ? Boolean(configEntries[pluginId]?.enabled)
-        : undefined;
+    const entryEnabled = readPluginEntryEnabled(
+      pluginId,
+      npmName ?? undefined,
+      configEntries,
+    );
     const enabledAllowList =
       allowList === null || npmName == null
         ? null
@@ -705,12 +765,10 @@ function maybeLogPluginStateDrift(report: PluginDriftDiagnosticsReport): void {
 
 // ── Enabled-state drift reconciliation ────────────────────────────────
 //
-// The write path (persistCompatPluginMutation) always updates both
-// plugins.entries[id].enabled AND the compat connector/streaming section.
-// However drift can occur if the config file is edited externally or a
-// migration only touched one location.  This pass detects any mismatch
-// and re-synchronises the compat section from plugins.entries, which is
-// the canonical source for the Settings UI.
+// The write path keeps plugins.entries, plugins.allow, and any connector
+// compatibility section aligned. External config edits can still split those
+// models, so this pass restores the Settings-owned compatibility section from
+// the canonical entries state.
 //
 // Runs once per process on the first buildPluginListResponse() call.
 
@@ -1342,14 +1400,25 @@ export function persistCompatPluginMutation(
   const configRecord = config as Record<string, unknown>;
   config.plugins ??= {};
   config.plugins.entries ??= {};
-  config.plugins.entries[pluginId] ??= {};
-  const pluginEntry = config.plugins.entries[pluginId] as Record<
-    string,
-    unknown
-  >;
+  const canonicalEntryId = canonicalPluginEntryId(pluginId, plugin.npmName);
+  const compatibilityEntry = config.plugins.entries[pluginId] as
+    | Record<string, unknown>
+    | undefined;
+  const canonicalEntry = config.plugins.entries[canonicalEntryId] as
+    | Record<string, unknown>
+    | undefined;
+  const pluginEntry = {
+    ...(compatibilityEntry ?? {}),
+    ...(canonicalEntry ?? {}),
+  };
+  config.plugins.entries[canonicalEntryId] = pluginEntry;
+  if (canonicalEntryId !== pluginId) {
+    delete config.plugins.entries[pluginId];
+  }
 
   if (typeof body.enabled === "boolean") {
     pluginEntry.enabled = body.enabled;
+    writePluginAllowListEnabled(config, pluginId, plugin.npmName, body.enabled);
 
     if (CAPABILITY_FEATURE_IDS.has(pluginId)) {
       config.features ??= {};


### PR DESCRIPTION
Closes #18283

# Summary

Fresh native-launch QA found four related registry consistency defects:

- the app compatibility mutation route updated `plugins.entries` and connector state without updating `plugins.allow`, so Settings and runtime could disagree about whether a plugin was enabled;
- runtime names already prefixed with `plugin-` were expanded again, making real workspace view bundles unavailable;
- after a legacy ID such as `google` was canonicalized to `google-workspace`, loaded-runtime reconciliation still read only the legacy entry and could flip a canonically disabled plugin back to enabled;
- the visible Agent Orchestrator registry record names the core library as metadata, so generic npm-derived canonicalization persisted and loaded core instead of the standalone orchestrator.

This change keeps every persisted enablement model aligned, resolves source-checkout view bundles from the current workspace before any global/install cache, preserves canonical disabled state even when a dependency plugin is loaded, and keeps registry IDs authoritative when first-party library metadata is not a plugin package.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e36490725244b8cc9a005ecefe3379987315a633:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: self-reported

# Implementation

- Enable/disable writes synchronize `plugins.entries`, `plugins.allow`, and connector compatibility state while preserving unrelated allowlist entries.
- Mismatched identities such as `google` / `@elizaos/plugin-google-workspace` migrate to the canonical `google-workspace` entry and remove stale aliases.
- Loaded-runtime reconciliation reads that same canonical entry, so a loaded-but-user-disabled dependency remains `enabled: false`.
- View package resolution recognizes prefixed runtime names and prefers the checked-out workspace bundle before Bun/global package resolution.
- Legacy `@elizaos/app-*` identities are covered in both enable and disable directions.
- First-party library metadata such as `@elizaos/core` falls back to the registry ID for persisted entries, allow-list state, drift analysis, and live apply; stale library-derived aliases are removed.

# Testing

Earlier exact object (before the current clean rebase):

- Base: `e36490725244b8cc9a005ecefe3379987315a633`
- Head: `973cdfbdc6d77dc762c36688afb4a40613695cdc`
- Tree: `e2675add9162aca76e36c0b8026598f74e1e0752`
- Three focused commits only; unrelated #18299 smoke-test maintenance was removed.

Completed proof:

- Plugin Registry focused tests: 21/21 passed, including canonical disabled + runtime-loaded Google Workspace.
- Agent view package-resolution tests: 7/7 passed.
- Plugin Registry and Agent typechecks passed.
- Exact-path Biome and `git diff --check` passed.
- The exact three-patch delta was also validated in the current-base consolidated tree: `bun run verify` passed 348/348 Turbo tasks plus all trailing audits.
- A real isolated current-head boot reached ready, registered Personal Assistant, loaded Google Workspace as its dependency, initialized Health, and built the Health view from this workspace (9,282 bytes; SHA-256 `a5cca2dc2cf0b20595ef39148d63c5d7a5a8c413662695388a0c00c7a64ca322`).

Current canonical publication:

- Head: `ccda50543a0657c87cbba2ee02fec21cddfc9ddb`, retaining the reviewed `develop@f492da5a02ec38916f3f9b8311fdb59c98cb5186` base while the exact `9294851…` source/runtime freeze is active.
- The prior three product commits are unchanged; the fourth commit is the narrow Agent Orchestrator registry-identity repair.
- Exact focused lane: 3 files / 46 tests passed, including enable + disable persistence and the real `collectPluginNames` package resolution.
- The real collector resolves `agent-orchestrator` to `@elizaos/plugin-agent-orchestrator` and forbids both `@elizaos/core` and `@elizaos/plugin-core`.
- Filtered Agent + Plugin Registry Turbo typecheck passed 58/58 dependency-aware tasks; both exact package typechecks also passed after those dependency builds.
- All five changed paths passed Biome and `git diff --check`.
- [Prior publication receipt for the unchanged three-commit foundation](https://github.com/elizaOS/eliza/pull/18285#issuecomment-5250553235).

# Evidence Gate

<!-- evidence-head:ccda50543a0657c87cbba2ee02fec21cddfc9ddb -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI or layout changed; this packet repairs server-side persistence and package resolution.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI or layout changed; the applicable real artifact is the built Health bundle.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] [Earlier full launch and bundle proof for the unchanged registry foundation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18283-plugin-launch-backend-proof.json)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend implementation changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no action, prompt, provider, planner, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Earlier-head sanitized partial live proof JSON (`973cdf…`; unchanged launch/view foundation only, not relabeled as current repair proof)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/pr18285-exact-head-partial-live-proof-973cdf.json)
- [x] [Earlier manually reviewed launch evidence](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18283-plugin-launch-evidence.md)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixel or text rendering changed.

# Evidence Details

The earlier-head artifact truthfully records what completed and what did not; it covers the unchanged launch/view foundation and is not relabeled as proof of the new Agent Orchestrator repair. The real runtime reached ready and produced the current-workspace Health bundle; exact deterministic persistence and collector tests cover the current repair. The first isolated launch used a throwaway `HOME` without disabling the OS keychain, so macOS displayed a keychain prompt. It was canceled; the proof processes were stopped; the real keychain was not written; the user QA ports and long-running native app were untouched.

For safety, the earlier live proof does **not** claim responses that were not captured: `GET /api/plugins`, `GET /api/plugins/diagnostics`, `GET /api/views/health`, or HTTP delivery of the bundle. The deterministic regression tests cover the canonical disabled/runtime-loaded response directly.

# Known gaps / failures

- The four exact-head HTTP responses listed above were not captured before the safety stop.
- The remaining `active_but_disabled` diagnostic is expected: Google Workspace may be loaded as a dormant Personal Assistant dependency while the user has it disabled. This PR preserves that user choice and eliminates persistent entries/allowlist drift.
- No product/runtime failure is known on the current head. Optional activity-collector and iMessage permission warnings remain unrelated.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@e36490725244b8cc9a005ecefe3379987315a633:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [plugin-launch-registry]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@e36490725244b8cc9a005ecefe3379987315a633:packages/skills/skills/contribute-to-eliza"} -->

# Current-head P1 repair and evidence restamp provenance

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-ios]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->