### PR TITLE
fix(plugin-task-coordinator): remove browser-only export from server entry (#18031)

### DIFF
--- a/plugins/plugin-task-coordinator/__tests__/unit/server-entry-no-ui-imports.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/server-entry-no-ui-imports.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression contract: the server-side plugin entry (`src/index.ts` →
+ * `dist/index.js`) must not statically import any browser-only React components
+ * or `@elizaos/ui` modules. The headless cloud agent image loads
+ * `dist/index.js` in Node, and the Dockerfile deliberately excludes the
+ * `@elizaos/ui` radix/three/recharts tree from the runtime-dep closure. A
+ * transitive `@radix-ui/react-slot` import through a re-exported GUI component
+ * crashes the plugin at boot with `Cannot find package '@radix-ui/react-slot'`
+ * (issue #18031).
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ENTRY_PATH = resolve(__dirname, "../../src/index.ts");
+
+describe("server entry — no browser/UI imports (#18031)", () => {
+  const source = readFileSync(ENTRY_PATH, "utf8");
+
+  it("does not re-export ProjectSwitcher or other browser-only components", () => {
+    // ProjectSwitcher is a React component whose transitive import chain
+    // reaches @elizaos/ui → @radix-ui/react-slot. It must only be reachable
+    // from the view bundle, not from the server entry.
+    expect(source).not.toMatch(
+      /export\s+\{[^}]*ProjectSwitcher[^}]*\}/,
+    );
+  });
+
+  it("does not import from @elizaos/ui", () => {
+    // The server entry must not carry a static import of any @elizaos/ui
+    // subpath — those pull in browser-only React/radix components.
+    expect(source).not.toMatch(/from\s+["']@elizaos\/ui/);
+  });
+
+  it("does not import React or react-dom", () => {
+    // The server entry has no server-side use of React.
+    expect(source).not.toMatch(/from\s+["']react(?:-dom)?["']/);
+  });
+});

--- a/plugins/plugin-task-coordinator/__tests__/unit/server-entry-no-ui-imports.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/server-entry-no-ui-imports.test.ts
@@ -21,9 +21,7 @@ describe("server entry — no browser/UI imports (#18031)", () => {
     // ProjectSwitcher is a React component whose transitive import chain
     // reaches @elizaos/ui → @radix-ui/react-slot. It must only be reachable
     // from the view bundle, not from the server entry.
-    expect(source).not.toMatch(
-      /export\s+\{[^}]*ProjectSwitcher[^}]*\}/,
-    );
+    expect(source).not.toMatch(/export\s+\{[^}]*ProjectSwitcher[^}]*\}/);
   });
 
   it("does not import from @elizaos/ui", () => {

--- a/plugins/plugin-task-coordinator/src/index.ts
+++ b/plugins/plugin-task-coordinator/src/index.ts
@@ -1,6 +1,6 @@
 /**
- * Plugin definition for the coding-agent task coordinator: the view manifest,
- * the orchestrator view's typed capability descriptors, and `init()`.
+ * Server-side plugin definition for the coding-agent task coordinator: the view
+ * manifest, the orchestrator view's typed capability descriptors, and `init()`.
  *
  * Declares three GUI views (`task-coordinator`, `orchestrator`, `cockpit`) with
  * their bundle path + component exports, and the capability list remote/control
@@ -9,6 +9,12 @@
  * registry; the deterministic handler action is the only server-side runtime
  * contribution. All task/session state is owned by
  * `@elizaos/plugin-agent-orchestrator` — this plugin is display + control only.
+ *
+ * GUI components (ProjectSwitcher, CodingAgentTasksPanel, …) live in the view
+ * bundle (`task-coordinator-view-bundle.ts`) or are reached via slot-registry
+ * lazy imports. They must NOT be re-exported from this entry: the headless cloud
+ * agent image loads `dist/index.js` in Node, and any `@elizaos/ui` transitives
+ * (e.g. `@radix-ui/react-slot`) are pruned from the Docker runtime-dep closure.
  */
 import type { Plugin, ViewCapability } from "@elizaos/core";
 import {
@@ -333,4 +339,3 @@ export {
   orchestratorStatusCommandAction,
   registerOrchestratorCommands,
 } from "./orchestrator-command";
-export { ProjectSwitcher } from "./ProjectSwitcher";


### PR DESCRIPTION
## Summary

Fixes #18031 — the cloud agent Docker image failed to load `@elizaos/plugin-task-coordinator` with `Cannot find package '@radix-ui/react-slot'`.

### Root cause

The server-side plugin entry (`dist/index.js`, built from `src/index.ts`) statically imported `ProjectSwitcher.js` via a re-export at the bottom of the file. `ProjectSwitcher.tsx` imports from `@elizaos/ui/components/ui/button`, which transitively requires `@radix-ui/react-slot`. The Dockerfile's `collect-docker-runtime-deps.mjs` deliberately excludes `@elizaos/ui` and its radix/three/recharts tree from the pruned runtime-dep closure (see the comment in `packages/app-core/deploy/Dockerfile.ci`). So `@radix-ui/react-slot` was absent from the image, and Node's ESM loader crashed when loading the plugin.

### Fix

Remove `export { ProjectSwitcher } from "./ProjectSwitcher"` from `src/index.ts`. `ProjectSwitcher` is a React GUI component only consumed by `CodingAgentTasksPanel.tsx` via a local `./ProjectSwitcher` import — never from the package root by any external consumer. The browser-side lazy import path (`@elizaos/plugin-task-coordinator/register` → `register-slots.ts` → `CodingAgentTasksPanel` → `ProjectSwitcher`) is unaffected; only the server entry's transitive reach into `@elizaos/ui` is severed.

### Regression test

`__tests__/unit/server-entry-no-ui-imports.test.ts` asserts the server entry has:
- No re-export of `ProjectSwitcher` or other browser-only components
- No imports from `@elizaos/ui`
- No imports from `react` or `react-dom`

## Evidence

| Check | Result |
|-------|--------|
| typecheck | `tsc --noEmit -p tsconfig.build.json` — PASS |
| unit tests | `server-entry-no-ui-imports.test.ts` 3/3 PASS; `orchestrator-command.action.test.ts` 4/4 PASS |
| RP review | APPROVE — verified root cause, Dockerfile exclusion mechanism, no broken consumers, test validity |
| backend-logs | typecheck clean exit; test runner 7/7 pass, 0 fail |
| evidence-head | d984983bbdc9af36bf7447ba60552fcbefca2ff3 |

<!-- evidence-head:d984983bbdc9af36bf7447ba60552fcbefca2ff3 -->

## RP Review Summary

RepoPrompt CE (design workflow, detached) independently verified:
- The Dockerfile exclusion is deliberate and documented
- The collect-docker-runtime-deps.mjs script excludes @elizaos/ui by design
- No external consumer imports ProjectSwitcher from the package root
- The server entry's full static closure is now UI-free
- The regression test regex catches the original bug
- **Verdict: APPROVE** — no must-fix items

Two minor non-blocking observations noted:
1. Test guards at source level (faithful proxy for current tsup build)
2. A repo-wide CI guard against any linked plugin's server entry importing @elizaos/ui would prevent recurrence (out of scope, follow-up issue)

AI provider/model: zai / glm-5.2 (manual) + GPT-5.6-sol (RepoPrompt CE review agent)
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@f618753be345ba12f97fb100cd9141cc023e0e4b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@f618753be345ba12f97fb100cd9141cc023e0e4b:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-row:backend-logs -->
- [ ] N/A - typecheck exit 0; 7/7 unit tests pass (server-entry-no-ui-imports 3/3 + orchestrator-command 4/4). Backend-only plugin entry fix.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend plugin-loading defect with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend plugin-loading defect with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend plugin-loading defect with no rendered UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend plugin-loading defect with no rendered UI surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/prompt behavior changes; fix is in build-time plugin entry exports

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB/on-chain/generated domain artifact changes

