### PR TITLE
feat(cloud): proactively DM Discord users after browser sign-in completes onboarding

### DIFF
--- a/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
@@ -858,4 +858,154 @@ describe("OnboardingSessionCoordinator", () => {
       ),
     ).toBe(false);
   });
+
+  describe("proactive greeting queue", () => {
+    const QUEUE = "proactive-greetings:discord";
+
+    function greeting(sessionId: string, overrides?: Record<string, unknown>) {
+      return {
+        sessionId,
+        platformUserId: sessionId.slice("platform:discord:".length) || "u",
+        message: "you're all set",
+        createdAt: new Date().toISOString(),
+        ...overrides,
+      };
+    }
+
+    function enqueue(
+      coordinator: OnboardingSessionCoordinator,
+      body: unknown,
+    ): Promise<Response> {
+      return coordinator.fetch(
+        new Request("https://onboarding.test/enqueue-greeting", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+      );
+    }
+
+    function drain(
+      coordinator: OnboardingSessionCoordinator,
+      limit?: number,
+    ): Promise<Response> {
+      return coordinator.fetch(
+        new Request("https://onboarding.test/drain-greetings", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(limit === undefined ? {} : { limit }),
+        }),
+      );
+    }
+
+    async function greetingsOf(
+      response: Response,
+    ): Promise<Array<{ sessionId: string }>> {
+      const body = (await response.json()) as {
+        greetings: Array<{ sessionId: string }>;
+      };
+      return body.greetings;
+    }
+
+    test("drain claims each greeting exactly once", async () => {
+      const harness = createCoordinatorHarness();
+      const queue = harness.objectByName(QUEUE);
+
+      expect(
+        (await enqueue(queue, greeting("platform:discord:greet-1"))).status,
+      ).toBe(200);
+      expect(
+        (await enqueue(queue, greeting("platform:discord:greet-2"))).status,
+      ).toBe(200);
+
+      const first = await greetingsOf(await drain(queue));
+      expect(first.map((entry) => entry.sessionId).sort()).toEqual([
+        "platform:discord:greet-1",
+        "platform:discord:greet-2",
+      ]);
+
+      // Already claimed: a second drain returns nothing (at-most-once).
+      expect(await greetingsOf(await drain(queue))).toEqual([]);
+    });
+
+    test("re-enqueueing the same session id overwrites instead of duplicating", async () => {
+      const harness = createCoordinatorHarness();
+      const queue = harness.objectByName(QUEUE);
+
+      await enqueue(queue, greeting("platform:discord:dup"));
+      await enqueue(
+        queue,
+        greeting("platform:discord:dup", { message: "second write" }),
+      );
+
+      const claimed = (await greetingsOf(await drain(queue))) as Array<{
+        sessionId: string;
+        message?: string;
+      }>;
+      expect(claimed).toHaveLength(1);
+      expect(claimed[0]?.message).toBe("second write");
+    });
+
+    test("expired greetings are dropped at drain time, never delivered", async () => {
+      const harness = createCoordinatorHarness();
+      const queue = harness.objectByName(QUEUE);
+
+      await enqueue(
+        queue,
+        greeting("platform:discord:stale", {
+          createdAt: new Date(Date.now() - 16 * 60 * 1000).toISOString(),
+        }),
+      );
+      await enqueue(queue, greeting("platform:discord:fresh"));
+
+      const claimed = await greetingsOf(await drain(queue));
+      expect(claimed.map((entry) => entry.sessionId)).toEqual([
+        "platform:discord:fresh",
+      ]);
+      // The stale entry was deleted, not left behind.
+      expect(await greetingsOf(await drain(queue))).toEqual([]);
+    });
+
+    test("malformed enqueue payloads are rejected with 400", async () => {
+      const harness = createCoordinatorHarness();
+      const queue = harness.objectByName(QUEUE);
+
+      const cases: unknown[] = [
+        {},
+        greeting("platform:discord:x", { platformUserId: "" }),
+        greeting("platform:discord:x", { message: "" }),
+        greeting("platform:discord:x", { message: "y".repeat(2001) }),
+        greeting("platform:discord:x", { createdAt: "not-a-date" }),
+        greeting("short", {}),
+      ];
+      for (const body of cases) {
+        expect((await enqueue(queue, body)).status).toBe(400);
+      }
+      expect(await greetingsOf(await drain(queue))).toEqual([]);
+    });
+
+    test("greeting keys never collide with session or replay storage", async () => {
+      const harness = createCoordinatorHarness();
+      const { coordinator, sessionId } = harness;
+
+      // A real onboarding turn and a greeting in the SAME durable object
+      // instance must not interfere.
+      await turn(coordinator, sessionId, "My name is Sam", "discord:msg-1");
+      await enqueue(coordinator, greeting(sessionId));
+
+      const claimed = await greetingsOf(await drain(coordinator));
+      expect(claimed.map((entry) => entry.sessionId)).toEqual([sessionId]);
+
+      // The session survives the drain untouched.
+      const followUp = await readResult(
+        await turn(coordinator, sessionId, "still here?", "discord:msg-2"),
+      );
+      expect(
+        followUp.session.history.some(
+          (message: { content: string }) =>
+            message.content === "My name is Sam",
+        ),
+      ).toBe(true);
+    });
+  });
 });

--- a/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
@@ -24,8 +24,13 @@ mock.module("../../shared/src/lib/cache/client", () => ({
   },
 }));
 
+let provisioningFailure: Error | undefined;
+
 mock.module("../../shared/src/lib/services/eliza-app/provisioning", () => ({
-  ensureElizaAppProvisioning: mock(async () => noProvisioning),
+  ensureElizaAppProvisioning: mock(async () => {
+    if (provisioningFailure) throw provisioningFailure;
+    return noProvisioning;
+  }),
   getElizaAppProvisioningStatus: mock(async () => noProvisioning),
 }));
 
@@ -981,6 +986,65 @@ describe("OnboardingSessionCoordinator", () => {
       for (const body of cases) {
         expect((await enqueue(queue, body)).status).toBe(400);
       }
+      expect(await greetingsOf(await drain(queue))).toEqual([]);
+    });
+
+    test("greeting enqueues only after the turn's durable commit (no false-success DM)", async () => {
+      const harness = createCoordinatorHarness();
+      const { coordinator, sessionId } = harness;
+      const queue = harness.objectByName(QUEUE);
+
+      await turn(
+        coordinator,
+        sessionId,
+        "My name is Sam",
+        "discord:greet-commit-1",
+      );
+      expect(await greetingsOf(await drain(queue))).toEqual([]);
+
+      const browserTurn = () =>
+        coordinator.fetch(
+          new Request("https://onboarding.test/turn", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              sessionId,
+              input: {
+                sessionId,
+                platform: "web",
+                idempotencyKey: "web:greet-commit",
+                authenticatedUser: {
+                  userId: "user-1",
+                  organizationId: "org-1",
+                },
+              },
+            }),
+          }),
+        );
+
+      // The browser continuation binds the account in memory, then
+      // provisioning throws BEFORE the durable transaction commits. The turn
+      // fails and the greeting must not exist anywhere: the user would be
+      // DMed "you're all set" for a sign-in that did not persist.
+      provisioningFailure = new Error("transient provisioning outage");
+      try {
+        expect((await browserTurn()).status).toBe(500);
+      } finally {
+        provisioningFailure = undefined;
+      }
+      expect(await greetingsOf(await drain(queue))).toEqual([]);
+
+      // Retrying after the outage commits the turn and enqueues exactly one
+      // greeting; the committed result never exposes the internal handoff.
+      const retried = await browserTurn();
+      expect(retried.status).toBe(200);
+      const committed = (await retried.json()) as Record<string, unknown>;
+      expect("proactiveGreeting" in committed).toBe(false);
+      const claimed = await greetingsOf(await drain(queue));
+      expect(claimed.map((entry) => entry.sessionId)).toEqual([sessionId]);
+
+      // A transport replay of the committed turn must not re-enqueue.
+      expect((await browserTurn()).status).toBe(200);
       expect(await greetingsOf(await drain(queue))).toEqual([]);
     });
 

--- a/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
@@ -1057,6 +1057,74 @@ describe("OnboardingSessionCoordinator", () => {
       expect(await greetingsOf(await drain(queue))).toEqual([]);
     });
 
+    test("a post-commit continuation-bind failure does not lose the greeting", async () => {
+      // Regression (PR #18353 review): the transaction commits, then the
+      // fallible cross-DO /bind runs. When the greeting enqueued only after a
+      // successful bind, a transient /bind outage permanently suppressed it —
+      // the same-key retry hits the replay branch (stripped, committed shape;
+      // must never re-enqueue) and a fresh-key retry sees an already-bound
+      // session and records no handoff. The enqueue therefore runs after the
+      // durable commit but BEFORE the bind; this pins that ordering.
+      const harness = createCoordinatorHarness();
+      const { coordinator, sessionId } = harness;
+      const queue = harness.objectByName(QUEUE);
+
+      const first = await readResult(
+        await turn(
+          coordinator,
+          sessionId,
+          "My name is Sam",
+          "discord:bind-fail-1",
+        ),
+      );
+      const token = first.session.continuationToken;
+      if (!token) throw new Error("expected a continuation token");
+
+      // Sabotage exactly the /bind endpoint on the token's DO, once.
+      const tokenObject = harness.objectByName(token);
+      const realFetch = tokenObject.fetch.bind(tokenObject);
+      let bindFailures = 1;
+      tokenObject.fetch = async (request: Request) => {
+        if (new URL(request.url).pathname === "/bind" && bindFailures > 0) {
+          bindFailures -= 1;
+          return new Response("bind outage", { status: 503 });
+        }
+        return realFetch(request);
+      };
+
+      const browserTurn = () =>
+        coordinator.fetch(
+          new Request("https://onboarding.test/turn", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              sessionId,
+              input: {
+                sessionId,
+                platform: "web",
+                idempotencyKey: "web:bind-fail",
+                confirmPlatformLink: true,
+                authenticatedUser: {
+                  userId: "user-1",
+                  organizationId: "org-1",
+                },
+              },
+            }),
+          }),
+        );
+
+      // The turn fails on the bind — but the sign-in itself durably
+      // committed, so the greeting must already be claimable.
+      expect((await browserTurn()).status).toBe(500);
+      const afterFailure = await greetingsOf(await drain(queue));
+      expect(afterFailure.map((entry) => entry.sessionId)).toEqual([sessionId]);
+
+      // The retry replays the committed turn, re-binds successfully, and
+      // must not enqueue a duplicate greeting.
+      expect((await browserTurn()).status).toBe(200);
+      expect(await greetingsOf(await drain(queue))).toEqual([]);
+    });
+
     test("greeting keys never collide with session or replay storage", async () => {
       const harness = createCoordinatorHarness();
       const { coordinator, sessionId } = harness;

--- a/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
@@ -881,6 +881,7 @@ describe("OnboardingSessionCoordinator", () => {
         platformUserId: sessionId.slice("platform:discord:".length) || "u",
         message: "you're all set",
         createdAt: new Date().toISOString(),
+        deliveryNonce: `nonce-${sessionId.replaceAll(/[^A-Za-z0-9_-]/g, "").slice(-12)}`,
         ...overrides,
       };
     }
@@ -911,16 +912,29 @@ describe("OnboardingSessionCoordinator", () => {
       );
     }
 
+    function acknowledge(
+      coordinator: OnboardingSessionCoordinator,
+      acknowledgements: Array<{ sessionId: string; leaseId: string }>,
+    ): Promise<Response> {
+      return coordinator.fetch(
+        new Request("https://onboarding.test/ack-greetings", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ acknowledgements }),
+        }),
+      );
+    }
+
     async function greetingsOf(
       response: Response,
-    ): Promise<Array<{ sessionId: string }>> {
+    ): Promise<Array<{ sessionId: string; leaseId: string }>> {
       const body = (await response.json()) as {
-        greetings: Array<{ sessionId: string }>;
+        greetings: Array<{ sessionId: string; leaseId: string }>;
       };
       return body.greetings;
     }
 
-    test("drain claims each greeting exactly once", async () => {
+    test("a live lease hides greetings until matching acknowledgement", async () => {
       const harness = createCoordinatorHarness();
       const queue = harness.objectByName(QUEUE);
 
@@ -937,11 +951,63 @@ describe("OnboardingSessionCoordinator", () => {
         "platform:discord:greet-2",
       ]);
 
-      // Already claimed: a second drain returns nothing (at-most-once).
+      // A concurrent poll cannot claim an actively leased entry.
+      expect(await greetingsOf(await drain(queue))).toEqual([]);
+
+      const wrongAck = await acknowledge(queue, [
+        { sessionId: first[0]?.sessionId ?? "", leaseId: "wrong-lease" },
+      ]);
+      expect((await wrongAck.json()) as unknown).toEqual({ acknowledged: 0 });
+      expect(await greetingsOf(await drain(queue))).toEqual([]);
+
+      const ackResponse = await acknowledge(
+        queue,
+        first.map(({ sessionId, leaseId }) => ({ sessionId, leaseId })),
+      );
+      expect((await ackResponse.json()) as unknown).toEqual({
+        acknowledged: 2,
+      });
       expect(await greetingsOf(await drain(queue))).toEqual([]);
     });
 
-    test("re-enqueueing the same session id overwrites instead of duplicating", async () => {
+    test("an unacknowledged greeting is reclaimable after lease expiry", async () => {
+      const harness = createCoordinatorHarness();
+      const queue = harness.objectByName(QUEUE);
+      const sessionId = "platform:discord:recover";
+      await enqueue(queue, greeting(sessionId));
+
+      const first = await greetingsOf(await drain(queue));
+      expect(first).toHaveLength(1);
+
+      const storage = harness.storageFor(QUEUE);
+      const key = `greeting:${encodeURIComponent(sessionId)}`;
+      const stored = await storage.get<Record<string, unknown>>(key);
+      if (!stored) throw new Error("leased greeting was not stored");
+      await storage.put(key, {
+        ...stored,
+        lease: { id: first[0]?.leaseId, expiresAt: Date.now() - 1 },
+      });
+
+      const reclaimed = await greetingsOf(await drain(queue));
+      expect(reclaimed).toHaveLength(1);
+      expect(reclaimed[0]?.sessionId).toBe(sessionId);
+      expect(reclaimed[0]?.leaseId).not.toBe(first[0]?.leaseId);
+
+      // A delayed acknowledgement from the old delivery cannot delete the
+      // newly leased entry.
+      const staleAck = await acknowledge(queue, [
+        { sessionId, leaseId: first[0]?.leaseId ?? "" },
+      ]);
+      expect((await staleAck.json()) as unknown).toEqual({ acknowledged: 0 });
+      expect(await greetingsOf(await drain(queue))).toEqual([]);
+
+      const currentAck = await acknowledge(queue, [
+        { sessionId, leaseId: reclaimed[0]?.leaseId ?? "" },
+      ]);
+      expect((await currentAck.json()) as unknown).toEqual({ acknowledged: 1 });
+    });
+
+    test("re-enqueueing the same session id preserves the original work", async () => {
       const harness = createCoordinatorHarness();
       const queue = harness.objectByName(QUEUE);
 
@@ -956,7 +1022,7 @@ describe("OnboardingSessionCoordinator", () => {
         message?: string;
       }>;
       expect(claimed).toHaveLength(1);
-      expect(claimed[0]?.message).toBe("second write");
+      expect(claimed[0]?.message).toBe("you're all set");
     });
 
     test("expired greetings are dropped at drain time, never delivered", async () => {

--- a/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
+++ b/packages/cloud/api/__tests__/onboarding-session-coordinator.test.ts
@@ -26,6 +26,14 @@ mock.module("../../shared/src/lib/cache/client", () => ({
 
 let provisioningFailure: Error | undefined;
 
+mock.module("../../shared/src/lib/services/eliza-app/user-service", () => ({
+  elizaAppUserService: {
+    findOrCreateByPhone: mock(async () => ({ success: true })),
+    linkPhoneToUser: mock(async () => ({ success: true })),
+    linkDiscordToUser: mock(async () => ({ success: true })),
+  },
+}));
+
 mock.module("../../shared/src/lib/services/eliza-app/provisioning", () => ({
   ensureElizaAppProvisioning: mock(async () => {
     if (provisioningFailure) throw provisioningFailure;
@@ -1013,6 +1021,7 @@ describe("OnboardingSessionCoordinator", () => {
                 sessionId,
                 platform: "web",
                 idempotencyKey: "web:greet-commit",
+                confirmPlatformLink: true,
                 authenticatedUser: {
                   userId: "user-1",
                   organizationId: "org-1",

--- a/packages/cloud/api/internal/discord/eliza-app/pending-greetings/route.test.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/pending-greetings/route.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Exercises the internal pending-greeting HTTP boundary with mocked queue
+ * storage while retaining real service authentication and request parsing.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const drain = mock(async () => [
+  {
+    sessionId: "platform:discord:123",
+    platformUserId: "123",
+    message: "you're all set",
+    createdAt: new Date().toISOString(),
+    deliveryNonce: "nonce-123",
+    leaseId: "lease-123",
+  },
+]);
+const acknowledge = mock(async () => 1);
+
+mock.module("@/lib/services/eliza-app/onboarding-proactive-greeting", () => ({
+  drainDiscordProactiveGreetings: drain,
+  acknowledgeDiscordProactiveGreetings: acknowledge,
+}));
+
+const { default: app } = await import("./route");
+
+function request(body: string, authorization = "Bearer test-secret") {
+  return app.request(
+    "http://localhost/",
+    {
+      method: "POST",
+      headers: {
+        authorization,
+        "content-type": "application/json",
+      },
+      body,
+    },
+    { INTERNAL_SECRET: "test-secret" } as never,
+  );
+}
+
+beforeEach(() => {
+  drain.mockClear();
+  acknowledge.mockClear();
+});
+
+describe("pending proactive greeting route", () => {
+  test("requires internal service authentication", async () => {
+    const response = await request(JSON.stringify({ action: "claim" }), "");
+    expect(response.status).toBe(401);
+    expect(drain).not.toHaveBeenCalled();
+  });
+
+  test("claims through the legacy empty body and explicit action", async () => {
+    for (const body of [{}, { action: "claim" }]) {
+      const response = await request(JSON.stringify(body));
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as {
+        greetings: Array<{ sessionId: string }>;
+      };
+      expect(payload.greetings.map((entry) => entry.sessionId)).toEqual([
+        "platform:discord:123",
+      ]);
+    }
+    expect(drain).toHaveBeenCalledTimes(2);
+  });
+
+  test("validates acknowledgements before crossing the storage boundary", async () => {
+    const invalidBodies = [
+      "not-json",
+      JSON.stringify({ action: "unknown" }),
+      JSON.stringify({ action: "ack", acknowledgements: "nope" }),
+      JSON.stringify({
+        action: "ack",
+        acknowledgements: [{ sessionId: "short", leaseId: "lease" }],
+      }),
+    ];
+    for (const body of invalidBodies) {
+      expect((await request(body)).status).toBe(400);
+    }
+    expect(acknowledge).not.toHaveBeenCalled();
+
+    const acknowledgements = [
+      { sessionId: "platform:discord:123", leaseId: "lease-123" },
+    ];
+    const response = await request(
+      JSON.stringify({ action: "ack", acknowledgements }),
+    );
+    expect(response.status).toBe(200);
+    expect((await response.json()) as unknown).toEqual({ acknowledged: 1 });
+    expect(acknowledge).toHaveBeenCalledWith(acknowledgements);
+  });
+});

--- a/packages/cloud/api/internal/discord/eliza-app/pending-greetings/route.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/pending-greetings/route.ts
@@ -1,0 +1,29 @@
+// Drains pending proactive onboarding greetings for the Discord gateway with
+// service-to-service auth. The gateway leader polls this route and delivers
+// each claimed greeting as a proactive DM; claiming is atomic in the
+// coordinator (at-most-once), so the gateway never double-sends.
+import { Hono } from "hono";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { drainDiscordProactiveGreetings } from "@/lib/services/eliza-app/onboarding-proactive-greeting";
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import { requireInternalAuth } from "../../../_auth";
+
+const app = new Hono<AppEnv>();
+
+app.post("/", async (c) => {
+  try {
+    const auth = await requireInternalAuth(c);
+    if (auth instanceof Response) return auth;
+
+    const greetings = await drainDiscordProactiveGreetings();
+    return c.json({ greetings });
+  } catch (err) {
+    logger.error("[internal/discord/eliza-app/pending-greetings]", {
+      error: err,
+    });
+    return failureResponse(c, err);
+  }
+});
+
+export default app;

--- a/packages/cloud/api/internal/discord/eliza-app/pending-greetings/route.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/pending-greetings/route.ts
@@ -1,24 +1,75 @@
-// Drains pending proactive onboarding greetings for the Discord gateway with
-// service-to-service auth. The gateway leader polls this route and delivers
-// each claimed greeting as a proactive DM; claiming is atomic in the
-// coordinator (at-most-once), so the gateway never double-sends.
+/**
+ * Leases and acknowledges proactive onboarding greetings for the authenticated
+ * Discord gateway leader without deleting work before external delivery.
+ */
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { drainDiscordProactiveGreetings } from "@/lib/services/eliza-app/onboarding-proactive-greeting";
+import {
+  acknowledgeDiscordProactiveGreetings,
+  drainDiscordProactiveGreetings,
+} from "@/lib/services/eliza-app/onboarding-proactive-greeting";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
 
 const app = new Hono<AppEnv>();
 
+interface Acknowledgement {
+  sessionId: string;
+  leaseId: string;
+}
+
+function parseAcknowledgements(value: unknown): Acknowledgement[] | null {
+  if (!Array.isArray(value) || value.length > 50) return null;
+  const parsed: Acknowledgement[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") return null;
+    const { sessionId, leaseId } = entry as Record<string, unknown>;
+    if (
+      typeof sessionId !== "string" ||
+      sessionId.length < 8 ||
+      sessionId.length > 180 ||
+      typeof leaseId !== "string" ||
+      !/^[A-Za-z0-9_-]{1,25}$/.test(leaseId)
+    ) {
+      return null;
+    }
+    parsed.push({ sessionId, leaseId });
+  }
+  return parsed;
+}
+
 app.post("/", async (c) => {
   try {
     const auth = await requireInternalAuth(c);
     if (auth instanceof Response) return auth;
 
+    // error-policy:J3 Invalid JSON is an explicit invalid request below.
+    const body: unknown = await c.req.json().catch(() => null);
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return c.json({ error: "Invalid greeting request" }, 400);
+    }
+    const action =
+      "action" in body ? (body as { action?: unknown }).action : undefined;
+    if (action === "ack") {
+      const acknowledgements = parseAcknowledgements(
+        (body as { acknowledgements?: unknown }).acknowledgements,
+      );
+      if (!acknowledgements) {
+        return c.json({ error: "Invalid greeting acknowledgements" }, 400);
+      }
+      const acknowledged =
+        await acknowledgeDiscordProactiveGreetings(acknowledgements);
+      return c.json({ acknowledged });
+    }
+    if (action !== undefined && action !== "claim") {
+      return c.json({ error: "Invalid greeting action" }, 400);
+    }
     const greetings = await drainDiscordProactiveGreetings();
     return c.json({ greetings });
   } catch (err) {
+    // error-policy:J1 This authenticated transport boundary returns the
+    // standard structured cloud failure without fabricating queue success.
     logger.error("[internal/discord/eliza-app/pending-greetings]", {
       error: err,
     });

--- a/packages/cloud/api/src/_router.generated.ts
+++ b/packages/cloud/api/src/_router.generated.ts
@@ -135,6 +135,7 @@ import _route_health_route from "../health/route";
 import _route_internal_auth_refresh_route from "../internal/auth/refresh/route";
 import _route_internal_auth_token_route from "../internal/auth/token/route";
 import _route_internal_discord_eliza_app_messages_route from "../internal/discord/eliza-app/messages/route";
+import _route_internal_discord_eliza_app_pending_greetings_route from "../internal/discord/eliza-app/pending-greetings/route";
 import _route_internal_discord_events_route from "../internal/discord/events/route";
 import _route_internal_discord_gateway_assignments_route from "../internal/discord/gateway/assignments/route";
 import _route_internal_discord_gateway_failover_route from "../internal/discord/gateway/failover/route";
@@ -978,6 +979,10 @@ export function mountRoutes(app: Hono<AppEnv>): void {
   app.route(
     "/api/internal/discord/eliza-app/messages",
     _route_internal_discord_eliza_app_messages_route,
+  );
+  app.route(
+    "/api/internal/discord/eliza-app/pending-greetings",
+    _route_internal_discord_eliza_app_pending_greetings_route,
   );
   app.route(
     "/api/internal/discord/events",

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -651,14 +651,23 @@ export class OnboardingSessionCoordinator {
         await transaction.setAlarm(replay.expiresAt);
       }
     });
-    await this.bindContinuation(result.session);
     // Commit ordering for the false-success DM hazard: the storage
     // transaction above is the turn's durable commit. Only now — with the
     // userId binding persisted — may the recorded greeting enqueue. A turn
     // that threw before this point (for example a provisioning outage) never
     // reaches here, so the user is never told "you're all set" for a sign-in
     // that did not durably complete. Enqueue itself stays best-effort.
+    //
+    // The enqueue runs BEFORE the fallible cross-DO `bindContinuation` below.
+    // If it ran after, a transient /bind failure would permanently suppress
+    // the greeting: the failed turn's retry lands in the replay branch (which
+    // stores the stripped, committed shape and must never re-enqueue), and a
+    // fresh-key retry sees an already-bound session and records no handoff.
+    // Enqueue-then-bind is safe in the failure direction: the sign-in itself
+    // IS durably committed at this point, so greeting a user whose
+    // continuation re-bind needs one more retry is correct, not premature.
     const committed = await deliverCommittedProactiveGreeting(result);
+    await this.bindContinuation(result.session);
     await this.mirrorSessionBestEffort(committed.session);
     return committed;
   }

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -55,13 +55,17 @@ const GREETING_KEY_PREFIX = "greeting:";
 // Mirrors GREETING_TTL_MS in onboarding-proactive-greeting.ts: stale greetings
 // are dropped at drain time, never delivered.
 const GREETING_TTL_MS = 15 * 60 * 1000;
+const GREETING_LEASE_MS = 2 * 60 * 1000;
 const GREETING_DRAIN_LIMIT_MAX = 50;
+const GREETING_SCAN_LIMIT = 128;
 
 interface StoredGreeting {
   sessionId: string;
   platformUserId: string;
   message: string;
   createdAt: string;
+  deliveryNonce: string;
+  lease?: { id: string; expiresAt: number };
 }
 
 function isValidGreeting(value: unknown): value is StoredGreeting {
@@ -78,8 +82,28 @@ function isValidGreeting(value: unknown): value is StoredGreeting {
     record.message.length >= 1 &&
     record.message.length <= 2000 &&
     typeof record.createdAt === "string" &&
-    Number.isFinite(Date.parse(record.createdAt))
+    Number.isFinite(Date.parse(record.createdAt)) &&
+    typeof record.deliveryNonce === "string" &&
+    /^[A-Za-z0-9_-]{1,25}$/.test(record.deliveryNonce) &&
+    (record.lease === undefined || isValidGreetingLease(record.lease))
   );
+}
+
+function isValidGreetingLease(
+  value: unknown,
+): value is StoredGreeting["lease"] {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    /^[A-Za-z0-9_-]{1,25}$/.test(record.id) &&
+    typeof record.expiresAt === "number" &&
+    Number.isFinite(record.expiresAt)
+  );
+}
+
+function greetingLeaseId(): string {
+  return crypto.randomUUID().replaceAll("-", "").slice(0, 25);
 }
 const REPLAY_KEY_PREFIX = "replay:";
 const REPLAY_CLEANUP_STATE_KEY = "replay-cleanup-state";
@@ -477,7 +501,7 @@ export class OnboardingSessionCoordinator {
 
   /**
    * Records a pending proactive greeting, keyed by session id (set semantics:
-   * a replayed authenticated turn overwrites rather than duplicates). Lives on
+   * a replayed authenticated turn is a no-op rather than a duplicate). Lives on
    * the well-known `proactive-greetings:<platform>` instance, not per-session
    * coordinators, so one drain call claims the whole platform queue.
    */
@@ -486,18 +510,16 @@ export class OnboardingSessionCoordinator {
     if (!isValidGreeting(body)) {
       return Response.json({ error: "Invalid greeting" }, { status: 400 });
     }
-    await this.state.storage.put(
-      `${GREETING_KEY_PREFIX}${storageComponent(body.sessionId)}`,
-      body,
-    );
+    const key = `${GREETING_KEY_PREFIX}${storageComponent(body.sessionId)}`;
+    const existing = await this.state.storage.get<StoredGreeting>(key);
+    if (!isValidGreeting(existing)) await this.state.storage.put(key, body);
     return Response.json({ success: true });
   }
 
   /**
-   * Atomically claims pending greetings: entries are deleted in the same
-   * serialized Durable Object operation that returns them, so exactly one
-   * drain caller ever sees each greeting (at-most-once delivery). Expired
-   * entries are deleted and dropped, never returned.
+   * Atomically leases pending greetings. A live lease excludes competing
+   * pollers, but the entry remains durable until a matching acknowledgement;
+   * a crash or lost response therefore becomes recoverable after lease expiry.
    */
   private async drainGreetings(request: Request): Promise<Response> {
     const body: unknown = await request.json();
@@ -511,29 +533,72 @@ export class OnboardingSessionCoordinator {
         : GREETING_DRAIN_LIMIT_MAX;
     const entries = await this.state.storage.list<StoredGreeting>({
       prefix: GREETING_KEY_PREFIX,
-      limit,
+      limit: GREETING_SCAN_LIMIT,
     });
     const now = Date.now();
-    const claimed: StoredGreeting[] = [];
+    const claimed: Array<StoredGreeting & { leaseId: string }> = [];
     const deletions: string[] = [];
     for (const [key, entry] of entries) {
-      deletions.push(key);
       if (
         !isValidGreeting(entry) ||
         now - Date.parse(entry.createdAt) > GREETING_TTL_MS
       ) {
+        deletions.push(key);
         logger.warn(
           "[OnboardingSessionCoordinator] dropped stale proactive greeting",
           { key },
         );
         continue;
       }
-      claimed.push(entry);
+      if (claimed.length >= limit) continue;
+      if (entry.lease && entry.lease.expiresAt > now) continue;
+      const leaseId = greetingLeaseId();
+      const leased = {
+        ...entry,
+        lease: { id: leaseId, expiresAt: now + GREETING_LEASE_MS },
+      };
+      await this.state.storage.put(key, leased);
+      claimed.push({ ...entry, leaseId });
     }
     if (deletions.length > 0) {
       await this.state.storage.delete(deletions);
     }
     return Response.json({ greetings: claimed });
+  }
+
+  /** Deletes only greetings still owned by the acknowledging lease. */
+  private async acknowledgeGreetings(request: Request): Promise<Response> {
+    const body: unknown = await request.json();
+    const acknowledgements =
+      body && typeof body === "object" && "acknowledgements" in body
+        ? (body as { acknowledgements?: unknown }).acknowledgements
+        : undefined;
+    if (!Array.isArray(acknowledgements) || acknowledgements.length > 50) {
+      return Response.json(
+        { error: "Invalid greeting acknowledgements" },
+        { status: 400 },
+      );
+    }
+    let acknowledged = 0;
+    for (const value of acknowledgements) {
+      if (!value || typeof value !== "object") continue;
+      const { sessionId, leaseId } = value as Record<string, unknown>;
+      if (
+        typeof sessionId !== "string" ||
+        sessionId.length < 8 ||
+        sessionId.length > 180 ||
+        typeof leaseId !== "string" ||
+        !/^[A-Za-z0-9_-]{1,25}$/.test(leaseId)
+      ) {
+        continue;
+      }
+      const key = `${GREETING_KEY_PREFIX}${storageComponent(sessionId)}`;
+      const entry = await this.state.storage.get<StoredGreeting>(key);
+      if (!isValidGreeting(entry) || entry.lease?.id !== leaseId) continue;
+      await this.state.storage.delete(key);
+      acknowledged += 1;
+    }
+    return Response.json({ acknowledged });
   }
 
   private async mirrorSessionBestEffort(
@@ -730,6 +795,9 @@ export class OnboardingSessionCoordinator {
         }
         if (pathname === "/drain-greetings") {
           return this.drainGreetings(request);
+        }
+        if (pathname === "/ack-greetings") {
+          return this.acknowledgeGreetings(request);
         }
         if (pathname === "/complete-claim") {
           return this.completeContinuationClaim(request);

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -51,6 +51,36 @@ interface StoredSession extends Omit<OnboardingSession, "history"> {
 
 const SESSION_KEY_PREFIX = "session:";
 const HISTORY_KEY_PREFIX = "history:";
+const GREETING_KEY_PREFIX = "greeting:";
+// Mirrors GREETING_TTL_MS in onboarding-proactive-greeting.ts: stale greetings
+// are dropped at drain time, never delivered.
+const GREETING_TTL_MS = 15 * 60 * 1000;
+const GREETING_DRAIN_LIMIT_MAX = 50;
+
+interface StoredGreeting {
+  sessionId: string;
+  platformUserId: string;
+  message: string;
+  createdAt: string;
+}
+
+function isValidGreeting(value: unknown): value is StoredGreeting {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.sessionId === "string" &&
+    record.sessionId.length >= 8 &&
+    record.sessionId.length <= 180 &&
+    typeof record.platformUserId === "string" &&
+    record.platformUserId.length >= 1 &&
+    record.platformUserId.length <= 64 &&
+    typeof record.message === "string" &&
+    record.message.length >= 1 &&
+    record.message.length <= 2000 &&
+    typeof record.createdAt === "string" &&
+    Number.isFinite(Date.parse(record.createdAt))
+  );
+}
 const REPLAY_KEY_PREFIX = "replay:";
 const REPLAY_CLEANUP_STATE_KEY = "replay-cleanup-state";
 const LEGACY_LEDGER_KEY = "ledger";
@@ -445,6 +475,67 @@ export class OnboardingSessionCoordinator {
     return Response.json({ status: "completed" });
   }
 
+  /**
+   * Records a pending proactive greeting, keyed by session id (set semantics:
+   * a replayed authenticated turn overwrites rather than duplicates). Lives on
+   * the well-known `proactive-greetings:<platform>` instance, not per-session
+   * coordinators, so one drain call claims the whole platform queue.
+   */
+  private async enqueueGreeting(request: Request): Promise<Response> {
+    const body: unknown = await request.json();
+    if (!isValidGreeting(body)) {
+      return Response.json({ error: "Invalid greeting" }, { status: 400 });
+    }
+    await this.state.storage.put(
+      `${GREETING_KEY_PREFIX}${storageComponent(body.sessionId)}`,
+      body,
+    );
+    return Response.json({ success: true });
+  }
+
+  /**
+   * Atomically claims pending greetings: entries are deleted in the same
+   * serialized Durable Object operation that returns them, so exactly one
+   * drain caller ever sees each greeting (at-most-once delivery). Expired
+   * entries are deleted and dropped, never returned.
+   */
+  private async drainGreetings(request: Request): Promise<Response> {
+    const body: unknown = await request.json();
+    const requested =
+      body && typeof body === "object" && "limit" in body
+        ? Number((body as { limit?: unknown }).limit)
+        : Number.NaN;
+    const limit =
+      Number.isInteger(requested) && requested > 0
+        ? Math.min(requested, GREETING_DRAIN_LIMIT_MAX)
+        : GREETING_DRAIN_LIMIT_MAX;
+    const entries = await this.state.storage.list<StoredGreeting>({
+      prefix: GREETING_KEY_PREFIX,
+      limit,
+    });
+    const now = Date.now();
+    const claimed: StoredGreeting[] = [];
+    const deletions: string[] = [];
+    for (const [key, entry] of entries) {
+      deletions.push(key);
+      if (
+        !isValidGreeting(entry) ||
+        now - Date.parse(entry.createdAt) > GREETING_TTL_MS
+      ) {
+        logger.warn(
+          "[OnboardingSessionCoordinator] dropped stale proactive greeting",
+          { key },
+        );
+        continue;
+      }
+      claimed.push(entry);
+    }
+    if (deletions.length > 0) {
+      await this.state.storage.delete(deletions);
+    }
+    return Response.json({ greetings: claimed });
+  }
+
   private async mirrorSessionBestEffort(
     session: OnboardingSession,
   ): Promise<void> {
@@ -610,6 +701,12 @@ export class OnboardingSessionCoordinator {
         }
         if (pathname === "/claim") {
           return this.claimContinuation(request);
+        }
+        if (pathname === "/enqueue-greeting") {
+          return this.enqueueGreeting(request);
+        }
+        if (pathname === "/drain-greetings") {
+          return this.drainGreetings(request);
         }
         if (pathname === "/complete-claim") {
           return this.completeContinuationClaim(request);

--- a/packages/cloud/api/src/onboarding-session-coordinator.ts
+++ b/packages/cloud/api/src/onboarding-session-coordinator.ts
@@ -563,6 +563,7 @@ export class OnboardingSessionCoordinator {
     // bootstrap boundary used by the main Hono application.
     const {
       assertTrustedTelegramContinuation,
+      deliverCommittedProactiveGreeting,
       loadCachedOnboardingSession,
       runOnboardingChatWithStore,
     } = await import("@/lib/services/eliza-app/onboarding-chat");
@@ -619,8 +620,14 @@ export class OnboardingSessionCoordinator {
     );
 
     const writes = storedSessionEntries(scope, result.session);
+    // The replay ledger stores the COMMITTED shape of the result: the
+    // greeting handoff is stripped below before this turn returns, and a
+    // replayed turn must never re-enqueue a greeting.
     const replay = request.input.idempotencyKey
-      ? storedReplay(request.input.idempotencyKey, result)
+      ? storedReplay(request.input.idempotencyKey, {
+          ...result,
+          proactiveGreeting: undefined,
+        })
       : undefined;
     if (replay) {
       writes[replayStorageKey(scope, replay.key, request.input)] = replay;
@@ -645,8 +652,15 @@ export class OnboardingSessionCoordinator {
       }
     });
     await this.bindContinuation(result.session);
-    await this.mirrorSessionBestEffort(result.session);
-    return result;
+    // Commit ordering for the false-success DM hazard: the storage
+    // transaction above is the turn's durable commit. Only now — with the
+    // userId binding persisted — may the recorded greeting enqueue. A turn
+    // that threw before this point (for example a provisioning outage) never
+    // reaches here, so the user is never told "you're all set" for a sign-in
+    // that did not durably complete. Enqueue itself stays best-effort.
+    const committed = await deliverCommittedProactiveGreeting(result);
+    await this.mirrorSessionBestEffort(committed.session);
+    return committed;
   }
 
   async alarm(): Promise<void> {

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -345,6 +345,12 @@ export class GatewayManager {
   private isElizaAppLeader: boolean = false;
   /** Interval for draining pending proactive onboarding greetings (leader only) */
   private greetingPollInterval: NodeJS.Timeout | null = null;
+  /**
+   * The currently running greeting drain, if any. Teardown paths await this
+   * BEFORE destroying the Discord client: the API deletes entries at claim
+   * time, so a batch interrupted between claim and send is permanently lost.
+   */
+  private greetingDrainInFlight: Promise<void> | null = null;
   /** Interval for leader election checks */
   private elizaAppLeaderInterval: NodeJS.Timeout | null = null;
 
@@ -575,6 +581,15 @@ export class GatewayManager {
     if (this.elizaAppLeaderInterval) clearInterval(this.elizaAppLeaderInterval);
     if (this.greetingPollInterval) clearInterval(this.greetingPollInterval);
     this.voiceHandler.stopCleanupJob();
+
+    // Settle any claimed-but-unsent greeting batch before the client goes
+    // away: the API deletes entries at claim time, so interrupting between
+    // claim and send loses those DMs permanently (intervals above are already
+    // cleared, so no new drain can start).
+    if (this.greetingDrainInFlight) {
+      await this.greetingDrainInFlight;
+      this.greetingDrainInFlight = null;
+    }
 
     // Release Eliza App bot leadership for faster failover
     if (this.isElizaAppLeader && this.redis) {
@@ -1927,6 +1942,13 @@ export class GatewayManager {
       clearInterval(this.greetingPollInterval);
       this.greetingPollInterval = null;
     }
+    // A claimed batch is already deleted server-side; destroying the client
+    // mid-send would lose those DMs permanently. Settle the in-flight drain
+    // first (its own errors are handled inside the drain promise).
+    if (this.greetingDrainInFlight) {
+      await this.greetingDrainInFlight;
+      this.greetingDrainInFlight = null;
+    }
     if (this.elizaAppClient) {
       logger.info("Disconnecting Eliza App bot", {
         podName: this.config.podName,
@@ -1945,11 +1967,21 @@ export class GatewayManager {
   private startGreetingPolling(): void {
     if (this.greetingPollInterval) return;
     this.greetingPollInterval = setInterval(() => {
-      this.drainAndDeliverGreetings().catch((error) => {
-        logger.error("Error draining proactive onboarding greetings", {
-          error: sanitizeError(error),
+      // Skip if the previous drain is still running; never claim a second
+      // batch while one is in flight.
+      if (this.greetingDrainInFlight) return;
+      const drain = this.drainAndDeliverGreetings()
+        .catch((error) => {
+          logger.error("Error draining proactive onboarding greetings", {
+            error: sanitizeError(error),
+          });
+        })
+        .finally(() => {
+          if (this.greetingDrainInFlight === drain) {
+            this.greetingDrainInFlight = null;
+          }
         });
-      });
+      this.greetingDrainInFlight = drain;
     }, GREETING_POLL_INTERVAL_MS);
     logger.info("Proactive onboarding greeting polling started", {
       podName: this.config.podName,

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -25,7 +25,10 @@ import {
   deliverManagedReply,
   postManagedAgentMessageWithRetry,
 } from "./managed-message-egress";
-import { drainAndDeliverGreetings as drainAndDeliverPendingGreetings } from "./proactive-greeting-delivery";
+import {
+  drainAndDeliverGreetings as drainAndDeliverPendingGreetings,
+  isTerminalDiscordDirectMessageError,
+} from "./proactive-greeting-delivery";
 import { createMockRedis, createNativeRedis } from "./redis-adapter";
 import {
   buildManagedFailureReplyOptions,
@@ -198,7 +201,8 @@ const ELIZA_APP_LEADER_TTL_SECONDS = 10;
 /**
  * Interval between drains of pending proactive onboarding greetings
  * (15 seconds). Only the Eliza App bot leader polls, and the API claims
- * entries atomically, so each greeting is delivered at most once.
+ * entries atomically. A stable enforced Discord nonce makes lease retries
+ * idempotent if the gateway loses the acknowledgement response.
  */
 const GREETING_POLL_INTERVAL_MS = parseIntEnv(
   "GREETING_POLL_INTERVAL_MS",
@@ -346,9 +350,9 @@ export class GatewayManager {
   /** Interval for draining pending proactive onboarding greetings (leader only) */
   private greetingPollInterval: NodeJS.Timeout | null = null;
   /**
-   * The currently running greeting drain, if any. Teardown paths await this
-   * BEFORE destroying the Discord client: the API deletes entries at claim
-   * time, so a batch interrupted between claim and send is permanently lost.
+   * The currently running greeting drain, if any. Polling never overlaps it;
+   * graceful teardown lets it finish promptly, while the durable lease and
+   * provider nonce also recover correctly from abrupt process termination.
    */
   private greetingDrainInFlight: Promise<void> | null = null;
   /** Interval for leader election checks */
@@ -582,10 +586,9 @@ export class GatewayManager {
     if (this.greetingPollInterval) clearInterval(this.greetingPollInterval);
     this.voiceHandler.stopCleanupJob();
 
-    // Settle any claimed-but-unsent greeting batch before the client goes
-    // away: the API deletes entries at claim time, so interrupting between
-    // claim and send loses those DMs permanently (intervals above are already
-    // cleared, so no new drain can start).
+    // Let an in-flight delivery acknowledge before disconnecting. This is an
+    // optimization, not the durability mechanism: abrupt termination leaves
+    // the lease recoverable and the provider nonce makes a retry idempotent.
     if (this.greetingDrainInFlight) {
       await this.greetingDrainInFlight;
       this.greetingDrainInFlight = null;
@@ -1942,9 +1945,8 @@ export class GatewayManager {
       clearInterval(this.greetingPollInterval);
       this.greetingPollInterval = null;
     }
-    // A claimed batch is already deleted server-side; destroying the client
-    // mid-send would lose those DMs permanently. Settle the in-flight drain
-    // first (its own errors are handled inside the drain promise).
+    // Let an in-flight delivery acknowledge before disconnecting. A crash or
+    // forced shutdown remains safe through lease expiry and nonce deduplication.
     if (this.greetingDrainInFlight) {
       await this.greetingDrainInFlight;
       this.greetingDrainInFlight = null;
@@ -1972,6 +1974,8 @@ export class GatewayManager {
       if (this.greetingDrainInFlight) return;
       const drain = this.drainAndDeliverGreetings()
         .catch((error) => {
+          // error-policy:J1 This timer callback is the background-job boundary;
+          // lease recovery preserves unacknowledged work for the next poll.
           logger.error("Error draining proactive onboarding greetings", {
             error: sanitizeError(error),
           });
@@ -1991,7 +1995,7 @@ export class GatewayManager {
 
   /**
    * Claims pending post-sign-in greetings from the API and delivers each as a
-   * proactive DM. At-most-once semantics live in
+   * proactive DM. Recoverable lease/ack semantics live in
    * {@link drainAndDeliverPendingGreetings}; this wrapper binds the production
    * fetch/auth/send closures.
    */
@@ -2009,13 +2013,31 @@ export class GatewayManager {
               "Content-Type": "application/json",
               ...this.getAuthHeader(),
             },
-            body: JSON.stringify({}),
+            body: JSON.stringify({ action: "claim" }),
             timeout: HTTP_TIMEOUT_MS,
           },
         ),
-      sendDirectMessage: async (userId, content) => {
-        await client.users.send(userId, content);
+      acknowledge: (acknowledgements) =>
+        fetchWithTimeout(
+          `${this.config.elizaCloudUrl}/api/internal/discord/eliza-app/pending-greetings`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...this.getAuthHeader(),
+            },
+            body: JSON.stringify({ action: "ack", acknowledgements }),
+            timeout: HTTP_TIMEOUT_MS,
+          },
+        ),
+      sendDirectMessage: async (userId, content, deliveryNonce) => {
+        await client.users.send(userId, {
+          content,
+          nonce: deliveryNonce,
+          enforceNonce: true,
+        });
       },
+      isTerminalError: isTerminalDiscordDirectMessageError,
       refreshAuth: () => this.refreshToken(),
       onEvent: (event) => {
         if (event.kind === "delivered") {
@@ -2031,10 +2053,17 @@ export class GatewayManager {
           logger.warn("Skipping malformed proactive greeting", {
             sessionId: event.sessionId ?? null,
           });
-        } else {
+        } else if (event.kind === "drain-failed") {
           logger.warn("Proactive greeting drain returned non-OK status", {
             status: event.status,
           });
+        } else {
+          logger.warn(
+            "Proactive greeting acknowledgement returned non-OK status",
+            {
+              status: event.status,
+            },
+          );
         }
       },
     });

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -25,6 +25,7 @@ import {
   deliverManagedReply,
   postManagedAgentMessageWithRetry,
 } from "./managed-message-egress";
+import { drainAndDeliverGreetings as drainAndDeliverPendingGreetings } from "./proactive-greeting-delivery";
 import { createMockRedis, createNativeRedis } from "./redis-adapter";
 import {
   buildManagedFailureReplyOptions,
@@ -194,6 +195,16 @@ const ELIZA_APP_LEADER_KEY =
 /** Leader election lock TTL in seconds (10 seconds) */
 const ELIZA_APP_LEADER_TTL_SECONDS = 10;
 
+/**
+ * Interval between drains of pending proactive onboarding greetings
+ * (15 seconds). Only the Eliza App bot leader polls, and the API claims
+ * entries atomically, so each greeting is delivered at most once.
+ */
+const GREETING_POLL_INTERVAL_MS = parseIntEnv(
+  "GREETING_POLL_INTERVAL_MS",
+  15_000,
+);
+
 /** How often to check/renew leadership (3 seconds) */
 const ELIZA_APP_LEADER_CHECK_INTERVAL_MS = 3000;
 
@@ -332,6 +343,8 @@ export class GatewayManager {
   private elizaAppClient: Client | null = null;
   /** Whether this pod is the Eliza App bot leader */
   private isElizaAppLeader: boolean = false;
+  /** Interval for draining pending proactive onboarding greetings (leader only) */
+  private greetingPollInterval: NodeJS.Timeout | null = null;
   /** Interval for leader election checks */
   private elizaAppLeaderInterval: NodeJS.Timeout | null = null;
 
@@ -560,6 +573,7 @@ export class GatewayManager {
     if (this.failoverInterval) clearInterval(this.failoverInterval);
     if (this.tokenRefreshTimeout) clearTimeout(this.tokenRefreshTimeout);
     if (this.elizaAppLeaderInterval) clearInterval(this.elizaAppLeaderInterval);
+    if (this.greetingPollInterval) clearInterval(this.greetingPollInterval);
     this.voiceHandler.stopCleanupJob();
 
     // Release Eliza App bot leadership for faster failover
@@ -1870,6 +1884,7 @@ export class GatewayManager {
         username: this.elizaAppClient?.user?.username,
         userId: this.elizaAppClient?.user?.id,
       });
+      this.startGreetingPolling();
     });
 
     this.elizaAppClient.on(Events.MessageCreate, async (message: Message) => {
@@ -1908,6 +1923,10 @@ export class GatewayManager {
    * Disconnect the Eliza App bot.
    */
   private async disconnectElizaAppBot(): Promise<void> {
+    if (this.greetingPollInterval) {
+      clearInterval(this.greetingPollInterval);
+      this.greetingPollInterval = null;
+    }
     if (this.elizaAppClient) {
       logger.info("Disconnecting Eliza App bot", {
         podName: this.config.podName,
@@ -1915,6 +1934,78 @@ export class GatewayManager {
       this.elizaAppClient.destroy();
       this.elizaAppClient = null;
     }
+  }
+
+  /**
+   * Start the proactive-greeting drain loop. Leader-only (called from
+   * connectElizaAppBot): the API's claim is atomic, but a single poller
+   * avoids pointless contention and keeps DM sends on the pod that owns the
+   * bot connection.
+   */
+  private startGreetingPolling(): void {
+    if (this.greetingPollInterval) return;
+    this.greetingPollInterval = setInterval(() => {
+      this.drainAndDeliverGreetings().catch((error) => {
+        logger.error("Error draining proactive onboarding greetings", {
+          error: sanitizeError(error),
+        });
+      });
+    }, GREETING_POLL_INTERVAL_MS);
+    logger.info("Proactive onboarding greeting polling started", {
+      podName: this.config.podName,
+      intervalMs: GREETING_POLL_INTERVAL_MS,
+    });
+  }
+
+  /**
+   * Claims pending post-sign-in greetings from the API and delivers each as a
+   * proactive DM. At-most-once semantics live in
+   * {@link drainAndDeliverPendingGreetings}; this wrapper binds the production
+   * fetch/auth/send closures.
+   */
+  private async drainAndDeliverGreetings(): Promise<void> {
+    const client = this.elizaAppClient;
+    if (!this.isElizaAppLeader || !client?.isReady()) return;
+
+    await drainAndDeliverPendingGreetings({
+      drain: () =>
+        fetchWithTimeout(
+          `${this.config.elizaCloudUrl}/api/internal/discord/eliza-app/pending-greetings`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...this.getAuthHeader(),
+            },
+            body: JSON.stringify({}),
+            timeout: HTTP_TIMEOUT_MS,
+          },
+        ),
+      sendDirectMessage: async (userId, content) => {
+        await client.users.send(userId, content);
+      },
+      refreshAuth: () => this.refreshToken(),
+      onEvent: (event) => {
+        if (event.kind === "delivered") {
+          logger.info("Delivered proactive onboarding greeting", {
+            sessionId: event.sessionId ?? null,
+          });
+        } else if (event.kind === "send-failed") {
+          logger.warn("Failed to deliver proactive onboarding greeting", {
+            sessionId: event.sessionId ?? null,
+            error: sanitizeError(event.error),
+          });
+        } else if (event.kind === "malformed") {
+          logger.warn("Skipping malformed proactive greeting", {
+            sessionId: event.sessionId ?? null,
+          });
+        } else {
+          logger.warn("Proactive greeting drain returned non-OK status", {
+            status: event.status,
+          });
+        }
+      },
+    });
   }
 
   /**

--- a/packages/cloud/services/gateway-discord/src/proactive-greeting-delivery.ts
+++ b/packages/cloud/services/gateway-discord/src/proactive-greeting-delivery.ts
@@ -1,0 +1,109 @@
+/**
+ * Delivers proactive post-sign-in onboarding greetings claimed from the cloud
+ * API. The API's drain endpoint removes entries atomically before returning
+ * them (at-most-once), so delivery here never retries a failed DM send:
+ * re-queueing on the gateway side would reintroduce the double-send class the
+ * atomic claim exists to prevent. Callers supply fetch/send/auth closures the
+ * same way managed-message-egress does.
+ */
+
+export interface PendingGreeting {
+  sessionId?: string;
+  platformUserId?: string;
+  message?: string;
+}
+
+export interface GreetingDeliveryReport {
+  claimed: number;
+  delivered: number;
+  malformed: number;
+  failed: number;
+  /** True when the drain response required an auth refresh (401). */
+  authRefreshed: boolean;
+}
+
+function parsePendingGreetings(body: unknown): PendingGreeting[] {
+  if (!body || typeof body !== "object") return [];
+  const greetings = (body as { greetings?: unknown }).greetings;
+  if (!Array.isArray(greetings)) return [];
+  return greetings.filter(
+    (entry): entry is PendingGreeting =>
+      Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
+  );
+}
+
+/** Discord hard cap on message content length. */
+const MAX_DM_LENGTH = 2000;
+
+/**
+ * Claims pending greetings via `drain` and sends each with `sendDirectMessage`.
+ *
+ * - 401 from the drain: `refreshAuth` runs and the batch is skipped; the
+ *   entries were never claimed, so the next poll delivers them.
+ * - Non-OK drain status: reported, nothing claimed, nothing lost.
+ * - Send failure: logged via the report; the entry is already claimed, so a
+ *   user with closed DMs (Discord 50007) or a deleted account is terminal.
+ */
+export async function drainAndDeliverGreetings(options: {
+  drain: () => Promise<Response>;
+  sendDirectMessage: (userId: string, content: string) => Promise<void>;
+  refreshAuth?: () => Promise<void>;
+  onEvent?: (event: {
+    kind: "drain-failed" | "malformed" | "delivered" | "send-failed";
+    sessionId?: string | null;
+    status?: number;
+    error?: unknown;
+  }) => void;
+}): Promise<GreetingDeliveryReport> {
+  const report: GreetingDeliveryReport = {
+    claimed: 0,
+    delivered: 0,
+    malformed: 0,
+    failed: 0,
+    authRefreshed: false,
+  };
+
+  const response = await options.drain();
+  if (response.status === 401) {
+    report.authRefreshed = true;
+    await options.refreshAuth?.();
+    return report;
+  }
+  if (!response.ok) {
+    options.onEvent?.({ kind: "drain-failed", status: response.status });
+    return report;
+  }
+
+  const greetings = parsePendingGreetings(await response.json());
+  report.claimed = greetings.length;
+
+  for (const greeting of greetings) {
+    const userId = greeting.platformUserId;
+    const content = greeting.message?.trim().slice(0, MAX_DM_LENGTH);
+    if (!userId || !content) {
+      report.malformed += 1;
+      options.onEvent?.({
+        kind: "malformed",
+        sessionId: greeting.sessionId ?? null,
+      });
+      continue;
+    }
+    try {
+      await options.sendDirectMessage(userId, content);
+      report.delivered += 1;
+      options.onEvent?.({
+        kind: "delivered",
+        sessionId: greeting.sessionId ?? null,
+      });
+    } catch (error) {
+      report.failed += 1;
+      options.onEvent?.({
+        kind: "send-failed",
+        sessionId: greeting.sessionId ?? null,
+        error,
+      });
+    }
+  }
+
+  return report;
+}

--- a/packages/cloud/services/gateway-discord/src/proactive-greeting-delivery.ts
+++ b/packages/cloud/services/gateway-discord/src/proactive-greeting-delivery.ts
@@ -1,16 +1,17 @@
 /**
  * Delivers proactive post-sign-in onboarding greetings claimed from the cloud
- * API. The API's drain endpoint removes entries atomically before returning
- * them (at-most-once), so delivery here never retries a failed DM send:
- * re-queueing on the gateway side would reintroduce the double-send class the
- * atomic claim exists to prevent. Callers supply fetch/send/auth closures the
- * same way managed-message-egress does.
+ * API. The API leases rather than deletes each entry; successful and
+ * definitively terminal sends are acknowledged, while retryable/ambiguous
+ * failures become claimable after lease expiry. The gateway supplies the
+ * entry's stable nonce with `enforceNonce`, making provider retries idempotent.
  */
 
 export interface PendingGreeting {
   sessionId?: string;
   platformUserId?: string;
   message?: string;
+  leaseId?: string;
+  deliveryNonce?: string;
 }
 
 export interface GreetingDeliveryReport {
@@ -18,6 +19,8 @@ export interface GreetingDeliveryReport {
   delivered: number;
   malformed: number;
   failed: number;
+  acknowledged: number;
+  retainedForRetry: number;
   /** True when the drain response required an auth refresh (401). */
   authRefreshed: boolean;
 }
@@ -36,20 +39,56 @@ function parsePendingGreetings(body: unknown): PendingGreeting[] {
 const MAX_DM_LENGTH = 2000;
 
 /**
- * Claims pending greetings via `drain` and sends each with `sendDirectMessage`.
+ * True only when Discord definitively rejected a DM in a way retrying this
+ * short-lived greeting cannot repair. Rate limits, 5xx responses, and network
+ * failures remain recoverable through the queue lease and enforced nonce.
+ */
+export function isTerminalDiscordDirectMessageError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const record = error as Record<string, unknown>;
+  const raw =
+    record.rawError && typeof record.rawError === "object"
+      ? (record.rawError as Record<string, unknown>)
+      : undefined;
+  const code = typeof record.code === "number" ? record.code : raw?.code;
+  if (code === 50007 || code === 10013) return true;
+  const status =
+    typeof record.status === "number"
+      ? record.status
+      : typeof record.statusCode === "number"
+        ? record.statusCode
+        : undefined;
+  return status === 400 || status === 403 || status === 404;
+}
+
+/**
+ * Leases pending greetings and sends each with a stable provider nonce.
  *
  * - 401 from the drain: `refreshAuth` runs and the batch is skipped; the
  *   entries were never claimed, so the next poll delivers them.
  * - Non-OK drain status: reported, nothing claimed, nothing lost.
- * - Send failure: logged via the report; the entry is already claimed, so a
- *   user with closed DMs (Discord 50007) or a deleted account is terminal.
+ * - Delivered and definitively terminal entries are acknowledged.
+ * - Retryable or ambiguous failures retain their entry for lease recovery.
  */
 export async function drainAndDeliverGreetings(options: {
   drain: () => Promise<Response>;
-  sendDirectMessage: (userId: string, content: string) => Promise<void>;
+  acknowledge: (
+    acknowledgements: Array<{ sessionId: string; leaseId: string }>,
+  ) => Promise<Response>;
+  sendDirectMessage: (
+    userId: string,
+    content: string,
+    deliveryNonce: string,
+  ) => Promise<void>;
+  isTerminalError?: (error: unknown) => boolean;
   refreshAuth?: () => Promise<void>;
   onEvent?: (event: {
-    kind: "drain-failed" | "malformed" | "delivered" | "send-failed";
+    kind:
+      | "drain-failed"
+      | "ack-failed"
+      | "malformed"
+      | "delivered"
+      | "send-failed";
     sessionId?: string | null;
     status?: number;
     error?: unknown;
@@ -60,6 +99,8 @@ export async function drainAndDeliverGreetings(options: {
     delivered: 0,
     malformed: 0,
     failed: 0,
+    acknowledged: 0,
+    retainedForRetry: 0,
     authRefreshed: false,
   };
 
@@ -76,32 +117,60 @@ export async function drainAndDeliverGreetings(options: {
 
   const greetings = parsePendingGreetings(await response.json());
   report.claimed = greetings.length;
+  const acknowledgements: Array<{ sessionId: string; leaseId: string }> = [];
 
   for (const greeting of greetings) {
     const userId = greeting.platformUserId;
     const content = greeting.message?.trim().slice(0, MAX_DM_LENGTH);
-    if (!userId || !content) {
+    const sessionId = greeting.sessionId;
+    const leaseId = greeting.leaseId;
+    const deliveryNonce = greeting.deliveryNonce;
+    if (!userId || !content || !sessionId || !leaseId || !deliveryNonce) {
       report.malformed += 1;
       options.onEvent?.({
         kind: "malformed",
         sessionId: greeting.sessionId ?? null,
       });
+      if (sessionId && leaseId) acknowledgements.push({ sessionId, leaseId });
       continue;
     }
     try {
-      await options.sendDirectMessage(userId, content);
+      await options.sendDirectMessage(userId, content, deliveryNonce);
       report.delivered += 1;
+      acknowledgements.push({ sessionId, leaseId });
       options.onEvent?.({
         kind: "delivered",
         sessionId: greeting.sessionId ?? null,
       });
     } catch (error) {
+      // error-policy:J4 A DM failure degrades this courtesy notification only;
+      // retryable work remains durable and terminal work is explicitly acked.
       report.failed += 1;
+      if (options.isTerminalError?.(error) === true) {
+        acknowledgements.push({ sessionId, leaseId });
+      } else {
+        report.retainedForRetry += 1;
+      }
       options.onEvent?.({
         kind: "send-failed",
         sessionId: greeting.sessionId ?? null,
         error,
       });
+    }
+  }
+
+  if (acknowledgements.length > 0) {
+    let ackResponse = await options.acknowledge(acknowledgements);
+    if (ackResponse.status === 401 && options.refreshAuth) {
+      await options.refreshAuth();
+      ackResponse = await options.acknowledge(acknowledgements);
+    }
+    if (!ackResponse.ok) {
+      options.onEvent?.({ kind: "ack-failed", status: ackResponse.status });
+    } else {
+      const body = (await ackResponse.json()) as { acknowledged?: unknown };
+      report.acknowledged =
+        typeof body.acknowledged === "number" ? body.acknowledged : 0;
     }
   }
 

--- a/packages/cloud/services/gateway-discord/tests/proactive-greeting-delivery.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/proactive-greeting-delivery.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Proves the proactive greeting delivery loop: claimed greetings become DM
+ * sends exactly once, auth refresh short-circuits without consuming entries,
+ * and malformed or failed entries are reported, never retried.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import { drainAndDeliverGreetings } from "../src/proactive-greeting-delivery";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("drainAndDeliverGreetings", () => {
+  test("delivers each claimed greeting as a DM exactly once", async () => {
+    const sent: Array<{ userId: string; content: string }> = [];
+    const report = await drainAndDeliverGreetings({
+      drain: async () =>
+        jsonResponse({
+          greetings: [
+            {
+              sessionId: "platform:discord:111",
+              platformUserId: "111",
+              message: "Sam, you're all set",
+            },
+            {
+              sessionId: "platform:discord:222",
+              platformUserId: "222",
+              message: "you're all set",
+            },
+          ],
+        }),
+      sendDirectMessage: async (userId, content) => {
+        sent.push({ userId, content });
+      },
+    });
+
+    expect(report).toEqual({
+      claimed: 2,
+      delivered: 2,
+      malformed: 0,
+      failed: 0,
+      authRefreshed: false,
+    });
+    expect(sent).toEqual([
+      { userId: "111", content: "Sam, you're all set" },
+      { userId: "222", content: "you're all set" },
+    ]);
+  });
+
+  test("401 refreshes auth and sends nothing (entries stay unclaimed server-side)", async () => {
+    const refreshAuth = mock(async () => {});
+    const sendDirectMessage = mock(async () => {});
+    const report = await drainAndDeliverGreetings({
+      drain: async () => jsonResponse({ error: "unauthorized" }, 401),
+      sendDirectMessage,
+      refreshAuth,
+    });
+
+    expect(report.authRefreshed).toBe(true);
+    expect(report.claimed).toBe(0);
+    expect(refreshAuth).toHaveBeenCalledTimes(1);
+    expect(sendDirectMessage).not.toHaveBeenCalled();
+  });
+
+  test("non-OK drain reports the status and sends nothing", async () => {
+    const events: Array<{ kind: string; status?: number }> = [];
+    const report = await drainAndDeliverGreetings({
+      drain: async () => jsonResponse({ error: "boom" }, 503),
+      sendDirectMessage: async () => {
+        throw new Error("must not send");
+      },
+      onEvent: (event) =>
+        events.push({ kind: event.kind, status: event.status }),
+    });
+
+    expect(report.claimed).toBe(0);
+    expect(events).toEqual([{ kind: "drain-failed", status: 503 }]);
+  });
+
+  test("a failed DM send is terminal: reported, not retried, later entries still delivered", async () => {
+    const sent: string[] = [];
+    const events: Array<{ kind: string; sessionId?: string | null }> = [];
+    const report = await drainAndDeliverGreetings({
+      drain: async () =>
+        jsonResponse({
+          greetings: [
+            {
+              sessionId: "platform:discord:closed-dms",
+              platformUserId: "closed",
+              message: "you're all set",
+            },
+            {
+              sessionId: "platform:discord:open-dms",
+              platformUserId: "open",
+              message: "you're all set",
+            },
+          ],
+        }),
+      sendDirectMessage: async (userId) => {
+        if (userId === "closed") {
+          throw new Error("Cannot send messages to this user (50007)");
+        }
+        sent.push(userId);
+      },
+      onEvent: (event) =>
+        events.push({ kind: event.kind, sessionId: event.sessionId }),
+    });
+
+    expect(report.delivered).toBe(1);
+    expect(report.failed).toBe(1);
+    expect(sent).toEqual(["open"]);
+    expect(events).toEqual([
+      { kind: "send-failed", sessionId: "platform:discord:closed-dms" },
+      { kind: "delivered", sessionId: "platform:discord:open-dms" },
+    ]);
+  });
+
+  test("malformed entries (missing user or empty message) are skipped, not sent", async () => {
+    const sendDirectMessage = mock(async () => {});
+    const report = await drainAndDeliverGreetings({
+      drain: async () =>
+        jsonResponse({
+          greetings: [
+            { sessionId: "no-user", message: "hello" },
+            { sessionId: "no-message", platformUserId: "333" },
+            { sessionId: "blank", platformUserId: "444", message: "   " },
+            "not-an-object",
+            null,
+          ],
+        }),
+      sendDirectMessage,
+    });
+
+    expect(report.malformed).toBe(3);
+    expect(report.delivered).toBe(0);
+    expect(sendDirectMessage).not.toHaveBeenCalled();
+  });
+
+  test("oversize greeting content is truncated to Discord's 2000-char cap", async () => {
+    let delivered = "";
+    await drainAndDeliverGreetings({
+      drain: async () =>
+        jsonResponse({
+          greetings: [
+            {
+              sessionId: "platform:discord:long",
+              platformUserId: "555",
+              message: "x".repeat(2500),
+            },
+          ],
+        }),
+      sendDirectMessage: async (_userId, content) => {
+        delivered = content;
+      },
+    });
+    expect(delivered).toHaveLength(2000);
+  });
+
+  test("a body without a greetings array claims nothing", async () => {
+    const sendDirectMessage = mock(async () => {});
+    const report = await drainAndDeliverGreetings({
+      drain: async () => jsonResponse({ unexpected: true }),
+      sendDirectMessage,
+    });
+    expect(report.claimed).toBe(0);
+    expect(sendDirectMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/services/gateway-discord/tests/proactive-greeting-delivery.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/proactive-greeting-delivery.test.ts
@@ -1,10 +1,12 @@
 /**
- * Proves the proactive greeting delivery loop: claimed greetings become DM
- * sends exactly once, auth refresh short-circuits without consuming entries,
- * and malformed or failed entries are reported, never retried.
+ * Proves lease/ack delivery of proactive greetings with deterministic mocks,
+ * including auth, provider, malformed-entry, and acknowledgement failures.
  */
 import { describe, expect, mock, test } from "bun:test";
-import { drainAndDeliverGreetings } from "../src/proactive-greeting-delivery";
+import {
+  drainAndDeliverGreetings,
+  isTerminalDiscordDirectMessageError,
+} from "../src/proactive-greeting-delivery";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -13,27 +15,37 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+function greeting(sessionId: string, overrides?: Record<string, unknown>) {
+  return {
+    sessionId,
+    platformUserId: sessionId.split(":").at(-1),
+    message: "you're all set",
+    leaseId: `lease-${sessionId.split(":").at(-1)}`,
+    deliveryNonce: `nonce-${sessionId.split(":").at(-1)}`,
+    ...overrides,
+  };
+}
+
 describe("drainAndDeliverGreetings", () => {
-  test("delivers each claimed greeting as a DM exactly once", async () => {
-    const sent: Array<{ userId: string; content: string }> = [];
+  test("delivers with the stable nonce and acknowledges the matching leases", async () => {
+    const sent: Array<{ userId: string; content: string; nonce: string }> = [];
+    const acknowledgements: unknown[] = [];
     const report = await drainAndDeliverGreetings({
       drain: async () =>
         jsonResponse({
           greetings: [
-            {
-              sessionId: "platform:discord:111",
-              platformUserId: "111",
+            greeting("platform:discord:111", {
               message: "Sam, you're all set",
-            },
-            {
-              sessionId: "platform:discord:222",
-              platformUserId: "222",
-              message: "you're all set",
-            },
+            }),
+            greeting("platform:discord:222"),
           ],
         }),
-      sendDirectMessage: async (userId, content) => {
-        sent.push({ userId, content });
+      acknowledge: async (entries) => {
+        acknowledgements.push(...entries);
+        return jsonResponse({ acknowledged: entries.length });
+      },
+      sendDirectMessage: async (userId, content, nonce) => {
+        sent.push({ userId, content, nonce });
       },
     });
 
@@ -42,19 +54,31 @@ describe("drainAndDeliverGreetings", () => {
       delivered: 2,
       malformed: 0,
       failed: 0,
+      acknowledged: 2,
+      retainedForRetry: 0,
       authRefreshed: false,
     });
     expect(sent).toEqual([
-      { userId: "111", content: "Sam, you're all set" },
-      { userId: "222", content: "you're all set" },
+      {
+        userId: "111",
+        content: "Sam, you're all set",
+        nonce: "nonce-111",
+      },
+      { userId: "222", content: "you're all set", nonce: "nonce-222" },
+    ]);
+    expect(acknowledgements).toEqual([
+      { sessionId: "platform:discord:111", leaseId: "lease-111" },
+      { sessionId: "platform:discord:222", leaseId: "lease-222" },
     ]);
   });
 
-  test("401 refreshes auth and sends nothing (entries stay unclaimed server-side)", async () => {
+  test("401 refreshes auth and leaves entries unclaimed server-side", async () => {
     const refreshAuth = mock(async () => {});
     const sendDirectMessage = mock(async () => {});
+    const acknowledge = mock(async () => jsonResponse({ acknowledged: 0 }));
     const report = await drainAndDeliverGreetings({
       drain: async () => jsonResponse({ error: "unauthorized" }, 401),
+      acknowledge,
       sendDirectMessage,
       refreshAuth,
     });
@@ -63,12 +87,16 @@ describe("drainAndDeliverGreetings", () => {
     expect(report.claimed).toBe(0);
     expect(refreshAuth).toHaveBeenCalledTimes(1);
     expect(sendDirectMessage).not.toHaveBeenCalled();
+    expect(acknowledge).not.toHaveBeenCalled();
   });
 
   test("non-OK drain reports the status and sends nothing", async () => {
     const events: Array<{ kind: string; status?: number }> = [];
     const report = await drainAndDeliverGreetings({
       drain: async () => jsonResponse({ error: "boom" }, 503),
+      acknowledge: async () => {
+        throw new Error("must not acknowledge");
+      },
       sendDirectMessage: async () => {
         throw new Error("must not send");
       },
@@ -80,63 +108,124 @@ describe("drainAndDeliverGreetings", () => {
     expect(events).toEqual([{ kind: "drain-failed", status: 503 }]);
   });
 
-  test("a failed DM send is terminal: reported, not retried, later entries still delivered", async () => {
-    const sent: string[] = [];
-    const events: Array<{ kind: string; sessionId?: string | null }> = [];
+  test("terminal DM failures are acknowledged while rate limits remain retryable", async () => {
+    const acknowledged: Array<{ sessionId: string; leaseId: string }> = [];
     const report = await drainAndDeliverGreetings({
       drain: async () =>
         jsonResponse({
           greetings: [
-            {
-              sessionId: "platform:discord:closed-dms",
-              platformUserId: "closed",
-              message: "you're all set",
-            },
-            {
-              sessionId: "platform:discord:open-dms",
-              platformUserId: "open",
-              message: "you're all set",
-            },
+            greeting("platform:discord:closed"),
+            greeting("platform:discord:limited"),
+            greeting("platform:discord:open"),
           ],
         }),
-      sendDirectMessage: async (userId) => {
-        if (userId === "closed") {
-          throw new Error("Cannot send messages to this user (50007)");
-        }
-        sent.push(userId);
+      acknowledge: async (entries) => {
+        acknowledged.push(...entries);
+        return jsonResponse({ acknowledged: entries.length });
       },
-      onEvent: (event) =>
-        events.push({ kind: event.kind, sessionId: event.sessionId }),
+      sendDirectMessage: async (userId) => {
+        if (userId === "closed") throw { code: 50007, status: 403 };
+        if (userId === "limited") throw { status: 429 };
+      },
+      isTerminalError: isTerminalDiscordDirectMessageError,
     });
 
-    expect(report.delivered).toBe(1);
-    expect(report.failed).toBe(1);
-    expect(sent).toEqual(["open"]);
-    expect(events).toEqual([
-      { kind: "send-failed", sessionId: "platform:discord:closed-dms" },
-      { kind: "delivered", sessionId: "platform:discord:open-dms" },
+    expect(report).toMatchObject({
+      delivered: 1,
+      failed: 2,
+      acknowledged: 2,
+      retainedForRetry: 1,
+    });
+    expect(acknowledged).toEqual([
+      { sessionId: "platform:discord:closed", leaseId: "lease-closed" },
+      { sessionId: "platform:discord:open", leaseId: "lease-open" },
     ]);
   });
 
-  test("malformed entries (missing user or empty message) are skipped, not sent", async () => {
+  test("network and 5xx failures retain their leases for recovery", async () => {
+    const acknowledge = mock(async () => jsonResponse({ acknowledged: 0 }));
+    const report = await drainAndDeliverGreetings({
+      drain: async () =>
+        jsonResponse({
+          greetings: [
+            greeting("platform:discord:network"),
+            greeting("platform:discord:server"),
+          ],
+        }),
+      acknowledge,
+      sendDirectMessage: async (userId) => {
+        if (userId === "network") throw new TypeError("fetch failed");
+        throw { status: 503 };
+      },
+      isTerminalError: isTerminalDiscordDirectMessageError,
+    });
+
+    expect(report).toMatchObject({ failed: 2, retainedForRetry: 2 });
+    expect(acknowledge).not.toHaveBeenCalled();
+  });
+
+  test("acknowledgement outage does not fabricate deletion", async () => {
+    const events: Array<{ kind: string; status?: number }> = [];
+    const report = await drainAndDeliverGreetings({
+      drain: async () =>
+        jsonResponse({ greetings: [greeting("platform:discord:ack-down")] }),
+      acknowledge: async () => jsonResponse({ error: "down" }, 503),
+      sendDirectMessage: async () => {},
+      onEvent: (event) =>
+        events.push({ kind: event.kind, status: event.status }),
+    });
+
+    expect(report.delivered).toBe(1);
+    expect(report.acknowledged).toBe(0);
+    expect(events).toContainEqual({ kind: "ack-failed", status: 503 });
+  });
+
+  test("401 acknowledgement refreshes auth and retries the same lease", async () => {
+    const refreshAuth = mock(async () => {});
+    let attempts = 0;
+    const report = await drainAndDeliverGreetings({
+      drain: async () =>
+        jsonResponse({ greetings: [greeting("platform:discord:ack-auth")] }),
+      acknowledge: async () => {
+        attempts += 1;
+        return attempts === 1
+          ? jsonResponse({ error: "unauthorized" }, 401)
+          : jsonResponse({ acknowledged: 1 });
+      },
+      sendDirectMessage: async () => {},
+      refreshAuth,
+    });
+
+    expect(attempts).toBe(2);
+    expect(refreshAuth).toHaveBeenCalledTimes(1);
+    expect(report.acknowledged).toBe(1);
+  });
+
+  test("malformed leased entries are poison-acked without sending", async () => {
+    const acknowledged: unknown[] = [];
     const sendDirectMessage = mock(async () => {});
     const report = await drainAndDeliverGreetings({
       drain: async () =>
         jsonResponse({
           greetings: [
-            { sessionId: "no-user", message: "hello" },
-            { sessionId: "no-message", platformUserId: "333" },
-            { sessionId: "blank", platformUserId: "444", message: "   " },
+            greeting("platform:discord:no-user", { platformUserId: "" }),
+            greeting("platform:discord:no-message", { message: "   " }),
+            { sessionId: "no-lease", platformUserId: "333", message: "hi" },
             "not-an-object",
             null,
           ],
         }),
+      acknowledge: async (entries) => {
+        acknowledged.push(...entries);
+        return jsonResponse({ acknowledged: entries.length });
+      },
       sendDirectMessage,
     });
 
     expect(report.malformed).toBe(3);
-    expect(report.delivered).toBe(0);
+    expect(report.acknowledged).toBe(2);
     expect(sendDirectMessage).not.toHaveBeenCalled();
+    expect(acknowledged).toHaveLength(2);
   });
 
   test("oversize greeting content is truncated to Discord's 2000-char cap", async () => {
@@ -145,13 +234,10 @@ describe("drainAndDeliverGreetings", () => {
       drain: async () =>
         jsonResponse({
           greetings: [
-            {
-              sessionId: "platform:discord:long",
-              platformUserId: "555",
-              message: "x".repeat(2500),
-            },
+            greeting("platform:discord:long", { message: "x".repeat(2500) }),
           ],
         }),
+      acknowledge: async () => jsonResponse({ acknowledged: 1 }),
       sendDirectMessage: async (_userId, content) => {
         delivered = content;
       },
@@ -163,9 +249,25 @@ describe("drainAndDeliverGreetings", () => {
     const sendDirectMessage = mock(async () => {});
     const report = await drainAndDeliverGreetings({
       drain: async () => jsonResponse({ unexpected: true }),
+      acknowledge: async () => jsonResponse({ acknowledged: 0 }),
       sendDirectMessage,
     });
     expect(report.claimed).toBe(0);
     expect(sendDirectMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("isTerminalDiscordDirectMessageError", () => {
+  test("classifies only definitive recipient/request failures as terminal", () => {
+    expect(isTerminalDiscordDirectMessageError({ code: 50007 })).toBe(true);
+    expect(
+      isTerminalDiscordDirectMessageError({ rawError: { code: 10013 } }),
+    ).toBe(true);
+    expect(isTerminalDiscordDirectMessageError({ status: 403 })).toBe(true);
+    expect(isTerminalDiscordDirectMessageError({ status: 429 })).toBe(false);
+    expect(isTerminalDiscordDirectMessageError({ status: 503 })).toBe(false);
+    expect(isTerminalDiscordDirectMessageError(new TypeError("network"))).toBe(
+      false,
+    );
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -81,6 +81,9 @@ mock.module("./user-service", () => ({
 const { runOnboardingChat, validateTelegramOnboardingContinuation } = await import(
   `./onboarding-chat.ts?test=onboarding-chat-${Date.now()}`
 );
+const { peekLocalGreetingQueue, clearLocalGreetingQueue } = await import(
+  "./onboarding-proactive-greeting"
+);
 
 describe("runOnboardingChat", () => {
   beforeEach(() => {
@@ -95,6 +98,7 @@ describe("runOnboardingChat", () => {
     launchManagedElizaAgent.mockReset();
     loggerWarn.mockReset();
     cloudEnv = {};
+    clearLocalGreetingQueue();
   });
 
   afterEach(() => {
@@ -1582,6 +1586,98 @@ describe("runOnboardingChat", () => {
       } finally {
         globalThis.fetch = originalFetch;
       }
+    });
+  });
+
+  describe("proactive post-sign-in greeting (Discord)", () => {
+    async function runTrustedDiscordHandoff(discordUserId: string) {
+      return runOnboardingChat({
+        message: "call me Sam",
+        platform: "discord",
+        platformUserId: discordUserId,
+        sessionId: `platform:discord:${discordUserId}`,
+        trustedPlatformIdentity: true,
+      });
+    }
+
+    test("queues exactly one greeting when a browser turn binds a trusted discord session", async () => {
+      getElizaAppProvisioningStatus.mockResolvedValue({
+        status: "provisioning",
+        agentId: null,
+        bridgeUrl: null,
+        sandbox: null,
+      });
+      ensureElizaAppProvisioning.mockResolvedValue({
+        status: "provisioning",
+        agentId: null,
+        bridgeUrl: null,
+        sandbox: null,
+      });
+      const gatewayTurn = await runTrustedDiscordHandoff("discord-user-greet");
+      expect(peekLocalGreetingQueue()).toHaveLength(0);
+
+      const continued = await runOnboardingChat({
+        sessionId: continuationToken(gatewayTurn),
+        platform: "web",
+        authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+      });
+      expect(continued.session.userId).toBe("user-1");
+
+      const queued = peekLocalGreetingQueue();
+      expect(queued).toHaveLength(1);
+      const entry = queued[0];
+      if (!entry) throw new Error("expected a queued greeting");
+      expect(entry.platformUserId).toBe("discord-user-greet");
+      expect(entry.sessionId).toBe("platform:discord:discord-user-greet");
+      expect(entry.message).toContain("Sam");
+      expect(entry.message).toContain("you're all set");
+
+      // A replayed/repeated authenticated turn must not queue a second
+      // greeting: the session is already bound.
+      await runOnboardingChat({
+        sessionId: continuationToken(gatewayTurn),
+        platform: "web",
+        authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        statusOnly: true,
+      });
+      expect(peekLocalGreetingQueue()).toHaveLength(1);
+    });
+
+    test("bot-transport turns never queue a greeting (the user just got a live reply)", async () => {
+      ensureElizaAppProvisioning.mockResolvedValue({
+        status: "provisioning",
+        agentId: null,
+        bridgeUrl: null,
+        sandbox: null,
+      });
+      await runTrustedDiscordHandoff("discord-user-live");
+      // Simulate the DM transport delivering an authenticated turn (e.g. a
+      // trusted gateway continuation): trustedPlatformIdentity excludes it.
+      await runOnboardingChat({
+        message: "hi again",
+        platform: "discord",
+        platformUserId: "discord-user-live",
+        sessionId: "platform:discord:discord-user-live",
+        trustedPlatformIdentity: true,
+        authenticatedUser: { userId: "user-2", organizationId: "org-2" },
+      });
+      expect(peekLocalGreetingQueue()).toHaveLength(0);
+    });
+
+    test("non-discord platforms never queue a greeting", async () => {
+      ensureElizaAppProvisioning.mockResolvedValue({
+        status: "provisioning",
+        agentId: null,
+        bridgeUrl: null,
+        sandbox: null,
+      });
+      const named = await runTrustedPhoneTurn("My name is Sam");
+      await runOnboardingChat({
+        sessionId: continuationToken(named),
+        platform: "web",
+        authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+      });
+      expect(peekLocalGreetingQueue()).toHaveLength(0);
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -1643,6 +1643,99 @@ describe("runOnboardingChat", () => {
       expect(peekLocalGreetingQueue()).toHaveLength(1);
     });
 
+    test("the committed result never exposes the greeting handoff field", async () => {
+      getElizaAppProvisioningStatus.mockResolvedValue({
+        status: "provisioning",
+        agentId: null,
+        bridgeUrl: null,
+        sandbox: null,
+      });
+      ensureElizaAppProvisioning.mockResolvedValue({
+        status: "provisioning",
+        agentId: null,
+        bridgeUrl: null,
+        sandbox: null,
+      });
+      const gatewayTurn = await runTrustedDiscordHandoff("discord-user-strip");
+      const continued = await runOnboardingChat({
+        sessionId: continuationToken(gatewayTurn),
+        platform: "web",
+        authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+      });
+      // Commit-ordering handoff is internal: the greeting was enqueued, but
+      // the field must not cross the service boundary in the result.
+      expect(peekLocalGreetingQueue()).toHaveLength(1);
+      expect("proactiveGreeting" in continued).toBe(false);
+    });
+
+    test("a turn that fails after binding never queues a greeting (no false-success DM)", async () => {
+      getElizaAppProvisioningStatus.mockResolvedValue({
+        status: "provisioning",
+        agentId: null,
+        bridgeUrl: null,
+        sandbox: null,
+      });
+      ensureElizaAppProvisioning.mockRejectedValue(new Error("transient provisioning outage"));
+      const gatewayTurn = await runTrustedDiscordHandoff("discord-user-fail");
+      expect(peekLocalGreetingQueue()).toHaveLength(0);
+
+      // The browser continuation binds the account in memory, then
+      // provisioning throws before the turn's durable save. The greeting must
+      // NOT be queued: the user would be told "you're all set" for a sign-in
+      // turn that failed.
+      await expect(
+        runOnboardingChat({
+          sessionId: continuationToken(gatewayTurn),
+          platform: "web",
+          authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        }),
+      ).rejects.toThrow("transient provisioning outage");
+      expect(peekLocalGreetingQueue()).toHaveLength(0);
+
+      // Once the outage clears, the retried turn commits and queues exactly
+      // one greeting.
+      ensureElizaAppProvisioning.mockResolvedValue({
+        status: "provisioning",
+        agentId: null,
+        bridgeUrl: null,
+        sandbox: null,
+      });
+      await runOnboardingChat({
+        sessionId: continuationToken(gatewayTurn),
+        platform: "web",
+        authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+      });
+      const queued = peekLocalGreetingQueue();
+      expect(queued).toHaveLength(1);
+      expect(queued[0]?.platformUserId).toBe("discord-user-fail");
+    });
+
+    test("the reserved greeting queue name is never adopted as a session id", async () => {
+      // An anonymous caller addressing the well-known queue instance must be
+      // re-keyed to a fresh session: a chat turn landing on the queue DO
+      // would contend its serialize lock and write chat state into queue
+      // storage.
+      const result = await runOnboardingChat({
+        message: "hello",
+        sessionId: "proactive-greetings:discord",
+      });
+      expect(result.session.id).not.toBe("proactive-greetings:discord");
+      expect(loggerWarn).toHaveBeenCalledWith(
+        "[eliza-app onboarding] rejected reserved queue instance name as session id",
+        expect.anything(),
+      );
+
+      // A trusted transport presenting the reserved name is re-keyed too.
+      const trusted = await runOnboardingChat({
+        message: "hello",
+        sessionId: "proactive-greetings:discord",
+        platform: "discord",
+        platformUserId: "queue-squatter",
+        trustedPlatformIdentity: true,
+      });
+      expect(trusted.session.id).toBe("platform:discord:queue-squatter");
+    });
+
     test("bot-transport turns never queue a greeting (the user just got a live reply)", async () => {
       ensureElizaAppProvisioning.mockResolvedValue({
         status: "provisioning",

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -1620,6 +1620,7 @@ describe("runOnboardingChat", () => {
         sessionId: continuationToken(gatewayTurn),
         platform: "web",
         authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        confirmPlatformLink: true,
       });
       expect(continued.session.userId).toBe("user-1");
 
@@ -1638,6 +1639,7 @@ describe("runOnboardingChat", () => {
         sessionId: continuationToken(gatewayTurn),
         platform: "web",
         authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        confirmPlatformLink: true,
         statusOnly: true,
       });
       expect(peekLocalGreetingQueue()).toHaveLength(1);
@@ -1661,6 +1663,7 @@ describe("runOnboardingChat", () => {
         sessionId: continuationToken(gatewayTurn),
         platform: "web",
         authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        confirmPlatformLink: true,
       });
       // Commit-ordering handoff is internal: the greeting was enqueued, but
       // the field must not cross the service boundary in the result.
@@ -1688,6 +1691,7 @@ describe("runOnboardingChat", () => {
           sessionId: continuationToken(gatewayTurn),
           platform: "web",
           authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+          confirmPlatformLink: true,
         }),
       ).rejects.toThrow("transient provisioning outage");
       expect(peekLocalGreetingQueue()).toHaveLength(0);
@@ -1704,6 +1708,7 @@ describe("runOnboardingChat", () => {
         sessionId: continuationToken(gatewayTurn),
         platform: "web",
         authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        confirmPlatformLink: true,
       });
       const queued = peekLocalGreetingQueue();
       expect(queued).toHaveLength(1);

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -17,7 +17,11 @@ import {
 } from "../../runtime/cloud-bindings";
 import { logger } from "../../utils/logger";
 import { launchManagedElizaAgent } from "../eliza-managed-launch";
-import { enqueueDiscordProactiveGreeting } from "./onboarding-proactive-greeting";
+import {
+  enqueueDiscordProactiveGreeting,
+  PROACTIVE_GREETING_QUEUE_PREFIX,
+  type ProactiveGreetingRequest,
+} from "./onboarding-proactive-greeting";
 import {
   type ElizaAppProvisioningStatus,
   ensureElizaAppProvisioning,
@@ -118,6 +122,15 @@ export interface OnboardingChatResult {
    * null here. Same loginUrl either way - presentation only.
    */
   cta?: OnboardingChatCta | null;
+  /**
+   * Commit-ordering handoff: the proactive greeting this turn produced, if
+   * any. The state machine only RECORDS it; the caller that owns the turn's
+   * durable commit (coordinator transaction or local store) enqueues it
+   * strictly AFTER the commit lands and strips this field before the result
+   * crosses the service boundary. A turn that fails to persist therefore can
+   * never DM "you're all set" for a sign-in that did not durably complete.
+   */
+  proactiveGreeting?: ProactiveGreetingRequest | null;
 }
 
 const SESSION_TTL_SECONDS = 14 * 24 * 60 * 60;
@@ -182,6 +195,17 @@ export function createOnboardingSessionId(input?: {
 const SESSION_ID_PATTERN = /^[a-zA-Z0-9:+_-]{8,180}$/;
 const PLATFORM_SESSION_PREFIX = "platform:";
 
+/**
+ * The proactive-greeting queues live in the same Durable Object namespace as
+ * per-session coordinators under a reserved, well-known name. No caller may
+ * ever address a queue instance as a chat session: a chat turn landing there
+ * would contend the queue's serialize lock and write chat state into queue
+ * storage.
+ */
+function isReservedSessionId(value: string): boolean {
+  return value.startsWith(PROACTIVE_GREETING_QUEUE_PREFIX);
+}
+
 function redactSessionIdForLog(sessionId: string): string {
   return sessionId.replace(/\d(?=\d{4})/g, "*");
 }
@@ -195,7 +219,11 @@ function redactSessionIdForLog(sessionId: string): string {
  */
 function sanitizeSessionId(value: string | undefined, input: OnboardingChatInput): string {
   const trimmed = value?.trim();
-  if (trimmed && SESSION_ID_PATTERN.test(trimmed)) {
+  if (trimmed && isReservedSessionId(trimmed)) {
+    logger.warn("[eliza-app onboarding] rejected reserved queue instance name as session id", {
+      sessionId: redactSessionIdForLog(trimmed),
+    });
+  } else if (trimmed && SESSION_ID_PATTERN.test(trimmed)) {
     if (!trimmed.startsWith(PLATFORM_SESSION_PREFIX)) {
       return trimmed;
     }
@@ -248,7 +276,11 @@ function isOnboardingContinuation(value: unknown): value is OnboardingContinuati
 
 async function resolveContinuationToken(token: string): Promise<string | null> {
   const trimmed = token.trim();
-  if (!SESSION_ID_PATTERN.test(trimmed) || trimmed.startsWith(PLATFORM_SESSION_PREFIX)) {
+  if (
+    !SESSION_ID_PATTERN.test(trimmed) ||
+    trimmed.startsWith(PLATFORM_SESSION_PREFIX) ||
+    isReservedSessionId(trimmed)
+  ) {
     return null;
   }
 
@@ -459,7 +491,7 @@ export async function claimTelegramOnboardingContinuation(
 ): Promise<TelegramOnboardingContinuationClaim> {
   const token = input.continuationToken.trim();
   const coordinator = onboardingCoordinator();
-  if (!coordinator || !SESSION_ID_PATTERN.test(token)) {
+  if (!coordinator || !SESSION_ID_PATTERN.test(token) || isReservedSessionId(token)) {
     throw trustedContinuationError(null);
   }
   const response = await coordinator.getByName(token).fetch("https://onboarding.internal/claim", {
@@ -1132,13 +1164,17 @@ export async function runOnboardingChatWithStore(
 
   // The exact moment a trusted Discord DM session becomes account-bound from
   // a BROWSER turn (not the DM transport itself) is the user completing the
-  // sign-in handoff. Their Discord chat is silent right now; queue the
-  // one-shot proactive greeting the gateway delivers there. Bot-transport
-  // turns (trustedPlatformIdentity) are excluded: on those the user just
-  // messaged and gets a synchronous reply. Enqueue is best-effort and keyed
-  // by session id (set semantics) so retried or replayed authenticated turns
+  // sign-in handoff. Their Discord chat is silent right now; RECORD the
+  // one-shot proactive greeting for the gateway to deliver there. The
+  // greeting is only recorded on the result here — the caller that owns the
+  // turn's durable commit enqueues it AFTER the commit lands, so a turn that
+  // fails mid-flight (for example a provisioning outage below) never DMs
+  // "you're all set" for a sign-in that did not durably complete.
+  // Bot-transport turns (trustedPlatformIdentity) are excluded: on those the
+  // user just messaged and gets a synchronous reply. Enqueue is keyed by
+  // session id (set semantics) so retried or replayed authenticated turns
   // cannot duplicate the greeting.
-  if (
+  const proactiveGreeting: ProactiveGreetingRequest | null =
     wasUnboundBeforeThisTurn &&
     session.userId &&
     input.authenticatedUser &&
@@ -1146,13 +1182,12 @@ export async function runOnboardingChatWithStore(
     session.platform === "discord" &&
     session.platformIdentityTrusted === true &&
     session.platformUserId
-  ) {
-    await enqueueDiscordProactiveGreeting({
-      sessionId: session.id,
-      platformUserId: session.platformUserId,
-      name: hasPreferredName(session) ? session.name : undefined,
-    });
-  }
+      ? {
+          sessionId: session.id,
+          platformUserId: session.platformUserId,
+          name: hasPreferredName(session) ? session.name : undefined,
+        }
+      : null;
 
   // statusOnly is a read-only poll: skip all user-message processing so it
   // can never mutate session history, name, or preferred-name state, even if
@@ -1263,7 +1298,24 @@ export async function runOnboardingChatWithStore(
     provisioning,
     handoffComplete,
     cta,
+    proactiveGreeting,
   };
+}
+
+/**
+ * Enqueues the turn's recorded proactive greeting (if any) and strips the
+ * commit-ordering field from the result. Called by the turn's durable-commit
+ * owner strictly AFTER persistence succeeds — never before — so a failed turn
+ * cannot produce a false-success DM. Enqueue itself remains best-effort.
+ */
+export async function deliverCommittedProactiveGreeting(
+  result: OnboardingChatResult,
+): Promise<OnboardingChatResult> {
+  const { proactiveGreeting, ...committed } = result;
+  if (proactiveGreeting) {
+    await enqueueDiscordProactiveGreeting(proactiveGreeting);
+  }
+  return committed;
 }
 
 const localQueues = new Map<string, Promise<void>>();
@@ -1343,10 +1395,16 @@ export async function runOnboardingChat(input: OnboardingChatInput): Promise<Onb
       );
       if (replay) return replay;
     }
-    const result = await runOnboardingChatWithStore(normalizedInput, sessionId, {
-      load: loadCachedOnboardingSession,
-      save: mirrorOnboardingSessionToCache,
-    });
+    // In the local path the store's save IS the durable commit, so once
+    // runOnboardingChatWithStore returns the session has persisted and the
+    // recorded greeting may enqueue (commit ordering: greeting only after a
+    // durably committed turn).
+    const result = await deliverCommittedProactiveGreeting(
+      await runOnboardingChatWithStore(normalizedInput, sessionId, {
+        load: loadCachedOnboardingSession,
+        save: mirrorOnboardingSessionToCache,
+      }),
+    );
     if (normalizedInput.idempotencyKey) {
       await cache.set(
         resultCacheKey(sessionId, normalizedInput.idempotencyKey, normalizedInput),

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -17,6 +17,7 @@ import {
 } from "../../runtime/cloud-bindings";
 import { logger } from "../../utils/logger";
 import { launchManagedElizaAgent } from "../eliza-managed-launch";
+import { enqueueDiscordProactiveGreeting } from "./onboarding-proactive-greeting";
 import {
   type ElizaAppProvisioningStatus,
   ensureElizaAppProvisioning,
@@ -1117,6 +1118,7 @@ export async function runOnboardingChatWithStore(
     session = { ...session, platformIdentityTrusted: true };
   }
 
+  const wasUnboundBeforeThisTurn = !session.userId;
   if (input.authenticatedUser) {
     assertAuthenticatedTelegramIdentity(session, input);
     session = {
@@ -1127,6 +1129,30 @@ export async function runOnboardingChatWithStore(
   }
 
   session = await maybeLinkAuthenticatedPlatformIdentity(session, input);
+
+  // The exact moment a trusted Discord DM session becomes account-bound from
+  // a BROWSER turn (not the DM transport itself) is the user completing the
+  // sign-in handoff. Their Discord chat is silent right now; queue the
+  // one-shot proactive greeting the gateway delivers there. Bot-transport
+  // turns (trustedPlatformIdentity) are excluded: on those the user just
+  // messaged and gets a synchronous reply. Enqueue is best-effort and keyed
+  // by session id (set semantics) so retried or replayed authenticated turns
+  // cannot duplicate the greeting.
+  if (
+    wasUnboundBeforeThisTurn &&
+    session.userId &&
+    input.authenticatedUser &&
+    input.trustedPlatformIdentity !== true &&
+    session.platform === "discord" &&
+    session.platformIdentityTrusted === true &&
+    session.platformUserId
+  ) {
+    await enqueueDiscordProactiveGreeting({
+      sessionId: session.id,
+      platformUserId: session.platformUserId,
+      name: hasPreferredName(session) ? session.name : undefined,
+    });
+  }
 
   // statusOnly is a read-only poll: skip all user-message processing so it
   // can never mutate session history, name, or preferred-name state, even if

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Proves the process-local proactive-greeting fallback uses the same lease,
+ * stable-nonce, acknowledgement, and set semantics as the Durable Object.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  acknowledgeDiscordProactiveGreetings,
+  clearLocalGreetingQueue,
+  drainDiscordProactiveGreetings,
+  enqueueDiscordProactiveGreeting,
+  peekLocalGreetingQueue,
+} from "./onboarding-proactive-greeting";
+
+beforeEach(() => clearLocalGreetingQueue());
+
+describe("local proactive greeting queue", () => {
+  test("retains a leased greeting until the matching acknowledgement", async () => {
+    const sessionId = "platform:discord:local-1";
+    await enqueueDiscordProactiveGreeting({
+      sessionId,
+      platformUserId: "local-1",
+      name: "Sam",
+    });
+
+    const first = await drainDiscordProactiveGreetings();
+    expect(first).toHaveLength(1);
+    expect(first[0]?.message).toContain("Sam");
+    expect(first[0]?.deliveryNonce).toMatch(/^[A-Za-z0-9_-]{1,25}$/);
+    expect(await drainDiscordProactiveGreetings()).toEqual([]);
+
+    expect(
+      await acknowledgeDiscordProactiveGreetings([{ sessionId, leaseId: "wrong-lease" }]),
+    ).toBe(0);
+    expect(peekLocalGreetingQueue()).toHaveLength(1);
+    expect(
+      await acknowledgeDiscordProactiveGreetings([{ sessionId, leaseId: first[0]?.leaseId ?? "" }]),
+    ).toBe(1);
+    expect(peekLocalGreetingQueue()).toEqual([]);
+  });
+
+  test("re-enqueue is a no-op that preserves the original work and live lease", async () => {
+    const sessionId = "platform:discord:local-2";
+    await enqueueDiscordProactiveGreeting({
+      sessionId,
+      platformUserId: "local-2",
+      name: "First",
+    });
+    const originalNonce = peekLocalGreetingQueue()[0]?.deliveryNonce;
+    const leased = await drainDiscordProactiveGreetings();
+
+    await enqueueDiscordProactiveGreeting({
+      sessionId,
+      platformUserId: "local-2",
+      name: "Second",
+    });
+    const queued = peekLocalGreetingQueue();
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.message).toContain("First");
+    expect(queued[0]?.deliveryNonce).toBe(originalNonce);
+
+    // Replayed enqueue cannot expose the same work to a second sender.
+    expect(await drainDiscordProactiveGreetings()).toEqual([]);
+    expect(
+      await acknowledgeDiscordProactiveGreetings([
+        { sessionId, leaseId: leased[0]?.leaseId ?? "" },
+      ]),
+    ).toBe(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.ts
@@ -13,10 +13,11 @@
  * Durable Object instance of the onboarding session coordinator
  * (`proactive-greetings:discord`), which gives atomic enqueue (set semantics
  * keyed by session id, so repeated authenticated turns can never duplicate a
- * greeting) and atomic drain (claimed entries are deleted in the same
- * serialized operation — single consumer, at-most-once delivery). Outside a
- * Worker (tests, local node runs) a process-local map provides the same
- * semantics.
+ * greeting) and lease/ack delivery. A drain leases entries without deleting
+ * them; the gateway acknowledges only delivered or definitively terminal DMs.
+ * An unacknowledged lease becomes claimable again after a bounded interval.
+ * Each entry also carries a stable Discord nonce so a provider retry is
+ * idempotent. Outside a Worker a process-local map provides the same semantics.
  *
  * Failure policy: enqueue failures are logged and swallowed — a missing
  * courtesy greeting must never fail the user's onboarding turn (the sign-in
@@ -44,6 +45,17 @@ export interface ProactiveGreetingEntry {
   message: string;
   /** ISO timestamp of enqueue; entries expire after {@link GREETING_TTL_MS}. */
   createdAt: string;
+  /** Stable Discord idempotency nonce (the API limit is 25 characters). */
+  deliveryNonce: string;
+}
+
+export interface LeasedProactiveGreetingEntry extends ProactiveGreetingEntry {
+  leaseId: string;
+}
+
+export interface ProactiveGreetingAcknowledgement {
+  sessionId: string;
+  leaseId: string;
 }
 
 /**
@@ -55,6 +67,9 @@ export const GREETING_TTL_MS = 15 * 60 * 1000;
 
 /** Upper bound on entries returned by a single drain. */
 export const MAX_GREETING_DRAIN = 20;
+
+/** Short enough to retry within Discord's enforced-nonce dedupe window. */
+export const GREETING_LEASE_MS = 2 * 60 * 1000;
 
 /**
  * Reserved instance-name prefix for the well-known greeting queues. The
@@ -87,7 +102,7 @@ function greetingCoordinator(): RuntimeDurableObjectNamespace | undefined {
 
 /** Process-local fallback queue for non-Worker runtimes (keyed by session id). */
 const localGreetingQueue = new Map<string, ProactiveGreetingEntry>();
-
+const localGreetingLeases = new Map<string, { leaseId: string; expiresAt: number }>();
 /** Test-only visibility into the local fallback queue. */
 export function peekLocalGreetingQueue(): ProactiveGreetingEntry[] {
   return [...localGreetingQueue.values()];
@@ -96,6 +111,11 @@ export function peekLocalGreetingQueue(): ProactiveGreetingEntry[] {
 /** Test-only reset of the local fallback queue. */
 export function clearLocalGreetingQueue(): void {
   localGreetingQueue.clear();
+  localGreetingLeases.clear();
+}
+
+function newOpaqueId(): string {
+  return crypto.randomUUID().replaceAll("-", "").slice(0, 25);
 }
 
 export function composeProactiveGreeting(name: string | undefined): string {
@@ -123,6 +143,7 @@ export async function enqueueDiscordProactiveGreeting(
     platformUserId: input.platformUserId,
     message: composeProactiveGreeting(input.name),
     createdAt: new Date().toISOString(),
+    deliveryNonce: newOpaqueId(),
   };
   try {
     const coordinator = greetingCoordinator();
@@ -142,10 +163,11 @@ export async function enqueueDiscordProactiveGreeting(
     if (hasCloudBindingsContext()) {
       throw new Error("ONBOARDING_SESSIONS binding is required in Worker deployments");
     }
-    localGreetingQueue.set(entry.sessionId, entry);
+    const existing = localGreetingQueue.get(entry.sessionId);
+    if (!existing) localGreetingQueue.set(entry.sessionId, entry);
   } catch (error) {
-    // error-policy: the proactive greeting is best-effort by design; a queue
-    // outage must not turn a successful sign-in into a failed onboarding turn.
+    // error-policy:J4 The durable sign-in already succeeded; a queue outage
+    // degrades only the explicitly best-effort courtesy greeting.
     logger.warn("[eliza-app onboarding] proactive greeting enqueue failed", {
       sessionId: entry.sessionId,
       error: error instanceof Error ? error.message : String(error),
@@ -154,11 +176,10 @@ export async function enqueueDiscordProactiveGreeting(
 }
 
 /**
- * Claims up to {@link MAX_GREETING_DRAIN} pending Discord greetings. Claimed
- * entries are removed atomically (at-most-once delivery); expired entries are
- * dropped with a log line and never returned.
+ * Leases up to {@link MAX_GREETING_DRAIN} pending Discord greetings. Entries
+ * remain stored until an acknowledgement with the matching lease id arrives.
  */
-export async function drainDiscordProactiveGreetings(): Promise<ProactiveGreetingEntry[]> {
+export async function drainDiscordProactiveGreetings(): Promise<LeasedProactiveGreetingEntry[]> {
   const coordinator = greetingCoordinator();
   if (coordinator) {
     const response = await coordinator
@@ -171,24 +192,67 @@ export async function drainDiscordProactiveGreetings(): Promise<ProactiveGreetin
     if (!response.ok) {
       throw new Error(`greeting drain failed (${response.status})`);
     }
-    const body = (await response.json()) as { greetings?: ProactiveGreetingEntry[] };
+    const body = (await response.json()) as {
+      greetings?: LeasedProactiveGreetingEntry[];
+    };
     return body.greetings ?? [];
   }
   if (hasCloudBindingsContext()) {
     throw new Error("ONBOARDING_SESSIONS binding is required in Worker deployments");
   }
   const now = Date.now();
-  const claimed: ProactiveGreetingEntry[] = [];
+  const claimed: LeasedProactiveGreetingEntry[] = [];
   for (const [key, entry] of localGreetingQueue) {
     if (claimed.length >= MAX_GREETING_DRAIN) break;
-    localGreetingQueue.delete(key);
     if (!isEntryFresh(entry, now)) {
+      localGreetingQueue.delete(key);
+      localGreetingLeases.delete(key);
       logger.warn("[eliza-app onboarding] dropped expired proactive greeting", {
         sessionId: entry.sessionId,
       });
       continue;
     }
-    claimed.push(entry);
+    const currentLease = localGreetingLeases.get(key);
+    if (currentLease && currentLease.expiresAt > now) continue;
+    const leaseId = newOpaqueId();
+    localGreetingLeases.set(key, {
+      leaseId,
+      expiresAt: now + GREETING_LEASE_MS,
+    });
+    claimed.push({ ...entry, leaseId });
   }
   return claimed;
+}
+
+/** Deletes only greetings whose current lease matches the acknowledgement. */
+export async function acknowledgeDiscordProactiveGreetings(
+  acknowledgements: ProactiveGreetingAcknowledgement[],
+): Promise<number> {
+  const coordinator = greetingCoordinator();
+  if (coordinator) {
+    const response = await coordinator
+      .getByName(DISCORD_GREETING_QUEUE_NAME)
+      .fetch("https://onboarding.internal/ack-greetings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ acknowledgements }),
+      });
+    if (!response.ok) {
+      throw new Error(`greeting acknowledgement failed (${response.status})`);
+    }
+    const body = (await response.json()) as { acknowledged?: number };
+    return body.acknowledged ?? 0;
+  }
+  if (hasCloudBindingsContext()) {
+    throw new Error("ONBOARDING_SESSIONS binding is required in Worker deployments");
+  }
+  let acknowledged = 0;
+  for (const acknowledgement of acknowledgements) {
+    const lease = localGreetingLeases.get(acknowledgement.sessionId);
+    if (lease?.leaseId !== acknowledgement.leaseId) continue;
+    localGreetingQueue.delete(acknowledgement.sessionId);
+    localGreetingLeases.delete(acknowledgement.sessionId);
+    acknowledged += 1;
+  }
+  return acknowledged;
 }

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.ts
@@ -23,6 +23,12 @@
  * itself already succeeded). Drain failures propagate to the caller (the
  * internal route), which fails closed; unclaimed entries survive for the next
  * poll until they expire.
+ *
+ * Commit ordering: the onboarding state machine only RECORDS a pending
+ * greeting on its result; the caller that owns the turn's durable commit (the
+ * session coordinator's storage transaction, or the local store save)
+ * enqueues it strictly AFTER that commit. A turn that fails to persist can
+ * therefore never produce a "you're all set" DM.
  */
 
 import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
@@ -50,8 +56,30 @@ export const GREETING_TTL_MS = 15 * 60 * 1000;
 /** Upper bound on entries returned by a single drain. */
 export const MAX_GREETING_DRAIN = 20;
 
+/**
+ * Reserved instance-name prefix for the well-known greeting queues. The
+ * queues share the ONBOARDING_SESSIONS namespace with per-session
+ * coordinators, so session-id validation must refuse to adopt any id under
+ * this prefix as a chat session: a chat turn landing on a queue instance
+ * would contend its serialize lock and write chat state into queue storage.
+ */
+export const PROACTIVE_GREETING_QUEUE_PREFIX = "proactive-greetings:";
+
 /** Well-known Durable Object instance name holding the Discord queue. */
-export const DISCORD_GREETING_QUEUE_NAME = "proactive-greetings:discord";
+export const DISCORD_GREETING_QUEUE_NAME = `${PROACTIVE_GREETING_QUEUE_PREFIX}discord`;
+
+/**
+ * Commit-ordering handoff describing a greeting that should enqueue once the
+ * turn that produced it has durably persisted.
+ */
+export interface ProactiveGreetingRequest {
+  /** Platform-scoped onboarding session id whose sign-in just completed. */
+  sessionId: string;
+  /** Discord user id to DM. */
+  platformUserId: string;
+  /** Preferred name to address in the greeting, when known. */
+  name?: string;
+}
 
 function greetingCoordinator(): RuntimeDurableObjectNamespace | undefined {
   return getCloudBinding<RuntimeDurableObjectNamespace>("ONBOARDING_SESSIONS");
@@ -87,11 +115,9 @@ function isEntryFresh(entry: ProactiveGreetingEntry, now: number): boolean {
  * Records a pending proactive greeting for a freshly bound Discord onboarding
  * session. Never throws: the greeting is a courtesy, the turn is not.
  */
-export async function enqueueDiscordProactiveGreeting(input: {
-  sessionId: string;
-  platformUserId: string;
-  name?: string;
-}): Promise<void> {
+export async function enqueueDiscordProactiveGreeting(
+  input: ProactiveGreetingRequest,
+): Promise<void> {
   const entry: ProactiveGreetingEntry = {
     sessionId: input.sessionId,
     platformUserId: input.platformUserId,

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.ts
@@ -1,0 +1,168 @@
+/**
+ * Proactive post-link greeting queue for messaging-platform onboarding.
+ *
+ * When a user starts onboarding in a platform DM (Discord), taps the login
+ * CTA, and authenticates in the browser, the messaging conversation goes
+ * silent: the platform gateway is request/response and nothing tells the user
+ * their sign-in worked. This module records a one-shot "you're all set"
+ * greeting at the exact moment a trusted platform session becomes bound to a
+ * cloud account from a browser turn. The platform gateway drains the queue and
+ * delivers the greeting as a proactive DM.
+ *
+ * Storage: in Worker deployments the queue lives in a dedicated, well-known
+ * Durable Object instance of the onboarding session coordinator
+ * (`proactive-greetings:discord`), which gives atomic enqueue (set semantics
+ * keyed by session id, so repeated authenticated turns can never duplicate a
+ * greeting) and atomic drain (claimed entries are deleted in the same
+ * serialized operation — single consumer, at-most-once delivery). Outside a
+ * Worker (tests, local node runs) a process-local map provides the same
+ * semantics.
+ *
+ * Failure policy: enqueue failures are logged and swallowed — a missing
+ * courtesy greeting must never fail the user's onboarding turn (the sign-in
+ * itself already succeeded). Drain failures propagate to the caller (the
+ * internal route), which fails closed; unclaimed entries survive for the next
+ * poll until they expire.
+ */
+
+import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
+import { getCloudBinding, hasCloudBindingsContext } from "../../runtime/cloud-bindings";
+import { logger } from "../../utils/logger";
+
+export interface ProactiveGreetingEntry {
+  /** Platform-scoped onboarding session id (`platform:discord:<userId>`). */
+  sessionId: string;
+  /** Discord user id to DM. */
+  platformUserId: string;
+  /** Server-authored greeting text the gateway delivers verbatim. */
+  message: string;
+  /** ISO timestamp of enqueue; entries expire after {@link GREETING_TTL_MS}. */
+  createdAt: string;
+}
+
+/**
+ * A greeting older than this is stale — the user has either already messaged
+ * again (and gotten a live reply) or moved on. Expired entries are dropped at
+ * drain time, never delivered.
+ */
+export const GREETING_TTL_MS = 15 * 60 * 1000;
+
+/** Upper bound on entries returned by a single drain. */
+export const MAX_GREETING_DRAIN = 20;
+
+/** Well-known Durable Object instance name holding the Discord queue. */
+export const DISCORD_GREETING_QUEUE_NAME = "proactive-greetings:discord";
+
+function greetingCoordinator(): RuntimeDurableObjectNamespace | undefined {
+  return getCloudBinding<RuntimeDurableObjectNamespace>("ONBOARDING_SESSIONS");
+}
+
+/** Process-local fallback queue for non-Worker runtimes (keyed by session id). */
+const localGreetingQueue = new Map<string, ProactiveGreetingEntry>();
+
+/** Test-only visibility into the local fallback queue. */
+export function peekLocalGreetingQueue(): ProactiveGreetingEntry[] {
+  return [...localGreetingQueue.values()];
+}
+
+/** Test-only reset of the local fallback queue. */
+export function clearLocalGreetingQueue(): void {
+  localGreetingQueue.clear();
+}
+
+export function composeProactiveGreeting(name: string | undefined): string {
+  const address = name?.trim() ? `${name.trim()}, ` : "";
+  return (
+    `${address}you're all set — your account is linked and your agent is spinning up. ` +
+    "This chat is yours now: message me anytime and your agent answers."
+  );
+}
+
+function isEntryFresh(entry: ProactiveGreetingEntry, now: number): boolean {
+  const createdAt = Date.parse(entry.createdAt);
+  return Number.isFinite(createdAt) && now - createdAt <= GREETING_TTL_MS;
+}
+
+/**
+ * Records a pending proactive greeting for a freshly bound Discord onboarding
+ * session. Never throws: the greeting is a courtesy, the turn is not.
+ */
+export async function enqueueDiscordProactiveGreeting(input: {
+  sessionId: string;
+  platformUserId: string;
+  name?: string;
+}): Promise<void> {
+  const entry: ProactiveGreetingEntry = {
+    sessionId: input.sessionId,
+    platformUserId: input.platformUserId,
+    message: composeProactiveGreeting(input.name),
+    createdAt: new Date().toISOString(),
+  };
+  try {
+    const coordinator = greetingCoordinator();
+    if (coordinator) {
+      const response = await coordinator
+        .getByName(DISCORD_GREETING_QUEUE_NAME)
+        .fetch("https://onboarding.internal/enqueue-greeting", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(entry),
+        });
+      if (!response.ok) {
+        throw new Error(`greeting enqueue failed (${response.status})`);
+      }
+      return;
+    }
+    if (hasCloudBindingsContext()) {
+      throw new Error("ONBOARDING_SESSIONS binding is required in Worker deployments");
+    }
+    localGreetingQueue.set(entry.sessionId, entry);
+  } catch (error) {
+    // error-policy: the proactive greeting is best-effort by design; a queue
+    // outage must not turn a successful sign-in into a failed onboarding turn.
+    logger.warn("[eliza-app onboarding] proactive greeting enqueue failed", {
+      sessionId: entry.sessionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Claims up to {@link MAX_GREETING_DRAIN} pending Discord greetings. Claimed
+ * entries are removed atomically (at-most-once delivery); expired entries are
+ * dropped with a log line and never returned.
+ */
+export async function drainDiscordProactiveGreetings(): Promise<ProactiveGreetingEntry[]> {
+  const coordinator = greetingCoordinator();
+  if (coordinator) {
+    const response = await coordinator
+      .getByName(DISCORD_GREETING_QUEUE_NAME)
+      .fetch("https://onboarding.internal/drain-greetings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ limit: MAX_GREETING_DRAIN }),
+      });
+    if (!response.ok) {
+      throw new Error(`greeting drain failed (${response.status})`);
+    }
+    const body = (await response.json()) as { greetings?: ProactiveGreetingEntry[] };
+    return body.greetings ?? [];
+  }
+  if (hasCloudBindingsContext()) {
+    throw new Error("ONBOARDING_SESSIONS binding is required in Worker deployments");
+  }
+  const now = Date.now();
+  const claimed: ProactiveGreetingEntry[] = [];
+  for (const [key, entry] of localGreetingQueue) {
+    if (claimed.length >= MAX_GREETING_DRAIN) break;
+    localGreetingQueue.delete(key);
+    if (!isEntryFresh(entry, now)) {
+      logger.warn("[eliza-app onboarding] dropped expired proactive greeting", {
+        sessionId: entry.sessionId,
+      });
+      continue;
+    }
+    claimed.push(entry);
+  }
+  return claimed;
+}


### PR DESCRIPTION
# Relates to

The fluid-onboarding path: a user starts in a Discord DM, confirms sign-in in the browser, then returns to Discord and should receive the next message without having to speak again.

# Root issue

The original implementation added the missing proactive DM, but its queue used delete-on-read. A gateway crash, shutdown, lost HTTP response, or ambiguous Discord send could therefore erase the greeting before delivery. It also initially handed the greeting off after a fallible continuation rebind, which could permanently suppress it after the onboarding transaction had committed.

# What this does

- Detects the exact browser turn that binds a trusted Discord onboarding session and durably enqueues one server-authored greeting after commit and before the fallible continuation rebind.
- Stores greetings in the existing onboarding Durable Object under isolated keys, with overwrite-by-session semantics and a 15-minute expiry.
- Replaces delete-on-read with a lease/ack protocol. Concurrent pollers cannot claim a live lease; delivered and definitively terminal entries are acknowledged; retryable and ambiguous failures remain durable until lease expiry.
- Gives every greeting a stable Discord nonce and sends with `enforceNonce`, so recovery after an ambiguous completion or lost acknowledgement is provider-idempotent.
- Adds an authenticated internal drain/ack route and leader-only gateway polling.
- Tracks and settles an in-flight poll during leadership loss and graceful shutdown. Forced termination is recoverable through the durable lease.
- Classifies known permanent Discord rejections separately from retryable/ambiguous failures.

# Why this fixes the root cause

The queue now separates claim from deletion. Ownership is explicit and time-bounded, acknowledgement is lease-checked, stale acknowledgements cannot delete a newer claim, and retries reuse the same provider nonce. The commit-to-handoff ordering also ensures a transient continuation-bind failure cannot strand a successfully committed onboarding transition.

# Validation

- Cloud API coordinator and internal-route tests: 26 passing, including concurrent claims, lease expiry, stale-ack protection, malformed input, and storage-key isolation.
- Discord gateway delivery tests: 11 passing, including authenticated drain/ack behavior, terminal versus retryable errors, stable nonce delivery, auth refresh, and malformed entries.
- Shared onboarding/greeting suites pass, including post-commit continuation failure and retry, exact once-only enqueue, and local fallback lease behavior.
- Package typechecks and production Wrangler dry-run pass.

# Scope

Discord only. Telegram can adopt the same queue contract separately. No UI code changes.

<!-- evidence-head:96c97c4bcc5197ddf8dbbfaf177019aff8087743 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend and Discord gateway behavior only; no rendered application surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend and Discord gateway behavior only; no rendered application surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - staging credential isolation currently prevents a safe live Discord delivery run; the complete protocol is exercised at the API/gateway boundary below

<!-- evidence-row:backend-logs -->
- [x] [Coordinator and internal-route regression output](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18353-tmp-18353-backend-v2.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic server-authored greeting; no model or prompt path changed

<!-- evidence-row:domain-artifacts -->
- [x] [Discord gateway delivery regression output](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18353-tmp-18353-gateway-v2.txt)
- [x] [Durability contract and verification summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18353-tmp-18353-domain-v2.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: original contribution `anthropic-proxy/claude-fable-5`; remediation `openai/gpt-5` (system-reported model family; deployment variant unavailable)
<!-- attribution-row:client -->
- Agent tooling: moltbot (original), Codex (remediation)
<!-- attribution-row:skill-revision -->
- Skill path: N/A - installed Codex plugin packages do not expose a repository commit SHA
<!-- attribution-row:status -->
- Provenance status: self-reported
