### PR TITLE
fix(cloud): publish ELIZA_APP_WEBHOOK_GATEWAY_URL+SECRET in deploy workflow (#18235)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -589,6 +589,8 @@ jobs:
           # while unset, so this is safe before ops adds the GH env secret and
           # keeps it published on every redeploy once they do.
           STEWARD_PLATFORM_KEYS: ${{ secrets.STEWARD_PLATFORM_KEYS }}
+          ELIZA_APP_WEBHOOK_GATEWAY_URL: ${{ vars.ELIZA_APP_WEBHOOK_GATEWAY_URL }}
+          ELIZA_APP_WEBHOOK_GATEWAY_SECRET: ${{ secrets.ELIZA_APP_WEBHOOK_GATEWAY_SECRET }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -788,7 +788,8 @@ jobs:
             FISH_AUDIO_API_KEY \
             FISH_AUDIO_REFERENCE_ID \
             VOICE_REALTIME_ELIZA_AUTHORIZATION \
-            STEWARD_PLATFORM_KEYS
+            STEWARD_PLATFORM_KEYS \
+            ELIZA_APP_WEBHOOK_GATEWAY_SECRET
           do
             publish_secret "$name"
           done
@@ -801,7 +802,8 @@ jobs:
             CARTESIA_VOICE_ID \
             WHISPER_STT_URL \
             WHISPER_STT_MODEL \
-            VOICE_BATCH_STT_PROVIDER
+            VOICE_BATCH_STT_PROVIDER \
+            ELIZA_APP_WEBHOOK_GATEWAY_URL
           do
             publish_toggle_secret "$name" || exit 1
           done

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -316,6 +316,10 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 #   CDP_API_KEY_ID / CDP_API_KEY_SECRET / CDP_WALLET_SECRET   x402
 #   DISCORD_BOT_TOKEN / DISCORD_CHANNEL_ID
 #   GATEWAY_BOOTSTRAP_SECRET / GATEWAY_INTERNAL_SECRET
+#   ELIZA_APP_WEBHOOK_GATEWAY_URL       Internal gateway-webhook service URL (Railway).
+#                                      Required for staging+prod webhook flows; without
+#                                      it, webhook routes 503 WEBHOOK_GATEWAY_NOT_CONFIGURED.
+#   ELIZA_APP_WEBHOOK_GATEWAY_SECRET    Shared secret for BFF→gateway forwarding (L3).
 #   JWT_SIGNING_PRIVATE_KEY / JWT_SIGNING_PUBLIC_KEY
 #   OIDC_SIGNING_JWKS                  OIDC provider key ring: JSON array of PRIVATE JWKs
 #                                      (element 0 signs, all published at jwks_uri).


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- AI provider/model: zai/glm-5.2
<!-- attribution-row:client -->
- Client / agent tooling: Hermes Agent
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@ecfefdff6522d2c7a6443f0d9edc7aab2fce9d2f:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Attribution status: self-reported

## Summary

Staging cannot run any messaging-webhook flow (Telegram/WhatsApp/etc.) end to end: the Worker's webhook routes are thin BFF forwarders to the internal `gateway-webhook` Railway service, and **staging has no gateway URL provisioned**. Every webhook returns 503 `WEBHOOK_GATEWAY_NOT_CONFIGURED`.

**Root cause:** The deploy workflow (`cloud-cf-deploy.yml`) never published `ELIZA_APP_WEBHOOK_GATEWAY_URL` or `ELIZA_APP_WEBHOOK_GATEWAY_SECRET` to the Worker's secrets. Without the URL binding, the BFF forwarders short-circuit with a 503.

## Fix

Adds both env vars to the cloud-cf-deploy publish loops:
- `ELIZA_APP_WEBHOOK_GATEWAY_URL` — routing toggle (published via `publish_toggle_secret` so presence/absence changes code paths cleanly)
- `ELIZA_APP_WEBHOOK_GATEWAY_SECRET` — BFF→gateway auth shared secret (published via `publish_secret`)

Also documents both in `wrangler.toml`'s secret comment block.

## Files changed
- `.github/workflows/cloud-cf-deploy.yml` — add both vars to publish loops
- `packages/cloud/api/wrangler.toml` — document the new bindings

<!-- evidence-row:backend-logs -->
N/A - the PR adds two env var bindings to the deploy workflow's publish loops. ELIZA_APP_WEBHOOK_GATEWAY_URL (vars.) goes through publish_toggle_secret; ELIZA_APP_WEBHOOK_GATEWAY_SECRET (secrets.) goes through publish_secret. The consuming code is in packages/cloud/api/eliza-app/webhook/_forward.ts lines 8-10 (URL keys) and 26-27 (secret keys) — it reads ELIZA_APP_WEBHOOK_GATEWAY_URL and returns 503 WEBHOOK_GATEWAY_NOT_CONFIGURED when absent. packages/cloud/api/__tests__/eliza-app-webhook-gateway-secret.test.ts exercises these vars at lines 85-118. Cloud Tests integration-tests gate PASSED on CI.

<!-- evidence-row:domain-artifacts -->
N/A - deploy workflow diff: STEWARD_PLATFORM_KEYS env block gains ELIZA_APP_WEBHOOK_GATEWAY_URL (vars.) and ELIZA_APP_WEBHOOK_GATEWAY_SECRET (secrets.) at lines 592-593. publish_secret loop adds the secret; publish_toggle_secret loop adds the URL. wrangler.toml documents both bindings in the secret reference comment block (lines 319-322).

<!-- evidence-row:frontend-logs -->
N/A - cloud deploy workflow change, no UI surface

<!-- evidence-row:llm-trajectory -->
N/A - deterministic deploy-config plumbing, no model path

<!-- evidence-row:before-screenshots -->
N/A - cloud deploy workflow change, no UI surface

<!-- evidence-row:after-screenshots -->
N/A - cloud deploy workflow change, no UI surface

<!-- evidence-row:walkthrough-video -->
N/A - cloud deploy workflow change, no UI surface

<!-- evidence-head:a271c486d98991d909ba624d41067c5c8c6916e9 -->

— [hermes/t3rpz]
