### PR TITLE
fix(lifeops): gate scheduled-task binding on canonical internal sources

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding-internal-sources.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding-internal-sources.test.ts
@@ -1,26 +1,94 @@
 /**
- * Provenance classification behind `bindScheduledTaskToInboundChat` (#17747).
+ * Provenance guards behind `bindScheduledTaskToInboundChat` (#17747).
  *
  * The guard is fail-open: a provenance it does not recognise is BOUND to
  * outbound connector dispatch, so every sentinel core defines is asserted
- * individually rather than as a count.
- *
- * Scope is deliberately the predicate, not the binding. The trusted-audience
- * record the binding requires is minted by the runtime under a module-private
- * symbol and cannot be constructed here, so a binding-level assertion in this
- * file would return null for the wrong reason and pass vacuously. End-to-end
- * coverage of the branch belongs to the pglite integration lane.
+ * individually rather than as a count. Binding-level cases mint real
+ * process-local audience evidence via the public
+ * `attestDeliveryAudienceFromCanonicalRoom` attestor so a regression that
+ * drops either call site cannot pass.
  */
-import { MESSAGE_SOURCES } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
-import { isInternalMessageSource } from "./delivery-binding";
+import {
+  attestDeliveryAudienceFromCanonicalRoom,
+  ChannelType,
+  MESSAGE_SOURCES,
+  type IAgentRuntime,
+  type Memory,
+  type Room,
+  type UUID,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  bindScheduledTaskToInboundChat,
+  isInternalMessageSource,
+} from "./delivery-binding";
 
 const INTERNAL_SENTINELS = Object.values(MESSAGE_SOURCES);
 
+const OWNER = "11111111-1111-4111-8111-111111111111" as UUID;
+const AGENT = "22222222-2222-4222-8222-222222222222" as UUID;
+const ROOM = "44444444-4444-4444-8444-444444444444" as UUID;
+const CHANNEL = "discord-dm-channel-1";
+
+function connectorRuntime(options: {
+  roomSource?: string;
+  channelId?: string;
+}): IAgentRuntime {
+  const roomSource = options.roomSource ?? "discord";
+  const channelId = options.channelId ?? CHANNEL;
+  return {
+    agentId: AGENT,
+    getRoom: vi.fn(async (roomId: UUID) =>
+      roomId === ROOM
+        ? ({
+            id: ROOM,
+            agentId: AGENT,
+            type: ChannelType.DM,
+            source: roomSource,
+            channelId,
+            metadata: { accountId: "acct-1" },
+          } as Room)
+        : null,
+    ),
+    getParticipantsForRoom: vi.fn(async () => [OWNER, AGENT]),
+    getSetting: vi.fn((key: string) =>
+      key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER : undefined,
+    ),
+    reportError: vi.fn(),
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function inboundMessage(source: string | undefined): Memory {
+  return {
+    id: "66666666-6666-4666-8666-666666666666" as UUID,
+    entityId: OWNER,
+    agentId: AGENT,
+    roomId: ROOM,
+    content: {
+      text: "remind me at nine",
+      ...(source ? { source } : {}),
+      channelType: ChannelType.DM,
+    },
+  } as Memory;
+}
+
+async function attestedMessage(
+  runtime: IAgentRuntime,
+  source: string | undefined,
+): Promise<Memory> {
+  const message = inboundMessage(source);
+  await attestDeliveryAudienceFromCanonicalRoom(runtime, message);
+  return message;
+}
+
 describe("isInternalMessageSource", () => {
   it("covers every sentinel core defines", () => {
-    // Pins the guard to the canonical list rather than to this file's opinion
-    // of it: a sentinel added upstream fails here as well as at typecheck.
     for (const sentinel of INTERNAL_SENTINELS) {
       expect(isInternalMessageSource(sentinel)).toBe(true);
     }
@@ -38,14 +106,11 @@ describe("isInternalMessageSource", () => {
   });
 
   it("treats absent or empty provenance as not-internal", () => {
-    // Absent provenance is handled by the attestation checks upstream; this
-    // predicate must not silently claim it.
     expect(isInternalMessageSource(undefined)).toBe(false);
     expect(isInternalMessageSource("")).toBe(false);
   });
 
   it("does not inherit Object.prototype keys", () => {
-    // A plain `in` or truthiness check would report these as internal.
     expect(isInternalMessageSource("toString")).toBe(false);
     expect(isInternalMessageSource("constructor")).toBe(false);
   });
@@ -55,10 +120,78 @@ describe("isInternalMessageSource", () => {
     expect(isInternalMessageSource("api")).toBe(true);
   });
 
-  it("refuses the three sentinels the old denylist left open", () => {
+  it("refuses the four sentinels the old denylist left open", () => {
     expect(isInternalMessageSource("sub_agent")).toBe(true);
     expect(isInternalMessageSource("coding-agent")).toBe(true);
     expect(isInternalMessageSource("agent_greeting")).toBe(true);
     expect(isInternalMessageSource("trigger-prompt")).toBe(true);
+  });
+});
+
+describe("bindScheduledTaskToInboundChat provenance guards", () => {
+  it("binds a genuine connector DM (positive control)", async () => {
+    const runtime = connectorRuntime({ roomSource: "discord" });
+    const message = await attestedMessage(runtime, "discord");
+    const binding = await bindScheduledTaskToInboundChat(runtime, message);
+    expect(binding).toMatchObject({
+      version: 1,
+      source: "discord",
+      roomId: ROOM,
+      channelId: CHANNEL,
+      accountId: "acct-1",
+      audience: {
+        kind: "direct",
+        provenance: "canonical_room",
+        ownerEntityId: OWNER,
+        agentEntityId: AGENT,
+      },
+    });
+  });
+
+  it.each(INTERNAL_SENTINELS)(
+    "returns null when message.content.source is %s",
+    async (sentinel) => {
+      const runtime = connectorRuntime({ roomSource: "discord" });
+      const message = await attestedMessage(runtime, sentinel);
+      await expect(
+        bindScheduledTaskToInboundChat(runtime, message),
+      ).resolves.toBeNull();
+    },
+  );
+
+  it("returns null when message.metadata.source is an internal sentinel", async () => {
+    const runtime = connectorRuntime({ roomSource: "discord" });
+    const message = await attestedMessage(runtime, "discord");
+    message.metadata = {
+      ...(typeof message.metadata === "object" && message.metadata
+        ? message.metadata
+        : {}),
+      source: "sub_agent",
+    };
+    await expect(
+      bindScheduledTaskToInboundChat(runtime, message),
+    ).resolves.toBeNull();
+  });
+
+  it.each(["client_chat", "api", "sub_agent", "coding-agent"] as const)(
+    "returns null when room.source is %s",
+    async (roomSource) => {
+      const runtime = connectorRuntime({ roomSource });
+      const message = await attestedMessage(runtime, "discord");
+      await expect(
+        bindScheduledTaskToInboundChat(runtime, message),
+      ).resolves.toBeNull();
+    },
+  );
+
+  it("returns null when channelId equals room.id (synthetic channel guard)", async () => {
+    const runtime = connectorRuntime({
+      roomSource: "discord",
+      channelId: ROOM,
+    });
+    const message = await attestedMessage(runtime, "discord");
+    await expect(
+      bindScheduledTaskToInboundChat(runtime, message),
+    ).resolves.toBeNull();
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding-internal-sources.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding-internal-sources.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Provenance classification behind `bindScheduledTaskToInboundChat` (#17747).
+ *
+ * The guard is fail-open: a provenance it does not recognise is BOUND to
+ * outbound connector dispatch, so every sentinel core defines is asserted
+ * individually rather than as a count.
+ *
+ * Scope is deliberately the predicate, not the binding. The trusted-audience
+ * record the binding requires is minted by the runtime under a module-private
+ * symbol and cannot be constructed here, so a binding-level assertion in this
+ * file would return null for the wrong reason and pass vacuously. End-to-end
+ * coverage of the branch belongs to the pglite integration lane.
+ */
+import { MESSAGE_SOURCES } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { isInternalMessageSource } from "./delivery-binding";
+
+const INTERNAL_SENTINELS = Object.values(MESSAGE_SOURCES);
+
+describe("isInternalMessageSource", () => {
+  it("covers every sentinel core defines", () => {
+    // Pins the guard to the canonical list rather than to this file's opinion
+    // of it: a sentinel added upstream fails here as well as at typecheck.
+    for (const sentinel of INTERNAL_SENTINELS) {
+      expect(isInternalMessageSource(sentinel)).toBe(true);
+    }
+    expect(INTERNAL_SENTINELS).toHaveLength(5);
+  });
+
+  it("covers the api transport label", () => {
+    expect(isInternalMessageSource("api")).toBe(true);
+  });
+
+  it("does not claim real connectors", () => {
+    for (const connector of ["discord", "telegram", "slack", "sms"]) {
+      expect(isInternalMessageSource(connector)).toBe(false);
+    }
+  });
+
+  it("treats absent or empty provenance as not-internal", () => {
+    // Absent provenance is handled by the attestation checks upstream; this
+    // predicate must not silently claim it.
+    expect(isInternalMessageSource(undefined)).toBe(false);
+    expect(isInternalMessageSource("")).toBe(false);
+  });
+
+  it("does not inherit Object.prototype keys", () => {
+    // A plain `in` or truthiness check would report these as internal.
+    expect(isInternalMessageSource("toString")).toBe(false);
+    expect(isInternalMessageSource("constructor")).toBe(false);
+  });
+
+  it("still refuses the original denylist names (regression pin)", () => {
+    expect(isInternalMessageSource("client_chat")).toBe(true);
+    expect(isInternalMessageSource("api")).toBe(true);
+  });
+
+  it("refuses the three sentinels the old denylist left open", () => {
+    expect(isInternalMessageSource("sub_agent")).toBe(true);
+    expect(isInternalMessageSource("coding-agent")).toBe(true);
+    expect(isInternalMessageSource("agent_greeting")).toBe(true);
+    expect(isInternalMessageSource("trigger-prompt")).toBe(true);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding-internal-sources.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding-internal-sources.test.ts
@@ -11,8 +11,8 @@
 import {
   attestDeliveryAudienceFromCanonicalRoom,
   ChannelType,
-  MESSAGE_SOURCES,
   type IAgentRuntime,
+  MESSAGE_SOURCES,
   type Memory,
   type Room,
   type UUID,
@@ -167,6 +167,20 @@ describe("bindScheduledTaskToInboundChat provenance guards", () => {
         ? message.metadata
         : {}),
       source: "sub_agent",
+    };
+    await expect(
+      bindScheduledTaskToInboundChat(runtime, message),
+    ).resolves.toBeNull();
+  });
+
+  it("does not let connector metadata mask internal content provenance", async () => {
+    const runtime = connectorRuntime({ roomSource: "discord" });
+    const message = await attestedMessage(runtime, "sub_agent");
+    message.metadata = {
+      ...(typeof message.metadata === "object" && message.metadata
+        ? message.metadata
+        : {}),
+      source: "discord",
     };
     await expect(
       bindScheduledTaskToInboundChat(runtime, message),

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
@@ -1,10 +1,57 @@
 import {
   evaluateOwnerExclusiveDisclosure,
   getTrustedDeliveryAudience,
+  MESSAGE_SOURCES,
   type IAgentRuntime,
   type Memory,
+  type MessageSourceSentinel,
 } from "@elizaos/core";
 import type { ScheduledTaskDispatchRecord } from "./index.js";
+
+/**
+ * Provenances that must never reach outbound connector dispatch.
+ *
+ * Enumerated deliberately rather than derived from `Object.values`. This is a
+ * fail-open boundary: a provenance the guard does not name is BOUND, so the
+ * cost of forgetting one is an internal turn rewritten into an unavailable
+ * connector send. Spelling every sentinel out means adding one to
+ * `@elizaos/core`'s `message-source.ts` leaves a missing key here and fails
+ * typecheck, forcing a decision instead of silently widening the guard.
+ *
+ * `api` is not a core sentinel — it is a first-party transport label — so it
+ * lives alongside the record rather than inside it.
+ *
+ * Used for both message provenance (`content.source` / `metadata.source`) and
+ * the room's connector label (`room.source`). Room sources are connector names
+ * in practice; classifying them with the same predicate is deliberate and
+ * matches the previous two-string denylist on both sites.
+ */
+const INTERNAL_MESSAGE_SOURCES: Record<MessageSourceSentinel, true> = {
+  [MESSAGE_SOURCES.CLIENT_CHAT]: true,
+  [MESSAGE_SOURCES.SUB_AGENT]: true,
+  [MESSAGE_SOURCES.CODING_AGENT]: true,
+  [MESSAGE_SOURCES.AGENT_GREETING]: true,
+  [MESSAGE_SOURCES.TRIGGER_PROMPT]: true,
+};
+
+const API_TRANSPORT_SOURCE = "api";
+
+/**
+ * Whether `source` names an internally-originated turn or first-party
+ * transport that must not bind to outbound connector dispatch (#17747).
+ *
+ * Returns a plain boolean (not a type predicate): a false result means
+ * "not internal", not "not a string".
+ */
+export function isInternalMessageSource(
+  source: string | undefined,
+): boolean {
+  if (!source) return false;
+  return (
+    source === API_TRANSPORT_SOURCE ||
+    Object.hasOwn(INTERNAL_MESSAGE_SOURCES, source)
+  );
+}
 
 export const SCHEDULED_TASK_DELIVERY_BINDING_KEY = "chatDeliveryBinding";
 
@@ -71,7 +118,7 @@ export async function bindScheduledTaskToInboundChat(
   const inboundSource =
     stringField(message.metadata?.source) ??
     stringField(message.content.source);
-  if (inboundSource === "api" || inboundSource === "client_chat") {
+  if (isInternalMessageSource(inboundSource)) {
     return null;
   }
 
@@ -81,7 +128,7 @@ export async function bindScheduledTaskToInboundChat(
   if (!room || !source || !channelId || room.id !== audience.roomId) {
     return null;
   }
-  if (source === "api" || source === "client_chat" || channelId === room.id) {
+  if (isInternalMessageSource(source) || channelId === room.id) {
     return null;
   }
 

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
@@ -1,8 +1,12 @@
+/**
+ * Captures and validates the canonical connector destination used by scheduled
+ * LifeOps delivery, keeping internal and synthetic turns on the in-app path.
+ */
 import {
   evaluateOwnerExclusiveDisclosure,
   getTrustedDeliveryAudience,
-  MESSAGE_SOURCES,
   type IAgentRuntime,
+  MESSAGE_SOURCES,
   type Memory,
   type MessageSourceSentinel,
 } from "@elizaos/core";
@@ -43,9 +47,7 @@ const API_TRANSPORT_SOURCE = "api";
  * Returns a plain boolean (not a type predicate): a false result means
  * "not internal", not "not a string".
  */
-export function isInternalMessageSource(
-  source: string | undefined,
-): boolean {
+export function isInternalMessageSource(source: string | undefined): boolean {
   if (!source) return false;
   return (
     source === API_TRANSPORT_SOURCE ||
@@ -115,10 +117,15 @@ export async function bindScheduledTaskToInboundChat(
   // inbound envelope before consulting that room. Otherwise internal scenario
   // and API turns are rewritten into unavailable outbound connector sends and
   // planner idempotency keys leak a synthetic room suffix.
-  const inboundSource =
-    stringField(message.metadata?.source) ??
-    stringField(message.content.source);
-  if (isInternalMessageSource(inboundSource)) {
+  const metadataSource = stringField(message.metadata?.source);
+  const contentSource = stringField(message.content.source);
+  // Either envelope field can carry the real provenance. Do not let a
+  // connector-looking metadata value mask an internal content sentinel (or
+  // vice versa) through nullish-coalescing precedence.
+  if (
+    isInternalMessageSource(metadataSource) ||
+    isInternalMessageSource(contentSource)
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Closes #17747

# Root issue

`bindScheduledTaskToInboundChat` used a two-string denylist (`api`, `client_chat`) even though core defines five internal message-source sentinels. A sub-agent, coding-agent, greeting, or trigger turn inside a real connector room could therefore acquire a scheduled-task connector binding and later be rewritten into outbound delivery.

The first revision expanded the denylist but still coalesced `metadata.source` over `content.source`. Connector-looking metadata could consequently mask an internal content provenance. The current head rejects either field independently.

# Fix

- Defines an exhaustive `Record<MessageSourceSentinel, true>` from core's canonical sentinel constants, plus the first-party `api` transport label.
- Uses one prototype-safe predicate for message and canonical-room provenance.
- Rejects an internal value in either `message.metadata.source` or `message.content.source`; neither can override the other.
- Preserves the canonical audience attestation and synthetic `channelId === room.id` guard.
- Keeps genuine connector DMs bindable.
- Makes a newly added core sentinel a typecheck failure at this boundary until explicitly classified.

# Validation

- Focused binding suite: 20/20 passing at the exact head.
- Tests use the public `attestDeliveryAudienceFromCanonicalRoom` attestor and drive `bindScheduledTaskToInboundChat`, not only the helper.
- Coverage includes all five content sentinels, internal metadata, conflicting connector metadata/internal content, internal room sources, a real-shaped connector-DM positive control, and the synthetic-channel guard.
- Biome passes on both touched files.
- A local package typecheck from this review worktree was not treated as evidence because dependency symlinks mixed workspace `src` and `dist` declarations; clean-install CI owns that check.

# Risk

Fail-closed routing change. Unknown connector labels remain supported; only canonical internal sentinels and the established `api` label are refused.

<!-- evidence-head:43350b24d4939786b49fdc252ac6326d35540f6b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend routing classification only; no rendered UI changes

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend routing classification only; no rendered UI changes

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user interface flow; the observable contract is a null delivery binding for internal provenance

<!-- evidence-row:backend-logs -->
- [x] [Exact-head binding regression output](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18290-binding-tests-v2.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or planner behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [Executed sentinel verdict matrix](https://github.com/user-attachments/files/30961715/18290-sentinel-matrix.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: original contribution `xAI/grok-4.5`; remediation `openai/gpt-5` (system-reported model family; deployment variant unavailable)
<!-- attribution-row:client -->
- Agent tooling: Claude Code via CLIProxyAPI (original), Codex (remediation)
<!-- attribution-row:skill-revision -->
- Skill path: original `elizaOS/army@1a8db2e762e394b85ff48d4007fbf052e4356db4:skills/contribute-to-eliza`; remediation N/A - installed Codex plugin packages do not expose a repository commit SHA
<!-- attribution-row:status -->
- Provenance status: self-reported

