### PR TITLE
fix(cloud): surface snapshot transfer error body for diagnosis (#18228)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-error-body-excerpt.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-error-body-excerpt.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for the `readErrorBodyExcerpt` helper that streams a bounded
+ * excerpt of a snapshot error response body for diagnostic logging (#18228).
+ * Covers JSON extraction, non-JSON passthrough, empty body, truncation at the
+ * 512-byte limit, read-failure fail-soft, reader cancellation, and multi-byte
+ * UTF-8 decoder flushing at the byte boundary (felirami P2 nit on PR #18336).
+ */
+import { describe, expect, test } from "bun:test";
+import { readErrorBodyExcerpt } from "./eliza-sandbox.ts?actual";
+
+/** Build a minimal Response-like object from raw body bytes. */
+function mockResponse(
+  body: string | Uint8Array | null,
+  contentType = "application/json",
+): Pick<Response, "body" | "headers"> {
+  if (body === null) {
+    return { body: null, headers: new Headers({ "content-type": contentType }) };
+  }
+  const bytes = typeof body === "string" ? new TextEncoder().encode(body) : body;
+  return {
+    body: new ReadableStream({
+      start(controller) {
+        controller.enqueue(bytes);
+        controller.close();
+      },
+    }),
+    headers: new Headers({ "content-type": contentType }),
+  };
+}
+
+/** Build a multi-chunk Response-like object from raw byte arrays. */
+function mockChunkedResponse(
+  chunks: Uint8Array[],
+  contentType = "application/json",
+): Pick<Response, "body" | "headers"> {
+  return {
+    body: new ReadableStream({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(c);
+        controller.close();
+      },
+    }),
+    headers: new Headers({ "content-type": contentType }),
+  };
+}
+
+describe("readErrorBodyExcerpt", () => {
+  test("extracts the error field from a JSON body", async () => {
+    const res = mockResponse(JSON.stringify({ error: "Container crashed" }));
+    expect(await readErrorBodyExcerpt(res)).toBe("Container crashed");
+  });
+
+  test("extracts the message field from a JSON body", async () => {
+    const res = mockResponse(JSON.stringify({ message: "Out of memory" }));
+    expect(await readErrorBodyExcerpt(res)).toBe("Out of memory");
+  });
+
+  test("prefers error field over message field in a JSON body", async () => {
+    const res = mockResponse(JSON.stringify({ error: "Primary error", message: "Secondary" }));
+    expect(await readErrorBodyExcerpt(res)).toBe("Primary error");
+  });
+
+  test("returns raw excerpt when JSON body has no error/message fields", async () => {
+    const res = mockResponse(JSON.stringify({ detail: "some detail" }));
+    expect(await readErrorBodyExcerpt(res)).toBe(JSON.stringify({ detail: "some detail" }));
+  });
+
+  test("returns raw excerpt for non-JSON content type", async () => {
+    const res = mockResponse("Internal Server Error", "text/plain");
+    expect(await readErrorBodyExcerpt(res)).toBe("Internal Server Error");
+  });
+
+  test("falls through to raw excerpt for HTML-like body with JSON content-type", async () => {
+    const html = "<html><body>502 Bad Gateway</body></html>";
+    const res = mockResponse(html);
+    // JSON.parse fails on HTML, so it should fall through to raw trimmed body.
+    expect(await readErrorBodyExcerpt(res)).toBe(html);
+  });
+
+  test("returns null for empty body", async () => {
+    const res = mockResponse("");
+    expect(await readErrorBodyExcerpt(res)).toBeNull();
+  });
+
+  test("returns null for whitespace-only body", async () => {
+    const res = mockResponse("   \n\t  ");
+    expect(await readErrorBodyExcerpt(res)).toBeNull();
+  });
+
+  test("returns null when body is null", async () => {
+    const res = mockResponse(null);
+    expect(await readErrorBodyExcerpt(res)).toBeNull();
+  });
+
+  test("truncates body larger than 512 bytes at the boundary", async () => {
+    // Create a body well beyond 512 bytes of ASCII text.
+    const longBody = "A".repeat(1000);
+    const res = mockResponse(longBody, "text/plain");
+    const result = await readErrorBodyExcerpt(res);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeLessThanOrEqual(512);
+    expect(result!.startsWith("AAAA")).toBe(true);
+  });
+
+  test("returns null when the reader throws during read (fail-soft)", async () => {
+    const res: Pick<Response, "body" | "headers"> = {
+      body: new ReadableStream({
+        start(controller) {
+          controller.error(new Error("Stream interrupted"));
+        },
+      }),
+      headers: new Headers({ "content-type": "application/json" }),
+    };
+    expect(await readErrorBodyExcerpt(res)).toBeNull();
+  });
+
+  test("handles reader cancellation gracefully after partial reads", async () => {
+    // Body larger than the 512-byte limit — the reader should be cancelled
+    // after the byte budget is hit, before consuming the full body.
+    // The stream must NOT be closed so that reader.cancel() actually fires
+    // the underlying source's cancel handler (cancel on a closed stream is a
+    // no-op).
+    let cancelCalled = false;
+    const longBody = "B".repeat(2000);
+    const res: Pick<Response, "body" | "headers"> = {
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(longBody));
+          // Deliberately do NOT close — the stream stays readable so
+          // reader.cancel() triggers the source's cancel() handler.
+        },
+        cancel() {
+          cancelCalled = true;
+        },
+      }),
+      headers: new Headers({ "content-type": "text/plain" }),
+    };
+    const result = await readErrorBodyExcerpt(res);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeLessThanOrEqual(512);
+    // The body (2000 bytes) far exceeds the 512-byte limit, so cancel()
+    // must be called to release the connection.
+    expect(cancelCalled).toBe(true);
+  });
+
+  test("flushes a multi-byte UTF-8 character split at the byte boundary", async () => {
+    // U+00E9 (é) is 2 bytes in UTF-8: 0xC3 0xA9. We build a body where
+    // byte 511 is the first byte of é and byte 512 is the second byte.
+    // The 512-byte slice cuts mid-character — the final decoder.decode()
+    // flush must reconstruct the é instead of dropping it.
+    const encoder = new TextEncoder();
+    const prefix = "x".repeat(511); // 511 ASCII bytes
+    const suffix = "tail"; // after the boundary
+
+    // Encode prefix + é + suffix, then split into chunks at byte 512.
+    const fullBytes = encoder.encode(prefix + "é" + suffix);
+    // fullBytes = [511 'x' bytes, 0xC3, 0xA9, 't', 'a', 'i', 'l']
+    // Byte 511 = 0xC3 (first byte of é), byte 512 = 0xA9 (second byte).
+    const firstChunk = fullBytes.slice(0, 512); // includes 0xC3 but not 0xA9
+    const secondChunk = fullBytes.slice(512); // 0xA9 + 'tail'
+
+    const res = mockChunkedResponse([firstChunk, secondChunk], "text/plain");
+    const result = await readErrorBodyExcerpt(res);
+
+    // Without the flush fix, the é (0xC3 byte) at position 511 would be
+    // dropped. With the flush, it should be reconstructed.
+    expect(result).not.toBeNull();
+    // The result should contain at least part of the multi-byte char.
+    // It may be truncated at 512 bytes, but the partial byte must be
+    // flushed, not silently dropped.
+    expect(result!.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1005,13 +1005,39 @@ class ManagedLaunchOwnershipLost extends Error {
  * `fetchSnapshotState` (#18228) so an agent-side 500 (carrying the thrown
  * error message) is distinguishable from a bridge/proxy-hop 500 (proxy error
  * page or empty body) in Worker logs.
+ *
+ * Streams the body via a ReadableStream reader and stops after
+ * SNAPSHOT_ERROR_BODY_EXCERPT_BYTES of UTF-8, cancelling the remainder —
+ * never buffering the full response (a malicious upstream could OOM the
+ * Worker with an unbounded body).
  */
 async function readErrorBodyExcerpt(
-  res: Pick<Response, "text" | "headers">,
+  res: Pick<Response, "body" | "headers">,
 ): Promise<string | null> {
+  // error-policy:J2 non-blocking diagnostic — a body-read failure degrades to
+  // a null excerpt (status-only message) without aborting the snapshot path.
   try {
-    const body = await res.text();
-    if (!body?.trim()) return null;
+    if (!res.body) return null;
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder("utf-8", { fatal: false });
+    const chunks: string[] = [];
+    let totalBytes = 0;
+    try {
+      // error-policy:J2 stream cancellation after the byte budget is reached.
+      while (totalBytes < SNAPSHOT_ERROR_BODY_EXCERPT_BYTES) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const remaining = SNAPSHOT_ERROR_BODY_EXCERPT_BYTES - totalBytes;
+        const sliced = value.length > remaining ? value.slice(0, remaining) : value;
+        chunks.push(decoder.decode(sliced, { stream: true }));
+        totalBytes += sliced.length;
+      }
+    } finally {
+      // Cancel the reader to release the connection even if the body is larger.
+      await reader.cancel().catch(() => {});
+    }
+    const body = chunks.join("");
+    if (!body.trim()) return null;
     const contentType = res.headers.get("content-type") ?? "";
     // JSON error bodies carry structured diagnostics — try to extract a message.
     if (contentType.includes("application/json")) {
@@ -1019,13 +1045,13 @@ async function readErrorBodyExcerpt(
         const data = JSON.parse(body) as { error?: unknown; message?: unknown };
         const msg = data.error ?? data.message;
         if (typeof msg === "string" && msg.trim()) {
-          return msg.trim().slice(0, SNAPSHOT_ERROR_BODY_EXCERPT_BYTES);
+          return msg.trim();
         }
       } catch {
         // Not valid JSON — fall through to raw excerpt.
       }
     }
-    return body.trim().slice(0, SNAPSHOT_ERROR_BODY_EXCERPT_BYTES);
+    return body.trim();
   } catch {
     return null;
   }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1011,7 +1011,7 @@ class ManagedLaunchOwnershipLost extends Error {
  * never buffering the full response (a malicious upstream could OOM the
  * Worker with an unbounded body).
  */
-async function readErrorBodyExcerpt(
+export async function readErrorBodyExcerpt(
   res: Pick<Response, "body" | "headers">,
 ): Promise<string | null> {
   // error-policy:J2 non-blocking diagnostic — a body-read failure degrades to
@@ -1036,6 +1036,11 @@ async function readErrorBodyExcerpt(
       // Cancel the reader to release the connection even if the body is larger.
       await reader.cancel().catch(() => {});
     }
+    // Flush any remaining buffered bytes from the final chunk — a multi-byte
+    // UTF-8 character split at the 512-byte boundary would be silently dropped
+    // without this final decode() call (felirami P2 nit on PR #18336).
+    const flushed = decoder.decode();
+    if (flushed) chunks.push(flushed);
     const body = chunks.join("");
     if (!body.trim()) return null;
     const contentType = res.headers.get("content-type") ?? "";

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -523,6 +523,14 @@ const DB_LIVENESS_RESTART_COOLDOWN_MS = 10 * 60_000;
 const DB_LIVENESS_RESTART_BUDGET_WINDOW_MS = 60 * 60_000;
 const SNAPSHOT_FETCH_TIMEOUT_MS = 120_000;
 /**
+ * Maximum bytes to read from a snapshot-fetch error response body for
+ * diagnostic logging (#18228). The body distinguishes an agent-side 500
+ * (carries the thrown error message) from a bridge/proxy-hop 500 (proxy
+ * error page or empty). Bounded so a malicious or misconfigured upstream
+ * cannot exhaust Worker memory.
+ */
+const SNAPSHOT_ERROR_BODY_EXCERPT_BYTES = 512;
+/**
  * Hydration budgets (#16639): the worker heap died buffering unbounded
  * snapshot bodies (`res.json()` retained everything, then a re-stringify
  * doubled it). The raw budget is enforced WHILE streaming — bytes past it are
@@ -988,6 +996,38 @@ class ManagedLaunchOwnershipLost extends Error {
   constructor() {
     super("Managed launch lost its agent ownership CAS");
     this.name = "ManagedLaunchOwnershipLost";
+  }
+}
+
+/**
+ * Read a bounded excerpt of an error response body for diagnostic logging.
+ * Returns a trimmed string or null when the body is empty. Used by
+ * `fetchSnapshotState` (#18228) so an agent-side 500 (carrying the thrown
+ * error message) is distinguishable from a bridge/proxy-hop 500 (proxy error
+ * page or empty body) in Worker logs.
+ */
+async function readErrorBodyExcerpt(
+  res: Pick<Response, "text" | "headers">,
+): Promise<string | null> {
+  try {
+    const body = await res.text();
+    if (!body?.trim()) return null;
+    const contentType = res.headers.get("content-type") ?? "";
+    // JSON error bodies carry structured diagnostics — try to extract a message.
+    if (contentType.includes("application/json")) {
+      try {
+        const data = JSON.parse(body) as { error?: unknown; message?: unknown };
+        const msg = data.error ?? data.message;
+        if (typeof msg === "string" && msg.trim()) {
+          return msg.trim().slice(0, SNAPSHOT_ERROR_BODY_EXCERPT_BYTES);
+        }
+      } catch {
+        // Not valid JSON — fall through to raw excerpt.
+      }
+    }
+    return body.trim().slice(0, SNAPSHOT_ERROR_BODY_EXCERPT_BYTES);
+  } catch {
+    return null;
   }
 }
 
@@ -9862,7 +9902,17 @@ export class ElizaSandboxService {
       throw new Error(SNAPSHOT_ENDPOINT_UNSUPPORTED);
     }
     if (!res.ok) {
-      throw new Error(`Snapshot fetch failed: HTTP ${res.status}`);
+      // #18228: the snapshot transfer failed somewhere between the agent's HTTP
+      // handler and this fetch — an agent-side 500 carries a diagnostic body
+      // (the thrown message), while a bridge/proxy hop 500 carries a proxy
+      // error page or an empty body. The Worker log previously reported only
+      // the status code and discarded the body, making the two indistinguishable.
+      // Read a bounded excerpt of the body and include it after the canonical
+      // `Snapshot fetch failed: HTTP <status>` prefix so the existing
+      // SNAPSHOT_HTTP_ERROR_SHAPE regex (anchored at the status) still classifies
+      // it, while the operator sees where the hop failed.
+      const excerpt = await readErrorBodyExcerpt(res);
+      throw new Error(`Snapshot fetch failed: HTTP ${res.status}${excerpt ? ` ${excerpt}` : ""}`);
     }
 
     // Bounded hydration (#16639): stream and count — bytes past the raw


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- AI provider/model: zai/glm-5.2
<!-- attribution-row:client -->
- Client / agent tooling: Hermes Agent
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@ecfefdff6522d2c7a6443f0d9edc7aab2fce9d2f:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

## Summary

A running managed agent could not be stopped, restarted, or relaunched because every lifecycle path funnels through `ElizaSandboxService.shutdown()`'s pre-stop capture, and the capture consistently failed with `Snapshot fetch failed: HTTP 500` — while the agent's own logs proved the snapshot succeeded agent-side. The 500 was injected somewhere between the agent's HTTP handler and the Worker's `fetchAgentApi` call (bridge/node proxy hop).

The gate is deliberately fail-closed (correct — a stop without a current capture discards state), but the error message discarded the response body entirely, making it impossible for operators to distinguish:
- **Agent-side 500** — carries a diagnostic JSON error body with the thrown message
- **Bridge/proxy hop 500** — carries a proxy error page or empty body

## Fix

`fetchSnapshotState` now reads a bounded (512-byte) excerpt of the error response body and appends it after the canonical `Snapshot fetch failed: HTTP <status>` prefix. The `SNAPSHOT_HTTP_ERROR_SHAPE` regex (anchored on the status code) still classifies correctly. JSON error bodies are parsed for a structured `error`/`message` field; plain text and proxy error pages pass through raw.

## Files changed

- `packages/cloud/shared/src/lib/services/eliza-sandbox.ts` — `readErrorBodyExcerpt` helper + `SNAPSHOT_ERROR_BODY_EXCERPT_BYTES` constant + error path wiring

## Verification

```
bun run --cwd packages/cloud/shared typecheck   # clean
bun run --cwd packages/cloud/shared lint         # clean
```

## Evidence

| | |
|---|---|
| Before screenshots | N/A - backend snapshot-error-body change, no UI surface |
| After screenshots | N/A - backend snapshot-error-body change, no UI surface |
| Walkthrough video | N/A - backend snapshot-error-body change, no UI surface |
| Backend logs | see below |
| Frontend console/network logs | N/A - backend snapshot-error-body change, no UI surface |
| Real-LLM trajectory | N/A - deterministic error-body extraction, no model path |
| Domain artifacts | see below |

<!-- evidence-row:before-screenshots -->
N/A - backend snapshot-error-body change, no UI surface
<!-- evidence-row:after-screenshots -->
N/A - backend snapshot-error-body change, no UI surface
<!-- evidence-row:walkthrough-video -->
N/A - backend snapshot-error-body change, no UI surface
<!-- evidence-row:backend-logs -->
<details><summary>Backend logs — typecheck + test output</summary>

```
$ bun run --cwd packages/cloud/shared typecheck
Done!

$ bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts -t "does NOT classify transient snapshot"
packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts:
(pass) isUnrecoverableSnapshotError (permanent-vs-transient classification) > does NOT classify transient snapshot HTTP failures — those must retry [0.27ms]

$ bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts -t "matches only this file"
packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts:
(pass) isUnrecoverableSnapshotError (permanent-vs-transient classification) > matches only this file's snapshot throw shapes — anchored, exact status [0.13ms]

$ bun /tmp/test-readErrorBodyExcerpt.mjs
PASS JSON error body (agent-side 500): got="Durable Object storage quota exceeded"
PASS JSON error with 'message' field: got="Internal agent error during snapshot serialization"
PASS Plain text error body: got="Worker exceeded CPU time limit"
PASS Proxy error page (HTML): got="<html><body>Bad Gateway: upstream timeout</body></html>"
PASS Empty body: got=null
PASS Whitespace-only body: got=null

SNAPSHOT_ERROR_BODY_EXCERPT_BYTES = 512
All tests passed.
```

</details>
<!-- evidence-row:frontend-logs -->
N/A - backend snapshot-error-body change, no UI surface
<!-- evidence-row:llm-trajectory -->
N/A - deterministic error-body extraction, no model path
<!-- evidence-row:domain-artifacts -->
<details><summary>Domain artifacts — readErrorBodyExcerpt behavior matrix</summary>

```
Constant: SNAPSHOT_ERROR_BODY_EXCERPT_BYTES = 512

Error message shapes (before vs after):

  Agent-side 500 (JSON {error}):
    BEFORE: Snapshot fetch failed: HTTP 500
    AFTER:  Snapshot fetch failed: HTTP 500 Durable Object storage quota exceeded

  Agent-side 500 (JSON {message}):
    BEFORE: Snapshot fetch failed: HTTP 500
    AFTER:  Snapshot fetch failed: HTTP 500 Internal agent error during snapshot serialization

  Bridge/proxy 502 (HTML):
    BEFORE: Snapshot fetch failed: HTTP 502
    AFTER:  Snapshot fetch failed: HTTP 502 <html><body>Bad Gateway: upstream timeout</body></html>

  Bridge/proxy 502 (plain text):
    BEFORE: Snapshot fetch failed: HTTP 502
    AFTER:  Snapshot fetch failed: HTTP 502 Worker exceeded CPU time limit

  Empty body:
    BEFORE: Snapshot fetch failed: HTTP 502
    AFTER:  Snapshot fetch failed: HTTP 502 (unchanged — excerpt is null)

Classification compatibility:
  The SNAPSHOT_HTTP_ERROR_SHAPE regex is anchored at the status code prefix.
  The appended excerpt does NOT affect classification:
  - isUnrecoverableSnapshotError("Snapshot fetch failed: HTTP 401 ...") -> true
  - isUnrecoverableSnapshotError("Snapshot fetch failed: HTTP 500 ...") -> false

Test run (existing classification tests still pass):
  $ bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts -t "isUnrecoverableSnapshotError"
  (pass) classifies permanent snapshot HTTP failures as unrecoverable — state is gone
  (pass) does NOT classify transient snapshot HTTP failures — those must retry
  (pass) matches only this file's snapshot throw shapes — anchored, exact status
```

</details>

<!-- evidence-head:aa616a867207b1ee5232f18ce72aa07784c5b343 -->

---

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Lane: hermes-t3rpz