### PR TITLE
fix(ui): keep cloud agent create failures visible

### DIFF
--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -309,6 +309,7 @@ function resetClientMocks() {
   clientMock.resumeCloudCompatAgent.mockReset();
   clientMock.getCloudCompatJobStatus.mockReset();
   clientMock.getCloudCompatAgentStatus.mockReset();
+  clientMock.selectOrProvisionCloudAgent.mockReset();
   persistenceMock.loadPersistedActiveServer.mockReset();
   persistenceMock.savePersistedActiveServer.mockReset();
   // deleteAgent now guards on window.confirm; default it to accept so the
@@ -316,6 +317,75 @@ function resetClientMocks() {
   // explicitly below).
   window.confirm = () => true;
 }
+
+describe("CloudAgentsSection create outcome", () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    appMock.value = { elizaCloudConnected: true, setActionNotice: vi.fn() };
+    resetClientMocks();
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: "cloud:agent-1",
+      label: "Old Name",
+      accessToken: "tok",
+    });
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps an agent-limit outcome visible without binding or reloading", async () => {
+    clientMock.selectOrProvisionCloudAgent.mockResolvedValue({
+      agentId: "agent-1",
+      agentName: "Old Name",
+      apiBase: "https://agent-1.example.test",
+      created: false,
+    });
+    await renderWithAgents([agent()]);
+
+    const input = screen.getByPlaceholderText(/Agent name/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Fresh Agent" } });
+    fireEvent.click(screen.getByText("Create", { selector: "button" }));
+
+    const alert = await screen.findByTestId("cloud-agent-create-error");
+    expect(alert.textContent).toContain("No new agent was created");
+    expect(alert.textContent).toContain("agent limit");
+    expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("No new agent was created"),
+      "error",
+      7000,
+    );
+    expect(input.value).toBe("Fresh Agent");
+    expect(persistenceMock.savePersistedActiveServer).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it("clears the durable create error when the user edits the name", async () => {
+    clientMock.selectOrProvisionCloudAgent.mockResolvedValue({
+      agentId: "agent-1",
+      agentName: "Old Name",
+      apiBase: "https://agent-1.example.test",
+      created: false,
+    });
+    await renderWithAgents([agent()]);
+
+    const input = screen.getByPlaceholderText(/Agent name/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Fresh Agent" } });
+    fireEvent.click(screen.getByText("Create", { selector: "button" }));
+    await screen.findByTestId("cloud-agent-create-error");
+
+    fireEvent.change(input, { target: { value: "Another Name" } });
+    expect(screen.queryByTestId("cloud-agent-create-error")).toBeNull();
+  });
+});
 
 describe("CloudAgentsSection lifecycle (suspend/resume)", () => {
   beforeEach(() => {

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -106,6 +106,7 @@ export function CloudAgentsSection() {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
   // The agent currently being woken (resumed + readiness-polled) before we
@@ -284,18 +285,19 @@ export function CloudAgentsSection() {
   const createAgent = useCallback(async () => {
     const name = newName.trim();
     if (!name) {
-      setActionNotice("Give your agent a name first.", "error", 3000);
+      const message = "Give your agent a name first.";
+      setCreateError(message);
+      setActionNotice(message, "error", 3000);
       return;
     }
     const token = currentCloudToken();
     if (!token) {
-      setActionNotice(
-        "Sign in to Eliza Cloud before creating an agent.",
-        "error",
-        4000,
-      );
+      const message = "Sign in to Eliza Cloud before creating an agent.";
+      setCreateError(message);
+      setActionNotice(message, "error", 4000);
       return;
     }
+    setCreateError(null);
     setCreating(true);
     try {
       const result = await client.selectOrProvisionCloudAgent({
@@ -305,28 +307,24 @@ export function CloudAgentsSection() {
         forceCreate: true,
         onProgress: () => {},
       });
-      // Honest outcome (#14487): with forceCreate the backend still reuses the
-      // org's existing agent when the org is at its per-org agent cap (#11023),
-      // returning `created: false`. Do NOT claim a fresh agent was made: bind
-      // to the (existing) agent we got back but tell the user why no new one
-      // appeared, so "Create a new agent" never silently lies.
-      const label = result.agentName || name;
+      // A reused result cannot satisfy an explicit create request. Keep the
+      // user on the form with durable corrective guidance; binding and
+      // reloading would erase the transient notice and look like a no-op when
+      // the returned agent is already active.
       if (result.created === false) {
-        bindAndReload(
-          result.agentId,
-          result.apiBase,
-          label,
-          `You've reached your agent limit, so we opened your existing agent “${label}” instead. Delete an agent or add credits to create another.`,
-        );
-      } else {
-        bindAndReload(result.agentId, result.apiBase, name);
+        const message =
+          "No new agent was created because this organization is already at its agent limit. Delete an existing agent before trying again.";
+        setCreateError(message);
+        setActionNotice(message, "error", 7000);
+        setCreating(false);
+        return;
       }
+      bindAndReload(result.agentId, result.apiBase, name);
     } catch (err) {
-      setActionNotice(
-        err instanceof Error ? err.message : "Failed to create agent.",
-        "error",
-        4000,
-      );
+      const message =
+        err instanceof Error ? err.message : "Failed to create agent.";
+      setCreateError(message);
+      setActionNotice(message, "error", 4000);
       setCreating(false);
     }
   }, [newName, cloudApiBase, bindAndReload, setActionNotice]);
@@ -764,7 +762,10 @@ export function CloudAgentsSection() {
         <div className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center">
           <Input
             value={newName}
-            onChange={(e) => setNewName(e.target.value)}
+            onChange={(e) => {
+              setNewName(e.target.value);
+              setCreateError(null);
+            }}
             placeholder={`Agent name (e.g. ${appName})`}
             className="flex-1"
             maxLength={AGENT_NAME_MAX_LENGTH}
@@ -782,6 +783,15 @@ export function CloudAgentsSection() {
             {creating ? "Creating…" : "Create"}
           </Button>
         </div>
+        {createError && (
+          <p
+            role="alert"
+            data-testid="cloud-agent-create-error"
+            className="px-4 pb-3 text-sm text-destructive"
+          >
+            {createError}
+          </p>
+        )}
       </SettingsGroup>
     </SettingsStack>
   );


### PR DESCRIPTION
# Relates to

Relates to #18304. This is the UI-honesty repair discovered during its exact staging acceptance; it does not close the broader pairing issue by itself.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop@04a98e6fe5d3ecba23f2a4b8267b424dee20e96e` with zero conflicts.
- [ ] `bun run verify` is pending; focused validation is recorded below.
- [ ] Exact staging screenshots, logs, and walkthrough are pending.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@04a98e6fe5d3ecba23f2a4b8267b424dee20e96e:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` is pending before ready-for-review.

# Risks

Low. The successful fresh-agent path is unchanged. The explicit `created:false` path no longer binds or reloads into an existing agent; it remains on the form and surfaces a persistent error with corrective guidance.

# Background

## What does this PR do?

Keeps an explicit cloud-agent creation failure visible in Settings. When the backend returns `created:false` for an organization at its agent limit, the form now:

- states that no new agent was created;
- preserves the requested name;
- does not overwrite the active-agent binding;
- does not reload away the message; and
- clears the durable error when the user edits the request.

Validation and authentication failures also render inline instead of existing only as transient shell notices.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No project documentation change is needed; the behavior is self-contained product error handling.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/settings/CloudAgentsSection.tsx` and the new create-outcome cases in `CloudAgentsSection.test.tsx`.

## Detailed testing steps

1. Open Settings → Eliza Cloud Agents while already at the organization agent limit.
2. Enter a new name and click Create.
3. Verify the form remains visible with an inline error saying no new agent was created.
4. Verify the existing agent is not rebound and the page does not reload.
5. Edit the requested name and verify the stale error clears.

Automated exact-head proof:

- `CloudAgentsSection.test.tsx`: 29/29 PASS.
- `bun run --cwd packages/ui typecheck`: PASS after building the declared cloud-routing and generated-keyword prerequisites.
- Biome on both touched files: PASS.
- `git diff --check`: PASS.

# Evidence Gate

<!-- evidence-head:2fe14ab6f5eb8d8a33047e0b0b0377235fd9c8fb -->

<!-- evidence-row:before-screenshots -->
- [ ] Before desktop and iOS Simulator screenshots pending exact staging capture.
<!-- evidence-row:after-screenshots -->
- [ ] After desktop and iOS Simulator screenshots pending exact staging capture.
<!-- evidence-row:walkthrough-video -->
- [ ] MP4 walkthrough pending exact staging capture.
<!-- evidence-row:backend-logs -->
- [ ] Backend request/outcome logs pending exact staging capture.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs pending exact staging capture.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the corrected failure path intentionally creates and persists no agent or binding.
<!-- evidence-row:ocr-review -->
- [ ] OCR review pending exact staging screenshots.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

Pending the exact staging acceptance rerun.

## Screenshots (before / after) + video walkthrough

Pending the exact staging acceptance rerun on desktop and the iOS Simulator.

## Audio / voice walkthrough

N/A - this PR does not alter voice, transcript, TTS, or STT behavior.

## Known gaps / failures

- Root `bun run verify` has not run yet; the focused suite, package typecheck, Biome, and diff checks pass.
- Required visual/native evidence remains pending, so this PR is intentionally draft.
- A fresh disposable-agent acceptance attempt remains procedurally blocked until the staging organization has capacity or a fresh staging organization is authorized.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@04a98e6fe5d3ecba23f2a4b8267b424dee20e96e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [kepler]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@04a98e6fe5d3ecba23f2a4b8267b424dee20e96e:packages/skills/skills/contribute-to-eliza"} -->
