### PR TITLE
fix(core): harden on-demand transcription per #18413

### DIFF
--- a/packages/core/src/features/working-memory/attachmentContext.ts
+++ b/packages/core/src/features/working-memory/attachmentContext.ts
@@ -6,8 +6,10 @@
  * id/locator match, or the sole attachment), and materializes readable content
  * for each — stored extracted text or description, falling back to an on-demand
  * vision description that reuses the shared content-addressed image cache.
- * Consumed by readAttachmentAction.ts; the `_data`/`_mimeType`/`_createdAt` fields
- * are inline-transport and ordering extensions carried alongside `Media`.
+ * Consumed by readAttachmentAction.ts; the `_data`/`_mimeType`/`_createdAt`/
+ * `_messageId` fields are inline-transport, ordering, and source-row extensions
+ * carried alongside `Media` — `_messageId` names the message memory whose
+ * stored copy of the attachment on-demand enrichment must update.
  */
 import { buildAccessContext } from "../../access-context.ts";
 import {
@@ -30,6 +32,7 @@ type AttachmentWithInlineData = Media & {
 	_data?: string;
 	_mimeType?: string;
 	_createdAt?: number;
+	_messageId?: UUID;
 	redacted?: true;
 };
 
@@ -223,7 +226,11 @@ export async function listConversationAttachments(
 			.map((attachment) =>
 				selectAttachmentForRequester(
 					message,
-					{ ...attachment, _createdAt: message.createdAt ?? Date.now() },
+					{
+						...attachment,
+						_createdAt: message.createdAt ?? Date.now(),
+						_messageId: message.id,
+					},
 					accessContext,
 					agentId,
 				),
@@ -238,6 +245,7 @@ export async function listConversationAttachments(
 	const rememberAttachment = (
 		attachment: AttachmentWithInlineData,
 		createdAt: number,
+		messageId: UUID | undefined,
 	) => {
 		const existing = attachmentsById.get(attachment.id);
 		if (existing && (existing._createdAt ?? 0) >= createdAt) {
@@ -246,6 +254,7 @@ export async function listConversationAttachments(
 		attachmentsById.set(attachment.id, {
 			...attachment,
 			_createdAt: createdAt,
+			_messageId: messageId,
 		});
 	};
 
@@ -256,7 +265,8 @@ export async function listConversationAttachments(
 			accessContext,
 			agentId,
 		);
-		if (selected) rememberAttachment(selected, message.createdAt ?? Date.now());
+		if (selected)
+			rememberAttachment(selected, message.createdAt ?? Date.now(), message.id);
 	}
 
 	for (const recentMessage of recentMessages) {
@@ -270,7 +280,7 @@ export async function listConversationAttachments(
 				accessContext,
 				agentId,
 			);
-			if (selected) rememberAttachment(selected, createdAt);
+			if (selected) rememberAttachment(selected, createdAt, recentMessage.id);
 		}
 	}
 

--- a/packages/core/src/features/working-memory/readAttachmentAction.transcription.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.transcription.test.ts
@@ -16,12 +16,16 @@
  *      honestly, without leaking internal error prose;
  *   3. TRANSIENT failures (network blip, provider 5xx, fetch-layer errors —
  *      whose messages can echo a hostile remote body) keep the retryable
- *      open-ended "yet" reply — they must NOT claim STT is disabled;
- *   4. relative media-store URLs (`/api/media/<sha256>.<ext>`) use the
- *      trusted local runtime fetch, never the remote-only URL parser;
+ *      open-ended "yet" reply — they must NOT claim STT is disabled, live or
+ *      via a stored ingest marker;
+ *   4. ONLY the canonical media-store shape (`/api/media/<sha256>.<ext>`)
+ *      reaches the trusted local runtime fetch — bounded by an abort signal —
+ *      and any other non-http(s) url (userinfo tricks like `@host/...`,
+ *      protocol-relative `//host/...`) is rejected without fetching anything;
  *   5. a successful transcript persists into the owning message memory with
  *      `notProcessed` cleared, and a persistence failure never breaks the
- *      reply.
+ *      reply — but a redacted-disclosure variant never persists at all, and a
+ *      stored entry that already has a transcript is never overwritten.
  */
 import { v4 as uuidv4 } from "uuid";
 import { describe, expect, it, vi } from "vitest";
@@ -43,6 +47,8 @@ const { readAttachmentAction } = await import("./readAttachmentAction.ts");
 
 const VIDEO_URL =
 	"https://cdn.discordapp.com/attachments/123/456/snaptik_video.mp4";
+/** 64-hex sha256 matching the strict media-store filename shape. */
+const STORED_SHA = "0a1b2c3d".repeat(8);
 const VIDEO_BYTES = Buffer.from("fake-video-bytes");
 const TRANSCRIPT = "hello from the tiktok video about home servers";
 const ANSWER = "It's a short clip about home servers.";
@@ -66,7 +72,7 @@ function makeRuntime(params: {
 	agentId: UUID;
 	calls: UseModelCall[];
 	transcription: (input: unknown) => Promise<string>;
-	localFetch?: (input: unknown) => Promise<Response>;
+	localFetch?: (input: unknown, init?: RequestInit) => Promise<Response>;
 	getMemoryById?: (id: UUID) => Promise<Memory | null>;
 	updateMemory?: (patch: MemoryUpdate) => Promise<boolean>;
 	reportedErrors?: ReportedError[];
@@ -100,7 +106,7 @@ async function runRead(params: {
 	attachment: Media;
 	transcription: (input: unknown) => Promise<string>;
 	fetchImpl?: () => Promise<{ buffer: Buffer }>;
-	localFetch?: (input: unknown) => Promise<Response>;
+	localFetch?: (input: unknown, init?: RequestInit) => Promise<Response>;
 	getMemoryById?: (id: UUID) => Promise<Memory | null>;
 	updateMemory?: (patch: MemoryUpdate) => Promise<boolean>;
 	reportedErrors?: ReportedError[];
@@ -237,41 +243,92 @@ describe("ATTACHMENT read on-demand transcription", () => {
 		).toHaveLength(0);
 	});
 
-	it("routes a relative media-store URL through the trusted local fetch", async () => {
+	it("routes a canonical media-store URL through the trusted local fetch, bounded at 30s", async () => {
+		const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
 		const localUrls: string[] = [];
+		const localSignals: (AbortSignal | null | undefined)[] = [];
 		let providerInput: unknown;
-		const { result, callbackTexts } = await runRead({
-			attachment: makeVideoAttachment({
-				url: "/api/media/0a1b2c3d.mp4",
-				title: "stored_clip.mp4",
-			}),
-			transcription: async (input) => {
-				providerInput = input;
-				return TRANSCRIPT;
-			},
-			localFetch: async (input) => {
-				localUrls.push(String(input));
-				return {
-					ok: true,
-					arrayBuffer: async () => Uint8Array.from(VIDEO_BYTES).buffer,
-				} as unknown as Response;
-			},
-		});
+		try {
+			const { result, callbackTexts } = await runRead({
+				attachment: makeVideoAttachment({
+					url: `/api/media/${STORED_SHA}.mp4`,
+					title: "stored_clip.mp4",
+				}),
+				transcription: async (input) => {
+					providerInput = input;
+					return TRANSCRIPT;
+				},
+				localFetch: async (input, init) => {
+					localUrls.push(String(input));
+					localSignals.push(init?.signal);
+					return {
+						ok: true,
+						arrayBuffer: async () => Uint8Array.from(VIDEO_BYTES).buffer,
+					} as unknown as Response;
+				},
+			});
 
-		expect(result?.success).toBe(true);
-		expect(callbackTexts).toEqual([ANSWER]);
-		// The canonical relative content-store shape must never reach the
-		// remote-only URL parser (it cannot parse, which dead-ended every
-		// local attachment on the transient-"yet" reply pre-#18413).
-		expect(fetchRemoteMediaMock).not.toHaveBeenCalled();
-		expect(localUrls).toHaveLength(1);
-		expect(localUrls[0]).toMatch(
-			/^http:\/\/localhost:\d+\/api\/media\/0a1b2c3d\.mp4$/,
-		);
-		// The provider received the locally fetched bytes as a Buffer.
-		expect(Buffer.isBuffer(providerInput)).toBe(true);
-		expect((providerInput as Buffer).equals(VIDEO_BYTES)).toBe(true);
+			expect(result?.success).toBe(true);
+			expect(callbackTexts).toEqual([ANSWER]);
+			// The canonical relative content-store shape must never reach the
+			// remote-only URL parser (it cannot parse, which dead-ended every
+			// local attachment on the transient-"yet" reply pre-#18413).
+			expect(fetchRemoteMediaMock).not.toHaveBeenCalled();
+			expect(localUrls).toHaveLength(1);
+			expect(localUrls[0]).toMatch(
+				new RegExp(`^http://localhost:\\d+/api/media/${STORED_SHA}\\.mp4$`),
+			);
+			// The local branch is time-bounded like the remote branch: a 30s
+			// timeout signal rides the fetch so a stalled local server cannot
+			// hang the turn (asserted via the wiring, not by sleeping 30s).
+			expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+			expect(localSignals[0]).toBeInstanceOf(AbortSignal);
+			expect(localSignals[0]).toBe(timeoutSpy.mock.results[0]?.value);
+			// The provider received the locally fetched bytes as a Buffer.
+			expect(Buffer.isBuffer(providerInput)).toBe(true);
+			expect((providerInput as Buffer).equals(VIDEO_BYTES)).toBe(true);
+		} finally {
+			timeoutSpy.mockRestore();
+		}
 	});
+
+	// getLocalServerUrl is a bare `http://localhost:PORT${url}` concat, so
+	// before #18429's shape validation a crafted non-http(s) url reached an
+	// attacker host through the TRUSTED local fetch: `@attacker.example/x`
+	// becomes `http://localhost:PORT@attacker.example/x` (userinfo trick).
+	it.each([
+		["userinfo trick", "@attacker.example/clip.mp4"],
+		["protocol-relative", "//evil.example/clip.mp4"],
+		["traversal off the media route", "/api/media/../../etc/passwd"],
+	])(
+		"refuses to fetch a non-media-store local url (%s) and keeps the 'yet' reply",
+		async (_kind, url) => {
+			const localCalls: string[] = [];
+			const { result, callbackTexts, calls } = await runRead({
+				attachment: makeVideoAttachment({ url }),
+				transcription: async () => TRANSCRIPT,
+				localFetch: async (input) => {
+					localCalls.push(String(input));
+					return {
+						ok: true,
+						arrayBuffer: async () => Uint8Array.from(VIDEO_BYTES).buffer,
+					} as unknown as Response;
+				},
+			});
+
+			expect(result?.success).toBe(true);
+			// NOTHING was fetched: not the local/trusted path, not the remote one.
+			expect(localCalls).toEqual([]);
+			expect(fetchRemoteMediaMock).not.toHaveBeenCalled();
+			expect(
+				calls.filter((c) => c.modelType === ModelType.TRANSCRIPTION),
+			).toHaveLength(0);
+			// The rejection is transient-class: the reply stays the honest "yet".
+			expect(callbackTexts).toEqual([
+				"I don't have a transcript for that attachment yet.",
+			]);
+		},
+	);
 
 	it("keeps the retryable 'yet' reply when a hostile remote body mimics unavailability prose", async () => {
 		// MediaFetchError messages embed up to ~200 chars of the remote response
@@ -387,6 +444,101 @@ describe("ATTACHMENT read on-demand transcription", () => {
 		expect(reportedErrors[0]?.scope).toBe(
 			"ReadAttachmentAction.persistTranscript",
 		);
+	});
+
+	it("never persists a redacted variant's transcript over the stored original", async () => {
+		// selectAttachmentForRequester hands a redacted-disclosure viewer a
+		// variant keeping the shared id/_messageId but with `url` swapped to the
+		// redacted bytes and text/description stripped — so its on-demand
+		// transcript is derived from the REDACTED media and must never be
+		// written over the original entry's stored transcript.
+		const lookups: UUID[] = [];
+		const updates: MemoryUpdate[] = [];
+		const redactedVariant = {
+			...makeVideoAttachment({
+				url: "https://cdn.discordapp.com/attachments/123/456/redacted_clip.mp4",
+			}),
+			redacted: true as const,
+		};
+		const { result, callbackTexts } = await runRead({
+			attachment: redactedVariant,
+			transcription: async () => TRANSCRIPT,
+			getMemoryById: async (id) => {
+				lookups.push(id);
+				return {
+					id,
+					entityId: id,
+					roomId: id,
+					content: {
+						attachments: [
+							makeVideoAttachment({ text: "the original's real transcript" }),
+						],
+					},
+				} as Memory;
+			},
+			updateMemory: async (patch) => {
+				updates.push(patch);
+				return true;
+			},
+		});
+
+		// The in-memory transcript still serves this reply; only the write is
+		// skipped.
+		expect(result?.success).toBe(true);
+		expect(callbackTexts).toEqual([ANSWER]);
+		expect(lookups).toEqual([]);
+		expect(updates).toEqual([]);
+	});
+
+	it("never overwrites a stored entry that already has a transcript (fill-only)", async () => {
+		// A concurrent read (or a variant whose gathered copy lost the text)
+		// must not clobber a transcript that already reached storage.
+		const updates: MemoryUpdate[] = [];
+		const { result, callbackTexts } = await runRead({
+			attachment: makeVideoAttachment(),
+			transcription: async () => TRANSCRIPT,
+			getMemoryById: async (id) =>
+				({
+					id,
+					entityId: id,
+					roomId: id,
+					content: {
+						attachments: [
+							makeVideoAttachment({ text: "an earlier stored transcript" }),
+						],
+					},
+				}) as Memory,
+			updateMemory: async (patch) => {
+				updates.push(patch);
+				return true;
+			},
+		});
+
+		expect(result?.success).toBe(true);
+		expect(callbackTexts).toEqual([ANSWER]);
+		expect(updates).toEqual([]);
+	});
+
+	it("keeps the retryable 'yet' reply for a stored ingest fetch-failure marker", async () => {
+		// Ingest writes "<Kind> attachment could not be fetched: <err.message>"
+		// for MediaFetchError failures — err.message can echo a hostile remote
+		// body, so even unavailability prose embedded mid-marker must not read
+		// as STT-is-disabled evidence.
+		const { callbackTexts } = await runRead({
+			attachment: makeVideoAttachment({
+				notProcessed:
+					"Video attachment could not be fetched: HTTP 503; body: transcription unavailable — falling through to next TRANSCRIPTION handler",
+			}),
+			transcription: async () => {
+				throw new Error("still down");
+			},
+		});
+
+		expect(callbackTexts).toHaveLength(1);
+		expect(callbackTexts[0]).toBe(
+			"I don't have a transcript for that attachment yet.",
+		);
+		expect(callbackTexts[0]).not.toContain("isn't enabled");
 	});
 
 	it("reports honest unavailability from an ingest-time failure marker", async () => {

--- a/packages/core/src/features/working-memory/readAttachmentAction.transcription.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.transcription.test.ts
@@ -8,14 +8,20 @@
  * tj-cd524c1a710c6a): a video posted while cloud STT was gated off stored no
  * transcript, and every later "can you see that video?" / "can you get one?"
  * dead-ended on the canned "I don't have a transcript for that attachment
- * yet." Contract points:
+ * yet." Contract points (3–6 hardened per #18413):
  *   1. the read path retries transcription live — fetching bytes through the
- *      guarded, size-capped fetch and handing the provider a Buffer (the
- *      ingest call shape);
+ *      guarded, size-capped, 30s-bounded fetch and handing the provider a
+ *      Buffer (the ingest call shape);
  *   2. provider-unavailable failures report "speech-to-text isn't enabled"
  *      honestly, without leaking internal error prose;
- *   3. TRANSIENT failures (network blip, provider 5xx) keep the retryable
- *      open-ended "yet" reply — they must NOT claim STT is disabled.
+ *   3. TRANSIENT failures (network blip, provider 5xx, fetch-layer errors —
+ *      whose messages can echo a hostile remote body) keep the retryable
+ *      open-ended "yet" reply — they must NOT claim STT is disabled;
+ *   4. relative media-store URLs (`/api/media/<sha256>.<ext>`) use the
+ *      trusted local runtime fetch, never the remote-only URL parser;
+ *   5. a successful transcript persists into the owning message memory with
+ *      `notProcessed` cleared, and a persistence failure never breaks the
+ *      reply.
  */
 import { v4 as uuidv4 } from "uuid";
 import { describe, expect, it, vi } from "vitest";
@@ -53,21 +59,32 @@ function makeVideoAttachment(overrides: Partial<Media> = {}): Media {
 }
 
 type UseModelCall = { modelType: unknown; options: unknown };
+type ReportedError = { scope: string; error: unknown };
+type MemoryUpdate = Partial<Memory> & { id: UUID };
 
 function makeRuntime(params: {
 	agentId: UUID;
 	calls: UseModelCall[];
 	transcription: (input: unknown) => Promise<string>;
+	localFetch?: (input: unknown) => Promise<Response>;
+	getMemoryById?: (id: UUID) => Promise<Memory | null>;
+	updateMemory?: (patch: MemoryUpdate) => Promise<boolean>;
+	reportedErrors?: ReportedError[];
 }): IAgentRuntime {
 	const runtime = {
 		agentId: params.agentId,
+		fetch: params.localFetch,
 		getConversationLength: () => 8,
 		getMemories: async () => [],
+		getMemoryById: params.getMemoryById ?? (async () => null),
+		updateMemory: params.updateMemory ?? (async () => true),
 		getRoom: async () => null,
 		getWorld: async () => null,
 		getService: () => null,
 		getSetting: () => undefined,
-		reportError: () => {},
+		reportError: (scope: string, error: unknown) => {
+			params.reportedErrors?.push({ scope, error });
+		},
 		useModel: async (modelType: unknown, options: unknown) => {
 			params.calls.push({ modelType, options });
 			if (modelType === ModelType.TRANSCRIPTION) {
@@ -83,6 +100,10 @@ async function runRead(params: {
 	attachment: Media;
 	transcription: (input: unknown) => Promise<string>;
 	fetchImpl?: () => Promise<{ buffer: Buffer }>;
+	localFetch?: (input: unknown) => Promise<Response>;
+	getMemoryById?: (id: UUID) => Promise<Memory | null>;
+	updateMemory?: (patch: MemoryUpdate) => Promise<boolean>;
+	reportedErrors?: ReportedError[];
 	text?: string;
 }) {
 	fetchRemoteMediaMock.mockReset();
@@ -95,6 +116,10 @@ async function runRead(params: {
 		agentId,
 		calls,
 		transcription: params.transcription,
+		localFetch: params.localFetch,
+		getMemoryById: params.getMemoryById,
+		updateMemory: params.updateMemory,
+		reportedErrors: params.reportedErrors,
 	});
 	const message: Memory = {
 		id: uuidv4() as UUID,
@@ -122,7 +147,7 @@ async function runRead(params: {
 		},
 		callback,
 	);
-	return { result, callbackTexts, calls };
+	return { result, callbackTexts, calls, message };
 }
 
 describe("ATTACHMENT read on-demand transcription", () => {
@@ -138,14 +163,17 @@ describe("ATTACHMENT read on-demand transcription", () => {
 
 		expect(result?.success).toBe(true);
 		expect(callbackTexts).toEqual([ANSWER]);
-		// The bytes came through the SSRF-guarded, size-capped media fetch.
+		// The bytes came through the SSRF-guarded, size-capped media fetch,
+		// bounded at the pre-rework 30s so a stalled host cannot hang the turn.
 		expect(fetchRemoteMediaMock).toHaveBeenCalledTimes(1);
 		const fetchArgs = fetchRemoteMediaMock.mock.calls[0]?.[0] as {
 			url?: string;
 			maxBytes?: number;
+			timeoutMs?: number;
 		};
 		expect(fetchArgs?.url).toBe(VIDEO_URL);
 		expect(fetchArgs?.maxBytes).toBe(50 * 1024 * 1024);
+		expect(fetchArgs?.timeoutMs).toBe(30_000);
 		// The provider received the buffer (ingest call shape), not a URL.
 		expect(Buffer.isBuffer(providerInput)).toBe(true);
 		// The answering TEXT_SMALL prompt saw the fresh transcript.
@@ -207,6 +235,158 @@ describe("ATTACHMENT read on-demand transcription", () => {
 		expect(
 			calls.filter((c) => c.modelType === ModelType.TRANSCRIPTION),
 		).toHaveLength(0);
+	});
+
+	it("routes a relative media-store URL through the trusted local fetch", async () => {
+		const localUrls: string[] = [];
+		let providerInput: unknown;
+		const { result, callbackTexts } = await runRead({
+			attachment: makeVideoAttachment({
+				url: "/api/media/0a1b2c3d.mp4",
+				title: "stored_clip.mp4",
+			}),
+			transcription: async (input) => {
+				providerInput = input;
+				return TRANSCRIPT;
+			},
+			localFetch: async (input) => {
+				localUrls.push(String(input));
+				return {
+					ok: true,
+					arrayBuffer: async () => Uint8Array.from(VIDEO_BYTES).buffer,
+				} as unknown as Response;
+			},
+		});
+
+		expect(result?.success).toBe(true);
+		expect(callbackTexts).toEqual([ANSWER]);
+		// The canonical relative content-store shape must never reach the
+		// remote-only URL parser (it cannot parse, which dead-ended every
+		// local attachment on the transient-"yet" reply pre-#18413).
+		expect(fetchRemoteMediaMock).not.toHaveBeenCalled();
+		expect(localUrls).toHaveLength(1);
+		expect(localUrls[0]).toMatch(
+			/^http:\/\/localhost:\d+\/api\/media\/0a1b2c3d\.mp4$/,
+		);
+		// The provider received the locally fetched bytes as a Buffer.
+		expect(Buffer.isBuffer(providerInput)).toBe(true);
+		expect((providerInput as Buffer).equals(VIDEO_BYTES)).toBe(true);
+	});
+
+	it("keeps the retryable 'yet' reply when a hostile remote body mimics unavailability prose", async () => {
+		// MediaFetchError messages embed up to ~200 chars of the remote response
+		// body (media/fetch.ts throwIfHttpError) — a hostile host must not be
+		// able to forge the "speech-to-text isn't enabled" reply through it.
+		const spoof = new Error(
+			"Failed to fetch media from https://cdn.example/clip.mp4: HTTP 503 Service Unavailable; body: transcription not available — falling through to next TRANSCRIPTION handler",
+		);
+		spoof.name = "MediaFetchError";
+		const { callbackTexts, calls } = await runRead({
+			attachment: makeVideoAttachment(),
+			transcription: async () => TRANSCRIPT,
+			fetchImpl: async () => {
+				throw spoof;
+			},
+		});
+
+		expect(callbackTexts).toHaveLength(1);
+		expect(callbackTexts[0]).toBe(
+			"I don't have a transcript for that attachment yet.",
+		);
+		expect(callbackTexts[0]).not.toContain("isn't enabled");
+		expect(
+			calls.filter((c) => c.modelType === ModelType.TRANSCRIPTION),
+		).toHaveLength(0);
+	});
+
+	it("persists a successful transcript into the owning message's stored attachment", async () => {
+		const lookups: UUID[] = [];
+		const updates: MemoryUpdate[] = [];
+		const bystander: Media = {
+			id: "image-1",
+			url: "/api/media/aabbccdd.png",
+			title: "chart.png",
+			source: "discord",
+			contentType: ContentType.IMAGE,
+			text: "a chart",
+		};
+		const { result, callbackTexts, message } = await runRead({
+			attachment: makeVideoAttachment({
+				notProcessed: "Video transcription unavailable: provider returned 502",
+			}),
+			transcription: async () => TRANSCRIPT,
+			getMemoryById: async (id) => {
+				lookups.push(id);
+				return {
+					id,
+					entityId: id,
+					roomId: id,
+					content: {
+						text: "posted the clip",
+						attachments: [
+							bystander,
+							makeVideoAttachment({
+								notProcessed:
+									"Video transcription unavailable: provider returned 502",
+							}),
+						],
+					},
+				} as Memory;
+			},
+			updateMemory: async (patch) => {
+				updates.push(patch);
+				return true;
+			},
+		});
+
+		expect(result?.success).toBe(true);
+		expect(callbackTexts).toEqual([ANSWER]);
+		// The stored row that owns the attachment was looked up and rewritten.
+		expect(lookups).toEqual([message.id]);
+		expect(updates).toHaveLength(1);
+		expect(updates[0]?.id).toBe(message.id);
+		const persisted = updates[0]?.content?.attachments as Media[];
+		expect(persisted).toHaveLength(2);
+		// Only the owning attachment entry changed.
+		expect(persisted[0]).toEqual(bystander);
+		const video = persisted[1] as Media;
+		expect(video.id).toBe("video-attachment-1");
+		expect(video.text).toBe(TRANSCRIPT);
+		expect(video.description).toBe(`Transcript: ${TRANSCRIPT}`);
+		expect(video.url).toBe(VIDEO_URL);
+		expect(video.title).toBe("snaptik_video.mp4");
+		// The stale failure marker is gone, not merely blanked.
+		expect("notProcessed" in video).toBe(false);
+		// Gathering-layer transport fields never reach storage.
+		expect("_messageId" in video).toBe(false);
+		expect("_createdAt" in video).toBe(false);
+	});
+
+	it("still replies with the transcript when persistence fails", async () => {
+		const reportedErrors: ReportedError[] = [];
+		const { result, callbackTexts } = await runRead({
+			attachment: makeVideoAttachment(),
+			transcription: async () => TRANSCRIPT,
+			getMemoryById: async (id) =>
+				({
+					id,
+					entityId: id,
+					roomId: id,
+					content: { attachments: [makeVideoAttachment()] },
+				}) as Memory,
+			updateMemory: async () => {
+				throw new Error("database offline");
+			},
+			reportedErrors,
+		});
+
+		expect(result?.success).toBe(true);
+		expect(callbackTexts).toEqual([ANSWER]);
+		// The failure is reported diagnostics-style (error-policy:J7), not thrown.
+		expect(reportedErrors).toHaveLength(1);
+		expect(reportedErrors[0]?.scope).toBe(
+			"ReadAttachmentAction.persistTranscript",
+		);
 	});
 
 	it("reports honest unavailability from an ingest-time failure marker", async () => {

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -32,6 +32,7 @@ import {
 	type State,
 	type UUID,
 } from "../../types/index.ts";
+import { getLocalServerUrl } from "../../utils.ts";
 import { DocumentService } from "../documents/service.ts";
 import {
 	createDocumentNoteFilename,
@@ -148,6 +149,8 @@ function missingReadableContentMessage(records: AttachmentRecord[]): string {
 
 /** Same cap the ingest path enforces (`ATTACHMENT_FETCH_MAX_BYTES`). */
 const ON_DEMAND_TRANSCRIPTION_MAX_BYTES = 50 * 1024 * 1024;
+/** Same bound the pre-rework provider-side transcription fetch enforced. */
+const ON_DEMAND_TRANSCRIPTION_TIMEOUT_MS = 30_000;
 
 /**
  * True when a TRANSCRIPTION failure means no provider can serve at all —
@@ -158,6 +161,13 @@ const ON_DEMAND_TRANSCRIPTION_MAX_BYTES = 50 * 1024 * 1024;
  */
 function isTranscriptionUnavailableError(err: unknown): err is Error {
 	if (!(err instanceof Error)) return false;
+	// Fetch-layer failures are NEVER unavailability evidence: MediaFetchError
+	// messages embed up to ~200 chars of the REMOTE response body
+	// (media/fetch.ts throwIfHttpError), so a hostile host could plant
+	// "TRANSCRIPTION not available" prose there and forge the disabled reply.
+	// Matched by name rather than instanceof so the exclusion survives module
+	// duplication across the multi-target build and test module mocks.
+	if (err.name === "MediaFetchError") return false;
 	if (err.name.endsWith("UnavailableError")) return true;
 	return /falling through to next TRANSCRIPTION handler|no (?:model )?handler.*TRANSCRIPTION|TRANSCRIPTION.*not (?:available|enabled|registered)/i.test(
 		err.message,
@@ -165,17 +175,113 @@ function isTranscriptionUnavailableError(err: unknown): err is Error {
 }
 
 /**
+ * Fetches a conversation attachment's bytes for transcription, mirroring the
+ * ingest split in `MessageService.fetchAttachmentBytes`: remote
+ * (attacker-influenceable) http(s) URLs go through the SSRF-guarded,
+ * size-capped, time-bounded media fetch, while relative media-store URLs
+ * (`/api/media/<sha256>.<ext>`, the canonical stored shape — they cannot pass
+ * remote-only URL parsing) resolve against the local server and use the
+ * trusted runtime fetch with the same size cap.
+ */
+async function fetchTranscribableBytes(
+	runtime: IAgentRuntime,
+	url: string,
+): Promise<Buffer> {
+	if (/^(http|https):\/\//.test(url)) {
+		const { buffer } = await fetchRemoteMedia({
+			url,
+			maxBytes: ON_DEMAND_TRANSCRIPTION_MAX_BYTES,
+			timeoutMs: ON_DEMAND_TRANSCRIPTION_TIMEOUT_MS,
+		});
+		return buffer;
+	}
+	const runtimeFetch = runtime.fetch ?? globalThis.fetch;
+	const res = await runtimeFetch(getLocalServerUrl(url));
+	if (!res.ok) {
+		throw new Error(`Failed to fetch attachment: ${res.statusText}`);
+	}
+	const buffer = Buffer.from(await res.arrayBuffer());
+	if (buffer.length > ON_DEMAND_TRANSCRIPTION_MAX_BYTES) {
+		throw new Error(
+			`Attachment exceeds ${ON_DEMAND_TRANSCRIPTION_MAX_BYTES} bytes`,
+		);
+	}
+	return buffer;
+}
+
+/**
+ * Persists a fresh on-demand transcript into the stored message memory that
+ * owns the attachment — the same `updateMemory` write ingest performs after
+ * `processAttachments` — so later reads answer from storage instead of
+ * re-downloading the bytes and re-billing the STT provider. Only the matching
+ * attachment entry changes: its stale `notProcessed` marker is dropped, every
+ * other stored field survives, and the gathering layer's underscore transport
+ * fields never reach storage. Never throws — the in-memory transcript already
+ * serves this reply, so a lost write only costs one future re-transcription.
+ */
+async function persistTranscript(
+	runtime: IAgentRuntime,
+	record: AttachmentRecord,
+	transcript: string,
+): Promise<void> {
+	const { attachment } = record;
+	const messageId = attachment._messageId;
+	// Without a known owning row (e.g. an unsaved in-flight message) there is
+	// nothing to update; the next read simply retries transcription.
+	if (!messageId) return;
+	try {
+		const stored = await runtime.getMemoryById(messageId);
+		const storedAttachments = stored?.content.attachments;
+		if (!stored || !Array.isArray(storedAttachments)) return;
+		let found = false;
+		const attachments = storedAttachments.map((entry) => {
+			if (entry.id !== attachment.id) return entry;
+			found = true;
+			const { notProcessed: _stale, ...rest } = entry;
+			return {
+				...rest,
+				text: transcript,
+				description: `Transcript: ${transcript}`,
+			};
+		});
+		if (!found) return;
+		const persisted = await runtime.updateMemory({
+			id: messageId,
+			content: { ...stored.content, attachments },
+		});
+		if (!persisted) {
+			logger.warn(
+				{ attachmentId: attachment.id, messageId },
+				"[ReadAttachment] updateMemory declined to persist the on-demand transcript",
+			);
+		}
+	} catch (err) {
+		// error-policy:J7 persistence is bookkeeping for future reads; its
+		// failure must not break the reply the transcript already serves.
+		logger.warn(
+			{ attachmentId: attachment.id, messageId, err },
+			"[ReadAttachment] Failed to persist the on-demand transcript",
+		);
+		runtime.reportError("ReadAttachmentAction.persistTranscript", err, {
+			attachmentId: attachment.id,
+			messageId,
+		});
+	}
+}
+
+/**
  * Live retry for media records whose ingest-time transcription produced
  * nothing (observed live: a video posted while cloud STT was gated off has no
  * transcript, and every later "can you get one?" dead-ended on the canned
  * missing-transcript reply even after STT came back). Fetches the stored
- * attachment bytes through core's SSRF-guarded, size-capped media fetch —
- * conversation media the ingest path already fetched once, not a new URL from
- * chat text (that still routes to WEB_FETCH) — and hands the provider a
- * buffer, mirroring the ingest call shape. Success fills the record in place
- * so read/save answer from the fresh transcript; unavailability keeps the
- * explicit unavailable state; a transient failure changes nothing so the
- * user-facing reply stays the honest open-ended "yet".
+ * attachment bytes with ingest's remote/local split — conversation media the
+ * ingest path already fetched once, not a new URL from chat text (that still
+ * routes to WEB_FETCH) — and hands the provider a buffer, mirroring the
+ * ingest call shape. Success fills the record in place so read/save answer
+ * from the fresh transcript and persists it to the owning message so later
+ * reads stop re-billing STT; unavailability keeps the explicit unavailable
+ * state; a transient failure (remote or local fetch, provider blip) changes
+ * nothing so the user-facing reply stays the honest open-ended "yet".
  */
 async function transcribeMediaOnDemand(
 	runtime: IAgentRuntime,
@@ -187,10 +293,7 @@ async function transcribeMediaOnDemand(
 		if (!isMediaAttachment(record) || record.content.trim()) continue;
 		if (typeof attachment.url !== "string" || !attachment.url.trim()) continue;
 		try {
-			const { buffer } = await fetchRemoteMedia({
-				url: attachment.url,
-				maxBytes: ON_DEMAND_TRANSCRIPTION_MAX_BYTES,
-			});
+			const buffer = await fetchTranscribableBytes(runtime, attachment.url);
 			const transcript = await runtime.useModel(
 				ModelType.TRANSCRIPTION,
 				buffer,
@@ -202,6 +305,7 @@ async function transcribeMediaOnDemand(
 				attachment.description = `Transcript: ${text}`;
 				attachment.notProcessed = undefined;
 				transcribedAny = true;
+				await persistTranscript(runtime, record, text);
 			}
 		} catch (err) {
 			// error-policy:J4 the attachment stays readable-as-absent and the

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -107,14 +107,20 @@ function isMediaAttachment(record: AttachmentRecord): boolean {
  * True when a media record's transcript is missing because transcription
  * itself was unavailable (ingest or on-demand), not because nobody has asked
  * yet. `notProcessed` carries the raw provider error; the user-facing message
- * must stay a clean sentence, never that internal prose.
+ * must stay a clean sentence, never that internal prose. Anchored to the
+ * writer-controlled marker prefix ("Transcription unavailable:" on-demand,
+ * "Audio/Video transcription unavailable:" ingest) — the appended error prose
+ * can echo a hostile remote body (media/fetch.ts embeds up to ~200 chars of
+ * it), so mid-string matches must never count as unavailability evidence.
  */
 function mediaTranscriptionUnavailable(records: AttachmentRecord[]): boolean {
 	return records.some(
 		(record) =>
 			isMediaAttachment(record) &&
 			typeof record.attachment.notProcessed === "string" &&
-			/transcription unavailable/i.test(record.attachment.notProcessed),
+			/^(?:(?:audio|video)\s+)?transcription unavailable/i.test(
+				record.attachment.notProcessed,
+			),
 	);
 }
 
@@ -151,6 +157,13 @@ function missingReadableContentMessage(records: AttachmentRecord[]): string {
 const ON_DEMAND_TRANSCRIPTION_MAX_BYTES = 50 * 1024 * 1024;
 /** Same bound the pre-rework provider-side transcription fetch enforced. */
 const ON_DEMAND_TRANSCRIPTION_TIMEOUT_MS = 30_000;
+/**
+ * The only local shape the content-addressed media store serves
+ * (`packages/agent/src/api/media-store.ts`: `MEDIA_URL_PREFIX` + the strict
+ * `MEDIA_FILE_NAME` of a 64-hex sha256 and short alphanumeric extension).
+ * Anything else must never reach the trusted local fetch.
+ */
+const LOCAL_MEDIA_STORE_URL = /^\/api\/media\/[a-f0-9]{64}\.[a-z0-9]{1,8}$/;
 
 /**
  * True when a TRANSCRIPTION failure means no provider can serve at all —
@@ -178,10 +191,15 @@ function isTranscriptionUnavailableError(err: unknown): err is Error {
  * Fetches a conversation attachment's bytes for transcription, mirroring the
  * ingest split in `MessageService.fetchAttachmentBytes`: remote
  * (attacker-influenceable) http(s) URLs go through the SSRF-guarded,
- * size-capped, time-bounded media fetch, while relative media-store URLs
- * (`/api/media/<sha256>.<ext>`, the canonical stored shape — they cannot pass
- * remote-only URL parsing) resolve against the local server and use the
- * trusted runtime fetch with the same size cap.
+ * size-capped, time-bounded media fetch, while local URLs must be exactly the
+ * canonical media-store shape (`/api/media/<sha256>.<ext>`) before resolving
+ * against the local server with the same size cap and timeout. Anything else
+ * is rejected before any fetch: `getLocalServerUrl` is a bare string concat,
+ * so an unvalidated `@attacker.example/x` would become
+ * `http://localhost:PORT@attacker.example/x` (userinfo trick) and hand the
+ * trusted local fetch to an attacker host. Rejections throw plain
+ * transient-class errors with static messages (never echoing the
+ * attacker-influenceable url) so the reply degrades to the honest "yet" path.
  */
 async function fetchTranscribableBytes(
 	runtime: IAgentRuntime,
@@ -195,8 +213,23 @@ async function fetchTranscribableBytes(
 		});
 		return buffer;
 	}
+	if (!LOCAL_MEDIA_STORE_URL.test(url)) {
+		throw new Error(
+			"Attachment URL is not a canonical media-store path; refusing local fetch",
+		);
+	}
+	// Defence in depth on top of the shape check: the resolved origin must be
+	// the local server itself before the trusted fetch runs.
+	const localUrl = new URL(getLocalServerUrl(url));
+	if (localUrl.hostname !== "localhost" && localUrl.hostname !== "127.0.0.1") {
+		throw new Error(
+			"Local media fetch resolved to a non-local host; refusing local fetch",
+		);
+	}
 	const runtimeFetch = runtime.fetch ?? globalThis.fetch;
-	const res = await runtimeFetch(getLocalServerUrl(url));
+	const res = await runtimeFetch(localUrl.href, {
+		signal: AbortSignal.timeout(ON_DEMAND_TRANSCRIPTION_TIMEOUT_MS),
+	});
 	if (!res.ok) {
 		throw new Error(`Failed to fetch attachment: ${res.statusText}`);
 	}
@@ -218,6 +251,13 @@ async function fetchTranscribableBytes(
  * other stored field survives, and the gathering layer's underscore transport
  * fields never reach storage. Never throws — the in-memory transcript already
  * serves this reply, so a lost write only costs one future re-transcription.
+ *
+ * Two guards keep this write from destroying stored data: a redacted-disclosure
+ * variant (selectAttachmentForRequester keeps the shared `id`/`_messageId` but
+ * swaps `url` to the redacted bytes and strips text/description) must never
+ * persist its transcript over the original entry, and a stored entry that
+ * already carries a non-empty transcript is never overwritten — this fill-only
+ * rule also settles concurrent reads racing to persist.
  */
 async function persistTranscript(
 	runtime: IAgentRuntime,
@@ -229,6 +269,10 @@ async function persistTranscript(
 	// Without a known owning row (e.g. an unsaved in-flight message) there is
 	// nothing to update; the next read simply retries transcription.
 	if (!messageId) return;
+	// A redacted variant's transcript came from the redacted bytes; writing it
+	// would replace the original entry's real transcript. The in-memory
+	// transcript still serves this reply — only the write is skipped.
+	if (attachment.redacted) return;
 	try {
 		const stored = await runtime.getMemoryById(messageId);
 		const storedAttachments = stored?.content.attachments;
@@ -236,6 +280,8 @@ async function persistTranscript(
 		let found = false;
 		const attachments = storedAttachments.map((entry) => {
 			if (entry.id !== attachment.id) return entry;
+			// Fill-only: an existing stored transcript always wins.
+			if (typeof entry.text === "string" && entry.text.trim()) return entry;
 			found = true;
 			const { notProcessed: _stale, ...rest } = entry;
 			return {

--- a/packages/core/src/services/message.processAttachments.test.ts
+++ b/packages/core/src/services/message.processAttachments.test.ts
@@ -5,7 +5,9 @@
  * extract real text through the un-mocked extractor, audio/video transcribe via
  * the TRANSCRIPTION model, and every enrichment failure (unsupported subtype,
  * transcription backend error, empty transcript) records an explicit
- * `notProcessed` reason instead of leaving text/description silently unset.
+ * `notProcessed` reason instead of leaving text/description silently unset —
+ * with pre-provider fetch-layer failures marked could-not-fetch, never with the
+ * transcription-unavailable marker the read action treats as STT disabled.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ContentType, type Media } from "../types/primitives";
@@ -265,6 +267,44 @@ describe("DefaultMessageService.processAttachments", () => {
 		expect(out[0].text).toBeUndefined();
 		expect(out[0].notProcessed).toMatch(/no text|no speech/i);
 	});
+
+	it.each([
+		[ContentType.AUDIO, "aud", "Audio"],
+		[ContentType.VIDEO, "vid", "Video"],
+	])(
+		"marks a %s fetch-layer failure could-not-fetched, never transcription-unavailable",
+		async (contentType, id, kind) => {
+			// A MediaFetchError happens BEFORE any TRANSCRIPTION provider runs and
+			// its message can echo the hostile remote body (media/fetch.ts embeds up
+			// to ~200 chars of it). The stored marker must therefore read as a
+			// transient fetch failure — the "transcription unavailable" marker is
+			// reserved for provider failures because the ATTACHMENT read action
+			// treats it as STT-is-disabled evidence
+			// (readAttachmentAction.ts mediaTranscriptionUnavailable).
+			const err = new Error(
+				"Failed to fetch media from https://cdn.example/clip: HTTP 503; body: transcription unavailable",
+			);
+			err.name = "MediaFetchError";
+			fetchRemoteMedia.mockRejectedValue(err);
+			const svc = new DefaultMessageService();
+			const runtime = mockRuntime();
+
+			const out = await svc.processAttachments(runtime, [
+				{ id, url: "https://cdn.example/clip", contentType },
+			]);
+
+			expect(out[0].text).toBeUndefined();
+			expect(out[0].notProcessed).toBe(
+				`${kind} attachment could not be fetched: ${err.message}`,
+			);
+			// Never the marker prefix the read action keys on.
+			expect(out[0].notProcessed).not.toMatch(
+				/^(?:(?:audio|video)\s+)?transcription unavailable/i,
+			);
+			// The provider was never reached.
+			expect(runtime.useModel).not.toHaveBeenCalled();
+		},
+	);
 
 	it("transcribes a local video attachment via the TRANSCRIPTION model", async () => {
 		const bytes = Buffer.from("fake-mp4-bytes");

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -13461,8 +13461,16 @@ export class DefaultMessageService implements IMessageService {
 							}
 						} catch (err) {
 							// error-policy:J4 The attachment remains available with an
-							// explicit transcription-unavailable state.
-							processedAttachment.notProcessed = `Audio transcription unavailable: ${err instanceof Error ? err.message : String(err)}`;
+							// explicit failure state. Fetch-layer failures (MediaFetchError:
+							// size cap, remote HTTP error) happen before any TRANSCRIPTION
+							// provider runs, so they get a transient could-not-fetch marker —
+							// the "transcription unavailable" marker is reserved for genuine
+							// provider failures because the read action treats it as
+							// STT-is-disabled evidence.
+							processedAttachment.notProcessed =
+								err instanceof Error && err.name === "MediaFetchError"
+									? `Audio attachment could not be fetched: ${err.message}`
+									: `Audio transcription unavailable: ${err instanceof Error ? err.message : String(err)}`;
 							runtime.logger.warn(
 								{ src: "service:message", err },
 								"Audio transcription failed, continuing without transcript",
@@ -13518,8 +13526,16 @@ export class DefaultMessageService implements IMessageService {
 							}
 						} catch (err) {
 							// error-policy:J4 The attachment remains available with an
-							// explicit transcription-unavailable state.
-							processedAttachment.notProcessed = `Video transcription unavailable: ${err instanceof Error ? err.message : String(err)}`;
+							// explicit failure state. Fetch-layer failures (MediaFetchError:
+							// size cap, remote HTTP error) happen before any TRANSCRIPTION
+							// provider runs, so they get a transient could-not-fetch marker —
+							// the "transcription unavailable" marker is reserved for genuine
+							// provider failures because the read action treats it as
+							// STT-is-disabled evidence.
+							processedAttachment.notProcessed =
+								err instanceof Error && err.name === "MediaFetchError"
+									? `Video attachment could not be fetched: ${err.message}`
+									: `Video transcription unavailable: ${err instanceof Error ? err.message : String(err)}`;
 							runtime.logger.warn(
 								{ src: "service:message", err },
 								"Video transcription failed, continuing without transcript",


### PR DESCRIPTION
Repairs the **#18348 seam** recorded in #18413 — all four audited items.

## The four repairs
1. **Local media-store URLs routed correctly.** `transcribeMediaOnDemand` sent every URL through remote-only `fetchRemoteMedia`, so a relative `/api/media/<sha256>.<ext>` (the canonical stored shape) failed URL parsing into a permanent retryable-"yet" dead end. Now mirrors ingest's `fetchAttachmentBytes` split exactly (`message.ts:13270-13273, 13565`): `^https?://` → SSRF-guarded remote fetch; relative → trusted `runtime.fetch` of `getLocalServerUrl(url)`, same 50MB cap.
2. **30s fetch timeout restored.** `timeoutMs: 30_000` on the remote fetch (routed to the SSRF guard's abort signal via `FetchMediaOptions.timeoutMs`) — parity with the pre-rework provider-side bound.
3. **Remote-body spoof of "STT isn't enabled" closed.** `MediaFetchError` messages embed up to ~200 chars of the remote response body, so a hostile host could plant "TRANSCRIPTION not available" prose and forge the disabled reply. Fetch-layer errors are now excluded by name **before** the unavailability regex — they are never unavailability evidence.
4. **Successful transcripts persisted.** New `persistTranscript` mirrors ingest's post-enrichment `updateMemory` write: loads the owning message row (via a new `_messageId` transport field following the existing `_createdAt` convention), rewrites only the matching attachment entry (transcript → `text`/`description`, stale `notProcessed` dropped), preserves everything else, and keeps transport fields out of storage. Later reads answer from storage instead of re-downloading + re-billing STT. Persistence failure is `error-policy:J7` (warn + `runtime.reportError`) and never breaks the reply.

## Proof
- `readAttachmentAction.transcription.test.ts`: **10/10** — 4 new cases (local routing asserts `fetchRemoteMedia` NOT called; hostile-body spoof → honest "yet" reply; persistence incl. right-row targeting + `notProcessed` cleared; persistence-failure still replies) + `timeoutMs` assertion added to the existing success case.
- **Spoof case verified failing pre-repair** (exclusion temporarily removed: 1 failed / 9 passed; restored).
- `src/features/working-memory/`: 4 files, 20/20 · adjacent consumers (connectors/providers/context-catalog/coalescing/bogus-candidates): 5 files, **79/79** · `bun run --cwd packages/core typecheck` exit 0 · Biome clean on the 3 touched files.

- Before screenshots `N/A - core runtime path, no UI surface`.
- After screenshots `N/A - core runtime path, no UI surface`.
- Walkthrough video `N/A - no UI surface`.
- Backend logs: test run output above (stub-runtime harness pins call shapes).
- Frontend logs `N/A - no frontend change`.
- Real-LLM trajectory `N/A - TRANSCRIPTION provider stubbed; no live model in scope`.
- Domain artifacts: persisted-row rewrite pinned by the right-row-targeting test.
- OCR review `N/A - no rendered visual surface`.

AI provider/model: anthropic / claude-fable-5 (implementation), claude-opus-4-8 (spec + review)
Client / agent tooling: Claude Code
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A - no contribution skill used"} -->

<!-- evidence-head:46f047fc17ecfdb5791ebb1d0f5815c7b880451c -->

<!-- evidence-row:before-screenshots -->
- N/A - core runtime path only; no UI surface changed

<!-- evidence-row:after-screenshots -->
- N/A - core runtime path only; no UI surface changed

<!-- evidence-row:walkthrough-video -->
- N/A - no UI surface or user interaction changed

<!-- evidence-row:backend-logs -->
- N/A - stub-runtime harness: readAttachmentAction.transcription.test.ts 10/10 pass (4 new cases), adjacent consumers 79/79 pass, typecheck clean, Biome clean on all touched files

<!-- evidence-row:frontend-logs -->
- N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- N/A - TRANSCRIPTION provider stubbed in tests; no live model interaction in scope

<!-- evidence-row:domain-artifacts -->
- N/A - persisted-row rewrite pinned by right-row-targeting test; no database rows or external artifacts produced at test time
