### PR TITLE
fix(ui): stop-voice tears down realtime Cartesia

### DIFF
--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -2145,6 +2145,67 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
     expect(result.current.handsFree).toBe(true);
   });
 
+  it("routes repeated programmatic stops through one realtime teardown", async () => {
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.startRecording("converse");
+      await Promise.resolve();
+    });
+    expect(result.current.handsFree).toBe(true);
+    expect(
+      window.localStorage.getItem("eliza:voice:continuous-chat-mode"),
+    ).toBe("always-on");
+
+    await act(async () => {
+      result.current.stopRecording();
+      result.current.stopRecording();
+      await Promise.resolve();
+    });
+
+    expect(realtimeVoiceMock.stop).toHaveBeenCalledTimes(1);
+    expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+    expect(result.current.handsFree).toBe(false);
+    expect(
+      window.localStorage.getItem("eliza:voice:continuous-chat-mode"),
+    ).toBe("off");
+  });
+
+  it.each(["active", "connecting"] as const)(
+    "routes an %s realtime owner through realtime teardown",
+    async (ownerState) => {
+      realtimeVoiceMock.state[ownerState] = true;
+      const { result } = renderHook(() => useShellController());
+
+      await act(async () => {
+        result.current.stopRecording();
+        await Promise.resolve();
+      });
+
+      expect(realtimeVoiceMock.stop).toHaveBeenCalledTimes(1);
+      expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps idle realtime mode from stealing legacy dictation teardown", async () => {
+    captureHandles = [];
+    installFakeCapture();
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.startRecording("dictate");
+      await Promise.resolve();
+    });
+    await act(async () => {
+      result.current.stopRecording();
+      await Promise.resolve();
+    });
+
+    expect(realtimeVoiceMock.stop).not.toHaveBeenCalled();
+    expect(captureHandles[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(captureHandles[0]?.dispose).toHaveBeenCalledTimes(1);
+  });
+
   it("parks Talk visibly OFF when a LIVE session dies past the client's recovery budget", async () => {
     const { result, rerender } = renderHook(() => useShellController());
 

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -1849,6 +1849,18 @@ export function useShellController(): ShellController {
   };
   stopRealtimeVoiceRef.current = stopRealtimeVoice;
 
+  const stopRecording = React.useCallback(() => {
+    if (
+      realtimeVoiceWantedRef.current ||
+      realtimeVoiceRef.current.active ||
+      realtimeVoiceRef.current.connecting
+    ) {
+      stopRealtimeVoice();
+      return;
+    }
+    stopCapture();
+  }, [stopCapture, stopRealtimeVoice]);
+
   // A LIVE Talk session that dies past the client's reconnect budget (network
   // outage longer than the recovery window, terminal server error) must park
   // Talk visibly OFF: restore the persisted mode, clear hands-free, and
@@ -2411,7 +2423,7 @@ export function useShellController(): ShellController {
     visionCapturing,
     toggleRecording,
     startRecording: startCapture,
-    stopRecording: stopCapture,
+    stopRecording,
     handsFree,
     realtimeVoice: {
       enabled: realtimeVoiceEnabled,

--- a/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
+++ b/packages/ui/src/hooks/useRealtimeVoiceSession.test.tsx
@@ -196,7 +196,13 @@ describe("useRealtimeVoiceSession", () => {
   });
 
   it("full flow: start → listening → partial → final → speaking → barge-in → stop through the REAL client", async () => {
-    const { options, ws, micCtx, pbCtx, getConsentNonce } = makeOptions();
+    const stopTrack = vi.fn();
+    const { options, ws, micCtx, pbCtx, getConsentNonce } = makeOptions({
+      getUserMedia: async () =>
+        ({
+          getTracks: () => [{ stop: stopTrack }],
+        }) as unknown as MediaStream,
+    });
     const { result } = renderHook(() => useRealtimeVoiceSession(options));
 
     // Flag on + ids present + not-yet-disabled ⇒ available for the batch caller
@@ -278,8 +284,13 @@ describe("useRealtimeVoiceSession", () => {
     // Clean stop → bye + teardown.
     await act(async () => {
       await result.current.stop();
+      await result.current.stop();
     });
     expect(sock.sentControls().some((c) => c.t === "bye")).toBe(true);
+    expect(sock.closed?.code).toBe(1000);
+    expect(stopTrack).toHaveBeenCalledTimes(1);
+    expect(micCtx.closed).toBe(true);
+    expect(pbCtx.closed).toBe(true);
     expect(result.current.active).toBe(false);
     expect(result.current.status).toBe("idle");
   });

--- a/packages/ui/src/os-intent/pipeline.test.ts
+++ b/packages/ui/src/os-intent/pipeline.test.ts
@@ -114,6 +114,20 @@ describe("os-intent pipeline", () => {
     expect(calls).toEqual(["open", "startRecording:converse"]);
   });
 
+  it("drives one realtime teardown from a redelivered StopVoice link", () => {
+    const store = new IntentDedupeStore();
+    const { controller, calls } = spyController();
+    const url =
+      "elizaos://voice?source=ios-app-shortcuts&action=stop-voice&assistant.launchId=siri-stop-1";
+
+    expect(launch(url, healthyContext(), store, controller)).toBe("routed");
+    expect(launch(url, healthyContext({ now: 1_100 }), store, controller)).toBe(
+      "duplicate",
+    );
+
+    expect(calls).toEqual(["stopRecording"]);
+  });
+
   it("does not touch the controller when the launch is blocked", () => {
     const store = new IntentDedupeStore();
     const { controller, calls } = spyController();


### PR DESCRIPTION
Closes #18374

## Summary

- route the shell's public `stopRecording` contract to Cartesia teardown whenever realtime voice is wanted, active, or connecting
- preserve the legacy recorder stop for idle realtime mode and explicit dictation
- prove repeated system/deep-link stop delivery is idempotent and that the real realtime client releases WebSocket, microphone, and playback ownership

## Risk

Low and bounded to voice-stop routing. Starting voice, the visible Talk control, legacy dictation, and the realtime client lifecycle are unchanged. The new callback selects the teardown path from existing ownership state and does not gate cleanup on the feature flag.

## Sync

- exact rebased base: `32eed149f5020ccc41e8ae7405919a0abba5e6cf`
- exact rebased head: `8fd2f92c7bdeca4757c176d3777f435445028356`
- stable patch ID: `439e7633c2a094170f3c009b8371408f30911cab`
- `origin/develop` remained exact rebased base before the lease-guarded push
- intervening PR #18400 changed only two `plugin-openai` paths; intersection with this four-file UI diff is zero
- clean four-file diff, +100/-2; no Cloud, browser, device, Simulator, deploy, or runtime mutation

## Focused proof

- controller + full OS-intent pipeline + real realtime hook/client: **3 files, 111/111 tests PASS**
- real stop proof asserts clean bye/socket close, one microphone track release, mic AudioContext close, playback close, and safe repeated stop
- `packages/ui` typecheck: PASS after the standard `@elizaos/cloud-routing` build prerequisite
- `@elizaos/cloud-routing` build: PASS
- Biome on all four changed files: PASS
- `git diff --check`: PASS
- full repository `bun run verify`: PASS (**348/348** build/typecheck tasks plus audit gates)

The managed iOS acceptance HOLD still forbids a fresh device or Simulator capture. The visible in-app Talk flow remains gauss's primary v3 path; structural start→stop proof requires this repair merged into a newly built artifact and a later explicit HANDOFF GO.

## Evidence

<!-- evidence-head:8fd2f92c7bdeca4757c176d3777f435445028356 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - controller lifecycle repair has no new rendered pixels; managed device/Simulator mutation remains held.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no visible layout changed; current-build runtime proof is explicitly post-merge and post-handoff.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - structural device execution remains revoked until a current artifact is built and gauss grants the bounded handoff after primary Talk acceptance.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-only routing change does not alter a backend endpoint.
<!-- evidence-row:frontend-logs -->
- [x] N/A - runtime mutation remains held; exact controller, intent, hook, and real client lifecycle proof is recorded above.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, scheduled-task, or generated-file output changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visible text or layout changed.

## Known gaps

- Exact installed-build structural start→stop evidence is intentionally pending merge, a newly built artifact, and explicit acceptance handoff. No older artifact or pixel is relabeled.
- The existing exact-aa Simulator archive does not contain this head and is not final proof.
- Existing React `act(...)` warnings in the broad shell test file remain unchanged; all 111 focused assertions pass.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-ios]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->