### PR TITLE
fix(orchestrator): planner sentinel id filters (none/null/any) are absent, not literal filters

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
@@ -189,6 +189,45 @@ describe("TASKS:history", () => {
     expect(historyCallback).not.toHaveBeenCalled();
   });
 
+  it("treats planner sentinel id filters as absent, never as a literal query or leaked text", async () => {
+    // Live 2026-08-10: a rhetorical "any burning fires?" routed to TASKS with
+    // projectId:"none" + sessionId:"none". Sentinels must not become real
+    // filters (a project/session named "none" matches nothing) nor surface in
+    // the reply as "project none" / "that session".
+    const tasks = [task({ id: "task-active", status: "active" })];
+    const taskService = {
+      getTaskForSession: vi.fn(async () => null),
+      listTasks: vi.fn(async () => tasks),
+    };
+    const historyCallback = callback();
+
+    const result = await taskHistoryAction.handler(
+      runtimeWithServices({ taskService }),
+      memory({ text: "any burning fires or admin things needed?" }),
+      state,
+      {
+        parameters: {
+          action: "history",
+          metric: "list",
+          projectId: "none",
+          sessionId: "none",
+        },
+      },
+      historyCallback,
+    );
+
+    // No session-scoping was attempted, and listTasks got no project filter.
+    expect(taskService.getTaskForSession).not.toHaveBeenCalled();
+    expect(taskService.listTasks).toHaveBeenCalledWith({
+      includeArchived: false,
+    });
+    expect(result?.success).toBe(true);
+    expect(result?.text).not.toContain("project none");
+    expect(result?.text).not.toContain("that session");
+    expect(result?.data?.filters).not.toHaveProperty("projectId");
+    expect(result?.data?.filters).not.toHaveProperty("sessionId");
+  });
+
   it("returns an empty scoped result when the session index has no match", async () => {
     const taskService = {
       getTaskForSession: vi.fn(async () => null),

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -2475,6 +2475,32 @@ function textValue(value: unknown): string | undefined {
     : undefined;
 }
 
+/**
+ * Sentinel words a weak planner emits for an *absent* structural id filter
+ * ("no project", "no session"). Left as-is they become a literal filter — a
+ * task query for a project/session named "none" matches nothing — and leak
+ * into the reply as "project none" / "that session" (live 2026-08-10: a
+ * rhetorical "any burning fires?" routed to TASKS with `projectId:"none"`,
+ * answered shaw with the reconstructed junk filter). Only structural id
+ * filters normalize these; a free-text `search` term is never coerced.
+ */
+const ABSENT_FILTER_SENTINELS = new Set([
+  "none",
+  "null",
+  "nil",
+  "undefined",
+  "n/a",
+  "na",
+  "any",
+  "all",
+]);
+
+function filterIdValue(value: unknown): string | undefined {
+  const text = textValue(value);
+  if (text === undefined) return undefined;
+  return ABSENT_FILTER_SENTINELS.has(text.toLowerCase()) ? undefined : text;
+}
+
 function inferMetric(text: string, value?: string): HistoryMetric {
   const normalized = value?.trim().toLowerCase();
   if (
@@ -2802,10 +2828,12 @@ async function runHistory(
   // Session-scoped history resolves through the durable session index. A task
   // may have several sessions, so comparing only its latest session would make
   // older sessions disappear or allow an unrelated thread into the answer.
-  const sessionId = textValue(params.sessionId) ?? textValue(content.sessionId);
+  const sessionId =
+    filterIdValue(params.sessionId) ?? filterIdValue(content.sessionId);
   // Registered-project filter: restrict the thread listing to tasks bound to
   // one project (the store filters on the indexed/structural `projectId`).
-  const projectId = textValue(params.projectId) ?? textValue(content.projectId);
+  const projectId =
+    filterIdValue(params.projectId) ?? filterIdValue(content.projectId);
   const includeArchived =
     pickBoolean(params, content, "includeArchived") ?? false;
   const windowFilters = buildWindowFilters(window);


### PR DESCRIPTION
## The incident

Live, 2026-08-10 — shaw asked the channel a rhetorical "any burning fires or admin things needed from anyone?" The planner routed it to TASKS history and hallucinated filter args, and the bot answered shaw with:

> I did not find any orchestrator task threads matching window active tasks right now; statuses active; search "burning fires admin"; project none; that session.

## Root cause (the part fixed here)

`textValue()` only rejects empty/whitespace, so a planner-emitted sentinel like `projectId: "none"` / `sessionId: "none"` (a weak model's way of saying "no filter") survived as a **literal structural filter**: `listTasks({ projectId: "none" })` queries a project named "none", matches nothing, and the reconstructed filter suffix then recites "project none" / "that session" back to the user. Two defects in one: a bogus filter that forces an empty result, and internal filter state leaked as prose.

## Fix

New `filterIdValue()` maps sentinel words (none/null/nil/undefined/n/a/na/any/all) to *unset* for the structural id filters (`projectId`, `sessionId`) only — a free-text `search` term is never coerced. Sentinels no longer filter and no longer appear in the reply.

Scope note: this does NOT fix the planner mis-routing a rhetorical broadcast to TASKS in the first place — that's Stage-1/planner-discretion and is reported separately for structural handling, not patched with output heuristics (per the no-regex-on-messageToUser rule).

## Verification

- New test replays the incident (`projectId:"none"`, `sessionId:"none"`): no session-scoping attempted, `listTasks` gets no project filter, reply contains neither "project none" nor "that session".
- plugin-agent-orchestrator: task-history 10/10, regression-lane matrix 113/113. Biome clean.

# Evidence

<!-- evidence-head:ed46af89a4279ea3d97d291c4d128589f9aa3a05 -->
- Before screenshots: N/A - chat/runtime behavior
- After screenshots: N/A - chat/runtime behavior
- Walkthrough video: N/A - chat/runtime behavior
- OCR review: N/A - chat/runtime behavior
- Frontend console/network logs: N/A - chat/runtime behavior
- Backend logs: the live leaked reply to shaw (quoted above) in PR thread
- Real-LLM trajectory: tj-9c10df8ada3c70 (rhetorical ask → TASKS history → sentinel filters)
- Domain artifacts: data.filters no longer carries the sentinel ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)
