### PR TITLE
fix(openai): scope DeepSeek V4 Flash forced-tool compatibility

### DIFF
--- a/plugins/plugin-openai/__tests__/opencode-go-tools.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/opencode-go-tools.shape.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Request-shape coverage for OpenCode Go DeepSeek V4 Flash. The provider's
+ * no-thinking value is `reasoning_effort: none`, and forced native tool choice
+ * must remain `required` on the same request. Mocked AI SDK, no network.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const aiMocks = vi.hoisted(() => ({
+  generateText: vi.fn(),
+  streamText: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+  generateText: aiMocks.generateText,
+  streamText: aiMocks.streamText,
+  jsonSchema: (schema: unknown) => ({ jsonSchema: schema }),
+  Output: {
+    json: () => ({}),
+    object: () => ({}),
+  },
+}));
+
+vi.mock("../providers", () => ({
+  createOpenAIClient: () => ({
+    chat: (modelName: string) => ({ modelName }),
+    responses: (modelName: string) => ({ modelName }),
+  }),
+}));
+
+const ENV_KEYS = [
+  "CEREBRAS_API_KEY",
+  "ELIZA_MOCK_OPENAI_BASE",
+  "ELIZA_PROVIDER",
+  "EVOLINK_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "OPENAI_BROWSER_BASE_URL",
+  "OPENAI_REASONING_EFFORT",
+  "OPENAI_SMALL_MODEL",
+  "SMALL_MODEL",
+] as const;
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    vi.stubEnv(key, undefined);
+  }
+  aiMocks.generateText.mockResolvedValue({
+    text: "",
+    toolCalls: [{ toolName: "lookup", input: { q: "eliza" } }],
+    finishReason: "tool-calls",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    providerMetadata: {},
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function createRuntime(settings: Record<string, string | undefined>) {
+  return {
+    character: { name: "Ada", system: "system prompt" },
+    emitEvent: vi.fn(),
+    getService: vi.fn(() => null),
+    getServicesByType: vi.fn(() => []),
+    getSetting: vi.fn((key: string) => settings[key]),
+  } as never;
+}
+
+async function captureRequest(
+  settings: Record<string, string | undefined>,
+  model = "deepseek-v4-flash"
+): Promise<Record<string, unknown>> {
+  const { handleTextSmall } = await import("../models/text");
+  await handleTextSmall(createRuntime(settings), {
+    prompt: "Use the lookup tool",
+    model,
+    tools: {
+      lookup: {
+        description: "Look something up",
+        inputSchema: {
+          type: "object",
+          properties: { q: { type: "string" } },
+          required: ["q"],
+        },
+      },
+    },
+    toolChoice: "required",
+    providerOptions: { eliza: { thinking: "off" } },
+  } as never);
+
+  return aiMocks.generateText.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+}
+
+describe("OpenCode Go DeepSeek V4 Flash forced tools", () => {
+  it("maps thinking=off to none while preserving required tool choice", async () => {
+    const call = await captureRequest({
+      OPENAI_API_KEY: "test-key",
+      OPENAI_BASE_URL: "https://opencode.ai/zen/go/v1",
+    });
+
+    expect(call.providerOptions).toMatchObject({
+      openai: { reasoningEffort: "none" },
+    });
+    expect(call.toolChoice).toBe("required");
+    expect(call.tools).toHaveProperty("lookup");
+    expect(aiMocks.generateText).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    "deepseek-v4-pro",
+    "openai/deepseek-v4-flash",
+    "deepseek-v4-flash:preview",
+    "deepseek-v4-flash-free",
+  ])("does not add reasoning effort for non-exact model %s", async (model) => {
+    const call = await captureRequest(
+      {
+        OPENAI_API_KEY: "test-key",
+        OPENAI_BASE_URL: "https://opencode.ai/zen/go/v1",
+      },
+      model
+    );
+
+    expect(call.providerOptions).not.toHaveProperty("openai.reasoningEffort");
+    expect(call.toolChoice).toBe("required");
+  });
+
+  it("does not add reasoning effort for the same model on another endpoint", async () => {
+    const call = await captureRequest({
+      OPENAI_API_KEY: "test-key",
+      OPENAI_BASE_URL: "https://api.openai.com/v1",
+    });
+
+    expect(call.providerOptions).not.toHaveProperty("openai.reasoningEffort");
+    expect(call.toolChoice).toBe("required");
+  });
+
+  it("does not inherit OpenCode semantics through an opaque browser proxy", async () => {
+    vi.stubGlobal("document", {});
+    const call = await captureRequest({
+      OPENAI_BASE_URL: "https://opencode.ai/zen/go/v1/",
+      OPENAI_BROWSER_BASE_URL: "https://app.example.test/openai-proxy",
+    });
+
+    expect(call.providerOptions).not.toHaveProperty("openai.reasoningEffort");
+    expect(call.toolChoice).toBe("required");
+  });
+
+  it("recognizes an exact OpenCode browser base without changing the node base", async () => {
+    vi.stubGlobal("document", {});
+    const call = await captureRequest({
+      OPENAI_BASE_URL: "https://api.openai.com/v1",
+      OPENAI_BROWSER_BASE_URL: "https://opencode.ai/zen/go/v1/",
+    });
+
+    expect(call.providerOptions).toMatchObject({
+      openai: { reasoningEffort: "none" },
+    });
+    expect(call.toolChoice).toBe("required");
+  });
+});

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -51,6 +51,7 @@ import {
   getSmallModel,
   getUsageProvider,
   isCerebrasMode,
+  isOpenCodeGoMode,
 } from "../utils/config";
 import { emitModelUsageEvent, type ModelRetryTelemetry } from "../utils/events";
 
@@ -338,6 +339,29 @@ function resolveCerebrasThinkingOffReasoningEffort(
   return undefined;
 }
 
+/**
+ * OpenCode Go's DeepSeek V4 Flash accepts `none` as its explicit no-thinking
+ * value. Scope the mapping to the exact endpoint/model pair: other compatible
+ * providers and other OpenCode Go models may reject the field or interpret it
+ * differently.
+ */
+function resolveOpenCodeGoThinkingOffReasoningEffort(
+  modelName: string | undefined
+): "none" | undefined {
+  if (!modelName) return undefined;
+  return modelName.trim().toLowerCase() === "deepseek-v4-flash" ? "none" : undefined;
+}
+
+function resolveThinkingOffReasoningEffort(
+  runtime: IAgentRuntime,
+  modelName: string | undefined
+): "low" | "none" | undefined {
+  if (isOpenCodeGoMode(runtime)) {
+    return resolveOpenCodeGoThinkingOffReasoningEffort(modelName);
+  }
+  return isCerebrasMode(runtime) ? resolveCerebrasThinkingOffReasoningEffort(modelName) : undefined;
+}
+
 function resolveReasoningEffort(
   runtime: IAgentRuntime,
   modelName?: string
@@ -371,16 +395,15 @@ function resolveProviderOptions(
   const rawProviderOptions = withOpenAIOptions.providerOptions;
   const promptCacheOptions = resolvePromptCacheOptions(params);
   const reasoningEffort = resolveReasoningEffort(runtime, modelName);
-  // Thinking-off suppression outranks the env pin and the Cerebras "low"
-  // default (matching plugin-elizacloud: Stage-1/planner calls stay cheap
-  // regardless of a user-pinned effort). An explicit caller
+  // Thinking-off suppression outranks the env pin and provider defaults
+  // (matching plugin-elizacloud: Stage-1/planner calls stay cheap regardless
+  // of a user-pinned effort). An explicit caller
   // `providerOptions.openai.reasoningEffort` still wins via the spread guard
-  // below. Scoped to Cerebras mode: OpenAI-direct rejects `"none"`.
+  // below. Each mapping is scoped to an exact provider/model contract because
+  // OpenAI-direct and some compatible endpoints reject `"none"`.
   const elizaThinking = (rawProviderOptions?.eliza as { thinking?: unknown } | undefined)?.thinking;
   const thinkingOffEffort =
-    elizaThinking === "off" && isCerebrasMode(runtime)
-      ? resolveCerebrasThinkingOffReasoningEffort(modelName)
-      : undefined;
+    elizaThinking === "off" ? resolveThinkingOffReasoningEffort(runtime, modelName) : undefined;
   const effectiveReasoningEffort = thinkingOffEffort ?? reasoningEffort;
 
   if (

--- a/plugins/plugin-openai/utils/config.ts
+++ b/plugins/plugin-openai/utils/config.ts
@@ -233,6 +233,36 @@ export function getBaseURL(runtime: IAgentRuntime): string {
   return baseURL;
 }
 
+/**
+ * Matches only the OpenCode Go OpenAI-compatible base URL. Provider-specific
+ * request fields must not leak to another compatible host or endpoint.
+ */
+function isOpenCodeGoBaseURL(value: string | undefined): boolean {
+  if (!value) return false;
+  try {
+    const baseURL = new URL(value);
+    const exactPath = baseURL.pathname === "/zen/go/v1" || baseURL.pathname === "/zen/go/v1/";
+    return (
+      baseURL.origin === "https://opencode.ai" &&
+      exactPath &&
+      baseURL.search === "" &&
+      baseURL.hash === ""
+    );
+  } catch {
+    // error-policy:J3 Malformed configuration is not a matching provider URL.
+    return false;
+  }
+}
+
+/**
+ * True when the effective request URL is OpenCode Go. This follows the same
+ * browser, mock, and configured-base precedence as `getBaseURL`, so a shadowed
+ * upstream cannot leak provider-specific options through a browser proxy.
+ */
+export function isOpenCodeGoMode(runtime: IAgentRuntime): boolean {
+  return isOpenCodeGoBaseURL(getBaseURL(runtime));
+}
+
 export function getEmbeddingBaseURL(runtime: IAgentRuntime): string {
   const embeddingURL = isBrowser()
     ? (getSetting(runtime, "OPENAI_BROWSER_EMBEDDING_URL") ??


### PR DESCRIPTION
# Relates to

Closes #18378

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza/SKILL.md`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto fetched `origin/develop` at `aa6677ea695512d3af174b4c45eb97f4a6f92db5`; zero conflicts.
- [x] The exact unrelated blockers to root `bun run verify` are documented in **Known gaps / failures** below.

# Risks

Low and deliberately narrow. The option is emitted only when the effective request URL is exactly `https://opencode.ai/zen/go/v1` (optional trailing slash), the exact trimmed/case-normalized wire model is `deepseek-v4-flash`, and Eliza explicitly requests `thinking: off`. Negative tests cover prefixed, suffixed, sibling, and other model IDs; another endpoint; and a browser proxy that shadows an OpenCode server URL.

# Background

## What does this PR do?

When Eliza marks deterministic response-handler/planner work with `providerOptions.eliza.thinking = "off"`, OpenCode Go's `deepseek-v4-flash` still enters thinking mode unless the OpenAI-compatible request carries `reasoning_effort: "none"`. Thinking mode rejects forced native-tool selection with `Thinking mode does not support this tool_choice`.

This PR:

- maps Eliza `thinking: off` to OpenAI `reasoningEffort: "none"` only for the exact OpenCode Go endpoint/model pair;
- preserves `toolChoice: "required"` on that same AI SDK call;
- follows `getBaseURL()` precedence, so an opaque browser proxy cannot inherit provider-specific semantics from a shadowed server URL;
- recognizes a direct OpenCode Go browser base; and
- leaves other models, aliases, suffixes, and compatible endpoints unchanged.

### Concurrent-work disclosure

At the pre-work duplicate check, #18378 had no comments or linked PR. #18400 was opened at 2026-08-11 14:20:05 UTC during final local verification, after this implementation and its initial focused tests existed. This is an independent concurrent implementation submitted transparently as an alternative, not a priority claim.

The distinguishing regression invokes the real plugin handler, captures the exact object handed to mocked AI SDK `generateText`, and asserts that `providerOptions.openai.reasoningEffort === "none"`, `toolChoice === "required"`, and the requested tool coexist on the same call. It also covers both P1 edge cases raised on #18400: effective browser-URL precedence and exact bare wire-model matching. This is handler-to-SDK request-shape evidence, not a serialized HTTP or live-provider run.

## What kind of change is this?

Bug fix (non-breaking, provider/model-scoped compatibility fix).

# Documentation changes needed?

No documentation change is required. This implements the endpoint/model behavior specified by #18378 without adding a public configuration surface.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-openai/__tests__/opencode-go-tools.shape.test.ts`
2. `resolveThinkingOffReasoningEffort` in `plugins/plugin-openai/models/text.ts`
3. `isOpenCodeGoMode` in `plugins/plugin-openai/utils/config.ts`

## Detailed testing steps

Focused verification was run from an external temporary harness because this checkout did not have the monorepo dependency tree installed:

- Vitest 4.1.5: the new OpenCode Go request-shape suite plus the existing reasoning-effort regression suite — **40/40 tests passed across 2 files**.
- Repository-pinned Biome 2.5.6 on all three changed files — **passed**.
- TypeScript 6.0.3 focused `noEmit` compile for the changed source/test files — **passed**, using a minimal temporary `@elizaos/core` type/runtime stub; this is not a substitute for workspace typecheck.
- `git diff --check` — **passed**.

The key regression invokes `handleTextSmall`, captures its call to mocked AI SDK `generateText`, and verifies `reasoningEffort: "none"`, `toolChoice: "required"`, and `tools.lookup` on the same call object. The mock prevents a network request; no live-provider success is claimed.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:14731750f96c77ffffb0ba5b31321d06b23ffcf3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface is changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface is changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this provider request-shape change has no UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no OpenCode Go credential was available for a live backend run; deterministic handler-to-SDK evidence is reported under **Testing**.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface or state is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no OpenCode Go credential was available; live-model validation remains an explicit gap.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this change produces no persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no OpenCode Go credential was available for this run. No live-model or HTTP-200 result is claimed.

## Backend + frontend logs

Backend: N/A - no credentialed live-provider run was possible.

Frontend: N/A - no frontend surface or request path is changed.

The deterministic plugin-to-AI-SDK request-shape evidence and exact passing test count are recorded under **Testing**.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior is changed.

## Known gaps / failures

- Root `bun install` and `bun run verify` were not run. The checkout had no monorepo dependency tree and approximately 4.2 GiB of local disk headroom, so materializing the full workspace was not safe within this bounded run. Full repository build/typecheck/test coverage remains for CI.
- The focused TypeScript pass used a temporary minimal `@elizaos/core` stub and is not equivalent to package or root workspace typecheck.
- No OpenCode Go credential was available, so there is no real-LLM trajectory, provider response, or end-to-end backend log. The regression proof stops at the real plugin handler's boundary with the mocked AI SDK function; live-provider validation remains outstanding.
- #18400 appeared during final verification and addresses the same issue. This PR is intentionally disclosed as a concurrent alternative; maintainers can choose the implementation/evidence shape they prefer.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [gg100-eng/codex-one-pr-pilot]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZRHJH045CDP2CBQEK8GBDE5","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-11T13:53:12.708Z","completed_at":"2026-08-11T14:52:25.507Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA0glq4Grth4o8ZQVu-r3-LeuynZu90apxoKrmAtbM-b0","device_key_id":"c32b8c79089de99283ce9afcd658ab2748d0c1d1902a0e90e06a6fe9acea1514","device_signature":"IuSKm2KplCe8hO7i9umUwSbHCHrdOCFL3H8_VfC648bUKOF10EbsbA7csaiMYnbaKXNZWhZem-njEs-3SSKzAA"}} -->
