### PR TITLE
fix(docs): make integrity tests path- and line-ending-safe on Windows (#18405)

### DIFF
--- a/packages/docs/test/docs.test.ts
+++ b/packages/docs/test/docs.test.ts
@@ -26,6 +26,7 @@ function readDocsConfig() {
 
 function normalizeRoute(route) {
   const cleanRoute = route
+    .replaceAll("\\", "/")
     .split("#")[0]
     .split("?")[0]
     .replace(/^\/+/, "")
@@ -163,17 +164,39 @@ function resolveInternalTarget(sourceFile, href) {
 }
 
 function extractMarkdownFrontmatter(content) {
-  if (!content.startsWith("---\n")) {
+  const opening = /^---(\r?\n)/.exec(content);
+  if (!opening) {
     return null;
   }
 
-  const end = content.indexOf("\n---", 4);
+  const bodyStart = opening[0].length;
+  const end = content.indexOf(`${opening[1]}---`, bodyStart);
   if (end === -1) {
-    return { closed: false, body: content.slice(4) };
+    return { closed: false, body: content.slice(bodyStart) };
   }
 
-  return { closed: true, body: content.slice(4, end) };
+  return { closed: true, body: content.slice(bodyStart, end) };
 }
+
+describe("docs integrity helpers", () => {
+  it("normalizes Windows path separators", () => {
+    assert.strictEqual(
+      normalizeRoute("tracks\\agent\\lifecycle.mdx"),
+      "tracks/agent/lifecycle",
+    );
+  });
+
+  it("extracts frontmatter with LF and CRLF line endings", () => {
+    for (const newline of ["\n", "\r\n"]) {
+      const content = `---${newline}title: Example${newline}description: Test${newline}---${newline}Body`;
+
+      assert.deepStrictEqual(extractMarkdownFrontmatter(content), {
+        closed: true,
+        body: `title: Example${newline}description: Test`,
+      });
+    }
+  });
+});
 
 describe("docs.json configuration", () => {
   it("docs.json exists and is valid JSON", () => {
@@ -353,9 +376,7 @@ describe("documentation files", () => {
     );
     const packageFiles = new Set(["AGENTS", "CLAUDE", "README"]);
     const hiddenPages = collectMarkdownFiles()
-      .map((file) =>
-        normalizeRoute(relative(DOCS_DIR, file).replaceAll("\\\\", "/")),
-      )
+      .map((file) => normalizeRoute(relative(DOCS_DIR, file)))
       .filter((page) => !packageFiles.has(page) && !navigationPages.has(page));
 
     assert.deepStrictEqual(


### PR DESCRIPTION
Fixes #18405

## Changes

1. **Path normalization** — Moved single-backslash-to-forward-slash conversion into the shared `normalizeRoute()` function so all callers handle Windows paths correctly (previously only the hidden-page test did a limited backslash replace).

2. **CRLF frontmatter support** — `extractMarkdownFrontmatter()` now accepts both LF (`---\n`) and CRLF (`---\r\n`) line endings for opening and closing frontmatter delimiters.

3. **Regression tests** — Added `docs integrity helpers` describe block covering:
   - Windows path separator normalization
   - Frontmatter extraction with both LF and CRLF line endings

## Verification

- All 25 existing tests pass (0 failures)
- `git diff --check`: clean

## Acceptance criteria

- [x] Normalize path separators in the shared route-normalization boundary, not at one caller.
- [x] Parse both LF and CRLF frontmatter delimiters without weakening structural validation.
- [x] Add focused synthetic regression coverage for Windows paths and both newline styles.

## AI assistance

- AI assistance: yes
- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: codex
- Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
- Attribution status: self-reported

<!-- evidence-head:381b6ccf21d9cae564a94737ff277d6e1816b1f1 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only documentation integrity portability change; no rendered UI surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only documentation integrity portability change; no rendered UI surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or runtime path changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser behavior changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the changed artifact is the deterministic documentation test itself; CI test output is the verification path

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text changed



<!-- maintainer-evidence-revalidated:381b6ccf21d9cae564a94737ff277d6e1816b1f1 -->

