### PR TITLE
fix(core): detect LifeOps plugin to drive passive-connector default

### DIFF
--- a/packages/agent/src/runtime/plugin-collector-telegram-standalone.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-telegram-standalone.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Exercises the pre-runtime standalone Telegram decision against the final
+ * configured plugin set, without constructing an AgentRuntime or bot client.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ElizaConfig } from "../config/config.ts";
+import { collectPluginNames } from "./plugin-collector.ts";
+
+const ENV_KEYS = [
+  "ELIZA_TELEGRAM_STANDALONE_BOT",
+  "ELIZA_LIFEOPS_PASSIVE_CONNECTORS",
+  "LIFEOPS_PASSIVE_CONNECTORS",
+] as const;
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("collectPluginNames standalone Telegram policy", () => {
+  it("loads Telegram for a plain agent that opts into the standalone poller", () => {
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
+
+    expect(collectPluginNames({} as ElizaConfig)).toContain(
+      "@elizaos/plugin-telegram",
+    );
+  });
+
+  it("keeps standalone Telegram dormant when LifeOps is configured", () => {
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
+    const config = {
+      plugins: {
+        entries: {
+          "personal-assistant": { enabled: true },
+        },
+      },
+    } as ElizaConfig;
+
+    const names = collectPluginNames(config);
+    expect(names).toContain("@elizaos/plugin-personal-assistant");
+    expect(names).not.toContain("@elizaos/plugin-telegram");
+  });
+
+  it("honors an explicit passive-mode opt-out for a LifeOps deployment", () => {
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
+    process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
+    const config = {
+      plugins: {
+        entries: {
+          "personal-assistant": { enabled: true },
+        },
+      },
+    } as ElizaConfig;
+
+    const names = collectPluginNames(config);
+    expect(names).toContain("@elizaos/plugin-personal-assistant");
+    expect(names).toContain("@elizaos/plugin-telegram");
+  });
+});

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -143,15 +143,18 @@ function gitpathologistRequested(config: ElizaConfig): boolean {
 
 /**
  * The opt-in standalone Telegram polling bot (the standalone mode of
- * `@elizaos/plugin-telegram`) only runs when LifeOps passive connectors are
- * explicitly disabled AND `ELIZA_TELEGRAM_STANDALONE_BOT` is truthy — the same
- * gate the `TelegramStandaloneService` self-checks. In the default
- * passive-connectors-on posture the passive telegram connector owns the
- * long-poll; this gate only ensures the Telegram plugin is loaded so its
- * standalone service can start.
+ * `@elizaos/plugin-telegram`) runs when `ELIZA_TELEGRAM_STANDALONE_BOT` is
+ * truthy and the resolved plugin set is not in LifeOps passive mode. The same
+ * runtime-time gate is enforced by `TelegramStandaloneService`; this host gate
+ * ensures the plugin is present for that service to start.
  */
-function telegramStandaloneRequested(): boolean {
-  if (lifeOpsPassiveConnectorsEnabled(null, process.env)) {
+function telegramStandaloneRequested(
+  pluginNames: ReadonlySet<string>,
+): boolean {
+  const resolvedPlugins = Array.from(pluginNames, (name) => ({ name }));
+  if (
+    lifeOpsPassiveConnectorsEnabled({ plugins: resolvedPlugins }, process.env)
+  ) {
     return false;
   }
   const raw = process.env.ELIZA_TELEGRAM_STANDALONE_BOT?.trim().toLowerCase();
@@ -599,17 +602,6 @@ export function collectPluginNames(
       "gitpathologist (auto-on when .git/ present; gate ELIZA_GITPATHOLOGIST)",
     );
   }
-  // Opt-in standalone Telegram polling bot. When passive connectors are
-  // disabled and ELIZA_TELEGRAM_STANDALONE_BOT is set, load the Telegram
-  // plugin so its self-gating TelegramStandaloneService owns the Telegraf
-  // long-poll lifecycle.
-  if (telegramStandaloneRequested()) {
-    pluginsToLoad.add("@elizaos/plugin-telegram");
-    track(
-      "@elizaos/plugin-telegram",
-      "telegram standalone bot (gate ELIZA_TELEGRAM_STANDALONE_BOT)",
-    );
-  }
   // Allow list is additive — extra plugins on top of auto-detection,
   // not an exclusive whitelist that blocks everything else.
   if (allowList && allowList.length > 0) {
@@ -939,6 +931,19 @@ export function collectPluginNames(
       }
       pluginsToLoad.delete(name);
     }
+  }
+
+  // Decide standalone Telegram only after every config, install, companion,
+  // and platform filter has produced the actual pre-runtime plugin set. This
+  // keeps host collection consistent with the service's runtime-time gate:
+  // LifeOps stays passive, while a plain standalone agent can opt into its
+  // poller without an unrelated passive-connectors override.
+  if (!onMobile && !leanChat && telegramStandaloneRequested(pluginsToLoad)) {
+    pluginsToLoad.add("@elizaos/plugin-telegram");
+    track(
+      "@elizaos/plugin-telegram",
+      "telegram standalone bot (gate ELIZA_TELEGRAM_STANDALONE_BOT)",
+    );
   }
 
   return pluginsToLoad;

--- a/packages/app-core/src/services/trigger-event-bridge.test.ts
+++ b/packages/app-core/src/services/trigger-event-bridge.test.ts
@@ -82,16 +82,22 @@ interface BridgeRuntimeHandle {
   setSetting: (key: string, value: unknown) => void;
 }
 
-function makeRuntime(): BridgeRuntimeHandle {
+function makeRuntime(
+  options: { lifeOpsPluginLoaded?: boolean } = {},
+): BridgeRuntimeHandle {
   const handlers = new Map<
     string,
     Set<(payload: EventPayload) => Promise<void>>
   >();
   const settings = new Map<string, unknown>();
+  const plugins = options.lifeOpsPluginLoaded
+    ? [{ name: "@elizaos/plugin-personal-assistant" }]
+    : [];
 
   const runtime = {
     agentId: AGENT_ID,
     character: { name: "bridge-test" },
+    plugins,
     getSetting: (key: string) => settings.get(key),
     logger: {
       info: vi.fn(),
@@ -231,6 +237,7 @@ describe("startTriggerEventBridge", () => {
   });
 
   it("suppresses passive connector events using connector source metadata aliases", async () => {
+    handle = makeRuntime({ lifeOpsPluginLoaded: true });
     const task = makeEventTriggerTask({ eventKind: "MESSAGE_RECEIVED" });
     startTriggerEventBridge(handle.runtime, {
       listTriggers: async () => [task],
@@ -259,6 +266,7 @@ describe("startTriggerEventBridge", () => {
   });
 
   it("suppresses custom connector events registered as passive metadata", async () => {
+    handle = makeRuntime({ lifeOpsPluginLoaded: true });
     registerConnectorSourceMetadata("custom-passive", {
       aliases: ["custom-passive-alias"],
       isPassive: true,

--- a/packages/core/src/__tests__/lifeops-passive-connectors.test.ts
+++ b/packages/core/src/__tests__/lifeops-passive-connectors.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Exercises passive-connector policy with deterministic runtime plugin sets
+ * and settings, including the pre-runtime fallback used by host collection.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { lifeOpsPassiveConnectorsEnabled } from "../lifeops-passive-connectors";
 
@@ -139,12 +143,9 @@ describe("lifeOpsPassiveConnectorsEnabled", () => {
 		});
 	});
 
-	describe("null / undefined runtime", () => {
-		it("returns true for null runtime — pre-runtime conservative default (shouldStartTelegramStandaloneBot path)", () => {
-			// null is the explicit pre-runtime signal: plugin list is not available,
-			// so passive mode stays on to avoid starting connectors for LifeOps
-			// deployments before the runtime exists.
-			expect(lifeOpsPassiveConnectorsEnabled(null)).toBe(true);
+	describe("absent runtime", () => {
+		it("returns false for null runtime when no LifeOps plugin set is available", () => {
+			expect(lifeOpsPassiveConnectorsEnabled(null)).toBe(false);
 		});
 
 		it("null runtime is overridden by explicit env false (operator opt-out)", () => {

--- a/packages/core/src/__tests__/lifeops-passive-connectors.test.ts
+++ b/packages/core/src/__tests__/lifeops-passive-connectors.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { lifeOpsPassiveConnectorsEnabled } from "../lifeops-passive-connectors";
+
+const LIFEOPS_PLUGIN = "@elizaos/plugin-personal-assistant";
+const OTHER_PLUGIN = "@elizaos/plugin-discord";
+
+function makeRuntime(opts: { setting?: string | boolean; plugins?: string[] }) {
+	return {
+		getSetting: (key: string) => {
+			if (
+				(key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS" ||
+					key === "LIFEOPS_PASSIVE_CONNECTORS") &&
+				opts.setting !== undefined
+			) {
+				return opts.setting;
+			}
+			return undefined;
+		},
+		plugins: (opts.plugins ?? []).map((name) => ({ name })),
+	};
+}
+
+describe("lifeOpsPassiveConnectorsEnabled", () => {
+	// Isolate from real process.env across tests
+	let savedEnv: Record<string, string | undefined>;
+	beforeEach(() => {
+		savedEnv = {};
+		for (const key of [
+			"ELIZA_LIFEOPS_PASSIVE_CONNECTORS",
+			"LIFEOPS_PASSIVE_CONNECTORS",
+		]) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+	afterEach(() => {
+		for (const [key, val] of Object.entries(savedEnv)) {
+			if (val === undefined) delete process.env[key];
+			else process.env[key] = val;
+		}
+	});
+
+	describe("default behaviour (no env var, no runtime setting)", () => {
+		it("returns false when no runtime is provided", () => {
+			expect(lifeOpsPassiveConnectorsEnabled()).toBe(false);
+		});
+
+		it("returns false when runtime has no plugins array", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled({ getSetting: () => undefined }),
+			).toBe(false);
+		});
+
+		it("returns false when runtime has an empty plugins array", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(makeRuntime({ plugins: [] })),
+			).toBe(false);
+		});
+
+		it("returns false when only unrelated plugins are loaded", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(
+					makeRuntime({ plugins: [OTHER_PLUGIN] }),
+				),
+			).toBe(false);
+		});
+
+		it("returns true when plugin-personal-assistant is loaded", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(
+					makeRuntime({ plugins: [LIFEOPS_PLUGIN] }),
+				),
+			).toBe(true);
+		});
+
+		it("returns true when plugin-personal-assistant is among other plugins", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(
+					makeRuntime({ plugins: [OTHER_PLUGIN, LIFEOPS_PLUGIN] }),
+				),
+			).toBe(true);
+		});
+	});
+
+	describe("explicit runtime setting overrides plugin detection", () => {
+		it("returns false when setting is 'false' even with LifeOps plugin loaded", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(
+					makeRuntime({ setting: "false", plugins: [LIFEOPS_PLUGIN] }),
+				),
+			).toBe(false);
+		});
+
+		it("returns true when setting is 'true' even without LifeOps plugin", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(
+					makeRuntime({ setting: "true", plugins: [] }),
+				),
+			).toBe(true);
+		});
+
+		it("recognises boolean false setting", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(makeRuntime({ setting: false })),
+			).toBe(false);
+		});
+
+		it("recognises boolean true setting", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(makeRuntime({ setting: true })),
+			).toBe(true);
+		});
+	});
+
+	describe("env var overrides plugin detection", () => {
+		it("returns false when env ELIZA_LIFEOPS_PASSIVE_CONNECTORS=false even with plugin loaded", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(
+					makeRuntime({ plugins: [LIFEOPS_PLUGIN] }),
+					{ ELIZA_LIFEOPS_PASSIVE_CONNECTORS: "false" },
+				),
+			).toBe(false);
+		});
+
+		it("returns true when env ELIZA_LIFEOPS_PASSIVE_CONNECTORS=true without plugin", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(makeRuntime({ plugins: [] }), {
+					ELIZA_LIFEOPS_PASSIVE_CONNECTORS: "true",
+				}),
+			).toBe(true);
+		});
+
+		it("recognises legacy LIFEOPS_PASSIVE_CONNECTORS env var", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(makeRuntime({ plugins: [] }), {
+					LIFEOPS_PASSIVE_CONNECTORS: "true",
+				}),
+			).toBe(true);
+		});
+	});
+
+	describe("null / undefined runtime", () => {
+		it("returns true for null runtime — pre-runtime conservative default (shouldStartTelegramStandaloneBot path)", () => {
+			// null is the explicit pre-runtime signal: plugin list is not available,
+			// so passive mode stays on to avoid starting connectors for LifeOps
+			// deployments before the runtime exists.
+			expect(lifeOpsPassiveConnectorsEnabled(null)).toBe(true);
+		});
+
+		it("null runtime is overridden by explicit env false (operator opt-out)", () => {
+			expect(
+				lifeOpsPassiveConnectorsEnabled(null, {
+					ELIZA_LIFEOPS_PASSIVE_CONNECTORS: "false",
+				}),
+			).toBe(false);
+		});
+
+		it("returns false for undefined runtime — no runtime provided, no plugin detected", () => {
+			expect(lifeOpsPassiveConnectorsEnabled(undefined)).toBe(false);
+		});
+
+		it("returns false when called with no arguments", () => {
+			expect(lifeOpsPassiveConnectorsEnabled()).toBe(false);
+		});
+	});
+});

--- a/packages/core/src/lifeops-passive-connectors.ts
+++ b/packages/core/src/lifeops-passive-connectors.ts
@@ -8,9 +8,9 @@
  *
  * Explicit env vars (`ELIZA_LIFEOPS_PASSIVE_CONNECTORS` / `LIFEOPS_PASSIVE_CONNECTORS`)
  * and runtime settings always take precedence over plugin-presence detection.
- * Passing `null` as the runtime is the pre-runtime signal (plugin list not yet
- * available); it conservatively enables passive mode so the standalone Telegram
- * polling bot does not start for LifeOps deployments before the runtime exists.
+ * Callers that run before `AgentRuntime` construction must supply the plugin
+ * set they have resolved from configuration. An absent runtime or plugin list
+ * means no LifeOps deployment was identified and therefore defaults active.
  */
 
 type SettingsReader = {
@@ -80,16 +80,6 @@ function isLifeOpsPluginLoaded(
 /**
  * Returns whether LifeOps passive-connector mode is active for this runtime.
  *
- * **`null` vs `undefined` are intentionally different:**
- * - `null`      → caller is pre-runtime (e.g. `shouldStartTelegramStandaloneBot`
- *                 in `app-core/src/runtime/telegram-standalone-policy.ts`); the
- *                 plugin list does not exist yet, so we conservatively return
- *                 `true` (passive on) to avoid starting connectors before the
- *                 runtime is initialized.
- * - `undefined` → no runtime provided (standalone call / test); falls through to
- *                 plugin-presence detection, which returns `false` (active-reply)
- *                 because `isLifeOpsPluginLoaded(undefined)` → `false`.
- *
  * **Default flip:** prior to this function the default was always `true` (passive).
  * It is now `false` for agents that do not load `plugin-personal-assistant` and
  * do not set either env var. Any existing deployment without that plugin will
@@ -103,11 +93,6 @@ export function lifeOpsPassiveConnectorsEnabled(
 	if (value !== undefined) {
 		// Explicit setting always wins — higher priority than plugin detection.
 		return !isExplicitFalse(value);
-	}
-	// null = pre-runtime signal; plugin list unavailable; stay passive.
-	// undefined = no runtime; falls through to plugin detection below.
-	if (runtime === null) {
-		return true;
 	}
 	return isLifeOpsPluginLoaded(runtime);
 }

--- a/packages/core/src/lifeops-passive-connectors.ts
+++ b/packages/core/src/lifeops-passive-connectors.ts
@@ -1,11 +1,21 @@
 /**
- * Resolves whether LifeOps passive connectors are enabled, reading the
- * `ELIZA_LIFEOPS_PASSIVE_CONNECTORS` / `LIFEOPS_PASSIVE_CONNECTORS` setting from
- * a runtime (`getSetting`) first, then the process env. Defaults to enabled;
- * only an explicit falsey value (`0`/`false`/`off`/`no`/`disabled`) disables it.
+ * Passive-connector gate for LifeOps deployments.
+ *
+ * When `plugin-personal-assistant` is loaded the runtime operates in passive
+ * mode: connectors ingest inbound messages into memory but do not auto-reply
+ * (the LifeOps pipeline drives responses instead). Standalone agents that do
+ * not load that plugin default to active-reply mode.
+ *
+ * Explicit env vars (`ELIZA_LIFEOPS_PASSIVE_CONNECTORS` / `LIFEOPS_PASSIVE_CONNECTORS`)
+ * and runtime settings always take precedence over plugin-presence detection.
+ * Passing `null` as the runtime is the pre-runtime signal (plugin list not yet
+ * available); it conservatively enables passive mode so the standalone Telegram
+ * polling bot does not start for LifeOps deployments before the runtime exists.
  */
+
 type SettingsReader = {
 	getSetting?: (key: string) => unknown;
+	plugins?: Array<{ name: string }>;
 };
 
 type EnvLike = Record<string, string | undefined>;
@@ -14,6 +24,8 @@ const PASSIVE_CONNECTOR_SETTING_KEYS = [
 	"ELIZA_LIFEOPS_PASSIVE_CONNECTORS",
 	"LIFEOPS_PASSIVE_CONNECTORS",
 ] as const;
+
+const LIFEOPS_PLUGIN_NAME = "@elizaos/plugin-personal-assistant";
 
 function readFirstSetting(
 	runtime: SettingsReader | null | undefined,
@@ -56,10 +68,46 @@ function isExplicitFalse(value: unknown): boolean {
 	);
 }
 
+function isLifeOpsPluginLoaded(
+	runtime: SettingsReader | null | undefined,
+): boolean {
+	return (
+		Array.isArray(runtime?.plugins) &&
+		runtime.plugins.some((p) => p.name === LIFEOPS_PLUGIN_NAME)
+	);
+}
+
+/**
+ * Returns whether LifeOps passive-connector mode is active for this runtime.
+ *
+ * **`null` vs `undefined` are intentionally different:**
+ * - `null`      → caller is pre-runtime (e.g. `shouldStartTelegramStandaloneBot`
+ *                 in `app-core/src/runtime/telegram-standalone-policy.ts`); the
+ *                 plugin list does not exist yet, so we conservatively return
+ *                 `true` (passive on) to avoid starting connectors before the
+ *                 runtime is initialized.
+ * - `undefined` → no runtime provided (standalone call / test); falls through to
+ *                 plugin-presence detection, which returns `false` (active-reply)
+ *                 because `isLifeOpsPluginLoaded(undefined)` → `false`.
+ *
+ * **Default flip:** prior to this function the default was always `true` (passive).
+ * It is now `false` for agents that do not load `plugin-personal-assistant` and
+ * do not set either env var. Any existing deployment without that plugin will
+ * begin auto-replying on connectors where it previously only ingested.
+ */
 export function lifeOpsPassiveConnectorsEnabled(
 	runtime?: SettingsReader | null,
 	env: EnvLike = defaultEnv(),
 ): boolean {
 	const value = readFirstSetting(runtime, env);
-	return value === undefined ? true : !isExplicitFalse(value);
+	if (value !== undefined) {
+		// Explicit setting always wins — higher priority than plugin detection.
+		return !isExplicitFalse(value);
+	}
+	// null = pre-runtime signal; plugin list unavailable; stay passive.
+	// undefined = no runtime; falls through to plugin detection below.
+	if (runtime === null) {
+		return true;
+	}
+	return isLifeOpsPluginLoaded(runtime);
 }

--- a/plugins/plugin-telegram/src/standalone/policy.ts
+++ b/plugins/plugin-telegram/src/standalone/policy.ts
@@ -1,4 +1,11 @@
-import { lifeOpsPassiveConnectorsEnabled } from "@elizaos/core";
+/**
+ * Selects the opt-in standalone Telegram poller from the resolved runtime
+ * plugin set and explicit deployment settings.
+ */
+import {
+  type IAgentRuntime,
+  lifeOpsPassiveConnectorsEnabled,
+} from "@elizaos/core";
 
 function isExplicitTrue(value: string | undefined): boolean {
   if (!value) {
@@ -11,14 +18,14 @@ function isExplicitTrue(value: string | undefined): boolean {
 /**
  * The standalone Telegram bot is an opt-in alternative to the full
  * `@elizaos/plugin-telegram` connector: it only runs when LifeOps passive
- * connectors are explicitly disabled AND `ELIZA_TELEGRAM_STANDALONE_BOT` is
- * truthy. In the default (passive-connectors-on) posture it never starts, so
- * the passive telegram connector owns the long-poll instead.
+ * `ELIZA_TELEGRAM_STANDALONE_BOT` is truthy and LifeOps passive mode is not
+ * active. Explicit passive-connector settings retain precedence.
  */
 export function shouldStartTelegramStandaloneBot(
   env: NodeJS.ProcessEnv = process.env,
+  runtime?: Pick<IAgentRuntime, "getSetting" | "plugins">,
 ): boolean {
-  if (lifeOpsPassiveConnectorsEnabled(null, env)) {
+  if (lifeOpsPassiveConnectorsEnabled(runtime, env)) {
     return false;
   }
   return isExplicitTrue(env.ELIZA_TELEGRAM_STANDALONE_BOT);

--- a/plugins/plugin-telegram/src/standalone/service.test.ts
+++ b/plugins/plugin-telegram/src/standalone/service.test.ts
@@ -33,9 +33,12 @@ import { shouldStartTelegramStandaloneBot } from "./policy";
 import { TelegramStandaloneService } from "./service";
 
 // Minimal runtime — the service only touches getService() at stop time.
-function fakeRuntime(): Parameters<typeof TelegramStandaloneService.start>[0] {
+function fakeRuntime(
+  plugins: string[] = [],
+): Parameters<typeof TelegramStandaloneService.start>[0] {
   return {
     agentId: "agent-standalone",
+    plugins: plugins.map((name) => ({ name })),
     getService: vi.fn(() => null),
     reportError: vi.fn(),
   } as unknown as Parameters<typeof TelegramStandaloneService.start>[0];
@@ -55,12 +58,12 @@ afterEach(async () => {
 });
 
 describe("shouldStartTelegramStandaloneBot (gate truth table)", () => {
-  it("is false by default (passive connectors on) even with the flag set", () => {
+  it("is true for a non-LifeOps runtime when the standalone flag is set", () => {
     expect(
       shouldStartTelegramStandaloneBot({
         ELIZA_TELEGRAM_STANDALONE_BOT: "1",
       } as NodeJS.ProcessEnv),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("is false when passive connectors are off but the flag is unset", () => {
@@ -79,15 +82,38 @@ describe("shouldStartTelegramStandaloneBot (gate truth table)", () => {
       } as NodeJS.ProcessEnv),
     ).toBe(true);
   });
+
+  it("is false when the resolved runtime loads LifeOps", () => {
+    expect(
+      shouldStartTelegramStandaloneBot(
+        { ELIZA_TELEGRAM_STANDALONE_BOT: "true" } as NodeJS.ProcessEnv,
+        fakeRuntime(["@elizaos/plugin-personal-assistant"]),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("TelegramStandaloneService lifecycle", () => {
-  it("no-ops (no poller) when the gate is off, even with a token present", async () => {
+  it("launches for a plain runtime with the standalone flag", async () => {
     delete process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS;
     process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "1";
     process.env.TELEGRAM_BOT_TOKEN = "test-token";
 
     const service = await TelegramStandaloneService.start(fakeRuntime());
+
+    expect(constructed).toEqual([{ token: "test-token" }]);
+    expect(launchMock).toHaveBeenCalledOnce();
+    await service.stop();
+  });
+
+  it("no-ops when LifeOps owns passive Telegram, even with the flag set", async () => {
+    delete process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS;
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "1";
+    process.env.TELEGRAM_BOT_TOKEN = "test-token";
+
+    const service = await TelegramStandaloneService.start(
+      fakeRuntime(["@elizaos/plugin-personal-assistant"]),
+    );
 
     expect(constructed).toHaveLength(0);
     expect(launchMock).not.toHaveBeenCalled();

--- a/plugins/plugin-telegram/src/standalone/service.ts
+++ b/plugins/plugin-telegram/src/standalone/service.ts
@@ -69,7 +69,7 @@ export class TelegramStandaloneService extends Service {
     runtime: IAgentRuntime,
   ): Promise<TelegramStandaloneService> {
     const service = new TelegramStandaloneService(runtime);
-    if (!shouldStartTelegramStandaloneBot()) {
+    if (!shouldStartTelegramStandaloneBot(process.env, runtime)) {
       return service;
     }
     await service.launch();


### PR DESCRIPTION
# Root issue

Standalone connector agents without `@elizaos/plugin-personal-assistant` were silently ingest-only because `lifeOpsPassiveConnectorsEnabled()` defaulted every deployment to passive mode.

The initial fix detected the plugin after runtime construction, but kept a `null` pre-runtime branch that always returned passive. That gave the same non-LifeOps Telegram deployment opposite answers: active at runtime connector gates, passive while the host decided whether to load the standalone poller. The poller could therefore never start without the unrelated passive-mode override.

# Fix

- Passive mode defaults from the resolved `@elizaos/plugin-personal-assistant` presence; explicit runtime/environment settings still win.
- Removes the behavioral distinction between `null` and `undefined`. An absent plugin set no longer fabricates a LifeOps deployment.
- Moves the host's standalone-Telegram decision after config entries, allow-list entries, installs, companion additions, and platform filters, then evaluates that final pre-runtime plugin set.
- Passes the real `AgentRuntime` into `TelegramStandaloneService`'s gate, so the service independently verifies the same policy before launching.
- Keeps mobile and lean-chat exclusions intact.

# Why this fixes the root cause

Both sides of the lifecycle now classify the same concrete fact: whether the resolved deployment loads LifeOps. A plain agent with `ELIZA_TELEGRAM_STANDALONE_BOT=true` loads and launches Telegram; a LifeOps agent remains passive; an explicit passive-mode setting overrides either default.

# Validation

- Core policy: 17/17 passing.
- Agent host collection: 3/3 passing, including plain-agent load, LifeOps suppression, and explicit LifeOps opt-out.
- Real Telegram service lifecycle with mocked network client: 9/9 passing, including launch for a plain runtime and no-op for a LifeOps runtime.
- App trigger bridge compatibility: 12/12 passing.
- Telegram package build passes; Biome passes on all touched files.
- Local aggregate typechecks were not claimed because this review worktree used cross-checkout dependency links; clean-install CI is authoritative for package type resolution.

# Risk

Intentional behavior change: non-LifeOps deployments become active-reply by default. Operators that deliberately relied on global ingest-only behavior can set `ELIZA_LIFEOPS_PASSIVE_CONNECTORS=true`.

<!-- evidence-head:0c2f089106a19efc77bd81fb30cc49ff4425b363 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - connector/runtime policy only; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - connector/runtime policy only; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no safe bot credential is available; the actual host collection and Telegram service lifecycle are exercised below

<!-- evidence-row:backend-logs -->
- [x] [Exact-head core, host, service, and bridge test output](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18322-runtime-tests-v2.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, or provider path changed

<!-- evidence-row:domain-artifacts -->
- [x] [Resolved deployment policy matrix](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18322-policy-matrix-v2.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: original contribution `anthropic/claude-sonnet-4-6`; remediation `openai/gpt-5` (system-reported model family; deployment variant unavailable)
<!-- attribution-row:client -->
- Agent tooling: Claude Code (original), Codex (remediation)
<!-- attribution-row:skill-revision -->
- Skill path: N/A - installed Codex plugin packages do not expose a repository commit SHA
<!-- attribution-row:status -->
- Provenance status: self-reported
