### PR TITLE
fix(plugin-elizacloud): retry cold-cache warming for image generation too

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/image-description-warming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/image-description-warming.test.ts
@@ -1,26 +1,40 @@
 /**
- * Regression coverage for handleImageDescription's transient-503 handling:
- * a cold-cache `billing_cache_warming` 503 must be retried in place (it clears
- * within ~1s on retry — the client companion to the server escape in #18249),
- * and a genuine failure must throw (fail closed) instead of fabricating a
- * `{ description: "Error: ..." }` object that would leak into LLM context.
+ * Regression coverage for the image model handlers' transient cold-cache
+ * warming handling. On this class of box, text runs on Cerebras so the cloud's
+ * per-model billing/auth admission cache goes cold between rare image calls;
+ * the first image then hits a warming 503/error that clears within ~1s on
+ * retry (the client companion to the server escape in #18249).
+ *   - handleImageDescription: retry the `billing_cache_warming` 503 in place,
+ *     and throw (fail closed) instead of fabricating a `{ description:"Error" }`.
+ *   - handleImageGeneration: retry the "admission cache is warming" throw.
  * The cloud SDK client is mocked; no network.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const postRaw = vi.fn();
+const generateImage = vi.fn();
 vi.mock("../src/utils/sdk-client", () => ({
-  createElizaCloudClient: () => ({ routes: { postApiV1ChatCompletionsRaw: postRaw } }),
+  createElizaCloudClient: () => ({
+    routes: { postApiV1ChatCompletionsRaw: postRaw },
+    generateImage,
+  }),
 }));
+vi.mock("../src/utils/config", async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getImageGenerationModel: () => "google/nano-banana-2/text-to-image",
+    getImageDescriptionModel: () => "openai/gpt-4o-mini",
+  };
+});
 
-const { handleImageDescription } = await import("../src/models/image");
+const { handleImageDescription, handleImageGeneration } = await import(
+  "../src/models/image"
+);
 
 function runtime(): IAgentRuntime {
-  return {
-    getSetting: () => "",
-    emitEvent: () => {},
-  } as unknown as IAgentRuntime;
+  return { getSetting: () => "", emitEvent: () => {} } as unknown as IAgentRuntime;
 }
 
 function warming503(): Response {
@@ -39,62 +53,74 @@ function warming503(): Response {
 
 function ok(description: string): Response {
   return new Response(
-    JSON.stringify({
-      choices: [{ message: { content: description } }],
-    }),
+    JSON.stringify({ choices: [{ message: { content: description } }] }),
     { status: 200, headers: { "Content-Type": "application/json" } }
   );
 }
 
 describe("handleImageDescription warming-503 retry", () => {
-  afterEach(() => {
-    postRaw.mockReset();
-  });
+  afterEach(() => postRaw.mockReset());
 
   it("rides through a cold-cache warming 503 and returns the description", async () => {
     postRaw
       .mockResolvedValueOnce(warming503())
       .mockResolvedValueOnce(ok("A red square."));
-
     const result = await handleImageDescription(runtime(), {
       imageUrl: "https://example.com/red.png",
       prompt: "describe",
     });
-
     expect(postRaw).toHaveBeenCalledTimes(2);
-    // parseImageDescriptionResponse yields a title/description; the content survived.
     expect(JSON.stringify(result)).toContain("red square");
   });
 
-  it("throws (fails closed) instead of fabricating an error description on a hard 500", async () => {
-    postRaw.mockResolvedValue(
-      new Response("upstream boom", { status: 500 })
-    );
-
+  it("throws (fails closed) on a hard 500 instead of fabricating a description", async () => {
+    postRaw.mockResolvedValue(new Response("upstream boom", { status: 500 }));
     await expect(
       handleImageDescription(runtime(), {
         imageUrl: "https://example.com/x.png",
         prompt: "describe",
       })
     ).rejects.toThrow();
-    // Must NOT resolve to a { description: "Error: ..." } object.
   });
 
-  it("does not retry a non-warming 503 forever — bounded and then throws", async () => {
+  it("fails fast on a non-warming 503 (one attempt)", async () => {
     postRaw.mockResolvedValue(
       new Response(JSON.stringify({ error: { message: "gone" } }), {
         status: 503,
         headers: { "Content-Type": "application/json" },
       })
     );
-
     await expect(
       handleImageDescription(runtime(), {
         imageUrl: "https://example.com/x.png",
         prompt: "describe",
       })
     ).rejects.toThrow();
-    // A bare 503 with no warming code is not the warming case: fail fast, one attempt.
     expect(postRaw).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handleImageGeneration warming retry", () => {
+  afterEach(() => generateImage.mockReset());
+
+  it("rides through a generative cold-cache warming throw and returns the image", async () => {
+    generateImage
+      .mockRejectedValueOnce(
+        new Error("Generative admission cache is warming; retry shortly")
+      )
+      .mockResolvedValueOnce({ images: [{ url: "https://cdn/x.png" }] });
+    const result = await handleImageGeneration(runtime(), {
+      prompt: "a red circle",
+    });
+    expect(generateImage).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([{ url: "https://cdn/x.png" }]);
+  });
+
+  it("fails fast on a non-warming generation error", async () => {
+    generateImage.mockRejectedValue(new Error("Unsupported image model"));
+    await expect(
+      handleImageGeneration(runtime(), { prompt: "a red circle" })
+    ).rejects.toThrow("Unsupported image model");
+    expect(generateImage).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/plugin-elizacloud/src/models/image.ts
+++ b/plugins/plugin-elizacloud/src/models/image.ts
@@ -35,7 +35,32 @@ export async function handleImageGeneration(
       model: modelName,
     };
 
-    const typedData = await createElizaCloudClient(runtime).generateImage(requestBody);
+    const client = createElizaCloudClient(runtime);
+    let typedData: Awaited<ReturnType<typeof client.generateImage>> | undefined;
+    let warmingRetries = 0;
+    for (;;) {
+      try {
+        typedData = await client.generateImage(requestBody);
+        break;
+      } catch (err) {
+        // Cold-cache warming: this box runs text on Cerebras, so the cloud's
+        // generative admission cache goes cold between rare image-gen calls
+        // and the first hit throws "Generative admission cache is warming;
+        // retry shortly", clearing within ~1s (verified live: success on the
+        // first retry). Ride through it — the same transient the description
+        // path handles in-place. A non-warming error still fails fast.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (/warming|admission cache/i.test(msg) && warmingRetries < 2) {
+          warmingRetries++;
+          logger.warn(
+            `[ELIZAOS_CLOUD] Image generation cold-cache warming, retry ${warmingRetries}/2...`
+          );
+          await new Promise((r) => setTimeout(r, 1500));
+          continue;
+        }
+        throw err;
+      }
+    }
 
     const result = typedData.images.map((img: { url?: string; image?: string }) => ({
       url: img.url ?? img.image ?? "",


### PR DESCRIPTION
## What

Companion to #18323 (image description). Live test found image GENERATION also fails on a cold cache: the bot replied "can't generate images right now." Direct probe of the generate-image endpoint with the box's existing cloud key returned `Generative admission cache is warming; retry shortly` — the same transient cold-cache warming (text runs on Cerebras, so the cloud's per-model generative admission cache goes cold between rare image-gen calls). Retrying warms through: the default model `google/nano-banana-2/text-to-image` returned a real 620KB image on the first retry. The model + endpoint are fine; the client just didn't retry.

`handleImageGeneration` (plugins/plugin-elizacloud/src/models/image.ts) made a single `generateImage` call and rethrew, so a cold-cache image-gen request hard-failed. #18323 fixed this for `handleImageDescription`; this does the same for the generation path.

## Fix

Wrap the `generateImage` call in a bounded retry: on an error whose message matches `/warming|admission cache/i`, sleep 1.5s and retry (up to 2 warming retries). Non-warming errors (e.g. "Unsupported image model") still fail fast. No model-default change — the default is supported and warms through.

## Verification

- 2 new tests: a warming-then-success sequence rides through and returns the image; a non-warming error fails fast in one attempt. Full file 5/5 (incl. the #18323 description cases).
- Live proof: real generate-image call returned a 620KB image on the first retry with the box's existing key.
- typecheck + biome clean.
- Deploying to the live bot + live image-gen read-back to confirm.

# Evidence

<!-- evidence-head:903ee36fb2b2eef4a3fe59da28a6347c43ec2b5e -->
- Before screenshots: N/A - runtime/model path
- After screenshots: N/A - runtime/model path
- Walkthrough video: N/A - runtime/model path
- OCR review: N/A - runtime/model path
- Frontend console/network logs: N/A - runtime/model path
- Backend logs: live "can't generate images" turn + post-fix generated image in PR thread
- Real-LLM trajectory: live generate-image returning a 620KB image on retry with the box key
- Domain artifacts: generated image delivered to the user instead of a failure reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)
