### PR TITLE
fix(ios): use installed app display name for widget gallery (fixes #18307)

### DIFF
--- a/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
@@ -109,20 +109,14 @@ final class DeviceExtensionSurfaceUITests: XCTestCase {
     ///
     /// Reads the host app's `label` (which mirrors `CFBundleDisplayName` /
     /// `ELIZA_DISPLAY_NAME` from `app.config.ts`) so the test stays aligned
-    /// with the build's actual display name and preserves white-label support
-    /// without hardcoding stale aliases.
+    /// with the build's actual display name and preserves white-label support.
+    /// Based on NubsCarson:c21d9237 — do not silently substitute a canonical
+    /// brand when the label is unavailable; fail fast per the repository's
+    /// unavailable-state policy.
     private var widgetAppDisplayName: String {
-        let app = XCUIApplication()
-        let label = app.label.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !label.isEmpty {
-            return label
-        }
-        let springboardApp = XCUIApplication(bundleIdentifier: "ai.elizaos.app")
-        let sbLabel = springboardApp.label.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !sbLabel.isEmpty {
-            return sbLabel
-        }
-        return "Eliza"
+        let label = XCUIApplication().label.trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertFalse(label.isEmpty, "Installed app must have a non-empty display label (CFBundleDisplayName/ELIZA_DISPLAY_NAME)")
+        return label
     }
 
     // MARK: - Home/Lock Screen widget

--- a/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
@@ -113,15 +113,28 @@ final class DeviceExtensionSurfaceUITests: XCTestCase {
     /// Based on NubsCarson:c21d9237 — do not silently substitute a canonical
     /// brand when the label is unavailable; fail fast per the repository's
     /// unavailable-state policy.
-    private var widgetAppDisplayName: String {
-        let label = XCUIApplication().label.trimmingCharacters(in: .whitespacesAndNewlines)
-        XCTAssertFalse(label.isEmpty, "Installed app must have a non-empty display label (CFBundleDisplayName/ELIZA_DISPLAY_NAME)")
-        return label
+    private func widgetAppDisplayName() throws -> String {
+        let app = XCUIApplication()
+        app.launch()
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: 15),
+            "Installed app must be running before XCUITest can read its display label."
+        )
+
+        let label = app.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        return try XCTUnwrap(
+            label.isEmpty ? nil : label,
+            "Installed app must have a non-empty display label (CFBundleDisplayName/ELIZA_DISPLAY_NAME)."
+        )
     }
 
     // MARK: - Home/Lock Screen widget
 
     private func installHomeScreenWidgetFromGallery() throws {
+        // XCUIApplication.label cannot be snapshotted after SpringBoard sends
+        // the app to the background, so resolve the required build identity
+        // while the installed target is running and carry it into the flow.
+        let displayName = try widgetAppDisplayName()
         goHome()
         attachScreenshot(named: "widget-assert-00-home-screen")
 
@@ -147,7 +160,6 @@ final class DeviceExtensionSurfaceUITests: XCTestCase {
         let search = springboard.searchFields.firstMatch
         XCTAssertTrue(search.waitForExistence(timeout: 8), "Widget gallery must expose a search field")
         search.tap()
-        let displayName = widgetAppDisplayName
         search.typeText(displayName)
         Thread.sleep(forTimeInterval: 2.0)
         attachScreenshot(named: "widget-assert-02-gallery-search-eliza")

--- a/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
@@ -103,6 +103,28 @@ final class DeviceExtensionSurfaceUITests: XCTestCase {
         attachScreenshot(named: "control-assert-03-gallery-search-eliza")
     }
 
+    // MARK: - Brand-aware display name
+
+    /// The installed target application's real accessibility label.
+    ///
+    /// Reads the host app's `label` (which mirrors `CFBundleDisplayName` /
+    /// `ELIZA_DISPLAY_NAME` from `app.config.ts`) so the test stays aligned
+    /// with the build's actual display name and preserves white-label support
+    /// without hardcoding stale aliases.
+    private var widgetAppDisplayName: String {
+        let app = XCUIApplication()
+        let label = app.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !label.isEmpty {
+            return label
+        }
+        let springboardApp = XCUIApplication(bundleIdentifier: "ai.elizaos.app")
+        let sbLabel = springboardApp.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !sbLabel.isEmpty {
+            return sbLabel
+        }
+        return "Eliza"
+    }
+
     // MARK: - Home/Lock Screen widget
 
     private func installHomeScreenWidgetFromGallery() throws {
@@ -131,12 +153,13 @@ final class DeviceExtensionSurfaceUITests: XCTestCase {
         let search = springboard.searchFields.firstMatch
         XCTAssertTrue(search.waitForExistence(timeout: 8), "Widget gallery must expose a search field")
         search.tap()
-        search.typeText("Eliza")
+        let displayName = widgetAppDisplayName
+        search.typeText(displayName)
         Thread.sleep(forTimeInterval: 2.0)
         attachScreenshot(named: "widget-assert-02-gallery-search-eliza")
 
-        let appRow = springboard.staticTexts["elizaOS"].firstMatch
-        XCTAssertTrue(appRow.waitForExistence(timeout: 8), "Widget gallery search must list elizaOS")
+        let appRow = springboard.staticTexts[displayName].firstMatch
+        XCTAssertTrue(appRow.waitForExistence(timeout: 8), "Widget gallery search must list \(displayName)")
         appRow.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
         Thread.sleep(forTimeInterval: 1.5)
         attachScreenshot(named: "widget-assert-03-detail")

--- a/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
@@ -1,14 +1,16 @@
+/**
+ Assert-level lane for iOS extension surfaces (#13695).
+
+ This suite is intentionally separate from WidgetGalleryCaptureUITests: the
+ capture harness keeps `continueAfterFailure = true` and only produces
+ screenshots, while this suite fails when an expected simulator-reachable
+ surface disappears. Hardware-only verification remains out of scope here:
+ Action Button physical press, device signing/profile faults, and custom
+ keyboard enablement still require the provisioned-device lane called out in
+ #13567/#13563.
+ */
 import XCTest
 
-/// Assert-level lane for iOS extension surfaces (#13695).
-///
-/// This suite is intentionally separate from WidgetGalleryCaptureUITests:
-/// the capture harness keeps `continueAfterFailure = true` and only produces
-/// screenshots, while this suite fails when an expected simulator-reachable
-/// surface disappears. Hardware-only verification remains out of scope here:
-/// Action Button physical press, device signing/profile faults, and custom
-/// keyboard enablement still require the provisioned-device lane called out in
-/// #13567/#13563.
 final class DeviceExtensionSurfaceUITests: XCTestCase {
 
     private let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")

--- a/packages/app-core/platforms/ios/App/AppUITests/WidgetGalleryCaptureUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/WidgetGalleryCaptureUITests.swift
@@ -1,26 +1,16 @@
+/**
+ Widget/control gallery capture harness for issue #12185.
+
+ Drives SpringBoard to open the Home Screen widget gallery and the Control
+ Center gallery, then attaches `.keepAlways` screenshots for the evidence
+ filmstrip. SpringBoard chrome differs across iOS majors, so each gallery leg
+ is best-effort and requires the app and ElizaWidgets extension to be installed.
+
+ A fully unsigned extension cannot be enumerated by the controls gallery; use
+ at least ad-hoc signing before capture.
+ */
 import XCTest
 
-/// Widget/control gallery capture harness (issue #12185).
-///
-/// Drives SpringBoard (not the app) to open the Home Screen widget gallery and
-/// the Control Center "Add a Control" gallery, searches for Eliza, and attaches
-/// `.keepAlways` screenshots at every step so
-/// `xcrun xcresulttool export attachments` yields the evidence filmstrip
-/// (run via packages/app/scripts/ios-device-capture.mjs
-/// --only-testing AppUITests/WidgetGalleryCaptureUITests).
-///
-/// SpringBoard's edit/gallery chrome differs across iOS majors, so each leg is
-/// best-effort: it screenshots whatever state it reached instead of failing the
-/// whole capture on a missing button. Requires the app (and therefore the
-/// ElizaWidgets extension) to already be installed on the target simulator.
-///
-/// Signing gotcha: a `CODE_SIGNING_ALLOWED=NO` simulator build registers the
-/// WIDGETS (static metadata) but the CONTROLS never appear in the gallery —
-/// control enumeration launches the appex, and a fully unsigned appex faults
-/// in XPC peer attribution (EXC_GUARD in `xpc_connection_copy_bundle_id`,
-/// `ExcUserFault_ElizaWidgets` crash log). Build with at least ad-hoc signing
-/// (`CODE_SIGNING_ALLOWED=YES CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=-`)
-/// before capturing the control gallery.
 final class WidgetGalleryCaptureUITests: XCTestCase {
 
     private let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")

--- a/packages/app-core/platforms/ios/App/AppUITests/WidgetGalleryCaptureUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/WidgetGalleryCaptureUITests.swift
@@ -25,6 +25,24 @@ final class WidgetGalleryCaptureUITests: XCTestCase {
 
     private let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
 
+    // MARK: - Brand-aware display name
+
+    /// The installed target application's real accessibility label, mirroring
+    /// `CFBundleDisplayName` / `ELIZA_DISPLAY_NAME` from `app.config.ts`.
+    private var widgetAppDisplayName: String {
+        let app = XCUIApplication()
+        let label = app.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !label.isEmpty {
+            return label
+        }
+        let sbApp = XCUIApplication(bundleIdentifier: "ai.elizaos.app")
+        let sbLabel = sbApp.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !sbLabel.isEmpty {
+            return sbLabel
+        }
+        return "Eliza"
+    }
+
     override func setUpWithError() throws {
         continueAfterFailure = true
     }
@@ -59,11 +77,12 @@ final class WidgetGalleryCaptureUITests: XCTestCase {
         let search = springboard.searchFields.firstMatch
         if search.waitForExistence(timeout: 5) {
             search.tap()
-            search.typeText("Eliza")
+            let displayName = widgetAppDisplayName
+            search.typeText(displayName)
             Thread.sleep(forTimeInterval: 2)
             attachScreenshot(named: "widget-03-gallery-search-eliza")
 
-            let appRow = springboard.staticTexts["elizaOS"].firstMatch
+            let appRow = springboard.staticTexts[displayName].firstMatch
             if appRow.waitForExistence(timeout: 5) {
                 // The result row is often "visible but not hittable" to XCUI's
                 // hit-tester inside the gallery sheet; a coordinate tap works.

--- a/packages/app-core/platforms/ios/App/AppUITests/WidgetGalleryCaptureUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/WidgetGalleryCaptureUITests.swift
@@ -35,10 +35,19 @@ final class WidgetGalleryCaptureUITests: XCTestCase {
     /// Based on NubsCarson:c21d9237 — do not silently substitute a canonical
     /// brand when the label is unavailable; fail fast per the repository's
     /// unavailable-state policy.
-    private var widgetAppDisplayName: String {
-        let label = XCUIApplication().label.trimmingCharacters(in: .whitespacesAndNewlines)
-        XCTAssertFalse(label.isEmpty, "Installed app must have a non-empty display label (CFBundleDisplayName/ELIZA_DISPLAY_NAME)")
-        return label
+    private func widgetAppDisplayName() throws -> String {
+        let app = XCUIApplication()
+        app.launch()
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: 15),
+            "Installed app must be running before XCUITest can read its display label."
+        )
+
+        let label = app.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        return try XCTUnwrap(
+            label.isEmpty ? nil : label,
+            "Installed app must have a non-empty display label (CFBundleDisplayName/ELIZA_DISPLAY_NAME)."
+        )
     }
 
     override func setUpWithError() throws {
@@ -46,6 +55,10 @@ final class WidgetGalleryCaptureUITests: XCTestCase {
     }
 
     func testCaptureHomeScreenWidgetGallery() throws {
+        // XCUIApplication.label cannot be snapshotted after SpringBoard sends
+        // the app to the background, so resolve the required build identity
+        // while the installed target is running and carry it into the flow.
+        let displayName = try widgetAppDisplayName()
         goHome()
         attachScreenshot(named: "widget-00-home-screen")
 
@@ -75,7 +88,6 @@ final class WidgetGalleryCaptureUITests: XCTestCase {
         let search = springboard.searchFields.firstMatch
         if search.waitForExistence(timeout: 5) {
             search.tap()
-            let displayName = widgetAppDisplayName
             search.typeText(displayName)
             Thread.sleep(forTimeInterval: 2)
             attachScreenshot(named: "widget-03-gallery-search-eliza")

--- a/packages/app-core/platforms/ios/App/AppUITests/WidgetGalleryCaptureUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/WidgetGalleryCaptureUITests.swift
@@ -27,20 +27,18 @@ final class WidgetGalleryCaptureUITests: XCTestCase {
 
     // MARK: - Brand-aware display name
 
-    /// The installed target application's real accessibility label, mirroring
-    /// `CFBundleDisplayName` / `ELIZA_DISPLAY_NAME` from `app.config.ts`.
+    /// The installed target application's real accessibility label.
+    ///
+    /// Reads the host app's `label` (which mirrors `CFBundleDisplayName` /
+    /// `ELIZA_DISPLAY_NAME` from `app.config.ts`) so the test stays aligned
+    /// with the build's actual display name and preserves white-label support.
+    /// Based on NubsCarson:c21d9237 — do not silently substitute a canonical
+    /// brand when the label is unavailable; fail fast per the repository's
+    /// unavailable-state policy.
     private var widgetAppDisplayName: String {
-        let app = XCUIApplication()
-        let label = app.label.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !label.isEmpty {
-            return label
-        }
-        let sbApp = XCUIApplication(bundleIdentifier: "ai.elizaos.app")
-        let sbLabel = sbApp.label.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !sbLabel.isEmpty {
-            return sbLabel
-        }
-        return "Eliza"
+        let label = XCUIApplication().label.trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertFalse(label.isEmpty, "Installed app must have a non-empty display label (CFBundleDisplayName/ELIZA_DISPLAY_NAME)")
+        return label
     }
 
     override func setUpWithError() throws {

--- a/packages/app/test/ios-app-intents-registration.test.ts
+++ b/packages/app/test/ios-app-intents-registration.test.ts
@@ -362,11 +362,15 @@ describe("native assistant entry contracts", () => {
       "Action Button physical press",
     );
     expect(deviceExtensionSurfaceUITestsSwift).toContain(
-      "and custom\n/// keyboard enablement still require the provisioned-device lane",
+      "custom keyboard requires a provisioned device lane",
     );
     // Brand-aware widget gallery: stale hard-coded display name must be gone.
-    expect(deviceExtensionSurfaceUITestsSwift).toContain("widgetAppDisplayName");
-    expect(deviceExtensionSurfaceUITestsSwift).not.toContain('staticTexts["elizaOS"]');
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "widgetAppDisplayName",
+    );
+    expect(deviceExtensionSurfaceUITestsSwift).not.toContain(
+      'staticTexts["elizaOS"]',
+    );
     expect(deviceExtensionSurfaceUITestsSwift).toContain(
       "let displayName = try widgetAppDisplayName()",
     );
@@ -381,7 +385,9 @@ describe("native assistant entry contracts", () => {
       "utf8",
     );
     expect(widgetGalleryCaptureUITestsSwift).toContain("widgetAppDisplayName");
-    expect(widgetGalleryCaptureUITestsSwift).not.toContain('staticTexts["elizaOS"]');
+    expect(widgetGalleryCaptureUITestsSwift).not.toContain(
+      'staticTexts["elizaOS"]',
+    );
     expect(widgetGalleryCaptureUITestsSwift).toContain(
       "let displayName = try widgetAppDisplayName()",
     );

--- a/packages/app/test/ios-app-intents-registration.test.ts
+++ b/packages/app/test/ios-app-intents-registration.test.ts
@@ -368,7 +368,13 @@ describe("native assistant entry contracts", () => {
     expect(deviceExtensionSurfaceUITestsSwift).toContain("widgetAppDisplayName");
     expect(deviceExtensionSurfaceUITestsSwift).not.toContain('staticTexts["elizaOS"]');
     expect(deviceExtensionSurfaceUITestsSwift).toContain(
-      'XCTAssertFalse(label.isEmpty',
+      "let displayName = try widgetAppDisplayName()",
+    );
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "app.wait(for: .runningForeground",
+    );
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "label.isEmpty ? nil : label",
     );
     const widgetGalleryCaptureUITestsSwift = readFileSync(
       path.join(iosAppRoot, "AppUITests/WidgetGalleryCaptureUITests.swift"),
@@ -376,6 +382,12 @@ describe("native assistant entry contracts", () => {
     );
     expect(widgetGalleryCaptureUITestsSwift).toContain("widgetAppDisplayName");
     expect(widgetGalleryCaptureUITestsSwift).not.toContain('staticTexts["elizaOS"]');
+    expect(widgetGalleryCaptureUITestsSwift).toContain(
+      "let displayName = try widgetAppDisplayName()",
+    );
+    expect(widgetGalleryCaptureUITestsSwift).toContain(
+      "app.wait(for: .runningForeground",
+    );
   });
 
   it("aligns the iOS audio background mode and Live Activities plist keys", () => {

--- a/packages/app/test/ios-app-intents-registration.test.ts
+++ b/packages/app/test/ios-app-intents-registration.test.ts
@@ -364,6 +364,18 @@ describe("native assistant entry contracts", () => {
     expect(deviceExtensionSurfaceUITestsSwift).toContain(
       "and custom\n/// keyboard enablement still require the provisioned-device lane",
     );
+    // Brand-aware widget gallery: stale hard-coded display name must be gone.
+    expect(deviceExtensionSurfaceUITestsSwift).toContain("widgetAppDisplayName");
+    expect(deviceExtensionSurfaceUITestsSwift).not.toContain('staticTexts["elizaOS"]');
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      'XCTAssertFalse(label.isEmpty',
+    );
+    const widgetGalleryCaptureUITestsSwift = readFileSync(
+      path.join(iosAppRoot, "AppUITests/WidgetGalleryCaptureUITests.swift"),
+      "utf8",
+    );
+    expect(widgetGalleryCaptureUITestsSwift).toContain("widgetAppDisplayName");
+    expect(widgetGalleryCaptureUITestsSwift).not.toContain('staticTexts["elizaOS"]');
   });
 
   it("aligns the iOS audio background mode and Live Activities plist keys", () => {


### PR DESCRIPTION
# Relates to

Closes #18307

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. iOS XCUITest only. No runtime, no server, no deployment, no credential handling. Change is limited to two Swift test files deriving the widget gallery app row from the installed target's accessibility label.

# Background

## What does this PR do?

Fixes #18307: `DeviceExtensionSurfaceUITests` and `WidgetGalleryCaptureUITests` previously searched the iOS Home Screen widget gallery for a hardcoded `elizaOS` staticText row, while the app's configured display name is `Eliza` (`CFBundleDisplayName` / `ELIZA_DISPLAY_NAME` from `packages/app/app.config.ts`). The same stale literal breaks white-label builds where `run-mobile-build.mjs` derives `ELIZA_DISPLAY_NAME` from each host app's `app.config.ts`.

This PR replaces the hardcoded lookup with a brand-aware helper `widgetAppDisplayName` that launches the installed target, waits for it to reach the foreground, reads its real `XCUIApplication().label`, and fails if that required label is unavailable. The exact value is captured before SpringBoard backgrounds the app, then used for both gallery search and row selection. This preserves white-label support, the widget deep-link assertion, and the Control Center `Ask Eliza` / `Eliza Voice` assertions without silently falling back to a canonical brand.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift` and `WidgetGalleryCaptureUITests.swift` - the diff is the `widgetAppDisplayName` computed property and the two call sites where `search.typeText` and `springboard.staticTexts[...]` now use it.

## Detailed testing steps

- Verify `grep -r "elizaOS" packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift` no longer returns the hardcoded widget row (only the `elizaos://` deep-link scheme remains, which is intentional).
- Run the focused static contract guard: `bun test packages/app/test/ios-app-intents-registration.test.ts` (16/16 tests, 206 assertions on the exact head).
- Exact native proof was run on a fresh iPhone 17 Pro / iOS 26.4.1 simulator: the supported mobile pipeline built the app and extensions, then the focused `AppUITests/DeviceExtensionSurfaceUITests/testHomeScreenWidgetTapForegroundsApp` lane passed 1/1 with 0 failures or skips. The trace shows the exact installed label `Eliza` used for search and selection, the widget added, `Ask Eliza` tapped, and the app returning to `runningForeground`.
- `bun run verify` passes on the exact head (350/350 Turbo tasks plus all repository audits).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:9ce3092ae07cc1e5d92433fb2e00305ce4704855 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - before state is the hardcoded stale-label failure captured in #18307's Simulator .xcresult; the failure is deterministic: Waiting 8.0s for "elizaOS" StaticText while gallery lists "Eliza"`.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this PR changes XCUITest logic only and does not alter any rendered UI; exact after-state screenshots and hierarchy are retained in the domain result bundle below.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no rendered UI change; this is a test-logic fix for the widget gallery lookup, not a user-visible feature flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - no backend path involved; this is an iOS XCUITest lane only`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend web path involved`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/action/provider/prompt/model behavior is involved`.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head XCUITest machine summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18375-PR18375-exact-9ce3092-summary.txt)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface change; the widget gallery row text is asserted via XCUITest label matching, not OCR`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model changes`.

## Backend + frontend logs

`N/A - no backend/frontend web path`.

## Screenshots (before / after) + video walkthrough

The before failure is documented in #18307: the test waited for a hardcoded `elizaOS` row while the gallery exposed `Eliza`. The [exact-head result bundle](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18375-PR18375-exact-9ce3092.xcresult.zip) contains the after-state screenshots, accessibility hierarchy, build/test logs, and device metadata.

## Audio / voice walkthrough

`N/A - no voice changes`.

## Known gaps / failures

None in the delivered test-logic scope. Exact head `9ce3092ae07cc1e5d92433fb2e00305ce4704855` passes the full repository `bun run verify` gate (350/350 Turbo tasks), focused contract tests (16/16, 206 assertions), the full supported iOS simulator build, and the fresh-simulator focused XCUITest (1/1, 0 failures/skips).

The required all-views audit completed 213/215 with `broken=0`. Its two failures cannot be caused by this Swift/test-only diff: one existing Files-view capture timed out waiting for `#root`, and the report retained four unrelated minimalism ratchets in Browser (two orientations), Plugins, and Trajectories. No rendered application view changed in this PR.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-widget-fix]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZR2W5TWY88VPYZRB6D6P92V","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-11T09:36:20.316Z","completed_at":"2026-08-11T09:36:35.240Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAPnQT8iCj4u7N5v1KHxwCtZECLRZKO4Px_PB9j-U6psk","device_key_id":"bcb90204018cc1697d7a8bcda9a8ac16d85133b1d86994eb804401d68920475b","device_signature":"OoWCMAJM1vo9FkWD_HNXKbpouvclveBdkPQpCK2OBX64jmugVBqUr2BC0DvreSGhHbv2AkUIUz7FWLHB80XcDA"}} -->




