### PR TITLE
fix(orchestrator): list_agents/history/share reads stay planner-only, never ship raw text

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/issue-read-ops-planner-only.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/issue-read-ops-planner-only.test.ts
@@ -194,3 +194,41 @@ describe("manage_issues planner-only read settlement (#18244)", () => {
     });
   });
 });
+
+describe("orchestrator read ops keep internal text planner-only", () => {
+  const fakeAcpService = {
+    listSessions: vi.fn(() => [] as unknown[]),
+    resolveAgentType: vi.fn(async () => "codex"),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (runtime.getService as ReturnType<typeof vi.fn>).mockImplementation(
+      (type: string) =>
+        type === "ACP_SERVICE" || type === "ACP_SUBPROCESS_SERVICE"
+          ? fakeAcpService
+          : undefined,
+    );
+  });
+
+  it("does not ship list_agents guidance text as a chat reply", async () => {
+    // The exact live 2026-08-10 leak: a status-y ask routed to list_agents and
+    // the planner-only guidance text shipped verbatim to Discord.
+    const callback = vi.fn(async () => []);
+    const result = await callHandler({ action: "list_agents" }, callback);
+
+    // Planner sees the observation; the user does not get it raw.
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("No active task agents");
+    expect(result.userFacingText).toBeUndefined();
+    expect(result.verifiedUserFacing).toBeUndefined();
+    expect(result.turnComplete).toBeUndefined();
+    expect(callback).not.toHaveBeenCalled();
+    expect(result.effectReceipts).toEqual([
+      expect.objectContaining({
+        outcome: "noop",
+        reason: "The operation only read orchestrator state.",
+      }),
+    ]);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -4531,11 +4531,16 @@ async function settleTasksOperation(args: {
   capturedCallbacks: CapturedCallback[];
   callback?: HandlerCallback;
 }): Promise<ActionResult> {
-  const plannerOnlyIssueRead = isIssueReadOperation(
-    args.operation,
-    args.params,
-    args.content,
-  );
+  // A read-only op's text is planner observation, never a user reply: keep it
+  // out of the canonical callback so the planner composes the answer instead of
+  // shipping the raw tool text. Covers the GitHub-issue reads (#18248) AND the
+  // orchestrator reads that share the same "no visible callback" contract —
+  // list_agents/history/share — whose internal text otherwise leaks verbatim
+  // (live 2026-08-10: a status-y ask routed to list_agents shipped
+  // "No active task agents. Use TASKS { action: \"create\" }..." to chat).
+  const plannerOnlyRead =
+    TASKS_READ_ONLY_OPERATIONS.has(args.operation) ||
+    isIssueReadOperation(args.operation, args.params, args.content);
   const { receipt, outcomeUnknown } = tasksEffectReceipt(args);
   const {
     userFacingText: _readUserFacingText,
@@ -4543,17 +4548,17 @@ async function settleTasksOperation(args: {
     turnComplete: _readTurnComplete,
     ...plannerOnlyResult
   } = args.result;
-  let result = plannerOnlyIssueRead ? plannerOnlyResult : args.result;
+  let result = plannerOnlyRead ? plannerOnlyResult : args.result;
   const helperEmittedCallback =
-    !plannerOnlyIssueRead && args.capturedCallbacks.length > 0;
+    !plannerOnlyRead && args.capturedCallbacks.length > 0;
   let canonical = helperEmittedCallback
     ? args.capturedCallbacks.at(-1)
     : undefined;
-  if (!plannerOnlyIssueRead && !canonical && effectString(result.text)) {
+  if (!plannerOnlyRead && !canonical && effectString(result.text)) {
     canonical = { response: { text: effectString(result.text) } };
   }
   if (
-    !plannerOnlyIssueRead &&
+    !plannerOnlyRead &&
     args.capturedCallbacks.length > 1 &&
     effectString(result.text) !== undefined
   ) {


### PR DESCRIPTION
## The incident

Live, 2026-08-10 — a status-y mention ("post-deploy health check — you good on the latest build?") was routed by the planner to the `list_agents` read op, and its planner-only guidance text shipped verbatim to Discord:

> No active task agents. Use TASKS { action: "create" } when the user needs anything more involved than a simple direct reply.

Normal chat is unaffected ("how are you?" → "chilling. ready to ship."). This needs a status-style ask that misroutes to a read op.

## Root cause

#18248 made GitHub-issue reads (`manage_issues` list/get) planner-only in `settleTasksOperation` — their text stays in the planner trajectory and never becomes a canonical user callback. But the gate (`isIssueReadOperation`) covered ONLY issue reads. The sibling orchestrator reads `list_agents`, `history`, and `share` carry the identical documented contract ("Read-only query: no visible callback") yet weren't wired to the gate, so their internal `text` fell through to the canonical-callback promotion and shipped raw. (This is also the class behind the earlier `history` "burning fires" leak.)

## Fix

Generalize the gate to every read-only op: `plannerOnlyRead = TASKS_READ_ONLY_OPERATIONS.has(op) || isIssueReadOperation(...)`. `TASKS_READ_ONLY_OPERATIONS` is the existing `{list_agents, history, share}` set. Now all orchestrator reads behave like the issue reads: the planner sees the observation and composes the reply; the raw text never ships.

## Verification

- New test reproduces the exact leak: `list_agents` with no sessions → result.text has the guidance (planner sees it), but userFacingText/verifiedUserFacing/turnComplete are undefined and NO callback is delivered.
- plugin-agent-orchestrator: issue-read-ops-planner-only 4/4, task-history + list-agents 14/14. Biome clean.
- Deploying to the live bot + live Discord read-back to confirm the status-ask no longer leaks.

# Evidence

<!-- evidence-head:f732db99cae251af16814da14a04bb3a53275c1d -->
- Before screenshots: N/A - chat/runtime behavior
- After screenshots: N/A - chat/runtime behavior
- Walkthrough video: N/A - chat/runtime behavior
- OCR review: N/A - chat/runtime behavior
- Frontend console/network logs: N/A - chat/runtime behavior
- Backend logs: the live leaked reply (quoted above) + post-fix clean read-back in PR thread
- Real-LLM trajectory: tj-5da16c511328ae (status ask → list_agents → raw text shipped)
- Domain artifacts: settleTasksOperation planner-only path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
