### PR TITLE
fix(voice): complete iOS Cartesia cloud session startup

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/mint-consent-route.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/mint-consent-route.test.ts
@@ -41,7 +41,21 @@ mock.module("@/db/repositories/agent-sandboxes", () => ({
             organization_id: "org-1",
             user_id: "user-1",
           }
-        : undefined,
+        : id === "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+          ? {
+              id,
+              character_id: null,
+              organization_id: "org-1",
+              user_id: "user-1",
+            }
+          : id === "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+            ? {
+                id,
+                character_id: null,
+                organization_id: "org-2",
+                user_id: "user-2",
+              }
+            : undefined,
     findLatestByCharacterId: async (characterId: string) =>
       characterId === "11111111-1111-4111-8111-111111111111"
         ? {
@@ -225,6 +239,47 @@ describe("voice-session mint route", () => {
     expect(verified.claims.agentId).toBe(
       "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
     );
+  });
+
+  test("accepts an owned dedicated sandbox with no linked character", async () => {
+    const app = appWithFlag("true");
+    const consentRes = await app.request("/api/v1/voice/session/consent", {
+      method: "POST",
+    });
+    const { consentNonce } = (await consentRes.json()) as {
+      consentNonce: string;
+    };
+    const res = await app.request("/api/v1/voice/session", {
+      method: "POST",
+      body: JSON.stringify({
+        agentId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        conversationId: "22222222-2222-4222-8222-222222222222",
+        consentNonce,
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string };
+    const verified = await verifyVoiceSessionToken(body.token);
+    expect(verified.claims.agentId).toBe(
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    );
+  });
+
+  test("hides a directly addressed sandbox owned by another tenant", async () => {
+    const app = appWithFlag("true");
+    const res = await app.request("/api/v1/voice/session", {
+      method: "POST",
+      body: JSON.stringify({
+        agentId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        conversationId: "22222222-2222-4222-8222-222222222222",
+        consentNonce: "unused",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("agent_not_found");
   });
 
   test("mint response never contains a provider key", async () => {

--- a/packages/cloud/api/v1/voice/session/route.ts
+++ b/packages/cloud/api/v1/voice/session/route.ts
@@ -1,4 +1,4 @@
-// Handles v1 cloud API realtime voice-session mint traffic (Phase 1, flag-gated).
+/** Handles flag-gated v1 Cloud realtime voice-session mint traffic. */
 import { Hono } from "hono";
 import { z } from "zod";
 
@@ -81,32 +81,39 @@ app.post("/", async (c) => {
   // user_characters and conversations are USER-owned (not just org-owned), so a
   // same-org peer who learns another user's IDs must still be refused.
   // The managed-cloud UI persists the selected agent_sandboxes UUID, while
-  // older callers submit the character UUID. Accept either public identifier,
-  // but always resolve both records and enforce the same user + org ownership
-  // before minting a server-credentialed session.
+  // older callers submit the character UUID. A dedicated sandbox does not need
+  // a linked character, so direct sandbox IDs authorize against the sandbox
+  // owner itself. The legacy character path still resolves both records.
   let sandboxAgent = await agentSandboxesRepository.findById(body.agentId);
-  const characterId = sandboxAgent?.character_id ?? body.agentId;
-  const agent = await userCharactersRepository.findByIdInOrganization(
-    characterId,
-    auth.organization_id,
-  );
-  if (!agent || agent.user_id !== auth.id) {
-    return c.json({ error: "agent not found", code: "agent_not_found" }, 404);
-  }
-  if (!sandboxAgent) {
-    sandboxAgent =
-      await agentSandboxesRepository.findLatestByCharacterId(characterId);
-  }
-  if (
-    !sandboxAgent ||
-    sandboxAgent.character_id !== agent.id ||
-    sandboxAgent.organization_id !== auth.organization_id ||
-    sandboxAgent.user_id !== auth.id
-  ) {
-    return c.json(
-      { error: "agent runtime not found", code: "agent_not_found" },
-      404,
+  if (sandboxAgent) {
+    if (
+      sandboxAgent.organization_id !== auth.organization_id ||
+      sandboxAgent.user_id !== auth.id
+    ) {
+      return c.json({ error: "agent not found", code: "agent_not_found" }, 404);
+    }
+  } else {
+    const agent = await userCharactersRepository.findByIdInOrganization(
+      body.agentId,
+      auth.organization_id,
     );
+    if (!agent || agent.user_id !== auth.id) {
+      return c.json({ error: "agent not found", code: "agent_not_found" }, 404);
+    }
+    sandboxAgent = await agentSandboxesRepository.findLatestByCharacterId(
+      agent.id,
+    );
+    if (
+      !sandboxAgent ||
+      sandboxAgent.character_id !== agent.id ||
+      sandboxAgent.organization_id !== auth.organization_id ||
+      sandboxAgent.user_id !== auth.id
+    ) {
+      return c.json(
+        { error: "agent runtime not found", code: "agent_not_found" },
+        404,
+      );
+    }
   }
 
   // A supplied conversationId that exists must belong to the caller (org AND

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -2130,6 +2130,21 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
     }
   });
 
+  it("routes programmatic converse capture to one realtime session", async () => {
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.startRecording("converse");
+      result.current.startRecording("converse");
+      await Promise.resolve();
+    });
+
+    expect(realtimeVoiceMock.start).toHaveBeenCalledTimes(1);
+    expect(realtimeVoiceMock.startedConversationIds).toEqual([conversationId]);
+    expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+    expect(result.current.handsFree).toBe(true);
+  });
+
   it("parks Talk visibly OFF when a LIVE session dies past the client's recovery budget", async () => {
     const { result, rerender } = renderHook(() => useShellController());
 

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -173,9 +173,9 @@ export interface ShellController {
   visionCapturing: boolean;
   /** Toggle continuous ("open voice") capture. Used by a quick tap on the mic. */
   toggleRecording: () => void;
-  /** Begin capture unconditionally. Used by push-to-talk press. `"dictate"`
-   *  routes the final transcript to the dictation sink (composer draft) and does
-   *  not send; `"converse"` (default) sends a VOICE_DM so the reply is spoken. */
+  /** Begin voice input unconditionally. `"converse"` (default) starts the
+   *  configured realtime session; `"dictate"` routes the final transcript to
+   *  the composer draft without sending. */
   startRecording: (intent?: CaptureIntent) => void;
   /** End capture unconditionally. Used by push-to-talk release. */
   stopRecording: () => void;
@@ -1106,6 +1106,7 @@ export function useShellController(): ShellController {
         realtimeVoiceEnabled &&
         (intent === undefined || intent === "converse")
       ) {
+        startRealtimeVoiceRef.current();
         return;
       }
       // Voice capture is independent of agent-respond readiness. A converse

--- a/packages/ui/src/hooks/useRealtimeVoiceMint.dedicated-cloud.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceMint.dedicated-cloud.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Exercises the default realtime-consent path from a persisted dedicated Cloud
+ * pairing through the configured control-plane transport boundary.
+ */
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const DEDICATED_AGENT_ID = "ef2fa8ee-1111-4222-8333-444455556666";
+const DEDICATED_BASE = `https://${DEDICATED_AGENT_ID}.staging.elizacloud.ai`;
+const CONTROL_PLANE_ORIGIN = "https://staging.elizacloud.ai";
+
+const readStoredStewardToken = vi.fn();
+const readCsrfTokenFromCookie = vi.fn();
+const requestViaAgentTransport = vi.fn();
+const fetchWithCsrf = vi.fn();
+
+vi.mock("@elizaos/shared/steward-session-client", () => ({
+  readStoredStewardToken: () => readStoredStewardToken(),
+}));
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: (...args: unknown[]) => fetchWithCsrf(...args),
+  readCsrfTokenFromCookie: () => readCsrfTokenFromCookie(),
+  requestViaAgentTransport: (...args: unknown[]) =>
+    requestViaAgentTransport(...args),
+}));
+vi.mock("../state/persistence", () => ({
+  loadPersistedActiveServer: () => ({
+    id: `cloud:${DEDICATED_AGENT_ID}`,
+    kind: "cloud",
+    label: "Eliza",
+    apiBase: DEDICATED_BASE,
+  }),
+}));
+vi.mock("../state/agent-session-recovery", () => ({
+  resolveDedicatedAgentId: () => DEDICATED_AGENT_ID,
+}));
+vi.mock("../voice/shared-runtime-voice", () => ({
+  configuredCloudVoiceOrigin: () => CONTROL_PLANE_ORIGIN,
+}));
+
+import { useRealtimeVoiceMint } from "./useRealtimeVoiceMint";
+
+describe("useRealtimeVoiceMint on a dedicated Cloud pairing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readStoredStewardToken.mockReturnValue("steward-token");
+    readCsrfTokenFromCookie.mockReturnValue("csrf-token");
+    requestViaAgentTransport.mockResolvedValue(
+      new Response(JSON.stringify({ consentNonce: "nonce-live" }), {
+        status: 200,
+      }),
+    );
+  });
+
+  it("uses the configured control-plane transport on the real default hook path", async () => {
+    const { result } = renderHook(() => useRealtimeVoiceMint());
+    expect(result.current.agentId).toBe(DEDICATED_AGENT_ID);
+
+    let nonce: string | null = null;
+    await act(async () => {
+      nonce = await result.current.getConsentNonce();
+    });
+
+    expect(nonce).toBe("nonce-live");
+    expect(fetchWithCsrf).not.toHaveBeenCalled();
+    expect(requestViaAgentTransport).toHaveBeenCalledOnce();
+    const [url, init] = requestViaAgentTransport.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe(`${CONTROL_PLANE_ORIGIN}/api/v1/voice/session/consent`);
+    expect(new Headers(init.headers).get("authorization")).toBe(
+      "Bearer steward-token",
+    );
+  });
+});

--- a/packages/ui/src/hooks/useRealtimeVoiceMint.ts
+++ b/packages/ui/src/hooks/useRealtimeVoiceMint.ts
@@ -39,8 +39,8 @@ export function isRealtimeVoiceForceEnabled(): boolean {
   }
 }
 
-// NOTE ON MODULE GRAPH: `../api/csrf-client` (the default consent fetch) pulls
-// the full native transport chain. We import it LAZILY (dynamic import inside
+// NOTE ON MODULE GRAPH: the default consent fetch pulls the full native/cloud
+// transport chain. We import it LAZILY (dynamic import inside
 // `defaultConsentFetch`) so a surface that renders this hook doesn't eagerly
 // load that chain, and a test that injects `fetch` never touches it at all.
 // `agent-session-recovery` + `persistence` ARE imported statically because the
@@ -48,15 +48,15 @@ export function isRealtimeVoiceForceEnabled(): boolean {
 // still exercises the real UUID guard on the injected value.
 
 /**
- * The default consent fetch = the same CSRF/bearer helper every other dashboard
- * /api/v1 call uses.
+ * The default consent fetch shares the voice-session control-plane policy with
+ * minting, so both legs always use the same origin and credential.
  */
 async function defaultConsentFetch(
   url: string,
   init?: RequestInit,
 ): Promise<Response> {
-  const { fetchWithCsrf } = await import("../api/csrf-client");
-  return fetchWithCsrf(url, init);
+  const { fetchVoiceSession } = await import("../voice/voice-session-fetch");
+  return fetchVoiceSession(url, init);
 }
 
 /** UUID v-any shape guard so we never mint with a non-UUID id (the route 400s). */

--- a/packages/ui/src/voice/voice-session-client.ts
+++ b/packages/ui/src/voice/voice-session-client.ts
@@ -150,9 +150,8 @@ export interface VoiceSessionClientOptions {
   getConsentNonce: () => Promise<string | null>;
 
   /**
-   * Injectable mint fetch. Defaults to the CSRF/bearer dashboard fetch
-   * (`fetchWithCsrf`), lazily imported so this module's static graph stays lean
-   * (the dashboard fetch pulls the boot-config/core chain). A caller in a
+   * Injectable mint fetch. Defaults to the voice-session control-plane fetch,
+   * lazily imported so this module's static graph stays lean. A caller in a
    * non-dashboard host (or a test) supplies its own.
    */
   fetch?: (url: string, init?: RequestInit) => Promise<Response>;
@@ -292,8 +291,8 @@ export function createVoiceSessionClient(
   const doFetch =
     options.fetch ??
     (async (url: string, init?: RequestInit) => {
-      const { fetchWithCsrf } = await import("../api/csrf-client");
-      return fetchWithCsrf(url, init);
+      const { fetchVoiceSession } = await import("./voice-session-fetch");
+      return fetchVoiceSession(url, init);
     });
   const wsFactory =
     options.webSocketFactory ??

--- a/packages/ui/src/voice/voice-session-fetch.test.ts
+++ b/packages/ui/src/voice/voice-session-fetch.test.ts
@@ -1,0 +1,107 @@
+/** Verifies realtime voice-session routing and credential isolation. */
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readStoredStewardToken = vi.fn();
+const readCsrfTokenFromCookie = vi.fn();
+const requestViaAgentTransport = vi.fn();
+const fetchWithCsrf = vi.fn();
+const loadPersistedActiveServer = vi.fn();
+const configuredCloudVoiceOrigin = vi.fn();
+
+vi.mock("@elizaos/shared/steward-session-client", () => ({
+  readStoredStewardToken: () => readStoredStewardToken(),
+}));
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: (...args: unknown[]) => fetchWithCsrf(...args),
+  readCsrfTokenFromCookie: () => readCsrfTokenFromCookie(),
+  requestViaAgentTransport: (...args: unknown[]) =>
+    requestViaAgentTransport(...args),
+}));
+vi.mock("../state/persistence", () => ({
+  loadPersistedActiveServer: () => loadPersistedActiveServer(),
+}));
+vi.mock("./shared-runtime-voice", () => ({
+  configuredCloudVoiceOrigin: () => configuredCloudVoiceOrigin(),
+}));
+
+import { fetchVoiceSession } from "./voice-session-fetch";
+
+describe("fetchVoiceSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configuredCloudVoiceOrigin.mockReturnValue("https://staging.elizacloud.ai");
+    requestViaAgentTransport.mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+    fetchWithCsrf.mockResolvedValue(new Response(null, { status: 204 }));
+  });
+
+  it("routes cloud consent to the control plane with the Steward credential", async () => {
+    loadPersistedActiveServer.mockReturnValue({ kind: "cloud" });
+    readStoredStewardToken.mockReturnValue("steward-token");
+    readCsrfTokenFromCookie.mockReturnValue("csrf-token");
+
+    await fetchVoiceSession("/api/v1/voice/session/consent", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+
+    expect(fetchWithCsrf).not.toHaveBeenCalled();
+    expect(requestViaAgentTransport).toHaveBeenCalledOnce();
+    const [url, init] = requestViaAgentTransport.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe(
+      "https://staging.elizacloud.ai/api/v1/voice/session/consent",
+    );
+    expect(init.credentials).toBe("include");
+    const headers = new Headers(init.headers);
+    expect(headers.get("authorization")).toBe("Bearer steward-token");
+    expect(headers.get("x-eliza-csrf")).toBe("csrf-token");
+  });
+
+  it("never substitutes the dedicated-agent bearer when Steward is absent", async () => {
+    loadPersistedActiveServer.mockReturnValue({ kind: "cloud" });
+    readStoredStewardToken.mockReturnValue(null);
+    readCsrfTokenFromCookie.mockReturnValue(null);
+
+    await fetchVoiceSession("/api/v1/voice/session", { method: "POST" });
+
+    expect(requestViaAgentTransport).toHaveBeenCalledOnce();
+    const [, init] = requestViaAgentTransport.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const headers = new Headers(init.headers);
+    expect(headers.has("authorization")).toBe(false);
+    expect(fetchWithCsrf).not.toHaveBeenCalled();
+  });
+
+  it("keeps self-hosted voice-session traffic on the selected runtime", async () => {
+    loadPersistedActiveServer.mockReturnValue({ kind: "remote" });
+
+    await fetchVoiceSession("/api/v1/voice/session/consent", {
+      method: "POST",
+    });
+
+    expect(fetchWithCsrf).toHaveBeenCalledWith(
+      "/api/v1/voice/session/consent",
+      { method: "POST" },
+    );
+    expect(requestViaAgentTransport).not.toHaveBeenCalled();
+  });
+
+  it("rejects an absolute cloud target before attaching credentials", async () => {
+    loadPersistedActiveServer.mockReturnValue({ kind: "cloud" });
+    readStoredStewardToken.mockReturnValue("steward-token");
+
+    await expect(
+      fetchVoiceSession("https://attacker.example/voice", { method: "POST" }),
+    ).rejects.toThrow("relative API path");
+    expect(requestViaAgentTransport).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/voice/voice-session-fetch.test.ts
+++ b/packages/ui/src/voice/voice-session-fetch.test.ts
@@ -81,6 +81,24 @@ describe("fetchVoiceSession", () => {
     expect(fetchWithCsrf).not.toHaveBeenCalled();
   });
 
+  it("preserves an explicit Authorization header", async () => {
+    loadPersistedActiveServer.mockReturnValue({ kind: "cloud" });
+    readStoredStewardToken.mockReturnValue("steward-token");
+
+    await fetchVoiceSession("/api/v1/voice/session", {
+      method: "POST",
+      headers: { Authorization: "Bearer explicit" },
+    });
+
+    const [, init] = requestViaAgentTransport.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(new Headers(init.headers).get("authorization")).toBe(
+      "Bearer explicit",
+    );
+  });
+
   it("keeps self-hosted voice-session traffic on the selected runtime", async () => {
     loadPersistedActiveServer.mockReturnValue({ kind: "remote" });
 

--- a/packages/ui/src/voice/voice-session-fetch.ts
+++ b/packages/ui/src/voice/voice-session-fetch.ts
@@ -1,0 +1,59 @@
+/**
+ * Routes realtime voice-session control traffic to the selected runtime or the
+ * Eliza Cloud control plane. Cloud sessions use the Steward credential rather
+ * than the dedicated agent token, while self-hosted sessions retain the normal
+ * dashboard transport.
+ */
+
+import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
+import { CSRF_HEADER_NAME } from "../api/auth/sessions";
+import {
+  readCsrfTokenFromCookie,
+  requestViaAgentTransport,
+} from "../api/csrf-client";
+import { loadPersistedActiveServer } from "../state/persistence";
+import { configuredCloudVoiceOrigin } from "./shared-runtime-voice";
+
+function cloudVoiceSessionUrl(path: string): string {
+  if (!path.startsWith("/") || path.startsWith("//")) {
+    throw new Error("Cloud voice-session requests require a relative API path");
+  }
+  const origin = configuredCloudVoiceOrigin();
+  if (!origin) {
+    throw new Error("Eliza Cloud voice-session origin is not configured");
+  }
+  return `${origin.replace(/\/+$/, "")}${path}`;
+}
+
+/**
+ * Fetch a consent, health, or mint route without leaking an agent-local bearer
+ * to the Cloud control plane. An explicit caller Authorization header remains
+ * authoritative for non-dashboard hosts and tests.
+ */
+export async function fetchVoiceSession(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  if (loadPersistedActiveServer()?.kind !== "cloud") {
+    const { fetchWithCsrf } = await import("../api/csrf-client");
+    return fetchWithCsrf(path, init);
+  }
+
+  const headers = new Headers(init.headers);
+  const method = (init.method ?? "GET").toUpperCase();
+  if (method === "POST") {
+    const csrfToken = readCsrfTokenFromCookie();
+    if (csrfToken) headers.set(CSRF_HEADER_NAME, csrfToken);
+  }
+
+  const stewardToken = readStoredStewardToken()?.trim();
+  if (stewardToken && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${stewardToken}`);
+  }
+
+  return requestViaAgentTransport(cloudVoiceSessionUrl(path), {
+    ...init,
+    credentials: "include",
+    headers,
+  });
+}


### PR DESCRIPTION
# Relates to

Closes #18317.

- [x] Targets `develop` and is rebased onto current `origin/develop@87112c2bcb6a1a0239a452b472fe575f084a3d8a`.
- [x] Focused tests, typechecks, formatting, the iOS cloud-simulator build, and current-build Simulator proof were run after sync.
- [ ] Full Cartesia audio on staging remains pending: this branch contains the cloud authorization repair, but that server code is not deployed and no shared staging/release lever is claimed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@26b9ea055e7ee22ff4a7c9d3f10011df781ca00d:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop@87112c2bcb6a1a0239a452b472fe575f084a3d8a` with zero conflicts.
- [x] `bun install` was already current; no lockfile or dependency inputs changed.
- [ ] Root `bun run verify` is currently blocked by two pre-existing Biome errors on `develop`: missing blank lines in `packages/app-core/src/services/multi-account-affinity-failover.test.ts:50` and `multi-account-rotation.test.ts:36`. This branch does not touch either file. All scoped checks below pass.

# Risks

Cloud voice consent and mint now use the configured cloud control plane, canonical Steward authentication, CSRF on POST, and the native transport on Capacitor. Runtime-local servers retain their existing relative fetch behavior. Absolute targets are rejected before credentials can be attached.

The cloud route now authorizes a direct sandbox ID against its organization and owner without requiring a character row. The legacy character-ID path still resolves and validates the linked sandbox, and foreign sandbox IDs remain tenant-hiding 404s.

# Background

## What does this PR do?

It closes three connected breaks in the supported iOS system-voice path:

1. Siri/App Shortcut/deep-link voice entered `startRecording("converse")`, but the realtime branch returned before invoking the existing Cartesia start authority.
2. Once realtime started, cloud consent and mint were incorrectly sent to the selected dedicated-agent origin with its paired agent bearer. Those account-scoped routes live on the cloud control plane and require the Steward token.
3. The control-plane mint route rejected a valid owned running sandbox when `character_id` was null, even though direct sandbox selection is a supported cloud state.

The result is one coherent startup path: system voice → Cartesia controller → control-plane consent/mint → owned sandbox authorization. Batch capture, dictation, provider selection, prompt/model behavior, and non-cloud servers are unchanged.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

N/A - this restores the documented system-entry and cloud voice-session contracts without introducing a new user-facing workflow.

# Testing

## Where should a reviewer start?

- `packages/ui/src/components/shell/useShellController.ts`
- `packages/ui/src/voice/voice-session-fetch.ts`
- `packages/ui/src/hooks/useRealtimeVoiceMint.ts`
- `packages/ui/src/voice/voice-session-client.ts`
- `packages/cloud/api/v1/voice/session/route.ts`
- Their colocated focused tests.

## Detailed testing results

- UI focused suite: 5 files, 156 tests passed, covering the shell controller, OS intent, realtime mint/session behavior, shared cloud fetch security, and non-cloud preservation.
- Cloud voice-session route: 8 tests passed with 24 expectations, including owned null-character sandbox success, foreign sandbox 404, and legacy character lookup.
- `bun run --cwd packages/ui typecheck` — passed.
- Cloud API `tsc6 --noEmit` build/typecheck — passed.
- Targeted Biome and `git diff --check` — passed.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer VITE_ELIZA_CLOUD_BASE=https://staging.elizacloud.ai VITE_VOICE_REALTIME_WS=1 VITE_VOICE_REALTIME_FORCE=0 bun run --cwd packages/app build:ios:cloud:sim` — `BUILD SUCCEEDED`.
- Fresh exact-head artifact installed over the existing authenticated iPhone 17 Pro / iOS 26.5 simulator app without deleting app data.
- Installed bundle manually inspected: it contains the new `voice-session-fetch` control-plane module.
- Live deep link exercised twice. Current-build CFNetwork logs show control-plane consent 200, followed by the known undeployed mint 404; the UI advances through `Connecting…` and reports “could not start a session,” replacing the old consent failure.

# Evidence Gate

<!-- evidence-head:26b9ea055e7ee22ff4a7c9d3f10011df781ca00d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered layout or styling changed; the pre-fix state was a functional consent error, preserved in the issue history.
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/eliza-18318-control-plane-26b9ea0.jpg)

![Current-build Cartesia session-start boundary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/eliza-18318-control-plane-26b9ea0.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] [16.6-second exact-head MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/eliza-18318-control-plane-26b9ea0.mp4), manually reviewed end to end. It shows idle → Connecting → the explicit session-start error → recoverable idle.
<!-- evidence-row:backend-logs -->
- [x] N/A - the repaired backend route is not deployed and the fleet's shared staging/release lever is unclaimed. No deployment or privileged staging-log access is claimed; route authorization is covered by the focused handler tests.
<!-- evidence-row:frontend-logs -->
- [x] [18318-eliza-18318-control-plane-26b9ea0.log.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18318-eliza-18318-control-plane-26b9ea0.log.txt)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, model selection, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the expected artifact is a voice session; staging cannot create it until this branch's server authorization change is deployed. The failed current-deploy boundary is explicitly shown rather than fabricated as success.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual design changed. The screenshot and every frame of the short MP4 were manually inspected; the rendered labels match the observed network boundary.

# Evidence Details

## Current-build native network evidence

```text
16:13:42.395  https://staging.elizacloud.ai/api/v1/voice/session/consent  start
16:13:42.711  consent response status 200
16:13:42.717  immediately following POST, same Connection 6, body 184 bytes
16:13:42.860  response status 404
```

The request ordering and body shape identify the second POST as mint. A direct authenticated probe against the currently deployed route returned `agent_not_found` for the selected owned running sandbox; that sandbox has `character_id = null`. The new server tests prove the repaired direct-sandbox authorization while preserving legacy and cross-tenant behavior. No token, private key, or credential is included in this evidence.

## Known gaps / failures

- Full Cartesia Ink → Eliza model → Sonic audio is not claimed until the backend commit is deployed to a claimed environment.
- Signed Siri/Shortcuts execution remains independently constrained by local ad-hoc simulator signing; the supported deep-link route was exercised directly on the current native build.
- Root verify remains upstream-red for the two unrelated current-`develop` formatting errors listed above.
- The active release hold remains respected. This PR is draft and must not merge or deploy itself.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@26b9ea055e7ee22ff4a7c9d3f10011df781ca00d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-ios-assistant]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@26b9ea055e7ee22ff4a7c9d3f10011df781ca00d:packages/skills/skills/contribute-to-eliza"} -->



