### PR TITLE
fix(scheduling): wall-clock tasks never fire without plugin-personal-assistant

### DIFF
--- a/plugins/plugin-scheduling/src/plugin.test.ts
+++ b/plugins/plugin-scheduling/src/plugin.test.ts
@@ -1,6 +1,6 @@
 /**
  * Scheduling plugin boot tests cover the seed hook's lifecycle barrier against
- * the runtime service registry.
+ * the runtime service registry and the core TaskService fallback registration.
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
@@ -71,11 +71,17 @@ describe("scheduling plugin boot", () => {
   });
 
   it("seeds after the registration barrier and registers the fallback pack", async () => {
+    const registerTaskWorker = vi.fn();
+    const createTask = vi.fn(async () => "driver-task-id");
     const runtime = {
       agentId: "agent-1",
       initPromise: Promise.resolve(),
       hasService: () => true,
       getServiceLoadPromise: vi.fn(async () => ({})),
+      getTaskWorker: () => undefined,
+      registerTaskWorker,
+      getTasks: vi.fn(async () => []),
+      createTask,
     } as unknown as IAgentRuntime;
 
     await schedulingPlugin.init?.({}, runtime);
@@ -86,5 +92,14 @@ describe("scheduling plugin boot", () => {
       expect.objectContaining({ id: "fallback-agent-1", fallback: true }),
     );
     expect(mocks.seedPacks).toHaveBeenCalledWith(runtime, mocks.runner);
+    expect(registerTaskWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "SCHEDULED_TASK_RUNNER" }),
+    );
+    expect(createTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "SCHEDULED_TASK_RUNNER",
+        tags: ["queue", "repeat", "scheduling"],
+      }),
+    );
   });
 });

--- a/plugins/plugin-scheduling/src/plugin.ts
+++ b/plugins/plugin-scheduling/src/plugin.ts
@@ -29,9 +29,11 @@ import {
 } from "./scheduled-task/standalone-tick.js";
 
 /**
- * One fallback tick timer per runtime. WeakMap so a torn-down runtime's timer
- * reference does not keep it alive; the timer itself is unref'd so it never
- * blocks process exit.
+ * One fallback tick timer per runtime. The interval callback closes over the
+ * runtime, so the WeakMap alone cannot release a torn-down runtime — the
+ * self-stop check inside the callback is what actually ends the timer's (and
+ * therefore the runtime's) lifetime. The timer is unref'd so it never blocks
+ * process exit.
  */
 const standaloneTickTimers = new WeakMap<
   IAgentRuntime,
@@ -41,6 +43,16 @@ const standaloneTickTimers = new WeakMap<
 function startStandaloneTickDriver(runtime: IAgentRuntime): void {
   if (standaloneTickTimers.has(runtime)) return;
   const timer = setInterval(() => {
+    // Self-stop on runtime teardown: a stopped runtime no longer resolves the
+    // runner service (`runtime.getService` returns null after stop), and
+    // without this check the closure would pin the runtime alive and throw a
+    // warn line every interval forever in multi-agent processes that
+    // stop/restart agents.
+    if (!runtime.getService(ScheduledTaskRunnerService.serviceType)) {
+      clearInterval(timer);
+      standaloneTickTimers.delete(runtime);
+      return;
+    }
     void runStandaloneSchedulingTick(runtime).catch((error) => {
       logger.warn(
         { src: "scheduling:standalone-tick", agentId: runtime.agentId },

--- a/plugins/plugin-scheduling/src/plugin.ts
+++ b/plugins/plugin-scheduling/src/plugin.ts
@@ -22,6 +22,37 @@ import {
   registerDefaultTaskPack,
   seedRegisteredTaskPacks,
 } from "./scheduled-task/seed-registry.js";
+import {
+  isStandaloneTickDisabled,
+  runStandaloneSchedulingTick,
+  STANDALONE_TICK_INTERVAL_MS,
+} from "./scheduled-task/standalone-tick.js";
+
+/**
+ * One fallback tick timer per runtime. WeakMap so a torn-down runtime's timer
+ * reference does not keep it alive; the timer itself is unref'd so it never
+ * blocks process exit.
+ */
+const standaloneTickTimers = new WeakMap<
+  IAgentRuntime,
+  ReturnType<typeof setInterval>
+>();
+
+function startStandaloneTickDriver(runtime: IAgentRuntime): void {
+  if (standaloneTickTimers.has(runtime)) return;
+  const timer = setInterval(() => {
+    void runStandaloneSchedulingTick(runtime).catch((error) => {
+      logger.warn(
+        { src: "scheduling:standalone-tick", agentId: runtime.agentId },
+        `[scheduling] standalone tick crashed; retrying next interval: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    });
+  }, STANDALONE_TICK_INTERVAL_MS);
+  timer.unref?.();
+  standaloneTickTimers.set(runtime, timer);
+}
 
 export async function waitForScheduledTaskRunnerService(
   runtime: IAgentRuntime,
@@ -100,6 +131,15 @@ export const schedulingPlugin: Plugin = {
             agentId: runtime.agentId,
           });
           await seedRegisteredTaskPacks(runtime, runner);
+          // Fallback wall-clock driver: without this, a runtime with no
+          // consumer host (plugin-personal-assistant) accepts scheduled
+          // tasks over REST but never fires them — `once`/`cron`/`interval`
+          // rows sat `scheduled` forever (sol-dev cutover QA 2026-08-11).
+          // The tick itself defers per-invocation when a consumer host's
+          // deps are registered, so starting it unconditionally is safe.
+          if (!isStandaloneTickDisabled()) {
+            startStandaloneTickDriver(runtime);
+          }
         } catch (error) {
           logger.warn(
             { src: "scheduling:boot-seed", agentId: runtime.agentId, error },

--- a/plugins/plugin-scheduling/src/plugin.ts
+++ b/plugins/plugin-scheduling/src/plugin.ts
@@ -23,48 +23,10 @@ import {
   seedRegisteredTaskPacks,
 } from "./scheduled-task/seed-registry.js";
 import {
-  isStandaloneTickDisabled,
-  runStandaloneSchedulingTick,
-  STANDALONE_TICK_INTERVAL_MS,
+  disposeStandaloneTick,
+  ensureStandaloneTickTask,
+  registerStandaloneTickWorker,
 } from "./scheduled-task/standalone-tick.js";
-
-/**
- * One fallback tick timer per runtime. The interval callback closes over the
- * runtime, so the WeakMap alone cannot release a torn-down runtime — the
- * self-stop check inside the callback is what actually ends the timer's (and
- * therefore the runtime's) lifetime. The timer is unref'd so it never blocks
- * process exit.
- */
-const standaloneTickTimers = new WeakMap<
-  IAgentRuntime,
-  ReturnType<typeof setInterval>
->();
-
-function startStandaloneTickDriver(runtime: IAgentRuntime): void {
-  if (standaloneTickTimers.has(runtime)) return;
-  const timer = setInterval(() => {
-    // Self-stop on runtime teardown: a stopped runtime no longer resolves the
-    // runner service (`runtime.getService` returns null after stop), and
-    // without this check the closure would pin the runtime alive and throw a
-    // warn line every interval forever in multi-agent processes that
-    // stop/restart agents.
-    if (!runtime.getService(ScheduledTaskRunnerService.serviceType)) {
-      clearInterval(timer);
-      standaloneTickTimers.delete(runtime);
-      return;
-    }
-    void runStandaloneSchedulingTick(runtime).catch((error) => {
-      logger.warn(
-        { src: "scheduling:standalone-tick", agentId: runtime.agentId },
-        `[scheduling] standalone tick crashed; retrying next interval: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    });
-  }, STANDALONE_TICK_INTERVAL_MS);
-  timer.unref?.();
-  standaloneTickTimers.set(runtime, timer);
-}
 
 export async function waitForScheduledTaskRunnerService(
   runtime: IAgentRuntime,
@@ -117,6 +79,7 @@ export const schedulingPlugin: Plugin = {
     },
   ],
   init: async (_config: Record<string, string>, runtime: IAgentRuntime) => {
+    registerStandaloneTickWorker(runtime);
     // Seed registered default-task packs once init has finished so the runner
     // service (and any consumer's injected deps + packs) are registered before
     // the seed runs. Failures are non-fatal to plugin load.
@@ -143,15 +106,13 @@ export const schedulingPlugin: Plugin = {
             agentId: runtime.agentId,
           });
           await seedRegisteredTaskPacks(runtime, runner);
-          // Fallback wall-clock driver: without this, a runtime with no
+          // Fallback TaskService worker: without this, a runtime with no
           // consumer host (plugin-personal-assistant) accepts scheduled
           // tasks over REST but never fires them — `once`/`cron`/`interval`
           // rows sat `scheduled` forever (sol-dev cutover QA 2026-08-11).
-          // The tick itself defers per-invocation when a consumer host's
-          // deps are registered, so starting it unconditionally is safe.
-          if (!isStandaloneTickDisabled()) {
-            startStandaloneTickDriver(runtime);
-          }
+          // The worker defers per-invocation when a consumer host's deps are
+          // registered. Core TaskService remains the only wall clock.
+          await ensureStandaloneTickTask(runtime);
         } catch (error) {
           logger.warn(
             { src: "scheduling:boot-seed", agentId: runtime.agentId, error },
@@ -162,5 +123,17 @@ export const schedulingPlugin: Plugin = {
       .catch(() => {
         /* initPromise rejection is surfaced elsewhere */
       });
+  },
+  dispose: async (runtime: IAgentRuntime) => {
+    try {
+      await disposeStandaloneTick(runtime);
+    } catch (error) {
+      // error-policy:J6 Plugin unload is best-effort; surface cleanup failure
+      // without turning an otherwise successful runtime shutdown into a crash.
+      logger.warn(
+        { src: "scheduling:dispose", agentId: runtime.agentId, error },
+        "[scheduling] Failed to remove the standalone tick task during teardown.",
+      );
+    }
   },
 };

--- a/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.test.ts
@@ -4,8 +4,8 @@
  * Regression (sol-dev cutover QA 2026-08-11): on a runtime WITHOUT
  * plugin-personal-assistant, `POST /api/lifeops/scheduled-tasks` accepted a
  * `once` reminder (201) but nothing ever fired it — the only production
- * caller of the due-task loop lived in PA. The standalone tick is the
- * in-plugin fallback driver; these tests pin:
+ * caller of the due-task loop lived in PA. The standalone tick is a core
+ * TaskService worker, not a second timer; these tests pin:
  *
  *  - a due `once` task FIRES through the real runner (fails before the fix:
  *    no fallback driver existed, so nothing transitions the row)
@@ -15,7 +15,7 @@
  *  - one throwing row does not starve the rest of the tick
  */
 
-import type { IAgentRuntime, UUID } from "@elizaos/core";
+import type { IAgentRuntime, Task, TaskWorker, UUID } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -23,8 +23,12 @@ import {
   ScheduledTaskRunnerService,
 } from "./runner-service.js";
 import {
+  disposeStandaloneTick,
+  ensureStandaloneTickTask,
   isStandaloneTickDisabled,
+  registerStandaloneTickWorker,
   runStandaloneSchedulingTick,
+  STANDALONE_TICK_TASK_NAME,
 } from "./standalone-tick.js";
 
 function makeFakeRuntime(): IAgentRuntime {
@@ -102,6 +106,62 @@ describe("standalone scheduling tick", () => {
       now: new Date("2026-08-11T09:47:00.000Z"),
     });
     expect(again.fires.filter((f) => f.outcome === "fired")).toEqual([]);
+  });
+
+  it("uses one durable core TaskService worker row and removes it on unload", async () => {
+    const workerByName = new Map<string, TaskWorker>();
+    const taskById = new Map<UUID, Task>();
+    let nextId = 1;
+    const runtime = {
+      ...makeFakeRuntime(),
+      getTaskWorker: (name: string) => workerByName.get(name),
+      registerTaskWorker: (worker: TaskWorker) => {
+        workerByName.set(worker.name, worker);
+      },
+      unregisterTaskWorker: (name: string) => workerByName.delete(name),
+      getTasks: async () => [...taskById.values()],
+      createTask: async (task: Task) => {
+        const id =
+          `00000000-0000-0000-0000-${String(nextId++).padStart(12, "0")}` as UUID;
+        taskById.set(id, { ...task, id });
+        return id;
+      },
+      updateTask: async (id: UUID, update: Partial<Task>) => {
+        const current = taskById.get(id);
+        if (!current) throw new Error(`missing task ${id}`);
+        taskById.set(id, { ...current, ...update });
+      },
+      deleteTask: async (id: UUID) => {
+        taskById.delete(id);
+      },
+    } as unknown as IAgentRuntime;
+
+    registerStandaloneTickWorker(runtime);
+    registerStandaloneTickWorker(runtime);
+    const firstId = await ensureStandaloneTickTask(runtime);
+    const secondId = await ensureStandaloneTickTask(runtime);
+
+    expect(secondId).toBe(firstId);
+    expect([...workerByName]).toHaveLength(1);
+    expect([...taskById.values()]).toMatchObject([
+      {
+        id: firstId,
+        name: STANDALONE_TICK_TASK_NAME,
+        tags: ["queue", "repeat", "scheduling"],
+        metadata: { blocking: true, maxFailures: 0, paused: false },
+      },
+    ]);
+
+    const worker = workerByName.get(STANDALONE_TICK_TASK_NAME);
+    const driverTask = taskById.get(firstId);
+    expect(driverTask).toBeDefined();
+    expect(driverTask && (await worker?.shouldRun?.(runtime, driverTask))).toBe(
+      true,
+    );
+
+    await disposeStandaloneTick(runtime);
+    expect(workerByName.size).toBe(0);
+    expect(taskById.size).toBe(0);
   });
 
   it("defers to a registered consumer host without touching tasks", async () => {

--- a/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Standalone scheduler tick tests.
+ *
+ * Regression (sol-dev cutover QA 2026-08-11): on a runtime WITHOUT
+ * plugin-personal-assistant, `POST /api/lifeops/scheduled-tasks` accepted a
+ * `once` reminder (201) but nothing ever fired it — the only production
+ * caller of the due-task loop lived in PA. The standalone tick is the
+ * in-plugin fallback driver; these tests pin:
+ *
+ *  - a due `once` task FIRES through the real runner (fails before the fix:
+ *    no fallback driver existed, so nothing transitions the row)
+ *  - a not-yet-due task does not fire
+ *  - the tick defers entirely when a consumer host has registered deps
+ *  - the ELIZA_DISABLE_SCHEDULING_TICK kill switch works
+ *  - one throwing row does not starve the rest of the tick
+ */
+
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  registerScheduledTaskRunnerDeps,
+  ScheduledTaskRunnerService,
+} from "./runner-service.js";
+import {
+  isStandaloneTickDisabled,
+  runStandaloneSchedulingTick,
+} from "./standalone-tick.js";
+
+function makeFakeRuntime(): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-0000-0000-0000000000t1" as UUID,
+    getService: () => null,
+    // Default dispatcher renders promptInstructions through the model before
+    // notifying; a deterministic stub keeps fires succeeding.
+    useModel: async () => "Rendered dispatch message.",
+    reportError: () => undefined,
+  } as unknown as IAgentRuntime;
+}
+
+/** Bind the started service into the runtime's getService lookup. */
+async function startServiceOn(runtime: IAgentRuntime) {
+  const service = await ScheduledTaskRunnerService.start(runtime);
+  (runtime as { getService: unknown }).getService = (type: string) =>
+    type === ScheduledTaskRunnerService.serviceType ? service : null;
+  return service;
+}
+
+const savedEnv = process.env.ELIZA_DISABLE_SCHEDULING_TICK;
+afterEach(() => {
+  if (savedEnv === undefined) {
+    delete process.env.ELIZA_DISABLE_SCHEDULING_TICK;
+  } else {
+    process.env.ELIZA_DISABLE_SCHEDULING_TICK = savedEnv;
+  }
+});
+
+describe("standalone scheduling tick", () => {
+  it("fires a due `once` task that no consumer host would otherwise drive", async () => {
+    const runtime = makeFakeRuntime();
+    const service = await startServiceOn(runtime);
+
+    const t0 = new Date("2026-08-11T09:40:00.000Z");
+    const runner = service.getRunner({
+      agentId: runtime.agentId,
+      now: () => t0,
+    });
+    const task = await runner.schedule({
+      kind: "reminder",
+      promptInstructions: "cutover regression: fire me",
+      trigger: { kind: "once", atIso: "2026-08-11T09:45:00.000Z" },
+      priority: "low",
+      respectsGlobalPause: false,
+      source: "user_chat",
+      createdBy: runtime.agentId,
+      ownerVisible: true,
+    });
+    expect(task.state.status).toBe("scheduled");
+
+    // Before due: the tick must not fire it.
+    const early = await runStandaloneSchedulingTick(runtime, {
+      now: new Date("2026-08-11T09:44:00.000Z"),
+    });
+    expect(early.skipped).toBeUndefined();
+    expect(early.fires).toEqual([]);
+
+    // Past due: the tick fires it through the real runner.
+    const late = await runStandaloneSchedulingTick(runtime, {
+      now: new Date("2026-08-11T09:46:00.000Z"),
+    });
+    expect(late.errors).toEqual([]);
+    expect(late.fires).toEqual([
+      { taskId: task.taskId, outcome: "fired" },
+    ]);
+
+    const after = await runner.list();
+    const fired = after.find((t) => t.taskId === task.taskId);
+    expect(fired?.state.status).toBe("fired");
+    expect(fired?.state.firedAt).toBe("2026-08-11T09:46:00.000Z");
+
+    // Idempotent: a second tick reports the settled row as skipped, not
+    // re-fired (once triggers never refire).
+    const again = await runStandaloneSchedulingTick(runtime, {
+      now: new Date("2026-08-11T09:47:00.000Z"),
+    });
+    expect(
+      again.fires.filter((f) => f.outcome === "fired"),
+    ).toEqual([]);
+  });
+
+  it("defers to a registered consumer host without touching tasks", async () => {
+    const runtime = makeFakeRuntime();
+    await startServiceOn(runtime);
+    // Simulate PA registering its production deps provider.
+    registerScheduledTaskRunnerDeps(runtime, () => {
+      throw new Error(
+        "consumer deps must not be built by the standalone tick",
+      );
+    });
+
+    const result = await runStandaloneSchedulingTick(runtime, {
+      now: new Date("2026-08-11T09:46:00.000Z"),
+    });
+    expect(result.skipped).toBe("consumer_host");
+    expect(result.fires).toEqual([]);
+  });
+
+  it("honors the ELIZA_DISABLE_SCHEDULING_TICK kill switch", async () => {
+    process.env.ELIZA_DISABLE_SCHEDULING_TICK = "1";
+    expect(isStandaloneTickDisabled()).toBe(true);
+
+    const runtime = makeFakeRuntime();
+    await startServiceOn(runtime);
+    const result = await runStandaloneSchedulingTick(runtime, {
+      now: new Date("2026-08-11T09:46:00.000Z"),
+    });
+    expect(result.skipped).toBe("disabled");
+    expect(result.fires).toEqual([]);
+  });
+
+  it("continues past a row whose fire throws", async () => {
+    const runtime = makeFakeRuntime();
+    const service = await startServiceOn(runtime);
+    const t0 = new Date("2026-08-11T09:40:00.000Z");
+    const runner = service.getRunner({
+      agentId: runtime.agentId,
+      now: () => t0,
+    });
+
+    const bad = await runner.schedule({
+      kind: "reminder",
+      promptInstructions: "bad row",
+      trigger: { kind: "once", atIso: "2026-08-11T09:41:00.000Z" },
+      priority: "low",
+      respectsGlobalPause: false,
+      source: "user_chat",
+      createdBy: runtime.agentId,
+      ownerVisible: true,
+    });
+    const good = await runner.schedule({
+      kind: "reminder",
+      promptInstructions: "good row",
+      trigger: { kind: "once", atIso: "2026-08-11T09:42:00.000Z" },
+      priority: "low",
+      respectsGlobalPause: false,
+      source: "user_chat",
+      createdBy: runtime.agentId,
+      ownerVisible: true,
+    });
+
+    // Sabotage only the bad row's fire by monkey-patching fireWithResult.
+    const realFire = runner.fireWithResult.bind(runner);
+    (runner as { fireWithResult: typeof runner.fireWithResult }).fireWithResult =
+      async (taskId, args) => {
+        if (taskId === bad.taskId) throw new Error("boom");
+        return realFire(taskId, args);
+      };
+
+    const result = await runStandaloneSchedulingTick(runtime, {
+      now: new Date("2026-08-11T09:46:00.000Z"),
+    });
+    expect(result.errors).toEqual([
+      { taskId: bad.taskId, message: "boom" },
+    ]);
+    expect(result.fires).toEqual([
+      { taskId: good.taskId, outcome: "fired" },
+    ]);
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.test.ts
@@ -89,9 +89,7 @@ describe("standalone scheduling tick", () => {
       now: new Date("2026-08-11T09:46:00.000Z"),
     });
     expect(late.errors).toEqual([]);
-    expect(late.fires).toEqual([
-      { taskId: task.taskId, outcome: "fired" },
-    ]);
+    expect(late.fires).toEqual([{ taskId: task.taskId, outcome: "fired" }]);
 
     const after = await runner.list();
     const fired = after.find((t) => t.taskId === task.taskId);
@@ -103,9 +101,7 @@ describe("standalone scheduling tick", () => {
     const again = await runStandaloneSchedulingTick(runtime, {
       now: new Date("2026-08-11T09:47:00.000Z"),
     });
-    expect(
-      again.fires.filter((f) => f.outcome === "fired"),
-    ).toEqual([]);
+    expect(again.fires.filter((f) => f.outcome === "fired")).toEqual([]);
   });
 
   it("defers to a registered consumer host without touching tasks", async () => {
@@ -113,9 +109,7 @@ describe("standalone scheduling tick", () => {
     await startServiceOn(runtime);
     // Simulate PA registering its production deps provider.
     registerScheduledTaskRunnerDeps(runtime, () => {
-      throw new Error(
-        "consumer deps must not be built by the standalone tick",
-      );
+      throw new Error("consumer deps must not be built by the standalone tick");
     });
 
     const result = await runStandaloneSchedulingTick(runtime, {
@@ -170,20 +164,17 @@ describe("standalone scheduling tick", () => {
 
     // Sabotage only the bad row's fire by monkey-patching fireWithResult.
     const realFire = runner.fireWithResult.bind(runner);
-    (runner as { fireWithResult: typeof runner.fireWithResult }).fireWithResult =
-      async (taskId, args) => {
-        if (taskId === bad.taskId) throw new Error("boom");
-        return realFire(taskId, args);
-      };
+    (
+      runner as { fireWithResult: typeof runner.fireWithResult }
+    ).fireWithResult = async (taskId, args) => {
+      if (taskId === bad.taskId) throw new Error("boom");
+      return realFire(taskId, args);
+    };
 
     const result = await runStandaloneSchedulingTick(runtime, {
       now: new Date("2026-08-11T09:46:00.000Z"),
     });
-    expect(result.errors).toEqual([
-      { taskId: bad.taskId, message: "boom" },
-    ]);
-    expect(result.fires).toEqual([
-      { taskId: good.taskId, outcome: "fired" },
-    ]);
+    expect(result.errors).toEqual([{ taskId: bad.taskId, message: "boom" }]);
+    expect(result.fires).toEqual([{ taskId: good.taskId, outcome: "fired" }]);
   });
 });

--- a/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.ts
@@ -1,0 +1,111 @@
+/**
+ * Standalone scheduler tick — the fallback wall-clock driver for the
+ * ScheduledTask spine when no consumer host is loaded.
+ *
+ * `@elizaos/plugin-scheduling` is the always-loaded scheduling primitive: it
+ * hosts the runner service, the REST surface (`POST /api/lifeops/scheduled-tasks`
+ * returns 201), and the seed registry. But the only production caller of the
+ * due-task evaluation loop lived in `@elizaos/plugin-personal-assistant`
+ * (`processDueScheduledTasks`, driven by its `LIFEOPS_SCHEDULER` task worker).
+ * On any runtime without PA, every wall-clock trigger — `once`, `cron`,
+ * `interval` — was accepted, persisted, listed... and never fired
+ * (sol-dev cutover QA 2026-08-11: a `once` reminder stayed `scheduled`
+ * indefinitely past its `atIso`).
+ *
+ * This module closes that gap with a minimal in-plugin tick:
+ *
+ * - **Defers to a consumer host.** The tick no-ops whenever
+ *   {@link getScheduledTaskRunnerDeps} reports an injected deps provider —
+ *   that provider's owner (PA) runs the production tick with owner facts,
+ *   quiet-hours gates, escalation ladders, and completion timeouts. The check
+ *   runs EVERY tick, so a host that registers after boot takes over cleanly.
+ * - **Reuses the runner's own safety.** Dueness comes from the shared
+ *   {@link isScheduledTaskDue}; firing goes through `fireWithResult` whose
+ *   CAS claim makes a race with any other driver observable (`raced`) instead
+ *   of a double-fire.
+ * - **Stays small on purpose.** No completion-timeout follow-ups, no
+ *   escalation advancement, no owner-facts enrichment — those are consumer
+ *   host domain content. This is only the "wall clock exists" guarantee the
+ *   spine's REST contract already implies.
+ */
+
+import { type IAgentRuntime, logger } from "@elizaos/core";
+import { isScheduledTaskDue } from "./due.js";
+import type { ScheduledTaskFireResult } from "./runner.js";
+import {
+  getScheduledTaskRunner,
+  getScheduledTaskRunnerDeps,
+} from "./runner-service.js";
+
+/** Base cadence of the fallback tick; mirrors PA's LIFEOPS_TASK_INTERVAL_MS. */
+export const STANDALONE_TICK_INTERVAL_MS = 60_000;
+
+/** Process-level kill switch, mirroring PA's ELIZA_DISABLE_LIFEOPS_SCHEDULER. */
+export function isStandaloneTickDisabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const raw = env.ELIZA_DISABLE_SCHEDULING_TICK?.trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+export interface StandaloneTickResult {
+  /** Why the tick did no work, when it didn't. */
+  skipped?: "consumer_host" | "disabled";
+  /** Fire attempts made this tick, in task order. */
+  fires: Array<{ taskId: string; outcome: ScheduledTaskFireResult["kind"] }>;
+  /** Per-task errors; one bad row must not starve the rest of the tick. */
+  errors: Array<{ taskId: string; message: string }>;
+}
+
+/**
+ * Run one standalone tick: fire every due wall-clock task through the runner.
+ * Exposed for tests and for the interval driver in the runner service.
+ */
+export async function runStandaloneSchedulingTick(
+  runtime: IAgentRuntime,
+  opts: { now?: Date } = {},
+): Promise<StandaloneTickResult> {
+  const result: StandaloneTickResult = { fires: [], errors: [] };
+  if (isStandaloneTickDisabled()) {
+    result.skipped = "disabled";
+    return result;
+  }
+  // A consumer host (e.g. plugin-personal-assistant) owns the production
+  // tick. Checked per-tick so late-registering hosts take over without a
+  // restart, and so the two drivers never run concurrently by design (the
+  // runner's CAS claim would still prevent double-fires if they did).
+  if (getScheduledTaskRunnerDeps(runtime) !== null) {
+    result.skipped = "consumer_host";
+    return result;
+  }
+
+  const now = opts.now ?? new Date();
+  const runner = getScheduledTaskRunner(runtime, {
+    agentId: runtime.agentId,
+    now: () => now,
+  });
+
+  const tasks = await runner.list();
+  for (const task of tasks) {
+    if (task.state.status === "dismissed") continue;
+    try {
+      const decision = await isScheduledTaskDue(task, { now });
+      if (!decision.due) continue;
+      // `allowTerminalRefire` lets a due next occurrence of a RECURRING task
+      // reopen from a parked status; `fireWithResult`'s own refire guard
+      // re-verifies dueness on the fresh row before claiming.
+      const fire = await runner.fireWithResult(task.taskId, {
+        allowTerminalRefire: true,
+      });
+      result.fires.push({ taskId: task.taskId, outcome: fire.kind });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push({ taskId: task.taskId, message });
+      logger.warn(
+        { src: "scheduling:standalone-tick", taskId: task.taskId },
+        `[scheduling] standalone tick failed for ${task.taskId}: ${message}`,
+      );
+    }
+  }
+  return result;
+}

--- a/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/standalone-tick.ts
@@ -1,6 +1,7 @@
 /**
- * Standalone scheduler tick — the fallback wall-clock driver for the
- * ScheduledTask spine when no consumer host is loaded.
+ * Standalone scheduler tick — the fallback TaskService worker for the
+ * ScheduledTask spine when no consumer host is loaded. Core owns the only
+ * process clock; this module contributes one durable repeat row and worker.
  *
  * `@elizaos/plugin-scheduling` is the always-loaded scheduling primitive: it
  * hosts the runner service, the REST surface (`POST /api/lifeops/scheduled-tasks`
@@ -29,7 +30,13 @@
  *   spine's REST contract already implies.
  */
 
-import { type IAgentRuntime, logger } from "@elizaos/core";
+import {
+  type IAgentRuntime,
+  logger,
+  type Task,
+  type TaskMetadata,
+  type UUID,
+} from "@elizaos/core";
 import { isScheduledTaskDue } from "./due.js";
 import type { ScheduledTaskFireResult } from "./runner.js";
 import {
@@ -39,6 +46,14 @@ import {
 
 /** Base cadence of the fallback tick; mirrors PA's LIFEOPS_TASK_INTERVAL_MS. */
 export const STANDALONE_TICK_INTERVAL_MS = 60_000;
+export const STANDALONE_TICK_TASK_NAME = "SCHEDULED_TASK_RUNNER" as const;
+export const STANDALONE_TICK_TASK_TAGS = [
+  "queue",
+  "repeat",
+  "scheduling",
+] as const;
+
+const STANDALONE_TICK_TASK_KIND = "standalone_scheduled_task_runner";
 
 /** Process-level kill switch, mirroring PA's ELIZA_DISABLE_LIFEOPS_SCHEDULER. */
 export function isStandaloneTickDisabled(
@@ -59,7 +74,7 @@ export interface StandaloneTickResult {
 
 /**
  * Run one standalone tick: fire every due wall-clock task through the runner.
- * Exposed for tests and for the interval driver in the runner service.
+ * Exposed for tests and for the TaskService worker registered below.
  */
 export async function runStandaloneSchedulingTick(
   runtime: IAgentRuntime,
@@ -101,6 +116,12 @@ export async function runStandaloneSchedulingTick(
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       result.errors.push({ taskId: task.taskId, message });
+      // error-policy:J7 A malformed or temporarily failing scheduled row must
+      // not starve independent rows; diagnostics make the isolated failure
+      // visible while the durable row remains eligible for the next tick.
+      runtime.reportError("SchedulingStandaloneTick.task", error, {
+        taskId: task.taskId,
+      });
       logger.warn(
         { src: "scheduling:standalone-tick", taskId: task.taskId },
         `[scheduling] standalone tick failed for ${task.taskId}: ${message}`,
@@ -108,4 +129,102 @@ export async function runStandaloneSchedulingTick(
     }
   }
   return result;
+}
+
+function isStandaloneTickTask(task: Task): boolean {
+  const marker = task.metadata?.schedulingTick;
+  return (
+    task.name === STANDALONE_TICK_TASK_NAME &&
+    typeof marker === "object" &&
+    marker !== null &&
+    "kind" in marker &&
+    marker.kind === STANDALONE_TICK_TASK_KIND
+  );
+}
+
+function buildStandaloneTickMetadata(): TaskMetadata {
+  return {
+    updateInterval: STANDALONE_TICK_INTERVAL_MS,
+    baseInterval: STANDALONE_TICK_INTERVAL_MS,
+    blocking: true,
+    maxFailures: 0,
+    paused: false,
+    schedulingTick: {
+      kind: STANDALONE_TICK_TASK_KIND,
+      version: 1,
+    },
+  };
+}
+
+/** Register the fallback tick as a core TaskService worker. */
+export function registerStandaloneTickWorker(runtime: IAgentRuntime): void {
+  if (runtime.getTaskWorker(STANDALONE_TICK_TASK_NAME)) return;
+  runtime.registerTaskWorker({
+    name: STANDALONE_TICK_TASK_NAME,
+    shouldRun: async () =>
+      !isStandaloneTickDisabled() &&
+      getScheduledTaskRunnerDeps(runtime) === null,
+    execute: async () => {
+      await runStandaloneSchedulingTick(runtime);
+      return { nextInterval: STANDALONE_TICK_INTERVAL_MS };
+    },
+  });
+}
+
+/**
+ * Ensure exactly one durable repeat row drives the fallback worker.
+ *
+ * The row remains present while a richer consumer host is loaded; the worker's
+ * `shouldRun` gate hands ownership to that host without introducing another
+ * wall clock. If the host unloads, the next core TaskService poll resumes the
+ * fallback automatically.
+ */
+export async function ensureStandaloneTickTask(
+  runtime: IAgentRuntime,
+): Promise<UUID> {
+  const tasks = await runtime.getTasks({
+    agentIds: [runtime.agentId],
+    tags: [...STANDALONE_TICK_TASK_TAGS],
+  });
+  const matches = tasks.filter(isStandaloneTickTask);
+  const [canonical, ...duplicates] = matches;
+
+  for (const duplicate of duplicates) {
+    if (duplicate.id) await runtime.deleteTask(duplicate.id);
+  }
+
+  const metadata = buildStandaloneTickMetadata();
+  if (canonical?.id) {
+    await runtime.updateTask(canonical.id, {
+      description:
+        "Drive scheduled tasks when no consumer host owns the runner",
+      metadata,
+    });
+    return canonical.id;
+  }
+
+  return runtime.createTask({
+    name: STANDALONE_TICK_TASK_NAME,
+    description: "Drive scheduled tasks when no consumer host owns the runner",
+    agentId: runtime.agentId,
+    tags: [...STANDALONE_TICK_TASK_TAGS],
+    metadata,
+    dueAt: Date.now(),
+  });
+}
+
+/** Remove the worker and its durable driver rows during plugin unload. */
+export async function disposeStandaloneTick(
+  runtime: IAgentRuntime,
+): Promise<void> {
+  runtime.unregisterTaskWorker(STANDALONE_TICK_TASK_NAME);
+  const tasks = await runtime.getTasks({
+    agentIds: [runtime.agentId],
+    tags: [...STANDALONE_TICK_TASK_TAGS],
+  });
+  for (const task of tasks) {
+    if (isStandaloneTickTask(task) && task.id) {
+      await runtime.deleteTask(task.id);
+    }
+  }
 }


### PR DESCRIPTION
## Root issue

`@elizaos/plugin-scheduling` accepts and persists wall-clock scheduled tasks on runtimes that do not load `@elizaos/plugin-personal-assistant`, but PA's `LIFEOPS_SCHEDULER` worker was the only production caller of the due-task loop. `once`, `cron`, and `interval` rows therefore remained scheduled forever even though manual fire worked.

## Fix

The scheduling spine now contributes a fallback `SCHEDULED_TASK_RUNNER` worker and one idempotent durable `queue`/`repeat` task. Core `TaskService` remains the sole owner of polling, overlap suppression, retry/backoff, shared-daemon coordination, and teardown.

- The worker evaluates due rows through the existing `isScheduledTaskDue` and `fireWithResult` contracts.
- Its `shouldRun` gate yields to an injected consumer host on every core poll, so PA can take over after startup without a second clock.
- The runner's compare-and-swap claim remains the final double-fire guard.
- Per-row failures are reported through `runtime.reportError` and do not starve independent rows.
- Init reconciles duplicate/missing driver rows; plugin disposal unregisters the worker and deletes its owned row.
- `ELIZA_DISABLE_SCHEDULING_TICK` disables execution while preserving the registered worker identity.

This supersedes the earlier raw `setInterval` implementation in this PR; no plugin-owned timer remains.

## Verification

- `bun run --cwd plugins/plugin-scheduling test`: 25 files, 325 tests passed.
- `bun run --cwd plugins/plugin-scheduling typecheck`: passed.
- Biome and `git diff --check`: passed.
- Tests cover real runner firing/idempotency, pre-due behavior, consumer-host handoff, kill switch, per-row failure isolation, single durable driver-row reconciliation, and unload cleanup.

<!-- evidence-head:d049033764b494840078e660ca95ccc06f6d3469 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only scheduling lifecycle; no UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only scheduling lifecycle; no UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only behavior is exercised through the real runner and TaskService worker contract

<!-- evidence-row:backend-logs -->
- [x] [Full scheduling package proof: 25 files / 325 tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18382-scheduling-proof-d0490337.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic scheduling lifecycle; no model call is under test

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual artifact

<!-- evidence-row:domain-artifacts -->
- [x] N/A - scheduling lifecycle assertions are recorded in the backend proof; this backend-only change produces no separate user-facing domain artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5 (system-reported model family; deployment variant unavailable)`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop app`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - installed Codex plugin packages do not expose a repository commit SHA`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
