### PR TITLE
fix(ui): route Cloud agent creation directly

### DIFF
--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -374,6 +374,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
       status: 200,
       data: {
         success: true,
+        created: true,
         data: { id: "dedicated-1", agentName: "My Agent", status: "pending" },
       },
     });

--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -291,6 +291,7 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     });
     createCloudCompatAgent.mockResolvedValue({
       success: true,
+      created: true,
       data: {
         agentId: "dedicated-target",
         agentName: "Eliza",
@@ -435,6 +436,7 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     });
     createCloudCompatAgent.mockResolvedValue({
       success: true,
+      created: true,
       data: {
         agentId: "agent-replacement",
         agentName: "Eliza",
@@ -525,6 +527,7 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
       fakeClient();
     createCloudCompatAgent.mockResolvedValue({
       success: true,
+      created: true,
       data: {
         agentId: "agent-forced-new",
         agentName: "Demo Fresh",
@@ -562,11 +565,9 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(result.agentId).toBe("agent-forced-new");
   });
 
-  it("reports created:false when the backend reused an existing agent despite forceCreate (org at per-org cap #11023) so the UI cannot claim a fresh agent (#14487)", async () => {
-    const { client, createCloudCompatAgent } = fakeClient();
-    // Backend hit the per-org cap: the reuse guard handed back the existing
-    // agent and the create route returned 200 `created: false`. The client
-    // must propagate that, not hardcode `created: true`.
+  it("rejects an existing-agent response to forceCreate without binding or inspecting that agent", async () => {
+    const { client, createCloudCompatAgent, getCloudCompatAgent } =
+      fakeClient();
     createCloudCompatAgent.mockResolvedValue({
       success: true,
       created: false,
@@ -579,30 +580,21 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
         message: "Agent created",
       },
     });
-    (client.getCloudCompatAgent as ReturnType<typeof vi.fn>).mockResolvedValue({
-      success: true,
-      data: makeAgent({
-        agent_id: "agent-existing",
-        agent_name: "Launch Verify Dedicated",
-        status: "running",
-        web_ui_url: "https://agent-existing.example.test",
-        webUiUrl: "https://agent-existing.example.test",
+
+    await expect(
+      client.selectOrProvisionCloudAgent({
+        ...BASE_OPTS,
+        name: "Demo Fresh",
+        forceCreate: true,
       }),
-    });
+    ).rejects.toThrow("did not confirm that a new agent was created");
 
-    const result = await client.selectOrProvisionCloudAgent({
-      ...BASE_OPTS,
-      name: "Demo Fresh",
-      forceCreate: true,
-    });
-
-    expect(result.created).toBe(false);
-    expect(result.agentId).toBe("agent-existing");
+    expect(getCloudCompatAgent).not.toHaveBeenCalled();
   });
 
-  it("keeps created:true when the create response omits the flag (older worker / non-direct path) so the pre-existing UX is unchanged", async () => {
-    const { client, createCloudCompatAgent } = fakeClient();
-    // No `created` field at all — the client must not demote a normal create.
+  it("rejects an ambiguous force-create response that omits the freshness flag", async () => {
+    const { client, createCloudCompatAgent, getCloudCompatAgent } =
+      fakeClient();
     createCloudCompatAgent.mockResolvedValue({
       success: true,
       data: {
@@ -614,24 +606,15 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
         message: "",
       },
     });
-    (client.getCloudCompatAgent as ReturnType<typeof vi.fn>).mockResolvedValue({
-      success: true,
-      data: makeAgent({
-        agent_id: "agent-legacy",
-        status: "provisioning",
-        web_ui_url: "https://agent-legacy.example.test",
-        webUiUrl: "https://agent-legacy.example.test",
+    await expect(
+      client.selectOrProvisionCloudAgent({
+        ...BASE_OPTS,
+        name: "Eliza",
+        forceCreate: true,
       }),
-    });
+    ).rejects.toThrow("did not confirm that a new agent was created");
 
-    const result = await client.selectOrProvisionCloudAgent({
-      ...BASE_OPTS,
-      name: "Eliza",
-      forceCreate: true,
-    });
-
-    expect(result.created).toBe(true);
-    expect(result.agentId).toBe("agent-legacy");
+    expect(getCloudCompatAgent).not.toHaveBeenCalled();
   });
 
   // Default first-run: a freshly-created dedicated agent whose container is

--- a/packages/ui/src/api/client-cloud-web-join-base.test.ts
+++ b/packages/ui/src/api/client-cloud-web-join-base.test.ts
@@ -1,14 +1,9 @@
-/** Verifies getCloudCompatAgents on hosted web with no agent baseUrl (join flow) through the package's configured test harness. */
-// @vitest-environment jsdom
-
 /**
- * Unit coverage for direct-Cloud base resolution during the hosted-web `/join`
- * flow: a signed-in Steward session with NO agent baseUrl yet. The base must
- * resolve from the PAGE host so `getCloudCompatAgents` hits the cloud worker
- * rather than the agent-proxy path (`/api/cloud/compat/agents`), which only
- * agent servers mount. Capacitor forced web + CapacitorHttp mocked, fetch
- * stubbed, no live cloud.
+ * Verifies hosted-web Cloud account requests choose the control plane without
+ * crossing agent and Steward credential boundaries. Capacitor is forced to web
+ * and fetch is stubbed; no live Cloud service is contacted.
  */
+// @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -153,5 +148,159 @@ describe("getCloudCompatAgents connected to a non-cloud agent while served from 
       expect(url).not.toContain("/api/v1/eliza/agents");
       expect(url).not.toContain("api.elizacloud.ai");
     }
+  });
+});
+
+describe("Cloud account management while connected to a dedicated Cloud agent", () => {
+  const dedicatedStagingBase =
+    "https://11111111-1111-4111-8111-111111111111.staging.elizacloud.ai";
+
+  it("uses the page-matched control plane and the stored Steward token for list and force-create", async () => {
+    setHostname("app-staging.elizacloud.ai");
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            success: true,
+            created: true,
+            data: {
+              id: "22222222-2222-4222-8222-222222222222",
+              agentName: "Disposable",
+              status: "pending",
+            },
+          },
+          202,
+        ),
+      );
+
+    const client = new ElizaClient(dedicatedStagingBase, "agent-bearer");
+    await client.getCloudCompatAgents();
+    await client.createCloudCompatAgent({
+      agentName: "Disposable",
+      forceCreate: true,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    for (const [url, init] of fetchSpy.mock.calls) {
+      expect(String(url)).toBe("/api/v1/eliza/agents");
+      expect(new Headers(init?.headers).get("authorization")).toBe(
+        "Bearer steward-jwt",
+      );
+      expect(String(url)).not.toContain("/api/cloud/compat/agents");
+    }
+    const createInit = fetchSpy.mock.calls[1][1] as RequestInit;
+    expect(createInit.method).toBe("POST");
+    expect(JSON.parse(String(createInit.body))).toEqual({
+      agentName: "Disposable",
+      alwaysOn: true,
+      forceCreate: true,
+    });
+  });
+
+  it("never relabels or sends the dedicated agent bearer when the Steward session is missing", async () => {
+    setHostname("app-staging.elizacloud.ai");
+    localStorage.removeItem("steward_session_token");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const client = new ElizaClient(dedicatedStagingBase, "agent-bearer");
+
+    await expect(
+      client.selectOrProvisionCloudAgent({
+        cloudApiBase: "https://staging.elizacloud.ai",
+        authToken: "agent-bearer",
+        name: "Disposable",
+        forceCreate: true,
+      }),
+    ).rejects.toThrow("Eliza Cloud login session is missing");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(localStorage.getItem("steward_session_token")).toBeNull();
+  });
+
+  it.each(["warm_pool", "warm_pool_recovery"])(
+    "accepts authoritative %s freshness when the backend omits created",
+    async (source) => {
+      setHostname("app-staging.elizacloud.ai");
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        jsonResponse({
+          success: true,
+          source,
+          data: {
+            id: "22222222-2222-4222-8222-222222222222",
+            agentName: "Disposable",
+            status: source === "warm_pool" ? "running" : "provisioning",
+          },
+        }),
+      );
+      const client = new ElizaClient(dedicatedStagingBase, "agent-bearer");
+
+      await expect(
+        client.createCloudCompatAgent({
+          agentName: "Disposable",
+          forceCreate: true,
+        }),
+      ).resolves.toMatchObject({ created: true });
+    },
+  );
+
+  it.each([false, undefined])(
+    "rejects force-create freshness confirmation %s before any agent bind or compat fallback",
+    async (created) => {
+      setHostname("app-staging.elizacloud.ai");
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        jsonResponse({
+          success: true,
+          ...(created === undefined ? {} : { created }),
+          data: {
+            id: "11111111-1111-4111-8111-111111111111",
+            agentName: "Existing",
+            status: "running",
+          },
+        }),
+      );
+      const client = new ElizaClient(dedicatedStagingBase, "agent-bearer");
+
+      await expect(
+        client.createCloudCompatAgent({
+          agentName: "Disposable",
+          forceCreate: true,
+        }),
+      ).rejects.toThrow("did not confirm that a new agent was created");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(String(fetchSpy.mock.calls[0][0])).toBe("/api/v1/eliza/agents");
+      expect(String(fetchSpy.mock.calls[0][0])).not.toContain(
+        "/api/cloud/compat/agents",
+      );
+    },
+  );
+
+  it("surfaces a quota rejection after one direct POST with no retry or compat fallback", async () => {
+    setHostname("app-staging.elizacloud.ai");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(
+        {
+          success: false,
+          error: "Agent quota exceeded",
+          code: "agent_quota_exceeded",
+        },
+        429,
+      ),
+    );
+    const client = new ElizaClient(dedicatedStagingBase, "agent-bearer");
+
+    await expect(
+      client.createCloudCompatAgent({
+        agentName: "Disposable",
+        forceCreate: true,
+      }),
+    ).rejects.toMatchObject({ status: 429 });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0][0])).toBe("/api/v1/eliza/agents");
+    expect(String(fetchSpy.mock.calls[0][0])).not.toContain(
+      "/api/cloud/compat/agents",
+    );
   });
 });

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -142,6 +142,20 @@ type DirectCloudAgentCreateData = {
   status: string;
 };
 
+function requireConfirmedFreshCloudAgentCreate(
+  forceCreate: boolean | undefined,
+  created: boolean | undefined,
+  source?: string,
+): void {
+  const freshWarmPoolSource =
+    source === "warm_pool" || source === "warm_pool_recovery";
+  if (forceCreate && created !== true && !freshWarmPoolSource) {
+    throw new Error(
+      "Eliza Cloud did not confirm that a new agent was created. No agent was opened; refresh your session and try again.",
+    );
+  }
+}
+
 /** Async-job envelope returned by the restart/suspend/resume lifecycle routes. */
 type LifecycleResult = { jobId: string; status: string; message: string };
 
@@ -177,6 +191,19 @@ function isDirectCloudBase(client: ElizaClient): boolean {
     // error-policy:J3 malformed base URL reads as "not a direct cloud base".
     return false;
   }
+}
+
+function resolveCloudPageApiBaseForDedicatedAgent(
+  client: ElizaClient,
+): string | null {
+  if (typeof window === "undefined") return null;
+  const baseUrl = client.getBaseUrl().trim();
+  if (!isDedicatedCloudAgentBase(baseUrl)) return null;
+  return (
+    DIRECT_ELIZA_CLOUD_API_BY_HOST.get(
+      window.location.hostname.toLowerCase(),
+    ) ?? null
+  );
 }
 
 function stringOrNull(value: unknown): string | null {
@@ -421,6 +448,8 @@ function resolveDirectCloudClientApiBase(client: ElizaClient): string | null {
       getBootConfig().cloudApiBase?.trim() || DEFAULT_DIRECT_CLOUD_BASE_URL,
     );
   }
+  const cloudPageApiBase = resolveCloudPageApiBaseForDedicatedAgent(client);
+  if (cloudPageApiBase) return cloudPageApiBase;
   // Web SPA served from a cloud host with no agent baseUrl yet — exactly the
   // /join flow's state (selectOrProvisionCloudAgent runs BEFORE any agent
   // connection exists). Resolve the control plane from the page host so the
@@ -465,6 +494,13 @@ export function getCloudAuthToken(client?: ElizaClient): string | null {
 }
 
 function readDirectCloudToken(client: ElizaClient): string | null {
+  // A managed app may be connected to a dedicated agent while rendering its
+  // account settings. Control-plane calls then resolve from the trusted page
+  // host, but only the independently stored Steward session may cross that
+  // boundary; the client's REST token belongs to the agent container.
+  if (resolveCloudPageApiBaseForDedicatedAgent(client)) {
+    return readStoredStewardToken()?.trim() || null;
+  }
   return getCloudAuthToken(client);
 }
 
@@ -547,15 +583,16 @@ export async function refreshCloudStewardSession(opts?: {
   } | null;
 }
 
-function isNativeDirectCloudAuthMissing(client: ElizaClient): boolean {
+function isDirectCloudAuthMissing(client: ElizaClient): boolean {
   return (
-    shouldUseNativeCloudHttp() &&
+    (shouldUseNativeCloudHttp() ||
+      Boolean(resolveCloudPageApiBaseForDedicatedAgent(client))) &&
     Boolean(resolveDirectCloudClientApiBase(client)) &&
     !readDirectCloudToken(client)
   );
 }
 
-function nativeDirectCloudAuthMissingMessage(): string {
+function directCloudAuthMissingMessage(): string {
   return "Eliza Cloud login session is missing. Sign in again.";
 }
 
@@ -1223,10 +1260,10 @@ declare module "./client-base" {
       /**
        * Whether the backend actually MINTED a fresh agent (201/202) versus
        * handing back an existing non-terminal one via the idempotent reuse
-       * guard (200, `created: false`), e.g. the org is at its per-org agent
-       * cap (#11023). Callers surfacing a "created" affordance must not claim a
-       * fresh agent when this is false (#14487). Undefined when the response
-       * omits the flag (older worker / non-direct path); treat as unknown.
+       * guard (200, `created: false`) when `forceCreate` is omitted. A forced
+       * request is quota-checked instead and must never reuse an existing row.
+       * Warm-pool branches confirm freshness through their source marker and
+       * are normalized to `true`; undefined otherwise means unknown.
        */
       created?: boolean;
       data: {
@@ -1902,11 +1939,11 @@ ElizaClient.prototype.getCloudCompatAgents = async function (
     };
   }
 
-  if (isNativeDirectCloudAuthMissing(this)) {
+  if (isDirectCloudAuthMissing(this)) {
     return {
       success: false,
       data: [],
-      error: nativeDirectCloudAuthMissingMessage(),
+      error: directCloudAuthMissingMessage(),
     };
   }
 
@@ -1983,10 +2020,11 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
   const tierFields = opts.preferSharedTier ? {} : { alwaysOn: true };
   const direct = await directCloudRequest<{
     success: boolean;
-    // `created: false` means the backend reused an existing non-terminal agent
-    // (idempotent 200) instead of minting a fresh one, e.g. the org hit its
-    // per-org cap (#11023). Thread it up so the UI can tell the truth (#14487).
+    // `created: false` means a non-forced request reused an existing
+    // non-terminal agent. Forced requests are rejected if they ever report
+    // reuse, because their contract is a distinct agent or an explicit error.
     created?: boolean;
+    source?: string;
     data: unknown;
     error?: string;
   }>(this, "/api/v1/eliza/agents", {
@@ -2010,10 +2048,15 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
     }),
   });
   if (direct) {
+    requireConfirmedFreshCloudAgentCreate(
+      opts.forceCreate,
+      direct.created,
+      direct.source,
+    );
     const data = parseDirectCloudAgentCreateData(direct.data, opts.agentName);
     return {
       success: direct.success,
-      created: direct.created,
+      created: opts.forceCreate ? true : direct.created,
       data: {
         agentId: data.id,
         agentName: data.agentName,
@@ -2025,7 +2068,7 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
     };
   }
 
-  if (isNativeDirectCloudAuthMissing(this)) {
+  if (isDirectCloudAuthMissing(this)) {
     return {
       success: false,
       data: {
@@ -2034,7 +2077,7 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
         jobId: "",
         status: "error",
         nodeId: null,
-        message: nativeDirectCloudAuthMissingMessage(),
+        message: directCloudAuthMissingMessage(),
       },
     };
   }
@@ -2042,8 +2085,9 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
   if (isDirectCloudBase(this)) {
     const response = await this.fetch<{
       success: boolean;
-      // See the direct-path note: `created: false` = idempotent reuse (#14487).
+      // See the direct-path note: `created: false` is valid only without force.
       created?: boolean;
+      source?: string;
       data: unknown;
       error?: string;
     }>("/api/v1/eliza/agents", {
@@ -2062,10 +2106,15 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
           : {}),
       }),
     });
+    requireConfirmedFreshCloudAgentCreate(
+      opts.forceCreate,
+      response.created,
+      response.source,
+    );
     const data = parseDirectCloudAgentCreateData(response.data, opts.agentName);
     return {
       success: response.success,
-      created: response.created,
+      created: opts.forceCreate ? true : response.created,
       data: {
         agentId: data.id,
         agentName: data.agentName,
@@ -2075,6 +2124,12 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
         message: response.success ? "Agent created" : (response.error ?? ""),
       },
     };
+  }
+
+  if (opts.forceCreate) {
+    throw new Error(
+      "Creating a distinct Cloud agent requires a signed-in direct Eliza Cloud session.",
+    );
   }
 
   return this.fetch("/api/cloud/compat/agents", {
@@ -2104,10 +2159,10 @@ ElizaClient.prototype.provisionCloudCompatAgent = async function (
     return normalizeCloudCompatProvisionResponse(direct, agentId);
   }
 
-  if (isNativeDirectCloudAuthMissing(this)) {
+  if (isDirectCloudAuthMissing(this)) {
     return {
       success: false,
-      error: nativeDirectCloudAuthMissingMessage(),
+      error: directCloudAuthMissingMessage(),
       data: { agentId, status: "auth-missing" },
     };
   }
@@ -2151,11 +2206,11 @@ ElizaClient.prototype.getCloudCompatAgent = async function (
     };
   }
 
-  if (isNativeDirectCloudAuthMissing(this)) {
+  if (isDirectCloudAuthMissing(this)) {
     return {
       success: false,
       data: toCloudCompatAgent({ id: agentId, status: "auth-missing" }),
-      error: nativeDirectCloudAuthMissingMessage(),
+      error: directCloudAuthMissingMessage(),
     };
   }
 
@@ -2415,14 +2470,14 @@ ElizaClient.prototype.deleteCloudCompatAgent = async function (
   });
   if (direct) return normalizeDelete(direct);
 
-  if (isNativeDirectCloudAuthMissing(this)) {
+  if (isDirectCloudAuthMissing(this)) {
     return {
       success: false,
-      error: nativeDirectCloudAuthMissingMessage(),
+      error: directCloudAuthMissingMessage(),
       data: {
         jobId: "",
         status: "auth-missing",
-        message: nativeDirectCloudAuthMissingMessage(),
+        message: directCloudAuthMissingMessage(),
       },
     };
   }
@@ -2477,10 +2532,10 @@ ElizaClient.prototype.updateCloudCompatAgent = async function (
   }>(this, path, { method: "PATCH", body });
   if (direct) return normalize(direct);
 
-  if (isNativeDirectCloudAuthMissing(this)) {
+  if (isDirectCloudAuthMissing(this)) {
     return {
       success: false,
-      error: nativeDirectCloudAuthMissingMessage(),
+      error: directCloudAuthMissingMessage(),
       data: { agentId, agentName: edit.agentName ?? "" },
     };
   }
@@ -2529,7 +2584,7 @@ ElizaClient.prototype.getCloudCompatAgentStatus = async function (
     };
   }
 
-  if (isNativeDirectCloudAuthMissing(this)) {
+  if (isDirectCloudAuthMissing(this)) {
     return {
       success: false,
       data: {
@@ -2538,10 +2593,10 @@ ElizaClient.prototype.getCloudCompatAgentStatus = async function (
         bridgeUrl: null,
         webUiUrl: null,
         currentNode: null,
-        suspendedReason: nativeDirectCloudAuthMissingMessage(),
+        suspendedReason: directCloudAuthMissingMessage(),
         databaseStatus: "unknown",
       },
-      error: nativeDirectCloudAuthMissingMessage(),
+      error: directCloudAuthMissingMessage(),
     };
   }
 
@@ -2620,14 +2675,14 @@ async function runCloudLifecycleAction(
   }>(client, directPath, { method: "POST" });
   if (direct) return normalizeCloudLifecycleResponse(direct, action);
 
-  if (isNativeDirectCloudAuthMissing(client)) {
+  if (isDirectCloudAuthMissing(client)) {
     return {
       success: false,
-      error: nativeDirectCloudAuthMissingMessage(),
+      error: directCloudAuthMissingMessage(),
       data: {
         jobId: "",
         status: "auth-missing",
-        message: nativeDirectCloudAuthMissingMessage(),
+        message: directCloudAuthMissingMessage(),
       },
     };
   }
@@ -2688,10 +2743,10 @@ ElizaClient.prototype.launchCloudCompatAgent = async function (
   });
   if (direct) return direct;
 
-  if (isNativeDirectCloudAuthMissing(this)) {
+  if (isDirectCloudAuthMissing(this)) {
     return {
       success: false,
-      error: nativeDirectCloudAuthMissingMessage(),
+      error: directCloudAuthMissingMessage(),
     };
   }
 
@@ -2732,15 +2787,15 @@ ElizaClient.prototype.getCloudCompatJobStatus = async function (
     };
   }
 
-  if (isNativeDirectCloudAuthMissing(this)) {
+  if (isDirectCloudAuthMissing(this)) {
     return {
       success: false,
       data: toCloudCompatJob({
         id: jobId,
         status: "failed",
-        error: nativeDirectCloudAuthMissingMessage(),
+        error: directCloudAuthMissingMessage(),
       }),
-      error: nativeDirectCloudAuthMissingMessage(),
+      error: directCloudAuthMissingMessage(),
     };
   }
 
@@ -3458,11 +3513,11 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   const resolvedCloudApiBase = resolveDirectCloudAuthApiBase(cloudApiBase);
   let forceCreateForTerminalAgents = false;
   let forceCreatePastSharedAgents = false;
-  // Ensure the direct-cloud requests below authenticate even on a cold boot,
-  // where the resolved token may be empty (the caller always passes the session
-  // token). Persist it through the canonical steward-session store so
-  // getCloudAuthToken() resolves it for those requests.
-  if (authToken) {
+  // Cold-boot callers pass the Steward session explicitly. Persist it only
+  // before a Cloud agent connection exists: once the app is bound to a
+  // dedicated agent, the caller's fallback may be that agent's bearer, which
+  // must never be relabeled as a control-plane credential.
+  if (authToken && !resolveCloudPageApiBaseForDedicatedAgent(this)) {
     writeStoredStewardToken(authToken);
   }
 
@@ -3595,6 +3650,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   if (!created.success || !created.data.agentId) {
     throw new Error(created.data.message || "Failed to create cloud agent");
   }
+  requireConfirmedFreshCloudAgentCreate(mustForceCreate, created.created);
   const agentId = created.data.agentId;
   // error-policy:J4 detail is an optimization probe (warm-pool fast path);
   // on failure the standard dedicated subdomain is still the desired default.
@@ -3649,12 +3705,9 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     agentName: created.data.agentName || name,
     apiBase,
     bridgeUrl: detailAgent?.bridge_url ?? null,
-    // Report what the backend ACTUALLY did, not what we asked for. When the org
-    // is at its per-org cap (#11023) the create POST returns 200 `created:
-    // false` (the reuse guard handed back the existing agent), and the caller's
-    // "created a new agent" affordance must not lie about it (#14487). Only an
-    // explicit `false` demotes to reuse; an absent flag (older worker) stays
-    // `true` so the pre-existing create UX is unchanged.
+    // Preserve compatibility for non-forced callers. A force-create response
+    // must explicitly confirm `created: true` above because a "Create new"
+    // action may never bind an existing or ambiguous agent response.
     created: created.created !== false,
     requiresAgentPairing: false,
     executionTier: detailAgent?.execution_tier ?? null,

--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -951,6 +951,9 @@ describe("CloudAgentsSection create credential boundary", () => {
       ),
     );
     expect(clientMock.selectOrProvisionCloudAgent).not.toHaveBeenCalled();
+    expect(screen.getByTestId("cloud-agent-create-error").textContent).toBe(
+      "Sign in to Eliza Cloud before creating an agent.",
+    );
   });
 
   it("does not bind an ambiguous force-create response", async () => {
@@ -962,7 +965,8 @@ describe("CloudAgentsSection create credential boundary", () => {
     });
     await renderWithAgents([agent({ agent_name: "Existing" })]);
 
-    fireEvent.change(screen.getByPlaceholderText(/Agent name/), {
+    const input = screen.getByPlaceholderText(/Agent name/) as HTMLInputElement;
+    fireEvent.change(input, {
       target: { value: "Disposable" },
     });
     fireEvent.click(screen.getByText("Create"));
@@ -974,7 +978,19 @@ describe("CloudAgentsSection create credential boundary", () => {
         7000,
       ),
     );
+    const alert = screen.getByTestId("cloud-agent-create-error");
+    expect(alert.textContent).toContain(
+      "did not confirm that a new agent was created",
+    );
+    expect(input.value).toBe("Disposable");
+    expect(
+      (screen.getByText("Create", { selector: "button" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
     expect(persistenceMock.savePersistedActiveServer).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: "Another disposable" } });
+    expect(screen.queryByTestId("cloud-agent-create-error")).toBeNull();
   });
 });
 

--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -1,13 +1,8 @@
-/** Verifies CloudAgentsSection rename through the package's configured test harness. */
-// @vitest-environment jsdom
-
 /**
- * Covers CloudAgentsSection rename (client call + persisted active-server label
- * sync, no-op on unchanged/empty names, error revert) and suspend/resume
- * lifecycle (direct-path client calls, error surfacing, status re-sync), and
- * safe teardown while a list request is pending. jsdom renders with the app
- * store, cloud API client, and persistence mocked.
+ * Verifies Cloud agent settings lifecycle and credential-safe creation through
+ * the app store, Cloud client, and persistence boundaries mocked in jsdom.
  */
+// @vitest-environment jsdom
 
 import {
   act,
@@ -37,6 +32,10 @@ const clientMock = vi.hoisted(() => ({
   getCloudCompatJobStatus: vi.fn(),
   getCloudCompatAgentStatus: vi.fn(),
   selectOrProvisionCloudAgent: vi.fn(),
+}));
+
+const cloudAuthMock = vi.hoisted(() => ({
+  token: "tok" as string | null,
 }));
 
 /** A status-poll response shaped like `getCloudCompatAgentStatus` returns. */
@@ -82,9 +81,7 @@ vi.mock("../../api", () => ({
 vi.mock("../../api/client-cloud", () => ({
   resolveCloudAgentApiBase: (args: { agentId: string }) =>
     `https://api.elizacloud.ai/api/v1/eliza/agents/${args.agentId}`,
-  // currentCloudToken now resolves Steward-first via getCloudAuthToken; return
-  // null so it falls through to the persisted active-server token these tests set.
-  getCloudAuthToken: () => null,
+  getCloudAuthToken: () => cloudAuthMock.token,
 }));
 
 vi.mock("../../config/boot-config", () => ({
@@ -910,6 +907,74 @@ describe("CloudAgentsSection load state (error vs empty)", () => {
     });
     expect(screen.getByText("Newest")).toBeTruthy();
     expect(screen.queryByTestId("cloud-agents-empty")).toBeNull();
+  });
+});
+
+describe("CloudAgentsSection create credential boundary", () => {
+  beforeEach(() => {
+    appMock.value = {
+      elizaCloudConnected: true,
+      setActionNotice: vi.fn(),
+    };
+    cloudAuthMock.token = "tok";
+    clientMock.getCloudCompatAgents.mockReset();
+    clientMock.selectOrProvisionCloudAgent.mockReset();
+    persistenceMock.loadPersistedActiveServer.mockReset();
+    persistenceMock.savePersistedActiveServer.mockReset();
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: "cloud:agent-1",
+      label: "Existing",
+      accessToken: "paired-agent-bearer",
+    });
+  });
+
+  afterEach(() => {
+    cloudAuthMock.token = "tok";
+    cleanup();
+  });
+
+  it("does not substitute the persisted agent bearer when the Steward session is missing", async () => {
+    cloudAuthMock.token = null;
+    await renderWithAgents([agent({ agent_name: "Existing" })]);
+
+    fireEvent.change(screen.getByPlaceholderText(/Agent name/), {
+      target: { value: "Disposable" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() =>
+      expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+        "Sign in to Eliza Cloud before creating an agent.",
+        "error",
+        4000,
+      ),
+    );
+    expect(clientMock.selectOrProvisionCloudAgent).not.toHaveBeenCalled();
+  });
+
+  it("does not bind an ambiguous force-create response", async () => {
+    clientMock.selectOrProvisionCloudAgent.mockResolvedValue({
+      agentId: "agent-existing",
+      agentName: "Existing",
+      apiBase: "https://agent-existing.elizacloud.ai",
+      created: undefined,
+    });
+    await renderWithAgents([agent({ agent_name: "Existing" })]);
+
+    fireEvent.change(screen.getByPlaceholderText(/Agent name/), {
+      target: { value: "Disposable" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() =>
+      expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+        expect.stringContaining("did not confirm that a new agent was created"),
+        "error",
+        7000,
+      ),
+    );
+    expect(persistenceMock.savePersistedActiveServer).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -77,18 +77,10 @@ function activeCloudAgentId(): string | null {
 
 /** The cloud access token for the current session. */
 function currentCloudToken(): string {
-  // Canonical Steward-first resolution (matches getCloudAuthToken: Steward JWT →
-  // runtime global → client), then fall back to the persisted active-server
-  // token for sessions without a Steward session. The old order read the
-  // persisted token first and skipped the Steward JWT entirely, which could send
-  // a stale/missing token from the agent manager.
-  const canonical = getCloudAuthToken();
-  if (canonical) return canonical;
-  const persisted = loadPersistedActiveServer();
-  if (persisted?.kind === "cloud" && persisted.accessToken) {
-    return persisted.accessToken;
-  }
-  return "";
+  // Agent management crosses the control-plane boundary, so only the
+  // independently stored Steward session is admissible. The active server's
+  // access token authenticates its container and must never substitute here.
+  return getCloudAuthToken() ?? "";
 }
 
 /**
@@ -305,19 +297,13 @@ export function CloudAgentsSection() {
         forceCreate: true,
         onProgress: () => {},
       });
-      // Honest outcome (#14487): with forceCreate the backend still reuses the
-      // org's existing agent when the org is at its per-org agent cap (#11023),
-      // returning `created: false`. Do NOT claim a fresh agent was made: bind
-      // to the (existing) agent we got back but tell the user why no new one
-      // appeared, so "Create a new agent" never silently lies.
-      const label = result.agentName || name;
-      if (result.created === false) {
-        bindAndReload(
-          result.agentId,
-          result.apiBase,
-          label,
-          `You've reached your agent limit, so we opened your existing agent “${label}” instead. Delete an agent or add credits to create another.`,
+      if (result.created !== true) {
+        setActionNotice(
+          "Eliza Cloud did not confirm that a new agent was created. No agent was opened; refresh your session and try again.",
+          "error",
+          7000,
         );
+        return;
       } else {
         bindAndReload(result.agentId, result.apiBase, name);
       }

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -98,6 +98,7 @@ export function CloudAgentsSection() {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
   // The agent currently being woken (resumed + readiness-polled) before we
@@ -276,18 +277,19 @@ export function CloudAgentsSection() {
   const createAgent = useCallback(async () => {
     const name = newName.trim();
     if (!name) {
-      setActionNotice("Give your agent a name first.", "error", 3000);
+      const message = "Give your agent a name first.";
+      setCreateError(message);
+      setActionNotice(message, "error", 3000);
       return;
     }
     const token = currentCloudToken();
     if (!token) {
-      setActionNotice(
-        "Sign in to Eliza Cloud before creating an agent.",
-        "error",
-        4000,
-      );
+      const message = "Sign in to Eliza Cloud before creating an agent.";
+      setCreateError(message);
+      setActionNotice(message, "error", 4000);
       return;
     }
+    setCreateError(null);
     setCreating(true);
     try {
       const result = await client.selectOrProvisionCloudAgent({
@@ -298,21 +300,20 @@ export function CloudAgentsSection() {
         onProgress: () => {},
       });
       if (result.created !== true) {
-        setActionNotice(
-          "Eliza Cloud did not confirm that a new agent was created. No agent was opened; refresh your session and try again.",
-          "error",
-          7000,
-        );
+        const message =
+          "Eliza Cloud did not confirm that a new agent was created. No agent was opened; refresh your session and try again.";
+        setCreateError(message);
+        setActionNotice(message, "error", 7000);
+        setCreating(false);
         return;
       } else {
         bindAndReload(result.agentId, result.apiBase, name);
       }
     } catch (err) {
-      setActionNotice(
-        err instanceof Error ? err.message : "Failed to create agent.",
-        "error",
-        4000,
-      );
+      const message =
+        err instanceof Error ? err.message : "Failed to create agent.";
+      setCreateError(message);
+      setActionNotice(message, "error", 4000);
       setCreating(false);
     }
   }, [newName, cloudApiBase, bindAndReload, setActionNotice]);
@@ -750,7 +751,10 @@ export function CloudAgentsSection() {
         <div className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center">
           <Input
             value={newName}
-            onChange={(e) => setNewName(e.target.value)}
+            onChange={(e) => {
+              setNewName(e.target.value);
+              setCreateError(null);
+            }}
             placeholder={`Agent name (e.g. ${appName})`}
             className="flex-1"
             maxLength={AGENT_NAME_MAX_LENGTH}
@@ -768,6 +772,15 @@ export function CloudAgentsSection() {
             {creating ? "Creating…" : "Create"}
           </Button>
         </div>
+        {createError && (
+          <p
+            role="alert"
+            data-testid="cloud-agent-create-error"
+            className="px-4 pb-3 text-sm text-destructive"
+          >
+            {createError}
+          </p>
+        )}
       </SettingsGroup>
     </SettingsStack>
   );


### PR DESCRIPTION
# Relates to

- Fixes the staging acceptance blocker tracked in #18304.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto
      `9f9048d7d24069ebfab9c8b3fafc13f4213cdca7` with zero conflicts. Develop's
      subsequent #18350 advance is path-disjoint; GitHub remains mergeable.
- [x] `bun install` and one full `bun run verify` passed after sync; the exact
      follow-up UX consolidation passed its focused suite, typecheck, Biome,
      and diff check without repeating the broad suite.
- [ ] A reviewer can confirm the live change without reading the code; exact
      staging screenshots/video/logs remain pending this draft's deployment.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased once onto `9f9048d7d24069ebfab9c8b3fafc13f4213cdca7`;
      subsequent develop drift has zero changed-path overlap.
- [x] Full `bun run verify` passed on the first product commit; the exact head's
      two-file UX delta passes its focused suite, typecheck, Biome, and diff
      check.

# Risks

**Medium.** This changes which Cloud endpoint and credential are used by the
account-management surface when the app is already connected to a dedicated
agent. A regression could block Cloud inventory/create, misroute an agent
bearer to the control plane, or bind an existing agent after an ambiguous
forced-create response. Focused tests cover each boundary and the existing
self-hosted/agent-proxy paths.

# Background

## What does this PR do?

When `app-staging.elizacloud.ai` rendered Settings while its client was already
bound to a dedicated `*.staging.elizacloud.ai` agent, Cloud account operations
failed to resolve the trusted control-plane base. They fell through to the
connected agent's legacy `/api/cloud/compat/*` surface. That made inventory and
creation depend on the age/shape of that agent container; the acceptance run
observed the compat inventory export failure and no disposable agent appeared.
The exact one-shot POST outcome remains unknown because the retained browser
capture contained no request/response event, so this PR does not invent a
server response or quota diagnosis.

This patch makes the boundary deterministic:

- a trusted Cloud page connected to a dedicated agent resolves account calls
  to its environment-matched Cloud control plane;
- only the independently stored Steward session may cross that boundary—the
  connected agent bearer cannot substitute or be relabelled as Steward;
- missing Steward auth fails closed without a request or compat fallback;
- forced creation never falls back to legacy compat and proceeds only when the
  direct response authoritatively confirms a fresh row (`created: true` or a
  documented fresh warm-pool source);
- ambiguous/reused forced-create responses surface an error and never bind or
  reload into an existing agent.

## What kind of change is this?

Bug fix (non-breaking Cloud routing, credential isolation, and honest
forced-create handling).

# Documentation changes needed?

No public documentation change is required. This repairs the existing Settings
→ Eliza Cloud contract without changing its user-facing workflow or API.

# Testing

## Where should a reviewer start?

Start in `packages/ui/src/api/client-cloud.ts`, then review the behavioral
coverage in `client-cloud-web-join-base.test.ts`,
`client-cloud-select-or-provision.test.ts`, and
`CloudAgentsSection.test.tsx`.

## Detailed testing steps

- Focused and adjacent UI suites before the path-disjoint develop advance:
  **8 files / 107 tests passed**.
- Exact-head credential regression lane, including the native direct-auth
  fixture: **4 files / 92 tests passed**.
- `bun run --cwd packages/ui typecheck`: passed.
- `bun run --cwd packages/ui lint:check`: passed with only 8 pre-existing,
  unrelated `noDocumentCookie` warnings.
- Focused Biome check on all 5 changed files: passed.
- `git diff --check`: passed.
- `bun run verify`: passed once in full at the patch-identical pre-rebase product
  commit `70a1ba5545f`
  (**348/348 Turbo tasks**, all subsequent audits green; anti-larp scanned
  7,801 tests clean). Per the operator's local-first rule, the two-file UX
  consolidation was validated with its exact focused suite and package gates
  rather than repeating the broad run.

The exact live acceptance remains intentionally stopped after its single
authorized create attempt. It will resume only after review, merge, coherent
staging deployment, and explicit authorization for one replacement attempt.

# Evidence Gate

<!-- evidence-head:21e28adccce79821e26b8915f696756a8bf084ad -->

<!-- evidence-row:before-screenshots -->
- [x] [Stopped one-shot staging state before the fix](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18362-cloud-agent-create-before.png)
<!-- evidence-row:after-screenshots -->
- [ ] Pending exact deployed staging capture after merge.
<!-- evidence-row:walkthrough-video -->
- [ ] Pending exact deployed staging walkthrough after merge.
<!-- evidence-row:backend-logs -->
- [ ] Pending redacted real staging create/provision receipt after merge.
<!-- evidence-row:frontend-logs -->
- [ ] Pending redacted console/network receipt from the resumed one-shot run.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this PR changes Cloud account routing and credential ownership; no
      prompt, model, action, provider, or response behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] Pending fresh disposable-agent row/provision receipt and verified cleanup
      from the resumed one-shot run.
<!-- evidence-row:ocr-review -->
- [ ] Pending OCR/manual text review of the exact deployed UI capture.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model behavior changes.

## Backend + frontend logs

Pending the exact deployed staging run. Logs will contain only redacted
method/path/status/timing and outcome fields; no cookies, tokens, account IDs,
agent IDs, or response bodies will be published.

## Screenshots (before / after) + video walkthrough

The manually reviewed before screenshot exists locally at
`/Users/nubs/.eliza-wt-1/qa-acceptance/runs/20260811T061035Z/cloud-agent-create-before.png`
and will be uploaded to this PR. After/video evidence requires the exact merged
staging deployment and one explicitly authorized replacement attempt.

## Audio / voice walkthrough

N/A for this routing patch. The existing acceptance packet separately requires
the real iOS Simulator text/voice/reload flow once disposable creation works.

## Known gaps / failures

- The prior staging attempt is evidence of the blocked state, not proof of the
  exact create response: its buffered network capture was empty/truncated.
- Live after/video/log/domain evidence is pending deployment and explicit
  reauthorization; the evidence gate remains intentionally open for that
  post-merge proof.
- No broad hosted-CI archaeology or repeated full-suite loop is planned; the
  single local full verification and focused real-path suites are green.

## Deploy notes

After merge, deploy the exact merged `develop` SHA to staging Pages/Worker for
the narrowly labelled create/routing proof. The full iOS artifact is rebuilt
only after the known voice and notification fixes join the coherent final SHA.
Preserve the existing oversized staging agent; this PR does not authorize
opening, modifying, or deleting it.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [kepler]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
