### PR TITLE
fix(ui): stop iOS focus zoom on chat-shell text controls

### DIFF
--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -1340,6 +1340,15 @@ describe("ChatOverlay", () => {
     expect(screen.getByTestId("chat-composer-mic")).toBeTruthy();
   });
 
+  it("keeps the persistent composer at 16px on coarse pointers", async () => {
+    await act(async () => {
+      render(<ChatOverlay controller={makeController()} />);
+    });
+    const className = screen.getByTestId("chat-composer-textarea").className;
+    expect(className).toContain("text-sm");
+    expect(className).toContain("pointer-coarse:text-[16px]");
+  });
+
   it("renders composer controls icon-only — no capsule/border/fill, neutral when active (#10711)", () => {
     // Resting: the + and one primary Talk control carry only the icon — no
     // round capsule, no border, no translucent white fill. The visible box is

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -6523,7 +6523,7 @@ export function ChatOverlay({
                   // even when the glass pill sits over dark wallpaper. During
                   // onboarding `disabled:opacity-100` prevents the browser from
                   // dimming the locked cue.
-                  className="scrollbar-hide max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-txt outline-none placeholder:text-muted-strong disabled:pointer-events-none disabled:opacity-100"
+                  className="scrollbar-hide max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-txt outline-none placeholder:text-muted-strong pointer-coarse:text-[16px] disabled:pointer-events-none disabled:opacity-100"
                 />
               )}
               {!transcriptionComposerActive &&

--- a/packages/ui/src/components/ui/input-textarea-focus-zoom.test.tsx
+++ b/packages/ui/src/components/ui/input-textarea-focus-zoom.test.tsx
@@ -13,29 +13,39 @@ import { Textarea } from "./textarea";
 afterEach(cleanup);
 
 describe("Input coarse-pointer font-size (iOS focus-zoom prevention)", () => {
-  it("includes pointer-coarse:text-[16px] in the base class", () => {
-    render(<Input aria-label="username" />);
-    expect(screen.getByLabelText("username").className).toContain(
-      "pointer-coarse:text-[16px]",
-    );
-  });
+  it.each(["default", "compact", "relaxed"] as const)(
+    "keeps the 16px coarse-pointer override at %s density",
+    (density) => {
+      render(<Input aria-label="username" density={density} />);
+      expect(screen.getByLabelText("username").className).toContain(
+        "pointer-coarse:text-[16px]",
+      );
+    },
+  );
 
-  it("retains text-sm for fine pointers (desktop unchanged)", () => {
-    render(<Input aria-label="username" />);
-    expect(screen.getByLabelText("username").className).toContain("text-sm");
+  it("preserves the override when a caller selects denser desktop text", () => {
+    render(<Input aria-label="username" className="text-xs" />);
+    const className = screen.getByLabelText("username").className;
+    expect(className).toContain("text-xs");
+    expect(className).toContain("pointer-coarse:text-[16px]");
   });
 });
 
 describe("Textarea coarse-pointer font-size (iOS focus-zoom prevention)", () => {
-  it("includes pointer-coarse:text-[16px] in the base class", () => {
-    render(<Textarea aria-label="message" />);
-    expect(screen.getByLabelText("message").className).toContain(
-      "pointer-coarse:text-[16px]",
-    );
-  });
+  it.each(["default", "compact", "relaxed"] as const)(
+    "keeps the 16px coarse-pointer override at %s density",
+    (density) => {
+      render(<Textarea aria-label="message" density={density} />);
+      expect(screen.getByLabelText("message").className).toContain(
+        "pointer-coarse:text-[16px]",
+      );
+    },
+  );
 
-  it("retains text-sm for fine pointers (desktop unchanged)", () => {
-    render(<Textarea aria-label="message" />);
-    expect(screen.getByLabelText("message").className).toContain("text-sm");
+  it("preserves the override when a caller selects denser desktop text", () => {
+    render(<Textarea aria-label="message" className="text-xs" />);
+    const className = screen.getByLabelText("message").className;
+    expect(className).toContain("text-xs");
+    expect(className).toContain("pointer-coarse:text-[16px]");
   });
 });

--- a/packages/ui/src/components/ui/input-textarea-focus-zoom.test.tsx
+++ b/packages/ui/src/components/ui/input-textarea-focus-zoom.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Verifies the shared Input and Textarea primitives carry the coarse-pointer
+ * 16px font-size override that prevents Mobile Safari from focus-zooming form
+ * controls below 16px (#18233).
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Input } from "./input";
+import { Textarea } from "./textarea";
+
+afterEach(cleanup);
+
+describe("Input coarse-pointer font-size (iOS focus-zoom prevention)", () => {
+  it("includes pointer-coarse:text-[16px] in the base class", () => {
+    render(<Input aria-label="username" />);
+    expect(screen.getByLabelText("username").className).toContain(
+      "pointer-coarse:text-[16px]",
+    );
+  });
+
+  it("retains text-sm for fine pointers (desktop unchanged)", () => {
+    render(<Input aria-label="username" />);
+    expect(screen.getByLabelText("username").className).toContain("text-sm");
+  });
+});
+
+describe("Textarea coarse-pointer font-size (iOS focus-zoom prevention)", () => {
+  it("includes pointer-coarse:text-[16px] in the base class", () => {
+    render(<Textarea aria-label="message" />);
+    expect(screen.getByLabelText("message").className).toContain(
+      "pointer-coarse:text-[16px]",
+    );
+  });
+
+  it("retains text-sm for fine pointers (desktop unchanged)", () => {
+    render(<Textarea aria-label="message" />);
+    expect(screen.getByLabelText("message").className).toContain("text-sm");
+  });
+});

--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -2,8 +2,8 @@
  * Text-input primitive with cva variants (default, and skins used across
  * settings/config forms). The canonical single-line input for the kit; other
  * inputs compose it rather than re-styling a bare `<input>`. Coarse-pointer
- * surfaces retain a 44px minimum hit area even when a compact density or
- * caller-provided size is used.
+ * surfaces retain a 44px minimum hit area and 16px font size (prevents iOS
+ * Safari focus-zoom) even when a compact density or caller-provided size is used.
  */
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
@@ -11,7 +11,7 @@ import * as React from "react";
 import { cn } from "../../lib/utils";
 
 const inputVariants = cva(
-  "w-full min-w-0 border text-sm transition-[border-color,box-shadow,background-color] pointer-coarse:min-h-touch pointer-coarse:min-w-touch disabled:cursor-not-allowed disabled:opacity-50",
+  "w-full min-w-0 border text-sm pointer-coarse:text-[16px] transition-[border-color,box-shadow,background-color] pointer-coarse:min-h-touch pointer-coarse:min-w-touch disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/packages/ui/src/components/ui/textarea.tsx
+++ b/packages/ui/src/components/ui/textarea.tsx
@@ -1,6 +1,7 @@
 /**
  * Multi-line text-input primitive with cva variants, mirroring the Input skins
  * so single- and multi-line fields share styling across settings/config forms.
+ * Coarse-pointer surfaces use 16px font size to prevent iOS Safari focus-zoom.
  */
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
@@ -8,7 +9,7 @@ import * as React from "react";
 import { cn } from "../../lib/utils";
 
 const textareaVariants = cva(
-  "w-full border text-sm resize-y transition-[border-color,box-shadow,background-color] disabled:cursor-not-allowed disabled:opacity-50",
+  "w-full border text-sm pointer-coarse:text-[16px] resize-y transition-[border-color,box-shadow,background-color] disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       variant: {


### PR DESCRIPTION
Closes #18233

## Problem

Mobile Safari automatically focus-zooms text controls whose computed font size is below 16px. The chat overlay composer, shared `Input`, and shared `Textarea` all used a 14px base size, so focusing them on iOS could contract `visualViewport` and crop/compress the fixed `100dvh` chat sheet.

## Root cause

The production chat shell already used the correct touch-only override in one composer, but the persistent `ChatOverlay` composer and the shared text-control primitives did not. Fixing only the visible composer would have left search, inline-edit, and settings controls vulnerable because those surfaces inherit the shared primitives.

## Fix

Add `pointer-coarse:text-[16px]` to:

1. `ChatOverlay.tsx` persistent composer `Textarea`
2. the shared `Input` primitive
3. the shared `Textarea` primitive

Tailwind emits this as `@media (pointer: coarse)`, preserving the 14px desktop/fine-pointer density while giving touch devices the 16px threshold that prevents Safari focus zoom. The hosted viewport remains user-zoomable; this does not add `maximum-scale=1`, `user-scalable=no`, or JavaScript zoom suppression.

## Review hardening

The focused primitive test now covers default, compact, and relaxed densities plus a caller-supplied `text-xs` override for both `Input` and `Textarea`. A separate `ChatOverlay` contract proves the persistent composer retains its desktop class and the touch override. This closes the weakness where a token-only test could pass without proving the production composer or variant precedence.

## Acceptance criteria

- [x] Coarse-pointer chat-shell text controls compute to at least 16px
- [x] Main composer, shared search/inline-edit inputs, and shared textareas are covered
- [x] Desktop/fine-pointer density remains unchanged
- [x] The hosted viewport remains zoomable
- [x] The production build emits the coarse-pointer media rule
- [x] Real iPhone Safari focus behavior is verified with a negative control

## Validation

Exact reviewed head: `26ad12acdeb20eeb2699ee35601fa1ece72681f6`

Rebased onto: `b47acfdb9e565462c4244525634441e4c3692614`

```text
bun run --cwd packages/ui test -- input-textarea-focus-zoom ChatOverlay.test.tsx
  2 files, 199 tests passed (8 primitive contracts + 191 ChatOverlay tests)

bun run --cwd packages/ui typecheck
  passed

bun run --cwd packages/ui lint
  passed; 8 unrelated existing noDocumentCookie warnings, no fixes

bun run --cwd packages/app build:web
  passed; production CSS contains @media(pointer:coarse) 16px rule
  chunk-safety and hosted viewport policy checks passed

mobile-chromium viewport-zoom-visualviewport.spec.ts
  2/2 passed: hosted shell accepts 2x zoom; lockdown negative control blocks it

bun run verify
  348/348 tasks passed; all repository audits passed
```

`bun run --cwd packages/app audit:app` captured 215 states: 214 passed and the final aggregate test reported four unrelated pre-existing minimalism-ratchet findings in browser/plugins/trajectories. All eight affected chat/settings captures (mobile portrait, mobile landscape, desktop, and iPad) were rated `good`, with no console, render-state, quality, or ratchet findings.

## Evidence

<!-- evidence-head:26ad12acdeb20eeb2699ee35601fa1ece72681f6 -->

<!-- evidence-row:before-screenshots -->
- [x] iPhone 16 Pro / iOS 18.1 Safari negative control: focus auto-zooms the 14px field to `visualViewport.scale=1.1417909860610962` and contracts visual width from 402px to 352px. ![iPhone Safari 14px negative control after focus zoom](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18311-pr18311-focus-legacy-v2.png)

<!-- evidence-row:after-screenshots -->
- [x] Same Safari runtime with the production coarse-pointer class: shared `Input` and `Textarea` compute to 16px, remain at `visualViewport.scale=1`, and retain the full 402px visual width after focus. ![Fixed shared Input and Textarea remain at scale 1](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18311-pr18311-focus-fixed-controls.png)

<!-- evidence-row:walkthrough-video -->
- [x] [21.3-second iPhone Safari walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18311-pr18311-focus-zoom-walkthrough-v2.mp4) showing the fixed control followed by the 14px auto-zoom negative control.

<!-- evidence-row:backend-logs -->
- [x] [Focused tests, production build, and root verification transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18311-pr18311-validation-v2.log).

<!-- evidence-row:frontend-logs -->
- [x] [Safari runtime and visualViewport telemetry](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18311-pr18311-safari-runtime-v2.log).

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, planner, or trajectory behavior

<!-- evidence-row:domain-artifacts -->
- [x] [Full 212-view app-audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18311-report.json); all eight affected chat/settings captures are `good`.

<!-- evidence-row:ocr-review -->
- [x] [Packaged OCR triage report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18311-ocr-triage.json): 192 verified, 20 needs-eyeball, 0 broken, 0 regressions; all eight affected chat/settings captures are verified with no regression.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: zai/glm-5.2
<!-- attribution-row:client -->
- Agent tooling: Hermes Agent
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@aff54b6d69d1ea758357853ee33f81bb6461e0e8:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@aff54b6d69d1ea758357853ee33f81bb6461e0e8:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@aff54b6d69d1ea758357853ee33f81bb6461e0e8:packages/skills/skills/contribute-to-eliza"} -->
