### PR TITLE
fix(workflow): isolate test files in fresh processes (#18301)

### DIFF
--- a/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
+++ b/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
@@ -88,6 +88,11 @@ const SKIPPABLE_EMPTY_PACKAGE_DIR = join(
   "packages",
   "__run_all_tests_genuinely_no_tests__",
 );
+const ISOLATED_WRAPPER_PACKAGE_DIR = join(
+  repoRoot,
+  "packages",
+  "__run_all_tests_isolated_bun_wrapper__",
+);
 
 function rootScript(name) {
   const rootPackage = JSON.parse(
@@ -331,6 +336,68 @@ describe("run-all-tests --require-work vacuous-green guard", () => {
       const result = run(["--no-cloud", "--min-tasks=abc", "--plan"]);
       expect(result.status).toBe(2);
       expect(result.stderr).toContain("--min-tasks/MIN_TEST_TASKS");
+    },
+    SPAWN_TIMEOUT_MS,
+  );
+
+  test(
+    "reconciles JUnit evidence from a supervised isolated Bun wrapper",
+    () => {
+      rmSync(ISOLATED_WRAPPER_PACKAGE_DIR, {
+        recursive: true,
+        force: true,
+      });
+      mkdirSync(join(ISOLATED_WRAPPER_PACKAGE_DIR, "scripts"), {
+        recursive: true,
+      });
+      try {
+        writeFileSync(
+          join(ISOLATED_WRAPPER_PACKAGE_DIR, "package.json"),
+          `${JSON.stringify(
+            {
+              name: "@elizaos/run-all-tests-isolated-bun-wrapper-fixture",
+              private: true,
+              type: "module",
+              scripts: {
+                test: "node ../../packages/scripts/run-with-flake-retry.mjs 'never-match' -- node ../../packages/scripts/run-with-deadline.mjs 5000 -- node scripts/run-isolated-tests.mjs",
+              },
+            },
+            null,
+            2,
+          )}\n`,
+        );
+        writeFileSync(
+          join(
+            ISOLATED_WRAPPER_PACKAGE_DIR,
+            "scripts",
+            "run-isolated-tests.mjs",
+          ),
+          [
+            'import { writeFileSync } from "node:fs";',
+            "const args = process.argv.slice(2);",
+            'const output = args.find((arg) => arg.startsWith("--reporter-outfile="))?.slice("--reporter-outfile=".length);',
+            'if (!args.includes("--reporter=junit") || !output) throw new Error("missing forwarded JUnit arguments");',
+            'writeFileSync(output, `<testsuites tests="1" failures="0" errors="0" skipped="0"><testsuite name="isolated" tests="1" failures="0" errors="0" skipped="0"><testcase name="real isolated work" /></testsuite></testsuites>`);',
+            "",
+          ].join("\n"),
+        );
+
+        const result = run([
+          "--only=test",
+          "--no-cloud",
+          "--filter=@elizaos/run-all-tests-isolated-bun-wrapper-fixture",
+          "--require-work",
+        ]);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain(
+          "EVIDENCE reports=1 tests=1 executed=1 skipped=0 unobserved-tasks=0",
+        );
+      } finally {
+        rmSync(ISOLATED_WRAPPER_PACKAGE_DIR, {
+          recursive: true,
+          force: true,
+        });
+      }
     },
     SPAWN_TIMEOUT_MS,
   );

--- a/packages/scripts/run-all-tests.mjs
+++ b/packages/scripts/run-all-tests.mjs
@@ -803,6 +803,34 @@ function isSingleBunTestCommand(command) {
   return /^bun\s+test\b/.test(commandWithoutEnv);
 }
 
+function unwrapKnownBunTestSupervisors(command) {
+  let current = stripLeadingEnvAssignments(command);
+  for (let depth = 0; depth < 3; depth += 1) {
+    const flakeRetry = current.match(
+      /^node\s+(?:\.\.\/)+packages\/scripts\/run-with-flake-retry\.mjs\s+(?:'[^']*'|"[^"]*"|\S+)\s+--\s+(.+)$/,
+    );
+    if (flakeRetry) {
+      current = flakeRetry[1];
+      continue;
+    }
+    const deadline = current.match(
+      /^node\s+(?:\.\.\/)+packages\/scripts\/run-with-deadline\.mjs\s+[1-9]\d*\s+--\s+(.+)$/,
+    );
+    if (deadline) {
+      current = deadline[1];
+      continue;
+    }
+    break;
+  }
+  return current;
+}
+
+function isSingleIsolatedBunTestWrapperCommand(command) {
+  return /^node\s+scripts\/run-isolated-tests\.mjs$/.test(
+    unwrapKnownBunTestSupervisors(command),
+  );
+}
+
 function structuredEvidenceKind(scriptName, scripts) {
   const command =
     resolveScriptCommand(scriptName, scripts) ||
@@ -814,7 +842,12 @@ function structuredEvidenceKind(scriptName, scripts) {
   ) {
     return null;
   }
-  if (isSingleBunTestCommand(command)) return "bun";
+  if (
+    isSingleBunTestCommand(command) ||
+    isSingleIsolatedBunTestWrapperCommand(command)
+  ) {
+    return "bun";
+  }
   if (
     isSingleVitestRunCommand(command) ||
     isSingleVitestWrapperCommand(command)

--- a/plugins/plugin-workflow/__tests__/unit/test-runner.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/test-runner.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests the workflow package's deterministic test-file discovery with a real
+ * temporary directory tree; child-process behavior is exercised by the full
+ * package command rather than mocked here.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  discoverWorkflowTestFiles,
+  parseWorkflowTestArgs,
+} from '../../scripts/run-isolated-tests.mjs';
+
+describe('workflow isolated test runner', () => {
+  it('discovers only test/spec modules in deterministic order', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'workflow-test-runner-'));
+    try {
+      const nested = path.join(root, 'nested');
+      mkdirSync(nested);
+      writeFileSync(path.join(root, 'z.test.ts'), '');
+      writeFileSync(path.join(root, 'a.spec.mjs'), '');
+      writeFileSync(path.join(root, 'fixture.ts'), '');
+      writeFileSync(path.join(nested, 'b.test.tsx'), '');
+
+      const relativeRoot = path.relative(path.resolve(import.meta.dir, '../..'), root);
+      expect(discoverWorkflowTestFiles(root)).toEqual([
+        path.join(relativeRoot, 'a.spec.mjs'),
+        path.join(relativeRoot, 'nested', 'b.test.tsx'),
+        path.join(relativeRoot, 'z.test.ts'),
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('requires a complete JUnit reporter pair', () => {
+    expect(parseWorkflowTestArgs([])).toEqual({ reporterOutfile: undefined });
+    expect(
+      parseWorkflowTestArgs(['--reporter=junit', '--reporter-outfile=/tmp/workflow.xml'])
+    ).toEqual({ reporterOutfile: '/tmp/workflow.xml' });
+    expect(() => parseWorkflowTestArgs(['--reporter=junit'])).toThrow('requires both');
+    expect(() => parseWorkflowTestArgs(['--unknown'])).toThrow('unknown argument');
+  });
+});

--- a/plugins/plugin-workflow/package.json
+++ b/plugins/plugin-workflow/package.json
@@ -48,7 +48,7 @@
     "build": "node ../../packages/scripts/rm-path-recursive.mjs dist && tsc6 --noCheck -p tsconfig.json",
     "dev": "tsc6 --watch",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
-    "test": "node ../../packages/scripts/run-with-flake-retry.mjs 'EEXIST[^\\n]*epoll_ctl|error: Failed to connect' -- node ../../packages/scripts/run-with-deadline.mjs 1500000 -- bun test --isolate",
+    "test": "node ../../packages/scripts/run-with-flake-retry.mjs 'EEXIST[^\\n]*epoll_ctl|error: Failed to connect' -- node ../../packages/scripts/run-with-deadline.mjs 1500000 -- node scripts/run-isolated-tests.mjs",
     "test:unit": "bun test --isolate __tests__/unit/",
     "test:e2e": "node ../../packages/app-core/scripts/run-local-plugin-live-smoke.mjs",
     "lint": "bunx @biomejs/biome check --write --unsafe .",

--- a/plugins/plugin-workflow/scripts/run-isolated-tests.mjs
+++ b/plugins/plugin-workflow/scripts/run-isolated-tests.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * Runs every workflow test file in its own Bun process, sequentially. The
+ * Smithers integration suites exercise child-process pipes heavily; a single
+ * long-lived Bun test process can corrupt its Linux epoll/stdio state and then
+ * fail unrelated files. Process isolation releases that state between files,
+ * while merged JUnit output lets the repository prove real testcases ran.
+ */
+
+import { spawn } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const pluginRoot = path.resolve(path.dirname(scriptPath), "..");
+const defaultTestRoot = path.join(pluginRoot, "__tests__");
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/;
+
+export function discoverWorkflowTestFiles(root = defaultTestRoot) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(absolutePath);
+      } else if (entry.isFile() && TEST_FILE_PATTERN.test(entry.name)) {
+        files.push(path.relative(pluginRoot, absolutePath));
+      }
+    }
+  };
+  visit(root);
+  return files.sort();
+}
+
+export function parseWorkflowTestArgs(argv) {
+  let reporter;
+  let reporterOutfile;
+  for (const arg of argv) {
+    if (arg === "--reporter=junit") {
+      reporter = "junit";
+    } else if (arg.startsWith("--reporter-outfile=")) {
+      reporterOutfile = arg.slice("--reporter-outfile=".length);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if ((reporter === "junit") !== Boolean(reporterOutfile)) {
+    throw new Error(
+      "JUnit evidence requires both --reporter=junit and --reporter-outfile=<path>",
+    );
+  }
+  return { reporterOutfile };
+}
+
+function runOneTestFile(file, bunBinary, fragmentPath, onChild) {
+  return new Promise((resolve) => {
+    const args = ["test", "--isolate"];
+    if (fragmentPath) {
+      args.push("--reporter=junit", `--reporter-outfile=${fragmentPath}`);
+    }
+    args.push(file);
+    const child = spawn(bunBinary, args, {
+      cwd: pluginRoot,
+      env: process.env,
+      stdio: "inherit",
+    });
+    onChild(child);
+    let settled = false;
+    const settle = (result) => {
+      if (settled) return;
+      settled = true;
+      onChild(undefined);
+      resolve(result);
+    };
+    child.once("error", (error) => {
+      process.stderr.write(
+        `[plugin-workflow:test] could not start ${file}: ${error.message}\n`,
+      );
+      settle(127);
+    });
+    child.once("close", (code, signal) => {
+      settle(code ?? (signal ? 1 : 0));
+    });
+  });
+}
+
+function readJunitFragment(fragmentPath, file) {
+  const xml = readFileSync(fragmentPath, "utf8");
+  const root = xml.match(/<testsuites\b([^>]*)>/);
+  if (!root) throw new Error(`JUnit fragment has no testsuites root: ${file}`);
+  const counts = {};
+  for (const name of ["tests", "assertions", "failures", "skipped"]) {
+    const raw = root[1].match(new RegExp(`\\b${name}="(\\d+)"`))?.[1];
+    if (raw === undefined) {
+      throw new Error(`JUnit fragment has no ${name} count: ${file}`);
+    }
+    counts[name] = Number(raw);
+  }
+  const bodyStart = root.index + root[0].length;
+  const bodyEnd = xml.lastIndexOf("</testsuites>");
+  if (bodyEnd < bodyStart) {
+    throw new Error(`JUnit fragment has an incomplete root: ${file}`);
+  }
+  return { body: xml.slice(bodyStart, bodyEnd).trim(), counts };
+}
+
+export function mergeWorkflowJunit(fragments, destination) {
+  const totals = { tests: 0, assertions: 0, failures: 0, skipped: 0 };
+  const bodies = [];
+  for (const { file, path: fragmentPath } of fragments) {
+    const { body, counts } = readJunitFragment(fragmentPath, file);
+    for (const name of Object.keys(totals)) totals[name] += counts[name];
+    bodies.push(body);
+  }
+  mkdirSync(path.dirname(destination), { recursive: true });
+  writeFileSync(
+    destination,
+    `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites tests="${totals.tests}" assertions="${totals.assertions}" failures="${totals.failures}" skipped="${totals.skipped}">\n${bodies.join("\n")}\n</testsuites>\n`,
+  );
+}
+
+export async function runWorkflowTestFiles({
+  bunBinary = process.env.BUN_BIN?.trim() || "bun",
+  files = discoverWorkflowTestFiles(),
+  reporterOutfile,
+} = {}) {
+  if (files.length === 0) {
+    process.stderr.write("[plugin-workflow:test] no test files found\n");
+    return 2;
+  }
+
+  const fragmentDirectory = reporterOutfile
+    ? mkdtempSync(path.join(os.tmpdir(), "eliza-workflow-junit-"))
+    : undefined;
+  const fragments = files.map((file, index) => ({
+    file,
+    path: fragmentDirectory
+      ? path.join(fragmentDirectory, `${index}.xml`)
+      : undefined,
+  }));
+  let activeChild;
+  let interrupted = false;
+  const setActiveChild = (child) => {
+    activeChild = child;
+  };
+  const forwardSignal = (signal) => {
+    interrupted = true;
+    activeChild?.kill(signal);
+  };
+  const onInterrupt = () => forwardSignal("SIGINT");
+  const onTerminate = () => forwardSignal("SIGTERM");
+  process.once("SIGINT", onInterrupt);
+  process.once("SIGTERM", onTerminate);
+
+  try {
+    for (const [index, fragment] of fragments.entries()) {
+      process.stdout.write(
+        `[plugin-workflow:test] ${index + 1}/${files.length} ${fragment.file}\n`,
+      );
+      const exitCode = await runOneTestFile(
+        fragment.file,
+        bunBinary,
+        fragment.path,
+        setActiveChild,
+      );
+      if (interrupted) return 1;
+      if (exitCode !== 0) {
+        process.stderr.write(
+          `[plugin-workflow:test] failed (${exitCode}): ${fragment.file}\n`,
+        );
+        return exitCode;
+      }
+    }
+    if (reporterOutfile) mergeWorkflowJunit(fragments, reporterOutfile);
+    process.stdout.write(
+      `[plugin-workflow:test] passed ${files.length}/${files.length} isolated test files\n`,
+    );
+    return 0;
+  } finally {
+    process.removeListener("SIGINT", onInterrupt);
+    process.removeListener("SIGTERM", onTerminate);
+    if (fragmentDirectory) {
+      rmSync(fragmentDirectory, { recursive: true, force: true });
+    }
+  }
+}
+
+if (import.meta.main || process.argv[1] === scriptPath) {
+  try {
+    const options = parseWorkflowTestArgs(process.argv.slice(2));
+    process.exitCode = await runWorkflowTestFiles(options);
+  } catch (error) {
+    // error-policy:J1 the executable boundary converts orchestration failures into a non-zero result.
+    process.stderr.write(
+      `[plugin-workflow:test] ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #18301.

Runs every `plugin-workflow` test file in a fresh Bun process, serially and in deterministic order, while preserving the package's 25-minute process-group deadline and one diagnostic retry. It also preserves the repository's vacuous-green protection by merging per-process JUnit fragments into one aggregate report.

The prerequisite #18295 is merged. This head is rebased directly onto `develop`; its effective diff is the workflow test runner, its unit tests, manifest wiring, and the repository runner.s narrowly-scoped evidence recognition.

## Root cause and fix

The first attempted fix (`--max-concurrency 1`) serialized Bun's scheduler but retained one long-lived Bun test process. Exact Linux CI still failed with the same `epoll_ctl ... EEXIST`, `Failed to connect`, and `process.stderr` cascade. That falsified the simple concurrency-pressure theory.

The shared failure boundary was process lifetime: subprocess-heavy Smithers tests repeatedly opened and closed child stdio/epoll resources inside one Bun process, and corrupted runtime state then leaked into unrelated test files. The new runner discovers test files recursively, sorts them, and launches one fresh `bun test <file>` OS process at a time. It is fail-fast, propagates SIGINT/SIGTERM to the active child, and remains inside the existing deadline/retry boundary.

The earlier process-isolation revision exposed a second issue rather than hiding it: the tests passed in CI, but the repository correctly rejected the task as vacuously green because the wrapper emitted no JUnit. The final runner gives every child a private JUnit destination, validates each fragment, totals the counts, and writes the aggregate artifact expected by the repository boundary. `run-all-tests.mjs` recognizes only this exact leaf command after unwrapping the two known supervisors; arbitrary wrappers do not gain structured-evidence status.

## Verification

Exact stacked head: `71fbb8cc69573fc2f13aa9c5b1607bd0fed24dc1`

```text
exact repository boundary:
  node packages/scripts/run-all-tests.mjs --only=test --no-cloud --concurrency=1 --require-work --filter=plugin-workflow
  passed 47/47 isolated files
  EVIDENCE reports=1 tests=440 executed=440 skipped=0 unobserved-tasks=0
vacuous-green guard suite: 21 passed, 47 assertions
runner unit tests: 2 passed, 5 assertions
plugin-workflow typecheck: passed
plugin-workflow lint:check: 119 files, no fixes
plugin-workflow build: passed
bun run verify: 348/348 Turbo tasks passed; all repository audits passed
```

<!-- evidence-head:71fbb8cc69573fc2f13aa9c5b1607bd0fed24dc1 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test orchestration only; no product pixels.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test orchestration only; no product pixels.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no product interaction changes.

<!-- evidence-row:backend-logs -->
- [x] Exact repository-boundary transcript:

```text
[plugin-workflow:test] passed 47/47 isolated test files
[eliza-test] PASS @elizaos/plugin-workflow (plugins/plugin-workflow)#test (109047ms)
[eliza-test] EVIDENCE reports=1 tests=440 executed=440 skipped=0 unobserved-tasks=0
```

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, planner, or trajectory behavior.

<!-- evidence-row:domain-artifacts -->
- [x] Real subprocess and evidence artifacts:

```text
boundary: every workflow test file ran in its own Bun OS process
coverage: Smithers worker pipes, crash recovery, deadlines, cancellation, persistence, providers, and route ownership
evidence: 47 validated per-file JUnit fragments merged to 440 executed testcases
guard: the repository rejected the prior no-report revision and accepted this aggregate with unobserved-tasks=0
```

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text or visual changes.

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [codex/openai-gpt-5.6-sol]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A"} -->