### PR TITLE
fix(discord): exempt DMs from the CHANNEL_IDS guild allowlist gate

### DIFF
--- a/plugins/plugin-discord/__tests__/discord-events-dm-dispatch.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-events-dm-dispatch.test.ts
@@ -161,6 +161,80 @@ describe("setupDiscordEventListeners — DM dispatch", () => {
 		expect(debouncerState.channelEnqueue).not.toHaveBeenCalled();
 	});
 
+	it("delivers a DM even when a CHANNEL_IDS allowlist is configured (DM-policy owns DM access, not the guild allowlist)", async () => {
+		// The bug this pins: with CHANNEL_IDS set, the guild-channel allowlist
+		// gate ran before the DM branch and silently dropped every DM (a DM
+		// channel id is never in CHANNEL_IDS). DM access must be governed by
+		// dmPolicy/allowFrom in the message manager, not the guild allowlist.
+		const service = makeService();
+		service.allowedChannelIds = ["guild-chan-1"] as never;
+		service.isChannelAllowed = vi.fn(
+			(id: string) => id === "guild-chan-1",
+		) as never;
+		const { channelDebouncer } = setupDiscordEventListeners(service as never);
+		service.channelDebouncer = channelDebouncer as never;
+
+		service.client.emit(
+			"messageCreate",
+			makeMessage(DiscordChannelType.DM, "dm-outside-allowlist"),
+		);
+		await tick();
+
+		expect(service.messageManager.handleMessage).toHaveBeenCalledTimes(1);
+		expect(debouncerState.channelEnqueue).not.toHaveBeenCalled();
+		// The allowlist gate must not have emitted the not-in-channels event for
+		// the DM either — the message was processed, not rejected.
+		expect(service.runtime.emitEvent).not.toHaveBeenCalledWith(
+			expect.stringContaining("NOT_IN_CHANNELS"),
+			expect.anything(),
+		);
+	});
+
+	it("delivers a group DM even when a CHANNEL_IDS allowlist is configured", async () => {
+		const service = makeService();
+		service.allowedChannelIds = ["guild-chan-1"] as never;
+		service.isChannelAllowed = vi.fn(
+			(id: string) => id === "guild-chan-1",
+		) as never;
+		const { channelDebouncer } = setupDiscordEventListeners(service as never);
+		service.channelDebouncer = channelDebouncer as never;
+
+		service.client.emit(
+			"messageCreate",
+			makeMessage(DiscordChannelType.GroupDM, "gdm-outside-allowlist"),
+		);
+		await tick();
+
+		expect(service.messageManager.handleMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it("still drops guild-channel messages outside the CHANNEL_IDS allowlist", async () => {
+		const service = makeService();
+		service.allowedChannelIds = ["guild-chan-1"] as never;
+		service.isChannelAllowed = vi.fn(
+			(id: string) => id === "guild-chan-1",
+		) as never;
+		// The rejection path fetches the channel to distinguish threads.
+		(service.client as never as { channels: unknown }).channels = {
+			fetch: vi.fn(async () => ({
+				id: "guild-chan-2",
+				isThread: () => false,
+				isTextBased: () => true,
+			})),
+		};
+		const { channelDebouncer } = setupDiscordEventListeners(service as never);
+		service.channelDebouncer = channelDebouncer as never;
+
+		service.client.emit(
+			"messageCreate",
+			makeMessage(DiscordChannelType.GuildText, "guild-chan-2"),
+		);
+		await tick();
+
+		expect(service.messageManager.handleMessage).not.toHaveBeenCalled();
+		expect(debouncerState.channelEnqueue).not.toHaveBeenCalled();
+	});
+
 	it("still routes guild-channel messages through the channel debouncer/enqueue path", async () => {
 		const service = makeService();
 		const { channelDebouncer } = setupDiscordEventListeners(service as never);

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -462,8 +462,19 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 			);
 		}
 
-		// Skip if channel restrictions are set and this channel is not allowed
+		const channelType = message.channel.type as DiscordChannelType;
+		const isDm =
+			channelType === DiscordChannelType.DM ||
+			channelType === DiscordChannelType.GroupDM;
+
+		// Skip if channel restrictions are set and this channel is not allowed.
+		// DMs (and group DMs) are exempt: CHANNEL_IDS scopes which *guild*
+		// surfaces the bot participates in, while DM access is governed by the
+		// DM policy (dmPolicy/allowFrom, enforced in the message manager via
+		// dm-access.ts). Without this exemption any CHANNEL_IDS deployment
+		// silently drops every DM before the DM policy ever runs.
 		if (
+			!isDm &&
 			service.allowedChannelIds &&
 			!service.isChannelAllowed(message.channel.id)
 		) {
@@ -528,11 +539,6 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 			if (!service.messageManager) {
 				return;
 			}
-
-			const channelType = message.channel.type as DiscordChannelType;
-			const isDm =
-				channelType === DiscordChannelType.DM ||
-				channelType === DiscordChannelType.GroupDM;
 
 			if (isDm) {
 				// DMs are 1:1 and gain nothing from channel-style debouncing.


### PR DESCRIPTION
## The bug

Any Discord deployment that sets `CHANNEL_IDS` (guild-channel allowlist) silently loses its **entire DM lane**. The `messageCreate` listener in `plugins/plugin-discord/discord-events.ts` ran the guild allowlist gate before the DM branch; a DM channel id is by definition never in `CHANNEL_IDS`, so every direct message was dropped (with a `NOT_IN_CHANNELS` event) before the DM policy (`dmPolicy`/`allowFrom`, enforced via `dm-access.ts` in the message manager) ever executed.

Found dogfooding the sol-dev cutover stack: character settings had `dmPolicy: "allowlist"` + `allowFrom` + `CHANNEL_IDS` for two guild channels — a completely reasonable "DMs from my owner + these two channels" config — and DMs never reached the agent.

## The fix

`CHANNEL_IDS` scopes which **guild** surfaces the bot participates in. DM access is governed by the DM policy. These are orthogonal policies; the fix keeps them that way:

- hoist the `isDm` (DM / GroupDM) computation above the allowlist gate
- skip the allowlist gate for DM channels — the DM policy remains the sole authority for DM access
- guild-channel behavior unchanged (pinned by test)

## Proof (bidirectional)

Reverted listener (fix stashed): the two new DM tests fail exactly as the bug describes —

```
Tests  2 failed | 8 passed (10)
  ✗ delivers a DM even when a CHANNEL_IDS allowlist is configured
  ✗ delivers a group DM even when a CHANNEL_IDS allowlist is configured
```

With fix: `__tests__/discord-events-dm-dispatch.test.ts` → 10/10 pass. Full plugin-discord suite: **72 files / 577 tests, all green.**

## Production path

`client.on("messageCreate")` listener in `setupDiscordEventListeners` (`discord-events.ts`) — the single ingress for every inbound Discord message on every deployment; the gate at issue is the `service.allowedChannelIds` check that precedes dispatch to `messageManager.handleMessage`.


<!-- evidence-head:8f3c667b6eefb5952f26405ba7ddfb6a552dcb0c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only connector event listener change, no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only connector event listener change, no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only, behavior proven by bidirectional unit tests

<!-- evidence-row:backend-logs -->
- [x] [18419-plugin-discord-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18419-plugin-discord-tests.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involvement in the allowlist gate

<!-- evidence-row:ocr-review -->
- [ ] N/A - no UI screenshots to OCR (backend-only change)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - test suite output attached as backend logs

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-5`
<!-- attribution-row:client -->
- Agent tooling: `moltbot subagent (0xSolace fleet)`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`