### PR TITLE
fix(plugin-elizacloud): retry cold-cache warming 503 for image description + fail closed instead of fabricating an error description

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/image-description-warming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/image-description-warming.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression coverage for handleImageDescription's transient-503 handling:
+ * a cold-cache `billing_cache_warming` 503 must be retried in place (it clears
+ * within ~1s on retry — the client companion to the server escape in #18249),
+ * and a genuine failure must throw (fail closed) instead of fabricating a
+ * `{ description: "Error: ..." }` object that would leak into LLM context.
+ * The cloud SDK client is mocked; no network.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const postRaw = vi.fn();
+vi.mock("../src/utils/sdk-client", () => ({
+  createElizaCloudClient: () => ({ routes: { postApiV1ChatCompletionsRaw: postRaw } }),
+}));
+
+const { handleImageDescription } = await import("../src/models/image");
+
+function runtime(): IAgentRuntime {
+  return {
+    getSetting: () => "",
+    emitEvent: () => {},
+  } as unknown as IAgentRuntime;
+}
+
+function warming503(): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: "Billing authorization is warming. Retry shortly.",
+        type: "service_unavailable",
+        code: "billing_cache_warming",
+        retryAfter: 1,
+      },
+    }),
+    { status: 503, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+function ok(description: string): Response {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: description } }],
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+describe("handleImageDescription warming-503 retry", () => {
+  afterEach(() => {
+    postRaw.mockReset();
+  });
+
+  it("rides through a cold-cache warming 503 and returns the description", async () => {
+    postRaw
+      .mockResolvedValueOnce(warming503())
+      .mockResolvedValueOnce(ok("A red square."));
+
+    const result = await handleImageDescription(runtime(), {
+      imageUrl: "https://example.com/red.png",
+      prompt: "describe",
+    });
+
+    expect(postRaw).toHaveBeenCalledTimes(2);
+    // parseImageDescriptionResponse yields a title/description; the content survived.
+    expect(JSON.stringify(result)).toContain("red square");
+  });
+
+  it("throws (fails closed) instead of fabricating an error description on a hard 500", async () => {
+    postRaw.mockResolvedValue(
+      new Response("upstream boom", { status: 500 })
+    );
+
+    await expect(
+      handleImageDescription(runtime(), {
+        imageUrl: "https://example.com/x.png",
+        prompt: "describe",
+      })
+    ).rejects.toThrow();
+    // Must NOT resolve to a { description: "Error: ..." } object.
+  });
+
+  it("does not retry a non-warming 503 forever — bounded and then throws", async () => {
+    postRaw.mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "gone" } }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    await expect(
+      handleImageDescription(runtime(), {
+        imageUrl: "https://example.com/x.png",
+        prompt: "describe",
+      })
+    ).rejects.toThrow();
+    // A bare 503 with no warming code is not the warming case: fail fast, one attempt.
+    expect(postRaw).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-elizacloud/src/models/image.ts
+++ b/plugins/plugin-elizacloud/src/models/image.ts
@@ -118,7 +118,8 @@ export async function handleImageDescription(
     // the caller fail fast.
     let response: Response | null = null;
     let attemptedRetry = false;
-    for (let attempt = 0; attempt < 2; attempt++) {
+    let warmingRetries = 0;
+    for (let attempt = 0; attempt < 4; attempt++) {
       const attemptResponse = await client.routes.postApiV1ChatCompletionsRaw({
         json: requestBody,
         timeoutMs: resolveCloudTimeoutMs("ELIZAOS_CLOUD_IMAGE_TIMEOUT_MS", 120_000),
@@ -127,6 +128,50 @@ export async function handleImageDescription(
         continue;
       }
       response = attemptResponse;
+      if (attemptResponse.ok) break;
+
+      // Transient cold-cache warming: this box runs text on Cerebras, so the
+      // cloud's per-model billing/auth admission cache for the vision model
+      // goes cold between rare image calls. The first image then hits a 503
+      // whose body carries `billing_cache_warming`/`auth_cache_warming`
+      // (type `service_unavailable`, retryable) that clears within ~1s — the
+      // client-side companion to the server escape in #18249. Riding through
+      // it here restores vision without waiting on the prod-cloud promote
+      // (verified live: 200 on the first retry). The 429 branch below stays a
+      // single retry; warming gets a few because a cold cache can need two.
+      if (attemptResponse.status === 503 && warmingRetries < 2) {
+        let warming = false;
+        let warmingWait = 1;
+        try {
+          const peek = (await attemptResponse.clone().json()) as {
+            error?: { code?: unknown; type?: unknown; retryAfter?: unknown };
+            code?: unknown;
+            type?: unknown;
+            retryAfter?: unknown;
+          };
+          const code = String(peek?.error?.code ?? peek?.code ?? "");
+          const type = String(peek?.error?.type ?? peek?.type ?? "");
+          warming =
+            code === "billing_cache_warming" ||
+            code === "auth_cache_warming" ||
+            type === "service_unavailable";
+          const ra = peek?.error?.retryAfter ?? peek?.retryAfter;
+          if (typeof ra === "number" && Number.isFinite(ra) && ra > 0) {
+            warmingWait = Math.min(ra, 3);
+          }
+        } catch {
+          // Body wasn't JSON — treat a bare 503 as non-warming, fail fast.
+        }
+        if (warming) {
+          warmingRetries++;
+          logger.warn(
+            `[ELIZAOS_CLOUD] Image analysis cold-cache warming (503), retry ${warmingRetries}/2 after ${warmingWait}s...`
+          );
+          await new Promise((r) => setTimeout(r, warmingWait * 1000));
+          continue;
+        }
+      }
+
       if (attemptResponse.status !== 429 || attemptedRetry) break;
 
       // `Number(null) === 0`, so guard against a missing header before
@@ -216,19 +261,20 @@ export async function handleImageDescription(
     }
 
     if (!content) {
-      return {
-        title: "Failed to analyze image",
-        description: "No response from API",
-      };
+      throw new Error(
+        "ElizaOS Cloud image description returned an empty completion"
+      );
     }
 
     return parseImageDescriptionResponse(content);
   } catch (error) {
+    // Fail closed: never fabricate a `{ description: "Error: ..." }` object.
+    // The caller (describeImageCached) catches this and returns null, so the
+    // agent honestly reports the image as undescribed instead of caching the
+    // error string under the image hash and leaking it into LLM context —
+    // the same contract plugin-openai / plugin-google-genai already uphold.
     const message = error instanceof Error ? error.message : String(error);
-    logger.error(`Error analyzing image: ${message}`);
-    return {
-      title: "Failed to analyze image",
-      description: `Error: ${message}`,
-    };
+    logger.warn(`Error analyzing image (failing closed): ${message}`);
+    throw error instanceof Error ? error : new Error(message);
   }
 }


### PR DESCRIPTION
## The incident

Live box, 2026-08-10: every incoming image to the bot produced `Error analyzing image: ElizaOS Cloud API error: 503` (8x). Operator asked why — "I thought we fixed image yesterday."

## Root cause (two client bugs, neither fixed on develop)

Eliza Cloud vision is UP (447 models, dozens vision-capable; a real image returns 200 on retry within ~1s, verified live). The 503 is a transient **cold-cache warming** response — `billing_cache_warming`/`auth_cache_warming`, type `service_unavailable`, retryable. Because this box runs text on Cerebras, the cloud's per-model billing/auth admission cache for the vision model goes cold between rare image calls, so the first image hits a cold-cache 503.

`plugin-elizacloud/src/models/image.ts` mishandled it twice:
1. **The retry loop only retries HTTP 429** (`if (status !== 429 …) break`) — it bails on the warming 503 with zero retry, so every cold image fails.
2. **The catch fabricated `{ title: "Failed to analyze image", description: "Error: …503" }`** instead of failing closed. `describeImageCached` treats that as success, caches it under the image hash, and the error string leaks into working-memory / LLM context.

(The server-side companion #18249 fixes the cloud's eternal-warming; #18245 is a different subsystem — plugin-vision live-camera readiness, disabled on this box — and does not touch this path.)

## Fix (keyless — works with the existing cloud key, no promote needed)

1. Retry the warming 503 in place: detect `billing_cache_warming`/`auth_cache_warming`/`service_unavailable` in the body, honor its `retryAfter` (capped 3s), up to 2 warming retries; 429 stays a single retry; a bare non-warming 503 still fails fast.
2. Fail closed: the empty-completion and catch paths now **throw** instead of fabricating an error description — matching the contract plugin-openai / plugin-google-genai already uphold (their tests assert exactly "throws instead of fabricating"). Caller returns null → honest "image undescribed".

## Verification

- 3 new tests: warming-503-then-200 rides through and returns the description; a hard 500 throws (no fabricated object); a non-warming 503 fails fast in one attempt.
- Live proof the warming clears on retry: a real test image returned "Red." from openai/gpt-4o-mini on the first retry against prod cloud.
- plugin-elizacloud typecheck + biome clean.
- Deploying to the live bot + live image read-back to confirm.

# Evidence

<!-- evidence-head:c637098d58b79753769f54fa80f95e5f69e3ad85 -->
- Before screenshots: N/A - runtime/model path
- After screenshots: N/A - runtime/model path
- Walkthrough video: N/A - runtime/model path
- OCR review: N/A - runtime/model path
- Frontend console/network logs: N/A - runtime/model path
- Backend logs: the 8x "Error analyzing image: 503" incident lines + post-fix clean image turn in PR thread
- Real-LLM trajectory: live cloud vision call returning 200 ("Red.") on retry with the box's existing key
- Domain artifacts: image description populated instead of the fabricated error string

🤖 Generated with [Claude Code](https://claude.com/claude-code)
