### PR TITLE
style(plugin-elizacloud): format image warming test

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/image-description-warming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/image-description-warming.test.ts
@@ -29,9 +29,7 @@ vi.mock("../src/utils/config", async (orig) => {
   };
 });
 
-const { handleImageDescription, handleImageGeneration } = await import(
-  "../src/models/image"
-);
+const { handleImageDescription, handleImageGeneration } = await import("../src/models/image");
 
 function runtime(): IAgentRuntime {
   return { getSetting: () => "", emitEvent: () => {} } as unknown as IAgentRuntime;
@@ -52,19 +50,17 @@ function warming503(): Response {
 }
 
 function ok(description: string): Response {
-  return new Response(
-    JSON.stringify({ choices: [{ message: { content: description } }] }),
-    { status: 200, headers: { "Content-Type": "application/json" } }
-  );
+  return new Response(JSON.stringify({ choices: [{ message: { content: description } }] }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 describe("handleImageDescription warming-503 retry", () => {
   afterEach(() => postRaw.mockReset());
 
   it("rides through a cold-cache warming 503 and returns the description", async () => {
-    postRaw
-      .mockResolvedValueOnce(warming503())
-      .mockResolvedValueOnce(ok("A red square."));
+    postRaw.mockResolvedValueOnce(warming503()).mockResolvedValueOnce(ok("A red square."));
     const result = await handleImageDescription(runtime(), {
       imageUrl: "https://example.com/red.png",
       prompt: "describe",
@@ -105,9 +101,7 @@ describe("handleImageGeneration warming retry", () => {
 
   it("rides through a generative cold-cache warming throw and returns the image", async () => {
     generateImage
-      .mockRejectedValueOnce(
-        new Error("Generative admission cache is warming; retry shortly")
-      )
+      .mockRejectedValueOnce(new Error("Generative admission cache is warming; retry shortly"))
       .mockResolvedValueOnce({ images: [{ url: "https://cdn/x.png" }] });
     const result = await handleImageGeneration(runtime(), {
       prompt: "a red circle",
@@ -118,9 +112,9 @@ describe("handleImageGeneration warming retry", () => {
 
   it("fails fast on a non-warming generation error", async () => {
     generateImage.mockRejectedValue(new Error("Unsupported image model"));
-    await expect(
-      handleImageGeneration(runtime(), { prompt: "a red circle" })
-    ).rejects.toThrow("Unsupported image model");
+    await expect(handleImageGeneration(runtime(), { prompt: "a red circle" })).rejects.toThrow(
+      "Unsupported image model"
+    );
     expect(generateImage).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Outcome

Formats the image-warming regression test added on current `develop` so the package and root Biome gates can run again. This changes test layout only; runtime behavior and assertions are equivalent.

## Exact object

- head: `c93fca2f44830bead2b634d48000c86892cca15e`
- tree: `333f0db9eb1b78f8064fcd72e0cd76e6ac354394`
- base: `c49f2087e83c4aee1df13b69e4490906494519fd`
- scope: 1 test file, formatting only

## Verification

- `bun run --cwd plugins/plugin-elizacloud test -- __tests__/image-description-warming.test.ts`: 5/5 PASS
- `bun run --cwd plugins/plugin-elizacloud typecheck`: PASS
- `bun run --cwd plugins/plugin-elizacloud lint:check`: PASS, 57 files checked
- `git diff --check`: PASS
- Manual diff review: no token, assertion, or control-flow changes

## Evidence checklist

<!-- evidence-head:c93fca2f44830bead2b634d48000c86892cca15e -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only formatting; no rendered surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only formatting; no rendered surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only formatting; no user journey

<!-- evidence-row:backend-logs -->
- [ ] N/A - no runtime path changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, action, or prompt behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - formatting emits no domain artifact

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual evidence applies

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@c49f2087e83c4aee1df13b69e4490906494519fd:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@c49f2087e83c4aee1df13b69e4490906494519fd:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [kepler]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@c49f2087e83c4aee1df13b69e4490906494519fd:packages/skills/skills/contribute-to-eliza"} -->
