### PR TITLE
test(app): create-mock confirms fresh creation for the forced reprovision path

### DIFF
--- a/packages/app/test/ui-smoke/cloud-agent-lifecycle.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-agent-lifecycle.spec.ts
@@ -158,6 +158,12 @@ async function installAgentStoreRoutes(
         store.agents.push(agent);
         await fulfillJson(route, 200, {
           success: true,
+          // The UI's forced-create path requires the server's explicit
+          // fresh-creation confirmation (client-cloud.ts
+          // requireConfirmedFreshCloudAgentCreate rejects
+          // `forceCreate && created !== true`); omit it and createAgent
+          // treats the response as idempotent reuse and never binds.
+          created: true,
           data: {
             id,
             agentId: id,


### PR DESCRIPTION
Root cause of the promote-2 cert red on #18370 (Smoke: `cloud-agent-lifecycle.spec.ts:290`, the only failing case): the Settings reprovision flow sends `forceCreate: true`, and `client-cloud.ts`'s `requireConfirmedFreshCloudAgentCreate` (line 153) rejects any create response without `created: true` — the anti-idempotent-reuse gate from #18362. The spec's create-POST mock predates that gate and omits the flag, so `bindAndReload` never ran and the 30s `elizaos:active-server` poll timed out at 38.8s. The #18362 author aligned the unit-test mock (`CloudAgentsSection.test.tsx`) but missed this ui-smoke spec — the #18315 test-alignment class, diagnosed independently by watchtower (behavioral) and vps-agent (code-level, exact line) with matching verdicts.

One-line semantic change (+comment): `created: true` as a sibling of `success: true` in the create-POST `fulfillJson`. **Sibling sweep**: no other ui-smoke spec intercepts `**/api/cloud/v1/eliza/agents` — this was the only stale create-mock.

Product behavior is CORRECT (prod emits `created`; vps-agent's prod probe confirmed) — spec-only fix. Unblocks the promote-2 re-pin.

- Before screenshots `N/A - test-only change`.
- After screenshots `N/A - test-only change`.
- Walkthrough video `N/A - test-only change`.
- Backend logs: cert run 31474562091 Smoke failure log + failure screenshot (linked in HQ #18309).
- Frontend logs `N/A - test mock change`.
- Real-LLM trajectory `N/A - no model path`.
- Domain artifacts: next cert generation's Smoke passes this spec (the re-pin run is the proof).
- OCR review `N/A - no rendered surface change`.

<!-- evidence-head:db58ae0b00dadd6789e2f5e9267e75533ea4a335 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)