### PR TITLE
fix: handle shared-agent warming retries and idempotency

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-messages-route.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-route.test.ts
@@ -168,6 +168,7 @@ describe("shared agent messages route", () => {
       "Eliza",
       expect.objectContaining({ waitUntil: expect.any(Function) }),
       DEFAULT_NAMESPACE,
+      undefined,
     );
   });
 
@@ -209,6 +210,7 @@ describe("shared agent messages route", () => {
       "Eliza",
       expect.objectContaining({ waitUntil: expect.any(Function) }),
       namespace,
+      undefined,
     );
   });
 
@@ -232,6 +234,7 @@ describe("shared agent messages route", () => {
     );
 
     expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("1");
     await expect(res.json()).resolves.toMatchObject({
       code: "shared_runtime_context_unavailable",
       retryable: true,
@@ -321,6 +324,40 @@ describe("shared agent messages route", () => {
     const res = await postMessage({ text: "  " });
     expect(res.status).toBe(400);
     expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("forwards a validated clientMessageId to shared admission", async () => {
+    sharedRestMessageSend.mockResolvedValue({
+      text: "hello",
+      agentName: "Eliza",
+    });
+    const res = await postMessage({
+      text: "hello",
+      clientMessageId: " turn-1 ",
+    });
+    expect(res.status).toBe(200);
+    expect(sharedRestMessageSend.mock.calls[0]?.[6]).toBe("turn-1");
+  });
+
+  test("rejects invalid clientMessageId before shared admission", async () => {
+    const res = await postMessage({ text: "hello", clientMessageId: " " });
+    expect(res.status).toBe(400);
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("returns terminal 409 for a shared idempotency conflict", async () => {
+    const { ElizaError } = await import("@elizaos/core");
+    sharedRestMessageSend.mockRejectedValue(
+      new ElizaError("clientMessageId conflict", {
+        code: "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT",
+      }),
+    );
+    const res = await postMessage({ text: "hello", clientMessageId: "turn-1" });
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "shared_runtime_idempotency_conflict",
+      retryable: false,
+    });
   });
 
   // The bug this pins: insufficient credits is a PERMANENT add-credits

--- a/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
@@ -834,6 +834,7 @@ describe("shared agent messages/stream", () => {
     const res = await postStream({ text: "must not dispatch" });
 
     expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("1");
     await expect(res.json()).resolves.toEqual({
       success: false,
       error: "Agent authorization cache is warming. Retry shortly.",

--- a/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
@@ -828,6 +828,7 @@ describe("shared agent messages/stream", () => {
   test("scope warming is explicitly retryable and never reaches the coordinator", async () => {
     resolveSharedAgent.mockResolvedValue({
       error: "Agent authorization cache is warming. Retry shortly.",
+      code: "agent_cache_warming",
       status: 503,
     });
 
@@ -838,6 +839,7 @@ describe("shared agent messages/stream", () => {
     await expect(res.json()).resolves.toEqual({
       success: false,
       error: "Agent authorization cache is warming. Retry shortly.",
+      code: "agent_cache_warming",
       retryable: true,
     });
     expect(coordinatorFetch).not.toHaveBeenCalled();

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -27,6 +27,7 @@ mock.module("@/lib/api/errors", () => ({
 
 let repositoryReads = 0;
 let repositoryWrites = 0;
+let providerDispatches = 0;
 let repositoryRow: unknown[] = [];
 const repositoryHistoryLengths: number[] = [];
 const repositoryHistories: unknown[][] = [];
@@ -111,6 +112,18 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
       }
       const channelId = rpc.params?.roomId ?? agent.id;
       const history = await options.historyStore.load(agent.id, channelId);
+      if (
+        history.some(
+          (message) => (message as { id?: unknown }).id === `message-${rpc.id}`,
+        )
+      ) {
+        return {
+          jsonrpc: "2.0",
+          id: rpc.id,
+          result: { historyLength: history.length, replayed: true },
+        };
+      }
+      providerDispatches++;
       await options.historyStore.merge(agent.id, channelId, [
         {
           id: `message-${rpc.id}`,
@@ -324,6 +337,42 @@ test("concurrent turns serialize through one room and retain both writes", async
     "turn-concurrent-two",
   ]);
   await Promise.all(background.splice(0));
+});
+
+test("concurrent duplicate ids serialize to one dispatch and one replay", async () => {
+  providerDispatches = 0;
+  const data = new Map<string, unknown>([
+    [
+      "conversation",
+      {
+        agentId: AGENT_FIXTURE.id,
+        channelId: "room-1",
+        history: [],
+        dirty: false,
+        version: 1,
+      },
+    ],
+  ]);
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    {} as never,
+  );
+  const invoke = makeInvoke(object);
+
+  const [first, duplicate] = await Promise.all([
+    invoke("duplicate"),
+    invoke("duplicate"),
+  ]);
+
+  expect(first).toMatchObject({ result: { historyLength: 1 } });
+  expect(duplicate).toMatchObject({
+    result: { historyLength: 1, replayed: true },
+  });
+  expect(providerDispatches).toBe(1);
+  expect(
+    (data.get("conversation") as { history: unknown[] }).history,
+  ).toHaveLength(1);
 });
 
 test("stream body cancellation persists before the room queue releases", async () => {

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -83,6 +83,18 @@ mock.module("@/db/repositories/shared-runtime-history", () => ({
       repositoryRow = merged;
       return merged;
     },
+    removeMessage: async (
+      _agentId: string,
+      _channelId: string,
+      messageId: string,
+    ) => {
+      repositoryWrites++;
+      repositoryRow = repositoryRow.filter(
+        (message) => (message as { id?: unknown }).id !== messageId,
+      );
+      repositoryHistoryLengths.push(repositoryRow.length);
+      repositoryHistories.push([...repositoryRow]);
+    },
   },
 }));
 mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
@@ -104,6 +116,11 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
             channelId: string,
             messages: unknown[],
           ): Promise<unknown[]>;
+          removeMessage(
+            agentId: string,
+            channelId: string,
+            messageId: string,
+          ): Promise<void>;
         };
       },
     ) => {
@@ -111,6 +128,22 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
         throw new RateLimitError("Organization rate limit exceeded.", 29);
       }
       const channelId = rpc.params?.roomId ?? agent.id;
+      if (rpc.id === "remove-marker") {
+        await options.historyStore.merge(agent.id, channelId, [
+          {
+            id: "pending-marker",
+            role: "user",
+            content: "not dispatched",
+            pendingProviderDispatch: true,
+          },
+        ]);
+        await options.historyStore.removeMessage(
+          agent.id,
+          channelId,
+          "pending-marker",
+        );
+        return { jsonrpc: "2.0", id: rpc.id, result: { removed: true } };
+      }
       const history = await options.historyStore.load(agent.id, channelId);
       if (
         history.some(
@@ -373,6 +406,42 @@ test("concurrent duplicate ids serialize to one dispatch and one replay", async 
   expect(
     (data.get("conversation") as { history: unknown[] }).history,
   ).toHaveLength(1);
+});
+
+test("pre-dispatch marker cleanup is durable and mirrored without exposing the tombstone", async () => {
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryRow = [];
+  repositoryHistoryLengths.length = 0;
+  repositoryHistories.length = 0;
+  const data = new Map<string, unknown>([
+    [
+      "conversation",
+      {
+        agentId: AGENT_FIXTURE.id,
+        channelId: "room-1",
+        history: [{ id: "prior", role: "assistant", content: "prior" }],
+        dirty: false,
+        version: 1,
+      },
+    ],
+  ]);
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    {} as never,
+  );
+
+  expect(await makeInvoke(object)("remove-marker")).toMatchObject({
+    result: { removed: true },
+  });
+  expect((data.get("conversation") as { history: unknown[] }).history).toEqual([
+    { id: "prior", role: "assistant", content: "prior" },
+  ]);
+  await Promise.all(background.splice(0));
+  expect(repositoryHistories.at(-1)).toEqual([
+    { id: "prior", role: "assistant", content: "prior" },
+  ]);
 });
 
 test("stream body cancellation persists before the room queue releases", async () => {

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -30,6 +30,8 @@ interface StoredConversation {
   history: SharedTurnMessage[];
   dirty: boolean;
   version: number;
+  /** Message ids that must also be deleted from the additive Postgres mirror. */
+  removedMessageIds?: string[];
 }
 
 const CONVERSATION_KEY = "conversation";
@@ -124,6 +126,7 @@ export class SharedRuntimeConversation {
           history,
           dirty: false,
           version: 0,
+          removedMessageIds: [],
         };
         await this.state.storage.put(CONVERSATION_KEY, this.conversation);
       })
@@ -159,6 +162,13 @@ export class SharedRuntimeConversation {
           snapshot.history,
           MAX_HISTORY_MESSAGES,
         );
+        for (const messageId of snapshot.removedMessageIds ?? []) {
+          await sharedRuntimeHistoryRepository.removeMessage(
+            snapshot.agentId,
+            snapshot.channelId,
+            messageId,
+          );
+        }
       });
       const current =
         await this.state.storage.get<StoredConversation>(CONVERSATION_KEY);
@@ -168,7 +178,7 @@ export class SharedRuntimeConversation {
         current.channelId === snapshot.channelId &&
         current.version === snapshot.version
       ) {
-        this.conversation = { ...current, dirty: false };
+        this.conversation = { ...current, dirty: false, removedMessageIds: [] };
         await this.state.storage.put(CONVERSATION_KEY, this.conversation);
       }
     } catch (error) {
@@ -199,6 +209,9 @@ export class SharedRuntimeConversation {
         (await this.loadConversation(agentId, channelId)).history,
       merge: async (agentId, channelId, messages) => {
         const current = await this.loadConversation(agentId, channelId);
+        const incomingIds = new Set(
+          messages.flatMap((message) => (message.id ? [message.id] : [])),
+        );
         const snapshot: StoredConversation = {
           agentId,
           channelId,
@@ -211,6 +224,9 @@ export class SharedRuntimeConversation {
           ),
           dirty: true,
           version: (this.conversation?.version ?? 0) + 1,
+          removedMessageIds: (current.removedMessageIds ?? []).filter(
+            (messageId) => !incomingIds.has(messageId),
+          ),
         };
         // Durable write FIRST: cancellation finalizers must be retryable. A
         // failed put leaves the prior in-memory state untouched so the same
@@ -219,6 +235,24 @@ export class SharedRuntimeConversation {
         this.conversation = snapshot;
         this.scheduleMirror(snapshot);
         return snapshot.history;
+      },
+      removeMessage: async (agentId, channelId, messageId) => {
+        const current = await this.loadConversation(agentId, channelId);
+        const snapshot: StoredConversation = {
+          agentId,
+          channelId,
+          history: current.history.filter(
+            (message) => message.id !== messageId,
+          ),
+          dirty: true,
+          version: (this.conversation?.version ?? 0) + 1,
+          removedMessageIds: [
+            ...new Set([...(current.removedMessageIds ?? []), messageId]),
+          ],
+        };
+        await this.state.storage.put(CONVERSATION_KEY, snapshot);
+        this.conversation = snapshot;
+        this.scheduleMirror(snapshot);
       },
     };
   }

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -338,6 +338,21 @@ export class SharedRuntimeConversation {
           { status: 503, headers: { "Retry-After": "1" } },
         );
       }
+      if (
+        error instanceof Error &&
+        (error as { code?: unknown }).code ===
+          "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT"
+      ) {
+        return Response.json(
+          {
+            success: false,
+            error: error.message,
+            code: "shared_runtime_idempotency_conflict",
+            retryable: false,
+          },
+          { status: 409 },
+        );
+      }
       const { InsufficientCreditsError, RateLimitError } = await import(
         "@/lib/api/errors"
       );

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
@@ -4,6 +4,7 @@
  * Scope authorization and conversation execution are cache-only through the
  * shared Durable Object; cold hydration returns retryable unavailability.
  */
+
 import { Hono } from "hono";
 import { InsufficientCreditsError, RateLimitError } from "@/lib/api/errors";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
@@ -46,7 +47,10 @@ app.get("/", async (c) => {
           code: worker.code,
           retryable: worker.retryable,
         },
-        { status: worker.status },
+        {
+          status: worker.status,
+          headers: worker.status === 503 ? { "Retry-After": "1" } : undefined,
+        },
       ),
       CORS_METHODS,
       origin,
@@ -62,9 +66,14 @@ app.get("/", async (c) => {
         {
           success: false,
           error: r.error,
-          ...(r.status === 503 ? { retryable: true } : {}),
+          ...(r.status === 503
+            ? { code: "agent_cache_warming", retryable: true }
+            : {}),
         },
-        { status: r.status },
+        {
+          status: r.status,
+          headers: r.status === 503 ? { "Retry-After": "1" } : undefined,
+        },
       ),
       CORS_METHODS,
       origin,
@@ -115,7 +124,10 @@ app.post("/", async (c) => {
           code: worker.code,
           retryable: worker.retryable,
         },
-        { status: worker.status },
+        {
+          status: worker.status,
+          headers: worker.status === 503 ? { "Retry-After": "1" } : undefined,
+        },
       ),
       CORS_METHODS,
       origin,
@@ -131,26 +143,62 @@ app.post("/", async (c) => {
         {
           success: false,
           error: r.error,
-          ...(r.status === 503 ? { retryable: true } : {}),
+          ...(r.status === 503
+            ? { code: "agent_cache_warming", retryable: true }
+            : {}),
         },
-        { status: r.status },
+        {
+          status: r.status,
+          headers: r.status === 503 ? { "Retry-After": "1" } : undefined,
+        },
       ),
       CORS_METHODS,
       origin,
     );
   }
   const conversationId = c.req.param("conversationId") ?? r.agentId;
-  const raw: unknown = await c.req.json().catch(() => ({}));
+  let raw: unknown = {};
+  try {
+    raw = await c.req.json();
+  } catch {
+    // error-policy:J3 malformed request JSON is handled by the normal required
+    // field validation below and never reaches the shared runtime.
+  }
   const text =
     raw &&
     typeof raw === "object" &&
     typeof (raw as { text?: unknown }).text === "string"
       ? (raw as { text: string }).text
       : "";
+  const rawClientMessageId =
+    raw && typeof raw === "object"
+      ? (raw as { clientMessageId?: unknown }).clientMessageId
+      : undefined;
+  const clientMessageId =
+    typeof rawClientMessageId === "string"
+      ? rawClientMessageId.trim()
+      : undefined;
   if (!text.trim()) {
     return applyCorsHeaders(
       Response.json(
         { success: false, error: "text is required" },
+        { status: 400 },
+      ),
+      CORS_METHODS,
+      origin,
+    );
+  }
+  if (
+    rawClientMessageId !== undefined &&
+    (!clientMessageId || clientMessageId.length > 128)
+  ) {
+    return applyCorsHeaders(
+      Response.json(
+        {
+          success: false,
+          error:
+            "clientMessageId must be a non-empty string of at most 128 characters",
+        },
         { status: 400 },
       ),
       CORS_METHODS,
@@ -166,6 +214,7 @@ app.post("/", async (c) => {
       r.agentName,
       worker.executionCtx,
       worker.namespace,
+      clientMessageId,
     );
   } catch (error) {
     // error-policy:J1 route boundary translates bridge/billing failures to HTTP responses.
@@ -181,7 +230,7 @@ app.post("/", async (c) => {
             code: "shared_runtime_cache_warming",
             retryable: true,
           },
-          { status: 503 },
+          { status: 503, headers: { "Retry-After": "1" } },
         ),
         CORS_METHODS,
         origin,
@@ -229,6 +278,25 @@ app.post("/", async (c) => {
             retryable: false,
           },
           { status: 402 },
+        ),
+        CORS_METHODS,
+        origin,
+      );
+    }
+    if (
+      error instanceof Error &&
+      (error as Error & { code?: unknown }).code ===
+        "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT"
+    ) {
+      return applyCorsHeaders(
+        Response.json(
+          {
+            success: false,
+            error: error.message,
+            code: "shared_runtime_idempotency_conflict",
+            retryable: false,
+          },
+          { status: 409 },
         ),
         CORS_METHODS,
         origin,

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -202,7 +202,10 @@ app.post("/", async (c) => {
           code: worker.code,
           retryable: worker.retryable,
         },
-        { status: worker.status },
+        {
+          status: worker.status,
+          headers: worker.status === 503 ? { "Retry-After": "1" } : undefined,
+        },
       ),
       CORS_METHODS,
       origin,
@@ -242,7 +245,10 @@ app.post("/", async (c) => {
           ...("code" in r ? { code: r.code } : {}),
           ...(r.status === 503 ? { retryable: true } : {}),
         },
-        { status: r.status },
+        {
+          status: r.status,
+          headers: r.status === 503 ? { "Retry-After": "1" } : undefined,
+        },
       ),
       CORS_METHODS,
       origin,

--- a/packages/cloud/shared/src/db/repositories/shared-runtime-history-merge.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-runtime-history-merge.integration.test.ts
@@ -49,6 +49,30 @@ afterAll(async () => {
 });
 
 describe("SharedRuntimeHistoryRepository.merge", () => {
+  test("removes only the failed pre-dispatch tombstone", async () => {
+    await sharedRuntimeHistoryRepository.merge(
+      "agent-1",
+      "channel-1",
+      [
+        { id: "prior", role: "assistant", content: "prior", createdAt: 1 },
+        {
+          id: "pending",
+          role: "user",
+          content: "not dispatched",
+          createdAt: 2,
+          pendingProviderDispatch: true,
+        },
+      ],
+      40,
+    );
+
+    await sharedRuntimeHistoryRepository.removeMessage("agent-1", "channel-1", "pending");
+
+    expect(await sharedRuntimeHistoryRepository.get("agent-1", "channel-1")).toEqual([
+      { id: "prior", role: "assistant", content: "prior", createdAt: 1 },
+    ]);
+  });
+
   test("concurrent first writes preserve both turns", async () => {
     await Promise.all([
       sharedRuntimeHistoryRepository.merge(

--- a/packages/cloud/shared/src/db/repositories/shared-runtime-history.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-runtime-history.ts
@@ -95,6 +95,35 @@ export class SharedRuntimeHistoryRepository {
     });
     return merged;
   }
+
+  async removeMessage(agentId: string, channelId: string, messageId: string): Promise<void> {
+    await dbWrite.transaction(async (tx) => {
+      const [row] = await tx
+        .select()
+        .from(sharedRuntimeHistory)
+        .where(
+          and(
+            eq(sharedRuntimeHistory.agent_id, agentId),
+            eq(sharedRuntimeHistory.channel_id, channelId),
+          ),
+        )
+        .for("update")
+        .limit(1);
+      if (!row) return;
+      const messages = Array.isArray(row.messages)
+        ? row.messages.filter((message) => message.id !== messageId)
+        : [];
+      await tx
+        .update(sharedRuntimeHistory)
+        .set({ messages: jsonbParam(messages), updated_at: new Date() })
+        .where(
+          and(
+            eq(sharedRuntimeHistory.agent_id, agentId),
+            eq(sharedRuntimeHistory.channel_id, channelId),
+          ),
+        );
+    });
+  }
 }
 
 export const sharedRuntimeHistoryRepository = new SharedRuntimeHistoryRepository();

--- a/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
+++ b/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
@@ -11,6 +11,14 @@ export type SharedRuntimeHistoryMessage = {
   createdAt?: number;
   /** True when an assistant message is a partial interrupted response. */
   interrupted?: boolean;
+  /** Structured terminal handoffs retained for idempotent completion replay. */
+  actionResults?: Array<{
+    actionName?: string;
+    success: boolean;
+    text?: string;
+    error?: string;
+    values?: Record<string, unknown>;
+  }>;
 };
 
 /**

--- a/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
+++ b/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
@@ -9,6 +9,8 @@ export type SharedRuntimeHistoryMessage = {
   content: string;
   /** Epoch-ms timestamp; used to order turns merged from concurrent writers. */
   createdAt?: number;
+  /** Internal idempotency tombstone excluded from conversational history. */
+  pendingProviderDispatch?: boolean;
   /** True when an assistant message is a partial interrupted response. */
   interrupted?: boolean;
   /** Structured terminal handoffs retained for idempotent completion replay. */

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
@@ -428,6 +428,63 @@ describe("ElizaSandboxService shared runtime billing", () => {
     }
   });
 
+  test("excludes conversation idempotency tombstones from the legacy bridge model history", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = sharedSandbox();
+    const findRunningSandboxSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockResolvedValue(sandbox);
+    const historyGetSpy = spyOn(sharedRuntimeHistoryRepository, "get").mockResolvedValue([
+      {
+        id: "visible-assistant",
+        role: "assistant",
+        content: "prior visible reply",
+        createdAt: 1,
+      },
+      {
+        id: "pending-user",
+        role: "user",
+        content: "must remain internal",
+        createdAt: 2,
+        pendingProviderDispatch: true,
+      },
+    ]);
+    const historyMergeSpy = spyOn(sharedRuntimeHistoryRepository, "merge").mockResolvedValue([]);
+
+    try {
+      await runWithCloudBindings({ CEREBRAS_API_KEY: "test-key" }, () =>
+        new ElizaSandboxService().bridge(sandbox.id, sandbox.organization_id, {
+          jsonrpc: "2.0",
+          id: "legacy-shared-turn",
+          method: "message.send",
+          params: { text: "next visible turn" },
+        }),
+      );
+
+      expect(runSharedAgentTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          history: [
+            expect.objectContaining({
+              id: "visible-assistant",
+              content: "prior visible reply",
+            }),
+          ],
+          message: "next visible turn",
+        }),
+      );
+      expect(runSharedAgentTurn).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          history: expect.arrayContaining([expect.objectContaining({ id: "pending-user" })]),
+        }),
+      );
+    } finally {
+      findRunningSandboxSpy.mockRestore();
+      historyGetSpy.mockRestore();
+      historyMergeSpy.mockRestore();
+    }
+  });
+
   // The credit-gate contract for a drained org / welcome-bonus-withheld signup:
   // the JSON-RPC bridge keeps the -32002 wire error (the /bridge route serves
   // raw JSON-RPC), while bridgeStream — whose callers are HTTP boundaries —

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -3387,7 +3387,12 @@ export class ElizaSandboxService {
     return (
       (message?.role === "user" || message?.role === "assistant") &&
       typeof message.content === "string" &&
-      message.content.trim().length > 0
+      message.content.trim().length > 0 &&
+      // Conversation Durable Objects persist undispatched turn identities in
+      // this shared mirror. Legacy bridge callers read the same row, so they
+      // must uphold the canonical history boundary instead of feeding an
+      // idempotency tombstone into billing or the model as user dialogue.
+      message.pendingProviderDispatch !== true
     );
   }
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 import { RateLimitError } from "../../api/errors";
 import * as coordinatorActual from "./conversation-coordinator";
 
@@ -77,6 +78,23 @@ describe("handleCanonicalScopedAgentStream", () => {
     });
   });
 
+  test("uses clientMessageId as the stable shared turn identity", async () => {
+    await handleCanonicalScopedAgentStream({
+      ...BASE,
+      body: { text: "hello", clientMessageId: " turn-1 " },
+    });
+    expect(coordinateSharedStream.mock.calls[0]?.[1].id).toBe("turn-1");
+  });
+
+  test("rejects an invalid clientMessageId before shared dispatch", async () => {
+    const res = await handleCanonicalScopedAgentStream({
+      ...BASE,
+      body: { text: "hello", clientMessageId: " " },
+    });
+    expect(res.status).toBe(400);
+    expect(coordinateSharedStream).not.toHaveBeenCalled();
+  });
+
   test("maps exact rate denial to a retryable 429 before SSE starts", async () => {
     coordinateSharedStream.mockRejectedValueOnce(
       new RateLimitError("Organization rate limit exceeded.", 41),
@@ -102,6 +120,7 @@ describe("handleCanonicalScopedAgentStream", () => {
     const res = await handleCanonicalScopedAgentStream(BASE);
 
     expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("1");
     await expect(res.json()).resolves.toMatchObject({
       code: "shared_runtime_cache_warming",
       retryable: true,
@@ -123,6 +142,20 @@ describe("handleCanonicalScopedAgentStream", () => {
     expect(data).toEqual({
       message: "Agent produced no streamed response",
       type: "error",
+    });
+  });
+
+  test("maps an idempotency conflict to a terminal 409", async () => {
+    coordinateSharedStream.mockRejectedValueOnce(
+      new ElizaError("clientMessageId conflict", {
+        code: "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT",
+      }),
+    );
+    const res = await handleCanonicalScopedAgentStream(BASE);
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "shared_runtime_idempotency_conflict",
+      retryable: false,
     });
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -80,6 +80,12 @@ export async function handleCanonicalScopedAgentStream(
     typeof (request.body as { text?: unknown }).text === "string"
       ? (request.body as { text: string }).text
       : "";
+  const rawClientMessageId =
+    request.body && typeof request.body === "object"
+      ? (request.body as { clientMessageId?: unknown }).clientMessageId
+      : undefined;
+  const clientMessageId =
+    typeof rawClientMessageId === "string" ? rawClientMessageId.trim() : undefined;
   timings.parse = elapsedMs(parseStartedAt);
   if (!text.trim()) {
     return applyCorsHeaders(
@@ -88,10 +94,23 @@ export async function handleCanonicalScopedAgentStream(
       request.origin,
     );
   }
+  if (rawClientMessageId !== undefined && (!clientMessageId || clientMessageId.length > 128)) {
+    return applyCorsHeaders(
+      Response.json(
+        {
+          success: false,
+          error: "clientMessageId must be a non-empty string of at most 128 characters",
+        },
+        { status: 400 },
+      ),
+      CORS_METHODS,
+      request.origin,
+    );
+  }
 
   const rpc: BridgeRequest = {
     jsonrpc: "2.0",
-    id: crypto.randomUUID(),
+    id: clientMessageId ?? crypto.randomUUID(),
     method: "message.send",
     params: {
       text,
@@ -167,7 +186,28 @@ export async function handleCanonicalScopedAgentStream(
               code: "shared_runtime_cache_warming",
               retryable: true,
             },
-            { status: 503 },
+            { status: 503, headers: { "Retry-After": "1" } },
+          ),
+          CORS_METHODS,
+          request.origin,
+        ),
+        timings,
+      );
+    }
+    if (
+      error instanceof Error &&
+      (error as Error & { code?: unknown }).code === "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT"
+    ) {
+      return addStreamTimingHeaders(
+        applyCorsHeaders(
+          Response.json(
+            {
+              success: false,
+              error: error.message,
+              code: "shared_runtime_idempotency_conflict",
+              retryable: false,
+            },
+            { status: 409 },
           ),
           CORS_METHODS,
           request.origin,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -6,6 +6,7 @@
  * deployment fault cannot fall through to repository-backed execution.
  */
 
+import { ElizaError } from "@elizaos/core";
 import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
 import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
 import { InsufficientCreditsError, RateLimitError } from "../../api/errors";
@@ -105,6 +106,11 @@ async function requireCoordinatorResponse(response: Response, surface: string): 
       (await readErrorMessage()) ?? "Organization rate limit exceeded.",
       Number.isFinite(retryAfter) ? retryAfter : undefined,
     );
+  }
+  if (response.status === 409) {
+    throw new ElizaError((await readErrorMessage()) ?? "Shared runtime idempotency conflict", {
+      code: "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT",
+    });
   }
   throw new Error(`[shared-runtime] ${surface} coordinator failed (${response.status})`);
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.test.ts
@@ -217,6 +217,7 @@ describe("resolveSharedAgent", () => {
       }),
     ).resolves.toEqual({
       error: "Agent authorization cache is warming. Retry shortly.",
+      code: "agent_cache_warming",
       status: 503,
     });
     expect(waited).toHaveLength(1);

--- a/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -47,6 +47,7 @@ export type ResolvedSharedAgent =
   | {
       error: string;
       status: 400 | 401 | 403 | 404 | 503;
+      code?: "agent_cache_warming";
       refusal?: SharedAgentRefusal;
     }
   | { agent: AgentSandbox; agentId: string; orgId: string; agentName: string };
@@ -533,6 +534,7 @@ export async function resolveSharedAgent(
     executionCtx.waitUntil(hydration);
     return {
       error: "Agent authorization cache is warming. Retry shortly.",
+      code: "agent_cache_warming",
       status: 503,
     };
   }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -40,6 +40,16 @@ export interface SharedTurnMessage {
    * stream. Model history keeps the text but annotates it as incomplete.
    */
   interrupted?: boolean;
+  /** Structured terminal handoffs replayed with a completed assistant turn. */
+  actionResults?: SharedTurnActionResult[];
+}
+
+export interface SharedTurnActionResult {
+  actionName?: string;
+  success: boolean;
+  text?: string;
+  error?: string;
+  values?: Record<string, unknown>;
 }
 
 export interface SharedAgentCharacter {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -36,6 +36,12 @@ export interface SharedTurnMessage {
   /** Epoch-ms timestamp used by REST chat clients to reconcile persisted turns. */
   createdAt?: number;
   /**
+   * Internal pre-dispatch tombstone. It participates in idempotency checks but
+   * is excluded from model and user-visible conversation history until the
+   * provider turn is completed.
+   */
+  pendingProviderDispatch?: boolean;
+  /**
    * True when an assistant message is a partial prefix from a canceled or failed
    * stream. Model history keeps the text but annotates it as incomplete.
    */

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -275,11 +275,13 @@ describe("shared-rest-adapter — messages", () => {
       "Eliza",
       EXECUTION_CTX,
       NAMESPACE,
+      "client-turn-1",
     );
     expect(out).toEqual({ text: "four", agentName: "Eliza" });
     const call = coordinateSharedBridge.mock.calls[0];
     expect(call[0]).toBe(SHARED_AGENT);
     expect(call[1].method).toBe("message.send");
+    expect(call[1].id).toBe("client-turn-1");
     expect(call[1].params).toMatchObject({ text: "2+2?", roomId: AGENT });
     expect(call[2]).toEqual({
       executionCtx: EXECUTION_CTX,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -513,10 +513,11 @@ export async function sharedRestMessageSend(
   agentName: string,
   executionCtx: BridgeExecutionContext,
   namespace: RuntimeDurableObjectNamespace,
+  clientMessageId?: string,
 ): Promise<{ text: string; agentName: string }> {
   const rpc: BridgeRequest = {
     jsonrpc: "2.0",
-    id: crypto.randomUUID(),
+    id: clientMessageId ?? crypto.randomUUID(),
     method: "message.send",
     params: { text, roomId: conversationId },
   };

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -22,6 +22,7 @@ const settleCalls: number[] = [];
 let settleUnknownCalls = 0;
 const billCalls: unknown[] = [];
 let characterReads = 0;
+const loggerInfo = mock(() => undefined);
 
 class ApiInsufficientCreditsError extends Error {}
 
@@ -46,6 +47,7 @@ mock.module("../../pricing", () => ({
 
 mock.module("../../utils/logger", () => ({
   logger: {
+    info: loggerInfo,
     warn: mock(() => undefined),
     error: mock(() => undefined),
   },
@@ -319,6 +321,7 @@ beforeEach(() => {
   turnError = null;
   streamTurnError = null;
   characterReads = 0;
+  loggerInfo.mockClear();
   enforceOrgRateLimit.mockClear();
   getInferenceAdmissionSnapshotCacheOnly.mockClear();
   admitOrganizationInference.mockClear();
@@ -407,6 +410,49 @@ describe("SharedRuntimeChatService", () => {
     expect(billCalls).toHaveLength(1);
     expect((billCalls[0] as unknown[])[2]).toBe(payoutAwareReservation);
     expect(settleCalls).toEqual([0.004]);
+  });
+
+  test("replays a completed client turn without a second admission or dispatch", async () => {
+    const service = new SharedRuntimeChatService();
+    const h = harness();
+
+    const first = await service.bridge(agent, rpc, h);
+    const admissionCalls = admitOrganizationInference.mock.calls.length;
+    const second = await new SharedRuntimeChatService().bridge(agent, rpc, h);
+
+    expect(second.result).toMatchObject({
+      text: first.result?.text,
+      messageId: first.result?.messageId,
+      userMessageId: first.result?.userMessageId,
+    });
+    expect(admitOrganizationInference).toHaveBeenCalledTimes(admissionCalls);
+    expect(h.history()).toHaveLength(3);
+    expect(loggerInfo).toHaveBeenCalledWith(
+      "[SharedRuntimeChatService] replaying completed idempotent turn",
+      expect.objectContaining({ agentId: agent.id, turnId: rpc.id }),
+    );
+  });
+
+  test("rejects reused ids with changed or incomplete persisted state", async () => {
+    const service = new SharedRuntimeChatService();
+    const h = harness();
+    const first = await service.bridge(agent, rpc, h);
+
+    await expect(
+      service.bridge(agent, { ...rpc, params: { ...rpc.params, text: "different" } }, h),
+    ).rejects.toMatchObject({ code: "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT" });
+
+    const incomplete = {
+      ...h,
+      historyStore: {
+        ...h.historyStore,
+        load: async () =>
+          h.history().filter((message) => message.id === first.result?.userMessageId),
+      },
+    };
+    await expect(service.bridge(agent, rpc, incomplete)).rejects.toMatchObject({
+      code: "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT",
+    });
   });
 
   test("rate denial and policy warming stop before billing admission or provider dispatch", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -23,6 +23,9 @@ let settleUnknownCalls = 0;
 const billCalls: unknown[] = [];
 let characterReads = 0;
 let providerDispatchCalls = 0;
+let providerDispatchError: Error | null;
+let turnInvocationCalls = 0;
+let streamInvocationCalls = 0;
 const loggerInfo = mock(() => undefined);
 
 class ApiInsufficientCreditsError extends Error {}
@@ -115,6 +118,7 @@ const admitOrganizationInference = mock(
       },
       markProviderDispatched: async () => {
         providerDispatchCalls++;
+        if (providerDispatchError) throw providerDispatchError;
       },
       reservation: payoutAwareReservation,
     };
@@ -163,6 +167,7 @@ mock.module("./run-shared-agent-turn", () => ({
     onProviderDispatch?: () => Promise<void>;
   }) => {
     if (!turn.degraded) await input.onProviderDispatch?.();
+    turnInvocationCalls++;
     if (turnError) throw turnError;
     const history = Array.isArray(turn.history)
       ? turn.history.map((message, index) =>
@@ -180,6 +185,7 @@ mock.module("./run-shared-agent-turn", () => ({
     onProviderDispatch?: () => Promise<void>;
   }) => {
     if (!streamTurn.degraded) await input.onProviderDispatch?.();
+    streamInvocationCalls++;
     if (streamTurnError) throw streamTurnError;
     streamAbortSignal = input.abortSignal;
     return streamTurn;
@@ -288,6 +294,7 @@ type TestMessage = {
   role: "user" | "assistant";
   content: string;
   createdAt?: number;
+  pendingProviderDispatch?: boolean;
   interrupted?: boolean;
   actionResults?: Array<{
     actionName?: string;
@@ -322,6 +329,9 @@ function harness() {
       },
       merge: async (_agentId: string, _channelId: string, messages: TestMessage[]) =>
         merge(messages),
+      removeMessage: async (_agentId: string, _channelId: string, messageId: string) => {
+        history = history.filter((message) => message.id !== messageId);
+      },
     },
     executionCtx: {
       waitUntil: (promise: Promise<unknown>) => background.push(promise),
@@ -340,6 +350,9 @@ beforeEach(() => {
   streamTurnError = null;
   characterReads = 0;
   providerDispatchCalls = 0;
+  providerDispatchError = null;
+  turnInvocationCalls = 0;
+  streamInvocationCalls = 0;
   loggerInfo.mockClear();
   enforceOrgRateLimit.mockClear();
   getInferenceAdmissionSnapshotCacheOnly.mockClear();
@@ -383,6 +396,23 @@ function wrappedProviderError(statusCode: number): Error {
 }
 
 describe("SharedRuntimeChatService", () => {
+  test("never exposes pre-dispatch tombstones through conversation history", async () => {
+    const service = new SharedRuntimeChatService();
+    const h = harness();
+    await h.historyStore.merge(agent.id, agent.id, [
+      {
+        id: "pending",
+        role: "user",
+        content: "not yet dispatched",
+        pendingProviderDispatch: true,
+      },
+    ]);
+
+    expect(await service.getHistory(agent.id, agent.id, h.historyStore)).toEqual([
+      { role: "assistant", content: "prior" },
+    ]);
+  });
+
   test("handles status, unknown methods, and invalid message input", async () => {
     const service = new SharedRuntimeChatService();
     expect((await service.bridge(agent, { ...rpc, method: "heartbeat" })).result).toMatchObject({
@@ -501,6 +531,7 @@ describe("SharedRuntimeChatService", () => {
       merge: async () => {
         throw new Error("durable marker write failed");
       },
+      removeMessage: async () => undefined,
     };
 
     await expect(service.bridge(agent, rpc, { historyStore })).rejects.toThrow(
@@ -530,6 +561,9 @@ describe("SharedRuntimeChatService", () => {
         history = [...history, ...messages];
         return history;
       },
+      removeMessage: async (_agentId: string, _channelId: string, messageId: string) => {
+        history = history.filter((message) => message.id !== messageId);
+      },
     };
 
     await expect(service.bridge(agent, rpc, { historyStore })).rejects.toThrow(
@@ -542,8 +576,53 @@ describe("SharedRuntimeChatService", () => {
     expect(admitOrganizationInference).toHaveBeenCalledTimes(1);
     expect(providerDispatchCalls).toBe(1);
     expect(history).toContainEqual(
-      expect.objectContaining({ role: "user", content: "hello", id: expect.any(String) }),
+      expect.objectContaining({
+        role: "user",
+        content: "hello",
+        id: expect.any(String),
+        pendingProviderDispatch: true,
+      }),
     );
+  });
+
+  test("a failed dispatch mark removes the hidden tombstone and permits a clean retry", async () => {
+    const service = new SharedRuntimeChatService();
+    const h = harness();
+    providerDispatchError = new TestInferenceAdmissionDispatchMarkError("dispatch mark failed");
+
+    await expect(service.bridge(agent, rpc, h)).rejects.toThrow(
+      "Provider dispatch marker failed before handoff",
+    );
+    expect(h.history()).toEqual([{ role: "assistant", content: "prior" }]);
+    expect(turnInvocationCalls).toBe(0);
+
+    providerDispatchError = null;
+    const retry = await service.bridge(agent, rpc, h);
+    expect(retry.result?.text).toBe("hello back");
+    expect(turnInvocationCalls).toBe(1);
+    expect(h.history()).not.toContainEqual(
+      expect.objectContaining({ pendingProviderDispatch: true }),
+    );
+  });
+
+  test("a failed stream dispatch mark never leaks its user turn into later model history", async () => {
+    const service = new SharedRuntimeChatService();
+    const h = harness();
+    providerDispatchError = new TestInferenceAdmissionDispatchMarkError("dispatch mark failed");
+
+    await expect(service.stream(agent, rpc, h)).rejects.toThrow(
+      "Provider dispatch marker failed before handoff",
+    );
+    expect(streamInvocationCalls).toBe(0);
+    expect(h.history()).toEqual([{ role: "assistant", content: "prior" }]);
+
+    providerDispatchError = null;
+    const nextRpc = { ...rpc, id: "turn-2", params: { text: "next", roomId: "room-1" } };
+    const response = await service.stream(agent, nextRpc, h);
+    await response.text();
+    expect(streamInvocationCalls).toBe(1);
+    expect(h.history().filter((message) => message.role === "user")).toHaveLength(1);
+    expect(h.history()).not.toContainEqual(expect.objectContaining({ content: "hello" }));
   });
 
   test("rejects reused ids with changed or incomplete persisted state", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -22,6 +22,7 @@ const settleCalls: number[] = [];
 let settleUnknownCalls = 0;
 const billCalls: unknown[] = [];
 let characterReads = 0;
+let providerDispatchCalls = 0;
 const loggerInfo = mock(() => undefined);
 
 class ApiInsufficientCreditsError extends Error {}
@@ -97,7 +98,7 @@ mock.module("../inference-admission-snapshot", () => ({
 
 const admitOrganizationInference = mock(
   async (params: {
-    context?: { metadata?: Record<string, unknown> };
+    context?: { requestId?: string; metadata?: Record<string, unknown> };
     executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   }) => {
     if (admissionError) throw admissionError;
@@ -111,6 +112,9 @@ const admitOrganizationInference = mock(
       settleUnknown: async () => {
         settleUnknownCalls++;
         return null;
+      },
+      markProviderDispatched: async () => {
+        providerDispatchCalls++;
       },
       reservation: payoutAwareReservation,
     };
@@ -154,7 +158,11 @@ mock.module("../../../db/repositories/characters", () => ({
 }));
 mock.module("./run-shared-agent-turn", () => ({
   resolveSharedAgentTurnModel: () => "openai/gpt-oss-120b",
-  runSharedAgentTurn: async (input: { messageIds?: { user: string; assistant: string } }) => {
+  runSharedAgentTurn: async (input: {
+    messageIds?: { user: string; assistant: string };
+    onProviderDispatch?: () => Promise<void>;
+  }) => {
+    if (!turn.degraded) await input.onProviderDispatch?.();
     if (turnError) throw turnError;
     const history = Array.isArray(turn.history)
       ? turn.history.map((message, index) =>
@@ -167,7 +175,11 @@ mock.module("./run-shared-agent-turn", () => ({
       : turn.history;
     return { ...turn, history };
   },
-  runSharedAgentTurnStream: async (input: { abortSignal?: AbortSignal }) => {
+  runSharedAgentTurnStream: async (input: {
+    abortSignal?: AbortSignal;
+    onProviderDispatch?: () => Promise<void>;
+  }) => {
+    if (!streamTurn.degraded) await input.onProviderDispatch?.();
     if (streamTurnError) throw streamTurnError;
     streamAbortSignal = input.abortSignal;
     return streamTurn;
@@ -277,6 +289,12 @@ type TestMessage = {
   content: string;
   createdAt?: number;
   interrupted?: boolean;
+  actionResults?: Array<{
+    actionName?: string;
+    success: boolean;
+    text?: string;
+    values?: Record<string, unknown>;
+  }>;
 };
 
 function harness() {
@@ -321,6 +339,7 @@ beforeEach(() => {
   turnError = null;
   streamTurnError = null;
   characterReads = 0;
+  providerDispatchCalls = 0;
   loggerInfo.mockClear();
   enforceOrgRateLimit.mockClear();
   getInferenceAdmissionSnapshotCacheOnly.mockClear();
@@ -430,6 +449,100 @@ describe("SharedRuntimeChatService", () => {
     expect(loggerInfo).toHaveBeenCalledWith(
       "[SharedRuntimeChatService] replaying completed idempotent turn",
       expect.objectContaining({ agentId: agent.id, turnId: rpc.id }),
+    );
+  });
+
+  test("replays the canonical completed stream with ids and structured results", async () => {
+    const service = new SharedRuntimeChatService();
+    const h = harness();
+    turn = {
+      degraded: false,
+      reply: "Opening Settings for you.",
+      history: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "Opening Settings for you." },
+      ],
+      model: "nav-intent",
+      navIntent: {
+        viewId: "settings",
+        label: "Settings",
+        reply: "Opening Settings for you.",
+      },
+    };
+
+    const first = await service.bridge(agent, rpc, h);
+    const admissions = admitOrganizationInference.mock.calls.length;
+    const response = await service.stream(agent, rpc, h);
+    const body = await response.text();
+    const payload = JSON.parse(body.split("data: ")[1]!.trim()) as Record<string, unknown>;
+
+    expect(payload).toMatchObject({
+      type: "done",
+      text: first.result?.text,
+      fullText: first.result?.text,
+      agentName: "Nova",
+      messageId: first.result?.messageId,
+      userMessageId: first.result?.userMessageId,
+      actionResults: [
+        {
+          actionName: "VIEWS",
+          success: true,
+          values: { mode: "show", viewId: "settings", source: "agent" },
+        },
+      ],
+    });
+    expect(admitOrganizationInference).toHaveBeenCalledTimes(admissions);
+  });
+
+  test("uses stable admission identities when the pre-dispatch marker cannot persist", async () => {
+    const service = new SharedRuntimeChatService();
+    const historyStore = {
+      load: async () => [{ role: "assistant" as const, content: "prior" }],
+      merge: async () => {
+        throw new Error("durable marker write failed");
+      },
+    };
+
+    await expect(service.bridge(agent, rpc, { historyStore })).rejects.toThrow(
+      "durable marker write failed",
+    );
+    await expect(service.bridge(agent, rpc, { historyStore })).rejects.toThrow(
+      "durable marker write failed",
+    );
+
+    expect(admitOrganizationInference).toHaveBeenCalledTimes(2);
+    const firstContext = admitOrganizationInference.mock.calls[0]![0].context;
+    const secondContext = admitOrganizationInference.mock.calls[1]![0].context;
+    expect(secondContext?.requestId).toBe(firstContext?.requestId);
+    expect(secondContext?.metadata?.idempotencyKey).toBe(firstContext?.metadata?.idempotencyKey);
+    expect(providerDispatchCalls).toBe(0);
+  });
+
+  test("a failed completion write leaves a durable marker that blocks redispatch", async () => {
+    const service = new SharedRuntimeChatService();
+    let history: TestMessage[] = [{ role: "assistant", content: "prior" }];
+    let merges = 0;
+    const historyStore = {
+      load: async () => history,
+      merge: async (_agentId: string, _channelId: string, messages: TestMessage[]) => {
+        merges++;
+        if (merges === 2) throw new Error("completion write failed");
+        history = [...history, ...messages];
+        return history;
+      },
+    };
+
+    await expect(service.bridge(agent, rpc, { historyStore })).rejects.toThrow(
+      "completion write failed",
+    );
+    await expect(service.bridge(agent, rpc, { historyStore })).rejects.toMatchObject({
+      code: "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT",
+    });
+
+    expect(admitOrganizationInference).toHaveBeenCalledTimes(1);
+    expect(providerDispatchCalls).toBe(1);
+    expect(history).toContainEqual(
+      expect.objectContaining({ role: "user", content: "hello", id: expect.any(String) }),
     );
   });
 
@@ -603,6 +716,7 @@ describe("SharedRuntimeChatService", () => {
     const body = await response.text();
     expect(body).toContain("event: chunk");
     expect(body).toContain("event: done");
+    expect(body).toContain('"type":"done"');
     expect(h.history()).toHaveLength(3);
     await Promise.all(h.background);
     expect(settleCalls).toEqual([0.004]);
@@ -763,7 +877,7 @@ describe("SharedRuntimeChatService", () => {
         },
         merge: async (_agentId: string, _channelId: string, messages: TestMessage[]) => {
           attempts++;
-          if (attempts === 1) throw new Error("durable put failed");
+          if (attempts === 2) throw new Error("durable put failed");
           history = [...history, ...messages];
           return history;
         },
@@ -789,13 +903,14 @@ describe("SharedRuntimeChatService", () => {
     const reader = response.body!.getReader();
     await reader.read();
     await expect(reader.cancel("first cancel")).rejects.toThrow("durable put failed");
-    expect(history).toHaveLength(1);
+    expect(history).toHaveLength(2);
+    expect(history.at(-1)).toMatchObject({ role: "user", content: "hello" });
 
     releaseProvider();
     await new Promise((resolve) => setTimeout(resolve, 0));
     await Promise.all(h.background);
 
-    expect(attempts).toBe(2);
+    expect(attempts).toBe(3);
     expect(history.at(-2)).toMatchObject({ role: "user", content: "hello" });
     expect(history.at(-1)).toMatchObject({
       role: "assistant",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -453,6 +453,22 @@ describe("SharedRuntimeChatService", () => {
     await expect(service.bridge(agent, rpc, incomplete)).rejects.toMatchObject({
       code: "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT",
     });
+
+    const interrupted = {
+      ...h,
+      historyStore: {
+        ...h.historyStore,
+        load: async () =>
+          h
+            .history()
+            .map((message) =>
+              message.id === first.result?.messageId ? { ...message, interrupted: true } : message,
+            ),
+      },
+    };
+    await expect(service.bridge(agent, rpc, interrupted)).rejects.toMatchObject({
+      code: "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT",
+    });
   });
 
   test("rate denial and policy warming stop before billing admission or provider dispatch", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -7,6 +7,7 @@
  */
 
 import crypto from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
 import type { UserCharacter } from "../../../db/repositories/characters";
 import {
@@ -126,6 +127,37 @@ function turnMessageIds(
     user: stableUuid(`shared-runtime:${agentId}:${roomId}:${turn}:user`),
     assistant: stableUuid(`shared-runtime:${agentId}:${roomId}:${turn}:assistant`),
   };
+}
+
+function completedTurn(
+  history: SharedTurnMessage[],
+  ids: { user: string; assistant: string },
+  text: string,
+): SharedTurnMessage | null {
+  const user = history.find((message) => message.id === ids.user);
+  const assistant = history.find((message) => message.id === ids.assistant);
+  if (!user && !assistant) return null;
+  if (user?.role !== "user" || user.content !== text || assistant?.role !== "assistant") {
+    throw new ElizaError("clientMessageId was already used for a different or incomplete turn", {
+      code: "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT",
+      context: { userMessageId: ids.user, assistantMessageId: ids.assistant },
+    });
+  }
+  return assistant;
+}
+
+function replayStream(
+  assistant: SharedTurnMessage,
+  ids: { user: string; assistant: string },
+): Response {
+  return new Response(
+    `event: done\ndata: ${JSON.stringify({
+      messageId: ids.assistant,
+      userMessageId: ids.user,
+      text: assistant.content,
+    })}\n\n`,
+    { headers: { "Content-Type": "text/event-stream; charset=utf-8" } },
+  );
 }
 
 function channelId(agentId: string, params: Record<string, unknown>): string {
@@ -587,13 +619,33 @@ export class SharedRuntimeChatService {
       };
     }
     const roomId = channelId(agent.id, params);
-    const [character, history] = await Promise.all([
-      characterFor(agent, {
-        cacheOnly: Boolean(options.historyStore),
-        executionCtx: options.executionCtx,
-      }),
-      loadHistory(agent.id, roomId, options.historyStore),
-    ]);
+    const history = await loadHistory(agent.id, roomId, options.historyStore);
+    const messageIds = turnMessageIds(agent.id, roomId, rpc);
+    const replay = completedTurn(history, messageIds, text);
+    if (replay) {
+      logger.info("[SharedRuntimeChatService] replaying completed idempotent turn", {
+        agentId: agent.id,
+        roomId,
+        turnId: rpcTurnIdentity(rpc),
+      });
+      return {
+        jsonrpc: "2.0",
+        id: rpc.id,
+        result: {
+          text: replay.content,
+          messageId: messageIds.assistant,
+          userMessageId: messageIds.user,
+          agentName: agent.agent_name ?? "Eliza agent",
+          channelId: roomId,
+          runtime: "shared",
+          transport: "shared-runtime",
+        },
+      };
+    }
+    const character = await characterFor(agent, {
+      cacheOnly: Boolean(options.historyStore),
+      executionCtx: options.executionCtx,
+    });
     let billing: BillingTurn | null;
     try {
       billing = await admitTurn(agent, character, history, text, roomId, options.executionCtx);
@@ -612,7 +664,6 @@ export class SharedRuntimeChatService {
       throw error;
     }
 
-    const messageIds = turnMessageIds(agent.id, roomId, rpc);
     let turn: RunSharedAgentTurnResult;
     try {
       turn = await runSharedAgentTurn({
@@ -699,13 +750,21 @@ export class SharedRuntimeChatService {
     const text = stringValue(params.text);
     if (!text) return sseError("message.send requires params.text");
     const roomId = channelId(agent.id, params);
-    const [character, history] = await Promise.all([
-      characterFor(agent, {
-        cacheOnly: Boolean(options.historyStore),
-        executionCtx: options.executionCtx,
-      }),
-      loadHistory(agent.id, roomId, options.historyStore),
-    ]);
+    const history = await loadHistory(agent.id, roomId, options.historyStore);
+    const messageIds = turnMessageIds(agent.id, roomId, rpc);
+    const replay = completedTurn(history, messageIds, text);
+    if (replay) {
+      logger.info("[SharedRuntimeChatService] replaying completed idempotent stream", {
+        agentId: agent.id,
+        roomId,
+        turnId: rpcTurnIdentity(rpc),
+      });
+      return replayStream(replay, messageIds);
+    }
+    const character = await characterFor(agent, {
+      cacheOnly: Boolean(options.historyStore),
+      executionCtx: options.executionCtx,
+    });
     let billing: BillingTurn | null;
     try {
       billing = await admitTurn(agent, character, history, text, roomId, options.executionCtx);
@@ -718,7 +777,6 @@ export class SharedRuntimeChatService {
       }
       throw error;
     }
-    const messageIds = turnMessageIds(agent.id, roomId, rpc);
     const generationAbort = new AbortController();
     const abortFromRequest = () => {
       generationAbort.abort(options.abortSignal?.reason);

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -75,6 +75,7 @@ export interface SharedRuntimeHistoryStore {
     channelId: string,
     messages: SharedTurnMessage[],
   ): Promise<SharedTurnMessage[]>;
+  removeMessage(agentId: string, channelId: string, messageId: string): Promise<void>;
 }
 
 export interface SharedRuntimeChatOptions {
@@ -221,6 +222,26 @@ async function mergeHistory(
   )) as SharedTurnMessage[];
 }
 
+async function removeHistoryMessage(
+  agentId: string,
+  roomId: string,
+  messageId: string,
+  store?: SharedRuntimeHistoryStore,
+): Promise<void> {
+  if (store) {
+    await store.removeMessage(agentId, roomId, messageId);
+    return;
+  }
+  const { sharedRuntimeHistoryRepository } = await import(
+    "../../../db/repositories/shared-runtime-history"
+  );
+  await sharedRuntimeHistoryRepository.removeMessage(agentId, roomId, messageId);
+}
+
+function conversationalHistory(history: SharedTurnMessage[]): SharedTurnMessage[] {
+  return history.filter((message) => message.pendingProviderDispatch !== true);
+}
+
 function persistProviderDispatch(
   agentId: string,
   roomId: string,
@@ -234,12 +255,26 @@ function persistProviderDispatch(
     role: "user",
     content: text,
     createdAt: Date.now(),
+    pendingProviderDispatch: true,
   };
   return async () => {
-    // Persist the logical turn before the irreversible provider handoff. If a
-    // worker exits after generation but before the completion merge, a retry
+    // Persist an idempotency-only tombstone before the irreversible provider
+    // handoff. It is never included in model history. A failed dispatch mark
+    // proves the provider did not run, so remove the tombstone and allow a
+    // same-id retry; an ambiguous post-dispatch failure deliberately retains it.
     await mergeHistory(agentId, roomId, [userMessage], store);
-    await billing?.markProviderDispatched?.();
+    try {
+      await billing?.markProviderDispatched?.();
+    } catch (error) {
+      // error-policy:J2 remove the provably pre-dispatch tombstone, then add
+      // turn identity while preserving the typed admission failure as cause.
+      await removeHistoryMessage(agentId, roomId, messageId, store);
+      throw new ElizaError("Provider dispatch marker failed before handoff", {
+        code: "SHARED_RUNTIME_DISPATCH_MARK_FAILED",
+        context: { agentId, roomId, messageId },
+        cause: error,
+      });
+    }
   };
 }
 
@@ -607,7 +642,7 @@ export class SharedRuntimeChatService {
     roomId = agentId,
     store?: SharedRuntimeHistoryStore,
   ): Promise<SharedTurnMessage[]> {
-    return await loadHistory(agentId, channelId(agentId, { roomId }), store);
+    return conversationalHistory(await loadHistory(agentId, channelId(agentId, { roomId }), store));
   }
 
   async getCharacter(
@@ -652,9 +687,9 @@ export class SharedRuntimeChatService {
       };
     }
     const roomId = channelId(agent.id, params);
-    const history = await loadHistory(agent.id, roomId, options.historyStore);
+    const persistedHistory = await loadHistory(agent.id, roomId, options.historyStore);
     const messageIds = turnMessageIds(agent.id, roomId, rpc);
-    const replay = completedTurn(history, messageIds, text);
+    const replay = completedTurn(persistedHistory, messageIds, text);
     if (replay) {
       logger.info("[SharedRuntimeChatService] replaying completed idempotent turn", {
         agentId: agent.id,
@@ -676,6 +711,7 @@ export class SharedRuntimeChatService {
         },
       };
     }
+    const history = conversationalHistory(persistedHistory);
     const character = await characterFor(agent, {
       cacheOnly: Boolean(options.historyStore),
       executionCtx: options.executionCtx,
@@ -806,9 +842,9 @@ export class SharedRuntimeChatService {
     const text = stringValue(params.text);
     if (!text) return sseError("message.send requires params.text");
     const roomId = channelId(agent.id, params);
-    const history = await loadHistory(agent.id, roomId, options.historyStore);
+    const persistedHistory = await loadHistory(agent.id, roomId, options.historyStore);
     const messageIds = turnMessageIds(agent.id, roomId, rpc);
-    const replay = completedTurn(history, messageIds, text);
+    const replay = completedTurn(persistedHistory, messageIds, text);
     if (replay) {
       logger.info("[SharedRuntimeChatService] replaying completed idempotent stream", {
         agentId: agent.id,
@@ -817,6 +853,7 @@ export class SharedRuntimeChatService {
       });
       return replayStream(replay, messageIds, agent.agent_name ?? "Eliza agent");
     }
+    const history = conversationalHistory(persistedHistory);
     const character = await characterFor(agent, {
       cacheOnly: Boolean(options.historyStore),
       executionCtx: options.executionCtx,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -154,12 +154,17 @@ function completedTurn(
 function replayStream(
   assistant: SharedTurnMessage,
   ids: { user: string; assistant: string },
+  agentName: string,
 ): Response {
   return new Response(
     `event: done\ndata: ${JSON.stringify({
+      type: "done",
       messageId: ids.assistant,
       userMessageId: ids.user,
       text: assistant.content,
+      fullText: assistant.content,
+      agentName,
+      ...(assistant.actionResults?.length ? { actionResults: assistant.actionResults } : {}),
     })}\n\n`,
     { headers: { "Content-Type": "text/event-stream; charset=utf-8" } },
   );
@@ -214,6 +219,28 @@ async function mergeHistory(
     valid,
     MAX_HISTORY_MESSAGES,
   )) as SharedTurnMessage[];
+}
+
+function persistProviderDispatch(
+  agentId: string,
+  roomId: string,
+  text: string,
+  messageId: string,
+  billing: BillingTurn | null,
+  store?: SharedRuntimeHistoryStore,
+): () => Promise<void> {
+  const userMessage: SharedTurnMessage = {
+    id: messageId,
+    role: "user",
+    content: text,
+    createdAt: Date.now(),
+  };
+  return async () => {
+    // Persist the logical turn before the irreversible provider handoff. If a
+    // worker exits after generation but before the completion merge, a retry
+    await mergeHistory(agentId, roomId, [userMessage], store);
+    await billing?.markProviderDispatched?.();
+  };
 }
 
 async function characterFor(
@@ -363,13 +390,14 @@ async function admitTurn(
   history: SharedTurnMessage[],
   text: string,
   roomId: string,
+  turnId: string,
   executionCtx?: BridgeExecutionContext,
 ): Promise<BillingTurn | null> {
   const model = resolveSharedAgentTurnModel(character.model);
   if (!model) return null;
   const estimatedInputTokens = estimateInputTokens(billingPrompt(character, history, text));
-  const requestId = `shared-runtime-${crypto.randomUUID()}`;
-  const idempotencyKey = `shared-runtime:${agent.id}:${roomId}:${crypto.randomUUID()}`;
+  const requestId = `shared-runtime-${turnId}`;
+  const idempotencyKey = `shared-runtime:${agent.id}:${roomId}:${turnId}`;
   const context = {
     organizationId: agent.organization_id,
     userId: agent.user_id,
@@ -644,6 +672,7 @@ export class SharedRuntimeChatService {
           channelId: roomId,
           runtime: "shared",
           transport: "shared-runtime",
+          ...(replay.actionResults?.length ? { actionResults: replay.actionResults } : {}),
         },
       };
     }
@@ -653,7 +682,15 @@ export class SharedRuntimeChatService {
     });
     let billing: BillingTurn | null;
     try {
-      billing = await admitTurn(agent, character, history, text, roomId, options.executionCtx);
+      billing = await admitTurn(
+        agent,
+        character,
+        history,
+        text,
+        roomId,
+        messageIds.user,
+        options.executionCtx,
+      );
     } catch (error) {
       // error-policy:J1 translate the money boundary to the JSON-RPC protocol.
       if (error instanceof InsufficientCreditsError) {
@@ -676,7 +713,14 @@ export class SharedRuntimeChatService {
         history,
         message: text,
         messageIds,
-        onProviderDispatch: billing?.markProviderDispatched,
+        onProviderDispatch: persistProviderDispatch(
+          agent.id,
+          roomId,
+          text,
+          messageIds.user,
+          billing,
+          options.historyStore,
+        ),
       });
     } catch (error) {
       await settleFailedProviderWorkOffPath(
@@ -696,12 +740,19 @@ export class SharedRuntimeChatService {
       if (turn.degraded) {
         await billing?.settle(0);
       } else {
+        const actionResults = turn.navIntent ? [navIntentActionResult(turn.navIntent)] : undefined;
         await mergeHistory(
           agent.id,
           roomId,
-          turn.history.filter(
-            (message) => message.id === messageIds.user || message.id === messageIds.assistant,
-          ),
+          turn.history
+            .filter(
+              (message) => message.id === messageIds.user || message.id === messageIds.assistant,
+            )
+            .map((message) =>
+              message.id === messageIds.assistant && actionResults
+                ? { ...message, actionResults }
+                : message,
+            ),
           options.historyStore,
         );
         if (turn.navIntent) {
@@ -764,7 +815,7 @@ export class SharedRuntimeChatService {
         roomId,
         turnId: rpcTurnIdentity(rpc),
       });
-      return replayStream(replay, messageIds);
+      return replayStream(replay, messageIds, agent.agent_name ?? "Eliza agent");
     }
     const character = await characterFor(agent, {
       cacheOnly: Boolean(options.historyStore),
@@ -772,7 +823,15 @@ export class SharedRuntimeChatService {
     });
     let billing: BillingTurn | null;
     try {
-      billing = await admitTurn(agent, character, history, text, roomId, options.executionCtx);
+      billing = await admitTurn(
+        agent,
+        character,
+        history,
+        text,
+        roomId,
+        messageIds.user,
+        options.executionCtx,
+      );
     } catch (error) {
       // error-policy:J1 translate the money boundary to the HTTP stream boundary.
       if (error instanceof InsufficientCreditsError) {
@@ -803,7 +862,14 @@ export class SharedRuntimeChatService {
         history,
         message: text,
         messageIds,
-        onProviderDispatch: billing?.markProviderDispatched,
+        onProviderDispatch: persistProviderDispatch(
+          agent.id,
+          roomId,
+          text,
+          messageIds.user,
+          billing,
+          options.historyStore,
+        ),
       });
     } catch (error) {
       detachRequestAbort();
@@ -853,7 +919,11 @@ export class SharedRuntimeChatService {
     }
 
     const encoder = new TextEncoder();
-    const makeTurnMessages = (reply: string, interrupted: boolean): SharedTurnMessage[] => {
+    const makeTurnMessages = (
+      reply: string,
+      interrupted: boolean,
+      actionResults?: SharedTurnMessage["actionResults"],
+    ): SharedTurnMessage[] => {
       const sentAt = Date.now();
       const messages: SharedTurnMessage[] = [
         { id: messageIds.user, role: "user", content: text, createdAt: sentAt },
@@ -866,6 +936,7 @@ export class SharedRuntimeChatService {
           content: assistantText,
           createdAt: sentAt + 1,
           interrupted,
+          ...(actionResults?.length ? { actionResults } : {}),
         });
       }
       return messages;
@@ -888,6 +959,7 @@ export class SharedRuntimeChatService {
       reply: string,
       interrupted: boolean,
       afterWrite?: () => Promise<void>,
+      actionResults?: SharedTurnMessage["actionResults"],
     ): Promise<void> => {
       if (finalized) return finalizationPromise ?? Promise.resolve();
       if (finalizationPromise) return finalizationPromise;
@@ -895,7 +967,7 @@ export class SharedRuntimeChatService {
         await mergeHistory(
           agent.id,
           roomId,
-          makeTurnMessages(reply, interrupted),
+          makeTurnMessages(reply, interrupted, actionResults),
           options.historyStore,
         );
         await afterWrite?.();
@@ -950,31 +1022,34 @@ export class SharedRuntimeChatService {
               );
               continue;
             }
-            await finalizeMessages(finalReply, false, async () => {
-              if (turn.navIntent) {
-                terminalSettlementStarted = true;
-                await billing?.settle(0);
-              } else if (billing) {
-                terminalSettlementStarted = true;
-                await settleOffResponsePath(options.executionCtx, () =>
-                  finishBilling(agent, billing, finalReply, text, part.usage),
-                );
-              }
-            });
-            const done = turn.navIntent
-              ? {
-                  messageId: messageIds.assistant,
-                  userMessageId: messageIds.user,
-                  text: finalReply,
-                  fullText: finalReply,
-                  actionResults: [navIntentActionResult(turn.navIntent)],
+            const actionResults = turn.navIntent
+              ? [navIntentActionResult(turn.navIntent)]
+              : undefined;
+            await finalizeMessages(
+              finalReply,
+              false,
+              async () => {
+                if (turn.navIntent) {
+                  terminalSettlementStarted = true;
+                  await billing?.settle(0);
+                } else if (billing) {
+                  terminalSettlementStarted = true;
+                  await settleOffResponsePath(options.executionCtx, () =>
+                    finishBilling(agent, billing, finalReply, text, part.usage),
+                  );
                 }
-              : {
-                  messageId: messageIds.assistant,
-                  userMessageId: messageIds.user,
-                  text: finalReply,
-                  fullText: finalReply,
-                };
+              },
+              actionResults,
+            );
+            const done = {
+              type: "done",
+              messageId: messageIds.assistant,
+              userMessageId: messageIds.user,
+              text: finalReply,
+              fullText: finalReply,
+              agentName: character.name,
+              ...(actionResults ? { actionResults } : {}),
+            };
             controller.enqueue(encoder.encode(chatSseFrame("done", done)));
           }
           if (!finished) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -137,7 +137,12 @@ function completedTurn(
   const user = history.find((message) => message.id === ids.user);
   const assistant = history.find((message) => message.id === ids.assistant);
   if (!user && !assistant) return null;
-  if (user?.role !== "user" || user.content !== text || assistant?.role !== "assistant") {
+  if (
+    user?.role !== "user" ||
+    user.content !== text ||
+    assistant?.role !== "assistant" ||
+    assistant.interrupted === true
+  ) {
     throw new ElizaError("clientMessageId was already used for a different or incomplete turn", {
       code: "SHARED_RUNTIME_IDEMPOTENCY_CONFLICT",
       context: { userMessageId: ids.user, assistantMessageId: ids.assistant },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
@@ -40,6 +40,23 @@ describe("shared runtime history merge policy", () => {
     expect(mergeSharedRuntimeHistoryMessages([longer], [complete], 40)).toEqual([complete]);
   });
 
+  test("a stale pending-dispatch tombstone cannot replace a completed user message", () => {
+    const completed = {
+      id: "user-1",
+      role: "user" as const,
+      content: "hello",
+      createdAt: 1,
+    };
+    const staleTombstone = { ...completed, pendingProviderDispatch: true };
+
+    expect(mergeSharedRuntimeHistoryMessages([completed], [staleTombstone], 40)).toEqual([
+      completed,
+    ]);
+    expect(mergeSharedRuntimeHistoryMessages([staleTombstone], [completed], 40)).toEqual([
+      completed,
+    ]);
+  });
+
   test("stale snapshots merge by id, reject invalid entries, and cap oldest turns", () => {
     const current = [
       { id: "one", role: "user" as const, content: "one", createdAt: 1 },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
@@ -11,6 +11,7 @@ export interface SharedRuntimeHistoryMessageLike {
   role: "user" | "assistant";
   content: string;
   createdAt?: number;
+  pendingProviderDispatch?: boolean;
   interrupted?: boolean;
   actionResults?: Array<{
     actionName?: string;
@@ -41,6 +42,9 @@ function chooseMergedMessage<T extends SharedRuntimeHistoryMessageLike>(
   incoming: T,
 ): T {
   if (!current) return incoming;
+  if (current.pendingProviderDispatch !== true && incoming.pendingProviderDispatch === true) {
+    return current;
+  }
   if (
     current.role === "assistant" &&
     incoming.role === "assistant" &&

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
@@ -12,6 +12,13 @@ export interface SharedRuntimeHistoryMessageLike {
   content: string;
   createdAt?: number;
   interrupted?: boolean;
+  actionResults?: Array<{
+    actionName?: string;
+    success: boolean;
+    text?: string;
+    error?: string;
+    values?: Record<string, unknown>;
+  }>;
 }
 
 function isPersistedMessage(value: unknown): value is SharedRuntimeHistoryMessageLike {

--- a/packages/ui/src/api/client-agent-stream.test.ts
+++ b/packages/ui/src/api/client-agent-stream.test.ts
@@ -155,12 +155,12 @@ describe("ElizaClient agent streaming transport", () => {
     expect(result.text).toContain("available_views:");
   });
 
-  it("surfaces done event action results for page handoffs", async () => {
+  it("parses a canonical replay completion with ids and structured action results", async () => {
     const encoder = new TextEncoder();
     const read = vi.fn().mockResolvedValueOnce({
       done: false,
       value: encoder.encode(
-        'data: {"type":"done","fullText":"Created.","agentName":"Eliza","actionResults":[{"actionName":"WORKFLOW","success":true,"values":{"workflowId":"workflow-1"}}]}\n\n',
+        'event: done\ndata: {"type":"done","text":"Created.","fullText":"Created.","agentName":"Eliza","messageId":"assistant-1","userMessageId":"user-1","actionResults":[{"actionName":"WORKFLOW","success":true,"values":{"workflowId":"workflow-1"}}]}\n\n',
       ),
     });
     const request = vi.fn(async () => {
@@ -188,6 +188,12 @@ describe("ElizaClient agent streaming transport", () => {
         values: { workflowId: "workflow-1" },
       },
     ]);
+    expect(result).toMatchObject({
+      completed: true,
+      text: "Created.",
+      messageId: "assistant-1",
+      userMessageId: "user-1",
+    });
   });
 
   it("preserves structured terminal error events as StreamGenerationError", async () => {

--- a/packages/ui/src/api/client-base-resume.test.ts
+++ b/packages/ui/src/api/client-base-resume.test.ts
@@ -120,13 +120,18 @@ describe("ElizaClient shared-agent warming retry", () => {
   });
   afterEach(() => vi.useRealTimers());
 
-  it("retries only the two structured warming codes with the same body", async () => {
+  it("retries resolver and coordinator warming route payloads with the same body", async () => {
     const request = vi
       .fn<AgentRequestTransport["request"]>()
       .mockResolvedValueOnce(
         jsonResponse(
           503,
-          { code: "agent_cache_warming" },
+          {
+            success: false,
+            error: "Agent authorization cache is warming. Retry shortly.",
+            code: "agent_cache_warming",
+            retryable: true,
+          },
           { "retry-after": "1" },
         ),
       )

--- a/packages/ui/src/api/client-base-resume.test.ts
+++ b/packages/ui/src/api/client-base-resume.test.ts
@@ -112,3 +112,97 @@ describe("ElizaClient 202 dedicated-agent resume handling", () => {
     expect(request).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("ElizaClient shared-agent warming retry", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("retries only the two structured warming codes with the same body", async () => {
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          503,
+          { code: "agent_cache_warming" },
+          { "retry-after": "1" },
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          503,
+          { code: "shared_runtime_cache_warming" },
+          { "retry-after": "1" },
+        ),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    const body = JSON.stringify({ text: "hello", clientMessageId: "turn-1" });
+    const pending = makeClient(request).fetch("/api/chat/stream", {
+      method: "POST",
+      body,
+    });
+    await vi.runAllTimersAsync();
+    await expect(pending).resolves.toMatchObject({ ok: true });
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request.mock.calls.map((call) => call[1]?.body)).toEqual([
+      body,
+      body,
+      body,
+    ]);
+  });
+
+  it("stops after three warming retries", async () => {
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValue(
+        jsonResponse(
+          503,
+          { code: "shared_runtime_cache_warming" },
+          { "retry-after": "0" },
+        ),
+      );
+    const pending = makeClient(request)
+      .fetch("/api/chat/stream")
+      .catch((error) => error);
+    await vi.runAllTimersAsync();
+    expect(((await pending) as { code?: string }).code).toBe(
+      "shared_runtime_cache_warming",
+    );
+    expect(request).toHaveBeenCalledTimes(4);
+  });
+
+  it("uses the one-second default when Retry-After is absent", async () => {
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValueOnce(
+        jsonResponse(503, { code: "shared_runtime_cache_warming" }),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    const pending = makeClient(request).fetch<{ ok: boolean }>(
+      "/api/chat/stream",
+    );
+    await vi.advanceTimersByTimeAsync(999);
+    expect(request).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toMatchObject({ ok: true });
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([402, 409, 503])("does not retry an unrelated %s", async (status) => {
+    const body =
+      status === 402
+        ? { code: "insufficient_credits" }
+        : status === 409
+          ? { code: "shared_runtime_idempotency_conflict", retryable: false }
+          : { code: "inference_unavailable", retryable: true };
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValue(jsonResponse(status, body));
+    await makeClient(request)
+      .fetch("/api/chat/stream")
+      .catch(() => undefined);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -709,6 +709,31 @@ const RESUME_MAX_RETRIES = 6;
 const RESUME_DEFAULT_DELAY_MS = 5_000;
 const RESUME_MIN_DELAY_MS = 500;
 const RESUME_MAX_DELAY_MS = 10_000;
+const WARMING_MAX_RETRIES = 3;
+const WARMING_DEFAULT_DELAY_MS = 1_000;
+const WARMING_CODES = new Set([
+  "agent_cache_warming",
+  "shared_runtime_cache_warming",
+]);
+
+async function warmingRetryDelayMs(res: Response): Promise<number | null> {
+  if (res.status !== 503) return null;
+  let body: { code?: unknown } | null;
+  try {
+    body = (await res.clone().json()) as { code?: unknown };
+  } catch {
+    // error-policy:J3 malformed or non-JSON 503 bodies are never classified as
+    // warming and therefore remain visible instead of being auto-retried.
+    return null;
+  }
+  if (typeof body?.code !== "string" || !WARMING_CODES.has(body.code))
+    return null;
+  const header = res.headers.get("Retry-After");
+  const seconds = header === null ? Number.NaN : Number(header);
+  return Number.isFinite(seconds) && seconds >= 0
+    ? Math.min(2_000, seconds * 1_000)
+    : WARMING_DEFAULT_DELAY_MS;
+}
 
 /** Clamp the agent's advertised `Retry-After` (seconds) into a sane wait (ms). */
 function resumeRetryDelayMs(res: Response): number {
@@ -1126,6 +1151,19 @@ export class ElizaClient {
       if (init?.signal?.aborted) break;
       resumeRetries += 1;
       res = await this.rawRequestOnce(path, requestUrl, init, options, token);
+    }
+    let warmingRetries = 0;
+    let warmingDelay = await warmingRetryDelayMs(res);
+    while (
+      warmingDelay !== null &&
+      warmingRetries < WARMING_MAX_RETRIES &&
+      !init?.signal?.aborted
+    ) {
+      await sleepUnlessAborted(warmingDelay, init?.signal);
+      if (init?.signal?.aborted) break;
+      warmingRetries += 1;
+      res = await this.rawRequestOnce(path, requestUrl, init, options, token);
+      warmingDelay = await warmingRetryDelayMs(res);
     }
     // Resume budget exhausted while the agent is still 202 (resuming): surface a
     // distinguishable error instead of returning the empty 202 placeholder as a

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -1222,6 +1222,36 @@ describe("useChatSend non-404 send failures", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.client.getBaseUrl.mockReturnValue("");
+    window.localStorage.clear();
+  });
+
+  it("retains the failed assistant turn for an insufficient-credits response", async () => {
+    mocks.client.sendConversationMessageStream.mockRejectedValue(
+      Object.assign(httpStatusError(402, "Insufficient credits"), {
+        code: "insufficient_credits",
+      }),
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hello", {
+        conversationId: "conv-1",
+      });
+    });
+
+    const assistant = deps.conversationMessagesRef.current.find(
+      (message) => message.role === "assistant",
+    );
+    expect(assistant).toMatchObject({
+      failureKind: "insufficient_credits",
+    });
+    expect(deps.setActionNotice).not.toHaveBeenCalled();
+    expect(listPendingChatTurns("conv-1")).toHaveLength(0);
   });
 
   it("surfaces a notice + keeps the user message on a transient (non-404) send failure", async () => {

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -1774,6 +1774,19 @@ export function useChatSend(deps: UseChatSendDeps) {
           return;
         }
 
+        if (
+          (err as { status?: number }).status === 402 &&
+          (err as { code?: string }).code === "insufficient_credits"
+        ) {
+          applyStreamingModificationForConversation(convId, {
+            messageId: assistantMsgId,
+            mode: "fail",
+            failureKind: "insufficient_credits",
+          });
+          clearPendingChatTurn(convId, clientMessageId);
+          return;
+        }
+
         const status = (err as { status?: number }).status;
         if (status === 404) {
           // A 404 on send usually means the conversation row was deleted —


### PR DESCRIPTION
# Relates to

Relates to #18045. This PR repairs the deterministic shared-agent warming/idempotency contracts but does **not** close the issue until the required credential-isolated staging create → cold-first-send evidence exists.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Contributor model: `openai/gpt-5.6-sol`
- Maintainer review and repair: `OpenAI GPT-5`
<!-- attribution-row:client -->
- Contributor tooling: `Codex`
- Maintainer tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Contributor skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `contributor self-reported; maintainer work recorded during review`

# Reviewed revision

- Base: `b53a3706181e9d8d986c106ac8dedd8b5fe64ed3`
- Head: `7287dc474449463c94e0f88bf10a5581dc3c5044`

# What this changes

- Propagates explicit cache-warming codes and `Retry-After`, and retries only those exact codes with the unchanged request body and a bounded attempt count.
- Validates and preserves `clientMessageId` through REST/SSE, derives stable turn/billing identities, and serializes duplicate room turns in the conversation Durable Object.
- Replays completed turns before billing/provider dispatch; changed-text, incomplete, interrupted, or ambiguous same-id state becomes a terminal conflict.
- Emits canonical typed SSE completion frames for live and replay paths, including full text, IDs, agent name, and structured action results.
- Persists a hidden pre-dispatch idempotency tombstone. Provably pre-dispatch mark failure removes it from Durable Object and Postgres state; ambiguous post-dispatch outcomes retain it to prevent same-id redispatch.
- Excludes tombstones from visible history, billing prompts, and model context.

# Maintainer review and repair

The contributor’s latest revision fixed the previously reported stranded user turn. Re-review found that the older shared bridge reads the same Postgres mirror and would still accept the new tombstone as conversational history. The exact head now enforces the same hidden-history boundary there and adds a regression proving only visible prior turns reach the legacy bridge model input.

# Verification

- Changed backend matrix: **145/145 passed** across 10 isolated suites, including real PGlite deletion/merge coverage.
- UI retry/parser/hook matrix: **110/110 passed** across 3 Vitest files.
- `packages/cloud/shared` typecheck: passed.
- Biome and `git diff --check`: passed.

# Remaining merge blocker

This changes provisioning-adjacent cache warming, billing admission, provider dispatch, persistence, and retry behavior. Repository policy requires the real boundary: a credential-isolated staging tenant must create a shared agent, issue the ordinary cold first send, and attach the created row/state, request/response logs, first-message result, billing/idempotency identities, and proof that retry did not dispatch or charge twice. The attempted preflight safely stopped because the available staging credential matched production; no live result is claimed.

# Evidence Gate

<!-- evidence-head:7287dc474449463c94e0f88bf10a5581dc3c5044 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no component markup, styling, copy, or rendered layout changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - bounded retry, persistence, and replay are non-visual transport behavior.

<!-- evidence-row:backend-logs -->
- [x] [18426-backend-review-head.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18426-backend-review-head.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser-only implementation changed; the UI client contract is covered by the exact-head Vitest matrix.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - repaired branches occur before model dispatch or replay persisted output; dispatch counts are asserted directly.

<!-- evidence-row:domain-artifacts -->
- [x] [18426-domain-review-head.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-7/18426-domain-review-head.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or layout changed.

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->

