### PR TITLE
feat(registry): add Adanos market sentiment plugin

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-adanos.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-adanos.json
@@ -1,0 +1,17 @@
+{
+  "package": "elizaos-plugin-adanos",
+  "repository": "github:adanos-software/elizaos-plugin-adanos",
+  "kind": "plugin",
+  "description": "Read-only Adanos stock and crypto market sentiment for elizaOS agents.",
+  "homepage": "https://adanos.org/",
+  "version": "0.1.0",
+  "tags": [
+    "elizaos",
+    "plugin",
+    "market-sentiment",
+    "stocks",
+    "crypto",
+    "alternative-data",
+    "adanos"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1092,6 +1092,53 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "elizaos-plugin-adanos": {
+      "git": {
+        "repo": "adanos-software/elizaos-plugin-adanos",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-adanos",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Read-only Adanos stock and crypto market sentiment for elizaOS agents.",
+      "homepage": "https://adanos.org/",
+      "topics": [
+        "elizaos",
+        "plugin",
+        "market-sentiment",
+        "stocks",
+        "crypto",
+        "alternative-data",
+        "adanos"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "elizaos-plugin-coinrailz": {
       "git": {
         "repo": "tdnupe3/elizaos-plugin-coinrailz",


### PR DESCRIPTION
# Relates to

N/A - standalone third-party registry submission.

- [x] This PR targets `develop` and is based on the latest upstream `develop` commit with zero conflicts.
- [x] Relevant registry validation is complete; sparse-checkout limitations are recorded below.
- [x] The public npm package and generated registry result let reviewers verify the change without reading plugin source.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a894ed40d8a91d3939afca4c008cc7a417f34d2e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on current `upstream/develop` (`533c457bba329d6673599c9cbc3e337cd8f8420b`); zero conflicts.
- [x] Relevant package checks pass; the non-applicable sparse-checkout limitation is documented in **Known gaps / failures**.

# Risks

Low. This adds declarative metadata for one third-party package and regenerates the derived third-party registry. It does not change elizaOS runtime code or first-party entries.

# Background

## What does this PR do?

Registers [`elizaos-plugin-adanos`](https://www.npmjs.com/package/elizaos-plugin-adanos), a read-only elizaOS v2 plugin for stock and crypto market sentiment from Adanos. The plugin exposes optional agent actions for sentiment, trending assets, comparisons, and broader market context; consumers provide their own `ADANOS_API_KEY`.

The package is public, its repository is public, and npm `0.1.0` points to the merged source commit `5871b07b68c6f16f76f2265c4f339dd307ff69cc` through `gitHead`.

## What kind of change is this?

Improvement: adds a third-party registry listing.

# Documentation changes needed?

No project documentation change is needed. The registry entry is the intended discovery metadata, while usage and configuration documentation live in the [plugin repository](https://github.com/adanos-software/elizaos-plugin-adanos).

# Testing

## Where should a reviewer start?

Review `packages/registry/entries/third-party/elizaos-plugin-adanos.json`, then confirm the matching generated block in `packages/registry/generated-registry.json`.

## Detailed testing steps

- `bun run --cwd packages/registry validate` - 39 third-party entries validated.
- `bun run --cwd packages/registry generate` - deterministic generated registry produced with 39 entries.
- `bun run --cwd packages/registry test` - 6 files and 36 tests passed.
- `bun run --cwd packages/registry typecheck` - passed.
- `bun run --cwd packages/registry lint:check` - passed.
- `bun run --cwd packages/registry format:check` - passed.
- `git diff --check` - passed.
- Published package validation on the exact merged source: typecheck, lint, 6 tests, build, `npm pack --dry-run`, fresh install, and production dependency audit all passed.

# Evidence Gate

<!-- evidence-head:e6a5a583072713258109f49242793affcc67e0ae -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - registry metadata only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - registry metadata only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - metadata-only registry listing with no interactive flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime behavior changed.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend files or behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, model, prompt, provider, or action behavior changed in this repository.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - registry metadata and its deterministic generated wire entry are the complete changed artifacts; repository registry validation is the proof path
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this PR contains registry metadata only.

## Backend + frontend logs

N/A - this PR changes no runtime path.

## Screenshots (before / after) + video walkthrough

N/A - this PR changes no UI.

## Audio / voice walkthrough

N/A - no voice or audio behavior changed.

## Known gaps / failures

- The working copy is an intentional sparse checkout containing the registry and contribution guidance. Root `bun install --frozen-lockfile` cannot resolve workspace directories omitted from that checkout.
- `generate:first-party:check` cannot be evaluated in that sparse checkout because the generator scans first-party package directories that are intentionally absent. This PR changes no first-party registry input or artifact.
- The targeted third-party registry validation, generation, tests, typecheck, lint, format, and diff checks all pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@a894ed40d8a91d3939afca4c008cc7a417f34d2e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex/registry-adanos]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@a894ed40d8a91d3939afca4c008cc7a417f34d2e:packages/skills/skills/contribute-to-eliza"} -->



<!-- maintainer-evidence-revalidated:e6a5a583072713258109f49242793affcc67e0ae -->

