### PR TITLE
fix(plugin-elizacloud): retry duration-rejecting music models as fixed-price

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
@@ -198,13 +198,14 @@ describe("media generation cold-cache warming retry", () => {
       routes: { postApiV1GenerateVideo: vi.fn(), postApiV1GenerateMusic },
     }));
 
-    await expect(
-      handleAudioGeneration(runtime(), {
-        prompt: "synthwave loop",
-        audioKind: "music",
-        durationSeconds: 10,
-      })
-    ).resolves.toMatchObject({ url: "https://cdn/m2.mp3" });
+    const result = await handleAudioGeneration(runtime(), {
+      prompt: "synthwave loop",
+      audioKind: "music",
+      durationSeconds: 10,
+    });
+
+    expect(result).toMatchObject({ url: "https://cdn/m2.mp3" });
+    expect(result).not.toHaveProperty("duration");
     expect(postApiV1GenerateMusic).toHaveBeenCalledTimes(2);
     // The retry dropped the rejected param.
     expect(postApiV1GenerateMusic.mock.calls[0]?.[0]?.json?.durationSeconds).toBe(10);

--- a/plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
@@ -177,4 +177,55 @@ describe("media generation cold-cache warming retry", () => {
     );
     expect(postApiV1GenerateVideo).toHaveBeenCalledTimes(1);
   });
+
+  // Fixed-price music models 400 with a machine-actionable "omit
+  // durationSeconds" hint (generate-music route). Observed live: "make me a
+  // 10 second synthwave loop" failed the whole turn. The handler must retry
+  // once without the param — and only for that exact rejection.
+  it("retries a duration-rejecting music model as a fixed-price generation", async () => {
+    const postApiV1GenerateMusic = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          "Model fal-ai/minimax-music/v2.6 does not support durationSeconds; omit durationSeconds and bill it as a fixed-price generation"
+        )
+      )
+      .mockResolvedValueOnce({
+        music: { url: "https://cdn/m2.mp3", content_type: "audio/mpeg" },
+        id: "m2",
+      });
+    setCloudMediaClientFactoryForTesting(() => ({
+      routes: { postApiV1GenerateVideo: vi.fn(), postApiV1GenerateMusic },
+    }));
+
+    await expect(
+      handleAudioGeneration(runtime(), {
+        prompt: "synthwave loop",
+        audioKind: "music",
+        durationSeconds: 10,
+      })
+    ).resolves.toMatchObject({ url: "https://cdn/m2.mp3" });
+    expect(postApiV1GenerateMusic).toHaveBeenCalledTimes(2);
+    // The retry dropped the rejected param.
+    expect(postApiV1GenerateMusic.mock.calls[0]?.[0]?.json?.durationSeconds).toBe(10);
+    expect(postApiV1GenerateMusic.mock.calls[1]?.[0]?.json?.durationSeconds).toBeUndefined();
+  });
+
+  it("does not strip durationSeconds for unrelated music failures", async () => {
+    const postApiV1GenerateMusic = vi
+      .fn()
+      .mockRejectedValue(new Error("music generation is not configured"));
+    setCloudMediaClientFactoryForTesting(() => ({
+      routes: { postApiV1GenerateVideo: vi.fn(), postApiV1GenerateMusic },
+    }));
+
+    await expect(
+      handleAudioGeneration(runtime(), {
+        prompt: "x",
+        audioKind: "music",
+        durationSeconds: 10,
+      })
+    ).rejects.toThrow("not configured");
+    expect(postApiV1GenerateMusic).toHaveBeenCalledTimes(1);
+  });
 });

--- a/plugins/plugin-elizacloud/src/models/media.ts
+++ b/plugins/plugin-elizacloud/src/models/media.ts
@@ -203,29 +203,56 @@ export async function handleAudioGeneration(
     numberValue(params.durationSeconds) ?? numberValue(params.duration);
 
   logger.log("[ELIZAOS_CLOUD] Using AUDIO model via /generate-music");
-  const response = await retryMediaWarming(
-    () =>
-      cloudMediaClientFactory(
-        runtime,
-      ).routes.postApiV1GenerateMusic<CloudMusicResponse>({
-        json: cleanRecord({
-          prompt,
-          model: stringValue(params.model),
-          provider: stringValue(params.provider),
-          durationSeconds,
-          referenceUrl: stringValue(params.referenceUrl ?? params.audioUrl),
-          seed: numberValue(params.seed),
-          outputFormat: stringValue(params.outputFormat),
-          instrumental: booleanValue(params.instrumental),
-          extraInput: params.genre ? { genre: params.genre } : undefined,
-        }),
-        timeoutMs: resolveCloudTimeoutMs(
-          "ELIZAOS_CLOUD_MUSIC_TIMEOUT_MS",
-          300_000,
-        ),
-      }),
-    "Music generation",
+  const requestJson = cleanRecord({
+    prompt,
+    model: stringValue(params.model),
+    provider: stringValue(params.provider),
+    durationSeconds,
+    referenceUrl: stringValue(params.referenceUrl ?? params.audioUrl),
+    seed: numberValue(params.seed),
+    outputFormat: stringValue(params.outputFormat),
+    instrumental: booleanValue(params.instrumental),
+    extraInput: params.genre ? { genre: params.genre } : undefined,
+  });
+  const timeoutMs = resolveCloudTimeoutMs(
+    "ELIZAOS_CLOUD_MUSIC_TIMEOUT_MS",
+    300_000,
   );
+  const postMusic = (json: Record<string, JsonValue>) =>
+    retryMediaWarming(
+      () =>
+        cloudMediaClientFactory(
+          runtime,
+        ).routes.postApiV1GenerateMusic<CloudMusicResponse>({
+          json,
+          timeoutMs,
+        }),
+      "Music generation",
+    );
+  let response: CloudMusicResponse;
+  try {
+    response = await postMusic(requestJson);
+  } catch (err) {
+    // error-policy:J2 fixed-price music models 400 with an explicitly
+    // machine-actionable hint ("...omit durationSeconds and bill it as a
+    // fixed-price generation" — generate-music route). Observed live: "make
+    // me a 10 second synthwave loop" set durationSeconds=10 against the
+    // default fal-ai/minimax-music model and the whole turn failed. Honour
+    // the server's instruction with ONE retry minus the param; any other
+    // failure rethrows unchanged.
+    const message = err instanceof Error ? err.message : String(err);
+    if (
+      requestJson.durationSeconds === undefined ||
+      !/does not support durationSeconds/i.test(message)
+    ) {
+      throw err;
+    }
+    logger.warn(
+      "[ELIZAOS_CLOUD] Music model rejects durationSeconds; retrying as a fixed-price generation",
+    );
+    const { durationSeconds: _omitted, ...fixedPriceJson } = requestJson;
+    response = await postMusic(fixedPriceJson);
+  }
 
   const audioUrl = response.music?.url;
   if (!audioUrl) {

--- a/plugins/plugin-elizacloud/src/models/media.ts
+++ b/plugins/plugin-elizacloud/src/models/media.ts
@@ -230,6 +230,7 @@ export async function handleAudioGeneration(
       "Music generation",
     );
   let response: CloudMusicResponse;
+  let outputDurationSeconds = durationSeconds;
   try {
     response = await postMusic(requestJson);
   } catch (err) {
@@ -252,6 +253,7 @@ export async function handleAudioGeneration(
     );
     const { durationSeconds: _omitted, ...fixedPriceJson } = requestJson;
     response = await postMusic(fixedPriceJson);
+    outputDurationSeconds = undefined;
   }
 
   const audioUrl = response.music?.url;
@@ -264,7 +266,7 @@ export async function handleAudioGeneration(
     audioUrl,
     mimeType: response.music?.content_type ?? "audio/mpeg",
     title: response.music?.file_name,
-    duration: durationSeconds,
+    duration: outputDurationSeconds,
     requestId: response.requestId,
     id: response.id,
     status: response.status,


### PR DESCRIPTION
## Summary

The default `fal-ai/minimax-music/v2.6` route rejects caller-supplied `durationSeconds` with an explicit instruction to omit it and bill the request as fixed-price. The Cloud media handler now follows that contract with exactly one retry after that exact rejection; unrelated failures still surface unchanged.

If the fixed-price retry succeeds, the returned record omits the rejected duration instead of claiming the user-requested value describes the generated track. The retry composes with the existing bounded cold-cache warming retry.

## Original regression

A live nubilio e2e battery run on 2026-08-11 at 06:23Z received “make me a short 10 second synthwave loop”. `GENERATE_MEDIA` supplied `durationSeconds: 10`; the generate-music route rejected it and the turn ended in the generic runtime-step failure. This historical receipt proves the regression only. It is not represented as exact-head post-fix success.

## Testing

Published head: `f6467e95cd1b39a0d5f26556167bd7445eeb226b`, rebased exactly onto `ba28980808d702acf547f530e2adeecd291d7652` with unchanged patch range-diff and zero touched-path overlap.

- Focused Vitest: 1 file, 8/8 PASS.
- `@elizaos/plugin-elizacloud` typecheck: PASS.
- Exact two-path Biome invocation returned PASS; the existing package `biome.json` processed the test file and excludes `src/models/**`, so `media.ts` is supported by the 8/8 behavior test, package typecheck, diff-check, and byte-identical blob proof rather than a false claim that Biome processed it.
- Exact-file diff-check: PASS.
- Published-head blobs equal the dependency-ready integration train byte-for-byte:
  - `src/models/media.ts`: `c009b8eb782f17fa347f08a3f016683b5a6c199f`
  - `__tests__/cloud-media-generation.test.ts`: `6e588c046c5064ad391810818fc657b2309161c8`

The focused contract proves the retry strips `durationSeconds`, unrelated errors do not retry, and successful fixed-price retries omit rejected duration metadata.

# Evidence Gate

<!-- evidence-head:f6467e95cd1b39a0d5f26556167bd7445eeb226b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Server-side Cloud media handler only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Server-side Cloud media handler only; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No rendered user flow changed; behavior is exercised by the focused handler contract.

<!-- evidence-row:backend-logs -->
- [x] Historical live failure and exact-head focused proof are pasted inline below.

<details>
<summary>Backend/runtime receipt</summary>

```text
run: nubilio live e2e battery, 2026-08-11 06:23Z
input: make me a short 10 second synthwave loop
action: GENERATE_MEDIA supplied durationSeconds=10
backend: Media generation failed (mediaType=audio, error=Model fal-ai/minimax-music/v2.6 does not support durationSeconds; omit durationSeconds and bill it as a fixed-price generation...)
outcome: generic runtime-step failure; no audio attachment returned
exact-head focused test: 1 file, 8/8 PASS
exact-head package typecheck: PASS
two-path Biome command: PASS (1 file processed; existing package config excludes src/models/**)
exact-head diff-check: PASS
```
</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend code or browser state changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - The raw provider/model trajectory bundle from the historical live failure was not retained, and the current final-activation hold forbids an exact-head Cloud replay; only the truthful input/action/error receipt above is claimed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - Post-fix audio requires deployment; the current final-activation hold forbids Cloud mutation, so no exact-head generated audio is claimed.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered visual surface or text changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-ios]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->


