### PR TITLE
fix(cloud): fail closed on OAuth success ticket storage and replay on Worker KV

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -269,7 +269,7 @@ describe.skipIf(!ENABLED)(
 
       const first = await runScript(MIGRATOR, database.url);
       expect(first.exitCode, first.output).toBe(0);
-      expect(first.output).toContain("pending migrations: 11");
+      expect(first.output).toContain("pending migrations: 12");
 
       const catalog = await database.client.query<{
         data_type: string;
@@ -317,7 +317,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 11");
+      expect(migrated.output).toContain("pending migrations: 12");
 
       await database.client.query(
         "UPDATE drizzle.__drizzle_migrations SET hash = 'checkpoint-drift' WHERE created_at = $1",
@@ -363,7 +363,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 11");
+      expect(migrated.output).toContain("pending migrations: 12");
       await database.client.end();
     }, 120_000);
 
@@ -373,7 +373,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 11");
+      expect(migrated.output).toContain("pending migrations: 12");
       await database.client.end();
     }, 120_000);
 
@@ -405,7 +405,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 11");
+      expect(migrated.output).toContain("pending migrations: 12");
       await database.client.end();
     }, 120_000);
 
@@ -425,7 +425,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 11");
+      expect(migrated.output).toContain("pending migrations: 12");
 
       const remaining = await database.client.query<{ count: string }>(
         "SELECT count(*)::text AS count FROM drizzle.__drizzle_migrations WHERE created_at = ANY($1::bigint[])",

--- a/packages/cloud/shared/src/db/migrations/0196_oauth_success_proof_tickets.sql
+++ b/packages/cloud/shared/src/db/migrations/0196_oauth_success_proof_tickets.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "oauth_success_proof_tickets" (
+	"nonce_hash" text PRIMARY KEY NOT NULL,
+	"platform" text NOT NULL,
+	"connection_id" text,
+	"organization_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "oauth_success_proof_tickets_expires_at_idx" ON "oauth_success_proof_tickets" USING btree ("expires_at");

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1366,6 +1366,13 @@
       "when": 1786564800000,
       "tag": "0195_job_terminal_completed_at_backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 195,
+      "version": "7",
+      "when": 1786651200000,
+      "tag": "0196_oauth_success_proof_tickets",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/oauth-success-proof-tickets.ts
+++ b/packages/cloud/shared/src/db/repositories/oauth-success-proof-tickets.ts
@@ -1,0 +1,48 @@
+/**
+ * Atomic persistence for OAuth success-proof tickets. Inserts fail loudly and
+ * `DELETE … RETURNING` gives exactly one verifier ownership of a live nonce.
+ */
+
+import { and, eq, gt, lte } from "drizzle-orm";
+import { dbWrite } from "../helpers";
+import {
+  type NewOAuthSuccessProofTicketRow,
+  type OAuthSuccessProofTicketRow,
+  oauthSuccessProofTickets,
+} from "../schemas/oauth-success-proof-tickets";
+
+export class OAuthSuccessProofTicketsRepository {
+  async insert(row: NewOAuthSuccessProofTicketRow): Promise<OAuthSuccessProofTicketRow> {
+    const [inserted] = await dbWrite.insert(oauthSuccessProofTickets).values(row).returning();
+    if (!inserted) {
+      throw new Error("OAuthSuccessProofTicketsRepository: failed to insert ticket");
+    }
+    return inserted;
+  }
+
+  async claim(
+    nonceHash: string,
+    now: Date = new Date(),
+  ): Promise<OAuthSuccessProofTicketRow | undefined> {
+    const [claimed] = await dbWrite
+      .delete(oauthSuccessProofTickets)
+      .where(
+        and(
+          eq(oauthSuccessProofTickets.nonce_hash, nonceHash),
+          gt(oauthSuccessProofTickets.expires_at, now),
+        ),
+      )
+      .returning();
+    return claimed;
+  }
+
+  async purgeExpired(now: Date = new Date()): Promise<number> {
+    const purged = await dbWrite
+      .delete(oauthSuccessProofTickets)
+      .where(lte(oauthSuccessProofTickets.expires_at, now))
+      .returning({ nonce_hash: oauthSuccessProofTickets.nonce_hash });
+    return purged.length;
+  }
+}
+
+export const oauthSuccessProofTicketsRepository = new OAuthSuccessProofTicketsRepository();

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -68,6 +68,7 @@ export * from "./llm-trajectories";
 export * from "./managed-domains";
 export * from "./model-pricing";
 export * from "./moderation-violations";
+export * from "./oauth-success-proof-tickets";
 export * from "./oidc";
 export * from "./org-rate-limit-overrides";
 export * from "./org-storage-quota";

--- a/packages/cloud/shared/src/db/schemas/oauth-success-proof-tickets.ts
+++ b/packages/cloud/shared/src/db/schemas/oauth-success-proof-tickets.ts
@@ -1,0 +1,27 @@
+/**
+ * Strongly consistent one-time tickets backing OAuth success-page proofs.
+ * Nonces are stored only as SHA-256 digests and claimed atomically through
+ * Postgres because the deployed Worker's cache is eventually consistent KV.
+ */
+
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+export const oauthSuccessProofTickets = pgTable(
+  "oauth_success_proof_tickets",
+  {
+    nonce_hash: text("nonce_hash").primaryKey(),
+    platform: text("platform").notNull(),
+    connection_id: text("connection_id"),
+    organization_id: text("organization_id").notNull(),
+    user_id: text("user_id").notNull(),
+    expires_at: timestamp("expires_at", { withTimezone: true }).notNull(),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    expiresAtIdx: index("oauth_success_proof_tickets_expires_at_idx").on(table.expires_at),
+  }),
+);
+
+export type OAuthSuccessProofTicketRow = InferSelectModel<typeof oauthSuccessProofTickets>;
+export type NewOAuthSuccessProofTicketRow = InferInsertModel<typeof oauthSuccessProofTickets>;

--- a/packages/cloud/shared/src/lib/services/oauth/success-proof.default-store.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/success-proof.default-store.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Exercises the DEFAULT ticket store (not the in-memory test override) against a
+ * mocked cache singleton, so the production atomicity gate at put() —
+ * cache.supportsAtomicOperations() — is actually covered.
+ *
+ * RP finding #2 on #18331: the original replay-regression test replaced the
+ * store with a custom in-memory implementation, so it never called
+ * defaultTicketStore.put() or .take() and never exercised the
+ * supportsAtomicOperations() gate. This file mocks the `cache` module directly
+ * and restores the default store (no __setOAuthSuccessProofTicketStoreForTests)
+ * to prove the real gate behaves correctly on both atomic and non-atomic
+ * backends.
+ *
+ * Uses bun:test `mock.module` to replace ../../cache/client before the
+ * success-proof module imports it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cache } from "../../cache/client";
+import {
+  consumeOAuthSuccessProof,
+  mintOAuthSuccessProof,
+  type OAuthSuccessProofTicket,
+  type OAuthSuccessProofTicketStore,
+} from "./success-proof";
+
+const PREV = { ...process.env };
+
+const BINDING = {
+  organizationId: "org-1",
+  userId: "user-1",
+};
+
+/**
+ * Control knob for the mocked cache. Set supportsAtomic before minting a proof
+ * so the test can assert the gate outcome. All fields default to "atomic + happy
+ * path" so each test overrides only what it needs.
+ */
+interface MockCacheState {
+  supportsAtomic: boolean;
+  writeKind: "written" | "unavailable" | "error" | "invalid";
+  /** Tickets stored by the (mocked) write path, keyed by nonce. */
+  tickets: Map<string, OAuthSuccessProofTicket>;
+}
+
+const state: MockCacheState = {
+  supportsAtomic: true,
+  writeKind: "written",
+  tickets: new Map(),
+};
+
+/**
+ * The typed mock surface success-proof touches on the real cache singleton:
+ * setWithOutcome (put), supportsAtomicOperations (gate), getAndDelete (take).
+ */
+/** Minimal structural shape of the cache methods the default store touches. */
+interface CacheMethodShim {
+  supportsAtomicOperations(): boolean;
+  setWithOutcome<T>(
+    key: string,
+    value: T,
+    ttlSeconds: number,
+  ): Promise<{ kind: "written" | "unavailable" | "error" | "invalid"; backend: string }>;
+  getAndDelete<T>(key: string): Promise<T | null>;
+}
+
+function buildMockCache(): CacheMethodShim {
+  return {
+    supportsAtomicOperations: () => state.supportsAtomic,
+    setWithOutcome: async <T>(_key: string, value: T, _ttlSeconds: number) => {
+      const ticket = value as unknown as OAuthSuccessProofTicket;
+      // Only persist when the backend would actually acknowledge the write.
+      if (state.writeKind === "written") {
+        state.tickets.set(_key, ticket);
+      }
+      return { kind: state.writeKind, backend: "redis_native" };
+    },
+    getAndDelete: async <T>(key: string): Promise<T | null> => {
+      const entry = state.tickets.get(key);
+      if (!entry) return null;
+      state.tickets.delete(key);
+      return entry as unknown as T;
+    },
+  };
+}
+
+describe("oauth success proof — default store atomicity gate", () => {
+  beforeEach(() => {
+    process.env.OAUTH_SUCCESS_PROOF_SECRET = "test-oauth-success-proof-secret-32b";
+    state.supportsAtomic = true;
+    state.writeKind = "written";
+    state.tickets.clear();
+    // Point the real module-imported cache at our mock. The success-proof
+    // module holds a live binding to the `cache` object imported at module
+    // load; we replace its methods in place so the default store sees the mock.
+    const mock = buildMockCache();
+    (cache as unknown as Record<string, unknown>).supportsAtomicOperations =
+      mock.supportsAtomicOperations;
+    (cache as unknown as Record<string, unknown>).setWithOutcome = mock.setWithOutcome;
+    (cache as unknown as Record<string, unknown>).getAndDelete = mock.getAndDelete;
+  });
+
+  afterEach(() => {
+    process.env = { ...PREV };
+  });
+
+  it("does not mint a proof on a non-atomic backend (KV) — gate at put()", async () => {
+    // RP #18331: supportsAtomicOperations() === false must cause put() to
+    // return false, so mintOAuthSuccessProof fails closed and returns null.
+    // The previous gate lived in take(); put() reported "written" and a
+    // dead proof was minted.
+    state.supportsAtomic = false;
+    const proof = await mintOAuthSuccessProof({
+      platform: "github",
+      connectionId: "conn-1",
+      ...BINDING,
+    });
+    expect(proof).toBeNull();
+    // No ticket was stored — the gate fired before setWithOutcome.
+    expect(state.tickets.size).toBe(0);
+  });
+
+  it("mints and consumes a proof through the default store on an atomic backend", async () => {
+    // The happy path: the default store (not the in-memory override) writes
+    // via setWithOutcome and consumes via getAndDelete.
+    const proof = await mintOAuthSuccessProof({
+      platform: "twitter",
+      ...BINDING,
+    });
+    expect(proof).toBeTruthy();
+    // The default store persisted the ticket under the real key prefix.
+    expect(state.tickets.size).toBe(1);
+    const first = await consumeOAuthSuccessProof(proof, BINDING);
+    expect(first.ok).toBe(true);
+    // Second consume is already_used (getAndDelete consumed the ticket).
+    const second = await consumeOAuthSuccessProof(proof, BINDING);
+    expect(second).toEqual({ ok: false, reason: "already_used" });
+  });
+
+  it("does not mint a proof when setWithOutcome reports unavailable", async () => {
+    // RP #18331 (carried from #18114): an unavailable backend must not be
+    // indistinguishable from a successful write. The default store maps a
+    // non-"written" outcome to false.
+    state.writeKind = "unavailable";
+    const proof = await mintOAuthSuccessProof({
+      platform: "github",
+      ...BINDING,
+    });
+    expect(proof).toBeNull();
+    expect(state.tickets.size).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/success-proof.default-store.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/success-proof.default-store.test.ts
@@ -1,152 +1,119 @@
 /**
- * Exercises the DEFAULT ticket store (not the in-memory test override) against a
- * mocked cache singleton, so the production atomicity gate at put() —
- * cache.supportsAtomicOperations() — is actually covered.
- *
- * RP finding #2 on #18331: the original replay-regression test replaced the
- * store with a custom in-memory implementation, so it never called
- * defaultTicketStore.put() or .take() and never exercised the
- * supportsAtomicOperations() gate. This file mocks the `cache` module directly
- * and restores the default store (no __setOAuthSuccessProofTicketStoreForTests)
- * to prove the real gate behaves correctly on both atomic and non-atomic
- * backends.
- *
- * Uses bun:test `mock.module` to replace ../../cache/client before the
- * success-proof module imports it.
+ * Proves the production OAuth success-proof store against the committed
+ * migration and an isolated PGlite database. The tests exercise the real
+ * Postgres insert and atomic `DELETE … RETURNING` path, including contention.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { cache } from "../../cache/client";
-import {
-  consumeOAuthSuccessProof,
-  mintOAuthSuccessProof,
-  type OAuthSuccessProofTicket,
-  type OAuthSuccessProofTicketStore,
-} from "./success-proof";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
-const PREV = { ...process.env };
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
 
-const BINDING = {
-  organizationId: "org-1",
-  userId: "user-1",
-};
+const MIGRATION = join(
+  import.meta.dir,
+  "../../../db/migrations/0196_oauth_success_proof_tickets.sql",
+);
 
-/**
- * Control knob for the mocked cache. Set supportsAtomic before minting a proof
- * so the test can assert the gate outcome. All fields default to "atomic + happy
- * path" so each test overrides only what it needs.
- */
-interface MockCacheState {
-  supportsAtomic: boolean;
-  writeKind: "written" | "unavailable" | "error" | "invalid";
-  /** Tickets stored by the (mocked) write path, keyed by nonce. */
-  tickets: Map<string, OAuthSuccessProofTicket>;
-}
+let closeDatabaseConnectionsForTests: () => Promise<void>;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let oauthSuccessProofTickets: typeof import("../../../db/schemas/oauth-success-proof-tickets").oauthSuccessProofTickets;
+let mintOAuthSuccessProof: typeof import("./success-proof").mintOAuthSuccessProof;
+let consumeOAuthSuccessProof: typeof import("./success-proof").consumeOAuthSuccessProof;
+let __setOAuthSuccessProofTicketStoreForTests: typeof import("./success-proof").__setOAuthSuccessProofTicketStoreForTests;
 
-const state: MockCacheState = {
-  supportsAtomic: true,
-  writeKind: "written",
-  tickets: new Map(),
-};
+const BINDING = { organizationId: "org-1", userId: "user-1" };
 
-/**
- * The typed mock surface success-proof touches on the real cache singleton:
- * setWithOutcome (put), supportsAtomicOperations (gate), getAndDelete (take).
- */
-/** Minimal structural shape of the cache methods the default store touches. */
-interface CacheMethodShim {
-  supportsAtomicOperations(): boolean;
-  setWithOutcome<T>(
-    key: string,
-    value: T,
-    ttlSeconds: number,
-  ): Promise<{ kind: "written" | "unavailable" | "error" | "invalid"; backend: string }>;
-  getAndDelete<T>(key: string): Promise<T | null>;
-}
+beforeAll(async () => {
+  expect(CAN_USE_ISOLATED_PGLITE).toBe(true);
+  ({ closeDatabaseConnectionsForTests, dbWrite } = await import("../../../db/client"));
+  ({ oauthSuccessProofTickets } = await import("../../../db/schemas/oauth-success-proof-tickets"));
+  const { sql } = await import("drizzle-orm");
+  for (const statement of readFileSync(MIGRATION, "utf8").split("--> statement-breakpoint")) {
+    const trimmed = statement.trim();
+    if (trimmed) await dbWrite.execute(sql.raw(trimmed));
+  }
+  ({ mintOAuthSuccessProof, consumeOAuthSuccessProof, __setOAuthSuccessProofTicketStoreForTests } =
+    await import("./success-proof"));
+});
 
-function buildMockCache(): CacheMethodShim {
-  return {
-    supportsAtomicOperations: () => state.supportsAtomic,
-    setWithOutcome: async <T>(_key: string, value: T, _ttlSeconds: number) => {
-      const ticket = value as unknown as OAuthSuccessProofTicket;
-      // Only persist when the backend would actually acknowledge the write.
-      if (state.writeKind === "written") {
-        state.tickets.set(_key, ticket);
-      }
-      return { kind: state.writeKind, backend: "redis_native" };
-    },
-    getAndDelete: async <T>(key: string): Promise<T | null> => {
-      const entry = state.tickets.get(key);
-      if (!entry) return null;
-      state.tickets.delete(key);
-      return entry as unknown as T;
-    },
-  };
-}
+beforeEach(async () => {
+  process.env.OAUTH_SUCCESS_PROOF_SECRET = "test-oauth-success-proof-secret-32b";
+  __setOAuthSuccessProofTicketStoreForTests(null);
+  await dbWrite.delete(oauthSuccessProofTickets);
+});
 
-describe("oauth success proof — default store atomicity gate", () => {
-  beforeEach(() => {
-    process.env.OAUTH_SUCCESS_PROOF_SECRET = "test-oauth-success-proof-secret-32b";
-    state.supportsAtomic = true;
-    state.writeKind = "written";
-    state.tickets.clear();
-    // Point the real module-imported cache at our mock. The success-proof
-    // module holds a live binding to the `cache` object imported at module
-    // load; we replace its methods in place so the default store sees the mock.
-    const mock = buildMockCache();
-    (cache as unknown as Record<string, unknown>).supportsAtomicOperations =
-      mock.supportsAtomicOperations;
-    (cache as unknown as Record<string, unknown>).setWithOutcome = mock.setWithOutcome;
-    (cache as unknown as Record<string, unknown>).getAndDelete = mock.getAndDelete;
-  });
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
 
-  afterEach(() => {
-    process.env = { ...PREV };
-  });
-
-  it("does not mint a proof on a non-atomic backend (KV) — gate at put()", async () => {
-    // RP #18331: supportsAtomicOperations() === false must cause put() to
-    // return false, so mintOAuthSuccessProof fails closed and returns null.
-    // The previous gate lived in take(); put() reported "written" and a
-    // dead proof was minted.
-    state.supportsAtomic = false;
-    const proof = await mintOAuthSuccessProof({
-      platform: "github",
-      connectionId: "conn-1",
-      ...BINDING,
-    });
-    expect(proof).toBeNull();
-    // No ticket was stored — the gate fired before setWithOutcome.
-    expect(state.tickets.size).toBe(0);
-  });
-
-  it("mints and consumes a proof through the default store on an atomic backend", async () => {
-    // The happy path: the default store (not the in-memory override) writes
-    // via setWithOutcome and consumes via getAndDelete.
+describe("OAuth success proof production ticket store", () => {
+  test("mints and consumes through the migrated Postgres table", async () => {
     const proof = await mintOAuthSuccessProof({
       platform: "twitter",
+      connectionId: "connection-1",
       ...BINDING,
     });
     expect(proof).toBeTruthy();
-    // The default store persisted the ticket under the real key prefix.
-    expect(state.tickets.size).toBe(1);
+    expect(await dbWrite.select().from(oauthSuccessProofTickets)).toHaveLength(1);
+
     const first = await consumeOAuthSuccessProof(proof, BINDING);
     expect(first.ok).toBe(true);
-    // Second consume is already_used (getAndDelete consumed the ticket).
-    const second = await consumeOAuthSuccessProof(proof, BINDING);
-    expect(second).toEqual({ ok: false, reason: "already_used" });
+    expect(await consumeOAuthSuccessProof(proof, BINDING)).toEqual({
+      ok: false,
+      reason: "already_used",
+    });
   });
 
-  it("does not mint a proof when setWithOutcome reports unavailable", async () => {
-    // RP #18331 (carried from #18114): an unavailable backend must not be
-    // indistinguishable from a successful write. The default store maps a
-    // non-"written" outcome to false.
-    state.writeKind = "unavailable";
-    const proof = await mintOAuthSuccessProof({
+  test("sixteen concurrent verifies produce exactly one winner", async () => {
+    const proof = await mintOAuthSuccessProof({ platform: "discord", ...BINDING });
+    expect(proof).toBeTruthy();
+
+    const results = await Promise.all(
+      Array.from({ length: 16 }, () => consumeOAuthSuccessProof(proof, BINDING)),
+    );
+    expect(results.filter((result) => result.ok)).toHaveLength(1);
+    expect(results.filter((result) => !result.ok && result.reason === "already_used")).toHaveLength(
+      15,
+    );
+  });
+
+  test("a database write failure cannot mint a proof", async () => {
+    const { sql } = await import("drizzle-orm");
+    await dbWrite.execute(sql`DROP TABLE "oauth_success_proof_tickets"`);
+    try {
+      const proof = await mintOAuthSuccessProof({ platform: "github", ...BINDING });
+      expect(proof).toBeNull();
+    } finally {
+      for (const statement of readFileSync(MIGRATION, "utf8").split("--> statement-breakpoint")) {
+        const trimmed = statement.trim();
+        if (trimmed) await dbWrite.execute(sql.raw(trimmed));
+      }
+    }
+  });
+
+  test("an expired row cannot be claimed and is removed opportunistically", async () => {
+    const { createHash } = await import("node:crypto");
+    const nonce = "expired-nonce";
+    await dbWrite.insert(oauthSuccessProofTickets).values({
+      nonce_hash: createHash("sha256").update(nonce).digest("hex"),
       platform: "github",
-      ...BINDING,
+      organization_id: BINDING.organizationId,
+      user_id: BINDING.userId,
+      expires_at: new Date(Date.now() - 1_000),
     });
-    expect(proof).toBeNull();
-    expect(state.tickets.size).toBe(0);
+    const { oauthSuccessProofTicketsRepository } = await import(
+      "../../../db/repositories/oauth-success-proof-tickets"
+    );
+    expect(
+      await oauthSuccessProofTicketsRepository.claim(
+        createHash("sha256").update(nonce).digest("hex"),
+      ),
+    ).toBeUndefined();
+    expect(await oauthSuccessProofTicketsRepository.purgeExpired()).toBe(1);
   });
 });

--- a/packages/cloud/shared/src/lib/services/oauth/success-proof.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/success-proof.test.ts
@@ -9,6 +9,7 @@ import {
   isOAuthSuccessConnectedParam,
   isOAuthSuccessLandingPath,
   mintOAuthSuccessProof,
+  type OAuthSuccessProofTicketStore,
   verifyOAuthSuccessProof,
 } from "./success-proof";
 
@@ -151,5 +152,101 @@ describe("oauth success proof", () => {
     expect(isOAuthSuccessLandingPath("/auth/success/")).toBe(true);
     expect(isOAuthSuccessLandingPath("/foo/auth/success")).toBe(false);
     expect(isOAuthSuccessLandingPath("/dashboard/settings")).toBe(false);
+  });
+
+  it("does not mint a proof when the ticket store did not acknowledge the write", async () => {
+    // Regression for #18114: the default store used the lossy `cache.set`
+    // wrapper that discarded the `unavailable`/`error` outcome, so a proof was
+    // signed and returned even though no nonce ticket was ever stored. A later
+    // verify then answered `already_used` instead of a retryable failure.
+    const unavailableStore: OAuthSuccessProofTicketStore = {
+      async put() {
+        return false;
+      },
+      async take() {
+        return null;
+      },
+    };
+    __setOAuthSuccessProofTicketStoreForTests(unavailableStore);
+    const proof = await mintOAuthSuccessProof({
+      platform: "github",
+      connectionId: "conn-1",
+      ...BINDING,
+    });
+    expect(proof).toBeNull();
+  });
+
+  it("does not mint a proof when the ticket store throws", async () => {
+    const throwingStore: OAuthSuccessProofTicketStore = {
+      async put() {
+        throw new Error("store down");
+      },
+      async take() {
+        return null;
+      },
+    };
+    __setOAuthSuccessProofTicketStoreForTests(throwingStore);
+    const proof = await mintOAuthSuccessProof({
+      platform: "github",
+      ...BINDING,
+    });
+    expect(proof).toBeNull();
+  });
+
+  it("guarantees exactly one consume under concurrent verification (atomic store)", async () => {
+    // Regression for #18114: the one-time ticket must be consumed exactly once
+    // even when multiple matching-session verifications race. The in-memory
+    // store is single-process atomic; a non-atomic backend (Cloudflare KV) is
+    // refused by the default store's `take` and must not reach this path.
+    const proof = await mintOAuthSuccessProof({
+      platform: "discord",
+      connectionId: "conn-1",
+      ...BINDING,
+    });
+    expect(proof).toBeTruthy();
+    // Fire many concurrent consumes against the same proof.
+    const results = await Promise.all(
+      Array.from({ length: 16 }, () => consumeOAuthSuccessProof(proof, BINDING)),
+    );
+    const oks = results.filter((r) => r.ok);
+    expect(oks).toHaveLength(1);
+    // Every loser must report already_used (the ticket was claimed), not a
+    // binding mismatch or store-unavailable result.
+    for (const r of results) {
+      if (!r.ok) expect(r.reason).toBe("already_used");
+    }
+  });
+
+  it("refuses a non-atomic backend store (KV replay guard)", async () => {
+    // Regression for #18114: Cloudflare KV's getdel is a two-step read/delete
+    // with eventual consistency; two concurrent verifications could both receive
+    // the same ticket. The default ticket store gates `take` on
+    // `cache.supportsAtomicOperations()` so a non-atomic backend yields null and
+    // the proof verifies as already_used rather than replaying. A fake store
+    // emulating that non-atomic read-then-delete must not produce a valid
+    // consume either, because the placeholder it stores cannot match the
+    // HMAC-bound ticket payload.
+    const kv = new Map<string, string>();
+    const racyKvLikeStore: OAuthSuccessProofTicketStore = {
+      async put(nonce) {
+        kv.set(nonce, JSON.stringify({ placeholder: true }));
+        return true;
+      },
+      // Deliberately non-atomic read-then-delete, matching KvCacheAdapter.getdel.
+      async take(nonce) {
+        const value = kv.get(nonce) ?? null;
+        if (value !== null) kv.delete(nonce);
+        // Return a value that cannot satisfy the binding check in consume.
+        return value ? (JSON.parse(value) as never) : null;
+      },
+    };
+    __setOAuthSuccessProofTicketStoreForTests(racyKvLikeStore);
+    const proof = await mintOAuthSuccessProof({
+      platform: "twitter",
+      ...BINDING,
+    });
+    expect(proof).toBeTruthy();
+    const result = await consumeOAuthSuccessProof(proof, BINDING);
+    expect(result.ok).toBe(false);
   });
 });

--- a/packages/cloud/shared/src/lib/services/oauth/success-proof.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/success-proof.ts
@@ -82,19 +82,37 @@ export interface OAuthSuccessProofTicket {
 
 /**
  * Pluggable ticket store so unit tests can hermetically exercise mint/consume
- * without a live Redis. Production uses {@link cache}.getAndDelete.
+ * without a live Redis. Production uses {@link cache}.
+ *
+ * Contract:
+ * - {@link put} MUST report whether the backend acknowledged the write. Callers
+ *   fail closed when `put` resolves `false`: no proof is signed/returned.
+ * - {@link take} MUST be an atomic get-and-delete (single one-time consume).
+ *   The default implementation refuses non-atomic backends (Cloudflare KV);
+ *   a production store behind KV must move tickets to a strongly consistent
+ *   primitive (Postgres `DELETE … RETURNING`, an atomic Redis backend, …).
  */
 export interface OAuthSuccessProofTicketStore {
-  put(nonce: string, ticket: OAuthSuccessProofTicket, ttlSeconds: number): Promise<void>;
+  /** Returns true only when the backend acknowledged a durable write. */
+  put(nonce: string, ticket: OAuthSuccessProofTicket, ttlSeconds: number): Promise<boolean>;
   /** Atomic get-and-delete. Returns null when missing or already consumed. */
   take(nonce: string): Promise<OAuthSuccessProofTicket | null>;
 }
 
 const defaultTicketStore: OAuthSuccessProofTicketStore = {
   async put(nonce, ticket, ttlSeconds) {
-    await cache.set(`${TICKET_KEY_PREFIX}${nonce}`, ticket, ttlSeconds);
+    // Use the outcome-bearing setter so an unavailable/error backend is NOT
+    // indistinguishable from a successful write. The legacy `cache.set` wrapper
+    // discards the outcome (#18114).
+    const outcome = await cache.setWithOutcome(`${TICKET_KEY_PREFIX}${nonce}`, ticket, ttlSeconds);
+    return outcome.kind === "written";
   },
   async take(nonce) {
+    // Cloudflare KV's getdel is a two-step read/delete and KV is eventually
+    // consistent, so two concurrent verifications can both receive the same
+    // ticket. Refuse the non-atomic backend rather than mint a replayable
+    // consume; production must select an atomic store for these tickets (#18114).
+    if (!cache.supportsAtomicOperations()) return null;
     return cache.getAndDelete<OAuthSuccessProofTicket>(`${TICKET_KEY_PREFIX}${nonce}`);
   },
 };
@@ -117,6 +135,7 @@ export function createMemoryOAuthSuccessProofTicketStore(): OAuthSuccessProofTic
         ticket,
         expiresAtMs: Date.now() + ttlSeconds * 1000,
       });
+      return true;
     },
     async take(nonce) {
       const entry = tickets.get(nonce);
@@ -209,12 +228,18 @@ export async function mintOAuthSuccessProof(args: {
     userId,
     exp,
   };
+  let written: boolean;
   try {
-    await ticketStore.put(nonce, ticket, ticketKeyTtlSeconds(exp));
+    written = await ticketStore.put(nonce, ticket, ticketKeyTtlSeconds(exp));
   } catch {
     // error-policy:J1 ticket registration failure — cannot mint a consumable proof.
     return null;
   }
+  // Fail closed: if the store did not acknowledge a durable write (backend
+  // unavailable, invalid value, or an error), do not sign/return a proof. The
+  // legacy `cache.set` wrapper discarded this outcome and minted an unconsumable
+  // proof (#18114).
+  if (!written) return null;
   const payloadB64 = b64url(JSON.stringify(payload));
   const signature = sign(secret, payloadB64);
   return `${payloadB64}.${signature}`;

--- a/packages/cloud/shared/src/lib/services/oauth/success-proof.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/success-proof.ts
@@ -85,12 +85,16 @@ export interface OAuthSuccessProofTicket {
  * without a live Redis. Production uses {@link cache}.
  *
  * Contract:
- * - {@link put} MUST report whether the backend acknowledged the write. Callers
- *   fail closed when `put` resolves `false`: no proof is signed/returned.
+ * - {@link put} MUST report whether the backend acknowledged the write AND
+ *   whether the backend supports atomic consume. Callers fail closed when `put`
+ *   resolves `false` (no atomic backend, write rejected, or backend error): no
+ *   proof is signed/returned. This is the atomicity gate — see
+ *   {@link defaultTicketStore}.
  * - {@link take} MUST be an atomic get-and-delete (single one-time consume).
- *   The default implementation refuses non-atomic backends (Cloudflare KV);
- *   a production store behind KV must move tickets to a strongly consistent
- *   primitive (Postgres `DELETE … RETURNING`, an atomic Redis backend, …).
+ *   The default implementation assumes the backend was already gated to atomic
+ *   at mint time; a production store behind a non-atomic backend (Cloudflare
+ *   KV) must move tickets to a strongly consistent primitive (Postgres
+ *   `DELETE … RETURNING`, an atomic Redis backend, …) before put() reports true.
  */
 export interface OAuthSuccessProofTicketStore {
   /** Returns true only when the backend acknowledged a durable write. */
@@ -101,6 +105,15 @@ export interface OAuthSuccessProofTicketStore {
 
 const defaultTicketStore: OAuthSuccessProofTicketStore = {
   async put(nonce, ticket, ttlSeconds) {
+    // Gate atomicity at MINT time, not consume time. Cloudflare KV (and any
+    // other eventually-consistent backend) reports supportsAtomicOperations()
+    // === false: its getdel is a two-step read/delete that lets two concurrent
+    // verifications both receive the same ticket. Waiting until take() to
+    // refuse is a dead-proof bug: put() succeeds (setWithOutcome reports
+    // "written"), a proof is minted and returned, but take() then yields null
+    // and the proof can never be consumed. Failing closed here ensures no
+    // unconsumable proof is ever signed (#18331).
+    if (!cache.supportsAtomicOperations()) return false;
     // Use the outcome-bearing setter so an unavailable/error backend is NOT
     // indistinguishable from a successful write. The legacy `cache.set` wrapper
     // discards the outcome (#18114).
@@ -108,11 +121,9 @@ const defaultTicketStore: OAuthSuccessProofTicketStore = {
     return outcome.kind === "written";
   },
   async take(nonce) {
-    // Cloudflare KV's getdel is a two-step read/delete and KV is eventually
-    // consistent, so two concurrent verifications can both receive the same
-    // ticket. Refuse the non-atomic backend rather than mint a replayable
-    // consume; production must select an atomic store for these tickets (#18114).
-    if (!cache.supportsAtomicOperations()) return null;
+    // Atomic get-and-delete via GETDEL. The atomicity gate lives in put(); a
+    // proof cannot have been minted against a non-atomic backend, so by the
+    // time we reach take() the backend is guaranteed atomic (#18331).
     return cache.getAndDelete<OAuthSuccessProofTicket>(`${TICKET_KEY_PREFIX}${nonce}`);
   },
 };

--- a/packages/cloud/shared/src/lib/services/oauth/success-proof.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/success-proof.ts
@@ -8,15 +8,14 @@
  * cannot succeed after the first verify.
  */
 
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
-import { cache } from "../../cache/client";
+import { createHash, createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { oauthSuccessProofTicketsRepository } from "../../../db/repositories/oauth-success-proof-tickets";
 import { getCloudAwareEnv } from "../../runtime/cloud-bindings";
 import { getAllProviderIds } from "./provider-registry";
 
 const DEFAULT_TTL_MS = 10 * 60 * 1000;
 /** Reject absurd query-string proofs before HMAC work (payload.sig base64url). */
 const MAX_PROOF_CHARS = 2_048;
-const TICKET_KEY_PREFIX = "oauth_success_proof:v1:";
 
 /** Connector-native providers that emit `*_connected` but are outside OAUTH_PROVIDERS. */
 const EXTRA_CONNECTED_MARKERS = new Set(["discord"]);
@@ -82,19 +81,14 @@ export interface OAuthSuccessProofTicket {
 
 /**
  * Pluggable ticket store so unit tests can hermetically exercise mint/consume
- * without a live Redis. Production uses {@link cache}.
+ * without a live database. Production uses Postgres because the deployed
+ * Worker cache is Cloudflare KV and cannot atomically consume a nonce.
  *
  * Contract:
- * - {@link put} MUST report whether the backend acknowledged the write AND
- *   whether the backend supports atomic consume. Callers fail closed when `put`
- *   resolves `false` (no atomic backend, write rejected, or backend error): no
- *   proof is signed/returned. This is the atomicity gate — see
- *   {@link defaultTicketStore}.
+ * - {@link put} MUST report whether durable storage acknowledged the write.
+ *   Callers fail closed when it resolves `false`.
  * - {@link take} MUST be an atomic get-and-delete (single one-time consume).
- *   The default implementation assumes the backend was already gated to atomic
- *   at mint time; a production store behind a non-atomic backend (Cloudflare
- *   KV) must move tickets to a strongly consistent primitive (Postgres
- *   `DELETE … RETURNING`, an atomic Redis backend, …) before put() reports true.
+ *   The default implementation uses Postgres `DELETE … RETURNING`.
  */
 export interface OAuthSuccessProofTicketStore {
   /** Returns true only when the backend acknowledged a durable write. */
@@ -104,27 +98,28 @@ export interface OAuthSuccessProofTicketStore {
 }
 
 const defaultTicketStore: OAuthSuccessProofTicketStore = {
-  async put(nonce, ticket, ttlSeconds) {
-    // Gate atomicity at MINT time, not consume time. Cloudflare KV (and any
-    // other eventually-consistent backend) reports supportsAtomicOperations()
-    // === false: its getdel is a two-step read/delete that lets two concurrent
-    // verifications both receive the same ticket. Waiting until take() to
-    // refuse is a dead-proof bug: put() succeeds (setWithOutcome reports
-    // "written"), a proof is minted and returned, but take() then yields null
-    // and the proof can never be consumed. Failing closed here ensures no
-    // unconsumable proof is ever signed (#18331).
-    if (!cache.supportsAtomicOperations()) return false;
-    // Use the outcome-bearing setter so an unavailable/error backend is NOT
-    // indistinguishable from a successful write. The legacy `cache.set` wrapper
-    // discards the outcome (#18114).
-    const outcome = await cache.setWithOutcome(`${TICKET_KEY_PREFIX}${nonce}`, ticket, ttlSeconds);
-    return outcome.kind === "written";
+  async put(nonce, ticket, _ttlSeconds) {
+    await oauthSuccessProofTicketsRepository.purgeExpired();
+    await oauthSuccessProofTicketsRepository.insert({
+      nonce_hash: hashNonce(nonce),
+      platform: ticket.platform,
+      connection_id: ticket.connectionId,
+      organization_id: ticket.organizationId,
+      user_id: ticket.userId,
+      expires_at: new Date(ticket.exp),
+    });
+    return true;
   },
   async take(nonce) {
-    // Atomic get-and-delete via GETDEL. The atomicity gate lives in put(); a
-    // proof cannot have been minted against a non-atomic backend, so by the
-    // time we reach take() the backend is guaranteed atomic (#18331).
-    return cache.getAndDelete<OAuthSuccessProofTicket>(`${TICKET_KEY_PREFIX}${nonce}`);
+    const claimed = await oauthSuccessProofTicketsRepository.claim(hashNonce(nonce));
+    if (!claimed) return null;
+    return {
+      platform: claimed.platform,
+      connectionId: claimed.connection_id,
+      organizationId: claimed.organization_id,
+      userId: claimed.user_id,
+      exp: claimed.expires_at.getTime(),
+    };
   },
 };
 
@@ -193,6 +188,10 @@ function safeEqual(a: string, b: string): boolean {
   const bb = Buffer.from(b);
   if (ab.length !== bb.length) return false;
   return timingSafeEqual(ab, bb);
+}
+
+function hashNonce(nonce: string): string {
+  return createHash("sha256").update(nonce).digest("hex");
 }
 
 function ticketKeyTtlSeconds(expMs: number): number {


### PR DESCRIPTION
Closes #18114.

## Root cause

OAuth callbacks minted a signed success proof after calling the cache's lossy `set` wrapper, even when the ticket write was unavailable. The deployed Worker also selects Cloudflare KV, whose read-then-delete emulation cannot make a nonce single-use. The initial PR merely refused KV; that closed replay by disabling success proofs in the environment that needed them.

## Fix

- Store OAuth success-proof tickets in Postgres, the Worker's existing strongly consistent store, rather than cache or KV.
- Store only a SHA-256 digest of the random nonce.
- Claim a live nonce with one `DELETE … RETURNING` statement, so exactly one concurrent verifier receives it.
- Fail closed on insert or claim outages; a proof is never signed unless the row was durably inserted.
- Add migration `0196_oauth_success_proof_tickets.sql`, matching Drizzle schema and repository boundaries.
- Keep session/org/user/provider/connection binding, expiry, and the hermetic pluggable store used by unit tests.
- Update the real-Postgres migration diagnostics contract for the newly added migration.

## Verification

- Production-store suite applies the committed migration to isolated PGlite and drives the real repository.
- 16 simultaneous verifies of one proof produce exactly one success and 15 `already_used` results.
- A dropped backing table proves a write outage cannot mint a proof.
- Expired tickets cannot be claimed and are purged opportunistically.
- Focused service and production-store tests: 17 passed, 0 failed.
- `bun run --cwd packages/cloud/shared typecheck` passed.
- `bun run --cwd packages/cloud/shared db:check-migrations` passed.
- Biome and `git diff --check` passed.

<!-- evidence-head:f2d79e6889c64eb66286e7742fed166059939f48 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend OAuth ticket persistence; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend OAuth ticket persistence; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic backend storage and replay contract with no visual surface.

<!-- evidence-row:backend-logs -->
- [x] [Exact-head migration-backed test log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18331-tmp-18331-backend-v3.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model, provider, or agent-decision path changed.

<!-- evidence-row:domain-artifacts -->
- [x] [Postgres single-use domain contract](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18331-tmp-18331-domain-v2.txt)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: zai/glm-5.2 (original implementation); openai/gpt-5 (review remediation, system-reported model family; deployment variant unavailable)
<!-- attribution-row:client -->
- Agent tooling: Hermes Agent and Codex
<!-- attribution-row:skill-revision -->
- Skill path: N/A - installed Codex plugin packages do not expose a repository commit SHA
<!-- attribution-row:status -->
- Provenance status: self-reported

