### PR TITLE
fix(ci): report resolved provisioning deployment receipt

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -562,8 +562,8 @@ jobs:
           title: "🚀 Eliza Provisioning Worker Deployed"
           nodetail: true
           description: |
-            Branch: develop
-            Commit: ${{ github.sha }}
+            Branch: ${{ needs.determine-env.outputs.branch }}
+            Commit: ${{ needs.determine-env.outputs.deployment_sha }}
           color: 0x00ff00
 
       - name: Notify Discord (Failure)
@@ -575,8 +575,8 @@ jobs:
           title: "❌ Eliza Provisioning Worker Deploy Failed"
           nodetail: true
           description: |
-            Branch: develop
-            Commit: ${{ github.sha }}
+            Branch: ${{ needs.determine-env.outputs.branch }}
+            Commit: ${{ needs.determine-env.outputs.deployment_sha }}
           color: 0xff0000
 
 # ci-touch: re-trigger prod daemon deploy (dispatch runs were runner-starved) 2026-06-21

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -52,6 +52,18 @@ describe("provisioning worker deployment contract", () => {
     );
   });
 
+  it("reports the resolved branch and immutable deployment SHA in both Discord receipts", () => {
+    const receipt = [
+      "description: |",
+      "            Branch: $" + "{{ needs.determine-env.outputs.branch }}",
+      "            Commit: $" +
+        "{{ needs.determine-env.outputs.deployment_sha }}",
+    ].join("\n");
+    expect(workflow.split(receipt)).toHaveLength(3);
+    expect(workflow).not.toContain("Branch: develop");
+    expect(workflow).not.toContain("Commit: $" + "{{ github.sha }}");
+  });
+
   it("fails checkout cleanup loudly and covers all shared-package changes", () => {
     expect(workflow).toContain("git reset --hard HEAD\n");
     expect(workflow).not.toContain("git reset --hard HEAD 2>/dev/null || true");


### PR DESCRIPTION
Relates to #18402

## Summary

- report the deployment branch resolved by `determine-env` in both Discord receipt paths
- report the validated immutable deployment SHA rather than the workflow trigger SHA
- lock the success and failure descriptions to the same resolved contract with a focused regression

## Root cause

The provisioner correctly resolves production to `main` and an immutable deployment SHA, but both notification descriptions were independently hardcoded to `develop` and `github.sha`. The exact-main production activation exposed the mismatch without sending an external message because no Discord webhook was configured.

## Scope and risk

Receipt metadata only. Checkout, image selection, daemon restart, health verification, and deployment behavior are byte-for-byte unchanged.

- exact base: `32eed149f5020ccc41e8ae7405919a0abba5e6cf`
- exact head: `1b0c7b8b71ec8b1dfac28e9e5925136a24c5f0c2`
- exact scope: 2 files, +16/-4
- worktree clean

## Verification

- provisioning workflow contract: **6/6 PASS, 33 expectations**
- `actionlint` on the changed workflow: PASS
- Biome on the changed test: PASS
- `git diff --check`: PASS
- root `bun run verify`: **348/348 Turbo tasks + every repository audit PASS**
- rebased patch identity: stable patch ID `68b3ff1b436f0c36973feda636db6fe2acc8ab30`; binary diff SHA-256 `c1e0fb69c98cd848a27a8bd7267c56c64e434749129f9a5f44236652190340ae`
- patch-identical predecessor reviews: no P0/P1/P2; fresh exact-head reviews requested

## Evidence

<!-- evidence-head:1b0c7b8b71ec8b1dfac28e9e5925136a24c5f0c2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow receipt metadata has no rendered product surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow receipt metadata has no rendered product surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no web, desktop, mobile, or Cloud UI behavior changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - staging admits only `develop`, so a PR-branch dispatch cannot exercise this workflow and a pre-merge `develop` dispatch would run the old YAML. The natural corrected receipt is an explicit post-merge verification gate.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, scheduled-task, or generated-file output changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visible text or layout changed.

## Post-merge verification

The exact source contract is fully verified. The protected `staging` environment admits only `develop`, which makes a truthful pre-merge runtime receipt impossible without weakening deployment policy: a PR-branch dispatch cannot enter the environment, while dispatching from `develop` before merge runs the old workflow YAML.

After merge, the natural `develop` push must run this corrected workflow. Keep #18402 in verification until the run proves the resolved staging branch and immutable landed SHA, both daemons healthy, and the generated Discord description `Branch: develop\nCommit: <landed-sha>`. No deploy was triggered for this PR.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - publishing used a local Codex GitHub workflow, not an in-repository contribution skill`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - publishing used a local Codex GitHub workflow, not an in-repository contribution skill
Attribution status: self-reported
— [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - publishing used a local Codex GitHub workflow, not an in-repository contribution skill"} -->


