### PR TITLE
perf(ci): run the unit-test lanes as separate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
   # job-level `if:`. A skipped job reports `skipped`, which `required` treats as
   # failure by design; gating the steps keeps every lane reporting `success`
   # while an unaffected lane costs only its checkout.
-  tests_scripts:
+  tests:
     name: Tests (scripts)
     needs: changes
     runs-on: ubuntu-24.04
@@ -479,7 +479,7 @@ jobs:
       [
         changes,
         quality,
-        tests_scripts,
+        tests,
         tests_server,
         tests_client,
         tests_plugins,
@@ -494,7 +494,7 @@ jobs:
           RESULTS: >-
             changes=${{ needs.changes.result }}
             quality=${{ needs.quality.result }}
-            tests-scripts=${{ needs.tests_scripts.result }}
+            tests-scripts=${{ needs.tests.result }}
             tests-server=${{ needs.tests_server.result }}
             tests-client=${{ needs.tests_client.result }}
             tests-plugins=${{ needs.tests_plugins.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,13 +111,21 @@ jobs:
       - name: Formatting
         run: bun run format:check
 
-  tests:
-    name: Tests
+  # The unit-test lanes were four steps on one runner, so their durations added
+  # up: 22.4 + 18.3 + 28.4 min on run 31504110080, a 71.8-minute job that set
+  # the whole run's wall clock. They share no state and each already had its own
+  # path gate, so they are four jobs and the run waits for the longest, not the
+  # sum.
+  #
+  # Each job is unconditional and gates its own steps instead of carrying a
+  # job-level `if:`. A skipped job reports `skipped`, which `required` treats as
+  # failure by design; gating the steps keeps every lane reporting `success`
+  # while an unaffected lane costs only its checkout.
+  tests_scripts:
+    name: Tests (scripts)
     needs: changes
     runs-on: ubuntu-24.04
-    # The four sequential lanes (scripts, server, client, plugins) legitimately
-    # total ~95-110 minutes on a cache-cold PR runner; 90 killed healthy runs.
-    timeout-minutes: 120
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -137,21 +145,89 @@ jobs:
           E2E_COVERAGE_GATE_ENFORCE: "1"
         run: bun run test:scripts
 
+  tests_server:
+    name: Tests (server)
+    needs: changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - uses: ./.github/actions/setup-bun-workspace
+        if: needs.changes.outputs.server == 'true'
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          install-command: bun install --frozen-lockfile --ignore-scripts
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
       - name: Server tests
         if: needs.changes.outputs.server == 'true'
         run: bun run test:server
+
+      - name: No affected server lane
+        if: needs.changes.outputs.server != 'true'
+        run: echo "No server test lane is affected."
+
+  tests_client:
+    name: Tests (client)
+    needs: changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - uses: ./.github/actions/setup-bun-workspace
+        if: needs.changes.outputs.client == 'true'
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          install-command: bun install --frozen-lockfile --ignore-scripts
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
 
       - name: Client tests
         if: needs.changes.outputs.client == 'true'
         run: bun run test:client
 
+      - name: No affected client lane
+        if: needs.changes.outputs.client != 'true'
+        run: echo "No client test lane is affected."
+
+  tests_plugins:
+    name: Tests (plugins)
+    needs: changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - uses: ./.github/actions/setup-bun-workspace
+        if: needs.changes.outputs.plugins == 'true'
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          install-command: bun install --frozen-lockfile --ignore-scripts
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
       - name: Plugin tests
         if: needs.changes.outputs.plugins == 'true'
         run: bun run test:plugins
 
-      - name: No affected unit-test lane
-        if: needs.changes.outputs.server != 'true' && needs.changes.outputs.client != 'true' && needs.changes.outputs.plugins != 'true'
-        run: echo "No server, client, or plugin test lane is affected."
+      - name: No affected plugin lane
+        if: needs.changes.outputs.plugins != 'true'
+        run: echo "No plugin test lane is affected."
 
   smoke:
     name: Smoke
@@ -399,7 +475,18 @@ jobs:
   required:
     name: Required
     if: always()
-    needs: [changes, quality, tests, smoke, android_aab, secrets]
+    needs:
+      [
+        changes,
+        quality,
+        tests_scripts,
+        tests_server,
+        tests_client,
+        tests_plugins,
+        smoke,
+        android_aab,
+        secrets,
+      ]
     runs-on: ubuntu-24.04
     steps:
       - name: Require every CI job to succeed
@@ -407,7 +494,10 @@ jobs:
           RESULTS: >-
             changes=${{ needs.changes.result }}
             quality=${{ needs.quality.result }}
-            tests=${{ needs.tests.result }}
+            tests-scripts=${{ needs.tests_scripts.result }}
+            tests-server=${{ needs.tests_server.result }}
+            tests-client=${{ needs.tests_client.result }}
+            tests-plugins=${{ needs.tests_plugins.result }}
             smoke=${{ needs.smoke.result }}
             android-aab=${{ needs.android_aab.result }}
             secrets=${{ needs.secrets.result }}


### PR DESCRIPTION
# Relates to

Closes #18420

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the workflow contract gates that apply are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the job graph and timings below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was loaded for this change`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `2471cf2ef39`; zero conflicts.
- [x] Workflow contract gates run post-sync — output in the evidence block.

# Risks

**Low.** No lane changes the command it runs; only where it runs changes.

- `Tests` becomes `Tests (scripts)`, `Tests (server)`, `Tests (client)`, `Tests (plugins)`. `CI / Required` is the canonical status and now observes all four; nothing else in the repository references the `tests` job (checked across `.github/workflows/*.yml` and `packages/scripts/ci-*.mjs`).
- Each lane job is **unconditional** and gates its steps. This is deliberate: `required` fails on any result that is not `success`, and a job-level `if:` that evaluates false reports `skipped`. The `smoke` job already uses this shape.
- Overlaps with #18396, which also edits `ci.yml`. The two touch different jobs; the only overlap is the `required` needs list, a two-line merge.

# Background

## What does this PR do?

Runs the four unit-test lanes as four jobs instead of four steps on one runner, so the run waits for the longest lane rather than their sum.

## What kind of change is this?

Improvements — CI execution topology.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The `required` job — confirm all four lanes are in its `needs` and in `RESULTS`, so a single failing lane still fails the gate.

## Detailed testing steps

The change is workflow topology; the repository's own workflow contracts are the executable check, and they all pass. Timings come from a real run and are quoted below.

# Evidence Gate

<!-- evidence-head:d8f84057e782a1ed7d632f9ace9e10ca6c2c7ff7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this change alters CI job topology only; no rendered surface exists before or after.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this change alters CI job topology only; no rendered surface exists before or after.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing flow in a workflow job graph.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server process runs in this diff; the runner output that matters is the job timing table below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer code changed, so there is no console or network trace to capture.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behaviour is touched by this change.
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the job graph and the measurement it is derived from.

<details><summary>Workflow contract gates on the current head — output</summary>

```
$ actionlint .github/workflows/ci.yml
(clean)
$ node packages/scripts/ci-windows-command-coverage-contract.mjs   -> OK
$ node packages/scripts/ci-bun-version-contract.mjs
ci bun version contract passed (canonical 1.3.14; 241 sites scanned; 49 workflow pin(s) in lockstep)
$ node packages/scripts/ci-turbo-cache-contract.mjs
ci turbo cache contract passed (shared cache pinned; 38 workflow(s) use no SaaS cache)
$ bun test packages/scripts/__tests__/github-action-pinning.test.ts
 10 pass  0 fail
$ bun test packages/scripts/__tests__/ci-path-gate.test.mjs
 6 pass  0 fail
```

</details>

Measured on run 31504110080, before this change:

| step inside `Tests` | duration |
| --- | --- |
| setup | 1.8 min |
| Script contract tests | 0.5 min |
| Server tests | 22.4 min |
| Client tests | 18.3 min |
| Plugin tests | 28.4 min |
| **job total** | **71.8 min** |

That job set the run's wall clock: the run finished in 74.3 min end to end, with the slowest Smoke shard at 35.9. Splitting the lanes should put the run near **32 min** — the longest lane plus setup — for about 6 min of extra runner time in duplicated installs.

<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels are produced or changed by a workflow job graph.

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill was loaded for this change
Attribution status: self-reported
— [stan-cloud]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"N/A - no contribution skill was loaded for this change"} -->


