### PR TITLE
fix(cloud): set completed_at on every terminal job transition (#18093)

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -104,7 +104,13 @@ async function seedAppliedPrefix(
 ): Promise<void> {
   await client.query(`
     CREATE TABLE jobs (
-      id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY
+      id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      status text NOT NULL DEFAULT 'pending',
+      execution_quiesced_at timestamp with time zone,
+      started_at timestamp with time zone,
+      completed_at timestamp with time zone,
+      created_at timestamp with time zone NOT NULL DEFAULT now(),
+      updated_at timestamp with time zone NOT NULL DEFAULT now()
     );
     CREATE TABLE agent_sandboxes (
       container_name text,
@@ -245,21 +251,39 @@ describe.skipIf(!ENABLED)(
     test("applies the append-only fix-forward once and passes the reusable catalog preflight", async () => {
       const database = await createDatabase();
       await seedAppliedPrefix(database.client, 184);
-      await database.client.query("INSERT INTO jobs DEFAULT VALUES");
+      await database.client.query(`
+        INSERT INTO jobs (
+          status,
+          execution_quiesced_at,
+          started_at,
+          created_at,
+          updated_at
+        ) VALUES (
+          'failed',
+          '2026-01-02T00:00:00Z',
+          '2026-01-01T12:00:00Z',
+          '2026-01-01T00:00:00Z',
+          '2026-01-03T00:00:00Z'
+        )
+      `);
 
       const first = await runScript(MIGRATOR, database.url);
       expect(first.exitCode, first.output).toBe(0);
-      expect(first.output).toContain("pending migrations: 10");
+      expect(first.output).toContain("pending migrations: 11");
 
       const catalog = await database.client.query<{
         data_type: string;
         is_nullable: string;
         column_default: string;
         zeros: string;
+        terminal_backfills: string;
       }>(`
       SELECT catalog_column.data_type, catalog_column.is_nullable,
         catalog_column.column_default,
-        (SELECT count(*)::text FROM jobs WHERE execution_interruptions = 0) AS zeros
+        (SELECT count(*)::text FROM jobs WHERE execution_interruptions = 0) AS zeros,
+        (SELECT count(*)::text FROM jobs
+          WHERE status = 'failed'
+            AND completed_at = execution_quiesced_at) AS terminal_backfills
       FROM information_schema.columns AS catalog_column
       WHERE catalog_column.table_schema = 'public'
         AND catalog_column.table_name = 'jobs'
@@ -270,6 +294,7 @@ describe.skipIf(!ENABLED)(
         is_nullable: "NO",
         column_default: "0",
         zeros: "1",
+        terminal_backfills: "1",
       });
 
       const second = await runScript(MIGRATOR, database.url);
@@ -292,7 +317,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 10");
+      expect(migrated.output).toContain("pending migrations: 11");
 
       await database.client.query(
         "UPDATE drizzle.__drizzle_migrations SET hash = 'checkpoint-drift' WHERE created_at = $1",
@@ -338,7 +363,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 10");
+      expect(migrated.output).toContain("pending migrations: 11");
       await database.client.end();
     }, 120_000);
 
@@ -348,7 +373,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 10");
+      expect(migrated.output).toContain("pending migrations: 11");
       await database.client.end();
     }, 120_000);
 
@@ -380,7 +405,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 10");
+      expect(migrated.output).toContain("pending migrations: 11");
       await database.client.end();
     }, 120_000);
 
@@ -400,7 +425,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 10");
+      expect(migrated.output).toContain("pending migrations: 11");
 
       const remaining = await database.client.query<{ count: string }>(
         "SELECT count(*)::text AS count FROM drizzle.__drizzle_migrations WHERE created_at = ANY($1::bigint[])",

--- a/packages/cloud/shared/src/db/job-terminal-completed-at-migration.test.ts
+++ b/packages/cloud/shared/src/db/job-terminal-completed-at-migration.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Applies the terminal-job timestamp backfill to real PGlite rows and proves
+ * its source precedence, idempotence, and non-terminal exclusion.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+const MIGRATION_PATH = join(
+  import.meta.dir,
+  "migrations/0195_job_terminal_completed_at_backfill.sql",
+);
+
+let client: PGlite;
+
+async function applyMigration(): Promise<void> {
+  for (const statement of readFileSync(MIGRATION_PATH, "utf8")
+    .split("--> statement-breakpoint")
+    .map((candidate) => candidate.trim())
+    .filter(Boolean)) {
+    await client.exec(statement);
+  }
+}
+
+beforeAll(async () => {
+  client = new PGlite();
+  await client.exec(`
+    CREATE TABLE jobs (
+      id uuid PRIMARY KEY,
+      status text NOT NULL,
+      execution_quiesced_at timestamp,
+      started_at timestamp,
+      completed_at timestamp,
+      created_at timestamp NOT NULL,
+      updated_at timestamp NOT NULL
+    );
+    INSERT INTO jobs
+      (id, status, execution_quiesced_at, started_at, completed_at, created_at, updated_at)
+    VALUES
+      ('00000000-0000-4000-8000-000000000001', 'failed',
+       '2026-01-02T00:00:00Z', '2026-01-01T12:00:00Z', NULL,
+       '2026-01-01T00:00:00Z', '2026-01-03T00:00:00Z'),
+      ('00000000-0000-4000-8000-000000000002', 'cancelled',
+       NULL, '2026-01-01T12:00:00Z', NULL,
+       '2026-01-01T00:00:00Z', '2026-01-04T00:00:00Z'),
+      ('00000000-0000-4000-8000-000000000003', 'failed',
+       '2026-01-02T00:00:00Z', '2026-01-01T12:00:00Z', '2026-01-02T12:00:00Z',
+       '2026-01-01T00:00:00Z', '2026-01-05T00:00:00Z'),
+      ('00000000-0000-4000-8000-000000000004', 'pending',
+       NULL, '2026-01-01T12:00:00Z', NULL,
+       '2026-01-01T00:00:00Z', '2026-01-06T00:00:00Z');
+  `);
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+describe("0195 job terminal completed_at backfill", () => {
+  test("backfills only missing terminal timestamps from the best durable source", async () => {
+    await applyMigration();
+    await applyMigration();
+
+    const result = await client.query<{ id: string; completed_at: Date | null }>(
+      "SELECT id, completed_at FROM jobs ORDER BY id",
+    );
+    expect(
+      result.rows.map((row) => ({
+        id: row.id,
+        completed_at: row.completed_at?.toISOString() ?? null,
+      })),
+    ).toEqual([
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        completed_at: "2026-01-02T00:00:00.000Z",
+      },
+      {
+        id: "00000000-0000-4000-8000-000000000002",
+        completed_at: "2026-01-04T00:00:00.000Z",
+      },
+      {
+        id: "00000000-0000-4000-8000-000000000003",
+        completed_at: "2026-01-02T12:00:00.000Z",
+      },
+      {
+        id: "00000000-0000-4000-8000-000000000004",
+        completed_at: null,
+      },
+    ]);
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/0195_job_terminal_completed_at_backfill.sql
+++ b/packages/cloud/shared/src/db/migrations/0195_job_terminal_completed_at_backfill.sql
@@ -1,0 +1,12 @@
+-- Backfill the immutable terminal timestamp for historical failures and
+-- cancellations. execution_quiesced_at is the closest durable terminal
+-- boundary; older rows fall back to their last mutation, start, or creation.
+UPDATE "jobs"
+SET "completed_at" = COALESCE(
+  "execution_quiesced_at",
+  "updated_at",
+  "started_at",
+  "created_at"
+)
+WHERE "status" IN ('failed', 'cancelled')
+  AND "completed_at" IS NULL;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1359,6 +1359,13 @@
       "when": 1786478400000,
       "tag": "0194_job_execution_interruptions_catalog_guard",
       "breakpoints": true
+    },
+    {
+      "idx": 194,
+      "version": "7",
+      "when": 1786564800000,
+      "tag": "0195_job_terminal_completed_at_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Exercises the terminal-timestamp contract: every transition into a terminal
+ * status (failed, cancelled, completed) sets `completed_at` transactionally,
+ * and retry transitions back to `pending` clear it. Uses real PGlite state.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { type Job, jobs } from "../../schemas/jobs";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+const PGLITE_TIMEOUT = 60_000;
+const ORG_ID = "00000000-0000-4000-8000-000000009000";
+const ACTOR_ID = "00000000-0000-4000-8000-000000009001";
+const AGENT_ID = "00000000-0000-4000-8000-000000009002";
+const JOB_STARTED_AT = new Date("2020-01-01T00:00:00.000Z");
+
+let dbWrite: typeof import("../../client").dbWrite;
+let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
+let repo: typeof import("../jobs").jobsRepository;
+let pgliteReady = true;
+
+async function seedJob(params: {
+  id: string;
+  maxAttempts: number;
+  attempts?: number;
+  type?: string;
+}): Promise<void> {
+  await dbWrite.insert(jobs).values({
+    id: params.id,
+    type: params.type ?? "agent_message",
+    status: "in_progress",
+    data: {},
+    data_storage: "inline",
+    attempts: params.attempts ?? 0,
+    max_attempts: params.maxAttempts,
+    organization_id: ORG_ID,
+    user_id: ACTOR_ID,
+    agent_id: AGENT_ID,
+    scheduled_for: JOB_STARTED_AT,
+    started_at: JOB_STARTED_AT,
+    created_at: JOB_STARTED_AT,
+    updated_at: JOB_STARTED_AT,
+  });
+}
+
+async function seedLease(jobId: string, generation: string, ownerId: string): Promise<void> {
+  await dbWrite.execute(
+    `INSERT INTO job_execution_leases (job_id, execution_generation, owner_id, expires_at) VALUES ('${jobId}', '${generation}', '${ownerId}', NOW() + INTERVAL '60 seconds')`,
+  );
+}
+
+async function getJob(id: string): Promise<Job | undefined> {
+  return await repo.findById(id);
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
+    ({ jobsRepository: repo } = await import("../jobs"));
+
+    await dbWrite.execute(
+      `CREATE TABLE IF NOT EXISTS jobs (
+				id uuid PRIMARY KEY,
+				type text NOT NULL,
+				status text NOT NULL DEFAULT 'pending',
+				data jsonb NOT NULL,
+				data_storage text NOT NULL DEFAULT 'inline',
+				data_key text,
+				agent_id text,
+				character_id text,
+				result jsonb,
+				result_storage text NOT NULL DEFAULT 'inline',
+				result_key text,
+				error text,
+				error_storage text NOT NULL DEFAULT 'inline',
+				error_key text,
+				attempts integer NOT NULL DEFAULT 0,
+				max_attempts integer NOT NULL DEFAULT 3,
+				organization_id uuid NOT NULL,
+				user_id uuid,
+				api_key_id uuid,
+				generation_id uuid,
+				webhook_url text,
+				webhook_status text,
+				estimated_completion_at timestamp,
+				scheduled_for timestamp NOT NULL DEFAULT now(),
+				started_at timestamp,
+				execution_generation uuid,
+				execution_quiesced_at timestamp,
+				completed_at timestamp,
+				created_at timestamp NOT NULL DEFAULT now(),
+				updated_at timestamp NOT NULL DEFAULT now()
+			)`,
+    );
+    await dbWrite.execute(
+      `CREATE TABLE IF NOT EXISTS job_execution_leases (
+				job_id uuid REFERENCES jobs(id) ON DELETE CASCADE,
+				execution_generation uuid NOT NULL,
+				owner_id text NOT NULL,
+				expires_at timestamp NOT NULL,
+				heartbeat_at timestamp NOT NULL DEFAULT now(),
+				created_at timestamp NOT NULL DEFAULT now(),
+				PRIMARY KEY (job_id, execution_generation, owner_id)
+			)`,
+    );
+  } catch (error) {
+    pgliteReady = false;
+    console.warn("[jobs-completed-at] PGlite unavailable, skipping:", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+function canRun(): boolean {
+  return pgliteReady;
+}
+
+describe("completed_at terminal-timestamp contract", () => {
+  beforeEach(async () => {
+    if (!canRun()) return;
+    await dbWrite.execute("DELETE FROM jobs;");
+  });
+
+  describe("updateStatus", () => {
+    test("sets completed_at when status is failed", async () => {
+      if (!canRun()) return;
+      const id = "00000000-0000-4900-8000-000000000001";
+      await seedJob({ id, maxAttempts: 1 });
+      await repo.updateStatus(id, "failed");
+      const job = await getJob(id);
+      expect(job?.status).toBe("failed");
+      expect(job?.completed_at).not.toBeNull();
+    });
+
+    test("sets completed_at when status is cancelled", async () => {
+      if (!canRun()) return;
+      const id = "00000000-0000-4900-8000-000000000002";
+      await seedJob({ id, maxAttempts: 1 });
+      await repo.updateStatus(id, "cancelled");
+      const job = await getJob(id);
+      expect(job?.status).toBe("cancelled");
+      expect(job?.completed_at).not.toBeNull();
+    });
+
+    test("sets completed_at when status is completed", async () => {
+      if (!canRun()) return;
+      const id = "00000000-0000-4900-8000-000000000003";
+      await seedJob({ id, maxAttempts: 1 });
+      await repo.updateStatus(id, "completed");
+      const job = await getJob(id);
+      expect(job?.status).toBe("completed");
+      expect(job?.completed_at).not.toBeNull();
+    });
+
+    test("clears completed_at when status transitions to pending", async () => {
+      if (!canRun()) return;
+      const id = "00000000-0000-4900-8000-000000000004";
+      await seedJob({ id, maxAttempts: 1 });
+      await repo.updateStatus(id, "completed");
+      let job = await getJob(id);
+      expect(job?.completed_at).not.toBeNull();
+      await repo.updateStatus(id, "pending");
+      job = await getJob(id);
+      expect(job?.status).toBe("pending");
+      expect(job?.completed_at).toBeNull();
+    });
+
+    test("respects explicit completed_at in additionalFields", async () => {
+      if (!canRun()) return;
+      const id = "00000000-0000-4900-8000-000000000005";
+      const explicitDate = new Date("2021-06-15T12:00:00.000Z");
+      await seedJob({ id, maxAttempts: 1 });
+      await repo.updateStatus(id, "failed", { completed_at: explicitDate });
+      const job = await getJob(id);
+      expect(job?.completed_at).toEqual(explicitDate);
+    });
+  });
+
+  describe("incrementAttempt", () => {
+    test("sets completed_at when attempt exhaustion flips to failed", async () => {
+      if (!canRun()) return;
+      const id = "00000000-0000-4900-8000-000000000010";
+      await seedJob({ id, maxAttempts: 1, attempts: 0 });
+      await repo.incrementAttempt(id, "boom", 1);
+      const job = await getJob(id);
+      expect(job?.status).toBe("failed");
+      expect(job?.completed_at).not.toBeNull();
+    });
+
+    test("keeps completed_at null on retry (not yet exhausted)", async () => {
+      if (!canRun()) return;
+      const id = "00000000-0000-4900-8000-000000000011";
+      await seedJob({ id, maxAttempts: 3, attempts: 0 });
+      await repo.incrementAttempt(id, "transient", 3);
+      const job = await getJob(id);
+      expect(job?.status).toBe("pending");
+      expect(job?.completed_at).toBeNull();
+    });
+  });
+
+  describe("settleExecution", () => {
+    test("sets completed_at when status is completed", async () => {
+      if (!canRun()) return;
+      const id = "00000000-0000-4900-8000-000000000020";
+      const generation = "a0000000-0000-4000-8000-000000000020";
+      const ownerId = "owner-1";
+      await seedJob({ id, maxAttempts: 1 });
+      await dbWrite.update(jobs).set({ execution_generation: generation }).where(eq(jobs.id, id));
+      await seedLease(id, generation, ownerId);
+      const claimed = await repo.findById(id);
+      if (!claimed) throw new Error("seeded job not found");
+      await repo.settleExecution(claimed, "completed", undefined, ownerId);
+      const job = await getJob(id);
+      expect(job?.status).toBe("completed");
+      expect(job?.completed_at).not.toBeNull();
+    });
+
+    test("sets completed_at when status is cancelled", async () => {
+      if (!canRun()) return;
+      const id = "00000000-0000-4900-8000-000000000021";
+      const generation = "a0000000-0000-4000-8000-000000000021";
+      const ownerId = "owner-2";
+      await seedJob({ id, maxAttempts: 1 });
+      await dbWrite.update(jobs).set({ execution_generation: generation }).where(eq(jobs.id, id));
+      await seedLease(id, generation, ownerId);
+      const claimed = await repo.findById(id);
+      if (!claimed) throw new Error("seeded job not found");
+      await repo.settleExecution(claimed, "cancelled", undefined, ownerId);
+      const job = await getJob(id);
+      expect(job?.status).toBe("cancelled");
+      expect(job?.completed_at).not.toBeNull();
+    });
+  });
+
+  describe("retryLaterWithoutIncrementingAttempts", () => {
+    test("clears completed_at on retry", async () => {
+      if (!canRun()) return;
+      const id = "00000000-0000-4900-8000-000000000030";
+      const generation = "b0000000-0000-4000-8000-000000000030";
+      const ownerId = "owner-3";
+      await seedJob({ id, maxAttempts: 1 });
+      await dbWrite.update(jobs).set({ execution_generation: generation }).where(eq(jobs.id, id));
+      await seedLease(id, generation, ownerId);
+      const claimed = await repo.findById(id);
+      if (!claimed) throw new Error("seeded job not found");
+      await repo.retryLaterWithoutIncrementingAttempts(claimed, "ambiguity", 5000, ownerId);
+      const job = await getJob(id);
+      expect(job?.status).toBe("pending");
+      expect(job?.completed_at).toBeNull();
+    });
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
@@ -176,6 +176,20 @@ describe("completed_at terminal-timestamp contract", () => {
       expect(job?.completed_at).toEqual(terminalAt);
       expect(job?.webhook_status).toBe("delivered");
     });
+
+    test("replaces a stale timestamp when a non-terminal row becomes terminal", async () => {
+      const id = "00000000-0000-4900-8000-000000000007";
+      const staleDate = new Date("2021-06-15T12:00:00.000Z");
+      await seedJob({ id, maxAttempts: 1 });
+      await dbWrite.update(jobs).set({ completed_at: staleDate }).where(eq(jobs.id, id));
+
+      await repo.updateStatus(id, "failed");
+
+      const job = await getJob(id);
+      expect(job?.status).toBe("failed");
+      expect(job?.completed_at).not.toEqual(staleDate);
+      expect(job?.completed_at?.getTime()).toBeGreaterThan(staleDate.getTime());
+    });
   });
 
   describe("incrementAttempt", () => {
@@ -227,6 +241,28 @@ describe("completed_at terminal-timestamp contract", () => {
       const job = await getJob(id);
       expect(job?.status).toBe("cancelled");
       expect(job?.completed_at).not.toBeNull();
+    });
+
+    test("replaces a stale timestamp when settling a claimed execution", async () => {
+      const id = "00000000-0000-4900-8000-000000000022";
+      const generation = "a0000000-0000-4000-8000-000000000022";
+      const ownerId = "owner-3";
+      const staleDate = new Date("2021-06-15T12:00:00.000Z");
+      await seedJob({ id, maxAttempts: 1 });
+      await dbWrite
+        .update(jobs)
+        .set({ execution_generation: generation, completed_at: staleDate })
+        .where(eq(jobs.id, id));
+      await seedLease(id, generation, ownerId);
+      const claimed = await repo.findById(id);
+      if (!claimed) throw new Error("seeded job not found");
+
+      await repo.settleExecution(claimed, "completed", undefined, ownerId);
+
+      const job = await getJob(id);
+      expect(job?.status).toBe("completed");
+      expect(job?.completed_at).not.toEqual(staleDate);
+      expect(job?.completed_at?.getTime()).toBeGreaterThan(staleDate.getTime());
     });
   });
 

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
@@ -20,7 +20,6 @@ const JOB_STARTED_AT = new Date("2020-01-01T00:00:00.000Z");
 let dbWrite: typeof import("../../client").dbWrite;
 let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
 let repo: typeof import("../jobs").jobsRepository;
-let pgliteReady = true;
 
 async function seedJob(params: {
   id: string;
@@ -57,12 +56,11 @@ async function getJob(id: string): Promise<Job | undefined> {
 }
 
 beforeAll(async () => {
-  try {
-    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
-    ({ jobsRepository: repo } = await import("../jobs"));
+  ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
+  ({ jobsRepository: repo } = await import("../jobs"));
 
-    await dbWrite.execute(
-      `CREATE TABLE IF NOT EXISTS jobs (
+  await dbWrite.execute(
+    `CREATE TABLE IF NOT EXISTS jobs (
 				id uuid PRIMARY KEY,
 				type text NOT NULL,
 				status text NOT NULL DEFAULT 'pending',
@@ -94,9 +92,9 @@ beforeAll(async () => {
 				created_at timestamp NOT NULL DEFAULT now(),
 				updated_at timestamp NOT NULL DEFAULT now()
 			)`,
-    );
-    await dbWrite.execute(
-      `CREATE TABLE IF NOT EXISTS job_execution_leases (
+  );
+  await dbWrite.execute(
+    `CREATE TABLE IF NOT EXISTS job_execution_leases (
 				job_id uuid REFERENCES jobs(id) ON DELETE CASCADE,
 				execution_generation uuid NOT NULL,
 				owner_id text NOT NULL,
@@ -105,30 +103,20 @@ beforeAll(async () => {
 				created_at timestamp NOT NULL DEFAULT now(),
 				PRIMARY KEY (job_id, execution_generation, owner_id)
 			)`,
-    );
-  } catch (error) {
-    pgliteReady = false;
-    console.warn("[jobs-completed-at] PGlite unavailable, skipping:", error);
-  }
+  );
 }, PGLITE_TIMEOUT);
 
 afterAll(async () => {
   if (closeDb) await closeDb();
 });
 
-function canRun(): boolean {
-  return pgliteReady;
-}
-
 describe("completed_at terminal-timestamp contract", () => {
   beforeEach(async () => {
-    if (!canRun()) return;
     await dbWrite.execute("DELETE FROM jobs;");
   });
 
   describe("updateStatus", () => {
     test("sets completed_at when status is failed", async () => {
-      if (!canRun()) return;
       const id = "00000000-0000-4900-8000-000000000001";
       await seedJob({ id, maxAttempts: 1 });
       await repo.updateStatus(id, "failed");
@@ -138,7 +126,6 @@ describe("completed_at terminal-timestamp contract", () => {
     });
 
     test("sets completed_at when status is cancelled", async () => {
-      if (!canRun()) return;
       const id = "00000000-0000-4900-8000-000000000002";
       await seedJob({ id, maxAttempts: 1 });
       await repo.updateStatus(id, "cancelled");
@@ -148,7 +135,6 @@ describe("completed_at terminal-timestamp contract", () => {
     });
 
     test("sets completed_at when status is completed", async () => {
-      if (!canRun()) return;
       const id = "00000000-0000-4900-8000-000000000003";
       await seedJob({ id, maxAttempts: 1 });
       await repo.updateStatus(id, "completed");
@@ -158,7 +144,6 @@ describe("completed_at terminal-timestamp contract", () => {
     });
 
     test("clears completed_at when status transitions to pending", async () => {
-      if (!canRun()) return;
       const id = "00000000-0000-4900-8000-000000000004";
       await seedJob({ id, maxAttempts: 1 });
       await repo.updateStatus(id, "completed");
@@ -171,7 +156,6 @@ describe("completed_at terminal-timestamp contract", () => {
     });
 
     test("respects explicit completed_at in additionalFields", async () => {
-      if (!canRun()) return;
       const id = "00000000-0000-4900-8000-000000000005";
       const explicitDate = new Date("2021-06-15T12:00:00.000Z");
       await seedJob({ id, maxAttempts: 1 });
@@ -179,11 +163,23 @@ describe("completed_at terminal-timestamp contract", () => {
       const job = await getJob(id);
       expect(job?.completed_at).toEqual(explicitDate);
     });
+
+    test("does not move completed_at when a terminal row is updated again", async () => {
+      const id = "00000000-0000-4900-8000-000000000006";
+      await seedJob({ id, maxAttempts: 1 });
+      await repo.updateStatus(id, "failed");
+      const terminalAt = (await getJob(id))?.completed_at;
+      expect(terminalAt).not.toBeNull();
+
+      await repo.updateStatus(id, "failed", { webhook_status: "delivered" });
+      const job = await getJob(id);
+      expect(job?.completed_at).toEqual(terminalAt);
+      expect(job?.webhook_status).toBe("delivered");
+    });
   });
 
   describe("incrementAttempt", () => {
     test("sets completed_at when attempt exhaustion flips to failed", async () => {
-      if (!canRun()) return;
       const id = "00000000-0000-4900-8000-000000000010";
       await seedJob({ id, maxAttempts: 1, attempts: 0 });
       await repo.incrementAttempt(id, "boom", 1);
@@ -193,7 +189,6 @@ describe("completed_at terminal-timestamp contract", () => {
     });
 
     test("keeps completed_at null on retry (not yet exhausted)", async () => {
-      if (!canRun()) return;
       const id = "00000000-0000-4900-8000-000000000011";
       await seedJob({ id, maxAttempts: 3, attempts: 0 });
       await repo.incrementAttempt(id, "transient", 3);
@@ -205,7 +200,6 @@ describe("completed_at terminal-timestamp contract", () => {
 
   describe("settleExecution", () => {
     test("sets completed_at when status is completed", async () => {
-      if (!canRun()) return;
       const id = "00000000-0000-4900-8000-000000000020";
       const generation = "a0000000-0000-4000-8000-000000000020";
       const ownerId = "owner-1";
@@ -221,7 +215,6 @@ describe("completed_at terminal-timestamp contract", () => {
     });
 
     test("sets completed_at when status is cancelled", async () => {
-      if (!canRun()) return;
       const id = "00000000-0000-4900-8000-000000000021";
       const generation = "a0000000-0000-4000-8000-000000000021";
       const ownerId = "owner-2";
@@ -239,7 +232,6 @@ describe("completed_at terminal-timestamp contract", () => {
 
   describe("retryLaterWithoutIncrementingAttempts", () => {
     test("clears completed_at on retry", async () => {
-      if (!canRun()) return;
       const id = "00000000-0000-4900-8000-000000000030";
       const generation = "b0000000-0000-4000-8000-000000000030";
       const ownerId = "owner-3";
@@ -251,6 +243,60 @@ describe("completed_at terminal-timestamp contract", () => {
       await repo.retryLaterWithoutIncrementingAttempts(claimed, "ambiguity", 5000, ownerId);
       const job = await getJob(id);
       expect(job?.status).toBe("pending");
+      expect(job?.completed_at).toBeNull();
+    });
+  });
+
+  describe("recoverStaleJobs", () => {
+    test("sets completed_at when stale recovery exhausts attempts", async () => {
+      const id = "00000000-0000-4900-8000-000000000040";
+      await seedJob({ id, maxAttempts: 1 });
+
+      const result = await repo.recoverStaleJobs({
+        type: "agent_message",
+        staleThresholdMs: 1,
+      });
+
+      expect(result).toMatchObject({ permanentlyFailed: 1, retried: 0, failures: [] });
+      const job = await getJob(id);
+      expect(job?.status).toBe("failed");
+      expect(job?.completed_at).not.toBeNull();
+    });
+
+    test("keeps completed_at null when stale recovery requeues", async () => {
+      const id = "00000000-0000-4900-8000-000000000041";
+      await seedJob({ id, maxAttempts: 3 });
+
+      const result = await repo.recoverStaleJobs({
+        type: "agent_message",
+        staleThresholdMs: 1,
+      });
+
+      expect(result).toMatchObject({ permanentlyFailed: 0, retried: 1, failures: [] });
+      const job = await getJob(id);
+      expect(job?.status).toBe("pending");
+      expect(job?.completed_at).toBeNull();
+    });
+
+    test("rolls completed_at back with the terminal flip when a dependent write fails", async () => {
+      const id = "00000000-0000-4900-8000-000000000042";
+      await seedJob({ id, maxAttempts: 1 });
+
+      const result = await repo.recoverStaleJobs({
+        type: "agent_message",
+        staleThresholdMs: 1,
+        buildFailureWriteback: () => async () => {
+          throw new Error("dependent row is locked");
+        },
+      });
+
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]?.cause).toEqual(
+        expect.objectContaining({ message: "dependent row is locked" }),
+      );
+      const job = await getJob(id);
+      expect(job?.status).toBe("in_progress");
+      expect(job?.attempts).toBe(0);
       expect(job?.completed_at).toBeNull();
     });
   });

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -1376,23 +1376,16 @@ export class JobsRepository {
    */
   async updateStatus(id: string, status: string, additionalFields?: Partial<Job>): Promise<void> {
     let updates: Partial<Job> = {
-      status,
-      updated_at: new Date(),
       ...additionalFields,
+      status,
+      updated_at: additionalFields?.updated_at ?? new Date(),
     };
 
     if (status === "in_progress" && !additionalFields?.started_at) {
       updates.started_at = new Date();
     }
-    if (
-      (status === "completed" || status === "failed" || status === "cancelled") &&
-      !additionalFields?.completed_at
-    ) {
-      updates.completed_at = new Date();
-    }
-    if (status === "pending" && !additionalFields?.completed_at) {
-      updates.completed_at = null;
-    }
+    const isTerminal = SETTLED_JOB_STATUSES.has(status);
+    const explicitCompletedAt = additionalFields?.completed_at;
 
     if (hasPayloadUpdates(updates)) {
       const [existing] = await dbWrite.select().from(jobs).where(eq(jobs.id, id)).limit(1);
@@ -1402,7 +1395,17 @@ export class JobsRepository {
       updates = await prepareJobPayload(updates, existing);
     }
 
-    await dbWrite.update(jobs).set(updates).where(eq(jobs.id, id));
+    await dbWrite
+      .update(jobs)
+      .set({
+        ...updates,
+        ...(status === "pending"
+          ? { completed_at: null }
+          : isTerminal && !(explicitCompletedAt instanceof Date)
+            ? { completed_at: sql`COALESCE(${jobs.completed_at}, NOW())` }
+            : {}),
+      })
+      .where(eq(jobs.id, id));
   }
 
   /**
@@ -1420,13 +1423,16 @@ export class JobsRepository {
     if (!executionOwnerId) {
       throw new Error(`Execution owner is required to settle claimed job ${claimedJob.id}`);
     }
+    const settledAt =
+      additionalFields?.completed_at instanceof Date
+        ? additionalFields.completed_at
+        : (claimedJob.completed_at ?? new Date());
     let updates: Partial<Job> = {
-      status,
-      completed_at:
-        status === "completed" || status === "cancelled" ? new Date() : claimedJob.completed_at,
-      execution_quiesced_at: new Date(),
-      updated_at: new Date(),
       ...additionalFields,
+      status,
+      completed_at: settledAt,
+      execution_quiesced_at: additionalFields?.execution_quiesced_at ?? new Date(),
+      updated_at: additionalFields?.updated_at ?? new Date(),
     };
     if (hasPayloadUpdates(updates)) {
       updates = await prepareJobPayload(updates, claimedJob);

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -1226,6 +1226,7 @@ export class JobsRepository {
           status: params.isFailed ? "failed" : "pending",
           ...payload,
           attempts: params.newAttempts,
+          completed_at: params.isFailed ? new Date() : null,
           execution_quiesced_at: new Date(),
           updated_at: new Date(),
         })
@@ -1383,8 +1384,14 @@ export class JobsRepository {
     if (status === "in_progress" && !additionalFields?.started_at) {
       updates.started_at = new Date();
     }
-    if (status === "completed" && !additionalFields?.completed_at) {
+    if (
+      (status === "completed" || status === "failed" || status === "cancelled") &&
+      !additionalFields?.completed_at
+    ) {
       updates.completed_at = new Date();
+    }
+    if (status === "pending" && !additionalFields?.completed_at) {
+      updates.completed_at = null;
     }
 
     if (hasPayloadUpdates(updates)) {
@@ -1415,7 +1422,8 @@ export class JobsRepository {
     }
     let updates: Partial<Job> = {
       status,
-      completed_at: status === "completed" ? new Date() : claimedJob.completed_at,
+      completed_at:
+        status === "completed" || status === "cancelled" ? new Date() : claimedJob.completed_at,
       execution_quiesced_at: new Date(),
       updated_at: new Date(),
       ...additionalFields,
@@ -1590,6 +1598,7 @@ export class JobsRepository {
           status: isFailed ? "failed" : "pending",
           ...payload,
           attempts: newAttempts,
+          completed_at: isFailed ? new Date() : null,
           execution_quiesced_at: expectedExecutionGeneration
             ? new Date()
             : job.execution_quiesced_at,
@@ -1731,6 +1740,7 @@ export class JobsRepository {
         .set({
           status: "pending",
           ...payload,
+          completed_at: null,
           execution_quiesced_at: new Date(),
           updated_at: new Date(),
           scheduled_for: scheduledFor,

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -1402,7 +1402,13 @@ export class JobsRepository {
         ...(status === "pending"
           ? { completed_at: null }
           : isTerminal && !(explicitCompletedAt instanceof Date)
-            ? { completed_at: sql`COALESCE(${jobs.completed_at}, NOW())` }
+            ? {
+                completed_at: sql`CASE
+                  WHEN ${jobs.status} IN ('completed', 'failed', 'cancelled')
+                    THEN COALESCE(${jobs.completed_at}, NOW())
+                  ELSE NOW()
+                END`,
+              }
             : {}),
       })
       .where(eq(jobs.id, id));
@@ -1424,9 +1430,7 @@ export class JobsRepository {
       throw new Error(`Execution owner is required to settle claimed job ${claimedJob.id}`);
     }
     const settledAt =
-      additionalFields?.completed_at instanceof Date
-        ? additionalFields.completed_at
-        : (claimedJob.completed_at ?? new Date());
+      additionalFields?.completed_at instanceof Date ? additionalFields.completed_at : new Date();
     let updates: Partial<Job> = {
       ...additionalFields,
       status,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -178,6 +178,20 @@ describe("enqueueAgentDeleteOnce.beforeInsert — cancels other pending jobs", (
       (c) => (c[0] as { status?: string })?.status === "cancelled",
     );
     expect(cancelSet).toBeDefined();
+    if (!cancelSet) {
+      throw new Error("cancellation update was not captured");
+    }
+    const cancelValues = cancelSet[0] as {
+      completed_at?: Date;
+      updated_at?: Date;
+    };
+    expect(cancelValues).toEqual(
+      expect.objectContaining({
+        completed_at: expect.any(Date),
+        updated_at: expect.any(Date),
+      }),
+    );
+    expect(cancelValues.completed_at).toEqual(cancelValues.updated_at);
 
     // The cancel WHERE is scoped to this org AND this agent, excludes
     // agent_delete (delete never self-cancels), and only touches pending rows.

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -1551,9 +1551,14 @@ export class ProvisioningJobService {
         }
         // A pending row is either unclaimed or was made retryable only after its
         // prior execution acknowledged quiescence.
+        const cancelledAt = new Date();
         const cancelled = await tx
           .update(jobs)
-          .set({ status: "cancelled", updated_at: new Date() })
+          .set({
+            status: "cancelled",
+            completed_at: cancelledAt,
+            updated_at: cancelledAt,
+          })
           .where(
             and(
               eq(jobs.organization_id, params.organizationId),


### PR DESCRIPTION
Closes #18093.

## Problem

Terminal transitions to `failed` and `cancelled` did not consistently set `completed_at`. Production cohorts keyed by that field therefore omitted failures and cancellations and could report a false-green failure rate.

## Root cause

The timestamp contract was fragmented across repository and service writers:

- attempt exhaustion and stale recovery changed status without setting terminal time;
- delete enqueue directly cancelled pending sibling jobs outside the repository;
- retries did not uniformly clear stale terminal time;
- repeated terminal `updateStatus` calls could move the timestamp;
- no migration repaired historical rows.

Deep review found a second, legacy-state failure hidden by the initial patch. A nonterminal row can already contain a stale `completed_at` from older code or partial repair. Preserving any non-null timestamp with `COALESCE(completed_at, NOW())` would then misreport that stale value as the new terminal time. `settleExecution` had the same weakness because it reused `claimedJob.completed_at` without checking whether the claimed row was already terminal.

The original test harness also caught PGlite setup errors and returned early from every test, allowing infrastructure failure to appear green. The repaired real-PostgreSQL fixture then exposed another gap: it claimed the first 184 migrations were applied while modeling `jobs` as an ID-only table. The fixture now models the historical terminal columns and proves migration 0195's backfill on PostgreSQL.

## Fix

- `updateStatus` now decides timestamp preservation from the row's **previous status** in the same SQL update: an already-terminal row preserves its first terminal time, while a nonterminal-to-terminal transition always receives `NOW()` unless an explicit authoritative date is supplied.
- `settleExecution` uses a fresh settlement time unless the caller supplies an explicit authoritative date; it never reuses an unexplained timestamp from a claimed nonterminal row.
- `incrementAttempt` and both stale-recovery paths set terminal time in the same transaction as status.
- Retry paths back to `pending` clear `completed_at`.
- Delete enqueue stamps directly-cancelled pending jobs with one shared cancellation/update timestamp.
- Migration `0195_job_terminal_completed_at_backfill` fills only missing failed/cancelled timestamps, preferring `execution_quiesced_at`, then `updated_at`, `started_at`, and `created_at`.
- PGlite tests fail fast if setup fails and cover idempotent migration, immutable terminal time, stale nonterminal timestamps, retries, stale recovery, cancellation, and dependent-write rollback.
- The real PostgreSQL migration-fencing fixture now represents the terminal columns present at its seeded historical prefix and asserts the 0195 backfill instead of failing on an impossible ID-only catalog.

## Validation

Exact head: `3ce937a4d54786c76299900041747ce1a5d631d2`
Base: `4fc8c7844f3dbbe80526ebaeeeb9252a02719b6c`

- Focused terminal/migration/delete-enqueue suites: 24 passed, 74 assertions, including both stale-timestamp adversarial cases.
- Real PostgreSQL migration fencing/contention suite: 10 passed, 46 assertions, including fix-forward application, hash/catalog drift, concurrent serialization, lock contention, bounded failure, and terminal backfill.
- Cloud Shared typecheck: passed.
- Cloud Shared Biome check: 1,830 files passed.
- `drizzle-kit check`: passed.
- Root `bun run verify`: 348/348 Turbo tasks and all follow-on audits passed.
- Full Cloud Shared harness on patch-equivalent pre-rebase head `967a445a0cd337eae009bf3216dffcceea1cbd0e`: 668 files across 158 isolated batches, exit 0. All four stable patch IDs are unchanged after rebasing over the unrelated vision squash.
- Existing recovery and scheduled-backup sentinels on the same patch-equivalent head: 53 passed, 310 assertions.

## Evidence

<!-- evidence-head:3ce937a4d54786c76299900041747ce1a5d631d2 -->

- GitHub head and base were revalidated after the final rebase; the four stable patch IDs match the fully reviewed predecessor exactly.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - database repository and migration change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - database repository and migration change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-final-head backend validation transcript:

```text
Terminal/migration/delete-enqueue: 24 tests passed; 74 assertions; 0 failed.
Real PostgreSQL migration fencing/contention: 10 tests passed; 46 assertions; 0 failed.
Cloud Shared typecheck: passed.
Cloud Shared Biome: 1,830 files passed.
drizzle-kit check: passed.
Root verify: 348/348 Turbo tasks plus all follow-on audits passed.
```
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic persistence behavior; no model, prompt, planner, provider, or action changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-final-head database domain-artifact transcript:

```text
Migration 0195 was exercised through real PGlite and real PostgreSQL.
Real PostgreSQL applied the append-only fix-forward once, tolerated only approved historical drift, serialized concurrent migrators, and failed observably after bounded lock retries.
Stale completed_at values on nonterminal rows were replaced on generic and leased terminal settlement paths.
Injected dependent-write failure rolled back status, attempts, and completed_at together.
```
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixel or text rendering changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.2`; `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`; `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: zai / glm-5.2; OpenAI / gpt-5.6-sol (review and repair)
Client / agent tooling: Hermes Agent; Codex Desktop
Skill revision: elizaOS/eliza@392196171b3206e1ccc162eba2faef3ea5b8347b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz] [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - contribute-to-eliza skill was not available"} -->
