### PR TITLE
chore: remove accidentally committed business PDFs from output/pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 /out
+/output/
 
 # triage-tests generated outputs (regenerate via packages/scripts/triage-tests.mjs)
 /coverage-matrix.csv


### PR DESCRIPTION
## Summary

`output/pdf/Invoice_FAH-2026-001_Alpha_Compute.pdf` and `output/pdf/W9_Fully_Autonomous_Holdings.pdf` are real business documents that landed in the public repo accidentally via 02d89802f2 ("wip(ci): workflow consolidation in-progress snapshot", Aug 7). They are not source artifacts.

This PR:
- removes `output/pdf/` from the tree
- adds `output/` to `.gitignore` so local doc-generation output can't be committed again

## Important caveat
Removing from the tip does **not** remove the files from git history — they remain fetchable via the original commit. If the org wants them fully gone, that requires a history scrub (BFG/filter-repo + force-push), which is a separate maintainer decision. Flagging for @lalalune.

🤖 Generated with real eyes on a real leak

<!-- evidence-head:16766caedc481b25e9d8955985134d4c64750854 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - maintenance chore removing binary PDF files; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - maintenance chore removing binary PDF files; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible interaction changed; this removes accidentally committed files.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend service path changed; this is a file deletion and .gitignore addition.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model change.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows, memories, or external artifacts produced.


