### PR TITLE
fix(scripts): guard the stale-archive sweep's temp-dir enumeration (#18413)

### DIFF
--- a/packages/scripts/__tests__/sync-artifacts-sweep-guard.test.ts
+++ b/packages/scripts/__tests__/sync-artifacts-sweep-guard.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression guard for the pre-early-exit stale-archive sweep in
+ * sync-artifacts.mjs: the temp-directory enumeration is best-effort
+ * (error-policy:J6), so an unreadable temp dir must never fail the
+ * skip path. Harness is real — the script runs as a subprocess with a
+ * broken TMPDIR; no mocks.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = join(import.meta.dirname, "..", "sync-artifacts.mjs");
+
+function runWithTmpdir(tmp: string) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ELIZA_SKIP_ARTIFACT_SYNC: "1",
+      TMPDIR: tmp,
+    },
+  });
+}
+
+describe("sync-artifacts stale-archive sweep", () => {
+  test("skip path exits 0 when the temp directory cannot be enumerated", () => {
+    const result = runWithTmpdir(
+      join(tmpdir(), `eliza-sweep-guard-missing-${process.pid}`, "nope"),
+    );
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain(
+      "could not enumerate temp dir for stale archives",
+    );
+    expect(result.stdout).toContain("skipped (ELIZA_SKIP_ARTIFACT_SYNC=1)");
+  });
+
+  test("skip path still exits 0 with a healthy temp directory", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "eliza-sweep-guard-ok-"));
+    try {
+      const result = runWithTmpdir(tmp);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("skipped (ELIZA_SKIP_ARTIFACT_SYNC=1)");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/scripts/sync-artifacts.mjs
+++ b/packages/scripts/sync-artifacts.mjs
@@ -113,7 +113,17 @@ function progressStatus(received, total, startedAt) {
 function cleanupStaleTempArchives() {
   const now = Date.now();
   let removed = 0;
-  for (const entry of readdirSync(tmpdir())) {
+  let entries;
+  try {
+    entries = readdirSync(tmpdir());
+  } catch (err) {
+    // error-policy:J6 best-effort temp cleanup; the sweep runs before every
+    // early exit, so an unreadable temp directory (missing TMPDIR, permission
+    // loss) must degrade to a warning — never fail the skip/no-op paths.
+    warn(`could not enumerate temp dir for stale archives: ${err.message}`);
+    return;
+  }
+  for (const entry of entries) {
     if (!/^eliza-artifacts-\d+\.tar\.gz$/.test(entry)) continue;
     const file = join(tmpdir(), entry);
     let stat;


### PR DESCRIPTION
Repairs the **#18363 seam** recorded in #18413.

## Defect
`cleanupStaleTempArchives()` runs before every early exit by design, but its `readdirSync(tmpdir())` enumeration was uncaught — per-file `statSync`/`rmSync` had `error-policy:J6` catches, the enumeration didn't. A missing/unreadable temp directory (`TMPDIR` pointing at a nonexistent path) failed the script with exit 1 **even under `ELIZA_SKIP_ARTIFACT_SYNC=1`**, exactly as recorded in the incident card.

## Fix
Translate enumeration failure to a `warn` + skip the sweep (`error-policy:J6` — the sweep is best-effort and must never fail the skip/no-op paths). Sweep-before-early-exit behavior is preserved.

## Proof
- New real-subprocess regression test (`sync-artifacts-sweep-guard.test.ts`, no mocks): broken `TMPDIR` + `SKIP=1` → **exit 0** with the warning on stderr and the skip log on stdout; healthy `TMPDIR` control case.
- **Verified failing pre-fix**: with the source change stashed, the regression case fails (`exit 1`); with it, 2/2 pass.
- Biome: no new diagnostics (2 pre-existing `noUndeclaredEnvVars` warnings on the script's env reads, untouched).

- Before screenshots `N/A - build tooling, no UI surface`.
- After screenshots `N/A - build tooling, no UI surface`.
- Walkthrough video `N/A - no UI surface`.
- Backend logs: test output above; subprocess harness captures both stdio streams.
- Frontend logs `N/A - no frontend change`.
- Real-LLM trajectory `N/A - no model path involved`.
- Domain artifacts: exit-0 skip path with broken TMPDIR pinned by the committed test.
- OCR review `N/A - no rendered visual surface`.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"Claude Code","skill_revision":"N/A - no contribution skill used"} -->