### PR TITLE
fix(ui): show keyboard focus on hosted sign-in

### DIFF
--- a/packages/app/test/ui-smoke/hosted-signin-focus.spec.ts
+++ b/packages/app/test/ui-smoke/hosted-signin-focus.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Browser regression for the hosted sign-in keyboard focus treatment. The
+ * real login route renders against a deterministic Steward provider response;
+ * Chromium supplies actual focus matching, layout, and computed styles.
+ */
+import { writeFile } from "node:fs/promises";
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+const VIEWPORTS = [
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "mobile", width: 390, height: 844 },
+] as const;
+
+const PROVIDERS = {
+  passkey: false,
+  email: true,
+  siwe: true,
+  siws: true,
+  google: true,
+  discord: true,
+  github: true,
+  twitter: false,
+  oauth: [],
+};
+
+type FocusStyle = {
+  backgroundColor: string;
+  borderColor: string;
+  boxShadow: string;
+  color: string;
+  outlineStyle: string;
+};
+
+async function readFocusStyle(locator: Locator): Promise<FocusStyle> {
+  return locator.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      backgroundColor: style.backgroundColor,
+      borderColor: style.borderColor,
+      boxShadow: style.boxShadow,
+      color: style.color,
+      outlineStyle: style.outlineStyle,
+    };
+  });
+}
+
+async function installProviderFixture(page: Page): Promise<void> {
+  await page.route("**/auth/providers", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(PROVIDERS),
+    });
+  });
+}
+
+for (const viewport of VIEWPORTS) {
+  test(`all nine hosted sign-in targets render a focus delta at ${viewport.name}`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize(viewport);
+    await installProviderFixture(page);
+
+    const frontendEvents: string[] = [];
+    page.on("console", (message) =>
+      frontendEvents.push(`console:${message.type()}:${message.text()}`),
+    );
+    page.on("requestfailed", (request) =>
+      frontendEvents.push(
+        `requestfailed:${request.method()}:${request.url()}:${request.failure()?.errorText ?? "unknown"}`,
+      ),
+    );
+    page.on("response", (response) =>
+      frontendEvents.push(
+        `response:${response.request().method()}:${response.status()}:${response.url()}`,
+      ),
+    );
+
+    await page.goto("/login");
+    await expect(
+      page.getByRole("heading", { name: "Sign in to Eliza Cloud" }),
+    ).toBeVisible();
+
+    const targets = [
+      page.getByRole("textbox", { name: "Email" }),
+      page.getByRole("button", { name: "Magic Link" }),
+      page.getByRole("button", { name: "Google" }),
+      page.getByRole("button", { name: "Discord" }),
+      page.getByRole("button", { name: "GitHub" }),
+      page.getByRole("button", { name: "EVM", exact: true }),
+      page.getByRole("button", { name: "Solana", exact: true }),
+      page.getByRole("link", { name: "Terms", exact: true }),
+      page.getByRole("link", { name: "Privacy Policy" }),
+    ];
+
+    await expect(targets[8]).toBeVisible();
+    await page.screenshot({
+      path: testInfo.outputPath(`${viewport.name}-rest.png`),
+      fullPage: true,
+    });
+
+    for (const target of targets) {
+      const resting = await readFocusStyle(target);
+      await page.keyboard.press("Tab");
+      await expect(target).toBeFocused();
+      await expect(target).toHaveCSS("border-color", /.+/);
+      await page.waitForTimeout(200);
+
+      const focused = await readFocusStyle(target);
+      expect(
+        await target.evaluate((element) => element.matches(":focus-visible")),
+      ).toBe(true);
+      expect(
+        focused.borderColor,
+        "focus must change the rendered border",
+      ).not.toBe(resting.borderColor);
+      expect(
+        focused.backgroundColor,
+        "focus must change the rendered background",
+      ).not.toBe(resting.backgroundColor);
+    }
+
+    await page.screenshot({
+      path: testInfo.outputPath(`${viewport.name}-privacy-focused.png`),
+      fullPage: true,
+    });
+    const frontendLogPath = testInfo.outputPath(
+      `${viewport.name}-frontend-network.log`,
+    );
+    await writeFile(
+      frontendLogPath,
+      `${frontendEvents.join("\n") || "No console messages or network responses."}\n`,
+    );
+    await testInfo.attach(`${viewport.name}-frontend-network-log`, {
+      path: frontendLogPath,
+      contentType: "text/plain",
+    });
+  });
+}

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -177,14 +177,14 @@ export default function LoginPage() {
           })}{" "}
           <Link
             to="/terms-of-service"
-            className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-sm px-2 font-medium text-txt underline-offset-4 transition-[opacity,background-color,color] hover:underline hover:opacity-80"
+            className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-sm border border-transparent px-2 font-medium text-txt underline-offset-4 transition-[opacity,background-color,border-color,color] hover:underline hover:opacity-80 focus-visible:border-accent focus-visible:bg-accent-subtle focus-visible:text-txt-strong"
           >
             {t("cloud.login.termsLink", { defaultValue: "Terms" })}
           </Link>{" "}
           {t("cloud.login.and", { defaultValue: "and" })}{" "}
           <Link
             to="/privacy-policy"
-            className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-sm px-2 font-medium text-txt underline-offset-4 transition-[opacity,background-color,color] hover:underline hover:opacity-80"
+            className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-sm border border-transparent px-2 font-medium text-txt underline-offset-4 transition-[opacity,background-color,border-color,color] hover:underline hover:opacity-80 focus-visible:border-accent focus-visible:bg-accent-subtle focus-visible:text-txt-strong"
           >
             {t("cloud.login.privacyPolicy", { defaultValue: "Privacy Policy" })}
           </Link>

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -177,14 +177,14 @@ export default function LoginPage() {
           })}{" "}
           <Link
             to="/terms-of-service"
-            className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-sm border border-transparent px-2 font-medium text-txt underline-offset-4 transition-[opacity,background-color,border-color,color] hover:underline hover:opacity-80 focus-visible:border-accent focus-visible:bg-accent-subtle focus-visible:text-txt-strong"
+            className="hosted-signin-focus-emphasis inline-flex min-h-touch min-w-touch items-center justify-center rounded-sm border border-transparent px-2 font-medium text-txt underline-offset-4 transition-[opacity,background-color,border-color,color] hover:underline hover:opacity-80"
           >
             {t("cloud.login.termsLink", { defaultValue: "Terms" })}
           </Link>{" "}
           {t("cloud.login.and", { defaultValue: "and" })}{" "}
           <Link
             to="/privacy-policy"
-            className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-sm border border-transparent px-2 font-medium text-txt underline-offset-4 transition-[opacity,background-color,border-color,color] hover:underline hover:opacity-80 focus-visible:border-accent focus-visible:bg-accent-subtle focus-visible:text-txt-strong"
+            className="hosted-signin-focus-emphasis inline-flex min-h-touch min-w-touch items-center justify-center rounded-sm border border-transparent px-2 font-medium text-txt underline-offset-4 transition-[opacity,background-color,border-color,color] hover:underline hover:opacity-80"
           >
             {t("cloud.login.privacyPolicy", { defaultValue: "Privacy Policy" })}
           </Link>

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -1175,7 +1175,7 @@ export default function StewardLoginSection() {
             }
           }}
           disabled={isLoading}
-          className="w-full min-h-touch rounded-md border border-input bg-bg-elevated px-4 py-3 text-txt outline-none transition-colors placeholder:text-muted hover:border-border-strong focus-visible:border-accent focus-visible:bg-accent-subtle disabled:opacity-50"
+          className="hosted-signin-focus-emphasis w-full min-h-touch rounded-md border border-input bg-bg-elevated px-4 py-3 text-txt outline-none transition-colors placeholder:text-muted hover:border-border-strong disabled:opacity-50"
           autoComplete={showPasskey ? "email webauthn" : "email"}
         />
       </div>
@@ -1199,7 +1199,7 @@ export default function StewardLoginSection() {
             type="button"
             onClick={handleEmail}
             disabled={isLoading}
-            className="flex min-h-touch flex-1 items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-3 font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+            className="hosted-signin-focus-emphasis flex min-h-touch flex-1 items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-3 font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
           >
             {loading === "email" ? <Spinner /> : <EmailIcon />}{" "}
             {t("cloud.login.button.magicLink", { defaultValue: "Magic Link" })}
@@ -1249,7 +1249,7 @@ export default function StewardLoginSection() {
               type="button"
               onClick={() => handleOAuth("google")}
               disabled={isLoading}
-              className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+              className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
             >
               {loading === "google" ? <Spinner /> : <GoogleIcon />}{" "}
               {t("cloud.login.button.google", { defaultValue: "Google" })}
@@ -1261,7 +1261,7 @@ export default function StewardLoginSection() {
               type="button"
               onClick={() => handleOAuth("discord")}
               disabled={isLoading}
-              className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+              className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
             >
               {loading === "discord" ? (
                 <Spinner />
@@ -1277,7 +1277,7 @@ export default function StewardLoginSection() {
               type="button"
               onClick={() => handleOAuth("github")}
               disabled={isLoading}
-              className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50 sm:col-span-2"
+              className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50 sm:col-span-2"
             >
               {loading === "github" ? (
                 <Spinner />
@@ -1344,7 +1344,7 @@ export default function StewardLoginSection() {
                   type="button"
                   onClick={() => handleWalletIntent("ethereum")}
                   disabled={isLoading}
-                  className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                  className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
                 >
                   {t("cloud.login.wallet.evm", { defaultValue: "EVM wallet" })}
                 </Button>
@@ -1355,7 +1355,7 @@ export default function StewardLoginSection() {
                   type="button"
                   onClick={() => handleWalletIntent("solana")}
                   disabled={isLoading}
-                  className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                  className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
                 >
                   {t("cloud.login.wallet.solana", {
                     defaultValue: "Solana wallet",

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -1175,7 +1175,7 @@ export default function StewardLoginSection() {
             }
           }}
           disabled={isLoading}
-          className="w-full min-h-touch rounded-md border border-input bg-bg-elevated px-4 py-3 text-txt outline-none transition-colors placeholder:text-muted hover:border-border-strong disabled:opacity-50"
+          className="w-full min-h-touch rounded-md border border-input bg-bg-elevated px-4 py-3 text-txt outline-none transition-colors placeholder:text-muted hover:border-border-strong focus-visible:border-accent focus-visible:bg-accent-subtle disabled:opacity-50"
           autoComplete={showPasskey ? "email webauthn" : "email"}
         />
       </div>
@@ -1199,7 +1199,7 @@ export default function StewardLoginSection() {
             type="button"
             onClick={handleEmail}
             disabled={isLoading}
-            className="flex min-h-touch flex-1 items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-3 font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+            className="flex min-h-touch flex-1 items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-3 font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
           >
             {loading === "email" ? <Spinner /> : <EmailIcon />}{" "}
             {t("cloud.login.button.magicLink", { defaultValue: "Magic Link" })}
@@ -1249,7 +1249,7 @@ export default function StewardLoginSection() {
               type="button"
               onClick={() => handleOAuth("google")}
               disabled={isLoading}
-              className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+              className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
             >
               {loading === "google" ? <Spinner /> : <GoogleIcon />}{" "}
               {t("cloud.login.button.google", { defaultValue: "Google" })}
@@ -1261,7 +1261,7 @@ export default function StewardLoginSection() {
               type="button"
               onClick={() => handleOAuth("discord")}
               disabled={isLoading}
-              className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+              className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
             >
               {loading === "discord" ? (
                 <Spinner />
@@ -1277,7 +1277,7 @@ export default function StewardLoginSection() {
               type="button"
               onClick={() => handleOAuth("github")}
               disabled={isLoading}
-              className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50 sm:col-span-2"
+              className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50 sm:col-span-2"
             >
               {loading === "github" ? (
                 <Spinner />
@@ -1344,7 +1344,7 @@ export default function StewardLoginSection() {
                   type="button"
                   onClick={() => handleWalletIntent("ethereum")}
                   disabled={isLoading}
-                  className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                  className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
                 >
                   {t("cloud.login.wallet.evm", { defaultValue: "EVM wallet" })}
                 </Button>
@@ -1355,7 +1355,7 @@ export default function StewardLoginSection() {
                   type="button"
                   onClick={() => handleWalletIntent("solana")}
                   disabled={isLoading}
-                  className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                  className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
                 >
                   {t("cloud.login.wallet.solana", {
                     defaultValue: "Solana wallet",

--- a/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
@@ -352,7 +352,7 @@ function EthereumButton({
       type="button"
       onClick={handleClick}
       disabled={disabled}
-      className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+      className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
     >
       {loading && <Spinner />}
       {t("cloud.login.wallet.evm", { defaultValue: "EVM wallet" })}
@@ -453,7 +453,7 @@ function SolanaButton({
       type="button"
       onClick={handleClick}
       disabled={disabled}
-      className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+      className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
     >
       {loading && <Spinner />}
       {t("cloud.login.wallet.solana", { defaultValue: "Solana wallet" })}

--- a/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
@@ -352,7 +352,7 @@ function EthereumButton({
       type="button"
       onClick={handleClick}
       disabled={disabled}
-      className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+      className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
     >
       {loading && <Spinner />}
       {t("cloud.login.wallet.evm", { defaultValue: "EVM wallet" })}
@@ -453,7 +453,7 @@ function SolanaButton({
       type="button"
       onClick={handleClick}
       disabled={disabled}
-      className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover focus-visible:border-accent focus-visible:bg-accent-subtle active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+      className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
     >
       {loading && <Spinner />}
       {t("cloud.login.wallet.solana", { defaultValue: "Solana wallet" })}

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -490,6 +490,15 @@ kbd {
 .keyboard-focus-emphasis:focus-visible {
   color: white;
 }
+
+/* Hosted sign-in controls use a filled accent state instead of a ring, which
+   keeps the product-wide no-ring policy while making keyboard position
+   unmistakable on the public authentication surface. */
+.hosted-signin-focus-emphasis:focus-visible {
+  border-color: var(--accent);
+  background-color: var(--accent-subtle);
+  color: var(--text-strong);
+}
 /* biome-ignore-end lint/complexity/noImportantStyles: end focus-ring ban override */
 
 /*


### PR DESCRIPTION
# Relates to

Fixes #18055.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop@75dddcdc31b5d3347322c8880bda453b2469682e` with zero conflicts.
- [x] `bun install --frozen-lockfile` and post-sync `bun run verify` were run. The unrelated strict visual-audit baseline gap is disclosed below.
- [x] A reviewer can confirm the keyboard-focus change from the browser assertions and inline evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@75dddcdc31b5d3347322c8880bda453b2469682e`; zero conflicts and 0 commits behind at verification time.
- [x] `bun run verify` passes post-sync: 348/348 Turbo tasks plus every follow-on repository audit.

# Risks

Low. This adds existing accent-token border/background styles only for keyboard `:focus-visible` state on hosted sign-in controls. It does not change authentication behavior, pointer styles, persistence, network contracts, permissions, secrets, or dependencies.

# Background

## What does this PR do?

Adds a visible high-contrast keyboard-focus treatment to the nine hosted sign-in targets: email, Magic Link, Google, Discord, GitHub, EVM, Solana, Terms, and Privacy Policy. The wallet treatment covers both immediate and deferred provider branches.

It also adds a material Chromium regression that tabs through the real `/login` route and verifies actual rendered `:focus-visible` border and background deltas at desktop and mobile sizes.

## What kind of change is this?

Bug fix (non-breaking accessibility improvement).

# Documentation changes needed?

No documentation change is required; behavior and public APIs are unchanged.

# Testing

## Where should a reviewer start?

Review `packages/app/test/ui-smoke/hosted-signin-focus.spec.ts`, then tab through `/login` and compare the attached before/after evidence.

## Detailed testing steps

1. Open the hosted `/login` route with email, Google, Discord, GitHub, EVM, and Solana providers available.
2. Press Tab through all nine interactive targets.
3. Confirm every target gains a warm accent border/background without layout shift.
4. Repeat at desktop `1440x900` and mobile `390x844`.

Automated results:

- Hosted sign-in Chromium: 2/2 passed; 18 target/viewport combinations covering all nine targets.
- UI focused unit tests: 2 files, 7/7 tests passed.
- UI package typecheck: passed.
- Changed-file Biome and `git diff --check`: passed.
- Repository verification: 348/348 Turbo tasks passed; focused-test audit scanned 7,813 files with zero focused tests or orphaned skips.
- Evidence doctor: passed in strict mode.

# Evidence Gate

<!-- evidence-head:e21c80fd563350b58d92990f96c7724b7309d257 -->

<!-- evidence-row:before-screenshots -->
- [x] ![Before desktop](https://github.com/user-attachments/assets/c6afacbb-ff92-4129-a883-6b0a8c0579e2) ![Before mobile](https://github.com/user-attachments/assets/ddf67948-d2ae-423c-8ef1-a74d7e6c172a)
<!-- evidence-row:after-screenshots -->
- [x] ![After desktop](https://github.com/user-attachments/assets/3a8bddd8-6da3-41f4-915c-b399a69d6a6b) ![After mobile](https://github.com/user-attachments/assets/e01a928d-a4cd-4399-8955-50ee5eb34acb)
<!-- evidence-row:walkthrough-video -->
- [x] [Reviewed-head walkthrough video](https://github.com/user-attachments/assets/39c42520-10e6-4d18-87e7-94c64a0adad0)
<!-- evidence-row:backend-logs -->
- [x] N/A - the changed path is client-only focus styling; no server behavior or backend request contract changes.
<!-- evidence-row:frontend-logs -->
- [x] [Sanitized frontend network and console summary](https://github.com/user-attachments/files/30957202/frontend-network-console.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, task, wallet, generated-domain, or other domain-data mutation.
<!-- evidence-row:ocr-review -->
- [x] [OCR review summary](https://github.com/user-attachments/files/30956552/ocr-summary.log) — packaged OCR processed 5/5 selected images with 0 failures.

# Evidence Details

## Real LLM-call trajectory

N/A - this is a deterministic CSS/accessibility change with no LLM path.

## Backend + frontend logs

Backend: N/A - no changed server path.

Frontend captures:

- [Desktop network/console capture](https://github.com/user-attachments/files/30957202/frontend-network-console.log)
- [Mobile network/console capture](https://github.com/user-attachments/files/30957202/frontend-network-console.log)

The captured logs contain no console errors. Provider fixture and application responses completed successfully; only expected reload/speculative-navigation `net::ERR_ABORTED` entries were observed.

## Screenshots (before / after) + video walkthrough

### Before

Desktop — focused Privacy Policy link has no visible focus delta:

[Before desktop screenshot](https://github.com/user-attachments/assets/c6afacbb-ff92-4129-a883-6b0a8c0579e2)

Mobile — focused Privacy Policy link has no visible focus delta:

[Before mobile screenshot](https://github.com/user-attachments/assets/ddf67948-d2ae-423c-8ef1-a74d7e6c172a)

### After

Desktop — focused Privacy Policy link has a distinct accent border/background with no layout shift:

[After desktop screenshot](https://github.com/user-attachments/assets/3a8bddd8-6da3-41f4-915c-b399a69d6a6b)

Mobile — focused Privacy Policy link has the same visible focus treatment:

[After mobile screenshot](https://github.com/user-attachments/assets/e01a928d-a4cd-4399-8955-50ee5eb34acb)

### Walkthrough video

[Desktop walkthrough MP4](https://github.com/user-attachments/assets/39c42520-10e6-4d18-87e7-94c64a0adad0)

The evidence is attached directly to this PR as first-party GitHub user attachments and was captured from the reviewed pre-rebase head; the exact post-rebase Chromium run reproduced all 18 focus deltas.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changes.

## Known gaps / failures

`bun run --cwd packages/app audit:app` completed 214/215 browser cases in 9.7 minutes with 0 broken views, 195 good, 13 needs-eyeball, 4 needs-work, 0 minimalism-budget failures, and 4 strict minimalism-ratchet failures. The failures are pre-existing/unrelated global baseline findings on untouched views:

- `/browser`, mobile portrait and landscape: border/divider density `60.76`, above the unbaselined `45.00` ceiling.
- `/apps/plugins`, mobile portrait: density `88.10`, above baselined 5% tolerance `79.75`.
- `/apps/trajectories`, mobile landscape: density `51.65`, above the unbaselined `45.00` ceiling.

The suite-level ratchet throw surfaced on the final trajectory audit case. No audit baseline was changed. This is the same untouched baseline class documented in repository status and PR #18390; none of the affected routes or components are changed here. The hosted sign-in regression passes 2/2 and the full repository verification passes 348/348.

The chained packaged-OCR step did not run after that nonzero audit capture exit, so it was run separately on the exact head: 212 views, 192 verified, 20 needs-eyeball, and 0 broken. Independent evidence OCR also reported 5 successful images and 0 failures. Before/after screenshots and the MP4 were personally inspected.

Reviewed commit: `e21c80fd563350b58d92990f96c7724b7309d257`  
Verified base: `75dddcdc31b5d3347322c8880bda453b2469682e`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [fid1699-issue-18055]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZRPW9MH8V84Y4BYAK2GFM02","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-11T15:25:55.729Z","completed_at":"2026-08-11T16:35:00.392Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAhF2ageyJvlDoe_JCeJ8dre---IaulxsqhaiFj11CQp8","device_key_id":"46ffa292f1c2f8b4f4ab4e8a1844b1ada18e416b6c0917274238cff9af1448e9","device_signature":"L_D3IoYkxL9_bUCLEtdO00iOro6ikbvHnvXgyIHyhW1qjik9M98oOQtNZpdGsgtKfoxNf_e6no4RFtpQbVcwAA"}} -->




<!-- maintainer-evidence-revalidated:e21c80fd563350b58d92990f96c7724b7309d257 -->
