### PR TITLE
fix(core): attachment reads retry transcription live and report stt absence honestly

### DIFF
--- a/packages/core/src/features/working-memory/readAttachmentAction.transcription.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.transcription.test.ts
@@ -1,0 +1,176 @@
+/**
+ * On-demand transcription coverage for ATTACHMENT action=read on audio/video
+ * records with no stored transcript. Deterministic harness — a hand-rolled
+ * runtime stub scripts the TRANSCRIPTION and TEXT_SMALL calls; no module
+ * mocks and no live model.
+ *
+ * Regression under test (observed live, trajectories tj-cd2aadf98b0cc7 /
+ * tj-cd524c1a710c6a): a video posted while cloud STT was gated off stored no
+ * transcript, and every later "can you see that video?" / "can you get one?"
+ * dead-ended on the canned "I don't have a transcript for that attachment
+ * yet." — even though the planner ran ATTACHMENT read successfully each time.
+ * The read path must (1) retry transcription live when a provider can serve,
+ * and (2) report unavailability honestly instead of an open-ended "yet".
+ */
+import { v4 as uuidv4 } from "uuid";
+import { describe, expect, it } from "vitest";
+import type {
+	HandlerCallback,
+	IAgentRuntime,
+	Media,
+	Memory,
+	UUID,
+} from "../../types/index.ts";
+import { ContentType, ModelType } from "../../types/index.ts";
+import { readAttachmentAction } from "./readAttachmentAction.ts";
+
+const VIDEO_URL =
+	"https://cdn.discordapp.com/attachments/123/456/snaptik_video.mp4";
+const TRANSCRIPT = "hello from the tiktok video about home servers";
+const ANSWER = "It's a short clip about home servers.";
+
+function makeVideoAttachment(overrides: Partial<Media> = {}): Media {
+	return {
+		id: "video-attachment-1",
+		url: VIDEO_URL,
+		title: "snaptik_video.mp4",
+		source: "discord",
+		contentType: ContentType.VIDEO,
+		...overrides,
+	};
+}
+
+type UseModelCall = { modelType: unknown; options: unknown };
+
+function makeRuntime(params: {
+	agentId: UUID;
+	calls: UseModelCall[];
+	transcription: () => Promise<string>;
+}): IAgentRuntime {
+	const runtime = {
+		agentId: params.agentId,
+		getConversationLength: () => 8,
+		getMemories: async () => [],
+		getRoom: async () => null,
+		getWorld: async () => null,
+		getService: () => null,
+		getSetting: () => undefined,
+		reportError: () => {},
+		useModel: async (modelType: unknown, options: unknown) => {
+			params.calls.push({ modelType, options });
+			if (modelType === ModelType.TRANSCRIPTION) {
+				return params.transcription();
+			}
+			return ANSWER;
+		},
+	};
+	return runtime as unknown as IAgentRuntime;
+}
+
+async function runRead(params: {
+	attachment: Media;
+	transcription: () => Promise<string>;
+	text?: string;
+}) {
+	const agentId = uuidv4() as UUID;
+	const calls: UseModelCall[] = [];
+	const runtime = makeRuntime({
+		agentId,
+		calls,
+		transcription: params.transcription,
+	});
+	const message: Memory = {
+		id: uuidv4() as UUID,
+		agentId,
+		entityId: uuidv4() as UUID,
+		roomId: uuidv4() as UUID,
+		createdAt: Date.now(),
+		content: {
+			text: params.text ?? "can you see that video?",
+			source: "discord",
+			attachments: [params.attachment],
+		},
+	};
+	const callbackTexts: string[] = [];
+	const callback: HandlerCallback = async (content) => {
+		if (typeof content?.text === "string") callbackTexts.push(content.text);
+		return [];
+	};
+	const result = await readAttachmentAction.handler?.(
+		runtime,
+		message,
+		undefined,
+		{
+			parameters: { action: "read", attachmentId: params.attachment.id },
+		},
+		callback,
+	);
+	return { result, callbackTexts, calls };
+}
+
+describe("ATTACHMENT read on-demand transcription", () => {
+	it("transcribes a media record live and answers from the transcript", async () => {
+		const { result, callbackTexts, calls } = await runRead({
+			attachment: makeVideoAttachment(),
+			transcription: async () => TRANSCRIPT,
+		});
+
+		expect(result?.success).toBe(true);
+		expect(callbackTexts).toEqual([ANSWER]);
+		// The TRANSCRIPTION call targeted the stored attachment URL.
+		const sttCall = calls.find((c) => c.modelType === ModelType.TRANSCRIPTION);
+		expect((sttCall?.options as { audioUrl?: string })?.audioUrl).toBe(
+			VIDEO_URL,
+		);
+		// The answering TEXT_SMALL prompt saw the fresh transcript.
+		const answerCall = calls.find((c) => c.modelType === ModelType.TEXT_SMALL);
+		expect((answerCall?.options as { prompt?: string })?.prompt).toContain(
+			TRANSCRIPT,
+		);
+	});
+
+	it("reports honest unavailability when no TRANSCRIPTION provider can serve", async () => {
+		const { result, callbackTexts } = await runRead({
+			attachment: makeVideoAttachment(),
+			transcription: async () => {
+				throw new Error(
+					"Eliza Cloud STT is not available — falling through to next TRANSCRIPTION handler",
+				);
+			},
+		});
+
+		expect(result?.success).toBe(true);
+		expect(callbackTexts).toHaveLength(1);
+		expect(callbackTexts[0]).toContain("speech-to-text isn't enabled");
+		// Never leak the internal provider prose.
+		expect(callbackTexts[0]).not.toContain("falling through");
+		expect(callbackTexts[0]).not.toContain("Eliza Cloud");
+	});
+
+	it("reports honest unavailability from an ingest-time failure marker", async () => {
+		const { callbackTexts } = await runRead({
+			attachment: makeVideoAttachment({
+				notProcessed:
+					"Video transcription unavailable: Eliza Cloud STT is not available — falling through to next TRANSCRIPTION handler",
+			}),
+			transcription: async () => {
+				throw new Error("still unavailable");
+			},
+		});
+
+		expect(callbackTexts).toHaveLength(1);
+		expect(callbackTexts[0]).toContain("speech-to-text isn't enabled");
+	});
+
+	it("keeps the open-ended reply when transcription returns no speech", async () => {
+		const { callbackTexts } = await runRead({
+			attachment: makeVideoAttachment(),
+			transcription: async () => "",
+		});
+
+		expect(callbackTexts).toHaveLength(1);
+		expect(callbackTexts[0]).toBe(
+			"I don't have a transcript for that attachment yet.",
+		);
+	});
+});

--- a/packages/core/src/features/working-memory/readAttachmentAction.transcription.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.transcription.test.ts
@@ -1,19 +1,24 @@
 /**
  * On-demand transcription coverage for ATTACHMENT action=read on audio/video
  * records with no stored transcript. Deterministic harness — a hand-rolled
- * runtime stub scripts the TRANSCRIPTION and TEXT_SMALL calls; no module
- * mocks and no live model.
+ * runtime stub scripts the TRANSCRIPTION call, and core's SSRF-guarded media
+ * fetch (the network boundary) is module-mocked; no live model, no network.
  *
  * Regression under test (observed live, trajectories tj-cd2aadf98b0cc7 /
  * tj-cd524c1a710c6a): a video posted while cloud STT was gated off stored no
  * transcript, and every later "can you see that video?" / "can you get one?"
  * dead-ended on the canned "I don't have a transcript for that attachment
- * yet." — even though the planner ran ATTACHMENT read successfully each time.
- * The read path must (1) retry transcription live when a provider can serve,
- * and (2) report unavailability honestly instead of an open-ended "yet".
+ * yet." Contract points:
+ *   1. the read path retries transcription live — fetching bytes through the
+ *      guarded, size-capped fetch and handing the provider a Buffer (the
+ *      ingest call shape);
+ *   2. provider-unavailable failures report "speech-to-text isn't enabled"
+ *      honestly, without leaking internal error prose;
+ *   3. TRANSIENT failures (network blip, provider 5xx) keep the retryable
+ *      open-ended "yet" reply — they must NOT claim STT is disabled.
  */
 import { v4 as uuidv4 } from "uuid";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type {
 	HandlerCallback,
 	IAgentRuntime,
@@ -22,10 +27,17 @@ import type {
 	UUID,
 } from "../../types/index.ts";
 import { ContentType, ModelType } from "../../types/index.ts";
-import { readAttachmentAction } from "./readAttachmentAction.ts";
+
+const fetchRemoteMediaMock = vi.fn();
+vi.mock("../../media/fetch.ts", () => ({
+	fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMediaMock(...args),
+}));
+
+const { readAttachmentAction } = await import("./readAttachmentAction.ts");
 
 const VIDEO_URL =
 	"https://cdn.discordapp.com/attachments/123/456/snaptik_video.mp4";
+const VIDEO_BYTES = Buffer.from("fake-video-bytes");
 const TRANSCRIPT = "hello from the tiktok video about home servers";
 const ANSWER = "It's a short clip about home servers.";
 
@@ -45,7 +57,7 @@ type UseModelCall = { modelType: unknown; options: unknown };
 function makeRuntime(params: {
 	agentId: UUID;
 	calls: UseModelCall[];
-	transcription: () => Promise<string>;
+	transcription: (input: unknown) => Promise<string>;
 }): IAgentRuntime {
 	const runtime = {
 		agentId: params.agentId,
@@ -59,7 +71,7 @@ function makeRuntime(params: {
 		useModel: async (modelType: unknown, options: unknown) => {
 			params.calls.push({ modelType, options });
 			if (modelType === ModelType.TRANSCRIPTION) {
-				return params.transcription();
+				return params.transcription(options);
 			}
 			return ANSWER;
 		},
@@ -69,9 +81,14 @@ function makeRuntime(params: {
 
 async function runRead(params: {
 	attachment: Media;
-	transcription: () => Promise<string>;
+	transcription: (input: unknown) => Promise<string>;
+	fetchImpl?: () => Promise<{ buffer: Buffer }>;
 	text?: string;
 }) {
+	fetchRemoteMediaMock.mockReset();
+	fetchRemoteMediaMock.mockImplementation(
+		params.fetchImpl ?? (async () => ({ buffer: VIDEO_BYTES })),
+	);
 	const agentId = uuidv4() as UUID;
 	const calls: UseModelCall[] = [];
 	const runtime = makeRuntime({
@@ -109,19 +126,28 @@ async function runRead(params: {
 }
 
 describe("ATTACHMENT read on-demand transcription", () => {
-	it("transcribes a media record live and answers from the transcript", async () => {
+	it("fetches bytes through the guarded capped fetch and answers from the transcript", async () => {
+		let providerInput: unknown;
 		const { result, callbackTexts, calls } = await runRead({
 			attachment: makeVideoAttachment(),
-			transcription: async () => TRANSCRIPT,
+			transcription: async (input) => {
+				providerInput = input;
+				return TRANSCRIPT;
+			},
 		});
 
 		expect(result?.success).toBe(true);
 		expect(callbackTexts).toEqual([ANSWER]);
-		// The TRANSCRIPTION call targeted the stored attachment URL.
-		const sttCall = calls.find((c) => c.modelType === ModelType.TRANSCRIPTION);
-		expect((sttCall?.options as { audioUrl?: string })?.audioUrl).toBe(
-			VIDEO_URL,
-		);
+		// The bytes came through the SSRF-guarded, size-capped media fetch.
+		expect(fetchRemoteMediaMock).toHaveBeenCalledTimes(1);
+		const fetchArgs = fetchRemoteMediaMock.mock.calls[0]?.[0] as {
+			url?: string;
+			maxBytes?: number;
+		};
+		expect(fetchArgs?.url).toBe(VIDEO_URL);
+		expect(fetchArgs?.maxBytes).toBe(50 * 1024 * 1024);
+		// The provider received the buffer (ingest call shape), not a URL.
+		expect(Buffer.isBuffer(providerInput)).toBe(true);
 		// The answering TEXT_SMALL prompt saw the fresh transcript.
 		const answerCall = calls.find((c) => c.modelType === ModelType.TEXT_SMALL);
 		expect((answerCall?.options as { prompt?: string })?.prompt).toContain(
@@ -130,12 +156,14 @@ describe("ATTACHMENT read on-demand transcription", () => {
 	});
 
 	it("reports honest unavailability when no TRANSCRIPTION provider can serve", async () => {
+		const unavailable = new Error(
+			"Eliza Cloud STT is not available — falling through to next TRANSCRIPTION handler",
+		);
+		unavailable.name = "CloudSttUnavailableError";
 		const { result, callbackTexts } = await runRead({
 			attachment: makeVideoAttachment(),
 			transcription: async () => {
-				throw new Error(
-					"Eliza Cloud STT is not available — falling through to next TRANSCRIPTION handler",
-				);
+				throw unavailable;
 			},
 		});
 
@@ -147,6 +175,40 @@ describe("ATTACHMENT read on-demand transcription", () => {
 		expect(callbackTexts[0]).not.toContain("Eliza Cloud");
 	});
 
+	it("keeps the retryable 'yet' reply on a TRANSIENT provider failure", async () => {
+		const { callbackTexts } = await runRead({
+			attachment: makeVideoAttachment(),
+			transcription: async () => {
+				throw new Error("provider returned 502");
+			},
+		});
+
+		expect(callbackTexts).toHaveLength(1);
+		expect(callbackTexts[0]).toBe(
+			"I don't have a transcript for that attachment yet.",
+		);
+		expect(callbackTexts[0]).not.toContain("isn't enabled");
+	});
+
+	it("keeps the retryable 'yet' reply when the media fetch itself fails", async () => {
+		const { callbackTexts, calls } = await runRead({
+			attachment: makeVideoAttachment(),
+			transcription: async () => TRANSCRIPT,
+			fetchImpl: async () => {
+				throw new Error("fetch failed: connect timeout");
+			},
+		});
+
+		expect(callbackTexts).toHaveLength(1);
+		expect(callbackTexts[0]).toBe(
+			"I don't have a transcript for that attachment yet.",
+		);
+		// The provider was never reached.
+		expect(
+			calls.filter((c) => c.modelType === ModelType.TRANSCRIPTION),
+		).toHaveLength(0);
+	});
+
 	it("reports honest unavailability from an ingest-time failure marker", async () => {
 		const { callbackTexts } = await runRead({
 			attachment: makeVideoAttachment({
@@ -154,7 +216,7 @@ describe("ATTACHMENT read on-demand transcription", () => {
 					"Video transcription unavailable: Eliza Cloud STT is not available — falling through to next TRANSCRIPTION handler",
 			}),
 			transcription: async () => {
-				throw new Error("still unavailable");
+				throw new Error("still down");
 			},
 		});
 

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -14,6 +14,7 @@
  * inference so routing stays language-agnostic (#10471).
  */
 
+import { fetchRemoteMedia } from "../../media/fetch.ts";
 import {
 	linkShareOwnText,
 	looksLikeBareLinkShare,
@@ -145,15 +146,36 @@ function missingReadableContentMessage(records: AttachmentRecord[]): string {
 		: "I don't have readable text for those attachments yet.";
 }
 
+/** Same cap the ingest path enforces (`ATTACHMENT_FETCH_MAX_BYTES`). */
+const ON_DEMAND_TRANSCRIPTION_MAX_BYTES = 50 * 1024 * 1024;
+
+/**
+ * True when a TRANSCRIPTION failure means no provider can serve at all —
+ * a provider's *UnavailableError fall-through (e.g. `CloudSttUnavailableError`)
+ * or the runtime having no registered handler — as opposed to a transient
+ * failure (network blip, provider 5xx) that a later retry could clear. Only
+ * the former may claim "speech-to-text isn't enabled" to the user.
+ */
+function isTranscriptionUnavailableError(err: unknown): err is Error {
+	if (!(err instanceof Error)) return false;
+	if (err.name.endsWith("UnavailableError")) return true;
+	return /falling through to next TRANSCRIPTION handler|no (?:model )?handler.*TRANSCRIPTION|TRANSCRIPTION.*not (?:available|enabled|registered)/i.test(
+		err.message,
+	);
+}
+
 /**
  * Live retry for media records whose ingest-time transcription produced
  * nothing (observed live: a video posted while cloud STT was gated off has no
  * transcript, and every later "can you get one?" dead-ended on the canned
- * missing-transcript reply even after STT came back). Re-runs the
- * TRANSCRIPTION model against the stored attachment URL — conversation media
- * the ingest path already fetched, not a new URL from chat text (that still
- * routes to WEB_FETCH) — and fills the record in place so read/save answer
- * from the fresh transcript. Failure keeps the explicit unavailable state.
+ * missing-transcript reply even after STT came back). Fetches the stored
+ * attachment bytes through core's SSRF-guarded, size-capped media fetch —
+ * conversation media the ingest path already fetched once, not a new URL from
+ * chat text (that still routes to WEB_FETCH) — and hands the provider a
+ * buffer, mirroring the ingest call shape. Success fills the record in place
+ * so read/save answer from the fresh transcript; unavailability keeps the
+ * explicit unavailable state; a transient failure changes nothing so the
+ * user-facing reply stays the honest open-ended "yet".
  */
 async function transcribeMediaOnDemand(
 	runtime: IAgentRuntime,
@@ -165,9 +187,14 @@ async function transcribeMediaOnDemand(
 		if (!isMediaAttachment(record) || record.content.trim()) continue;
 		if (typeof attachment.url !== "string" || !attachment.url.trim()) continue;
 		try {
-			const transcript = await runtime.useModel(ModelType.TRANSCRIPTION, {
-				audioUrl: attachment.url,
+			const { buffer } = await fetchRemoteMedia({
+				url: attachment.url,
+				maxBytes: ON_DEMAND_TRANSCRIPTION_MAX_BYTES,
 			});
+			const transcript = await runtime.useModel(
+				ModelType.TRANSCRIPTION,
+				buffer,
+			);
 			if (typeof transcript === "string" && transcript.trim()) {
 				const text = transcript.trim();
 				record.content = text;
@@ -177,14 +204,18 @@ async function transcribeMediaOnDemand(
 				transcribedAny = true;
 			}
 		} catch (err) {
-			// error-policy:J4 the attachment stays readable-as-absent with an
-			// explicit transcription-unavailable state; the caller's fallback
-			// message reports it honestly. Expected whenever no TRANSCRIPTION
-			// provider is enabled, so log at debug, not warn.
-			attachment.notProcessed ??= `Transcription unavailable: ${err instanceof Error ? err.message : String(err)}`;
+			// error-policy:J4 the attachment stays readable-as-absent and the
+			// caller's fallback message reports the state honestly. Only a
+			// no-provider-can-serve failure marks the record unavailable (and
+			// thus the "isn't enabled" reply); a transient fetch/provider error
+			// leaves the record untouched so the reply stays the retryable
+			// "yet". Expected whenever STT is disabled, so debug, not warn.
+			if (isTranscriptionUnavailableError(err)) {
+				attachment.notProcessed ??= `Transcription unavailable: ${err.message}`;
+			}
 			logger.debug(
 				{ attachmentId: attachment.id, err },
-				"[ReadAttachment] On-demand transcription unavailable",
+				"[ReadAttachment] On-demand transcription did not produce a transcript",
 			);
 		}
 	}

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -94,6 +94,28 @@ function attachmentAnswerTokenBudget(content: string): number {
 	);
 }
 
+function isMediaAttachment(record: AttachmentRecord): boolean {
+	return (
+		record.attachment.contentType === ContentType.AUDIO ||
+		record.attachment.contentType === ContentType.VIDEO
+	);
+}
+
+/**
+ * True when a media record's transcript is missing because transcription
+ * itself was unavailable (ingest or on-demand), not because nobody has asked
+ * yet. `notProcessed` carries the raw provider error; the user-facing message
+ * must stay a clean sentence, never that internal prose.
+ */
+function mediaTranscriptionUnavailable(records: AttachmentRecord[]): boolean {
+	return records.some(
+		(record) =>
+			isMediaAttachment(record) &&
+			typeof record.attachment.notProcessed === "string" &&
+			/transcription unavailable/i.test(record.attachment.notProcessed),
+	);
+}
+
 function missingReadableContentMessage(records: AttachmentRecord[]): string {
 	const hasOnlyImages = records.every(
 		(record) => record.attachment.contentType === ContentType.IMAGE,
@@ -103,12 +125,17 @@ function missingReadableContentMessage(records: AttachmentRecord[]): string {
 			? "I couldn't generate a readable description for that image."
 			: "I couldn't generate readable descriptions for those images.";
 	}
-	const hasOnlyMedia = records.every(
-		(record) =>
-			record.attachment.contentType === ContentType.AUDIO ||
-			record.attachment.contentType === ContentType.VIDEO,
-	);
+	const hasOnlyMedia = records.every(isMediaAttachment);
 	if (hasOnlyMedia) {
+		// Honest unavailability beats an open-ended "yet": when no TRANSCRIPTION
+		// provider can serve (observed live: cloud STT gated off with no local
+		// fallback), "yet" reads as "ask me again later" and the retry dead-ends
+		// on the same reply.
+		if (mediaTranscriptionUnavailable(records)) {
+			return records.length === 1
+				? "I can't transcribe that attachment — speech-to-text isn't enabled on this deployment."
+				: "I can't transcribe those attachments — speech-to-text isn't enabled on this deployment.";
+		}
 		return records.length === 1
 			? "I don't have a transcript for that attachment yet."
 			: "I don't have transcripts for those attachments yet.";
@@ -116,6 +143,52 @@ function missingReadableContentMessage(records: AttachmentRecord[]): string {
 	return records.length === 1
 		? "I don't have readable text for that attachment yet."
 		: "I don't have readable text for those attachments yet.";
+}
+
+/**
+ * Live retry for media records whose ingest-time transcription produced
+ * nothing (observed live: a video posted while cloud STT was gated off has no
+ * transcript, and every later "can you get one?" dead-ended on the canned
+ * missing-transcript reply even after STT came back). Re-runs the
+ * TRANSCRIPTION model against the stored attachment URL — conversation media
+ * the ingest path already fetched, not a new URL from chat text (that still
+ * routes to WEB_FETCH) — and fills the record in place so read/save answer
+ * from the fresh transcript. Failure keeps the explicit unavailable state.
+ */
+async function transcribeMediaOnDemand(
+	runtime: IAgentRuntime,
+	records: AttachmentRecord[],
+): Promise<boolean> {
+	let transcribedAny = false;
+	for (const record of records) {
+		const { attachment } = record;
+		if (!isMediaAttachment(record) || record.content.trim()) continue;
+		if (typeof attachment.url !== "string" || !attachment.url.trim()) continue;
+		try {
+			const transcript = await runtime.useModel(ModelType.TRANSCRIPTION, {
+				audioUrl: attachment.url,
+			});
+			if (typeof transcript === "string" && transcript.trim()) {
+				const text = transcript.trim();
+				record.content = text;
+				attachment.text = text;
+				attachment.description = `Transcript: ${text}`;
+				attachment.notProcessed = undefined;
+				transcribedAny = true;
+			}
+		} catch (err) {
+			// error-policy:J4 the attachment stays readable-as-absent with an
+			// explicit transcription-unavailable state; the caller's fallback
+			// message reports it honestly. Expected whenever no TRANSCRIPTION
+			// provider is enabled, so log at debug, not warn.
+			attachment.notProcessed ??= `Transcription unavailable: ${err instanceof Error ? err.message : String(err)}`;
+			logger.debug(
+				{ attachmentId: attachment.id, err },
+				"[ReadAttachment] On-demand transcription unavailable",
+			);
+		}
+	}
+	return transcribedAny;
 }
 
 function titleForRecord(record: AttachmentRecord): string {
@@ -477,7 +550,12 @@ export const readAttachmentAction: Action = {
 				};
 			}
 
-			const hasContent = hasReadableContent(records);
+			let hasContent = hasReadableContent(records);
+			// Media with no stored transcript gets one live attempt before the
+			// missing-content fallback, covering both read and save_as_document.
+			if (!hasContent && (await transcribeMediaOnDemand(runtime, records))) {
+				hasContent = hasReadableContent(records);
+			}
 			const storedContent = hasContent ? contentForRecords(records) : "";
 			if (action === "save_as_document") {
 				return saveAttachmentAsDocument({

--- a/plugins/plugin-elizacloud/__tests__/cloud-stt-tts-warming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-stt-tts-warming.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression coverage for the STT/TTS handlers' transient cold-cache warming
+ * handling — the raw-Response companion to the throw-shaped retries already
+ * covering image/video/music (#18323/#18325/#18333). On a box whose text
+ * brain runs elsewhere, the cloud's per-model admission cache goes cold
+ * between rare voice calls and the first one 503s with a machine-readable
+ * warming body that clears within ~1s on retry.
+ *   - warmingRetryWaitSeconds: the pure Response-shape detector.
+ *   - handleTranscription: retries the warming 503 in place (mocked fetch,
+ *     real client — matching cloud-transcription-contract.test.ts).
+ *   - handleTextToSpeech: retries via the injected client factory.
+ * No network.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleTextToSpeech, setCloudTtsClientFactoryForTesting } from "../src/models/speech";
+import { handleTranscription } from "../src/models/transcription";
+import { warmingRetryWaitSeconds } from "../src/utils/warming";
+
+function makeRuntime(): IAgentRuntime {
+  const settings: Record<string, string> = {
+    ELIZAOS_CLOUD_API_KEY: "test-key",
+    ELIZAOS_CLOUD_BASE_URL: "https://cloud.test.local/api/v1",
+    ELIZAOS_CLOUD_ENABLED: "true",
+  };
+  return {
+    getSetting: (key: string) => settings[key],
+  } as unknown as IAgentRuntime;
+}
+
+function warming503(): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: "Billing authorization is warming. Retry shortly.",
+        type: "service_unavailable",
+        code: "billing_cache_warming",
+        retryAfter: 1,
+      },
+    }),
+    { status: 503, headers: { "content-type": "application/json" } }
+  );
+}
+
+const ISOLATED_ENV_KEYS = [
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZAOS_CLOUD_USE_STT",
+  "ELIZAOS_CLOUD_USE_TTS",
+] as const;
+let savedEnv: Record<string, string | undefined> = {};
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of ISOLATED_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+afterEach(() => {
+  for (const key of ISOLATED_ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  setCloudTtsClientFactoryForTesting(null);
+  vi.restoreAllMocks();
+});
+
+describe("warmingRetryWaitSeconds", () => {
+  it("detects the warming 503 shape and honours a capped retryAfter", async () => {
+    expect(await warmingRetryWaitSeconds(warming503())).toBe(1);
+    const longWait = new Response(
+      JSON.stringify({ error: { code: "auth_cache_warming", retryAfter: 30 } }),
+      { status: 503 }
+    );
+    expect(await warmingRetryWaitSeconds(longWait)).toBe(3);
+  });
+
+  it("defaults the wait when the body has no retryAfter", async () => {
+    const bare = new Response(JSON.stringify({ code: "service_unavailable" }), { status: 503 });
+    expect(await warmingRetryWaitSeconds(bare)).toBe(1.5);
+  });
+
+  it("returns null for non-503s, non-warming 503s, and non-JSON bodies", async () => {
+    expect(await warmingRetryWaitSeconds(new Response("{}", { status: 500 }))).toBeNull();
+    expect(
+      await warmingRetryWaitSeconds(
+        new Response(JSON.stringify({ error: { code: "api_error" } }), { status: 503 })
+      )
+    ).toBeNull();
+    expect(
+      await warmingRetryWaitSeconds(new Response("upstream boom", { status: 503 }))
+    ).toBeNull();
+  });
+
+  it("leaves the caller's body consumable (reads a clone)", async () => {
+    const response = warming503();
+    await warmingRetryWaitSeconds(response);
+    expect((await response.json()).error.code).toBe("billing_cache_warming");
+  });
+});
+
+describe("handleTranscription warming-503 retry", () => {
+  it("rides through a cold-cache warming 503 and returns the transcript", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(warming503())
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ text: "hello from the video" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+    const transcript = await handleTranscription(makeRuntime(), Buffer.from("fake-audio-bytes"));
+    expect(transcript).toBe("hello from the video");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails fast on a non-warming 503", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: "api_error" } }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    await expect(
+      handleTranscription(makeRuntime(), Buffer.from("fake-audio-bytes"))
+    ).rejects.toThrow("Failed to transcribe audio: 503");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handleTextToSpeech warming-503 retry", () => {
+  it("rides through a cold-cache warming 503 and returns audio", async () => {
+    const postApiV1VoiceTts = vi
+      .fn()
+      .mockResolvedValueOnce(warming503())
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "audio/mpeg" },
+        })
+      );
+    setCloudTtsClientFactoryForTesting(() => ({
+      routes: { postApiV1VoiceTts },
+    }));
+    const audio = await handleTextToSpeech(makeRuntime(), "say hi");
+    expect(audio).toBeDefined();
+    expect(postApiV1VoiceTts).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails fast on a non-warming TTS error", async () => {
+    const postApiV1VoiceTts = vi.fn().mockResolvedValue(new Response("boom", { status: 500 }));
+    setCloudTtsClientFactoryForTesting(() => ({
+      routes: { postApiV1VoiceTts },
+    }));
+    await expect(handleTextToSpeech(makeRuntime(), "say hi")).rejects.toThrow(/500/);
+    expect(postApiV1VoiceTts).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-elizacloud/src/models/speech.ts
+++ b/plugins/plugin-elizacloud/src/models/speech.ts
@@ -9,6 +9,7 @@ import {
   resolveCloudTimeoutMs,
 } from "../utils/config";
 import { webStreamToNodeStream } from "../utils/helpers";
+import { warmingRetryWaitSeconds } from "../utils/warming";
 import { createElizaCloudClient } from "../utils/sdk-client";
 
 /**
@@ -135,17 +136,36 @@ async function fetchTextToSpeech(
   const voiceId = resolveVoiceId(options);
 
   try {
-    const res = (await cloudTtsClientFactory(runtime).routes.postApiV1VoiceTts({
-      headers: {
-        ...(format === "mp3" ? { Accept: "audio/mpeg" } : {}),
-      },
-      json: {
-        text: options.text,
-        ...(voiceId ? { voiceId } : {}),
-        ...(modelId ? { modelId } : {}),
-      },
-      timeoutMs: resolveCloudTimeoutMs("ELIZAOS_CLOUD_TTS_TIMEOUT_MS", 60_000),
-    })) as Response;
+    // Ride through the cloud's transient cold-cache warming 503 — the
+    // raw-Response companion to the throw-shaped retries in image/video/music
+    // (#18323/#18325/#18333). A non-warming failure still throws immediately.
+    let res: Response;
+    let warmingRetries = 0;
+    for (;;) {
+      res = (await cloudTtsClientFactory(runtime).routes.postApiV1VoiceTts({
+        headers: {
+          ...(format === "mp3" ? { Accept: "audio/mpeg" } : {}),
+        },
+        json: {
+          text: options.text,
+          ...(voiceId ? { voiceId } : {}),
+          ...(modelId ? { modelId } : {}),
+        },
+        timeoutMs: resolveCloudTimeoutMs("ELIZAOS_CLOUD_TTS_TIMEOUT_MS", 60_000),
+      })) as Response;
+      if (warmingRetries < 2) {
+        const waitSeconds = await warmingRetryWaitSeconds(res);
+        if (waitSeconds !== null) {
+          warmingRetries++;
+          logger.warn(
+            `[ELIZAOS_CLOUD] TTS cold-cache warming (503), retry ${warmingRetries}/2 after ${waitSeconds}s...`,
+          );
+          await new Promise((r) => setTimeout(r, waitSeconds * 1000));
+          continue;
+        }
+      }
+      break;
+    }
 
     if (!res.ok) {
       const err = await res.text();

--- a/plugins/plugin-elizacloud/src/models/transcription.ts
+++ b/plugins/plugin-elizacloud/src/models/transcription.ts
@@ -4,6 +4,7 @@ import type { OpenAITranscriptionParams } from "../types";
 import { isCloudSttAvailable, resolveCloudTimeoutMs } from "../utils/config";
 import { detectAudioMimeType } from "../utils/helpers";
 import { createElizaCloudClient } from "../utils/sdk-client";
+import { warmingRetryWaitSeconds } from "../utils/warming";
 
 /**
  * Thrown when Cloud STT cannot serve (no API key, or neither
@@ -135,10 +136,32 @@ export async function handleTranscription(
   }
 
   try {
-    const response = await createElizaCloudClient(runtime).routes.postApiV1VoiceSttRaw({
-      body: formData,
-      timeoutMs: resolveCloudTimeoutMs("ELIZAOS_CLOUD_STT_TIMEOUT_MS", 60_000),
-    });
+    // Ride through the cloud's transient cold-cache warming 503: on a box
+    // whose text brain runs elsewhere the STT admission cache goes cold
+    // between rare calls and the first one 503s with a warming body that
+    // clears in ~1s — the raw-Response companion to the throw-shaped retries
+    // in image/video/music (#18323/#18325/#18333). A non-warming failure
+    // still throws immediately.
+    let response: Response;
+    let warmingRetries = 0;
+    for (;;) {
+      response = await createElizaCloudClient(runtime).routes.postApiV1VoiceSttRaw({
+        body: formData,
+        timeoutMs: resolveCloudTimeoutMs("ELIZAOS_CLOUD_STT_TIMEOUT_MS", 60_000),
+      });
+      if (warmingRetries < 2) {
+        const waitSeconds = await warmingRetryWaitSeconds(response);
+        if (waitSeconds !== null) {
+          warmingRetries++;
+          logger.warn(
+            `[ELIZAOS_CLOUD] STT cold-cache warming (503), retry ${warmingRetries}/2 after ${waitSeconds}s...`
+          );
+          await new Promise((r) => setTimeout(r, waitSeconds * 1000));
+          continue;
+        }
+      }
+      break;
+    }
 
     if (!response.ok) {
       throw new Error(`Failed to transcribe audio: ${response.status} ${response.statusText}`);

--- a/plugins/plugin-elizacloud/src/utils/warming.ts
+++ b/plugins/plugin-elizacloud/src/utils/warming.ts
@@ -1,0 +1,49 @@
+/**
+ * Cold-cache warming detection for raw-`Response` cloud media calls (STT/TTS).
+ *
+ * On a box whose text brain runs elsewhere (e.g. Cerebras), the cloud's
+ * per-model billing/auth admission cache goes cold between rare media calls;
+ * the first call after idle answers 503 with a machine-readable warming body
+ * that clears within ~1s on retry. The throw-shaped SDK calls already ride
+ * through this (`retryMediaWarming` in models/media.ts, inline handlers in
+ * models/image.ts — #18323/#18325/#18333; server escape #18249); this helper
+ * is the companion for handlers that receive a raw `Response` and must peek
+ * its body instead of a thrown error. A non-warming 503 (or any other status)
+ * returns null so the caller fails fast.
+ */
+
+interface WarmingPeek {
+  error?: { code?: unknown; type?: unknown; retryAfter?: unknown };
+  code?: unknown;
+  type?: unknown;
+  retryAfter?: unknown;
+}
+
+/**
+ * Returns the seconds to wait before retrying a warming 503, or null when the
+ * response is not the gateway's explicit cache-warming shape. Reads a clone so
+ * the caller's body remains consumable.
+ */
+export async function warmingRetryWaitSeconds(
+  response: Response,
+): Promise<number | null> {
+  if (response.status !== 503) return null;
+  try {
+    const peek = (await response.clone().json()) as WarmingPeek;
+    const code = String(peek?.error?.code ?? peek?.code ?? "");
+    const type = String(peek?.error?.type ?? peek?.type ?? "");
+    const warming =
+      code.endsWith("_cache_warming") ||
+      code === "service_unavailable" ||
+      type === "service_unavailable";
+    if (!warming) return null;
+    const ra = peek?.error?.retryAfter ?? peek?.retryAfter;
+    return typeof ra === "number" && Number.isFinite(ra) && ra > 0
+      ? Math.min(ra, 3)
+      : 1.5;
+  } catch {
+    // error-policy:J3 a non-JSON 503 body is an explicit "not warming"
+    // verdict; the caller surfaces the original HTTP failure.
+    return null;
+  }
+}


### PR DESCRIPTION
Observed live in cozy-devs (trajectories `tj-cd2aadf98b0cc7` / `tj-cd524c1a710c6a`): a video posted while cloud STT was gated off stored no transcript, and every later "can you see that video?" / "can you get one?" dead-ended on the canned *"I don't have a transcript for that attachment yet."* — even though the planner ran `ATTACHMENT read` successfully each time. Transcription only ever ran once, at ingest; no code path could create a transcript on demand, and "yet" implied waiting would help when it never would.

Two commits, one incident:

1. **core — on-demand transcription in `ATTACHMENT read`**: media records with no stored transcript get one live `TRANSCRIPTION` attempt against the stored attachment URL (conversation media the ingest path already fetched — not a new URL from chat text) before the missing-content fallback, covering both `read` and `save_as_document`. When no provider can serve, the fallback now says *"speech-to-text isn't enabled on this deployment"* — honest, and without leaking internal provider error prose.
2. **plugin-elizacloud — STT/TTS cold-cache warming retry**: completes the media warming family (#18323 / #18325 / #18333) for the two raw-`Response` handlers via a shared `warmingRetryWaitSeconds` detector; bounded retry on the gateway's explicit warming 503 shape, non-warming failures still fail fast.

**Evidence**: 4 new core tests (`readAttachmentAction.transcription.test.ts`, 14/14 with sibling suites, core tsc clean) + 8 new plugin tests (`cloud-stt-tts-warming.test.ts`, 29/29 with contract suites, plugin tsc clean); biome clean. Root-cause trace incl. ingest timing spans (`model:TRANSCRIPTION outcome=error 0ms`) in the incident artifact.

- Before screenshots `N/A - backend/chat behavior change, no UI surface`.
- After screenshots `N/A - backend/chat behavior change, no UI surface`.
- Walkthrough video `N/A - chat-turn behavior; trajectories cited instead`.
- Backend logs: ingest fall-through + 0ms gate rejection quoted above and in linked trajectories.
- Frontend logs `N/A - no frontend change`.
- Real-LLM trajectory: tj-cd2aadf98b0cc7 / tj-cd524c1a710c6a (planner ran ATTACHMENT read, dead-ended pre-fix).
- Domain artifacts: attachment record with `notProcessed` STT marker (quoted in PR description).
- OCR review `N/A - no rendered visual surface`.

<!-- evidence-head:15d66e6fd82a6e61065e22eeba68e1c918634e47 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)