### PR TITLE
fix(registry): synchronize plugins.allow on enable toggle and strip double plugin- prefix from view resolution

### DIFF
--- a/packages/agent/src/api/views-registry.package-resolution.test.ts
+++ b/packages/agent/src/api/views-registry.package-resolution.test.ts
@@ -35,6 +35,17 @@ describe("pluginPackageNameCandidates", () => {
       "@acme/plugin-custom",
     ]);
   });
+
+  it("strips a redundant plugin- prefix to avoid @elizaos/plugin-plugin-*", () => {
+    expect(pluginPackageNameCandidates("plugin-health")).toEqual([
+      "@elizaos/plugin-health",
+      "plugin-health",
+    ]);
+    expect(pluginPackageNameCandidates("plugin-browser")).toEqual([
+      "@elizaos/plugin-browser",
+      "plugin-browser",
+    ]);
+  });
 });
 
 describe("registerPluginViews package-dir resolution", () => {

--- a/packages/agent/src/api/views-registry.package-resolution.test.ts
+++ b/packages/agent/src/api/views-registry.package-resolution.test.ts
@@ -46,6 +46,13 @@ describe("pluginPackageNameCandidates", () => {
       "plugin-browser",
     ]);
   });
+
+  it("does not strip plugin- when it appears in the middle of a name", () => {
+    expect(pluginPackageNameCandidates("my-plugin-health")).toEqual([
+      "@elizaos/plugin-my-plugin-health",
+      "my-plugin-health",
+    ]);
+  });
 });
 
 describe("registerPluginViews package-dir resolution", () => {

--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -82,11 +82,19 @@ const VIEW_BUNDLE_WARNING_BYTES = 1024 * 1024;
  * (e.g. plugin "birdclaw" vs the `birdclaw` CLI on npm), and under Bun a
  * bare-name resolve can hit that package's install cache — registering the
  * view against a directory that isn't this plugin at all.
+ *
+ * Runtime names that already include the `plugin-` prefix (e.g. plugin-health)
+ * must not be double-prefixed into `@elizaos/plugin-plugin-health`. The
+ * prefix is stripped before canonicalisation so the real package resolves.
  */
 export function pluginPackageNameCandidates(pluginName: string): string[] {
-  return pluginName.startsWith("@")
-    ? [pluginName]
-    : [`@elizaos/plugin-${pluginName}`, pluginName];
+  if (pluginName.startsWith("@")) {
+    return [pluginName];
+  }
+  // Strip a leading "plugin-" so "plugin-health" resolves to
+  // "@elizaos/plugin-health", not "@elizaos/plugin-plugin-health".
+  const baseName = pluginName.replace(/^plugin-/, "");
+  return [`@elizaos/plugin-${baseName}`, pluginName];
 }
 
 /**

--- a/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
@@ -455,5 +455,40 @@ describe("app plugin compatibility routes", () => {
         "@elizaos/plugin-browser",
       ]);
     });
+
+    it("removes app- prefixed short aliases from @elizaos/app-* packages", () => {
+      currentConfig = {
+        env: {},
+        plugins: {
+          entries: {
+            "database-viewer": { enabled: true },
+          },
+          allow: [
+            "@elizaos/app-database-viewer",
+            "app-database-viewer",
+            "@elizaos/plugin-discord",
+          ],
+        },
+      };
+
+      const result = persistCompatPluginMutation(
+        "database-viewer",
+        { enabled: false },
+        makePlugin({
+          id: "database-viewer",
+          npmName: "@elizaos/app-database-viewer",
+          category: "app",
+        }) as never,
+      );
+
+      expect(result.status).toBe(200);
+      // The app- prefixed short alias must also be removed.
+      expect(
+        (savedConfig as Record<string, unknown>)?.plugins as Record<
+          string,
+          unknown
+        >,
+      ).toHaveProperty("allow", ["@elizaos/plugin-discord"]);
+    });
   });
 });

--- a/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
@@ -224,6 +224,7 @@ describe("app plugin compatibility routes", () => {
           enabled: true,
         },
       },
+      allow: ["@elizaos/plugin-discord"],
     });
     expect(savedConfig?.connectors).toEqual({
       discord: {
@@ -320,5 +321,139 @@ describe("app plugin compatibility routes", () => {
       "Invalid plugin path",
     );
     expect(mocks.saveElizaConfig).toHaveBeenCalledTimes(saveCallCount);
+  });
+
+  describe("persistCompatPluginMutation plugins.allow synchronization", () => {
+    it("adds npm name to plugins.allow when enabling a plugin", () => {
+      const result = persistCompatPluginMutation(
+        "personal-assistant",
+        { enabled: true },
+        makePlugin({
+          id: "personal-assistant",
+          npmName: "@elizaos/plugin-personal-assistant",
+          category: "feature",
+        }) as never,
+      );
+
+      expect(result.status).toBe(200);
+      expect(
+        (savedConfig as Record<string, unknown>)?.plugins as Record<
+          string,
+          unknown
+        >,
+      ).toHaveProperty("allow", [
+        "@elizaos/plugin-personal-assistant",
+      ]);
+    });
+
+    it("removes all aliases from plugins.allow when disabling", () => {
+      currentConfig = {
+        env: {},
+        plugins: {
+          entries: {
+            "personal-assistant": { enabled: true },
+          },
+          allow: [
+            "@elizaos/plugin-personal-assistant",
+            "personal-assistant",
+            "@elizaos/plugin-discord",
+          ],
+        },
+      };
+
+      const result = persistCompatPluginMutation(
+        "personal-assistant",
+        { enabled: false },
+        makePlugin({
+          id: "personal-assistant",
+          npmName: "@elizaos/plugin-personal-assistant",
+          category: "feature",
+        }) as never,
+      );
+
+      expect(result.status).toBe(200);
+      // Only the unrelated discord entry remains.
+      expect(
+        (savedConfig as Record<string, unknown>)?.plugins as Record<
+          string,
+          unknown
+        >,
+      ).toHaveProperty("allow", ["@elizaos/plugin-discord"]);
+    });
+
+    it("initialises plugins.allow as an array when absent", () => {
+      const result = persistCompatPluginMutation(
+        "discord",
+        { enabled: true },
+        makePlugin() as never,
+      );
+
+      expect(result.status).toBe(200);
+      expect(
+        (savedConfig as Record<string, unknown>)?.plugins as Record<
+          string,
+          unknown
+        >,
+      ).toHaveProperty("allow", ["@elizaos/plugin-discord"]);
+    });
+
+    it("does not duplicate entries on repeated enable", () => {
+      currentConfig = {
+        env: {},
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+          },
+          allow: ["@elizaos/plugin-discord"],
+        },
+      };
+
+      const result = persistCompatPluginMutation(
+        "discord",
+        { enabled: true },
+        makePlugin() as never,
+      );
+
+      expect(result.status).toBe(200);
+      expect(
+        (savedConfig as Record<string, unknown>)?.plugins as Record<
+          string,
+          unknown
+        >,
+      ).toHaveProperty("allow", ["@elizaos/plugin-discord"]);
+    });
+
+    it("preserves unrelated allowlist entries on disable", () => {
+      currentConfig = {
+        env: {},
+        plugins: {
+          entries: {
+            discord: { enabled: false },
+          },
+          allow: [
+            "@elizaos/plugin-discord",
+            "@elizaos/plugin-telegram",
+            "@elizaos/plugin-browser",
+          ],
+        },
+      };
+
+      const result = persistCompatPluginMutation(
+        "discord",
+        { enabled: false },
+        makePlugin() as never,
+      );
+
+      expect(result.status).toBe(200);
+      expect(
+        (savedConfig as Record<string, unknown>)?.plugins as Record<
+          string,
+          unknown
+        >,
+      ).toHaveProperty("allow", [
+        "@elizaos/plugin-telegram",
+        "@elizaos/plugin-browser",
+      ]);
+    });
   });
 });

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -438,6 +438,52 @@ function writeCompatSectionEnabled(
   parent[sectionKey] = section;
 }
 
+/**
+ * Synchronise `plugins.allow` with the enable toggle. On enable, the npm
+ * package name is added (the canonical form the allowlist loader expects).
+ * On disable, every alias — npm name, short id, and normalised id — is
+ * removed so drift does not persist under a secondary name. Unrelated
+ * allowlist entries are always preserved.
+ */
+function syncPluginsAllowlist(
+  config: Record<string, unknown>,
+  pluginId: string,
+  npmName: string | undefined,
+  enabled: boolean,
+): void {
+  const plugins = asRecord(config.plugins) ?? {};
+  const allow = Array.isArray(plugins.allow)
+    ? [...(plugins.allow as string[])]
+    : [];
+
+  // Every name form this plugin can appear under in the allowlist.
+  const aliases = new Set<string>();
+  aliases.add(pluginId);
+  aliases.add(normalizePluginId(pluginId));
+  if (typeof npmName === "string" && npmName.length > 0) {
+    aliases.add(npmName);
+    aliases.add(normalizePluginId(npmName));
+  }
+
+  if (enabled) {
+    // Add the canonical npm name if available, else the short id.
+    const canonical = npmName ?? pluginId;
+    if (!allow.some((entry) => aliases.has(entry))) {
+      allow.push(canonical);
+    }
+  } else {
+    // Remove every alias without touching unrelated entries.
+    for (let i = allow.length - 1; i >= 0; i--) {
+      if (aliases.has(allow[i])) {
+        allow.splice(i, 1);
+      }
+    }
+  }
+
+  plugins.allow = allow;
+  config.plugins = plugins;
+}
+
 function syncCompatConnectorConfigValues(
   config: Record<string, unknown>,
   pluginId: string,
@@ -1364,6 +1410,12 @@ export function persistCompatPluginMutation(
         body.enabled,
       );
     }
+
+    // Keep plugins.allow aligned with entries[pluginId].enabled so the
+    // drift check in analyzePluginStateDrift stays clean. The allowlist
+    // stores npm names (or short ids) — remove every known alias when
+    // disabling so drift does not persist under a secondary name.
+    syncPluginsAllowlist(config, pluginId, plugin.npmName, body.enabled);
   }
 
   if (body.config !== undefined) {

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -444,6 +444,12 @@ function writeCompatSectionEnabled(
  * On disable, every alias — npm name, short id, and normalised id — is
  * removed so drift does not persist under a secondary name. Unrelated
  * allowlist entries are always preserved.
+ *
+ * The alias set mirrors every form the drift detector checks: it tests
+ * `allowList.has(npmName) || allowList.has(shortId)` where `shortId` comes
+ * from {@link shortPluginIdFromNpmName}. For `@elizaos/app-*` packages that
+ * short id is `app-<name>`, so both that and the normalised id must be in
+ * the removal set or the entry survives and drift persists.
  */
 function syncPluginsAllowlist(
   config: Record<string, unknown>,
@@ -456,12 +462,16 @@ function syncPluginsAllowlist(
     ? [...(plugins.allow as string[])]
     : [];
 
-  // Every name form this plugin can appear under in the allowlist.
+  // Every name form this plugin can appear under in the allowlist. Uses the
+  // same derivation as shortPluginIdFromNpmName + normalizePluginId so the
+  // removal set is a superset of everything the drift detector checks.
   const aliases = new Set<string>();
   aliases.add(pluginId);
   aliases.add(normalizePluginId(pluginId));
   if (typeof npmName === "string" && npmName.length > 0) {
     aliases.add(npmName);
+    const shortId = shortPluginIdFromNpmName(npmName);
+    if (shortId) aliases.add(shortId);
     aliases.add(normalizePluginId(npmName));
   }
 


### PR DESCRIPTION
## Summary

Fixes #18283 — two plugin registry consistency defects exposed by a fresh native launch.

### Defect 1: Compatibility enable writes desynchronize `plugins.allow`

`persistCompatPluginMutation` (the compat-tier `PUT /api/plugins/:id` handler) updated `plugins.entries` and the `connectors` compat section but **not** `plugins.allow`. This caused `entries_vs_allowlist` drift: an enabled plugin (e.g. Personal Assistant) could report as enabled in Settings but disabled in the runtime allowlist model, disagreeing across surfaces.

**Fix:** Added `syncPluginsAllowlist()` — called inside the `body.enabled` branch of `persistCompatPluginMutation`. On enable, the npm package name is added to `plugins.allow`. On disable, every alias (npm name, short id, normalised id) is removed so drift does not persist under a secondary name. Unrelated allowlist entries are always preserved.

### Defect 2: Prefixed view names resolve to nonexistent `@elizaos/plugin-plugin-*`

`pluginPackageNameCandidates` in `views-registry.ts` prepended `@elizaos/plugin-` unconditionally. When a plugin's runtime name already includes the `plugin-` prefix (e.g. `plugin-health` — its `HEALTH_PLUGIN_NAME`), the function produced `@elizaos/plugin-plugin-health`, which does not exist. The view bundle was therefore unavailable.

**Fix:** Strip a leading `plugin-` prefix before canonicalisation: `"plugin-health"` → `"@elizaos/plugin-health"`. The bare name is still kept as a fallback candidate.

## Root cause analysis

**Defect 1:** The compat-tier handler (`handlePluginsCompatRoutes` → `persistCompatPluginMutation`) was written separately from the agent-tier handler (`handlePluginRoutes`). The agent-tier PUT handler at `plugin-routes.ts:965-977` explicitly syncs `plugins.allow`, but the compat-tier handler never gained that logic. Both handlers can be active in different deployment modes (agent vs app-core compat layer), so only one path writing `plugins.allow` creates drift whenever the compat handler is the one that processes the toggle.

**Defect 2:** `plugin-health` is the only first-party plugin whose runtime `name` includes the `plugin-` prefix — most use bare names (`"telegram"`, `"discord"`, `"blocker"`). The `pluginPackageNameCandidates` function was written for the common case and never accounted for names that already carry the prefix. The `resolveWorkspacePluginPackageDir` fallback also failed because the double-prefixed name didn't match any `plugins/` subdirectory.

## Changes

| File | Change |
|------|--------|
| `plugins/plugin-registry/src/api/app-plugins-routes.ts` | Added `syncPluginsAllowlist()` helper; called in `persistCompatPluginMutation` enable/disable branch |
| `plugins/plugin-registry/src/api/app-plugins-routes.test.ts` | 5 new tests: enable adds to allow, disable removes all aliases, init when absent, no-dedupe on repeated enable, preserve unrelated on disable. Updated existing connector mirror test to expect the now-synced allowlist. |
| `packages/agent/src/api/views-registry.ts` | `pluginPackageNameCandidates` strips leading `plugin-` before prefixing `@elizaos/plugin-` |
| `packages/agent/src/api/views-registry.package-resolution.test.ts` | New test case for `plugin-health` and `plugin-browser` prefix-stripping |

## Evidence

### Tests

```
✓ plugins/plugin-registry/src/api/app-plugins-routes.test.ts (12 tests) 15ms
  ✓ persistCompatPluginMutation plugins.allow synchronization > adds npm name to plugins.allow when enabling a plugin
  ✓ persistCompatPluginMutation plugins.allow synchronization > removes all aliases from plugins.allow when disabling
  ✓ persistCompatPluginMutation plugins.allow synchronization > initialises plugins.allow as an array when absent
  ✓ persistCompatPluginMutation plugins.allow synchronization > does not duplicate entries on repeated enable
  ✓ persistCompatPluginMutation plugins.allow synchronization > preserves unrelated allowlist entries on disable

✓ packages/agent/src/api/views-registry.package-resolution.test.ts (6 tests) 8ms
  ✓ pluginPackageNameCandidates > strips a redundant plugin- prefix to avoid @elizaos/plugin-plugin-*
```

### Typecheck

```
$ bun run --cwd plugins/plugin-registry typecheck  # clean
$ bun run --cwd packages/agent typecheck           # clean
```

## Acceptance criteria checklist

- [x] Compatibility enable and disable writes keep `plugins.entries`, `plugins.allow`, and connector compatibility state aligned
- [x] All known aliases for a disabled plugin are removed without disabling unrelated plugins
- [x] Runtime names already prefixed with `plugin-` resolve the real `@elizaos/plugin-*` workspace package
- [x] Focused tests cover both directions (enable/disable) and the exact `plugin-health` case

---

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza"} -->