### PR TITLE
fix(plugin-elizacloud): retry cold-cache warming for video and music generation

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
@@ -128,3 +128,59 @@ describe("Eliza Cloud media model handlers", () => {
     expect(postApiV1GenerateMusic).not.toHaveBeenCalled();
   });
 });
+
+describe("media generation cold-cache warming retry", () => {
+  it("rides through a warming throw on video generation and returns the video", async () => {
+    const postApiV1GenerateVideo = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("Generative admission cache is warming; retry shortly")
+      )
+      .mockResolvedValueOnce({
+        video: { url: "https://cdn/v.mp4", content_type: "video/mp4" },
+        id: "v1",
+      });
+    setCloudMediaClientFactoryForTesting(() => ({
+      routes: { postApiV1GenerateVideo, postApiV1GenerateMusic: vi.fn() },
+    }));
+
+    await expect(
+      handleVideoGeneration(runtime(), { prompt: "a lighthouse pan" })
+    ).resolves.toMatchObject({ url: "https://cdn/v.mp4" });
+    expect(postApiV1GenerateVideo).toHaveBeenCalledTimes(2);
+  });
+
+  it("rides through a warming throw on music generation and returns the audio", async () => {
+    const postApiV1GenerateMusic = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("Generative admission cache is warming; retry shortly")
+      )
+      .mockResolvedValueOnce({
+        music: { url: "https://cdn/m.mp3", content_type: "audio/mpeg" },
+        id: "m1",
+      });
+    setCloudMediaClientFactoryForTesting(() => ({
+      routes: { postApiV1GenerateVideo: vi.fn(), postApiV1GenerateMusic },
+    }));
+
+    await expect(
+      handleAudioGeneration(runtime(), { prompt: "calm piano", audioKind: "music" })
+    ).resolves.toMatchObject({ url: "https://cdn/m.mp3" });
+    expect(postApiV1GenerateMusic).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails fast on a non-warming video error", async () => {
+    const postApiV1GenerateVideo = vi
+      .fn()
+      .mockRejectedValue(new Error("Unsupported video model"));
+    setCloudMediaClientFactoryForTesting(() => ({
+      routes: { postApiV1GenerateVideo, postApiV1GenerateMusic: vi.fn() },
+    }));
+
+    await expect(
+      handleVideoGeneration(runtime(), { prompt: "x" })
+    ).rejects.toThrow("Unsupported video model");
+    expect(postApiV1GenerateVideo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-elizacloud/src/models/media.ts
+++ b/plugins/plugin-elizacloud/src/models/media.ts
@@ -71,6 +71,53 @@ interface CloudVideoResponse {
   seed?: number;
 }
 
+/**
+ * Ride through the cloud's transient cold-cache warming for a media call. This
+ * box runs text on Cerebras, so the cloud's per-model generative admission
+ * cache goes cold between rare video/music calls; the first one throws
+ * "Generative admission cache is warming; retry shortly" (or a
+ * billing/auth-cache warming message) that clears within ~1s on retry — the
+ * client companion to the server escape in #18249, mirroring the image
+ * handlers (#18323/#18325). A non-warming error still fails fast.
+ */
+async function retryMediaWarming<T>(
+  fn: () => Promise<T>,
+  label: string,
+): Promise<T> {
+  let warmingRetries = 0;
+  for (;;) {
+    try {
+      return await fn();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // Prefer the structured warming code the cloud sets on the thrown API
+      // error (billing_cache_warming / auth_cache_warming / service_unavailable);
+      // fall back to the message text for SDK shapes that don't surface a code.
+      const errRecord = err as {
+        code?: unknown;
+        error?: { code?: unknown; type?: unknown };
+      };
+      const code = String(
+        errRecord?.code ?? errRecord?.error?.code ?? errRecord?.error?.type ?? "",
+      );
+      const isWarming =
+        code === "billing_cache_warming" ||
+        code === "auth_cache_warming" ||
+        code === "service_unavailable" ||
+        /warming|admission cache/i.test(message);
+      if (isWarming && warmingRetries < 2) {
+        warmingRetries++;
+        logger.warn(
+          `[ELIZAOS_CLOUD] ${label} cold-cache warming, retry ${warmingRetries}/2...`,
+        );
+        await new Promise((r) => setTimeout(r, 1500));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
 export async function handleVideoGeneration(
   runtime: IAgentRuntime,
   params: VideoProcessingParams,
@@ -86,20 +133,27 @@ export async function handleVideoGeneration(
     numberValue(params.durationSeconds) ?? numberValue(params.duration);
 
   logger.log("[ELIZAOS_CLOUD] Using VIDEO model via /generate-video");
-  const response = await cloudMediaClientFactory(
-    runtime,
-  ).routes.postApiV1GenerateVideo<CloudVideoResponse>({
-    json: cleanRecord({
-      prompt,
-      model: stringValue(params.model),
-      referenceUrl,
-      durationSeconds,
-      resolution: stringValue(params.resolution ?? params.aspectRatio),
-      audio: booleanValue(params.audio),
-      voiceControl: booleanValue(params.voiceControl),
-    }),
-    timeoutMs: resolveCloudTimeoutMs("ELIZAOS_CLOUD_VIDEO_TIMEOUT_MS", 300_000),
-  });
+  const response = await retryMediaWarming(
+    () =>
+      cloudMediaClientFactory(
+        runtime,
+      ).routes.postApiV1GenerateVideo<CloudVideoResponse>({
+        json: cleanRecord({
+          prompt,
+          model: stringValue(params.model),
+          referenceUrl,
+          durationSeconds,
+          resolution: stringValue(params.resolution ?? params.aspectRatio),
+          audio: booleanValue(params.audio),
+          voiceControl: booleanValue(params.voiceControl),
+        }),
+        timeoutMs: resolveCloudTimeoutMs(
+          "ELIZAOS_CLOUD_VIDEO_TIMEOUT_MS",
+          300_000,
+        ),
+      }),
+    "Video generation",
+  );
 
   const videoUrl = response.video?.url;
   if (!videoUrl) {
@@ -149,22 +203,29 @@ export async function handleAudioGeneration(
     numberValue(params.durationSeconds) ?? numberValue(params.duration);
 
   logger.log("[ELIZAOS_CLOUD] Using AUDIO model via /generate-music");
-  const response = await cloudMediaClientFactory(
-    runtime,
-  ).routes.postApiV1GenerateMusic<CloudMusicResponse>({
-    json: cleanRecord({
-      prompt,
-      model: stringValue(params.model),
-      provider: stringValue(params.provider),
-      durationSeconds,
-      referenceUrl: stringValue(params.referenceUrl ?? params.audioUrl),
-      seed: numberValue(params.seed),
-      outputFormat: stringValue(params.outputFormat),
-      instrumental: booleanValue(params.instrumental),
-      extraInput: params.genre ? { genre: params.genre } : undefined,
-    }),
-    timeoutMs: resolveCloudTimeoutMs("ELIZAOS_CLOUD_MUSIC_TIMEOUT_MS", 300_000),
-  });
+  const response = await retryMediaWarming(
+    () =>
+      cloudMediaClientFactory(
+        runtime,
+      ).routes.postApiV1GenerateMusic<CloudMusicResponse>({
+        json: cleanRecord({
+          prompt,
+          model: stringValue(params.model),
+          provider: stringValue(params.provider),
+          durationSeconds,
+          referenceUrl: stringValue(params.referenceUrl ?? params.audioUrl),
+          seed: numberValue(params.seed),
+          outputFormat: stringValue(params.outputFormat),
+          instrumental: booleanValue(params.instrumental),
+          extraInput: params.genre ? { genre: params.genre } : undefined,
+        }),
+        timeoutMs: resolveCloudTimeoutMs(
+          "ELIZAOS_CLOUD_MUSIC_TIMEOUT_MS",
+          300_000,
+        ),
+      }),
+    "Music generation",
+  );
 
   const audioUrl = response.music?.url;
   if (!audioUrl) {


### PR DESCRIPTION
## What

Extends the image warming fixes (#18323/#18325) to the other GENERATE_MEDIA capabilities. `handleVideoGeneration` (/generate-video, fal-ai/veo3) and `handleAudioGeneration` music (/generate-music, fal-ai/minimax-music/v2.6) had ZERO cold-cache warming coverage: this box runs text on Cerebras, so the cloud's per-model generative admission cache goes cold between rare video/music calls and the first one throws `Generative admission cache is warming; retry shortly` (or a billing/auth-cache warming code) straight into the runtime failover ladder = user-visible failure.

## Fix

A shared `retryMediaWarming` helper wraps both route calls: on a thrown warming error — detected by the structured `code` (billing_cache_warming / auth_cache_warming / service_unavailable) with a message-regex fallback — it retries up to 2× with a 1.5s backoff. Non-warming errors (e.g. "Unsupported video model") still fail fast.

## Verification

- 3 new tests on the existing media harness: video and music each ride through a warming-then-success sequence (2 calls), and a non-warming error fails fast (1 call). Suite 6/6.
- Same transient proven live for image (warmed through on the first retry) — video/music use the same generative-admission cache.
- typecheck + biome clean.

## Scope note

TTS (`speech.ts`) and STT (`transcription.ts`) also lack warming coverage but return a **Response with .status** (not a throw), so they need the `isWarmingUnavailableResponse(status, bodyText)` helper from text.ts rather than this throw-catcher — tracked as fast-follow. RESEARCH is throwing-shaped but rarely a first/cold call. The realtime voice path (Cartesia Ink STT + Sonic TTS) is a separate cloud-worker service, not these handlers.

# Evidence

<!-- evidence-head:b56ca69da9d3095ef54c5d1af905cdebf63c579f -->
- Before screenshots: N/A - runtime/model path
- After screenshots: N/A - runtime/model path
- Walkthrough video: N/A - runtime/model path
- OCR review: N/A - runtime/model path
- Frontend console/network logs: N/A - runtime/model path
- Backend logs: media warming retry log line + the image-parity live evidence in PR thread
- Real-LLM trajectory: N/A - deterministic handler retry; live image parity proves the transient
- Domain artifacts: generated video/music delivered instead of a cold-cache failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
