### PR TITLE
fix(cloud-api): serve registry artifacts on the plugins host

### DIFF
--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -16,6 +16,7 @@ import type { Hono } from "hono";
 import { makeCronHandler } from "@/lib/cron/cloudflare-cron";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { serveBlobHostRequest } from "./blob-host";
+import { serveRegistryHostRequest } from "./registry-host";
 
 export { AnonymousChatGate } from "./anonymous-chat-gate";
 export { InferenceAdmissionGate } from "./inference-admission-gate";
@@ -450,6 +451,8 @@ export default {
     if (frontendAliasResponse) return frontendAliasResponse;
     const blobResponse = await serveBlobHostRequest(request, url, env);
     if (blobResponse) return blobResponse;
+    const registryResponse = await serveRegistryHostRequest(request, url, env);
+    if (registryResponse) return registryResponse;
     const agentProxyResponse = proxyGeneratedAgentRequest(request, env, url);
     if (agentProxyResponse) return agentProxyResponse;
     const frontendRedirect = redirectFrontendHost(url, env);

--- a/packages/cloud/api/src/registry-host.test.ts
+++ b/packages/cloud/api/src/registry-host.test.ts
@@ -98,6 +98,19 @@ describe("serveRegistryHostRequest", () => {
     expect(body?.code).toBe("resource_not_found");
   });
 
+  test("fails closed when the upstream fetch rejects outright", async () => {
+    stubUpstream(() => {
+      throw new TypeError("fetch failed: connection reset");
+    });
+    const [request, url] = req(
+      "https://plugins.elizacloud.ai/generated-registry.json",
+    );
+    const response = await serveRegistryHostRequest(request, url, ENV);
+    expect(response?.status).toBe(404);
+    const body = (await response?.json()) as { code?: string };
+    expect(body?.code).toBe("resource_not_found");
+  });
+
   test("rejects writes with 405", async () => {
     stubUpstream(() => new Response("{}"));
     const [request, url] = req(

--- a/packages/cloud/api/src/registry-host.test.ts
+++ b/packages/cloud/api/src/registry-host.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The registry host (`plugins.elizacloud.ai`) must serve the committed
+ * registry artifacts from the worker itself: the wildcard `*.elizacloud.ai/*`
+ * route shadows the host, so before this handler the canonical registry URL
+ * (`packages/registry` README) 404'd on the JSON router on every env.
+ * Deterministic — upstream raw-GitHub fetch is stubbed via the global fetch;
+ * no network.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { serveRegistryHostRequest } from "./registry-host";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function stubUpstream(
+  responder: (url: string, init?: RequestInit) => Response,
+): { calls: string[] } {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    calls.push(url);
+    return responder(url, init);
+  }) as typeof fetch;
+  return { calls };
+}
+
+function req(url: string, method = "GET"): [Request, URL] {
+  return [new Request(url, { method }), new URL(url)];
+}
+
+const ENV = {} as Parameters<typeof serveRegistryHostRequest>[2];
+
+describe("serveRegistryHostRequest", () => {
+  test("returns null for non-registry hosts (falls through to the router)", async () => {
+    const { calls } = stubUpstream(() => new Response("{}"));
+    const [request, url] = req(
+      "https://api.elizacloud.ai/generated-registry.json",
+    );
+    expect(await serveRegistryHostRequest(request, url, ENV)).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  test("serves the committed artifact with a JSON content-type", async () => {
+    const { calls } = stubUpstream(
+      () =>
+        new Response('{"registry":true}', {
+          status: 200,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        }),
+    );
+    const [request, url] = req(
+      "https://plugins.elizacloud.ai/generated-registry.json",
+    );
+    const response = await serveRegistryHostRequest(request, url, ENV);
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(response?.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response?.headers.get("cache-control")).toContain("max-age=");
+    expect(await response?.text()).toBe('{"registry":true}');
+    expect(calls[0]).toContain(
+      "raw.githubusercontent.com/elizaOS/eliza/develop/packages/registry/generated-registry.json",
+    );
+  });
+
+  test("serves the staging host from the same allowlist", async () => {
+    stubUpstream(() => new Response("{}", { status: 200 }));
+    const [request, url] = req(
+      "https://plugins.staging.elizacloud.ai/generated-registry.json",
+    );
+    const response = await serveRegistryHostRequest(request, url, ENV);
+    expect(response?.status).toBe(200);
+  });
+
+  test("404s paths outside the artifact allowlist without touching upstream", async () => {
+    const { calls } = stubUpstream(() => new Response("{}"));
+    const [request, url] = req("https://plugins.elizacloud.ai/secrets.json");
+    const response = await serveRegistryHostRequest(request, url, ENV);
+    expect(response?.status).toBe(404);
+    const body = (await response?.json()) as { code?: string };
+    expect(body?.code).toBe("resource_not_found");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("fails closed on an upstream error instead of leaking it", async () => {
+    stubUpstream(() => new Response("upstream boom", { status: 500 }));
+    const [request, url] = req(
+      "https://plugins.elizacloud.ai/generated-registry.json",
+    );
+    const response = await serveRegistryHostRequest(request, url, ENV);
+    expect(response?.status).toBe(404);
+    const body = (await response?.json()) as { code?: string };
+    expect(body?.code).toBe("resource_not_found");
+  });
+
+  test("rejects writes with 405", async () => {
+    stubUpstream(() => new Response("{}"));
+    const [request, url] = req(
+      "https://plugins.elizacloud.ai/generated-registry.json",
+      "POST",
+    );
+    const response = await serveRegistryHostRequest(request, url, ENV);
+    expect(response?.status).toBe(405);
+    expect(response?.headers.get("allow")).toBe("GET, HEAD");
+  });
+
+  test("HEAD returns headers with an empty body", async () => {
+    stubUpstream(() => new Response("{}", { status: 200 }));
+    const [request, url] = req(
+      "https://plugins.elizacloud.ai/generated-registry.json",
+      "HEAD",
+    );
+    const response = await serveRegistryHostRequest(request, url, ENV);
+    expect(response?.status).toBe(200);
+    expect(await response?.text()).toBe("");
+  });
+
+  test("honours a configured base domain", async () => {
+    stubUpstream(() => new Response("{}", { status: 200 }));
+    const [request, url] = req(
+      "https://plugins.example.dev/generated-registry.json",
+    );
+    const response = await serveRegistryHostRequest(request, url, {
+      ELIZA_CLOUD_AGENT_BASE_DOMAIN: "example.dev",
+    } as typeof ENV);
+    expect(response?.status).toBe(200);
+  });
+});

--- a/packages/cloud/api/src/registry-host.ts
+++ b/packages/cloud/api/src/registry-host.ts
@@ -1,0 +1,105 @@
+/**
+ * Plugin-registry artifact serving for the registry host
+ * (`plugins.elizacloud.ai` / `plugins.staging.elizacloud.ai`).
+ *
+ * The canonical registry data URL (`packages/registry` README + types) is
+ * `plugins.elizacloud.ai/generated-registry.json`, but the wildcard
+ * `*.elizacloud.ai/*` Worker route shadows the host — the same disease the
+ * blob host has (see `blob-host.ts`) — so every registry fetch 404'd on this
+ * worker's JSON router even though the artifact is committed in-repo and raw
+ * GitHub serves it fine.
+ *
+ * This handler makes the worker itself serve the host: GET/HEAD requests for
+ * a deny-by-default allowlist of registry artifacts are proxied from raw
+ * GitHub (the committed artifact is the source of truth; it is regenerated on
+ * `develop`, so both prod and staging hosts serve the current registry rather
+ * than a promote-lagged copy). Anything else on the host stays a JSON 404.
+ */
+
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const DEFAULT_BASE_DOMAIN = "elizacloud.ai";
+
+/**
+ * Deny-by-default allowlist of served artifact paths → upstream raw-GitHub
+ * URLs. Add a path only when `packages/registry` documents it as a published
+ * artifact consumed over HTTP.
+ */
+const REGISTRY_ARTIFACTS: Readonly<Record<string, string>> = {
+  "/generated-registry.json":
+    "https://raw.githubusercontent.com/elizaOS/eliza/develop/packages/registry/generated-registry.json",
+};
+
+/** Worker-edge + client cache horizon. The artifact changes only when a
+ * registry PR lands on develop; five minutes keeps consumers fresh without
+ * hammering raw GitHub. */
+const CACHE_TTL_SECONDS = 300;
+
+/** The only binding this handler reads — narrow so tests need no casts. */
+type RegistryHostBindings = Pick<
+  AppEnv["Bindings"],
+  "ELIZA_CLOUD_AGENT_BASE_DOMAIN"
+>;
+
+function registryHosts(env: RegistryHostBindings): readonly string[] {
+  const base =
+    typeof env.ELIZA_CLOUD_AGENT_BASE_DOMAIN === "string" &&
+    env.ELIZA_CLOUD_AGENT_BASE_DOMAIN.trim().length > 0
+      ? env.ELIZA_CLOUD_AGENT_BASE_DOMAIN.trim().toLowerCase()
+      : DEFAULT_BASE_DOMAIN;
+  return [`plugins.${base}`, `plugins.staging.${base}`];
+}
+
+function notFound(): Response {
+  return Response.json(
+    { success: false, error: "Not found", code: "resource_not_found" },
+    { status: 404 },
+  );
+}
+
+export async function serveRegistryHostRequest(
+  request: Request,
+  url: URL,
+  env: RegistryHostBindings,
+): Promise<Response | null> {
+  if (!registryHosts(env).includes(url.hostname.toLowerCase())) return null;
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return Response.json(
+      {
+        success: false,
+        error: "Method not allowed",
+        code: "method_not_allowed",
+      },
+      { status: 405, headers: { allow: "GET, HEAD" } },
+    );
+  }
+
+  const upstreamUrl = REGISTRY_ARTIFACTS[url.pathname];
+  if (!upstreamUrl) return notFound();
+
+  const upstream = await fetch(upstreamUrl, {
+    method: request.method,
+    cf: { cacheTtl: CACHE_TTL_SECONDS, cacheEverything: true },
+  } as RequestInit);
+  if (!upstream.ok) {
+    // Fail closed with this host's own 404 shape — never leak the upstream
+    // response through as if it were the artifact.
+    return notFound();
+  }
+
+  const headers = new Headers();
+  // raw GitHub labels .json as text/plain; restore the artifact's contract.
+  headers.set("content-type", "application/json; charset=utf-8");
+  headers.set("cache-control", `public, max-age=${CACHE_TTL_SECONDS}`);
+  // Registry data is public and consumed cross-origin (docs site, app UIs).
+  headers.set("access-control-allow-origin", "*");
+  headers.set("x-content-type-options", "nosniff");
+  const length = upstream.headers.get("content-length");
+  if (length) headers.set("content-length", length);
+
+  if (request.method === "HEAD") {
+    return new Response(null, { status: 200, headers });
+  }
+  return new Response(upstream.body, { status: 200, headers });
+}

--- a/packages/cloud/api/src/registry-host.ts
+++ b/packages/cloud/api/src/registry-host.ts
@@ -78,10 +78,19 @@ export async function serveRegistryHostRequest(
   const upstreamUrl = REGISTRY_ARTIFACTS[url.pathname];
   if (!upstreamUrl) return notFound();
 
-  const upstream = await fetch(upstreamUrl, {
-    method: request.method,
-    cf: { cacheTtl: CACHE_TTL_SECONDS, cacheEverything: true },
-  } as RequestInit);
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl, {
+      method: request.method,
+      cf: { cacheTtl: CACHE_TTL_SECONDS, cacheEverything: true },
+    } as RequestInit);
+  } catch {
+    // error-policy:J1 boundary translation — a rejected upstream fetch (DNS
+    // failure, connection reset to raw GitHub) fails closed as this host's own
+    // JSON 404; the worker entry has no other catch on this path, so letting it
+    // escape would surface a Cloudflare 1101 exception page instead.
+    return notFound();
+  }
   if (!upstream.ok) {
     // Fail closed with this host's own 404 shape — never leak the upstream
     // response through as if it were the artifact.


### PR DESCRIPTION
The canonical registry URL (`packages/registry` README + types) is `plugins.elizacloud.ai/generated-registry.json`, but the wildcard `*.elizacloud.ai/*` Worker route shadows the host — the same disease `blob-host.ts` cures for blob URLs — so every registry fetch 404'd on the JSON router on every env while the committed artifact sat servable in-repo (kepler's registry-404 triage in HQ #18309 confirmed live on both prod and staging).

Fix mirrors blob-host: a deny-by-default host handler (`registry-host.ts`) serving allowlisted artifacts (currently `generated-registry.json`) proxied from the committed source (regenerated on develop, so prod and staging serve the current registry rather than a promote-lagged copy), correct `application/json` content-type (raw GitHub labels it text/plain), 5-minute edge caching, fail-closed on upstream errors, GET/HEAD only, wired into the worker entry alongside `serveBlobHostRequest`.

**Evidence**: 8 new tests (`registry-host.test.ts`: host miss → null, artifact allowlist, staging host, configured base domain, fail-closed upstream, 405 writes, HEAD) + 14/14 blob-host regression green; cloud-api tsc clean; biome clean.

- Before screenshots `N/A - API host routing fix, no UI surface`.
- After screenshots `N/A - API host routing fix, no UI surface`.
- Walkthrough video `N/A - no UI surface`.
- Backend logs: live probes in HQ (both hosts returning the cloud worker's `resource_not_found` with `server-timing=cloud_worker`).
- Frontend logs `N/A - no frontend change`.
- Real-LLM trajectory `N/A - no model path involved`.
- Domain artifacts: post-deploy, `curl https://plugins.elizacloud.ai/generated-registry.json` returns the committed registry JSON (verifiable after the next promote).
- OCR review `N/A - no rendered visual surface`.

<!-- evidence-head:91550f14fc01fa810d2ea4770def36a71ffdb98e -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)