### PR TITLE
fix(agent): exclude internal scratch worlds from the inbox room scan

### DIFF
--- a/packages/agent/src/api/__tests__/inbox-internal-world-starvation.test.ts
+++ b/packages/agent/src/api/__tests__/inbox-internal-world-starvation.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Inbox feed starvation by internal scratch worlds.
+ *
+ * The bug this pins: `collectAgentRoomIds` (backing GET /api/inbox/messages
+ * and GET /api/inbox/sources) enumerated rooms from EVERY world, including
+ * internal scratch worlds (Autonomy World, Advanced Memory, Relationships
+ * World), while the chats sidebar's `collectAgentWorlds` already skipped
+ * them. `getMemoriesByRoomIds` returns newest-first across all scanned rooms
+ * under a bounded limit, so an active autonomy loop — which emits synthetic
+ * messages continuously into its own room — monopolized the fetch window.
+ * Every fetched row was then discarded by the connector source filter and
+ * the inbox rendered empty ("messages":[], "sources":[]) even though real
+ * Discord messages existed just past the window.
+ *
+ * The harness models the real adapter contract (global newest-first order +
+ * limit applied across the requested roomIds) so the starvation reproduces
+ * mechanically: >3x-overfetch autonomy messages are newer than the connector
+ * messages. Without the internal-world exclusion both routes return empty;
+ * with it, the Discord messages surface.
+ */
+import type http from "node:http";
+import type { AgentRuntime, RouteHelpers, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleInboxRoute, type InboxRouteState } from "../inbox-routes";
+
+// The messages route lazily imports the full connector plugin for avatar
+// caching; the test exercises room enumeration, not avatar fetching.
+vi.mock("@elizaos/plugin-discord", () => ({
+  cacheDiscordAvatarUrl: async (avatarUrl: string | undefined) => avatarUrl,
+}));
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
+const GUILD_WORLD_ID = "00000000-0000-0000-0000-0000000000e1" as UUID;
+const AUTONOMY_WORLD_ID = "00000000-0000-0000-0000-0000000000e2" as UUID;
+const DISCORD_ROOM_ID = "00000000-0000-0000-0000-0000000000b1" as UUID;
+const AUTONOMY_ROOM_ID = "00000000-0000-0000-0000-0000000000b2" as UUID;
+
+interface StoredMemory {
+  id: UUID;
+  roomId: UUID;
+  entityId?: UUID;
+  content: { text: string; source?: string };
+  createdAt: number;
+}
+
+function makeHarness(options: { autonomyMessageCount: number }) {
+  const worlds = [
+    { id: GUILD_WORLD_ID, agentId: AGENT_ID, name: "Guild" },
+    // Name-marker match for isInternalWorld — same shape the autonomy
+    // service creates in production.
+    { id: AUTONOMY_WORLD_ID, agentId: AGENT_ID, name: "Autonomy World" },
+  ];
+  const roomsByWorld = new Map<string, Array<Record<string, unknown>>>([
+    [
+      GUILD_WORLD_ID,
+      [
+        {
+          id: DISCORD_ROOM_ID,
+          name: "#general",
+          source: "discord",
+          type: "GROUP",
+          worldId: GUILD_WORLD_ID,
+          channelId: "discord-channel-1",
+        },
+      ],
+    ],
+    [
+      AUTONOMY_WORLD_ID,
+      [
+        {
+          id: AUTONOMY_ROOM_ID,
+          name: "Autonomous Thoughts",
+          source: "autonomy-service",
+          type: "SELF",
+          worldId: AUTONOMY_WORLD_ID,
+        },
+      ],
+    ],
+  ]);
+
+  // One shared, globally newest-first store — the adapter contract the
+  // production SQL implements (ORDER BY created_at DESC ... LIMIT n across
+  // the requested roomIds).
+  const memories: StoredMemory[] = [];
+  // Older, real connector traffic.
+  for (let i = 0; i < 5; i++) {
+    memories.push({
+      id: `00000000-0000-0000-0000-0000000000d${i}` as UUID,
+      roomId: DISCORD_ROOM_ID,
+      entityId: `00000000-0000-0000-0000-0000000000f${i}` as UUID,
+      content: { text: `real dm ${i}`, source: "discord" },
+      createdAt: 1_000 + i,
+    });
+  }
+  // Newer autonomy chatter that crowds the fetch window.
+  for (let i = 0; i < options.autonomyMessageCount; i++) {
+    memories.push({
+      id: `00000000-0000-0000-${String(1000 + i).padStart(4, "0")}-000000000000` as UUID,
+      roomId: AUTONOMY_ROOM_ID,
+      entityId: AGENT_ID,
+      content: { text: `autonomous thought ${i}` },
+      createdAt: 10_000 + i,
+    });
+  }
+
+  const runtime = {
+    agentId: AGENT_ID,
+    getAllWorlds: async () => worlds,
+    getRoomsByWorlds: async (worldIds: UUID[]) =>
+      worldIds.flatMap((worldId) => roomsByWorld.get(worldId) ?? []),
+    getMemories: async () => [],
+    getMemoriesByRoomIds: async ({
+      roomIds,
+      limit,
+    }: {
+      roomIds: UUID[];
+      limit?: number;
+    }) => {
+      const requested = new Set<string>(roomIds);
+      const matched = memories
+        .filter((memory) => requested.has(memory.roomId))
+        .sort((a, b) => b.createdAt - a.createdAt);
+      return limit !== undefined ? matched.slice(0, limit) : matched;
+    },
+    getRoom: async (roomId: UUID) => {
+      for (const rooms of roomsByWorld.values()) {
+        const found = rooms.find((room) => room.id === roomId);
+        if (found) return found;
+      }
+      return null;
+    },
+    getService: () => null,
+  } as unknown as AgentRuntime;
+
+  return { runtime };
+}
+
+async function getRoute(runtime: AgentRuntime, pathname: string) {
+  let payload: Record<string, unknown> | undefined;
+  const helpers = {
+    json: (_res: http.ServerResponse, data: unknown) => {
+      payload = data as Record<string, unknown>;
+    },
+    error: (_res: http.ServerResponse, message: string) => {
+      throw new Error(`route error: ${message}`);
+    },
+    readJsonBody: async () => null,
+  } as unknown as RouteHelpers;
+
+  const handled = await handleInboxRoute(
+    { url: pathname } as http.IncomingMessage,
+    {} as http.ServerResponse,
+    pathname,
+    "GET",
+    { runtime } as InboxRouteState,
+    helpers,
+  );
+  expect(handled).toBe(true);
+  if (!payload) throw new Error("route did not respond");
+  return payload;
+}
+
+describe("GET /api/inbox — internal worlds must not starve the connector feed", () => {
+  it("returns connector messages even when a busy autonomy room has newer traffic than the whole fetch window", async () => {
+    // 350 > default limit (100) * PER_ROOM_OVERFETCH_MULTIPLIER (3): with
+    // the autonomy room included in the scan, the entire window is
+    // autonomy chatter and the discord messages never surface.
+    const { runtime } = makeHarness({ autonomyMessageCount: 350 });
+
+    const payload = await getRoute(runtime, "/api/inbox/messages");
+    const messages = payload.messages as Array<Record<string, unknown>>;
+
+    expect(payload.count).toBe(5);
+    expect(messages).toHaveLength(5);
+    for (const message of messages) {
+      expect(message.source).toBe("discord");
+    }
+  });
+
+  it("reports discord in /api/inbox/sources despite >1000 newer autonomy messages", async () => {
+    // loadInboxSources samples a bounded 1000-message page; enough newer
+    // autonomy chatter previously pushed every connector row out of it.
+    const { runtime } = makeHarness({ autonomyMessageCount: 1_200 });
+
+    const payload = await getRoute(runtime, "/api/inbox/sources");
+    expect(payload.sources).toEqual(["discord"]);
+  });
+});

--- a/packages/agent/src/api/inbox-routes.ts
+++ b/packages/agent/src/api/inbox-routes.ts
@@ -1564,12 +1564,22 @@ async function resolveDiscordRoomProfile(
  * Eliza install this is bounded by the number of connector chats the
  * agent participates in; for multi-tenant it would need a tenant scope
  * but Eliza's runtime is single-tenant per process.
+ *
+ * Internal scratch worlds (autonomy self-talk, advanced memory,
+ * relationships graph) are excluded, mirroring collectAgentWorlds.
+ * Including them starves the feed: getMemoriesByRoomIds orders
+ * newest-first across ALL scanned rooms with a bounded limit, and an
+ * active autonomy loop emits messages continuously, so its synthetic
+ * rooms monopolize the fetch window. Every row is then dropped by the
+ * connector source filter and the inbox reads empty even though real
+ * connector messages exist just past the window.
  */
 async function collectAgentRoomIds(runtime: AgentRuntime): Promise<UUID[]> {
   const worlds = await runtime.getAllWorlds();
   if (worlds.length === 0) return [];
 
   const worldIds = worlds
+    .filter((w) => !isInternalWorld(w))
     .map((w) => w.id)
     .filter((id): id is UUID => typeof id === "string");
 


### PR DESCRIPTION
## The bug

On a live deployment with the autonomy loop enabled, `GET /api/inbox/messages` returned `{"messages":[],"count":0}` and the sources chip list starved — even though real Discord messages existed in the DB. (Observed dogfooding the sol-dev cutover stack: 4 discord message memories present; feed empty.)

Root cause: `collectAgentRoomIds` (the room scan behind `/api/inbox/messages` and `/api/inbox/sources`) enumerated rooms from **every** world, including internal scratch worlds — Autonomy World, Advanced Memory, Relationships World — while the chats sidebar's `collectAgentWorlds` already excluded them (that exclusion's own comment: "Including them used to consume the entire room-scan budget and drown out real connector channels").

`getMemoriesByRoomIds` orders newest-first across all scanned rooms under a bounded limit (`limit × PER_ROOM_OVERFETCH_MULTIPLIER`). An active autonomy loop emits synthetic messages continuously into its own room (on sol-dev: 300/300 of the newest message memories were `Autonomous Thoughts`), so the entire fetch window is autonomy chatter. Every row is then discarded by the connector source filter → inbox reads empty.

## The fix

Filter internal worlds out of the roomIds scan in `collectAgentRoomIds`, mirroring `collectAgentWorlds`. One-line predicate reusing the existing `isInternalWorld`.

## Proof (bidirectional)

Test harness models the real adapter contract (global newest-first + limit across requested roomIds), with >3× overfetch of newer autonomy messages above 5 older Discord messages.

- **Reverted fix:** both tests fail — messages feed returns 0, sources returns `[]` (the bug verbatim): `Tests 2 failed (2)`
- **With fix:** `2 passed (2)`; full inbox route suites: `inbox-account-routing` 28/28, `inbox-request-authorization` 3/3, `lifeops-inbox-fallback-routes` 3/3 green. (`inbox-thread-mute.test.ts` fails identically on clean develop — pre-existing `@elizaos/plugin-meetings` entry-resolution failure, unrelated.)

## Production path

`handleInboxRoute` → `loadInboxMessages` / `loadInboxSources` → `collectAgentRoomIds` in `packages/agent/src/api/inbox-routes.ts` — the request path for the inbox view on every agent-server deployment.


<!-- evidence-head:c87318404e7eebc737d6775d8b25331aa4dd8f5f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only room-scan predicate, no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only room-scan predicate, no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only, behavior proven by bidirectional unit tests

<!-- evidence-row:backend-logs -->
- [x] [18422-inbox-route-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18422-inbox-route-tests.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM involvement in room enumeration

<!-- evidence-row:ocr-review -->
- [ ] N/A - no UI screenshots to OCR (backend-only change)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - test suite output attached as backend logs

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-5`
<!-- attribution-row:client -->
- Agent tooling: `moltbot subagent (0xSolace fleet)`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`