### PR TITLE
fix(ci): match flake signatures incrementally so they survive long output (#18294)

### DIFF
--- a/packages/scripts/__tests__/run-with-flake-retry.test.ts
+++ b/packages/scripts/__tests__/run-with-flake-retry.test.ts
@@ -14,6 +14,7 @@ function runWrapper(args: string[], timeoutMs = 30_000) {
 	return spawnSync(NODE_BIN, [WRAPPER, ...args], {
 		encoding: "utf8",
 		timeout: timeoutMs,
+		maxBuffer: 20 * 1024 * 1024,
 	});
 }
 
@@ -25,6 +26,28 @@ function flakyChild(counterFile: string, failureLine: string): string {
 		fs.appendFileSync(${JSON.stringify(counterFile)}, "x");
 		if (fs.readFileSync(${JSON.stringify(counterFile)}, "utf8").length === 1) {
 			console.error(${JSON.stringify(failureLine)});
+			process.exit(1);
+		}
+		process.exit(0);
+	`;
+}
+
+// Child that emits the flake signature EARLY, then floods stderr with more
+// output than the overlap window can retain, before exiting non-zero. The
+// flood pushes the signature out of any bounded tail so that only incremental
+// matching can catch it. Smaller chunks avoid pipe-buffer contention.
+function flakyChildWithFlood(counterFile: string, signatureLine: string, floodBytes: number): string {
+	return `
+		const fs = require("node:fs");
+		fs.appendFileSync(${JSON.stringify(counterFile)}, "x");
+		if (fs.readFileSync(${JSON.stringify(counterFile)}, "utf8").length === 1) {
+			console.error(${JSON.stringify(signatureLine)});
+			// Flood stderr with non-signature data to fill the overlap window.
+			// Written in smaller chunks to avoid pipe-buffer contention.
+			const chunk = "x".repeat(4096);
+			for (let i = 0; i < ${floodBytes}; i += chunk.length) {
+				console.error(chunk);
+			}
 			process.exit(1);
 		}
 		process.exit(0);
@@ -72,6 +95,33 @@ describe("run-with-flake-retry", () => {
 			"-e",
 			flakyChild(counter, "error: EEXIST: file already exists, epoll_ctl"),
 		]);
+		expect(result.status).toBe(0);
+		expect(readFileSync(counter, "utf8")).toBe("xx");
+		expect(result.stderr).toContain("matched flake signature");
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	test("retries when the signature is followed by more output than the old tail", () => {
+		const dir = mkdtempSync(path.join(tmpdir(), "flake-retry-"));
+		const counter = path.join(dir, "runs");
+		// Emit the flake line, then 1.25 MiB of follow-on output — past both the
+		// old 256 KiB tail AND the new 1 MiB overlap window, so ONLY incremental
+		// matching can catch the signature (it is gone from any bounded tail at
+		// exit).
+		const result = runWrapper(
+			[
+				"EEXIST[^\\n]*epoll_ctl|error: Failed to connect",
+				"--",
+				NODE_BIN,
+				"-e",
+				flakyChildWithFlood(
+					counter,
+					"error: EEXIST: file already exists, epoll_ctl",
+					1310720,
+				),
+			],
+			60_000,
+		);
 		expect(result.status).toBe(0);
 		expect(readFileSync(counter, "utf8")).toBe("xx");
 		expect(result.stderr).toContain("matched flake signature");

--- a/packages/scripts/run-with-flake-retry.mjs
+++ b/packages/scripts/run-with-flake-retry.mjs
@@ -6,6 +6,13 @@
  * subprocess stdio wiring emitting `EEXIST … epoll_ctl` / `Failed to connect`
  * between tests) gets one bounded second chance. A failure that does not
  * match the signature is never retried.
+ *
+ * Signatures are matched incrementally as each stdout/stderr chunk arrives —
+ * not just from a retained tail after the child exits. This prevents the
+ * signature from being lost when a chatty suite emits more than the overlap
+ * window of output after the flake line. Cross-chunk matching is preserved via
+ * a bounded sliding overlap, so memory stays flat regardless of suite length.
+ *
  * Exit codes: the final attempt's own code, 127 when the command cannot
  * start, 2 on usage errors.
  *
@@ -30,15 +37,45 @@ try {
 }
 const [command, ...args] = argv.slice(2);
 
+/** Bounded overlap window for cross-chunk regex matching (1 MiB). */
+const OVERLAP_BYTES = 1048576;
+
+/**
+ * Incremental signature matcher: feeds every chunk through `signature.test`
+ * against a sliding overlap so a match that straddles chunk boundaries is
+ * still caught. Once matched, the flag stays set for the remainder of the run
+ * — a signature is never forgotten once seen, even if subsequent output
+ * pushes it out of the overlap window.
+ */
+function createSignatureTracker(signature) {
+  let matched = false;
+  let overlap = "";
+  return {
+    get matched() {
+      return matched;
+    },
+    feed(chunk) {
+      if (matched) return;
+      const text = overlap + chunk.toString();
+      if (signature.test(text)) {
+        matched = true;
+        overlap = "";
+        return;
+      }
+      // Keep only the tail for cross-chunk boundary matching. Memory is bounded
+      // regardless of total output volume.
+      overlap = text.slice(-OVERLAP_BYTES);
+    },
+  };
+}
+
 function runOnce() {
   return new Promise((resolve) => {
     const child = spawn(command, args, { stdio: ["inherit", "pipe", "pipe"] });
-    let tail = "";
+    const tracker = createSignatureTracker(signature);
     const capture = (chunk, sink) => {
       sink.write(chunk);
-      // Only the tail is needed for signature matching; unbounded capture of a
-      // chatty suite would hold the whole log in memory.
-      tail = (tail + chunk.toString()).slice(-262144);
+      tracker.feed(chunk);
     };
     child.stdout.on("data", (chunk) => capture(chunk, process.stdout));
     child.stderr.on("data", (chunk) => capture(chunk, process.stderr));
@@ -46,16 +83,16 @@ function runOnce() {
       console.error(
         `[run-with-flake-retry] failed to start "${command}": ${error.message}`,
       );
-      resolve({ code: 127, tail });
+      resolve({ code: 127, matched: tracker.matched });
     });
     child.on("close", (code, signal) => {
-      resolve({ code: code ?? (signal ? 1 : 0), tail });
+      resolve({ code: code ?? (signal ? 1 : 0), matched: tracker.matched });
     });
   });
 }
 
 const first = await runOnce();
-if (first.code === 0 || first.code === 127 || !signature.test(first.tail)) {
+if (first.code === 0 || first.code === 127 || !first.matched) {
   process.exit(first.code);
 }
 console.error(


### PR DESCRIPTION
## Summary

Fixes #18294

`packages/scripts/run-with-flake-retry.mjs` retained only the last 256 KiB of child output and tested for the signature after the child exited. Long suites that emit the flake signature followed by more than 256 KiB of teardown/test output lost the match before it was tested, so the promised retry never happened. This was observed twice in the `plugin-workflow` Develop PR lane: Bun/Linux emitted `EEXIST … epoll_ctl` and `error: Failed to connect` — both explicitly configured signatures — but no `[run-with-flake-retry] ... retrying once` line appeared.

## Fix

Replace the post-hoc 256 KiB tail with an **incremental signature tracker**:

1. Each stdout/stderr chunk is tested against the regex **as it arrives** — the signature is caught on the first chunk that contains it, before any subsequent flood.
2. A bounded sliding overlap (1 MiB) preserves cross-chunk boundary matching.
3. Once matched, the flag is **sticky** — subsequent output cannot forget a signature already seen.
4. Memory stays flat regardless of total output volume (peak: ~1 MiB overlap + chunk).

## Root cause

The old code:
```js
tail = (tail + chunk.toString()).slice(-262144);  // only last 256 KiB
// ...
if (!signature.test(first.tail)) {  // tested AFTER child exits
```

If the suite emits the flake signature and then >256 KiB more output, the signature is evicted from `tail` before matching runs.

## Acceptance criteria

- [x] **Match configured signatures incrementally while forwarding child stdout/stderr.** — `tracker.feed(chunk)` is called on every `"data"` event, testing immediately.
- [x] **Preserve cross-chunk matching and bounded memory.** — 1 MiB sliding overlap window; memory is O(1) regardless of output volume.
- [x] **Retry at most once and only for a failed first attempt with a matching signature.** — unchanged retry gate: `first.code !== 0 && first.code !== 127 && first.matched`.
- [x] **Add a real-child regression test where the signature is followed by more output than the retained tail.** — `flakyChildWithFlood` emits the signature then 1.25 MiB of flood (> the 1 MiB overlap), so only incremental matching catches it.
- [x] **Keep ordinary assertion failures loud and un-retried.** — unchanged: non-matching failures exit with the child code, no retry.

## Tests

```
bun test packages/scripts/__tests__/run-with-flake-retry.test.ts

 5 pass
 0 fail
 12 expect() calls
```

### Test matrix

| Test | Old behavior | New behavior |
|------|-------------|-------------|
| Passes through success | OK | OK |
| Does not retry non-signature failure | OK | OK |
| Retries when output matches signature | OK | OK |
| **Retries when signature followed by >1 MiB flood** | FAIL (signature lost) | OK (incremental match) |
| Fails on invalid usage | OK | OK |

## Typecheck

```
bun run --cwd packages/scripts typecheck
 Tasks:    217 successful, 217 total
```

## Independent review

RepoPrompt CE review agent (CC Zai / opus) verdict: **APPROVE — ship it.** Verified:
- Incremental matching ✓, sticky match ✓, memory bound ✓, cross-chunk boundary ✓
- `.test()` statefulness safe (no flags → no `.lastIndex` corruption)
- CLI contract unchanged, all 5 acceptance criteria met
- One finding: initial 400 KiB flood test didn't exceed the 1 MiB overlap — **fixed**, flood bumped to 1.25 MiB so only incremental matching catches the signature.

## Contribution provenance

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:a891046c21e767818229dc3ed21903fa4257d799 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI script change, no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI script change, no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CI script change, no UI

<!-- evidence-row:backend-logs -->
- [ ] N/A - CI flake-retry script, not a server runtime change

<!-- evidence-row:frontend-logs -->
- [ ] N/A - CI script change, no frontend

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - CI flake-retry wrapper, no model/agent path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - CI tooling, no domain artifact
