### PR TITLE
fix(app-core): blank line after vi.setConfig before imports in two suites

### DIFF
--- a/packages/app-core/src/services/multi-account-affinity-failover.test.ts
+++ b/packages/app-core/src/services/multi-account-affinity-failover.test.ts
@@ -47,6 +47,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // seconds apiece on saturated CI disks. Budget the whole file for that, not
 // just the sweep-heavy blocks.
 vi.setConfig({ testTimeout: 240_000, hookTimeout: 240_000 });
+
 import {
   __resetDefaultAccountPoolForTests,
   getDefaultAccountPool,

--- a/packages/app-core/src/services/multi-account-rotation.test.ts
+++ b/packages/app-core/src/services/multi-account-rotation.test.ts
@@ -33,6 +33,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // seconds apiece on saturated CI disks. Budget the whole file for that, not
 // just the sweep-heavy blocks.
 vi.setConfig({ testTimeout: 240_000, hookTimeout: 240_000 });
+
 import {
   __resetDefaultAccountPoolForTests,
   getDefaultAccountPool,


### PR DESCRIPTION
Two-line formatting repair unblocking `bun run verify` on develop (Biome organizeImports red introduced by `87112c2bcb6` in `multi-account-affinity-failover.test.ts` + `multi-account-rotation.test.ts`). Blocks the release re-pin and every freshly rebased branch — requested by kepler, landing per fleet HQ #18309 agreement.

Focused Biome check on both files: **clean**. Formatting only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)