### PR TITLE
fix(dev-ui): drain children on shutdown instead of SIGKILLing at 1.5 s

### DIFF
--- a/packages/app-core/scripts/dev-ui.mjs
+++ b/packages/app-core/scripts/dev-ui.mjs
@@ -40,6 +40,10 @@ import { resolveViteCommand } from "./lib/dev-ui-vite.mjs";
 import { signalSpawnedProcessTree } from "./lib/kill-process-tree.mjs";
 import { resolveMacNativeEffectsDevPlan } from "./lib/macos-native-effects-dev.mjs";
 import { extendNodePathEnv } from "./lib/node-path-env.mjs";
+import {
+  drainSpawnedChildren,
+  resolveShutdownDrainWindowMs,
+} from "./lib/shutdown-drain.mjs";
 import { syncElizaEnvAliases } from "./lib/sync-eliza-env-aliases.mjs";
 import {
   chooseElizaRuntime,
@@ -864,6 +868,13 @@ let viteReady = false;
 const VITE_READY_BUDGET_MS =
   Number(process.env.ELIZA_DEV_VITE_READY_BUDGET_MS) || 120_000;
 
+// Shutdown drain window: children get a bounded window to finish their own
+// graceful teardown (the Discord connector alone is entitled to 10 s of turn
+// drain + 2 s of reaction reconcile — plugins/plugin-discord/shutdown-drain.ts,
+// elizaOS/eliza#16318) before any SIGKILL escalation. Override via
+// ELIZA_DEV_SHUTDOWN_DRAIN_MS for CI or impatient local loops.
+const SHUTDOWN_DRAIN_WINDOW_MS = resolveShutdownDrainWindowMs(process.env);
+
 function terminateChild(proc, signal = "SIGTERM") {
   if (!proc) return;
   const sig = signal === "SIGKILL" ? "SIGKILL" : "SIGTERM";
@@ -882,9 +893,6 @@ function cleanup(exitCode = 0) {
     sourceWatcher.close();
     sourceWatcher = null;
   }
-  terminateChild(viteProcess, "SIGTERM");
-  terminateChild(apiProcess, "SIGTERM");
-  terminateChild(visionDepsProcess, "SIGTERM");
   if (viteRestartTimer) {
     clearTimeout(viteRestartTimer);
     viteRestartTimer = null;
@@ -894,15 +902,26 @@ function cleanup(exitCode = 0) {
     viteHealthTimer = null;
   }
 
-  setTimeout(() => {
-    terminateChild(viteProcess, "SIGKILL");
-    terminateChild(apiProcess, "SIGKILL");
-    terminateChild(visionDepsProcess, "SIGKILL");
-  }, 1500).unref();
-
-  setTimeout(() => {
+  // SIGTERM the children and wait — bounded — for them to finish their own
+  // graceful teardown, instead of SIGKILLing every tree on a fixed 1.5 s
+  // fuse that was shorter than the teardown children are entitled to
+  // perform (elizaOS/eliza#16318). Children that exit promptly release the
+  // supervisor immediately; only a straggler that outlives the window is
+  // escalated, and loudly. A second Ctrl-C still force-exits at once via
+  // the `shuttingDown` branch above.
+  void drainSpawnedChildren({
+    children: [
+      { name: "vite", child: viteProcess },
+      { name: "api", child: apiProcess },
+      { name: "vision-deps", child: visionDepsProcess },
+    ],
+    drainWindowMs: SHUTDOWN_DRAIN_WINDOW_MS,
+    signalTree: signalSpawnedProcessTree,
+    log: (message) => console.log(message),
+    warn: (message) => console.error(message),
+  }).then(() => {
     process.exit(exitCode);
-  }, 1800).unref();
+  });
 }
 
 process.on("SIGINT", () => cleanup(0));

--- a/packages/app-core/scripts/lib/shutdown-drain.mjs
+++ b/packages/app-core/scripts/lib/shutdown-drain.mjs
@@ -1,0 +1,157 @@
+/**
+ * Bounded supervisor shutdown drain for the dev host scripts.
+ *
+ * `dev-ui.mjs` used to SIGTERM its children and then SIGKILL every child
+ * process tree on a fixed 1.5 s fuse, without ever awaiting a child `exit`
+ * event. That fuse is shorter than the bounded teardown children are entitled
+ * to perform: the Discord connector alone may spend up to 10 s draining
+ * in-flight turns plus 2 s reconciling status reactions before its process
+ * exits (`plugins/plugin-discord/shutdown-drain.ts`), so the drain that merged
+ * in #17749 could never finish under the dev supervisor (elizaOS/eliza#16318).
+ *
+ * This module inverts that contract. Children that exit promptly release the
+ * supervisor immediately, sooner than the old fixed fuse ever did; only a
+ * child that outlives the window is escalated to SIGKILL, per straggler and
+ * loudly, so a drain timeout is an observable event instead of a silent kill.
+ * The wait stays bounded end to end (window + kill grace): a child that
+ * survives even SIGKILL delivery cannot wedge supervisor exit.
+ */
+
+/** Environment override for the drain window, in milliseconds. */
+export const SHUTDOWN_DRAIN_WINDOW_ENV = "ELIZA_DEV_SHUTDOWN_DRAIN_MS";
+
+/**
+ * Default drain window. Covers the longest bounded child-side teardown the
+ * repo currently ships (Discord: 10 s turn drain + 2 s reaction reconcile)
+ * with margin for runtime teardown that runs before connector stop.
+ */
+export const DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS = 15_000;
+
+/**
+ * Bounded wait after SIGKILL escalation for the kill to be delivered and the
+ * children reaped, so supervisor exit does not race the escalation it just
+ * issued. This path is already the failure path; the wait must be tight.
+ */
+export const DEFAULT_KILL_GRACE_MS = 2_000;
+
+/**
+ * Resolve the drain window from the environment. Unset, empty, non-numeric,
+ * and non-positive values all fall back to the default: a broken override
+ * must degrade to the safe window, never to "kill immediately" or "wait
+ * forever".
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveShutdownDrainWindowMs(env = process.env) {
+  const raw = env[SHUTDOWN_DRAIN_WINDOW_ENV];
+  if (raw === undefined || raw === "") return DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS;
+  }
+  return Math.floor(value);
+}
+
+/**
+ * A child is live when it exists and has not yet reported an exit. A child
+ * that failed to spawn (`error` event, no pid) is treated as live and simply
+ * never emits `exit`; the window bound covers it, and signaling it is a
+ * no-op in the tree killer.
+ *
+ * @param {import("node:child_process").ChildProcess | null | undefined} child
+ * @returns {boolean}
+ */
+function isLive(child) {
+  return Boolean(child) && child.exitCode == null && child.signalCode == null;
+}
+
+/**
+ * @typedef {Object} DrainResult
+ * @property {boolean} timedOut
+ *   True when the drain window elapsed with children still running. This is
+ *   the only sound "shutdown was not clean" signal; `killed` alone cannot
+ *   distinguish a straggler that was reaped during the kill grace from one
+ *   that never was.
+ * @property {string[]} killed
+ *   Names of children that were escalated to SIGKILL, in escalation order.
+ */
+
+/**
+ * SIGTERM every live child, await their exits up to `drainWindowMs`, then
+ * SIGKILL only the stragglers and wait a bounded grace for the kill to land.
+ *
+ * @param {Object} options
+ * @param {{ name: string, child: import("node:child_process").ChildProcess | null }[]} options.children
+ *   Named child handles. Null and already-exited entries are skipped.
+ * @param {number} options.drainWindowMs
+ * @param {(child: import("node:child_process").ChildProcess, signal: "SIGTERM" | "SIGKILL") => void} options.signalTree
+ *   Tree-aware signal delivery (dev hosts pass `signalSpawnedProcessTree`).
+ * @param {number} [options.killGraceMs]
+ * @param {(message: string) => void} [options.log]
+ * @param {(message: string) => void} [options.warn]
+ * @returns {Promise<DrainResult>}
+ */
+export function drainSpawnedChildren(options) {
+  const {
+    children,
+    drainWindowMs,
+    signalTree,
+    killGraceMs = DEFAULT_KILL_GRACE_MS,
+    log = console.log.bind(console),
+    warn = console.error.bind(console),
+  } = options;
+
+  const live = children.filter((entry) => isLive(entry.child));
+  for (const entry of live) {
+    signalTree(entry.child, "SIGTERM");
+  }
+  if (live.length === 0) {
+    return Promise.resolve({ timedOut: false, killed: [] });
+  }
+  log(
+    `[eliza] Draining ${live.length} child process${
+      live.length === 1 ? "" : "es"
+    } (up to ${drainWindowMs} ms)…`,
+  );
+
+  return new Promise((resolve) => {
+    const remaining = new Set(live);
+    /** @type {string[]} */
+    const killed = [];
+    let settled = false;
+    /** @type {ReturnType<typeof setTimeout> | null} */
+    let graceTimer = null;
+
+    // Deliberately ref'd: children hold the event loop open while they run,
+    // and every path below ends in the caller's `process.exit`, so a ref'd
+    // timer cannot outlive the process — but an unref'd one could fail to
+    // fire if a child closed its stdio without exiting.
+    const windowTimer = setTimeout(() => {
+      for (const entry of remaining) {
+        warn(
+          `[eliza] ${entry.name} did not exit within ${drainWindowMs} ms — escalating to SIGKILL.`,
+        );
+        killed.push(entry.name);
+        signalTree(entry.child, "SIGKILL");
+      }
+      graceTimer = setTimeout(() => finish(true), killGraceMs);
+    }, drainWindowMs);
+
+    /** @param {boolean} timedOut */
+    function finish(timedOut) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(windowTimer);
+      if (graceTimer) clearTimeout(graceTimer);
+      resolve({ timedOut, killed });
+    }
+
+    for (const entry of live) {
+      entry.child.once("exit", () => {
+        remaining.delete(entry);
+        if (remaining.size === 0) finish(killed.length > 0);
+      });
+    }
+  });
+}

--- a/packages/app-core/scripts/lib/shutdown-drain.mjs
+++ b/packages/app-core/scripts/lib/shutdown-drain.mjs
@@ -9,10 +9,10 @@
  * exits (`plugins/plugin-discord/shutdown-drain.ts`), so the drain that merged
  * in #17749 could never finish under the dev supervisor (elizaOS/eliza#16318).
  *
- * This module inverts that contract. Children that exit promptly release the
- * supervisor immediately, sooner than the old fixed fuse ever did; only a
- * child that outlives the window is escalated to SIGKILL, per straggler and
- * loudly, so a drain timeout is an observable event instead of a silent kill.
+ * This module inverts that contract. Supervisor exit follows child exit
+ * directly instead of a fixed schedule; only a child that outlives the window
+ * is escalated to SIGKILL, per straggler and loudly, so a drain timeout is an
+ * observable event instead of a silent kill.
  * The wait stays bounded end to end (window + kill grace): a child that
  * survives even SIGKILL delivery cannot wedge supervisor exit.
  */

--- a/packages/app-core/scripts/lib/shutdown-drain.mjs
+++ b/packages/app-core/scripts/lib/shutdown-drain.mjs
@@ -34,6 +34,11 @@ export const DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS = 15_000;
  */
 export const DEFAULT_KILL_GRACE_MS = 2_000;
 
+// Node clamps larger delays to 1 ms and emits TimeoutOverflowWarning. Keep
+// environment-derived windows within the documented 32-bit timer range so a
+// malformed "very large" override cannot become an immediate SIGKILL fuse.
+const MAX_NODE_TIMEOUT_MS = 2_147_483_647;
+
 /**
  * Resolve the drain window from the environment. Unset, empty, non-numeric,
  * and non-positive values all fall back to the default: a broken override
@@ -47,23 +52,33 @@ export function resolveShutdownDrainWindowMs(env = process.env) {
   const raw = env[SHUTDOWN_DRAIN_WINDOW_ENV];
   if (raw === undefined || raw === "") return DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS;
   const value = Number(raw);
-  if (!Number.isFinite(value) || value <= 0) {
+  const floored = Math.floor(value);
+  if (
+    !Number.isFinite(value) ||
+    floored <= 0 ||
+    floored > MAX_NODE_TIMEOUT_MS
+  ) {
     return DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS;
   }
-  return Math.floor(value);
+  return floored;
 }
 
 /**
- * A child is live when it exists and has not yet reported an exit. A child
- * that failed to spawn (`error` event, no pid) is treated as live and simply
- * never emits `exit`; the window bound covers it, and signaling it is a
- * no-op in the tree killer.
+ * A child is live when it has a valid spawned PID and has not yet reported an
+ * exit. A child that failed to spawn has no PID and may never emit `exit`, so
+ * waiting for it would burn the entire drain window without a process to reap.
  *
  * @param {import("node:child_process").ChildProcess | null | undefined} child
  * @returns {boolean}
  */
 function isLive(child) {
-  return Boolean(child) && child.exitCode == null && child.signalCode == null;
+  return (
+    Boolean(child) &&
+    Number.isInteger(child.pid) &&
+    child.pid > 0 &&
+    child.exitCode == null &&
+    child.signalCode == null
+  );
 }
 
 /**

--- a/packages/app-core/scripts/lib/shutdown-drain.test.mjs
+++ b/packages/app-core/scripts/lib/shutdown-drain.test.mjs
@@ -1,0 +1,260 @@
+/** Exercises the bounded supervisor shutdown drain (elizaOS/eliza#16318). */
+import { spawn } from "node:child_process";
+import { EventEmitter, once } from "node:events";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { signalSpawnedProcessTree } from "./kill-process-tree.mjs";
+import {
+  DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS,
+  drainSpawnedChildren,
+  resolveShutdownDrainWindowMs,
+  SHUTDOWN_DRAIN_WINDOW_ENV,
+} from "./shutdown-drain.mjs";
+
+const libDir = path.dirname(fileURLToPath(import.meta.url));
+
+function makeChild() {
+  const child = new EventEmitter();
+  child.exitCode = null;
+  child.signalCode = null;
+  child.pid = 12345;
+  return child;
+}
+
+function exitChild(child, code = 0) {
+  child.exitCode = code;
+  child.emit("exit", code, null);
+}
+
+describe("resolveShutdownDrainWindowMs", () => {
+  it("defaults when the override is unset or empty", () => {
+    expect(resolveShutdownDrainWindowMs({})).toBe(
+      DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS,
+    );
+    expect(
+      resolveShutdownDrainWindowMs({ [SHUTDOWN_DRAIN_WINDOW_ENV]: "" }),
+    ).toBe(DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS);
+  });
+
+  it("honors a positive override, flooring fractions", () => {
+    expect(
+      resolveShutdownDrainWindowMs({ [SHUTDOWN_DRAIN_WINDOW_ENV]: "3000" }),
+    ).toBe(3000);
+    expect(
+      resolveShutdownDrainWindowMs({ [SHUTDOWN_DRAIN_WINDOW_ENV]: "2500.9" }),
+    ).toBe(2500);
+  });
+
+  it("degrades broken overrides to the default, never to zero", () => {
+    for (const raw of ["nope", "-5", "0", "NaN", "Infinity"]) {
+      expect(
+        resolveShutdownDrainWindowMs({ [SHUTDOWN_DRAIN_WINDOW_ENV]: raw }),
+      ).toBe(DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS);
+    }
+  });
+});
+
+describe("drainSpawnedChildren (deterministic)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("resolves immediately when no child is live, signaling nothing", async () => {
+    const signalTree = vi.fn();
+    const exited = makeChild();
+    exited.exitCode = 0;
+
+    const result = await drainSpawnedChildren({
+      children: [
+        { name: "null", child: null },
+        { name: "exited", child: exited },
+      ],
+      drainWindowMs: 5000,
+      signalTree,
+      log: () => {},
+      warn: () => {},
+    });
+
+    expect(result).toEqual({ timedOut: false, killed: [] });
+    expect(signalTree).not.toHaveBeenCalled();
+  });
+
+  it("SIGTERMs every live child up front and releases as soon as all exit", async () => {
+    const signalTree = vi.fn();
+    const a = makeChild();
+    const b = makeChild();
+
+    const drain = drainSpawnedChildren({
+      children: [
+        { name: "a", child: a },
+        { name: "b", child: b },
+      ],
+      drainWindowMs: 5000,
+      signalTree,
+      log: () => {},
+      warn: () => {},
+    });
+
+    expect(signalTree).toHaveBeenCalledWith(a, "SIGTERM");
+    expect(signalTree).toHaveBeenCalledWith(b, "SIGTERM");
+
+    exitChild(a);
+    exitChild(b);
+    // No timer advance: prompt exits must resolve the drain on their own.
+    const result = await drain;
+    expect(result).toEqual({ timedOut: false, killed: [] });
+    expect(signalTree).not.toHaveBeenCalledWith(a, "SIGKILL");
+    expect(signalTree).not.toHaveBeenCalledWith(b, "SIGKILL");
+  });
+
+  it("escalates only stragglers when the window elapses, loudly", async () => {
+    const signalTree = vi.fn();
+    const warn = vi.fn();
+    const prompt = makeChild();
+    const straggler = makeChild();
+
+    const drain = drainSpawnedChildren({
+      children: [
+        { name: "prompt", child: prompt },
+        { name: "straggler", child: straggler },
+      ],
+      drainWindowMs: 5000,
+      signalTree,
+      log: () => {},
+      warn,
+    });
+
+    exitChild(prompt);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(signalTree).toHaveBeenCalledWith(straggler, "SIGKILL");
+    expect(signalTree).not.toHaveBeenCalledWith(prompt, "SIGKILL");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("straggler");
+    expect(warn.mock.calls[0][0]).toContain("5000");
+
+    // The kill lands within the grace: the drain still reports the timeout.
+    exitChild(straggler, null);
+    const result = await drain;
+    expect(result).toEqual({ timedOut: true, killed: ["straggler"] });
+  });
+
+  it("gives up after the kill grace when even SIGKILL does not reap", async () => {
+    const signalTree = vi.fn();
+    const wedged = makeChild();
+
+    const drain = drainSpawnedChildren({
+      children: [{ name: "wedged", child: wedged }],
+      drainWindowMs: 1000,
+      killGraceMs: 500,
+      signalTree,
+      log: () => {},
+      warn: () => {},
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(signalTree).toHaveBeenCalledWith(wedged, "SIGKILL");
+    await vi.advanceTimersByTimeAsync(500);
+
+    const result = await drain;
+    expect(result).toEqual({ timedOut: true, killed: ["wedged"] });
+  });
+});
+
+describe.skipIf(process.platform === "win32")(
+  "drainSpawnedChildren (real processes)",
+  () => {
+    /**
+     * Spawn a child that installs its SIGTERM disposition and then reports
+     * readiness on stdout. Signaling before the handler is installed would
+     * hit the default disposition and kill even the "stubborn" child.
+     */
+    async function spawnReadyScript(handlerSource) {
+      const child = spawn(
+        process.execPath,
+        [
+          "-e",
+          `${handlerSource}; process.stdout.write("ready"); setInterval(() => {}, 1000);`,
+        ],
+        { stdio: ["ignore", "pipe", "ignore"] },
+      );
+      await once(child.stdout, "data");
+      return child;
+    }
+
+    function isAlive(pid) {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    it("releases promptly when a real child honors SIGTERM", async () => {
+      const child = await spawnReadyScript(
+        'process.on("SIGTERM", () => process.exit(0))',
+      );
+
+      const startedAt = Date.now();
+      const result = await drainSpawnedChildren({
+        children: [{ name: "cooperative", child }],
+        drainWindowMs: 8000,
+        signalTree: signalSpawnedProcessTree,
+        log: () => {},
+        warn: () => {},
+      });
+
+      expect(result).toEqual({ timedOut: false, killed: [] });
+      // Prompt exit must not burn the window; generous bound for slow CI.
+      expect(Date.now() - startedAt).toBeLessThan(4000);
+    }, 15_000);
+
+    it("SIGKILLs a real child that ignores SIGTERM and reports it", async () => {
+      const child = await spawnReadyScript('process.on("SIGTERM", () => {})');
+      const warn = vi.fn();
+
+      const result = await drainSpawnedChildren({
+        children: [{ name: "stubborn", child }],
+        drainWindowMs: 300,
+        killGraceMs: 2000,
+        signalTree: signalSpawnedProcessTree,
+        log: () => {},
+        warn,
+      });
+
+      expect(result.timedOut).toBe(true);
+      expect(result.killed).toEqual(["stubborn"]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(isAlive(child.pid)).toBe(false);
+    }, 15_000);
+  },
+);
+
+describe("dev-ui supervisor wiring", () => {
+  const devUiSource = readFileSync(
+    path.join(libDir, "..", "dev-ui.mjs"),
+    "utf8",
+  );
+
+  it("routes cleanup through the bounded drain", () => {
+    expect(devUiSource).toContain("void drainSpawnedChildren({");
+    expect(devUiSource).toContain("drainWindowMs: SHUTDOWN_DRAIN_WINDOW_MS,");
+    expect(devUiSource).toContain("signalTree: signalSpawnedProcessTree,");
+  });
+
+  it("no longer SIGKILLs children on a fixed fuse", () => {
+    expect(devUiSource).not.toContain('terminateChild(viteProcess, "SIGKILL")');
+    expect(devUiSource).not.toContain("}, 1500).unref();");
+    expect(devUiSource).not.toContain("}, 1800).unref();");
+  });
+
+  it("keeps the second-signal force exit", () => {
+    expect(devUiSource).toContain('console.log("\\n[eliza] Force exit.");');
+    expect(devUiSource).toContain(
+      "process.exit(exitCode === 0 ? 1 : exitCode);",
+    );
+  });
+});

--- a/packages/app-core/scripts/lib/shutdown-drain.test.mjs
+++ b/packages/app-core/scripts/lib/shutdown-drain.test.mjs
@@ -65,6 +65,19 @@ describe("resolveShutdownDrainWindowMs", () => {
       ).toBe(DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS);
     }
   });
+
+  it("accepts the timer-safe boundaries as-is", () => {
+    // Guards the range staying inclusive: 1 is the smallest schedulable
+    // window and 2147483647 the largest before Node's 32-bit overflow.
+    expect(
+      resolveShutdownDrainWindowMs({ [SHUTDOWN_DRAIN_WINDOW_ENV]: "1" }),
+    ).toBe(1);
+    expect(
+      resolveShutdownDrainWindowMs({
+        [SHUTDOWN_DRAIN_WINDOW_ENV]: "2147483647",
+      }),
+    ).toBe(2_147_483_647);
+  });
 });
 
 describe("drainSpawnedChildren (deterministic)", () => {

--- a/packages/app-core/scripts/lib/shutdown-drain.test.mjs
+++ b/packages/app-core/scripts/lib/shutdown-drain.test.mjs
@@ -49,7 +49,17 @@ describe("resolveShutdownDrainWindowMs", () => {
   });
 
   it("degrades broken overrides to the default, never to zero", () => {
-    for (const raw of ["nope", "-5", "0", "NaN", "Infinity"]) {
+    for (const raw of [
+      "nope",
+      "-5",
+      "0",
+      "0.1",
+      "0.999",
+      "NaN",
+      "Infinity",
+      "2147483648",
+      "1e20",
+    ]) {
       expect(
         resolveShutdownDrainWindowMs({ [SHUTDOWN_DRAIN_WINDOW_ENV]: raw }),
       ).toBe(DEFAULT_SHUTDOWN_DRAIN_WINDOW_MS);
@@ -65,11 +75,14 @@ describe("drainSpawnedChildren (deterministic)", () => {
     const signalTree = vi.fn();
     const exited = makeChild();
     exited.exitCode = 0;
+    const spawnFailed = makeChild();
+    spawnFailed.pid = undefined;
 
     const result = await drainSpawnedChildren({
       children: [
         { name: "null", child: null },
         { name: "exited", child: exited },
+        { name: "spawn-failed", child: spawnFailed },
       ],
       drainWindowMs: 5000,
       signalTree,


### PR DESCRIPTION
# Relates to

Slice of #16318 (supervisor chain only), per [the claim comment](https://github.com/elizaOS/eliza/issues/16318#issuecomment-5256741194). This PR must NOT close the issue: the runtime-level ingress cordon, startup reconciliation of stranded status reactions, live Discord restart evidence, and packaged-runtime (electrobun) supervisor behavior remain open there.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; `verify` passed
      (exit 0). One environmental test failure outside this diff is recorded in
      **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync (exit 0; agents-claude, biome version,
      bun/turbo contracts, dep checks, alias guard, monorepo typecheck + lint,
      build-model/turbo-deps/tee/fleet/scripts/inventory/view-bundle/focused
      audits all green).

# Risks

Low. The change touches only the dev host supervisor script and a new script-lib module; no runtime, agent, or production code path is involved. Behavior change for developers: `bun run dev` shutdown now waits (bounded, default 15 s, `ELIZA_DEV_SHUTDOWN_DRAIN_MS` override) for children that are actually doing teardown work, instead of SIGKILLing every child tree at 1.5 s. Children that exit promptly release the supervisor as soon as they are reaped. A second Ctrl-C still force-exits immediately, so an impatient developer is never held hostage by the window.

# Background

## What does this PR do?

`cleanup()` in `packages/app-core/scripts/dev-ui.mjs` SIGTERMed its three children (vite, api, vision-deps) fire-and-forget, scheduled an unconditional SIGKILL of every child tree at 1500 ms and its own exit at 1800 ms, and never awaited a child `exit` event. That fuse is shorter than the bounded teardown children are entitled to perform: the Discord connector alone may spend up to `DISCORD_SHUTDOWN_DRAIN_TIMEOUT_MS = 10_000` draining in-flight turns plus `DISCORD_REACTION_RECONCILE_TIMEOUT_MS = 2_000` reconciling status reactions (`plugins/plugin-discord/shutdown-drain.ts`, merged in #17749). Under the dev supervisor, that merged drain was killed at 15% of its window, in exactly the environment developers actually run.

This PR routes `cleanup()` through a new `drainSpawnedChildren` module (`packages/app-core/scripts/lib/shutdown-drain.mjs`): SIGTERM every live child up front, await their exits up to a bounded window, then SIGKILL only the stragglers, per child and loudly, with a bounded kill grace so supervisor exit cannot race the escalation it just issued. Supervisor exit follows child exit directly instead of a fixed schedule. The second-signal force-exit path is unchanged, and the module is deliberately reusable for the sibling dev hosts (`dev-platform.mjs` has the same fuse; not changed here, it belongs to the packaged-runtime slice that remains open on #16318).

## What kind of change is this?

Bug fix (non-breaking; dev tooling only).

# Documentation changes needed?

None. The env override and defaults are documented at the definition site; there is no user-facing docs surface for the dev supervisor.

# Testing

## Where should a reviewer start?

1. `packages/app-core/scripts/lib/shutdown-drain.mjs` (the whole contract is ~150 lines).
2. The rewired `cleanup()` in `packages/app-core/scripts/dev-ui.mjs`.
3. `packages/app-core/scripts/lib/shutdown-drain.test.mjs`: deterministic suite (fake children, fake timers, same idiom as `api-supervisor.test.mjs`), a real-process suite proving actual SIGTERM/SIGKILL delivery, and source-shape wiring assertions for `dev-ui.mjs`.

## Detailed testing steps

```bash
cd packages/app-core
node ../scripts/run-vitest.mjs run --config vitest.config.ts scripts/lib/shutdown-drain.test.mjs
```

Live, from the repo root:

```bash
bun run dev            # wait for boot, then Ctrl-C or SIGTERM the supervisor
# expect: "[eliza] Draining N child processes (up to 15000 ms)…", children run
# their own teardown ("Dev server shutting down…"), supervisor exits 0, no SIGKILL

ELIZA_DEV_SHUTDOWN_DRAIN_MS=200 bun run dev   # then SIGTERM after boot
# expect: "[eliza] vite did not exit within 200 ms — escalating to SIGKILL."
# (only the straggler is escalated; children that made the window are not)
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e9b182692d38781162b168eee03b604ae65c64db -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - dev supervisor script change; no UI surface renders`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - dev supervisor script change; no UI surface renders`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - terminal-only supervisor behavior; the complete real process logs of both drain paths are attached on the backend-logs row`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end: full supervisor logs of a completing drain ([evidence-drain-normal.txt](https://github.com/user-attachments/files/30947256/evidence-drain-normal.txt)) and a forced escalation ([evidence-drain-escalation.txt](https://github.com/user-attachments/files/30947254/evidence-drain-escalation.txt)), captured from real `dev-ui.mjs` runs at this head. The same logs are pasted inline directly below. Attached via user-attachments because fork PRs cannot upload to the repository evidence release (404 without upstream write access).

<details>
<summary>Full log: completing drain, stock 15 s window (apt progress lines collapsed)</summary>

```
eliza dev mode

  [eliza] Starting API and UI dev servers in parallel...

  [eliza] API log level=info (startup + warnings/errors)
  [eliza] Skipping Capacitor plugin build (source checkout).
  [eliza] Agent hot-reload on: watching 106 source dirs (set ELIZA_DEV_NO_WATCH=1 to disable).

  [eliza] Waiting for API server... 1s[eliza] Script starting... (timing: child-spawn env ELIZA_API_PROCESS_SPAWNED_AT_MS; pre-body/import delay: 1522ms)
[eliza] Static imports complete (1523ms since child-spawn env ELIZA_API_PROCESS_SPAWNED_AT_MS; module body 1ms)
[eliza] dotenv loaded (1528ms since child-spawn env ELIZA_API_PROCESS_SPAWNED_AT_MS; module body 6ms)

  [eliza] Waiting for API server... 2s
  [eliza] Waiting for API server... 3s
  [eliza] Waiting for API server... 4s
  [eliza] Waiting for API server... 5s Info       [eliza-api] upstreamStartApiServer took 225ms
[eliza] API ready: http://localhost:31337 (3868ms)
[eliza] Startup init complete in 3874ms, agent bootstrapping...
 Info       [eliza] Runtime bootstrap starting (startup)

  [eliza] API port open (5.5s)          

  [eliza] Waiting for agent to be ready... 6s
  [eliza] UI ready at http://localhost:2138/ (7.0s)
  [eliza] Local access: no password required on this machine
  [eliza] Security settings: http://localhost:2138/settings#security

  [eliza] Installing fswebcam via apt-get...
Reading package lists...

  [eliza] Waiting for agent to be ready... 7sBuilding dependency tree...
Reading state information...
The following NEW packages will be installed:
  fswebcam

  [eliza] Waiting for agent to be ready... 8s0 upgraded, 1 newly installed, 0 to remove and 138 not upgraded.
Need to get 47.4 kB of archives.
After this operation, 130 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu noble/universe amd64 fswebcam amd64 20140113-2 [47.4 kB]
 Info       [eliza] Deferring local embedding warmup until runtime ready
 Info       [eliza-boot] static-plugins-blocking-import: 75ms (t+75ms)
 Error      [eliza] Runtime bootstrap failed (vault: master key unavailable (unavailable (keychain bypassed: host unsafe; no ELIZA_VAULT_PASSPHRASE set)): vault: OS keychain is unsafe on this host (headless Linux with no reachable D-Bus session, or ELIZA_VAULT_DISABLE_KEYCHAIN=1). Set ELIZA_VAULT_PASSPHRASE (≥12 chars) to enable a passphrase-derived master key, or pass an inMemoryMasterKey.. On a desktop session ensure the OS keychain (gnome-keyring / kwallet / Keychain) is reachable; on a headless host set ELIZA_VAULT_PASSPHRASE (≥12 chars) and restart.). Retrying in 1s
Fetched 47.4 kB in 0s (122 kB/s)

  [eliza] Waiting for agent to be ready... 9sSelecting previously unselected package fswebcam.

(Reading database ... 
(Reading database ... 5%..100% [progress lines collapsed]
(Reading database ... 78833 files and directories currently installed.)

Preparing to unpack .../fswebcam_20140113-2_amd64.deb ...

Unpacking fswebcam (20140113-2) ...

Setting up fswebcam (20140113-2) ...

Processing triggers for man-db (2.12.0-4build2) ...

 Info       [eliza] Runtime bootstrap starting (retry)
 Info       [eliza] Deferring local embedding warmup until runtime ready
 Info       [eliza-boot] static-plugins-blocking-import: 1ms (t+1ms)
 Error      [eliza] Runtime bootstrap failed (vault: master key unavailable (unavailable (keychain bypassed: host unsafe; no ELIZA_VAULT_PASSPHRASE set)): vault: OS keychain is unsafe on this host (headless Linux with no reachable D-Bus session, or ELIZA_VAULT_DISABLE_KEYCHAIN=1). Set ELIZA_VAULT_PASSPHRASE (≥12 chars) to enable a passphrase-derived master key, or pass an inMemoryMasterKey.. On a desktop session ensure the OS keychain (gnome-keyring / kwallet / Keychain) is reachable; on a headless host set ELIZA_VAULT_PASSPHRASE (≥12 chars) and restart.). Retrying in 2s

  [eliza] Waiting for agent to be ready... 10s
  [eliza] Waiting for agent to be ready... 11s Info       [eliza] Runtime bootstrap starting (retry)
 Info       [eliza] Deferring local embedding warmup until runtime ready
 Info       [eliza-boot] static-plugins-blocking-import: 0ms (t+0ms)
 Error      [eliza] Runtime bootstrap failed (vault: master key unavailable (unavailable (keychain bypassed: host unsafe; no ELIZA_VAULT_PASSPHRASE set)): vault: OS keychain is unsafe on this host (headless Linux with no reachable D-Bus session, or ELIZA_VAULT_DISABLE_KEYCHAIN=1). Set ELIZA_VAULT_PASSPHRASE (≥12 chars) to enable a passphrase-derived master key, or pass an inMemoryMasterKey.. On a desktop session ensure the OS keychain (gnome-keyring / kwallet / Keychain) is reachable; on a headless host set ELIZA_VAULT_PASSPHRASE (≥12 chars) and restart.). Retrying in 4s (UI state set to error)
[eliza] Draining 3 child processes (up to 15000 ms)…
 Info       [eliza] Dev server shutting down…

  [eliza] Vision dependency auto-install failed.
  [eliza] Camera and vision features will be unavailable in this session until the native tools are installed.
  [eliza] Retry manually: node packages/app-core/scripts/ensure-vision-deps.mjs --name=eliza
  [eliza] Failure detail: vision deps check exited with code null

  [eliza] Waiting for agent to be ready... 12s== supervisor exited code=0 at 10:52:12.871 ==
```

</details>

<details>
<summary>Full log: forced escalation, ELIZA_DEV_SHUTDOWN_DRAIN_MS=200</summary>

```
eliza dev mode

  [eliza] Starting API and UI dev servers in parallel...

  [eliza] API log level=info (startup + warnings/errors)
  [eliza] Skipping Capacitor plugin build (source checkout).
  [eliza] Agent hot-reload on: watching 106 source dirs (set ELIZA_DEV_NO_WATCH=1 to disable).

  [eliza] Waiting for API server... 1s[eliza] Script starting... (timing: child-spawn env ELIZA_API_PROCESS_SPAWNED_AT_MS; pre-body/import delay: 1765ms)
[eliza] Static imports complete (1765ms since child-spawn env ELIZA_API_PROCESS_SPAWNED_AT_MS; module body 0ms)
[eliza] dotenv loaded (1770ms since child-spawn env ELIZA_API_PROCESS_SPAWNED_AT_MS; module body 5ms)

  [eliza] Waiting for API server... 2s
  [eliza] UI ready at http://localhost:2138/ (2.3s)
  [eliza] Local access: no password required on this machine
  [eliza] Security settings: http://localhost:2138/settings#security

 Info       [eliza-api] upstreamStartApiServer took 208ms
[eliza] API ready: http://localhost:31337 (852ms)
[eliza] Startup init complete in 856ms, agent bootstrapping...
 Info       [eliza] Runtime bootstrap starting (startup)

  [eliza] Waiting for API server... 3s
  [eliza] API port open (3.0s)          
 Info       [eliza] Deferring local embedding warmup until runtime ready
 Info       [eliza-boot] static-plugins-blocking-import: 90ms (t+90ms)
 Error      [eliza] Runtime bootstrap failed (vault: master key unavailable (unavailable (keychain bypassed: host unsafe; no ELIZA_VAULT_PASSPHRASE set)): vault: OS keychain is unsafe on this host (headless Linux with no reachable D-Bus session, or ELIZA_VAULT_DISABLE_KEYCHAIN=1). Set ELIZA_VAULT_PASSPHRASE (≥12 chars) to enable a passphrase-derived master key, or pass an inMemoryMasterKey.. On a desktop session ensure the OS keychain (gnome-keyring / kwallet / Keychain) is reachable; on a headless host set ELIZA_VAULT_PASSPHRASE (≥12 chars) and restart.). Retrying in 1s

  [eliza] Waiting for agent to be ready... 4s Info       [eliza] Runtime bootstrap starting (retry)
 Info       [eliza] Deferring local embedding warmup until runtime ready
 Info       [eliza-boot] static-plugins-blocking-import: 0ms (t+0ms)
 Error      [eliza] Runtime bootstrap failed (vault: master key unavailable (unavailable (keychain bypassed: host unsafe; no ELIZA_VAULT_PASSPHRASE set)): vault: OS keychain is unsafe on this host (headless Linux with no reachable D-Bus session, or ELIZA_VAULT_DISABLE_KEYCHAIN=1). Set ELIZA_VAULT_PASSPHRASE (≥12 chars) to enable a passphrase-derived master key, or pass an inMemoryMasterKey.. On a desktop session ensure the OS keychain (gnome-keyring / kwallet / Keychain) is reachable; on a headless host set ELIZA_VAULT_PASSPHRASE (≥12 chars) and restart.). Retrying in 2s

  [eliza] Waiting for agent to be ready... 5s
  [eliza] Waiting for agent to be ready... 6s Info       [eliza] Runtime bootstrap starting (retry)
 Info       [eliza] Deferring local embedding warmup until runtime ready
 Info       [eliza-boot] static-plugins-blocking-import: 1ms (t+1ms)
 Error      [eliza] Runtime bootstrap failed (vault: master key unavailable (unavailable (keychain bypassed: host unsafe; no ELIZA_VAULT_PASSPHRASE set)): vault: OS keychain is unsafe on this host (headless Linux with no reachable D-Bus session, or ELIZA_VAULT_DISABLE_KEYCHAIN=1). Set ELIZA_VAULT_PASSPHRASE (≥12 chars) to enable a passphrase-derived master key, or pass an inMemoryMasterKey.. On a desktop session ensure the OS keychain (gnome-keyring / kwallet / Keychain) is reachable; on a headless host set ELIZA_VAULT_PASSPHRASE (≥12 chars) and restart.). Retrying in 4s (UI state set to error)

  [eliza] Agent ready (6.6s)          
[eliza] Draining 2 child processes (up to 200 ms)…
 Info       [eliza] Dev server shutting down…
[eliza] vite did not exit within 200 ms — escalating to SIGKILL.
== supervisor exited code=0 at 10:52:25.171 ==
```

</details>

Note on the first log: the `vision-deps` child was mid `apt-get install` when SIGTERM arrived; its own failure handler ran ("vision deps check exited with code null") and it exited within the window, so it was never escalated. Cancelling an optional dependency install on shutdown is the expected outcome.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend involvement`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no domain outputs; the supervisor process logs on the backend-logs row are the artifact this change produces`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model change.`

## Backend + frontend logs

Both logs captured from real `bun run dev` supervisor runs in a headless Linux sandbox at `06e9e97f6`; the two commits since (`bd8b5ac`, `e9b1826`) harden only the env-override resolver and `isLive`, not the drain paths these logs exercise. Key excerpts first; complete logs in the details blocks below. Frontend: `N/A - no frontend involvement`.

Completing drain (stock window). The API child prints its own teardown line, the work the old fixed fuse could kill mid-flight:

```
[eliza] Draining 3 child processes (up to 15000 ms)…
 Info       [eliza] Dev server shutting down…
== supervisor exited code=0 at 10:52:12.871 ==
```

Forced escalation (`ELIZA_DEV_SHUTDOWN_DRAIN_MS=200`). Only the straggler is escalated; the api child made the window and was not killed:

```
[eliza] Draining 2 child processes (up to 200 ms)…
 Info       [eliza] Dev server shutting down…
[eliza] vite did not exit within 200 ms — escalating to SIGKILL.
== supervisor exited code=0 at 10:52:25.171 ==
```



## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - terminal-only supervisor behavior; process logs attached instead.`

## Audio / voice walkthrough

`N/A - no voice surface.`

## Known gaps / failures

- The boot portions of the attached logs show `vault: master key unavailable` bootstrap retries. These are environmental (headless sandbox without `ELIZA_VAULT_PASSPHRASE`), present on `develop` before this change, and unrelated to shutdown behavior.
- The live Discord restart-during-turn evidence required by #16318's acceptance remains open on the issue; it belongs to the connector/live slice, not this supervisor slice.
- `dev-platform.mjs` retains its own 1.5 s fuse; packaged-runtime supervisors are explicitly out of scope here and remain open on #16318. The new module is importable there when that slice is picked up.
- Full app-core suite: 1705 passed, 1 failed, 14 skipped. The failure is `scripts/docker-entrypoint.test.ts > starts the cloud-agent command without tailscale when no auth key is configured`, exit code 127 (missing container binary in the offline sandbox this was validated in). Reproduced identically in isolation at this head; the file exercises `deploy/cloud-agent-docker-entrypoint.sh` and shares nothing with this diff. Root `bun run verify` passes (exit 0).
- The compute receipt below reports zero project-attributed tokens with `unavailable` confidence: the isolated build environment has no local Claude Code usage data for ccusage to read. Signed zero rather than fabricated usage, per the skill contract.

<!-- gate-refresh: marker re-pinned to e9b182692d after the race with the synchronize-event check run -->

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-code-wbaxterh]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01KZRYMNQE4W44KQP7TPTY95K4","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-11T17:41:34.575Z","completed_at":"2026-08-11T18:08:47.097Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ6-B_keoGBnP1vX0AEdBc1-mwYlyxZ0hgzt21ESQWaQ","device_key_id":"972ca87555be4523e052622617f964f99285337b7f81650e8da644fb2ac176b6","device_signature":"yhWaGvLrel5LwL5wHVcXAaGtI-qHjgZixdF6LxRYT0FVtH_lqrHsEsCpt7NLSh2SIUHbyrbb-C8pDKWGLA0CAg"}} -->
