### PR TITLE
fix(app): track ui smoke auth renderer variant

### DIFF
--- a/packages/app-core/scripts/README.md
+++ b/packages/app-core/scripts/README.md
@@ -22,7 +22,7 @@ Most scripts here are invoked from **root `package.json`** (`bun run …`). **Ap
 
 | Module | Why it exists |
 |--------|----------------|
-| `vite-renderer-dist-stale.mjs` | Renderer-manifest variant and mtime checks so `vite build` is skipped only when `apps/app/dist` is reusable — avoids redundant multi-minute production builds on restart. |
+| `vite-renderer-dist-stale.mjs` | Renderer mtime checks, plus opt-in UI-smoke manifest validation, so reusable `apps/app/dist` builds skip redundant multi-minute rebuilds. |
 | `kill-ui-listen-port.mjs` | Clears the UI port before Vite binds; Unix uses `lsof`, Windows uses `netstat` + `taskkill` because `lsof` is not standard there. |
 | `kill-process-tree.mjs` | Kills **only** the PID tree rooted at each spawned child — avoids `pkill bun` style collateral damage to other workspaces. |
 

--- a/packages/app-core/scripts/README.md
+++ b/packages/app-core/scripts/README.md
@@ -22,7 +22,7 @@ Most scripts here are invoked from **root `package.json`** (`bun run …`). **Ap
 
 | Module | Why it exists |
 |--------|----------------|
-| `vite-renderer-dist-stale.mjs` | Cheap mtime check so `vite build` is skipped when `apps/app/dist` is still fresh — avoids redundant multi‑minute production builds on restart. |
+| `vite-renderer-dist-stale.mjs` | Renderer-manifest variant and mtime checks so `vite build` is skipped only when `apps/app/dist` is reusable — avoids redundant multi-minute production builds on restart. |
 | `kill-ui-listen-port.mjs` | Clears the UI port before Vite binds; Unix uses `lsof`, Windows uses `netstat` + `taskkill` because `lsof` is not standard there. |
 | `kill-process-tree.mjs` | Kills **only** the PID tree rooted at each spawned child — avoids `pkill bun` style collateral damage to other workspaces. |
 

--- a/packages/app-core/scripts/lib/mobile-web-build-reuse.test.mts
+++ b/packages/app-core/scripts/lib/mobile-web-build-reuse.test.mts
@@ -40,6 +40,7 @@ function makeAppDist(
     variant?: string;
     capacitorTarget?: string;
     runtimeMode?: string;
+    playwrightTestAuth?: boolean;
   } = {},
 ) {
   const appDir = path.join(tmp, "app");
@@ -47,7 +48,10 @@ function makeAppDist(
   fs.mkdirSync(path.join(distDir, "assets"), { recursive: true });
   fs.writeFileSync(path.join(distDir, "index.html"), "<div id=root></div>");
   fs.writeFileSync(path.join(distDir, "assets", "index-abc123.js"), "boot()");
-  writeRendererBuildManifest(distDir, meta);
+  writeRendererBuildManifest(distDir, {
+    ...meta,
+    playwrightTestAuth: meta.playwrightTestAuth ?? false,
+  });
   return { appDir, distDir };
 }
 

--- a/packages/app-core/scripts/lib/renderer-build-manifest.d.mts
+++ b/packages/app-core/scripts/lib/renderer-build-manifest.d.mts
@@ -49,6 +49,11 @@ export function readRendererBuildManifest(
   dir: string,
 ): RendererBuildManifest | null;
 
+export function rendererBuildManifestMatchesDist(
+  distDir: string,
+  manifest: unknown,
+): manifest is RendererBuildManifest;
+
 export function assertStagedRendererMatchesBuild(
   freshDistDir: string,
   stagedDir: string,

--- a/packages/app-core/scripts/lib/renderer-build-manifest.d.mts
+++ b/packages/app-core/scripts/lib/renderer-build-manifest.d.mts
@@ -17,6 +17,7 @@ export interface RendererBuildManifest {
   variant: string | null;
   capacitorTarget: string | null;
   runtimeMode: string | null;
+  playwrightTestAuth: boolean | null;
 }
 
 export interface RendererBuildManifestMeta {
@@ -25,6 +26,7 @@ export interface RendererBuildManifestMeta {
   variant?: string | null;
   capacitorTarget?: string | null;
   runtimeMode?: string | null;
+  playwrightTestAuth?: boolean | null;
 }
 
 export function computeRendererFingerprint(distDir: string): {

--- a/packages/app-core/scripts/lib/renderer-build-manifest.mjs
+++ b/packages/app-core/scripts/lib/renderer-build-manifest.mjs
@@ -122,6 +122,59 @@ export function readRendererBuildManifest(dir) {
   }
 }
 
+function isNullableString(value) {
+  return value === null || typeof value === "string";
+}
+
+/**
+ * Return whether a parsed manifest has the v1 shape and matches the renderer
+ * bytes beside it. This is the reuse boundary; a copied or partial stamp must
+ * not make a stale renderer look current.
+ *
+ * @param {string} distDir
+ * @param {unknown} manifest
+ */
+export function rendererBuildManifestMatchesDist(distDir, manifest) {
+  if (
+    manifest === null ||
+    typeof manifest !== "object" ||
+    Array.isArray(manifest)
+  ) {
+    return false;
+  }
+
+  if (
+    manifest.schema !== RENDERER_BUILD_MANIFEST_SCHEMA ||
+    typeof manifest.buildId !== "string" ||
+    !/^[a-f0-9]{64}$/.test(manifest.buildId) ||
+    typeof manifest.indexHtmlSha256 !== "string" ||
+    !/^[a-f0-9]{64}$/.test(manifest.indexHtmlSha256) ||
+    !Number.isInteger(manifest.assetCount) ||
+    manifest.assetCount < 0 ||
+    typeof manifest.builtAt !== "string" ||
+    !Number.isFinite(Date.parse(manifest.builtAt)) ||
+    !isNullableString(manifest.commit) ||
+    !isNullableString(manifest.variant) ||
+    !isNullableString(manifest.capacitorTarget) ||
+    !isNullableString(manifest.runtimeMode) ||
+    (manifest.playwrightTestAuth !== null &&
+      typeof manifest.playwrightTestAuth !== "boolean")
+  ) {
+    return false;
+  }
+
+  try {
+    const fingerprint = computeRendererFingerprint(distDir);
+    return (
+      manifest.buildId === fingerprint.buildId &&
+      manifest.indexHtmlSha256 === fingerprint.indexHtmlSha256 &&
+      manifest.assetCount === fingerprint.assetCount
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Assert a STAGED renderer directory carries exactly the renderer that was just
  * built in `freshDistDir`. Throws loudly on any mismatch so a stale/missing/

--- a/packages/app-core/scripts/lib/renderer-build-manifest.mjs
+++ b/packages/app-core/scripts/lib/renderer-build-manifest.mjs
@@ -74,7 +74,8 @@ export function computeRendererFingerprint(distDir) {
  * Build the manifest object for a renderer dir (does not write it).
  * @param {string} distDir
  * @param {{ builtAt?: string, commit?: string|null, variant?: string|null,
- *           capacitorTarget?: string|null, runtimeMode?: string|null }} [meta]
+ *           capacitorTarget?: string|null, runtimeMode?: string|null,
+ *           playwrightTestAuth?: boolean|null }} [meta]
  */
 export function buildRendererManifest(distDir, meta = {}) {
   const fingerprint = computeRendererFingerprint(distDir);
@@ -88,6 +89,7 @@ export function buildRendererManifest(distDir, meta = {}) {
     variant: meta.variant ?? null,
     capacitorTarget: meta.capacitorTarget ?? null,
     runtimeMode: meta.runtimeMode ?? null,
+    playwrightTestAuth: meta.playwrightTestAuth ?? null,
   };
 }
 

--- a/packages/app-core/scripts/lib/renderer-build-manifest.test.mts
+++ b/packages/app-core/scripts/lib/renderer-build-manifest.test.mts
@@ -108,6 +108,7 @@ describe("writeRendererBuildManifest / readRendererBuildManifest", () => {
       commit: "deadbeef",
       variant: "store",
       capacitorTarget: "ios",
+      playwrightTestAuth: true,
     });
     expect(
       fs.existsSync(path.join(dist, RENDERER_BUILD_MANIFEST_FILENAME)),
@@ -116,6 +117,7 @@ describe("writeRendererBuildManifest / readRendererBuildManifest", () => {
     expect(read).toEqual(written);
     expect(read?.variant).toBe("store");
     expect(read?.capacitorTarget).toBe("ios");
+    expect(read?.playwrightTestAuth).toBe(true);
     expect(read?.buildId).toBe(computeRendererFingerprint(dist).buildId);
   });
 
@@ -290,5 +292,6 @@ describe("buildRendererManifest", () => {
     expect(manifest.commit).toBeNull();
     expect(manifest.variant).toBeNull();
     expect(manifest.capacitorTarget).toBeNull();
+    expect(manifest.playwrightTestAuth).toBeNull();
   });
 });

--- a/packages/app-core/scripts/lib/vite-renderer-dist-stale.mjs
+++ b/packages/app-core/scripts/lib/vite-renderer-dist-stale.mjs
@@ -1,7 +1,8 @@
 /**
- * Returns true when the main app needs a production `vite build` before Electrobun dev.
+ * Returns true when the main app needs a production `vite build`.
  *
- * Uses **mtime** of `dist/index.html` vs. app sources, shared packages, and key config files.
+ * Uses the renderer manifest for build-time variants, then **mtime** of `dist/index.html`
+ * vs. app sources, shared packages, and key config files.
  * **Why not always build:** A full Vite production compile is expensive; skipping when dist
  * is fresh makes `dev:desktop` restarts fast. **Why mtime:** Good enough for local dev; use
  * `--force-renderer` / `ELIZA_DESKTOP_RENDERER_BUILD=always` when you need a guaranteed
@@ -9,6 +10,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { readRendererBuildManifest } from "./renderer-build-manifest.mjs";
 
 const TEXT_EXT = new Set([
   ".ts",
@@ -68,12 +70,37 @@ function maxMtimeAcrossDirs(dirs) {
 }
 
 /**
+ * UI-smoke may reuse a renderer only when its test-auth build flag exactly
+ * matches the current invocation. Missing legacy metadata fails closed.
+ */
+export function rendererDistMatchesPlaywrightTestAuth(
+  appDir,
+  expectedPlaywrightTestAuth,
+) {
+  const manifest = readRendererBuildManifest(path.join(appDir, "dist"));
+  return (
+    typeof manifest?.buildId === "string" &&
+    manifest.buildId.length > 0 &&
+    manifest.playwrightTestAuth === expectedPlaywrightTestAuth
+  );
+}
+
+/**
  * @param {string} appDir absolute path to packages/app
  * @param {string} repoRoot absolute path to repo root
+ * @param {{ expectedPlaywrightTestAuth?: boolean }} [options]
  */
-export function viteRendererBuildNeeded(appDir, repoRoot) {
+export function viteRendererBuildNeeded(appDir, repoRoot, options = {}) {
   const distIndex = path.join(appDir, "dist", "index.html");
   if (!fs.existsSync(distIndex)) {
+    return true;
+  }
+  const expectedPlaywrightTestAuth =
+    options.expectedPlaywrightTestAuth ??
+    process.env.VITE_PLAYWRIGHT_TEST_AUTH === "true";
+  if (
+    !rendererDistMatchesPlaywrightTestAuth(appDir, expectedPlaywrightTestAuth)
+  ) {
     return true;
   }
   const distMtime = fileMtime(distIndex);

--- a/packages/app-core/scripts/lib/vite-renderer-dist-stale.mjs
+++ b/packages/app-core/scripts/lib/vite-renderer-dist-stale.mjs
@@ -10,7 +10,11 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { readRendererBuildManifest } from "./renderer-build-manifest.mjs";
+import { loadEnv } from "vite";
+import {
+  readRendererBuildManifest,
+  rendererBuildManifestMatchesDist,
+} from "./renderer-build-manifest.mjs";
 
 const TEXT_EXT = new Set([
   ".ts",
@@ -77,11 +81,18 @@ export function rendererDistMatchesPlaywrightTestAuth(
   appDir,
   expectedPlaywrightTestAuth,
 ) {
-  const manifest = readRendererBuildManifest(path.join(appDir, "dist"));
+  const distDir = path.join(appDir, "dist");
+  const manifest = readRendererBuildManifest(distDir);
   return (
-    typeof manifest?.buildId === "string" &&
-    manifest.buildId.length > 0 &&
+    rendererBuildManifestMatchesDist(distDir, manifest) &&
     manifest.playwrightTestAuth === expectedPlaywrightTestAuth
+  );
+}
+
+/** Resolve the UI-smoke auth variant with Vite's production env precedence. */
+export function resolvePlaywrightTestAuth(appDir) {
+  return (
+    loadEnv("production", appDir, "VITE_").VITE_PLAYWRIGHT_TEST_AUTH === "true"
   );
 }
 
@@ -95,11 +106,12 @@ export function viteRendererBuildNeeded(appDir, repoRoot, options = {}) {
   if (!fs.existsSync(distIndex)) {
     return true;
   }
-  const expectedPlaywrightTestAuth =
-    options.expectedPlaywrightTestAuth ??
-    process.env.VITE_PLAYWRIGHT_TEST_AUTH === "true";
   if (
-    !rendererDistMatchesPlaywrightTestAuth(appDir, expectedPlaywrightTestAuth)
+    typeof options.expectedPlaywrightTestAuth === "boolean" &&
+    !rendererDistMatchesPlaywrightTestAuth(
+      appDir,
+      options.expectedPlaywrightTestAuth,
+    )
   ) {
     return true;
   }
@@ -109,6 +121,10 @@ export function viteRendererBuildNeeded(appDir, repoRoot, options = {}) {
   const candidates = [
     path.join(appDir, "index.html"),
     path.join(appDir, "vite.config.ts"),
+    path.join(appDir, ".env"),
+    path.join(appDir, ".env.local"),
+    path.join(appDir, ".env.production"),
+    path.join(appDir, ".env.production.local"),
   ];
 
   for (const p of candidates) {

--- a/packages/app-core/scripts/lib/vite-renderer-dist-stale.test.mts
+++ b/packages/app-core/scripts/lib/vite-renderer-dist-stale.test.mts
@@ -1,0 +1,133 @@
+/**
+ * Verifies renderer reuse against the real build manifest so UI-smoke cannot
+ * cross the Playwright test-auth build boundary in either direction.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  RENDERER_BUILD_MANIFEST_FILENAME,
+  writeRendererBuildManifest,
+} from "./renderer-build-manifest.mjs";
+import { resolveElizaWorkspaceRootFromImportMeta } from "./repo-root.mjs";
+import {
+  rendererDistMatchesPlaywrightTestAuth,
+  viteRendererBuildNeeded,
+} from "./vite-renderer-dist-stale.mjs";
+
+const repoRoot = resolveElizaWorkspaceRootFromImportMeta(import.meta.url);
+const cleanupHelperScript = path.join(
+  repoRoot,
+  "packages",
+  "scripts",
+  "rm-path-recursive.mjs",
+);
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "renderer-auth-variant-"));
+});
+
+afterEach(() => {
+  execFileSync(process.execPath, [cleanupHelperScript, tmp], {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+});
+
+function makeRenderer(playwrightTestAuth?: boolean) {
+  const appDir = path.join(tmp, "app");
+  const distDir = path.join(appDir, "dist");
+  fs.mkdirSync(distDir, { recursive: true });
+  fs.writeFileSync(path.join(distDir, "index.html"), "<div id=root></div>");
+  writeRendererBuildManifest(distDir, { playwrightTestAuth });
+  return { appDir, distDir };
+}
+
+describe("Playwright test-auth renderer reuse", () => {
+  it.each([true, false])(
+    "reuses a fresh renderer when test auth is %s in both build and invocation",
+    (playwrightTestAuth) => {
+      const { appDir } = makeRenderer(playwrightTestAuth);
+
+      expect(
+        rendererDistMatchesPlaywrightTestAuth(appDir, playwrightTestAuth),
+      ).toBe(true);
+      expect(
+        viteRendererBuildNeeded(appDir, tmp, {
+          expectedPlaywrightTestAuth: playwrightTestAuth,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it.each([
+    { built: false, requested: true },
+    { built: true, requested: false },
+  ])(
+    "rebuilds when a $built build is reused by a $requested invocation",
+    ({ built, requested }) => {
+      const { appDir } = makeRenderer(built);
+
+      expect(rendererDistMatchesPlaywrightTestAuth(appDir, requested)).toBe(
+        false,
+      );
+      expect(
+        viteRendererBuildNeeded(appDir, tmp, {
+          expectedPlaywrightTestAuth: requested,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it.each(["legacy", "absent", "malformed", "partial"])(
+    "fails closed when test-auth manifest metadata is %s",
+    (manifestState) => {
+      const { appDir, distDir } = makeRenderer();
+      const manifestPath = path.join(distDir, RENDERER_BUILD_MANIFEST_FILENAME);
+      if (manifestState === "legacy") {
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+        delete manifest.playwrightTestAuth;
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+      } else if (manifestState === "absent") {
+        fs.unlinkSync(manifestPath);
+      } else if (manifestState === "partial") {
+        fs.writeFileSync(
+          manifestPath,
+          JSON.stringify({ playwrightTestAuth: false }),
+        );
+      } else {
+        fs.writeFileSync(manifestPath, "{not-json");
+      }
+
+      expect(rendererDistMatchesPlaywrightTestAuth(appDir, false)).toBe(false);
+      expect(
+        viteRendererBuildNeeded(appDir, tmp, {
+          expectedPlaywrightTestAuth: false,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it("treats a normal invocation as test auth disabled", () => {
+    const previousPlaywrightTestAuth = process.env.VITE_PLAYWRIGHT_TEST_AUTH;
+    delete process.env.VITE_PLAYWRIGHT_TEST_AUTH;
+    try {
+      const { appDir } = makeRenderer(false);
+
+      expect(viteRendererBuildNeeded(appDir, tmp)).toBe(false);
+
+      makeRenderer(true);
+      expect(viteRendererBuildNeeded(appDir, tmp)).toBe(true);
+    } finally {
+      if (previousPlaywrightTestAuth === undefined) {
+        delete process.env.VITE_PLAYWRIGHT_TEST_AUTH;
+      } else {
+        process.env.VITE_PLAYWRIGHT_TEST_AUTH = previousPlaywrightTestAuth;
+      }
+    }
+  });
+});

--- a/packages/app-core/scripts/lib/vite-renderer-dist-stale.test.mts
+++ b/packages/app-core/scripts/lib/vite-renderer-dist-stale.test.mts
@@ -14,6 +14,7 @@ import {
 import { resolveElizaWorkspaceRootFromImportMeta } from "./repo-root.mjs";
 import {
   rendererDistMatchesPlaywrightTestAuth,
+  resolvePlaywrightTestAuth,
   viteRendererBuildNeeded,
 } from "./vite-renderer-dist-stale.mjs";
 
@@ -83,45 +84,68 @@ describe("Playwright test-auth renderer reuse", () => {
     },
   );
 
-  it.each(["legacy", "absent", "malformed", "partial"])(
-    "fails closed when test-auth manifest metadata is %s",
-    (manifestState) => {
-      const { appDir, distDir } = makeRenderer();
-      const manifestPath = path.join(distDir, RENDERER_BUILD_MANIFEST_FILENAME);
-      if (manifestState === "legacy") {
-        const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-        delete manifest.playwrightTestAuth;
-        fs.writeFileSync(manifestPath, JSON.stringify(manifest));
-      } else if (manifestState === "absent") {
-        fs.unlinkSync(manifestPath);
-      } else if (manifestState === "partial") {
-        fs.writeFileSync(
-          manifestPath,
-          JSON.stringify({ playwrightTestAuth: false }),
-        );
-      } else {
-        fs.writeFileSync(manifestPath, "{not-json");
-      }
-
-      expect(rendererDistMatchesPlaywrightTestAuth(appDir, false)).toBe(false);
-      expect(
-        viteRendererBuildNeeded(appDir, tmp, {
-          expectedPlaywrightTestAuth: false,
+  it.each([
+    "legacy",
+    "absent",
+    "malformed",
+    "partial",
+    "wrong-schema",
+    "wrong-fingerprint",
+  ])("fails closed when test-auth manifest metadata is %s", (manifestState) => {
+    const { appDir, distDir } = makeRenderer();
+    const manifestPath = path.join(distDir, RENDERER_BUILD_MANIFEST_FILENAME);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    if (manifestState === "legacy") {
+      delete manifest.playwrightTestAuth;
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+    } else if (manifestState === "absent") {
+      fs.unlinkSync(manifestPath);
+    } else if (manifestState === "partial") {
+      fs.writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          buildId: manifest.buildId,
+          playwrightTestAuth: false,
         }),
-      ).toBe(true);
-    },
-  );
+      );
+    } else if (manifestState === "wrong-schema") {
+      manifest.schema = "elizaos.renderer.build/v0";
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+    } else if (manifestState === "wrong-fingerprint") {
+      manifest.buildId = "0".repeat(64);
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+    } else {
+      fs.writeFileSync(manifestPath, "{not-json");
+    }
 
-  it("treats a normal invocation as test auth disabled", () => {
+    expect(rendererDistMatchesPlaywrightTestAuth(appDir, false)).toBe(false);
+    expect(
+      viteRendererBuildNeeded(appDir, tmp, {
+        expectedPlaywrightTestAuth: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("uses Vite production env precedence for the expected variant", () => {
     const previousPlaywrightTestAuth = process.env.VITE_PLAYWRIGHT_TEST_AUTH;
     delete process.env.VITE_PLAYWRIGHT_TEST_AUTH;
     try {
-      const { appDir } = makeRenderer(false);
-
-      expect(viteRendererBuildNeeded(appDir, tmp)).toBe(false);
-
+      const appDir = path.join(tmp, "app");
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(appDir, ".env.production"),
+        "VITE_PLAYWRIGHT_TEST_AUTH=true\n",
+      );
       makeRenderer(true);
-      expect(viteRendererBuildNeeded(appDir, tmp)).toBe(true);
+
+      const expectedPlaywrightTestAuth = resolvePlaywrightTestAuth(appDir);
+
+      expect(expectedPlaywrightTestAuth).toBe(true);
+      expect(
+        viteRendererBuildNeeded(appDir, tmp, {
+          expectedPlaywrightTestAuth,
+        }),
+      ).toBe(false);
     } finally {
       if (previousPlaywrightTestAuth === undefined) {
         delete process.env.VITE_PLAYWRIGHT_TEST_AUTH;
@@ -129,5 +153,36 @@ describe("Playwright test-auth renderer reuse", () => {
         process.env.VITE_PLAYWRIGHT_TEST_AUTH = previousPlaywrightTestAuth;
       }
     }
+  });
+
+  it("rebuilds when a production env file changes the requested variant", () => {
+    const previousPlaywrightTestAuth = process.env.VITE_PLAYWRIGHT_TEST_AUTH;
+    delete process.env.VITE_PLAYWRIGHT_TEST_AUTH;
+    try {
+      const { appDir } = makeRenderer(false);
+      fs.writeFileSync(
+        path.join(appDir, ".env.production"),
+        "VITE_PLAYWRIGHT_TEST_AUTH=true\n",
+      );
+
+      expect(
+        viteRendererBuildNeeded(appDir, tmp, {
+          expectedPlaywrightTestAuth: resolvePlaywrightTestAuth(appDir),
+        }),
+      ).toBe(true);
+    } finally {
+      if (previousPlaywrightTestAuth === undefined) {
+        delete process.env.VITE_PLAYWRIGHT_TEST_AUTH;
+      } else {
+        process.env.VITE_PLAYWRIGHT_TEST_AUTH = previousPlaywrightTestAuth;
+      }
+    }
+  });
+
+  it("lets generic desktop callers reuse renderers without a manifest", () => {
+    const { appDir, distDir } = makeRenderer();
+    fs.unlinkSync(path.join(distDir, RENDERER_BUILD_MANIFEST_FILENAME));
+
+    expect(viteRendererBuildNeeded(appDir, tmp)).toBe(false);
   });
 });

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -39,6 +39,7 @@ import { resolveMainAppDir } from "./lib/app-dir.mjs";
 import { shouldForceStubStack } from "./lib/ui-smoke-stub-decision.mjs";
 import {
   rendererDistMatchesPlaywrightTestAuth,
+  resolvePlaywrightTestAuth,
   viteRendererBuildNeeded,
 } from "./lib/vite-renderer-dist-stale.mjs";
 import {
@@ -78,8 +79,7 @@ const READY_TIMEOUT_MS = 180_000;
 const API_PORT = Number(process.env.ELIZA_UI_SMOKE_API_PORT ?? "31337");
 const UI_PORT = Number(process.env.ELIZA_UI_SMOKE_PORT ?? "2138");
 const UI_SMOKE_RUN_ID = process.env.ELIZA_UI_SMOKE_RUN_ID?.trim() ?? "";
-const EXPECTED_PLAYWRIGHT_TEST_AUTH =
-  process.env.VITE_PLAYWRIGHT_TEST_AUTH === "true";
+const EXPECTED_PLAYWRIGHT_TEST_AUTH = resolvePlaywrightTestAuth(APP_DIR);
 const LIVE_PROVIDER = await selectLiveProviderAsync();
 const REAL_LOCAL_STACK = process.env.ELIZA_UI_SMOKE_REAL_LOCAL_STACK === "1";
 const BACKEND_LOG_PATH = process.env.ELIZA_UI_SMOKE_BACKEND_LOG_PATH?.trim();
@@ -883,7 +883,9 @@ async function ensureUiDistReady(): Promise<void> {
 
   try {
     await access(distIndex);
-    needsBuild = viteRendererBuildNeeded(APP_DIR, REPO_ROOT);
+    needsBuild = viteRendererBuildNeeded(APP_DIR, REPO_ROOT, {
+      expectedPlaywrightTestAuth: EXPECTED_PLAYWRIGHT_TEST_AUTH,
+    });
   } catch {
     needsBuild = true;
   }
@@ -956,6 +958,16 @@ async function ensureUiDistReady(): Promise<void> {
   if (child.exitCode !== 0) {
     throw new Error(
       `app renderer build failed (exit ${child.exitCode}).\n${logs.join("").slice(-8_000)}`,
+    );
+  }
+  if (
+    !rendererDistMatchesPlaywrightTestAuth(
+      APP_DIR,
+      EXPECTED_PLAYWRIGHT_TEST_AUTH,
+    )
+  ) {
+    throw new Error(
+      `Renderer build completed with a manifest that does not match VITE_PLAYWRIGHT_TEST_AUTH=${EXPECTED_PLAYWRIGHT_TEST_AUTH}.`,
     );
   }
 }

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -37,7 +37,10 @@ import {
 } from "../test/helpers/live-provider.ts";
 import { resolveMainAppDir } from "./lib/app-dir.mjs";
 import { shouldForceStubStack } from "./lib/ui-smoke-stub-decision.mjs";
-import { viteRendererBuildNeeded } from "./lib/vite-renderer-dist-stale.mjs";
+import {
+  rendererDistMatchesPlaywrightTestAuth,
+  viteRendererBuildNeeded,
+} from "./lib/vite-renderer-dist-stale.mjs";
 import {
   clearPendingWebSocketQueue,
   createPendingWebSocketQueueState,
@@ -75,6 +78,8 @@ const READY_TIMEOUT_MS = 180_000;
 const API_PORT = Number(process.env.ELIZA_UI_SMOKE_API_PORT ?? "31337");
 const UI_PORT = Number(process.env.ELIZA_UI_SMOKE_PORT ?? "2138");
 const UI_SMOKE_RUN_ID = process.env.ELIZA_UI_SMOKE_RUN_ID?.trim() ?? "";
+const EXPECTED_PLAYWRIGHT_TEST_AUTH =
+  process.env.VITE_PLAYWRIGHT_TEST_AUTH === "true";
 const LIVE_PROVIDER = await selectLiveProviderAsync();
 const REAL_LOCAL_STACK = process.env.ELIZA_UI_SMOKE_REAL_LOCAL_STACK === "1";
 const BACKEND_LOG_PATH = process.env.ELIZA_UI_SMOKE_BACKEND_LOG_PATH?.trim();
@@ -891,12 +896,22 @@ async function ensureUiDistReady(): Promise<void> {
   if (needsBuild && process.env.ELIZA_UI_SMOKE_SKIP_BUILD === "1") {
     try {
       await access(distIndex);
-      needsBuild = false;
     } catch {
       throw new Error(
         `ELIZA_UI_SMOKE_SKIP_BUILD=1 but no built renderer at ${distIndex}. Build once (bun run --cwd packages/app build:web) before skipping.`,
       );
     }
+    if (
+      !rendererDistMatchesPlaywrightTestAuth(
+        APP_DIR,
+        EXPECTED_PLAYWRIGHT_TEST_AUTH,
+      )
+    ) {
+      throw new Error(
+        `ELIZA_UI_SMOKE_SKIP_BUILD=1 but the renderer manifest does not match VITE_PLAYWRIGHT_TEST_AUTH=${EXPECTED_PLAYWRIGHT_TEST_AUTH}. Rebuild without ELIZA_UI_SMOKE_SKIP_BUILD=1.`,
+      );
+    }
+    needsBuild = false;
   }
 
   if (!needsBuild) {

--- a/packages/app/docs/TEST_AUTH.md
+++ b/packages/app/docs/TEST_AUTH.md
@@ -17,6 +17,8 @@ Chromium renderer tests that need a Steward session use
 - Pass `{ jwt: true }` only when the spec intentionally needs a decodable JWT
   shape. The helper creates an unsigned JWT with `exp`; client-cloud refresh
   logic only attempts refresh for JWT-like tokens that carry an expiry.
+- UI-smoke compares the requested `VITE_PLAYWRIGHT_TEST_AUTH` value with the
+  renderer build manifest for every project and rebuilds on either transition.
 
 ## Surface Matrix
 

--- a/packages/app/docs/TEST_AUTH.md
+++ b/packages/app/docs/TEST_AUTH.md
@@ -17,8 +17,9 @@ Chromium renderer tests that need a Steward session use
 - Pass `{ jwt: true }` only when the spec intentionally needs a decodable JWT
   shape. The helper creates an unsigned JWT with `exp`; client-cloud refresh
   logic only attempts refresh for JWT-like tokens that carry an expiry.
-- UI-smoke compares the requested `VITE_PLAYWRIGHT_TEST_AUTH` value with the
-  renderer build manifest for every project and rebuilds on either transition.
+- UI-smoke resolves `VITE_PLAYWRIGHT_TEST_AUTH` with Vite's production `.env*`
+  precedence, compares it with the renderer manifest for every project, and
+  verifies the same value again after any rebuild.
 
 ## Surface Matrix
 

--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -324,8 +324,8 @@ export default defineConfig({
             // Cloud-surface aesthetic audit (#10725/#11342) — run with `audit:cloud`
             // (`--project=audit-cloud`). Walks every registered cloud route at
             // desktop + mobile internally. Requires a renderer built with
-            // VITE_PLAYWRIGHT_TEST_AUTH=true; the runner invalidates dist for this
-            // project so a cached non-auth build cannot skip the local auth shell.
+            // VITE_PLAYWRIGHT_TEST_AUTH=true; the renderer manifest check applies
+            // to every project so a cached non-auth build cannot skip the shell.
             name: "audit-cloud",
             testMatch: [AUDIT_CLOUD_SPEC, AUDIT_PROJECT_WORKER_CONTRACT_SPEC],
             use: {

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -444,19 +444,6 @@ if (
   }
 }
 
-if (
-  hasPlaywrightConfig("playwright.ui-smoke.config.ts") &&
-  hasPlaywrightProject("audit-cloud") &&
-  env.VITE_PLAYWRIGHT_TEST_AUTH === "true" &&
-  env.ELIZA_UI_SMOKE_SKIP_BUILD !== "1"
-) {
-  const appDistDir = path.join(appDir, "dist");
-  console.log(
-    "[ui-smoke] Removing app dist before audit-cloud so VITE_PLAYWRIGHT_TEST_AUTH is baked into a fresh renderer build.",
-  );
-  removePathRecursive(appDistDir, "app dist for audit-cloud auth build");
-}
-
 // The ui-smoke web server builds the renderer (`packages/app build:web`) whenever
 // the dist is stale — in BOTH stub and live mode (see playwright-ui-live-stack.ts
 // `viteRendererBuildNeeded` → `build:web`). That vite build needs linked

--- a/packages/app/src/renderer-build-manifest-plugin.test.ts
+++ b/packages/app/src/renderer-build-manifest-plugin.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Proves the renderer manifest records the same Playwright test-auth value
+ * that Vite loads from env files and compiles into the browser bundle.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { build } from "vite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readRendererBuildManifest } from "../../app-core/scripts/lib/renderer-build-manifest.mjs";
+import { rendererBuildManifestPlugin } from "../vite/renderer-build-manifest-plugin.ts";
+
+const cleanupHelperScript = path.resolve(
+  import.meta.dirname,
+  "../../scripts/rm-path-recursive.mjs",
+);
+
+let tmp: string;
+let previousPlaywrightTestAuth: string | undefined;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "renderer-manifest-plugin-"));
+  previousPlaywrightTestAuth = process.env.VITE_PLAYWRIGHT_TEST_AUTH;
+  delete process.env.VITE_PLAYWRIGHT_TEST_AUTH;
+});
+
+afterEach(() => {
+  if (previousPlaywrightTestAuth === undefined) {
+    delete process.env.VITE_PLAYWRIGHT_TEST_AUTH;
+  } else {
+    process.env.VITE_PLAYWRIGHT_TEST_AUTH = previousPlaywrightTestAuth;
+  }
+  execFileSync(process.execPath, [cleanupHelperScript, tmp], {
+    stdio: "inherit",
+  });
+});
+
+describe("rendererBuildManifestPlugin", () => {
+  it("records test auth loaded by Vite from an env file", async () => {
+    const outDir = path.join(tmp, "dist");
+    fs.writeFileSync(
+      path.join(tmp, "index.html"),
+      '<script type="module" src="/main.js"></script>',
+    );
+    fs.writeFileSync(
+      path.join(tmp, "main.js"),
+      "globalThis.testAuth = import.meta.env.VITE_PLAYWRIGHT_TEST_AUTH;",
+    );
+    fs.writeFileSync(
+      path.join(tmp, ".env.production"),
+      "VITE_PLAYWRIGHT_TEST_AUTH=true\n",
+    );
+
+    await build({
+      root: tmp,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [rendererBuildManifestPlugin()],
+      build: { outDir, minify: false },
+    });
+
+    const bundleSource = fs
+      .readdirSync(path.join(outDir, "assets"))
+      .filter((name) => name.endsWith(".js"))
+      .map((name) => fs.readFileSync(path.join(outDir, "assets", name), "utf8"))
+      .join("\n");
+    expect(bundleSource).toMatch(/globalThis\.testAuth\s*=\s*["']true["']/);
+    expect(readRendererBuildManifest(outDir)?.playwrightTestAuth).toBe(true);
+  });
+});

--- a/packages/app/src/renderer-build-stamp.ts
+++ b/packages/app/src/renderer-build-stamp.ts
@@ -24,6 +24,7 @@ export interface RendererBuildStamp {
   variant: string | null;
   capacitorTarget: string | null;
   runtimeMode: string | null;
+  playwrightTestAuth: boolean | null;
 }
 
 declare global {

--- a/packages/app/test/ui-smoke/cloud-console-routes.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-console-routes.spec.ts
@@ -2,7 +2,6 @@
  * Playwright UI-smoke spec for the Cloud Console Routes app flow using the
  * real renderer fixture.
  */
-import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { expect, type Page, test } from "@playwright/test";
 import {
   expectNoPageDiagnostics,
@@ -10,31 +9,11 @@ import {
   installPageDiagnosticsGuard,
 } from "./helpers";
 import { installCloudApiStubs } from "./helpers/cloud-audit-fixtures";
+import { seedStewardSession } from "./helpers/test-auth";
 
 const TEST_AUTH_ENABLED =
   process.env.VITE_PLAYWRIGHT_TEST_AUTH === "true" ||
   process.env.NEXT_PUBLIC_PLAYWRIGHT_TEST_AUTH === "true";
-
-function makeJwt(payload: Record<string, unknown>): string {
-  const encode = (value: object) =>
-    Buffer.from(JSON.stringify(value)).toString("base64url");
-  return `${encode({ alg: "HS256", typ: "JWT" })}.${encode(payload)}.sig`;
-}
-
-async function seedStewardToken(page: Page): Promise<string> {
-  const token = makeJwt({
-    sub: "cloud-console-route-smoke-user",
-    email: "cloud-console-route-smoke@agent.local",
-    exp: Math.floor(Date.now() / 1000) + 600,
-  });
-  await page.addInitScript(
-    ({ key, value }) => {
-      localStorage.setItem(key, value);
-    },
-    { key: STEWARD_TOKEN_KEY, value: token },
-  );
-  return token;
-}
 
 async function installAdminModerationRoutes(page: Page): Promise<void> {
   await page.route("**/api/v1/admin/moderation**", async (route) => {
@@ -132,7 +111,11 @@ test.describe("cloud console route wiring", () => {
     installPageDiagnosticsGuard(page);
     await installDefaultAppRoutes(page);
     await installCloudApiStubs(page);
-    stewardToken = await seedStewardToken(page);
+    stewardToken = await seedStewardSession(page, {
+      jwt: true,
+      subject: "cloud-console-route-smoke-user",
+      email: "cloud-console-route-smoke@agent.local",
+    });
   });
 
   test("registers /dashboard/analytics instead of falling through to the cloud 404", async ({

--- a/packages/app/vite/renderer-build-manifest-plugin.ts
+++ b/packages/app/vite/renderer-build-manifest-plugin.ts
@@ -38,11 +38,15 @@ function resolveCommit(): string | null {
 
 export function rendererBuildManifestPlugin(): Plugin {
   let outDir = "dist";
+  let playwrightTestAuth = false;
   return {
     name: "renderer-build-manifest",
     apply: "build",
     configResolved(config) {
       outDir = config.build.outDir;
+      // Use Vite's resolved env so values loaded from `.env*` match the
+      // `import.meta.env` value compiled into the renderer.
+      playwrightTestAuth = config.env.VITE_PLAYWRIGHT_TEST_AUTH === "true";
     },
     closeBundle() {
       // Model-tester and other secondary single-file builds emit no index.html;
@@ -57,6 +61,7 @@ export function rendererBuildManifestPlugin(): Plugin {
             process.env.VITE_ELIZA_ANDROID_RUNTIME_MODE ??
             process.env.ELIZA_RUNTIME_MODE ??
             null,
+          playwrightTestAuth,
         });
         this.info?.(
           `[renderer-build-manifest] wrote ${RENDERER_BUILD_MANIFEST_FILENAME} buildId=${manifest.buildId.slice(0, 12)} (${manifest.assetCount} assets)`,


### PR DESCRIPTION
# Relates to

Closes #18047.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] The pinned Bun 1.3.14 frozen install completed, the rebase did not change
      the lockfile, and `bun run verify` passed after sync.
- [x] A reviewer can confirm the change from the deterministic unit,
      integration, browser, and manifest evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `6d124fb7d2b1562334b741767502542be9f3b0a1`; zero conflicts.
- [x] Exact-head manifest/reuse tests, Vite integration, lint, diff, and the required app audit were rerun after the final rebase; the prior full verify and real Chromium proof remain applicable to the unchanged PR diff.

# Risks

Low. The change only affects renderer build metadata and local UI-smoke build
reuse. Switching between normal and test-auth smoke invocations may cause one
additional renderer rebuild, which is the intended correctness boundary. There
is no production runtime, API, database, Redis, resolver-ingestion, or Alchemy
CU impact.

# Background

## What does this PR do?

- Records the Vite-resolved `VITE_PLAYWRIGHT_TEST_AUTH` value in the renderer
  manifest, including values loaded from `.env*` files.
- Refuses to reuse a renderer when its test-auth variant differs from the
  current UI-smoke invocation, in either direction. Reuse now requires a
  complete v1 manifest whose fingerprint matches the built files.
- Resolves `.env*` through Vite before checking reuse and validates the emitted
  manifest again immediately after a successful UI-smoke build.
- Keeps generic scaffolded desktop apps on ordinary mtime reuse unless their
  caller explicitly opts into the auth-variant contract.
- Applies the same check to every Playwright project and removes the special
  audit-cloud dist deletion path.
- Replaces the cloud-console spec's hand-built JWT with the canonical
  `seedStewardSession(..., { jwt: true })` helper.
- Documents the new manifest field and test-auth reuse rule.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

The relevant test-auth and renderer-script documentation is updated in this
PR.

# Testing

## Where should a reviewer start?

Start with
`packages/app-core/scripts/lib/vite-renderer-dist-stale.mjs`, then
`packages/app/vite/renderer-build-manifest-plugin.ts` and
`packages/app/src/renderer-build-manifest-plugin.test.ts`.

## Detailed testing steps

Run with Node 24.15.0 and Bun 1.3.14:

```bash
bun run --cwd packages/app-core test -- \
  scripts/lib/renderer-build-manifest.test.mts \
  scripts/lib/vite-renderer-dist-stale.test.mts \
  scripts/lib/mobile-web-build-reuse.test.mts

node packages/scripts/run-vitest.mjs run \
  --config packages/app/vitest.config.ts \
  src/renderer-build-manifest-plugin.test.ts

env -u VITE_PLAYWRIGHT_TEST_AUTH \
  bun run --cwd packages/app test:e2e \
  test/ui-smoke/warming-shell-startup.spec.ts --project=chromium

VITE_PLAYWRIGHT_TEST_AUTH=true \
  bun run --cwd packages/app test:e2e \
  test/ui-smoke/cloud-console-routes.spec.ts --project=chromium

bun run verify
```

Observed results:

- App-core manifest/reuse suites: 3 files, 41 tests passed, including malformed
  manifest, wrong-fingerprint, `.env.production`, and generic-app coverage.
- Real Vite `.env.production` integration: 1 file, 1 test passed; it asserts
  both the emitted bundle and renderer manifest contain the same `true` value.
- Test-auth cloud-console Chromium smoke: 3/3 passed; manifest rebuilt to
  `playwrightTestAuth: true` with no page diagnostics.
- Ordinary auth-disabled Chromium smoke: 1/1 passed after the inverse switch;
  manifest rebuilt to `playwrightTestAuth: false`.
- Full app audit: 214/215 Playwright cases passed; the only failed ratchet was
  four pre-existing minimalism baselines in untouched views. Separate packaged
  OCR classified 192/212 views as verified, 20 as needs-eyeball, and 0 broken.
- Repository verification: 348/348 turbo tasks passed; all follow-on audits
  passed, including 7,814 test files with zero focused tests
  or orphaned skips.

# Evidence Gate

<!-- evidence-head:b4ee9c5caa9af17995cd1ceb815415020d2d5f75 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this is a build/test-harness correction with no rendered UI,
      component, style, or visible product defect.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed; both affected pages already rendered
      correctly before the background request failure.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no visible interaction change to demonstrate.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code path changed; the fix prevents the wrong local
      renderer variant from reaching the stub catch-all.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no new frontend request or user-visible state transition was added;
      deterministic Playwright results and diagnostic-guard proof are included
      inline below.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - renderer manifests are transient build outputs and must not be
      committed; relevant values captured from both variants are included below.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text or UI surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this is a deterministic renderer build/test-harness fix with no LLM
behavior.

## Backend + frontend logs

Backend: N/A - no backend code path changed.

Frontend browser proof:

```text
[chromium] cloud-console-routes.spec.ts: 3 passed (1.2m)
  ✓ analytics route, no diagnostics
  ✓ admin persisted-token gate, no diagnostics
  ✓ MCP persisted-token route, no diagnostics
[chromium] warming-shell-startup.spec.ts: 1 passed (1.1m)
```

The cloud-console suite retained `expectNoPageDiagnostics`, so a stale
renderer's `/api/auth/steward-session` 501 would fail these tests rather than
being masked by a new stub.

## Domain artifacts

The same dist was rebuilt across the auth boundary on commit
`5f3ef2aaf532d7e379b2c5749c5f01a0415b68be`. In both runs the complete v1
manifest and its fingerprint were revalidated against the emitted files:

```json
{
  "schema": "elizaos.renderer.build/v1",
  "commit": "5f3ef2aaf532d7e379b2c5749c5f01a0415b68be",
  "playwrightTestAuth": true
}
```

```json
{
  "schema": "elizaos.renderer.build/v1",
  "commit": "5f3ef2aaf532d7e379b2c5749c5f01a0415b68be",
  "playwrightTestAuth": false,
  "assetCount": 1218
}
```

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI, visual text, component, styling, or user interaction
changed. The issue is a background build-variant mismatch in the local smoke
harness.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

No product or patch-validation gaps remain.

- The full app audit passed 214/215 cases. Its final ratchet reported four
  pre-existing minimalism baselines in untouched browser, plugins, and
  trajectories mobile views; direct inspection found no broken UI, and packaged
  OCR classified 192/212 views as verified, 20 as needs-eyeball, and 0 broken. This PR does not alter those
  surfaces or their baselines.

- The first sandboxed browser attempt could not bind `127.0.0.1` (`EPERM`);
  rerunning with local loopback permission passed 1/1 and 3/3.
- Playwright Chromium was initially absent; repository-pinned Chromium 1228
  was installed and all final browser proof passed.
- The first sandboxed `bun run verify` reached Wrangler and could not create its
  preferences directory; the authorized retry passed all 348/348 tasks and
  follow-on audits.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [fid1699-implementation]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZR5E7WPSG3G92TG5585BMRR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-11T10:21:09.398Z","completed_at":"2026-08-11T11:02:42.822Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAhF2ageyJvlDoe_JCeJ8dre---IaulxsqhaiFj11CQp8","device_key_id":"46ffa292f1c2f8b4f4ab4e8a1844b1ada18e416b6c0917274238cff9af1448e9","device_signature":"xOwBUy8KCMLdlbfYVkBuSnaXeSIL94C0qtYaO_9hXg2NWxv59DhDwIcICSqd_TRplWAOVNZvaVG8cSjpIZ_xAw"}} -->
