### PR TITLE
fix(browser): capability-aware dispatch with no side-effect replay (#18258)

### DIFF
--- a/plugins/plugin-browser/src/__tests__/browser-service.test.ts
+++ b/plugins/plugin-browser/src/__tests__/browser-service.test.ts
@@ -434,8 +434,111 @@ describe("isIdempotentBrowserSubaction", () => {
     expect(isIdempotentBrowserSubaction("navigate")).toBe(false);
     expect(isIdempotentBrowserSubaction("open")).toBe(false);
     expect(isIdempotentBrowserSubaction("upload")).toBe(false);
-    expect(isIdempotentBrowserSubaction("submit")).toBe(false);
+    expect(isIdempotentBrowserSubaction("dblclick")).toBe(false);
     expect(isIdempotentBrowserSubaction("scroll")).toBe(false);
     expect(isIdempotentBrowserSubaction("press")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bridge capability manifest regression (issue #18258 review P1 #2)
+//
+// The bridge target advertises session-gated subactions (open/navigate/close/
+// show/hide/back/forward/reload) in BRIDGE_SUPPORTED_SUBACTIONS. But the
+// executor unconditionally rejects every one of them because a LifeOps session
+// is required. An unpinned side-effecting command can therefore select the
+// high-priority bridge as "capable", hit a known pre-execution rejection, and
+// be mislabeled UNCERTAIN_OUTCOME instead of selecting a genuinely capable
+// target. The fix: BRIDGE_SUPPORTED_SUBACTIONS must only include subactions
+// the bridge can execute directly, not session-gated ones.
+// ---------------------------------------------------------------------------
+
+describe("Bridge capability manifest excludes session-gated subactions (#18258 review)", () => {
+  it("BRIDGE_SUPPORTED_SUBACTIONS does not advertise session-gated operations", async () => {
+    const { BRIDGE_SUPPORTED_SUBACTIONS } = await import(
+      "../targets/bridge-target.js"
+    );
+
+    // Direct-executable subactions the bridge handles without a session.
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("list")).toBe(true);
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("state")).toBe(true);
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("get")).toBe(true);
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("tab")).toBe(true);
+
+    // Session-gated subactions — must NOT be in the manifest so the
+    // pre-dispatch capability check skips the bridge for them.
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("open")).toBe(false);
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("navigate")).toBe(false);
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("close")).toBe(false);
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("show")).toBe(false);
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("hide")).toBe(false);
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("back")).toBe(false);
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("forward")).toBe(false);
+    expect(BRIDGE_SUPPORTED_SUBACTIONS.has("reload")).toBe(false);
+  });
+
+  it("does not select the bridge for a session-gated side-effecting command", async () => {
+    // Simulate the real bridge-vs-workspace race: bridge has higher priority
+    // and advertises only direct subactions. A `navigate` (session-gated,
+    // side-effecting) must skip the bridge and select workspace.
+    const service = new BrowserService();
+
+    // Mirror the real bridge target's capability manifest.
+    const bridge = createTarget({
+      id: "bridge",
+      priority: 200,
+      score: () => 160,
+      supports: (cmd) => {
+        // Only direct-executable subactions.
+        return ["list", "state", "get", "tab"].includes(cmd.subaction);
+      },
+    });
+
+    // Workspace supports everything.
+    const workspace = createTarget({ id: "workspace", priority: 100 });
+
+    service.registerTarget(bridge);
+    service.registerTarget(workspace);
+
+    // navigate is side-effecting and session-gated — bridge must be skipped.
+    const result = await service.execute({
+      subaction: "navigate",
+      url: "https://example.test",
+    });
+
+    expect(result.value).toBe("workspace");
+    expect(bridge.execute).not.toHaveBeenCalled();
+    expect(workspace.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mislabel a session-gated operation as UNCERTAIN_OUTCOME when the bridge skips it", async () => {
+    // Regression: previously the bridge was selected as "capable" for
+    // session-gated ops, then rejected at execute time, which for a
+    // side-effecting command was classified as UNCERTAIN_OUTCOME.
+    // Now the bridge is skipped pre-dispatch and a capable workspace is
+    // selected instead — no UNCERTAIN_OUTCOME.
+    const service = new BrowserService();
+
+    const bridge = createTarget({
+      id: "bridge",
+      priority: 200,
+      score: () => 160,
+      supports: (cmd) =>
+        ["list", "state", "get", "tab"].includes(cmd.subaction),
+      fail: true, // even if selected, it would fail
+    });
+    const workspace = createTarget({ id: "workspace", priority: 100 });
+
+    service.registerTarget(bridge);
+    service.registerTarget(workspace);
+
+    const result = await service.execute({
+      subaction: "open",
+      url: "https://example.test",
+    });
+
+    // Workspace handles it successfully — bridge was never called.
+    expect(result.value).toBe("workspace");
+    expect(bridge.execute).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-browser/src/__tests__/browser-service.test.ts
+++ b/plugins/plugin-browser/src/__tests__/browser-service.test.ts
@@ -1,10 +1,21 @@
 /**
  * BrowserService tests for target registration, resolution, and dispatch behavior.
+ *
+ * Capability-aware dispatch (issue #18258): these tests prove that
+ *   - a capable target is selected before dispatch (capability-aware selection),
+ *   - pre-dispatch fallback is permitted for UNSUPPORTED/UNAVAILABLE failures,
+ *   - a command is NEVER replayed against another target after dispatch,
+ *   - side-effecting commands that fail opaquely surface UNCERTAIN_OUTCOME.
  */
 
 import { ElizaError, logger } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BrowserService, type BrowserTarget } from "../browser-service.js";
+import {
+  BrowserDispatchFailure,
+  isBrowserDispatchFailure,
+  isIdempotentBrowserSubaction,
+} from "../dispatch-types.js";
 
 const originalEnv = { ...process.env };
 
@@ -15,6 +26,8 @@ function createTarget(args: {
   availableError?: Error;
   fail?: boolean;
   score?: BrowserTarget["score"];
+  supports?: BrowserTarget["supports"];
+  executeMock?: BrowserTarget["execute"];
 }): BrowserTarget {
   return {
     id: args.id,
@@ -22,18 +35,21 @@ function createTarget(args: {
     description: args.id,
     priority: args.priority,
     ...(args.score ? { score: args.score } : {}),
+    ...(args.supports ? { supports: args.supports } : {}),
     available: vi.fn(async () => {
       if (args.availableError) throw args.availableError;
       return args.available ?? true;
     }),
-    execute: vi.fn(async (command) => {
-      if (args.fail) throw new Error(`${args.id} failed`);
-      return {
-        mode: "web",
-        subaction: command.subaction,
-        value: args.id,
-      };
-    }),
+    execute:
+      args.executeMock ??
+      (vi.fn(async (command) => {
+        if (args.fail) throw new Error(`${args.id} failed`);
+        return {
+          mode: "web",
+          subaction: command.subaction,
+          value: args.id,
+        };
+      }) as BrowserTarget["execute"]),
   };
 }
 
@@ -50,94 +66,6 @@ describe("BrowserService target routing", () => {
     const result = await service.execute({ subaction: "state" });
 
     expect(result.value).toBe("workspace");
-  });
-
-  it("falls back to the next automatic target when an unpinned target fails", async () => {
-    const service = new BrowserService();
-    const workspace = createTarget({
-      id: "workspace",
-      priority: 100,
-      fail: true,
-    });
-    const bridge = createTarget({ id: "bridge", priority: 80 });
-    service.registerTarget(workspace);
-    service.registerTarget(bridge);
-
-    const result = await service.execute({ subaction: "state" });
-
-    expect(result.value).toBe("bridge");
-    expect(workspace.execute).toHaveBeenCalledTimes(1);
-    expect(bridge.execute).toHaveBeenCalledTimes(1);
-  });
-
-  it("excludes an unpinned target whose availability check throws, still resolves a healthy one, and logs the exclusion", async () => {
-    const logSpy = vi
-      .spyOn(logger, "debug")
-      .mockImplementation(() => logger as never);
-    const service = new BrowserService();
-    const broken = createTarget({
-      id: "broken",
-      priority: 200,
-      availableError: new Error("probe boom"),
-    });
-    const workspace = createTarget({ id: "workspace", priority: 100 });
-    service.registerTarget(broken);
-    service.registerTarget(workspace);
-
-    // Automatic (unpinned) resolution must not throw: the broken candidate is
-    // skipped and the next healthy target is selected (designed failover).
-    const result = await service.execute({ subaction: "state" });
-    expect(result.value).toBe("workspace");
-    expect(broken.execute).not.toHaveBeenCalled();
-    // The exclusion is observable, not silently swallowed by an empty catch.
-    expect(
-      logSpy.mock.calls.some(
-        (call) =>
-          typeof call[0] === "string" &&
-          call[0].includes('"broken"') &&
-          call[0].includes("probe boom"),
-      ),
-    ).toBe(true);
-    logSpy.mockRestore();
-  });
-
-  it("does not fall back when the caller pins a target", async () => {
-    const service = new BrowserService();
-    service.registerTarget(
-      createTarget({ id: "workspace", priority: 100, fail: true }),
-    );
-    service.registerTarget(createTarget({ id: "bridge", priority: 80 }));
-
-    await expect(
-      service.execute({ subaction: "state" }, "workspace"),
-    ).rejects.toThrow("workspace failed");
-  });
-
-  it("preserves pinned target availability failures as typed errors", async () => {
-    const service = new BrowserService();
-    const availabilityError = new Error("bridge health probe failed");
-    service.registerTarget(
-      createTarget({
-        id: "bridge",
-        priority: 80,
-        availableError: availabilityError,
-      }),
-    );
-    service.registerTarget(createTarget({ id: "workspace", priority: 100 }));
-
-    try {
-      await service.execute({ subaction: "state" }, "bridge");
-      throw new Error("expected pinned target availability failure");
-    } catch (error) {
-      expect(error).toBeInstanceOf(ElizaError);
-      expect((error as ElizaError).code).toBe("BROWSER_TARGET_UNAVAILABLE");
-      expect((error as ElizaError).context).toEqual({
-        targetId: "bridge",
-        subaction: "state",
-      });
-      expect((error as ElizaError).severity).toBe("ephemeral");
-      expect((error as Error).cause).toBe(availabilityError);
-    }
   });
 
   it("passes desktop context so companion targets can win when available", async () => {
@@ -180,6 +108,301 @@ describe("BrowserService target routing", () => {
     expect(bridge.execute).not.toHaveBeenCalled();
     expect(workspace.execute).toHaveBeenCalledTimes(1);
   });
+
+  it("excludes an unpinned target whose availability check throws, still resolves a healthy one, and logs the exclusion", async () => {
+    const logSpy = vi
+      .spyOn(logger, "debug")
+      .mockImplementation(() => logger as never);
+    const service = new BrowserService();
+    const broken = createTarget({
+      id: "broken",
+      priority: 200,
+      availableError: new Error("probe boom"),
+    });
+    const workspace = createTarget({ id: "workspace", priority: 100 });
+    service.registerTarget(broken);
+    service.registerTarget(workspace);
+
+    // Automatic (unpinned) resolution must not throw: the broken candidate is
+    // skipped and the next healthy target is selected (designed failover).
+    const result = await service.execute({ subaction: "state" });
+    expect(result.value).toBe("workspace");
+    expect(broken.execute).not.toHaveBeenCalled();
+    // The exclusion is observable, not silently swallowed by an empty catch.
+    expect(
+      logSpy.mock.calls.some(
+        (call) =>
+          typeof call[0] === "string" &&
+          call[0].includes('"broken"') &&
+          call[0].includes("probe boom"),
+      ),
+    ).toBe(true);
+    logSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capability-aware dispatch (issue #18258)
+// ---------------------------------------------------------------------------
+
+describe("BrowserService capability-aware dispatch (#18258)", () => {
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("selects a capable target before dispatch and skips an incapable one pre-dispatch", async () => {
+    const service = new BrowserService();
+    // bridge only supports read-only subactions
+    const bridge = createTarget({
+      id: "bridge",
+      priority: 200,
+      supports: (cmd) => cmd.subaction === "state" || cmd.subaction === "list",
+    });
+    // workspace supports everything
+    const workspace = createTarget({ id: "workspace", priority: 100 });
+
+    service.registerTarget(bridge);
+    service.registerTarget(workspace);
+
+    // A `click` is side-effecting and the bridge doesn't support it — workspace
+    // must be selected (the bridge.execute is never called).
+    const result = await service.execute({
+      subaction: "click",
+      selector: "#btn",
+    });
+
+    expect(result.value).toBe("workspace");
+    expect(bridge.execute).not.toHaveBeenCalled();
+    expect(workspace.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers the higher-scoring capable target when it supports the command", async () => {
+    const service = new BrowserService();
+    const bridge = createTarget({
+      id: "bridge",
+      priority: 200,
+      supports: (cmd) => cmd.subaction === "state",
+    });
+    const workspace = createTarget({ id: "workspace", priority: 100 });
+
+    service.registerTarget(bridge);
+    service.registerTarget(workspace);
+
+    const result = await service.execute({ subaction: "state" });
+
+    expect(result.value).toBe("bridge");
+  });
+
+  it("returns a typed UNSUPPORTED failure when no available target supports the command", async () => {
+    const service = new BrowserService();
+    const readonlyOnly = createTarget({
+      id: "readonly",
+      priority: 100,
+      supports: (cmd) => cmd.subaction === "state",
+    });
+    service.registerTarget(readonlyOnly);
+
+    try {
+      await service.execute({ subaction: "click", selector: "#btn" });
+      throw new Error("expected UNSUPPORTED failure");
+    } catch (error) {
+      expect(isBrowserDispatchFailure(error)).toBe(true);
+      const failure = error as BrowserDispatchFailure;
+      expect(failure.kind).toBe("UNSUPPORTED");
+      expect(failure.fallbackSafe).toBe(true);
+      expect(readonlyOnly.execute).not.toHaveBeenCalled();
+    }
+  });
+
+  it("returns a typed UNAVAILABLE failure when no target is available", async () => {
+    const service = new BrowserService();
+    service.registerTarget(
+      createTarget({ id: "workspace", priority: 100, available: false }),
+    );
+
+    try {
+      await service.execute({ subaction: "state" });
+      throw new Error("expected UNAVAILABLE failure");
+    } catch (error) {
+      expect(isBrowserDispatchFailure(error)).toBe(true);
+      expect((error as BrowserDispatchFailure).kind).toBe("UNAVAILABLE");
+      expect((error as BrowserDispatchFailure).fallbackSafe).toBe(true);
+    }
+  });
+
+  it("does not fall back when the caller pins a target", async () => {
+    const service = new BrowserService();
+    const workspace = createTarget({
+      id: "workspace",
+      priority: 100,
+      fail: true,
+    });
+    const bridge = createTarget({ id: "bridge", priority: 80 });
+    service.registerTarget(workspace);
+    service.registerTarget(bridge);
+
+    await expect(
+      service.execute({ subaction: "state" }, "workspace"),
+    ).rejects.toThrow("workspace failed");
+    // bridge.execute must never have been called — pinned, no fallback.
+    expect(bridge.execute).not.toHaveBeenCalled();
+  });
+
+  it("returns a typed UNSUPPORTED failure when a pinned target does not support the command", async () => {
+    const service = new BrowserService();
+    const bridge = createTarget({
+      id: "bridge",
+      priority: 80,
+      supports: (cmd) => cmd.subaction === "state",
+    });
+    const workspace = createTarget({ id: "workspace", priority: 100 });
+    service.registerTarget(bridge);
+    service.registerTarget(workspace);
+
+    try {
+      await service.execute({ subaction: "click", selector: "#x" }, "bridge");
+      throw new Error("expected UNSUPPORTED");
+    } catch (error) {
+      expect(isBrowserDispatchFailure(error)).toBe(true);
+      expect((error as BrowserDispatchFailure).kind).toBe("UNSUPPORTED");
+      // workspace is not tried because the pin is honored.
+      expect(workspace.execute).not.toHaveBeenCalled();
+    }
+  });
+
+  it("NEVER replays a non-idempotent (side-effecting) command after dispatch, even on failure", async () => {
+    const service = new BrowserService();
+    const primary = createTarget({
+      id: "primary",
+      priority: 200,
+      fail: true, // throws after dispatch
+    });
+    const fallback = createTarget({ id: "fallback", priority: 100 });
+    service.registerTarget(primary);
+    service.registerTarget(fallback);
+
+    // `click` is side-effecting. Once primary.execute throws, the command must
+    // NOT be retried on fallback — it may have already clicked.
+    await expect(
+      service.execute({ subaction: "click", selector: "#submit" }),
+    ).rejects.toThrow();
+
+    expect(primary.execute).toHaveBeenCalledTimes(1);
+    expect(fallback.execute).not.toHaveBeenCalled();
+  });
+
+  it("classifies an opaque failure of a side-effecting command as UNCERTAIN_OUTCOME", async () => {
+    const service = new BrowserService();
+    const primary = createTarget({
+      id: "primary",
+      priority: 200,
+      fail: true,
+    });
+    service.registerTarget(primary);
+
+    try {
+      await service.execute({ subaction: "navigate", url: "https://x.test" });
+      throw new Error("expected failure");
+    } catch (error) {
+      expect(isBrowserDispatchFailure(error)).toBe(true);
+      const failure = error as BrowserDispatchFailure;
+      expect(failure.kind).toBe("UNCERTAIN_OUTCOME");
+      expect(failure.fallbackSafe).toBe(false);
+      expect(failure.targetId).toBe("primary");
+    }
+  });
+
+  it("does not wrap an opaque failure of an idempotent (read-only) command as UNCERTAIN_OUTCOME", async () => {
+    const service = new BrowserService();
+    const primary = createTarget({
+      id: "primary",
+      priority: 200,
+      fail: true,
+    });
+    service.registerTarget(primary);
+
+    // `state` is idempotent — no side effect is possible, so the original error
+    // is rethrown (not wrapped in BrowserDispatchFailure).
+    await expect(service.execute({ subaction: "state" })).rejects.toThrow(
+      "primary failed",
+    );
+  });
+
+  it("preserves a typed BrowserDispatchFailure thrown by the target", async () => {
+    const service = new BrowserService();
+    const sessionGone = new BrowserDispatchFailure(
+      "SESSION_GONE",
+      "The Steel session has ended.",
+      { targetId: "cloud" },
+    );
+    const cloud = createTarget({
+      id: "cloud",
+      priority: 200,
+      executeMock: vi.fn(async () => {
+        throw sessionGone;
+      }),
+    });
+    service.registerTarget(cloud);
+
+    try {
+      await service.execute({ subaction: "navigate", url: "https://x.test" });
+      throw new Error("expected failure");
+    } catch (error) {
+      // The exact failure thrown by the target is preserved (not re-wrapped).
+      expect(error).toBe(sessionGone);
+    }
+  });
+
+  it("pre-dispatch fallback across candidates is permitted for UNSUPPORTED before execution begins", async () => {
+    const service = new BrowserService();
+    // Higher-scoring target that does NOT support `click`.
+    const readonly = createTarget({
+      id: "readonly",
+      priority: 200,
+      supports: (cmd) => cmd.subaction === "state",
+    });
+    // Lower-scoring target that DOES support `click`.
+    const workspace = createTarget({ id: "workspace", priority: 100 });
+    service.registerTarget(readonly);
+    service.registerTarget(workspace);
+
+    const result = await service.execute({
+      subaction: "click",
+      selector: "#b",
+    });
+
+    expect(result.value).toBe("workspace");
+    // readonly was skipped pre-dispatch (never executed).
+    expect(readonly.execute).not.toHaveBeenCalled();
+    expect(workspace.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves pinned target availability failures as typed errors", async () => {
+    const service = new BrowserService();
+    const availabilityError = new Error("bridge health probe failed");
+    service.registerTarget(
+      createTarget({
+        id: "bridge",
+        priority: 80,
+        availableError: availabilityError,
+      }),
+    );
+    service.registerTarget(createTarget({ id: "workspace", priority: 100 }));
+
+    try {
+      await service.execute({ subaction: "state" }, "bridge");
+      throw new Error("expected pinned target availability failure");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe("BROWSER_TARGET_UNAVAILABLE");
+      expect((error as ElizaError).context).toEqual({
+        targetId: "bridge",
+        subaction: "state",
+      });
+      expect((error as ElizaError).severity).toBe("ephemeral");
+      expect((error as Error).cause).toBe(availabilityError);
+    }
+  });
 });
 
 describe("BrowserService workspace snapshot seam (item #12091-14)", () => {
@@ -192,5 +415,27 @@ describe("BrowserService workspace snapshot seam (item #12091-14)", () => {
     const snapshot = await service.getWorkspaceSnapshot();
     expect(typeof snapshot.mode).toBe("string");
     expect(Array.isArray(snapshot.tabs)).toBe(true);
+  });
+});
+
+describe("isIdempotentBrowserSubaction", () => {
+  it("classifies read-only subactions as idempotent", () => {
+    expect(isIdempotentBrowserSubaction("state")).toBe(true);
+    expect(isIdempotentBrowserSubaction("list")).toBe(true);
+    expect(isIdempotentBrowserSubaction("get")).toBe(true);
+    expect(isIdempotentBrowserSubaction("snapshot")).toBe(true);
+    expect(isIdempotentBrowserSubaction("screenshot")).toBe(true);
+  });
+
+  it("classifies side-effecting subactions as non-idempotent", () => {
+    expect(isIdempotentBrowserSubaction("click")).toBe(false);
+    expect(isIdempotentBrowserSubaction("type")).toBe(false);
+    expect(isIdempotentBrowserSubaction("fill")).toBe(false);
+    expect(isIdempotentBrowserSubaction("navigate")).toBe(false);
+    expect(isIdempotentBrowserSubaction("open")).toBe(false);
+    expect(isIdempotentBrowserSubaction("upload")).toBe(false);
+    expect(isIdempotentBrowserSubaction("submit")).toBe(false);
+    expect(isIdempotentBrowserSubaction("scroll")).toBe(false);
+    expect(isIdempotentBrowserSubaction("press")).toBe(false);
   });
 });

--- a/plugins/plugin-browser/src/actions/browser.test.ts
+++ b/plugins/plugin-browser/src/actions/browser.test.ts
@@ -532,3 +532,115 @@ describe("BROWSER routing hint (#12209)", () => {
     expect(hint).toContain("COMPUTER_USE");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Typed dispatch failure propagation at the action boundary (#18258 review P1 #3)
+//
+// The service layer distinguishes UNSUPPORTED/UNAVAILABLE (safe pre-dispatch
+// declines) from UNCERTAIN_OUTCOME (a side-effecting command may have partially
+// executed — must NOT be retried). The BROWSER action must propagate this typed
+// state instead of collapsing every failure to "BROWSER_FAILED".
+// ---------------------------------------------------------------------------
+
+describe("BROWSER action propagates typed dispatch failures (#18258 review)", () => {
+  it("propagates a safe pre-dispatch decline (UNSUPPORTED) with fallbackSafe=true", async () => {
+    const { BrowserDispatchFailure } = await import("../dispatch-types.js");
+    const service = {
+      execute: vi.fn(async () => {
+        throw new BrowserDispatchFailure(
+          "UNSUPPORTED",
+          'No available browser target supports subaction "upload".',
+          { targetId: null },
+        );
+      }),
+    };
+
+    const { result } = await runBrowserAction({
+      service: service as never,
+      parameters: { action: "upload" },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        values: expect.objectContaining({
+          success: false,
+          error: "UNSUPPORTED",
+          dispatchKind: "UNSUPPORTED",
+          fallbackSafe: true,
+        }),
+        data: expect.objectContaining({
+          actionName: "BROWSER",
+          dispatchFailure: expect.objectContaining({
+            kind: "UNSUPPORTED",
+            fallbackSafe: true,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("propagates an uncertain post-dispatch failure (UNCERTAIN_OUTCOME) with fallbackSafe=false", async () => {
+    const { BrowserDispatchFailure } = await import("../dispatch-types.js");
+    const service = {
+      execute: vi.fn(async () => {
+        throw new BrowserDispatchFailure(
+          "UNCERTAIN_OUTCOME",
+          'Browser command "click" against target "bridge" failed after dispatch and may have partially completed.',
+          { targetId: "bridge" },
+        );
+      }),
+    };
+
+    const { result } = await runBrowserAction({
+      service: service as never,
+      parameters: { action: "click", selector: "#submit" },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        values: expect.objectContaining({
+          success: false,
+          error: "UNCERTAIN_OUTCOME",
+          dispatchKind: "UNCERTAIN_OUTCOME",
+          fallbackSafe: false,
+          targetId: "bridge",
+        }),
+        data: expect.objectContaining({
+          actionName: "BROWSER",
+          dispatchFailure: expect.objectContaining({
+            kind: "UNCERTAIN_OUTCOME",
+            fallbackSafe: false,
+            targetId: "bridge",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("falls back to BROWSER_FAILED for non-dispatch errors", async () => {
+    const service = {
+      execute: vi.fn(async () => {
+        throw new Error("Something went wrong");
+      }),
+    };
+
+    const { result } = await runBrowserAction({
+      service: service as never,
+      parameters: { action: "state" },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        values: expect.objectContaining({
+          success: false,
+          error: "BROWSER_FAILED",
+        }),
+      }),
+    );
+    // Must NOT have dispatchFailure in data for a plain error.
+    expect(result?.data).not.toHaveProperty("dispatchFailure");
+  });
+});

--- a/plugins/plugin-browser/src/actions/browser.ts
+++ b/plugins/plugin-browser/src/actions/browser.ts
@@ -16,6 +16,10 @@ import {
   type BrowserService,
 } from "../browser-service.js";
 import {
+  type BrowserDispatchFailure,
+  isBrowserDispatchFailure,
+} from "../dispatch-types.js";
+import {
   type BrowserWorkspaceCommand,
   type BrowserWorkspaceCommandResult,
   executeBrowserWorkspaceCommand,
@@ -822,7 +826,21 @@ export const browserAction: Action = {
     } catch (error) {
       const errorText =
         error instanceof Error ? error.message : "Browser action failed";
-      logger.warn(`[BROWSER] Failed: ${errorText}`);
+
+      // Preserve the typed dispatch failure state (issue #18258 review):
+      // The service layer distinguishes UNSUPPORTED/UNAVAILABLE (safe
+      // pre-dispatch declines — OK to try a different approach) from
+      // UNCERTAIN_OUTCOME (a side-effecting command may have partially
+      // executed — must NOT be retried). Collapsing everything to
+      // "BROWSER_FAILED" drops this distinction at the action boundary,
+      // so the planner/action consumer cannot tell safe declines from
+      // outcomes that must not be retried.
+      const dispatchFailure: BrowserDispatchFailure | null =
+        isBrowserDispatchFailure(error) ? error : null;
+
+      logger.warn(
+        `[BROWSER] Failed: ${errorText}${dispatchFailure ? ` (kind=${dispatchFailure.kind}, target=${dispatchFailure.targetId ?? "none"}, fallbackSafe=${dispatchFailure.fallbackSafe})` : ""}`,
+      );
       await emitBrowserStepProgress(
         callback,
         command,
@@ -834,10 +852,30 @@ export const browserAction: Action = {
       return {
         text: `Browser action failed: ${errorText}`,
         success: false,
-        values: { success: false, error: "BROWSER_FAILED" },
+        values: {
+          success: false,
+          error: dispatchFailure?.kind ?? "BROWSER_FAILED",
+          ...(dispatchFailure
+            ? {
+                dispatchKind: dispatchFailure.kind,
+                fallbackSafe: dispatchFailure.fallbackSafe,
+                targetId: dispatchFailure.targetId,
+              }
+            : {}),
+        },
         data: {
           actionName: "BROWSER",
           command,
+          ...(dispatchFailure
+            ? {
+                dispatchFailure: {
+                  kind: dispatchFailure.kind,
+                  fallbackSafe: dispatchFailure.fallbackSafe,
+                  targetId: dispatchFailure.targetId,
+                  message: dispatchFailure.message,
+                },
+              }
+            : {}),
         },
       };
     }

--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -29,9 +29,15 @@
 
 import { ElizaError, type IAgentRuntime, logger, Service } from "@elizaos/core";
 import {
+  BrowserDispatchFailure,
+  isBrowserDispatchFailure,
+  isIdempotentBrowserSubaction,
+} from "./dispatch-types.js";
+import {
   BROWSER_BRIDGE_ROUTE_SERVICE_TYPE,
   type BrowserBridgeRouteService,
 } from "./service.js";
+import { BRIDGE_SUPPORTED_SUBACTIONS } from "./targets/bridge-target.js";
 import { maybeCreateStagehandTarget } from "./targets/stagehand-target.js";
 import {
   ensureBrowserWorkspaceDefaultTabWithRetry,
@@ -59,9 +65,18 @@ export interface BrowserTargetResolutionContext {
  * (electrobun bridge, Chrome companion HTTP, puppeteer CDP, etc.) and
  * return the canonical BrowserWorkspaceCommandResult.
  *
- * Targets MAY decline subactions they don't support — throw a clear
- * `Error` from `execute` and the caller will see the message. Don't
- * silently ignore it.
+ * Capability-aware dispatch (issue #18258): targets SHOULD declare which
+ * subactions they support via {@link BrowserTarget.supports} so the dispatcher
+ * can skip an incapable target *before* dispatch (returning `UNSUPPORTED`)
+ * instead of relying on a thrown error after the command may have begun.
+ * Targets that omit `supports` are assumed to accept every subaction (legacy
+ * behavior, e.g. the `workspace` target).
+ *
+ * When a target detects mid-execution that a side effect may have occurred
+ * before an error was observed (e.g. a click fired but the page response
+ * timed out), it SHOULD throw a {@link BrowserDispatchFailure} with kind
+ * `UNCERTAIN_OUTCOME` so the dispatcher knows the command must not be
+ * replayed against another target.
  */
 export interface BrowserTarget {
   /** Stable identifier — `workspace`, `bridge`, `computeruse`, etc. */
@@ -85,7 +100,23 @@ export interface BrowserTarget {
    * (no network round-trips) when possible.
    */
   available(): Promise<boolean>;
-  /** Run the command. Throw on unsupported subactions. */
+  /**
+   * Capability check: return `true` if this target can execute `command`'s
+   * subaction, `false` if it cannot (the dispatcher returns `UNSUPPORTED`
+   * and tries the next target). When omitted, the target is treated as
+   * supporting every subaction (legacy behavior).
+   *
+   * This is a pre-dispatch selection signal — it must NOT have side effects
+   * and must be cheap. Implementations typically test a static `Set` of
+   * supported subaction strings.
+   */
+  supports?(command: BrowserWorkspaceCommand): boolean;
+  /**
+   * Run the command. Throw on unsupported subactions (legacy behavior) or,
+   * preferably, return a {@link BrowserDispatchFailure}. If a side effect may
+   * have begun before the error, throw a `BrowserDispatchFailure` with kind
+   * `UNCERTAIN_OUTCOME` so the command is never replayed.
+   */
   execute(
     command: BrowserWorkspaceCommand,
   ): Promise<BrowserWorkspaceCommandResult>;
@@ -267,40 +298,130 @@ export class BrowserService extends Service {
   }
 
   /**
-   * Dispatch a command. `targetId` pins the target; otherwise the service
-   * picks the first available one in registration order.
+   * Dispatch a command with capability-aware selection and side-effect safety
+   * (issue #18258).
+   *
+   * Selection phase (pre-dispatch): among available targets, the dispatcher
+   * finds one whose {@link BrowserTarget.supports} declares it can handle the
+   * command's subaction. Targets that omit `supports` are assumed capable.
+   * Fallback across candidates is permitted **only** in this phase — for
+   * `UNAVAILABLE` (no target available) and `UNSUPPORTED` (target can't handle
+   * the subaction) failures.
+   *
+   * Execution phase (post-dispatch): once a target's `execute()` is invoked,
+   * the command is committed to that target. If `execute()` throws, the command
+   * is **never replayed** against another target, because a click / submit /
+   * navigation / upload may have partially or fully completed before the error
+   * was observed. The original failure is surfaced to the caller. If the target
+   * throws a {@link BrowserDispatchFailure} with `UNCERTAIN_OUTCOME`, that kind
+   * is preserved so callers can branch on it. For idempotent (read-only)
+   * subactions, pre-dispatch fallback still applies but post-dispatch replay
+   * remains forbidden by default.
+   *
+   * `targetId` pins the target: no fallback is attempted, and capability is
+   * still checked (an `UNSUPPORTED` pin returns a typed failure rather than
+   * throwing deep inside the target).
    */
   async execute(
     command: BrowserWorkspaceCommand,
     targetId?: string,
   ): Promise<BrowserWorkspaceCommandResult> {
-    const targets = await this.resolveTargets(targetId, command);
-    if (targets.length === 0) {
-      const availableIds = this.targetOrder.join(", ") || "(none)";
-      throw new Error(
-        targetId
-          ? `Browser target "${targetId}" is not available. Registered targets: ${availableIds}.`
-          : `No browser target is available. Registered targets: ${availableIds}.`,
-      );
+    // --- Selection phase (pre-dispatch) -------------------------------------
+    // Find an available target that supports this command. Targets without a
+    // `supports` method are treated as supporting everything (legacy behavior).
+    const candidates = await this.resolveTargets(targetId, command);
+    if (candidates.length === 0) {
+      throw this.unavailableFailure(command, targetId);
     }
 
-    let lastError: unknown = null;
-    for (const target of targets) {
-      try {
-        return await target.execute(command);
-      } catch (err) {
-        lastError = err;
-        if (targetId) break;
-        const message = err instanceof Error ? err.message : String(err);
-        logger.debug(
-          `[BrowserService] target "${target.id}" failed; trying next target: ${message}`,
+    // For an unpinned dispatch, find the highest-scoring target that supports
+    // the command. Unsupported targets are skipped here (pre-dispatch fallback).
+    // For a pinned dispatch, honor the pin but still surface UNSUPPORTED as a
+    // typed failure instead of letting execute() throw opaquely.
+    let selected: BrowserTarget | null = null;
+    if (targetId) {
+      const pinned = candidates[0];
+      if (pinned) {
+        selected = pinned;
+        if (selected.supports && !selected.supports(command)) {
+          throw new BrowserDispatchFailure(
+            "UNSUPPORTED",
+            `Browser target "${selected.id}" does not support subaction "${command.subaction}".`,
+            { targetId: selected.id },
+          );
+        }
+      }
+    } else {
+      for (const candidate of candidates) {
+        if (!candidate.supports || candidate.supports(command)) {
+          selected = candidate;
+          break;
+        }
+      }
+      if (!selected) {
+        // Every available target declined this subaction.
+        throw new BrowserDispatchFailure(
+          "UNSUPPORTED",
+          `No available browser target supports subaction "${command.subaction}". Targets checked: ${candidates
+            .map((t) => `"${t.id}"`)
+            .join(", ")}.`,
         );
       }
     }
 
-    throw lastError instanceof Error
-      ? lastError
-      : new Error("Browser target execution failed.");
+    if (!selected) {
+      throw this.unavailableFailure(command, targetId);
+    }
+
+    // --- Execution phase (post-dispatch) ------------------------------------
+    // The command is now committed to `selected`. NEVER replay it against
+    // another target, even on error — a side effect may have already occurred.
+    try {
+      return await selected.execute(command);
+    } catch (err) {
+      // Preserve a typed dispatch failure's kind so callers can branch on
+      // UNCERTAIN_OUTCOME / STALE_REF / SESSION_GONE / AUTH_REQUIRED /
+      // POLICY_BLOCKED. Wrap any other error as UNCERTAIN_OUTCOME for
+      // side-effecting commands (we can't prove it didn't partially complete),
+      // or rethrow as-is for idempotent reads where no side effect is possible.
+      if (isBrowserDispatchFailure(err)) {
+        throw err;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      const idempotent = isIdempotentBrowserSubaction(command.subaction);
+      logger.debug(
+        `[BrowserService] target "${selected.id}" failed for ${command.subaction} (idempotent=${idempotent}): ${message}`,
+      );
+      if (idempotent) {
+        // Read-only command — no side effect possible. Rethrow the original so
+        // the caller sees the real cause; there's nothing to protect.
+        throw err;
+      }
+      // Side-effecting command failed opaquely. We cannot prove it didn't
+      // partially execute, so classify as UNCERTAIN_OUTCOME and never replay.
+      throw new BrowserDispatchFailure(
+        "UNCERTAIN_OUTCOME",
+        `Browser command "${command.subaction}" against target "${selected.id}" failed after dispatch and may have partially completed: ${message}. It will not be replayed against another target.`,
+        { targetId: selected.id, cause: err },
+      );
+    }
+  }
+
+  /**
+   * Build the typed `UNAVAILABLE` failure with helpful diagnostics.
+   */
+  private unavailableFailure(
+    command: BrowserWorkspaceCommand,
+    targetId?: string,
+  ): BrowserDispatchFailure {
+    const availableIds = this.targetOrder.join(", ") || "(none)";
+    return new BrowserDispatchFailure(
+      "UNAVAILABLE",
+      targetId
+        ? `Browser target "${targetId}" is not available. Registered targets: ${availableIds}.`
+        : `No browser target is available for subaction "${command.subaction}". Registered targets: ${availableIds}.`,
+      { targetId: targetId ?? null },
+    );
   }
 }
 
@@ -338,6 +459,11 @@ async function maybeCreateBridgeTarget(
     kind: "companion",
     priority: 80,
     score: ({ mobile }) => (mobile ? null : 80),
+    // Capability-aware pre-dispatch check (issue #18258): the bridge only
+    // handles a read-mostly subset of subactions. Declaring it here lets the
+    // dispatcher skip the bridge for unsupported commands *before* dispatch
+    // instead of discovering it via a thrown error.
+    supports: (command) => BRIDGE_SUPPORTED_SUBACTIONS.has(command.subaction),
     available: async () => {
       try {
         const companions = await service.listBrowserCompanions();

--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -314,9 +314,11 @@ export class BrowserService extends Service {
    * navigation / upload may have partially or fully completed before the error
    * was observed. The original failure is surfaced to the caller. If the target
    * throws a {@link BrowserDispatchFailure} with `UNCERTAIN_OUTCOME`, that kind
-   * is preserved so callers can branch on it. For idempotent (read-only)
-   * subactions, pre-dispatch fallback still applies but post-dispatch replay
-   * remains forbidden by default.
+   * is preserved so callers can branch on it. Post-dispatch replay is
+   * forbidden for read-only subactions too — targets are distinct browser
+   * sessions, so a fallback read would answer from a different browser.
+   * Idempotency only selects the error shape: reads rethrow the original
+   * cause, opaque mutation failures become `UNCERTAIN_OUTCOME`.
    *
    * `targetId` pins the target: no fallback is attempted, and capability is
    * still checked (an `UNSUPPORTED` pin returns a typed failure rather than

--- a/plugins/plugin-browser/src/dispatch-types.ts
+++ b/plugins/plugin-browser/src/dispatch-types.ts
@@ -1,0 +1,147 @@
+/**
+ * Capability-aware dispatch contract for BrowserService (issue #18258).
+ *
+ * BrowserService historically resolved a target by probing each candidate's
+ * `available()` and then *retried* `execute()` across every candidate on any
+ * thrown error. That retry-on-any-error behavior is unsafe for commands that
+ * may have caused a side effect before the error was observed — a click,
+ * submit, navigation, or upload can partially or fully complete, and replaying
+ * it against a different target duplicates the effect with no way to undo it.
+ *
+ * This module makes dispatch capability-aware and side-effect safe:
+ *
+ * 1. **Typed failures** ({@link BrowserDispatchFailureKind}) replace opaque
+ *    thrown errors so the dispatcher can decide whether fallback is legal.
+ * 2. **Capability manifests** ({@link BrowserTargetCapabilities}) let a target
+ *    declare which subactions it supports *before* dispatch, so unsupported
+ *    commands never reach `execute()`.
+ * 3. **Idempotency classification** ({@link isIdempotentBrowserSubaction})
+ *    separates safe-to-retry read-only commands from side-effecting commands
+ *    that must never be replayed once execution begins.
+ */
+
+import type {
+  BrowserWorkspaceCommand,
+  BrowserWorkspaceSubaction,
+} from "./workspace/browser-workspace-types.js";
+
+/**
+ * The canonical typed failure kinds for a browser dispatch attempt.
+ *
+ * - `UNAVAILABLE` — no target was available to receive the command.
+ * - `UNSUPPORTED` — the selected target does not support this subaction.
+ * - `STALE_REF` — a snapshot element/tab reference is stale; re-snapshot and retry on the same session.
+ * - `SESSION_GONE` — the browser session backing the target has ended.
+ * - `AUTH_REQUIRED` — the command reached a page requiring authentication / manual handoff.
+ * - `POLICY_BLOCKED` — a bridge/security policy declined the command.
+ * - `UNCERTAIN_OUTCOME` — the command may have partially or fully completed before an error was observed; it must NOT be replayed.
+ */
+export const BROWSER_DISPATCH_FAILURE_KINDS = [
+  "UNAVAILABLE",
+  "UNSUPPORTED",
+  "STALE_REF",
+  "SESSION_GONE",
+  "AUTH_REQUIRED",
+  "POLICY_BLOCKED",
+  "UNCERTAIN_OUTCOME",
+] as const;
+
+export type BrowserDispatchFailureKind =
+  (typeof BROWSER_DISPATCH_FAILURE_KINDS)[number];
+
+/**
+ * A typed dispatch failure. Failures whose kind is `UNSUPPORTED` or
+ * `UNAVAILABLE` are **pre-dispatch** — the command never began execution, so
+ * fallback to another target is permitted. All other kinds are
+ * **post-dispatch** and must never be replayed against another target (the
+ * command may have caused a side effect).
+ */
+export class BrowserDispatchFailure extends Error {
+  override readonly name = "BrowserDispatchFailure";
+  readonly kind: BrowserDispatchFailureKind;
+  /** The target id that produced (or would have received) the command. */
+  readonly targetId: string | null;
+  /** Whether fallback to another target is safe for this failure kind. */
+  readonly fallbackSafe: boolean;
+
+  constructor(
+    kind: BrowserDispatchFailureKind,
+    message: string,
+    options?: { targetId?: string | null; cause?: unknown },
+  ) {
+    super(
+      message,
+      options?.cause !== undefined ? { cause: options.cause } : undefined,
+    );
+    this.kind = kind;
+    this.targetId = options?.targetId ?? null;
+    this.fallbackSafe = kind === "UNSUPPORTED" || kind === "UNAVAILABLE";
+    Object.setPrototypeOf(this, BrowserDispatchFailure.prototype);
+  }
+}
+
+export function isBrowserDispatchFailure(
+  value: unknown,
+): value is BrowserDispatchFailure {
+  return value instanceof BrowserDispatchFailure;
+}
+
+/**
+ * Read-only subactions that are safe to retry across targets because they have
+ * no side effect on the page or session. Anything not in this set is treated as
+ * potentially side-effecting (click, type, navigate, open, submit, upload,
+ * etc.) and is never replayed after execution has begun.
+ */
+const IDEMPOTENT_SUBACTIONS: ReadonlySet<BrowserWorkspaceSubaction> = new Set([
+  "list",
+  "state",
+  "get",
+  "snapshot",
+  "screenshot",
+  "inspect",
+  "console",
+  "errors",
+  "network",
+  "diff",
+]);
+
+/**
+ * Returns `true` when a subaction is read-only and therefore safe to retry on a
+ * different target. Side-effecting commands (click, type, fill, navigate, open,
+ * close, submit, upload, drag, scroll, press, set, cookies, storage, etc.)
+ * return `false` — once `execute()` has been called on any target the command
+ * must not be dispatched to another.
+ */
+export function isIdempotentBrowserSubaction(
+  subaction: BrowserWorkspaceSubaction,
+): boolean {
+  return IDEMPOTENT_SUBACTIONS.has(subaction);
+}
+
+/**
+ * Capability manifest for a {@link CapabilityAwareBrowserTarget}. A target
+ * returns this from {@link CapabilityAwareBrowserTarget.capabilities} to declare
+ * which subactions it can execute *before* dispatch. The dispatcher uses it to
+ * skip targets that cannot handle the command, returning `UNSUPPORTED` instead
+ * of throwing.
+ *
+ * `subactions` is optional for backward compatibility — a target that does not
+ * declare a manifest is assumed to support everything (legacy behavior).
+ */
+export interface BrowserTargetCapabilities {
+  /**
+   * Set of supported subaction strings. When omitted, the target claims support
+   * for all subactions (legacy `workspace`-style target).
+   */
+  subactions?: ReadonlySet<string>;
+}
+
+/**
+ * A target id (opaque session/profile/tab identity) plus the kind of action a
+ * command represents, so a capability check can be done generically.
+ */
+export function classifySubactionSideEffects(
+  command: BrowserWorkspaceCommand,
+): "read" | "mutate" {
+  return isIdempotentBrowserSubaction(command.subaction) ? "read" : "mutate";
+}

--- a/plugins/plugin-browser/src/dispatch-types.ts
+++ b/plugins/plugin-browser/src/dispatch-types.ts
@@ -12,18 +12,22 @@
  *
  * 1. **Typed failures** ({@link BrowserDispatchFailureKind}) replace opaque
  *    thrown errors so the dispatcher can decide whether fallback is legal.
- * 2. **Capability manifests** ({@link BrowserTargetCapabilities}) let a target
- *    declare which subactions it supports *before* dispatch, so unsupported
- *    commands never reach `execute()`.
- * 3. **Idempotency classification** ({@link isIdempotentBrowserSubaction})
- *    separates safe-to-retry read-only commands from side-effecting commands
- *    that must never be replayed once execution begins.
+ * 2. **Idempotency classification** ({@link isIdempotentBrowserSubaction})
+ *    separates read-only commands from side-effecting commands so a
+ *    post-dispatch failure can be typed accurately.
+ *
+ * Replay is forbidden for ALL subactions once execution begins — even
+ * read-only ones. Registered targets are distinct browser sessions (the
+ * embedded workspace vs. the user's real Chrome/Safari via the bridge), so
+ * retrying a failed read against a different target would silently answer
+ * from a different browser. The classification only controls error shape: a
+ * failed read rethrows its original cause, while an opaquely failed mutation
+ * is wrapped as `UNCERTAIN_OUTCOME`. The availability tradeoff is deliberate —
+ * a transient read failure surfaces to the caller instead of being masked by
+ * a cross-session fallback.
  */
 
-import type {
-  BrowserWorkspaceCommand,
-  BrowserWorkspaceSubaction,
-} from "./workspace/browser-workspace-types.js";
+import type { BrowserWorkspaceSubaction } from "./workspace/browser-workspace-types.js";
 
 /**
  * The canonical typed failure kinds for a browser dispatch attempt.
@@ -87,10 +91,11 @@ export function isBrowserDispatchFailure(
 }
 
 /**
- * Read-only subactions that are safe to retry across targets because they have
- * no side effect on the page or session. Anything not in this set is treated as
- * potentially side-effecting (click, type, navigate, open, submit, upload,
- * etc.) and is never replayed after execution has begun.
+ * Read-only subactions with no side effect on the page or session. Anything
+ * not in this set is treated as potentially side-effecting (click, type,
+ * navigate, open, submit, upload, etc.). Membership does not permit replay —
+ * no subaction is replayed post-dispatch — it only determines how a
+ * post-dispatch failure is typed.
  */
 const IDEMPOTENT_SUBACTIONS: ReadonlySet<BrowserWorkspaceSubaction> = new Set([
   "list",
@@ -106,42 +111,14 @@ const IDEMPOTENT_SUBACTIONS: ReadonlySet<BrowserWorkspaceSubaction> = new Set([
 ]);
 
 /**
- * Returns `true` when a subaction is read-only and therefore safe to retry on a
- * different target. Side-effecting commands (click, type, fill, navigate, open,
- * close, submit, upload, drag, scroll, press, set, cookies, storage, etc.)
- * return `false` — once `execute()` has been called on any target the command
- * must not be dispatched to another.
+ * Returns `true` when a subaction is read-only. The dispatcher uses this after
+ * a post-dispatch failure to pick the error shape: read-only failures rethrow
+ * the original cause, while opaque side-effecting failures (click, type, fill,
+ * navigate, open, close, submit, upload, etc.) become `UNCERTAIN_OUTCOME`.
+ * In neither case is the command replayed against another target.
  */
 export function isIdempotentBrowserSubaction(
   subaction: BrowserWorkspaceSubaction,
 ): boolean {
   return IDEMPOTENT_SUBACTIONS.has(subaction);
-}
-
-/**
- * Capability manifest for a {@link CapabilityAwareBrowserTarget}. A target
- * returns this from {@link CapabilityAwareBrowserTarget.capabilities} to declare
- * which subactions it can execute *before* dispatch. The dispatcher uses it to
- * skip targets that cannot handle the command, returning `UNSUPPORTED` instead
- * of throwing.
- *
- * `subactions` is optional for backward compatibility — a target that does not
- * declare a manifest is assumed to support everything (legacy behavior).
- */
-export interface BrowserTargetCapabilities {
-  /**
-   * Set of supported subaction strings. When omitted, the target claims support
-   * for all subactions (legacy `workspace`-style target).
-   */
-  subactions?: ReadonlySet<string>;
-}
-
-/**
- * A target id (opaque session/profile/tab identity) plus the kind of action a
- * command represents, so a capability check can be done generically.
- */
-export function classifySubactionSideEffects(
-  command: BrowserWorkspaceCommand,
-): "read" | "mutate" {
-  return isIdempotentBrowserSubaction(command.subaction) ? "read" : "mutate";
 }

--- a/plugins/plugin-browser/src/index.ts
+++ b/plugins/plugin-browser/src/index.ts
@@ -42,6 +42,13 @@ export {
 } from "./browser-service.js";
 export * from "./companion-auth.js";
 export * from "./contracts.js";
+export {
+  BROWSER_DISPATCH_FAILURE_KINDS,
+  BrowserDispatchFailure,
+  type BrowserDispatchFailureKind,
+  isBrowserDispatchFailure,
+  isIdempotentBrowserSubaction,
+} from "./dispatch-types.js";
 export { BrowserBridgeAdapter } from "./message-adapter.js";
 export * from "./packaging.js";
 export * from "./parity/index.js";

--- a/plugins/plugin-browser/src/targets/bridge-target.ts
+++ b/plugins/plugin-browser/src/targets/bridge-target.ts
@@ -34,28 +34,62 @@ import type {
   BrowserWorkspaceTab,
 } from "../workspace/browser-workspace-types.js";
 
-const SUPPORTED_SUBACTIONS = new Set<BrowserWorkspaceCommand["subaction"]>([
+/**
+ * Subactions the bridge can execute directly without a LifeOps session.
+ * These are read-mostly operations that map cleanly to the companion's
+ * tab/page-context API.
+ */
+const BRIDGE_DIRECT_SUBACTIONS = new Set<BrowserWorkspaceCommand["subaction"]>([
   "list",
   "state",
+  "get",
+  "tab",
+]);
+
+/**
+ * Subactions that require a LifeOps browser session to record and gate
+ * account-affecting operations behind owner confirmation. The bridge's session
+ * APIs are not called from the generic BROWSER target, so these are advertised
+ * as unsupported in the pre-dispatch capability manifest — the dispatcher will
+ * skip the bridge and select a genuinely capable target instead of selecting
+ * the bridge and hitting a known rejection.
+ *
+ * (issue #18258 review: previously these were in SUPPORTED_SUBACTIONS, causing
+ * the bridge to be selected as "capable" and then unconditionally rejecting
+ * at execute time, mislabeling side-effecting commands as UNCERTAIN_OUTCOME.)
+ */
+const SESSION_GATED_SUBACTIONS = new Set<BrowserWorkspaceCommand["subaction"]>([
   "open",
   "navigate",
   "close",
   "show",
   "hide",
-  "tab",
-  "get",
   "back",
   "forward",
   "reload",
 ]);
 
 /**
+ * All subactions the bridge recognizes (direct + session-gated). The executor
+ * switch still handles the session-gated case to give a clear, actionable error
+ * when a caller pins target=bridge explicitly.
+ */
+const ALL_RECOGNIZED_SUBACTIONS = new Set([
+  ...BRIDGE_DIRECT_SUBACTIONS,
+  ...SESSION_GATED_SUBACTIONS,
+]);
+
+/**
  * Capability manifest for the bridge target. Exported so the BrowserService
  * bridge-target factory can wire a `supports()` pre-dispatch check from the
  * same single source of truth (issue #18258).
+ *
+ * Only includes subactions the bridge can execute directly — session-gated
+ * operations are excluded so the pre-dispatch capability check skips the
+ * bridge for them.
  */
 export const BRIDGE_SUPPORTED_SUBACTIONS: ReadonlySet<string> =
-  SUPPORTED_SUBACTIONS;
+  BRIDGE_DIRECT_SUBACTIONS;
 
 function bridgeTabToWorkspaceTab(
   tab: BrowserBridgeTabSummary,
@@ -85,7 +119,7 @@ export async function dispatchBridgeCommand(
   service: BrowserBridgeRouteService,
   command: BrowserWorkspaceCommand,
 ): Promise<BrowserWorkspaceCommandResult> {
-  if (!SUPPORTED_SUBACTIONS.has(command.subaction)) {
+  if (!ALL_RECOGNIZED_SUBACTIONS.has(command.subaction)) {
     throw unsupported(command.subaction);
   }
   switch (command.subaction) {

--- a/plugins/plugin-browser/src/targets/bridge-target.ts
+++ b/plugins/plugin-browser/src/targets/bridge-target.ts
@@ -49,6 +49,14 @@ const SUPPORTED_SUBACTIONS = new Set<BrowserWorkspaceCommand["subaction"]>([
   "reload",
 ]);
 
+/**
+ * Capability manifest for the bridge target. Exported so the BrowserService
+ * bridge-target factory can wire a `supports()` pre-dispatch check from the
+ * same single source of truth (issue #18258).
+ */
+export const BRIDGE_SUPPORTED_SUBACTIONS: ReadonlySet<string> =
+  SUPPORTED_SUBACTIONS;
+
 function bridgeTabToWorkspaceTab(
   tab: BrowserBridgeTabSummary,
 ): BrowserWorkspaceTab {


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- AI provider/model: zai/glm-5.2; anthropic/claude-fable-5 (review fixes)
<!-- attribution-row:client -->
- Client / agent tooling: Hermes Agent; Claude Code (review fixes)
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@ecfefdff6522d2c7a6443f0d9edc7aab2fce9d2f:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:lane -->
- Lane: hermes-t3rpz
<!-- attribution-row:status -->
- Attribution status: self-reported

## Summary

BrowserService dispatch was exception-driven with retry-on-any-error, meaning a side-effecting command (click, type, navigate) could be replayed against another target after partially executing on the first. This is unsafe.

## Fix

Two-phase dispatch:
1. **Selection phase** — checks capability (supports()) and availability before execution. Pre-dispatch fallback allowed for UNSUPPORTED/UNAVAILABLE.
2. **Execution phase** — committed to the selected target. NEVER replays the command on another target — for any subaction, including read-only ones. Registered targets are distinct browser sessions (embedded workspace vs. the user's real Chrome/Safari via the bridge), so a fallback read would silently answer from a different browser. Idempotency classification only selects the error shape: a failed read rethrows its original cause; an opaque failure of a side-effecting command is wrapped as UNCERTAIN_OUTCOME. The availability tradeoff (a transient read failure surfaces instead of being masked by cross-session fallback) is documented in the dispatch-types file header.

New typed failure kinds: UNSUPPORTED, UNAVAILABLE, STALE_REF, SESSION_GONE, AUTH_REQUIRED, POLICY_BLOCKED, UNCERTAIN_OUTCOME.

Review follow-up (dfcffefc887): removed the dead exports `BrowserTargetCapabilities` and `classifySubactionSideEffects` (never imported anywhere; their JSDoc @link'd a nonexistent `CapabilityAwareBrowserTarget` type) and aligned the dispatch-types/browser-service docstrings to the actual no-replay-post-dispatch contract described above.

## Files changed
- plugins/plugin-browser/src/dispatch-types.ts — typed failure kinds, idempotency classification, no-replay contract docs; dead capability-manifest exports removed
- plugins/plugin-browser/src/browser-service.ts — two-phase dispatch + null-safety fix
- plugins/plugin-browser/src/targets/bridge-target.ts — supports() capability declaration
- plugins/plugin-browser/src/index.ts — export dispatch types
- plugins/plugin-browser/src/__tests__/browser-service.test.ts — dispatch tests

## Verification

- `bun run --cwd plugins/plugin-browser typecheck` PASS
- `bun run --cwd plugins/plugin-browser lint` (Biome) PASS — no fixes applied
- `vitest run` full plugin-browser suite: 26 files, 170 tests passed

---

AI provider/model: zai / glm-5.2
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@ecfefdff6522:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2","client":"Hermes Agent","skill_revision":"elizaOS/eliza@ecfefdff6522:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:dfcffefc8872a60f7ea463b9f18a55e1117abeba -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - backend browser plugin dispatch change with no rendered UI surface`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - backend browser plugin dispatch change with no rendered UI surface`.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - backend browser plugin dispatch change with no user-visible flow to record`.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - library-level dispatch contract change verified by the plugin test suite rather than a running server`. Verification: typecheck PASS, Biome lint PASS, full plugin-browser vitest suite 26 files / 170 tests PASS.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - backend browser plugin dispatch change with no frontend interaction`.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - typed dispatch and capability fix with no model, prompt, or trajectory change`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no database rows, media, or generated files are produced by this change`. The shipped contract is covered by regression tests: bridge manifest contents, session-gated skip, safe pre-dispatch decline (UNSUPPORTED), uncertain post-dispatch failure (UNCERTAIN_OUTCOME), non-dispatch error fallback.