### PR TITLE
fix(security): extend the GHSA-54rx spawn env denylist

### DIFF
--- a/packages/core/src/security/spawn-env-policy.test.ts
+++ b/packages/core/src/security/spawn-env-policy.test.ts
@@ -37,6 +37,53 @@ describe("isBlockedSpawnEnvKey (loader/interpreter hijack keys)", () => {
 	});
 });
 
+describe("isBlockedSpawnEnvKey (shell startup hooks)", () => {
+	// A non-interactive bash executes the file named by BASH_ENV before the
+	// requested command, and this router spawns `sh`/`bash` with `-c`. SHELLOPTS
+	// + PS4 is the second execution primitive: xtrace command-substitutes PS4 on
+	// every traced line.
+	it.each(["BASH_ENV", "bash_env", "SHELLOPTS", "PS4", "GLOBIGNORE", "IFS"])(
+		"blocks %s",
+		(key) => {
+			expect(isBlockedSpawnEnvKey(key)).toBe(true);
+		},
+	);
+
+	// ENV is deliberately NOT blocked: it is a plausible generic application
+	// variable, `sh` is not an allowed MCP command, and a rejected MCP env is a
+	// fatal startup error rather than a silent drop.
+	it("leaves the generic ENV variable alone", () => {
+		expect(isBlockedSpawnEnvKey("ENV")).toBe(false);
+	});
+});
+
+describe("isBlockedSpawnEnvKey (runtime/loader hijacks on sudo's env_delete list)", () => {
+	it.each([
+		"JAVA_TOOL_OPTIONS",
+		"_JAVA_OPTIONS",
+		"CLASSPATH",
+		"GCONV_PATH",
+		"NLSPATH",
+		"HOSTALIASES",
+		"RES_OPTIONS",
+		"LOCALDOMAIN",
+		"PYTHONINSPECT",
+		"PYTHONUSERBASE",
+		"PYTHONWARNINGS",
+		"PERLIO_DEBUG",
+		"GEM_HOME",
+		"GEM_PATH",
+		"RUBYSHELL",
+		"TERMINFO",
+		"TERMINFO_DIRS",
+		"TERMCAP",
+		"GIT_SSH_COMMAND",
+		"GIT_EXTERNAL_DIFF",
+	])("blocks %s", (key) => {
+		expect(isBlockedSpawnEnvKey(key)).toBe(true);
+	});
+});
+
 describe("sanitizeSpawnEnv", () => {
 	it("drops LD_AUDIT / PYTHONPATH but keeps benign keys", () => {
 		const out = sanitizeSpawnEnv({
@@ -47,5 +94,27 @@ describe("sanitizeSpawnEnv", () => {
 			LANG: "en_US.UTF-8",
 		});
 		expect(out).toEqual({ MY_APP_SETTING: "ok", LANG: "en_US.UTF-8" });
+	});
+
+	it("drops shell-startup and runtime hijack keys from a spawn env", () => {
+		const out = sanitizeSpawnEnv({
+			BASH_ENV: "/tmp/evil.sh",
+			SHELLOPTS: "xtrace",
+			PS4: "$(/tmp/evil)",
+			IFS: ",",
+			JAVA_TOOL_OPTIONS: "-javaagent:/tmp/evil.jar",
+			GCONV_PATH: "/tmp/evil-gconv",
+			GIT_SSH_COMMAND: "/tmp/evil.sh",
+			MY_APP_SETTING: "ok",
+			LANG: "en_US.UTF-8",
+		});
+		expect(out).toEqual({ MY_APP_SETTING: "ok", LANG: "en_US.UTF-8" });
+	});
+
+	it("still allows ordinary application keys that only look shell-adjacent", () => {
+		expect(isBlockedSpawnEnvKey("ENVIRONMENT")).toBe(false);
+		expect(isBlockedSpawnEnvKey("NODE_ENV")).toBe(false);
+		expect(isBlockedSpawnEnvKey("TERM")).toBe(false);
+		expect(isBlockedSpawnEnvKey("GIT_AUTHOR_NAME")).toBe(false);
 	});
 });

--- a/packages/core/src/security/spawn-env-policy.test.ts
+++ b/packages/core/src/security/spawn-env-policy.test.ts
@@ -84,6 +84,32 @@ describe("isBlockedSpawnEnvKey (runtime/loader hijacks on sudo's env_delete list
 	});
 });
 
+describe("isBlockedSpawnEnvKey (git config injection)", () => {
+	it.each([
+		"GIT_CONFIG_COUNT",
+		"GIT_CONFIG_GLOBAL",
+		"GIT_CONFIG_SYSTEM",
+		"git_config_global",
+		"GIT_CONFIG_KEY_0",
+		"GIT_CONFIG_VALUE_0",
+		"GIT_CONFIG_KEY_17",
+		"GIT_CONFIG_VALUE_17",
+	])("blocks %s", (key) => {
+		expect(isBlockedSpawnEnvKey(key)).toBe(true);
+	});
+
+	it("leaves benign git keys and prefix lookalikes alone", () => {
+		expect(isBlockedSpawnEnvKey("GIT_AUTHOR_NAME")).toBe(false);
+		expect(isBlockedSpawnEnvKey("GIT_COMMITTER_NAME")).toBe(false);
+		expect(isBlockedSpawnEnvKey("GIT_TERMINAL_PROMPT")).toBe(false);
+		// Shares ten characters with the prefix; the trailing underscore is what
+		// makes GIT_CONFIG_ a namespace, so this must not match.
+		expect(isBlockedSpawnEnvKey("GIT_CONFIGURATION")).toBe(false);
+		// Bare GIT_CONFIG does not resolve aliases, so it is not listed.
+		expect(isBlockedSpawnEnvKey("GIT_CONFIG")).toBe(false);
+	});
+});
+
 describe("sanitizeSpawnEnv", () => {
 	it("drops LD_AUDIT / PYTHONPATH but keeps benign keys", () => {
 		const out = sanitizeSpawnEnv({
@@ -109,6 +135,19 @@ describe("sanitizeSpawnEnv", () => {
 			LANG: "en_US.UTF-8",
 		});
 		expect(out).toEqual({ MY_APP_SETTING: "ok", LANG: "en_US.UTF-8" });
+	});
+
+	it("drops the git config injection family but keeps benign git keys", () => {
+		const out = sanitizeSpawnEnv({
+			GIT_CONFIG_COUNT: "1",
+			GIT_CONFIG_KEY_0: "core.sshCommand",
+			GIT_CONFIG_VALUE_0: "sh -c 'id>/tmp/pwned'",
+			GIT_CONFIG_GLOBAL: "/tmp/evil.gitconfig",
+			GIT_CONFIG_SYSTEM: "/tmp/evil.gitconfig",
+			GIT_AUTHOR_NAME: "ok",
+			LANG: "en_US.UTF-8",
+		});
+		expect(out).toEqual({ GIT_AUTHOR_NAME: "ok", LANG: "en_US.UTF-8" });
 	});
 
 	it("still allows ordinary application keys that only look shell-adjacent", () => {

--- a/packages/core/src/security/spawn-env-policy.ts
+++ b/packages/core/src/security/spawn-env-policy.ts
@@ -88,6 +88,19 @@ export const BLOCKED_SPAWN_ENV_KEYS: ReadonlySet<string> = new Set([
 	// arbitrary execution.
 	"GIT_SSH_COMMAND",
 	"GIT_EXTERNAL_DIFF",
+	// The GIT_CONFIG_* family reaches the same primitives indirectly: it injects
+	// configuration, and configuration carries commands — alias.*, core.pager,
+	// core.sshCommand, diff.external, credential.helper, core.fsmonitor,
+	// uploadpack.packObjectsHook. GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM each
+	// point git at an attacker-written config file; GIT_CONFIG_COUNT enables the
+	// indexed GIT_CONFIG_KEY_<n> / GIT_CONFIG_VALUE_<n> pairs handled by prefix
+	// below. Without these, the two entries above are reproducible through
+	// core.sshCommand and diff.external, so blocking only those raises the bar by
+	// roughly nothing. Bare GIT_CONFIG is deliberately not listed: it does not
+	// resolve aliases and is not an execution primitive (verified, git 2.50.1).
+	"GIT_CONFIG_COUNT",
+	"GIT_CONFIG_GLOBAL",
+	"GIT_CONFIG_SYSTEM",
 ]);
 
 export const BLOCKED_SPAWN_ENV_PREFIXES = [
@@ -103,6 +116,10 @@ export const BLOCKED_SPAWN_ENV_PREFIXES = [
 	"DOCKER_",
 	"PODMAN_",
 	"BASH_FUNC_",
+	// Indexed git config injection; <n> is unbounded so these cannot be enumerated
+	// as exact keys.
+	"GIT_CONFIG_KEY_",
+	"GIT_CONFIG_VALUE_",
 ] as const;
 
 export function isBlockedSpawnEnvKey(key: string): boolean {

--- a/packages/core/src/security/spawn-env-policy.ts
+++ b/packages/core/src/security/spawn-env-policy.ts
@@ -41,6 +41,53 @@ export const BLOCKED_SPAWN_ENV_KEYS: ReadonlySet<string> = new Set([
 	"PATH",
 	"HOME",
 	"SHELL",
+	// Shell startup hooks, for the exported sanitizeSpawnEnv/runShell surface and
+	// for any allowed command that itself spawns a shell. A non-interactive bash
+	// reads BASH_ENV, expands it, and EXECUTES that file before the requested
+	// command — the same arbitrary-code primitive BASH_FUNC_ below defends
+	// against. SHELLOPTS=xtrace plus a command-substituting PS4 is a second
+	// execution primitive, and GLOBIGNORE and IFS rewrite expansion and field
+	// splitting under the command.
+	"BASH_ENV",
+	"SHELLOPTS",
+	"PS4",
+	"GLOBIGNORE",
+	"IFS",
+	// JVM option/agent injection: both are read before main() and accept
+	// `-javaagent`, the Java equivalent of LD_PRELOAD. CLASSPATH is the Java
+	// module-path hijack that mirrors the blocked PYTHONPATH/RUBYLIB above.
+	"JAVA_TOOL_OPTIONS",
+	"_JAVA_OPTIONS",
+	"CLASSPATH",
+	// glibc loader/resolver hooks, all on sudo's env_delete list. GCONV_PATH loads
+	// an attacker-supplied charset conversion module; the resolver vars redirect
+	// name resolution for the spawned process.
+	"GCONV_PATH",
+	"NLSPATH",
+	"HOSTALIASES",
+	"RES_OPTIONS",
+	"LOCALDOMAIN",
+	// Remaining interpreter hijacks whose siblings are already blocked above.
+	// The Python three matter most directly: `python`/`python3` are on the MCP
+	// validator's ALLOWED_MCP_COMMANDS, so a config that names them is spawned
+	// with whatever env survives this list.
+	"PYTHONINSPECT",
+	"PYTHONUSERBASE",
+	"PYTHONWARNINGS",
+	"PERLIO_DEBUG",
+	"GEM_HOME",
+	"GEM_PATH",
+	"RUBYSHELL",
+	// terminfo/termcap descriptions are compiled data the terminal library loads
+	// from an attacker-chosen directory.
+	"TERMINFO",
+	"TERMINFO_DIRS",
+	"TERMCAP",
+	// git runs these as commands: GIT_SSH_COMMAND on every transport operation and
+	// GIT_EXTERNAL_DIFF on every diff, so either turns a routine git call into
+	// arbitrary execution.
+	"GIT_SSH_COMMAND",
+	"GIT_EXTERNAL_DIFF",
 ]);
 
 export const BLOCKED_SPAWN_ENV_PREFIXES = [


### PR DESCRIPTION
# Relates to

Closes #18416

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused suites, typecheck, and Biome recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused suites pass post-sync; see **Testing** below.

# Risks

Low and additive. `BLOCKED_SPAWN_ENV_KEYS` gains entries; none is removed, no control flow changes, and `isBlockedSpawnEnvKey` / `sanitizeSpawnEnv` are untouched. The only behavioral change is that a child process no longer inherits these keys from a caller-supplied env.

One compatibility note worth flagging: `validateServerConfigs` throws with `severity: "fatal"`, so an existing MCP config that sets a newly blocked key will fail agent startup rather than degrade quietly. Each entry was judged against that cost, and the tests assert `NODE_ENV`, `ENVIRONMENT`, `TERM`, `GIT_AUTHOR_NAME`, and `ENV` still pass so ordinary configuration cannot trip it. No fixture, example, or character file in the repo sets any newly blocked key.

# Background

## What does this PR do?

Extends the GHSA-54rx spawn env denylist, which `sanitizeSpawnEnv` (shell/spawn) and `rejectMcpEnvEntry` (user-supplied MCP server config) both read. `@elizaos/plugin-mcp` re-validates on the spawn path itself, where the child's environment is exactly the validated config env plus `PATH` — so this list is the sole gate on what a spawned MCP server receives, which is why omissions from it matter.

**This PR does not claim the list is exhaustive.** Review found two omissions in it: @tokenmaxxor identified one and routed it through private vulnerability reporting, and @isfinne identified the `GIT_CONFIG_*` family, which is now added here. A denylist of injection primitives is an open set — read this as closing a known class, not as finishing the list.

The load-bearing additions are `PYTHONINSPECT` / `PYTHONUSERBASE` / `PYTHONWARNINGS` — `python` and `python3` are on `ALLOWED_MCP_COMMANDS` while their siblings `PYTHONPATH` / `PYTHONSTARTUP` / `PYTHONHOME` were already blocked — and `GCONV_PATH`, a glibc module-load primitive that applies to every allowed command. The rest fill out the class: shell startup hooks (`BASH_ENV`, `SHELLOPTS`, `PS4`, `GLOBIGNORE`, `IFS`), JVM option/agent injection, glibc resolver variables, the remaining Perl/Ruby siblings, terminfo, the two git variables git runs as commands, and the `GIT_CONFIG_*` family that reaches those same primitives through injected configuration. Most are on sudo's default `env_delete` list, the standard the file's comment already cites; the git entries are not on that list and rest on the executed reproduction instead.

`ENV` is deliberately excluded and a test asserts it stays allowed — see **Known gaps** below.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation. `packages/docs/security.md` documents `BLOCKED_ENV_KEYS` in `packages/agent/src/config/blocked-env-keys.ts`, which is a different set and is not touched here.

# Testing

## Where should a reviewer start?

`packages/core/src/security/spawn-env-policy.ts` — the added entries, grouped by primitive with a comment per group. Then `spawn-env-policy.test.ts`, which asserts each new key is blocked and that ordinary application keys still pass.

## Detailed testing steps

Reverting only the source file and re-running the tests fails 27 of 42, so the assertions are bound to the change rather than passing vacuously:

```
# with the fix
Test Files  1 passed (1)
     Tests  52 passed (52)

# source file reverted, tests kept
Test Files  1 failed (1)
     Tests  36 failed | 16 passed (52)
```

Full `packages/core/src/security` suite, and the downstream consumers of this list:

```
packages/core   src/security/                       30 files, 431 passed
packages/agent  shell-execution-router.test.ts               13 passed
packages/agent  test/api/server-helpers-mcp.test.ts          20 passed
plugin-mcp      __tests__/mcp-config-security.test.ts         5 passed
```

`tsc --noEmit -p packages/core/tsconfig.json`: clean. `biome check` on both changed files: clean. 28 exact keys and 2 prefix families added, all asserted, plus 12 negative controls — including `GIT_CONFIGURATION`, which shares ten characters with the `GIT_CONFIG_` prefix and must not match, and bare `GIT_CONFIG`, which is deliberately not blocked because it does not resolve aliases.

The primitives were reproduced directly rather than assumed — `BASH_ENV=hook.sh bash -c …` runs the hook before the command, `SHELLOPTS=xtrace` with a command-substituting `PS4` executes on a traced line, and `PYTHONUSERBASE` pointed at a scratch directory puts it on `sys.path` and imports a module planted there. The attached log carries all of it.

# Known gaps / failures

- **The `GIT_CONFIG_*` family has legitimate in-tree users, none of which route through this sanitizer.** `plugin-agent-orchestrator` sets `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_<n>` / `GIT_CONFIG_VALUE_<n>` to install a `credential.helper` for spawned coding agents (`credential-proxy-env.ts:227`, `workspace-service.ts:371`); three deploy workflows set `safe.directory` the same way; and `packages/skills` / `packages/elizaos` tests set `GIT_CONFIG_GLOBAL` for isolation. All of those spawn through `execFile` and none imports `sanitizeSpawnEnv`, so nothing breaks today. Two things follow. First, the orchestrator's own usage is in-tree confirmation that this family installs an executable — it is the same primitive, used benignly. Second, anything that later routes those spawns through the sanitizer would silently lose the credential helper, because `sanitizeSpawnEnv` drops keys without erroring. Worth knowing before the sanitizer's reach is widened.

No exploit is claimed, and the limits belong on the record rather than implied:

- `bash`/`sh` are not on `ALLOWED_MCP_COMMANDS`, so `BASH_ENV` reaches an MCP server only through an allowed command that itself spawns a shell.
- No in-tree caller passes attacker-controlled env to `runShell` — `packages/agent/src/api/misc-routes.ts:540` passes a hardcoded `{ FORCE_COLOR: "0" }`. The shell-side entries harden `sanitizeSpawnEnv` / `runShell` as exported API that plugins call with their own env.
- `sanitizeSpawnEnv` filters only the caller-supplied env; the shell router still merges the parent `process.env`, so this stops injection through the sanitizer, not a host already carrying these variables. The MCP path has no such inheritance.
- `ENV` was considered and excluded: I could not get it to fire for a non-interactive `sh` on the test host, `sh` is not an allowed MCP command, and a rejected MCP env is a fatal startup error rather than a silent drop. A test asserts it stays allowed.
- `TERMINFO` / `TERMINFO_DIRS` / `TERMCAP` are the remaining contestable entries — they are on sudo's list and unused anywhere in this repo, but have legitimate uses in terminal-heavy container images. Happy to drop them if you would rather keep the surface minimal.

Out of scope, but worth a separate look: `BLOCKED_ENV_KEYS` in `packages/agent/src/config/blocked-env-keys.ts` (the `PUT /api/env` denylist) has the same structural gaps and no Python variables at all.

# Evidence

<!-- evidence-head:c109c1b2356e4024553102bbb7fb4b07b20f92bf -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; this changes a `packages/core` denylist constant.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; behavior is asserted by the unit tests above.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the observable behavior is a set-membership check; the revert-and-fail run is the demonstration.
<!-- evidence-row:backend-logs -->
- [x] Verification for the current head `c109c1b` is inline below. The attached `.txt` is the original run at `f5eb834` and covers the first 25 keys; its counts predate the `GIT_CONFIG_*` commit.
[evidence-spawn-env-policy.txt](https://github.com/user-attachments/files/30943476/evidence-spawn-env-policy.txt)

<details><summary>Verification at <code>c109c1b</code> (git 2.50.1, vitest 4.1.5)</summary>

```
$ printf '[alias]\n\tpwn = !echo EXECUTED_VIA\n' > evil.gitconfig
GIT_CONFIG_GLOBAL    -> EXECUTED_VIA
GIT_CONFIG_SYSTEM    -> EXECUTED_VIA
GIT_CONFIG           -> git: 'pwn' is not a git command.      (not listed; not a primitive)
GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.pwn2 ...            -> EXECUTED_VIA_INDEXED

$ vitest run packages/core/src/security/spawn-env-policy.test.ts
 Test Files  1 passed (1)
      Tests  52 passed (52)

$ # same tests, spawn-env-policy.ts reverted to unmodified develop
 Test Files  1 failed (1)
      Tests  36 failed | 16 passed (52)

$ vitest run packages/core/src/security/
 Test Files  30 passed (30)
      Tests  431 passed (431)

$ node ../shared/scripts/generate-keywords.mjs && tsc --noEmit -p ./tsconfig.json
TSC_EXIT=0    error lines: 0

$ biome check packages/core/src/security/spawn-env-policy{,.test}.ts
Checked 2 files in 15ms. No fixes applied.
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface is touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, scheduled-task, or generated-file output changed.

---

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported

