### PR TITLE
fix(scripts): sweep stale artifact archives before sync early-exits

### DIFF
--- a/packages/scripts/sync-artifacts.mjs
+++ b/packages/scripts/sync-artifacts.mjs
@@ -41,6 +41,13 @@ const warn = (m) => console.warn(`[sync-artifacts] WARNING: ${m}`);
 const PROGRESS_INTERVAL_MS = 5000;
 const STALE_TMP_MAX_AGE_MS = 6 * 60 * 60_000;
 
+// Sweep BEFORE any early exit. On shared self-hosted runners most jobs skip
+// the sync (ELIZA_SKIP_ARTIFACT_SYNC=1) or exit on the manifest/marker checks,
+// and a cancelled job leaks its ~1GB partial download — observed live: a
+// canonical prod node doubling as a CI runner reached 100% disk with a /tmp
+// full of eliza-artifacts-*.tar.gz that no surviving code path ever swept.
+cleanupStaleTempArchives();
+
 if (process.env.ELIZA_SKIP_ARTIFACT_SYNC === "1") {
   log("skipped (ELIZA_SKIP_ARTIFACT_SYNC=1)");
   process.exit(0);
@@ -52,7 +59,6 @@ if (!existsSync(MANIFEST)) {
 
 const m = JSON.parse(readFileSync(MANIFEST, "utf8"));
 const { version, asset } = m;
-cleanupStaleTempArchives();
 
 if (existsSync(MARKER) && readFileSync(MARKER, "utf8").trim() === version) {
   log(`artifacts already at ${version}; nothing to do`);


### PR DESCRIPTION
Live incident (2026-08-11): canonical prod node `eliza-core-prod-2` — which doubles as a self-hosted CI runner — reached **100% disk (94G/98G, 0 bytes free)** with `/tmp` holding 12,936 entries including a pile of ~972MB `eliza-artifacts-<pid>.tar.gz` tarballs.

Root cause: `cleanupStaleTempArchives()` runs AFTER the `ELIZA_SKIP_ARTIFACT_SYNC=1` and manifest/marker early-exits. On shared runners most jobs skip the sync (e.g. quality.yml) or exit on the version marker, so the sweep almost never executes there — while every **cancelled** job (this week produced many) leaks its partial ~1GB download with nothing left to reclaim it. Fix: hoist the sweep above all early exits (function declaration hoisting makes the call-before-definition safe); every invocation now reclaims stale archives regardless of path taken.

Manual remediation already applied on the node (aged tarballs + buildx cache volumes removed: 100% → ~80%); this PR prevents recurrence.

**Evidence**: skip-path smoke run locally (script logs the skip after sweeping); biome clean; incident numbers above from the live node.

- Before screenshots `N/A - build tooling, no UI surface`.
- After screenshots `N/A - build tooling, no UI surface`.
- Walkthrough video `N/A - no UI surface`.
- Backend logs: node df/du transcript in HQ #18309 (capacity incident).
- Frontend logs `N/A - no frontend change`.
- Real-LLM trajectory `N/A - no model path involved`.
- Domain artifacts: /tmp on the runner stays bounded after merge (verifiable on the node).
- OCR review `N/A - no rendered visual surface`.

<!-- evidence-head:4f076be71887c3c8f5aa9f84924029fd8c870ca0 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)