### PR TITLE
fix(agent): report the active Cerebras endpoint

### DIFF
--- a/packages/agent/src/api/model-config-routes.test.ts
+++ b/packages/agent/src/api/model-config-routes.test.ts
@@ -220,6 +220,33 @@ describe("POST /api/models/config chat writes", () => {
     });
   });
 
+  it("keeps endpoint validation independent from a catalog-backed model write", async () => {
+    const { ctx, json, config, managerStart } = makeHarness(
+      "POST",
+      { target: "large", model: "gpt-oss-120b" },
+      {
+        config: {
+          serviceRouting: {
+            llmText: {
+              backend: "cerebras",
+              transport: "direct",
+              accountId: "cerebras",
+            },
+          },
+          env: { OPENAI_BASE_URL: "not a URL" },
+        } as never,
+      },
+    );
+    await handleModelConfigRoutes(ctx as never);
+    expect(responseOf(json).status).toBeUndefined();
+    expect(managerStart).toHaveBeenCalledOnce();
+    const env = (config as Record<string, unknown>).env as Record<
+      string,
+      unknown
+    >;
+    expect(env.OPENAI_LARGE_MODEL).toBe("gpt-oss-120b");
+  });
+
   it("writes ANTHROPIC keys (model + per-target effort) for claude-chat", async () => {
     // sonnet-5, not haiku: haiku carries no chat effort knob (live-probed).
     const { ctx, config, processEnv } = makeHarness("POST", {
@@ -546,6 +573,24 @@ describe("GET /api/models/config activeChat", () => {
       },
     },
   } as never;
+  const directCerebrasConfig = {
+    serviceRouting: {
+      llmText: {
+        backend: "cerebras",
+        transport: "direct",
+        accountId: "cerebras",
+      },
+    },
+  } as never;
+  const directAnthropicConfig = {
+    serviceRouting: {
+      llmText: {
+        backend: "anthropic",
+        transport: "direct",
+        accountId: "anthropic",
+      },
+    },
+  } as never;
 
   it("names the cloud brain + its endpoint under cloud-proxy routing", async () => {
     const { ctx, json } = makeHarness("GET", null, {
@@ -581,16 +626,11 @@ describe("GET /api/models/config activeChat", () => {
 
   it("names the direct provider endpoint under cerebras routing and omits cloud defaults", async () => {
     const { ctx, json } = makeHarness("GET", null, {
-      config: {
-        serviceRouting: {
-          llmText: {
-            backend: "cerebras",
-            transport: "direct",
-            accountId: "cerebras",
-          },
-        },
-      } as never,
-      processEnv: { OPENAI_BASE_URL: "https://api.cerebras.ai/v1" },
+      config: directCerebrasConfig,
+      processEnv: {
+        OPENAI_BASE_URL: "https://api.cerebras.ai/v1",
+        CEREBRAS_BASE_URL: "https://unused.example/v1",
+      },
     });
     await handleModelConfigRoutes(ctx as never);
     const { body } = responseOf(json);
@@ -605,6 +645,343 @@ describe("GET /api/models/config activeChat", () => {
     >;
     expect(targets.small?.ELIZAOS_CLOUD_SMALL_MODEL).toBeNull();
     expect(targets.large?.ELIZAOS_CLOUD_LARGE_MODEL).toBeNull();
+  });
+
+  it("reports the canonical Cerebras endpoint when no base override exists", async () => {
+    const { ctx, json } = makeHarness("GET", null, {
+      config: directCerebrasConfig,
+      processEnv: { CEREBRAS_API_KEY: "cerebras-test-key" },
+    });
+    await handleModelConfigRoutes(ctx as never);
+    expect(responseOf(json).body.activeChat).toEqual({
+      provider: "cerebras",
+      family: "OPENAI",
+      endpoint: "api.cerebras.ai",
+    });
+  });
+
+  it("reports a configured Cerebras base when the OpenAI compatibility base is absent", async () => {
+    const { ctx, json } = makeHarness("GET", null, {
+      config: directCerebrasConfig,
+      processEnv: {
+        CEREBRAS_API_KEY: "cerebras-test-key",
+        CEREBRAS_BASE_URL: "https://private.cerebras.example/v1",
+      },
+    });
+    await handleModelConfigRoutes(ctx as never);
+    expect(responseOf(json).body.activeChat).toEqual({
+      provider: "cerebras",
+      family: "OPENAI",
+      endpoint: "private.cerebras.example",
+    });
+  });
+
+  it.each(["", "   "])(
+    "falls through a blank persisted OpenAI base to the nested plugin setting: %j",
+    async (blankBase) => {
+      const { ctx, json } = makeHarness("GET", null, {
+        config: {
+          serviceRouting: {
+            llmText: {
+              backend: "cerebras",
+              transport: "direct",
+              accountId: "cerebras",
+            },
+          },
+          env: {
+            OPENAI_BASE_URL: blankBase,
+            vars: { OPENAI_BASE_URL: "https://nested.cerebras.ai/v1" },
+          },
+        } as never,
+        processEnv: {
+          OPENAI_BASE_URL: "https://lower-priority.example/v1",
+        },
+      });
+      await handleModelConfigRoutes(ctx as never);
+      expect(responseOf(json).body.activeChat).toEqual({
+        provider: "cerebras",
+        family: "OPENAI",
+        endpoint: "nested.cerebras.ai",
+      });
+    },
+  );
+
+  it.each([
+    "not a URL",
+    "javascript:opaque",
+    "javascript://secret.example/private",
+  ])(
+    "returns an observable config error when the selected base is not an HTTP endpoint: %s",
+    async (openAiBase) => {
+      const { ctx, json } = makeHarness("GET", null, {
+        config: directCerebrasConfig,
+        processEnv: {
+          ELIZA_PROVIDER: "cerebras",
+          OPENAI_BASE_URL: openAiBase,
+          CEREBRAS_BASE_URL: "https://lower-priority.example/v1",
+        },
+      });
+      await handleModelConfigRoutes(ctx as never);
+      const { body, status } = responseOf(json);
+      expect(status).toBe(400);
+      expect(body).toEqual({
+        error:
+          "OPENAI_BASE_URL must be an absolute HTTP(S) URL with a hostname",
+        code: "MODEL_CONFIG_INVALID",
+        context: { key: "OPENAI_BASE_URL" },
+      });
+      expect(JSON.stringify(body)).not.toContain(openAiBase);
+    },
+  );
+
+  it("reports the EvoLink endpoint when the shared OpenAI plugin is in EvoLink mode", async () => {
+    const { ctx, json } = makeHarness("GET", null, {
+      config: directCerebrasConfig,
+      processEnv: {
+        ELIZA_PROVIDER: "evolink",
+        EVOLINK_API_KEY: "evolink-test-key",
+        EVOLINK_BASE_URL: "https://private.evolink.example/v1",
+      },
+    });
+    await handleModelConfigRoutes(ctx as never);
+    expect(responseOf(json).body.activeChat).toEqual({
+      provider: "cerebras",
+      family: "OPENAI",
+      endpoint: "private.evolink.example",
+    });
+  });
+
+  it("reports the test wire proxy that plugin-openai gives highest precedence", async () => {
+    const { ctx, json } = makeHarness("GET", null, {
+      config: directCerebrasConfig,
+      processEnv: {
+        CEREBRAS_API_KEY: "cerebras-test-key",
+        ELIZA_MOCK_OPENAI_BASE: "  https://wire-proxy.example/v1  ",
+      },
+    });
+    await handleModelConfigRoutes(ctx as never);
+    expect(responseOf(json).body.activeChat).toEqual({
+      provider: "cerebras",
+      family: "OPENAI",
+      endpoint: "wire-proxy.example",
+    });
+  });
+
+  it("reports the test wire proxy that plugin-anthropic gives highest precedence", async () => {
+    const { ctx, json } = makeHarness("GET", null, {
+      config: directAnthropicConfig,
+      processEnv: {
+        ANTHROPIC_BASE_URL: "https://configured.anthropic.example/v1",
+        ELIZA_MOCK_ANTHROPIC_BASE: "https://wire-anthropic.example/v1",
+      },
+    });
+    await handleModelConfigRoutes(ctx as never);
+    expect(responseOf(json).body.activeChat).toEqual({
+      provider: "claude-chat",
+      family: "ANTHROPIC",
+      endpoint: "wire-anthropic.example",
+    });
+  });
+
+  it.each([
+    {
+      name: "Eliza Cloud",
+      config: cloudRoutedConfig,
+      key: "ELIZAOS_CLOUD_BASE_URL",
+      value: "javascript://cloud-secret.example/private",
+    },
+    {
+      name: "Anthropic",
+      config: directAnthropicConfig,
+      key: "ANTHROPIC_BASE_URL",
+      value: "   ",
+      leakNeedle: null,
+    },
+  ])(
+    "returns an observable config error for an invalid $name base",
+    async ({ config, key, value, leakNeedle = value }) => {
+      const { ctx, json } = makeHarness("GET", null, {
+        config,
+        processEnv: { [key]: value },
+      });
+      await handleModelConfigRoutes(ctx as never);
+      const { body, status } = responseOf(json);
+      expect(status).toBe(400);
+      expect(body).toEqual({
+        error: `${key} must be an absolute HTTP(S) URL with a hostname`,
+        code: "MODEL_CONFIG_INVALID",
+        context: { key },
+      });
+      if (leakNeedle) expect(JSON.stringify(body)).not.toContain(leakNeedle);
+    },
+  );
+
+  it.each([
+    {
+      name: "Eliza Cloud",
+      config: cloudRoutedConfig,
+      key: "ELIZAOS_CLOUD_BASE_URL",
+      endpoint: "elizacloud.ai",
+    },
+    {
+      name: "Anthropic",
+      config: directAnthropicConfig,
+      key: "ANTHROPIC_BASE_URL",
+      endpoint: "api.anthropic.com",
+    },
+  ])(
+    "treats a blank $name base as unset, matching its plugin resolver",
+    async ({ config, key, endpoint }) => {
+      const { ctx, json } = makeHarness("GET", null, {
+        config,
+        processEnv: { [key]: "" },
+      });
+      await handleModelConfigRoutes(ctx as never);
+      const activeChat = responseOf(json).body.activeChat as {
+        endpoint: string;
+      };
+      expect(activeChat.endpoint).toBe(endpoint);
+    },
+  );
+
+  it("falls through a blank persisted Cloud base to the effective process setting", async () => {
+    const { ctx, json } = makeHarness("GET", null, {
+      config: {
+        serviceRouting: {
+          llmText: {
+            backend: "elizacloud",
+            transport: "cloud-proxy",
+            accountId: "elizacloud",
+          },
+        },
+        env: { ELIZAOS_CLOUD_BASE_URL: "" },
+      } as never,
+      processEnv: {
+        ELIZAOS_CLOUD_BASE_URL: "https://lower-priority.example/v1",
+      },
+    });
+    await handleModelConfigRoutes(ctx as never);
+    expect(responseOf(json).body.activeChat).toEqual({
+      provider: "elizacloud",
+      family: "ELIZAOS_CLOUD",
+      endpoint: "lower-priority.example",
+    });
+  });
+
+  it("falls through a blank runtime Anthropic base to its process setting", async () => {
+    const { ctx, json } = makeHarness("GET", null, {
+      config: {
+        serviceRouting: {
+          llmText: {
+            backend: "anthropic",
+            transport: "direct",
+            accountId: "anthropic",
+          },
+        },
+        env: { ANTHROPIC_BASE_URL: "   " },
+      } as never,
+      processEnv: {
+        ANTHROPIC_BASE_URL: "https://process.anthropic.example/v1",
+      },
+    });
+    await handleModelConfigRoutes(ctx as never);
+    expect(responseOf(json).body.activeChat).toEqual({
+      provider: "claude-chat",
+      family: "ANTHROPIC",
+      endpoint: "process.anthropic.example",
+    });
+  });
+
+  it("fails closed when a nested Anthropic base projects whitespace to the plugin process", async () => {
+    const { ctx, json } = makeHarness("GET", null, {
+      config: {
+        serviceRouting: {
+          llmText: {
+            backend: "anthropic",
+            transport: "direct",
+            accountId: "anthropic",
+          },
+        },
+        env: { vars: { ANTHROPIC_BASE_URL: "   " } },
+      } as never,
+      processEnv: {
+        ANTHROPIC_BASE_URL: "https://lower-priority.example/v1",
+      },
+    });
+    await handleModelConfigRoutes(ctx as never);
+    expect(responseOf(json)).toEqual({
+      body: {
+        error:
+          "ANTHROPIC_BASE_URL must be an absolute HTTP(S) URL with a hostname",
+        code: "MODEL_CONFIG_INVALID",
+        context: { key: "ANTHROPIC_BASE_URL" },
+      },
+      status: 400,
+    });
+  });
+
+  it("returns only the hostname from a credentialed compatible base", async () => {
+    const { ctx, json } = makeHarness("GET", null, {
+      config: directCerebrasConfig,
+      processEnv: {
+        OPENAI_BASE_URL:
+          "https://route-user:route-password@edge.cerebras.ai/v1?token=route-secret",
+      },
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const activeChat = responseOf(json).body.activeChat;
+    expect(activeChat).toEqual({
+      provider: "cerebras",
+      family: "OPENAI",
+      endpoint: "edge.cerebras.ai",
+    });
+    expect(JSON.stringify(activeChat)).not.toMatch(
+      /route-user|route-password|route-secret|\/v1/,
+    );
+  });
+
+  it.each(["openai-test-key", "   "])(
+    "retains the OpenAI endpoint when an effective OpenAI key keeps the shared plugin out of Cerebras mode: %j",
+    async (openAiKey) => {
+      const { ctx, json } = makeHarness("GET", null, {
+        config: directCerebrasConfig,
+        processEnv: {
+          CEREBRAS_API_KEY: "cerebras-test-key",
+          OPENAI_API_KEY: openAiKey,
+        },
+      });
+      await handleModelConfigRoutes(ctx as never);
+      expect(responseOf(json).body.activeChat).toEqual({
+        provider: "cerebras",
+        family: "OPENAI",
+        endpoint: "api.openai.com",
+      });
+    },
+  );
+
+  it("uses a nested OpenAI key when the persisted direct copy is blank", async () => {
+    const { ctx, json } = makeHarness("GET", null, {
+      config: {
+        serviceRouting: {
+          llmText: {
+            backend: "cerebras",
+            transport: "direct",
+            accountId: "cerebras",
+          },
+        },
+        env: {
+          OPENAI_API_KEY: "",
+          vars: { OPENAI_API_KEY: "openai-test-key" },
+        },
+      } as never,
+      processEnv: { CEREBRAS_API_KEY: "cerebras-test-key" },
+    });
+    await handleModelConfigRoutes(ctx as never);
+    expect(responseOf(json).body.activeChat).toEqual({
+      provider: "cerebras",
+      family: "OPENAI",
+      endpoint: "api.openai.com",
+    });
   });
 
   it("omits activeChat when no routing is configured", async () => {

--- a/packages/agent/src/api/model-config-routes.ts
+++ b/packages/agent/src/api/model-config-routes.ts
@@ -526,57 +526,173 @@ function resolveEffective(
 }
 
 /**
- * The chat provider actually serving inference right now, resolved from the
- * canonical serviceRouting topology — the same signal the plugin-collector
- * uses to decide which model plugin loads. `endpoint` is the host that
- * answers, so operator surfaces (/model show, the settings panel) can name
- * what ACTUALLY serves instead of guessing from OPENAI_BASE_URL, which stays
- * pinned in the environment even when cloud-proxy routing makes it inert.
+ * The configured chat provider and its effective serving endpoint. `provider`
+ * is the catalog backend selected by canonical serviceRouting — the same
+ * signal model writes and plugin collection use. `endpoint` follows the
+ * selected provider plugin's wire-mode precedence, so a shared OpenAI plugin
+ * can honestly report an OpenAI- or EvoLink-compatible host without changing
+ * which model catalog the configured Cerebras backend owns.
  */
 export interface ActiveChatInfo {
+  /** Catalog backend selected by serviceRouting. */
   provider: string;
   family: ChatKeyFamily;
+  /** Validated HTTP(S) hostname selected by the serving plugin. */
   endpoint: string;
 }
 
-function hostOf(value: string | undefined): string | null {
-  if (!value) return null;
-  try {
-    return new URL(value).hostname;
-  } catch {
-    // error-policy:J3 a non-URL base value can't name a host; callers fall
-    // back to the provider's canonical endpoint.
-    return null;
-  }
+interface SelectedEndpointBase {
+  key: string;
+  value: string;
 }
 
-export function resolveActiveChat(
+function endpointHost(
+  selected: SelectedEndpointBase | null,
+  canonicalHost: string,
+): string {
+  if (!selected) return canonicalHost;
+  let parsed: URL;
+  try {
+    parsed = new URL(selected.value);
+  } catch {
+    // error-policy:J3 malformed endpoint input becomes a typed, redacted error.
+    throw invalid(
+      `${selected.key} must be an absolute HTTP(S) URL with a hostname`,
+      { key: selected.key },
+    );
+  }
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    !parsed.hostname
+  ) {
+    throw invalid(
+      `${selected.key} must be an absolute HTTP(S) URL with a hostname`,
+      { key: selected.key },
+    );
+  }
+  return parsed.hostname;
+}
+
+function resolveConfiguredChatProvider(
   config: ElizaConfig,
-  processEnv: NodeJS.ProcessEnv,
-): ActiveChatInfo | null {
+): string | undefined {
   const routing = resolveServiceRoutingInConfig(
     config as Record<string, unknown>,
   );
   const llmText = routing?.llmText;
   const backend =
     typeof llmText?.backend === "string" ? llmText.backend : undefined;
-  const provider =
-    llmText?.transport === "cloud-proxy" && backend === "elizacloud"
-      ? "elizacloud"
-      : llmText?.transport === "direct" && backend !== undefined
-        ? LLM_BACKEND_TO_CHAT_PROVIDER[backend]
-        : undefined;
+  return llmText?.transport === "cloud-proxy" && backend === "elizacloud"
+    ? "elizacloud"
+    : llmText?.transport === "direct" && backend !== undefined
+      ? LLM_BACKEND_TO_CHAT_PROVIDER[backend]
+      : undefined;
+}
+
+export function resolveActiveChat(
+  config: ElizaConfig,
+  processEnv: NodeJS.ProcessEnv,
+): ActiveChatInfo | null {
+  const provider = resolveConfiguredChatProvider(config);
   const family =
     provider !== undefined ? CHAT_PROVIDER_KEY_FAMILY[provider] : undefined;
   if (provider === undefined || family === undefined) return null;
-  const baseFor = (key: string): string | undefined =>
-    resolveEffective(config, processEnv, key)?.value;
+  const configRawFor = (key: string): string | undefined => {
+    const env = (config as Record<string, unknown>).env;
+    if (env && typeof env === "object" && !Array.isArray(env)) {
+      const direct = (env as Record<string, unknown>)[key];
+      if (typeof direct === "string" && direct.trim()) return direct;
+      const vars = (env as Record<string, unknown>).vars;
+      if (vars && typeof vars === "object" && !Array.isArray(vars)) {
+        const nested = (vars as Record<string, unknown>)[key];
+        if (typeof nested === "string" && nested) return nested;
+      }
+    }
+    return undefined;
+  };
+  const rawFor = (key: string): string | undefined => {
+    const configValue = configRawFor(key);
+    if (configValue !== undefined) return configValue;
+    const processValue = processEnv[key];
+    return typeof processValue === "string" ? processValue : undefined;
+  };
+  const selectedBase = (...keys: string[]): SelectedEndpointBase | null => {
+    for (const key of keys) {
+      const value = rawFor(key);
+      if (value !== undefined) return { key, value };
+    }
+    return null;
+  };
+  const selectedCloudBase = (): SelectedEndpointBase | null => {
+    const value = resolveEffective(
+      config,
+      processEnv,
+      "ELIZAOS_CLOUD_BASE_URL",
+    )?.value;
+    return value === undefined
+      ? null
+      : { key: "ELIZAOS_CLOUD_BASE_URL", value };
+  };
+  const selectedAnthropicBase = (): SelectedEndpointBase | null => {
+    const configValue = configRawFor("ANTHROPIC_BASE_URL");
+    if (configValue !== undefined) {
+      return { key: "ANTHROPIC_BASE_URL", value: configValue };
+    }
+    const processValue = processEnv.ANTHROPIC_BASE_URL;
+    return typeof processValue === "string" && processValue.length > 0
+      ? { key: "ANTHROPIC_BASE_URL", value: processValue }
+      : null;
+  };
+  const openAiBase = rawFor("OPENAI_BASE_URL");
+  const explicitProvider = rawFor("ELIZA_PROVIDER")?.toLowerCase();
+  const cerebrasMode =
+    provider === "cerebras" &&
+    (explicitProvider === "cerebras" ||
+      (openAiBase !== undefined &&
+        /(^|\.)cerebras\.ai(\/|$)/i.test(openAiBase)) ||
+      (Boolean(rawFor("CEREBRAS_API_KEY")) &&
+        !rawFor("OPENAI_API_KEY") &&
+        openAiBase === undefined));
+  const evolinkMode =
+    family === "OPENAI" &&
+    !cerebrasMode &&
+    (explicitProvider === "evolink" ||
+      (openAiBase !== undefined &&
+        /(^|\.)evolink\.ai(\/|$)/i.test(openAiBase)) ||
+      (Boolean(rawFor("EVOLINK_API_KEY")) &&
+        !rawFor("OPENAI_API_KEY") &&
+        openAiBase === undefined));
+  const mockBase = processEnv.ELIZA_MOCK_OPENAI_BASE?.trim();
+  const anthropicMockBase = processEnv.ELIZA_MOCK_ANTHROPIC_BASE;
   const endpoint =
-    family === "ELIZAOS_CLOUD"
-      ? (hostOf(baseFor("ELIZAOS_CLOUD_BASE_URL")) ?? "elizacloud.ai")
-      : family === "ANTHROPIC"
-        ? (hostOf(baseFor("ANTHROPIC_BASE_URL")) ?? "api.anthropic.com")
-        : (hostOf(baseFor("OPENAI_BASE_URL")) ?? "api.openai.com");
+    family === "OPENAI" && mockBase
+      ? endpointHost(
+          { key: "ELIZA_MOCK_OPENAI_BASE", value: mockBase },
+          "api.openai.com",
+        )
+      : cerebrasMode
+        ? endpointHost(
+            selectedBase("OPENAI_BASE_URL", "CEREBRAS_BASE_URL"),
+            "api.cerebras.ai",
+          )
+        : evolinkMode
+          ? endpointHost(
+              selectedBase("OPENAI_BASE_URL", "EVOLINK_BASE_URL"),
+              "direct.evolink.ai",
+            )
+          : family === "ELIZAOS_CLOUD"
+            ? endpointHost(selectedCloudBase(), "elizacloud.ai")
+            : family === "ANTHROPIC"
+              ? endpointHost(
+                  anthropicMockBase
+                    ? {
+                        key: "ELIZA_MOCK_ANTHROPIC_BASE",
+                        value: anthropicMockBase,
+                      }
+                    : selectedAnthropicBase(),
+                  "api.anthropic.com",
+                )
+              : endpointHost(selectedBase("OPENAI_BASE_URL"), "api.openai.com");
   return { provider, family, endpoint };
 }
 
@@ -645,11 +761,22 @@ export async function handleModelConfigRoutes(
   const processEnv = ctx.processEnv ?? process.env;
 
   if (method === "GET") {
-    const activeChat = resolveActiveChat(state.config, processEnv);
-    json(res, {
-      targets: buildEffectiveConfig(state.config, processEnv, activeChat),
-      ...(activeChat ? { activeChat } : {}),
-    });
+    try {
+      const activeChat = resolveActiveChat(state.config, processEnv);
+      json(res, {
+        targets: buildEffectiveConfig(state.config, processEnv, activeChat),
+        ...(activeChat ? { activeChat } : {}),
+      });
+    } catch (err) {
+      // error-policy:J1 GET transport boundary — invalid endpoint metadata is
+      // an observable configuration error, never a fabricated canonical host.
+      if (!(err instanceof ElizaError)) throw err;
+      json(
+        res,
+        { error: err.message, code: err.code, context: err.context },
+        400,
+      );
+    }
     return true;
   }
 
@@ -692,7 +819,7 @@ export async function handleModelConfigRoutes(
     const writes = resolveChatWrites(
       catalog,
       body,
-      resolveActiveChat(state.config, processEnv)?.provider,
+      resolveConfiguredChatProvider(state.config),
     );
     const conflicts: string[] = [];
     const outcome = await ctx.runtimeOperationManager.start({


### PR DESCRIPTION
# Relates to

Fixes #18389.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` completed after the final sync.
- [x] A reviewer can confirm the change from the exact-head tests and redacted route transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8073280419749e12a3c4211d13e887fc3c090f3f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact testing/evidence head: `ee7b0689f1487d986e3e780e651e2a3e51240b48`.
- [x] Parent and current `origin/develop` at publication: `9b0600ccbd372b28c0a48d585b4ed969033bb82a`.
- [x] Exactly one commit over `develop`; worktree clean; zero conflicts.
- [x] Scope is exactly two files, +548/-44.
- [x] Binary diff SHA-256: `f60924b027db326688f2aa3bfc35521d37edd2a3fb8fc9601fd1974478d9a821`.
- [x] Open-PR overlap scan: only this PR touches either changed path across 82 open PRs.

# Risks

Moderate and bounded to model-configuration API metadata and validation. Inference routing, credentials, prompts, and model execution are unchanged. A malformed selected endpoint now returns a typed, redacted `MODEL_CONFIG_INVALID` 400 instead of fabricating a healthy canonical hostname. Provider-omitted chat-model writes continue to use the configured catalog provider and no longer depend on endpoint parsing.

# Background

## What does this PR do?

`activeChat` previously derived Cerebras from the shared `OPENAI` model-key family and could report `api.openai.com` even when the runtime served Cerebras. Later edge cases could also make the DTO disagree with the serving plugin when mocks, EvoLink, nested/process config precedence, whitespace, malformed URLs, or dual provider keys were involved.

This patch makes the contract explicit:

- `activeChat.provider` is the canonical service-routing/catalog backend used for plugin collection and model writes;
- `activeChat.endpoint` is the validated hostname selected by the runtime's serving plugin;
- Cerebras, EvoLink, OpenAI, Anthropic, and Eliza Cloud endpoint selection mirrors each plugin's real configuration projection and precedence;
- explicit malformed, opaque, or non-HTTP(S) selected bases fail with a redacted typed 400 instead of falling back to a fabricated hostname;
- credentials, paths, query strings, and raw invalid values are never returned;
- supported dual-key Cerebras catalog mode remains `provider: cerebras`, while the endpoint follows the OpenAI-compatible wire mode actually selected by plugin-openai;
- POST chat-model writes resolve only the catalog provider, so endpoint metadata errors cannot block an explicit recovery write.

## What kind of change is this?

Bug fix (non-breaking metadata truthfulness correction, with fail-fast validation for invalid selected endpoint configuration).

# Documentation changes needed?

N/A - this makes the existing `activeChat` fields honor their serving-runtime contract; it does not add a public configuration key or UI surface.

# Testing

## Where should a reviewer start?

- `packages/agent/src/api/model-config-routes.ts`
- `packages/agent/src/api/model-config-routes.test.ts`

## Detailed testing steps

From exact head `ee7b0689f1487d986e3e780e651e2a3e51240b48`:

1. `bun install --frozen-lockfile`
2. `node packages/shared/scripts/generate-keywords.mjs`
3. `bun run build:core`
4. Run the focused model-config/slash/models route tests.
5. `bun run --cwd packages/agent test`
6. `bun run --cwd plugins/plugin-openai test`
7. Run agent and plugin-openai typechecks.
8. Run targeted Biome on the two changed files.
9. `git diff --check origin/develop...HEAD`
10. `bun run verify`

Exact-head results:

- focused agent route matrix: 3 files, 63/63 tests passed;
- plugin Cerebras configuration matrix: 17/17 passed;
- executable real-plugin OpenAI-compatible parity/precedence/redaction/error matrix: 107/107 passed;
- executable Cloud/Anthropic parity/error matrix: 11/11 passed;
- full plugin-openai suite: 18 files, 275 tests passed;
- full agent suite: 387/387 isolated test files passed;
- agent and plugin-openai typechecks passed;
- targeted Biome and `git diff --check` passed;
- root `bun run verify`: 348/348 Turbo tasks plus all repository audits passed;
- two independent exact-head reviews: PASS, no P0/P1/P2;
- final worktree, scope, hashes, and current-base ancestry recheck passed.

# Evidence Gate

<!-- evidence-head:ee7b0689f1487d986e3e780e651e2a3e51240b48 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this backend DTO change has no rendered UI surface; the current renderer does not display `activeChat.endpoint`.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this backend DTO change has no rendered UI surface; the current renderer does not display `activeChat.endpoint`.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-visible flow or visual state change.
<!-- evidence-row:backend-logs -->
- [x] Exact-head redacted handler transcript (no tokens, headers, message content, raw invalid URLs, or credential values were inspected):

  ```text
  GET /api/models/config => 200 {activeChat:{provider:"cerebras",family:"OPENAI",endpoint:"api.cerebras.ai"}}
  GET /api/models/config with an explicitly invalid selected base => 400 {code:"MODEL_CONFIG_INVALID"}
  Error context => {key:"OPENAI_BASE_URL"}; raw value, credentials, path, and query are absent
  ```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or rendered state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - inference routing, model calls, prompts, actions, and providers are unchanged; this corrects and validates operator-facing route metadata only.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the change creates no DB rows, memories, scheduled tasks, files, or external artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Backend + frontend logs

Exact-head loopback proof exercised the actual route handler:

```text
valid direct Cerebras: status=200 provider=cerebras family=OPENAI endpoint=api.cerebras.ai
invalid selected base: status=400 code=MODEL_CONFIG_INVALID context.key=OPENAI_BASE_URL
redaction: raw URL, credentials, path, query, headers, tokens, and message content were absent
```

An earlier full-agent safe route readback established the original direct-Cerebras symptom and is retained as provenance only; the exact-head handler transcript and exact-head executable matrices above are the proof for this broader final implementation.

Frontend logs: N/A - no frontend code or state changed.

## Real LLM-call trajectory

N/A - no model-call path, prompt, action, provider registration, or inference selection behavior changed.

## Screenshots (before / after) + video walkthrough

N/A - `activeChat.endpoint` is not rendered by the current UI, and this diff contains no frontend files.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio code changed.

## Known gaps / failures

- Fresh exact-head CI Tests job `93873292747` had one path-disjoint timing failure: the E2E coverage route-manifest discovery assertion exceeded its fixed 5-second fence at 5.24 seconds. Its other assertions passed, and the same assertion completed in about 248 ms in a focused exact-head execution.
- This is classified as a repository-wide script-load timing flake, not a product assertion from the two-file agent change. A genuine failed-job rerun is still required; the PR is not CI-green until that rerun passes.
- Historical CI from earlier heads and bases is provenance only.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@8073280419749e12a3c4211d13e887fc3c090f3f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [gauss]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@8073280419749e12a3c4211d13e887fc3c090f3f:packages/skills/skills/contribute-to-eliza"} -->

