### PR TITLE
fix(cloud-scripts): give warm-pool replenish a creation-sized phase budget

### DIFF
--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -1430,12 +1430,13 @@ async function runBoundedPhase<T>(
   label: string,
   phase: () => Promise<T>,
   onResult: (result: T) => void,
+  timeoutMs: number = PHASE_TIMEOUT_MS,
 ): Promise<void> {
   const { withTimeout } = await loadDeps();
   try {
     const result = await withTimeout(
       phase(),
-      PHASE_TIMEOUT_MS,
+      timeoutMs,
       `[provisioning-worker] ${label}`,
     );
     onResult(result);
@@ -1834,6 +1835,14 @@ async function runInfraMaintenanceCycle(
         );
       }
     },
+    // A warm container creation takes ~70s end-to-end (image start + Steward
+    // registration + readiness), so the default 60s wedge budget expired every
+    // cycle while the entry then completed seconds later (observed live on
+    // cp-prod: "cycle timed out after 60000ms" followed by "pool entry
+    // ready"). Maintenance phases are off the watchdog-critical WORK group,
+    // so a 2-minute budget is invariant-safe and stops the false alarm
+    // without unbounding a genuinely wedged replenish.
+    2 * 60_000,
   );
 
   // FIX 3: orphan-container reconciliation. Runs LAST so it sees the fresh


### PR DESCRIPTION
Observed live on cp-prod right after enabling the warm pool (launch chain step 4): every maintenance cycle logs `warm pool replenish cycle timed out after 60000ms` — and then `pool entry ready` lands seconds later. A warm container creation takes ~70s end-to-end (image start + Steward registration + readiness), so the 60s per-phase wedge budget is structurally shorter than the phase's own success path.

Fix: optional `timeoutMs` on `runBoundedPhase` (default `PHASE_TIMEOUT_MS`, all other phases unchanged) and a 2-minute budget for replenish only. Maintenance phases are off the watchdog-critical WORK group, so `WORKER_TIMING`/`assertWatchdogInvariant` are untouched — the timing-pin tests prove it.

**Evidence**: 51/51 worker unit tests (incl. FIX-F timing pins); live journal excerpts (timeout-then-ready pairs) in HQ #18309.

- Before screenshots `N/A - daemon script, no UI surface`.
- After screenshots `N/A - daemon script, no UI surface`.
- Walkthrough video `N/A - no UI surface`.
- Backend logs: cp-prod journal timeout-then-ready pairs (quoted in HQ).
- Frontend logs `N/A - no frontend change`.
- Real-LLM trajectory `N/A - no model path involved`.
- Domain artifacts: post-deploy the false alarm disappears while replenish results still log.
- OCR review `N/A - no rendered visual surface`.

<!-- evidence-head:6aacb7d97885f28330d052a95a49e6ced8fee4e5 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Evidence Gate

<!-- evidence-head:6aacb7d97885f28330d052a95a49e6ced8fee4e5 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend cloud-script timing change with no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend cloud-script timing change with no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - CI-only budget correction; behavior is covered by the cloud-script test suite.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path is involved.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, model, action, or provider behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifacts are produced by this timing-budget change.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surface changed.