### PR TITLE
fix(cloud): allow reentrant demo canary upgrades

### DIFF
--- a/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
@@ -2237,6 +2237,47 @@ describe("admin agent image rollout on primary PGlite", () => {
     }
   });
 
+  test("a second canary accepts the immutable demo image as its exact source pair", async () => {
+    const seeded = await seedAgents(1);
+    const firstTarget = seeded.targets[0]!;
+    const nextImage = `ghcr.io/elizaos/eliza-demo@${NEXT_DIGEST}`;
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ docker_image: TARGET_IMAGE, image_digest: TARGET_DIGEST })
+      .where(eq(agentSandboxes.id, firstTarget.agentId));
+
+    const result = await executeUpgradeCanary({
+      actorUserId: seeded.actorUserId,
+      targetImage: nextImage,
+      targets: [
+        {
+          ...firstTarget,
+          expectedSourceImage: TARGET_IMAGE,
+          expectedSourceDigest: TARGET_DIGEST,
+        },
+      ],
+    });
+
+    expect(result.targets).toEqual([
+      expect.objectContaining({
+        sourceImage: TARGET_IMAGE,
+        sourceDigest: TARGET_DIGEST,
+        targetImage: nextImage,
+        targetDigest: NEXT_DIGEST,
+      }),
+    ]);
+    const [job] = await dbWrite
+      .select()
+      .from(jobs)
+      .where(eq(jobs.type, JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE));
+    expect(readAdminCanaryImageJobData(job!)).toMatchObject({
+      sourceImage: TARGET_IMAGE,
+      sourceDigest: TARGET_DIGEST,
+      targetImage: nextImage,
+      targetDigest: NEXT_DIGEST,
+    });
+  });
+
   test("one conflicting fifth target rolls back every canary insert", async () => {
     const seeded = await seedAgents(5);
     const blocked = seeded.targets[4]!;

--- a/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
@@ -2237,16 +2237,21 @@ describe("admin agent image rollout on primary PGlite", () => {
     }
   });
 
-  test("a second canary accepts the immutable demo image as its exact source pair", async () => {
+  test("a reentrant canary rolls back to its recorded demo source pair", async () => {
     const seeded = await seedAgents(1);
     const firstTarget = seeded.targets[0]!;
     const nextImage = `ghcr.io/elizaos/eliza-demo@${NEXT_DIGEST}`;
-    await dbWrite
-      .update(agentSandboxes)
-      .set({ docker_image: TARGET_IMAGE, image_digest: TARGET_DIGEST })
-      .where(eq(agentSandboxes.id, firstTarget.agentId));
+    const first = await executeUpgradeCanary({
+      actorUserId: seeded.actorUserId,
+      targets: seeded.targets,
+    });
+    const [firstJob] = await dbWrite
+      .select()
+      .from(jobs)
+      .where(eq(jobs.id, first.targets[0]!.jobId!));
+    await completeUpgradeJob(firstJob!);
 
-    const result = await executeUpgradeCanary({
+    const second = await executeUpgradeCanary({
       actorUserId: seeded.actorUserId,
       targetImage: nextImage,
       targets: [
@@ -2258,7 +2263,7 @@ describe("admin agent image rollout on primary PGlite", () => {
       ],
     });
 
-    expect(result.targets).toEqual([
+    expect(second.targets).toEqual([
       expect.objectContaining({
         sourceImage: TARGET_IMAGE,
         sourceDigest: TARGET_DIGEST,
@@ -2266,16 +2271,32 @@ describe("admin agent image rollout on primary PGlite", () => {
         targetDigest: NEXT_DIGEST,
       }),
     ]);
-    const [job] = await dbWrite
+    const [secondJob] = await dbWrite
       .select()
       .from(jobs)
-      .where(eq(jobs.type, JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE));
-    expect(readAdminCanaryImageJobData(job!)).toMatchObject({
+      .where(eq(jobs.id, second.targets[0]!.jobId!));
+    expect(readAdminCanaryImageJobData(secondJob!)).toMatchObject({
       sourceImage: TARGET_IMAGE,
       sourceDigest: TARGET_DIGEST,
       targetImage: nextImage,
       targetDigest: NEXT_DIGEST,
     });
+    await completeUpgradeJob(secondJob!);
+
+    const rollback = await executeRollbackCanary({
+      actorUserId: seeded.actorUserId,
+      source: { jobId: secondJob!.id },
+    });
+
+    expect(rollback.targets).toEqual([
+      expect.objectContaining({
+        operation: "rollback",
+        sourceImage: nextImage,
+        sourceDigest: NEXT_DIGEST,
+        targetImage: TARGET_IMAGE,
+        targetDigest: TARGET_DIGEST,
+      }),
+    ]);
   });
 
   test("one conflicting fifth target rolls back every canary insert", async () => {

--- a/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.ts
+++ b/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.ts
@@ -11,6 +11,7 @@ import {
   type AdminCanaryImageJobData,
   type AdminCanaryPlannedTarget,
   type AdminCanaryRolloutInput,
+  assertAdminCanaryCanonicalOrDemoPair,
   assertAdminCanaryImageJobData,
   assertAdminCanaryRequestId,
   assertAdminCanaryRolloutInput,
@@ -322,6 +323,9 @@ export class AdminAgentImageRolloutService {
       ) {
         throw conflict(`Agent ${data.agentId} no longer has the completed canary rollback pair`);
       }
+      // Dry runs must validate the same immutable target pair that enqueue and
+      // execution will use, including a demo image from an earlier canary.
+      assertAdminCanaryCanonicalOrDemoPair(data.sourceImage, data.sourceDigest, "targetImage");
 
       plans.push({
         operation: "rollback",

--- a/packages/cloud/shared/src/lib/services/admin-canary-image.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-canary-image.test.ts
@@ -47,6 +47,39 @@ describe("admin canary image contract", () => {
         ],
       }),
     ).not.toThrow();
+
+    expect(() =>
+      assertAdminCanaryRolloutInput({
+        operation: "upgrade",
+        requestId: REQUEST,
+        dryRun: true,
+        targetImage: `ghcr.io/elizaos/eliza-demo@${PLAN_FINGERPRINT}`,
+        targets: [
+          {
+            agentId: AGENT,
+            organizationId: ORG,
+            expectedSourceImage: TARGET_IMAGE,
+            expectedSourceDigest: TARGET_DIGEST,
+          },
+        ],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertAdminCanaryRolloutInput({
+        operation: "upgrade",
+        requestId: REQUEST,
+        dryRun: true,
+        targetImage: `ghcr.io/elizaos/eliza-demo@${PLAN_FINGERPRINT}`,
+        targets: [
+          {
+            agentId: AGENT,
+            organizationId: ORG,
+            expectedSourceImage: TARGET_IMAGE,
+            expectedSourceDigest: SOURCE_DIGEST,
+          },
+        ],
+      }),
+    ).toThrow("must equal sourceDigest");
   });
 
   test("requires canonical lowercase request IDs without changing other UUID fields", () => {
@@ -163,6 +196,19 @@ describe("admin canary image contract", () => {
       canonicalRequestHash: REQUEST_HASH,
     };
     expect(() => assertAdminCanaryImageJobData(data)).not.toThrow();
+    expect(() =>
+      assertAdminCanaryImageJobData({
+        ...data,
+        sourceImage: TARGET_IMAGE,
+        sourceDigest: TARGET_DIGEST,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertAdminCanaryImageJobData({
+        ...data,
+        sourceImage: TARGET_IMAGE,
+      }),
+    ).toThrow("must equal sourceDigest");
     expect(() => assertAdminCanaryImageJobData({ ...data, targetDigest: SOURCE_DIGEST })).toThrow(
       "must equal",
     );

--- a/packages/cloud/shared/src/lib/services/admin-canary-image.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-canary-image.test.ts
@@ -79,7 +79,26 @@ describe("admin canary image contract", () => {
           },
         ],
       }),
-    ).toThrow("must equal sourceDigest");
+    ).toThrow("must equal its image digest");
+    expect(() =>
+      assertAdminCanaryRolloutInput({
+        operation: "upgrade",
+        requestId: REQUEST,
+        dryRun: true,
+        targetImage: TARGET_IMAGE,
+        targets: [
+          {
+            agentId: AGENT,
+            organizationId: ORG,
+            expectedSourceImage: TARGET_IMAGE,
+            expectedSourceDigest: TARGET_DIGEST,
+          },
+        ],
+      }),
+    ).toThrow("must change the current image pair");
+    expect(() =>
+      parseAdminCanaryDemoImage(`ghcr.io/attacker/eliza-demo@${TARGET_DIGEST}`, "sourceImage"),
+    ).toThrow("sourceImage must use");
   });
 
   test("requires canonical lowercase request IDs without changing other UUID fields", () => {
@@ -208,7 +227,7 @@ describe("admin canary image contract", () => {
         ...data,
         sourceImage: TARGET_IMAGE,
       }),
-    ).toThrow("must equal sourceDigest");
+    ).toThrow("must equal its image digest");
     expect(() => assertAdminCanaryImageJobData({ ...data, targetDigest: SOURCE_DIGEST })).toThrow(
       "must equal",
     );
@@ -223,6 +242,13 @@ describe("admin canary image contract", () => {
       sourceJobId: AGENT,
     };
     expect(() => assertAdminCanaryImageJobData(rollback)).not.toThrow();
+    expect(() =>
+      assertAdminCanaryImageJobData({
+        ...rollback,
+        targetImage: TARGET_IMAGE,
+        targetDigest: TARGET_DIGEST,
+      }),
+    ).not.toThrow();
     expect(() =>
       assertAdminCanaryImageJobData({
         ...rollback,

--- a/packages/cloud/shared/src/lib/services/admin-canary-image.ts
+++ b/packages/cloud/shared/src/lib/services/admin-canary-image.ts
@@ -144,20 +144,23 @@ export function assertAdminCanaryRequestId(value: string): void {
   }
 }
 
-export function parseAdminCanaryDemoImage(image: string): {
+export function parseAdminCanaryDemoImage(
+  image: string,
+  field = "targetImage",
+): {
   repository: string;
   digest: string;
 } {
   const prefix = `${ADMIN_CANARY_DEMO_IMAGE_REPOSITORY}@`;
   if (!image.startsWith(prefix)) {
     throw ValidationError(
-      `targetImage must use the allowlisted ${ADMIN_CANARY_DEMO_IMAGE_REPOSITORY} repository`,
+      `${field} must use the allowlisted ${ADMIN_CANARY_DEMO_IMAGE_REPOSITORY} repository`,
     );
   }
   const digest = image.slice(prefix.length);
-  assertSha256Digest(digest, "targetImage digest");
+  assertSha256Digest(digest, `${field} digest`);
   if (image !== `${ADMIN_CANARY_DEMO_IMAGE_REPOSITORY}@${digest}`) {
-    throw ValidationError("targetImage must be an exact repository@sha256 digest reference");
+    throw ValidationError(`${field} must be an exact repository@sha256 digest reference`);
   }
   return { repository: ADMIN_CANARY_DEMO_IMAGE_REPOSITORY, digest };
 }
@@ -184,20 +187,24 @@ export function assertDemoSourceImage(image: string, field: string): void {
  * therefore require an exact image/digest pair; canonical sources retain their
  * existing tag-plus-digest contract.
  */
-export function assertAdminCanaryUpgradeSourcePair(
+export function assertAdminCanaryCanonicalOrDemoPair(
   image: string,
   digest: string,
   field: string,
 ): void {
   if (imageRepo(image) === ADMIN_CANARY_CANONICAL_IMAGE_REPOSITORY) return;
 
-  const source = parseAdminCanaryDemoImage(image);
+  const source = parseAdminCanaryDemoImage(image, field);
   if (source.digest !== digest) {
-    throw ValidationError(`${field} digest must equal sourceDigest`);
+    throw ValidationError(`${field} digest must equal its image digest`);
   }
 }
 
-function assertTargetExpectations(targets: AdminCanaryTargetExpectation[]): void {
+function assertTargetExpectations(
+  targets: AdminCanaryTargetExpectation[],
+  targetImage: string,
+  targetDigest: string,
+): void {
   if (targets.length < 1 || targets.length > ADMIN_CANARY_MAX_TARGETS) {
     throw ValidationError(`targets must contain between 1 and ${ADMIN_CANARY_MAX_TARGETS} agents`);
   }
@@ -212,11 +219,17 @@ function assertTargetExpectations(targets: AdminCanaryTargetExpectation[]): void
       throw ValidationError(`targets contains duplicate agent ${target.agentId}`);
     }
     seen.add(key);
-    assertAdminCanaryUpgradeSourcePair(
+    assertAdminCanaryCanonicalOrDemoPair(
       target.expectedSourceImage,
       target.expectedSourceDigest,
       `targets[${index}].expectedSourceImage`,
     );
+    if (
+      target.expectedSourceImage === targetImage &&
+      target.expectedSourceDigest === targetDigest
+    ) {
+      throw ValidationError(`targets[${index}] must change the current image pair`);
+    }
   }
 }
 
@@ -240,8 +253,8 @@ export function assertAdminCanaryRolloutInput(input: AdminCanaryRolloutInput): v
   }
 
   if (input.operation === "upgrade") {
-    assertTargetExpectations(input.targets);
-    parseAdminCanaryDemoImage(input.targetImage);
+    const target = parseAdminCanaryDemoImage(input.targetImage);
+    assertTargetExpectations(input.targets, input.targetImage, target.digest);
     return;
   }
 
@@ -388,7 +401,7 @@ export function assertAdminCanaryImageJobData(data: AdminCanaryImageJobData): vo
     if (data.sourceRolloutId !== undefined || data.sourceJobId !== undefined) {
       throw ValidationError("upgrade jobs cannot reference a rollback source");
     }
-    assertAdminCanaryUpgradeSourcePair(data.sourceImage, data.sourceDigest, "sourceImage");
+    assertAdminCanaryCanonicalOrDemoPair(data.sourceImage, data.sourceDigest, "sourceImage");
     const target = parseAdminCanaryDemoImage(data.targetImage);
     if (target.digest !== data.targetDigest) {
       throw ValidationError("targetImage digest must equal targetDigest");
@@ -397,11 +410,11 @@ export function assertAdminCanaryImageJobData(data: AdminCanaryImageJobData): vo
     if (data.sourceRolloutId === undefined || data.sourceJobId === undefined) {
       throw ValidationError("rollback jobs require the exact source rollout and job");
     }
-    const source = parseAdminCanaryDemoImage(data.sourceImage);
+    const source = parseAdminCanaryDemoImage(data.sourceImage, "sourceImage");
     if (source.digest !== data.sourceDigest) {
       throw ValidationError("sourceImage digest must equal sourceDigest");
     }
-    assertCanonicalSourceImage(data.targetImage, "targetImage");
+    assertAdminCanaryCanonicalOrDemoPair(data.targetImage, data.targetDigest, "targetImage");
   }
   if (data.userId !== data.actorUserId) {
     throw ValidationError("userId must equal actorUserId");

--- a/packages/cloud/shared/src/lib/services/admin-canary-image.ts
+++ b/packages/cloud/shared/src/lib/services/admin-canary-image.ts
@@ -178,6 +178,25 @@ export function assertDemoSourceImage(image: string, field: string): void {
   }
 }
 
+/**
+ * An upgrade starts on the canonical release image, but a later canary starts
+ * on the immutable demo image produced by the earlier canary. Demo sources
+ * therefore require an exact image/digest pair; canonical sources retain their
+ * existing tag-plus-digest contract.
+ */
+export function assertAdminCanaryUpgradeSourcePair(
+  image: string,
+  digest: string,
+  field: string,
+): void {
+  if (imageRepo(image) === ADMIN_CANARY_CANONICAL_IMAGE_REPOSITORY) return;
+
+  const source = parseAdminCanaryDemoImage(image);
+  if (source.digest !== digest) {
+    throw ValidationError(`${field} digest must equal sourceDigest`);
+  }
+}
+
 function assertTargetExpectations(targets: AdminCanaryTargetExpectation[]): void {
   if (targets.length < 1 || targets.length > ADMIN_CANARY_MAX_TARGETS) {
     throw ValidationError(`targets must contain between 1 and ${ADMIN_CANARY_MAX_TARGETS} agents`);
@@ -193,7 +212,11 @@ function assertTargetExpectations(targets: AdminCanaryTargetExpectation[]): void
       throw ValidationError(`targets contains duplicate agent ${target.agentId}`);
     }
     seen.add(key);
-    assertCanonicalSourceImage(target.expectedSourceImage, `targets[${index}].expectedSourceImage`);
+    assertAdminCanaryUpgradeSourcePair(
+      target.expectedSourceImage,
+      target.expectedSourceDigest,
+      `targets[${index}].expectedSourceImage`,
+    );
   }
 }
 
@@ -365,7 +388,7 @@ export function assertAdminCanaryImageJobData(data: AdminCanaryImageJobData): vo
     if (data.sourceRolloutId !== undefined || data.sourceJobId !== undefined) {
       throw ValidationError("upgrade jobs cannot reference a rollback source");
     }
-    assertCanonicalSourceImage(data.sourceImage, "sourceImage");
+    assertAdminCanaryUpgradeSourcePair(data.sourceImage, data.sourceDigest, "sourceImage");
     const target = parseAdminCanaryDemoImage(data.targetImage);
     if (target.digest !== data.targetDigest) {
       throw ValidationError("targetImage digest must equal targetDigest");

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -7177,7 +7177,7 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
 
   test("admin canary requires reported blue digest and uses the primary exact-pair read", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const SOURCE_IMAGE = "ghcr.io/elizaos/eliza:sha-production";
+    const SOURCE_IMAGE = `ghcr.io/elizaos/eliza-demo@${FROM_DIGEST}`;
     const TARGET_IMAGE = `ghcr.io/elizaos/eliza-demo@${TO_DIGEST}`;
     const agent: AgentSandbox = { ...liveAgentRow(), docker_image: SOURCE_IMAGE };
     const primarySpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -7621,10 +7621,13 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
     runtimeStatus?: (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;
     runtimeHealth?: (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;
     environmentVars?: Record<string, string>;
+    targetImage?: string;
+    targetDigest?: string;
   }) {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const SOURCE_IMAGE = `ghcr.io/elizaos/eliza-demo@${CURRENT_DIGEST}`;
-    const TARGET_IMAGE = "ghcr.io/elizaos/eliza:sha-production";
+    const TARGET_IMAGE = options.targetImage ?? "ghcr.io/elizaos/eliza:sha-production";
+    const TARGET_DIGEST = options.targetDigest ?? PREV_DIGEST;
     const agent: AgentSandbox = {
       ...upgradedAgentRow(),
       docker_image: SOURCE_IMAGE,
@@ -7650,7 +7653,7 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
     const lifecycleEvents: string[] = [];
     const { provider, stop, stopOnSpecificNode, runtimeFetch } = await makeDockerProvider({
       create: async () =>
-        blueHandle(PREV_DIGEST, options.failPostCutoverCleanup ? "vpn-old-rollback" : undefined),
+        blueHandle(TARGET_DIGEST, options.failPostCutoverCleanup ? "vpn-old-rollback" : undefined),
       checkHealth: async () => true,
       runtimeStatus: async (input, init) => {
         lifecycleEvents.push("status");
@@ -7704,7 +7707,7 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
         sourceImage: SOURCE_IMAGE,
         sourceDigest: CURRENT_DIGEST,
         targetImage: TARGET_IMAGE,
-        targetDigest: PREV_DIGEST,
+        targetDigest: TARGET_DIGEST,
         onCutoverInTx: options.onCutoverInTx,
         onConvergedInTx: async () => {},
       });
@@ -8369,6 +8372,18 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
       }),
     );
     expect(stop).not.toHaveBeenCalled();
+  });
+
+  test("admin canary rollback restores an immutable demo target from a prior canary", async () => {
+    const targetImage = `ghcr.io/elizaos/eliza-demo@${PREV_DIGEST}`;
+    const { result, transactionCalled } = await runAdminCanaryRollback({
+      onCutoverInTx: async () => {},
+      targetImage,
+      targetDigest: PREV_DIGEST,
+    });
+
+    expect(result.success).toBe(true);
+    expect(transactionCalled).toBe(true);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -51,8 +51,7 @@ import { logger } from "../utils/logger";
 import { settleOffResponsePath } from "../utils/settle-off-response-path";
 import { withTimeout } from "../utils/with-timeout";
 import {
-  assertAdminCanaryUpgradeSourcePair,
-  assertCanonicalSourceImage,
+  assertAdminCanaryCanonicalOrDemoPair,
   assertDemoSourceImage,
   assertSha256Digest,
   parseAdminCanaryDemoImage,
@@ -7893,7 +7892,7 @@ export class ElizaSandboxService {
     onConvergedInTx: AdminCanaryImageExecutionPolicy["onConvergedInTx"];
   }): Promise<ImageSwapResult> {
     assertSha256Digest(params.sourceDigest, "sourceDigest");
-    assertAdminCanaryUpgradeSourcePair(params.sourceImage, params.sourceDigest, "sourceImage");
+    assertAdminCanaryCanonicalOrDemoPair(params.sourceImage, params.sourceDigest, "sourceImage");
     const target = parseAdminCanaryDemoImage(params.targetImage);
     if (target.digest !== params.targetDigest) {
       return { success: false, error: "Canary target image and digest do not match" };
@@ -8400,12 +8399,12 @@ export class ElizaSandboxService {
     onConvergedInTx: AdminCanaryImageExecutionPolicy["onConvergedInTx"];
   }): Promise<ImageSwapResult> {
     assertDemoSourceImage(params.sourceImage, "sourceImage");
-    const source = parseAdminCanaryDemoImage(params.sourceImage);
+    const source = parseAdminCanaryDemoImage(params.sourceImage, "sourceImage");
     if (source.digest !== params.sourceDigest) {
       return { success: false, error: "Canary rollback source image and digest do not match" };
     }
-    assertCanonicalSourceImage(params.targetImage, "targetImage");
     assertSha256Digest(params.targetDigest, "targetDigest");
+    assertAdminCanaryCanonicalOrDemoPair(params.targetImage, params.targetDigest, "targetImage");
     return await this.executeDowngradeWithPolicy(
       params.agentId,
       params.organizationId,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -51,6 +51,7 @@ import { logger } from "../utils/logger";
 import { settleOffResponsePath } from "../utils/settle-off-response-path";
 import { withTimeout } from "../utils/with-timeout";
 import {
+  assertAdminCanaryUpgradeSourcePair,
   assertCanonicalSourceImage,
   assertDemoSourceImage,
   assertSha256Digest,
@@ -7891,8 +7892,8 @@ export class ElizaSandboxService {
     onCutoverInTx: AdminCanaryImageExecutionPolicy["onCutoverInTx"];
     onConvergedInTx: AdminCanaryImageExecutionPolicy["onConvergedInTx"];
   }): Promise<ImageSwapResult> {
-    assertCanonicalSourceImage(params.sourceImage, "sourceImage");
     assertSha256Digest(params.sourceDigest, "sourceDigest");
+    assertAdminCanaryUpgradeSourcePair(params.sourceImage, params.sourceDigest, "sourceImage");
     const target = parseAdminCanaryDemoImage(params.targetImage);
     if (target.digest !== params.targetDigest) {
       return { success: false, error: "Canary target image and digest do not match" };


### PR DESCRIPTION
# Relates to

Fixes #18029.

- [x] This PR targets `develop` and is rebased onto upstream `develop` at
      `32eed149f502b6058d50b148b0089769700d00fb` with zero conflicts.
- [ ] `bun run verify` was not run; see **Known gaps / failures**.
- [x] A reviewer can confirm the contract, execution, and durable PGlite path from the focused evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `upstream/develop` at `32eed149f502b6058d50b148b0089769700d00fb`; zero conflicts. The fork's `origin/develop` is not the authoritative upstream branch.
- [ ] `bun run verify` was not run post-sync; the exact gap is documented below.

# Risks

Low and bounded. This changes rollback admission for one already allowlisted source class: rollback now accepts an immutable `ghcr.io/elizaos/eliza-demo@sha256:…` target only when its embedded digest exactly equals the recorded durable digest. Canonical targets remain accepted; mutable demo references, foreign repositories, and digest mismatches remain rejected. Upgrade target validation and lifecycle locking are unchanged.

# Background

## What does this PR do?

Makes admin image canaries reentrant and rollback-safe. A first canary changes an agent's source image to the immutable demo repository, but the next upgrade previously rejected that source before planning. One shared validator now permits either the existing canonical source or an exact demo source pair during request validation, durable-job validation, and execution. The rollback path accepts the same exact immutable demo pair so a reentrant canary can restore its recorded source rather than failing after cutover.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No documentation change is required; this restores the existing admin-canary lifecycle contract.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/admin-canary-image.ts`, then the reentrant canary regression in `admin-agent-image-rollout.pglite.test.ts` and the direct rollback regression in `eliza-sandbox.test.ts`.

## Detailed testing steps

1. Run `bun test packages/cloud/shared/src/lib/services/admin-canary-image.test.ts` — 6/6 pass (31 assertions), including the accepted exact demo source and rejected mutable, foreign, and digest-mismatch cases.
2. Run the two focused cases in `packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts` — 2/2 pass (21 assertions): upgrade reaches the blue-digest guard from a demo source, and rollback restores an immutable demo target from a prior canary.
3. Run `bun test packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts` — 48/48 pass (404 assertions). The reentrant scenario persists the demo source pair, enqueues the next immutable demo image, and rolls back to the recorded demo source pair.
4. Run `bun run --cwd packages/cloud/shared typecheck` and the scoped Biome check — both pass.

# Evidence Gate

<!-- evidence-head:5b2632bb074757022b15355a75b47a0231c3b45b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Cloud contract; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Cloud contract; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed; the PGlite integration suite exercises the durable service path.
<!-- evidence-row:backend-logs -->
- [x] N/A - no local Cloud deployment or privileged production credentials; the direct service and PGlite regressions exercise the durable rollback path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model path changed.
<!-- evidence-row:domain-artifacts -->
- [x] PGlite integration regression proves the durable `agent_sandboxes` source pair, queued canary job payload, and rollback to the recorded immutable demo source.

  <details><summary>Manually inspected PGlite proof on exact head 5b2632bb074757022b15355a75b47a0231c3b45b</summary>

  ```text
  $ bun test packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
  (pass) ... dry-run preserves requested targets exactly and writes no jobs; execute inserts all five
  (pass) ... a reentrant canary rolls back to its recorded demo source pair
  (pass) ... rollback target pair comes only from one successful durable upgrade audit
  (pass) ... successful rollback commits the canonical pair and durable audit atomically

   48 pass
   0 fail
   404 expect() calls
  ```

  The regression writes the real PGlite `agent_sandboxes` row as
  `eliza-demo@sha256:<target>`, enqueues the next exact immutable demo pair,
  reads the durable source/target job fields, executes rollback, and inspects
  the restored recorded demo source pair.
  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-backed behavior changed.

## Backend + frontend logs

Backend deployment logs: N/A - this validation intentionally used the repository's isolated PGlite service/database harness and did not invoke a Cloud deployment. Frontend logs: N/A - no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only validation contract with no rendered UI surface.

## Known gaps / failures

- `bun run verify` was not run after sync. It is the repository-wide ~45-minute gate; focused contract, direct-execution, complete PGlite, scoped typecheck, Biome, and diff-integrity checks passed on this exact head.
- The locked install was performed with lifecycle scripts disabled. The repository's workspace-link generator and `@elizaos/core` package build were then run explicitly before the focused tests. No lockfile or dependency change is included in this PR.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-zorba]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
