### PR TITLE
fix(ci): bind release-electrobun assets to the canonical tag and release (#18272)

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -108,33 +108,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          ref: ${{ github.workflow_sha }}
           submodules: false
+          persist-credentials: false
 
-      - name: Determine version + env
+      - name: Resolve tag to peeled commit
         id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          if [[ -n "${{ inputs.tag }}" ]]; then
-            TAG="${{ inputs.tag }}"
-          elif [[ "${{ github.ref_type }}" == "tag" ]]; then
-            TAG="${{ github.ref_name }}"
-          else
-            echo "Manual branch dispatches must provide inputs.tag; refusing to derive a release tag from package.json." >&2
-            exit 1
-          fi
-          VERSION="${TAG#v}"
-          # canary for pre-release tags, stable for everything else
-          if [[ "$VERSION" == *"-"* ]]; then
-            BUILD_ENV="canary"
-          else
-            BUILD_ENV="stable"
-          fi
-          {
-            echo "tag=$TAG"
-            echo "version=$VERSION"
-            echo "env=$BUILD_ENV"
-            echo "source_sha=$GITHUB_SHA"
-          } >> "$GITHUB_OUTPUT"
-          echo "Release: $VERSION (tag: $TAG, env: $BUILD_ENV, sha: $GITHUB_SHA)"
+          node packages/scripts/electrobun-release-identity.mjs resolve \
+            --repository "$REPOSITORY" \
+            --input-tag "$INPUT_TAG" \
+            --ref-type "$REF_TYPE" \
+            --ref-name "$REF_NAME" \
+            --event-name "$EVENT_NAME" \
+            --event-sha "$GITHUB_SHA" \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Select desktop platform matrix
         id: desktop-matrix
@@ -174,10 +170,23 @@ jobs:
       run:
         shell: bash -euo pipefail {0}
     steps:
-      - name: Checkout
+      - name: Checkout tagged commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           submodules: false
+          ref: ${{ needs.prepare.outputs.source_sha }}
+
+      - name: Verify checkout matches tagged commit
+        env:
+          EXPECTED_SHA: ${{ needs.prepare.outputs.source_sha }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          CURRENT_SHA="$(git rev-parse HEAD)"
+          if [[ "$CURRENT_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Checkout HEAD $CURRENT_SHA does not match tagged commit $EXPECTED_SHA." >&2
+            exit 1
+          fi
+          echo "Verified: checked out commit $CURRENT_SHA matches tag $RELEASE_TAG"
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -329,10 +338,21 @@ jobs:
             Write-Host "Enabled Git long paths in global config."
           }
 
-      - name: Checkout
+      - name: Checkout tagged commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           submodules: false
+          ref: ${{ needs.prepare.outputs.source_sha }}
+
+      - name: Verify checkout matches tagged commit
+        env:
+          EXPECTED_SHA: ${{ needs.prepare.outputs.source_sha }}
+        run: |
+          CURRENT_SHA="$(git rev-parse HEAD)"
+          if [[ "$CURRENT_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Checkout HEAD $CURRENT_SHA does not match tagged commit $EXPECTED_SHA." >&2
+            exit 1
+          fi
 
       - name: Validate public desktop signing inputs
         env:
@@ -1558,10 +1578,11 @@ jobs:
           compression-level: 6
 
   release:
-    name: Create Release
+    name: Upload Release Assets
     if: >-
       ${{
         (inputs.platform == '' || inputs.platform == 'all') &&
+        !inputs.draft &&
         (github.event_name != 'workflow_call' || inputs.publish_release) &&
         (github.event_name != 'push' || needs.prepare.outputs.env != 'canary')
       }}
@@ -1572,8 +1593,27 @@ jobs:
       contents: write
       packages: write
     steps:
-      - name: Checkout
+      - name: Checkout tagged commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+
+      - name: Verify checkout matches tagged commit
+        env:
+          EXPECTED_SHA: ${{ needs.prepare.outputs.source_sha }}
+        run: |
+          CURRENT_SHA="$(git rev-parse HEAD)"
+          if [[ "$CURRENT_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Checkout HEAD $CURRENT_SHA does not match tagged commit $EXPECTED_SHA." >&2
+            exit 1
+          fi
+
+      - name: Checkout trusted release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
+          persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -1634,18 +1674,28 @@ jobs:
           sha256sum -- * > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
-        with:
-          tag_name: ${{ needs.prepare.outputs.tag }}
-          target_commitish: ${{ needs.prepare.outputs.source_sha }}
-          name: Eliza ${{ needs.prepare.outputs.tag }}
-          draft: ${{ inputs.draft || false }}
-          prerelease: ${{ contains(needs.prepare.outputs.version, '-') }}
-          generate_release_notes: true
-          files: release-files/*
+      - name: Reverify canonical tag and GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          EXPECTED_SHA: ${{ needs.prepare.outputs.source_sha }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          node .release-tooling/packages/scripts/electrobun-release-identity.mjs verify \
+            --repository "$REPOSITORY" \
+            --tag "$TAG" \
+            --expected-commit "$EXPECTED_SHA"
+
+      - name: Upload assets to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          # Never use --clobber here: it deletes an existing asset before the
+          # replacement upload, so a failed retry can destroy valid release
+          # material. Duplicate names fail closed for explicit reconciliation.
+          gh release upload "$TAG" release-files/*
 
       # Upload platform-prefixed update manifests + tarballs to the eliza
       # releases host so the Electrobun updater can discover them via the
@@ -1689,8 +1739,27 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout
+      - name: Checkout tagged commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+
+      - name: Verify checkout matches tagged commit
+        env:
+          EXPECTED_SHA: ${{ needs.prepare.outputs.source_sha }}
+        run: |
+          CURRENT_SHA="$(git rev-parse HEAD)"
+          if [[ "$CURRENT_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Checkout HEAD $CURRENT_SHA does not match tagged commit $EXPECTED_SHA." >&2
+            exit 1
+          fi
+
+      - name: Checkout trusted release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
+          persist-credentials: false
 
       - name: Generate channel manifest
         env:
@@ -1719,6 +1788,19 @@ jobs:
           echo "Channel manifest:"
           cat "latest-${CHANNEL}.json"
 
+      - name: Reverify canonical tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          EXPECTED_SHA: ${{ needs.prepare.outputs.source_sha }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          node .release-tooling/packages/scripts/electrobun-release-identity.mjs verify \
+            --repository "$REPOSITORY" \
+            --tag "$TAG" \
+            --expected-commit "$EXPECTED_SHA"
+
       - name: Attach channel manifest to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1726,11 +1808,7 @@ jobs:
           BUILD_ENV: ${{ needs.prepare.outputs.env }}
         run: |
           CHANNEL="${BUILD_ENV}"
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            echo "::warning::No GitHub release found for $TAG; skipping OTA manifest upload."
-            exit 0
-          fi
-          gh release upload "$TAG" "latest-${CHANNEL}.json" --clobber
+          gh release upload "$TAG" "latest-${CHANNEL}.json"
           echo "OTA manifest attached: latest-${CHANNEL}.json"
           echo "Update check URL: https://github.com/${{ github.repository }}/releases/download/${TAG}/latest-${CHANNEL}.json"
 

--- a/packages/docs/build-and-release.md
+++ b/packages/docs/build-and-release.md
@@ -51,6 +51,23 @@ package-owned scripts rather than independent GitHub Actions release graphs.
 This keeps store credentials and platform troubleshooting out of the npm
 transaction.
 
+### Desktop release lane (`release-electrobun.yml`)
+
+`.github/workflows/release-electrobun.yml` is the Electrobun desktop build lane.
+It is **tag-bound and upload-only**: it resolves the existing release tag to its
+peeled commit SHA, checks out that exact commit for every validation, build, and
+release step, and uploads assets to the canonical GitHub Release created by
+`release.yaml`. It does not create a missing tag or GitHub Release.
+
+The workflow rejects malformed or nonexistent tags before any build work begins.
+For tag-push events, it proves the push SHA resolves to the same tagged commit.
+The `release` and OTA jobs re-resolve the tag immediately before publication and
+require the canonical non-draft GitHub Release to name the same exact commit. A
+moved tag, missing release, conflicting release target, or duplicate asset name
+fails closed; the desktop lane never replaces an existing release asset. Manual
+dispatches with `draft: true` retain only their Actions build artifacts and do
+not mutate the public release or OTA channel.
+
 Useful entry points include:
 
 ```bash

--- a/packages/scripts/__tests__/release-electrobun-tag-binding.test.ts
+++ b/packages/scripts/__tests__/release-electrobun-tag-binding.test.ts
@@ -1,0 +1,567 @@
+/**
+ * Exercises Electrobun release identity through an ephemeral GitHub API and
+ * validates the workflow wiring that consumes it. The real HTTP boundary
+ * covers lightweight and annotated tags, drift, malformed input, canonical
+ * Release identity, and the upload-only publication contract.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import http, { type Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  ElectrobunReleaseIdentityError,
+  parseReleaseTag,
+  resolveElectrobunReleaseSource,
+  resolveGitHubTag,
+  selectReleaseTag,
+  verifyExistingElectrobunRelease,
+} from "../electrobun-release-identity.mjs";
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const workflowPath = path.join(
+  repoRoot,
+  ".github/workflows/release-electrobun.yml",
+);
+const workflowSource = fs.readFileSync(workflowPath, "utf8");
+const identityScript = path.join(
+  repoRoot,
+  "packages/scripts/electrobun-release-identity.mjs",
+);
+const COMMIT_A = "a".repeat(40);
+const COMMIT_B = "b".repeat(40);
+const TAG_OBJECT_A = "c".repeat(40);
+const TAG_OBJECT_B = "d".repeat(40);
+
+interface WorkflowStep {
+  name?: string;
+  env?: Record<string, string>;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string | number | boolean>;
+}
+
+interface WorkflowJob {
+  if?: string;
+  name?: string;
+  outputs?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+interface RouteResponse {
+  body: unknown;
+  status?: number;
+  raw?: boolean;
+}
+
+const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const servers: Server[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function requireJob(id: string): WorkflowJob {
+  const job = workflow.jobs?.[id];
+  if (!job) throw new Error(`Missing workflow job: ${id}`);
+  return job;
+}
+
+function requireStep(job: WorkflowJob, name: string): WorkflowStep {
+  const step = job.steps?.find((candidate) => candidate.name === name);
+  if (!step) throw new Error(`Missing workflow step: ${name}`);
+  return step;
+}
+
+async function startApi(routes: Record<string, RouteResponse>) {
+  const requests: Array<{
+    authorization: string | undefined;
+    method: string | undefined;
+    url: string | undefined;
+  }> = [];
+  const server = http.createServer((request, response) => {
+    requests.push({
+      authorization: request.headers.authorization,
+      method: request.method,
+      url: request.url,
+    });
+    const route = routes[request.url ?? ""];
+    if (!route) {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ message: "not found" }));
+      return;
+    }
+    response.writeHead(route.status ?? 200, {
+      "content-type": "application/json",
+    });
+    response.end(route.raw ? String(route.body) : JSON.stringify(route.body));
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Unable to bind GitHub fixture API");
+  }
+  return {
+    apiUrl: `http://127.0.0.1:${address.port}/api/`,
+    requests,
+  };
+}
+
+function tagRef(type: string, sha: string) {
+  return { ref: "refs/tags/v1.2.3", object: { type, sha } };
+}
+
+function release(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 71,
+    tag_name: "v1.2.3",
+    target_commitish: COMMIT_A,
+    draft: false,
+    prerelease: false,
+    ...overrides,
+  };
+}
+
+describe("Electrobun release tag validation", () => {
+  test.each([
+    ["v0.0.0", "stable", false],
+    ["v1.2.3", "stable", false],
+    ["v1.2.3-beta.0", "canary", true],
+    ["v1.2.3-rc.1+build.9", "canary", true],
+    ["v1.2.3+build.01", "stable", false],
+  ])("accepts strict tag %s", (tag, channel, prerelease) => {
+    expect(parseReleaseTag(tag)).toMatchObject({
+      tag,
+      version: tag.slice(1),
+      channel,
+      prerelease,
+    });
+  });
+
+  test.each([
+    "1.2.3",
+    "v01.2.3",
+    "v1.02.3",
+    "v1.2.03",
+    "v1.2",
+    "v1.2.3-01",
+    "v1.2.3-beta.01",
+    "v1.2.3-",
+    "v1.2.3+",
+    "v1.2.3;echo-pwned",
+  ])("rejects malformed tag %s", (tag) => {
+    try {
+      parseReleaseTag(tag);
+      throw new Error("Expected malformed tag to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElectrobunReleaseIdentityError);
+      expect((error as Error).message).toContain("Malformed release tag");
+      expect((error as Error).message.split("\n")).toHaveLength(1);
+    }
+  });
+
+  test("escapes control characters in invalid-tag diagnostics", () => {
+    try {
+      parseReleaseTag("v1.2.3\n::warning::pwned");
+      throw new Error("Expected malformed tag to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElectrobunReleaseIdentityError);
+      expect((error as Error).message).toContain("\\n::warning::pwned");
+      expect((error as Error).message.split("\n")).toHaveLength(1);
+    }
+  });
+
+  test("requires an explicit tag outside a tag ref", () => {
+    expect(() =>
+      selectReleaseTag({ inputTag: "", refType: "branch", refName: "develop" }),
+    ).toThrow("must provide an existing release tag");
+    expect(
+      selectReleaseTag({ inputTag: "", refType: "tag", refName: "v1.2.3" }),
+    ).toMatchObject({ tag: "v1.2.3" });
+  });
+});
+
+describe("Electrobun GitHub identity boundary", () => {
+  test("resolves a lightweight tag and binds a tag-push SHA", async () => {
+    const api = await startApi({
+      "/api/repos/elizaOS/eliza/git/ref/tags/v1.2.3": {
+        body: tagRef("commit", COMMIT_A),
+      },
+    });
+    const result = await resolveElectrobunReleaseSource({
+      apiUrl: api.apiUrl,
+      repository: "elizaOS/eliza",
+      inputTag: "",
+      refType: "tag",
+      refName: "v1.2.3",
+      eventName: "push",
+      eventSha: COMMIT_A,
+      token: "fixture-token",
+    });
+    expect(result).toMatchObject({
+      tag: "v1.2.3",
+      sourceSha: COMMIT_A,
+      peelDepth: 0,
+    });
+    expect(api.requests).toEqual([
+      {
+        authorization: "Bearer fixture-token",
+        method: "GET",
+        url: "/api/repos/elizaOS/eliza/git/ref/tags/v1.2.3",
+      },
+    ]);
+  });
+
+  test("recursively peels annotated tags to a commit", async () => {
+    const api = await startApi({
+      "/api/repos/elizaOS/eliza/git/ref/tags/v1.2.3": {
+        body: tagRef("tag", TAG_OBJECT_A),
+      },
+      [`/api/repos/elizaOS/eliza/git/tags/${TAG_OBJECT_A}`]: {
+        body: { object: { type: "tag", sha: TAG_OBJECT_B } },
+      },
+      [`/api/repos/elizaOS/eliza/git/tags/${TAG_OBJECT_B}`]: {
+        body: { object: { type: "commit", sha: COMMIT_A } },
+      },
+    });
+    await expect(
+      resolveGitHubTag({
+        apiUrl: api.apiUrl,
+        repository: "elizaOS/eliza",
+        tag: "v1.2.3",
+        token: "fixture-token",
+      }),
+    ).resolves.toEqual({ sourceSha: COMMIT_A, peelDepth: 2 });
+  });
+
+  test("fails closed when annotated tags form a cycle", async () => {
+    const api = await startApi({
+      "/api/repos/elizaOS/eliza/git/ref/tags/v1.2.3": {
+        body: tagRef("tag", TAG_OBJECT_A),
+      },
+      [`/api/repos/elizaOS/eliza/git/tags/${TAG_OBJECT_A}`]: {
+        body: { object: { type: "tag", sha: TAG_OBJECT_B } },
+      },
+      [`/api/repos/elizaOS/eliza/git/tags/${TAG_OBJECT_B}`]: {
+        body: { object: { type: "tag", sha: TAG_OBJECT_A } },
+      },
+    });
+    await expect(
+      resolveGitHubTag({
+        apiUrl: api.apiUrl,
+        repository: "elizaOS/eliza",
+        tag: "v1.2.3",
+        token: "fixture-token",
+      }),
+    ).rejects.toMatchObject({ kind: "conflict" });
+    expect(api.requests).toHaveLength(3);
+  });
+
+  test("rejects push mismatch, missing refs, malformed JSON, and non-commit targets", async () => {
+    const mismatchApi = await startApi({
+      "/api/repos/elizaOS/eliza/git/ref/tags/v1.2.3": {
+        body: tagRef("commit", COMMIT_A),
+      },
+    });
+    await expect(
+      resolveElectrobunReleaseSource({
+        apiUrl: mismatchApi.apiUrl,
+        repository: "elizaOS/eliza",
+        inputTag: "v1.2.3",
+        refType: "branch",
+        refName: "develop",
+        eventName: "push",
+        eventSha: COMMIT_B,
+        token: "fixture-token",
+      }),
+    ).rejects.toThrow("does not match peeled tag commit");
+
+    const missingApi = await startApi({});
+    try {
+      await resolveGitHubTag({
+        apiUrl: missingApi.apiUrl,
+        repository: "elizaOS/eliza",
+        tag: "v1.2.3",
+        token: "fixture-token",
+      });
+      throw new Error("Expected a missing tag to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElectrobunReleaseIdentityError);
+      expect((error as ElectrobunReleaseIdentityError).kind).toBe("not-found");
+      expect((error as ElectrobunReleaseIdentityError).status).toBe(404);
+    }
+
+    const malformedApi = await startApi({
+      "/api/repos/elizaOS/eliza/git/ref/tags/v1.2.3": {
+        body: "not-json",
+        raw: true,
+      },
+    });
+    await expect(
+      resolveGitHubTag({
+        apiUrl: malformedApi.apiUrl,
+        repository: "elizaOS/eliza",
+        tag: "v1.2.3",
+        token: "fixture-token",
+      }),
+    ).rejects.toMatchObject({ kind: "malformed-response" });
+
+    const treeApi = await startApi({
+      "/api/repos/elizaOS/eliza/git/ref/tags/v1.2.3": {
+        body: tagRef("tree", COMMIT_A),
+      },
+    });
+    await expect(
+      resolveGitHubTag({
+        apiUrl: treeApi.apiUrl,
+        repository: "elizaOS/eliza",
+        tag: "v1.2.3",
+        token: "fixture-token",
+      }),
+    ).rejects.toThrow("is not a commit");
+  });
+
+  test("preserves transport causes without exposing response bodies", async () => {
+    const cause = new Error("fixture socket closed");
+    try {
+      await resolveGitHubTag({
+        repository: "elizaOS/eliza",
+        tag: "v1.2.3",
+        token: "fixture-token",
+        fetchImpl: async () => {
+          throw cause;
+        },
+      });
+      throw new Error("Expected transport failure");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElectrobunReleaseIdentityError);
+      expect((error as ElectrobunReleaseIdentityError).kind).toBe("transport");
+      expect((error as Error).cause).toBe(cause);
+      expect((error as Error).message).not.toContain("fixture socket closed");
+    }
+  });
+
+  test("verifies the tag and canonical non-draft Release exact identity", async () => {
+    const api = await startApi({
+      "/api/repos/elizaOS/eliza/git/ref/tags/v1.2.3": {
+        body: tagRef("commit", COMMIT_A),
+      },
+      "/api/repos/elizaOS/eliza/releases/tags/v1.2.3": {
+        body: release(),
+      },
+    });
+    await expect(
+      verifyExistingElectrobunRelease({
+        apiUrl: api.apiUrl,
+        repository: "elizaOS/eliza",
+        tag: "v1.2.3",
+        expectedCommit: COMMIT_A,
+        token: "fixture-token",
+      }),
+    ).resolves.toEqual({
+      releaseId: 71,
+      sourceSha: COMMIT_A,
+      tag: "v1.2.3",
+      prerelease: false,
+    });
+  });
+
+  test("rejects tag drift before reading or mutating a Release", async () => {
+    const api = await startApi({
+      "/api/repos/elizaOS/eliza/git/ref/tags/v1.2.3": {
+        body: tagRef("commit", COMMIT_B),
+      },
+    });
+    await expect(
+      verifyExistingElectrobunRelease({
+        apiUrl: api.apiUrl,
+        repository: "elizaOS/eliza",
+        tag: "v1.2.3",
+        expectedCommit: COMMIT_A,
+        token: "fixture-token",
+      }),
+    ).rejects.toThrow(`moved from prepared commit ${COMMIT_A} to ${COMMIT_B}`);
+    expect(api.requests).toHaveLength(1);
+  });
+
+  test.each([
+    ["different target", { target_commitish: COMMIT_B }],
+    ["draft release", { draft: true }],
+    ["wrong prerelease state", { prerelease: true }],
+    ["wrong tag", { tag_name: "v1.2.4" }],
+  ])("rejects a canonical Release with %s", async (_name, overrides) => {
+    const api = await startApi({
+      "/api/repos/elizaOS/eliza/git/ref/tags/v1.2.3": {
+        body: tagRef("commit", COMMIT_A),
+      },
+      "/api/repos/elizaOS/eliza/releases/tags/v1.2.3": {
+        body: release(overrides),
+      },
+    });
+    await expect(
+      verifyExistingElectrobunRelease({
+        apiUrl: api.apiUrl,
+        repository: "elizaOS/eliza",
+        tag: "v1.2.3",
+        expectedCommit: COMMIT_A,
+        token: "fixture-token",
+      }),
+    ).rejects.toMatchObject({ kind: "conflict" });
+  });
+
+  test("CLI writes only validated source identity to GitHub output", async () => {
+    const api = await startApi({
+      "/api/repos/elizaOS/eliza/git/ref/tags/v1.2.3-beta.1": {
+        body: {
+          ref: "refs/tags/v1.2.3-beta.1",
+          object: { type: "commit", sha: COMMIT_A },
+        },
+      },
+    });
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "electrobun-identity-"));
+    roots.push(root);
+    const githubOutput = path.join(root, "github-output");
+    const processHandle = Bun.spawn(
+      [
+        "node",
+        identityScript,
+        "resolve",
+        "--repository",
+        "elizaOS/eliza",
+        "--input-tag",
+        "v1.2.3-beta.1",
+        "--ref-type",
+        "branch",
+        "--ref-name",
+        "develop",
+        "--event-name",
+        "workflow_dispatch",
+        "--event-sha",
+        COMMIT_B,
+        "--github-output",
+        githubOutput,
+      ],
+      {
+        env: {
+          ...process.env,
+          GH_TOKEN: "fixture-token",
+          GITHUB_API_URL: api.apiUrl,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      processHandle.exited,
+      new Response(processHandle.stdout).text(),
+      new Response(processHandle.stderr).text(),
+    ]);
+    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
+    expect(JSON.parse(stdout)).toMatchObject({
+      tag: "v1.2.3-beta.1",
+      sourceSha: COMMIT_A,
+      channel: "canary",
+    });
+    expect(fs.readFileSync(githubOutput, "utf8")).toBe(
+      `tag=v1.2.3-beta.1\nversion=1.2.3-beta.1\nenv=canary\nsource_sha=${COMMIT_A}\n`,
+    );
+  });
+});
+
+describe("release-electrobun workflow binding", () => {
+  test("prepare executes trusted identity tooling and exports its source SHA", () => {
+    const prepare = requireJob("prepare");
+    const checkout = requireStep(prepare, "Checkout");
+    const resolve = requireStep(prepare, "Resolve tag to peeled commit");
+    expect(checkout.with?.ref).toBe(`\${{ github.workflow_sha }}`);
+    expect(checkout.with?.["persist-credentials"]).toBe(false);
+    expect(resolve.run).toContain(
+      "node packages/scripts/electrobun-release-identity.mjs resolve",
+    );
+    expect(resolve.run).not.toMatch(/\$\{\{.*(?:inputs|github)\./);
+    expect(prepare.outputs?.source_sha).toBe(
+      `\${{ steps.version.outputs.source_sha }}`,
+    );
+  });
+
+  test.each(["validate-release", "build", "release", "ota-publish"])(
+    "%s checks out and verifies the exact prepared commit",
+    (jobId) => {
+      const job = requireJob(jobId);
+      const checkout = requireStep(job, "Checkout tagged commit");
+      const verify = requireStep(job, "Verify checkout matches tagged commit");
+      expect(checkout.with?.ref).toBe(
+        `\${{ needs.prepare.outputs.source_sha }}`,
+      );
+      expect(verify.env?.EXPECTED_SHA).toBe(
+        `\${{ needs.prepare.outputs.source_sha }}`,
+      );
+      expect(verify.run).toContain("git rev-parse HEAD");
+      expect(verify.run).not.toContain("${{");
+    },
+  );
+
+  test.each(["release", "ota-publish"])(
+    "%s reverifies tag and Release identity with trusted tooling",
+    (jobId) => {
+      const job = requireJob(jobId);
+      const tooling = requireStep(job, "Checkout trusted release tooling");
+      const verify = requireStep(
+        job,
+        "Reverify canonical tag and GitHub Release",
+      );
+      expect(tooling.with?.ref).toBe(`\${{ github.workflow_sha }}`);
+      expect(tooling.with?.["persist-credentials"]).toBe(false);
+      expect(verify.run).toContain(
+        ".release-tooling/packages/scripts/electrobun-release-identity.mjs verify",
+      );
+      expect(verify.env?.EXPECTED_SHA).toBe(
+        `\${{ needs.prepare.outputs.source_sha }}`,
+      );
+    },
+  );
+
+  test("public upload is non-draft, upload-only, and never clobbers assets", () => {
+    const releaseJob = requireJob("release");
+    const upload = requireStep(releaseJob, "Upload assets to GitHub Release");
+    expect(releaseJob.name).toBe("Upload Release Assets");
+    expect(releaseJob.if).toContain("!inputs.draft");
+    expect(upload.run).toContain("gh release upload");
+    expect(upload.run).not.toMatch(/gh release upload[^\n]*--clobber/);
+    expect(workflowSource).not.toContain("softprops/action-gh-release");
+  });
+
+  test("OTA publication fails closed and never replaces an existing manifest", () => {
+    const ota = requireJob("ota-publish");
+    const attach = requireStep(
+      ota,
+      "Attach channel manifest to GitHub Release",
+    );
+    expect(attach.run).toContain("gh release upload");
+    expect(attach.run).not.toMatch(/gh release upload[^\n]*--clobber/);
+    expect(attach.run).not.toContain("exit 0");
+  });
+
+  test("source binding never derives from the dispatch SHA", () => {
+    for (const line of workflowSource
+      .split("\n")
+      .filter((candidate) => candidate.includes("source_sha="))) {
+      expect(line).not.toContain("$GITHUB_SHA");
+    }
+  });
+});

--- a/packages/scripts/electrobun-release-identity.mjs
+++ b/packages/scripts/electrobun-release-identity.mjs
@@ -1,0 +1,424 @@
+/**
+ * Resolves the canonical Electrobun release tag and verifies its existing
+ * GitHub Release without creating or mutating either identity. The workflow
+ * invokes this boundary before builds and again immediately before uploads so
+ * a moved tag or conflicting release fails closed.
+ */
+
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+import { validateGitHubRepository } from "./lib/release-contract.mjs";
+
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const TAG_PATTERN =
+  /^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const MAX_TAG_PEEL_DEPTH = 8;
+
+export class ElectrobunReleaseIdentityError extends Error {
+  constructor(message, { kind, status, cause } = {}) {
+    super(message, cause ? { cause } : undefined);
+    this.name = "ElectrobunReleaseIdentityError";
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
+export function normalizeGitHubApiUrl(apiUrl) {
+  let parsed;
+  try {
+    parsed = new URL(apiUrl);
+  } catch (error) {
+    // error-policy:J2 retain the invalid GitHub endpoint as context
+    throw new ElectrobunReleaseIdentityError(
+      `Invalid GitHub API URL ${apiUrl}`,
+      { kind: "invalid-input", cause: error },
+    );
+  }
+  const loopback =
+    parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost";
+  if (
+    parsed.protocol !== "https:" &&
+    !(parsed.protocol === "http:" && loopback)
+  ) {
+    throw new ElectrobunReleaseIdentityError(
+      "GitHub API URL must use HTTPS (HTTP is allowed only on loopback)",
+      { kind: "invalid-input" },
+    );
+  }
+  if (parsed.username || parsed.password) {
+    throw new ElectrobunReleaseIdentityError(
+      "GitHub API URL must not contain credentials",
+      { kind: "invalid-input" },
+    );
+  }
+  parsed.hash = "";
+  parsed.search = "";
+  if (!parsed.pathname.endsWith("/")) parsed.pathname += "/";
+  return parsed.toString();
+}
+
+function statusKind(status) {
+  if (status === 401 || status === 403) return "authentication";
+  if (status === 404) return "not-found";
+  if (status === 409 || status === 422) return "conflict";
+  if (status === 429) return "throttling";
+  if (status >= 500) return "server";
+  return "unexpected-status";
+}
+
+async function requestGitHubJson(url, { token, fetchImpl = fetch }) {
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method: "GET",
+      redirect: "error",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+      },
+    });
+  } catch (error) {
+    // error-policy:J2 preserve the transport cause at the GitHub boundary
+    throw new ElectrobunReleaseIdentityError(
+      `GitHub transport failed for ${url}`,
+      { kind: "transport", cause: error },
+    );
+  }
+  if (!response.ok) {
+    throw new ElectrobunReleaseIdentityError(
+      `GitHub returned HTTP ${response.status} for ${url}`,
+      { kind: statusKind(response.status), status: response.status },
+    );
+  }
+  const source = await response.text();
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    // error-policy:J2 malformed success output cannot prove release identity
+    throw new ElectrobunReleaseIdentityError(
+      `GitHub returned malformed JSON for ${url}`,
+      { kind: "malformed-response", status: response.status, cause: error },
+    );
+  }
+}
+
+function repositoryPath(repository) {
+  const [owner, name] = validateGitHubRepository(repository).split("/");
+  return `repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+}
+
+function endpoint(apiUrl, repository, suffix) {
+  return new URL(
+    `${repositoryPath(repository)}/${suffix}`,
+    normalizeGitHubApiUrl(apiUrl),
+  ).toString();
+}
+
+function requireGitObject(value, context) {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    !value.object ||
+    typeof value.object !== "object" ||
+    Array.isArray(value.object) ||
+    typeof value.object.type !== "string" ||
+    typeof value.object.sha !== "string" ||
+    !COMMIT_SHA_PATTERN.test(value.object.sha)
+  ) {
+    throw new ElectrobunReleaseIdentityError(
+      `GitHub returned an invalid ${context} object`,
+      { kind: "malformed-response" },
+    );
+  }
+  return { type: value.object.type, sha: value.object.sha };
+}
+
+export function parseReleaseTag(tag) {
+  if (typeof tag !== "string") {
+    throw new ElectrobunReleaseIdentityError("Release tag must be a string", {
+      kind: "invalid-input",
+    });
+  }
+  const match = TAG_PATTERN.exec(tag);
+  if (!match) {
+    throw new ElectrobunReleaseIdentityError(
+      `Malformed release tag ${JSON.stringify(tag)}. Expected strict semver v<major>.<minor>.<patch> with optional prerelease/build suffix.`,
+      { kind: "invalid-input" },
+    );
+  }
+  const prerelease = match[4] ?? "";
+  for (const identifier of prerelease.split(".")) {
+    if (
+      /^[0-9]+$/.test(identifier) &&
+      identifier.length > 1 &&
+      identifier[0] === "0"
+    ) {
+      throw new ElectrobunReleaseIdentityError(
+        `Malformed release tag ${JSON.stringify(tag)}: numeric prerelease identifiers must not contain leading zeros.`,
+        { kind: "invalid-input" },
+      );
+    }
+  }
+  return {
+    tag,
+    version: tag.slice(1),
+    channel: prerelease ? "canary" : "stable",
+    prerelease: prerelease.length > 0,
+  };
+}
+
+export function selectReleaseTag({ inputTag, refType, refName }) {
+  const selected = inputTag || (refType === "tag" ? refName : "");
+  if (!selected) {
+    throw new ElectrobunReleaseIdentityError(
+      "Manual branch dispatches and reusable callers must provide an existing release tag",
+      { kind: "invalid-input" },
+    );
+  }
+  return parseReleaseTag(selected);
+}
+
+export async function resolveGitHubTag({
+  apiUrl = "https://api.github.com/",
+  repository,
+  tag,
+  token,
+  fetchImpl = fetch,
+}) {
+  if (typeof token !== "string" || token.length === 0) {
+    throw new ElectrobunReleaseIdentityError(
+      "GitHub tag resolution requires a token",
+      { kind: "invalid-input" },
+    );
+  }
+  parseReleaseTag(tag);
+  const ref = await requestGitHubJson(
+    endpoint(apiUrl, repository, `git/ref/tags/${encodeURIComponent(tag)}`),
+    { token, fetchImpl },
+  );
+  if (ref?.ref !== `refs/tags/${tag}`) {
+    throw new ElectrobunReleaseIdentityError(
+      `GitHub tag response did not identify refs/tags/${tag}`,
+      { kind: "malformed-response" },
+    );
+  }
+  let current = requireGitObject(ref, `tag reference ${tag}`);
+  const seenTagObjects = new Set();
+  let peelDepth = 0;
+  while (current.type === "tag") {
+    if (peelDepth >= MAX_TAG_PEEL_DEPTH || seenTagObjects.has(current.sha)) {
+      throw new ElectrobunReleaseIdentityError(
+        `Tag ${tag} did not resolve to a commit within ${MAX_TAG_PEEL_DEPTH} annotated tag objects`,
+        { kind: "conflict" },
+      );
+    }
+    seenTagObjects.add(current.sha);
+    const tagObject = await requestGitHubJson(
+      endpoint(apiUrl, repository, `git/tags/${current.sha}`),
+      { token, fetchImpl },
+    );
+    current = requireGitObject(tagObject, `annotated tag ${current.sha}`);
+    peelDepth += 1;
+  }
+  if (current.type !== "commit") {
+    throw new ElectrobunReleaseIdentityError(
+      `Resolved tag target type '${current.type}' is not a commit`,
+      { kind: "conflict" },
+    );
+  }
+  return { sourceSha: current.sha, peelDepth };
+}
+
+export async function resolveElectrobunReleaseSource({
+  apiUrl,
+  repository,
+  inputTag,
+  refType,
+  refName,
+  eventName,
+  eventSha,
+  token,
+  fetchImpl,
+}) {
+  const identity = selectReleaseTag({ inputTag, refType, refName });
+  const resolved = await resolveGitHubTag({
+    apiUrl,
+    repository,
+    tag: identity.tag,
+    token,
+    fetchImpl,
+  });
+  if (eventName === "push" && eventSha !== resolved.sourceSha) {
+    throw new ElectrobunReleaseIdentityError(
+      `Push event SHA ${eventSha} does not match peeled tag commit ${resolved.sourceSha}`,
+      { kind: "conflict" },
+    );
+  }
+  return { ...identity, ...resolved };
+}
+
+export async function verifyExistingElectrobunRelease({
+  apiUrl,
+  repository,
+  tag,
+  expectedCommit,
+  token,
+  fetchImpl,
+}) {
+  const identity = parseReleaseTag(tag);
+  if (!COMMIT_SHA_PATTERN.test(expectedCommit)) {
+    throw new ElectrobunReleaseIdentityError(
+      `Expected release commit '${expectedCommit}' is not a full commit SHA`,
+      { kind: "invalid-input" },
+    );
+  }
+  const resolved = await resolveGitHubTag({
+    apiUrl,
+    repository,
+    tag,
+    token,
+    fetchImpl,
+  });
+  if (resolved.sourceSha !== expectedCommit) {
+    throw new ElectrobunReleaseIdentityError(
+      `Release tag ${tag} moved from prepared commit ${expectedCommit} to ${resolved.sourceSha}`,
+      { kind: "conflict" },
+    );
+  }
+  const release = await requestGitHubJson(
+    endpoint(apiUrl, repository, `releases/tags/${encodeURIComponent(tag)}`),
+    { token, fetchImpl },
+  );
+  if (
+    !release ||
+    typeof release !== "object" ||
+    Array.isArray(release) ||
+    !Number.isSafeInteger(release.id) ||
+    release.id <= 0 ||
+    release.tag_name !== tag ||
+    release.target_commitish !== expectedCommit ||
+    release.draft !== false ||
+    release.prerelease !== identity.prerelease
+  ) {
+    throw new ElectrobunReleaseIdentityError(
+      `GitHub Release for ${tag} does not match prepared commit ${expectedCommit} and canonical publication state`,
+      { kind: "conflict" },
+    );
+  }
+  return {
+    releaseId: release.id,
+    sourceSha: resolved.sourceSha,
+    tag,
+    prerelease: identity.prerelease,
+  };
+}
+
+function parseCli(argv) {
+  const [command, ...tokens] = argv;
+  if (command !== "resolve" && command !== "verify") {
+    throw new ElectrobunReleaseIdentityError(
+      "Usage: electrobun-release-identity.mjs <resolve|verify> [options]",
+      { kind: "invalid-input" },
+    );
+  }
+  const options = Object.create(null);
+  for (let index = 0; index < tokens.length; index += 2) {
+    const flag = tokens[index];
+    const value = tokens[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      throw new ElectrobunReleaseIdentityError(
+        `Invalid CLI argument near '${flag ?? ""}'`,
+        { kind: "invalid-input" },
+      );
+    }
+    const key = flag.slice(2);
+    if (Object.hasOwn(options, key)) {
+      throw new ElectrobunReleaseIdentityError(
+        `Duplicate CLI option --${key}`,
+        { kind: "invalid-input" },
+      );
+    }
+    options[key] = value;
+  }
+  const allowed =
+    command === "resolve"
+      ? new Set([
+          "api-url",
+          "event-name",
+          "event-sha",
+          "github-output",
+          "input-tag",
+          "ref-name",
+          "ref-type",
+          "repository",
+        ])
+      : new Set(["api-url", "expected-commit", "repository", "tag"]);
+  for (const key of Object.keys(options)) {
+    if (!allowed.has(key)) {
+      throw new ElectrobunReleaseIdentityError(
+        `Unknown option --${key} for ${command}`,
+        { kind: "invalid-input" },
+      );
+    }
+  }
+  return { command, options };
+}
+
+function requiredOption(options, key) {
+  const value = options[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new ElectrobunReleaseIdentityError(
+      `Missing required option --${key}`,
+      { kind: "invalid-input" },
+    );
+  }
+  return value;
+}
+
+async function runCli(argv) {
+  const { command, options } = parseCli(argv);
+  const readEnvironment = (name) => process.env[name];
+  const common = {
+    apiUrl: options["api-url"] || readEnvironment("GITHUB_API_URL"),
+    repository: requiredOption(options, "repository"),
+    token: readEnvironment("GH_TOKEN"),
+  };
+  if (command === "resolve") {
+    const result = await resolveElectrobunReleaseSource({
+      ...common,
+      inputTag: options["input-tag"] ?? "",
+      refType: options["ref-type"] ?? "",
+      refName: options["ref-name"] ?? "",
+      eventName: options["event-name"] ?? "",
+      eventSha: options["event-sha"] ?? "",
+    });
+    const githubOutput = requiredOption(options, "github-output");
+    fs.appendFileSync(
+      githubOutput,
+      `tag=${result.tag}\nversion=${result.version}\nenv=${result.channel}\nsource_sha=${result.sourceSha}\n`,
+    );
+    process.stdout.write(
+      `${JSON.stringify({ ...result, repository: common.repository })}\n`,
+    );
+    return;
+  }
+  const result = await verifyExistingElectrobunRelease({
+    ...common,
+    tag: requiredOption(options, "tag"),
+    expectedCommit: requiredOption(options, "expected-commit"),
+  });
+  process.stdout.write(
+    `${JSON.stringify({ ...result, repository: common.repository })}\n`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    // error-policy:J1 CLI boundary returns a sanitized, typed failure
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`[electrobun-release-identity] ${message}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Closes #18272

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - contribute-to-eliza skill was not available`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Summary

The Electrobun workflow accepted a selected tag but could build the dispatch ref, treat the dispatch SHA as the release source, and use an upload action that created a missing Release. That let the desktop lane publish assets without proving that the tag, built commit, and canonical Release still identified one immutable source.

This revision makes the desktop lane read-only with respect to release identity. Trusted workflow tooling resolves and recursively peels the existing tag, every build checkout uses that exact commit, and both public upload paths re-resolve the tag and re-read the canonical Release immediately before mutation. Missing, moved, malformed, draft, or conflicting identity now fails closed.

## Review repairs

The original patch fixed the initial checkout mismatch, but deeper review found several remaining publication risks:

- tag identity was resolved only during `prepare`, leaving a tag-move race before upload;
- `gh release view` proved only that a named Release existed, not that it targeted the prepared commit or had the expected publication state;
- annotated tags were peeled only once;
- numeric prerelease identifiers with leading zeros were accepted despite strict SemVer;
- manual `draft: true` runs could still mutate an existing public Release;
- `gh release upload --clobber` deleted an existing asset before replacement, so an interrupted retry could destroy valid release material;
- OTA publication silently succeeded when the canonical Release was missing;
- the tests mostly inspected workflow substrings and did not execute the GitHub API boundary.

The repaired implementation:

- adds reusable, typed release-identity tooling with strict SemVer parsing, exact repository/ref/Release response validation, recursive annotated-tag peeling, cycle/depth protection, sanitized failures, and preserved transport causes;
- checks out trusted workflow tooling separately from the tagged source;
- binds tag-push events and every downstream checkout to the peeled commit SHA;
- reverifies the tag and exact non-draft/prerelease Release identity immediately before both desktop-asset and OTA-manifest uploads;
- makes draft dispatches artifact-only;
- removes release creation and all destructive `--clobber` behavior from the desktop lane;
- makes duplicate asset names and a missing OTA Release explicit failures requiring operator reconciliation;
- replaces substring-only coverage with an ephemeral real HTTP API exercising lightweight tags, nested annotated tags, cycles, malformed responses, missing refs, tag drift, Release conflicts, transport failures, and CLI output.

## Verification on exact head

- Electrobun identity/workflow suite: **39 passed, 0 failed, 102 assertions**
- canonical release workflow suite: **5 passed, 0 failed, 24 assertions**
- GitHub release integration suite: **6 passed, 0 failed, 28 assertions**
- GitHub action pinning/topology suite: **10 passed, 0 failed, 35 assertions**
- docs contract suite: **23 passed, 0 failed**
- docs lint: passed
- `actionlint .github/workflows/release-electrobun.yml`: passed
- full script lane during review: **1,285 passed, 23 skipped, 0 failed, 24,738 assertions**
- `bun run verify`: passed (**348/348 Turbo tasks**, repository audits clean)
- `git diff --check`: passed
- exact head `41675e3e3a19f2b945d0fcae92405c4df8b1e017` is rebased directly on current `develop` (`617b6ade3c57e8aea88d2f9d61ce407e02ccf560`); the release patch remained unchanged across the rebase

## Evidence matrix

<!-- evidence-head:41675e3e3a19f2b945d0fcae92405c4df8b1e017 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18299-before-wallet-desktop-mobile.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18299-after-wallet-desktop-mobile.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18299-wallet-agent-bridge-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] Exact-head verification transcript:

<details><summary>test and verification output</summary>

```text
bun test packages/scripts/__tests__/release-electrobun-tag-binding.test.ts — 39 passed, 0 failed, 102 assertions
bun test packages/scripts/__tests__/release-workflow.test.ts — 5 passed, 0 failed, 24 assertions
bun test packages/scripts/__tests__/release-github.integration.test.ts — 6 passed, 0 failed, 28 assertions
bun test packages/scripts/__tests__/github-action-pinning.test.ts — 10 passed, 0 failed, 35 assertions
bun test packages/docs/test/docs.test.ts — 23 passed, 0 failed
bun run --cwd packages/docs lint — passed
actionlint .github/workflows/release-electrobun.yml — passed
bun run verify — 348 successful Turbo tasks; all repository audits passed on 41675e3e3a19f2b945d0fcae92405c4df8b1e017
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Mintlify preview console transcript:

<details><summary>desktop and mobile preview</summary>

```text
desktop 1440x1000: rendered release topology section; 0 console errors
mobile 390x844: rendered release topology section; 0 console errors and no horizontal overflow
console notices: Mintlify preview Socket.io connection messages only; no failed network requests observed
```

</details>

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - release identity and publication decisions are deterministic and intentionally do not use a model.

<!-- evidence-row:domain-artifacts -->
- [x] Read-only live GitHub identity proof:

<details><summary>annotated-tag resolution</summary>

```text
repository: elizaOS/eliza
tag: v2.0.3-beta.7
peeled commit: 9fb92aae1ac5c86993d057d3fba68d1bb6d7a93c
peel depth: 1
derived channel: canary
```

The call exercised the same HTTPS GitHub REST boundary used by the workflow without mutating the tag or Release.

</details>

<!-- evidence-row:ocr-review -->
- [x] [18299-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18299-ocr-triage.json)

---

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: N/A - contribute-to-eliza skill was not available
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex","skill_revision":"N/A - contribute-to-eliza skill was not available"} -->

<!-- evidence-refresh:41675e3e -->
