### PR TITLE
test(app): deep-link connector expectation follows the per-connector settings pages

### DIFF
--- a/packages/app/src/deep-link-handler.test.ts
+++ b/packages/app/src/deep-link-handler.test.ts
@@ -101,13 +101,16 @@ describe("createDeepLinkHandler — top-level-surface navigation intents", () =>
     });
   });
 
-  it("maps the connectors deep path from a universal link to the Settings connectors section", () => {
+  it("maps the connectors deep path from a universal link to the per-connector Settings detail page", () => {
+    // Connectors nest a detail segment since the per-connector Settings pages
+    // (56cee4c21f0): the slug must survive into the subview so settings-route
+    // can open the connector's own page instead of the flat index.
     const { handle, dispatchNavigationIntent } = makeHandler();
     handle("https://eliza.app/settings/connectors/discord");
     expect(dispatchNavigationIntent).toHaveBeenCalledWith({
       viewId: "settings",
       viewPath: "/settings",
-      subview: "connectors",
+      subview: "connectors/discord",
     });
     expect(window.location.hash).toBe("");
   });


### PR DESCRIPTION
## What

Develop's Tests lane is red by exactly one assertion: `deep-link-handler.test.ts` still expects the pre-56cee4c21f0 flat `subview: "connectors"`, but that commit's per-connector Settings detail pages deliberately made deep links carry the slug (`connectors/discord`) — its own `settings-route.ts` consumes the nested form ("Only connectors may nest: #connectors/<connectorId>"). The handler is right; the expectation is stale.

Updated the expectation to the new contract with a comment pinning WHY the slug must survive.

## Verification

- `packages/app` deep-link suite: 13/13 (was 12/13 on develop — CI run 31370986165's only Tests failure).
- Biome clean.

# Evidence

<!-- evidence-head:f31d4405bce927e61f9127ff3275906552bce4ba -->
- Before screenshots: N/A - test-only change
- After screenshots: N/A - test-only change
- Walkthrough video: N/A - test-only change
- OCR review: N/A - test-only change
- Frontend console/network logs: N/A - test-only change
- Backend logs: CI run 31370986165 Tests failure log (the single failing assertion)
- Real-LLM trajectory: N/A - no model path
- Domain artifacts: N/A - deterministic unit suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
