### PR TITLE
style: blank line after vi.setConfig file-budget preambles

### DIFF
--- a/packages/app-core/src/services/multi-account-affinity-failover.test.ts
+++ b/packages/app-core/src/services/multi-account-affinity-failover.test.ts
@@ -47,6 +47,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // seconds apiece on saturated CI disks. Budget the whole file for that, not
 // just the sweep-heavy blocks.
 vi.setConfig({ testTimeout: 240_000, hookTimeout: 240_000 });
+
 import {
   __resetDefaultAccountPoolForTests,
   getDefaultAccountPool,

--- a/packages/app-core/src/services/multi-account-rotation.test.ts
+++ b/packages/app-core/src/services/multi-account-rotation.test.ts
@@ -33,6 +33,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // seconds apiece on saturated CI disks. Budget the whole file for that, not
 // just the sweep-heavy blocks.
 vi.setConfig({ testTimeout: 240_000, hookTimeout: 240_000 });
+
 import {
   __resetDefaultAccountPoolForTests,
   getDefaultAccountPool,


### PR DESCRIPTION
Two-line Biome fix: blank line after the vi.setConfig file-budget preamble in the two multi-account app-core test files — the current develop lint-red kepler diagnosed (its local proof was reverted, never landed). Same commit is riding release/promote-791b59e7af so the launch cert is not blocked.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
