### PR TITLE
fix(security): align BLOCKED_ENV_KEYS with the spawn denylist

### DIFF
--- a/packages/agent/src/config/blocked-env-keys.test.ts
+++ b/packages/agent/src/config/blocked-env-keys.test.ts
@@ -21,6 +21,63 @@ describe("BLOCKED_ENV_KEYS", () => {
     expect(BLOCKED_ENV_KEYS.has("OPINION_PRIVATE_KEY")).toBe(true);
   });
 
+  it("is a superset of core's spawn denylist so the two cannot drift", async () => {
+    // BLOCKED_SPAWN_ENV_KEYS guards a caller-supplied child environment. This
+    // list guards config/API writes, which reach process.env and are then
+    // inherited by every spawn site that passes no explicit env. A key blocked
+    // there but not here is reachable through that path.
+    const { BLOCKED_SPAWN_ENV_KEYS } = await import(
+      "@elizaos/core/security/spawn-env-policy"
+    );
+    const missing = [...BLOCKED_SPAWN_ENV_KEYS].filter(
+      (key) => !BLOCKED_ENV_KEYS.has(key),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("blocks the loader and interpreter hijack keys reachable through process.env", () => {
+    for (const key of [
+      "LD_AUDIT",
+      "DYLD_FRAMEWORK_PATH",
+      "PYTHONPATH",
+      "PYTHONSTARTUP",
+      "PYTHONHOME",
+      "PERL5OPT",
+      "PERL5LIB",
+      "RUBYOPT",
+      "RUBYLIB",
+    ]) {
+      expect(BLOCKED_ENV_KEYS.has(key)).toBe(true);
+    }
+  });
+
+  it("drops loader hijack keys during startup env collection", () => {
+    const envVars = collectConfigEnvVars({
+      env: {
+        vars: {
+          LD_AUDIT: "/tmp/evil.so",
+          PYTHONPATH: "/tmp/evil-modules",
+          SAFE_PUBLIC_FLAG: "enabled",
+        },
+        DYLD_FRAMEWORK_PATH: "/tmp/evil-frameworks",
+        RUBYOPT: "-r/tmp/evil",
+        SAFE_DIRECT_VALUE: "direct",
+      },
+    });
+
+    expect(envVars).toEqual({
+      SAFE_PUBLIC_FLAG: "enabled",
+      SAFE_DIRECT_VALUE: "direct",
+    });
+  });
+
+  it("still allows ordinary application keys that only look loader-adjacent", () => {
+    expect(BLOCKED_ENV_KEYS.has("PYTHON_VERSION")).toBe(false);
+    expect(BLOCKED_ENV_KEYS.has("NODE_ENV")).toBe(false);
+    expect(BLOCKED_ENV_KEYS.has("LD_FLAGS")).toBe(false);
+    expect(BLOCKED_ENV_KEYS.has("RUBY_VERSION")).toBe(false);
+  });
+
   it("blocks canonical secret keys during startup env collection", () => {
     const envVars = collectConfigEnvVars({
       env: {

--- a/packages/agent/src/config/blocked-env-keys.ts
+++ b/packages/agent/src/config/blocked-env-keys.ts
@@ -9,12 +9,39 @@
  * - Privilege escalation and step-up tokens
  * - Wallet/steward/private trading secrets
  * - Database connection strings
+ *
+ * The process-level code-injection category must stay a superset of core's
+ * BLOCKED_SPAWN_ENV_KEYS. That list guards a caller-supplied child environment;
+ * this one guards config and API writes, which land in `process.env` and are
+ * then inherited by every spawn site that does not pass an explicit env. A key
+ * blocked there but not here is reachable through this path, so the two lists
+ * are kept aligned and a test in blocked-env-keys.test.ts enforces it. The keys
+ * are listed literally rather than spread from core: mcp-server-config.ts
+ * records that the core barrel must not be captured at module-init.
  */
 export const BLOCKED_ENV_KEYS = new Set([
   "LD_PRELOAD",
   "LD_LIBRARY_PATH",
+  // ld.so audit hook: loads an arbitrary shared object into every spawned
+  // dynamically linked binary, the same code-injection primitive as LD_PRELOAD
+  // above. Several spawn sites hand this process's environment straight to a
+  // child (audio-redaction, sandbox-engine, workspace, shell router), so a key
+  // that survives this list reaches them all.
+  "LD_AUDIT",
   "DYLD_INSERT_LIBRARIES",
   "DYLD_LIBRARY_PATH",
+  "DYLD_FRAMEWORK_PATH",
+  // Interpreter module-path and startup hijacks. These only bite when a
+  // matching interpreter is spawned, but they are the same class as
+  // NODE_OPTIONS/NODE_PATH below and the spawn/MCP denylist already blocks
+  // them; keeping the two lists aligned is what stops the drift.
+  "PYTHONPATH",
+  "PYTHONSTARTUP",
+  "PYTHONHOME",
+  "PERL5OPT",
+  "PERL5LIB",
+  "RUBYOPT",
+  "RUBYLIB",
   "NODE_OPTIONS",
   "NODE_EXTRA_CA_CERTS",
   "NODE_TLS_REJECT_UNAUTHORIZED",


### PR DESCRIPTION
# Relates to

Closes #18423

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused suites, typecheck, and Biome recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused suites pass post-sync; see **Testing** below.

# Risks

Low and additive. Nine entries are added to `BLOCKED_ENV_KEYS`; none is removed, no control flow changes, and every consumer reads the same `Set` through `.has(key.toUpperCase())`.

Over-blocking was the failure mode I checked hardest for. Nothing in the repository — source, config, fixture, example, or documentation — sets any of the nine keys, so there is no known compatibility surface. The plugin config path (`server-helpers-plugin.ts:186`) checks a per-plugin `allowedParamKeys` allowlist *before* consulting this list, so the additions are defense-in-depth there rather than a new rejection surface. Four negative controls (`NODE_ENV`, `PYTHON_VERSION`, `LD_FLAGS`, `RUBY_VERSION`) are asserted to still pass.

# Background

## What does this PR do?

`BLOCKED_ENV_KEYS` guards config and API environment writes, and its header names its first category as process-level code injection. For that category it was a strict subset of core's `BLOCKED_SPAWN_ENV_KEYS`: it blocked `LD_PRELOAD` but not `LD_AUDIT`, `DYLD_INSERT_LIBRARIES` but not `DYLD_FRAMEWORK_PATH`, and `NODE_OPTIONS` but no Python, Perl, or Ruby variable at all.

`LD_AUDIT` is the significant one — core's own comment beside it reads *"ld.so audit hook: loads an arbitrary shared object into every spawned dynamically linked binary — same code-injection primitive as LD_PRELOAD."* The primitive already blocked under one name was unblocked under another.

A key that survives this list is persisted to `eliza.json` and applied to `process.env` on the next config load (`config.ts:100`), and several spawn sites hand that environment to a child without filtering:

```
audio-redaction.ts:349   spawn(bin, args, { windowsHide: true })   no env -> inherits
sandbox-engine.ts:142    spawn(binary, args, { stdio: [...] })     no env -> inherits
workspace.ts:57          env: opts.env ?? process.env
shell-execution-router.ts:159   { ...process.env, ...sanitizeChildEnv(req.env) }
```

`sanitizeSpawnEnv` filters only a caller-supplied env and never inspects `process.env`, so the spawn-side mitigation cannot see anything arriving through the config path. `config-routes.ts:426-430` describes this route as the one it exists to close.

This adds the nine keys grouped by primitive and records the invariant in the header. A test asserts the superset relation so the two lists cannot drift apart again.

The keys are listed literally rather than spread from core at module scope: `mcp-server-config.ts` records that the core barrel must not be captured at module-init, and `new Set([...BLOCKED_SPAWN_ENV_KEYS])` would do exactly that.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/config/blocked-env-keys.ts` — the added entries and the header invariant. Then `blocked-env-keys.test.ts`, which asserts the superset relation, the nine keys individually, that `collectConfigEnvVars` drops them, and that ordinary keys still pass.

## Detailed testing steps

Reverting only the source file and re-running fails 3 of 6, so the assertions are bound to the change. The third failure is the reachability itself rather than a membership check — it shows the key surviving the collector that feeds `process.env`:

```
AssertionError: expected [ 'LD_AUDIT', …(8) ] to deeply equal []
AssertionError: expected false to be true
AssertionError: expected { LD_AUDIT: '/tmp/evil.so', …(5) }
              to deeply equal { SAFE_PUBLIC_FLAG: 'enabled', …(1) }
```

```
with the fix                                       6 passed (6)
source reverted, tests kept              3 failed | 3 passed (6)
packages/agent/src/config + model-config-routes    5 files, 52 passed
```

Biome clean on both changed files. `tsc --noEmit -p packages/agent/tsconfig.json` reports 26 errors both with and without this change — all pre-existing unbuilt-workspace-dependency errors (`@elizaos/cloud-routing`, `plugin-notes`), none in these files.

# Known gaps / failures

- No exploit is claimed. The loader behaviour is cited from ld.so/dyld semantics and core's own comment; it was **not reproduced here** — this host is macOS and `LD_AUDIT` is glibc. What the tests demonstrate is the reachability: the key survives the filter that feeds `process.env`.
- `LD_AUDIT` / `DYLD_FRAMEWORK_PATH` need no particular child. The Python/Perl/Ruby keys need a matching interpreter; no in-tree call site names one as its command, the shell router will spawn one if a user or agent runs it, and MCP servers receive `{...config.env, PATH}` rather than `process.env`, so they are unaffected. Those keys are included for consistency with the spawn denylist rather than on their own reachability.
- The persisted `config-env` store (`config.ts:251`) is applied to `process.env` without this filter by design. Every writer uses a hardcoded key constant (`first-time-setup.ts`, `remote-capability-routes.ts`) or migrates keys already present (`vault-bootstrap.ts`), so it is a closed set; it is noted here only so the asymmetry is not mistaken for an oversight.
- The superset test couples the two lists' release order: if #18417 lands first, its keys must be added here too or this test fails. That coupling is the point — it makes drift a build failure — but it is a real constraint and is one deletable test block if you would rather not carry it.
- **Overlap with #18473.** That PR derives `BLOCKED_ENV_KEYS` from `BLOCKED_SPAWN_ENV_KEYS` by spread, which covers all nine keys added here. If it lands first these nine become redundant and this PR should be closed; it is held open until then rather than leaving the gap to an unmerged PR.
- The prefix list has no counterpart on this path at all (`BASH_FUNC_`, `NPM_CONFIG_`, `DENO_`, …). That is a different defect class requiring a predicate at ten call sites, and is recorded in #18423 as a separate follow-up rather than bundled here.

# Evidence

<!-- evidence-head:989a46b49b050a150eabe3b5af5bb71cedcc75ac -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; this changes a `packages/agent` denylist constant.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; behavior is asserted by the unit tests above.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the observable behavior is a set-membership check; the revert-and-fail run is the demonstration.
<!-- evidence-row:backend-logs -->
- [x] Full verification log attached below: the gap measured on clean develop, tests with the fix, the same tests with the source reverted, and the full config suite.
[evidence-blocked-env-keys.txt](https://github.com/user-attachments/files/30944756/evidence-blocked-env-keys.txt)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface is touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, scheduled-task, or generated-file output changed.

---

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported

