### PR TITLE
fix(agent): record llm captures from tool-call-only completions

### DIFF
--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -1584,6 +1584,23 @@ function snapshotCaptureParams(
   return snapshot;
 }
 
+/**
+ * A tool-call-only completion (`finishReason=tool-calls` — a planner turn that
+ * emits only a tool call, or a Stage-1 truncated at its completion-token cap)
+ * produces no assistant text, so producers hand this recorder
+ * `response: undefined` despite the declared string type. `validateLlmCapture`
+ * accepts an EMPTY response (allowEmpty) but rejects a missing one, which
+ * silently dropped the llm sub-capture for exactly the tool-heavy turns
+ * trajectories exist to explain. Coerce only absence — a present-but-non-string
+ * response is still a producer bug and must keep failing validation.
+ */
+function coerceAbsentLlmResponse(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  if (params.response != null) return params;
+  return { ...params, response: "" };
+}
+
 export function normalizeLlmCallPayload(
   args: unknown[],
 ): { stepId: string; params: Record<string, unknown> } | null {
@@ -1602,10 +1619,12 @@ export function normalizeLlmCallPayload(
         context: { field: !stepId ? "stepId" : "payload" },
       });
     }
-    const params = redactTrajectoryParams({
-      ...details,
-      stepId,
-    });
+    const params = redactTrajectoryParams(
+      coerceAbsentLlmResponse({
+        ...details,
+        stepId,
+      }),
+    );
     validateLlmCapture(params, stepId);
     const snapshot = snapshotCaptureParams(params, stepId);
     validateLlmCapture(snapshot, stepId);
@@ -1631,7 +1650,9 @@ export function normalizeLlmCallPayload(
   }
   const normalizedParams =
     params.stepId === stepId ? params : { ...params, stepId };
-  const redactedParams = redactTrajectoryParams(normalizedParams);
+  const redactedParams = redactTrajectoryParams(
+    coerceAbsentLlmResponse(normalizedParams),
+  );
   validateLlmCapture(redactedParams, stepId);
   const snapshot = snapshotCaptureParams(redactedParams, stepId);
   validateLlmCapture(snapshot, stepId);

--- a/packages/agent/src/runtime/trajectory-redaction.test.ts
+++ b/packages/agent/src/runtime/trajectory-redaction.test.ts
@@ -51,6 +51,44 @@ describe("normalizeLlmCallPayload redaction", () => {
   });
 });
 
+describe("normalizeLlmCallPayload tool-call-only response coercion", () => {
+  // A tool-call-only completion (finishReason=tool-calls) has no assistant
+  // text, so producers pass response=undefined; the recorder must coerce it to
+  // "" instead of rejecting the whole capture (TRAJECTORY_CAPTURE_INVALID) and
+  // dropping the llm evidence for tool-heavy turns.
+  const base = {
+    model: "test-model",
+    purpose: "planner",
+    actionType: "tool-call",
+    userPrompt: "check the CI on your PRs",
+  };
+
+  it("coerces a missing response to '' (object payload shape)", () => {
+    const result = normalizeLlmCallPayload([
+      { stepId: "s-1", ...base, finishReason: "tool-calls" },
+    ]);
+    expect(result?.params.response).toBe("");
+  });
+
+  it("coerces a missing response to '' (stepId + details shape)", () => {
+    const result = normalizeLlmCallPayload(["s-1", { ...base }]);
+    expect(result?.params.response).toBe("");
+  });
+
+  it("still rejects a present-but-non-string response", () => {
+    expect(() =>
+      normalizeLlmCallPayload([{ stepId: "s-1", ...base, response: 42 }]),
+    ).toThrow();
+  });
+
+  it("preserves a real response unchanged", () => {
+    const result = normalizeLlmCallPayload([
+      { stepId: "s-1", ...base, response: "on it." },
+    ]);
+    expect(result?.params.response).toBe("on it.");
+  });
+});
+
 describe("shouldEnableTrajectoryLoggingByDefault", () => {
   it("returns false in NODE_ENV=production without explicit opt-in", () => {
     expect(


### PR DESCRIPTION
A tool-call-only completion (`finishReason=tool-calls` — a planner turn emitting only a tool call, or a Stage-1 truncated at its completion-token cap) has no assistant text, so producers hand the trajectory DB recorder `response: undefined`. `validateLlmCapture` accepts an *empty* response (`allowEmpty`) but rejected a *missing* one, dropping the llm sub-capture (`TRAJECTORY_CAPTURE_INVALID field=response`) for exactly the tool-heavy turns trajectories exist to explain.

Observed live on nubilio: Stage-1 hit `maxTokens=2048` with 1982 reasoning tokens, finished `tool-calls`, and the capture was rejected (`stepId 9b8a7b06-…`, `diagnosticOnly=true`).

Fix: coerce absence to `""` at the recorder boundary (`normalizeLlmCallPayload`, both payload shapes) — matching the `?? ""` every sibling capture site already applies — while a present-but-non-string response still fails validation.

**Evidence**: 4 new tests in `trajectory-redaction.test.ts` (both shapes, wrong-type still rejected, real text preserved); 68/68 across the trajectory unit + integration suites; biome clean; agent tsc clean on touched files.

- Before screenshots `N/A - diagnostic persistence fix, no UI surface`.
- After screenshots `N/A - diagnostic persistence fix, no UI surface`.
- Walkthrough video `N/A - no UI surface`.
- Backend logs: the live rejection line quoted above.
- Frontend logs `N/A - no frontend change`.
- Real-LLM trajectory: tj-69b24cd35c86ec (the tool-call-only planner turn whose capture was dropped).
- Domain artifacts: trajectory DB row now records `response:""` for such turns (test-asserted).
- OCR review `N/A - no rendered visual surface`.

<!-- evidence-head:6776d365632050ab4e3ff2422f54eceb2db6f308 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)