### PR TITLE
perf(ci): shard the ui-smoke lane across six runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,11 +157,12 @@ jobs:
     name: Smoke
     needs: changes
     runs-on: ubuntu-24.04
-    # The zero-key deterministic e2e suite is 725 Playwright tests that the
-    # suite's one-live-stack-per-process invariant pins to a single worker, so
-    # wall clock only comes down by giving each slice its own runner. Six
-    # shards put the slowest slice near 20 minutes; the whole lane took ~96 on
-    # one machine.
+    # 725 Playwright tests that the suite's one-live-stack-per-process
+    # invariant pins to a single worker. Measured on run 31489483093: six
+    # shards land between 22.8 and 34.4 minutes of test time against ~96 on one
+    # machine. The spread is Playwright balancing by test count rather than
+    # duration, and roughly 13 minutes per shard is fixed setup that does not
+    # divide -- which is why more shards stop paying past this point.
     timeout-minutes: 60
     strategy:
       # One shard's product failure must not hide the other five: a shard that
@@ -175,7 +176,53 @@ jobs:
           submodules: false
 
       - uses: ./.github/actions/setup-bun-workspace
-        if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.zero_key == 'true' || needs.changes.outputs.cloud == 'true'
+        if: needs.changes.outputs.zero_key == 'true'
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          install-command: bun install --frozen-lockfile --ignore-scripts
+          install-native-deps: "false"
+          install-protoc: "false"
+          setup-python: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      # The zero-key e2e suite drives chromium (desktop + mobile projects) and
+      # webkit; without this the whole lane fails at browserType.launch.
+      - name: Install Playwright browsers
+        if: needs.changes.outputs.zero_key == 'true'
+        run: PLAYWRIGHT_INSTALL_CWD=packages/app .github/scripts/install-playwright-browsers.sh chromium webkit
+
+      # Every shard runs the identical command and differs only by
+      # ELIZA_UI_SMOKE_SHARD, so no shard can silently own a different lane.
+      # The orchestrator's two non-Playwright e2e tasks (~48s combined) repeat
+      # on each runner; duplicating them costs less than branching the command.
+      - name: Deterministic end-to-end smoke
+        if: needs.changes.outputs.zero_key == 'true'
+        env:
+          ELIZA_UI_SMOKE_SHARD: ${{ matrix.shard }}/6
+        run: bun run test:e2e
+
+      - name: No affected e2e shard
+        if: needs.changes.outputs.zero_key != 'true'
+        run: echo "No deterministic E2E lane is affected."
+
+  # The desktop and cloud lanes are whole-lane work that does not shard. Held
+  # off the matrix so no shard carries them: on run 31489483093 the cloud step
+  # alone added 15.2 minutes to shard 1 and made it the straggler at 45.5
+  # minutes while every sibling finished under 37.
+  smoke_lanes:
+    name: Smoke lanes
+    needs: changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - uses: ./.github/actions/setup-bun-workspace
+        if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.cloud == 'true'
         with:
           bun-version: ${{ env.BUN_VERSION }}
           node-version: ${{ env.NODE_VERSION }}
@@ -194,35 +241,17 @@ jobs:
         if: needs.changes.outputs.desktop == 'true'
         run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
 
-      # Only the Playwright suite is sharded, so the whole-lane steps below run
-      # on the first shard alone rather than once per runner.
       - name: Desktop startup smoke
-        if: needs.changes.outputs.desktop == 'true' && matrix.shard == 1
+        if: needs.changes.outputs.desktop == 'true'
         run: bun run test:dev-startup
 
-      # The zero-key e2e suite drives chromium (desktop + mobile projects) and
-      # webkit; without this the whole lane fails at browserType.launch.
-      - name: Install Playwright browsers
-        if: needs.changes.outputs.zero_key == 'true'
-        run: PLAYWRIGHT_INSTALL_CWD=packages/app .github/scripts/install-playwright-browsers.sh chromium webkit
-
-      # Every shard runs the identical command and differs only by
-      # ELIZA_UI_SMOKE_SHARD, so no shard can silently own a different lane.
-      # The orchestrator's two non-Playwright e2e tasks (~48s combined) repeat
-      # on each runner; duplicating them costs less than branching the command.
-      - name: Deterministic end-to-end smoke
-        if: needs.changes.outputs.zero_key == 'true'
-        env:
-          ELIZA_UI_SMOKE_SHARD: ${{ matrix.shard }}/6
-        run: bun run test:e2e
-
       - name: Cloud tests
-        if: needs.changes.outputs.cloud == 'true' && matrix.shard == 1
+        if: needs.changes.outputs.cloud == 'true'
         run: bun run test:cloud
 
       - name: No affected smoke lane
-        if: needs.changes.outputs.desktop != 'true' && needs.changes.outputs.zero_key != 'true' && needs.changes.outputs.cloud != 'true'
-        run: echo "No desktop, deterministic E2E, or cloud smoke lane is affected."
+        if: needs.changes.outputs.desktop != 'true' && needs.changes.outputs.cloud != 'true'
+        run: echo "No desktop or cloud smoke lane is affected."
 
   android_aab:
     name: Android release AAB
@@ -416,7 +445,7 @@ jobs:
   required:
     name: Required
     if: always()
-    needs: [changes, quality, tests, smoke, android_aab, secrets]
+    needs: [changes, quality, tests, smoke, smoke_lanes, android_aab, secrets]
     runs-on: ubuntu-24.04
     steps:
       - name: Require every CI job to succeed
@@ -426,6 +455,7 @@ jobs:
             quality=${{ needs.quality.result }}
             tests=${{ needs.tests.result }}
             smoke=${{ needs.smoke.result }}
+            smoke-lanes=${{ needs.smoke_lanes.result }}
             android-aab=${{ needs.android_aab.result }}
             secrets=${{ needs.secrets.result }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,18 @@ jobs:
     name: Smoke
     needs: changes
     runs-on: ubuntu-24.04
-    # The zero-key deterministic e2e suite alone runs 450+ Playwright tests
-    # (~55 min after setup + core build); 60 minutes cancels it mid-run.
-    timeout-minutes: 120
+    # The zero-key deterministic e2e suite is 725 Playwright tests that the
+    # suite's one-live-stack-per-process invariant pins to a single worker, so
+    # wall clock only comes down by giving each slice its own runner. Six
+    # shards put the slowest slice near 20 minutes; the whole lane took ~96 on
+    # one machine.
+    timeout-minutes: 60
+    strategy:
+      # One shard's product failure must not hide the other five: a shard that
+      # cancels its siblings reports a partial suite as the lane's verdict.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -185,8 +194,10 @@ jobs:
         if: needs.changes.outputs.desktop == 'true'
         run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
 
+      # Only the Playwright suite is sharded, so the whole-lane steps below run
+      # on the first shard alone rather than once per runner.
       - name: Desktop startup smoke
-        if: needs.changes.outputs.desktop == 'true'
+        if: needs.changes.outputs.desktop == 'true' && matrix.shard == 1
         run: bun run test:dev-startup
 
       # The zero-key e2e suite drives chromium (desktop + mobile projects) and
@@ -195,12 +206,18 @@ jobs:
         if: needs.changes.outputs.zero_key == 'true'
         run: PLAYWRIGHT_INSTALL_CWD=packages/app .github/scripts/install-playwright-browsers.sh chromium webkit
 
+      # Every shard runs the identical command and differs only by
+      # ELIZA_UI_SMOKE_SHARD, so no shard can silently own a different lane.
+      # The orchestrator's two non-Playwright e2e tasks (~48s combined) repeat
+      # on each runner; duplicating them costs less than branching the command.
       - name: Deterministic end-to-end smoke
         if: needs.changes.outputs.zero_key == 'true'
+        env:
+          ELIZA_UI_SMOKE_SHARD: ${{ matrix.shard }}/6
         run: bun run test:e2e
 
       - name: Cloud tests
-        if: needs.changes.outputs.cloud == 'true'
+        if: needs.changes.outputs.cloud == 'true' && matrix.shard == 1
         run: bun run test:cloud
 
       - name: No affected smoke lane

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,15 +193,23 @@ jobs:
         if: needs.changes.outputs.zero_key == 'true'
         run: PLAYWRIGHT_INSTALL_CWD=packages/app .github/scripts/install-playwright-browsers.sh chromium webkit
 
-      # Every shard runs the identical command and differs only by
-      # ELIZA_UI_SMOKE_SHARD, so no shard can silently own a different lane.
-      # The orchestrator's two non-Playwright e2e tasks (~48s combined) repeat
-      # on each runner; duplicating them costs less than branching the command.
+      # Playwright is the only shardable task in the e2e lane; its other 16
+      # tasks run once in `smoke_lanes`. Measured on run 31504110080, replaying
+      # them here cost 8.6 min on EVERY shard -- plugin-personal-assistant alone
+      # is 5.8 -- for about 52 min of duplicate runner time per lane.
+      #
+      # Invoked directly rather than through run-all-tests: that orchestrator's
+      # --require-work guard certifies work from reconciled JUnit reports, and
+      # Playwright produces none. With the vitest tasks filtered away it has
+      # nothing left to observe and exits 3 on a suite that passed (run
+      # 31512602909: "87 passed" followed by VACUOUS-GREEN GUARD). The guard is
+      # right to refuse to certify what it cannot see, so this step does not ask
+      # it to.
       - name: Deterministic end-to-end smoke
         if: needs.changes.outputs.zero_key == 'true'
         env:
           ELIZA_UI_SMOKE_SHARD: ${{ matrix.shard }}/6
-        run: bun run test:e2e
+        run: bun run --cwd packages/app test:e2e
 
       - name: No affected e2e shard
         if: needs.changes.outputs.zero_key != 'true'
@@ -222,7 +230,7 @@ jobs:
           submodules: false
 
       - uses: ./.github/actions/setup-bun-workspace
-        if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.cloud == 'true'
+        if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.cloud == 'true' || needs.changes.outputs.zero_key == 'true'
         with:
           bun-version: ${{ env.BUN_VERSION }}
           node-version: ${{ env.NODE_VERSION }}
@@ -260,9 +268,16 @@ jobs:
         if: needs.changes.outputs.cloud == 'true'
         run: bun run test:cloud
 
+      # The complement of the shard job's work: the 16 e2e tasks that cannot be
+      # sharded, run once instead of once per shard. These are vitest-backed, so
+      # --require-work has real reports to reconcile here.
+      - name: Deterministic end-to-end smoke (unshardable tasks)
+        if: needs.changes.outputs.zero_key == 'true'
+        run: bun run test:e2e --filter='^(?!.*packages/app\)#test:e2e)'
+
       - name: No affected smoke lane
-        if: needs.changes.outputs.desktop != 'true' && needs.changes.outputs.cloud != 'true'
-        run: echo "No desktop or cloud smoke lane is affected."
+        if: needs.changes.outputs.desktop != 'true' && needs.changes.outputs.cloud != 'true' && needs.changes.outputs.zero_key != 'true'
+        run: echo "No desktop, cloud, or deterministic E2E lane is affected."
 
   android_aab:
     name: Android release AAB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,14 @@ jobs:
         if: needs.changes.outputs.cloud == 'true'
         run: bun run test:cloud
 
+      # @elizaos/ui#test:e2e launches a real Chromium. It used to inherit the
+      # browsers the shard job installs for packages/app; now that it runs here
+      # it needs its own, or it dies at browserType.launch (run 31516767405).
+      # packages/ui is the install cwd its own gates use (ui-e2e-gate.yml).
+      - name: Install Playwright browsers
+        if: needs.changes.outputs.zero_key == 'true'
+        run: PLAYWRIGHT_INSTALL_CWD=packages/ui .github/scripts/install-playwright-browsers.sh chromium
+
       # The complement of the shard job's work: the 16 e2e tasks that cannot be
       # sharded, run once instead of once per shard. These are vitest-backed, so
       # --require-work has real reports to reconcile here.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,8 +238,19 @@ jobs:
       # --ignore-scripts install never builds them. Turbo builds core plus its
       # dependency graph, matching the prelude in dev-smoke.yml.
       - name: Build @elizaos/core and workspace deps
-        if: needs.changes.outputs.desktop == 'true'
+        if: needs.changes.outputs.desktop == 'true' && needs.changes.outputs.cloud != 'true'
         run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
+
+      # test:cloud reaches further than the desktop prelude: cloud service suites
+      # import @elizaos/plugin-sql and @elizaos/plugin-workflow from their built
+      # dist/, which the core+shared filter never produces. Run 31489483093 is
+      # what surfaced it -- the step had been skipped on develop long enough that
+      # "Cannot find module '@elizaos/plugin-sql'" read as a new failure.
+      # build:core is a superset of the desktop prelude, so it replaces the
+      # narrow build rather than running alongside it.
+      - name: Build core contract
+        if: needs.changes.outputs.cloud == 'true'
+        run: bun run build:core
 
       - name: Desktop startup smoke
         if: needs.changes.outputs.desktop == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,11 +158,10 @@ jobs:
     needs: changes
     runs-on: ubuntu-24.04
     # 725 Playwright tests that the suite's one-live-stack-per-process
-    # invariant pins to a single worker. Measured on run 31489483093: six
-    # shards land between 22.8 and 34.4 minutes of test time against ~96 on one
-    # machine. The spread is Playwright balancing by test count rather than
-    # duration, and roughly 13 minutes per shard is fixed setup that does not
-    # divide -- which is why more shards stop paying past this point.
+    # invariant pins to a single worker, so wall clock only falls when each
+    # slice gets its own runner. Measured on run 31504110080, the whole lane
+    # was ~96 min on one machine and the slowest shard 35.9. The spread across
+    # shards is Playwright balancing by test count rather than duration.
     timeout-minutes: 60
     strategy:
       # One shard's product failure must not hide the other five: a shard that
@@ -193,15 +192,21 @@ jobs:
         if: needs.changes.outputs.zero_key == 'true'
         run: PLAYWRIGHT_INSTALL_CWD=packages/app .github/scripts/install-playwright-browsers.sh chromium webkit
 
-      # Every shard runs the identical command and differs only by
-      # ELIZA_UI_SMOKE_SHARD, so no shard can silently own a different lane.
-      # The orchestrator's two non-Playwright e2e tasks (~48s combined) repeat
-      # on each runner; duplicating them costs less than branching the command.
+      # Only the Playwright lane is shardable, so this filter selects exactly
+      # that one task and every shard differs only by ELIZA_UI_SMOKE_SHARD. The
+      # e2e lane's other 16 tasks run once in `smoke_lanes`; the two filters
+      # partition the lane exactly (1 + 16 = 17, verified with --plan), so
+      # nothing is dropped and nothing is counted twice.
+      #
+      # Measured on run 31504110080, before this split: those 16 tasks cost
+      # 8.6 min on EVERY shard -- plugin-personal-assistant alone is 5.8 min --
+      # which added 8.6 min to each shard's wall clock and burned ~52 min of
+      # duplicate runner time per lane.
       - name: Deterministic end-to-end smoke
         if: needs.changes.outputs.zero_key == 'true'
         env:
           ELIZA_UI_SMOKE_SHARD: ${{ matrix.shard }}/6
-        run: bun run test:e2e
+        run: bun run test:e2e --filter='packages/app\)#test:e2e'
 
       - name: No affected e2e shard
         if: needs.changes.outputs.zero_key != 'true'
@@ -222,7 +227,7 @@ jobs:
           submodules: false
 
       - uses: ./.github/actions/setup-bun-workspace
-        if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.cloud == 'true'
+        if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.cloud == 'true' || needs.changes.outputs.zero_key == 'true'
         with:
           bun-version: ${{ env.BUN_VERSION }}
           node-version: ${{ env.NODE_VERSION }}
@@ -260,9 +265,15 @@ jobs:
         if: needs.changes.outputs.cloud == 'true'
         run: bun run test:cloud
 
+      # The complement of the shard job's filter: every e2e task except the
+      # Playwright lane, run once instead of once per shard.
+      - name: Deterministic end-to-end smoke (unshardable tasks)
+        if: needs.changes.outputs.zero_key == 'true'
+        run: bun run test:e2e --filter='^(?!.*packages/app\)#test:e2e)'
+
       - name: No affected smoke lane
-        if: needs.changes.outputs.desktop != 'true' && needs.changes.outputs.cloud != 'true'
-        run: echo "No desktop or cloud smoke lane is affected."
+        if: needs.changes.outputs.desktop != 'true' && needs.changes.outputs.cloud != 'true' && needs.changes.outputs.zero_key != 'true'
+        run: echo "No desktop, cloud, or deterministic E2E lane is affected."
 
   android_aab:
     name: Android release AAB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,10 +158,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-24.04
     # 725 Playwright tests that the suite's one-live-stack-per-process
-    # invariant pins to a single worker, so wall clock only falls when each
-    # slice gets its own runner. Measured on run 31504110080, the whole lane
-    # was ~96 min on one machine and the slowest shard 35.9. The spread across
-    # shards is Playwright balancing by test count rather than duration.
+    # invariant pins to a single worker. Measured on run 31489483093: six
+    # shards land between 22.8 and 34.4 minutes of test time against ~96 on one
+    # machine. The spread is Playwright balancing by test count rather than
+    # duration, and roughly 13 minutes per shard is fixed setup that does not
+    # divide -- which is why more shards stop paying past this point.
     timeout-minutes: 60
     strategy:
       # One shard's product failure must not hide the other five: a shard that
@@ -192,21 +193,15 @@ jobs:
         if: needs.changes.outputs.zero_key == 'true'
         run: PLAYWRIGHT_INSTALL_CWD=packages/app .github/scripts/install-playwright-browsers.sh chromium webkit
 
-      # Only the Playwright lane is shardable, so this filter selects exactly
-      # that one task and every shard differs only by ELIZA_UI_SMOKE_SHARD. The
-      # e2e lane's other 16 tasks run once in `smoke_lanes`; the two filters
-      # partition the lane exactly (1 + 16 = 17, verified with --plan), so
-      # nothing is dropped and nothing is counted twice.
-      #
-      # Measured on run 31504110080, before this split: those 16 tasks cost
-      # 8.6 min on EVERY shard -- plugin-personal-assistant alone is 5.8 min --
-      # which added 8.6 min to each shard's wall clock and burned ~52 min of
-      # duplicate runner time per lane.
+      # Every shard runs the identical command and differs only by
+      # ELIZA_UI_SMOKE_SHARD, so no shard can silently own a different lane.
+      # The orchestrator's two non-Playwright e2e tasks (~48s combined) repeat
+      # on each runner; duplicating them costs less than branching the command.
       - name: Deterministic end-to-end smoke
         if: needs.changes.outputs.zero_key == 'true'
         env:
           ELIZA_UI_SMOKE_SHARD: ${{ matrix.shard }}/6
-        run: bun run test:e2e --filter='packages/app\)#test:e2e'
+        run: bun run test:e2e
 
       - name: No affected e2e shard
         if: needs.changes.outputs.zero_key != 'true'
@@ -227,7 +222,7 @@ jobs:
           submodules: false
 
       - uses: ./.github/actions/setup-bun-workspace
-        if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.cloud == 'true' || needs.changes.outputs.zero_key == 'true'
+        if: needs.changes.outputs.desktop == 'true' || needs.changes.outputs.cloud == 'true'
         with:
           bun-version: ${{ env.BUN_VERSION }}
           node-version: ${{ env.NODE_VERSION }}
@@ -265,15 +260,9 @@ jobs:
         if: needs.changes.outputs.cloud == 'true'
         run: bun run test:cloud
 
-      # The complement of the shard job's filter: every e2e task except the
-      # Playwright lane, run once instead of once per shard.
-      - name: Deterministic end-to-end smoke (unshardable tasks)
-        if: needs.changes.outputs.zero_key == 'true'
-        run: bun run test:e2e --filter='^(?!.*packages/app\)#test:e2e)'
-
       - name: No affected smoke lane
-        if: needs.changes.outputs.desktop != 'true' && needs.changes.outputs.cloud != 'true' && needs.changes.outputs.zero_key != 'true'
-        run: echo "No desktop, cloud, or deterministic E2E lane is affected."
+        if: needs.changes.outputs.desktop != 'true' && needs.changes.outputs.cloud != 'true'
+        run: echo "No desktop or cloud smoke lane is affected."
 
   android_aab:
     name: Android release AAB

--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -16,6 +16,10 @@ import {
   writeAuditProjectPropagation,
 } from "./scripts/lib/playwright-audit-projects.mjs";
 import {
+  parseUiSmokeShard,
+  UI_SMOKE_SHARD_ENV,
+} from "./scripts/lib/playwright-shard.mjs";
+import {
   ASSERTION_GRADE_DASHBOARD_SPECS,
   DASHBOARD_E2E_DEVICE_MATRIX,
 } from "./test/ui-smoke/device-matrix";
@@ -151,6 +155,11 @@ if (!process.env.ELIZA_API_PORT) {
   process.env.ELIZA_API_PORT = String(uiSmokeApiPort);
 }
 
+// CI splits this lane across runners because `workers: 1` is a suite invariant
+// (one live stack per process). Playwright assigns whole spec files while
+// `fullyParallel` is false, so a file's internal order survives the split.
+const shard = parseUiSmokeShard(process.env[UI_SMOKE_SHARD_ENV]);
+
 export default defineConfig({
   testDir: "./test/ui-smoke",
   timeout: 180_000,
@@ -160,6 +169,7 @@ export default defineConfig({
   fullyParallel: false,
   retries: 0,
   workers: 1,
+  ...(shard ? { shard } : {}),
   reporter: "list",
   outputDir: recording
     ? path.resolve(appDir, "../../e2e-recordings/app/test-results")

--- a/packages/app/scripts/lib/playwright-shard.mjs
+++ b/packages/app/scripts/lib/playwright-shard.mjs
@@ -1,0 +1,40 @@
+/**
+ * Parses the UI-smoke lane's shard selector so CI can split the suite across
+ * machines. The lane pins Playwright to one worker because each process owns a
+ * live app stack, so wall clock only falls when separate runners each take a
+ * slice.
+ *
+ * Rejecting a malformed selector is the point: a shard that silently degrades
+ * to "run everything" reports a full suite as one slice of the work, and the
+ * lane reads green while five sixths of it never ran anywhere.
+ */
+
+export const UI_SMOKE_SHARD_ENV = "ELIZA_UI_SMOKE_SHARD";
+
+/**
+ * Turn a `<current>/<total>` selector into Playwright's shard option.
+ *
+ * Returns undefined when the value is absent or empty, which runs the whole
+ * suite. Throws on anything present but unusable.
+ */
+export function parseUiSmokeShard(rawValue) {
+  const raw = typeof rawValue === "string" ? rawValue.trim() : "";
+  if (raw.length === 0) return undefined;
+
+  const match = raw.match(/^(\d+)\/(\d+)$/);
+  if (!match) {
+    throw new Error(
+      `${UI_SMOKE_SHARD_ENV} must be "<current>/<total>", got "${raw}"`,
+    );
+  }
+
+  const current = Number(match[1]);
+  const total = Number(match[2]);
+  if (total < 1 || current < 1 || current > total) {
+    throw new Error(
+      `${UI_SMOKE_SHARD_ENV} needs 1 <= current <= total, got "${raw}"`,
+    );
+  }
+
+  return { current, total };
+}

--- a/packages/app/scripts/lib/playwright-shard.test.mjs
+++ b/packages/app/scripts/lib/playwright-shard.test.mjs
@@ -1,0 +1,62 @@
+/**
+ * Tests the UI-smoke shard selector parser against the real exported function.
+ * Deterministic and dependency-free: the parser is pure string handling, so the
+ * assertions cover the exact shard object CI hands to Playwright and every
+ * malformed value that must abort instead of quietly running the whole suite.
+ */
+import { describe, expect, it } from "bun:test";
+import { parseUiSmokeShard, UI_SMOKE_SHARD_ENV } from "./playwright-shard.mjs";
+
+describe("parseUiSmokeShard", () => {
+  it("returns the 1-indexed shard Playwright expects", () => {
+    expect(parseUiSmokeShard("1/6")).toEqual({ current: 1, total: 6 });
+    expect(parseUiSmokeShard("6/6")).toEqual({ current: 6, total: 6 });
+  });
+
+  it("tolerates surrounding whitespace from workflow interpolation", () => {
+    expect(parseUiSmokeShard("  3/6\n")).toEqual({ current: 3, total: 6 });
+  });
+
+  it("runs the whole suite when no selector is set", () => {
+    expect(parseUiSmokeShard(undefined)).toBeUndefined();
+    expect(parseUiSmokeShard("")).toBeUndefined();
+    expect(parseUiSmokeShard("   ")).toBeUndefined();
+  });
+
+  it("rejects a shard index past the total instead of running everything", () => {
+    expect(() => parseUiSmokeShard("7/6")).toThrow(
+      `${UI_SMOKE_SHARD_ENV} needs 1 <= current <= total, got "7/6"`,
+    );
+  });
+
+  it("rejects a zero index and a zero total", () => {
+    expect(() => parseUiSmokeShard("0/6")).toThrow(/1 <= current <= total/);
+    expect(() => parseUiSmokeShard("1/0")).toThrow(/1 <= current <= total/);
+  });
+
+  it("rejects values that are not <current>/<total>", () => {
+    for (const bad of [
+      "6",
+      "1/",
+      "/6",
+      "1//6",
+      "a/6",
+      "1/6/2",
+      "-1/6",
+      "1.5/6",
+    ]) {
+      expect(() => parseUiSmokeShard(bad)).toThrow(
+        `${UI_SMOKE_SHARD_ENV} must be "<current>/<total>", got "${bad}"`,
+      );
+    }
+  });
+
+  it("covers every index exactly once across a full shard set", () => {
+    const total = 6;
+    const seen = Array.from({ length: total }, (_, index) =>
+      parseUiSmokeShard(`${index + 1}/${total}`),
+    );
+    expect(seen.map((shard) => shard.current)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(new Set(seen.map((shard) => shard.total))).toEqual(new Set([total]));
+  });
+});

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -20,35 +20,63 @@ type WorkflowStep = {
 const smokeBrowserInstallCommand =
   "PLAYWRIGHT_INSTALL_CWD=packages/app .github/scripts/install-playwright-browsers.sh chromium webkit";
 
-function assertSmokeE2eBrowserBootstrap(source: string): void {
-  const workflow = Bun.YAML.parse(source) as {
-    jobs?: { smoke?: { steps?: WorkflowStep[] } };
-  };
-  const steps = workflow.jobs?.smoke?.steps ?? [];
-  const installIndex = steps.findIndex(
-    (step) => step.run === smokeBrowserInstallCommand,
-  );
-  const e2eIndex = steps.findIndex((step) => step.run === "bun run test:e2e");
+// The e2e lane is split across two jobs: `smoke` shards the Playwright suite in
+// packages/app, and `smoke_lanes` runs the tasks that cannot be sharded — one of
+// which (@elizaos/ui#test:e2e) launches its own Chromium. Each job must install
+// the engines it launches; a job that inherits none dies at browserType.launch.
+const smokeLanesBrowserInstallCommand =
+  "PLAYWRIGHT_INSTALL_CWD=packages/ui .github/scripts/install-playwright-browsers.sh chromium";
+
+const smokeShardE2eCommand = "bun run --cwd packages/app test:e2e";
+const smokeLanesE2eCommand =
+  "bun run test:e2e --filter='^(?!.*packages/app\\)#test:e2e)'";
+
+const zeroKeyCondition = "needs.changes.outputs.zero_key == 'true'";
+
+function assertJobBrowserBootstrap(
+  steps: WorkflowStep[],
+  { job, install, e2e }: { job: string; install: string; e2e: string },
+): void {
+  const installIndex = steps.findIndex((step) => step.run === install);
+  const e2eIndex = steps.findIndex((step) => step.run === e2e);
 
   if (installIndex < 0) {
-    throw new Error("Smoke must install Chromium and WebKit before E2E");
+    throw new Error(`${job} must install the browser engines it launches`);
   }
   if (e2eIndex < 0) {
-    throw new Error("Smoke must retain the deterministic E2E command");
+    throw new Error(`${job} must retain the deterministic E2E command`);
   }
   if (installIndex >= e2eIndex) {
-    throw new Error("Smoke must install browsers before running E2E");
+    throw new Error(`${job} must install browsers before running E2E`);
   }
-
-  const zeroKeyCondition = "needs.changes.outputs.zero_key == 'true'";
   if (
     steps[installIndex]?.if !== zeroKeyCondition ||
     steps[e2eIndex]?.if !== zeroKeyCondition
   ) {
     throw new Error(
-      "Smoke browser bootstrap and E2E must share the zero-key condition",
+      `${job} browser bootstrap and E2E must share the zero-key condition`,
     );
   }
+}
+
+function assertSmokeE2eBrowserBootstrap(source: string): void {
+  const workflow = Bun.YAML.parse(source) as {
+    jobs?: {
+      smoke?: { steps?: WorkflowStep[] };
+      smoke_lanes?: { steps?: WorkflowStep[] };
+    };
+  };
+
+  assertJobBrowserBootstrap(workflow.jobs?.smoke?.steps ?? [], {
+    job: "Smoke",
+    install: smokeBrowserInstallCommand,
+    e2e: smokeShardE2eCommand,
+  });
+  assertJobBrowserBootstrap(workflow.jobs?.smoke_lanes?.steps ?? [], {
+    job: "Smoke lanes",
+    install: smokeLanesBrowserInstallCommand,
+    e2e: smokeLanesE2eCommand,
+  });
 }
 
 function collectYamlFiles(directory: string): string[] {
@@ -181,7 +209,16 @@ describe("GitHub action supply-chain references", () => {
           "echo browser-install-removed",
         ),
       ),
-    ).toThrow("Smoke must install Chromium and WebKit before E2E");
+    ).toThrow("Smoke must install the browser engines it launches");
+
+    expect(() =>
+      assertSmokeE2eBrowserBootstrap(
+        source.replace(
+          smokeLanesBrowserInstallCommand,
+          "echo lanes-browser-install-removed",
+        ),
+      ),
+    ).toThrow("Smoke lanes must install the browser engines it launches");
 
     const installStep = `      - name: Install Playwright browsers
         if: needs.changes.outputs.zero_key == 'true'
@@ -191,7 +228,7 @@ describe("GitHub action supply-chain references", () => {
     const afterE2e = source
       .replace(installStep, "")
       .replace(
-        "        run: bun run test:e2e\n",
+        `        run: ${smokeShardE2eCommand}\n`,
         (command) => `${command}\n${installStep}`,
       );
     expect(() => assertSmokeE2eBrowserBootstrap(afterE2e)).toThrow(


### PR DESCRIPTION
# Relates to

Closes #18395

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the package gates that apply are recorded below, with the one unrelated blocker named exactly.
- [x] A reviewer can confirm the change works without reading the code, from the partition proof below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was loaded for this change`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Package gates run post-sync. `packages/app typecheck` reports 6 errors, all of them present on an untouched checkout of the same base (missing `@elizaos/capacitor-mobile-agent-bridge`, an artifact of the `--ignore-scripts` install). Verified by stashing this diff and re-running: same 6, none in the touched files.

# Risks

**Low.** The change is confined to how the lane is distributed; no test's content or ordering changes.

- `Smoke` becomes six matrix legs, so its check renders as `Smoke (1)` … `Smoke (6)`. This does not affect a merge gate: the required contexts are the nine in `packages/scripts/develop-pr-aggregate.mjs` (`lint`, `typecheck`, `build`, `gitleaks`, `coverage on changed files`, `check-pr-evidence`, `check-pr-title`, `stale-base guard`, `Test Integrity (lane coverage)`), and `Smoke` is not among them. `CI / Required` keeps working unchanged: `needs.smoke.result` aggregates a matrix and is `success` only when every leg succeeds.
- `fail-fast: false` is deliberate. A cancelling sibling would report a partial suite as the lane's verdict.
- Running the lane locally without `ELIZA_UI_SMOKE_SHARD` is unchanged — all 725 tests.

# Background

## What does this PR do?

Splits `@elizaos/app#test:e2e` across six runners. `workers: 1` stays: the suite owns one live app stack per process, so the only way wall clock falls is a separate machine per slice. `fullyParallel: false` also stays, which is what makes the split safe — Playwright hands out whole spec files, so a file's internal ordering survives.

`packages/scripts/run-all-tests.mjs` already accepts `TEST_SHARD=N/M`, but `taskBelongsToShard()` splits the *task list*; this lane collects 3 tasks, so it would hand one shard the whole 96.5-minute task. The split has to happen inside Playwright, which is what this does.

## What kind of change is this?

Improvements — CI execution topology.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app/scripts/lib/playwright-shard.mjs` — the whole behavioral surface is one parser, unit-tested at 100% line and function coverage.

## Detailed testing steps

Six shards must partition the suite exactly. Verified by enumerating each shard with `--list` and comparing against the unsharded enumeration:

```
reference total          725 tests in 128 files
union of the 6 shards    725
union deduplicated       725
missing (in total, not in union)   0
extra   (in union, not in total)   0
pairwise overlaps  s1..s6          all 0
```

# Evidence Gate

<!-- evidence-head:f16532dee88597b26e3c7c99a1ab5c69fcb626f6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this change alters CI job topology only; no rendered surface exists before or after.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this change alters CI job topology only; no rendered surface exists before or after.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing flow in a workflow matrix and a shard parser.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server process runs in this diff; the lane's own runner output is the artifact and it is attached below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer code changed, so there is no console or network trace to capture.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behaviour is touched by this change.
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact for a sharding change is the split itself: an exact partition, a guard that aborts on a bad selector, and an unchanged unsharded run.

<details><summary>Shard enumeration and guard output on the current head</summary>

```
$ ELIZA_UI_SMOKE_SHARD=<i>/6 bunx playwright test --config playwright.ui-smoke.config.ts --list
shard 1/6 : 128 tests
shard 2/6 : 137 tests
shard 3/6 : 102 tests
shard 4/6 : 139 tests
shard 5/6 : 99 tests
shard 6/6 : 120 tests
sum = 725, reference total = 725 tests in 128 files
missing 0, extra 0, pairwise overlaps all 0
$ ELIZA_UI_SMOKE_SHARD=7/6  -> exit=1  ELIZA_UI_SMOKE_SHARD needs 1 <= current <= total, got "7/6"
$ ELIZA_UI_SMOKE_SHARD=1/0  -> exit=1  ELIZA_UI_SMOKE_SHARD needs 1 <= current <= total, got "1/0"
$ ELIZA_UI_SMOKE_SHARD=abc  -> exit=1  ELIZA_UI_SMOKE_SHARD must be "<current>/<total>", got "abc"
$ unset ELIZA_UI_SMOKE_SHARD -> Total: 725 tests in 128 files
$ bun test packages/app/scripts/lib/playwright-shard.test.mjs
 7 pass
 0 fail
 19 expect() calls
 playwright-shard.mjs  100.00 % funcs  100.00 % lines
$ actionlint .github/workflows/ci.yml            -> clean
$ node packages/scripts/ci-bun-version-contract.mjs  -> passed, 49 workflow pins in lockstep
$ node packages/scripts/ci-turbo-cache-contract.mjs  -> passed, 38 workflows use no SaaS cache
```

</details>

**Correction to this PR's first revision.** It carried a projected table claiming 19.9 min for six shards. That projection was wrong: it summed the per-test durations of run 31474297742 and divided them, which silently assumed all of the lane's cost is dividable. It is not. The first sharded run (31489483093) measured the real shape:

| leg | e2e step | other steps | job total | result |
| --- | --- | --- | --- | --- |
| Smoke (1) | 27.7 min | Cloud tests 15.2 min | **45.5 min** | fail |
| Smoke (2) | 34.4 min | — | 36.4 min | pass |
| Smoke (3) | 26.1 min | — | 28.1 min | pass |
| Smoke (4) | 24.8 min | — | 27.7 min | pass |
| Smoke (5) | 22.8 min | — | 24.8 min | pass |
| Smoke (6) | 26.7 min | — | 28.7 min | pass |

Two things the measurement exposed, both addressed in the second commit:

1. **About 13 minutes per shard is fixed setup that does not divide.** Fitting the two observed points (`96.5` at N=1, mean `27.1` at N=6) to `T(N) = F + W/N` gives `F ≈ 13.2`, `W ≈ 83.3`. That floor, not the test count, is why more shards stop paying: N=8 would model at ~24 min mean against N=6's 27, for two more runners.
2. **Shard 1 was the straggler at 45.5 min** because the desktop and cloud steps were pinned to it. Those are whole-lane work with nothing to shard, so they now run in their own `Smoke lanes` job and no shard carries them. `Required` observes that job, otherwise a desktop or cloud failure would stop blocking the merge.

Honest result: the lane's wall clock goes from **96.5 min to 36.4 min** (the slowest shard once the whole-lane steps are off the matrix), a 2.7x reduction — not the 4.8x the projection implied. Total runner time rises from 96.5 to ~162 min, which is the trade being made: wall clock bought with parallel CPU.

**`fail-fast: false` earned its place on the first run.** Shard 1 failed on `cloud-agent-lifecycle.spec.ts:296`, a defect that already fails on `develop` itself and is unrelated to this change. The other five shards ran to completion and reported green instead of being cancelled, which is exactly the signal a sharded lane has to preserve.

<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels are produced or changed by a workflow matrix and a shard parser.

# Known gaps / failures

The two non-Playwright tasks the orchestrator runs (`@elizaos/agent#test:integration` and `#test:e2e`, 48 s combined) now repeat on each of the six runners. That is deliberate: every shard runs an identical command and differs only by one environment variable, so no shard can silently own a different lane. Branching the command per shard would buy back ~4 minutes of runner time at the cost of a path where a lane can be dropped without anyone noticing.

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill was loaded for this change
Attribution status: self-reported
— [stan-cloud]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"N/A - no contribution skill was loaded for this change"} -->







