### PR TITLE
feat(cloud-shared): raise node-autoscaler ceiling to 14 for launch

### DIFF
--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
@@ -62,7 +62,10 @@ export interface AutoscalePolicy {
 export const DEFAULT_AUTOSCALE_POLICY: AutoscalePolicy = {
   minFreeSlotsBuffer: containersEnv.autoscaleMinFreeSlotsBuffer(),
   minHotAvailableSlots: containersEnv.autoscaleMinHotAvailableSlots(),
-  maxNodes: 12,
+  // Launch capacity bump 12 → 14 (#18052): the launch chain enables the warm
+  // pool, whose standing replenishment consumes slots the old ceiling had
+  // reserved for on-demand provisioning headroom.
+  maxNodes: 14,
   scaleUpCooldownMs: 5 * 60 * 1000,
   idleNodeMinAgeMs: 30 * 60 * 1000,
   defaultServerType: containersEnv.defaultHcloudServerType(),


### PR DESCRIPTION
Launch-chain step 4 (#18052, HQ #18309 8-step chain): `WARM_POOL_ENABLED` is now ON on the prod daemon host (flipped + worker restarted + healthy, 06:04Z), and warm-pool replenishment consumes standing node slots — the hardcoded `maxNodes: 12` ceiling would squeeze the on-demand provisioning headroom the buffer policies assume. One-line bump of `DEFAULT_AUTOSCALE_POLICY.maxNodes` to 14.

**Evidence**: constant-only change; no test asserts the old cap (grepped); biome clean. Autoscaler behavior gates (`minFreeSlotsBuffer`, cooldowns, canonical-node protections) unchanged — verified live on cp-prod that canonical nodes are not autoscaler-replaced (journal line quoted in HQ).

- Before screenshots `N/A - backend capacity constant, no UI surface`.
- After screenshots `N/A - backend capacity constant, no UI surface`.
- Walkthrough video `N/A - no UI surface`.
- Backend logs: cp-prod provisioning-worker healthy post warm-pool flip (journal excerpts in HQ #18309).
- Frontend logs `N/A - no frontend change`.
- Real-LLM trajectory `N/A - no model path involved`.
- Domain artifacts: autoscaler policy dump post-deploy will show maxNodes=14.
- OCR review `N/A - no rendered visual surface`.

Parked under kepler's bounded hold like #18348/49/50 — merge after their staging receipt.

<!-- evidence-head:d400c554e009c7cc62c273542de8e303618dd889 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)