### PR TITLE
fix(ui): secure trusted-shell Cloud agent control

### DIFF
--- a/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
+++ b/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
@@ -43,6 +43,7 @@ vi.mock("@capacitor/core", () => ({
 
 import { DEFAULT_BOOT_CONFIG, setBootConfig } from "../config/boot-config";
 import { ElizaClient } from "./client-base";
+import { DIRECT_ELIZA_CLOUD_API_BY_HOST } from "./direct-cloud-endpoints";
 // Side-effect imports: patch the cloud + chat domains onto the prototype.
 import "./client-cloud";
 import "./client-chat";
@@ -396,6 +397,7 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
 
   afterAll(async () => {
     await new Promise<void>((resolve) => server.close(() => resolve()));
+    DIRECT_ELIZA_CLOUD_API_BY_HOST.delete("127.0.0.1");
     setBootConfig(DEFAULT_BOOT_CONFIG);
   });
 
@@ -404,8 +406,10 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
     state.conversations.clear();
     state.requests.length = 0;
     state.resumeCalls.length = 0;
-    // Make the mock origin the recognized direct-cloud base for both
-    // isDirectCloudBase() (client-base origin match) and the native fallback.
+    // The production resolver trusts only the canonical host table. This
+    // explicit test-only entry makes the real local server a recognized
+    // control plane without weakening the configured-origin boundary.
+    DIRECT_ELIZA_CLOUD_API_BY_HOST.set("127.0.0.1", base);
     setBootConfig({ ...DEFAULT_BOOT_CONFIG, cloudApiBase: base });
   });
 

--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -966,7 +966,9 @@ describe("ElizaClient direct Cloud auth on native", () => {
       throw new Error(`Unexpected native Cloud request: ${method} ${url}`);
     });
 
-    const client = new ElizaClient("http://localhost:31337");
+    // Native Cloud account setup starts without an agent binding. A non-empty
+    // local/self-hosted base is intentionally kept on its own compat origin.
+    const client = new ElizaClient("");
     const login = await client.cloudLoginDirect("https://www.elizacloud.ai");
     const poll = await client.cloudLoginPollDirect(
       login.apiBase ?? "https://api.elizacloud.ai",

--- a/packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts
+++ b/packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Verifies dedicated-agent account management crosses to the Cloud control
+ * plane only from trusted native, desktop, and local-development app shells.
+ */
+// @vitest-environment jsdom
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const platform = vi.hoisted(() => ({
+  native: false,
+  request: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => platform.native },
+  CapacitorHttp: {
+    get: vi.fn(),
+    post: vi.fn(),
+    request: platform.request,
+  },
+}));
+
+import { setBootConfig } from "../config/boot-config";
+import { ElizaClient } from "./client-base";
+import "./client-cloud";
+
+const DEDICATED_STAGING_BASE =
+  "https://11111111-1111-4111-8111-111111111111.staging.elizacloud.ai";
+const STAGING_CONTROL_PLANE = "https://api-staging.elizacloud.ai";
+const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "location",
+);
+
+type ElectrobunWindow = Window & { __electrobunWindowId?: number };
+
+function setPageLocation(
+  hostname: string,
+  protocol: "http:" | "https:" = "http:",
+): void {
+  const port = protocol === "http:" ? "2138" : "";
+  const host = port ? `${hostname}:${port}` : hostname;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      hostname,
+      host,
+      port,
+      protocol,
+      origin: `${protocol}//${host}`,
+      href: `${protocol}//${host}/settings`,
+    },
+  });
+}
+
+function setElectrobunRuntime(enabled: boolean): void {
+  const runtimeWindow = window as ElectrobunWindow;
+  if (enabled) {
+    Object.defineProperty(runtimeWindow, "__electrobunWindowId", {
+      configurable: true,
+      value: 1,
+    });
+  } else {
+    delete runtimeWindow.__electrobunWindowId;
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function assertStewardRequests(
+  calls: ReadonlyArray<readonly [RequestInfo | URL, RequestInit?]>,
+): void {
+  for (const [url, init] of calls) {
+    expect(String(url)).toMatch(
+      /^https:\/\/api-staging\.elizacloud\.ai\/api\/v1\//,
+    );
+    expect(String(url)).not.toContain("/api/cloud/compat/");
+    expect(new Headers(init?.headers).get("authorization")).toBe(
+      "Bearer steward-jwt",
+    );
+  }
+}
+
+beforeEach(() => {
+  platform.native = false;
+  platform.request.mockReset();
+  localStorage.removeItem(STEWARD_TOKEN_KEY);
+  setElectrobunRuntime(false);
+  setBootConfig({
+    branding: {},
+    cloudApiBase: "https://staging.elizacloud.ai",
+  });
+});
+
+afterEach(() => {
+  localStorage.removeItem(STEWARD_TOKEN_KEY);
+  setElectrobunRuntime(false);
+  if (originalLocationDescriptor) {
+    Object.defineProperty(window, "location", originalLocationDescriptor);
+  }
+  vi.restoreAllMocks();
+});
+
+describe("dedicated Cloud account boundary on trusted app shells", () => {
+  it("uses only the stored Steward session for native list, create, and lifecycle requests", async () => {
+    platform.native = true;
+    localStorage.setItem(STEWARD_TOKEN_KEY, "steward-jwt");
+    platform.request
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { success: true, data: [] },
+      })
+      .mockResolvedValueOnce({
+        status: 202,
+        data: {
+          success: true,
+          created: true,
+          data: {
+            id: "agent-new",
+            agentName: "Disposable",
+            status: "provisioning",
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        status: 202,
+        data: {
+          success: true,
+          data: {
+            jobId: "job-resume",
+            status: "queued",
+            message: "Resume job created.",
+          },
+        },
+      });
+    const client = new ElizaClient(DEDICATED_STAGING_BASE, "agent-bearer");
+
+    await client.getCloudCompatAgents();
+    await client.createCloudCompatAgent({
+      agentName: "Disposable",
+      forceCreate: true,
+    });
+    await client.resumeCloudCompatAgent("agent-new");
+
+    expect(platform.request).toHaveBeenCalledTimes(3);
+    for (const [request] of platform.request.mock.calls) {
+      expect(request.url).toMatch(
+        /^https:\/\/api-staging\.elizacloud\.ai\/api\/v1\//,
+      );
+      expect(request.url).not.toContain("/api/cloud/compat/");
+      expect(request.headers.Authorization).toBe("Bearer steward-jwt");
+    }
+    expect(platform.request.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        method: "POST",
+        data: expect.objectContaining({ forceCreate: true }),
+      }),
+    );
+    expect(platform.request.mock.calls[2]?.[0]).toEqual(
+      expect.objectContaining({
+        method: "POST",
+        url: `${STAGING_CONTROL_PLANE}/api/v1/eliza/agents/agent-new/resume`,
+      }),
+    );
+  });
+
+  it("fails native list, create, and lifecycle closed when only the agent bearer exists", async () => {
+    platform.native = true;
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const client = new ElizaClient(DEDICATED_STAGING_BASE, "agent-bearer");
+
+    await expect(
+      client.selectOrProvisionCloudAgent({
+        cloudApiBase: "https://staging.elizacloud.ai",
+        authToken: "agent-bearer",
+        name: "Disposable",
+        forceCreate: true,
+      }),
+    ).rejects.toThrow("Eliza Cloud login session is missing");
+    const listed = await client.getCloudCompatAgents();
+    const created = await client.createCloudCompatAgent({
+      agentName: "Disposable",
+      forceCreate: true,
+    });
+    const resumed = await client.resumeCloudCompatAgent("agent-new");
+
+    expect(listed).toMatchObject({
+      success: false,
+      error: "Eliza Cloud login session is missing. Sign in again.",
+    });
+    expect(created).toMatchObject({
+      success: false,
+      data: { status: "error" },
+    });
+    expect(resumed).toMatchObject({
+      success: false,
+      data: { status: "auth-missing" },
+    });
+    expect(platform.request).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+  });
+
+  it.each([
+    { label: "Electrobun", hostname: "127.0.0.1", electrobun: true },
+    { label: "localhost dev", hostname: "localhost", electrobun: false },
+  ])(
+    "routes $label list, create, and lifecycle requests directly with Steward",
+    async ({ hostname, electrobun }) => {
+      setPageLocation(hostname);
+      setElectrobunRuntime(electrobun);
+      localStorage.setItem(STEWARD_TOKEN_KEY, "steward-jwt");
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(jsonResponse({ success: true, data: [] }))
+        .mockResolvedValueOnce(
+          jsonResponse(
+            {
+              success: true,
+              created: true,
+              data: {
+                id: "agent-new",
+                agentName: "Disposable",
+                status: "provisioning",
+              },
+            },
+            202,
+          ),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse(
+            {
+              success: true,
+              data: {
+                jobId: "job-resume",
+                status: "queued",
+                message: "Resume job created.",
+              },
+            },
+            202,
+          ),
+        );
+      const client = new ElizaClient(DEDICATED_STAGING_BASE, "agent-bearer");
+
+      await client.getCloudCompatAgents();
+      await client.createCloudCompatAgent({
+        agentName: "Disposable",
+        forceCreate: true,
+      });
+      await client.resumeCloudCompatAgent("agent-new");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      assertStewardRequests(fetchSpy.mock.calls);
+      expect(fetchSpy.mock.calls[1]?.[1]).toEqual(
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"forceCreate":true'),
+        }),
+      );
+      expect(String(fetchSpy.mock.calls[2]?.[0])).toBe(
+        `${STAGING_CONTROL_PLANE}/api/v1/eliza/agents/agent-new/resume`,
+      );
+    },
+  );
+
+  it.each([
+    { label: "Electrobun", hostname: "127.0.0.1", electrobun: true },
+    { label: "localhost dev", hostname: "localhost", electrobun: false },
+  ])(
+    "fails $label closed without Steward and never tries direct or compat transport",
+    async ({ hostname, electrobun }) => {
+      setPageLocation(hostname);
+      setElectrobunRuntime(electrobun);
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      const client = new ElizaClient(DEDICATED_STAGING_BASE, "agent-bearer");
+
+      await expect(
+        client.selectOrProvisionCloudAgent({
+          cloudApiBase: "https://staging.elizacloud.ai",
+          authToken: "agent-bearer",
+          name: "Disposable",
+          forceCreate: true,
+        }),
+      ).rejects.toThrow("Eliza Cloud login session is missing");
+      const listed = await client.getCloudCompatAgents();
+      const created = await client.createCloudCompatAgent({
+        agentName: "Disposable",
+        forceCreate: true,
+      });
+      const resumed = await client.resumeCloudCompatAgent("agent-new");
+
+      expect(listed).toMatchObject({ success: false, data: [] });
+      expect(created).toMatchObject({
+        success: false,
+        data: { status: "error" },
+      });
+      expect(resumed).toMatchObject({
+        success: false,
+        data: { status: "auth-missing" },
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    },
+  );
+
+  it("does not grant an arbitrary self-hosted page direct control-plane access", async () => {
+    setPageLocation("dashboard.example.test", "https:");
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: [] }));
+    const client = new ElizaClient(DEDICATED_STAGING_BASE, "agent-bearer");
+
+    await expect(
+      client.selectOrProvisionCloudAgent({
+        cloudApiBase: "https://staging.elizacloud.ai",
+        authToken: "agent-bearer",
+        name: "Disposable",
+        forceCreate: true,
+      }),
+    ).rejects.toThrow("requires a signed-in direct Eliza Cloud session");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+
+    localStorage.setItem(STEWARD_TOKEN_KEY, "steward-jwt");
+    await client.getCloudCompatAgents();
+    await expect(
+      client.createCloudCompatAgent({
+        agentName: "Disposable",
+        forceCreate: true,
+      }),
+    ).rejects.toThrow("requires a signed-in direct Eliza Cloud session");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+      `${DEDICATED_STAGING_BASE}/api/cloud/compat/agents`,
+    );
+    expect(String(fetchSpy.mock.calls[0]?.[0])).not.toContain(
+      STAGING_CONTROL_PLANE,
+    );
+  });
+});

--- a/packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts
+++ b/packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts
@@ -309,6 +309,83 @@ describe("dedicated Cloud account boundary on trusted app shells", () => {
     },
   );
 
+  it.each([
+    {
+      label: "native",
+      hostname: "localhost",
+      native: true,
+      electrobun: false,
+    },
+    {
+      label: "Electrobun",
+      hostname: "127.0.0.1",
+      native: false,
+      electrobun: true,
+    },
+    {
+      label: "localhost dev",
+      hostname: "localhost",
+      native: false,
+      electrobun: false,
+    },
+  ])(
+    "rejects a hostile configured Cloud endpoint from $label without any transport",
+    async ({ hostname, native, electrobun }) => {
+      platform.native = native;
+      setPageLocation(hostname);
+      setElectrobunRuntime(electrobun);
+      setBootConfig({
+        branding: {},
+        cloudApiBase: "https://attacker.example",
+      });
+      localStorage.setItem(STEWARD_TOKEN_KEY, "steward-jwt");
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      const client = new ElizaClient(DEDICATED_STAGING_BASE, "agent-bearer");
+
+      const listed = await client.getCloudCompatAgents();
+      const created = await client.createCloudCompatAgent({
+        agentName: "Disposable",
+        forceCreate: true,
+      });
+      const resumed = await client.resumeCloudCompatAgent("agent-new");
+
+      expect(listed).toMatchObject({ success: false, data: [] });
+      expect(created).toMatchObject({
+        success: false,
+        data: { status: "error" },
+      });
+      expect(resumed).toMatchObject({
+        success: false,
+        data: { status: "auth-missing" },
+      });
+      expect(platform.request).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps an arbitrary self-hosted native client on its own compat origin", async () => {
+    platform.native = true;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: [] }));
+    const selfHostedBase = "https://agent.example.test";
+    const client = new ElizaClient(selfHostedBase, "agent-bearer");
+
+    await client.getCloudCompatAgents();
+
+    expect(platform.request).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+      `${selfHostedBase}/api/cloud/compat/agents`,
+    );
+    expect(String(fetchSpy.mock.calls[0]?.[0])).not.toContain(
+      STAGING_CONTROL_PLANE,
+    );
+    expect(
+      new Headers(fetchSpy.mock.calls[0]?.[1]?.headers).get("authorization"),
+    ).toBe("Bearer agent-bearer");
+  });
+
   it("does not grant an arbitrary self-hosted page direct control-plane access", async () => {
     setPageLocation("dashboard.example.test", "https:");
     const fetchSpy = vi

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -167,38 +167,31 @@ function isCloudRouteNotFound(error: unknown): error is ApiError {
   );
 }
 
-function originsMatch(left: string, right: string): boolean {
+function resolveKnownDirectCloudApiBase(baseUrl: string): string | null {
   try {
-    return new URL(left).origin === new URL(right).origin;
+    return (
+      DIRECT_ELIZA_CLOUD_API_BY_HOST.get(
+        new URL(baseUrl).hostname.toLowerCase(),
+      ) ?? null
+    );
   } catch {
-    // error-policy:J3 malformed URL input fails closed (no origin match).
-    return false;
+    // error-policy:J3 malformed Cloud endpoints fail closed.
+    return null;
   }
 }
 
 function isDirectCloudBase(client: ElizaClient): boolean {
   const baseUrl = client.getBaseUrl().trim();
   if (!baseUrl) return false;
-
-  const configuredCloudBase =
-    getBootConfig().cloudApiBase?.trim() || DEFAULT_DIRECT_CLOUD_BASE_URL;
-  if (originsMatch(baseUrl, configuredCloudBase)) return true;
-
-  try {
-    const host = new URL(baseUrl).hostname.toLowerCase();
-    return DIRECT_ELIZA_CLOUD_API_BY_HOST.has(host);
-  } catch {
-    // error-policy:J3 malformed base URL reads as "not a direct cloud base".
-    return false;
-  }
+  return resolveKnownDirectCloudApiBase(baseUrl) !== null;
 }
 
 function isDedicatedCloudAgentClient(client: ElizaClient): boolean {
   return isDedicatedCloudAgentBase(client.getBaseUrl());
 }
 
-function resolveConfiguredDirectCloudApiBase(): string {
-  return resolveDirectCloudAuthApiBase(
+function resolveConfiguredDirectCloudApiBase(): string | null {
+  return resolveKnownDirectCloudApiBase(
     getBootConfig().cloudApiBase?.trim() || DEFAULT_DIRECT_CLOUD_BASE_URL,
   );
 }
@@ -479,7 +472,7 @@ function resolveDirectCloudClientApiBase(client: ElizaClient): string | null {
   const dedicatedControlPlaneApiBase =
     resolveDedicatedCloudAgentControlPlaneApiBase(client);
   if (dedicatedControlPlaneApiBase) return dedicatedControlPlaneApiBase;
-  if (shouldUseNativeCloudHttp()) {
+  if (shouldUseNativeCloudHttp() && !baseUrl) {
     return resolveConfiguredDirectCloudApiBase();
   }
   // Web SPA served from a cloud host with no agent baseUrl yet — exactly the
@@ -617,11 +610,18 @@ export async function refreshCloudStewardSession(opts?: {
 }
 
 function isDirectCloudAuthMissing(client: ElizaClient): boolean {
-  return (
+  const directApiBase = resolveDirectCloudClientApiBase(client);
+  const dedicatedControlPlaneRequired =
+    isDedicatedCloudAgentClient(client) &&
     (shouldUseNativeCloudHttp() ||
+      isElectrobunRuntime() ||
+      isTrustedLocalCloudPage() ||
+      isPageServedFromDirectCloudHost());
+  return (
+    (dedicatedControlPlaneRequired && !directApiBase) ||
+    ((shouldUseNativeCloudHttp() ||
       Boolean(resolveDedicatedCloudAgentControlPlaneApiBase(client))) &&
-    Boolean(resolveDirectCloudClientApiBase(client)) &&
-    !readDirectCloudToken(client)
+      !readDirectCloudToken(client))
   );
 }
 

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -193,17 +193,50 @@ function isDirectCloudBase(client: ElizaClient): boolean {
   }
 }
 
-function resolveCloudPageApiBaseForDedicatedAgent(
+function isDedicatedCloudAgentClient(client: ElizaClient): boolean {
+  return isDedicatedCloudAgentBase(client.getBaseUrl());
+}
+
+function resolveConfiguredDirectCloudApiBase(): string {
+  return resolveDirectCloudAuthApiBase(
+    getBootConfig().cloudApiBase?.trim() || DEFAULT_DIRECT_CLOUD_BASE_URL,
+  );
+}
+
+function isTrustedLocalCloudPage(): boolean {
+  if (typeof window === "undefined") return false;
+  const protocol = window.location.protocol.toLowerCase();
+  if (protocol !== "http:" && protocol !== "https:") return false;
+  const hostname = window.location.hostname.toLowerCase();
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]" ||
+    hostname === "::1"
+  );
+}
+
+function resolveDedicatedCloudAgentControlPlaneApiBase(
   client: ElizaClient,
 ): string | null {
-  if (typeof window === "undefined") return null;
-  const baseUrl = client.getBaseUrl().trim();
-  if (!isDedicatedCloudAgentBase(baseUrl)) return null;
-  return (
-    DIRECT_ELIZA_CLOUD_API_BY_HOST.get(
+  if (!isDedicatedCloudAgentClient(client)) return null;
+  if (typeof window !== "undefined") {
+    const pageApiBase = DIRECT_ELIZA_CLOUD_API_BY_HOST.get(
       window.location.hostname.toLowerCase(),
-    ) ?? null
-  );
+    );
+    if (pageApiBase) return pageApiBase;
+  }
+  // Native app shells, packaged desktop, and local app development are all
+  // first-party Cloud CORS origins. They have no Cloud page hostname to map,
+  // so their configured environment is the authoritative control plane.
+  if (
+    shouldUseNativeCloudHttp() ||
+    isElectrobunRuntime() ||
+    isTrustedLocalCloudPage()
+  ) {
+    return resolveConfiguredDirectCloudApiBase();
+  }
+  return null;
 }
 
 function stringOrNull(value: unknown): string | null {
@@ -443,13 +476,12 @@ function resolveDirectCloudClientApiBase(client: ElizaClient): string | null {
   if (baseUrl && isDirectCloudBase(client)) {
     return resolveDirectCloudAuthApiBase(baseUrl);
   }
+  const dedicatedControlPlaneApiBase =
+    resolveDedicatedCloudAgentControlPlaneApiBase(client);
+  if (dedicatedControlPlaneApiBase) return dedicatedControlPlaneApiBase;
   if (shouldUseNativeCloudHttp()) {
-    return resolveDirectCloudAuthApiBase(
-      getBootConfig().cloudApiBase?.trim() || DEFAULT_DIRECT_CLOUD_BASE_URL,
-    );
+    return resolveConfiguredDirectCloudApiBase();
   }
-  const cloudPageApiBase = resolveCloudPageApiBaseForDedicatedAgent(client);
-  if (cloudPageApiBase) return cloudPageApiBase;
   // Web SPA served from a cloud host with no agent baseUrl yet — exactly the
   // /join flow's state (selectOrProvisionCloudAgent runs BEFORE any agent
   // connection exists). Resolve the control plane from the page host so the
@@ -494,11 +526,12 @@ export function getCloudAuthToken(client?: ElizaClient): string | null {
 }
 
 function readDirectCloudToken(client: ElizaClient): string | null {
-  // A managed app may be connected to a dedicated agent while rendering its
-  // account settings. Control-plane calls then resolve from the trusted page
-  // host, but only the independently stored Steward session may cross that
-  // boundary; the client's REST token belongs to the agent container.
-  if (resolveCloudPageApiBaseForDedicatedAgent(client)) {
+  // A managed app may be connected to a dedicated agent while rendering
+  // account settings from hosted web, Capacitor, Electrobun, or localhost.
+  // The agent base owns the client's REST token regardless of the page host;
+  // only the independently stored Steward session may cross to the control
+  // plane.
+  if (isDedicatedCloudAgentClient(client)) {
     return readStoredStewardToken()?.trim() || null;
   }
   return getCloudAuthToken(client);
@@ -586,7 +619,7 @@ export async function refreshCloudStewardSession(opts?: {
 function isDirectCloudAuthMissing(client: ElizaClient): boolean {
   return (
     (shouldUseNativeCloudHttp() ||
-      Boolean(resolveCloudPageApiBaseForDedicatedAgent(client))) &&
+      Boolean(resolveDedicatedCloudAgentControlPlaneApiBase(client))) &&
     Boolean(resolveDirectCloudClientApiBase(client)) &&
     !readDirectCloudToken(client)
   );
@@ -3517,7 +3550,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   // before a Cloud agent connection exists: once the app is bound to a
   // dedicated agent, the caller's fallback may be that agent's bearer, which
   // must never be relabeled as a control-plane credential.
-  if (authToken && !resolveCloudPageApiBaseForDedicatedAgent(this)) {
+  if (authToken && !isDedicatedCloudAgentClient(this)) {
     writeStoredStewardToken(authToken);
   }
 


### PR DESCRIPTION
Closes #18365

## What changed

- Resolve the configured Eliza Cloud control plane for dedicated-agent clients running in trusted Capacitor, Electrobun, and HTTP(S) loopback app shells.
- Keep hosted Cloud pages on their existing page-matched control plane.
- Key Steward credential isolation and `selectOrProvisionCloudAgent` persistence on the dedicated-agent client binding, not `window.location.hostname`.
- Keep arbitrary self-hosted pages outside the direct control-plane boundary.
- Add focused native, Electrobun, localhost-dev, missing-Steward, create, lifecycle, and arbitrary-self-host contract coverage.

## Root cause and impact

PR #18362 correctly isolated Steward credentials on recognized Eliza Cloud web hosts, but its boundary disengaged when the renderer hostname was `localhost` or `127.0.0.1`. Native clients could then fall back to the bound agent bearer, while Electrobun and localhost development used the legacy agent compat surface. This change makes the dedicated-agent binding the credential invariant and uses the configured Cloud environment only for explicitly trusted app shells.

A missing Steward session now fails closed before any control-plane or compat request. The bound agent bearer is never persisted or sent as a Steward credential.

## Validation

- `bun run --cwd packages/ui test -- <all 16 client-cloud*.test.ts files>` — 16 files, 172/172 tests passed
- `bun run --cwd packages/ui typecheck` — passed
- `bunx @biomejs/biome check packages/ui/src/api/client-cloud.ts packages/ui/src/api/client-cloud-trusted-shell-boundary.test.ts` — passed
- `git diff --check origin/develop...HEAD` — passed
- Rebasing proof: one clean rebase onto `8d4010f3e3f8e1f3f5d104c644bfaa9804a41c0e`; no overlap in the two touched files

## Evidence boundaries

- Live Cloud/device/browser execution: N/A — coordination explicitly prohibited Cloud, device, and browser mutation for this security fast-follow.
- Visual screenshots/video: N/A — no rendered UI or copy changes.
- Real model trajectory/audio/domain artifact: N/A — no model, voice, or domain-output behavior changed.
- Transport proof is deterministic contract coverage; it does not claim live service evidence.

## Parallel audit credit

The dedicated-client credential invariant and prototype-fixture compatibility guard incorporate Kepler's parallel audit at commit `854017115ad60678e04278e1fa5f5187962c13a1`. The trusted-shell resolver and broader transport matrix complete the routing portion of #18365.
