### PR TITLE
fix(app-core): compat dispatcher 401s per-agent message/event routes for all callers

### DIFF
--- a/packages/app-core/src/api/route-auth-policy.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.test.ts
@@ -113,6 +113,52 @@ describe("compat route auth policy table", () => {
     });
   });
 
+  it("passes per-agent message/event routes through to the agent server's own auth gate", async () => {
+    // Regression (sol-dev cutover QA 2026-08-11): the "/api/agents" managed
+    // prefix fail-closed 401'd POST /api/agents/:id/message for EVERY caller,
+    // including a valid ELIZA_API_TOKEN bearer, because the route was never
+    // declared. The owning handler (packages/agent chat-routes.ts) enforces
+    // its own bearer/loopback/X-Server-Token auth, so the dispatcher must
+    // pass these through rather than pre-empt with its session vocabulary.
+    expect(
+      resolveCompatRouteAuthPolicy(
+        "POST",
+        "/api/agents/df5d4664-7631-07ce-b4e6-45da0f27a0a5/message",
+      ),
+    ).toMatchObject({ id: "agents.message", tier: "public" });
+    expect(
+      resolveCompatRouteAuthPolicy(
+        "POST",
+        "/api/agents/df5d4664-7631-07ce-b4e6-45da0f27a0a5/event",
+      ),
+    ).toMatchObject({ id: "agents.event", tier: "public" });
+
+    const req = fakeReq({
+      method: "POST",
+      pathname: "/api/agents/some-agent/message",
+    });
+    const res = fakeRes();
+    await expect(
+      enforceCompatRouteAuthPolicy(
+        req,
+        res.res,
+        STATE,
+        "POST",
+        "/api/agents/some-agent/message",
+      ),
+    ).resolves.toBe("allowed");
+
+    // Non-message/event sub-paths under /api/agents stay fail-closed.
+    expect(
+      resolveCompatRouteAuthPolicy("POST", "/api/agents/some-agent/delete"),
+    ).toBeNull();
+    expect(isCompatManagedRoute("/api/agents/some-agent/delete")).toBe(true);
+    // GET on message stays undeclared (the handler only serves POST).
+    expect(
+      resolveCompatRouteAuthPolicy("GET", "/api/agents/some-agent/message"),
+    ).toBeNull();
+  });
+
   it("fails closed for undeclared app-core-managed routes", async () => {
     const req = fakeReq({ method: "GET", pathname: "/api/dev/not-declared" });
     const res = fakeRes();

--- a/packages/app-core/src/api/route-auth-policy.ts
+++ b/packages/app-core/src/api/route-auth-policy.ts
@@ -108,6 +108,17 @@ const sessionRegex = (
   matcher: { kind: "regex", pattern },
 });
 
+const publicRegex = (
+  id: string,
+  method: keyof typeof METHODS,
+  pattern: RegExp,
+): CompatRouteAuthPolicy => ({
+  id,
+  tier: "public",
+  methods: METHODS[method],
+  matcher: { kind: "regex", pattern },
+});
+
 export const COMPAT_ROUTE_AUTH_POLICIES: readonly CompatRouteAuthPolicy[] = [
   publicExact("i18n.locale", "GET", "/api/i18n/locale"),
   publicExact("cloud.pair-popup", "GET", "/pair"),
@@ -190,6 +201,21 @@ export const COMPAT_ROUTE_AUTH_POLICIES: readonly CompatRouteAuthPolicy[] = [
   sessionExact("first-run.submit", "POST", "/api/first-run"),
   sessionRegex("plugins.ui-spec", "GET", /^\/api\/plugins\/[^/]+\/ui-spec$/),
   sessionExact("agents.list", "GET", "/api/agents"),
+  // Per-agent message/event endpoints are OWNED by the upstream agent server
+  // (packages/agent chat-routes.ts / misc-routes.ts), whose shared auth gate
+  // (server.ts `isAuthorized`) accepts the full credential vocabulary for
+  // these routes: ELIZA_API_TOKEN bearer, trusted loopback, and the cloud
+  // gateway's `X-Server-Token` (AGENT_SERVER_SHARED_SECRET). The compat
+  // dispatcher manages the "/api/agents" prefix fail-closed, so without these
+  // declarations every POST /api/agents/:id/message returned 401 for ALL
+  // callers — including a valid ELIZA_API_TOKEN bearer — because the
+  // undeclared-managed-route branch rejects before any credential is examined
+  // (sol-dev cutover QA 2026-08-11). Declared pass-through (same pattern as
+  // `internal.device-secret` above) so the owning handler's auth gate runs;
+  // this does NOT expose the routes unauthenticated — the agent server 401s
+  // any caller its own gate does not recognize.
+  publicRegex("agents.message", "POST", /^\/api\/agents\/[^/]+\/message$/),
+  publicRegex("agents.event", "POST", /^\/api\/agents\/[^/]+\/event$/),
   sessionExact("config.read", "GET", "/api/config"),
   sessionExact("config.schema", "GET", "/api/config/schema"),
   ownerExact("config.write", "PUT", "/api/config"),

--- a/packages/app-core/src/api/route-auth-policy.wrapped-server.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.wrapped-server.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Exercises the app-core compatibility middleware and upstream agent auth gate
+ * together over a real HTTP listener. The regression contract proves the
+ * per-agent message and event routes pass through app-core without becoming
+ * public: missing or invalid credentials stop at 401, while both supported
+ * service credential forms reach the owning agent handlers.
+ */
+import type { startApiServer as startApiServerType } from "@elizaos/agent";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startApiServer } from "./server";
+
+const ENV_KEYS = [
+  "AGENT_SERVER_SHARED_SECRET",
+  "ELIZA_API_BIND",
+  "ELIZA_API_TOKEN",
+  "ELIZA_DISABLE_AUTO_API_TOKEN",
+  "ELIZA_REQUIRE_LOCAL_AUTH",
+] as const;
+
+const OWNER_TOKEN = "compat-owner-token";
+const SERVER_TOKEN = "compat-server-token";
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+
+type ApiServer = Awaited<ReturnType<typeof startApiServerType>>;
+
+let savedEnv: Record<(typeof ENV_KEYS)[number], string | undefined>;
+let server: ApiServer | null = null;
+let baseUrl = "";
+
+async function post(
+  route: "message" | "event",
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const body =
+    route === "message"
+      ? { userId: "review-user", text: "hello" }
+      : { type: "review_probe", userId: "review-user", payload: { ok: true } };
+  return fetch(`${baseUrl}/api/agents/${AGENT_ID}/${route}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe.sequential("per-agent compat pass-through auth", () => {
+  beforeAll(async () => {
+    savedEnv = Object.fromEntries(
+      ENV_KEYS.map((key) => [key, process.env[key]]),
+    ) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+    process.env.ELIZA_API_BIND = "127.0.0.1";
+    process.env.ELIZA_REQUIRE_LOCAL_AUTH = "1";
+    process.env.ELIZA_DISABLE_AUTO_API_TOKEN = "1";
+    process.env.ELIZA_API_TOKEN = OWNER_TOKEN;
+    process.env.AGENT_SERVER_SHARED_SECRET = SERVER_TOKEN;
+
+    server = await startApiServer({
+      port: 0,
+      skipDeferredStartupWork: true,
+    });
+    baseUrl = `http://127.0.0.1:${server.port}`;
+  });
+
+  afterAll(async () => {
+    await server?.close();
+    server = null;
+    for (const key of ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  for (const route of ["message", "event"] as const) {
+    it(`keeps /${route} closed to missing and invalid credentials`, async () => {
+      expect((await post(route)).status).toBe(401);
+      expect(
+        (
+          await post(route, {
+            authorization: "Bearer invalid-token",
+          })
+        ).status,
+      ).toBe(401);
+    });
+
+    it(`lets /${route} reach the agent handler with an API bearer`, async () => {
+      const response = await post(route, {
+        authorization: `Bearer ${OWNER_TOKEN}`,
+      });
+      expect(response.status).toBe(route === "message" ? 503 : 200);
+    });
+
+    it(`lets /${route} reach the agent handler with a server token`, async () => {
+      const response = await post(route, {
+        "x-server-token": SERVER_TOKEN,
+      });
+      expect(response.status).toBe(route === "message" ? 503 : 200);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

`POST /api/agents/:id/message` (and `/event`) return **401 Unauthorized for every caller** on any deployment that fronts the agent with the app-core compat dispatcher — including callers presenting a valid `ELIZA_API_TOKEN` bearer.

Found live while exercising a local-mode deployment (sol-dev cutover QA 2026-08-11): the same request against the bare agent server (port-mapped container) works; against the app-core host it 401s before any credential is read.

## Root cause

`COMPAT_MANAGED_PREFIXES` includes `/api/agents`, so the dispatcher owns the whole prefix fail-closed. Only `GET /api/agents` (agents.list) was ever declared in `COMPAT_ROUTE_AUTH_POLICIES`. Every other sub-route hits the undeclared-managed-route branch in `enforceCompatRouteAuthPolicy` and is rejected with 401 **before any auth is evaluated**:

```ts
if (!policy) {
  if (!isCompatManagedRoute(pathname)) return "unmanaged";
  sendJsonError(res, 401, "Unauthorized");   // <- always taken for /api/agents/:id/message
  return "denied";
}
```

The routes are actually owned by the **agent server** (`packages/agent/src/api/chat-routes.ts` `POST /api/agents/:id/message`, `misc-routes.ts` `/event`), whose shared gate (`server.ts` → `isAuthorized`) accepts the full credential vocabulary for these surfaces: `ELIZA_API_TOKEN` bearer, trusted loopback, and the cloud gateway's `X-Server-Token` (`AGENT_SERVER_SHARED_SECRET`). The dispatcher's session vocabulary is a strict subset, so even declaring them at session tier would still break the documented gateway contract.

## Fix

Declare the two routes as **pass-through** (public tier at the dispatcher, same established pattern as `internal.device-secret`), so the owning handler's own auth gate runs. This does **not** expose anything unauthenticated — `isAuthProtectedRoute` covers all of `/api/` in the agent server, and its gate 401s any unrecognized caller.

Scope stays tight (regex, POST-only): all other `/api/agents/*` sub-paths and GET on these paths remain fail-closed — pinned by test.

## Test proof (bidirectional)

- **Before (policy reverted, test kept):** `route-auth-policy.test.ts` fails — `resolveCompatRouteAuthPolicy("POST", "/api/agents/:id/message")` returns null → dispatcher denies (1 failed / 7 passed).
- **After:** the policy, dispatcher, and actual wrapped-server suites pass 20/20. The wrapped server proves missing and invalid credentials return 401 for both routes, while valid `ELIZA_API_TOKEN` bearer and `X-Server-Token` credentials cross the compat boundary and reach each owning handler.

## Production path

`packages/app-core/src/api/route-auth-policy.ts` → `enforceCompatRouteAuthPolicy` is called by `handleCompatRouteInner` in `packages/app-core/src/api/server.ts`, which is the request path for every app-core-hosted deployment (desktop, local dev stacks, steward containers).

# Evidence Gate

<!-- evidence-head:1b5e990d367109e31e183a7dc2dadf0a44d2725d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend auth-policy table change only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend auth-policy table change only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - HTTP-level policy fix; the exact-head wrapped-server suite exercises both unauthorized and authorized requests through the real listener.
<!-- evidence-row:backend-logs -->
- [x] [18381-backend-tests-1b5e990d.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18381-backend-tests-1b5e990d.txt) — exact head `1b5e990d367109e31e183a7dc2dadf0a44d2725d`: policy, dispatcher, and wrapped-server suites 20 pass / 0 fail; app-core lint clean.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involvement; callers are server-to-server (gateway X-Server-Token, ELIZA_API_TOKEN bearer).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model/prompt changes; dispatcher auth policy only.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain writes; the auth decision table is the entire change and is pinned by the attached tests.
# Review remediation provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5 (system-reported model family; deployment variant unavailable)
<!-- attribution-row:client -->
- Agent tooling: Codex
<!-- attribution-row:skill-revision -->
- Skill path: N/A - installed Codex plugin packages do not expose a repository commit SHA
<!-- attribution-row:status -->
- Provenance status: self-reported
